### PR TITLE
fix(state): orphaned backend no longer blocks state.db FTS repair forever (#93155)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -461,6 +461,18 @@ def _render_state_db_stats(stats: dict, holders=None) -> list:
             "",
         ))
 
+    deferral = stats.get("fts_rebuild_deferral")
+    if isinstance(deferral, dict):
+        attempts = deferral.get("attempts")
+        pids = deferral.get("holder_pids") or []
+        lines.append((
+            "warn",
+            f"state.db FTS repair is blocked after {attempts or '?'} "
+            f"deferral(s) by PID(s) {pids or 'unknown'}",
+            "(stop the listed processes, then run 'hermes sessions "
+            "optimize-storage' with the gateway stopped)",
+        ))
+
     # Advisory: oversized database. Suggest auto_prune, and — when the v23
     # FTS rebuild is pending OR the DB still carries the legacy inline
     # trigram layout (fts_storage_version marker absent) — the offline

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -77,6 +77,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     escape_like as _escape_like,
     DEFERRED_INDEX_SQL,
     FTS_CJK_STALE_KEY,
+    FTS_REBUILD_DEFERRAL_KEY,
     FTS_SQL,
     FTS_STALE_KEY,
     FTS_STORAGE_VERSION,
@@ -3767,6 +3768,7 @@ def collect_state_db_stats(db_path: Path) -> Dict[str, Any]:
     - ``fts_rebuild_pending`` — True when the deferred v23 backfill has not
       finished (high_water present and progress < high_water)
     - ``fts_rebuild_high_water`` / ``fts_rebuild_progress`` — raw ints
+    - ``fts_rebuild_deferral`` — durable blocked-repair diagnostic, when present
     """
     stats: Dict[str, Any] = {
         "page_count": None,
@@ -3782,6 +3784,7 @@ def collect_state_db_stats(db_path: Path) -> Dict[str, Any]:
         "fts_rebuild_pending": None,
         "fts_rebuild_high_water": None,
         "fts_rebuild_progress": None,
+        "fts_rebuild_deferral": None,
     }
 
     # WAL sidecar size needs no connection at all.
@@ -3872,6 +3875,17 @@ def collect_state_db_stats(db_path: Path) -> Dict[str, Any]:
             stats["fts_rebuild_pending"] = False
         else:
             stats["fts_rebuild_pending"] = (progress or 0) < high_water
+        try:
+            row = conn.execute(
+                "SELECT value FROM state_meta WHERE key = ? LIMIT 1",
+                (FTS_REBUILD_DEFERRAL_KEY,),
+            ).fetchone()
+            if row:
+                parsed = json.loads(row[0])
+                if isinstance(parsed, dict):
+                    stats["fts_rebuild_deferral"] = parsed
+        except Exception:
+            pass
     finally:
         try:
             conn.close()
@@ -3913,6 +3927,23 @@ def count_db_holders(db_path: Path) -> Optional[int]:
         return holders
     except Exception:
         return None
+
+
+def _is_inactive_orphan_desktop_holder(
+    *,
+    ppid: int,
+    age_seconds: float,
+    min_age_seconds: float,
+    ephemeral_backend: bool,
+    connection_statuses: List[str],
+) -> bool:
+    """Pure safety predicate for the narrow Desktop holder reap."""
+    return (
+        ppid in (0, 1)
+        and age_seconds >= min_age_seconds
+        and ephemeral_backend
+        and "ESTABLISHED" not in connection_statuses
+    )
 
 
 def _read_proc_cmdline(pid: int) -> Optional[str]:
@@ -5135,6 +5166,69 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
             return holders or [(-1, f"open-file scan failed: {exc}")]
         return holders
+
+    def _reap_inactive_orphan_desktop_holders(
+        self, holders: List[Tuple[int, str]], *, min_age_seconds: float
+    ) -> List[int]:
+        """Terminate old PPID-1 Desktop ephemeral backends with no client.
+
+        Inspection fails closed: anything whose parent, age, argv, or network
+        connections cannot be proved safe remains a repair-blocking holder.
+        """
+        if not sys.platform.startswith("linux") or psutil is None:
+            return []
+        try:
+            from hermes_cli.dashboard_procs import _is_ephemeral_port_zero_backend
+        except Exception:
+            return []
+
+        now = time.time()
+        candidates = []
+        for pid, _path in holders:
+            if pid <= 0:
+                continue
+            try:
+                process = psutil.Process(pid)
+                statuses = [
+                    conn.status for conn in process.net_connections(kind="inet")
+                ]
+                if not _is_inactive_orphan_desktop_holder(
+                    ppid=process.ppid(),
+                    age_seconds=now - process.create_time(),
+                    min_age_seconds=min_age_seconds,
+                    ephemeral_backend=_is_ephemeral_port_zero_backend(process.cmdline()),
+                    connection_statuses=statuses,
+                ):
+                    continue
+            except Exception:
+                continue
+            candidates.append(process)
+
+        signalled: List[int] = []
+        for process in candidates:
+            try:
+                process.terminate()
+                signalled.append(process.pid)
+            except (psutil.Error, OSError):
+                continue
+        if not signalled:
+            return []
+
+        try:
+            _gone, alive = psutil.wait_procs(candidates, timeout=1.5)
+        except Exception:
+            alive = []
+        for process in alive:
+            try:
+                process.kill()
+            except (psutil.Error, OSError):
+                continue
+        if alive:
+            try:
+                psutil.wait_procs(alive, timeout=1.5)
+            except Exception:
+                pass
+        return signalled
 
     def _try_runtime_fts_rebuild(self, exc: sqlite3.DatabaseError) -> bool:
         """One-shot in-place FTS rebuild after a corrupt-index write failure.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3946,6 +3946,29 @@ def _is_inactive_orphan_desktop_holder(
     )
 
 
