### PR TITLE
Colon-bearing session ids no longer break sandbox mounts (#92414, consolidates 6 PRs)

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -405,3 +405,68 @@ class TestCwdMarker:
         env1 = _TestableEnv()
         env2 = _TestableEnv()
         assert env1._cwd_marker != env2._cwd_marker
+
+
+class TestSanitizeTaskIdForPath:
+    """sanitize_task_id_for_path must yield mountable, collision-free segments.
+
+    A raw task id like ``session:agent:main:telegram:dm:12345`` used as a
+    sandbox directory name made docker -v split the bind-mount on the embedded
+    colons and the daemon rejected it with "invalid mode" / exit 125 (#92414).
+    The helper is shared by every backend that builds host paths from task_id
+    (docker persistent sandboxes, singularity overlays), fixing the class once.
+    """
+
+    def test_docker_unsafe_characters_are_replaced(self):
+        from tools.environments.base import sanitize_task_id_for_path
+
+        out = sanitize_task_id_for_path("session:agent:main:telegram:dm:12345")
+        assert ":" not in out
+        assert "/" not in out and "\\" not in out
+
+    def test_safe_ids_pass_through_verbatim(self):
+        """Existing sandboxes keep resolving to their current directory."""
+        from tools.environments.base import sanitize_task_id_for_path
+
+        for value in ("default", "task-01.abc_def", "astropy__astropy-12907"):
+            assert sanitize_task_id_for_path(value) == value
+
+    def test_deterministic_and_collision_free_for_distinct_inputs(self):
+        from tools.environments.base import sanitize_task_id_for_path
+
+        assert sanitize_task_id_for_path("a:b") == sanitize_task_id_for_path("a:b")
+        # substitution alone is not injective — the digest must disambiguate
+        assert sanitize_task_id_for_path("a:b") != sanitize_task_id_for_path("a_b")
+        assert sanitize_task_id_for_path("!!!") != sanitize_task_id_for_path("@@@")
+
+    def test_empty_and_traversal_inputs_are_neutralized(self):
+        from tools.environments.base import sanitize_task_id_for_path
+
+        assert sanitize_task_id_for_path("") == "default"
+        for value in (".", "..", "../../etc", "..\\..\\escape"):
+            out = sanitize_task_id_for_path(value)
+            assert out not in {".", ".."}
+            assert "/" not in out and "\\" not in out
+
+    def test_oversized_input_truncates_with_unique_digest(self):
+        from tools.environments.base import (
+            _SANDBOX_DIR_MAX_LEN,
+            sanitize_task_id_for_path,
+        )
+
+        long_a = "a" * 300 + ":1"
+        long_b = "a" * 300 + ":2"
+        out_a = sanitize_task_id_for_path(long_a)
+        out_b = sanitize_task_id_for_path(long_b)
+        assert len(out_a) <= _SANDBOX_DIR_MAX_LEN
+        assert ":" not in out_a
+        assert out_a != out_b
+
+    def test_sanitized_dir_is_creatable(self, tmp_path):
+        from tools.environments.base import sanitize_task_id_for_path
+
+        target = tmp_path / "docker" / sanitize_task_id_for_path(
+            "session:agent:main:telegram:dm:12345"
+        )
+        target.mkdir(parents=True)
+        assert target.is_dir()

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -590,6 +590,113 @@ def test_run_command_sanitizes_unsafe_task_id(monkeypatch):
     )
 
 
