### PR TITLE
fix(classifier): 429 quota walls route to billing across providers; reset signals stay retryable (consolidates #39441, #63021, #74785)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -245,10 +245,15 @@ _USAGE_LIMIT_TRANSIENT_SIGNALS = [
     "retry",
     "resets at",
     "reset in",
+    "resets in",
+    "reset after",
+    "available in",
     "wait",
     "requests remaining",
     "periodic",
     "window",
+    "per minute",
+    "per second",
 ]
 
 # Payload-too-large patterns detected from message text (no status_code attr).
@@ -1346,17 +1351,37 @@ def _classify_by_status(
         # branch below used to retry it and Desktop rendered a provider error
         # instead of the billing/quota recovery. Preserve periodic quotas when
         # the response supplies an explicit reset/retry signal.
+        #
+        # The check covers the narrow #93419 core (Anthropic's
+        # ``usage_limit_reached``) plus the broader ``_USAGE_LIMIT_PATTERNS``
+        # ("quota", "limit exceeded", "key limit exceeded") so other providers'
+        # hard quota walls also route to billing — but ONLY when the message is
+        # not itself an explicit rate-limit phrase. Without that guard,
+        # "Rate limit exceeded" ("limit exceeded" substring) would wrongly
+        # promote to non-retryable billing. (broadening + guard credit #39441)
         has_usage_limit = (
             error_code.lower() == "usage_limit_reached"
-            or "usage limit" in error_msg
             or "usage_limit_reached" in error_msg
+            or any(p in error_msg for p in _USAGE_LIMIT_PATTERNS)
+        )
+        # Explicit billing phrases in a 429 body are a hard wall regardless of
+        # usage-limit wording — a provider that wraps "insufficient credits" in
+        # a 429 (rather than 402) was previously retried as a rate limit and
+        # burned the pool. (credit #39441)
+        has_billing = any(p in error_msg for p in _BILLING_PATTERNS)
+        has_explicit_rate_limit = any(
+            p in error_msg for p in _RATE_LIMIT_PATTERNS
         )
         has_transient_signal = _has_usage_limit_transient_signal(
             error_msg,
             body,
             response_headers,
         )
-        if has_usage_limit and not has_transient_signal:
+        if (
+            (has_billing or has_usage_limit)
+            and not has_explicit_rate_limit
+            and not has_transient_signal
+        ):
             return result_fn(
                 FailoverReason.billing,
                 retryable=False,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -355,6 +355,62 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.rate_limit
         assert result.retryable is True
 
+    def test_429_generic_quota_wall_is_billing(self):
+        # Broadened from the narrow "usage limit" core to the full
+        # _USAGE_LIMIT_PATTERNS: a bare "quota" / "limit exceeded" 429 with no
+        # reset signal is a hard wall, not a retryable throttle. (credit #39441)
+        for msg in ("Monthly quota reached.", "API key limit exceeded."):
+            e = MockAPIError(msg, status_code=429)
+            result = classify_api_error(e, provider="groq", model="llama-3")
+            assert result.reason == FailoverReason.billing, msg
+            assert result.retryable is False, msg
+
+    def test_429_insufficient_credits_is_billing(self):
+        e = MockAPIError("Insufficient credits remaining.", status_code=429)
+        result = classify_api_error(e, provider="openrouter", model="x")
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+
+    def test_429_rate_limit_phrase_never_promotes_to_billing(self):
+        # The exclusion guard: "Rate limit exceeded" contains the
+        # "limit exceeded" usage-limit substring, but an explicit rate-limit
+        # phrase must stay a retryable rate limit. (guard credit #39441)
+        for msg in (
+            "Rate limit exceeded, please slow down.",
+            "Too many requests; rate_limit hit.",
+        ):
+            e = MockAPIError(msg, status_code=429)
+            result = classify_api_error(e, provider="anthropic", model="claude-opus-5")
+            assert result.reason == FailoverReason.rate_limit, msg
+            assert result.retryable is True, msg
+
+    def test_codex_weekly_usage_limit_resets_in_stays_rate_limit(self):
+        # Codex surfaces "Weekly usage limit reached. Resets in 6hr 29min."
+        # "resets in" was NOT a transient signal before, so this wrongly read
+        # as terminal billing. (transient-signal credit #63021)
+        e = MockAPIError(
+            "Weekly usage limit reached. Resets in 6hr 29min.",
+            status_code=429,
+        )
+        result = classify_api_error(e, provider="openai-codex", model="gpt-5-codex")
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
+    @pytest.mark.parametrize(
+        "phrase",
+        [
+            "usage limit reached, reset after 3600s",
+            "usage limit reached, available in 42 minutes",
+            "usage limit reached; 20 requests per minute",
+        ],
+    )
+    def test_429_usage_limit_with_extra_transient_phrases_stays_rate_limit(self, phrase):
+        # Additional transient signals. (credit #74785)
+        e = MockAPIError(phrase, status_code=429)
+        result = classify_api_error(e, provider="anthropic", model="claude-opus-5")
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
     def test_alibaba_rate_increased_too_quickly(self):
         """Alibaba/DashScope returns a unique throttling message.
 


### PR DESCRIPTION
## Summary
A `429` that is a hard quota/credit wall now routes to billing (non-retryable, fall back / rotate) across providers, while a `429` carrying any reset signal stays a retryable rate limit. Builds on the merged #93419 Anthropic core, consolidating three independent contributor findings into the single 429 branch of the classifier instead of merging them one at a time.

## Changes (`agent/error_classifier.py`)
- Broaden the 429 usage-limit check from the narrow `"usage limit"` string to the full `_USAGE_LIMIT_PATTERNS` (`quota`, `limit exceeded`, `key limit exceeded`) **and** detect `_BILLING_PATTERNS` on 429 (`insufficient credits` wrapped in a 429 rather than 402 was previously retried and burned the pool), guarded by a `_RATE_LIMIT_PATTERNS` exclusion so an explicit "Rate limit exceeded" never promotes to non-retryable billing. — credit @Pluviobyte (#39441, earliest submitter)
- Add `"resets in"` to the transient signals: Codex's "Weekly usage limit reached. Resets in 6hr 29min." wrongly read as terminal billing because main only had `"reset in"` (no substring match). — credit @LeonSGP43 (#63021)
- Add `"reset after"` / `"available in"` / `"per minute"` / `"per second"` transient signals. — credit @jtstothard (#74785)

Supersedes #65633 (defective branch placement, no tests). The auxiliary-client path already covers these shapes (`_is_payment_error` catches weekly/quota walls, `_is_rate_limit_error` treats "resets in" as transient), so no change there.

## Validation
| Case | Result |
|---|---|
| `429` "Monthly quota reached." / "key limit exceeded" (no reset) | billing, non-retryable |
| `429` "insufficient credits" | billing, non-retryable |
| `429` "Rate limit exceeded" (contains "limit exceeded") | rate_limit, retryable (guard holds) |
| Codex "Weekly usage limit reached. Resets in 6hr 29min." | rate_limit, retryable |
| `429` usage-limit + "reset after"/"available in"/"per minute" | rate_limit, retryable |

Targeted: `test_error_classifier.py` + `test_error_surface.py` 141 passed; 6 new cases; the rate-limit exclusion guard is sabotage-verified (removing it fails the guard test).

## Infographic

![429: wall or wait?](https://v3b.fal.media/files/b/0aa791a2/TnDL-fCk65Aw1zMlRbZkY_LYmYgeY4.png)