+def _concrete_state_db_holder_pids(
+    db_path: Path, holders: List[Tuple[int, str]]
+) -> List[int]:
+    """Return unique PIDs proven to hold this DB or one of its sidecars."""
+    canonical_db = os.path.normcase(os.path.abspath(os.fspath(db_path)))
+    watched = {
+        canonical_db,
+        canonical_db + "-wal",
+        canonical_db + "-shm",
+    }
+    pids: List[int] = []
+    seen = set()
+    for pid, path in holders:
+        canonical_path = os.path.normcase(
+            os.path.abspath(path.removesuffix(" (deleted)"))
+        )
+        if pid <= 0 or pid in seen or canonical_path not in watched:
+            continue
+        seen.add(pid)
+        pids.append(pid)
+    return pids
+
+
 def _read_proc_cmdline(pid: int) -> Optional[str]:
     """Read /proc/<pid>/cmdline, world-readable even when fd table is not.
 
@@ -5184,9 +5207,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         now = time.time()
         candidates = []
-        for pid, _path in holders:
-            if pid <= 0:
-                continue
+        for pid in _concrete_state_db_holder_pids(self.db_path, holders):
             try:
                 process = psutil.Process(pid)
                 statuses = [

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -733,6 +733,9 @@ FTS_CJK_STALE_KEY = "fts_cjk_stale"
 # them would preserve an unknown index gap.
 FTS_STALE_KEY = "fts_stale"
 
+# Durable diagnostic for stale FTS recovery blocked across process restarts.
+FTS_REBUILD_DEFERRAL_KEY = "fts_rebuild_deferral"
+
 
 # ── Legacy (v22 / inline-content) FTS DDL ──────────────────────────────
 # Used ONLY to keep an existing pre-v23 install's search working and its

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -11,12 +11,14 @@ module-level constants live in hermes_state_common.
 import logging
 import json
 import sqlite3
+import time
 from typing import Dict, Optional, Sequence
 
 from hermes_constants import get_hermes_home
 from hermes_state_common import (
     DEFERRED_INDEX_SQL,
     FTS_CJK_STALE_KEY,
+    FTS_REBUILD_DEFERRAL_KEY,
     FTS_STALE_KEY,
     FTS_SQL,
     FTS_STORAGE_VERSION,
@@ -34,6 +36,9 @@ from hermes_state_common import (
 # Moved methods logged under the "hermes_state" logger before the split;
 # keep that logger identity so log filtering/capture behavior is unchanged.
 logger = logging.getLogger("hermes_state")
+
+_FTS_HOLDER_ESCALATE_ATTEMPTS = 3
+_FTS_HOLDER_ESCALATE_SECONDS = 60.0
 
 # Cache for schema_read_probe_statements() — parsing SCHEMA_SQL spins up an
 # in-memory SQLite database, so derive the statements once per process.
@@ -397,13 +402,78 @@ class SessionSchemaMixin:
         """Atomically rebuild stale base/trigram indexes and resume syncing."""
         foreign_holders = self._foreign_state_db_holders()
         if foreign_holders:
-            logger.warning(
-                "Deferred stale state.db FTS rebuild while foreign processes "
-                "hold the database or WAL sidecars (%s); canonical writes and "
-                "LIKE search remain available.",
-                foreign_holders,
+            now = time.time()
+            record = None
+            try:
+                row = cursor.execute(
+                    "SELECT value FROM state_meta WHERE key = ? LIMIT 1",
+                    (FTS_REBUILD_DEFERRAL_KEY,),
+                ).fetchone()
+                if row:
+                    raw = row["value"] if isinstance(row, sqlite3.Row) else row[0]
+                    parsed = json.loads(raw)
+                    if isinstance(parsed, dict):
+                        record = parsed
+            except (sqlite3.Error, TypeError, ValueError, json.JSONDecodeError):
+                record = None
+
+            try:
+                first_seen = float((record or {}).get("first_seen", now))
+                attempts = int((record or {}).get("attempts", 0)) + 1
+            except (TypeError, ValueError):
+                first_seen = now
+                attempts = 1
+            if first_seen > now or first_seen < 0:
+                first_seen = now
+            holder_pids = sorted({pid for pid, _path in foreign_holders if pid > 0})
+            diagnostic = {
+                "first_seen": first_seen,
+                "last_seen": now,
+                "attempts": attempts,
+                "holder_pids": holder_pids,
+            }
+            cursor.execute(
+                "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                (FTS_REBUILD_DEFERRAL_KEY, json.dumps(diagnostic, sort_keys=True)),
             )
-            return False
+
+            escalated = (
+                attempts >= _FTS_HOLDER_ESCALATE_ATTEMPTS
+                and now - first_seen >= _FTS_HOLDER_ESCALATE_SECONDS
+            )
+            if escalated:
+                reaped = self._reap_inactive_orphan_desktop_holders(
+                    foreign_holders,
+                    min_age_seconds=_FTS_HOLDER_ESCALATE_SECONDS,
+                )
+                if reaped:
+                    logger.error(
+                        "Reaped inactive orphan Desktop backend(s) %s after %d "
+                        "state.db FTS rebuild deferrals; checking holders again.",
+                        reaped,
+                        attempts,
+                    )
+                    foreign_holders = self._foreign_state_db_holders()
+                if foreign_holders:
+                    logger.error(
+                        "state.db FTS repair remains blocked after %d deferrals "
+                        "by holder(s) %s. Stop the listed processes, then run "
+                        "`hermes sessions optimize-storage` with the gateway stopped. "
+                        "`hermes doctor` reports this degraded state.",
+                        attempts,
+                        foreign_holders,
+                    )
+
+            if foreign_holders:
+                logger.warning(
+                    "Deferred stale state.db FTS rebuild while foreign processes "
+                    "hold the database or WAL sidecars (%s); canonical writes and "
+                    "LIKE search remain available (deferral %d).",
+                    foreign_holders,
+                    attempts,
+                )
+                return False
         # Full structural rebuild: admit through the single cross-process
         # authority (fail closed). Losing the race means another process is
         # already performing this exact recovery; the stale breadcrumb stays
@@ -483,7 +553,8 @@ class SessionSchemaMixin:
             "BEGIN IMMEDIATE;"
             + drop_sql
             + rebuild_sql
-            + f"DELETE FROM state_meta WHERE key = '{FTS_STALE_KEY}';"
+            + "DELETE FROM state_meta WHERE key IN "
+            + f"('{FTS_STALE_KEY}', '{FTS_REBUILD_DEFERRAL_KEY}');"
             + "COMMIT;"
         )
         try:

--- a/tests/state/test_fts_runtime_rebuild.py
+++ b/tests/state/test_fts_runtime_rebuild.py
@@ -30,6 +30,7 @@ from hermes_state import (
     SCHEMA_SQL,
     SessionDB,
     _FTS_TRIGGERS,
+    _concrete_state_db_holder_pids,
     _is_inactive_orphan_desktop_holder,
 )
 
@@ -91,6 +92,31 @@ def _base_fts_triggers(db_path):
 
 
 class TestRuntimeFtsRebuild:
+    def test_reap_candidates_exclude_uninspectable_holder_suspicions(
+        self, tmp_path
+    ):
+        db_path = tmp_path / "state.db"
+
+        assert _concrete_state_db_holder_pids(
+            db_path,
+            [
+                (222, "uninspectable holder: python -m hermes_cli.main serve --port 0"),
+                (-1, "open-file scan failed"),
+            ],
+        ) == []
+
+    def test_reap_candidates_deduplicate_multiple_proven_watched_fds(self, tmp_path):
+        db_path = tmp_path / "state.db"
+
+        assert _concrete_state_db_holder_pids(
+            db_path,
+            [
+                (222, str(db_path)),
+                (222, f"{db_path}-wal"),
+                (222, f"{db_path}-shm (deleted)"),
+            ],
+        ) == [222]
+
     def test_inactive_orphan_reap_predicate_preserves_live_or_ambiguous_holders(self):
         common = {
             "ppid": 1,

--- a/tests/state/test_fts_runtime_rebuild.py
+++ b/tests/state/test_fts_runtime_rebuild.py
@@ -13,6 +13,7 @@ sync triggers, and retries the canonical write. Search degrades to ``LIKE``
 until a later open atomically rebuilds the index and restores the triggers.
 """
 
