### PR TITLE
fix(web): guard optional rolldown filter in React Compiler preset

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -8,7 +8,7 @@ import react, { reactCompilerPreset } from "@vitejs/plugin-react";
  *  module — which made the babel pass parse the whole codebase. */
 function compilerPreset() {
   const preset = reactCompilerPreset();
-  preset.rolldown.filter.code = /\/>|<\/|from\s*['"][^'"]*react/;
+  (preset.rolldown.filter ??= {}).code = /\/>|<\/|from\s*['"][^'"]*react/;
   return preset;
 }
 import tailwindcss from "@tailwindcss/vite";


### PR DESCRIPTION
## Problem

`npm run build --workspace=web` fails on a clean tree:

```
vite.config.ts(11,3): error TS18048: 'preset.rolldown.filter' is possibly 'undefined'.
npm error Lifecycle script `build` failed with error:
```

This breaks `hermes dashboard` for anyone whose machine has to build the web UI from source — the launcher falls back to serving a stale (or missing) dist.

## Root cause

`reactCompilerPreset()` is typed as returning a `RolldownBabelPreset`, where `rolldown.filter` is declared **optional** in `@rolldown/plugin-babel@0.2.3`:

```ts
rolldown: {
  filter?: {
    id?: GeneralHookFilter;
    moduleType?: ModuleTypeFilter;
    code?: GeneralHookFilter;
  };
  ...
}
```

So the bare assignment `preset.rolldown.filter.code = ...` at vite.config.ts:11 doesn't type-check under `tsc -b`.

## Fix

One line — coerce the optional object before assigning:

```ts
(preset.rolldown.filter ??= {}).code = /\/>|<\/|from\s*['"][^'"]*react/;
```

No runtime behavior change: the preset populates `filter` in practice; this only satisfies the checker and makes the intent explicit.

## Testing

- `npm run build --workspace=web`: tsc + vite build pass on a clean tree
- `hermes dashboard`: builds fresh and serves on :9119 (previously fell back to stale dist)