### PR TITLE
feat(guardrails): pre-tool-call required-argument validation to break empty-shell retry loops

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -126,6 +126,16 @@ class ToolCallGuardrailConfig:
     idempotent_tools: frozenset[str] = field(default_factory=lambda: IDEMPOTENT_TOOL_NAMES)
     mutating_tools: frozenset[str] = field(default_factory=lambda: MUTATING_TOOL_NAMES)
     loop_caps: "LoopCapConfig" = field(default_factory=lambda: LoopCapConfig())
+    pre_tool_validation: bool = True
+    conditional_required: Mapping[str, Any] = field(
+        default_factory=lambda: {
+            "skill_manage": [
+                {"condition": {"action": ["create", "edit"]}, "require": ["content"]},
+                {"condition": {"action": "patch"}, "require": ["old_string", "new_string"]},
+                {"condition": {"action": "write_file"}, "require": ["file_path", "file_content"]},
+            ],
+        }
+    )
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any] | None) -> "ToolCallGuardrailConfig":
@@ -141,6 +151,12 @@ class ToolCallGuardrailConfig:
             hard_stop_after = {}
 
         defaults = cls()
+        raw_cond = data.get("conditional_required")
+        if isinstance(raw_cond, Mapping):
+            conditional_required = raw_cond
+        else:
+            conditional_required = defaults.conditional_required
+
         return cls(
             warnings_enabled=_as_bool(data.get("warnings_enabled"), defaults.warnings_enabled),
             hard_stop_enabled=_as_bool(data.get("hard_stop_enabled"), defaults.hard_stop_enabled),
@@ -169,6 +185,8 @@ class ToolCallGuardrailConfig:
                 defaults.no_progress_block_after,
             ),
             loop_caps=LoopCapConfig.from_mapping(data.get("loop_caps")),
+            pre_tool_validation=_as_bool(data.get("pre_tool_validation"), defaults.pre_tool_validation),
+            conditional_required=conditional_required,
         )
 
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -738,6 +738,14 @@ DEFAULT_CONFIG = {
             "max_web_searches": 50,   # max web_search calls per turn (0 = unlimited)
             "max_subagents": 50,      # max subagents spawned per turn (0 = unlimited)
         },
