### PR TITLE
hermes sessions usage: per-session token/cost drill-down + insights --json (Amp Explain Usage port)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12452,6 +12452,7 @@ def cmd_tools(args):
 
 
 def cmd_insights(args):
+    as_json = bool(getattr(args, "json", False))
     db = None
     try:
         from hermes_state import SessionDB
@@ -12460,9 +12461,21 @@ def cmd_insights(args):
         db = SessionDB()
         engine = InsightsEngine(db)
         report = engine.generate(days=args.days, source=args.source)
-        print(engine.format_terminal(report))
+        if as_json:
+            import json as _json
+
+            # default=str covers any non-JSON-native values (Decimal,
+            # datetime) that slip into computed breakdowns.
+            print(_json.dumps(report, indent=2, ensure_ascii=False, default=str))
+        else:
+            print(engine.format_terminal(report))
     except Exception as e:
-        print(f"Error generating insights: {e}")
+        if as_json:
+            import json as _json
+
+            print(_json.dumps({"error": str(e)}))
+        else:
+            print(f"Error generating insights: {e}")
     finally:
         if db is not None:
             try:
@@ -13933,6 +13946,22 @@ def main():
     )
 
     sessions_subparsers.add_parser("stats", help="Show session store statistics")
+
+    sessions_usage = sessions_subparsers.add_parser(
+        "usage",
+        help="Show token/cost usage for one session, with per-model breakdown",
+        description="Display token counts, API/tool call counts, cost, and a "
+        "per-model route breakdown for a single session. Accepts a full "
+        "session ID or unique prefix.",
+    )
+    sessions_usage.add_argument(
+        "session_id", help="Session ID (or unique prefix) to inspect"
+    )
+    sessions_usage.add_argument(
+        "--json",
+        action="store_true",
+        help="Output usage data as machine-readable JSON",
+    )
 
     sessions_rename = sessions_subparsers.add_parser(
         "rename", help="Set or change a session's title"

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -1435,6 +1435,131 @@ def cmd_sessions(args, sessions_parser=None):
             else:
                 print("Aborted — nothing was changed.")
 
+    elif action == "usage":
+        resolved_session_id = db.resolve_session_id(args.session_id)
+        if not resolved_session_id:
+            print(f"Session not found: {args.session_id}")
+            db.close()
+            return
+        session = db.get_session(resolved_session_id)
+
+        with db._lock:
+            usage_rows = db._conn.execute(
+                """SELECT model, billing_provider, billing_mode, task,
+                          api_call_count, input_tokens, output_tokens,
+                          cache_read_tokens, cache_write_tokens, reasoning_tokens,
+                          estimated_cost_usd, actual_cost_usd, cost_status
+                     FROM session_model_usage
+                    WHERE session_id = ?
+                    ORDER BY (input_tokens + output_tokens + cache_read_tokens +
+                              cache_write_tokens + reasoning_tokens) DESC""",
+                (resolved_session_id,),
+            ).fetchall()
+
+        def _num(v):
+            return v or 0
+
+        breakdown = []
+        for r in usage_rows:
+            r = dict(r)
+            breakdown.append(
+                {
+                    "model": r["model"],
+                    "provider": r["billing_provider"] or None,
+                    "billing_mode": r["billing_mode"] or None,
+                    "task": r["task"] or "main",
+                    "api_calls": _num(r["api_call_count"]),
+                    "input_tokens": _num(r["input_tokens"]),
+                    "output_tokens": _num(r["output_tokens"]),
+                    "cache_read_tokens": _num(r["cache_read_tokens"]),
+                    "cache_write_tokens": _num(r["cache_write_tokens"]),
+                    "reasoning_tokens": _num(r["reasoning_tokens"]),
+                    "estimated_cost_usd": r["estimated_cost_usd"],
+                    "actual_cost_usd": r["actual_cost_usd"],
+                    "cost_status": r["cost_status"] or None,
+                }
+            )
+
+        totals = {
+            "input_tokens": _num(session.get("input_tokens")),
+            "output_tokens": _num(session.get("output_tokens")),
+            "cache_read_tokens": _num(session.get("cache_read_tokens")),
+            "cache_write_tokens": _num(session.get("cache_write_tokens")),
+            "reasoning_tokens": _num(session.get("reasoning_tokens")),
+            "api_calls": _num(session.get("api_call_count")),
+            "tool_calls": _num(session.get("tool_call_count")),
+            "estimated_cost_usd": session.get("estimated_cost_usd"),
+            "actual_cost_usd": session.get("actual_cost_usd"),
+            "cost_status": session.get("cost_status") or None,
+        }
+        totals["total_tokens"] = (
+            totals["input_tokens"]
+            + totals["output_tokens"]
+            + totals["cache_read_tokens"]
+            + totals["cache_write_tokens"]
+        )
+
+        if getattr(args, "json", False):
+            print(
+                _json.dumps(
+                    {
+                        "session_id": resolved_session_id,
+                        "title": session.get("title"),
+                        "source": session.get("source"),
+                        "model": session.get("model"),
+                        "provider": session.get("billing_provider") or None,
+                        "started_at": session.get("started_at"),
+                        "totals": totals,
+                        "by_model": breakdown,
+                    },
+                    indent=2,
+                    ensure_ascii=False,
+                    default=str,
+                )
+            )
+        else:
+            title = session.get("title") or "(untitled)"
+            print(f"\nSession {resolved_session_id[:12]} — {title}")
+            print(f"  Model:        {session.get('model') or 'unknown'}")
+            if session.get("billing_provider"):
+                print(f"  Provider:     {session['billing_provider']}")
+            print(f"  Input:        {totals['input_tokens']:,}")
+            if totals["cache_read_tokens"]:
+                print(f"  Cache read:   {totals['cache_read_tokens']:,}")
+            if totals["cache_write_tokens"]:
+                print(f"  Cache write:  {totals['cache_write_tokens']:,}")
+            print(f"  Output:       {totals['output_tokens']:,}")
+            if totals["reasoning_tokens"]:
+                print(f"  Reasoning:    {totals['reasoning_tokens']:,}")
+            print(f"  Total:        {totals['total_tokens']:,}")
+            print(f"  API calls:    {totals['api_calls']:,}")
+            print(f"  Tool calls:   {totals['tool_calls']:,}")
+            cost = totals["actual_cost_usd"] or totals["estimated_cost_usd"]
+            if cost:
+                prefix = "" if totals["actual_cost_usd"] else "~"
+                print(f"  Cost:         {prefix}${float(cost):.4f}")
+            if breakdown:
+                print("\n  Per-route breakdown:")
+                for b in breakdown:
+                    btotal = (
+                        b["input_tokens"]
+                        + b["output_tokens"]
+                        + b["cache_read_tokens"]
+                        + b["cache_write_tokens"]
+                    )
+                    bcost = b["actual_cost_usd"] or b["estimated_cost_usd"]
+                    cost_str = ""
+                    if bcost:
+                        bprefix = "" if b["actual_cost_usd"] else "~"
+                        cost_str = f", {bprefix}${float(bcost):.4f}"
+                    task = f" [{b['task']}]" if b["task"] != "main" else ""
+                    provider = f" via {b['provider']}" if b["provider"] else ""
+                    print(
+                        f"    {b['model']}{provider}{task}: "
+                        f"{btotal:,} tokens, {b['api_calls']} calls{cost_str}"
+                    )
+            print()
+
     elif action == "stats":
         total = db.session_count()
         msgs = db.message_count()

--- a/hermes_cli/subcommands/insights.py
+++ b/hermes_cli/subcommands/insights.py
@@ -22,4 +22,9 @@ def build_insights_parser(subparsers, *, cmd_insights: Callable) -> None:
     insights_parser.add_argument(
         "--source", help="Filter by platform (cli, telegram, discord, etc.)"
     )
+    insights_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output the full insights report as machine-readable JSON",
+    )
     insights_parser.set_defaults(func=cmd_insights)

