### PR TITLE
fix: keep MCP tool errors out of circuit breaker

### DIFF
--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -170,6 +170,52 @@ def test_circuit_breaker_half_opens_after_cooldown(monkeypatch, tmp_path):
         _cleanup(mcp_tool, "srv")
 
 
+def test_application_tool_errors_do_not_trip_server_breaker(monkeypatch, tmp_path):
+    """CallToolResult(isError=True) is an application failure, not transport loss.
+
+    A server may reject an invalid allowlist target while remaining fully
+    reachable. Repeating such validation errors must not park every tool on the
+    server behind the transport circuit breaker.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    call_count = {"n": 0}
+
+    async def _call_tool_validation_error(*a, **kw):
+        call_count["n"] += 1
+        result = MagicMock()
+        result.is_error = True
+        block = MagicMock()
+        block.text = "Application is not allowlisted"
+        result.content = [block]
+        return result
+
+    _install_stub_server(mcp_tool, "srv", _call_tool_validation_error)
+    mcp_tool._ensure_mcp_loop()
+
+    try:
+        # Start one strike below the open threshold. The first completed RPC
+        # must clear the stale transport strike even though the tool rejects
+        # its arguments.
+        mcp_tool._server_error_counts["srv"] = (
+            mcp_tool._CIRCUIT_BREAKER_THRESHOLD - 1
+        )
+        handler = _make_tool_handler("srv", "app_health", 10.0)
+
+        for _ in range(4):
+            parsed = json.loads(handler({"app": "invalid"}))
+            assert "Application is not allowlisted" in parsed.get("error", "")
+            assert "unreachable" not in parsed.get("error", "").lower()
+
+        assert call_count["n"] == 4
+        assert mcp_tool._server_error_counts.get("srv", 0) == 0
+    finally:
+        _cleanup(mcp_tool, "srv")
+
+
 def test_circuit_breaker_reopens_on_probe_failure(monkeypatch, tmp_path):
     """If the half-open probe fails, the breaker must re-arm the
     cooldown (not let every subsequent call through).

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5965,15 +5965,14 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
 
         try:
             result = _call_once()
-            # Check if the MCP tool itself returned an error
-            try:
-                parsed = json.loads(result)
-                if "error" in parsed:
-                    _bump_server_error(server_name)
-                else:
-                    _reset_server_error(server_name)  # success — reset
-            except (json.JSONDecodeError, TypeError):
-                _reset_server_error(server_name)  # non-JSON = success
+            # A completed tools/call round-trip proves the MCP transport is
+            # healthy, even when the server returns CallToolResult(isError=True)
+            # for an application-level validation failure. Do not let benign
+            # tool errors (invalid allowlist target, bad query, etc.) trip the
+            # server circuit breaker and hide every other tool on that server.
+            # Transport/session exceptions still reach the except path below
+            # and increment the breaker as intended.
+            _reset_server_error(server_name)
             return result
         except InterruptedError:
             return _interrupted_call_result()


### PR DESCRIPTION
## Summary
- treat completed `tools/call` RPCs as transport success even when the MCP tool returns `isError`
- keep application validation failures from parking every tool on an otherwise healthy MCP server
- preserve circuit-breaker strikes for real transport/session exceptions
- add regression coverage that repeats an allowlist validation error above the breaker threshold

## Verification
- `145 passed` across MCP handler, circuit-breaker, reconnect, resource, session-expiry, and trust-gating tests
- `ruff check tools/mcp_tool.py tests/tools/test_mcp_circuit_breaker.py`
- `git diff --check`

## Reproduction
A healthy MCP broker returned `CallToolResult(isError=True)` for an invalid application allowlist target. The existing outer handler converted that application error into a server breaker strike; after three invalid calls Hermes reported the entire broker as unreachable for the cooldown period.