+import json
 import os
 import sqlite3
 from types import SimpleNamespace
@@ -20,13 +21,16 @@ from types import SimpleNamespace
 import pytest
 
 import hermes_state
+import hermes_state_schema
 from hermes_state import (
+    FTS_REBUILD_DEFERRAL_KEY,
     FTS_STALE_KEY,
     LEGACY_FTS_SQL,
     LEGACY_FTS_TRIGRAM_SQL,
     SCHEMA_SQL,
     SessionDB,
     _FTS_TRIGGERS,
+    _is_inactive_orphan_desktop_holder,
 )
 
 
@@ -87,6 +91,29 @@ def _base_fts_triggers(db_path):
 
 
 class TestRuntimeFtsRebuild:
+    def test_inactive_orphan_reap_predicate_preserves_live_or_ambiguous_holders(self):
+        common = {
+            "ppid": 1,
+            "age_seconds": 120.0,
+            "min_age_seconds": 60.0,
+            "ephemeral_backend": True,
+            "connection_statuses": [],
+        }
+        assert _is_inactive_orphan_desktop_holder(**common)
+        assert not _is_inactive_orphan_desktop_holder(**{**common, "ppid": 42})
+        assert not _is_inactive_orphan_desktop_holder(
+            **{**common, "age_seconds": 10.0}
+        )
+        assert not _is_inactive_orphan_desktop_holder(
+            **{**common, "ephemeral_backend": False}
+        )
+        assert not _is_inactive_orphan_desktop_holder(
+            **{
+                **common,
+                "connection_statuses": ["ESTABLISHED"],
+            }
+        )
+
     def test_foreign_holder_detection_includes_deleted_wal(
         self, db, tmp_path, monkeypatch
     ):
