### PR TITLE
fix(desktop): bound reconnect awaits so a stuck IPC round-trip can't latch the UI frozen

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -479,6 +479,48 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect(callCount).toBeGreaterThanOrEqual(3)
   })
 
+  it('a revalidateConnection() that hangs on reconnect does not permanently latch the backoff loop (#93454)', async () => {
+    // Same failure mode as the getConnection() repro above, but for the OTHER
+    // unbounded IPC await in the same try block: a wedged revalidation after a
+    // liveness-probe trip (the PR's own named trigger) must also unlatch.
+    const desktop = fakeDesktop()
+    let revalidateCallCount = 0
+
+    desktop.revalidateConnection = vi.fn(() => {
+      revalidateCallCount += 1
+
+      // Every reconnect attempt after the drop hangs indefinitely; getConnection
+      // itself stays fast so this isolates the revalidate call specifically.
+      return new Promise(() => undefined)
+    })
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+    const callsBeforeDrop = desktop.getConnection.mock.calls.length
+
+    act(() => FakeWebSocket.instances[0].drop())
+    await advanceBackoff()
+
+    expect(revalidateCallCount).toBe(1)
+    expect($gatewayState.get()).not.toBe('open')
+    // Still stuck behind the hung revalidate — execution never reached
+    // getConnection() at all.
+    expect(desktop.getConnection.mock.calls.length).toBe(callsBeforeDrop)
+
+    // Advance past the internal reconnect-attempt timeout (20s) — the stalled
+    // revalidate await must reject (swallowed, as it always was for a genuine
+    // rejection) so execution proceeds to getConnection() and the socket
+    // reopens, instead of latching on the still-pending revalidate forever.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000)
+    })
+
+    expect(desktop.getConnection.mock.calls.length).toBeGreaterThan(callsBeforeDrop)
+    expect($gatewayState.get()).toBe('open')
+  })
+
   it('rebinds Bot tabs owned by the restarted primary without touching another gateway', async () => {
     render(<Harness />)
     await flushAsync()

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -435,6 +435,50 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect($desktopBoot.get().error).toBeNull()
   })
 
