### PR TITLE
fix(desktop): show a visible focus state on row-list keyboard focus

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -495,7 +495,7 @@ function SidebarSessionRowImpl({
                   <span className="min-w-0 flex-1 self-center">
                     <OverflowTip label={title}>
                       <SidebarRowLabel
-                        className="hover-marquee block font-normal group-hover:text-foreground group-data-[working=true]:text-foreground/90"
+                        className="hover-marquee block font-normal group-hover:text-foreground group-has-[:focus-visible]:text-foreground group-data-[working=true]:text-foreground/90"
                         onPointerEnter={armMarquee}
                         onPointerLeave={disarmMarquee}
                       >

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -935,7 +935,7 @@ function CronJobRuns({
         <div className="flex flex-col gap-px">
           {runs.map(run => (
             <button
-              className="row-hover flex items-center justify-between gap-3 rounded-md px-2 py-1 text-left text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+              className="row-hover flex items-center justify-between gap-3 rounded-md px-2 py-1 text-left text-xs"
               key={run.id}
               onClick={() => onOpenSession?.(run.id)}
               type="button"

--- a/apps/desktop/src/app/overlays/panel.tsx
+++ b/apps/desktop/src/app/overlays/panel.tsx
@@ -183,7 +183,7 @@ export function PanelListRow({
   const row = (
     <div
       className={cn(
-        'group/row row-hover relative flex h-7 w-full items-center rounded-md text-[0.78rem] hover:text-foreground',
+        'group/row row-hover relative flex h-7 w-full items-center rounded-md text-[0.78rem] hover:text-foreground has-[:focus-visible]:text-foreground',
         active ? 'bg-(--ui-row-active-background) text-foreground' : 'text-(--ui-text-secondary)'
       )}
       data-panel-row={rowKey}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -985,7 +985,9 @@
     color 100ms ease-out,
     background-color 100ms ease-out;
 
-  &:hover {
+  &:hover,
+  &:focus-visible,
+  &:has(:focus-visible) {
     background-color: var(--ui-row-hover-background);
     transition: none;
   }


### PR DESCRIPTION
## What does this PR do?

Tabbing through any row list in the desktop app (cron jobs, cron run history, sessions, capabilities, ...) gave zero visual indication of which row was keyboard-focused. The app deliberately kills every native outline and Tailwind `focus-visible:ring-*` globally (`styles.css`: "No focus rings, anywhere"), and the shared `row-hover` utility that every row list uses only reacted to `:hover` — so a keyboard user landed on a row with no affordance at all. The row's own kebab menu button did become visible on focus (`focus-visible:opacity-100`), but with its ring also zeroed it was easy to miss, which is what prompted the report.

This is not a one-off — it's the intended keyboard-focus indicator for every row list in the app, so fixing the shared utility fixes the whole class of rows at once rather than patching each row component individually.

## Related Issue

No existing issue found (searched open/closed issues and PRs for "focus visible", "tab navigation", "keyboard focus", "accessibility desktop", "kebab menu" — nothing matching).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/styles.css`: `row-hover` utility now also matches `:focus-visible` (when the utility is on the focusable element itself) and `:has(:focus-visible)` (when it wraps one), reusing the existing hover background — the same `:has(:focus-visible)` pattern already used elsewhere in this file for keyboard-only highlights.
- `apps/desktop/src/app/overlays/panel.tsx`: `PanelListRow` gets `has-[:focus-visible]:text-foreground` alongside its existing `hover:text-foreground`, so the focused row's text brightens to match hover instead of looking duller.
- `apps/desktop/src/app/cron/index.tsx`: dropped the now-fully-dead `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40` classes on the cron run-history row button — `row-hover` covers it now.
- `apps/desktop/src/app/chat/sidebar/session-row.tsx`: the sessions-list row title brightens via `group-hover:text-foreground` with no focus counterpart — same text/background asymmetry `panel.tsx` had. Added `group-has-[:focus-visible]:text-foreground` alongside it (`SidebarRowShell` already inherits the `row-hover` background fix, since it uses the same shared utility).

## How to Test

1. `npm run dev` in `apps/desktop`.
2. Open the Scheduled jobs list, click into the panel, and press Tab to move through the job rows — each row should highlight the same way it does on mouse hover.
3. Open a job that has run history and Tab to a run row in the "Run History" section — same highlight.
4. On the landing screen, Tab through the SESSIONS list in the left sidebar — row background and title text should both brighten together, matching hover.
5. Compare against `main` — before this change, tabbing gives no visible feedback on any of the three.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(desktop):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, no Python touched
- [ ] I've added tests for my changes — N/A, pure Tailwind/CSS class change with no meaningful unit assertion; verified manually per "How to Test"
- [x] I've tested on my platform: macOS (Sonoma/Sequoia, arm64)

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or tool schemas affected
- [x] I've considered cross-platform impact — CSS-only (`:focus-visible`, `:has()`), both fully supported by Electron's bundled Chromium on every platform

## Screenshots / Logs

Verified live in dev mode: tabbing now lights up the row background/text identically to mouse hover, for the cron job list, the run-history list, and the sessions list.

