### PR TITLE
fix(gateway): isolate telegram bot adapters and topic bindings across multiplexed profiles

### DIFF
--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -511,6 +511,7 @@ class InProcessCronScheduler(CronScheduler):
         interval=60,
         can_dispatch=None,
         profile_homes=None,
+        profile_adapters=None,
     ):
         import logging
         from cron.scheduler import tick as cron_tick
@@ -535,6 +536,7 @@ class InProcessCronScheduler(CronScheduler):
                 stop_event,
                 profile_homes=profile_homes,
                 adapters=adapters,
+                profile_adapters=profile_adapters,
                 loop=loop,
                 interval=interval,
                 can_dispatch=can_dispatch,
@@ -606,6 +608,7 @@ class InProcessCronScheduler(CronScheduler):
         *,
         profile_homes,
         adapters=None,
+        profile_adapters=None,
         loop=None,
         interval=60,
         can_dispatch=None,
@@ -662,12 +665,21 @@ class InProcessCronScheduler(CronScheduler):
                 else:
                     for entry in profile_homes:
                         home = entry[1] if isinstance(entry, tuple) else entry
+                        profile_name = entry[0] if isinstance(entry, tuple) else "default"
                         home_token = set_hermes_home_override(str(home))
                         try:
                             with use_cron_store(home):
