### PR TITLE
docs(skills): add technical-writing checklist for docs and PR prose

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -941,6 +941,8 @@ Include:
 - **What platforms** you tested on
 - Reference any related issues
 
+For the prose itself (PR body, commit message, `CONTRIBUTING.md`, `AGENTS.md`, `website/docs/`), load the bundled `technical-writing` skill at `skills/software-development/technical-writing/SKILL.md`. It is the checklist for document mode, one thought per sentence, and repo-grounded paths. It is not for product UI copy.
+
 ### Commit messages
 
 We use [Conventional Commits](https://www.conventionalcommits.org/):

--- a/skills/software-development/technical-writing/SKILL.md
+++ b/skills/software-development/technical-writing/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: technical-writing
+description: "Checklist for Hermes docs, runbooks, AGENTS.md, PR descriptions, and commit messages. Not product UI copy."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [docs, writing, pull-requests, contributing, gardener]
+    related_skills: [hermes-agent-skill-authoring, requesting-code-review, github-pr-workflow]
+---
+
+# Technical writing checklist
+
+Use this when writing or reviewing Hermes documentation and PR prose: `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, `website/docs/`, runbooks, PR descriptions, and commit messages. Do not use it for product UI copy.
+
+There is no separate docs-gardener tree in this repo. Load this skill instead.
+
+## 1. Pick one document mode
+
+Choose first. Do not mix modes in one page.
+
+| Mode | Job |
+|---|---|
+| Tutorial | Walk a new reader through one successful path |
+| How-to | Solve one concrete task |
+| Reference | List facts, flags, paths, and contracts |
+| Explanation | Why the design is this way |
+
+`CONTRIBUTING.md` is mostly how-to plus reference. `website/docs/developer-guide/architecture.md` is explanation. A PR description is how-to: what changed, how to test.
+
+## 2. Write like a developer talking to a developer
+
+- Lead with the action: `Run scripts/run_tests.sh`, not "You may want to consider running the test script."
+- One thought per sentence. If you need "and" for a second instruction, start a new sentence.
+- Name the thing. Prefer `hermes_cli/skills_hub.py` over "the skills module" when a path exists.
+- Prefer the imperative in procedures. Prefer the present tense in reference.
+
+## 3. Remove ambiguous grammar
+
+Write for readers who do not share your first language.
+
+- Do not use "this" or "it" when two nouns are in play. Repeat the noun.
+- Do not use "should" when you mean must or must not. Say the rule.
+- Do not stack hedges ("might possibly", "fairly unique").
+- Do not use unexplained we/our. Name the actor: the CLI, the gateway, the reviewer.
+
+## 4. Ground every symbol in this repo
+
+- Paths, commands, flags, and env vars must exist on the branch you are editing. Open the file or run the command before you cite it.
+- Do not invent counts. If you need a count, show the command that produced it on this branch.
+- For generated or changing counts, paste the regeneration command next to the number.
+
+Examples of honest count commands:
+
+```bash
+git grep -l "HERMES_HOME" -- skills | wc -l
+rg -c "def should_allow_install" tools/skills_guard.py
+```
+
+Do not copy those numbers into a doc unless you just ran the command.
+
+## Procedure
+
+1. Name the document mode in a heading or the first sentence.
+2. State the reader and the outcome.
+3. Put each instruction in its own sentence.
+4. Check every path and command against the tree.
+5. Drop any count you cannot regenerate.
+6. Read once for leftover "this/it/should/might".
+
+## Before / after
+
+Bad (mixed mode, hedge, stale path, invented count):
+
+```markdown
+You might want to look at the skills hub if things feel off. This has about
+12 install paths and they are all documented in docs/skills.md.
+```
+
+Good (how-to, one thought, real paths, no count):
+
+```markdown
+If `hermes skills install` exits non-zero after a successful write, read the
+scan-report print in `hermes_cli/skills_hub.py`. The report is built by
+`format_scan_report()` in `tools/skills_guard.py`.
+```
+
+Bad (PR description):
+
+```markdown
+Improved various docs and fixed some stuff around skills.
+```
+
+Good (PR description):
+
+```markdown
+Add `skills/software-development/technical-writing/SKILL.md` for docs and PR
+prose. Link it from CONTRIBUTING.md under Pull Request Process. No code
+paths change. Closes #78355.
+```
+
+## Pitfalls
+
+- Do not import Cursor-only skills, slash commands, or runtime names.
+- Do not turn this checklist into a style essay. Keep it short.
+- Do not "fix" UI strings with this skill.
+
+## Verification
+
+- Every path in the draft exists (`test -e <path>` or open the file).
+- Every command in the draft is copied from the repo or from `--help` on this branch.
+- A second reader can tell the document mode from the first heading.

--- a/skills/software-development/technical-writing/SKILL.md
+++ b/skills/software-development/technical-writing/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: technical-writing
-description: "Checklist for Hermes docs, runbooks, AGENTS.md, PR descriptions, and commit messages. Not product UI copy."
-version: 1.0.0
-author: Hermes Agent
+description: "Checklist for Hermes docs and PR prose, not UI copy."
+version: 1.0.1
+author: Patrick Gibbs (mcpeezy), Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
@@ -11,66 +11,72 @@ metadata:
     related_skills: [hermes-agent-skill-authoring, requesting-code-review, github-pr-workflow]
 ---
 
-# Technical writing checklist
+# Technical Writing Skill
 
-Use this when writing or reviewing Hermes documentation and PR prose: `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, `website/docs/`, runbooks, PR descriptions, and commit messages. Do not use it for product UI copy.
+Checklist for Hermes documentation and PR prose. Covers `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, `website/docs/`, runbooks, PR descriptions, and commit messages. Do not use it for product UI copy.
 
 There is no separate docs-gardener tree in this repo. Load this skill instead.
 
-## 1. Pick one document mode
+## When to Use
 
-Choose first. Do not mix modes in one page.
+- Writing or reviewing `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, or `website/docs/`
+- Drafting a PR description or commit message for this repo
+- Cleaning AI-generated docs that mix tutorial, how-to, and reference in one page
+- Checking that cited paths, commands, flags, and counts exist on the current branch
 
-| Mode | Job |
-|---|---|
-| Tutorial | Walk a new reader through one successful path |
-| How-to | Solve one concrete task |
-| Reference | List facts, flags, paths, and contracts |
-| Explanation | Why the design is this way |
+Do not use for product UI strings, marketing copy, or Cursor-only skill imports.
 
-`CONTRIBUTING.md` is mostly how-to plus reference. `website/docs/developer-guide/architecture.md` is explanation. A PR description is how-to: what changed, how to test.
+## Prerequisites
 
-## 2. Write like a developer talking to a developer
+- Working tree on the branch you will document (paths must exist here, not on memory of main)
+- Ability to open cited files and run cited commands before publishing them
+- For skill PRs, also load `hermes-agent-skill-authoring` so frontmatter and section order stay valid
 
-- Lead with the action: `Run scripts/run_tests.sh`, not "You may want to consider running the test script."
-- One thought per sentence. If you need "and" for a second instruction, start a new sentence.
-- Name the thing. Prefer `hermes_cli/skills_hub.py` over "the skills module" when a path exists.
-- Prefer the imperative in procedures. Prefer the present tense in reference.
+## How to Run
 
-## 3. Remove ambiguous grammar
+1. Load this skill before drafting or reviewing the doc/PR prose.
+2. Pick one document mode (see Quick Reference).
+3. Write or edit with one thought per sentence and grounded paths.
+4. Run the Verification checklist before you commit or open the PR.
 
-Write for readers who do not share your first language.
+## Quick Reference
 
-- Do not use "this" or "it" when two nouns are in play. Repeat the noun.
-- Do not use "should" when you mean must or must not. Say the rule.
-- Do not stack hedges ("might possibly", "fairly unique").
-- Do not use unexplained we/our. Name the actor: the CLI, the gateway, the reviewer.
+| Mode | Job | Typical Hermes targets |
+|---|---|---|
+| Tutorial | Walk a new reader through one successful path | Getting-started guides |
+| How-to | Solve one concrete task | `CONTRIBUTING.md` PR steps, runbooks |
+| Reference | List facts, flags, paths, and contracts | CLI flag pages, config tables |
+| Explanation | Why the design is this way | `website/docs/developer-guide/architecture.md` |
 
-## 4. Ground every symbol in this repo
+A PR description is how-to: what changed, why, how to test.
 
-- Paths, commands, flags, and env vars must exist on the branch you are editing. Open the file or run the command before you cite it.
-- Do not invent counts. If you need a count, show the command that produced it on this branch.
-- For generated or changing counts, paste the regeneration command next to the number.
-
-Examples of honest count commands:
+Honest count commands (run them; do not invent the number):
 
 ```bash
 git grep -l "HERMES_HOME" -- skills | wc -l
 rg -c "def should_allow_install" tools/skills_guard.py
 ```
 
-Do not copy those numbers into a doc unless you just ran the command.
-
 ## Procedure
 
 1. Name the document mode in a heading or the first sentence.
 2. State the reader and the outcome.
-3. Put each instruction in its own sentence.
-4. Check every path and command against the tree.
-5. Drop any count you cannot regenerate.
-6. Read once for leftover "this/it/should/might".
+3. Lead with the action: `Run scripts/run_tests.sh`, not "You may want to consider running the test script."
+4. Put each instruction in its own sentence. If you need "and" for a second instruction, start a new sentence.
+5. Name the thing. Prefer `hermes_cli/skills_hub.py` over "the skills module" when a path exists.
+6. Prefer the imperative in procedures. Prefer the present tense in reference.
+7. Remove ambiguous grammar for global readers:
+   - Do not use "this" or "it" when two nouns are in play. Repeat the noun.
+   - Do not use "should" when you mean must or must not. Say the rule.
+   - Do not stack hedges ("might possibly", "fairly unique").
+   - Do not use unexplained we/our. Name the actor: the CLI, the gateway, the reviewer.
+8. Ground every symbol in this repo:
+   - Paths, commands, flags, and env vars must exist on the branch you are editing.
+   - Open the file or run the command before you cite it.
+   - Do not invent counts. If you need a count, show the command that produced it on this branch.
+9. Drop any count you cannot regenerate. Read once for leftover "this/it/should/might".
 
-## Before / after
+### Before / after
 
 Bad (mixed mode, hedge, stale path, invented count):
 
@@ -106,9 +112,13 @@ paths change. Closes #78355.
 - Do not import Cursor-only skills, slash commands, or runtime names.
 - Do not turn this checklist into a style essay. Keep it short.
 - Do not "fix" UI strings with this skill.
+- Do not cite paths from memory of another branch.
+- Do not ship a skill PR that fails the hardline authoring gates this skill's sibling `hermes-agent-skill-authoring` describes.
 
 ## Verification
 
 - Every path in the draft exists (`test -e <path>` or open the file).
 - Every command in the draft is copied from the repo or from `--help` on this branch.
 - A second reader can tell the document mode from the first heading.
+- No unexplained "this/it/should/might" remains where a noun or rule should be.
+- For this skill itself: description ≤ 60 chars, human author first, modern section headings present, and referenced paths like `tools/skills_guard.py` exist.

--- a/tests/skills/test_technical_writing_skill.py
+++ b/tests/skills/test_technical_writing_skill.py
@@ -1,0 +1,127 @@
+"""Tests for the technical-writing bundled skill.
+
+Asserts the hardline SKILL.md contract (frontmatter, description length,
+human-first author, modern section order) and that prose-grounded repo
+paths cited by the skill still exist on the branch.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_PATH = (
+    REPO_ROOT / "skills" / "software-development" / "technical-writing" / "SKILL.md"
+)
+
+MODERN_SECTIONS = (
+    "## When to Use",
+    "## Prerequisites",
+    "## How to Run",
+    "## Quick Reference",
+    "## Procedure",
+    "## Pitfalls",
+    "## Verification",
+)
+
+GROUNDED_PATHS = (
+    REPO_ROOT / "tools" / "skills_guard.py",
+    REPO_ROOT / "hermes_cli" / "skills_hub.py",
+    REPO_ROOT / "scripts" / "run_tests.sh",
+    REPO_ROOT / "CONTRIBUTING.md",
+)
+
+
+def _frontmatter_and_body() -> tuple[dict, str]:
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert content.startswith("---"), "SKILL.md must start with ---"
+    match = re.search(r"\n---\s*\n", content[3:])
+    assert match, "frontmatter must close with ---"
+    frontmatter = yaml.safe_load(content[3 : match.start() + 3])
+    assert isinstance(frontmatter, dict), "frontmatter must be a YAML mapping"
+    body = content[match.end() + 3 :]
+    return frontmatter, body
+
+
+def test_skill_file_exists() -> None:
+    assert SKILL_PATH.is_file()
+
+
+def test_required_frontmatter_fields() -> None:
+    frontmatter, _ = _frontmatter_and_body()
+    for field in ("name", "description", "version", "author", "license", "platforms"):
+        assert field in frontmatter, f"missing frontmatter field: {field}"
+    assert frontmatter["name"] == "technical-writing"
+    hermes = (frontmatter.get("metadata") or {}).get("hermes") or {}
+    assert hermes.get("tags"), "metadata.hermes.tags must be present"
+
+
+def test_description_hardline() -> None:
+    frontmatter, _ = _frontmatter_and_body()
+    description = str(frontmatter["description"])
+    assert len(description) <= 60, (
+        f"description is {len(description)} chars; hardline is 60: {description!r}"
+    )
+    assert description.rstrip().endswith("."), "description must end with a period"
+    assert description.count(".") == 1, "description must be one sentence"
+
+
+def test_author_credits_human_first() -> None:
+    frontmatter, _ = _frontmatter_and_body()
+    author = str(frontmatter["author"])
+    assert not author.startswith("Hermes Agent"), (
+        "author must credit the human contributor first"
+    )
+    assert "mcpeezy" in author
+    assert "Hermes Agent" in author
+
+
+def test_modern_section_order() -> None:
+    _, body = _frontmatter_and_body()
+    positions = []
+    for heading in MODERN_SECTIONS:
+        index = body.find(heading)
+        assert index != -1, f"SKILL.md missing section: {heading}"
+        positions.append(index)
+    assert positions == sorted(positions), "modern sections must appear in standard order"
+
+
+def test_related_skills_resolve_in_repo() -> None:
+    frontmatter, _ = _frontmatter_and_body()
+    hermes = (frontmatter.get("metadata") or {}).get("hermes") or {}
+    for name in hermes.get("related_skills") or []:
+        hits = (
+            list(REPO_ROOT.glob(f"skills/*/{name}/SKILL.md"))
+            + list(REPO_ROOT.glob(f"skills/*/*/{name}/SKILL.md"))
+            + list(REPO_ROOT.glob(f"optional-skills/*/{name}/SKILL.md"))
+            + list(REPO_ROOT.glob(f"optional-skills/*/*/{name}/SKILL.md"))
+        )
+        assert hits, f"related_skills entry does not resolve in-repo: {name}"
+
+
+def test_grounded_repo_paths_exist() -> None:
+    for path in GROUNDED_PATHS:
+        assert path.is_file(), f"skill-grounded path missing: {path.relative_to(REPO_ROOT)}"
+
+
+def test_body_names_guard_and_hub_symbols() -> None:
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert "tools/skills_guard.py" in content
+    assert "hermes_cli/skills_hub.py" in content
+    assert "format_scan_report()" in content
+    assert "should_allow_install" in content
+
+
+def test_contributing_points_at_skill() -> None:
+    contributing = (REPO_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    assert "skills/software-development/technical-writing/SKILL.md" in contributing
+    assert "not for product UI copy" in contributing
+
+
+def test_no_machine_local_paths() -> None:
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert not re.search(r"/home/(?!runner\b)[a-z0-9_-]+/", content)
+    assert "C:\\Users\\" not in content


### PR DESCRIPTION
## Summary
- Add bundled skill `skills/software-development/technical-writing/SKILL.md` for README, CONTRIBUTING, AGENTS.md, website docs, PR descriptions, and commit messages. Not UI copy.
- Cross-link it from `CONTRIBUTING.md` under Pull Request Process. This repo has no separate docs-gardener tree.
- Meet hardline skill authoring standards: ≤60-char description, human-first author, modern section order, and `tests/skills/test_technical_writing_skill.py`.

Closes #78355.

## Test plan
- [x] `scripts/run_tests.sh tests/skills/test_technical_writing_skill.py tests/skills/test_authoring_standards.py -q` (1212 passed)
- [x] Description ≤ 60 chars, one sentence, ends with period
- [x] Author is `Patrick Gibbs (mcpeezy), Hermes Agent`
- [x] Modern sections present in order: When to Use → Prerequisites → How to Run → Quick Reference → Procedure → Pitfalls → Verification
- [x] Grounded paths exist (`tools/skills_guard.py`, `hermes_cli/skills_hub.py`, `scripts/run_tests.sh`)
- [x] `CONTRIBUTING.md` PR description section links the skill and keeps the not-for-UI-copy boundary