### PR TITLE
fix(desktop): preserve clarify and message integrity

### DIFF
--- a/apps/desktop/e2e/chat.spec.ts
+++ b/apps/desktop/e2e/chat.spec.ts
@@ -8,10 +8,9 @@
  * Prerequisite: `npm run build` must have been run so dist/ exists.
  */
 
-import { expect, test } from './test'
-
 import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
 import { BLOCKING_CLARIFY_QUESTION, BLOCKING_CLARIFY_TRIGGER } from './mock-server'
+import { expect, test } from './test'
 import { expectVisualSnapshot } from './visual-snapshot'
 
 let fixture: MockBackendFixture | null = null
@@ -86,12 +85,13 @@ test.describe('chat interaction with mock backend', () => {
     await expectVisualSnapshot(fixture!.page, { name: 'chat-with-messages', app: fixture!.app })
   })
 
-  test('offers stop, steer, and queue actions while busy', async ({}, testInfo) => {
+  test('keeps clarify visible and queues typed prose while busy', async ({ browserName: _browserName }, testInfo) => {
     const page = fixture!.page
     const composer = page.locator('[contenteditable="true"]').first()
     const primary = page.locator('[data-slot="composer-root"] button[type="submit"]')
     const queue = page.locator('[data-slot="composer-root"] button[aria-label="Queue message"]')
     const dictation = page.locator('[data-slot="composer-root"] button[aria-label="Voice dictation"]')
+
     const speakReplies = page.locator(
       '[data-slot="composer-root"] button[aria-label="Read replies aloud"], [data-slot="composer-root"] button[aria-label="Stop reading replies aloud"]'
     )
@@ -111,12 +111,15 @@ test.describe('chat interaction with mock backend', () => {
     await expect(speakReplies).toBeVisible()
     await expect(queue).toBeVisible()
     await expect(queue.locator('svg.tabler-icon-layers-intersect-2')).toBeVisible()
+
     const controlLabels = await page
       .locator('[data-slot="composer-root"] button')
       .evaluateAll(buttons => buttons.map(button => button.getAttribute('aria-label')))
+
     const speakRepliesIndex = controlLabels.findIndex(
       label => label === 'Read replies aloud' || label === 'Stop reading replies aloud'
     )
+
     expect(controlLabels.indexOf('Voice dictation')).toBeLessThan(speakRepliesIndex)
     expect(speakRepliesIndex).toBeLessThan(controlLabels.indexOf('Queue message'))
     expect(controlLabels.indexOf('Queue message')).toBeLessThan(
@@ -125,11 +128,14 @@ test.describe('chat interaction with mock backend', () => {
     await page.screenshot({ path: testInfo.outputPath('busy-composer-steer.png') })
     await expect(primary.locator('svg.tabler-icon-steering-wheel')).toBeVisible()
 
-    await queue.click()
+    // Plain Enter used to auto-skip the visible clarify with answer='' and
+    // steer the prose. It must now preserve the question and queue the prose.
+    await page.keyboard.press('Enter')
     await expect(primary).toHaveAttribute('aria-label', 'Stop')
     await expect(queue).toHaveCount(0)
     await page.screenshot({ path: testInfo.outputPath('busy-composer-queue.png') })
     await expect(page.getByText('1 Queued')).toBeVisible()
+    await expect(page.getByText(BLOCKING_CLARIFY_QUESTION)).toHaveCount(1)
 
     await primary.click()
     await expect(page.getByText('1 Queued — paused')).toBeVisible()

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
@@ -2,7 +2,13 @@ import { act, cleanup, render, waitFor } from '@testing-library/react'
 import { useLayoutEffect } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { clearSessionDraft, type ComposerAttachment, mainComposerScope, stashSessionDraft } from '@/store/composer'
+import {
+  clearSessionDraft,
+  type ComposerAttachment,
+  mainComposerScope,
+  stashSessionDraft,
+  takeSessionDraft
+} from '@/store/composer'
 import { $connection } from '@/store/session'
 
 import { useComposerActions } from '../../hooks/use-composer-actions'
@@ -29,8 +35,10 @@ interface ProbeHarnessProps {
   sessionId: string
 }
 
+let latestDraftApi: ReturnType<typeof useComposerDraft> | null = null
+
 function ProbeHarness({ activeQueueSessionKey, onLayoutSnapshot, sessionId }: ProbeHarnessProps) {
-  useComposerDraft({
+  latestDraftApi = useComposerDraft({
     activeQueueSessionKey,
     focusKey: null,
     inputDisabled: false,
@@ -247,6 +255,63 @@ describe('useComposerDraft — draft survives full unmount (Settings navigation,
     expect(mockComposerApi.setText).toHaveBeenCalledWith('unsent thought')
 
     remount.unmount()
+  })
+
+  it('does not let a visual clear overwrite a submit receipt during unmount', () => {
+    stashSessionDraft('session-nav', 'pending gateway acceptance', [])
+
+    const view = render(
+      <ProbeHarness activeQueueSessionKey="session-nav" onLayoutSnapshot={() => undefined} sessionId="session-nav" />
+    )
+
+    act(() => latestDraftApi!.clearDraft(true))
+    view.unmount()
+
+    expect(takeSessionDraft('session-nav')).toMatchObject({ text: 'pending gateway acceptance' })
+  })
+
+  it('does not resurrect a removed attachment after an attachment-only rejection', () => {
+    const attachment: ComposerAttachment = { id: 'file-rejected', kind: 'file', label: 'rejected.txt' }
+    stashSessionDraft('session-nav', '', [attachment])
+
+    const view = render(
+      <ProbeHarness activeQueueSessionKey="session-nav" onLayoutSnapshot={() => undefined} sessionId="session-nav" />
+    )
+
+    act(() => {
+      latestDraftApi!.clearDraft(true)
+      latestDraftApi!.loadIntoComposer('', [attachment])
+    })
+    const restoredGeneration = latestDraftApi!.draftIntentGenerationRef.current
+
+    act(() => {
+      mainComposerScope.remove(attachment.id)
+    })
+    expect(latestDraftApi!.draftIntentGenerationRef.current).toBeGreaterThan(restoredGeneration)
+    view.unmount()
+
+    expect(takeSessionDraft('session-nav')).toEqual({ attachments: [], text: '' })
+  })
+
+  it('persists the next attachment-only draft after a submitted receipt settles', () => {
+    const nextAttachment: ComposerAttachment = {
+      id: 'file-next',
+      kind: 'file',
+      label: 'next.txt',
+      occurrenceId: 'next-occurrence'
+    }
+
+    const view = render(
+      <ProbeHarness activeQueueSessionKey="session-nav" onLayoutSnapshot={() => undefined} sessionId="session-nav" />
+    )
+
+    act(() => {
+      latestDraftApi!.clearDraft(true)
+      mainComposerScope.add(nextAttachment)
+    })
+    view.unmount()
+
+    expect(takeSessionDraft('session-nav')).toEqual({ attachments: [nextAttachment], text: '' })
   })
 })
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -105,8 +105,11 @@ export function useComposerDraft({
 
   const editorRef = useRef<HTMLDivElement | null>(null)
   const draftRef = useRef('')
+  const draftIntentGenerationRef = useRef(0)
+  const applyingProgrammaticDraftRef = useRef(false)
   const pendingDraftPersistRef = useRef<{ scope: string | null; text: string } | null>(null)
   const draftPersistTimerRef = useRef<number | undefined>(undefined)
+  const preservePersistedDraftRef = useRef(false)
   const activeQueueSessionKeyRef = useRef(activeQueueSessionKey)
   activeQueueSessionKeyRef.current = activeQueueSessionKey
   // Owned only by the swap effect below — unlike activeQueueSessionKeyRef this
@@ -138,6 +141,10 @@ export function useComposerDraft({
   // editor — so the visible text never lags the store.
   const paintDraft = useCallback(
     (next: string, focus = true) => {
+      if (!applyingProgrammaticDraftRef.current && next !== draftRef.current) {
+        draftIntentGenerationRef.current += 1
+      }
+
       draftRef.current = next
       setComposerText(next)
 
@@ -232,6 +239,11 @@ export function useComposerDraft({
     stashSessionDraft(scope, text, attachments)
 
   const loadIntoComposer = (text: string, attachments: ComposerAttachment[]) => {
+    // A visible restore starts a fresh draft lifecycle. Keeping the submitted
+    // receipt guard armed after rejection would make an attachment-only draft
+    // ignore later chip removal on pagehide/session switch/unmount.
+    preservePersistedDraftRef.current = false
+
     // Diagnostic breadcrumb for #59305-class reports: identifies WHAT kind of
     // state got restored into the composer (session switch, queue-edit
     // restore, history browse) without logging any raw content. REF_RE has the
@@ -247,11 +259,18 @@ export function useComposerDraft({
       })
     }
 
-    attachmentScope.$attachments.set(cloneAttachments(attachments))
-    paintDraft(text, false)
+    applyingProgrammaticDraftRef.current = true
+
+    try {
+      attachmentScope.$attachments.set(cloneAttachments(attachments))
+      paintDraft(text, false)
+    } finally {
+      applyingProgrammaticDraftRef.current = false
+    }
   }
 
-  const clearDraft = useCallback(() => {
+  const clearDraft = useCallback((preservePersistedDraft = false) => {
+    preservePersistedDraftRef.current = preservePersistedDraft
     setComposerText('')
     draftRef.current = ''
 
@@ -260,6 +279,44 @@ export function useComposerDraft({
       placeCaretEnd(editorRef.current)
     }
   }, [setComposerText])
+
+  const releasePersistedDraftReceipt = useCallback(() => {
+    preservePersistedDraftRef.current = false
+  }, [])
+
+  // The submitted receipt guard ignores the intentional empty emission from
+  // clearDraft(true). A later attachment add is new user intent even without a
+  // text event, so release the guard synchronously before pagehide/unmount can
+  // skip that attachment-only draft.
+  // eslint-disable-next-line no-restricted-syntax -- attachment atom events own receipt generation, not React renders
+  useEffect(() => {
+    let initialized = false
+
+    return attachmentScope.$attachments.subscribe(nextAttachments => {
+      if (!initialized) {
+        initialized = true
+
+        return
+      }
+
+      if (applyingProgrammaticDraftRef.current) {
+        return
+      }
+
+      // clearDraft(true) + submitted attachment removal is the submit engine's
+      // own visual clear. Any other transition, including non-empty -> empty,
+      // is newer user intent and must invalidate the receipt generation.
+      if (nextAttachments.length === 0 && preservePersistedDraftRef.current) {
+        return
+      }
+
+      draftIntentGenerationRef.current += 1
+
+      if (preservePersistedDraftRef.current) {
+        preservePersistedDraftRef.current = false
+      }
+    })
+  }, [attachmentScope])
 
   // Read the editor's current plain text into draftRef + composer state. This
   // closes the "queued rAF flush hasn't run yet" window so scope-swap/pagehide
@@ -313,6 +370,18 @@ export function useComposerDraft({
 
       if (isBrowsingHistory(sessionIdRef.current) || queueEditRef.current) {
         return
+      }
+
+      // A submitted/steered draft remains the crash-safe local receipt until
+      // the gateway accepts it. Clearing the visible editor emits an empty
+      // composer update; never let that debounce overwrite the receipt. Any
+      // later real typing or restore starts a fresh draft lifecycle.
+      if (preservePersistedDraftRef.current) {
+        if (!text) {
+          return
+        }
+
+        preservePersistedDraftRef.current = false
       }
 
       const scope = draftScopeRef.current
@@ -404,6 +473,7 @@ export function useComposerDraft({
     // fire later would just clobber with an older snapshot.
     window.clearTimeout(draftPersistTimerRef.current)
     pendingDraftPersistRef.current = null
+    preservePersistedDraftRef.current = false
     draftScopeRef.current = activeQueueSessionKey
 
     const { attachments, text } = takeSessionDraft(activeQueueSessionKey)
@@ -415,7 +485,7 @@ export function useComposerDraft({
 
       if (editing?.sessionKey === activeQueueSessionKey) {
         stashAt(activeQueueSessionKey, editing.draft, editing.attachments)
-      } else if (!isBrowsingHistory(sessionId)) {
+      } else if (!isBrowsingHistory(sessionId) && !preservePersistedDraftRef.current) {
         stashAt(activeQueueSessionKey, latestText)
       }
 
@@ -436,7 +506,10 @@ export function useComposerDraft({
     if (mode === 'flush') {
       window.clearTimeout(draftPersistTimerRef.current)
       pendingDraftPersistRef.current = null
-      stashAt(draftScopeRef.current, syncDraftFromEditor())
+
+      if (!preservePersistedDraftRef.current) {
+        stashAt(draftScopeRef.current, syncDraftFromEditor())
+      }
 
       return
     }
@@ -471,6 +544,10 @@ export function useComposerDraft({
         return
       }
 
+      if (preservePersistedDraftRef.current) {
+        return
+      }
+
       const latestText = syncDraftFromEditor()
       pendingDraftPersistRef.current = null
       stashAt(scope, latestText)
@@ -487,6 +564,7 @@ export function useComposerDraft({
   return {
     activeQueueSessionKeyRef,
     clearDraft,
+    draftIntentGenerationRef,
     draftRef,
     editorRef,
     focusInput,
@@ -496,6 +574,7 @@ export function useComposerDraft({
     isHelpHint,
     isSteerableText,
     loadIntoComposer,
+    releasePersistedDraftReceipt,
     requestMainFocus,
     sessionIdRef,
     setComposerText,

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
@@ -1,6 +1,7 @@
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { $clarifyRequests } from '@/store/clarify'
 import {
   $parkedQueueSessions,
   $queuedPromptsBySession,
@@ -52,9 +53,22 @@ function renderQueueHook(overrides: { busy?: boolean; onCancel?: () => void; onS
   return { hook, onCancel, onSubmit }
 }
 
+function setPendingClarify(): void {
+  $clarifyRequests.set({
+    'rt-session-queue-hook': {
+      requestId: 'req-queue-hook',
+      question: 'choose first',
+      choices: ['a', 'b'],
+      multiSelect: false,
+      sessionId: 'rt-session-queue-hook'
+    }
+  })
+}
+
 describe('useComposerQueue park integration', () => {
   beforeEach(() => {
     window.localStorage.clear()
+    $clarifyRequests.set({})
     $queuedPromptsBySession.set({})
     $parkedQueueSessions.set({})
   })
@@ -62,6 +76,7 @@ describe('useComposerQueue park integration', () => {
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
+    $clarifyRequests.set({})
     $queuedPromptsBySession.set({})
     $parkedQueueSessions.set({})
   })
@@ -70,6 +85,32 @@ describe('useComposerQueue park integration', () => {
     enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'flows' })
 
     const { onSubmit } = renderQueueHook()
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
+    expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(0)
+  })
+
+  it('holds every drain path while clarify is pending', async () => {
+    const entry = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'wait for answer' })!
+    setPendingClarify()
+    const onSteer = vi.fn(async () => true)
+    const { hook, onCancel, onSubmit } = renderQueueHook({ busy: true, onSteer })
+
+    expect(hook.result.current.sendQueuedNow(entry.id)).toBe(false)
+    expect(await hook.result.current.steerQueuedNow(entry.id)).toBe(false)
+    expect(await hook.result.current.drainNextQueued()).toBe(false)
+    hook.rerender({ busy: false })
+
+    await act(async () => Promise.resolve())
+    expect(onCancel).not.toHaveBeenCalled()
+    expect(onSteer).not.toHaveBeenCalled()
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(1)
+
+    act(() => {
+      $clarifyRequests.set({})
+      hook.rerender({ busy: false })
+    })
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
     expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(0)

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -4,6 +4,7 @@ import { type RefObject, useCallback, useEffect, useRef, useState } from 'react'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { useSessionSlice } from '@/lib/use-session-slice'
+import { $clarifyRequests } from '@/store/clarify'
 import { type ComposerAttachment } from '@/store/composer'
 import { resetBrowseState } from '@/store/composer-input-history'
 import {
@@ -80,6 +81,8 @@ export function useComposerQueue({
   // is fine; the auto-drain effect below reads it as a gate.
   const parkedSessions = useStore($parkedQueueSessions)
   const queueParked = Boolean(activeQueueSessionKey && parkedSessions[activeQueueSessionKey])
+  const clarifyRequests = useStore($clarifyRequests)
+  const clarifyPending = Boolean(clarifyRequests[sessionId ?? ''])
 
   const [queueEdit, setQueueEdit] = useState<QueueEditState | null>(null)
   queueEditRef.current = queueEdit
@@ -200,7 +203,7 @@ export function useComposerQueue({
   // `pickEntry` lets each caller choose head, by-id, or skip-edited.
   const runDrain = useCallback(
     async (pickEntry: (entries: QueuedPromptEntry[]) => QueuedPromptEntry | undefined): Promise<boolean> => {
-      if (drainingQueueRef.current || !activeQueueSessionKey) {
+      if (drainingQueueRef.current || !activeQueueSessionKey || clarifyPending) {
         return false
       }
 
@@ -243,7 +246,7 @@ export function useComposerQueue({
         drainingQueueRef.current = false
       }
     },
-    [activeQueueSessionKey, onSubmit, sessionId]
+    [activeQueueSessionKey, clarifyPending, onSubmit, sessionId]
   )
 
   const pickDrainHead = useCallback(
@@ -259,7 +262,7 @@ export function useComposerQueue({
 
   const sendQueuedNow = useCallback(
     (id: string) => {
-      if (!activeQueueSessionKey || id === queueEdit?.entryId) {
+      if (!activeQueueSessionKey || id === queueEdit?.entryId || clarifyPending) {
         return false
       }
 
@@ -283,7 +286,7 @@ export function useComposerQueue({
 
       return runDrain(entries => entries.find(e => e.id === id))
     },
-    [activeQueueSessionKey, busy, onCancel, queueEdit, runDrain]
+    [activeQueueSessionKey, busy, clarifyPending, onCancel, queueEdit, runDrain]
   )
 
   // Deliver a queued entry as a mid-turn redirect — the queue-panel sibling of
@@ -294,7 +297,13 @@ export function useComposerQueue({
   // busy — idle has no turn to redirect, and `sendQueuedNow` already covers it.
   const steerQueuedNow = useCallback(
     async (id: string): Promise<boolean> => {
-      if (!onSteer || !busy || !activeQueueSessionKey || id === queueEditRef.current?.entryId) {
+      if (
+        !onSteer ||
+        !busy ||
+        !activeQueueSessionKey ||
+        id === queueEditRef.current?.entryId ||
+        clarifyPending
+      ) {
         return false
       }
 
@@ -323,7 +332,7 @@ export function useComposerQueue({
 
       return true
     },
-    [activeQueueSessionKey, busy, onSteer, queueEditRef]
+    [activeQueueSessionKey, busy, clarifyPending, onSteer, queueEditRef]
   )
 
   // Edge-independent auto-drain: send the head whenever the session is idle and
@@ -331,7 +340,7 @@ export function useComposerQueue({
   // a stale-session 404) can't strand the entry permanently nor spin-loop. The
   // drain lock serializes sends; a remount/reconnect resets the failure counts.
   const autoDrainNext = useCallback(() => {
-    if (busy || queueParked || drainingQueueRef.current || !activeQueueSessionKey) {
+    if (busy || queueParked || drainingQueueRef.current || !activeQueueSessionKey || clarifyPending) {
       return
     }
 
@@ -362,7 +371,7 @@ export function useComposerQueue({
         }
       })
       .catch(onFail)
-  }, [activeQueueSessionKey, busy, pickDrainHead, queueParked, queuedPrompts, runDrain, t])
+  }, [activeQueueSessionKey, busy, clarifyPending, pickDrainHead, queueParked, queuedPrompts, runDrain, t])
 
   // Re-key on a runtime session-id change. A stable stored id (queueSessionKey)
   // never churns, so a change there is a real session switch and must NOT

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -4,7 +4,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { PaneVisibleContext } from '@/components/pane-shell/pane-visibility'
 import { $clarifyRequests } from '@/store/clarify'
-import type { ComposerAttachment } from '@/store/composer'
+import {
+  clearSessionDraft,
+  type ComposerAttachment,
+  stashSessionDraft,
+  takeSessionDraft
+} from '@/store/composer'
 import { $gateway } from '@/store/gateway'
 import {
   clearAllPrompts,
@@ -48,6 +53,7 @@ function renderSubmitHook({
 }: SubmitHarnessOptions = {}) {
   const resolvedSurfaceId = surfaceId === undefined ? `test-surface-${++surfaceSequence}` : surfaceId
   const draftRef = { current: text }
+  const draftIntentGenerationRef = { current: 0 }
   const editor = window.document.createElement('div')
   editor.dataset.slot = 'composer-rich-input'
   editor.textContent = text
@@ -56,6 +62,10 @@ function renderSubmitHook({
   const onSteer = vi.fn(async () => true)
   const onSubmit = vi.fn(async () => true)
   const queueCurrentDraft = vi.fn(() => true)
+  const loadIntoComposer = vi.fn()
+  const releasePersistedDraftReceipt = vi.fn()
+  const stashAt = vi.fn(stashSessionDraft)
+  const activeQueueSessionKeyRef = { current: sessionKey }
   let updatePaneVisible: Dispatch<SetStateAction<boolean>> | undefined
 
   const clearDraft = vi.fn(() => {
@@ -94,39 +104,47 @@ function renderSubmitHook({
     () =>
       useComposerSubmit({
         activeQueueSessionKey: sessionKey,
-        activeQueueSessionKeyRef: { current: sessionKey },
+        activeQueueSessionKeyRef,
         attachments,
         busy,
         compacting,
         clearDraft,
         disabled: false,
+        draftIntentGenerationRef,
         draftRef,
         drainNextQueued: vi.fn(async () => false),
         editorRef,
         exitQueuedEdit: vi.fn(() => false),
         focusInput: vi.fn(),
         inputDisabled,
-        loadIntoComposer: vi.fn(),
+        loadIntoComposer,
         onCancel,
         onSteer,
         onSubmit,
         queueCurrentDraft,
         queueEdit: null,
         queuedPrompts: [],
+        releasePersistedDraftReceipt,
         sessionId: 'runtime-session',
         setComposerText: vi.fn(),
-        stashAt: vi.fn()
+        stashAt
       }),
     { wrapper: Wrapper }
   )
 
   return {
+    activeQueueSessionKeyRef,
     clearDraft,
+    draftIntentGenerationRef,
+    draftRef,
+    editorRef,
     hook,
+    loadIntoComposer,
     onCancel,
     onSteer,
     onSubmit,
     queueCurrentDraft,
+    stashAt,
     composerSurfaceId: resolvedSurfaceId,
     setPaneVisible(nextVisible: boolean) {
       if (!updatePaneVisible) {
@@ -137,6 +155,12 @@ function renderSubmitHook({
     }
   }
 }
+
+afterEach(() => {
+  clearSessionDraft('stored-session')
+  clearSessionDraft(null)
+  MAIN_COMPOSER_SCOPE.attachments.clear()
+})
 
 describe('useComposerSubmit external request routing', () => {
   afterEach(() => {
@@ -166,6 +190,16 @@ describe('useComposerSubmit external request routing', () => {
     expect(hiddenMain.onSubmit).not.toHaveBeenCalled()
     expect(visibleTile.onSubmit).not.toHaveBeenCalled()
     expect(hiddenTile.onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('keeps an unrelated persisted draft when an external submit is accepted', async () => {
+    stashSessionDraft('stored-session', 'unsent composer draft', [])
+    const visibleMain = renderSubmitHook({ sessionKey: 'stored-session', text: 'unsent composer draft' })
+
+    expect(requestComposerSubmit('ship review result', { target: 'main' })).toBe(true)
+    await waitFor(() => expect(visibleMain.onSubmit).toHaveBeenCalledTimes(1))
+
+    expect(takeSessionDraft('stored-session').text).toBe('unsent composer draft')
   })
 
   it('routes a tile-targeted submit to that tile only', async () => {
@@ -372,6 +406,246 @@ describe('useComposerSubmit busy-turn routing', () => {
     expect(onCancel).not.toHaveBeenCalled()
   })
 
+  it('stashes an idle submit before clearing the visible draft while acceptance is pending', () => {
+    const { clearDraft, hook, onSubmit, stashAt } = renderSubmitHook({ text: 'do not lose this' })
+    onSubmit.mockReturnValueOnce(new Promise(() => {}))
+
+    act(() => {
+      hook.result.current.submitDraft()
+    })
+
+    expect(stashAt).toHaveBeenCalledWith('stored-session', 'do not lose this', [])
+    expect(stashAt.mock.invocationCallOrder[0]).toBeLessThan(clearDraft.mock.invocationCallOrder[0])
+  })
+
+  it('stashes a steer before clearing the visible draft', () => {
+    const { clearDraft, hook, onSteer, stashAt } = renderSubmitHook({ busy: true, text: 'redirect safely' })
+    onSteer.mockReturnValueOnce(new Promise(() => {}))
+
+    act(() => {
+      hook.result.current.submitDraft()
+    })
+
+    expect(stashAt).toHaveBeenCalledWith('stored-session', 'redirect safely', [])
+    expect(stashAt.mock.invocationCallOrder[0]).toBeLessThan(clearDraft.mock.invocationCallOrder[0])
+  })
+
+  it('restores a steer draft when the handler throws synchronously', async () => {
+    const { hook, loadIntoComposer, onSteer, stashAt } = renderSubmitHook({ busy: true, text: 'restore sync throw' })
+    onSteer.mockImplementationOnce(() => {
+      throw new Error('socket closed before promise')
+    })
+
+    act(() => {
+      hook.result.current.submitDraft()
+    })
+
+    await waitFor(() => expect(loadIntoComposer).toHaveBeenCalledWith('restore sync throw', []))
+    expect(stashAt).toHaveBeenLastCalledWith('stored-session', 'restore sync throw', [])
+  })
+
+  it('does not overwrite newer visible text when a steer throws late', async () => {
+    let rejectSteer!: (error: Error) => void
+
+    const pendingSteer = new Promise<boolean>((_resolve, reject) => {
+      rejectSteer = reject
+    })
+
+    const { draftIntentGenerationRef, draftRef, editorRef, hook, loadIntoComposer, onSteer } = renderSubmitHook({
+      busy: true,
+      text: 'redirect first'
+    })
+
+    onSteer.mockReturnValueOnce(pendingSteer)
+
+    act(() => hook.result.current.submitDraft())
+    draftIntentGenerationRef.current += 1
+    draftRef.current = 'newer steer intent'
+    editorRef.current!.textContent = 'newer steer intent'
+    rejectSteer(new Error('late redirect failure'))
+
+    await act(async () => pendingSteer.catch(() => false))
+    expect(loadIntoComposer).not.toHaveBeenCalled()
+    expect(draftRef.current).toBe('newer steer intent')
+  })
+
+  it('does not overwrite a newer attachment-only draft when a steer throws late', async () => {
+    let rejectSteer!: (error: Error) => void
+
+    const pendingSteer = new Promise<boolean>((_resolve, reject) => {
+      rejectSteer = reject
+    })
+
+    const { draftIntentGenerationRef, hook, loadIntoComposer, onSteer } = renderSubmitHook({
+      busy: true,
+      text: 'redirect first'
+    })
+
+    onSteer.mockReturnValueOnce(pendingSteer)
+
+    act(() => hook.result.current.submitDraft())
+    draftIntentGenerationRef.current += 1
+    MAIN_COMPOSER_SCOPE.attachments.add({ id: 'steer-next', kind: 'file', label: 'next.txt', occurrenceId: 'next' })
+    rejectSteer(new Error('late redirect failure'))
+
+    await act(async () => pendingSteer.catch(() => false))
+    expect(loadIntoComposer).not.toHaveBeenCalled()
+    expect(MAIN_COMPOSER_SCOPE.attachments.$attachments.get()).toHaveLength(1)
+  })
+
+  it('does not clear a newer draft when an older idle submit is accepted late', async () => {
+    let resolveAccepted!: (accepted: boolean) => void
+
+    const accepted = new Promise<boolean>(resolve => {
+      resolveAccepted = resolve
+    })
+
+    const { hook, onSubmit } = renderSubmitHook({ text: 'submitted first' })
+    onSubmit.mockReturnValueOnce(accepted)
+
+    act(() => hook.result.current.submitDraft())
+    stashSessionDraft('stored-session', 'typed while pending', [])
+    resolveAccepted(true)
+
+    await act(async () => accepted)
+    expect(takeSessionDraft('stored-session').text).toBe('typed while pending')
+  })
+
+  it('does not overwrite newer visible text when the old submit rejects before debounce', async () => {
+    let resolveAccepted!: (accepted: boolean) => void
+
+    const accepted = new Promise<boolean>(resolve => {
+      resolveAccepted = resolve
+    })
+
+    const { draftIntentGenerationRef, draftRef, editorRef, hook, loadIntoComposer, onSubmit } = renderSubmitHook({ text: 'submitted first' })
+    onSubmit.mockReturnValueOnce(accepted)
+
+    act(() => hook.result.current.submitDraft())
+    draftIntentGenerationRef.current += 1
+    draftRef.current = 'new intent before debounce'
+    editorRef.current!.textContent = 'new intent before debounce'
+    resolveAccepted(false)
+
+    await act(async () => accepted)
+    expect(loadIntoComposer).not.toHaveBeenCalled()
+    expect(draftRef.current).toBe('new intent before debounce')
+  })
+
+  it('does not overwrite a newer attachment-only draft when the old submit rejects', async () => {
+    let resolveAccepted!: (accepted: boolean) => void
+
+    const accepted = new Promise<boolean>(resolve => {
+      resolveAccepted = resolve
+    })
+
+    const { draftIntentGenerationRef, hook, loadIntoComposer, onSubmit } = renderSubmitHook({ text: 'submitted first' })
+    onSubmit.mockReturnValueOnce(accepted)
+
+    act(() => hook.result.current.submitDraft())
+    draftIntentGenerationRef.current += 1
+    MAIN_COMPOSER_SCOPE.attachments.add({ id: 'new-file', kind: 'file', label: 'new.txt', occurrenceId: 'new-occ' })
+    resolveAccepted(false)
+
+    await act(async () => accepted)
+    expect(loadIntoComposer).not.toHaveBeenCalled()
+    expect(MAIN_COMPOSER_SCOPE.attachments.$attachments.get()).toHaveLength(1)
+  })
+
+  it('clears a rehydrated receipt when its late acceptance arrives after a session round-trip', async () => {
+    let resolveAccepted!: (accepted: boolean) => void
+
+    const accepted = new Promise<boolean>(resolve => {
+      resolveAccepted = resolve
+    })
+
+    const { activeQueueSessionKeyRef, clearDraft, draftRef, editorRef, hook, onSubmit } = renderSubmitHook({
+      text: 'accepted once'
+    })
+
+    onSubmit.mockReturnValueOnce(accepted)
+
+    act(() => hook.result.current.submitDraft())
+    activeQueueSessionKeyRef.current = 'session-b'
+    activeQueueSessionKeyRef.current = 'stored-session'
+    draftRef.current = 'accepted once'
+    editorRef.current!.textContent = 'accepted once'
+    resolveAccepted(true)
+
+    await act(async () => accepted)
+    expect(clearDraft).toHaveBeenCalledTimes(2)
+    expect(draftRef.current).toBe('')
+    expect(takeSessionDraft('stored-session')).toEqual({ attachments: [], text: '' })
+  })
+
+  it('preserves newer A-B-A text when an older submit is accepted', async () => {
+    let resolveAccepted!: (accepted: boolean) => void
+
+    const accepted = new Promise<boolean>(resolve => {
+      resolveAccepted = resolve
+    })
+
+    const { clearDraft, draftIntentGenerationRef, draftRef, editorRef, hook, onSubmit } = renderSubmitHook({ text: 'A' })
+    onSubmit.mockReturnValueOnce(accepted)
+
+    act(() => hook.result.current.submitDraft())
+    draftIntentGenerationRef.current += 2
+    draftRef.current = 'A'
+    editorRef.current!.textContent = 'A'
+    resolveAccepted(true)
+
+    await act(async () => accepted)
+    expect(clearDraft).toHaveBeenCalledTimes(1)
+    expect(draftRef.current).toBe('A')
+  })
+
+  it.each([
+    ['accepted', true],
+    ['queued after rejection', false]
+  ])('preserves newer A-B-A text when a steer is %s', async (_label, steerAccepted) => {
+    let resolveSteer!: (accepted: boolean) => void
+
+    const pendingSteer = new Promise<boolean>(resolve => {
+      resolveSteer = resolve
+    })
+
+    const { clearDraft, draftIntentGenerationRef, draftRef, editorRef, hook, onSteer } = renderSubmitHook({
+      busy: true,
+      text: 'A'
+    })
+
+    onSteer.mockReturnValueOnce(pendingSteer)
+
+    act(() => hook.result.current.submitDraft())
+    draftIntentGenerationRef.current += 2
+    draftRef.current = 'A'
+    editorRef.current!.textContent = 'A'
+    resolveSteer(steerAccepted)
+
+    await act(async () => pendingSteer)
+    expect(clearDraft).toHaveBeenCalledTimes(1)
+    expect(draftRef.current).toBe('A')
+  })
+
+  it('does not repaint a rejected submit into a different active session', async () => {
+    let resolveAccepted!: (accepted: boolean) => void
+
+    const accepted = new Promise<boolean>(resolve => {
+      resolveAccepted = resolve
+    })
+
+    const { activeQueueSessionKeyRef, hook, loadIntoComposer, onSubmit } = renderSubmitHook({ text: 'session-a text' })
+    onSubmit.mockReturnValueOnce(accepted)
+
+    act(() => hook.result.current.submitDraft())
+    activeQueueSessionKeyRef.current = 'session-b'
+    resolveAccepted(false)
+
+    await act(async () => accepted)
+    expect(loadIntoComposer).not.toHaveBeenCalledWith('session-a text', [])
+    expect(takeSessionDraft('stored-session').text).toBe('session-a text')
+  })
+
   it('threads the loaded composer scope through onSubmit for the #59305 submit-time guard', async () => {
     const { hook, onSubmit } = renderSubmitHook({ text: 'hello' })
 
@@ -409,36 +683,33 @@ describe('useComposerSubmit with a clarify parked on the session', () => {
     vi.restoreAllMocks()
   })
 
-  it('skips the question and still sends the typed message on an idle session', async () => {
+  it('keeps the question visible and queues typed prose instead of silently skipping it', () => {
     parkClarify('runtime-session')
-    const { hook, onSubmit } = renderSubmitHook({ text: 'actually do this instead' })
+    const { hook, onSteer, onSubmit, queueCurrentDraft } = renderSubmitHook({ text: 'actually do this instead' })
 
     act(() => {
       hook.result.current.submitDraft()
     })
 
-    await waitFor(() =>
-      expect(gatewayRequest).toHaveBeenCalledWith('clarify.respond', {
-        request_id: 'req-runtime-session',
-        answer: ''
-      })
-    )
-    await waitFor(() =>
-      expect(onSubmit).toHaveBeenCalledWith('actually do this instead', expect.objectContaining({ attachments: [] }))
-    )
-    expect($clarifyRequests.get()['runtime-session']).toBeUndefined()
+    expect(queueCurrentDraft).toHaveBeenCalledTimes(1)
+    expect(gatewayRequest).not.toHaveBeenCalled()
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(onSteer).not.toHaveBeenCalled()
+    expect($clarifyRequests.get()['runtime-session']).toBeDefined()
   })
 
-  it('skips the question before steering a busy turn', async () => {
+  it('keeps the question visible and queues a busy-turn follow-up', () => {
     parkClarify('runtime-session')
-    const { hook, onSteer } = renderSubmitHook({ busy: true, text: 'change course' })
+    const { hook, onSteer, queueCurrentDraft } = renderSubmitHook({ busy: true, text: 'change course' })
 
     act(() => {
       hook.result.current.submitDraft()
     })
 
-    await waitFor(() => expect(onSteer).toHaveBeenCalledWith('change course'))
-    expect(gatewayRequest).toHaveBeenCalledWith('clarify.respond', { request_id: 'req-runtime-session', answer: '' })
+    expect(queueCurrentDraft).toHaveBeenCalledTimes(1)
+    expect(onSteer).not.toHaveBeenCalled()
+    expect(gatewayRequest).not.toHaveBeenCalled()
+    expect($clarifyRequests.get()['runtime-session']).toBeDefined()
   })
 
   it('leaves the question alone for an empty Enter (Stop, not an answer)', () => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -3,8 +3,12 @@ import { type RefObject, useLayoutEffect, useRef } from 'react'
 import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
-import { hasClarifyRequest, skipClarifyRequest } from '@/store/clarify'
-import { clearSessionDraft, type ComposerAttachment } from '@/store/composer'
+import { hasClarifyRequest } from '@/store/clarify'
+import {
+  clearSessionDraftIfRevision,
+  type ComposerAttachment,
+  isSessionDraftRevisionCurrent
+} from '@/store/composer'
 import { resetBrowseState } from '@/store/composer-input-history'
 import { enqueueQueuedPrompt, type QueuedPromptEntry } from '@/store/composer-queue'
 import { hasMcpSetupRequest, skipMcpSetupRequest } from '@/store/mcp-setup'
@@ -23,8 +27,9 @@ interface UseComposerSubmitArgs {
   attachments: ComposerAttachment[]
   busy: boolean
   compacting: boolean
-  clearDraft: () => void
+  clearDraft: (preservePersistedDraft?: boolean) => void
   disabled: boolean
+  draftIntentGenerationRef: RefObject<number>
   draftRef: RefObject<string>
   drainNextQueued: () => Promise<boolean>
   editorRef: RefObject<HTMLDivElement | null>
@@ -38,9 +43,27 @@ interface UseComposerSubmitArgs {
   queueCurrentDraft: () => boolean
   queueEdit: QueueEditState | null
   queuedPrompts: QueuedPromptEntry[]
+  releasePersistedDraftReceipt: () => void
   sessionId: string | null | undefined
   setComposerText: (value: string) => void
-  stashAt: (scope: string | null, text?: string, attachments?: ComposerAttachment[]) => void
+  stashAt: (scope: string | null, text: string, attachments: ComposerAttachment[]) => number
+}
+
+function sameAttachmentReceipt(current: ComposerAttachment[], submitted: ComposerAttachment[]): boolean {
+  if (current.length !== submitted.length) {
+    return false
+  }
+
+  return current.every((attachment, index) => {
+    const receipt = submitted[index]!
+
+    return attachment.occurrenceId !== undefined || receipt.occurrenceId !== undefined
+      ? attachment.id === receipt.id && attachment.occurrenceId === receipt.occurrenceId
+      : attachment.id === receipt.id &&
+          attachment.kind === receipt.kind &&
+          attachment.path === receipt.path &&
+          attachment.refText === receipt.refText
+  })
 }
 
 /**
@@ -60,6 +83,7 @@ export function useComposerSubmit({
   compacting,
   clearDraft,
   disabled,
+  draftIntentGenerationRef,
   draftRef,
   drainNextQueued,
   editorRef,
@@ -73,6 +97,7 @@ export function useComposerSubmit({
   queueCurrentDraft,
   queueEdit,
   queuedPrompts,
+  releasePersistedDraftReceipt,
   sessionId,
   setComposerText,
   stashAt
@@ -83,25 +108,98 @@ export function useComposerSubmit({
 
   // Shared send primitive: fire onSubmit, and if the gateway rejects (accepted
   // === false) or throws, re-load + re-stash the draft so the words survive.
-  const dispatchSubmit = (text: string, attachments?: ComposerAttachment[], displayKind?: 'hidden') => {
+  const dispatchSubmit = (
+    text: string,
+    attachments?: ComposerAttachment[],
+    displayKind?: 'hidden',
+    clearRehydratedReceipt = false,
+    ownsComposerReceipt = true
+  ) => {
     const submittedScope = activeQueueSessionKeyRef.current
     const submittedAttachments = attachments ?? []
+    const receiptIntentGeneration = draftIntentGenerationRef.current
 
-    const restore = () => {
-      loadIntoComposer(text, submittedAttachments)
-      // Use the scope captured at dispatch, not whatever session is focused
-      // now — the gateway can reject well after the user has switched away,
-      // and re-stashing into the currently-focused session would overwrite
-      // its draft with the rejected text from a different session (#54527).
-      stashAt(submittedScope, text, submittedAttachments)
-    }
-
-    void Promise.resolve(
+    const submit = () =>
       attachments
         ? onSubmit(text, { attachments, composerScope: submittedScope, ...(displayKind ? { displayKind } : {}) })
         : onSubmit(text, { composerScope: submittedScope, ...(displayKind ? { displayKind } : {}) })
-    )
-      .then(accepted => void (accepted === false ? restore() : clearSessionDraft(submittedScope)))
+
+    // Review-pane and other routed submits do not originate in this composer.
+    // Their retry/receipt state belongs to the caller; borrowing this session's
+    // stash would overwrite an unrelated unsent draft.
+    if (!ownsComposerReceipt) {
+      void Promise.resolve()
+        .then(submit)
+        .catch(() => undefined)
+
+      return
+    }
+
+    // Keep one durable local copy until the gateway explicitly accepts the
+    // submit. The visible editor can clear immediately, but a hung RPC,
+    // reconnect, or late rejection must still have words to restore.
+    const receiptRevision = stashAt(submittedScope, text, submittedAttachments)
+
+    const restore = () => {
+      // A later keystroke/attachment owns newer visible intent even before its
+      // debounce advances the persisted revision. Restore only into the still
+      // empty submitted composer or over the exact same rehydrated receipt.
+      const liveAttachments = scope.attachments.$attachments.get()
+      const composerEmpty = !draftRef.current && liveAttachments.length === 0
+
+      const visibleReceiptMatches =
+        draftIntentGenerationRef.current === receiptIntentGeneration &&
+        draftRef.current === text &&
+        sameAttachmentReceipt(liveAttachments, submittedAttachments)
+
+      if (
+        isSessionDraftRevisionCurrent(submittedScope, receiptRevision) &&
+        draftIntentGenerationRef.current === receiptIntentGeneration &&
+        activeQueueSessionKeyRef.current === submittedScope &&
+        (composerEmpty || visibleReceiptMatches)
+      ) {
+        loadIntoComposer(text, submittedAttachments)
+      }
+    }
+
+    const settleAcceptance = () => {
+      const activeScopeMatches = activeQueueSessionKeyRef.current === submittedScope
+
+      if (!activeScopeMatches) {
+        clearSessionDraftIfRevision(submittedScope, receiptRevision)
+
+        return
+      }
+
+      const liveAttachments = scope.attachments.$attachments.get()
+      const composerEmpty = !draftRef.current && liveAttachments.length === 0
+
+      const visibleReceiptMatches =
+        clearRehydratedReceipt &&
+        draftIntentGenerationRef.current === receiptIntentGeneration &&
+        draftRef.current === text &&
+        sameAttachmentReceipt(liveAttachments, submittedAttachments)
+
+      // A normal submit leaves the composer empty while the receipt waits in
+      // the stash. A session round-trip can repaint that exact receipt; clear
+      // both copies on acceptance. Any other visible state is a newer draft.
+      if (composerEmpty) {
+        // Release clearDraft(true)'s receipt guard once the matching request is
+        // accepted, so the next attachment-only draft persists normally.
+        releasePersistedDraftReceipt()
+      } else if (visibleReceiptMatches) {
+        clearDraft()
+        scope.attachments.removeOccurrences(submittedAttachments)
+      }
+
+      if (composerEmpty || visibleReceiptMatches) {
+        clearSessionDraftIfRevision(submittedScope, receiptRevision)
+      }
+    }
+
+    void Promise.resolve()
+      .then(submit)
+      .then(accepted => void (accepted === false ? restore() : settleAcceptance()))
       .catch(restore)
   }
 
@@ -122,7 +220,7 @@ export function useComposerSubmit({
           paneVisible &&
           !inputDisabled
         ) {
-          dispatchSubmitRef.current(text, undefined, displayKind)
+          dispatchSubmitRef.current(text, undefined, displayKind, false, false)
         }
       }),
     [inputDisabled, paneVisible, scope.target, surfaceId]
@@ -158,19 +256,17 @@ export function useComposerSubmit({
     const text = pathifyRefs(draftRef.current)
     const payloadPresent = text.trim().length > 0 || attachments.length > 0
 
-    // A clarify card parked on this session owns the turn: the agent is blocked
-    // inside its tool batch waiting on `clarify.respond`, so a follow-up routed
-    // through steer/queue sits undelivered until the clarify's own timeout
-    // (default 5 min) — the message looks sent and nothing happens. Typing a
-    // real message instead of picking an option IS the answer "none of these":
-    // skip the question so the tool returns, then route the words normally.
-    //
-    // Fire-and-forget, not awaited: the skip clears the card synchronously and
-    // both RPCs ride the same socket in call order, so the gateway resolves the
-    // clarify before it sees the follow-up. Awaiting first would leave the draft
-    // live for a tick — long enough for a second Enter to send it twice.
-    if (payloadPresent && !queueEdit && hasClarifyRequest(sessionId)) {
-      void skipClarifyRequest(sessionId)
+    // A clarify card is an explicit user decision surface. Typing unrelated
+    // prose must not silently answer it with an empty value and tear the card
+    // down. Park the prose visibly as the next queued turn; the card remains
+    // live until the user chooses an option or presses its explicit Skip.
+    const pendingClarify = payloadPresent && !queueEdit && hasClarifyRequest(sessionId)
+
+    if (pendingClarify) {
+      queueCurrentDraft()
+      focusInput()
+
+      return
     }
 
     // Same deal for a pending MCP setup card: the agent is blocked on
@@ -200,8 +296,8 @@ export function useComposerSubmit({
       // for the current turn to finish, which is how the TUI never behaves.
       if (!attachments.length && SLASH_COMMAND_RE.test(text.trim())) {
         triggerHaptic('submit')
-        clearDraft()
-        dispatchSubmit(text)
+        dispatchSubmit(text, undefined, undefined, true)
+        clearDraft(true)
       } else if (!compacting && !blockingPrompt && !attachments.length && text.trim()) {
         // Cursor-style stop-and-correct: interrupt the live turn and redirect
         // it with this text. redirect() preserves the shown reasoning/work; if
@@ -225,9 +321,9 @@ export function useComposerSubmit({
       const submittedAttachments = cloneAttachments(attachments)
       triggerHaptic('submit')
       resetBrowseState(sessionId)
-      clearDraft()
+      dispatchSubmit(text, submittedAttachments, undefined, true)
+      clearDraft(true)
       scope.attachments.clear()
-      dispatchSubmit(text, submittedAttachments)
     }
 
     focusInput()
@@ -245,14 +341,73 @@ export function useComposerSubmit({
       return
     }
 
-    triggerHaptic('submit')
-    clearDraft()
+    const submittedScope = activeQueueSessionKeyRef.current
+    const submittedAttachments: ComposerAttachment[] = []
+    const receiptIntentGeneration = draftIntentGenerationRef.current
+    const receiptRevision = stashAt(submittedScope, text, submittedAttachments)
 
-    void Promise.resolve(onSteer(text)).then(accepted => {
-      if (!accepted && activeQueueSessionKey) {
-        enqueueQueuedPrompt(activeQueueSessionKey, { text, attachments: [] })
+    const restore = () => {
+      const liveAttachments = scope.attachments.$attachments.get()
+      const composerEmpty = !draftRef.current && liveAttachments.length === 0
+
+      const visibleReceiptMatches =
+        draftIntentGenerationRef.current === receiptIntentGeneration &&
+        draftRef.current === text &&
+        sameAttachmentReceipt(liveAttachments, submittedAttachments)
+
+      if (
+        isSessionDraftRevisionCurrent(submittedScope, receiptRevision) &&
+        draftIntentGenerationRef.current === receiptIntentGeneration &&
+        activeQueueSessionKeyRef.current === submittedScope &&
+        (composerEmpty || visibleReceiptMatches)
+      ) {
+        loadIntoComposer(text, submittedAttachments)
       }
-    })
+    }
+
+    const settleSteerReceipt = () => {
+      const activeScopeMatches = activeQueueSessionKeyRef.current === submittedScope
+
+      if (!activeScopeMatches) {
+        clearSessionDraftIfRevision(submittedScope, receiptRevision)
+
+        return
+      }
+
+      const liveAttachments = scope.attachments.$attachments.get()
+      const composerEmpty = !draftRef.current && liveAttachments.length === 0
+
+      const visibleReceiptMatches =
+        draftIntentGenerationRef.current === receiptIntentGeneration &&
+        draftRef.current === text &&
+        sameAttachmentReceipt(liveAttachments, submittedAttachments)
+
+      if (composerEmpty) {
+        releasePersistedDraftReceipt()
+        clearSessionDraftIfRevision(submittedScope, receiptRevision)
+      } else if (visibleReceiptMatches) {
+        clearDraft()
+        clearSessionDraftIfRevision(submittedScope, receiptRevision)
+      }
+    }
+
+    // Same durability contract as an idle submit: the editor may clear, but
+    // the per-session stash remains until steer acceptance or queue fallback.
+    triggerHaptic('submit')
+    clearDraft(true)
+
+    void Promise.resolve()
+      .then(() => onSteer(text))
+      .then(accepted => {
+        if (accepted) {
+          settleSteerReceipt()
+        } else if (submittedScope && enqueueQueuedPrompt(submittedScope, { text, attachments: submittedAttachments })) {
+          settleSteerReceipt()
+        } else {
+          restore()
+        }
+      })
+      .catch(restore)
   }
 
   const queueDraft = () => {

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -223,6 +223,7 @@ export function ChatBar({
   const {
     activeQueueSessionKeyRef,
     clearDraft,
+    draftIntentGenerationRef,
     draftRef,
     editorRef,
     focusInput,
@@ -232,6 +233,7 @@ export function ChatBar({
     isHelpHint,
     isSteerableText,
     loadIntoComposer,
+    releasePersistedDraftReceipt,
     requestMainFocus,
     sessionIdRef,
     setComposerText,
@@ -362,6 +364,7 @@ export function ChatBar({
     compacting,
     clearDraft,
     disabled,
+    draftIntentGenerationRef,
     draftRef,
     drainNextQueued,
     editorRef,
@@ -377,6 +380,7 @@ export function ChatBar({
     queueCurrentDraft,
     queueEdit,
     queuedPrompts,
+    releasePersistedDraftReceipt,
     sessionId,
     setComposerText,
     stashAt
@@ -429,6 +433,7 @@ export function ChatBar({
     const nextDraft = sanitizeComposerInput(composerPlainText(editor))
 
     if (nextDraft !== draftRef.current) {
+      draftIntentGenerationRef.current += 1
       draftRef.current = nextDraft
       setComposerText(nextDraft)
     }
@@ -484,6 +489,7 @@ export function ChatBar({
       return
     }
 
+    draftIntentGenerationRef.current += 1
     recordUndoPoint({ coalesce: inputType === 'insertText' || inputType === 'deleteContentBackward' })
   }
 
@@ -551,6 +557,7 @@ export function ChatBar({
     // not text they typed and want to keep (`@url:@url:\`https://…\``).
     const scope = openDirectiveScope(event.currentTarget)
 
+    draftIntentGenerationRef.current += 1
     recordUndoPoint()
     insertComposerContentsAtCaret(event.currentTarget, pathifyRefs(linkifyUrls(pastedText)), scope)
     scheduleFlushEditorToDraft(event.currentTarget)

--- a/apps/desktop/src/app/chat/transcript-backfill.test.ts
+++ b/apps/desktop/src/app/chat/transcript-backfill.test.ts
@@ -202,6 +202,20 @@ describe('mergeOlderTranscriptPage', () => {
 
     expect(mergeOlderTranscriptPage(existing, older)).toHaveLength(2)
   })
+  it('keeps timestamp-like keys inside tool arguments as semantic payload', () => {
+    const toolPart = (timestamp: number, completedAt: number) =>
+      ({
+        args: { timestamp, nested: { completedAt } },
+        toolCallId: 'same-call',
+        toolName: 'terminal',
+        type: 'tool-call'
+      }) as ChatMessage['parts'][number]
+
+    const existing = [{ ...chat('tool-new', 20), timestamp: 1_700_000_000, parts: [toolPart(10, 20)] }]
+    const older = [{ ...chat('tool-old', 2), timestamp: 1_700_000_000, parts: [toolPart(11, 21)] }]
+
+    expect(mergeOlderTranscriptPage(existing, older)).toHaveLength(2)
+  })
 
   it('keeps reference identity when every older row is already present', () => {
     const existing = [chat('a', 1), chat('b', 2)]

--- a/apps/desktop/src/app/chat/transcript-backfill.test.ts
+++ b/apps/desktop/src/app/chat/transcript-backfill.test.ts
@@ -122,6 +122,87 @@ describe('mergeOlderTranscriptPage', () => {
     expect(mergeOlderTranscriptPage(existing, older).map(m => m.rowId)).toEqual([1, 2, 3])
   })
 
+  it('dedupes a compaction-generation copy by logical identity when row ids changed', () => {
+    const existing = [{ ...chat('new-generation', 20), timestamp: 1_700_000_000 }]
+    const older = [{ ...chat('old-generation', 2), timestamp: 1_700_000_000, parts: existing[0].parts }]
+
+    expect(mergeOlderTranscriptPage(existing, older)).toBe(existing)
+  })
+
+  it('ignores locally enriched timeline metadata when matching a compaction copy', () => {
+    const text = { text: 'same durable content', type: 'text' as const }
+
+    const existing = [
+      {
+        ...chat('warm-generation', 20),
+        timestamp: 900,
+        durableTimestamp: 1_000,
+        parts: [{ ...text, timestamp: 900, completedAt: 950 }]
+      }
+    ]
+
+    const older = [
+      {
+        ...chat('fresh-generation', 2),
+        timestamp: 1_000,
+        durableTimestamp: 1_000,
+        parts: [{ ...text, timestamp: 1_000 }]
+      }
+    ]
+
+    expect(mergeOlderTranscriptPage(existing, older)).toBe(existing)
+  })
+
+  it('preserves multiplicity for distinct identical persisted rows', () => {
+    const existing = [{ ...chat('warm-copy', 20), timestamp: 1_000, durableTimestamp: 1_000 }]
+
+    const older = [
+      { ...chat('older-copy', 2), timestamp: 1_000, durableTimestamp: 1_000, parts: existing[0].parts },
+      { ...chat('distinct-repeat', 3), timestamp: 1_000, durableTimestamp: 1_000, parts: existing[0].parts }
+    ]
+
+    expect(mergeOlderTranscriptPage(existing, older).map(message => message.rowId)).toEqual([3, 20])
+  })
+
+  it('consumes an exact overlap before preserving a distinct identical row', () => {
+    const existing = [{ ...chat('warm-copy', 20), timestamp: 1_000, durableTimestamp: 1_000 }]
+
+    const older = [
+      { ...chat('exact-overlap', 20), timestamp: 1_000, durableTimestamp: 1_000, parts: existing[0].parts },
+      { ...chat('distinct-repeat', 3), timestamp: 1_000, durableTimestamp: 1_000, parts: existing[0].parts }
+    ]
+
+    expect(mergeOlderTranscriptPage(existing, older).map(message => message.rowId)).toEqual([3, 20])
+  })
+
+  it('pre-accounts a later exact overlap before an earlier distinct identical row', () => {
+    const existing = [{ ...chat('warm-copy', 20), timestamp: 1_000, durableTimestamp: 1_000 }]
+
+    const older = [
+      { ...chat('distinct-repeat', 3), timestamp: 1_000, durableTimestamp: 1_000, parts: existing[0].parts },
+      { ...chat('exact-overlap', 20), timestamp: 1_000, durableTimestamp: 1_000, parts: existing[0].parts }
+    ]
+
+    expect(mergeOlderTranscriptPage(existing, older).map(message => message.rowId)).toEqual([3, 20])
+  })
+
+  it('keeps truly repeated text when timestamps differ', () => {
+    const existing = [{ ...chat('new-generation', 20), timestamp: 1_700_000_001 }]
+    const older = [{ ...chat('old-generation', 2), timestamp: 1_700_000_000, parts: existing[0].parts }]
+
+    expect(mergeOlderTranscriptPage(existing, older)).toHaveLength(2)
+  })
+
+  it('keeps distinct tool calls even when timestamp and visible result match', () => {
+    const toolPart = (toolCallId: string) =>
+      ({ args: {}, toolCallId, toolName: 'terminal', type: 'tool-call' }) as ChatMessage['parts'][number]
+
+    const existing = [{ ...chat('tool-new', 20), timestamp: 1_700_000_000, parts: [toolPart('call-new')] }]
+    const older = [{ ...chat('tool-old', 2), timestamp: 1_700_000_000, parts: [toolPart('call-old')] }]
+
+    expect(mergeOlderTranscriptPage(existing, older)).toHaveLength(2)
+  })
+
   it('keeps reference identity when every older row is already present', () => {
     const existing = [chat('a', 1), chat('b', 2)]
     const older = [chat('a', 1)]
@@ -142,6 +223,45 @@ describe('graftRefreshedTailOntoBackfill', () => {
     const refreshed = [chat('b', 2), chat('c', 3), chat('d', 4)]
 
     expect(graftRefreshedTailOntoBackfill(refreshed, previous).map(m => m.rowId)).toEqual([1, 2, 3, 4])
+  })
+
+  it('anchors a refreshed compaction generation by logical identity instead of duplicating it', () => {
+    const copied = { ...chat('old-generation', 2), timestamp: 1_700_000_000 }
+    const refreshedCopy = { ...chat('new-generation', 20), timestamp: 1_700_000_000, parts: copied.parts }
+    const previous = [chat('prefix', 1), copied, chat('stale-tail', 3)]
+    const refreshed = [refreshedCopy, chat('fresh-tail', 21)]
+
+    expect(graftRefreshedTailOntoBackfill(refreshed, previous).map(m => m.rowId)).toEqual([1, 20, 21])
+  })
+
+  it('anchors ambiguous identical rows at the newest occurrence and preserves multiplicity', () => {
+    const first = { ...chat('repeat-one', 2), timestamp: 1_000, durableTimestamp: 1_000 }
+    const second = { ...chat('repeat-two', 3), timestamp: 1_000, durableTimestamp: 1_000, parts: first.parts }
+    const refreshedCopy = { ...chat('refreshed-repeat', 20), timestamp: 1_000, durableTimestamp: 1_000, parts: first.parts }
+    const previous = [chat('prefix', 1), first, second, chat('stale-tail', 4)]
+
+    expect(graftRefreshedTailOntoBackfill([refreshedCopy, chat('fresh-tail', 21)], previous).map(m => m.rowId)).toEqual([
+      1, 2, 20, 21
+    ])
+  })
+
+  it('sequence-aligns a refreshed run of identical persisted rows', () => {
+    const first = { ...chat('repeat-one', 2), timestamp: 1_000, durableTimestamp: 1_000 }
+    const second = { ...chat('repeat-two', 3), timestamp: 1_000, durableTimestamp: 1_000, parts: first.parts }
+    const third = { ...chat('repeat-three', 4), timestamp: 1_000, durableTimestamp: 1_000, parts: first.parts }
+
+    const refreshed = [20, 21, 22].map(rowId => ({
+      ...chat(`refreshed-${rowId}`, rowId),
+      timestamp: 1_000,
+      durableTimestamp: 1_000,
+      parts: first.parts
+    }))
+
+    const previous = [chat('prefix', 1), first, second, third, chat('stale-tail', 5)]
+
+    expect(graftRefreshedTailOntoBackfill([...refreshed, chat('fresh-tail', 23)], previous).map(m => m.rowId)).toEqual([
+      1, 20, 21, 22, 23
+    ])
   })
 
   it('returns the refreshed tail unchanged when no anchor is found', () => {

--- a/apps/desktop/src/app/chat/transcript-backfill.ts
+++ b/apps/desktop/src/app/chat/transcript-backfill.ts
@@ -27,6 +27,51 @@ export function transcriptBackfillAvailable(
   return Boolean(transcriptTailState(storedSessionId, profile)?.possiblyTruncated)
 }
 
+/** Strip renderer-only timing before deterministic semantic serialization. */
+function durablePartValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(durablePartValue)
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value
+  }
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([key]) => key !== 'timestamp' && key !== 'completedAt')
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, durablePartValue(entry)])
+  )
+}
+
+/**
+ * Identity that survives compaction's protected-tail copy. A compaction epoch
+ * preserves durable row time + semantic parts but assigns a fresh DB row id.
+ * Live timeline reconciliation may rewrite display timestamps/completedAt, so
+ * those fields are excluded. Timestamp-less optimistic projections return null.
+ */
+export function logicalTranscriptMessageKey(message: ChatMessage): null | string {
+  const durableTimestamp = message.durableTimestamp ?? message.timestamp
+
+  if (durableTimestamp === undefined) {
+    return null
+  }
+
+  return JSON.stringify([
+    message.role,
+    durableTimestamp,
+    durablePartValue(message.parts),
+    message.attachmentRefs ?? []
+  ])
+}
+
+function sameLogicalTranscriptMessage(left: ChatMessage, right: ChatMessage): boolean {
+  const leftKey = logicalTranscriptMessageKey(left)
+
+  return leftKey !== null && leftKey === logicalTranscriptMessageKey(right)
+}
+
 /**
  * Prepend an older page onto the in-memory transcript, deduplicating rows the
  * store already holds (offset drift makes overlap normal — see module doc).
@@ -43,6 +88,7 @@ export function mergeOlderTranscriptPage(existing: ChatMessage[], olderPage: Cha
 
   const existingRowIds = new Set<number>()
   const existingIds = new Set<string>()
+  const unmatchedLogicalCounts = new Map<string, number>()
 
   for (const message of existing) {
     if (message.rowId !== undefined) {
@@ -50,11 +96,46 @@ export function mergeOlderTranscriptPage(existing: ChatMessage[], olderPage: Cha
     }
 
     existingIds.add(message.id)
+    const logicalKey = logicalTranscriptMessageKey(message)
+
+    if (logicalKey !== null) {
+      unmatchedLogicalCounts.set(logicalKey, (unmatchedLogicalCounts.get(logicalKey) ?? 0) + 1)
+    }
   }
 
-  const fresh = olderPage.filter(
-    message => !(message.rowId !== undefined && existingRowIds.has(message.rowId)) && !existingIds.has(message.id)
-  )
+  const consumeLogicalOverlap = (message: ChatMessage): boolean => {
+    const logicalKey = logicalTranscriptMessageKey(message)
+    const remaining = logicalKey === null ? 0 : (unmatchedLogicalCounts.get(logicalKey) ?? 0)
+
+    if (logicalKey === null || remaining <= 0) {
+      return false
+    }
+
+    unmatchedLogicalCounts.set(logicalKey, remaining - 1)
+
+    return true
+  }
+
+  // Reserve semantic multiplicity for exact row/id overlaps before page-order
+  // filtering. Older pages are chronological, so a distinct identical row may
+  // appear before the exact boundary row that proves the overlap.
+  for (const message of olderPage) {
+    if ((message.rowId !== undefined && existingRowIds.has(message.rowId)) || existingIds.has(message.id)) {
+      consumeLogicalOverlap(message)
+    }
+  }
+
+  const fresh = olderPage.filter(message => {
+    if ((message.rowId !== undefined && existingRowIds.has(message.rowId)) || existingIds.has(message.id)) {
+      return false
+    }
+
+    if (consumeLogicalOverlap(message)) {
+      return false
+    }
+
+    return true
+  })
 
   if (fresh.length === 0) {
     return existing
@@ -77,13 +158,46 @@ export function graftRefreshedTailOntoBackfill(refreshedTail: ChatMessage[], pre
     return refreshedTail
   }
 
-  const first = refreshedTail[0]
+  const sameTranscriptOccurrence = (left: ChatMessage, right: ChatMessage) =>
+    (left.rowId !== undefined && right.rowId !== undefined && left.rowId === right.rowId) ||
+    left.id === right.id ||
+    sameLogicalTranscriptMessage(left, right)
 
-  const anchor = previous.findIndex(
-    message =>
-      (first.rowId !== undefined && message.rowId !== undefined && message.rowId === first.rowId) ||
-      message.id === first.id
-  )
+  let anchor = -1
+  let longestOverlap = 0
+  let bestStartsExact = false
+
+  // Align the longest previous suffix segment with the refreshed prefix. A
+  // first-row reverse match duplicates repeated runs; sequence alignment maps
+  // all N refreshed copies onto the corresponding N previous occurrences.
+  for (let index = 0; index < previous.length; index += 1) {
+    let overlap = 0
+
+    while (
+      index + overlap < previous.length &&
+      overlap < refreshedTail.length &&
+      sameTranscriptOccurrence(previous[index + overlap]!, refreshedTail[overlap]!)
+    ) {
+      overlap += 1
+    }
+
+    const startsExact =
+      overlap > 0 &&
+      ((previous[index]!.rowId !== undefined &&
+        refreshedTail[0]!.rowId !== undefined &&
+        previous[index]!.rowId === refreshedTail[0]!.rowId) ||
+        previous[index]!.id === refreshedTail[0]!.id)
+
+    if (
+      overlap > longestOverlap ||
+      (overlap > 0 && overlap === longestOverlap && startsExact && !bestStartsExact) ||
+      (overlap > 0 && overlap === longestOverlap && startsExact === bestStartsExact && index > anchor)
+    ) {
+      anchor = index
+      longestOverlap = overlap
+      bestStartsExact = startsExact
+    }
+  }
 
   if (anchor <= 0) {
     return refreshedTail

--- a/apps/desktop/src/app/chat/transcript-backfill.ts
+++ b/apps/desktop/src/app/chat/transcript-backfill.ts
@@ -27,10 +27,10 @@ export function transcriptBackfillAvailable(
   return Boolean(transcriptTailState(storedSessionId, profile)?.possiblyTruncated)
 }
 
-/** Strip renderer-only timing before deterministic semantic serialization. */
-function durablePartValue(value: unknown): unknown {
+/** Strip renderer-only timing from each part before deterministic semantic serialization. */
+function durablePartValue(value: unknown, depth = 0): unknown {
   if (Array.isArray(value)) {
-    return value.map(durablePartValue)
+    return value.map(entry => durablePartValue(entry, depth + 1))
   }
 
   if (!value || typeof value !== 'object') {
@@ -39,9 +39,9 @@ function durablePartValue(value: unknown): unknown {
 
   return Object.fromEntries(
     Object.entries(value as Record<string, unknown>)
-      .filter(([key]) => key !== 'timestamp' && key !== 'completedAt')
+      .filter(([key]) => depth !== 1 || (key !== 'timestamp' && key !== 'completedAt'))
       .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entry]) => [key, durablePartValue(entry)])
+      .map(([key, entry]) => [key, durablePartValue(entry, depth + 1)])
   )
 }
 
@@ -170,8 +170,19 @@ export function graftRefreshedTailOntoBackfill(refreshedTail: ChatMessage[], pre
   // Align the longest previous suffix segment with the refreshed prefix. A
   // first-row reverse match duplicates repeated runs; sequence alignment maps
   // all N refreshed copies onto the corresponding N previous occurrences.
-  for (let index = 0; index < previous.length; index += 1) {
-    let overlap = 0
+  const refreshedHead = refreshedTail[0]!
+
+  // Newest-first preserves the existing tie-break while making the common
+  // exact-tail anchor an early exit. Non-candidates never enter the overlap
+  // scan, so unrelated long transcripts remain linear.
+  for (let index = previous.length - 1; index >= 0; index -= 1) {
+    const previousHead = previous[index]!
+
+    if (!sameTranscriptOccurrence(previousHead, refreshedHead)) {
+      continue
+    }
+
+    let overlap = 1
 
     while (
       index + overlap < previous.length &&
@@ -182,20 +193,23 @@ export function graftRefreshedTailOntoBackfill(refreshedTail: ChatMessage[], pre
     }
 
     const startsExact =
-      overlap > 0 &&
-      ((previous[index]!.rowId !== undefined &&
-        refreshedTail[0]!.rowId !== undefined &&
-        previous[index]!.rowId === refreshedTail[0]!.rowId) ||
-        previous[index]!.id === refreshedTail[0]!.id)
+      (previousHead.rowId !== undefined &&
+        refreshedHead.rowId !== undefined &&
+        previousHead.rowId === refreshedHead.rowId) ||
+      previousHead.id === refreshedHead.id
 
     if (
       overlap > longestOverlap ||
-      (overlap > 0 && overlap === longestOverlap && startsExact && !bestStartsExact) ||
-      (overlap > 0 && overlap === longestOverlap && startsExact === bestStartsExact && index > anchor)
+      (overlap === longestOverlap && startsExact && !bestStartsExact) ||
+      (overlap === longestOverlap && startsExact === bestStartsExact && index > anchor)
     ) {
       anchor = index
       longestOverlap = overlap
       bestStartsExact = startsExact
+    }
+
+    if (longestOverlap === refreshedTail.length && bestStartsExact) {
+      break
     }
   }
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -162,7 +162,7 @@ const COMPARED_FIELDS = [
   'durationS'
 ] as const
 
-const IGNORED_FIELDS = ['attachmentRefs', 'parts', 'rowId'] as const
+const IGNORED_FIELDS = ['attachmentRefs', 'parts', 'rowId', 'durableTimestamp'] as const
 
 // Compile-time check: every ChatMessagePart discriminant must be handled by
 // chatPartsEquivalent. If @assistant-ui adds a new part type, this fails tsc.

--- a/apps/desktop/src/lib/chat-messages/hydration.ts
+++ b/apps/desktop/src/lib/chat-messages/hydration.ts
@@ -147,6 +147,7 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
 
     active.parts = [...active.parts, ...parts]
     active.timestamp = earliestTimestamp(active.timestamp, timestamp, ...parts.map(part => part.timestamp))
+    active.durableTimestamp = earliestTimestamp(active.durableTimestamp, timestamp)
 
     return true
   }
@@ -161,7 +162,8 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
         id: `${pendingToolTimestamp || Date.now()}-${index}-tools`,
         role: 'assistant',
         parts: pendingToolParts,
-        timestamp: pendingToolTimestamp
+        timestamp: pendingToolTimestamp,
+        durableTimestamp: pendingToolTimestamp
       })
       activeAssistantIndex = result.length - 1
     }
@@ -286,6 +288,7 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
           message.timestamp,
           ...parts.map(part => part.timestamp)
         )
+        activeAssistant.durableTimestamp = earliestTimestamp(activeAssistant.durableTimestamp, message.timestamp)
 
         return
       }
@@ -304,6 +307,7 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
       role: displayRole,
       parts,
       timestamp: earliestTimestamp(message.timestamp, ...parts.map(part => part.timestamp)),
+      durableTimestamp: message.timestamp,
       ...(rowId !== undefined ? { rowId } : {}),
       ...(reactions.length ? { reactions } : {}),
       ...(extractedAttachmentRefs ? { attachmentRefs: extractedAttachmentRefs } : {})

--- a/apps/desktop/src/lib/chat-messages/types.ts
+++ b/apps/desktop/src/lib/chat-messages/types.ts
@@ -19,6 +19,10 @@ export type ChatMessage = {
   role: SessionMessage['role']
   parts: ChatMessagePart[]
   timestamp?: number
+  /** Original backend row timestamp. Unlike `timestamp`, local timeline
+   * reconciliation never rewrites it, so compaction generations retain one
+   * stable semantic identity across warm-cache and fresh hydration. */
+  durableTimestamp?: number
   completedAt?: number
   pending?: boolean
   error?: string

--- a/apps/desktop/src/store/composer.test.ts
+++ b/apps/desktop/src/store/composer.test.ts
@@ -5,10 +5,12 @@ import {
   $voiceConversationStartRequest,
   addComposerAttachment,
   clearSessionDraft,
+  clearSessionDraftIfRevision,
   type ComposerAttachment,
   createComposerAttachmentOccurrenceId,
   createComposerAttachmentScope,
   migrateSessionDraft,
+  reloadPersistedDrafts,
   removeComposerAttachment,
   requestVoiceConversationStart,
   SESSION_DRAFTS_STORAGE_KEY,
@@ -256,6 +258,39 @@ describe('session drafts', () => {
     clearSessionDraft('session-a')
 
     expect(takeSessionDraft('session-a')).toEqual({ attachments: [], text: '' })
+  })
+
+  it('compare-and-clear preserves a newer draft revision', () => {
+    const submitted = stashSessionDraft('session-a', 'submitted', [])
+    stashSessionDraft('session-a', 'typed while pending', [])
+
+    expect(clearSessionDraftIfRevision('session-a', submitted)).toBe(false)
+    expect(takeSessionDraft('session-a').text).toBe('typed while pending')
+  })
+
+  it('compare-and-clear removes only the matching submitted revision', () => {
+    const submitted = stashSessionDraft('session-a', 'submitted', [])
+
+    expect(clearSessionDraftIfRevision('session-a', submitted)).toBe(true)
+    expect(takeSessionDraft('session-a').text).toBe('')
+  })
+
+  it('cross-window reload invalidates an older submit revision', () => {
+    const submitted = stashSessionDraft('session-a', 'submitted', [])
+    window.localStorage.setItem(SESSION_DRAFTS_STORAGE_KEY, JSON.stringify({ 'session-a': 'other window draft' }))
+    reloadPersistedDrafts()
+
+    expect(clearSessionDraftIfRevision('session-a', submitted)).toBe(false)
+    expect(takeSessionDraft('session-a').text).toBe('other window draft')
+  })
+
+  it('cross-window deletion also invalidates an older submit revision', () => {
+    const submitted = stashSessionDraft('session-a', 'submitted', [])
+    window.localStorage.removeItem(SESSION_DRAFTS_STORAGE_KEY)
+    reloadPersistedDrafts()
+
+    expect(clearSessionDraftIfRevision('session-a', submitted)).toBe(false)
+    expect(takeSessionDraft('session-a').text).toBe('')
   })
 
   it('returns clones so callers cannot mutate the stash', () => {

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -208,6 +208,12 @@ function loadPersistedDraftTexts(): [string, SessionDraft][] {
 }
 
 const draftsBySession = new Map<string, SessionDraft>(loadPersistedDraftTexts())
+const draftRevisionsBySession = new Map<string, number>()
+let nextDraftRevision = 0
+
+for (const key of draftsBySession.keys()) {
+  draftRevisionsBySession.set(key, ++nextDraftRevision)
+}
 
 /**
  * Patch one asynchronous attachment occurrence wherever the main composer owns
@@ -299,7 +305,13 @@ export function reloadPersistedDrafts(): void {
 
   for (const [key, draft] of incoming) {
     const local = draftsBySession.get(key)
-    draftsBySession.set(key, local?.attachments.length ? { ...local, text: draft.text } : draft)
+    const next = local?.attachments.length ? { ...local, text: draft.text } : draft
+
+    if (!local || local.text !== next.text) {
+      draftRevisionsBySession.set(key, ++nextDraftRevision)
+    }
+
+    draftsBySession.set(key, next)
     publishDraftTitle(key, deriveDraftTitle(draft.text))
   }
 
@@ -307,6 +319,7 @@ export function reloadPersistedDrafts(): void {
   for (const key of [...draftsBySession.keys()]) {
     if (!incoming.has(key)) {
       draftsBySession.delete(key)
+      draftRevisionsBySession.set(key, ++nextDraftRevision)
       publishDraftTitle(key, '')
     }
   }
@@ -379,8 +392,13 @@ function persistDraftTexts() {
   }
 }
 
-export function stashSessionDraft(scope: string | null | undefined, text: string, attachments: ComposerAttachment[]) {
+export function stashSessionDraft(
+  scope: string | null | undefined,
+  text: string,
+  attachments: ComposerAttachment[]
+): number {
   const key = draftKey(scope)
+  const revision = ++nextDraftRevision
 
   // Delete-then-set keeps MRU order for MAX_PERSISTED_DRAFTS eviction.
   draftsBySession.delete(key)
@@ -389,8 +407,11 @@ export function stashSessionDraft(scope: string | null | undefined, text: string
     draftsBySession.set(key, cloneDraft({ attachments, text }))
   }
 
+  draftRevisionsBySession.set(key, revision)
   persistDraftTexts()
   publishDraftTitle(key, deriveDraftTitle(text))
+
+  return revision
 }
 
 export function takeSessionDraft(scope: string | null | undefined): SessionDraft {
@@ -400,6 +421,19 @@ export function takeSessionDraft(scope: string | null | undefined): SessionDraft
 }
 
 export const clearSessionDraft = (scope: string | null | undefined) => stashSessionDraft(scope, '', [])
+
+export const isSessionDraftRevisionCurrent = (scope: string | null | undefined, revision: number): boolean =>
+  draftRevisionsBySession.get(draftKey(scope)) === revision
+
+export function clearSessionDraftIfRevision(scope: string | null | undefined, revision: number): boolean {
+  if (!isSessionDraftRevisionCurrent(scope, revision)) {
+    return false
+  }
+
+  clearSessionDraft(scope)
+
+  return true
+}
 
 /**
  * Move a stashed composer draft from one session key onto another.


### PR DESCRIPTION
## What does this PR do?

Fixes four interacting Hermes Desktop message-integrity failures:

1. A typed follow-up silently skipped a live `clarify` card with an empty answer.
2. Queued prose could drain while that explicit decision was unresolved.
3. Late submit/steer settlement could erase newer text or attachments, repaint another session's receipt, or resurrect an accepted draft.
4. Compression generations could duplicate or drop persisted transcript occurrences because row IDs change and renderer timing metadata is mutable.

## Root causes

- `useComposerSubmit` treated any typed payload during clarify as explicit Skip.
- Queue drain paths did not share an awaiting-clarify gate.
- Draft receipts were scope-keyed but not revision- and intent-generation-keyed.
- External routed submits borrowed the visible composer's stash.
- Transcript reconciliation relied on fresh row IDs or mutable display projections without preserving occurrence multiplicity.

## Fix

- Keep clarify cards live and place unrelated typed prose in the visible per-session queue.
- Gate auto-drain, manual drain, send-now, and steer-now while clarify is pending; release through the normal settle path after answer/Skip.
- Add per-session draft revisions, compare-and-clear, and cross-window invalidation.
- Track explicit user-intent generations across native `beforeinput`, paste, programmatic edits, and attachment changes; suppress generation for programmatic rehydrate.
- Restore or clear a receipt only when scope, persisted revision, and visible intent generation still belong to that receipt.
- Keep external submit receipts independent of the composer stash.
- Preserve immutable backend `durableTimestamp`, strip renderer-only timing from semantic identity, pre-account exact overlaps, and sequence-align repeated occurrences across refreshed tails.

## Related issues / PRs

- #92916
- #93059
- #68927
- #92816
- Related open work: #93178, #92730, #92733, #68954

## Verification

- Focused Desktop message-integrity on upstream `main`: **110/110 PASS**
- Full Desktop UI on upstream `main`: **585/585 files, 5645/5645 PASS**
- Electron unit on upstream `main`: **1623 PASS / 3 skip**
- Backend focused canonical: **598/598 PASS**
- Desktop typecheck: **PASS**
- Production Desktop build + dist assertion: **PASS**
- Packaged Desktop `test:desktop:all`: **PASS** (Linux unpacked app, clean commit stamp)
- Plugin tests: **528/528 PASS**
- Full repository lint: **PASS** (0 errors; 115 upstream warnings)
- Touched ESLint: **0 errors**; two pre-existing `stashAt` hook warnings unchanged from base
- Static secret/injection scan: **0 matches**
- Independent bounded review: **PASS**
  - Reviewer focused suite: **114/114 PASS**
  - Known-counterexample probes before transplant: **5 runs × 8 tests = 40/40 PASS**
  - Upstream-base transplant probes: **5 runs × 8 tests = 40/40 PASS**
  - Findings: **0**
- Verified upstream-base commit: `f5ff8b2d4fbe`

## Environment limitation

The Electron Playwright clarify/queue scenario is included. This VDS cannot start Xvfb without a system `/usr/bin/xkbcomp` installation, so Electron stops before the test body. The same state transitions are covered by focused unit/store tests, the full UI suite, Electron unit tests, and adversarial counterexample probes. Packaged Windows viewport acceptance remains a post-install check.

## Checklist

- [x] No state.db migration or historical-row mutation
- [x] No provider/model/config changes
- [x] No new runtime dependency
- [x] Regression tests cover clarify hold/release, double-send paths, session/profile isolation, pre-debounce settlement, A/B/A intent collisions, external submits, attachment-only drafts, cross-window revisions, and transcript multiplicity
- [x] Final independent review PASS
- [x] Final full UI suite PASS