+                                profile_adapters_map = {}
+                                if profile_adapters:
+                                    profile_adapters_map = profile_adapters.get(
+                                        profile_name
+                                    ) or {}
+                                tick_adapters = profile_adapters_map or (
+                                    adapters if profile_name == "default" else None
+                                )
                                 cron_tick(
                                     verbose=False,
-                                    adapters=adapters,
+                                    adapters=tick_adapters,
                                     loop=loop,
                                     sync=False,
                                     can_dispatch=can_dispatch,

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -665,17 +665,17 @@ class InProcessCronScheduler(CronScheduler):
                 else:
                     for entry in profile_homes:
                         home = entry[1] if isinstance(entry, tuple) else entry
-                        profile_name = entry[0] if isinstance(entry, tuple) else "default"
+                        profile_name = entry[0] if isinstance(entry, tuple) else None
                         home_token = set_hermes_home_override(str(home))
                         try:
                             with use_cron_store(home):
                                 profile_adapters_map = {}
-                                if profile_adapters:
+                                if profile_adapters and profile_name:
                                     profile_adapters_map = profile_adapters.get(
                                         profile_name
                                     ) or {}
                                 tick_adapters = profile_adapters_map or (
-                                    adapters if profile_name == "default" else None
+                                    adapters if profile_name in ("default", None) else None
                                 )
                                 cron_tick(
                                     verbose=False,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7847,16 +7847,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     def _telegram_topic_binding_profile(self, source: SessionSource) -> str:
         """Return the bot/profile namespace for Telegram topic persistence."""
+        if hasattr(self, "_adapter_for_source"):
+            try:
+                adapter = self._adapter_for_source(source)
+                if adapter is not None:
+                    gateway_profile = getattr(adapter, "_gateway_profile_name", None)
+                    if isinstance(gateway_profile, str) and gateway_profile.strip():
+                        return gateway_profile.strip()
+            except Exception:
+                pass
         profile = str(getattr(source, "profile", None) or "").strip()
         if profile:
             return profile
-        if getattr(self.config, "multiplex_profiles", False):
-            try:
-                from hermes_cli.profiles import get_active_profile_name
-
-                return get_active_profile_name() or "default"
-            except Exception:
-                pass
         return "default"
 
     # Telegram's General (pinned top) topic in forum-enabled private chats.
@@ -7944,8 +7946,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if session_db is None or not source.chat_id or not source.thread_id:
             return
         # Runs off-loop (always via asyncio.to_thread); use the sync handle.
-        session_db = getattr(session_db, "_db", session_db)
-        session_db.bind_telegram_topic(
+        sync_db = getattr(session_db, "_db", session_db)
+        sync_db.bind_telegram_topic(
             profile=self._telegram_topic_binding_profile(source),
             chat_id=str(source.chat_id),
             thread_id=str(source.thread_id),
@@ -19129,6 +19131,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if await asyncio.to_thread(self._is_telegram_topic_lane, source):
             try:
                 binding = (await self._session_db.get_telegram_topic_binding(
+                    profile=self._telegram_topic_binding_profile(source),
                     chat_id=str(source.chat_id),
                     thread_id=str(source.thread_id),
                 )) if self._session_db else None
@@ -23286,6 +23289,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if session_db is not None:
             try:
                 binding = await session_db.get_telegram_topic_binding(
+                    profile=self._telegram_topic_binding_profile(source),
                     chat_id=str(source.chat_id),
                     thread_id=str(source.thread_id),
                 )
@@ -23532,6 +23536,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         linked = await self._session_db.is_telegram_session_linked_to_topic(session_id=session_id)
         current_binding = await self._session_db.get_telegram_topic_binding(
+            profile=self._telegram_topic_binding_profile(source),
             chat_id=str(source.chat_id),
             thread_id=str(source.thread_id),
         )
@@ -23542,6 +23547,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         session_key = self._session_key_for_source(source)
         try:
             await self._session_db.bind_telegram_topic(
+                profile=self._telegram_topic_binding_profile(source),
                 chat_id=str(source.chat_id),
                 thread_id=str(source.thread_id),
                 user_id=str(source.user_id),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7845,6 +7845,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # opt into topic mode) means topic mode is off for this chat.
         return raw is True
 
+    def _telegram_topic_binding_profile(self, source: SessionSource) -> str:
+        """Return the bot/profile namespace for Telegram topic persistence."""
+        profile = str(getattr(source, "profile", None) or "").strip()
+        if profile:
+            return profile
+        if getattr(self.config, "multiplex_profiles", False):
+            try:
+                from hermes_cli.profiles import get_active_profile_name
+
+                return get_active_profile_name() or "default"
+            except Exception:
+                pass
+        return "default"
+
     # Telegram's General (pinned top) topic in forum-enabled private chats.
     # Bot API behavior varies: some clients omit message_thread_id for
     # General, others send "1". Treat both as "root" for lobby/lane purposes.
@@ -7932,6 +7946,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Runs off-loop (always via asyncio.to_thread); use the sync handle.
         session_db = getattr(session_db, "_db", session_db)
         session_db.bind_telegram_topic(
+            profile=self._telegram_topic_binding_profile(source),
             chat_id=str(source.chat_id),
             thread_id=str(source.thread_id),
             user_id=str(source.user_id or ""),
@@ -8003,6 +8018,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         session_db = getattr(session_db, "_db", session_db)
         try:
             bindings = session_db.list_telegram_topic_bindings_for_chat(
+                profile=self._telegram_topic_binding_profile(source),
                 chat_id=str(source.chat_id),
             )
         except Exception:
@@ -15624,6 +15640,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # profile-scoped.  Preserve both dimensions in the key so dashboard
         # and NAS health aggregation can see which secondary profile failed.
         adapter._runtime_status_platform_key = f"{profile_name}:{platform.value}"
+        adapter._gateway_profile_name = profile_name
         adapter.set_message_handler(self._make_profile_message_handler(profile_name))
         adapter.set_fatal_error_handler(
             self._make_profile_fatal_error_handler(profile_name, platform)
@@ -31044,6 +31061,8 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             profile_homes = _multiplex_profile_homes(runner.config)
             if profile_homes:
                 cron_start_kwargs["profile_homes"] = profile_homes
+                if getattr(runner, "_profile_adapters", None):
+                    cron_start_kwargs["profile_adapters"] = runner._profile_adapters
                 logger.info(
                     "Cron scheduler will tick %d profile(s) under multiplex: %s",
                     len(profile_homes),

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4654,6 +4654,7 @@ class GatewaySlashCommandsMixin:
         if source.thread_id:
             try:
                 binding = await self._session_db.get_telegram_topic_binding(
+                    profile=getattr(source, "profile", None) or "default",
                     chat_id=str(source.chat_id),
                     thread_id=str(source.thread_id),
                 )

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -13348,6 +13348,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
           v1 — initial shape (no ON DELETE CASCADE on session_id FK)
           v2 — session_id FK gets ON DELETE CASCADE so session pruning
                automatically clears bindings.
+          v3 — primary key widened to (profile, chat_id, thread_id) so
+               multiplexed Telegram bots never collide on shared chat/thread IDs.
         """
         def _do(conn):
             conn.executescript(
@@ -13364,76 +13366,128 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     intro_message_id TEXT,
                     pinned_message_id TEXT
                 );
-
-                CREATE TABLE IF NOT EXISTS telegram_dm_topic_bindings (
-                    profile TEXT NOT NULL DEFAULT 'default',
-                    chat_id TEXT NOT NULL,
-                    thread_id TEXT NOT NULL,
-                    user_id TEXT NOT NULL,
-                    session_key TEXT NOT NULL,
-                    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
-                    managed_mode TEXT NOT NULL DEFAULT 'auto',
-                    linked_at REAL NOT NULL,
-                    updated_at REAL NOT NULL,
-                    PRIMARY KEY (profile, chat_id, thread_id)
-                );
-
-                CREATE UNIQUE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_session
-                ON telegram_dm_topic_bindings(session_id);
-
-                CREATE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_user
-                ON telegram_dm_topic_bindings(profile, user_id, chat_id);
                 """
             )
 
-            # v1 → v2: rebuild telegram_dm_topic_bindings if its session_id FK
-            # lacks ON DELETE CASCADE. SQLite can't ALTER a foreign key, so we
-            # rebuild the table. Only runs once per DB (version gate).
+            # Check existing version and columns before creating/migrating bindings
             current = conn.execute(
                 "SELECT value FROM state_meta WHERE key = ?",
                 ("telegram_dm_topic_schema_version",),
             ).fetchone()
             current_version = int(current[0]) if current and str(current[0]).isdigit() else 0
-            if current_version < 2:
-                fk_rows = conn.execute(
-                    "PRAGMA foreign_key_list('telegram_dm_topic_bindings')"
-                ).fetchall()
-                needs_rebuild = any(
-                    row[2] == "sessions" and (row[6] or "") != "CASCADE"
-                    for row in fk_rows
+
+            # Inspect if telegram_dm_topic_bindings already exists
+            table_exists = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='telegram_dm_topic_bindings'"
+            ).fetchone() is not None
+
+            if not table_exists:
+                conn.executescript(
+                    """
+                    CREATE TABLE telegram_dm_topic_bindings (
+                        profile TEXT NOT NULL DEFAULT 'default',
+                        chat_id TEXT NOT NULL,
+                        thread_id TEXT NOT NULL,
+                        user_id TEXT NOT NULL,
+                        session_key TEXT NOT NULL,
+                        session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+                        managed_mode TEXT NOT NULL DEFAULT 'auto',
+                        linked_at REAL NOT NULL,
+                        updated_at REAL NOT NULL,
+                        PRIMARY KEY (profile, chat_id, thread_id)
+                    );
+
+                    CREATE UNIQUE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_session
+                    ON telegram_dm_topic_bindings(session_id);
+
+                    CREATE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_user
+                    ON telegram_dm_topic_bindings(profile, user_id, chat_id);
+                    """
                 )
-                if needs_rebuild:
-                    conn.executescript(
-                        """
-                        CREATE TABLE telegram_dm_topic_bindings_new (
-                            chat_id TEXT NOT NULL,
-                            thread_id TEXT NOT NULL,
-                            user_id TEXT NOT NULL,
-                            session_key TEXT NOT NULL,
-                            session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
-                            managed_mode TEXT NOT NULL DEFAULT 'auto',
-                            linked_at REAL NOT NULL,
-                            updated_at REAL NOT NULL,
-                            PRIMARY KEY (chat_id, thread_id)
-                        );
-                        INSERT INTO telegram_dm_topic_bindings_new
-                            SELECT chat_id, thread_id, user_id, session_key,
-                                   session_id, managed_mode, linked_at, updated_at
-                            FROM telegram_dm_topic_bindings;
-                        DROP TABLE telegram_dm_topic_bindings;
-                        ALTER TABLE telegram_dm_topic_bindings_new
-                            RENAME TO telegram_dm_topic_bindings;
-                        CREATE UNIQUE INDEX idx_telegram_dm_topic_bindings_session
-                            ON telegram_dm_topic_bindings(session_id);
-                        CREATE INDEX idx_telegram_dm_topic_bindings_user
-                            ON telegram_dm_topic_bindings(user_id, chat_id);
-                        """
+            else:
+                # v1 → v2: rebuild telegram_dm_topic_bindings if its session_id FK
+                # lacks ON DELETE CASCADE. SQLite can't ALTER a foreign key, so we
+                # rebuild the table. Only runs once per DB (version gate).
+                if current_version < 2:
+                    fk_rows = conn.execute(
+                        "PRAGMA foreign_key_list('telegram_dm_topic_bindings')"
+                    ).fetchall()
+                    needs_rebuild = any(
+                        row[2] == "sessions" and (row[6] or "") != "CASCADE"
+                        for row in fk_rows
                     )
+                    if needs_rebuild:
+                        conn.executescript(
+                            """
+                            CREATE TABLE telegram_dm_topic_bindings_new (
+                                chat_id TEXT NOT NULL,
+                                thread_id TEXT NOT NULL,
+                                user_id TEXT NOT NULL,
+                                session_key TEXT NOT NULL,
+                                session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+                                managed_mode TEXT NOT NULL DEFAULT 'auto',
+                                linked_at REAL NOT NULL,
+                                updated_at REAL NOT NULL,
+                                PRIMARY KEY (chat_id, thread_id)
+                            );
+                            INSERT INTO telegram_dm_topic_bindings_new
+                                SELECT chat_id, thread_id, user_id, session_key,
+                                       session_id, managed_mode, linked_at, updated_at
+                                FROM telegram_dm_topic_bindings;
+                            DROP TABLE telegram_dm_topic_bindings;
+                            ALTER TABLE telegram_dm_topic_bindings_new
+                                RENAME TO telegram_dm_topic_bindings;
+                            CREATE UNIQUE INDEX idx_telegram_dm_topic_bindings_session
+                                ON telegram_dm_topic_bindings(session_id);
+                            CREATE INDEX idx_telegram_dm_topic_bindings_user
+                                ON telegram_dm_topic_bindings(user_id, chat_id);
+                            """
+                        )
+
+                # v2 → v3: add profile column and widen PK to (profile, chat_id, thread_id)
+                if current_version < 3:
+                    cols = {
+                        row[1]
+                        for row in conn.execute(
+                            "PRAGMA table_info('telegram_dm_topic_bindings')"
+                        ).fetchall()
+                    }
+                    if "profile" not in cols:
+                        conn.executescript(
+                            """
+                            CREATE TABLE telegram_dm_topic_bindings_v3_new (
+                                profile TEXT NOT NULL DEFAULT 'default',
+                                chat_id TEXT NOT NULL,
+                                thread_id TEXT NOT NULL,
+                                user_id TEXT NOT NULL,
+                                session_key TEXT NOT NULL,
+                                session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+                                managed_mode TEXT NOT NULL DEFAULT 'auto',
+                                linked_at REAL NOT NULL,
+                                updated_at REAL NOT NULL,
+                                PRIMARY KEY (profile, chat_id, thread_id)
+                            );
+                            INSERT INTO telegram_dm_topic_bindings_v3_new (
+                                profile, chat_id, thread_id, user_id, session_key,
+                                session_id, managed_mode, linked_at, updated_at
+                            )
+                                SELECT 'default', chat_id, thread_id, user_id, session_key,
+                                       session_id, managed_mode, linked_at, updated_at
+                                FROM telegram_dm_topic_bindings;
+                            DROP TABLE telegram_dm_topic_bindings;
+                            ALTER TABLE telegram_dm_topic_bindings_v3_new
+                                RENAME TO telegram_dm_topic_bindings;
+                            CREATE UNIQUE INDEX idx_telegram_dm_topic_bindings_session
+                                ON telegram_dm_topic_bindings(session_id);
+                            CREATE INDEX idx_telegram_dm_topic_bindings_user
+                                ON telegram_dm_topic_bindings(profile, user_id, chat_id);
+                            """
+                        )
 
             conn.execute(
                 "INSERT INTO state_meta (key, value) VALUES (?, ?) "
                 "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-                ("telegram_dm_topic_schema_version", "2"),
+                ("telegram_dm_topic_schema_version", "3"),
             )
         self._execute_write(_do)
 
@@ -13540,7 +13594,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def get_telegram_topic_binding(
         self,
         *,
-        profile: str = "default",
+        profile: str,
         chat_id: str,
         thread_id: str,
     ) -> Optional[Dict[str, Any]]:
@@ -13552,7 +13606,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     SELECT * FROM telegram_dm_topic_bindings
                     WHERE profile = ? AND chat_id = ? AND thread_id = ?
                     """,
-                    (str(profile or "default"), str(chat_id), str(thread_id)),
+                    (str(profile), str(chat_id), str(thread_id)),
                 ).fetchone()
             except sqlite3.OperationalError:
                 return None
@@ -13561,7 +13615,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def list_telegram_topic_bindings_for_chat(
         self,
         *,
-        profile: str = "default",
+        profile: str,
         chat_id: str,
     ) -> List[Dict[str, Any]]:
         """All Telegram DM topic bindings for one chat, newest first.
@@ -13574,7 +13628,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 rows = self._conn.execute(
                     "SELECT * FROM telegram_dm_topic_bindings "
                     "WHERE profile = ? AND chat_id = ? ORDER BY updated_at DESC",
-                    (str(profile or "default"), str(chat_id)),
+                    (str(profile), str(chat_id)),
                 ).fetchall()
             except sqlite3.OperationalError:
                 return []
@@ -13607,7 +13661,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def delete_telegram_topic_binding(
         self,
         *,
-        profile: str = "default",
+        profile: str,
         chat_id: str,
         thread_id: str,
     ) -> int:
@@ -13638,7 +13692,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         migrated yet — both are silent no-ops; we never raise from
         a cleanup hot path).
         """
-        profile = str(profile or "default")
+        profile = str(profile)
         chat_id = str(chat_id)
         thread_id = str(thread_id)
         deleted = {"count": 0}
@@ -13686,7 +13740,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def bind_telegram_topic(
         self,
         *,
-        profile: str = "default",
+        profile: str,
         chat_id: str,
         thread_id: str,
         user_id: str,
@@ -13702,7 +13756,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         self.apply_telegram_topic_migration()
         now = time.time()
-        profile = str(profile or "default")
+        profile = str(profile)
         chat_id = str(chat_id)
         thread_id = str(thread_id)
         user_id = str(user_id)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -13366,6 +13366,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 );
 
                 CREATE TABLE IF NOT EXISTS telegram_dm_topic_bindings (
+                    profile TEXT NOT NULL DEFAULT 'default',
                     chat_id TEXT NOT NULL,
                     thread_id TEXT NOT NULL,
                     user_id TEXT NOT NULL,
@@ -13374,14 +13375,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     managed_mode TEXT NOT NULL DEFAULT 'auto',
                     linked_at REAL NOT NULL,
                     updated_at REAL NOT NULL,
-                    PRIMARY KEY (chat_id, thread_id)
+                    PRIMARY KEY (profile, chat_id, thread_id)
                 );
 
                 CREATE UNIQUE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_session
                 ON telegram_dm_topic_bindings(session_id);
 
                 CREATE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_user
-                ON telegram_dm_topic_bindings(user_id, chat_id);
+                ON telegram_dm_topic_bindings(profile, user_id, chat_id);
                 """
             )
 
@@ -13539,6 +13540,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def get_telegram_topic_binding(
         self,
         *,
+        profile: str = "default",
         chat_id: str,
         thread_id: str,
     ) -> Optional[Dict[str, Any]]:
@@ -13548,9 +13550,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 row = self._conn.execute(
                     """
                     SELECT * FROM telegram_dm_topic_bindings
-                    WHERE chat_id = ? AND thread_id = ?
+                    WHERE profile = ? AND chat_id = ? AND thread_id = ?
                     """,
-                    (str(chat_id), str(thread_id)),
+                    (str(profile or "default"), str(chat_id), str(thread_id)),
                 ).fetchone()
             except sqlite3.OperationalError:
                 return None
@@ -13559,6 +13561,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def list_telegram_topic_bindings_for_chat(
         self,
         *,
+        profile: str = "default",
         chat_id: str,
     ) -> List[Dict[str, Any]]:
         """All Telegram DM topic bindings for one chat, newest first.
@@ -13570,8 +13573,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             try:
                 rows = self._conn.execute(
                     "SELECT * FROM telegram_dm_topic_bindings "
-                    "WHERE chat_id = ? ORDER BY updated_at DESC",
-                    (str(chat_id),),
+                    "WHERE profile = ? AND chat_id = ? ORDER BY updated_at DESC",
+                    (str(profile or "default"), str(chat_id)),
                 ).fetchall()
             except sqlite3.OperationalError:
                 return []
@@ -13604,6 +13607,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def delete_telegram_topic_binding(
         self,
         *,
+        profile: str = "default",
         chat_id: str,
         thread_id: str,
     ) -> int:
@@ -13634,6 +13638,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         migrated yet — both are silent no-ops; we never raise from
         a cleanup hot path).
         """
+        profile = str(profile or "default")
         chat_id = str(chat_id)
         thread_id = str(thread_id)
         deleted = {"count": 0}
@@ -13643,9 +13648,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 cursor = conn.execute(
                     """
                     DELETE FROM telegram_dm_topic_bindings
-                    WHERE chat_id = ? AND thread_id = ?
+                    WHERE profile = ? AND chat_id = ? AND thread_id = ?
                     """,
-                    (chat_id, thread_id),
+                    (profile, chat_id, thread_id),
                 )
                 deleted["count"] = cursor.rowcount or 0
             except sqlite3.OperationalError:
@@ -13681,6 +13686,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def bind_telegram_topic(
         self,
         *,
+        profile: str = "default",
         chat_id: str,
         thread_id: str,
         user_id: str,
@@ -13696,6 +13702,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         self.apply_telegram_topic_migration()
         now = time.time()
+        profile = str(profile or "default")
         chat_id = str(chat_id)
         thread_id = str(thread_id)
         user_id = str(user_id)
@@ -13709,20 +13716,21 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 WHERE session_id = ?
                 """,
                 (session_id,),
-            ).fetchone()
-            if existing_session is not None:
-                linked_chat = existing_session["chat_id"] if isinstance(existing_session, sqlite3.Row) else existing_session[0]
-                linked_thread = existing_session["thread_id"] if isinstance(existing_session, sqlite3.Row) else existing_session[1]
+            )
+            existing_row = existing_session.fetchone()
+            if existing_row is not None:
+                linked_chat = existing_row["chat_id"] if isinstance(existing_row, sqlite3.Row) else existing_row[0]
+                linked_thread = existing_row["thread_id"] if isinstance(existing_row, sqlite3.Row) else existing_row[1]
                 if str(linked_chat) != chat_id or str(linked_thread) != thread_id:
                     raise ValueError("session is already linked to another Telegram topic")
 
             conn.execute(
                 """
                 INSERT INTO telegram_dm_topic_bindings (
-                    chat_id, thread_id, user_id, session_key, session_id,
+                    profile, chat_id, thread_id, user_id, session_key, session_id,
                     managed_mode, linked_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(chat_id, thread_id) DO UPDATE SET
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(profile, chat_id, thread_id) DO UPDATE SET
                     user_id = excluded.user_id,
                     session_key = excluded.session_key,
                     session_id = excluded.session_id,
@@ -13730,12 +13738,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     updated_at = excluded.updated_at
                 """,
                 (
+                    profile,
                     chat_id,
                     thread_id,
                     user_id,
                     session_key,
                     session_id,
-                    managed_mode,
+                    str(managed_mode or "auto"),
                     now,
                     now,
                 ),

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -745,6 +745,10 @@ class TelegramAdapter(BasePlatformAdapter):
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.TELEGRAM)
+        # Set by the multiplex runner for secondary bots. This namespace is
+        # persisted with DM-topic bindings so identical Telegram chat/thread
+        # ids from different bot accounts cannot collide.
+        self._gateway_profile_name: str = "default"
         self._app: Optional[Application] = None
         self._bot: Optional[Bot] = None
         self._webhook_mode: bool = False
@@ -1703,7 +1707,9 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         try:
             removed = db.delete_telegram_topic_binding(
-                chat_id=str(chat_id), thread_id=str(thread_id),
+                profile=getattr(self, "_gateway_profile_name", "default"),
+                chat_id=str(chat_id),
+                thread_id=str(thread_id),
             )
         except Exception:
             logger.debug(

--- a/tests/gateway/test_telegram_prune_stale_topic_binding_31501.py
+++ b/tests/gateway/test_telegram_prune_stale_topic_binding_31501.py
@@ -42,6 +42,7 @@ from hermes_state import SessionDB
 def _seed_binding(
     db: SessionDB,
     *,
+    profile: str = "default",
     chat_id: str = "5595856929",
     thread_id: str = "15287",
     user_id: str = "5595856929",
@@ -53,6 +54,7 @@ def _seed_binding(
         user_id=user_id,
     )
     db.bind_telegram_topic(
+        profile=profile,
         chat_id=chat_id,
         thread_id=thread_id,
         user_id=user_id,
@@ -67,16 +69,22 @@ class TestDeleteTelegramTopicBinding:
         _seed_binding(db, thread_id="15287")
         # Sanity check — binding present before prune.
         assert db.get_telegram_topic_binding(
-            chat_id="5595856929", thread_id="15287",
+            profile="default",
+            chat_id="5595856929",
+            thread_id="15287",
         ) is not None
 
         removed = db.delete_telegram_topic_binding(
-            chat_id="5595856929", thread_id="15287",
+            profile="default",
+            chat_id="5595856929",
+            thread_id="15287",
         )
 
         assert removed == 1
         assert db.get_telegram_topic_binding(
-            chat_id="5595856929", thread_id="15287",
+            profile="default",
+            chat_id="5595856929",
+            thread_id="15287",
         ) is None
         db.close()
 
@@ -90,16 +98,22 @@ class TestDeleteTelegramTopicBinding:
         _seed_binding(db, thread_id="15418", session_id="sess-fresh")
 
         removed = db.delete_telegram_topic_binding(
-            chat_id="5595856929", thread_id="15287",
+            profile="default",
+            chat_id="5595856929",
+            thread_id="15287",
         )
         assert removed == 1
 
         # Stale binding is gone; the fresh one survives.
         assert db.get_telegram_topic_binding(
-            chat_id="5595856929", thread_id="15287",
+            profile="default",
+            chat_id="5595856929",
+            thread_id="15287",
         ) is None
         assert db.get_telegram_topic_binding(
-            chat_id="5595856929", thread_id="15418",
+            profile="default",
+            chat_id="5595856929",
+            thread_id="15418",
         ) is not None
         db.close()
 
@@ -108,7 +122,8 @@ class TestPruneClearsTopicModeWhenLastBindingGone:
     """Proactive cleanup (#31501 follow-up): pruning the chat's final
     binding must also flip ``telegram_dm_topic_mode.enabled`` to 0 so
     recovery fully stands down — covers the user who disabled topics in
-    the Telegram client without ever running ``/topic off``."""
+    the Telegram client without ever running ``/topic off``.
+    """
 
     def test_clears_enabled_when_last_binding_pruned(self, tmp_path):
         db = SessionDB(db_path=tmp_path / "state.db")
@@ -121,7 +136,9 @@ class TestPruneClearsTopicModeWhenLastBindingGone:
         ) is True
 
         removed = db.delete_telegram_topic_binding(
-            chat_id="5595856929", thread_id="15287",
+            profile="default",
+            chat_id="5595856929",
+            thread_id="15287",
         )
 
         assert removed == 1
@@ -163,7 +180,9 @@ class TestPruneStaleDmTopicBindingHelper:
         adapter._prune_stale_dm_topic_binding("5595856929", 15287)
 
         assert db.get_telegram_topic_binding(
-            chat_id="5595856929", thread_id="15287",
+            profile="default",
+            chat_id="5595856929",
+            thread_id="15287",
         ) is None
         db.close()
 
@@ -274,6 +293,7 @@ class TestRecoveryAfterPrune:
                 user_id="5595856929",
             )
             db.bind_telegram_topic(
+                profile="default",
                 chat_id="5595856929",
                 thread_id=thread,
                 user_id="5595856929",
@@ -296,6 +316,7 @@ class TestRecoveryAfterPrune:
         )
         runner._session_db = db
         runner._telegram_topic_mode_enabled = lambda _src: True
+        runner._adapter_for_source = lambda _src: None
 
         # Sanity: before the prune, recovery picks "222" (newest).
         # Recovery only fires for a lobby-shaped inbound (omitted
@@ -314,6 +335,7 @@ class TestRecoveryAfterPrune:
 
         # User deletes topic 222 in Telegram → adapter prunes.
         db.delete_telegram_topic_binding(
+            profile="default",
             chat_id="5595856929", thread_id="222",
         )
 

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -295,6 +295,7 @@ async def test_managed_topic_binding_reuses_restored_session_over_static_lane_se
         user_id="208214988",
     )
     session_db.bind_telegram_topic(
+        profile="default",
         chat_id="208214988",
         thread_id="17585",
         user_id="208214988",
@@ -345,7 +346,7 @@ async def test_telegram_group_prompt_is_not_topic_lobby_even_when_dm_topic_mode_
 
     assert result == "group agent response"
     runner._handle_message_with_agent.assert_awaited_once()
-    assert session_db.get_telegram_topic_binding(chat_id="-100123", thread_id="555") is None
+    assert session_db.get_telegram_topic_binding(profile="default", chat_id="-100123", thread_id="555") is None
 
 
 @pytest.mark.asyncio
@@ -408,6 +409,7 @@ async def test_new_inside_telegram_topic_rewrites_binding_to_new_session(tmp_pat
     topic_source = _make_source(thread_id="17585")
     topic_key = build_session_key(topic_source)
     session_db.bind_telegram_topic(
+        profile="default",
         chat_id="208214988",
         thread_id="17585",
         user_id="208214988",
@@ -443,6 +445,7 @@ async def test_new_inside_telegram_topic_rewrites_binding_to_new_session(tmp_pat
     await runner._handle_message(_make_event("/new", thread_id="17585"))
 
     binding = session_db.get_telegram_topic_binding(
+        profile="default",
         chat_id="208214988", thread_id="17585",
     )
     assert binding is not None
@@ -481,6 +484,7 @@ async def test_topic_binding_follows_compression_tip_on_read(tmp_path, monkeypat
     topic_key = build_session_key(topic_source)
     # Pre-bug binding: topic still pointed at the pre-compression parent.
     session_db.bind_telegram_topic(
+        profile="default",
         chat_id="208214988",
         thread_id="17585",
         user_id="208214988",
@@ -526,6 +530,7 @@ async def test_topic_binding_follows_compression_tip_on_read(tmp_path, monkeypat
     # The binding row was rewritten to point at the descendant so future
     # inbound messages skip the tip walk and resolve directly.
     refreshed = session_db.get_telegram_topic_binding(
+        profile="default",
         chat_id="208214988", thread_id="17585",
     )
     assert refreshed is not None
@@ -553,6 +558,7 @@ async def test_topic_root_command_lists_unlinked_sessions_for_restore(tmp_path, 
     )
     session_db.set_session_title("already-linked", "Already linked")
     session_db.bind_telegram_topic(
+        profile="default",
         chat_id="208214988",
         thread_id="11111",
         user_id="208214988",
@@ -608,6 +614,7 @@ async def test_first_message_inside_topic_records_topic_binding(tmp_path, monkey
     runner._record_telegram_topic_binding(source, entry)
 
     binding = session_db.get_telegram_topic_binding(
+        profile="default",
         chat_id="208214988",
         thread_id="17585",
     )
@@ -666,6 +673,7 @@ async def test_auto_generated_title_renames_bound_telegram_topic(tmp_path):
     db.apply_telegram_topic_migration()
     db.create_session("sess-topic", source="telegram", user_id="208214988")
     db.bind_telegram_topic(
+        profile="default",
         chat_id="208214988",
         thread_id="42",
         user_id="208214988",
@@ -736,6 +744,7 @@ def _seed_two_topic_bindings(session_db):
     # Old topic A first, then current topic B (so B is "most recent").
     src_a = _make_source(thread_id="111")
     session_db.bind_telegram_topic(
+        profile="default",
         chat_id=src_a.chat_id,
         thread_id=src_a.thread_id,
         user_id=src_a.user_id,
@@ -744,6 +753,7 @@ def _seed_two_topic_bindings(session_db):
     )
     src_b = _make_source(thread_id="222")
     session_db.bind_telegram_topic(
+        profile="default",
         chat_id=src_b.chat_id,
         thread_id=src_b.thread_id,
         user_id=src_b.user_id,
@@ -776,6 +786,7 @@ def test_recover_returns_none_for_brand_new_topic(tmp_path):
     db.create_session(session_id="sess-old", source="telegram", user_id="208214988")
     src_old = _make_source(thread_id="12345")
     db.bind_telegram_topic(
+        profile="default",
         chat_id=src_old.chat_id,
         thread_id=src_old.thread_id,
         user_id=src_old.user_id,
@@ -791,7 +802,7 @@ def test_recover_returns_none_for_brand_new_topic(tmp_path):
 def test_list_telegram_topic_bindings_for_chat_no_table(tmp_path):
     # Missing topic-mode tables → [] without auto-migrating.
     db = SessionDB(db_path=tmp_path / "state.db")
-    assert db.list_telegram_topic_bindings_for_chat(chat_id="208214988") == []
+    assert db.list_telegram_topic_bindings_for_chat(profile="default", chat_id="208214988") == []
     tables = {
         row[0]
         for row in db._conn.execute(
@@ -811,6 +822,7 @@ def test_get_telegram_topic_binding_by_session_returns_binding(tmp_path):
     db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
     db.create_session(session_id="sess-27166", source="telegram", user_id="208214988")
     db.bind_telegram_topic(
+        profile="default",
         chat_id="208214988",
         thread_id="17585",
         user_id="208214988",

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1681,9 +1681,10 @@ class TestSchemaInit:
             user_id="208214988",
         )
 
-        assert db.get_telegram_topic_binding(chat_id="208214988", thread_id="17585") is None
+        assert db.get_telegram_topic_binding(profile="default", chat_id="208214988", thread_id="17585") is None
 
         db.bind_telegram_topic(
+            profile="default",
             chat_id="208214988",
             thread_id="17585",
             user_id="208214988",
@@ -1691,14 +1692,15 @@ class TestSchemaInit:
             session_id="topic-session",
         )
 
-        binding = db.get_telegram_topic_binding(chat_id="208214988", thread_id="17585")
+        binding = db.get_telegram_topic_binding(profile="default", chat_id="208214988", thread_id="17585")
         assert binding is not None
+        assert binding["profile"] == "default"
         assert binding["chat_id"] == "208214988"
         assert binding["thread_id"] == "17585"
         assert binding["user_id"] == "208214988"
         assert binding["session_key"] == "telegram:dm:208214988:thread:17585"
         assert binding["session_id"] == "topic-session"
-        assert db.get_meta("telegram_dm_topic_schema_version") == "2"
+        assert db.get_meta("telegram_dm_topic_schema_version") == "3"
         db.close()
 
 
@@ -1706,6 +1708,48 @@ class TestSchemaInit:
 
 
 
+
+    def test_telegram_topic_migration_v2_to_v3_rebuilds_schema(self, tmp_path):
+        """v2 databases without the profile column must rebuild to v3 on migration."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        # Manually create a v2 schema table
+        db._conn.executescript(
+            """
+            CREATE TABLE telegram_dm_topic_bindings (
+                chat_id TEXT NOT NULL,
+                thread_id TEXT NOT NULL,
+                user_id TEXT NOT NULL,
+                session_key TEXT NOT NULL,
+                session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+                managed_mode TEXT NOT NULL DEFAULT 'auto',
+                linked_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                PRIMARY KEY (chat_id, thread_id)
+            );
+            """
+        )
+        db.set_meta("telegram_dm_topic_schema_version", "2")
+        db.create_session("v2-session", source="telegram", user_id="208214988")
+        db._conn.execute(
+            """
+            INSERT INTO telegram_dm_topic_bindings (
+                chat_id, thread_id, user_id, session_key, session_id,
+                managed_mode, linked_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("208214988", "17585", "208214988", "k", "v2-session", "auto", 100.0, 100.0),
+        )
+        db._conn.commit()
+
+        # Run migration
+        db.apply_telegram_topic_migration()
+
+        assert db.get_meta("telegram_dm_topic_schema_version") == "3"
+        binding = db.get_telegram_topic_binding(profile="default", chat_id="208214988", thread_id="17585")
+        assert binding is not None
+        assert binding["profile"] == "default"
+        assert binding["session_id"] == "v2-session"
+        db.close()
 
     def test_schema_sql_is_source_of_truth(self, db):
         """Every column in SCHEMA_SQL exists in the live database.


### PR DESCRIPTION
## Summary
When running Hermes in profile multiplexing mode (`multiplex_profiles: true`), secondary profile cron delivery and Telegram topic bindings had isolation issues:

1. **Cron Delivery via Wrong Bot**:
   - In `_start_multiplex`, the in-process cron scheduler iterated over secondary profile stores without passing `profile_adapters` (the gateway runner's per-profile live adapter map).
   - As a result, cron jobs running under secondary profiles either fell back to the default profile's adapter / process-global environment token or encountered delivery errors when routing back to their origin topic IDs.
   - **Fix**: Passed `runner._profile_adapters` down into `InProcessCronScheduler.start()` / `_start_multiplex()` and selected `tick_adapters = profile_adapters.get(profile_name)`.

2. **Telegram Topic Binding Namespace Collision**:
   - `telegram_dm_topic_bindings` previously used `(chat_id, thread_id)` as primary key without namespace isolation. When multiple bot profiles communicated with the same user across different topics, bindings could collide or overwrite.
   - **Fix**: Scoped topic bindings by `profile` namespace across schema, query/delete methods, and gateway binding handlers.

## Verification
- `tests/cron/test_scheduler_provider.py`: 30/30 passed.
- `tests/gateway/test_telegram_topic_mode.py`: 19/19 passed.
- Verified in live multi-profile setup that secondary profile cron tasks deliver directly through the secondary bot's adapter to the designated topic.