### PR TITLE
fix: sort model IDs returned by custom /v1/models probing

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2257,15 +2257,18 @@ def probe_api_models(
             continue
         if _neg_key is not None:
             _probe_neg_cache.pop(_neg_key, None)
-        models = [m.get("id", "") for m in data.get("data", [])]
-        # Filter empty IDs and sort case-insensitively so the
-        # /model picker renders a stable, alphabetical order.
-        # Built-in providers (anthropic/xai/github) already sort
-        # their catalogs; this custom OpenAI-compatible path did
-        # not, so the ordering changed with every /v1/models
-        # response and cache refresh.
+        models = [str(m.get("id") or "").strip() for m in data.get("data", [])]
+        # Coerce ids to strings at extraction: a misbehaving proxy
+        # may return non-string ids (e.g. {"id": 12345}), which
+        # would crash str.lower below and take down the whole
+        # probe. Filter empty ids and sort + dedupe
+        # case-insensitively so the /model picker renders a stable,
+        # alphabetical order. Built-in providers
+        # (anthropic/xai/github) already sort their catalogs; this
+        # custom OpenAI-compatible path did not, so the ordering
+        # changed with every /v1/models response and cache refresh.
         models = [m for m in models if m]
-        models = sorted(models, key=str.lower)
+        models = sorted(set(models), key=str.lower)
         return _probe_result(
             models, url, candidate_base.rstrip("/"),
             alternate_base if alternate_base != candidate_base else normalized, is_fallback)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2257,8 +2257,17 @@ def probe_api_models(
             continue
         if _neg_key is not None:
             _probe_neg_cache.pop(_neg_key, None)
+        models = [m.get("id", "") for m in data.get("data", [])]
+        # Filter empty IDs and sort case-insensitively so the
+        # /model picker renders a stable, alphabetical order.
+        # Built-in providers (anthropic/xai/github) already sort
+        # their catalogs; this custom OpenAI-compatible path did
+        # not, so the ordering changed with every /v1/models
+        # response and cache refresh.
+        models = [m for m in models if m]
+        models = sorted(models, key=str.lower)
         return _probe_result(
-            [m.get("id", "") for m in data.get("data", [])], url, candidate_base.rstrip("/"),
+            models, url, candidate_base.rstrip("/"),
             alternate_base if alternate_base != candidate_base else normalized, is_fallback)
 
     if _neg_key is not None and not reachable:

--- a/tests/hermes_cli/test_probe_api_models_sort.py
+++ b/tests/hermes_cli/test_probe_api_models_sort.py
@@ -92,3 +92,40 @@ def test_probe_api_models_sort_is_stable_on_already_sorted_input():
         result = probe_api_models("sk-key", "https://gw.example.com/v1")
 
     assert result["models"] == ["alpha-model", "bravo-model", "charlie-model"]
+
+
+def test_probe_api_models_coerces_non_string_ids():
+    """Non-string ids (e.g. numeric) are coerced to strings, not crashed on.
+
+    A misbehaving proxy may return ``{"id": 12345}``; extraction must
+    coerce it to a string so the case-insensitive sort does not raise
+    ``AttributeError`` and take down the whole probe.
+    """
+    unordered = [
+        {"id": "bravo-model"},
+        {"id": 12345},
+        {"id": "alpha-model"},
+    ]
+    with patch(
+        "hermes_cli.models._urlopen_model_catalog_request",
+        return_value=_Resp(_payload(unordered)),
+    ):
+        result = probe_api_models("sk-key", "https://gw.example.com/v1")
+
+    assert result["models"] == ["12345", "alpha-model", "bravo-model"]
+
+
+def test_probe_api_models_deduplicates_repeated_ids():
+    """A provider echoing the same id twice returns it exactly once."""
+    duplicated = [
+        {"id": "alpha-model"},
+        {"id": "bravo-model"},
+        {"id": "alpha-model"},
+    ]
+    with patch(
+        "hermes_cli.models._urlopen_model_catalog_request",
+        return_value=_Resp(_payload(duplicated)),
+    ):
+        result = probe_api_models("sk-key", "https://gw.example.com/v1")
+
+    assert result["models"] == ["alpha-model", "bravo-model"]

--- a/tests/hermes_cli/test_probe_api_models_sort.py
+++ b/tests/hermes_cli/test_probe_api_models_sort.py
@@ -1,0 +1,94 @@
+"""``probe_api_models()`` must return alphabetically sorted, non-empty IDs.
+
+Custom OpenAI-compatible endpoints (``custom_providers`` rows, bare
+``provider: custom``) previously returned the provider's raw ``/v1/models``
+response order unchanged, so the ``/model`` picker showed a different,
+non-alphabetical ordering every time the cache refreshed or a new session
+re-fetched. Built-in providers (anthropic / xai / github) already sort their
+catalogs; these tests pin the same stable ordering on the generic custom
+path.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from hermes_cli.models import probe_api_models
+
+
+class _Resp:
+    """Minimal file-like context manager matching the ``with ... as resp``
+    seam inside ``probe_api_models``."""
+
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return self._payload
+
+
+def _payload(models: list[dict]) -> bytes:
+    return json.dumps({"data": models}).encode()
+
+
+def test_probe_api_models_sorts_ids_case_insensitively():
+    """Unordered, mixed-case IDs come back lowercase-alphabetical."""
+    unordered = [
+        {"id": "zulu-model"},
+        {"id": "Alpha-model"},
+        {"id": "mike-model"},
+        {"id": "bravo-model"},
+    ]
+    with patch(
+        "hermes_cli.models._urlopen_model_catalog_request",
+        return_value=_Resp(_payload(unordered)),
+    ):
+        result = probe_api_models("sk-key", "https://gw.example.com/v1")
+
+    assert result["models"] == [
+        "Alpha-model",
+        "bravo-model",
+        "mike-model",
+        "zulu-model",
+    ]
+
+
+def test_probe_api_models_filters_empty_ids():
+    """Empty (falsy) IDs from the provider are dropped before sorting."""
+    unordered = [
+        {"id": "zulu-model"},
+        {"id": ""},
+        {"id": "alpha-model"},
+        {"id": None},
+        {"id": "bravo-model"},
+    ]
+    with patch(
+        "hermes_cli.models._urlopen_model_catalog_request",
+        return_value=_Resp(_payload(unordered)),
+    ):
+        result = probe_api_models("sk-key", "https://gw.example.com/v1")
+
+    assert result["models"] == ["alpha-model", "bravo-model", "zulu-model"]
+
+
+def test_probe_api_models_sort_is_stable_on_already_sorted_input():
+    """An already-sorted response is unchanged (sort is idempotent)."""
+    ordered = [
+        {"id": "alpha-model"},
+        {"id": "bravo-model"},
+        {"id": "charlie-model"},
+    ]
+    with patch(
+        "hermes_cli.models._urlopen_model_catalog_request",
+        return_value=_Resp(_payload(ordered)),
+    ):
+        result = probe_api_models("sk-key", "https://gw.example.com/v1")
+
+    assert result["models"] == ["alpha-model", "bravo-model", "charlie-model"]


### PR DESCRIPTION
## What does this PR do?

`probe_api_models()` — the generic OpenAI-compatible `/v1/models` probe used by
`custom_providers` rows, bare `provider: custom`, and per-endpoint-map entries —
returned the provider's raw response order unchanged. As a result the `/model`
picker showed a different, non-alphabetical ordering on every session and cache
refresh, because the upstream endpoint's ordering is not stable across requests.

Built-in providers already sort their catalogs (`_fetch_anthropic_models` ranks
opus/sonnet/haiku, `_xai_finalize_catalog` sorts, GitHub models sort); this change
brings the generic custom path in line.

- Filter empty (falsy) IDs before returning
- Stable-sort case-insensitively by model ID

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/models.py` — `probe_api_models()` now filters empty IDs and sorts
  the returned model list case-insensitively (`sorted(models, key=str.lower)`)
  before returning, instead of passing through the provider's raw `/models` order.
- `tests/hermes_cli/test_probe_api_models_sort.py` — new test file with 3 cases:
  unordered mixed-case input → alphabetical order; empty/`None` IDs dropped;
  already-sorted input is unchanged (idempotent).

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_probe_api_models_sort.py` — 3 tests pass.
2. `scripts/run_tests.sh tests/hermes_cli/test_cached_fetch_api_models.py tests/hermes_cli/test_models.py tests/hermes_cli/test_custom_provider_model_switch.py` — regression passes (no ordering contract broken).
3. Manual: configure a `custom_providers` endpoint, open `/model` across two sessions; the model list stays in stable alphabetical order.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux, Python 3.12)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline code comment added)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `str.lower` + list sort are platform-agnostic, no path/encoding changes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

N/A — this is a bug fix, not a new skill.

## Screenshots / Logs

N/A
