### PR TITLE
fix(cli): desktop entry for uv-venv shebang no longer dies silently

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -98,8 +98,12 @@ def _needs_interpreter(bin_path: Path) -> bool:
         # Native binary (uv tool shim, PyInstaller, distro package) — its own
         # loader is self-sufficient.
         return False
-    shebang = head.decode("utf-8", errors="replace").strip().lower()
-    if "python" not in shebang:
+    shebang = head.decode("utf-8", errors="replace").strip()
+    # Only the substring gate may lowercase: shebang paths are real
+    # filesystem paths, and Linux is case-sensitive — lowercasing
+    # "#!/.../CaseDir/python3" would resolve the wrong (or a nonexistent)
+    # file and wrongly force an interpreter prefix.
+    if "python" not in shebang.lower():
         # A shell wrapper (e.g. the installer's bash launcher) execs the venv
         # python itself — leave it alone.
         return False

--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -103,6 +103,29 @@ def _needs_interpreter(bin_path: Path) -> bool:
         # A shell wrapper (e.g. the installer's bash launcher) execs the venv
         # python itself — leave it alone.
         return False
+    # Compare the shebang's interpreter against the running one by REAL path.
+    # A textual comparison breaks for uv-created venvs: venv/bin/python3 is a
+    # symlink to the managed interpreter, so resolving sys.executable yields
+    # the managed python's directory, and a text lookup of that dir in the
+    # shebang fails even though the shebang resolves to the very same file
+    # (menu launch then dies with ModuleNotFoundError).
+    parts = shebang[2:].split()
+    if not parts:
+        return True
+    interp = parts[0]
+    if interp == "/usr/bin/env":
+        # env-based shebang: resolves via PATH in the DE session, which can
+        # differ from ours — treat as needing the explicit interpreter.
+        return True
+    if not interp.startswith("/"):
+        return True
+    try:
+        resolved_interp = Path(interp).resolve()
+    except OSError:
+        return True
+    if resolved_interp == Path(sys.executable).resolve():
+        # Same interpreter file (directly or via symlink) — shebang is fine.
+        return False
     # A python shebang pointing INSIDE the running interpreter's environment
     # already resolves correctly; anything else (``/usr/bin/env python3``,
     # a system path) would escape the venv when spawned by the DE.

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -182,6 +182,33 @@ def test_exec_leaves_symlinked_venv_shebang_alone(tmp_path, xdg_home, monkeypatc
     assert exec_line == f"{hermes_bin} desktop"
 
 
+def test_exec_leaves_case_sensitive_shebang_path_alone(tmp_path, xdg_home, monkeypatch):
+    import sys
+
+    # Linux paths are case-sensitive: lowercasing the shebang before parsing
+    # the interpreter path would resolve the wrong (or a nonexistent) file
+    # and wrongly force a prefix. The uppercase directory must survive.
+    bin_dir = tmp_path / "CaseDir" / "bin"
+    bin_dir.mkdir(parents=True)
+    symlink_interp = bin_dir / "python3"
+    try:
+        symlink_interp.symlink_to(Path(sys.executable).resolve())
+    except OSError:
+        pytest.skip("symlinks unavailable on this platform")
+
+    root = _make_project(tmp_path)
+    hermes_bin = bin_dir / "hermes"
+    hermes_bin.write_text(f"#!{symlink_interp}\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert exec_line == f"{hermes_bin} desktop"
+
+
 def test_install_is_idempotent_and_skips_cache_refresh(tmp_path, xdg_home, monkeypatch):
     root = _make_project(tmp_path)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: "/usr/bin/hermes")

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -149,6 +149,39 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
     assert exec_line == f"{hermes_bin} desktop"
 
 
+def test_exec_leaves_symlinked_venv_shebang_alone(tmp_path, xdg_home, monkeypatch):
+    import sys
+
+    # uv-created venvs: venv/bin/python3 is a SYMLINK to the managed
+    # interpreter, so the shebang text (`.../venv/bin/python3`) differs from
+    # the resolved sys.executable even though both name the same file. A
+    # textual containment check alone then wrongly decides the shebang
+    # escapes the venv and prefixes the Exec with the MANAGED interpreter,
+    # which lacks hermes_cli in site-packages → silent ModuleNotFoundError on
+    # menu launch.
+    bin_dir = tmp_path / "venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    symlink_interp = bin_dir / "python3"
+    try:
+        symlink_interp.symlink_to(Path(sys.executable).resolve())
+    except OSError:
+        pytest.skip("symlinks unavailable on this platform")
+
+    root = _make_project(tmp_path)
+    hermes_bin = bin_dir / "hermes"
+    hermes_bin.write_text(f"#!{symlink_interp}\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    # Shebang resolves to the running interpreter (through the uv-style
+    # symlink) — correct as-is, no interpreter prefix.
+    assert exec_line == f"{hermes_bin} desktop"
+
+
 def test_install_is_idempotent_and_skips_cache_refresh(tmp_path, xdg_home, monkeypatch):
     root = _make_project(tmp_path)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: "/usr/bin/hermes")


### PR DESCRIPTION
## Summary

Linux `hermes.desktop` launches die silently (`Terminal=false`) when Hermes lives in a uv-managed venv (the standard `install.sh` layout: `~/.hermes/hermes-agent/venv`). The app only opens via `hermes desktop` from a terminal.

## Root cause

Follow-up to #90292. The guard added there decides whether the resolved launcher's python shebang escapes the running venv by checking if the **resolved** `sys.executable` directory appears in the shebang **text**. uv-creates venvs break this heuristic:

- `venv/bin/python3` is a SYMLINK to the managed interpreter (`~/.local/share/uv/python/cpython-3.11.../bin/python3.11`)
- the shebang text is `#!/.../hermes-agent/venv/bin/python3`
- `Path(sys.executable).resolve()` yields the managed interpreter's directory, which never appears in that text

→ the code wrongly concludes the shebang escapes the venv, and prefixes `Exec=` with the **managed** interpreter. That interpreter has no `hermes_cli` in its site-packages, so the entry dies with `ModuleNotFoundError: No module named 'hermes_cli'` before Electron ever starts.

## Change

`_needs_interpreter`: resolve the shebang's interpreter path and compare it against the resolved `sys.executable` first. Only when they differ (env-based shebangs, system python, non-absolute interpreters) fall back to the original containment check. The uv-venv case resolves to the same file → no prefix.

## Test plan

- New regression test `test_exec_leaves_symlinked_venv_shebang_alone`: symlinked venv python in the shebang must not attract an interpreter prefix. Fails against the old heuristic with the exact buggy Exec (managed interpreter prefixed); passes with the fix.
- Full file: 16 passed, 2 skipped (macOS/Windows no-op markers). `ruff check` clean.
- Manual: menu launch of `hermes.desktop` on the affected machine now reaches `Launching packaged Hermes Desktop`.