@@ -516,6 +543,59 @@ class TestRuntimeFtsRebuild:
             assert _base_fts_triggers(db_path) == set()
             reopened.append_message("s1", "user", "after deferred recovery")
             assert _message_contents(db_path)[-1] == "after deferred recovery"
+        finally:
+            reopened.close()
+
+    def test_repeated_deferrals_reap_inactive_orphan_then_rebuild(
+        self, db, tmp_path, monkeypatch
+    ):
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db_path = tmp_path / "state.db"
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "seed")
+        _corrupt_fts(db_path)
+        monkeypatch.setattr(
+            db,
+            "rebuild_fts",
+            lambda: (_ for _ in ()).throw(sqlite3.DatabaseError("still corrupt")),
+        )
+        db.append_message("s1", "user", "before restart")
+        db.close()
+
+        raw = sqlite3.connect(str(db_path))
+        raw.execute(
+            "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (
+                FTS_REBUILD_DEFERRAL_KEY,
+                json.dumps({"first_seen": 1.0, "last_seen": 30.0, "attempts": 2}),
+            ),
+        )
+        raw.commit()
+        raw.close()
+
+        holder_scans = iter(([(4242, str(db_path) + "-wal")], []))
+        reaped = []
+        monkeypatch.setattr(
+            SessionDB,
+            "_foreign_state_db_holders",
+            lambda self: next(holder_scans),
+        )
+        monkeypatch.setattr(
+            SessionDB,
+            "_reap_inactive_orphan_desktop_holders",
+            lambda self, holders, *, min_age_seconds: reaped.extend(holders) or [4242],
+        )
+        monkeypatch.setattr(hermes_state_schema.time, "time", lambda: 120.0)
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert reaped == [(4242, str(db_path) + "-wal")]
+            assert reopened._fts_stale is False
+            assert _meta_value(db_path, FTS_STALE_KEY) is None
+            assert _meta_value(db_path, FTS_REBUILD_DEFERRAL_KEY) is None
+            assert reopened.search_messages("before restart")
         finally:
             reopened.close()
 

