### PR TITLE
fix(tools): increase cua-driver readiness probe timeout to 5s (#93312)

### DIFF
--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -736,7 +736,7 @@ class _EmbeddedCuaDaemon:
                     stdin=subprocess.DEVNULL,
                     capture_output=True,
                     text=True,
-                    timeout=2.0,
+                    timeout=5.0,
                     env=env,
                 )
             except (OSError, subprocess.SubprocessError):


### PR DESCRIPTION
## Summary

Fixes #93312

cua-driver 0.21.0 added a Computer History attestation path that commonly needs 2.0-2.35 seconds for a `status --socket` call. The previous 2.0s per-probe timeout killed healthy clients just before they returned, then retried with the same insufficient deadline, ultimately reporting a misleading "startup timed out" error.

## Root Cause

`_EmbeddedCuaDaemon.start()` gives each readiness probe exactly 2 seconds:

```python
subprocess.run(
    [self._command, "status", "--socket", self.socket_path],
    ...,
    timeout=2.0,
)
```

With cua-driver 0.21.0, a healthy `status --socket` call commonly needs 2.0-2.35s. Hermes kills each probe just before it returns, retries with the same deadline, then shuts down the running daemon.

## Fix

Increase the per-probe timeout from 2.0s to 5.0s. The overall `_START_TIMEOUT_SECONDS` (15s) still bounds total startup time, so this doesn't extend the worst-case wait.

## Changes

- `tools/computer_use/cua_backend.py`: `timeout=2.0` → `timeout=5.0` for the readiness probe

## Testing

- `py_compile` syntax check passes
