### PR TITLE
fix(desktop): isolate a failed lazy syntax-diff import from the workspace pane

### DIFF
--- a/apps/desktop/src/components/chat/diff-lines.test.tsx
+++ b/apps/desktop/src/components/chat/diff-lines.test.tsx
@@ -1,0 +1,63 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Regression coverage for #93479: a failed dynamic import of the lazily-loaded
+// Shiki diff module (packaged asar/asar.unpacked path mismatch, or any other
+// fetch failure) rejects the `React.lazy()` promise. React.Suspense only
+// covers the *pending* state, so the rejection throws past it to the nearest
+// error boundary — which in production is the whole workspace `ContribBoundary`
+// — and blanks the transcript instead of degrading to the plain colored diff.
+vi.mock('./syntax-diff', () => {
+  throw new Error(
+    'Failed to fetch dynamically imported module: file:///Hermes.app/Contents/Resources/app.asar/dist/assets/syntax-diff-Bo0962zh.js'
+  )
+})
+
+import { ErrorBoundary } from '@/components/error-boundary'
+
+import { FileDiffPanel } from './diff-lines'
+
+afterEach(cleanup)
+
+const DIFF = [
+  'diff --git a/file.ts b/file.ts',
+  '--- a/file.ts',
+  '+++ b/file.ts',
+  '@@ -1,2 +1,2 @@',
+  ' const a = 1',
+  '-const b = 2',
+  '+const b = 3'
+].join('\n')
+
+const WORKSPACE_FALLBACK_TEXT = 'workspace failed to render'
+
+// The failure surfaces only from console.error noise, not from the assertion.
+function renderQuietly(node: Parameters<typeof render>[0]) {
+  const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+  try {
+    return render(node)
+  } finally {
+    spy.mockRestore()
+  }
+}
+
+describe('FileDiffPanel survives a failed lazy syntax-diff chunk', () => {
+  it('degrades to the plain colored diff instead of taking down the surrounding boundary', async () => {
+    const { container } = renderQuietly(
+      <ErrorBoundary fallback={() => <div>{WORKSPACE_FALLBACK_TEXT}</div>} label="workspace">
+        <FileDiffPanel diff={DIFF} path="file.ts" />
+      </ErrorBoundary>
+    )
+
+    // The rejection settles a tick after the initial Suspense-pending render
+    // (which coincidentally shows the same plain text already) — give it
+    // real time to propagate before asserting nothing regressed.
+    await act(() => new Promise(resolve => setTimeout(resolve, 300)))
+
+    expect(container.textContent).toContain('const a = 1')
+    expect(container.textContent).toContain('const b = 2')
+    expect(container.textContent).toContain('const b = 3')
+    expect(container.textContent).not.toContain(WORKSPACE_FALLBACK_TEXT)
+  })
+})

--- a/apps/desktop/src/components/chat/diff-lines.tsx
+++ b/apps/desktop/src/components/chat/diff-lines.tsx
@@ -5,6 +5,7 @@ import type { BundledLanguage, ShikiTransformer, ThemedToken } from 'shiki'
 
 import { chunkLines, type LineChunk, useFixedRowWindow } from '@/components/chat/fixed-row-window'
 import { exceedsHighlightBudget, SHIKI_THEME } from '@/components/chat/shiki-highlighter'
+import { ErrorBoundary } from '@/components/error-boundary'
 import { shikiLanguageForFilename } from '@/lib/markdown-code'
 import { cn } from '@/lib/utils'
 