+  it('a getConnection() that hangs on reconnect does not permanently latch the backoff loop (#93454)', async () => {
+    // Repro: a remote gateway drops, the backoff loop kicks off a reconnect,
+    // and the IPC round-trip into main (desktop.getConnection) never settles
+    // — e.g. a wedged revalidation after a liveness-probe trip, even though
+    // the backend itself answers fine. Without an internal timeout on that
+    // await, `reconnecting` never clears and every later
+    // scheduleReconnect()/attemptReconnect() early-returns forever, so the UI
+    // stays stuck until the app is restarted.
+    const desktop = fakeDesktop()
+    const originalGetConnection = desktop.getConnection
+    let callCount = 0
+
+    desktop.getConnection = vi.fn((profile?: null | string) => {
+      callCount += 1
+
+      // The initial boot call succeeds; every reconnect attempt after the
+      // drop hangs indefinitely.
+      return callCount === 1 ? originalGetConnection(profile) : new Promise(() => undefined)
+    })
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+    expect(callCount).toBe(1)
+
+    act(() => FakeWebSocket.instances[0].drop())
+    await advanceBackoff()
+
+    expect(callCount).toBe(2)
+    expect($gatewayState.get()).not.toBe('open')
+
+    // Advance past the internal reconnect-attempt timeout (20s) — the stalled
+    // await must reject so the `reconnecting` guard clears and the backoff
+    // loop schedules another attempt, instead of latching forever on the
+    // still-pending first hang.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000)
+    })
+    await advanceBackoff()
+
+    expect(callCount).toBeGreaterThanOrEqual(3)
+  })
+
   it('rebinds Bot tabs owned by the restarted primary without touching another gateway', async () => {
     render(<Harness />)
     await flushAsync()

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -89,6 +89,35 @@ const BOOT_RETRY_MAX_ATTEMPTS = 5
 // loop's 300ms: each attempt may rebuild an SSH master + remote dashboard.
 const BOOT_RETRY_BASE_DELAY_MS = 2_000
 
+// desktop.getConnection() / resolveGatewayWsUrl() are IPC round-trips into the
+// main process with no timeout of their own (#93454). A remote backend that
+// looks alive to a fresh probe but leaves the main-process reconnect path
+// stuck (e.g. a wedged revalidation after a liveness-probe trip) hangs these
+// awaits forever. While either is pending, `reconnecting` never clears, so
+// scheduleReconnect()/attemptReconnect() early-return permanently and the
+// backoff loop is latched — the UI stays "reconnecting" until the app is
+// restarted even though the gateway is reachable again. Bound both so a stall
+// rejects instead, letting the existing catch/finally clear the guard and
+// resume backoff. gateway.connect() already has its own connect timeout.
+const RECONNECT_ATTEMPT_TIMEOUT_MS = 20_000
+
+function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms)
+
+    promise.then(
+      value => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      err => {
+        clearTimeout(timer)
+        reject(err)
+      }
+    )
+  })
+}
+
 /** Registry identity whose runtimes died with the primary connection. */
 export function primaryRuntimeConnectionId(connection: Pick<HermesConnection, 'connectionId' | 'mode'>): null | string {
   const connectionId = connection.connectionId?.trim()
@@ -233,7 +262,11 @@ export function useGatewayBoot({
         // (same as boot/softSwitch). Passing $activeGatewayProfile would retarget
         // this primary socket at a secondary profile's backend after a live swap.
         // Secondaries reconnect via reconnectSecondaryGateways().
-        const conn = await desktop.getConnection()
+        const conn = await withTimeout(
+          desktop.getConnection(),
+          RECONNECT_ATTEMPT_TIMEOUT_MS,
+          'Timed out reconnecting to Hermes backend'
+        )
 
         if (cancelled) {
           return
@@ -254,7 +287,12 @@ export function useGatewayBoot({
         // explicit auth rejection asks for sign-in; transport failures stay in
         // this reconnect loop. For local/token gateways the URL carries a
         // long-lived token and the re-mint is a cheap no-op.
-        const wsUrl = await resolveGatewayWsUrl(desktop, conn)
+        const wsUrl = await withTimeout(
+          resolveGatewayWsUrl(desktop, conn),
+          RECONNECT_ATTEMPT_TIMEOUT_MS,
+          'Timed out re-minting the gateway WebSocket URL'
+        )
+
         await gateway.connect(wsUrl)
 
         if (cancelled) {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -89,16 +89,17 @@ const BOOT_RETRY_MAX_ATTEMPTS = 5
 // loop's 300ms: each attempt may rebuild an SSH master + remote dashboard.
 const BOOT_RETRY_BASE_DELAY_MS = 2_000
 
-// desktop.getConnection() / resolveGatewayWsUrl() are IPC round-trips into the
-// main process with no timeout of their own (#93454). A remote backend that
-// looks alive to a fresh probe but leaves the main-process reconnect path
-// stuck (e.g. a wedged revalidation after a liveness-probe trip) hangs these
-// awaits forever. While either is pending, `reconnecting` never clears, so
-// scheduleReconnect()/attemptReconnect() early-return permanently and the
-// backoff loop is latched — the UI stays "reconnecting" until the app is
-// restarted even though the gateway is reachable again. Bound both so a stall
-// rejects instead, letting the existing catch/finally clear the guard and
-// resume backoff. gateway.connect() already has its own connect timeout.
+// desktop.revalidateConnection() / getConnection() / resolveGatewayWsUrl() are
+// IPC round-trips into the main process with no timeout of their own (#93454).
+// A remote backend that looks alive to a fresh probe but leaves the
+// main-process reconnect path stuck (e.g. a wedged revalidation after a
+// liveness-probe trip) hangs these awaits forever. While any is pending,
+// `reconnecting` never clears, so scheduleReconnect()/attemptReconnect()
+// early-return permanently and the backoff loop is latched — the UI stays
+// "reconnecting" until the app is restarted even though the gateway is
+// reachable again. Bound all three so a stall rejects instead, letting the
+// existing catch/finally clear the guard and resume backoff. gateway.connect()
+// already has its own connect timeout.
 const RECONNECT_ATTEMPT_TIMEOUT_MS = 20_000
 
 function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
@@ -256,7 +257,13 @@ export function useGatewayBoot({
         // whose 'exit' would clear the main process's cached descriptor — without
         // this the renderer re-dials the same dead endpoint forever and stays on
         // "Starting Hermes…". The probe is a no-op for a healthy or local backend.
-        await desktop.revalidateConnection?.().catch(() => undefined)
+        // Bounded like the two awaits below: a wedged revalidation (#93454) is
+        // the specific hang this loop must survive, not just a rejection.
+        await withTimeout(
+          desktop.revalidateConnection?.() ?? Promise.resolve(),
+          RECONNECT_ATTEMPT_TIMEOUT_MS,
+          'Timed out revalidating the gateway connection'
+        ).catch(() => undefined)
 
         // Primary sleep/wake reconnect must dial the WINDOW-owned primary backend
         // (same as boot/softSwitch). Passing $activeGatewayProfile would retarget


### PR DESCRIPTION
## What does this PR do?

Bounds the three IPC-round-trip awaits in the primary reconnect loop
(`attemptReconnect()` in `use-gateway-boot.ts`) with a 20s timeout, so a
stuck main-process call can no longer permanently freeze Desktop's
reconnect backoff.

## Problem

Fixes #93454.

Desktop connected to a remote gateway over an SSH tunnel periodically
freezes on reconnect after a transient liveness-probe failure. The UI is
left stuck ("gateway needs setup" / stuck reconnecting) with no error
surfaced, even though the backend itself is confirmed healthy the whole
time (`curl .../api/status` → 200 OK). Only killing and relaunching the
app recovers it.

`attemptReconnect()` sets a `reconnecting` guard, then does:

```ts
await desktop.revalidateConnection?.().catch(() => undefined)
const conn = await desktop.getConnection()
...
const wsUrl = await resolveGatewayWsUrl(desktop, conn)
await gateway.connect(wsUrl)
```

`revalidateConnection()`, `getConnection()`, and `resolveGatewayWsUrl()` are
all IPC calls into the Electron main process with no timeout of their own. If
any stalls (a wedged revalidation after the liveness probe trips, even
though the remote backend answers fine), the await never settles. While it's
pending, `reconnecting` never clears, so every later `scheduleReconnect()` /
`attemptReconnect()` early-returns forever — the backoff loop is latched
and the UI never self-heals.

An earlier version of this PR bounded only `getConnection()` and
`resolveGatewayWsUrl()` — review correctly flagged that the PR's own
diagnosis names a "wedged revalidation" as the trigger, and that call
(`revalidateConnection()`) sat one line above the first bounded await,
untouched, with only a `.catch(() => undefined)` that swallows a rejection
but does nothing for a promise that never settles. This revision bounds
that call too.

This is the same defect described (and fixed, but never merged) in closed
PR #40008 for a different trigger (no-network suspend); the code has
since grown several more `getConnection()`/`resolveGatewayWsUrl()` call
sites, so that patch no longer applies, but the primary automatic
reconnect loop this issue reports against still has no timeout.

## Fix

Add a small `withTimeout()` helper and wrap all three awaits in
`attemptReconnect()` with a 20s bound — including `revalidateConnection()`,
which keeps its original best-effort `.catch(() => undefined)` (a stall or
a rejection there is still non-fatal to the reconnect attempt; only
`getConnection()`/`resolveGatewayWsUrl()` failing aborts it). On timeout
each await rejects, the existing `catch`/`finally` clears the
`reconnecting` guard, and `scheduleReconnect()` resumes the backoff — so the
UI recovers on its own once the gateway is reachable again, matching the
reporter's expected behavior. `gateway.connect()` already has its own
separate 15s connect timeout and is unchanged.

## How to Test

1. Connect Desktop to a remote gateway (SSH local port-forward).
2. Force the reconnect path's `revalidateConnection()`/`getConnection()`/
   `resolveGatewayWsUrl()` IPC call to hang (e.g. a wedged main-process
   revalidation) while the remote backend itself keeps answering
   `/api/status` with 200 OK.
3. Before this fix: the UI stays stuck "reconnecting" indefinitely.
4. After this fix: within ~20s the stalled call times out, the backoff
   loop resumes, and the app reconnects on its own.

Automated regression tests in `use-gateway-boot.test.tsx`:
- one hangs `desktop.getConnection()` forever (`new Promise(() =>
  undefined)`) on every reconnect attempt after a drop, and asserts a
  further reconnect attempt still fires after the internal timeout elapses.
- a second hangs `desktop.revalidateConnection()` specifically (the call
  named in the bug report and this file's own comment as the trigger,
  `getConnection()` left fast/unmocked) and asserts `getConnection()` is
  still reached and the socket reopens once the timeout elapses — this is
  the case review found missing from the first version of this PR.

```text
$ npx vitest run --project ui src/app/gateway/hooks/use-gateway-boot.test.tsx
 Test Files  1 passed (1)
      Tests  21 passed (21)
```

Confirmed the new revalidateConnection() test fails without the fix
(reverted only the source file via `git stash push -- <file>`, kept the
test):

```text
AssertionError: expected 1 to be greater than 1
 ❯ src/app/gateway/hooks/use-gateway-boot.test.tsx:520:53
 Tests  1 failed | 20 passed (21)
```

```text
$ npm run typecheck
> tsc -p . --noEmit && tsc -p tsconfig.electron.json --noEmit && tsc -p tsconfig.e2e.json --noEmit
(clean)

$ npx eslint src/app/gateway/hooks/use-gateway-boot.ts src/app/gateway/hooks/use-gateway-boot.test.tsx
(clean)

$ npx vitest run --project ui src/app/gateway
 Test Files  3 passed (3)
      Tests  30 passed (30)
```

## Checklist

- [x] I've read the Contribution Guide and repository `AGENTS.md`.
- [x] My commit message follows Conventional Commits.
- [x] The PR contains only the reconnect-timeout fix and its regression test.
- [x] I've added a behavior-level regression test and confirmed it fails
      without the fix.

## AI assistance disclosure

This change was drafted with AI assistance (Claude) and reviewed before
submission.
