### PR TITLE
feat(agent): add request context budget window

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2066,6 +2066,9 @@ class _AnthropicCompletionsAdapter:
         messages = kwargs.get("messages", [])
         model = kwargs.get("model", self._model)
         tools = kwargs.get("tools")
+        # Anthropic-compatible endpoints reject a tool choice without tools.
+        if not tools:
+            kwargs.pop("tool_choice", None)
         tool_choice = kwargs.get("tool_choice")
         reasoning_config = kwargs.get("_reasoning_config")
         # ZAI's Anthropic-compatible endpoint rejects max_tokens on vision
@@ -2101,6 +2104,8 @@ class _AnthropicCompletionsAdapter:
                 if isinstance(_rc, dict):
                     _reasoning_cfg = _rc
 
+        if not tools:
+            normalized_tool_choice = None
         anthropic_kwargs = build_anthropic_kwargs(
             model=model,
             messages=messages,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -37,6 +37,10 @@ from agent.conversation_compression import (
     conversation_history_after_compression,
 )
 from agent.context_engine import automatic_compaction_status_message
+from agent.request_context_budget import (
+    build_request_context_budget,
+    select_request_context_window,
+)
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.message_metadata import append_message
@@ -1683,6 +1687,70 @@ def _redecorate_prompt_cache_for_provider(
     return messages, prepared, planned_tools
 
 
+def _apply_request_context_budget_window(
+    agent: Any,
+    api_messages: List[Dict[str, Any]],
+    *,
+    fixed_prefix_count: int,
+) -> List[Dict[str, Any]]:
+    """Apply the built-in request-only sliding window without touching history.
+
+    Fixed prompt messages (the active system prompt and ephemeral prefills) are
+    charged before history.  This closes the mid-turn undercount where dynamic
+    system prompt bytes were absent from the pressure calculation.
+    """
+    compressor = getattr(agent, "context_compressor", None)
+    context_length = getattr(compressor, "context_length", 0)
+    if isinstance(context_length, bool) or not isinstance(context_length, int) or context_length <= 0:
+        return api_messages
+
+    reserved_output = getattr(agent, "max_tokens", None)
+    if not isinstance(reserved_output, int) or isinstance(reserved_output, bool) or reserved_output < 0:
+        reserved_output = getattr(compressor, "max_tokens", 0)
+    if not isinstance(reserved_output, int) or isinstance(reserved_output, bool) or reserved_output < 0:
+        reserved_output = 0
+
+    fixed_prefix_count = max(0, min(int(fixed_prefix_count), len(api_messages)))
+    fixed_prompt_tokens = estimate_messages_tokens_rough(api_messages[:fixed_prefix_count])
+    tools = getattr(agent, "tools", None) or []
+    tool_schema_tokens = _estimate_tools_tokens_rough(tools) if tools else 0
+    budget = build_request_context_budget(
+        context_window_tokens=context_length,
+        reserved_output_tokens=reserved_output,
+        system_prompt_tokens=fixed_prompt_tokens,
+        tool_schema_tokens=tool_schema_tokens,
+        confidence="rough",
+    )
+    # Request-local observability only; this is never persisted as transcript
+    # state and is intentionally best effort for lightweight test doubles.
+    try:
+        agent._last_request_context_budget = budget
+    except Exception:
+        pass
+
+    history = api_messages[fixed_prefix_count:]
+    history_tokens = estimate_messages_tokens_rough(history)
+    if history_tokens <= budget.history_budget_tokens:
+        return api_messages
+
+    selection = select_request_context_window(
+        api_messages,
+        fixed_prefix_count=fixed_prefix_count,
+        budget=budget,
+    )
+    if selection.omitted_message_count:
+        logger.info(
+            "Request sliding window selected %s history messages (~%s tokens; "
+            "budget=%s, pinned=%s) and omitted %s older messages",
+            len(selection.messages) - fixed_prefix_count,
+            selection.selected_tokens,
+            budget.history_budget_tokens,
+            selection.pinned_tokens,
+            selection.omitted_message_count,
+        )
+    return selection.messages
+
+
 def _apply_context_engine_selection(
     agent: Any,
     api_messages: List[Dict[str, Any]],
@@ -2453,6 +2521,12 @@ def run_conversation(
                 # containers (same aliasing class as the history build).
                 api_messages.insert(sys_offset + idx, _clone_message_for_send(pfm))
 
+        # System prompt and ephemeral prefill are fixed request components, not
+        # durable transcript history. Charge them before any request-only tail
+        # selection so their dynamic bytes cannot be hidden from the budget.
+        _request_fixed_prefix_count = len(api_messages) - len(messages)
+        _request_fixed_prefix_count = max(0, _request_fixed_prefix_count)
+
         # Per-turn context selection hook (additive, no-op by default).
         # Lets a context engine select/replace which context enters the
         # prompt for THIS call only — retrieval, topic routing, role/branch
@@ -2471,6 +2545,16 @@ def run_conversation(
             messages,
             _sel_incoming,
             logger=request_logger,
+        )
+
+        # Built-in Dynamic Sliding Window. This runs after an optional plugin
+        # selection so every provider request has a final request-local cap.
+        # The durable SessionDB transcript and ContextCompressor lifecycle are
+        # deliberately untouched.
+        api_messages = _apply_request_context_budget_window(
+            agent,
+            api_messages,
+            fixed_prefix_count=_request_fixed_prefix_count,
         )
 
         # Safety net: strip orphaned tool results / add stubs for missing

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -561,7 +561,14 @@ def _translate_tools_to_gemini(tools: Any) -> List[Dict[str, Any]]:
     return [{"functionDeclarations": declarations}] if declarations else []
 
 
-def _translate_tool_choice_to_gemini(tool_choice: Any) -> Optional[Dict[str, Any]]:
+def _translate_tool_choice_to_gemini(
+    tool_choice: Any,
+    *,
+    has_tool_declarations: bool,
+) -> Optional[Dict[str, Any]]:
+    """Translate tool choice only when the request declares callable tools."""
+    if not has_tool_declarations:
+        return None
     if tool_choice is None:
         return None
     if isinstance(tool_choice, str):
@@ -662,7 +669,10 @@ def build_gemini_request(
     if gemini_tools:
         request["tools"] = gemini_tools
 
-    tool_config = _translate_tool_choice_to_gemini(tool_choice)
+    tool_config = _translate_tool_choice_to_gemini(
+        tool_choice,
+        has_tool_declarations=bool(gemini_tools),
+    )
     if tool_config:
         request["toolConfig"] = tool_config
 

--- a/agent/request_context_budget.py
+++ b/agent/request_context_budget.py
@@ -1,0 +1,202 @@
+"""Request-local context budgets and safe token-based history selection.
+
+This module deliberately does not mutate the durable transcript.  It computes
+what may be sent for one provider request and returns a selected history copy.
+Durable summarization remains owned by ``ContextCompressor``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Callable, Literal, Mapping, Sequence
+
+
+BudgetConfidence = Literal["exact", "tokenizer", "rough"]
+_VALID_CONFIDENCE = frozenset({"exact", "tokenizer", "rough"})
+
+
+@dataclass(frozen=True)
+class RequestContextBudget:
+    """Token allocation for one provider request.
+
+    ``history_budget_tokens`` is derived after reserving output capacity and
+    fixed request components.  It is never negative: an oversized system/tool
+    payload leaves zero room for history and the caller can retain only pinned
+    active-turn messages.
+    """
+
+    context_window_tokens: int
+    reserved_output_tokens: int
+    system_prompt_tokens: int
+    tool_schema_tokens: int
+    confidence: BudgetConfidence
+
+    def __post_init__(self) -> None:
+        for name in (
+            "context_window_tokens",
+            "reserved_output_tokens",
+            "system_prompt_tokens",
+            "tool_schema_tokens",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(f"{name} must be a non-negative integer")
+        if self.confidence not in _VALID_CONFIDENCE:
+            raise ValueError("confidence must be one of: exact, tokenizer, rough")
+
+    @property
+    def safe_input_budget_tokens(self) -> int:
+        """Maximum prompt input after reserving output capacity."""
+        return max(0, self.context_window_tokens - self.reserved_output_tokens)
+
+    @property
+    def fixed_input_tokens(self) -> int:
+        """Input tokens consumed outside conversation history."""
+        return self.system_prompt_tokens + self.tool_schema_tokens
+
+    @property
+    def history_budget_tokens(self) -> int:
+        """Pure history allowance after all fixed request components."""
+        return max(0, self.safe_input_budget_tokens - self.fixed_input_tokens)
+
+
+@dataclass(frozen=True)
+class TokenBudgetedHistorySelection:
+    """Request-only result of history-tail selection."""
+
+    messages: list[dict[str, Any]]
+    history_budget_tokens: int
+    selected_tokens: int
+    pinned_tokens: int
+    omitted_message_count: int
+
+
+def build_request_context_budget(
+    *,
+    context_window_tokens: int,
+    reserved_output_tokens: int,
+    system_prompt_tokens: int,
+    tool_schema_tokens: int,
+    confidence: BudgetConfidence = "rough",
+) -> RequestContextBudget:
+    """Build a budget from already-measured request components."""
+    return RequestContextBudget(
+        context_window_tokens=context_window_tokens,
+        reserved_output_tokens=reserved_output_tokens,
+        system_prompt_tokens=system_prompt_tokens,
+        tool_schema_tokens=tool_schema_tokens,
+        confidence=confidence,
+    )
+
+
+def _rough_message_tokens(message: Mapping[str, Any]) -> int:
+    """Conservative local fallback for selection when no tokenizer is available."""
+    try:
+        serialized = json.dumps(message, ensure_ascii=False, default=str, separators=(",", ":"))
+    except (TypeError, ValueError):
+        serialized = str(message)
+    return max(1, (len(serialized) + 3) // 4)
+
+
+def _latest_user_start(messages: Sequence[Mapping[str, Any]]) -> int:
+    for index in range(len(messages) - 1, -1, -1):
+        if messages[index].get("role") == "user":
+            return index
+    # A malformed/resumed transcript with no user message is kept intact.  The
+    # standard request sanitizer remains responsible for repairing it.
+    return 0
+
+
+def _previous_group_start(messages: Sequence[Mapping[str, Any]], end: int) -> int:
+    """Return the start of the immediately preceding complete conversation turn.
+
+    A turn starts at a user message and includes every following assistant/tool
+    activity until the next user message. This keeps ordinary assistant replies
+    coherent with the request that prompted them, and also makes every
+    ``assistant(tool_calls) + tool results`` block indivisible. Malformed
+    history with no preceding user is kept as one conservative group for the
+    standard request sanitizer to repair later.
+    """
+    for start in range(end - 1, -1, -1):
+        if messages[start].get("role") == "user":
+            return start
+    return 0
+
+
+def select_token_budgeted_history_tail(
+    messages: Sequence[Mapping[str, Any]],
+    *,
+    history_budget_tokens: int,
+    estimate_message_tokens: Callable[[Mapping[str, Any]], int] = _rough_message_tokens,
+) -> TokenBudgetedHistorySelection:
+    """Select the newest safe history tail without mutating ``messages``.
+
+    The latest user turn and every following message are pinned even if they
+    alone exceed budget.  Earlier groups are added only when the whole group
+    fits, so oversized old tool output is omitted first and can use the existing
+    spillover/preview path rather than breaking tool-call/result pairing.
+    """
+    if (
+        isinstance(history_budget_tokens, bool)
+        or not isinstance(history_budget_tokens, int)
+        or history_budget_tokens < 0
+    ):
+        raise ValueError("history_budget_tokens must be a non-negative integer")
+    copied = [dict(message) for message in messages]
+    if not copied:
+        return TokenBudgetedHistorySelection([], history_budget_tokens, 0, 0, 0)
+
+    pinned_start = _latest_user_start(copied)
+    pinned_tokens = sum(max(0, int(estimate_message_tokens(message))) for message in copied[pinned_start:])
+    selected_start = pinned_start
+    selected_tokens = pinned_tokens
+
+    while selected_start > 0:
+        group_start = _previous_group_start(copied, selected_start)
+        group_tokens = sum(
+            max(0, int(estimate_message_tokens(message)))
+            for message in copied[group_start:selected_start]
+        )
+        if selected_tokens + group_tokens > history_budget_tokens:
+            break
+        selected_start = group_start
+        selected_tokens += group_tokens
+
+    return TokenBudgetedHistorySelection(
+        messages=copied[selected_start:],
+        history_budget_tokens=history_budget_tokens,
+        selected_tokens=selected_tokens,
+        pinned_tokens=pinned_tokens,
+        omitted_message_count=selected_start,
+    )
+
+
+def select_request_context_window(
+    request_messages: Sequence[Mapping[str, Any]],
+    *,
+    fixed_prefix_count: int,
+    budget: RequestContextBudget,
+    estimate_message_tokens: Callable[[Mapping[str, Any]], int] = _rough_message_tokens,
+) -> TokenBudgetedHistorySelection:
+    """Select a request-only history tail while preserving fixed prompt prefix.
+
+    ``fixed_prefix_count`` is for system and ephemeral prefill messages that
+    are not durable conversation history.  They stay verbatim; only the
+    remaining history consumes ``budget.history_budget_tokens``.
+    """
+    if fixed_prefix_count < 0 or fixed_prefix_count > len(request_messages):
+        raise ValueError("fixed_prefix_count must identify a request prefix")
+    prefix = [dict(message) for message in request_messages[:fixed_prefix_count]]
+    tail = select_token_budgeted_history_tail(
+        request_messages[fixed_prefix_count:],
+        history_budget_tokens=budget.history_budget_tokens,
+        estimate_message_tokens=estimate_message_tokens,
+    )
+    return TokenBudgetedHistorySelection(
+        messages=prefix + tail.messages,
+        history_budget_tokens=tail.history_budget_tokens,
+        selected_tokens=tail.selected_tokens,
+        pinned_tokens=tail.pinned_tokens,
+        omitted_message_count=tail.omitted_message_count,
+    )

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -660,8 +660,16 @@ class ResponsesApiTransport(ProviderTransport):
             kwargs["include"] = []
 
         request_overrides = params.get("request_overrides")
-        if request_overrides:
+        if isinstance(request_overrides, dict):
             kwargs.update(request_overrides)
+
+        # The OpenAI Responses SDK eagerly iterates ``tools``. A request with
+        # no exposed functions must omit every tool-related field, including
+        # values reintroduced by request_overrides.
+        if not response_tools:
+            kwargs.pop("tools", None)
+            kwargs.pop("tool_choice", None)
+            kwargs.pop("parallel_tool_calls", None)
 
         if "prompt_cache_key" in kwargs:
             bounded_cache_key = _bounded_prompt_cache_key(kwargs["prompt_cache_key"])

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -567,3 +567,37 @@ class TestGemini3ToolCallIds:
         result = translate_gemini_response(resp, model="gemini-2.5-flash")
         tool_calls = result.choices[0].message.tool_calls
         assert tool_calls[0].id.startswith("call_")
+
+def test_tool_choice_is_omitted_without_tool_declarations():
+    from agent.gemini_native_adapter import build_gemini_request
+
+    request = build_gemini_request(
+        messages=[{"role": "user", "content": "hello"}],
+        tools=[],
+        tool_choice="required",
+    )
+
+    assert "tools" not in request
+    assert "toolConfig" not in request
+
+
+def test_required_tool_choice_is_translated_when_tools_are_declared():
+    from agent.gemini_native_adapter import build_gemini_request
+
+    tools = [{
+        "type": "function",
+        "function": {
+            "name": "terminal",
+            "description": "Run a command",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }]
+    request = build_gemini_request(
+        messages=[{"role": "user", "content": "hello"}],
+        tools=tools,
+        tool_choice="required",
+    )
+
+    assert request["tools"]
+    assert request["toolConfig"] == {"functionCallingConfig": {"mode": "ANY"}}
+

--- a/tests/agent/test_request_context_budget.py
+++ b/tests/agent/test_request_context_budget.py
@@ -1,0 +1,204 @@
+"""Tests for request-level context budgeting and token-based history selection."""
+
+from types import SimpleNamespace
+
+from agent.conversation_loop import _apply_request_context_budget_window
+from agent.request_context_budget import (
+    RequestContextBudget,
+    select_request_context_window,
+    select_token_budgeted_history_tail,
+)
+
+
+def _message(role: str, content: str, **extra):
+    return {"role": role, "content": content, **extra}
+
+
+class TestRequestContextBudget:
+    def test_reserves_system_tools_and_output_before_history(self):
+        budget = RequestContextBudget(
+            context_window_tokens=1000,
+            reserved_output_tokens=250,
+            system_prompt_tokens=200,
+            tool_schema_tokens=150,
+            confidence="rough",
+        )
+
+        assert budget.history_budget_tokens == 400
+        assert budget.safe_input_budget_tokens == 750
+        assert budget.fixed_input_tokens == 350
+
+    def test_never_allocates_negative_history_budget_for_large_fixed_prompt(self):
+        budget = RequestContextBudget(
+            context_window_tokens=1000,
+            reserved_output_tokens=300,
+            system_prompt_tokens=800,
+            tool_schema_tokens=200,
+            confidence="rough",
+        )
+
+        assert budget.safe_input_budget_tokens == 700
+        assert budget.history_budget_tokens == 0
+
+    def test_rejects_unknown_confidence(self):
+        try:
+            RequestContextBudget(
+                context_window_tokens=1000,
+                reserved_output_tokens=1,
+                system_prompt_tokens=1,
+                tool_schema_tokens=1,
+                confidence="guessed",
+            )
+        except ValueError as exc:
+            assert "confidence" in str(exc)
+        else:
+            raise AssertionError("unknown confidence must be rejected")
+
+    def test_rejects_non_integer_history_budget_input(self):
+        messages = [_message("user", "latest request")]
+
+        try:
+            select_token_budgeted_history_tail(messages, history_budget_tokens="10")
+        except ValueError as exc:
+            assert "history_budget_tokens" in str(exc)
+        else:
+            raise AssertionError("non-integer budget must be rejected")
+
+
+class TestTokenBudgetedHistoryTail:
+    def test_drops_old_messages_before_latest_user_turn_when_budget_is_exhausted(self):
+        messages = [
+            _message("user", "old user " + "a" * 200),
+            _message("assistant", "old assistant " + "b" * 200),
+            _message("user", "latest user request"),
+            _message("assistant", "latest answer"),
+        ]
+
+        selected = select_token_budgeted_history_tail(messages, history_budget_tokens=20)
+
+        assert selected.messages == messages[2:]
+        assert selected.omitted_message_count == 2
+        assert selected.pinned_tokens > selected.history_budget_tokens
+
+    def test_keeps_active_tool_chain_with_its_latest_user_turn(self):
+        messages = [
+            _message("user", "old request " + "x" * 200),
+            _message("assistant", "old reply " + "y" * 200),
+            _message("user", "deploy now"),
+            _message(
+                "assistant",
+                "",
+                tool_calls=[{"id": "call-1", "function": {"name": "terminal", "arguments": "{}"}}],
+            ),
+            _message("tool", "build output", tool_call_id="call-1"),
+        ]
+
+        selected = select_token_budgeted_history_tail(messages, history_budget_tokens=5)
+
+        assert selected.messages == messages[2:]
+        assert selected.messages[-2]["tool_calls"][0]["id"] == "call-1"
+        assert selected.messages[-1]["tool_call_id"] == "call-1"
+
+    def test_adds_only_complete_older_tool_group_when_it_fits(self):
+        messages = [
+            _message("user", "older request"),
+            _message(
+                "assistant",
+                "",
+                tool_calls=[{"id": "call-1", "function": {"name": "read_file", "arguments": "{}"}}],
+            ),
+            _message("tool", "small result", tool_call_id="call-1"),
+            _message("assistant", "older conclusion"),
+            _message("user", "latest request"),
+        ]
+
+        selected = select_token_budgeted_history_tail(messages, history_budget_tokens=80)
+
+        assert selected.messages == messages
+        assert selected.omitted_message_count == 0
+
+    def test_does_not_orphan_prior_assistant_response_from_its_user_turn(self):
+        messages = [
+            _message("user", "older request " + "a" * 100),
+            _message("assistant", "older conclusion"),
+            _message("user", "latest request"),
+        ]
+
+        selected = select_token_budgeted_history_tail(messages, history_budget_tokens=25)
+
+        assert selected.messages == messages[-1:]
+        assert selected.omitted_message_count == 2
+
+    def test_excludes_oversized_old_tool_result_without_mutating_source(self):
+        huge_tool = _message("tool", "z" * 10_000, tool_call_id="call-1")
+        messages = [
+            _message("user", "old request"),
+            _message(
+                "assistant",
+                "",
+                tool_calls=[{"id": "call-1", "function": {"name": "terminal", "arguments": "{}"}}],
+            ),
+            huge_tool,
+            _message("user", "latest request"),
+        ]
+
+        selected = select_token_budgeted_history_tail(messages, history_budget_tokens=20)
+
+        assert selected.messages == messages[-1:]
+        assert selected.omitted_message_count == 3
+        assert huge_tool["content"] == "z" * 10_000
+
+
+class TestRequestContextWindow:
+    def test_preserves_fixed_system_prefix_while_clipping_history(self):
+        request_messages = [
+            _message("system", "dynamic system prompt " + "s" * 100),
+            _message("user", "old request " + "a" * 1_000),
+            _message("assistant", "old reply " + "b" * 1_000),
+            _message("user", "latest request"),
+        ]
+        budget = RequestContextBudget(
+            context_window_tokens=100,
+            reserved_output_tokens=20,
+            system_prompt_tokens=30,
+            tool_schema_tokens=20,
+            confidence="rough",
+        )
+
+        selected = select_request_context_window(
+            request_messages,
+            fixed_prefix_count=1,
+            budget=budget,
+        )
+
+        assert selected.messages[0] == request_messages[0]
+        assert selected.messages[1:] == request_messages[-1:]
+        assert selected.omitted_message_count == 2
+
+
+class TestConversationLoopBudgetIntegration:
+    def test_uses_active_system_and_tool_schema_before_selecting_history(self):
+        agent = SimpleNamespace(
+            context_compressor=SimpleNamespace(context_length=100),
+            max_tokens=20,
+            tools=[{"type": "function", "function": {"name": "tool", "parameters": {}}}],
+        )
+        request_messages = [
+            _message("system", "dynamic system prompt " + "s" * 100),
+            _message("user", "old request " + "a" * 1_000),
+            _message("assistant", "old response " + "b" * 1_000),
+            _message("user", "latest request"),
+        ]
+
+        selected = _apply_request_context_budget_window(
+            agent,
+            request_messages,
+            fixed_prefix_count=1,
+        )
+
+        assert selected[0] == request_messages[0]
+        assert selected[-1] == request_messages[-1]
+        assert len(selected) == 2
+        assert agent._last_request_context_budget.system_prompt_tokens > 0
+        assert agent._last_request_context_budget.tool_schema_tokens > 0
+        assert agent._last_request_context_budget.reserved_output_tokens == 20

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -61,6 +61,48 @@ class TestCodexBuildKwargs:
 
 
 
+    def test_no_tools_strips_tool_overrides_after_request_overrides(self, transport):
+        kwargs = transport.build_kwargs(
+            model="gpt-5.6",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=[],
+            request_overrides={
+                "tools": [],
+                "tool_choice": "required",
+                "parallel_tool_calls": True,
+            },
+        )
+
+        assert "tools" not in kwargs
+        assert "tool_choice" not in kwargs
+        assert "parallel_tool_calls" not in kwargs
+
+    def test_tools_keep_default_tool_control_fields(self, transport):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "description": "Run a command",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"command": {"type": "string"}},
+                        "required": ["command"],
+                    },
+                },
+            },
+        ]
+
+        kwargs = transport.build_kwargs(
+            model="gpt-5.6",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=tools,
+        )
+
+        assert kwargs["tools"]
+        assert kwargs["tool_choice"] == "auto"
+        assert kwargs["parallel_tool_calls"] is True
+
     def test_cache_key_is_content_addressed_not_session_id(self, transport):
         """prompt_cache_key is content-addressed from the static prefix
         (instructions + tools), not the session_id. This keeps recurring cron


### PR DESCRIPTION
## Summary
- Add request-local `RequestContextBudget` accounting for context window, reserved output, active system prompt, and tool schemas.
- Apply a token-budgeted sliding window before provider requests without mutating durable SessionDB transcript or ContextCompressor state.
- Pin the latest user turn and preserve complete historical user turns with assistant/tool activity.

## Validation
- `tests/agent/test_request_context_budget.py`: 11 passed
- Related context regressions: 197 passed
- Ruff, `compileall`, and `git diff --check`: passed

## Note
The full Windows suite is blocked during collection by unrelated platform-specific tests requiring Teams dependencies, `os.geteuid`, and `fcntl`.