### PR TITLE
fix(agent): stop treating max_tokens as context-length candidate (#93412)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2310,7 +2310,7 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
             if resp.status_code == 200:
                 data = resp.json()
                 # vLLM returns max_model_len
-                ctx = data.get("max_model_len") or data.get("context_length") or data.get("max_tokens")
+                ctx = data.get("max_model_len") or data.get("context_length")
                 if ctx and isinstance(ctx, (int, float)):
                     return int(ctx)
 
@@ -2344,7 +2344,6 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                             "context_window",
                             "max_model_len",
                             "max_context_length",
-                            "max_tokens",
                             "n_ctx_train",
                         ):
                             val = source.get(key)


### PR DESCRIPTION
## Summary

Fixes #93412

The local-endpoint context-length probe incorrectly used `max_tokens` (the output completion cap) as a fallback for the model's context window. For endpoints that advertise both a real context window (e.g. 1M tokens) and a separate `max_tokens` output cap (e.g. 393K), Hermes mis-detected the context length as the smaller `max_tokens` value.

## Root Cause

Two code paths in `_query_local_context_length_uncached` included `max_tokens` as a context-length candidate:

1. The `/v1/models/{model}` branch: `ctx = data.get("max_model_len") or data.get("context_length") or data.get("max_tokens")`
2. The `/v1/models` list branch: key iteration tuple included `"max_tokens"`

The `_CONTEXT_LENGTH_KEYS` tuple (used by `_extract_context_length`) already correctly excludes `max_tokens`, but these two local code paths still fell back to it.

## Fix

Removed `max_tokens` from both code paths. The `_MAX_COMPLETION_KEYS` tuple (line 681) correctly retains `max_tokens` for completion-token extraction — this change only affects context-length detection.

## Changes

- `agent/model_metadata.py`: Remove `max_tokens` from context-length fallback in two spots

## Testing

- `py_compile` syntax check passes
- Pre-existing Teams test fixture error (unrelated)