+        "pre_tool_validation": True,
+        "conditional_required": {
+            "skill_manage": [
+                {"condition": {"action": ["create", "edit"]}, "require": ["content"]},
+                {"condition": {"action": "patch"}, "require": ["old_string", "new_string"]},
+                {"condition": {"action": "write_file"}, "require": ["file_path", "file_content"]},
+            ],
+        },
     },
 
     "compression": {

--- a/model_tools.py
+++ b/model_tools.py
@@ -1189,6 +1189,137 @@ def _emit_post_tool_call_hook(
         logger.debug("post_tool_call hook error: %s", _hook_err)
 
 
+def _match_tool_arg_condition(condition: Any, args: Dict[str, Any]) -> bool:
+    """Evaluate whether an argument condition matches the supplied tool call arguments."""
+    if not condition or not isinstance(condition, dict):
+        return True
+    for key, expected in condition.items():
+        if key.endswith("!="):
+            actual_key = key[:-2].strip()
+            val = args.get(actual_key)
+            if isinstance(expected, (list, tuple, set)):
+                if val in expected:
+                    return False
+            else:
+                if val == expected:
+                    return False
+        else:
+            val = args.get(key)
+            if isinstance(expected, (list, tuple, set)):
+                if val not in expected:
+                    return False
+            else:
+                if val != expected:
+                    return False
+    return True
+
+
+def validate_required_tool_args(
+    tool_name: str,
+    args: Optional[Dict[str, Any]],
+    *,
+    session_id: str = "",
+    turn_id: str = "",
+) -> Optional[str]:
+    """Return a block message if the tool call is missing required arguments, else None.
+
+    1) Schema required: Checks parameters.required from ToolRegistry.get_schema(tool_name).
+       Missing keys or None values are reported as missing.
+    2) Conditional required: Reads tool_loop_guardrails.conditional_required from config,
+       matches conditions against args, and checks require/require_any lists.
+    3) Message assembly: Produces an actionable guidance string for the model:
+       "Tool {tool_name} is missing required argument(s): {missing}. {arg: description}"
+    """
+    if not tool_name:
+        return None
+    args_dict = args if isinstance(args, dict) else {}
+
+    missing: List[str] = []
+    custom_hints: Dict[str, str] = {}
+    properties: Dict[str, Any] = {}
+
+    # 1) Universal: inspect registered tool schema from registry
+    try:
+        schema = registry.get_schema(tool_name)
+    except Exception:
+        schema = None
+
+    if isinstance(schema, dict):
+        fn_schema = schema.get("function") if isinstance(schema.get("function"), dict) else schema
+        params = fn_schema.get("parameters")
+        if not isinstance(params, dict):
+            params = fn_schema
+        if isinstance(params.get("properties"), dict):
+            properties = params["properties"]
+        if isinstance(params.get("required"), list):
+            for req in params["required"]:
+                if args_dict.get(req) is None and req not in missing:
+                    missing.append(req)
+
+    # 2) Conditional rules: read tool_loop_guardrails.conditional_required from config
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly() or {}
+    except Exception:
+        cfg = {}
+
+    tlg_cfg = cfg.get("tool_loop_guardrails")
+    if not isinstance(tlg_cfg, dict):
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+        tlg_cfg = DEFAULT_CONFIG.get("tool_loop_guardrails") or {}
+
+    cond_map = tlg_cfg.get("conditional_required")
+    if not isinstance(cond_map, dict):
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+        cond_map = (
+            (DEFAULT_CONFIG.get("tool_loop_guardrails") or {}).get("conditional_required") or {}
+        )
+
+    rules = cond_map.get(tool_name) if isinstance(cond_map, dict) else None
+    if rules:
+        rule_list = rules if isinstance(rules, list) else [rules]
+        for rule in rule_list:
+            if isinstance(rule, dict) and _match_tool_arg_condition(rule.get("condition"), args_dict):
+                for req in rule.get("require", []):
+                    if args_dict.get(req) is None and req not in missing:
+                        missing.append(req)
+                        if rule.get("hint") and req not in custom_hints:
+                            custom_hints[req] = rule["hint"]
+                require_any = rule.get("require_any", [])
+                if require_any and isinstance(require_any, list):
+                    if all(args_dict.get(req) is None for req in require_any):
+                        any_desc = " or ".join(require_any)
+                        if any_desc not in missing:
+                            missing.append(any_desc)
+                            if rule.get("hint") and any_desc not in custom_hints:
+                                custom_hints[any_desc] = rule["hint"]
+
+    if not missing:
+        return None
+
+    # 3) Assemble actionable message
+    hints: List[str] = []
+    for req in missing:
+        prop_desc = None
+        if req in properties and isinstance(properties[req], dict):
+            prop_desc = properties[req].get("description")
+        if prop_desc:
+            hints.append(f"{req}: {str(prop_desc).strip()}")
+        elif req in custom_hints:
+            hints.append(f"{req}: {str(custom_hints[req]).strip()}")
+        else:
+            hints.append(f"Please provide '{req}'.")
+
+    missing_str = ", ".join(missing)
+    msg = f"Tool {tool_name} is missing required argument(s): {missing_str}."
+    if hints:
+        msg += " " + " ".join(hints)
+    return msg
+
+
 def handle_function_call(
     function_name: str,
     function_args: Dict[str, Any],
@@ -1417,6 +1548,42 @@ def handle_function_call(
                     middleware_trace=list(_tool_middleware_trace),
                 )
                 return result
+
+        # Pre-tool-call required-argument validation (tool_loop_guardrails.pre_tool_validation).
+        # Runs after plugin hooks so plugins keep priority to modify/supply args;
+        # blocks before execution so broken calls never enter failure-loop accounting.
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            _agent_cfg = load_config_readonly() or {}
+            _tlg_cfg = _agent_cfg.get("tool_loop_guardrails") or {}
+            _req_validation_enabled = _tlg_cfg.get("pre_tool_validation", True)
+            if _req_validation_enabled:
+                _req_msg = validate_required_tool_args(
+                    function_name,
+                    function_args,
+                    session_id=session_id or "",
+                    turn_id=turn_id or "",
+                )
+                if _req_msg is not None:
+                    _req_result = tool_error(_req_msg)
+                    _emit_post_tool_call_hook(
+                        function_name=function_name,
+                        function_args=function_args,
+                        result=_req_result,
+                        task_id=task_id,
+                        session_id=session_id,
+                        tool_call_id=tool_call_id,
+                        turn_id=turn_id,
+                        api_request_id=api_request_id,
+                        status="blocked",
+                        error_type="missing_required_args",
+                        error_message=_req_msg,
+                        middleware_trace=list(_tool_middleware_trace),
+                    )
+                    return _req_result
+        except Exception as _req_err:
+            logger.debug("required-arg validation error: %s", _req_err)
 
         # ACP/Zed edit approval runs before any file mutation.  The requester
         # is bound via ContextVar only for ACP sessions, so CLI/gateway paths

--- a/model_tools.py
+++ b/model_tools.py
@@ -1228,6 +1228,9 @@ def _bump_validation_block_count(key: Tuple[Any, ...]) -> int:
     try:
         count = _validation_block_counts.get(key, 0) + 1
         _validation_block_counts[key] = count
+        # LRU: a re-hit key moves to the tail so the FIFO eviction below
+        # drops long-idle keys first (OrderedDict keeps insertion order).
+        _validation_block_counts.move_to_end(key)
         while len(_validation_block_counts) > _VALIDATION_BLOCK_COUNTS_CAP:
             _validation_block_counts.popitem(last=False)
         return count
@@ -1294,17 +1297,15 @@ def validate_required_tool_args(
                     missing.append(req)
 
     # 2) Conditional rules: use the resolved ToolCallGuardrailConfig when given,
-    #    otherwise fall back to bundled defaults (keeps direct-call tests simple).
+    #    otherwise fall back to the bundled defaults (keeps direct-call tests simple).
+    #    Both paths consume the same dataclass so defaults stay single-sourced.
     if tlg is not None:
         cond_map = getattr(tlg, "conditional_required", None) or {}
     else:
-        cond_map = {}
         try:
-            from hermes_cli.config_defaults import DEFAULT_CONFIG
+            from agent.tool_guardrails import ToolCallGuardrailConfig
 
-            cond_map = (
-                (DEFAULT_CONFIG.get("tool_loop_guardrails") or {}).get("conditional_required") or {}
-            )
+            cond_map = ToolCallGuardrailConfig().conditional_required or {}
         except Exception:
             cond_map = {}
 
@@ -1351,16 +1352,19 @@ def validate_required_tool_args(
     # Escalate when the exact same malformed call shape is repeated within one
     # turn: blocked calls are excluded from failure-loop accounting, so without
     # this a weak model could re-emit the identical call forever with no hard
-    # stop. The count is keyed per (session, turn, tool, missing-set).
+    # stop. The count is keyed per (session, turn, tool, missing-set) — only
+    # tracked when both session and turn are known, so call paths without that
+    # context (e.g. MCP servers) never collide on a shared global key.
     try:
-        key = (session_id, turn_id, tool_name, tuple(sorted(missing)))
-        repeat = _bump_validation_block_count(key)
-        if repeat >= 3:
-            msg += (
-                f" This is the {_ordinal(repeat)} time this exact call was blocked this turn — "
-                "stop retrying this shape. Read the tool schema, fix the arguments, "
-                "or switch to an alternative tool."
-            )
+        if session_id and turn_id:
+            key = (session_id, turn_id, tool_name, tuple(sorted(missing)))
+            repeat = _bump_validation_block_count(key)
+            if repeat >= 3:
+                msg += (
+                    f" This is the {_ordinal(repeat)} time this exact call was blocked this turn — "
+                    "stop retrying this shape. Read the tool schema, fix the arguments, "
+                    "or switch to an alternative tool."
+                )
     except Exception:
         pass
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -24,6 +24,7 @@ import os
 import json
 import re
 import asyncio
+from collections import OrderedDict
 from contextlib import contextmanager
 from contextvars import ContextVar
 import logging
@@ -1214,21 +1215,57 @@ def _match_tool_arg_condition(condition: Any, args: Dict[str, Any]) -> bool:
     return True
 
 
+# Per-turn repeat-block tracker for required-arg validation. Keyed by
+# (session_id, turn_id, tool_name, frozen missing-set) so a model that keeps
+# re-emitting the exact same malformed call accumulates an escalation even
+# though blocked calls are otherwise excluded from failure-loop accounting.
+_validation_block_counts: "OrderedDict[Any, int]" = OrderedDict()
+_VALIDATION_BLOCK_COUNTS_CAP = 200
+
+
+def _bump_validation_block_count(key: Tuple[Any, ...]) -> int:
+    """Increment the per-turn repeat counter for a blocked call shape."""
+    try:
+        count = _validation_block_counts.get(key, 0) + 1
+        _validation_block_counts[key] = count
+        while len(_validation_block_counts) > _VALIDATION_BLOCK_COUNTS_CAP:
+            _validation_block_counts.popitem(last=False)
+        return count
+    except Exception:
+        return 1
+
+
+def _ordinal(n: int) -> str:
+    """Format a small positive integer as an English ordinal (1st, 2nd, 3rd, 11th...)."""
+    try:
+        if 10 <= n % 100 <= 20:
+            suffix = "th"
+        else:
+            suffix = {1: "st", 2: "nd", 3: "rd"}.get(n % 10, "th")
+        return f"{n}{suffix}"
+    except Exception:
+        return f"{n}th"
+
+
 def validate_required_tool_args(
     tool_name: str,
     args: Optional[Dict[str, Any]],
     *,
     session_id: str = "",
     turn_id: str = "",
+    tlg: Optional[Any] = None,
 ) -> Optional[str]:
     """Return a block message if the tool call is missing required arguments, else None.
 
     1) Schema required: Checks parameters.required from ToolRegistry.get_schema(tool_name).
        Missing keys or None values are reported as missing.
-    2) Conditional required: Reads tool_loop_guardrails.conditional_required from config,
-       matches conditions against args, and checks require/require_any lists.
+    2) Conditional required: Uses tool_loop_guardrails.conditional_required from the
+       resolved ToolCallGuardrailConfig (``tlg``) when provided, else falls back to the
+       bundled defaults. Conditions are matched against args; require/require_any lists
+       are checked.
     3) Message assembly: Produces an actionable guidance string for the model:
        "Tool {tool_name} is missing required argument(s): {missing}. {arg: description}"
+       Repeated identical block shapes within one turn escalate the message.
     """
     if not tool_name:
         return None
@@ -1256,27 +1293,20 @@ def validate_required_tool_args(
                 if args_dict.get(req) is None and req not in missing:
                     missing.append(req)
 
-    # 2) Conditional rules: read tool_loop_guardrails.conditional_required from config
-    try:
-        from hermes_cli.config import load_config_readonly
+    # 2) Conditional rules: use the resolved ToolCallGuardrailConfig when given,
+    #    otherwise fall back to bundled defaults (keeps direct-call tests simple).
+    if tlg is not None:
+        cond_map = getattr(tlg, "conditional_required", None) or {}
+    else:
+        cond_map = {}
+        try:
+            from hermes_cli.config_defaults import DEFAULT_CONFIG
 
-        cfg = load_config_readonly() or {}
-    except Exception:
-        cfg = {}
-
-    tlg_cfg = cfg.get("tool_loop_guardrails")
-    if not isinstance(tlg_cfg, dict):
-        from hermes_cli.config_defaults import DEFAULT_CONFIG
-
-        tlg_cfg = DEFAULT_CONFIG.get("tool_loop_guardrails") or {}
-
-    cond_map = tlg_cfg.get("conditional_required")
-    if not isinstance(cond_map, dict):
-        from hermes_cli.config_defaults import DEFAULT_CONFIG
-
-        cond_map = (
-            (DEFAULT_CONFIG.get("tool_loop_guardrails") or {}).get("conditional_required") or {}
-        )
+            cond_map = (
+                (DEFAULT_CONFIG.get("tool_loop_guardrails") or {}).get("conditional_required") or {}
+            )
+        except Exception:
+            cond_map = {}
 
     rules = cond_map.get(tool_name) if isinstance(cond_map, dict) else None
     if rules:
@@ -1317,6 +1347,23 @@ def validate_required_tool_args(
     msg = f"Tool {tool_name} is missing required argument(s): {missing_str}."
     if hints:
         msg += " " + " ".join(hints)
+
+    # Escalate when the exact same malformed call shape is repeated within one
+    # turn: blocked calls are excluded from failure-loop accounting, so without
+    # this a weak model could re-emit the identical call forever with no hard
+    # stop. The count is keyed per (session, turn, tool, missing-set).
+    try:
+        key = (session_id, turn_id, tool_name, tuple(sorted(missing)))
+        repeat = _bump_validation_block_count(key)
+        if repeat >= 3:
+            msg += (
+                f" This is the {_ordinal(repeat)} time this exact call was blocked this turn — "
+                "stop retrying this shape. Read the tool schema, fix the arguments, "
+                "or switch to an alternative tool."
+            )
+    except Exception:
+        pass
+
     return msg
 
 
@@ -1550,20 +1597,24 @@ def handle_function_call(
                 return result
 
         # Pre-tool-call required-argument validation (tool_loop_guardrails.pre_tool_validation).
-        # Runs after plugin hooks so plugins keep priority to modify/supply args;
-        # blocks before execution so broken calls never enter failure-loop accounting.
+        # The toggle and rule table resolve through ToolCallGuardrailConfig so there is a
+        # single authority for the feature's configuration. Runs after plugin hooks so
+        # plugins keep priority to modify/supply args; blocks before execution so broken
+        # calls never enter failure-loop accounting.
         try:
             from hermes_cli.config import load_config_readonly
+            from agent.tool_guardrails import ToolCallGuardrailConfig
 
-            _agent_cfg = load_config_readonly() or {}
-            _tlg_cfg = _agent_cfg.get("tool_loop_guardrails") or {}
-            _req_validation_enabled = _tlg_cfg.get("pre_tool_validation", True)
-            if _req_validation_enabled:
+            _guardrail_cfg = ToolCallGuardrailConfig.from_mapping(
+                (load_config_readonly() or {}).get("tool_loop_guardrails") or {}
+            )
+            if _guardrail_cfg.pre_tool_validation:
                 _req_msg = validate_required_tool_args(
                     function_name,
                     function_args,
                     session_id=session_id or "",
                     turn_id=turn_id or "",
+                    tlg=_guardrail_cfg,
                 )
                 if _req_msg is not None:
                     _req_result = tool_error(_req_msg)

--- a/tests/hermes_cli/test_required_arg_validation.py
+++ b/tests/hermes_cli/test_required_arg_validation.py
@@ -252,3 +252,58 @@ def test_e2e_pre_tool_validation_disabled_in_config(monkeypatch, tmp_path):
     result = json.loads(result_raw)
     assert result.get("custom") == "dispatched"
     assert dispatch_mock.called
+
+
+def test_repeated_malformed_call_escalates_in_same_turn():
+    """The exact same malformed call shape repeated in one turn escalates the message."""
+    sess, turn = "s_rep", "t_rep"
+    args = {"action": "create", "name": "x"}
+    msgs = [
+        validate_required_tool_args("skill_manage", args, session_id=sess, turn_id=turn)
+        for _ in range(3)
+    ]
+    # 1st and 2nd are plain actionable blocks
+    assert msgs[0] is not None and "stop retrying" not in msgs[0]
+    assert msgs[1] is not None and "stop retrying" not in msgs[1]
+    # 3rd escalates with a hard stop warning
+    assert msgs[2] is not None
+    assert "3rd time" in msgs[2] and "stop retrying" in msgs[2]
+
+
+def test_repeated_block_count_is_per_turn():
+    """The repeat counter resets per (session, turn) — a new turn starts fresh."""
+    args = {"action": "create", "name": "x"}
+    for i in range(2):
+        m = validate_required_tool_args(
+            "skill_manage", args, session_id="s_turn", turn_id=f"turn_{i}"
+        )
+        assert m is not None and "stop retrying" not in m
+    # Same session, same shape, but a fresh turn: no escalation on first call
+    m = validate_required_tool_args(
+        "skill_manage", args, session_id="s_turn", turn_id="turn_new"
+    )
+    assert m is not None and "stop retrying" not in m
+
+
+def test_validate_uses_resolved_guardrail_config():
+    """The resolved ToolCallGuardrailConfig is the single authority for conditional rules."""
+    from agent.tool_guardrails import ToolCallGuardrailConfig
+
+    cfg = ToolCallGuardrailConfig.from_mapping(
+        {
+            "conditional_required": {
+                "skill_manage": [
+                    {"condition": {"action": "custom_op"}, "require": ["custom_field"]}
+                ]
+            }
+        }
+    )
+    # Matches the rule from the resolved config object (not bundled defaults)
+    m = validate_required_tool_args(
+        "skill_manage",
+        {"action": "custom_op"},
+        session_id="s_cfg",
+        turn_id="t_cfg",
+        tlg=cfg,
+    )
+    assert m is not None and "custom_field" in m

--- a/tests/hermes_cli/test_required_arg_validation.py
+++ b/tests/hermes_cli/test_required_arg_validation.py
@@ -1,0 +1,254 @@
+"""Tests for pre-tool-call required argument validation.
+
+Covers:
+1. Unit tests for `validate_required_tool_args`:
+   - conditional_required rules on skill_manage (create/edit missing content, patch missing old_string/new_string, write_file missing file_path/file_content)
+   - schema.required on built-in tools (write_file missing content, write_file missing path)
+   - valid tool calls (all required args supplied) returning None
+   - schema-less / rule-less tools returning None (no false positives)
+   - empty string vs None distinction (empty string preserved for tool semantics)
+2. E2E tests for `handle_function_call`:
+   - broken call blocked with tool_error containing actionable guidance
+   - post_tool_call hook emitted with status="blocked" and error_type="missing_required_args"
+   - blocked before edit approval and execution dispatch
+   - plugin pre_tool_call hook argument modification (priority preserved)
+   - opt-out via tool_loop_guardrails.pre_tool_validation config toggle
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+import pytest
+
+from model_tools import handle_function_call, validate_required_tool_args
+from tools.registry import tool_error
+
+
+# ─── Unit Tests: validate_required_tool_args ──────────────────────────────────
+
+
+def test_skill_manage_create_missing_content():
+    """skill_manage create without content must return a block message specifying content."""
+    msg = validate_required_tool_args("skill_manage", {"action": "create", "name": "my-skill"})
+    assert msg is not None
+    assert "Tool skill_manage is missing required argument(s): content." in msg
+    assert "content:" in msg
+
+
+def test_skill_manage_edit_missing_content():
+    """skill_manage edit without content must return a block message specifying content."""
+    msg = validate_required_tool_args("skill_manage", {"action": "edit", "name": "my-skill"})
+    assert msg is not None
+    assert "Tool skill_manage is missing required argument(s): content." in msg
+    assert "content:" in msg
+
+
+def test_skill_manage_patch_missing_old_and_new_string():
+    """skill_manage patch without old_string/new_string must report both as missing."""
+    msg = validate_required_tool_args("skill_manage", {"action": "patch", "name": "my-skill"})
+    assert msg is not None
+    assert "old_string" in msg
+    assert "new_string" in msg
+
+
+def test_skill_manage_patch_missing_new_string_only():
+    """skill_manage patch with old_string but without new_string must report new_string."""
+    msg = validate_required_tool_args(
+        "skill_manage",
+        {"action": "patch", "name": "my-skill", "old_string": "def old(): pass"},
+    )
+    assert msg is not None
+    assert "new_string" in msg
+    assert "old_string" not in msg.split("missing required argument(s):")[1].split(".")[0]
+
+
+def test_skill_manage_write_file_missing_file_path_and_file_content():
+    """skill_manage write_file without file_path/file_content must report both."""
+    msg = validate_required_tool_args("skill_manage", {"action": "write_file", "name": "my-skill"})
+    assert msg is not None
+    assert "file_path" in msg
+    assert "file_content" in msg
+
+
+def test_write_file_missing_content():
+    """write_file without content must be blocked by schema.required check."""
+    msg = validate_required_tool_args("write_file", {"path": "example.py"})
+    assert msg is not None
+    assert "Tool write_file is missing required argument(s): content." in msg
+
+
+def test_write_file_missing_path():
+    """write_file without path must be blocked by schema.required check."""
+    msg = validate_required_tool_args("write_file", {"content": "print('hello')"})
+    assert msg is not None
+    assert "Tool write_file is missing required argument(s): path." in msg
+
+
+def test_valid_calls_return_none():
+    """Valid calls with all required args must return None (no block)."""
+    assert validate_required_tool_args(
+        "skill_manage",
+        {"action": "create", "name": "my-skill", "content": "# My Skill"},
+    ) is None
+
+    assert validate_required_tool_args(
+        "skill_manage",
+        {"action": "patch", "name": "my-skill", "old_string": "foo", "new_string": "bar"},
+    ) is None
+
+    assert validate_required_tool_args(
+        "skill_manage",
+        {"action": "write_file", "name": "my-skill", "file_path": "references/ref.md", "file_content": "data"},
+    ) is None
+
+    assert validate_required_tool_args(
+        "write_file",
+        {"path": "test.txt", "content": "content here"},
+    ) is None
+
+    assert validate_required_tool_args(
+        "web_search",
+        {"query": "hermes agent"},
+    ) is None
+
+
+def test_tools_without_required_args_return_none():
+    """Tools with empty schema.required and no conditional rules must never be blocked."""
+    assert validate_required_tool_args("session_search", {}) is None
+    assert validate_required_tool_args("skills_list", {}) is None
+    assert validate_required_tool_args("unknown_custom_tool", {}) is None
+
+
+def test_empty_string_versus_none_distinction():
+    """Empty string is preserved for tool semantics (e.g. deletion in patch), while None is missing."""
+    # new_string as empty string (valid replacement for deletion)
+    assert validate_required_tool_args(
+        "skill_manage",
+        {"action": "patch", "name": "my-skill", "old_string": "to_remove", "new_string": ""},
+    ) is None
+
+    # new_string as explicit None -> treated as missing
+    msg = validate_required_tool_args(
+        "skill_manage",
+        {"action": "patch", "name": "my-skill", "old_string": "to_remove", "new_string": None},
+    )
+    assert msg is not None
+    assert "new_string" in msg
+
+
+# ─── E2E Tests: handle_function_call ──────────────────────────────────────────
+
+
+def test_e2e_handle_function_call_blocks_missing_args(monkeypatch, tmp_path):
+    """handle_function_call returns tool_error JSON when missing required args."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    result_raw = handle_function_call(
+        "skill_manage",
+        {"action": "create", "name": "broken-skill"},
+        task_id="t-1",
+        session_id="s-1",
+    )
+    result = json.loads(result_raw)
+    assert "error" in result
+    assert "Tool skill_manage is missing required argument(s): content." in result["error"]
+    assert "Full SKILL.md content" in result["error"]
+
+
+def test_e2e_post_tool_call_hook_emitted_on_validation_block(monkeypatch, tmp_path):
+    """When validation blocks a tool call, post_tool_call observer hook is emitted with status='blocked'."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli import lifecycle
+
+    hook_calls = []
+    monkeypatch.setattr(lifecycle, "has_hook", lambda name: name == "post_tool_call")
+    monkeypatch.setattr(
+        lifecycle,
+        "invoke_hook",
+        lambda name, **kwargs: hook_calls.append((name, kwargs)) or [],
+    )
+
+    handle_function_call(
+        "skill_manage",
+        {"action": "create", "name": "broken-skill"},
+        task_id="t-1",
+        session_id="s-1",
+        turn_id="turn-1",
+    )
+
+    post_calls = [c for c in hook_calls if c[0] == "post_tool_call"]
+    assert len(post_calls) == 1
+    _, kwargs = post_calls[0]
+    assert kwargs["status"] == "blocked"
+    assert kwargs["error_type"] == "missing_required_args"
+    assert "content" in kwargs["error_message"]
+
+
+def test_e2e_blocked_before_execution_and_edit_approval(monkeypatch, tmp_path):
+    """Validation blocks broken calls before reaching registry.dispatch or edit approval."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    dispatch_mock = MagicMock()
+    approval_mock = MagicMock()
+
+    monkeypatch.setattr("model_tools.registry.dispatch", dispatch_mock)
+    with patch("acp_adapter.edit_approval.maybe_require_edit_approval", approval_mock):
+        result_raw = handle_function_call(
+            "write_file",
+            {"path": "foo.py"},  # missing content
+            task_id="t-1",
+            session_id="s-1",
+        )
+
+    assert "Tool write_file is missing required argument(s): content." in result_raw
+    assert not dispatch_mock.called
+    assert not approval_mock.called
+
+
+def test_e2e_plugin_modify_supplies_missing_arg(monkeypatch, tmp_path):
+    """When a plugin pre_tool_call hook modifies args to supply the missing arg, validation allows dispatch."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    def fake_pre_dispatch(name, args, **kwargs):
+        # Plugin supplies the missing "content"
+        new_args = dict(args)
+        new_args["content"] = "# Added by plugin"
+        return None, new_args
+
+    monkeypatch.setattr("hermes_cli.plugins._dispatch_pre_tool_call_hooks", fake_pre_dispatch)
+    monkeypatch.setattr(
+        "model_tools.registry.dispatch",
+        lambda name, args, **kw: json.dumps({"success": True, "saved_content": args.get("content")}),
+    )
+
+    result_raw = handle_function_call(
+        "skill_manage",
+        {"action": "create", "name": "plugin-assisted-skill"},  # missing content initially
+        task_id="t-1",
+        session_id="s-1",
+    )
+    result = json.loads(result_raw)
+    assert result.get("success") is True
+    assert result.get("saved_content") == "# Added by plugin"
+
+
+def test_e2e_pre_tool_validation_disabled_in_config(monkeypatch, tmp_path):
+    """When pre_tool_validation is disabled in config, validation is bypassed and dispatch is reached."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"tool_loop_guardrails": {"pre_tool_validation": False}},
+    )
+
+    dispatch_mock = MagicMock(return_value=json.dumps({"success": True, "custom": "dispatched"}))
+    monkeypatch.setattr("model_tools.registry.dispatch", dispatch_mock)
+
+    result_raw = handle_function_call(
+        "skill_manage",
+        {"action": "create", "name": "no-val-skill"},  # missing content, but validation disabled
+        task_id="t-1",
+        session_id="s-1",
+    )
+    result = json.loads(result_raw)
+    assert result.get("custom") == "dispatched"
+    assert dispatch_mock.called

--- a/tests/hermes_cli/test_required_arg_validation.py
+++ b/tests/hermes_cli/test_required_arg_validation.py
@@ -307,3 +307,12 @@ def test_validate_uses_resolved_guardrail_config():
         tlg=cfg,
     )
     assert m is not None and "custom_field" in m
+
+
+def test_repeat_escalation_requires_session_and_turn_context():
+    """Without session/turn context (e.g. MCP call paths) repeats never escalate,
+    so long-lived processes don't collide on a shared global key."""
+    args = {"action": "create", "name": "x"}
+    for _ in range(3):
+        m = validate_required_tool_args("skill_manage", args, session_id="", turn_id="")
+        assert m is not None and "stop retrying" not in m

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -43,7 +43,7 @@ class TestHandleFunctionCall:
             patch("hermes_cli.plugins.has_hook", return_value=True),
             patch("hermes_cli.plugins.invoke_hook") as mock_invoke_hook,
         ):
-            handle_function_call("web_search", {"q": "test"}, task_id="t1")
+            handle_function_call("web_search", {"query": "test"}, task_id="t1")
 
         kwargs_by_hook = {
             c.args[0]: c.kwargs for c in mock_invoke_hook.call_args_list
@@ -90,7 +90,7 @@ class TestHandleFunctionCall:
             patch("hermes_cli.plugins.has_hook", return_value=False),
             patch("hermes_cli.plugins.invoke_hook") as mock_invoke_hook,
         ):
-            result = handle_function_call("web_search", {"q": "test"}, task_id="t1")
+            result = handle_function_call("web_search", {"query": "test"}, task_id="t1")
 
         assert result == '{"ok":true}'
         fired = {c.args[0] for c in mock_invoke_hook.call_args_list}
@@ -135,16 +135,16 @@ class TestHandleFunctionCall:
         result = json.loads(
             handle_function_call(
                 "web_search",
-                {"q": "test"},
+                {"query": "test"},
                 task_id="task-1",
                 tool_call_id="tool-1",
                 session_id="session-1",
             )
         )
 
-        assert seen["execution_args"] == {"q": "test", "rewritten": True}
-        assert seen["dispatch"][1] == {"q": "test", "rewritten": True, "wrapped": True}
-        assert result["args"] == {"q": "test", "rewritten": True, "wrapped": True}
+        assert seen["execution_args"] == {"query": "test", "rewritten": True}
+        assert seen["dispatch"][1] == {"query": "test", "rewritten": True, "wrapped": True}
+        assert result["args"] == {"query": "test", "rewritten": True, "wrapped": True}
         expected_trace = [{"source": "test-middleware", "reason": "rewrite"}]
         pre_call = next(call for call in hook_calls if call[0] == "pre_tool_call")
         post_call = next(call for call in hook_calls if call[0] == "post_tool_call")
@@ -170,7 +170,7 @@ class TestHandleFunctionCall:
         result = json.loads(
             handle_function_call(
                 "web_search",
-                {"q": "test"},
+                {"query": "test"},
                 task_id="task-1",
                 session_id="session-1",
                 tool_call_id="tool-1",


### PR DESCRIPTION
## Summary

Adds a pre-tool-call required-argument validation layer to `tool_loop_guardrails`. Tool calls missing arguments the tool itself declares mandatory are now blocked **before execution**, with a message that names the missing arguments and carries the schema's own guidance for each — so the block message doubles as a repair hint the model can act on immediately.

Motivation: in a real session while deploying a service (self-hosted setup), the agent called `skill_manage create` **nine times in a row** without `content` (one retry even passed `file_content`, the wrong key). Every call executed, failed, and re-entered loop detection; the built-in `Tool loop warning` only fires at 9 same-tool failures and is a warning, not a halt. Validating required args before dispatch cuts the empty-shell retry cycle at the source — no failed execution, no retry, no loop.

## Changes

- **`model_tools.py`** — new `validate_required_tool_args()`:
  - Universal check: `parameters.required` from `ToolRegistry.get_schema(tool_name)`.
  - Conditional check: a `conditional_required` rule table (config) for tools whose schemas are intentionally loose — e.g. `skill_manage` only declares `["action", "name"]` as required, while `content` is required for `create`/`edit`, `old_string`/`new_string` for `patch`, `file_path`/`file_content` for `write_file`.
  - Message: `Tool X is missing required argument(s): Y. <schema description for Y>`.
- **Placement** — inside `handle_function_call`, after plugin `pre_tool_call` hooks (plugins keep priority to `modify`/supply args) and before ACP edit approval. Blocked calls emit `post_tool_call` with `status="blocked"`, `error_type="missing_required_args"`, so they are **not** counted as failures by loop guardrails.
- **`config_defaults.py` / `agent/tool_guardrails.py`** — `pre_tool_validation` (default `true`) and `conditional_required` (overridable; falls back to defaults when absent) under `tool_loop_guardrails`. No new env vars; no change to the tool schemas sent to the model.

Boundary choice: a missing key or explicit `None` is treated as missing; an empty string is not (e.g. `skill_manage patch new_string=""` legitimately deletes matched text).

## Testing

- `tests/hermes_cli/test_required_arg_validation.py` — 15 tests: unit coverage of both check paths (schema `required` + conditional rules), valid calls return `None`, unrelated tools not flagged, empty-string-vs-`None` boundary, plus E2E via `handle_function_call` with a temp `HERMES_HOME` (block before execution/edit-approval, `post_tool_call` observed with `status="blocked"`, plugin `modify` can still supply the missing arg, config disable works).
- Existing tests: `tests/test_model_tools.py`, `tests/agent/test_tool_guardrails.py`, `tests/run_agent/test_tool_call_guardrail_runtime.py` — 56 passed. One stale mock in `tests/test_model_tools.py` was corrected (`{"q": ...}` → `{"query": ...}` — `web_search` requires `query`).

## Related

- Closes #93464 (this feature).
- #84601 is complementary: it covers aggregate failure counting across sibling tools; this is pre-execution argument validation.
- Design signals: the failure-counting/cooldown layers are inspired by Gemini CLI's `LoopDetectionService` (TOOL_CALL_LOOP_THRESHOLD / alternating-cycle detection); the required-argument pre-flight layer is an angle we haven't seen in other agents.

## Out of scope

- Failure counting/halting (covered by #84601 and existing `same_tool_failure_halt_after`).
- Making every tool schema strict.