### PR TITLE
fix(desktop): open a branched session in the main workspace, not just a tile

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1402,10 +1402,21 @@ describe('branchStoredSession desktop source tagging', () => {
     vi.restoreAllMocks()
   })
 
-  it('opens the branch as a new tab and leaves the parent chat selected', async () => {
+  it('opens the branch as the primary session in the main workspace (#93444)', async () => {
     const requestGateway = vi.fn(async (method: string) => {
       if (method === 'session.create') {
         return { session_id: 'branch-runtime', stored_session_id: 'branch-stored' } as never
+      }
+
+      if (method === 'session.resume') {
+        return {
+          info: {},
+          message_count: 0,
+          messages: [],
+          resumed: 'branch-stored',
+          session_id: 'branch-runtime',
+          session_key: 'branch-stored'
+        } as never
       }
 
       return {} as never
@@ -1432,11 +1443,12 @@ describe('branchStoredSession desktop source tagging', () => {
 
     await expect(branchStoredSession!('stored-parent')).resolves.toBe(true)
 
-    // The branch opened as its own tab...
-    expect($sessionTiles.get().some(tile => tile.storedSessionId === 'branch-stored')).toBe(true)
-    // ...without stealing the primary selection or navigating away from the parent.
-    expect($selectedStoredSessionId.get()).toBe('stored-parent')
-    expect(navigate).not.toHaveBeenCalledWith(sessionRoute('branch-stored'))
+    // The branch becomes the primary session — this is what routes the main
+    // workspace area to it, not just a new sidebar row.
+    expect($selectedStoredSessionId.get()).toBe('branch-stored')
+    // It must not ALSO exist as a tile: a session is either the main thread or
+    // a tile, never both (resumeSession closes any tile with the same id).
+    expect($sessionTiles.get().some(tile => tile.storedSessionId === 'branch-stored')).toBe(false)
   })
 
   it('tags desktop branch sessions as desktop sessions', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1437,6 +1437,7 @@ describe('branchStoredSession desktop source tagging', () => {
         navigate={navigate}
         onReady={branch => (branchStoredSession = branch)}
         requestGateway={requestGateway}
+        selectedStoredSessionId="stored-parent"
       />
     )
     await waitFor(() => expect(branchStoredSession).not.toBeNull())
@@ -1449,6 +1450,56 @@ describe('branchStoredSession desktop source tagging', () => {
     // It must not ALSO exist as a tile: a session is either the main thread or
     // a tile, never both (resumeSession closes any tile with the same id).
     expect($sessionTiles.get().some(tile => tile.storedSessionId === 'branch-stored')).toBe(false)
+  })
+
+  it('keeps the current view when branching a different session from the sidebar (does not reintroduce #69750)', async () => {
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.create') {
+        return { session_id: 'branch-runtime', stored_session_id: 'branch-stored' } as never
+      }
+
+      if (method === 'session.resume') {
+        return {
+          info: {},
+          message_count: 0,
+          messages: [],
+          resumed: 'branch-stored',
+          session_id: 'branch-runtime',
+          session_key: 'branch-stored'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    // The user is looking at "stored-other" and right-clicks a DIFFERENT,
+    // unrelated session ("stored-parent") in the sidebar to branch it.
+    setSessions([storedSession({ id: 'stored-parent', message_count: 1 })])
+    setSelectedStoredSessionId('stored-other')
+    vi.mocked(getAllSessionMessages).mockResolvedValue({
+      messages: [{ content: 'branch me', role: 'user', timestamp: 1 }],
+      session_id: 'stored-parent'
+    } as never)
+
+    const navigate = vi.fn()
+    let branchStoredSession: ((storedSessionId: string) => Promise<boolean>) | null = null
+    render(
+      <BranchHarness
+        navigate={navigate}
+        onReady={branch => (branchStoredSession = branch)}
+        requestGateway={requestGateway}
+        selectedStoredSessionId="stored-other"
+      />
+    )
+    await waitFor(() => expect(branchStoredSession).not.toBeNull())
+
+    await expect(branchStoredSession!('stored-parent')).resolves.toBe(true)
+
+    // Branching a session that is not the one currently open must not steal
+    // the user's active view — "stored-other" stays selected.
+    expect($selectedStoredSessionId.get()).toBe('stored-other')
+    // The branch instead opens as its own tile.
+    expect($sessionTiles.get().some(tile => tile.storedSessionId === 'branch-stored')).toBe(true)
   })
 
   it('tags desktop branch sessions as desktop sessions', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -1656,11 +1656,20 @@ export function useSessionActions({
           updateSessionState(branched.session_id, state => ({ ...state, ...runtimeInfo }), routedSessionId)
         }
 
-        // Load the branch as the primary session so it opens in the main
-        // workspace, not just a sidebar row. resumeSession reuses the runtime
-        // warm-cached above (ensureSessionState/updateSessionState) instead of
-        // an extra resume RPC.
-        await resumeSession(routedSessionId)
+        // Only take over the main pane when the chat being branched is the one
+        // already open there — branching a background/sidebar session must
+        // not yank the user's current view away from what they're looking at
+        // (the #69750 focus-stealing bug, reintroduced if this fires
+        // unconditionally). resumeSession reuses the runtime warm-cached above
+        // (ensureSessionState/updateSessionState) instead of an extra resume RPC.
+        if (parentStoredId !== null && selectedStoredSessionIdRef.current === parentStoredId) {
+          await resumeSession(routedSessionId)
+        } else {
+          openSessionTile(routedSessionId, 'center')
+          patchSessionTile(routedSessionId, { runtimeId: branched.session_id })
+          revealTreePane(`session-tile:${routedSessionId}`)
+        }
+
         broadcastSessionsChanged()
 
         return true
@@ -1674,7 +1683,15 @@ export function useSessionActions({
         }, 0)
       }
     },
-    [copy, creatingSessionRef, ensureSessionState, requestGateway, resumeSession, updateSessionState]
+    [
+      copy,
+      creatingSessionRef,
+      ensureSessionState,
+      requestGateway,
+      resumeSession,
+      selectedStoredSessionIdRef,
+      updateSessionState
+    ]
   )
 
   // Branch the open chat — optionally from a specific message — off its live transcript.

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -1649,8 +1649,6 @@ export function useSessionActions({
           routedSessionId
         )
 
-        // The branch opens as its own tile in the parent's worktree, not as the
-        // primary session — keep its runtime out of the main composer atoms.
         const runtimeInfo = applyRuntimeInfo(branched.info, { foreground: false })
         patchSessionWorkspace(routedSessionId, runtimeInfo?.cwd)
 
@@ -1658,13 +1656,11 @@ export function useSessionActions({
           updateSessionState(branched.session_id, state => ({ ...state, ...runtimeInfo }), routedSessionId)
         }
 
-        // Open the branch as its own tab and switch to it, leaving the parent
-        // chat exactly where it is. Prime the tile with the create runtime so it
-        // skips a redundant resume. Do NOT select it as the primary session
-        // first — openSessionTile no-ops when the id is already primary.
-        openSessionTile(routedSessionId, 'center')
-        patchSessionTile(routedSessionId, { runtimeId: branched.session_id })
-        revealTreePane(`session-tile:${routedSessionId}`)
+        // Load the branch as the primary session so it opens in the main
+        // workspace, not just a sidebar row. resumeSession reuses the runtime
+        // warm-cached above (ensureSessionState/updateSessionState) instead of
+        // an extra resume RPC.
+        await resumeSession(routedSessionId)
         broadcastSessionsChanged()
 
         return true
@@ -1678,7 +1674,7 @@ export function useSessionActions({
         }, 0)
       }
     },
-    [copy, creatingSessionRef, ensureSessionState, requestGateway, updateSessionState]
+    [copy, creatingSessionRef, ensureSessionState, requestGateway, resumeSession, updateSessionState]
   )
 
   // Branch the open chat — optionally from a specific message — off its live transcript.


### PR DESCRIPTION
## Summary

Fixes #93444. Creating a branch from the session you're currently viewing
(right-click → "Branch") only added a new row in the left sidebar — the main
workspace area stayed on the parent session, so branching looked like it did
nothing.

## Root cause

In `apps/desktop/src/app/session/hooks/use-session-actions/index.ts`,
`forkBranch` ended by opening the branch as a session-tile and deliberately
leaving the primary selection on the parent (introduced in `6326b30c93` /
#69750, to fix a different bug: branching stealing focus from the parent
chat).

In the default layout there is no visible tile pane, so `openSessionTile(...,
'center')` + `revealTreePane(...)` had almost no visible effect — the only
observable result was the new sidebar row. It's worse in the most common
case: branching the session you're currently viewing. `openSessionTile`
short-circuits when the target is already `$selectedStoredSessionId`, so the
tile-open is a straight no-op there.

## Fix

`forkBranch` is shared by every branch entry point (message GitFork button,
`/branch` and `/fork`, sidebar right-click, tile Branch) — some of those
branch the session currently open in the main pane, others branch an
unrelated session from the sidebar while looking at something else. Loading
the branch as primary unconditionally (an earlier version of this PR) would
have reintroduced #69750 for the latter case: branching a *different*
session from the sidebar would yank the active view away from whatever the
user was looking at.

So the fix only takes over the main pane when the session being branched is
the one already selected:

```ts
if (parentStoredId !== null && selectedStoredSessionIdRef.current === parentStoredId) {
  await resumeSession(routedSessionId)
} else {
  openSessionTile(routedSessionId, 'center')
  patchSessionTile(routedSessionId, { runtimeId: branched.session_id })
  revealTreePane(`session-tile:${routedSessionId}`)
}
```

`resumeSession` is the canonical "load session as primary" path — it sets
`$selectedStoredSessionId` (which drives the route to the main workspace) and
closes any tile with the same id (a session is either the main thread or a
tile, never both). It also reuses the runtime already warm-cached by
`forkBranch`'s preceding `ensureSessionState`/`updateSessionState` calls
(`runtimeIdByStoredSessionIdRef` / `sessionStateByRuntimeIdRef`), so this
doesn't cost an extra resume RPC beyond what the old tile-open path already
did implicitly. When the branched session isn't the one currently selected,
behavior is unchanged from before this PR: it opens as its own tile.

## Test

Updated `use-session-actions.test.tsx`'s
`branchStoredSession desktop source tagging` suite:

- The existing test now explicitly sets the harness's
  `selectedStoredSessionId` to the branched parent (the "currently-open
  chat" case) and asserts the branch becomes primary and does not exist as a
  tile.
- Added a new test, "keeps the current view when branching a different
  session from the sidebar (does not reintroduce #69750)": the harness is
  selected on `stored-other`, and a *different* session, `stored-parent`, is
  branched (the sidebar/background path). Asserts `$selectedStoredSessionId`
  stays on `stored-other` and the branch opens as a tile instead.

Confirmed the new test fails without the source fix (i.e. against the
previous, unconditional-`resumeSession` version of this PR):

```
$ git show HEAD~1:apps/desktop/src/app/session/hooks/use-session-actions/index.ts \
    > apps/desktop/src/app/session/hooks/use-session-actions/index.ts
$ npx vitest run src/app/session/hooks/use-session-actions.test.tsx

 FAIL  src/app/session/hooks/use-session-actions.test.tsx > branchStoredSession desktop source tagging
   > keeps the current view when branching a different session from the sidebar (does not reintroduce #69750)
AssertionError: expected 'branch-stored' to be 'stored-other'
 Test Files  1 failed (1)
      Tests  1 failed | 57 passed (58)

$ git checkout HEAD -- apps/desktop/src/app/session/hooks/use-session-actions/index.ts
```

And passes with the fix restored:

```
$ npx vitest run src/app/session/hooks/use-session-actions.test.tsx
 Test Files  1 passed (1)
      Tests  58 passed (58)
```

Full session-hooks suite (43 files, 665 tests) also passes:

```
$ npx vitest run src/app/session
 Test Files  43 passed (43)
      Tests  665 passed (665)
```

`tsc -p apps/desktop --noEmit` and `eslint` on both changed files are clean.

## AI assistance disclosure

This change was developed with AI assistance (Claude Code), including
locating the relevant code, implementing the fix, and updating/verifying the
test.
