### PR TITLE
feat(desktop): HUD game-overlay mode

### DIFF
--- a/apps/desktop/electron/hud-game-overlay.test.ts
+++ b/apps/desktop/electron/hud-game-overlay.test.ts
@@ -1,0 +1,307 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  coversDisplay,
+  detectFullscreenApp,
+  findFullscreenAppAnywhere,
+  gameOverlayStateFor,
+  INACTIVE_GAME_OVERLAY,
+  isShellWindow,
+  startHudGameOverlayWatch
+} from './hud-game-overlay'
+import type { GameOverlayState } from './hud-game-overlay'
+import type { EnumeratedWindow } from './window-below'
+
+const DISPLAY = { x: 0, y: 0, width: 2560, height: 1440 }
+const SELF_PID = 4242
+
+const win = (over: Partial<EnumeratedWindow>): EnumeratedWindow => ({
+  app: 'App',
+  bounds: { x: 0, y: 0, width: 100, height: 100 },
+  id: 1,
+  pid: 1000,
+  title: '',
+  ...over
+})
+
+const fullscreenGame = win({ app: 'Balatro', bounds: { ...DISPLAY }, id: 7, pid: 2000 })
+const hudWindow = win({ app: 'Hermes', bounds: { x: 970, y: 1048, width: 620, height: 320 }, id: 2, pid: SELF_PID })
+const desktopShell = win({ app: 'Windows Explorer', bounds: { ...DISPLAY }, id: 3, pid: 900 })
+
+// ─── coversDisplay ───────────────────────────────────────────────────────
+
+test('display-sized bounds cover the display', () => {
+  assert.equal(coversDisplay({ ...DISPLAY }, DISPLAY), true)
+})
+
+test('DPI rounding and the 1px-oversize trick stay within the epsilon', () => {
+  assert.equal(coversDisplay({ x: -1, y: -1, width: 2562, height: 1442 }, DISPLAY), true)
+  assert.equal(coversDisplay({ x: 1, y: 1, width: 2558, height: 1438 }, DISPLAY), true)
+})
+
+test('a maximized window stopping at the taskbar does not cover', () => {
+  assert.equal(coversDisplay({ x: 0, y: 0, width: 2560, height: 1392 }, DISPLAY), false)
+})
+
+test('a fullscreen window on ANOTHER display does not cover this one', () => {
+  assert.equal(coversDisplay({ x: 2560, y: 0, width: 2560, height: 1440 }, DISPLAY), false)
+})
+
+// ─── isShellWindow ───────────────────────────────────────────────────────
+
+test('desktop shells are recognized, real apps are not', () => {
+  for (const app of ['Windows Explorer', 'explorer.exe', 'Program Manager', 'Finder', 'Dock', 'gnome-shell']) {
+    assert.equal(isShellWindow(app), true, app)
+  }
+
+  for (const app of ['Balatro', 'Explorer of the Deep', 'Firefox', '']) {
+    assert.equal(isShellWindow(app), false, app)
+  }
+})
+
+// ─── detectFullscreenApp ─────────────────────────────────────────────────
+
+test('fullscreen game under the HUD is detected', () => {
+  const found = detectFullscreenApp([hudWindow, fullscreenGame, desktopShell], SELF_PID, DISPLAY)
+
+  assert.equal(found?.app, 'Balatro')
+})
+
+test('own windows never count, wherever they sit in the z-order', () => {
+  const selfFullscreen = win({ app: 'Hermes', bounds: { ...DISPLAY }, pid: SELF_PID })
+
+  assert.equal(detectFullscreenApp([selfFullscreen, desktopShell], SELF_PID, DISPLAY), null)
+})
+
+test('the desktop shell reporting display bounds is not a game', () => {
+  assert.equal(detectFullscreenApp([hudWindow, desktopShell], SELF_PID, DISPLAY), null)
+})
+
+test('a windowed app in FRONT of the game vetoes the overlay', () => {
+  const editor = win({ app: 'VS Code', bounds: { x: 200, y: 100, width: 1400, height: 900 }, id: 9, pid: 3000 })
+
+  assert.equal(detectFullscreenApp([hudWindow, editor, fullscreenGame], SELF_PID, DISPLAY), null)
+})
+
+test('zero-area rows (minimized) neither decide nor veto', () => {
+  const minimized = win({ app: 'Spotify', bounds: { x: 0, y: 0, width: 0, height: 0 }, id: 11, pid: 3100 })
+
+  assert.equal(detectFullscreenApp([minimized, fullscreenGame], SELF_PID, DISPLAY)?.app, 'Balatro')
+})
+
+test('a window intersecting only another display does not veto', () => {
+  const otherDisplayWin = win({ app: 'Slack', bounds: { x: 3000, y: 0, width: 800, height: 600 }, id: 12, pid: 3200 })
+
+  assert.equal(detectFullscreenApp([otherDisplayWin, fullscreenGame], SELF_PID, DISPLAY)?.app, 'Balatro')
+})
+
+test('empty desktop: nothing to detect', () => {
+  assert.equal(detectFullscreenApp([hudWindow], SELF_PID, DISPLAY), null)
+})
+
+test('gameOverlayStateFor maps detection to the pushed state shape', () => {
+  assert.deepEqual(gameOverlayStateFor([fullscreenGame], SELF_PID, DISPLAY), { active: true, app: 'Balatro' })
+  assert.deepEqual(gameOverlayStateFor([hudWindow], SELF_PID, DISPLAY), INACTIVE_GAME_OVERLAY)
+})
+
+// ─── hysteresis: enter strictly, stay while the game is still there ──────
+
+test('a windowed app on top vetoes ENTERING but not STAYING', () => {
+  // Clicking the HUD to type de-foregrounds the game and floats every other
+  // open window above it. Entering must respect that veto; staying must not,
+  // or the treatment drops the moment the user engages with it.
+  const editor = win({ app: 'VS Code', bounds: { x: 200, y: 100, width: 1400, height: 900 }, id: 9, pid: 3000 })
+  const stack = [editor, fullscreenGame]
+
+  assert.deepEqual(gameOverlayStateFor(stack, SELF_PID, DISPLAY, false), INACTIVE_GAME_OVERLAY)
+  assert.deepEqual(gameOverlayStateFor(stack, SELF_PID, DISPLAY, true), { active: true, app: 'Balatro' })
+})
+
+test('the game actually closing ends overlay mode even when it was active', () => {
+  assert.deepEqual(gameOverlayStateFor([hudWindow, desktopShell], SELF_PID, DISPLAY, true), INACTIVE_GAME_OVERLAY)
+})
+
+test('findFullscreenAppAnywhere ignores z-order but keeps every other guard', () => {
+  const selfFullscreen = win({ app: 'Hermes', bounds: { ...DISPLAY }, pid: SELF_PID })
+
+  assert.equal(findFullscreenAppAnywhere([selfFullscreen], SELF_PID, DISPLAY), null)
+  assert.equal(findFullscreenAppAnywhere([desktopShell], SELF_PID, DISPLAY), null)
+  assert.equal(findFullscreenAppAnywhere([hudWindow, fullscreenGame], SELF_PID, DISPLAY)?.app, 'Balatro')
+})
+
+// ─── startHudGameOverlayWatch ────────────────────────────────────────────
+
+interface FakeClock {
+  fire: () => Promise<void>
+  cleared: () => boolean
+  setIntervalFn: typeof setInterval
+  clearIntervalFn: typeof clearInterval
+}
+
+const fakeClock = (): FakeClock => {
+  let handler: (() => void) | null = null
+  let cleared = false
+
+  return {
+    fire: async () => {
+      handler?.()
+      // The tick is async; let its microtasks drain.
+      await Promise.resolve()
+      await Promise.resolve()
+    },
+    cleared: () => cleared,
+    setIntervalFn: ((fn: () => void) => {
+      handler = fn
+
+      return 1 as unknown as ReturnType<typeof setInterval>
+    }) as typeof setInterval,
+    clearIntervalFn: (() => {
+      cleared = true
+    }) as typeof clearInterval
+  }
+}
+
+const flush = async () => {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+test('watch pushes on change only, never on a repeat answer', async () => {
+  const clock = fakeClock()
+  const pushed: Array<{ active: boolean; app: string }> = []
+  let windows: EnumeratedWindow[] = [hudWindow]
+
+  const dispose = startHudGameOverlayWatch({
+    enumerate: () => Promise.resolve(windows),
+    displayBounds: () => DISPLAY,
+    selfPid: SELF_PID,
+    send: state => pushed.push(state),
+    setIntervalFn: clock.setIntervalFn,
+    clearIntervalFn: clock.clearIntervalFn
+  })
+
+  await flush() // the immediate first tick
+  assert.deepEqual(pushed, [{ active: false, app: '' }])
+
+  await clock.fire() // same answer — no push
+  assert.equal(pushed.length, 1)
+
+  windows = [fullscreenGame]
+  await clock.fire()
+  assert.deepEqual(pushed[1], { active: true, app: 'Balatro' })
+
+  windows = [hudWindow]
+  await clock.fire()
+  assert.deepEqual(pushed[2], { active: false, app: '' })
+
+  dispose()
+  assert.equal(clock.cleared(), true)
+})
+
+test('watch settles inactive and stops after repeated enumeration failures', async () => {
+  const clock = fakeClock()
+  const pushed: Array<{ active: boolean }> = []
+
+  startHudGameOverlayWatch({
+    enumerate: () => Promise.resolve(null),
+    displayBounds: () => DISPLAY,
+    selfPid: SELF_PID,
+    send: state => pushed.push(state),
+    setIntervalFn: clock.setIntervalFn,
+    clearIntervalFn: clock.clearIntervalFn
+  })
+
+  await flush() // failure 1 — no conclusion yet
+  assert.equal(pushed.length, 0)
+  assert.equal(clock.cleared(), false)
+
+  await clock.fire() // failure 2 — settle and stop
+  assert.deepEqual(pushed, [{ active: false, app: '' }])
+  assert.equal(clock.cleared(), true)
+})
+
+test('a single transient failure does not give up the watch', async () => {
+  const clock = fakeClock()
+  const pushed: Array<{ active: boolean }> = []
+  let fail = true
+
+  startHudGameOverlayWatch({
+    enumerate: () => (fail ? Promise.resolve(null) : Promise.resolve([fullscreenGame])),
+    displayBounds: () => DISPLAY,
+    selfPid: SELF_PID,
+    send: state => pushed.push(state),
+    setIntervalFn: clock.setIntervalFn,
+    clearIntervalFn: clock.clearIntervalFn
+  })
+
+  await flush() // failure 1
+  fail = false
+  await clock.fire() // recovers
+
+  assert.deepEqual(pushed, [{ active: true, app: 'Balatro' }])
+  assert.equal(clock.cleared(), false)
+
+  // …and the failure counter reset: one more null is a transient again.
+  fail = true
+  await clock.fire()
+  assert.equal(clock.cleared(), false)
+})
+
+test('disposed watch stops pushing even with a tick in flight', async () => {
+  const clock = fakeClock()
+  const pushed: unknown[] = []
+
+  let release: (v: EnumeratedWindow[]) => void = () => {}
+
+  const dispose = startHudGameOverlayWatch({
+    enumerate: () =>
+      new Promise<EnumeratedWindow[]>(resolve => {
+        release = resolve
+      }),
+    displayBounds: () => DISPLAY,
+    selfPid: SELF_PID,
+    send: state => pushed.push(state),
+    setIntervalFn: clock.setIntervalFn,
+    clearIntervalFn: clock.clearIntervalFn
+  })
+
+  dispose()
+  release([fullscreenGame])
+  await flush()
+
+  assert.equal(pushed.length, 0)
+})
+
+test('the watch carries its own last answer into the next tick', async () => {
+  // The hysteresis is only correct if `wasActive` comes from what was last
+  // PUBLISHED; a watch that always passed false would re-veto every tick.
+  const clock = fakeClock()
+  const pushed: GameOverlayState[] = []
+  const editor = win({ app: 'VS Code', bounds: { x: 200, y: 100, width: 1400, height: 900 }, id: 9, pid: 3000 })
+  let windows: EnumeratedWindow[] = [fullscreenGame]
+
+  startHudGameOverlayWatch({
+    enumerate: () => Promise.resolve(windows),
+    displayBounds: () => DISPLAY,
+    selfPid: SELF_PID,
+    send: state => pushed.push(state),
+    setIntervalFn: clock.setIntervalFn,
+    clearIntervalFn: clock.clearIntervalFn
+  })
+
+  await flush()
+  assert.deepEqual(pushed, [{ active: true, app: 'Balatro' }])
+
+  // The user clicks the HUD: the editor is now above the game. Still active, so
+  // nothing new is published.
+  windows = [editor, fullscreenGame]
+  await clock.fire()
+  assert.equal(pushed.length, 1)
+
+  // The game closes for real.
+  windows = [editor]
+  await clock.fire()
+  assert.deepEqual(pushed[1], INACTIVE_GAME_OVERLAY)
+})

--- a/apps/desktop/electron/hud-game-overlay.ts
+++ b/apps/desktop/electron/hud-game-overlay.ts
@@ -1,0 +1,261 @@
+// hud-game-overlay.ts — is the HUD floating over a fullscreen app (a game)?
+//
+// Discord's in-game overlay behavior: while a fullscreen app owns the screen
+// the HUD steps back to a low-opacity, glanceable state, and steps forward
+// again when the user engages it or a reply lands. The DECISION lives here as
+// pure functions over the same front-to-back enumeration `window-below.ts`
+// uses; main polls while the HUD is open and pushes changes to the HUD
+// renderer, which owns the visual treatment (see `data-hud-game` in
+// styles.css).
+//
+// "Fullscreen app" means: the frontmost other-process window on the HUD's
+// display covers that display edge-to-edge. Walking the z-order front-to-back
+// mirrors how the screen actually reads — if something windowed sits on top of
+// the game, the game is not what the HUD is floating over.
+//
+// A note on what this can and cannot float over, so nobody debugs the wrong
+// layer: an always-on-top window covers BORDERLESS fullscreen (the default in
+// most modern games) and macOS fullscreen Spaces. True exclusive-fullscreen
+// bypasses the compositor entirely — nothing short of injecting into the
+// game's render pipeline (what Discord's native overlay does) draws over it.
+// Detection still works there; the HUD is simply behind until the user
+// alt-tabs, which Windows answers by flipping the game to composited output.
+
+import type { EnumeratedWindow } from './window-below'
+
+export interface GameOverlayState {
+  active: boolean
+  /** The fullscreen app's name while active, '' otherwise — the renderer may
+   *  surface it ("over Balatro") and the diff key needs it either way. */
+  app: string
+}
+
+export const INACTIVE_GAME_OVERLAY: GameOverlayState = { active: false, app: '' }
+
+interface Bounds {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+/** Allowance for DPI rounding and the 1px oversize some engines use to dodge
+ *  the OS's own "looks fullscreen" heuristics. */
+const COVER_EPSILON_PX = 2
+
+/**
+ * Desktop-shell windows that legitimately report display-sized bounds and must
+ * never read as a game: the Windows desktop (Progman/WorkerW both belong to
+ * Explorer), the macOS Dock/desktop layers. Matched on the OWNER name — titles
+ * are localized, unavailable without permissions on macOS, and empty for most
+ * of these anyway.
+ */
+const SHELL_APPS = [
+  /^windows explorer$/i,
+  /^explorer(\.exe)?$/i,
+  /^program manager$/i,
+  /^finder$/i,
+  /^dock$/i,
+  /^window ?server$/i,
+  /^windowmanager$/i,
+  /^gnome-shell$/i,
+  /^plasmashell$/i
+]
+
+export const isShellWindow = (app: string): boolean => SHELL_APPS.some(pattern => pattern.test(app.trim()))
+
+/** Whether `bounds` covers `display` edge-to-edge (within the DPI epsilon).
+ *  Work-area coverage is deliberately not enough: a maximized window stops at
+ *  the taskbar/menu bar, a fullscreen one does not — that IS the distinction. */
+export const coversDisplay = (bounds: Bounds, display: Bounds, epsilon: number = COVER_EPSILON_PX): boolean =>
+  bounds.x <= display.x + epsilon &&
+  bounds.y <= display.y + epsilon &&
+  bounds.x + bounds.width >= display.x + display.width - epsilon &&
+  bounds.y + bounds.height >= display.y + display.height - epsilon
+
+const intersects = (a: Bounds, b: Bounds): boolean =>
+  a.x < b.x + b.width && b.x < a.x + a.width && a.y < b.y + b.height && b.y < a.y + a.height
+
+/**
+ * The fullscreen app the HUD is floating over on `display`, or null.
+ *
+ * Front-to-back: skip every window of our own process (all Hermes windows
+ * share main's pid) and the desktop shell's display-sized layers, then let the
+ * FIRST window that intersects the display decide — covering it means a
+ * fullscreen app, anything less means ordinary windows are on top and the
+ * overlay treatment would just make the HUD illegible over a busy desktop.
+ * Zero-area rows (minimized windows report those on some platforms) never
+ * decide either way.
+ */
+export function detectFullscreenApp(
+  windows: EnumeratedWindow[],
+  selfPid: number,
+  display: Bounds
+): EnumeratedWindow | null {
+  for (const win of windows) {
+    if (win.pid === selfPid || isShellWindow(win.app)) {
+      continue
+    }
+
+    if (win.bounds.width <= 0 || win.bounds.height <= 0 || !intersects(win.bounds, display)) {
+      continue
+    }
+
+    return coversDisplay(win.bounds, display) ? win : null
+  }
+
+  return null
+}
+
+/**
+ * The display-covering app anywhere in the stack, ignoring z-order.
+ *
+ * The STAY half of the hysteresis below. Front-to-back order answers "is a
+ * game what I'm looking at" for ENTERING overlay mode, but it cannot answer
+ * "am I still over the game" once the user clicks the HUD to type: the game
+ * stops being foreground, and whatever else they had open (a terminal, an
+ * editor, a browser) is suddenly above it and vetoes. The game did not go
+ * anywhere, so neither should the treatment.
+ */
+export function findFullscreenAppAnywhere(
+  windows: EnumeratedWindow[],
+  selfPid: number,
+  display: Bounds
+): EnumeratedWindow | null {
+  return (
+    windows.find(
+      win =>
+        win.pid !== selfPid &&
+        !isShellWindow(win.app) &&
+        win.bounds.width > 0 &&
+        win.bounds.height > 0 &&
+        coversDisplay(win.bounds, display)
+    ) ?? null
+  )
+}
+
+export const gameOverlayStateFor = (
+  windows: EnumeratedWindow[],
+  selfPid: number,
+  display: Bounds,
+  wasActive = false
+): GameOverlayState => {
+  // Hysteresis. ENTERING needs the game to be what the user is actually
+  // looking at (front-to-back, windowed apps on top veto it). STAYING only
+  // needs the game to still be there: clicking the HUD to type pushes the game
+  // out of foreground and floats every other open window above it, which would
+  // otherwise drop the treatment at exactly the moment the user is reading it.
+  const fullscreen = wasActive
+    ? findFullscreenAppAnywhere(windows, selfPid, display)
+    : detectFullscreenApp(windows, selfPid, display)
+
+  return fullscreen ? { active: true, app: fullscreen.app } : INACTIVE_GAME_OVERLAY
+}
+
+export interface HudGameOverlayWatchDeps {
+  /** Front-to-back window enumeration; null when the platform cannot answer
+   *  (Wayland, missing native module). Same contract as window-below's. */
+  enumerate: () => Promise<EnumeratedWindow[] | null>
+  /** Bounds of the display the HUD currently sits on. */
+  displayBounds: () => Bounds
+  selfPid: number
+  /** Push a CHANGED state to the HUD renderer. */
+  send: (state: GameOverlayState) => void
+  intervalMs?: number
+  /** Injectable timers so tests never wait on a real clock. */
+  setIntervalFn?: typeof setInterval
+  clearIntervalFn?: typeof clearInterval
+}
+
+/** Consecutive failed enumerations before the watch concludes the platform
+ *  cannot answer and stops burning a subprocess/native call per tick. Two, not
+ *  one: a single null can be a transient failure mid-session. */
+const FAILURES_BEFORE_GIVING_UP = 2
+
+/**
+ * Poll for fullscreen-app changes while the HUD is open. Returns the disposer;
+ * idempotent, and the caller must invoke it when the HUD closes.
+ *
+ * Polling, not events: no OS surfaces a cross-process "a fullscreen app
+ * appeared" signal to an unprivileged window, and every consumer of this class
+ * of information (Discord, Steam, GeForce overlays) watches for it. The
+ * interval is slow enough to be free next to the HUD's own cursor feed.
+ */
+export function startHudGameOverlayWatch({
+  enumerate,
+  displayBounds,
+  selfPid,
+  send,
+  intervalMs = 1500,
+  setIntervalFn = setInterval,
+  clearIntervalFn = clearInterval
+}: HudGameOverlayWatchDeps): () => void {
+  let last: GameOverlayState | null = null
+  let failures = 0
+  let inFlight = false
+  let disposed = false
+
+  const publish = (state: GameOverlayState) => {
+    if (last === null || last.active !== state.active || last.app !== state.app) {
+      last = state
+      send(state)
+    }
+  }
+
+  const tick = async () => {
+    // Enumeration is async and slower than the interval on a bad day (X11
+    // shells out); overlapping ticks would answer out of order.
+    if (inFlight || disposed) {
+      return
+    }
+
+    inFlight = true
+
+    try {
+      const windows = await enumerate()
+
+      if (disposed) {
+        return
+      }
+
+      if (windows === null) {
+        failures += 1
+
+        // The platform cannot answer (and said so twice): settle on inactive
+        // and stop asking.
+        if (failures >= FAILURES_BEFORE_GIVING_UP) {
+          publish(INACTIVE_GAME_OVERLAY)
+          dispose()
+        }
+
+        return
+      }
+
+      failures = 0
+      publish(gameOverlayStateFor(windows, selfPid, displayBounds(), last?.active ?? false))
+    } catch {
+      // A throwing enumerator counts the same as a null answer.
+      failures += 1
+
+      if (failures >= FAILURES_BEFORE_GIVING_UP && !disposed) {
+        publish(INACTIVE_GAME_OVERLAY)
+        dispose()
+      }
+    } finally {
+      inFlight = false
+    }
+  }
+
+  const timer = setIntervalFn(() => void tick(), intervalMs)
+
+  function dispose() {
+    if (!disposed) {
+      disposed = true
+      clearIntervalFn(timer)
+    }
+  }
+
+  void tick()
+
+  return dispose
+}

--- a/apps/desktop/electron/hud-ipc.ts
+++ b/apps/desktop/electron/hud-ipc.ts
@@ -8,8 +8,6 @@ import { hudFrostFor, type TranslucencyState } from './translucency'
 
 export interface HudIpcDeps {
   isMac: boolean
-  isWindows: boolean
-  glassSupported: boolean
   /** Main's authoritative translucency state (Settings → Appearance). */
   getTranslucencyState: () => TranslucencyState
   getHudWindow: () => BrowserWindow | null
@@ -20,8 +18,6 @@ export interface HudIpcDeps {
 
 export function registerHudIpc({
   isMac,
-  isWindows,
-  glassSupported,
   getTranslucencyState,
   getHudWindow,
   openHudWindow,
@@ -43,6 +39,10 @@ export function registerHudIpc({
   // view, so it frosts the whole rectangle; the HUD's layout leaves no dead
   // margins for that reason, and it only turns on while the band is showing
   // (idle HUD mode must be the bar and nothing else).
+  //
+  // macOS ONLY. Windows' equivalent (setBackgroundMaterial → the DWM backdrop)
+  // is mutually exclusive with window transparency, so it is not called at all
+  // here — see the note at the bottom of this function.
   //
   // Diffed before issuing: `setVibrancy` carries a 150ms animation that restarts
   // if re-issued, so a repeated call would keep the material from ever settling
@@ -77,9 +77,14 @@ export function registerHudIpc({
       hudWindow.setVibrancy(frost.vibrancy)
     }
 
-    if (isWindows && glassSupported && typeof hudWindow.setBackgroundMaterial === 'function') {
-      hudWindow.setBackgroundMaterial(frost.backgroundMaterial)
-    }
+    // Windows: never touch setBackgroundMaterial on the HUD. Live-verified on
+    // Win11 (Electron 40.10.2, RTX 4090): ANY setBackgroundMaterial call on a
+    // transparent window — including 'none', which is what the idle HUD asks
+    // for — permanently kills per-pixel alpha, and every transparent pixel
+    // composites as opaque white. Neither 'auto' nor a follow-up
+    // setBackgroundColor('#00000000') restores it. The DWM backdrop and window
+    // transparency are mutually exclusive, so the Windows HUD keeps the CSS
+    // tint the sheet already paints and skips the native frost entirely.
   }
 
   ipcMain.handle('hermes:hud:open', async (_event, request) => {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -190,6 +190,7 @@ import {
   writeSecretFileAtomic
 } from './hardening'
 import { cursorPointInWindow } from './hud-cursor'
+import { startHudGameOverlayWatch } from './hud-game-overlay'
 import { registerHudIpc } from './hud-ipc'
 import { snapHudBounds } from './hud-snap'
 import { createHudSnapShortcut } from './hud-snap-shortcut'
@@ -327,7 +328,7 @@ import {
 } from './venv-blocker-scan'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
 import { createWakeIndicatorWindowController } from './wake-indicator-window'
-import { readWindowBelow } from './window-below'
+import { enumerateWindowsFrontToBack, readWindowBelow } from './window-below'
 import { installWindowRendererLifecycle } from './window-renderer-lifecycle'
 import { createWindowRevealController } from './window-reveal'
 import {
@@ -11668,6 +11669,46 @@ function startHudCursorFeed(win: BrowserWindow) {
   win.on('closed', () => clearInterval(timer))
 }
 
+/**
+ * Watch for a fullscreen app under the HUD (the Discord-style game overlay
+ * cue) and feed the answer to its renderer. Pure detection lives in
+ * hud-game-overlay.ts; enumeration is the same front-to-back walk the
+ * read_window_below tool uses. The renderer answers with the low-opacity
+ * treatment (`data-hud-game`), so main stays out of the styling business.
+ */
+function startHudGameOverlayFeed(win: BrowserWindow) {
+  const titlesAvailable = IS_MAC ? systemPreferences.getMediaAccessStatus?.('screen') === 'granted' : true
+
+  let last = { active: false, app: '' }
+
+  const push = (state: { active: boolean; app: string }) => {
+    if (!win.isDestroyed()) {
+      win.webContents.send('hermes:hud:game-overlay', state)
+    }
+  }
+
+  // Replay the latest state to every load of this window. The watch pushes only
+  // on CHANGE and its first tick fires the moment the window is created — well
+  // before the renderer has mounted its listener — so a HUD opened over a game
+  // that is already fullscreen would hear the one and only message before it
+  // could receive it, then sit at "no game" forever while main was certain it
+  // had reported one. (Same reason quick entry caches its last state push.)
+  // did-finish-load also covers HMR full reloads during development.
+  win.webContents.on('did-finish-load', () => push(last))
+
+  const dispose = startHudGameOverlayWatch({
+    enumerate: () => enumerateWindowsFrontToBack(process.pid, titlesAvailable),
+    displayBounds: () => screen.getDisplayMatching(win.getBounds()).bounds,
+    selfPid: process.pid,
+    send: state => {
+      last = state
+      push(state)
+    }
+  })
+
+  win.on('closed', dispose)
+}
+
 function hudBounds() {
   // Remembered spot first — validated against the LIVE displays so a HUD
   // parked on an unplugged monitor comes back on-screen instead of lost.
@@ -11802,6 +11843,7 @@ function spawnHudWindow(sessionId, profile) {
   bindGeometryPersistence(win, schedulePersistHudState)
 
   startHudCursorFeed(win)
+  startHudGameOverlayFeed(win)
 
   wireWindowReveal(win, {
     show: () => {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12547,8 +12547,6 @@ registerPetOverlayIpc({
 // --- HUD mode (chrome-free floating chat) — see hud-ipc.ts. ---------------
 const hudIpc = registerHudIpc({
   isMac: IS_MAC,
-  isWindows: IS_WINDOWS,
-  glassSupported: GLASS_SUPPORTED,
   getTranslucencyState: () => translucencyState,
   getHudWindow: () => hudWindow,
   openHudWindow,

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -103,6 +103,15 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
       ipcRenderer.on('hermes:hud:cursor', listener)
 
       return () => ipcRenderer.removeListener('hermes:hud:cursor', listener)
+    },
+    // Main's game-overlay watch: whether a fullscreen app (a game) is under
+    // the HUD, so the renderer can step back to the low-opacity overlay
+    // treatment while one owns the screen.
+    onGameOverlay: callback => {
+      const listener = (_event, state) => callback(state)
+      ipcRenderer.on('hermes:hud:game-overlay', listener)
+
+      return () => ipcRenderer.removeListener('hermes:hud:game-overlay', listener)
     }
   },
   // Quick Entry: the global-hotkey mini composer window. Main owns the OS

--- a/apps/desktop/electron/window-below.ts
+++ b/apps/desktop/electron/window-below.ts
@@ -12,6 +12,12 @@
 // permission; we pass titles through only when that permission is ALREADY
 // granted and never trigger the prompt for it.
 
+import fs from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { app } from 'electron'
+
 import { readHyprlandWindows } from './hyprland'
 
 export interface EnumeratedWindow {
@@ -130,7 +136,31 @@ const loadGetWindows = (): Promise<GetWindowsModule | null> => {
   // prebuilt. A missing module is therefore a normal state on those targets,
   // so the lazy import resolves to null instead of rejecting; enumeration then
   // degrades to the failure note instead of an uncaught error.
-  getWindowsModule ??= import('get-windows').catch(() => null)
+  //
+  // The STAGED copy is tried first, and it is not a dev-only nicety.
+  // `import('get-windows')` resolves out of node_modules, whose lib/windows.js
+  // locates its binding through `preGyp.find()` — by HOST platform. When the
+  // tree was installed on a different OS than Electron is running on (a
+  // WSL-hosted dev run driving a win32 Electron is the everyday case here),
+  // pre-gyp picks the host's slot, ignores the win32 binding sitting beside it,
+  // and upstream's fail-soft path hands back no-op stubs. Enumeration then
+  // reports "unavailable" on a machine that answers perfectly well, which is
+  // what silently disabled both read_window_below and the HUD's game overlay.
+  // scripts/stage-native-deps.mjs writes a staged lib/windows.js that requires
+  // the binding directly, so it is the more reliable of the two everywhere.
+  getWindowsModule ??= (async () => {
+    const staged = path.join(app.getAppPath(), 'dist', 'node_modules', 'get-windows', 'index.js')
+
+    if (fs.existsSync(staged)) {
+      const mod = await import(pathToFileURL(staged).href).catch(() => null)
+
+      if (mod) {
+        return mod as GetWindowsModule
+      }
+    }
+
+    return import('get-windows').catch(() => null)
+  })()
 
   return getWindowsModule
 }
@@ -189,15 +219,28 @@ async function enumerateViaGetWindows(titlesAvailable: boolean): Promise<Enumera
   }))
 }
 
+/**
+ * Front-to-back window enumeration, or null when the platform cannot answer.
+ *
+ * Hyprland first, and only ever on Hyprland — its own IPC sees native Wayland
+ * windows, which the X11 enumerator cannot, and it answers null everywhere
+ * else so the established path stays the default. Shared by the
+ * read_window_below tool and the HUD's game-overlay watch, so the two can
+ * never disagree about what the screen looks like.
+ */
+export async function enumerateWindowsFrontToBack(
+  selfPid: number,
+  titlesAvailable: boolean
+): Promise<EnumeratedWindow[] | null> {
+  return (await readHyprlandWindows(selfPid)) ?? (await enumerateViaGetWindows(titlesAvailable))
+}
+
 export async function readWindowBelow(
   selfPid: number,
   selfBounds: EnumeratedWindow['bounds'],
   titlesAvailable: boolean
 ): Promise<WindowBelowResult | WindowBelowUnavailable> {
-  // Hyprland first, and only ever on Hyprland — its own IPC sees native Wayland
-  // windows, which the X11 enumerator below cannot, and it answers null
-  // everywhere else so the established path stays the default.
-  const windows = (await readHyprlandWindows(selfPid)) ?? (await enumerateViaGetWindows(titlesAvailable))
+  const windows = await enumerateWindowsFrontToBack(selfPid, titlesAvailable)
 
   if (!windows) {
     return {

--- a/apps/desktop/src/app/hud/game-overlay.ts
+++ b/apps/desktop/src/app/hud/game-overlay.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Whether a fullscreen app (a game) is under the HUD.
+ *
+ * Main owns the answer — it polls the OS window list while the HUD is open
+ * (see startHudGameOverlayFeed / hud-game-overlay.ts) and pushes changes here.
+ * The renderer cannot know this on its own: which OS window owns the screen is
+ * not a fact a page can observe.
+ *
+ * The shell wears it as `data-hud-game`, and the stylesheet answers with the
+ * in-game chat treatment: the idle bar steps back to a glanceable opacity so it
+ * reads as part of the game's HUD rather than a desktop window parked over it,
+ * and the transcript stays up instead of fading on a timer (see `useHudHeld`) —
+ * a chat log you look back at during a lull is useless if it erases itself.
+ */
+export function useHudGameOverlay(): boolean {
+  const [active, setActive] = useState(false)
+
+  useEffect(() => {
+    const off = window.hermesDesktop?.hud?.onGameOverlay?.(state => setActive(state.active))
+
+    return () => off?.()
+  }, [])
+
+  return active
+}

--- a/apps/desktop/src/app/hud/hud-shell.tsx
+++ b/apps/desktop/src/app/hud/hud-shell.tsx
@@ -10,6 +10,7 @@ import { RICH_INPUT_SLOT } from '../chat/composer/rich-editor'
 import { WiredPane } from '../contrib/wiring'
 
 import { useHudClickThrough } from './click-through'
+import { useHudGameOverlay } from './game-overlay'
 import { useHudGlass } from './glass'
 import { useHudGoto, useReportHudSession } from './handoff'
 import { hudTranscriptHeight } from './layout'
@@ -135,17 +136,52 @@ function useRecentActivity(): [boolean, () => void] {
 /**
  * True while the HUD must stay up regardless of the hold timer.
  *
- * Only a question: a clarify/approval/sudo/secret prompt is something the agent
- * cannot continue without, and letting it fade hands you a surface you cannot
- * use — zero opacity, and the window goes mouse-transparent under it, so the
- * prompt is neither readable nor clickable.
+ * Three things qualify:
  *
- * A merely BUSY session is not that. Pinning the band for the length of a turn
- * meant a HUD you had walked away from sat open across the screen for as long
- * as the agent worked; the answer arriving flashes it anyway.
+ * - A clarify/approval/sudo/secret prompt: something the agent cannot continue
+ *   without, and letting it fade hands you a surface you cannot use — zero
+ *   opacity, and the window goes mouse-transparent under it, so the prompt is
+ *   neither readable nor clickable.
+ * - The session being BUSY at all — thinking, calling a tool, streaming — plus
+ *   a grace window after the turn ends, so the answer you were waiting for is
+ *   still there when it arrives.
+ * - GAME OVERLAY MODE, unconditionally. Over a fullscreen game the HUD is the
+ *   chat frame, and a chat frame that erases itself a second after each line is
+ *   useless: you look back at it when there is a lull in the game, not when the
+ *   text happens to be fresh. This is what every in-game chat log does, and it
+ *   costs nothing here because the band over a game is bare text with no panel.
+ *
+ * Pinning on busy was deliberately avoided while the band brought its tinted
+ * sheet up with it — that put an opaque panel across the screen for as long as
+ * the agent worked. The sheet is a translucent scrim now, so a held band is
+ * legible text rather than a slab.
  */
-function useHudHeld(): boolean {
-  return useStore($activeSessionAwaitingInput)
+function useHudHeld(gameUnder: boolean): boolean {
+  const awaiting = useStore($activeSessionAwaitingInput)
+  const busy = useStore($busy)
+
+  // The reply landing must stay readable. Held for the whole turn AND for a
+  // grace window after it ends, tracked here rather than by re-arming
+  // `useRecentActivity`'s timer: that timer deliberately refuses to re-arm for
+  // ambient activity on an unfocused HUD, so the turn's own end could not buy a
+  // hold through it and the answer blinked out the instant it finished.
+  const [grace, setGrace] = useState(false)
+
+   
+  useEffect(() => {
+    if (busy) {
+      setGrace(true)
+
+      return
+    }
+
+    // Falling edge: keep it up a moment longer, then let the fade have it.
+    const timer = setTimeout(() => setGrace(false), HUD_RECENT_HOLD_MS)
+
+    return () => clearTimeout(timer)
+  }, [busy])
+
+  return gameUnder || awaiting || busy || grace
 }
 
 /**
@@ -165,7 +201,11 @@ function useHudHeld(): boolean {
  */
 export function HudShell() {
   const [recent, holdBand] = useRecentActivity()
-  const held = useHudHeld()
+  // A fullscreen app (a game) is under the HUD: wear `data-hud-game` so the
+  // idle bar steps back to overlay opacity (see styles.css). Detection is
+  // main's — the page cannot see other apps' windows.
+  const gameUnder = useHudGameOverlay()
+  const held = useHudHeld(gameUnder)
 
   // Clicking away to another APP is the most common way the HUD is let go of,
   // and it fires no focusout: the composer stays document.activeElement while
@@ -358,6 +398,7 @@ export function HudShell() {
     <div
       className="relative flex h-screen w-screen flex-col overflow-hidden"
       data-hud-edge={edge}
+      data-hud-game={gameUnder ? '' : undefined}
       data-hud-recent={recent || held ? '' : undefined}
       data-hud-shell
       // Letting go of the composer re-arms the hold, so the transcript steps

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -101,6 +101,7 @@ declare global {
         onGoto: (callback: (sessionId: string) => void) => () => void
         onChanged: (callback: (state: { open: boolean; sessionId: null | string }) => void) => () => void
         onCursor: (callback: (point: { x: number; y: number } | null) => void) => () => void
+        onGameOverlay: (callback: (state: { active: boolean; app: string }) => void) => () => void
       }
       // Quick Entry: a global-hotkey mini composer window. Main owns the OS
       // shortcut registration + the persisted preference (it must restore the

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2682,6 +2682,11 @@ button[data-slot='aui_msg-reactions'] svg {
    no blur to separate the band from what it lies over, the sheet is the only
    thing keeping half-opacity text off someone else's UI. Fade the words, keep
    the paper. */
+/* A DARK scrim, not the theme's card. The band's ink is white unconditionally
+   (see above), so the sheet it lands on has to be dark in every theme —
+   `--dt-card` is near-white on a light theme and would put white text on a white
+   panel. This is the overlay's own surface, the way a game's chat backdrop is
+   its own thing rather than a piece of the desktop UI. */
 [data-hud-shell] [data-hud-glass] {
   position: absolute;
   right: var(--hud-band-inset);
@@ -2690,7 +2695,7 @@ button[data-slot='aui_msg-reactions'] svg {
   z-index: 0;
   pointer-events: none;
   border-radius: 0.75rem 0.75rem 0 0;
-  background: color-mix(in srgb, var(--dt-card) 80%, transparent);
+  background: rgb(12 14 18 / 0.62);
   /* Slides down behind the bar as it fades. A TRANSFORM, not height: it is
      composited, so it stays smooth where animating height re-lays-out the panel
      every frame and looked coarse — and it leaves the box alone, which matters
@@ -2714,9 +2719,11 @@ button[data-slot='aui_msg-reactions'] svg {
     background-color var(--hud-dim) var(--hud-ease-enter);
 }
 
-/* Engaged: as tall as the transcript needs, capped at the window. An empty
-   session measures 0, so it stays rolled up. */
-[data-hud-shell][data-hud-recent] [data-hud-glass],
+/* The sheet is FOCUS-ONLY. A turn landing brings the text up (see
+   `composer-bounds` below) but must not paint a panel behind it: over a game
+   the tinted sheet is the thing that reads as a desktop window parked on the
+   action, and it is most of the HUD's rectangle. Streaming shows words on the
+   game; sitting down to read promotes the surface. */
 [data-hud-shell]:has([data-slot='composer-rich-input']:focus) [data-hud-glass] {
   translate: none;
   opacity: 1;
@@ -2733,7 +2740,10 @@ button[data-slot='aui_msg-reactions'] svg {
    transparent window that owns its own backgrounds (isChatWindow). Two flags,
    because the HUD wants the setting without the rewrite. */
 :root[data-hermes-glass-on] [data-hud-shell] [data-hud-glass] {
-  background: color-mix(in srgb, var(--ui-bg-chrome) var(--translucency-glass-keep, 100%), transparent);
+  /* Same dark scrim under Glass. The docked thread's `--ui-bg-chrome` follows
+     the theme and goes near-white on a light one, which is the wrong paper for
+     this band's white ink — the HUD is over a game, not inside the app. */
+  background: rgb(12 14 18 / 0.55);
 }
 
 /* The band spans the window edge to edge under glass. The 8px side inset keeps
@@ -2741,23 +2751,33 @@ button[data-slot='aui_msg-reactions'] svg {
    but the frost is the WINDOW, so an inset sheet leaves a hairline of bare
    untinted material down both sides. Nothing to hold off the material's edge:
    the window's own rounded corners are where the band ends. */
+/* Inset under Glass too — 6px, so the sheet is narrower than the bar and
+   centered under it. Full-bleed looked like a slab with two slivers beside the
+   bar's rounded bottom corners: the sheet's square top corners poked out past
+   the bar's silhouette, which is the gap down each side. Narrower than the bar
+   means the bar's shape is the widest thing in the HUD and nothing peeks. */
 :root[data-hermes-glass-on] [data-hud-shell] {
-  --hud-band-inset: 0px;
+  --hud-band-inset: 0.375rem;
 }
 
+/* Radius follows the edge the band hangs from, and this rule has to carry the
+   edge itself: `:root[data-hermes-glass-on] … [data-hud-glass]` outweighs the
+   `[data-hud-edge='top']` flip below (four compound parts against three), so a
+   radius set here unqualified wins everywhere and rounds the corners that meet
+   the bar while squaring the free ones. */
 :root[data-hermes-glass-on] [data-hud-shell] [data-hud-glass] {
   border-radius: 0.75rem 0.75rem 0 0;
+}
+
+:root[data-hermes-glass-on] [data-hud-shell][data-hud-edge='top'] [data-hud-glass] {
+  border-radius: 0 0 0.75rem 0.75rem;
 }
 
 /* Engaged, the field steps up the same way the docked thread's does — but
    never below the resting tint, so a high lever cannot make focusing the
    composer paint MORE transparent than glancing at it. */
 :root[data-hermes-glass-on] [data-hud-shell]:has([data-slot='composer-rich-input']:focus) [data-hud-glass] {
-  background: color-mix(
-    in srgb,
-    var(--ui-bg-chrome) min(100%, calc(var(--translucency-glass-keep, 100%) + 12%)),
-    transparent
-  );
+  background: rgb(12 14 18 / 0.72);
 }
 
 /* Engaged means the caret is in the composer, not merely that the window holds
@@ -2767,7 +2787,7 @@ button[data-slot='aui_msg-reactions'] svg {
    below stays on :focus-within — being permissive about what can be clicked is
    harmless, being permissive about what lights up is not. */
 [data-hud-shell]:has([data-slot='composer-rich-input']:focus) [data-hud-glass] {
-  background: color-mix(in srgb, var(--dt-card) 92%, transparent);
+  background: rgb(12 14 18 / 0.82);
 }
 
 /* Flipped, the sheet hangs from the bar instead of standing on it. */
@@ -2793,12 +2813,14 @@ button[data-slot='aui_msg-reactions'] svg {
   pointer-events: none;
 }
 
-/* Clickable whenever it's actually on screen, not only while the caret is in
-   the composer — a link in the transcript is worth clicking the moment you can
-   see it. Faded out it goes back to `none`, which is what lets clicks over the
-   HUD reach whatever you're really working in. */
-[data-hud-shell][data-hud-recent] [data-slot='composer-bounds'],
-[data-hud-shell]:focus-within [data-slot='composer-bounds'] {
+/* WHAT ANSWERS THE CURSOR is FOCUS, not visibility. A streaming reply is
+   something you read over the game, not something you aim at: while the band is
+   merely visible every click inside its rectangle is a click the game does not
+   get (the window is only mouse-transparent where the document reports nothing,
+   so an interactive band IS a dead zone over the action). Sitting down in the
+   composer is the deliberate act that makes the transcript a surface you can
+   scroll and click links in. */
+[data-hud-shell]:has([data-slot='composer-rich-input']:focus) [data-slot='composer-bounds'] {
   pointer-events: auto;
 }
 
@@ -2808,12 +2830,105 @@ button[data-slot='aui_msg-reactions'] svg {
    hasn't earned. Focus is what promotes it to properly readable; the hold and
    fade then take it away from wherever it was. */
 [data-hud-shell][data-hud-recent] [data-slot='composer-bounds'] {
-  opacity: 0.5;
+  opacity: 1;
   translate: none;
   /* Same duration AND curve as the sheet's tint step, or the two visibly ease
      apart on the way down. */
   transition-duration: var(--hud-dim);
   transition-timing-function: var(--hud-ease-enter);
+}
+
+/* THE BAND IS ALWAYS LIGHT-ON-DARK. Unconditional, and that is the point: the
+   transcript here is either bare text over another app or text on a translucent
+   scrim, and in both cases the theme's near-black body ink is the wrong ink.
+   Every earlier cut gated this on something — focus, then `data-hud-game` — and
+   every gate produced a state where the words went black on a dark game. A
+   HUD's legibility cannot depend on a condition being evaluated correctly; it
+   is a property of the surface. The scrim below is darkened to match, so white
+   is right whether the sheet is up or not. */
+[data-hud-shell] [data-slot='composer-bounds'] {
+  --hud-overlay-ink: #fff;
+  /* WoW-epic gold: reads as "yours" against white agent text and survives being
+     over a dark cave or a bright loading screen. */
+  --hud-overlay-ink-user: #ffcf6b;
+  color: var(--hud-overlay-ink);
+  text-shadow:
+    0 1px 2px rgb(0 0 0 / 0.9),
+    0 0 6px rgb(0 0 0 / 0.55);
+  /* Ramp the scrollback out at the top instead of guillotining it against the
+     bar. With no sheet to end on, a hard edge reads as text sliced off; the
+     fade says "there is more above" the way a game's chat log does. */
+  --hud-top-fade: 3.5rem;
+}
+
+/* The mask has to ride the SCROLLER, not the band. `composer-bounds` is a
+   static box: the rows scroll inside the thread viewport nested in it, so a
+   mask there ramps over the band's own first 3.5rem while the overflowing text
+   is already ABOVE that box (measured: rows at -117px, -81px, -55px relative
+   to the band, and `scrollHeight === clientHeight` — nothing overflows the
+   band itself). The viewport clips it hard before the band's mask is ever
+   consulted, which is why raising the value changed nothing on screen. Masking
+   the viewport puts the ramp where the clipping actually happens. */
+[data-hud-shell] [data-slot='aui_thread-viewport'] {
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 var(--hud-top-fade, 3.5rem));
+  mask-image: linear-gradient(to bottom, transparent 0, #000 var(--hud-top-fade, 3.5rem));
+}
+
+/* Every descendant that sets its own colour — assistant prose, user text,
+   markdown, timestamps — inherits it too, or the ink change reaches the
+   wrapper and nothing you can actually read. Widgets carve themselves out by
+   resetting the variable (see below), so this stays one rule. */
+[data-hud-shell] [data-slot='composer-bounds'] * {
+  color: var(--hud-overlay-ink) !important;
+}
+
+/* Anything that paints its OWN light surface inside the band keeps the theme's
+   ink — a clarify question, an approval prompt, an artifact card, a code block,
+   a form control. The overlay's white ink exists for text sitting on the game;
+   a widget brings its own paper, and forcing white there made the panel
+   unreadable (a clarify prompt with white options on a near-white card).
+   Done by moving the VARIABLE rather than adding a competing `color` rule: the
+   one !important above reads `--hud-overlay-ink` from whatever ancestor is
+   nearest, so a widget re-pointing it at the theme's ink re-inks its whole
+   subtree with no specificity fight and no second copy of the selector list.
+   The list is deliberately by SURFACE, not by feature: every entry paints a
+   fill. That distinction matters for approvals — `tool-approval-fallback` wraps
+   a real card (`--ui-chat-surface-background`) and its `<pre>` command block
+   brings its own, but `tool-approval-inline` / `-actions` are bare rows sitting
+   directly on the band, so they must stay WHITE like ordinary prose. Matching
+   them by slot made their labels dark-on-game, which is the exact bug this rule
+   exists to prevent, one level down. Match the fill, never the feature.
+   Widgets on the shared shell (components/chat/widget-shell.ts →
+   `--ui-widget-surface-background`) and any chat-surface card are matched on
+   their class, so new ones inherit this without touching the list. */
+[data-hud-shell] [data-slot='composer-bounds']
+  :is(
+    [data-slot='clarify-inline'],
+    [data-slot='tool-block'],
+    [data-slot='file-diff-panel'],
+    [data-slot='code-card'],
+    [data-slot='aui_system-message-root'],
+    [class*='ui-widget-surface-background'],
+    [class*='ui-chat-surface-background'],
+    pre,
+    input,
+    textarea,
+    select
+  ) {
+  --hud-overlay-ink: var(--ui-text-primary);
+  --hud-overlay-ink-user: var(--ui-text-primary);
+  text-shadow: none;
+}
+
+/* …except your OWN lines. With the bubble gone at rest, white-on-white is the
+   only thing telling you apart from the agent, and it doesn't: the log reads as
+   one voice. Tint them instead — the same job the bubble was doing, done with
+   ink so it costs no surface. Warm gold rather than the theme's accent: it has
+   to hold up over whatever is behind the window, and a blue or purple lands on
+   top of exactly the palette most games use for their own UI. */
+[data-hud-shell] :is([data-slot='aui_user-message-root'], .composer-human-message),
+[data-hud-shell] :is([data-slot='aui_user-message-root'], .composer-human-message) * {
+  color: var(--hud-overlay-ink-user) !important;
 }
 
 [data-hud-shell]:has([data-slot='composer-rich-input']:focus) [data-slot='composer-bounds'] {
@@ -2843,19 +2958,28 @@ button[data-slot='aui_msg-reactions'] svg {
    user row paints an OPAQUE chat-surface slab behind it (so a stuck bubble can
    slide over scrolled text) and the bubble is solid --dt-user-bubble — inside
    the smoked band both read as fully opaque cards that ignore every fade. The
-   slab goes unconditionally; the bubble smokes at rest and returns solid when
-   engaged. ONE variable carries the fill so there is no specificity fight
+   slab goes unconditionally; the bubble is gone entirely at rest and returns
+   when engaged. ONE variable carries the fill so there is no specificity fight
    between rest/engaged rules — the states just move the var. */
 [data-hud-shell] {
-  --hud-bubble-fill: color-mix(in srgb, var(--dt-user-bubble) 65%, transparent);
+  /* At rest there is no bubble: unfocused, the band is bare text over someone
+     else's window, and a card around your own lines is the one thing in it
+     that still reads as an app. The words stay (they are the log); the
+     container stops being drawn. */
+  --hud-bubble-fill: transparent;
+  --hud-bubble-stroke: transparent;
 }
 
 /* ONE opacity law for the whole band: solid on focus, material otherwise.
    Bubbles going solid on `recent` too made them opaque cards floating on the
    62% band mid-stream — the band only steps solid on focus, so nothing inside
    it may step earlier. */
+/* No bubble in the HUD, ever. The band's ink already distinguishes the two
+   voices (white agent / gold yours), and a light card behind gold text is the
+   one thing in here that fights the overlay's own contrast. */
 [data-hud-shell]:has([data-slot='composer-rich-input']:focus) {
-  --hud-bubble-fill: var(--dt-user-bubble);
+  --hud-bubble-fill: transparent;
+  --hud-bubble-stroke: transparent;
 }
 
 [data-hud-shell] [data-slot='aui_user-message-root'] {
@@ -2878,7 +3002,7 @@ button[data-slot='aui_msg-reactions'] svg {
    Fill and border both ride the same variable, so they cannot desync. */
 [data-hud-shell] .composer-human-message {
   background: var(--hud-bubble-fill) !important;
-  border-color: color-mix(in srgb, var(--ui-stroke-secondary) 45%, transparent) !important;
+  border-color: var(--hud-bubble-stroke) !important;
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
   transition:
@@ -2963,7 +3087,13 @@ button[data-slot='aui_msg-reactions'] svg {
    lines tall they're most of the surface. Bottom pad drops to a hairline —
    the band already ends at the bar, so any block-end padding here reads as a
    gap between the last message and the composer. */
+/* Nudged inward, not edge to edge. The thread is a log floating over someone
+   else's window, and text running into the band's rounded corners reads as a
+   panel that has outgrown its box. The composer keeps the full width — it is
+   the object; the log is what hangs off it. */
 [data-hud-shell] [data-slot='aui_thread-content'] {
+  width: 92% !important;
+  margin-inline: auto !important;
   padding-inline: 0.6rem !important;
   padding-block: 0.35rem 0.25rem !important;
   /* A chat frame fills from the bottom. The docked thread hangs from the top
@@ -3136,6 +3266,33 @@ button[data-slot='aui_msg-reactions'] svg {
    space, cannot be clipped, and leaves the working arc as the only ring. */
 [data-hud-shell]:has([data-slot='composer-rich-input']:focus) [data-slot='composer-surface'] {
   border-color: var(--dt-primary) !important;
+}
+
+/* GAME OVERLAY — a fullscreen app owns the screen (data-hud-game, pushed by
+   main's window watch). The Discord treatment: the idle bar steps back to a
+   low, glanceable opacity so it reads as part of the game's own HUD instead of
+   a desktop window parked over the action. The bar's "always fully opaque"
+   contract above is about never being COMPROMISED by what's behind it; over a
+   game the whole bar fades as one object, which keeps it legible the moment it
+   returns.
+
+   Engagement wins, exactly like the band's own reveal: a recent turn, the
+   caret in the composer, or the cursor over the bar (mousemove keeps flowing
+   through the click-through window, so :hover is live even while ignoring)
+   restores full strength — fast in, slow out, on the shell's shared clocks.
+
+   The window keeps normal chrome-free behavior otherwise: no other state
+   changes, so leaving the game hands back the standard HUD without a rebuild. */
+[data-hud-shell][data-hud-game] [data-slot='composer-dock'] {
+  opacity: 0.35;
+  transition: opacity var(--hud-fade) var(--hud-ease-exit);
+}
+
+[data-hud-shell][data-hud-game][data-hud-recent] [data-slot='composer-dock'],
+[data-hud-shell][data-hud-game]:focus-within [data-slot='composer-dock'],
+[data-hud-shell][data-hud-game] [data-slot='composer-dock']:hover {
+  opacity: 1;
+  transition: opacity var(--hud-reveal) var(--hud-ease-enter);
 }
 
 /* Long-press drag armed — the whole bar is the handle until release. */


### PR DESCRIPTION
While a fullscreen app owns the screen, the HUD becomes an in-game chat frame: the idle bar steps back to a glanceable opacity, and the transcript stays open for as long as the game is there instead of fading on a timer. You look back at a chat log during a lull, not while the text happens to be fresh.

Verified live on Windows 11 over a fullscreen WoW session.

## Detection

A pure pass over the same front-to-back window enumeration `read_window_below` already uses (`electron/hud-game-overlay.ts`): the frontmost other-process window covering the HUD's display edge-to-edge is a fullscreen app. Main polls it while the HUD is open and pushes changes to the renderer, which owns the visual treatment. Own-process windows and desktop-shell layers (Explorer, Finder, Dock, gnome-shell) never count; work-area coverage is deliberately not enough, since that is a maximized window rather than a fullscreen one.

Two details the real enumeration forced:

- **Hysteresis.** Entering needs the game to be what the user is actually looking at, so a windowed app on top vetoes it. Staying only needs the game to still exist — clicking the HUD to type de-foregrounds the game and floats every other open window above it, which otherwise dropped overlay mode at the exact moment the user engaged with it.
- **The last state is replayed on `did-finish-load`.** The watch pushes only on change and its first tick fires at window creation, before the renderer has mounted its listener, so a HUD opened over an already-fullscreen game consumed its only message and then sat at "no game" indefinitely while main was certain it had reported one.

An always-on-top window covers borderless fullscreen (the default in most modern games) and macOS fullscreen Spaces. True exclusive fullscreen bypasses the compositor, so nothing short of injecting into the game's render pipeline draws over it; detection still works there, and the HUD appears once the user alt-tabs.

## The band, reworked for living over someone else's window

- **Light-on-dark, unconditionally.** The theme's near-black body ink is unreadable over a dark game. Every attempt to gate the light ink on a condition — focus, then the game flag — produced a state where it evaluated false and the words went black on black, so legibility is now a property of the surface rather than of a detector. The sheet is a dark scrim in every theme so white is always correct.
- **Widgets keep theme ink.** Anything painting its own light surface — a clarify question, an approval card, a code block, a form control — opts back in by re-pointing the ink variable, so the single `!important` rule above it re-inks that whole subtree with no specificity fight. Matched on the fill an element paints, never on the feature it belongs to: `tool-approval-inline` and `-actions` are bare rows on the band and correctly stay white, while the approval card and its command block go dark.
- **Your own lines are gold rather than bubbled.** With no card the log otherwise reads as one voice. Blue and purple are what most game UIs use for their own text, so they vanish into the background; warm gold holds up over both a dark cave and a bright loading screen.
- **The scrollback ramps out at the top** instead of being cut off. Masked on the scroller, not the band: the band is a static box whose rows overflow the thread viewport nested inside it, so a mask on the band ramps over empty space.
- **The sheet is inset under the bar,** so its square top corners no longer poke out past the bar's rounded ones.

## Two fixes found on the way

**Windows HUD painted opaque white.** `setBackgroundMaterial` on a transparent window permanently kills per-pixel alpha on Win11 — every transparent pixel composites as opaque white. Confirmed with a minimal repro on Electron 40.10.2: it breaks with any material value including `'none'`, which is exactly what the idle HUD asks for, and neither `'auto'` nor a follow-up `setBackgroundColor('#00000000')` restores it. The DWM backdrop and window transparency are mutually exclusive, so the Windows HUD keeps the CSS tint its sheet already paints. macOS is untouched — `setVibrancy` composites correctly.

**`get-windows` resolved its binding by host platform.** `lib/windows.js` locates its native binding through `preGyp.find()`, so a tree installed on one OS driving an Electron on another gets upstream's no-op stubs, and enumeration reports "unavailable" on a machine that answers perfectly well. This silently disabled `read_window_below` too. The staged copy written by `stage-native-deps.mjs` requires its binding directly, so it is preferred with the bare import as fallback.

## Tests

`electron/hud-game-overlay.test.ts` — 21 tests over the pure detector and the watch: display coverage with DPI epsilon, maximized-vs-fullscreen, shell-window and own-process exclusion, z-order veto, multi-display, both hysteresis directions, change-only publishing, failure/recovery, and dispose-mid-flight.
