### PR TITLE
fix(state): only follow compression edges in resolve_resume_session_id

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8585,6 +8585,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         The chain is always walked via the child whose ``started_at`` is
         latest; that matches the single-chain shape that compression creates.
         A depth cap (32) guards against accidental loops in malformed data.
+
+        Only compression-created edges are followed: a child counts as a
+        continuation only when its parent ended with ``end_reason =
+        'compression'`` — the same discriminator ``get_compression_tip``
+        uses. The gateway links EVERY rotated session to its predecessor via
+        ``parent_session_id`` (idle/daily expiry ends the old row with
+        ``session_reset``, ``/reset`` with ``session_switch``), so without
+        this gate an explicit ``/resume <id>`` silently lands on whatever
+        unrelated newer chat happens to descend from the target.
         """
         if not session_id:
             return session_id
@@ -8624,20 +8633,27 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 if row is not None:
                     best = current
 
-                # Walk to the most-recently-started child — but skip explicit
-                # branch (`_branched_from`), delegate/subagent (`_delegate_from`),
-                # and tool children. They also carry a ``parent_session_id`` yet
-                # are NOT compression continuations; following them would hijack
-                # the resume target to an unrelated session (e.g. a subagent
-                # run). This mirrors the child-exclusion in ``get_compression_tip``.
+                # Walk to the most-recently-started child — but only across a
+                # compression edge (parent ended with end_reason='compression',
+                # mirroring get_compression_tip), and skip explicit branch
+                # (`_branched_from`), delegate/subagent (`_delegate_from`),
+                # and tool children. They also carry a ``parent_session_id``
+                # yet are NOT compression continuations; following them would
+                # hijack the resume target to an unrelated session (e.g. a
+                # subagent run, or the gateway's next rotated chat — idle/
+                # daily resets link every session to its predecessor via
+                # parent_session_id). This mirrors the child-exclusion in
+                # ``get_compression_tip``.
                 try:
                     child_row = self._conn.execute(
-                        "SELECT id FROM sessions "
-                        "WHERE parent_session_id = ? "
-                        "  AND json_extract(COALESCE(model_config, '{}'), '$._branched_from') IS NULL "
-                        "  AND json_extract(COALESCE(model_config, '{}'), '$._delegate_from') IS NULL "
-                        "  AND COALESCE(source, '') != 'tool' "
-                        "ORDER BY started_at DESC, id DESC LIMIT 1",
+                        "SELECT sessions.id FROM sessions "
+                        "JOIN sessions AS parent ON parent.id = sessions.parent_session_id "
+                        "WHERE sessions.parent_session_id = ? "
+                        "  AND parent.end_reason = 'compression' "
+                        "  AND json_extract(COALESCE(sessions.model_config, '{}'), '$._branched_from') IS NULL "
+                        "  AND json_extract(COALESCE(sessions.model_config, '{}'), '$._delegate_from') IS NULL "
+                        "  AND COALESCE(sessions.source, '') != 'tool' "
+                        "ORDER BY sessions.started_at DESC, sessions.id DESC LIMIT 1",
                         (current,),
                     ).fetchone()
                 except Exception:

--- a/tests/hermes_state/test_resolve_resume_session_id.py
+++ b/tests/hermes_state/test_resolve_resume_session_id.py
@@ -52,7 +52,16 @@ def test_returns_self_when_only_parent_has_messages(db):
 
 def test_walks_from_middle_of_chain(db):
     # If the user happens to know an intermediate ID, we still find the msg-bearing descendant.
+    # Real compression chains mark every ended hop with end_reason='compression'
+    # (the discriminator get_compression_tip uses), so model that here.
     _make_chain(db, [("a", None), ("b", "a"), ("c", "b"), ("d", "c")])
+    conn = db._conn
+    for sid in ("a", "b", "c"):
+        conn.execute(
+            "UPDATE sessions SET end_reason = 'compression', ended_at = ? WHERE id = ?",
+            (int(time.time()), sid),
+        )
+    conn.commit()
     db.append_message("d", role="user", content="x")
     assert db.resolve_resume_session_id("b") == "d"
     assert db.resolve_resume_session_id("c") == "d"
@@ -95,8 +104,65 @@ def test_prefers_most_recent_child_when_fork_exists(db):
         ("older_fork", "parent"),
         ("newer_fork", "parent"),
     ])
+    db._conn.execute(
+        "UPDATE sessions SET end_reason = 'compression', ended_at = ? WHERE id = 'parent'",
+        (int(time.time()),),
+    )
+    db._conn.commit()
     db.append_message("newer_fork", role="user", content="x")
     assert db.resolve_resume_session_id("parent") == "newer_fork"
+
+
+def test_does_not_follow_gateway_rotation_chain(db):
+    # The gateway links EVERY rotated session to its predecessor via
+    # parent_session_id: idle/daily expiry ends the old row with
+    # end_reason='session_reset', /reset with 'session_switch'. Those edges
+    # are NOT compression continuations — resuming an older chat by explicit
+    # id must stay on that chat instead of silently landing on whatever
+    # newer conversation descends from it (reported on Telegram: /resume
+    # <old_id> restored a different session's title and 1-message history).
+    _make_chain(db, [
+        ("older", None),
+        ("newer", "older"),
+    ])
+    db.append_message("older", role="user", content="real conversation")
+    db.end_session("older", "session_reset")
+    db.append_message("newer", role="user", content="unrelated newer chat")
+
+    assert db.resolve_resume_session_id("older") == "older"
+
+
+def test_still_follows_multi_hop_compression_chain(db):
+    # Compression chains can span several hops; every followed edge must be
+    # a compression edge (parent ended with 'compression'). Once a hop ends
+    # with a rotation reason ('session_reset'), the chain is broken.
+    base = int(time.time()) - 10_000
+    conn = db._conn
+
+    def _mk(sid, parent, started, end_reason=None, ended_at=None):
+        db.create_session(sid, source="cli", parent_session_id=parent)
+        sets = ["started_at = ?"]
+        args = [base + started]
+        if end_reason:
+            sets.append("end_reason = ?")
+            args.append(end_reason)
+        if ended_at is not None:
+            sets.append("ended_at = ?")
+            args.append(base + ended_at)
+        args.append(sid)
+        conn.execute(f"UPDATE sessions SET {', '.join(sets)} WHERE id = ?", args)
+
+    _mk("root", None, 0, end_reason="compression", ended_at=50)
+    _mk("cont1", "root", 100, end_reason="session_reset", ended_at=150)
+    _mk("tip", "cont1", 300)
+    db.append_message("cont1", role="user", content="post-compression turn")
+    conn.commit()
+
+    # root → cont1 is a compression edge and is followed; cont1 → tip sits
+    # behind a rotation edge and must NOT be.
+    assert db.resolve_resume_session_id("root") == "cont1"
+    # And the rotation child never hijacks the target.
+    assert db.get_compression_tip("root") == "cont1"
 
 
 


### PR DESCRIPTION
## What does this PR do?

`SessionDB.resolve_resume_session_id()` — the helper behind `/resume <id>` on the gateway (and `--resume` in the CLI) — followed **any** parent→child edge when redirecting a resume target to the descendant that holds the messages. But the gateway links *every* rotated session to its predecessor via `parent_session_id`: idle/daily expiry ends the old row with `end_reason='session_reset'`, `/reset` with `session_switch`. So resuming an older chat by explicit id silently landed the user in whatever newer, unrelated conversation happened to descend from it.

This PR gates every hop of that walk on `parent.end_reason = 'compression'` — the exact discriminator `get_compression_tip()` already applies one step earlier in the same function. Genuine compression chains still resolve to their live tip (#15000 behavior preserved); rotation chains no longer hijack explicit resume targets.

## Related Issue

Fixes #93463

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)

## Changes Made

- `hermes_state.py` — `resolve_resume_session_id()`: the child-walk query now joins the parent and requires `parent.end_reason = 'compression'` (same discriminator as `get_compression_tip()`); docstring documents why rotation edges must not be followed.
- `tests/hermes_state/test_resolve_resume_session_id.py`:
  - new `test_does_not_follow_gateway_rotation_chain` — pins the reported symptom (`/resume <older id>` must stay put when the child was created by a reset);
  - new `test_still_follows_multi_hop_compression_chain` — a compression hop is followed, then the walk stops at a rotation edge;
  - existing chain tests updated to mark ended hops with `end_reason='compression'`, matching what real compression chains write (they previously modeled chains that never existed).

## How to Test

1. On a gateway chat, let sessions rotate at least once (idle/daily expiry), so `state.db` holds `A (session_reset) ← B`.
2. Before this patch: `/resume <id-of-A>` restores **B** (wrong title/history). After: it restores A.
3. Compression redirect still works: end a session with `end_reason='compression'`, give the child messages, resume the parent id → resolves to the child tip (covered by `test_follows_compression_tip_when_parent_retains_messages`, unchanged).
4. `pytest tests/hermes_state tests/cli/test_cli_resume_command.py tests/cli/test_resume_display.py tests/cli/test_resume_quiet_stderr.py -q` → 119 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
  *(ran the touched suites: hermes_state (90) + CLI resume suites (29) + gateway resume ownership/compression selection (33) — all green)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(docstring updated)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Reported reproduction (Telegram gateway):

```
/resume 20260823_233930_c44e7c37      # "友好问候 #3" — 171 messages
↻ Resumed session 排查新会话空返回问题 (1 message). Conversation restored.   # wrong session
```

After the fix, against the same production DB:

```
resolve_resume_session_id("20260823_233930_c44e7c37") -> "20260823_233930_c44e7c37"   # stays put
get_compression_tip("20260820_160213_82c10f")         -> "20260820_161349_0aa29b"     # real chain still follows
```