--- a/tests/hermes_cli/test_insights_json_flag.py
+++ b/tests/hermes_cli/test_insights_json_flag.py
@@ -1,0 +1,67 @@
+"""Tests for `hermes insights --json` (machine-readable insights report)."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _args(**kw):
+    base = {"days": 7, "source": None, "json": True}
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def test_insights_json_outputs_report(capsys):
+    from hermes_cli.main import cmd_insights
+
+    report = {
+        "days": 7,
+        "source_filter": None,
+        "empty": True,
+        "overview": {},
+        "models": [],
+        "platforms": [],
+        "tools": [],
+        "skills": {"summary": {}, "top_skills": []},
+        "activity": {},
+        "top_sessions": [],
+    }
+    with (
+        patch("hermes_state.SessionDB") as mock_db,
+        patch("agent.insights.InsightsEngine") as mock_engine,
+    ):
+        mock_engine.return_value.generate.return_value = report
+        mock_db.return_value = MagicMock()
+        cmd_insights(_args())
+
+    data = json.loads(capsys.readouterr().out)
+    assert data["days"] == 7
+    assert data["empty"] is True
+    # format_terminal must not have been used
+    mock_engine.return_value.format_terminal.assert_not_called()
+
+
+def test_insights_json_error_is_json(capsys):
+    from hermes_cli.main import cmd_insights
+
+    with patch("hermes_state.SessionDB", side_effect=RuntimeError("boom")):
+        cmd_insights(_args())
+
+    data = json.loads(capsys.readouterr().out)
+    assert "boom" in data["error"]
+
+
+def test_insights_text_path_unchanged(capsys):
+    from hermes_cli.main import cmd_insights
+
+    with (
+        patch("hermes_state.SessionDB") as mock_db,
+        patch("agent.insights.InsightsEngine") as mock_engine,
+    ):
+        mock_engine.return_value.generate.return_value = {"empty": True}
+        mock_engine.return_value.format_terminal.return_value = "TERMINAL-REPORT"
+        mock_db.return_value = MagicMock()
+        cmd_insights(_args(json=False))
+
+    out = capsys.readouterr().out
+    assert "TERMINAL-REPORT" in out

--- a/tests/hermes_cli/test_sessions_usage_cmd.py
+++ b/tests/hermes_cli/test_sessions_usage_cmd.py
@@ -1,0 +1,83 @@
+"""Tests for `hermes sessions usage <id>` (per-session usage breakdown).
+
+Inspired by Amp's `amp threads usage <thread-id> --details` (Explain Usage,
+Aug 2026): a per-thread token/cost drill-down with machine-readable output.
+"""
+
+import json
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.sessions_cmd import cmd_sessions
+
+
+@pytest.fixture()
+def seeded_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import hermes_state
+
+    db = hermes_state.SessionDB(db_path=tmp_path / "state.db")
+    sid = "usagetest-0123456789abcdef"
+    db._conn.execute(
+        "INSERT INTO sessions (id, source, started_at) VALUES (?, 'cli', ?)",
+        (sid, time.time()),
+    )
+    db._conn.commit()
+    db.update_token_counts(
+        sid,
+        input_tokens=1000,
+        output_tokens=250,
+        cache_read_tokens=400,
+        cache_write_tokens=50,
+        reasoning_tokens=30,
+        model="test/model-x",
+        billing_provider="openrouter",
+        billing_base_url="https://openrouter.ai/api/v1",
+    )
+    db.flush_token_counts()
+    db.close()
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    orig = hermes_state.SessionDB
+
+    def _open(*a, **k):
+        k.setdefault("db_path", tmp_path / "state.db")
+        return orig(*a, **k)
+
+    monkeypatch.setattr(hermes_state, "SessionDB", _open)
+    return sid
+
+
+def _args(session_id, as_json=False):
+    return SimpleNamespace(sessions_action="usage", session_id=session_id, json=as_json)
+
+
+def test_usage_text_output(seeded_db, capsys):
+    cmd_sessions(_args("usagetest"))
+    out = capsys.readouterr().out
+    assert "test/model-x" in out
+    assert "1,000" in out  # input tokens
+    assert "1,700" in out  # total tokens
+    assert "Per-route breakdown" in out
+    assert "openrouter" in out
+
+
+def test_usage_json_output(seeded_db, capsys):
+    cmd_sessions(_args("usagetest", as_json=True))
+    data = json.loads(capsys.readouterr().out)
+    assert data["session_id"] == seeded_db
+    assert data["totals"]["input_tokens"] == 1000
+    assert data["totals"]["total_tokens"] == 1700
+    assert data["totals"]["reasoning_tokens"] == 30
+    assert len(data["by_model"]) == 1
+    route = data["by_model"][0]
+    assert route["model"] == "test/model-x"
+    assert route["provider"] == "openrouter"
+
+
+def test_usage_session_not_found(seeded_db, capsys):
+    cmd_sessions(_args("does-not-exist"))
+    out = capsys.readouterr().out
+    assert "Session not found" in out

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1532,6 +1532,7 @@ Subcommands:
 | `prune` | Delete sessions matching filters: time bounds `--older-than`/`--newer-than`/`--before`/`--after` (durations like `5h`/`2d`, bare days, or ISO timestamps); attributes `--source`, `--title`, `--model`, `--provider`, `--branch`, `--end-reason`, `--user`, `--chat-id`, `--chat-type`, `--cwd`; numeric bounds `--min/--max-messages`, `--min/--max-tokens`, `--min/--max-cost`, `--min/--max-tool-calls`; plus `--include-archived`, `--dry-run`, `--yes`. Default: older than 90 days. |
 | `archive` | Bulk-archive (soft-hide, no deletion) sessions matching the same filters as `prune`. Requires at least one filter. |
 | `stats` | Show session-store statistics. |
+| `usage <session-id> [--json]` | Show token/cost usage for one session — totals plus a per-model route breakdown (main loop, auxiliary tasks, delegation routes). Accepts a unique ID prefix. `--json` emits a machine-readable report. |
 | `rename <session-id> <title>` | Set or change a session title. |
 | `optimize` | Reclaim disk space: merge FTS5 index segments + VACUUM. Non-destructive — no session data changes. |
 | `optimize-storage` | Migrate the full-text search index to the compact v23 external-content layout; on large databases this reclaims a large fraction of `state.db`. |
@@ -1543,13 +1544,14 @@ Subcommands:
 ## `hermes insights`
 
 ```bash
-hermes insights [--days N] [--source platform]
+hermes insights [--days N] [--source platform] [--json]
 ```
 
 | Option | Description |
 |--------|-------------|
 | `--days <n>` | Analyze the last `n` days (default: 30). |
 | `--source <platform>` | Filter by source such as `cli`, `telegram`, or `discord`. |
+| `--json` | Output the full insights report as machine-readable JSON. |
 
 ## `hermes claw`
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/cli-commands.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/cli-commands.md
@@ -1075,18 +1075,20 @@ hermes sessions <subcommand>
 | `delete <session-id>` | 删除单个会话。 |
 | `prune` | 删除旧会话。 |
 | `stats` | 显示会话存储统计信息。 |
+| `usage <session-id> [--json]` | 显示单个会话的令牌/费用使用情况 — 总计及按模型路由的明细（主循环、辅助任务、委派路由）。接受唯一的 ID 前缀。`--json` 输出机器可读报告。 |
 | `rename <session-id> <title>` | 设置或更改会话标题。 |
 
 ## `hermes insights`
 
 ```bash
-hermes insights [--days N] [--source platform]
+hermes insights [--days N] [--source platform] [--json]
 ```
 
 | 选项 | 说明 |
 |--------|-------------|
 | `--days <n>` | 分析最近 `n` 天（默认：30）。 |
 | `--source <platform>` | 按来源过滤，如 `cli`、`telegram` 或 `discord`。 |
+| `--json` | 以机器可读的 JSON 格式输出完整的分析报告。 |
 
 ## `hermes claw`
 


### PR DESCRIPTION
## Summary
`hermes sessions usage <id>` gives a per-session token/cost drill-down (with per-model route breakdown), and `hermes insights --json` makes the analytics report machine-readable — so both users and the agent itself can answer "where did my tokens go?" without spelunking state.db.

Weekly Amp feature scout port: Amp shipped **Explain Usage** (Aug 21 2026, https://ampcode.com/news/explain-usage) — `amp usage --details`, `amp threads usage <thread-id> --details`, and a meta-agent (Puck) that reads that data to answer usage questions in natural language. Hermes had aggregate analytics (`hermes insights`), live-session `/usage`, and desktop surfaces in flight, but **no per-session drill-down from the CLI and no machine-readable output** for either — which also blocks the "agent reads its own usage" pattern, since the agent can only parse JSON reliably.

## Their mechanism vs ours
- **Amp:** `amp threads usage <id> --details` + Puck reading personal/per-thread usage APIs.
- **Hermes (this PR):** `hermes sessions usage <id> [--json]` reads the `sessions` aggregate row plus the `session_model_usage` per-route table (main loop vs auxiliary tasks vs delegation routes) — data we already record but never exposed per-session. `hermes insights --json` dumps the existing `InsightsEngine.generate()` report verbatim. Zero new model tools (terminal + skill pattern per AGENTS.md footprint ladder); the agent can run these via the terminal tool today.

## Changes
- `hermes_cli/sessions_cmd.py`: new `usage` action — totals (input/output/cache/reasoning tokens, API + tool calls, actual-or-estimated cost) and per-model route breakdown; accepts unique ID prefixes; `--json` for machine-readable output.
- `hermes_cli/main.py`: `sessions usage` subparser; `cmd_insights` honors `--json` (errors also emitted as JSON in JSON mode).
- `hermes_cli/subcommands/insights.py`: `--json` flag.
- Docs: `website/docs/reference/cli-commands.md` + zh-Hans mirror.
- Tests: `tests/hermes_cli/test_sessions_usage_cmd.py` (real SessionDB in temp HERMES_HOME), `tests/hermes_cli/test_insights_json_flag.py`.

## Validation
| Check | Result |
|---|---|
| E2E: seeded temp-HOME session → `sessions usage` text + `--json` (totals, breakdown, prefix resolution, not-found) | pass |
| E2E: `insights --json` parses; text path unchanged | pass |
| `pytest tests/hermes_cli/test_sessions_usage_cmd.py tests/hermes_cli/test_insights_json_flag.py` | 6 passed |
| `pytest tests/agent/test_insights.py` + sibling sessions-cmd tests | 53 passed |
| ruff check + format | clean |

## Infographic

![Where did my tokens go — hermes sessions usage + insights --json](https://v3b.fal.media/files/b/0aa79241/Ufd8Y9tX4k_FcTzjg4Vw9_yv3Y7fQs.png)