+def _bind_mount_specs(run_args):
+    """Return every spec string passed via ``-v``."""
+    return [
+        run_args[i + 1]
+        for i, flag in enumerate(run_args[:-1])
+        if flag == "-v"
+    ]
+
+
+def test_persistent_bind_mounts_survive_a_session_key_task_id(monkeypatch, tmp_path):
+    """A gateway session key reaches the persistent sandbox path as-is, and it
+    carries colons (``session:agent:main:telegram:dm:<chat_id>``). Docker reads
+    every colon in a ``-v`` spec as a field separator, so the raw key made
+    ``docker run`` fail with "invalid spec ... too many colons" (exit 125) and
+    no tool call could run for any Telegram DM session."""
+    monkeypatch.setenv("TERMINAL_SANDBOX_DIR", str(tmp_path))
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(
+        task_id="session:agent:main:telegram:dm:8439114563",
+        persistent_filesystem=True,
+    )
+
+    specs = _bind_mount_specs(_run_args_from_calls(calls))
+    mounts = [s for s in specs if s.endswith((":/root", ":/workspace"))]
+    assert len(mounts) == 2, f"expected /root and /workspace binds; got {specs}"
+    for spec in mounts:
+        source, _, target = spec.rpartition(":")
+        assert ":" not in source, (
+            f"bind source still contains a colon, docker run would fail with "
+            f"'too many colons': {spec}"
+        )
+        # Docker splits on ':' — a sane spec has exactly source:target.
+        assert spec.count(":") == 1, f"spec is not a two-field bind: {spec}"
+        assert target in {"/root", "/workspace"}
+
+
+def test_distinct_session_keys_get_distinct_sandbox_dirs(monkeypatch, tmp_path):
+    """Sanitizing colons to underscores is not injective on its own: two
+    different chats must not be collapsed onto one persistent sandbox, or one
+    DM's ``/root`` (shell history, credentials, installed packages) shows up in
+    another's container."""
+    monkeypatch.setenv("TERMINAL_SANDBOX_DIR", str(tmp_path))
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+
+    sources = []
+    for task_id in (
+        "session:agent:main:telegram:dm:111",
+        "session:agent:main:telegram:dm:222",
+        # Collides with the first key under a plain ':' -> '_' rewrite.
+        "session_agent_main_telegram_dm_111",
+    ):
+        calls = _mock_subprocess_run(monkeypatch)
+        _make_dummy_env(task_id=task_id, persistent_filesystem=True)
+        specs = _bind_mount_specs(_run_args_from_calls(calls))
+        sources.append(
+            next(s.rpartition(":")[0] for s in specs if s.endswith(":/root"))
+        )
+
+    assert len(set(sources)) == 3, f"sandbox sources collided: {sources}"
+
+
+def test_sandbox_dir_name_keeps_existing_names_verbatim():
+    """The shared container and RL/benchmark rollouts must keep resolving to the
+    directory they already use — renaming those strands a user's installed
+    packages and /root state in an orphaned sandbox."""
+    for value in ("default", "bench-env", "astropy__astropy-12907", "v1.2.3_x"):
+        assert docker_env._sandbox_dir_name(value) == value
+
+
+def test_sandbox_dir_name_drops_separators_docker_and_the_fs_reserve():
+    """':' is what docker's -v parser splits on; '/' and '\\' would place the
+    sandbox outside its root entirely."""
+    for value in (
+        "session:agent:main:telegram:dm:8439114563",
+        "task/with:weird*chars",
+        "..\\..\\escape",
+        "../../etc",
+    ):
+        name = docker_env._sandbox_dir_name(value)
+        assert not (set(name) & set(':/\\')), name
+
+
+def test_sandbox_dir_name_is_stable_across_calls():
+    """Cross-process container reuse resolves the sandbox by name, so the
+    mapping must be a pure function of the id — no randomness, no pid."""
+    value = "session:agent:main:discord:guild:1:2"
+    assert docker_env._sandbox_dir_name(value) == docker_env._sandbox_dir_name(value)
+
+
+def test_sandbox_dir_name_bounds_pathological_ids():
+    """Long keys (a Matrix room plus thread id) must stay inside the
+    per-component filesystem limit."""
+    name = docker_env._sandbox_dir_name("session:" + "x:" * 500)
+    assert 0 < len(name) <= 128
+
+
+def test_sandbox_dir_name_never_resolves_to_the_sandbox_root():
+    """'.'/'..' would mount the docker sandbox root, and an empty component
+    would bind every task's state into one container."""
+    for value in ("", ".", "..", "  ", None):
+        name = docker_env._sandbox_dir_name(value)
+        assert name not in {"", ".", ".."}, repr(value)
+        assert not (set(name) & set(':/\\')), name
+
+
 def test_labels_attribute_populated_after_init(monkeypatch):
     """``self._labels`` must be set to the same key/value pairs that went onto
     docker run, so subsequent reuse / reaper paths can match without re-running

--- a/tests/tools/test_singularity_persistent_overlay.py
+++ b/tests/tools/test_singularity_persistent_overlay.py
@@ -1,0 +1,80 @@
+"""Persistent-overlay path safety for the Singularity environment.
+
+A raw task id used as an overlay directory name carries the same class of
+bug as the Docker persistent-sandbox mount path (#92414): colon-bearing
+session ids break bind specs and are unrepresentable on Windows. Overlay
+components must go through the shared sanitizer in tools.environments.base.
+"""
+
+from tools.environments import singularity as singularity_env
+from tools.environments.base import sanitize_task_id_for_path
+
+
+def _stub_singularity(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        singularity_env, "_ensure_singularity_available", lambda: "/usr/bin/apptainer"
+    )
+    monkeypatch.setattr(
+        singularity_env,
+        "_get_or_build_sif",
+        lambda image, executable="apptainer": str(tmp_path / "image.sif"),
+    )
+    monkeypatch.setattr(singularity_env, "_get_scratch_dir", lambda: tmp_path / "scratch")
+    monkeypatch.setattr(
+        singularity_env.SingularityEnvironment, "_start_instance", lambda self: None
+    )
+    monkeypatch.setattr(
+        singularity_env.SingularityEnvironment, "init_session", lambda self: None
+    )
+
+
+def test_persistent_overlay_dir_sanitizes_colon_in_task_id(monkeypatch, tmp_path):
+    _stub_singularity(monkeypatch, tmp_path)
+
+    task_id = "session:agent:main:telegram:dm:12345"
+    env = singularity_env.SingularityEnvironment(
+        image="python:3.11",
+        persistent_filesystem=True,
+        task_id=task_id,
+    )
+
+    assert env._overlay_dir is not None
+    assert env._overlay_dir.name == f"overlay-{sanitize_task_id_for_path(task_id)}"
+    assert ":" not in env._overlay_dir.name
+    assert env._overlay_dir.is_dir()
+
+
+def test_persistent_overlay_dir_keeps_safe_task_ids_verbatim(monkeypatch, tmp_path):
+    """Existing overlays for already-safe ids must keep resolving to the same
+    directory — renaming would strand a user's persistent overlay state."""
+    _stub_singularity(monkeypatch, tmp_path)
+
+    env = singularity_env.SingularityEnvironment(
+        image="python:3.11",
+        persistent_filesystem=True,
+        task_id="default",
+    )
+
+    assert env._overlay_dir is not None
+    assert env._overlay_dir.name == "overlay-default"
+
+
+def test_distinct_session_keys_get_distinct_overlay_dirs(monkeypatch, tmp_path):
+    """Sanitization must stay injective across backends: two ids that differ
+    only in colon placement must not share one overlay."""
+    _stub_singularity(monkeypatch, tmp_path)
+
+    names = set()
+    for task_id in (
+        "session:agent:main:telegram:dm:111",
+        "session_agent_main_telegram_dm_111",
+    ):
+        env = singularity_env.SingularityEnvironment(
+            image="python:3.11",
+            persistent_filesystem=True,
+            task_id=task_id,
+        )
+        assert env._overlay_dir is not None
+        names.add(env._overlay_dir.name)
+
+    assert len(names) == 2, f"overlay dirs collided: {names}"

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -7,6 +7,7 @@ or a temp file (local).
 """
 
 import codecs
+import hashlib
 import json
 import logging
 import os
@@ -292,6 +293,58 @@ def get_sandbox_dir() -> Path:
         p = get_hermes_home() / "sandboxes"
     p.mkdir(parents=True, exist_ok=True)
     return p
+
+
+# A persistent sandbox's host directory is named after task_id, and that name
+# then becomes the source half of a `-v <source>:<target>` spec (Docker) or a
+# writable-overlay directory (Singularity). Docker splits the spec on ':', so
+# a colon-bearing name arrives as extra mount fields and the run is refused
+# outright ("invalid spec ... too many colons" / "invalid mode", exit 125).
+# Path separators would additionally escape the sandbox root, and Windows
+# forbids ':' in path segments entirely.
+_SANDBOX_DIR_UNSAFE_RE = re.compile(r"[^A-Za-z0-9._-]")
+_SANDBOX_DIR_MAX_LEN = 128
+_SANDBOX_DIR_HASH_LEN = 12
+
+
+def sanitize_task_id_for_path(task_id: str) -> str:
+    """Return a bind-mountable directory name for *task_id*'s sandbox.
+
+    Shared by every environment backend that turns a task id into a host
+    filesystem path component (Docker persistent sandboxes, Singularity
+    persistent overlays). Names that are already safe are returned verbatim,
+    so the shared ``default`` sandbox and RL/benchmark task ids keep resolving
+    to the directory they have always used — no installed package or ``/root``
+    state moves. Only ids that could never have produced a working bind mount
+    are rewritten.
+
+    A rewrite also appends a digest of the original id, because the character
+    substitution alone is not injective: ``a:b`` and ``a_b`` would otherwise
+    share one persistent sandbox and leak one session's ``/root`` into
+    another's container. The digest is a pure function of the id, so the same
+    session resolves to the same directory in every process — cross-process
+    container reuse depends on that.
+    """
+    value = task_id if isinstance(task_id, str) else ""
+    if not value:
+        # An empty component collapses the path onto the sandbox root, which
+        # would bind-mount every task's state at once.
+        return "default"
+
+    cleaned = _SANDBOX_DIR_UNSAFE_RE.sub("_", value)
+    if (
+        cleaned == value
+        and len(value) <= _SANDBOX_DIR_MAX_LEN
+        and value not in {".", ".."}
+        # Windows silently strips trailing dots/spaces, aliasing two ids onto
+        # one directory.
+        and not value.endswith((".", " "))
+    ):
+        return value
+
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:_SANDBOX_DIR_HASH_LEN]
+    stem = cleaned[: _SANDBOX_DIR_MAX_LEN - _SANDBOX_DIR_HASH_LEN - 1].strip("._")
+    return f"{stem or 'task'}-{digest}"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -130,6 +130,54 @@ def _sanitize_label_value(value: str) -> str:
     return cleaned
 
 
+# A persistent sandbox's host directory is named after task_id, and that name
+# then becomes the source half of a `-v <source>:<target>` spec. Docker splits
+# the spec on ':', so a colon-bearing name arrives as extra mount fields and
+# the run is refused outright ("invalid spec ... too many colons", exit 125).
+# Path separators would additionally escape the sandbox root.
+_SANDBOX_DIR_UNSAFE_RE = re.compile(r"[^A-Za-z0-9._-]")
+_SANDBOX_DIR_MAX_LEN = 128
+_SANDBOX_DIR_HASH_LEN = 12
+
+
+def _sandbox_dir_name(task_id: str) -> str:
+    """Return a bind-mountable directory name for *task_id*'s sandbox.
+
+    Names that are already safe are returned verbatim, so the shared
+    ``default`` sandbox and RL/benchmark task ids keep resolving to the
+    directory they have always used — no installed package or ``/root`` state
+    moves. Only ids that could never have produced a working bind mount are
+    rewritten.
+
+    A rewrite also appends a digest of the original id, because the character
+    substitution alone is not injective: ``a:b`` and ``a_b`` would otherwise
+    share one persistent sandbox and leak one session's ``/root`` into
+    another's container. The digest is a pure function of the id, so the same
+    session resolves to the same directory in every process — cross-process
+    container reuse depends on that.
+    """
+    value = task_id if isinstance(task_id, str) else ""
+    if not value:
+        # An empty component collapses the path onto the docker sandbox root,
+        # which would bind-mount every task's state at once.
+        return "default"
+
+    cleaned = _SANDBOX_DIR_UNSAFE_RE.sub("_", value)
+    if (
+        cleaned == value
+        and len(value) <= _SANDBOX_DIR_MAX_LEN
+        and value not in {".", ".."}
+        # Windows silently strips trailing dots/spaces, aliasing two ids onto
+        # one directory.
+        and not value.endswith((".", " "))
+    ):
+        return value
+
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:_SANDBOX_DIR_HASH_LEN]
+    stem = cleaned[: _SANDBOX_DIR_MAX_LEN - _SANDBOX_DIR_HASH_LEN - 1].strip("._")
+    return f"{stem or 'task'}-{digest}"
+
+
 def _get_active_profile_name() -> str:
     """Return the active Hermes profile name, or ``"default"`` on any error.
 
@@ -980,7 +1028,9 @@ class DockerEnvironment(BaseEnvironment):
         self._home_dir: Optional[str] = None
         writable_args = []
         if self._persistent:
-            sandbox = get_sandbox_dir() / "docker" / task_id
+            # _sandbox_dir_name(): a raw session-key task_id carries colons,
+            # which `-v` reads as extra spec fields (exit 125).
+            sandbox = get_sandbox_dir() / "docker" / _sandbox_dir_name(task_id)
             self._home_dir = str(sandbox / "home")
             os.makedirs(self._home_dir, exist_ok=True)
             writable_args.extend([

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -22,6 +22,7 @@ from tools.environments.base import (
     BaseEnvironment,
     EnvironmentConnectionError,
     _popen_bash,
+    sanitize_task_id_for_path,
 )
 from tools.environments.local import (
     _HERMES_PROVIDER_ENV_BLOCKLIST,
@@ -130,52 +131,11 @@ def _sanitize_label_value(value: str) -> str:
     return cleaned
 
 
-# A persistent sandbox's host directory is named after task_id, and that name
-# then becomes the source half of a `-v <source>:<target>` spec. Docker splits
-# the spec on ':', so a colon-bearing name arrives as extra mount fields and
-# the run is refused outright ("invalid spec ... too many colons", exit 125).
-# Path separators would additionally escape the sandbox root.
-_SANDBOX_DIR_UNSAFE_RE = re.compile(r"[^A-Za-z0-9._-]")
-_SANDBOX_DIR_MAX_LEN = 128
-_SANDBOX_DIR_HASH_LEN = 12
-
-
-def _sandbox_dir_name(task_id: str) -> str:
-    """Return a bind-mountable directory name for *task_id*'s sandbox.
-
-    Names that are already safe are returned verbatim, so the shared
-    ``default`` sandbox and RL/benchmark task ids keep resolving to the
-    directory they have always used — no installed package or ``/root`` state
-    moves. Only ids that could never have produced a working bind mount are
-    rewritten.
-
-    A rewrite also appends a digest of the original id, because the character
-    substitution alone is not injective: ``a:b`` and ``a_b`` would otherwise
-    share one persistent sandbox and leak one session's ``/root`` into
-    another's container. The digest is a pure function of the id, so the same
-    session resolves to the same directory in every process — cross-process
-    container reuse depends on that.
-    """
-    value = task_id if isinstance(task_id, str) else ""
-    if not value:
-        # An empty component collapses the path onto the docker sandbox root,
-        # which would bind-mount every task's state at once.
-        return "default"
-
-    cleaned = _SANDBOX_DIR_UNSAFE_RE.sub("_", value)
-    if (
-        cleaned == value
-        and len(value) <= _SANDBOX_DIR_MAX_LEN
-        and value not in {".", ".."}
-        # Windows silently strips trailing dots/spaces, aliasing two ids onto
-        # one directory.
-        and not value.endswith((".", " "))
-    ):
-        return value
-
-    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:_SANDBOX_DIR_HASH_LEN]
-    stem = cleaned[: _SANDBOX_DIR_MAX_LEN - _SANDBOX_DIR_HASH_LEN - 1].strip("._")
-    return f"{stem or 'task'}-{digest}"
+# The task_id -> host-directory-name mapping is shared with every backend
+# that persists per-task state on the host filesystem (Singularity overlays
+# use the same helper), so the whole bug class is fixed in one place:
+# tools.environments.base.sanitize_task_id_for_path.
+_sandbox_dir_name = sanitize_task_id_for_path
 
 
 def _get_active_profile_name() -> str:

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -20,6 +20,7 @@ from tools.environments.base import (
     _load_json_store,
     _popen_bash,
     _save_json_store,
+    sanitize_task_id_for_path,
 )
 
 logger = logging.getLogger(__name__)
@@ -191,7 +192,11 @@ class SingularityEnvironment(BaseEnvironment):
         if self._persistent:
             overlay_base = _get_scratch_dir() / "hermes-overlays"
             overlay_base.mkdir(parents=True, exist_ok=True)
-            self._overlay_dir = overlay_base / f"overlay-{task_id}"
+            # A raw session-key task_id carries colons and other characters
+            # that are unsafe in host path components (same class of bug as
+            # the docker -v mount failure); route it through the shared
+            # sanitizer so all backends agree on the mapping.
+            self._overlay_dir = overlay_base / f"overlay-{sanitize_task_id_for_path(task_id)}"
             self._overlay_dir.mkdir(parents=True, exist_ok=True)
 
         self._start_instance()


### PR DESCRIPTION
## Summary
Docker (and Singularity) sandboxes no longer fail with `invalid mode: /root` / exit 125 when the task id contains colons — i.e. every gateway session id (`session:agent:main:telegram:dm:…`). Host paths built from raw task ids broke the `-v` spec; labels were sanitized, mount paths weren't. One shared sanitizer in `base.py` now fixes the class for all backends: safe ids pass through verbatim (existing sandboxes keep working), rewritten ids get a stable digest suffix (no collisions).

Consolidation of a six-PR race — earliest-filed #92331 by @HexLab98 cherry-picked as the base (primary credit), with pieces layered from #92396 (@salch-cred: base.py placement + singularity wiring), #92757 (@Parker-Fawcett: singularity coverage), #92646 (@chelsealong: collision test cases) via Co-authored-by. Closes #92414. Closes #92640.

## Changes
- `tools/environments/base.py`: shared `sanitize_task_id_for_path` — verbatim-if-safe, sha256 digest suffix on rewrite, length bound, traversal/Windows edge cases
- `tools/environments/docker.py`: sandbox dir uses the shared helper
- `tools/environments/singularity.py`: overlay paths wired to the same helper
- Tests: #92331's suite + shared-helper contract tests (collision `a:b` ≠ `a_b`, determinism, oversize digest) + singularity overlay tests incl. cross-backend collision

Sibling audit: only docker.py and singularity.py build host paths from task_id; vercel/modal/daytona use it as keys/labels only — no change needed.

## Validation
Docker daemon not available on the build box (disclosed) — A/B via real imports constructing the actual `-v` specs:

| | Before (main) | After (branch) |
|---|---|---|
| task_id `session:agent:main:telegram:dm:12345` | host path carries 5 colons → docker parses `mode=/root`, exit 125 | `session_agent_main_telegram_dm_12345-63b7ef75ed43`, clean 2-field spec |
| collision | — | `session:agent:a:b:1` ≠ `session_agent_a_b_1` (digest suffix) ✓ |
| Tests | — | 88 passed |

## Infographic

![Sandbox paths sanitized across all backends](https://v3b.fal.media/files/b/0aa7925b/qCivkDj19jzdVPyzcrtb1_doUIYFQA.png)