--- a/tests/test_state_db_stats.py
+++ b/tests/test_state_db_stats.py
@@ -10,6 +10,7 @@ Covers:
   the doctor state.db section prints from.
 """
 
+import json
 import os
 import sqlite3
 import sys
@@ -76,6 +77,33 @@ def test_collect_stats_is_read_only(populated_db):
     db = SessionDB(db_path=populated_db)
     assert db.get_session("sess-alpha") is not None
     db.close()
+
+
+def test_collect_and_render_stale_fts_holder_deferral(populated_db):
+    conn = sqlite3.connect(str(populated_db))
+    conn.execute(
+        "INSERT INTO state_meta (key, value) VALUES (?, ?)",
+        (
+            "fts_rebuild_deferral",
+            json.dumps({"attempts": 4, "holder_pids": [4242], "first_seen": 1.0}),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    stats = collect_state_db_stats(populated_db)
+    assert stats["fts_rebuild_deferral"]["attempts"] == 4
+    assert stats["fts_rebuild_deferral"]["holder_pids"] == [4242]
+
+    from hermes_cli.doctor import _render_state_db_stats
+
+    rendered = _render_state_db_stats(stats)
+    warnings = [
+        " ".join((text, detail))
+        for kind, text, detail in rendered
+        if kind == "warn"
+    ]
+    assert any("4242" in warning and "optimize-storage" in warning for warning in warnings)
 
 
 def test_collect_stats_missing_file_never_raises(tmp_path):


### PR DESCRIPTION
## Summary
An orphaned Desktop backend holding `state.db` (or its WAL sidecars) no longer blocks FTS/corruption repair indefinitely with no signal. Previously the repair path deferred forever while any foreign process held the database — recording holder PIDs only in a log line, with no liveness check, no escalation, and nothing user-visible. Fixes #93155.

Salvages #93191 by @fangliquanflq (2 commits, authorship preserved).

## Changes
- `hermes_state_schema.py` / `hermes_state.py` / `hermes_state_common.py`: persist a durable deferral record (`FTS_REBUILD_DEFERRAL_KEY`: first_seen, attempts, holder_pids) so deferrals count across restarts. After ≥3 attempts and ≥60s, escalate: reap only *provably* dead orphan Desktop holders (`_is_inactive_orphan_desktop_holder` — Linux+psutil, ppid∈{0,1}, past min-age, ephemeral port-0 backend argv, no ESTABLISHED connection), then **re-scan holders and only rebuild if the scan is clear**. Anything uninspectable stays a repair-blocking holder (fail closed).
- `hermes_cli/doctor.py`: surfaces the degraded state with the offline recovery command.

## Corruption-guard safety (#90950 constraint)
The foreign-holder guard is load-bearing — structural FTS maintenance while another process holds an old WAL/SHM inode is exactly what caused the #90806/#90871 corruption incidents. This fix never weakens it: it removes only proven-dead orphans, then **re-runs `_foreign_state_db_holders()` and aborts the rebuild if any holder remains**. Repair still flows through the cross-process `fts_rebuild_admission` authority (composed with main's #69609 during salvage).

## Validation
| | Result |
|---|---|
| `tests/state/test_fts_runtime_rebuild.py` + `tests/test_state_db_stats.py` | 33 passed |
| Reap/orphan/deferral path tests | 4 passed (verified on sqlite 3.53.1 — real WAL, not a vacuous skip) |

## Infographic

![Reap the orphan, repair the DB](https://v3b.fal.media/files/b/0aa79163/wPDKhQffXeqhT7txCq_NI_gJ7SewCk.png)