@@ -469,10 +470,18 @@ function SyntaxDiff({ language, lines }: { language: string; lines: DiffLine[] }
   // The Shiki hook lives in a lazily-loaded module (syntax-diff.tsx) so the
   // multi-MB shiki chunk stays off the cold-start path. Until it (and the
   // highlight itself) resolves, show the plain colored diff — no flash.
+  //
+  // A rejected dynamic import (e.g. a packaged app whose renderer window is
+  // pointed at the asar copy of dist/ while the chunk only exists in
+  // app.asar.unpacked, #93479) throws past Suspense, which only covers the
+  // pending state. Without a local boundary that throw reaches the workspace
+  // ContribBoundary and blanks the whole pane instead of just this diff.
   return (
-    <React.Suspense fallback={<DiffBody lines={lines} />}>
-      <LazySyntaxDiff language={language} lines={lines} />
-    </React.Suspense>
+    <ErrorBoundary fallback={() => <DiffBody lines={lines} />} label="syntax-diff">
+      <React.Suspense fallback={<DiffBody lines={lines} />}>
+        <LazySyntaxDiff language={language} lines={lines} />
+      </React.Suspense>
+    </ErrorBoundary>
   )
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes item **C** from #93479's own proposed fix list: a failed lazy load of the Shiki syntax-diff chunk (`apps/desktop/src/components/chat/syntax-diff.tsx`) currently takes down the entire workspace pane instead of degrading to the plain colored diff.

`SyntaxDiff` in `diff-lines.tsx` wraps `LazySyntaxDiff` (`React.lazy(() => import('./syntax-diff'))`) in a `React.Suspense` whose fallback is the plain `DiffBody`. `Suspense` only covers the *pending* state of a lazy import — when the dynamic import **rejects**, the rejection throws past `Suspense` to the nearest error boundary. In this tree that's the whole workspace `ContribBoundary`, so one missing/failed highlighter chunk blanks the entire chat transcript. The issue's root-cause analysis traces one concrete trigger (a packaged app whose renderer window resolves to the `app.asar` copy of `dist/` while `dist/**` is `asarUnpack`-only, so Chromium's ESM loader 404s the chunk that only exists under `app.asar.unpacked/`), but any dynamic-import failure for this chunk hits the same blast radius.

`markdown-text.tsx` already wraps its own render surface in a local `ErrorBoundary` for exactly this failure class (see the comment there referencing the same "workspace failed to render" crash). Diffs didn't have the equivalent, and the issue calls that gap out explicitly ("Diffs do not").

This PR only addresses the isolation (item C). Items A/B in the issue (loading the packaged renderer from the unpacked tree, and teaching the torn-bundle guard about lazy chunks pulled via `__vite__mapDeps`) are packaging/build-config changes with a different, larger blast radius and are left for a separate PR — but this fix stands on its own: no matter *why* the chunk fails to load, the transcript now stays up.

## Related Issue

Fixes #93479

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/chat/diff-lines.tsx`: wrap `LazySyntaxDiff` in a local `ErrorBoundary` (the same component `markdown-text.tsx` uses) that falls back to `<DiffBody lines={lines} />` on catch, so a failed dynamic import degrades in place instead of escaping to the workspace boundary.
- `apps/desktop/src/components/chat/diff-lines.test.tsx` (new): regression test that mocks `./syntax-diff` to fail its dynamic import and asserts the diff content stays on screen inside a surrounding `ErrorBoundary`, and that boundary's fallback never fires.

## How to Test

1. `npm ci` at repo root, then from `apps/desktop`: `npx vitest run src/components/chat/diff-lines.test.tsx --project ui`.
2. To see the regression: `git stash push -- apps/desktop/src/components/chat/diff-lines.tsx`, rerun the same command (fails — the outer boundary's "workspace failed to render" fallback replaces the diff content), then `git stash pop` to restore the fix.

### Real output

Without the fix (`diff-lines.tsx` reverted, test kept):
```
 ❯ src/components/chat/diff-lines.test.tsx:58:35
AssertionError: expected 'workspace failed to render' to contain 'const a = 1'
Expected: "const a = 1"
Received: "workspace failed to render"
 Test Files  1 failed (1)
      Tests  1 failed (1)
```

With the fix:
```
 ✓ |ui| src/components/chat/diff-lines.test.tsx > FileDiffPanel survives a failed lazy syntax-diff chunk > degrades to the plain colored diff instead of taking down the surrounding boundary
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Also ran for regressions (all pass):
```
npx vitest run src/components/chat src/components/error-boundary.test.tsx --project ui
 Test Files  6 passed (6)
      Tests  33 passed (33)

npx eslint src/components/chat/diff-lines.tsx src/components/chat/diff-lines.test.tsx
(clean)

npx tsc -p . --noEmit
(clean)
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(desktop):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've added tests for my changes
- [ ] I've tested on my platform — tested via the `ui` vitest project (jsdom) only; I don't have access to a packaged macOS build to reproduce the asar path directly, so this verifies the isolation behavior (item C), not the packaging root cause (items A/B).

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or tool schemas changed.

## Screenshots / Logs

N/A (no packaged build available in this environment); see the real vitest output above for the failing→passing proof.

---

Note: this fix was developed with AI assistance (an autonomous coding agent) and verified by running the project's real lint, typecheck, and test commands, including proving the added test fails against the pre-fix code and passes against the fix.
