### PR TITLE
fix(host-hygiene): writer-aware log rotation, loud bind conflicts, sandbox process reaping

### DIFF
--- a/hermes_cli/doctor_logs.py
+++ b/hermes_cli/doctor_logs.py
@@ -1,22 +1,25 @@
 """``hermes doctor logs <path>`` — one-shot log rotation (t_57aac3e7 fix 1).
 
 A small, self-contained rotator so an operator or host-ops automation can
-rotate a *foreign* log on demand instead of hand-truncating it. Foreign
-writers (oMLX's ``server.log``, launchd-supervised ``dashboard.error.log``)
-hold the file open; rename-rotation moves the inode aside (``<path>`` ->
-``<path>.1``, shifting ``.1 -> .2 -> ...`` up to ``--backups``) so the writer's
-open fd keeps pointing at the old inode while a fresh file is created for the
-next write. This reuses :func:`hermes_cli.stderr_timestamp._rotate_error_log_if_needed`
-via import rather than re-implementing the shift logic.
+rotate a *foreign* log on demand instead of hand-truncating it. For ordinary
+external logs it performs bounded rename-rotation. The oMLX application log is
+different: its server process can retain an open descriptor indefinitely, so
+we refuse to rotate it unless the caller supplies a controlled reopen/restart
+command and the fresh path gains a writer afterwards.
 
 Exit codes:
     0  rotated (or nothing to do: file absent/empty), reported cleanly
     2  usage error (bad path / unreadable argument)
+    3  oMLX rotation refused because no reopen command was supplied
+    4  reopen command failed, or no writer opened the fresh oMLX log
 """
 
 from __future__ import annotations
 
+import shutil
+import subprocess
 import sys
+import time
 from pathlib import Path
 
 
@@ -27,6 +30,63 @@ def _human(n: int) -> str:
             return f"{n:.0f} {unit}" if unit == "B" else f"{n:.1f} {unit}"
         n /= 1024.0
     return f"{n:.1f} TiB"
+
+
+def _is_omlx_managed_server_log(log_path: Path) -> bool:
+    """True only for oMLX's app-managed ``Application Support`` server log."""
+    parts = tuple(part.casefold() for part in log_path.parts)
+    return (
+        log_path.name == "server.log"
+        and "omlx" in parts
+        and "application support" in parts
+    )
+
+
+def _writer_pids(log_path: Path) -> list[int] | None:
+    """Return processes with *log_path* open, or ``None`` if lsof is unavailable."""
+    lsof = shutil.which("lsof")
+    if not lsof:
+        return None
+    try:
+        result = subprocess.run(
+            [lsof, "-t", str(log_path)],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    return [int(line) for line in result.stdout.splitlines() if line.isdigit()]
+
+
+def _run_reopen_command(command: list[str], timeout: float) -> tuple[bool, str]:
+    """Run an explicit operator-provided reopen command without a shell."""
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, str(exc)
+    if result.returncode == 0:
+        return True, ""
+    detail = (result.stderr or result.stdout).strip().splitlines()
+    return False, detail[-1] if detail else f"exit {result.returncode}"
+
+
+def _wait_for_writer(log_path: Path, timeout: float) -> list[int] | None:
+    """Wait for a process to open the replacement log after a controlled restart."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        pids = _writer_pids(log_path)
+        if pids:
+            return pids
+        time.sleep(0.1)
+    return _writer_pids(log_path)
 
 
 def run_doctor_logs(args) -> int:
@@ -51,14 +111,28 @@ def run_doctor_logs(args) -> int:
     if backups is None:
         backups = inferred_backups
     force = bool(getattr(args, "force", False))
+    reopen_command = list(getattr(args, "reopen_command", None) or [])
+    reopen_timeout = float(getattr(args, "reopen_timeout", 30.0))
 
-    if max_bytes < 0 or backups < 0:
-        print("error: --max-bytes and --backups must be >= 0", file=sys.stderr)
+    if max_bytes < 0 or backups < 0 or reopen_timeout <= 0:
+        print(
+            "error: --max-bytes and --backups must be >= 0; --reopen-timeout must be > 0",
+            file=sys.stderr,
+        )
         return 2
 
     if not log_path.exists():
         print(f"nothing to rotate: {log_path} does not exist")
         return 0
+
+    managed_omlx_log = _is_omlx_managed_server_log(log_path)
+    if managed_omlx_log and not reopen_command:
+        print(
+            "refusing to rotate oMLX server.log without --reopen-command: "
+            "the active writer would keep appending to the backup",
+            file=sys.stderr,
+        )
+        return 3
 
     before_size = log_path.stat().st_size
     # Snapshot existing backups so we can report the shift accurately.
@@ -80,11 +154,35 @@ def run_doctor_logs(args) -> int:
 
     now_backups = [g for g in range(1, backups + 1) if _backup_exists(g)]
 
+    if managed_omlx_log and rotated:
+        # Make the replacement pathname visible immediately. It only becomes a
+        # successful handoff after the controlled restart opens it.
+        log_path.touch(exist_ok=True)
+        reopened, detail = _run_reopen_command(reopen_command, reopen_timeout)
+        if not reopened:
+            print(f"status:          rotation incomplete; reopen command failed: {detail}")
+            return 4
+        writer_pids = _wait_for_writer(log_path, reopen_timeout)
+        if not writer_pids:
+            print(
+                "status:          rotation incomplete; no writer opened fresh log",
+                file=sys.stderr,
+            )
+            return 4
+        after = log_path.stat().st_size
+        print(f"log:            {log_path}")
+        print(f"size before:     {_human(before_size)}")
+        print(f"size after:      {_human(after)}")
+        print(f"backups kept:    {now_backups}")
+        print(f"active writers:  {writer_pids}")
+        print("status:          rotated and writer handoff verified")
+        return 0
+
     print(f"log:            {log_path}")
     print(f"size before:     {_human(before_size)}")
     if rotated:
         after = log_path.stat().st_size if log_path.exists() else 0
-        print(f"size after:      {_human(after)} (fresh file created)")
+        print(f"size after:      {_human(after)}")
         print(f"backups kept:    {now_backups}")
         print("status:          rotated")
     else:

--- a/hermes_cli/doctor_logs.py
+++ b/hermes_cli/doctor_logs.py
@@ -1,0 +1,95 @@
+"""``hermes doctor logs <path>`` — one-shot log rotation (t_57aac3e7 fix 1).
+
+A small, self-contained rotator so an operator or host-ops automation can
+rotate a *foreign* log on demand instead of hand-truncating it. Foreign
+writers (oMLX's ``server.log``, launchd-supervised ``dashboard.error.log``)
+hold the file open; rename-rotation moves the inode aside (``<path>`` ->
+``<path>.1``, shifting ``.1 -> .2 -> ...`` up to ``--backups``) so the writer's
+open fd keeps pointing at the old inode while a fresh file is created for the
+next write. This reuses :func:`hermes_cli.stderr_timestamp._rotate_error_log_if_needed`
+via import rather than re-implementing the shift logic.
+
+Exit codes:
+    0  rotated (or nothing to do: file absent/empty), reported cleanly
+    2  usage error (bad path / unreadable argument)
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _human(n: int) -> str:
+    """Compact byte count for reporting."""
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if n < 1024 or unit == "TiB":
+            return f"{n:.0f} {unit}" if unit == "B" else f"{n:.1f} {unit}"
+        n /= 1024.0
+    return f"{n:.1f} TiB"
+
+
+def run_doctor_logs(args) -> int:
+    """Rotate ``args.path`` on demand. Returns a process exit code."""
+    from hermes_cli.stderr_timestamp import (
+        _get_external_log_rotation_config,
+        _rotate_error_log_if_needed,
+    )
+
+    raw = getattr(args, "path", None)
+    if not raw:
+        print("error: no log path given", file=sys.stderr)
+        return 2
+    log_path = Path(raw).expanduser()
+
+    # Infer caps from the path unless the operator overrode them.
+    inferred_max, inferred_backups = _get_external_log_rotation_config(log_path)
+    max_bytes = getattr(args, "max_bytes", None)
+    backups = getattr(args, "backups", None)
+    if max_bytes is None:
+        max_bytes = inferred_max
+    if backups is None:
+        backups = inferred_backups
+    force = bool(getattr(args, "force", False))
+
+    if max_bytes < 0 or backups < 0:
+        print("error: --max-bytes and --backups must be >= 0", file=sys.stderr)
+        return 2
+
+    if not log_path.exists():
+        print(f"nothing to rotate: {log_path} does not exist")
+        return 0
+
+    before_size = log_path.stat().st_size
+    # Snapshot existing backups so we can report the shift accurately.
+    def _backup_exists(gen: int) -> bool:
+        return log_path.with_suffix(log_path.suffix + f".{gen}").exists()
+
+    had_backups = [g for g in range(1, backups + 1) if _backup_exists(g)]
+
+    _rotate_error_log_if_needed(log_path, max_bytes, backups, force=force)
+
+    # Determine outcome. A successful rotation leaves a fresh ``.1`` in place
+    # (and the main file either gone or re-created empty by the writer).
+    rotated = _backup_exists(1) and (not log_path.exists() or log_path.stat().st_size < before_size)
+    if force and not rotated:
+        # force should always rotate an existing non-empty file; if .1 is
+        # missing the file was empty (rename of an empty file still yields .1,
+        # so this only happens on a permission error swallowed upstream).
+        rotated = _backup_exists(1)
+
+    now_backups = [g for g in range(1, backups + 1) if _backup_exists(g)]
+
+    print(f"log:            {log_path}")
+    print(f"size before:     {_human(before_size)}")
+    if rotated:
+        after = log_path.stat().st_size if log_path.exists() else 0
+        print(f"size after:      {_human(after)} (fresh file created)")
+        print(f"backups kept:    {now_backups}")
+        print("status:          rotated")
+    else:
+        print(
+            f"status:          not rotated "
+            f"(under cap {_human(max_bytes)}; use --force to rotate anyway)"
+        )
+    return 0

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4665,6 +4665,97 @@ def _launchd_unsupported_marker_path() -> Path:
     return get_hermes_home() / ".gateway-launchd-unsupported"
 
 
+def _write_bind_conflict_status(host: str, port: int, detail: str) -> None:
+    """Surface a port bind conflict in the gateway status file (t_57aac3e7 fix 2).
+
+    A duplicate instance on the same port causes an infinite silent restart
+    loop (KeepAlive + ThrottleInterval). This writes a ``bind_conflict``
+    marker next to the existing gateway state so ``hermes gateway status``
+    and the dashboard can surface it without the operator tailing a log.
+    Best-effort: never throws.
+    """
+    import json
+    import time as _time
+    try:
+        from hermes_constants import get_hermes_home
+        status_path = get_hermes_home() / "gateway" / "bind_conflict.json"
+        status_path.parent.mkdir(parents=True, exist_ok=True)
+        status_path.write_text(
+            json.dumps({
+                "host": host,
+                "port": port,
+                "detail": detail[:500],
+                "at": int(_time.time()),
+                "hint": f"Port {port} is already in use on {host}. Stop the duplicate instance (lsof -i :{port} / hermes gateway stop) and retry.",
+            }),
+            encoding="utf-8",
+        )
+    except Exception:
+        pass
+
+
+def _bind_conflict_status_path():
+    """Path of the bind-conflict status file (t_57aac3e7 fix 2)."""
+    from hermes_constants import get_hermes_home
+    return get_hermes_home() / "gateway" / "bind_conflict.json"
+
+
+def _read_bind_conflict_status(max_age_seconds: int = 3600) -> dict | None:
+    """Read the bind-conflict status file, or None if absent/stale/corrupt.
+
+    A conflict older than ``max_age_seconds`` is treated as stale (the port was
+    presumably freed since) and not surfaced. Best-effort: never throws.
+    """
+    import json
+    import time as _time
+    try:
+        p = _bind_conflict_status_path()
+        if not p.exists():
+            return None
+        data = json.loads(p.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return None
+        at = int(data.get("at", 0) or 0)
+        if at and (_time.time() - at) > max_age_seconds:
+            return None
+        return data
+    except Exception:
+        return None
+
+
+def _clear_bind_conflict_status() -> None:
+    """Delete the bind-conflict status file (called on a successful bind)."""
+    try:
+        _bind_conflict_status_path().unlink(missing_ok=True)
+    except Exception:
+        pass
+
+
+def _print_bind_conflict_block() -> bool:
+    """Print a prominent bind-conflict block from the status file.
+
+    Returns True if a (non-stale) conflict was found and printed. Stale
+    conflicts are cleared silently. Used by ``hermes gateway status`` and
+    ``launchd_status`` so the operator sees the conflict without tailing a log.
+    """
+    data = _read_bind_conflict_status()
+    if not data:
+        return False
+    port = data.get("port", "?")
+    host = data.get("host", "?")
+    print()
+    print(f"✗ BIND CONFLICT: port {port} is already in use on {host}")
+    print(f"  Another dashboard/gateway instance holds {host}:{port}.")
+    print(f"  Stop the duplicate (`hermes gateway stop` / `lsof -i :{port}`) and retry.")
+    print(f"  The supervisor (launchd/systemd) may keep respawning it every")
+    print(f"  ThrottleInterval until the conflict clears — this message is how")
+    print(f"  you tell that apart from a crash-loop.")
+    hint = data.get("hint")
+    if hint:
+        print(f"  {hint}")
+    return True
+
+
 def _write_launchd_unsupported_marker() -> None:
     """Persist that launchd cannot supervise the gateway on this host."""
     import json
@@ -4894,7 +4985,17 @@ def generate_launchd_plist() -> str:
     <key>KeepAlive</key>
     <true/>
 
-    <!-- ThrottleInterval raises launchd's default 10s minimum respawn interval
+    <!-- KeepAlive stays unconditionally true (#37388): the drain-then-exit
+         graceful-restart protocol (SIGUSR1 to request_restart) relies on a
+         clean exit(0) being relaunched, so a SuccessfulExit=false dict would
+         silently break the graceful restart flag. That means a bind-conflict
+         clean exit (t_57aac3e7 D2) does NOT stop the respawn loop by itself —
+         it still restarts every ThrottleInterval like a crash would. What D2
+         actually buys under this KeepAlive policy is the loud stderr message
+         plus the bind_conflict.json status file surfaced by
+         `hermes gateway status` / launchd_status, so the operator sees WHY
+         it's looping instead of a silent unauthenticated-request storm.
+         ThrottleInterval raises launchd's default 10s minimum respawn interval
          to 30s so a crash-looping gateway can't hammer launchd into a rapid
          respawn storm; ExitTimeOut gives the gateway 25s of graceful-drain
          headroom before launchd escalates from SIGTERM to SIGKILL on stop. -->
@@ -5579,6 +5680,13 @@ def launchd_status(deep: bool = False):
         print("  Run: hermes gateway start")
         if fallback_pid:
             print(f"  Note: a detached gateway process is running (PID {fallback_pid})")
+
+    # Surface a bind conflict (t_57aac3e7 fix 2): the service exits cleanly on
+    # EADDRINUSE (rather than a raw traceback / rc=1), but KeepAlive/Restart
+    # policy is unconditional (#37388), so the supervisor may still keep
+    # respawning it. This block is how the operator learns WHY, whether it's
+    # currently up or mid-restart-loop.
+    _print_bind_conflict_block()
 
     if deep:
         log_file = get_hermes_home() / "logs" / "gateway.log"
@@ -8324,6 +8432,13 @@ def _gateway_command_inner(args):
         full = getattr(args, "full", False)
         system = getattr(args, "system", False)
         snapshot = get_gateway_runtime_snapshot(system=system)
+
+        # Surface a bind conflict up front, on every platform (t_57aac3e7 fix
+        # 2): the service exits cleanly on EADDRINUSE instead of a raw
+        # traceback, but the supervisor's unconditional restart policy
+        # (#37388) may still be respawning it — this block tells the operator
+        # WHY, in either case.
+        _print_bind_conflict_block()
 
         # Check for service first
         _windows_service_installed = False

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5179,6 +5179,12 @@ def reclaim_task(
     # a fresh budget. (_clear_failure_counter opens its own write_txn,
     # so it runs after the enclosing one commits.)
     _clear_failure_counter(conn, task_id)
+    # Terminal transition — reap the reclaimed worker's host tree + sandbox
+    # container processes (t_57aac3e7 D4). Best-effort, never throws.
+    try:
+        _reap_task_processes(conn, task_id, worker_pid=row["worker_pid"])
+    except Exception:
+        pass
     return True
 
 
@@ -5428,6 +5434,7 @@ def complete_task(
     metadata = _merge_completion_prose_artifacts(
         conn, task_id, metadata, summary=summary, result=result,
     )
+    _complete_worker_pid: Optional[int] = None
     with write_txn(conn):
         # Parent completion is a hard invariant even for direct human review
         # approval. A parent may have been reopened after this task entered
@@ -5435,10 +5442,11 @@ def complete_task(
         if not _parents_satisfied(conn, task_id):
             return False
         prior = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?",
+            "SELECT status, worker_pid FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         prior_status = prior["status"] if prior else None
+        _complete_worker_pid = int(prior["worker_pid"]) if prior and prior["worker_pid"] else None
         if expected_run_id is None:
             cur = conn.execute(
                 """
@@ -5577,6 +5585,15 @@ def complete_task(
     _clear_failure_counter(conn, task_id)
     # Recompute ready status for dependents (separate txn so children see done).
     recompute_ready(conn)
+    # Reap orphaned child processes of this task's worker (t_57aac3e7 fix 3).
+    # Workers run with start_new_session=True; their children (vitest, walk,
+    # etc.) stay alive as orphans after the worker exits. Kill the session
+    # group (host tree) AND the task's sandbox-container processes (Layer B).
+    # Must use the pre-clear worker_pid captured before the UPDATE.
+    try:
+        _reap_task_processes(conn, task_id, worker_pid=_complete_worker_pid)
+    except Exception:
+        pass
     # Clean up the scratch workspace and any stale tmux session for the worker.
     _cleanup_workspace(conn, task_id)
     _done_task = get_task(conn, task_id)
@@ -6283,13 +6300,15 @@ def block_task(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
         )
     recurrences = 0
+    _block_worker_pid: Optional[int] = None
     with write_txn(conn):
         cur_row = conn.execute(
-            "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
+            "SELECT status, worker_pid, block_kind, block_recurrences FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         if cur_row is None:
             return False
+        _block_worker_pid = int(cur_row["worker_pid"]) if cur_row["worker_pid"] else None
         source_status = (
             _retry_status_for_run(conn, task_id)
             if cur_row["status"] == "running"
@@ -6460,6 +6479,12 @@ def block_task(
                 run_id=run_id,
             )
         _blocked_task = get_task(conn, task_id)
+    # Reap orphans after the status flip — same rationale as complete_task.
+    # Host tree (Layer A) + sandbox-container processes (Layer B).
+    try:
+        _reap_task_processes(conn, task_id, worker_pid=_block_worker_pid)
+    except Exception:
+        pass
     _fire_kanban_lifecycle_hook(
         "kanban_task_blocked",
         task_id,
@@ -8328,6 +8353,371 @@ def _worker_survived_termination(termination: dict) -> bool:
     )
 
 
+def _kill_direct_children(parent_pid: int, sig_module) -> int:
+    """SIGTERM then SIGKILL the *direct* children of ``parent_pid``.
+
+    Used by the D1 self-kill guard in :func:`_reap_task_orphans`. When the
+    completing process *is* the worker (``worker_pid == os.getpid()``), a
+    process-group kill would take the completer down with its children (the
+    worker is the session leader, so its pgid == its own pid). Instead we reap
+    only the worker's direct children, leaving the completer alive to finish
+    workspace cleanup + lifecycle hooks. Best-effort, never throws.
+    """
+    import time as _time
+
+    def _children() -> list:
+        found = []
+        if sys.platform == "linux":
+            try:
+                import pathlib as _pl
+                for proc_dir in _pl.Path("/proc").iterdir():
+                    if not proc_dir.name.isdigit():
+                        continue
+                    try:
+                        stat = (proc_dir / "stat").read_text(errors="replace")
+                        fields = stat.split()
+                        # field 4 (index 3) is ppid
+                        if int(fields[3]) == parent_pid:
+                            found.append(int(proc_dir.name))
+                    except (OSError, ValueError, IndexError):
+                        continue
+            except OSError:
+                pass
+        elif sys.platform == "darwin":
+            try:
+                import subprocess as _sp
+                r = _sp.run(
+                    ["pgrep", "-P", str(parent_pid)],
+                    capture_output=True, text=True, timeout=2,
+                )
+                if r.returncode == 0:
+                    for line in r.stdout.strip().splitlines():
+                        try:
+                            found.append(int(line.strip()))
+                        except ValueError:
+                            continue
+            except Exception:
+                pass
+        # Never signal ourselves even if a scan misattributes us.
+        return [p for p in found if p != os.getpid()]
+
+    killed = 0
+    for _pid in _children():
+        try:
+            os.kill(_pid, sig_module.SIGTERM)
+            killed += 1
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+    _time.sleep(0.3)
+    for _pid in _children():
+        try:
+            os.kill(_pid, sig_module.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+    return killed
+
+
+def _reap_task_orphans(worker_pid: Optional[int]) -> int:
+    """Kill remaining child processes of a completed task's worker (t_57aac3e7 fix 3).
+
+    Workers are spawned with ``start_new_session=True``, so the worker is a
+    session leader (sid == pid) and every tool/process it spawned (vitest,
+    os.walk, etc.) belongs to that session's process group. When the worker
+    exits, those children are reparented to init but keep running as orphans
+    (the 6h os.walk + 9 vitest workers observed). Killing the process group
+    reaps them. Also sweeps direct children via ``/proc`` as a fallback for
+    platforms where pgrp != sid (macOS session quirks).
+
+    Returns the count of PIDs signalled. Best-effort, never throws — the
+    task's DB transition already succeeded; log loss is worse than a leaked
+    child but an exception here must not rollback the completion.
+    """
+    if not worker_pid or worker_pid <= 0:
+        return 0
+    import signal as _sig
+    killed = 0
+    # D1 self-kill guard (t_57aac3e7, severity-critical): complete_task /
+    # block_task run IN-PROCESS inside the worker (the kanban tool calls them
+    # directly), so worker_pid == os.getpid(). A blind os.killpg(worker_pid)
+    # would SIGTERM the completing worker mid-completion — its SIGTERM handler
+    # hard-exits, truncating workspace cleanup + lifecycle hooks after the DB
+    # write commits. Never kill our own process group. Also skip when the
+    # target shares the caller's session (a gateway completing on behalf of a
+    # same-session worker). In both cases we still reap the worker's direct
+    # children individually so orphans don't leak.
+    _is_self = (int(worker_pid) == os.getpid())
+    _same_session = False
+    try:
+        _caller_sid = os.getsid(0)  # type: ignore[attr-defined]
+        _target_sid = os.getsid(int(worker_pid))  # type: ignore[attr-defined]
+        _same_session = bool(_caller_sid) and _caller_sid == _target_sid
+    except (AttributeError, OSError, ProcessLookupError):
+        pass
+    if _is_self or _same_session:
+        return _kill_direct_children(int(worker_pid), _sig)
+    # 1) Process group kill — covers the common case (session leader).
+    try:
+        os.killpg(int(worker_pid), _sig.SIGTERM)  # type: ignore[attr-defined]
+        killed += 1
+    except (ProcessLookupError, PermissionError, OSError, AttributeError):
+        pass
+    # Small grace then SIGKILL for survivors.
+    import time as _time
+    _time.sleep(0.3)
+    try:
+        os.killpg(int(worker_pid), _sig.SIGKILL)  # type: ignore[attr-defined]
+    except (ProcessLookupError, PermissionError, OSError, AttributeError):
+        pass
+    # 2) Fallback: scan /proc for direct children reparented to 1 whose
+    # original ppid was this worker (Linux only, best-effort).
+    if sys.platform == "linux":
+        try:
+            import pathlib as _pl
+            for proc_dir in _pl.Path("/proc").iterdir():
+                if not proc_dir.name.isdigit():
+                    continue
+                pid = int(proc_dir.name)
+                if pid == int(worker_pid) or pid == os.getpid():
+                    continue
+                try:
+                    stat = (proc_dir / "stat").read_text(errors="replace")
+                    # stat field 4 is ppid
+                    ppid = int(stat.split()[3])
+                    if ppid == 1:
+                        # Check if this was a child of our worker by looking
+                        # at its session id (field 6: session).
+                        # If session == worker_pid, it was in our session.
+                        try:
+                            sid = int(stat.split()[5])
+                            if sid == int(worker_pid):
+                                os.kill(pid, _sig.SIGTERM)
+                                killed += 1
+                        except (IndexError, ValueError, OSError):
+                            pass
+                except (OSError, ValueError, IndexError):
+                    continue
+        except OSError:
+            pass
+        # Second pass SIGKILL
+        _time.sleep(0.2)
+        # (reuse scan — just SIGKILL the same set; cheap enough to rescan)
+        try:
+            import pathlib as _pl2
+            for proc_dir in _pl2.Path("/proc").iterdir():
+                if not proc_dir.name.isdigit():
+                    continue
+                pid = int(proc_dir.name)
+                if pid == int(worker_pid) or pid == os.getpid():
+                    continue
+                try:
+                    stat = (proc_dir / "stat").read_text(errors="replace")
+                    sid = int(stat.split()[5])
+                    if sid == int(worker_pid):
+                        try:
+                            os.kill(pid, _sig.SIGKILL)
+                        except (ProcessLookupError, PermissionError, OSError):
+                            pass
+                except (OSError, ValueError, IndexError):
+                    continue
+        except OSError:
+            pass
+    # 3) macOS fallback: use pgrep to find session children
+    elif sys.platform == "darwin":
+        try:
+            import subprocess as _sp
+            result = _sp.run(
+                ["pgrep", "-s", str(int(worker_pid))],
+                capture_output=True, text=True, timeout=2,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                for line in result.stdout.strip().splitlines():
+                    try:
+                        pid = int(line.strip())
+                        if pid != int(worker_pid) and pid != os.getpid():
+                            os.kill(pid, _sig.SIGTERM)
+                            killed += 1
+                    except (ValueError, ProcessLookupError, PermissionError, OSError):
+                        continue
+                _time.sleep(0.3)
+                result2 = _sp.run(
+                    ["pgrep", "-s", str(int(worker_pid))],
+                    capture_output=True, text=True, timeout=2,
+                )
+                if result2.returncode == 0 and result2.stdout.strip():
+                    for line in result2.stdout.strip().splitlines():
+                        try:
+                            pid = int(line.strip())
+                            if pid != int(worker_pid) and pid != os.getpid():
+                                os.kill(pid, _sig.SIGKILL)
+                        except (ValueError, ProcessLookupError, PermissionError, OSError):
+                            continue
+        except (OSError, _sp.SubprocessError, _sp.TimeoutExpired):
+            pass
+    return killed
+
+
+def _reap_container_task_processes(task_id: str, *, docker_exe: Optional[str] = None) -> int:
+    """Layer B (t_57aac3e7 D4): kill sandbox-container processes for a finished task.
+
+    Host-side ``os.killpg`` / ``/proc`` sweeps cannot see processes running
+    *inside* the profile's shared sandbox container (different PID namespace) —
+    that is exactly the incident class (a 6h ``os.walk`` + 9 vitest workers
+    living in the shared ``hermes-task-id=default`` container). This helper is
+    docker-native: it finds every container labeled ``hermes-agent=1`` whose
+    ``hermes-task-id`` is this task (or the shared ``default``), and inside each
+    kills exactly the processes whose **cwd** or **argv** references the
+    finished task's workspace path. SIGTERM, 0.5 s grace, SIGKILL survivors.
+
+    Shared profile containers are NEVER stopped — only per-task processes are
+    signalled, so sibling tasks sharing the same container are untouched.
+    Best-effort, never throws: any failure (no docker, no matching container,
+    exec error) logs at debug and returns whatever was reaped before the
+    failure. Returns the count of PIDs signalled.
+    """
+    import subprocess as _sp
+
+    # Workspace path the finished task's processes reference. Containers run
+    # with the host kanban-workspaces dir mounted at /workspace/kanban-workspaces.
+    ws = f"/workspace/kanban-workspaces/{task_id}"
+
+    try:
+        from tools.environments.docker import find_docker as _find_docker
+        _sanitize = None
+        try:
+            from tools.environments.docker import _sanitize_label_value as _sanitize
+        except Exception:
+            pass
+    except Exception:
+        _find_docker = None
+        _sanitize = None
+
+    docker = docker_exe or (_find_docker() if _find_docker else None)
+    if not docker:
+        return 0
+    label_val = _sanitize(task_id) if _sanitize else str(task_id)
+
+    def _list_containers(label_value: str) -> list[str]:
+        try:
+            r = _sp.run(
+                [docker, "ps", "-a",
+                 "--filter", "label=hermes-agent=1",
+                 "--filter", f"label=hermes-task-id={label_value}",
+                 "--format", "{{.ID}}"],
+                capture_output=True, text=True, encoding="utf-8", errors="replace",
+                timeout=15, check=False, stdin=_sp.DEVNULL,
+            )
+        except (_sp.TimeoutExpired, OSError):
+            return []
+        if r.returncode != 0:
+            return []
+        return [ln.strip() for ln in r.stdout.splitlines() if ln.strip()]
+
+    # Per-task container first, then the shared default container (the incident
+    # class). De-duped, order preserved.
+    seen: set[str] = set()
+    containers: list[str] = []
+    for lv in dict.fromkeys([label_val, "default"]):
+        for cid in _list_containers(lv):
+            if cid not in seen:
+                seen.add(cid)
+                containers.append(cid)
+    if not containers:
+        return 0
+
+    # Enumerate candidate PIDs by cwd OR argv referencing the workspace, then
+    # signal them individually (never pkill -f on the whole container — that
+    # would hit sibling tasks' processes). pgrep -f matches argv only, so we
+    # also scan /proc/<pid>/cwd for the cwd-only case (e.g. a bare `sleep`).
+    probe_script = (
+        "for d in /proc/[0-9]*; do "
+        "p=${d#/proc/}; "
+        "case \"$p\" in $$|$PPID) continue;; esac; "
+        "cwd=$(readlink $d/cwd 2>/dev/null); "
+        "cmd=$(tr '\\0' ' ' < $d/cmdline 2>/dev/null); "
+        "if case \"$cwd\" in *WS*) true;; *) false;; esac "
+        "|| case \"$cmd\" in *WS*) true;; *) false;; esac; then "
+        "echo $p; fi; done"
+    ).replace("WS", ws)
+
+    total = 0
+    for cid in containers:
+        def _pgrep() -> list[str]:
+            try:
+                r = _sp.run(
+                    [docker, "exec", cid, "sh", "-c", probe_script],
+                    capture_output=True, text=True, encoding="utf-8", errors="replace",
+                    timeout=20, check=False, stdin=_sp.DEVNULL,
+                )
+            except (_sp.TimeoutExpired, OSError):
+                return []
+            return [ln.strip() for ln in r.stdout.splitlines() if ln.strip().isdigit()]
+
+        def _kill(sig: str) -> None:
+            pids = _pgrep()
+            if not pids:
+                return
+            try:
+                _sp.run(
+                    [docker, "exec", cid, "sh", "-c",
+                     "kill -%s %s" % (sig, " ".join(pids))],
+                    capture_output=True, text=True, encoding="utf-8", errors="replace",
+                    timeout=20, check=False, stdin=_sp.DEVNULL,
+                )
+            except (_sp.TimeoutExpired, OSError):
+                pass
+
+        initial = _pgrep()
+        if not initial:
+            continue
+        total += len(initial)
+        _kill("TERM")
+        time.sleep(0.5)
+        _kill("KILL")
+    if total:
+        _log.info(
+            "Reaped %d container process(es) for task %s", total, task_id,
+        )
+    return total
+
+
+def _reap_task_processes(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    worker_pid: Optional[int] = None,
+) -> dict[str, int]:
+    """Combined terminal-transition reap: host tree (Layer A) + sandbox (Layer B).
+
+    Called on EVERY terminal transition (complete, block, reclaim, timeout,
+    crash-detection). Layer A kills the worker's host-side process group /
+    direct children; Layer B kills the finished task's processes inside its
+    sandbox container(s). Both are best-effort and never throw. When anything
+    was reaped, a ``reaped_container_processes`` event is recorded on the task
+    (in its own write txn, so this is safe to call outside an open txn).
+    """
+    host_killed = 0
+    if worker_pid:
+        try:
+            host_killed = _reap_task_orphans(worker_pid)
+        except Exception:
+            pass
+    container_killed = 0
+    try:
+        container_killed = _reap_container_task_processes(task_id)
+    except Exception:
+        pass
+    if host_killed or container_killed:
+        try:
+            with write_txn(conn):
+                _append_event(
+                    conn, task_id, "reaped_container_processes",
+                    {"host": host_killed, "container": container_killed},
+                )
+        except Exception:
+            pass
+    return {"host": host_killed, "container": container_killed}
+
+
 def _defer_reclaim_for_live_worker(
     conn: sqlite3.Connection,
     task_id: str,
@@ -8537,6 +8927,13 @@ def enforce_max_runtime(
                     "retry_status": retry_status,
                 },
             )
+        # Terminal transition — reap the timed-out worker's host tree + sandbox
+        # container processes (t_57aac3e7 D4). An orphan left by a timed-out
+        # task is just as orphaned as one left by a completed one.
+        try:
+            _reap_task_processes(conn, tid, worker_pid=pid)
+        except Exception:
+            pass
     return timed_out
 
 
@@ -9146,6 +9543,21 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 board=_board,
                 **hook_fields,
             )
+    # Terminal transition — reap each reclaimed task's sandbox-container
+    # processes (t_57aac3e7 D4). The worker PID is already dead (that's how we
+    # detected it), so Layer A is a no-op; Layer B is what matters — a crashed
+    # worker's long-running children (os.walk, vitest) live on inside the shared
+    # container. Best-effort, never throws.
+    for _tid, _pid, *_rest in crash_details:
+        try:
+            _reap_task_processes(conn, _tid, worker_pid=_pid)
+        except Exception:
+            pass
+    for _tid in rate_limited:
+        try:
+            _reap_task_processes(conn, _tid)
+        except Exception:
+            pass
     return crashed
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5649,6 +5649,13 @@ def cmd_hooks(args):
 
 def cmd_doctor(args):
     """Check configuration and dependencies."""
+    # ``hermes doctor logs <path>`` — one-shot log rotation (t_57aac3e7 fix 1).
+    # Dispatched before run_doctor so the plain ``hermes doctor`` path is
+    # untouched when no subcommand is given.
+    if getattr(args, "doctor_command", None) == "logs":
+        from hermes_cli.doctor_logs import run_doctor_logs
+
+        sys.exit(run_doctor_logs(args))
     from hermes_cli.doctor import run_doctor
 
     run_doctor(args)

--- a/hermes_cli/stderr_timestamp.py
+++ b/hermes_cli/stderr_timestamp.py
@@ -33,12 +33,102 @@ def _write_timestamped_line(log_file: TextIO, line: str) -> None:
     log_file.flush()
 
 
+# Size-capped rotation for gateway.error.log (t_57aac3e7 fix 1).
+# launchd's StandardErrorPath writes without rotation; if the same bind
+# error repeats ~3/min (24k lines observed), the file grows without bound.
+# These defaults match the 5 MiB / 3-backup shape used by hermes_logging
+# for agent.log, scaled slightly for the lower-volume error log.
+_ERROR_LOG_MAX_BYTES = 5 * 1024 * 1024  # 5 MiB
+_ERROR_LOG_BACKUP_COUNT = 3
+# oMLX Application Support log (t_57aac3e7 fix 1) — same treatment for the
+# 1.4 GB unrotated oMLX server.log.
+_OMLX_LOG_MAX_BYTES = 10 * 1024 * 1024  # 10 MiB
+_OMLX_LOG_BACKUP_COUNT = 3
+
+
+def _rotate_error_log_if_needed(
+    log_path: Path,
+    max_bytes: int = _ERROR_LOG_MAX_BYTES,
+    backup_count: int = _ERROR_LOG_BACKUP_COUNT,
+    force: bool = False,
+) -> None:
+    """Rotate *log_path* when it exceeds *max_bytes* (best-effort, no throw).
+
+    ``force=True`` rotates unconditionally (used by the one-shot
+    ``hermes doctor logs`` rotator); the default size-gated behaviour is
+    unchanged for the live wrapper path.
+    """
+    try:
+        if not log_path.exists():
+            return
+        if not force and log_path.stat().st_size <= max_bytes:
+            return
+        if backup_count <= 0:
+            log_path.unlink()
+            return
+        oldest = log_path.with_suffix(log_path.suffix + f".{backup_count}")
+        try:
+            if oldest.exists():
+                oldest.unlink()
+        except OSError:
+            pass
+        for gen in range(backup_count - 1, 0, -1):
+            src = log_path.with_suffix(log_path.suffix + f".{gen}")
+            if not src.exists():
+                continue
+            try:
+                src.rename(log_path.with_suffix(log_path.suffix + f".{gen + 1}"))
+            except OSError:
+                pass
+        log_path.rename(log_path.with_suffix(log_path.suffix + ".1"))
+    except OSError:
+        pass
+
+
+def _get_external_log_rotation_config(log_path: Path) -> tuple[int, int]:
+    """Return (max_bytes, backup_count) for *log_path*.
+
+    Recognizes the oMLX Application Support log by path substring and
+    applies its larger cap; all other external logs (gateway.error.log,
+    dashboard.error.log) use the error-log defaults. Future external logs
+    get error-log defaults — the right failure mode is conservative caps,
+    not unbounded growth.
+    """
+    p = str(log_path)
+    if "oMLX" in p or "omlx" in p:
+        return _OMLX_LOG_MAX_BYTES, _OMLX_LOG_BACKUP_COUNT
+    return _ERROR_LOG_MAX_BYTES, _ERROR_LOG_BACKUP_COUNT
+
+
 def _copy_stderr_with_timestamps(stderr: BinaryIO, log_path: Path) -> None:
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    with log_path.open("a", encoding="utf-8", buffering=1) as log_file:
+    max_bytes, backup_count = _get_external_log_rotation_config(log_path)
+    # Check once at open time — if the file is already oversized (leftover
+    # from a previous run that never rotated), rotate before appending.
+    _rotate_error_log_if_needed(log_path, max_bytes, backup_count)
+    log_file: TextIO | None = None
+    try:
+        log_file = log_path.open("a", encoding="utf-8", buffering=1)
         for raw_line in iter(stderr.readline, b""):
             line = raw_line.decode("utf-8", errors="replace")
             _write_timestamped_line(log_file, line)
+            # Size check after each line — cheap (buffered tell) and catches
+            # the tight bind-error loop (24k lines) within one rotation window.
+            try:
+                if log_file.tell() > max_bytes:
+                    log_file.flush()
+                    log_file.close()
+                    log_file = None
+                    _rotate_error_log_if_needed(log_path, max_bytes, backup_count)
+                    log_file = log_path.open("a", encoding="utf-8", buffering=1)
+            except OSError:
+                break
+    finally:
+        if log_file is not None:
+            try:
+                log_file.close()
+            except Exception:
+                pass
 
 
 def _command_exit_code(returncode: int) -> int:

--- a/hermes_cli/subcommands/doctor.py
+++ b/hermes_cli/subcommands/doctor.py
@@ -6,6 +6,7 @@ Handler injected to avoid importing ``main``.
 
 from __future__ import annotations
 
+import argparse
 from typing import Callable
 
 
@@ -41,10 +42,9 @@ def build_doctor_parser(subparsers, *, cmd_doctor: Callable) -> None:
             "doctor` first to see active advisories and their IDs."
         ),
     )
-    # ``hermes doctor logs <path>`` — one-shot rename-rotation of a foreign
-    # log (oMLX server.log, dashboard.error.log) so an operator or host-ops
-    # automation can rotate on demand instead of hand-truncating (t_57aac3e7
-    # fix 1). Reuses _rotate_error_log_if_needed via import.
+    # ``hermes doctor logs <path>`` rotates ordinary external logs. oMLX's
+    # app-managed server.log additionally requires an explicit reopen command
+    # and verifies that the replacement path has an active writer.
     doctor_sub = doctor_parser.add_subparsers(
         dest="doctor_command", metavar="{logs}"
     )
@@ -54,9 +54,9 @@ def build_doctor_parser(subparsers, *, cmd_doctor: Callable) -> None:
         description=(
             "One-shot rename-rotation of a single log file. Rotates "
             "<path> to <path>.1 (shifting .1 -> .2 -> ... up to --backups) "
-            "so the writer's open fd keeps pointing at the old inode while a "
-            "fresh file is created. Safe for foreign writers (oMLX, launchd "
-            "stderr) that hold the file open."
+            "so the writer's open fd keeps pointing at the old inode. For "
+            "oMLX Application Support/server.log, --reopen-command is required "
+            "and the new path must gain a writer before success is reported."
         ),
     )
     logs_parser.add_argument(
@@ -83,5 +83,17 @@ def build_doctor_parser(subparsers, *, cmd_doctor: Callable) -> None:
         "--force",
         action="store_true",
         help="Rotate even if the file is under the size cap (default).",
+    )
+    logs_parser.add_argument(
+        "--reopen-timeout",
+        type=float,
+        default=30.0,
+        help="Seconds to wait for the controlled oMLX restart/reopen (default 30).",
+    )
+    logs_parser.add_argument(
+        "--reopen-command",
+        nargs=argparse.REMAINDER,
+        default=None,
+        help="Required for oMLX server.log: explicit no-shell command that restarts or reopens its writer; must be last.",
     )
     doctor_parser.set_defaults(func=cmd_doctor)

--- a/hermes_cli/subcommands/doctor.py
+++ b/hermes_cli/subcommands/doctor.py
@@ -41,4 +41,47 @@ def build_doctor_parser(subparsers, *, cmd_doctor: Callable) -> None:
             "doctor` first to see active advisories and their IDs."
         ),
     )
+    # ``hermes doctor logs <path>`` — one-shot rename-rotation of a foreign
+    # log (oMLX server.log, dashboard.error.log) so an operator or host-ops
+    # automation can rotate on demand instead of hand-truncating (t_57aac3e7
+    # fix 1). Reuses _rotate_error_log_if_needed via import.
+    doctor_sub = doctor_parser.add_subparsers(
+        dest="doctor_command", metavar="{logs}"
+    )
+    logs_parser = doctor_sub.add_parser(
+        "logs",
+        help="Rotate a log file on demand (rename-rotation)",
+        description=(
+            "One-shot rename-rotation of a single log file. Rotates "
+            "<path> to <path>.1 (shifting .1 -> .2 -> ... up to --backups) "
+            "so the writer's open fd keeps pointing at the old inode while a "
+            "fresh file is created. Safe for foreign writers (oMLX, launchd "
+            "stderr) that hold the file open."
+        ),
+    )
+    logs_parser.add_argument(
+        "path",
+        help="Absolute path to the log file to rotate",
+    )
+    logs_parser.add_argument(
+        "--max-bytes",
+        type=int,
+        default=None,
+        help=(
+            "Size cap in bytes. When omitted, the cap is inferred from the "
+            "path (10 MiB for oMLX logs, 5 MiB otherwise). With --force this "
+            "only affects reporting; rotation happens regardless."
+        ),
+    )
+    logs_parser.add_argument(
+        "--backups",
+        type=int,
+        default=None,
+        help="Number of rotated backups to keep (default 3). 0 deletes instead.",
+    )
+    logs_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Rotate even if the file is under the size cap (default).",
+    )
     doctor_parser.set_defaults(func=cmd_doctor)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19358,7 +19358,43 @@ def start_server(
             config.load()
         server.lifespan = config.lifespan_class(config)
         with server.capture_signals():
-            await server.startup()
+            try:
+                await server.startup()
+            except OSError as _startup_exc:
+                # Bind-conflict backstop (t_57aac3e7 fix 2): uvicorn holds the
+                # socket for the whole startup (no separate preflight probe —
+                # that TOCTOU-prone bind/close/rebind dance was removed), so a
+                # duplicate instance on this port surfaces here as EADDRINUSE
+                # from create_server(). Give it a loud, terminal shape — stderr
+                # message + status file + clean exit(0) instead of a raw
+                # traceback — so `hermes gateway status` can explain it. Note
+                # the supervisor's restart policy is unconditional (launchd
+                # KeepAlive=true / systemd Restart=always, #37388), so this
+                # does not by itself stop a respawn loop; it only makes the
+                # cause visible instead of a silent crash-loop.
+                _errno = getattr(_startup_exc, "errno", None)
+                _is_in_use = (
+                    _errno in (48, 98, 10048)
+                    or "in use" in str(_startup_exc).lower()
+                    or "already in use" in str(_startup_exc).lower()
+                )
+                if not _is_in_use:
+                    raise
+                _msg = (
+                    f"Port {port} is already in use — another dashboard/gateway "
+                    f"instance is bound to {host}:{port} ({_startup_exc}). "
+                    f"Stop the duplicate (`hermes gateway stop` / `lsof -i :{port}`) "
+                    f"and retry. This is a terminal bind conflict, not a transient "
+                    f"error — check `hermes gateway status` if the supervisor keeps "
+                    f"respawning it."
+                )
+                print(f"ERROR: {_msg}", file=sys.stderr, flush=True)
+                try:
+                    from hermes_cli.gateway import _write_bind_conflict_status
+                    _write_bind_conflict_status(host, port, str(_startup_exc))
+                except Exception:
+                    pass
+                raise SystemExit(0)
             if server.should_exit:
                 return
 
@@ -19402,6 +19438,16 @@ def start_server(
 
             actual_port = _read_bound_port(server, fallback=port)
             app.state.bound_port = actual_port
+
+            # Stale-clear (t_57aac3e7 fix 2): we just bound successfully, so any
+            # prior bind-conflict status file is now stale — delete it so a
+            # resolved conflict doesn't linger in `hermes gateway status`.
+            if actual_port:
+                try:
+                    from hermes_cli.gateway import _clear_bind_conflict_status
+                    _clear_bind_conflict_status()
+                except Exception:
+                    pass
 
             _write_dashboard_ready_file(actual_port)
             # Port-discovery sentinel parsed by the desktop spawn. `serve` is a

--- a/tests/hermes_cli/test_doctor_logs.py
+++ b/tests/hermes_cli/test_doctor_logs.py
@@ -3,6 +3,11 @@
 from __future__ import annotations
 
 import argparse
+import signal
+import subprocess
+import sys
+import textwrap
+import time
 
 import pytest
 
@@ -29,6 +34,14 @@ def test_doctor_logs_parser_wiring():
     assert ns.force is True
     assert ns.backups == 2
     assert ns.max_bytes == 100
+
+
+def test_doctor_logs_parser_accepts_reopen_command():
+    root = _build_doctor_parser()
+    ns = root.parse_args(
+        ["doctor", "logs", "/tmp/x.log", "--reopen-command", "/bin/kill", "-HUP", "123"]
+    )
+    assert ns.reopen_command == ["/bin/kill", "-HUP", "123"]
 
 
 def test_plain_doctor_has_no_logs_subcommand():
@@ -87,3 +100,58 @@ def test_run_doctor_logs_bad_args_exit_2(tmp_path):
     args = argparse.Namespace(path=str(log), max_bytes=None, backups=-1, force=True)
     rc = run_doctor_logs(args)
     assert rc == 2
+
+
+def test_omlx_log_refuses_rotation_without_reopen_command(tmp_path):
+    from hermes_cli.doctor_logs import run_doctor_logs
+
+    log = tmp_path / "Library" / "Application Support" / "oMLX" / "logs" / "server.log"
+    log.parent.mkdir(parents=True)
+    log.write_text("before\n", encoding="utf-8")
+    rc = run_doctor_logs(
+        argparse.Namespace(path=str(log), max_bytes=None, backups=3, force=True)
+    )
+    assert rc == 3
+    assert log.exists()
+    assert not log.with_suffix(".log.1").exists()
+
+
+def test_omlx_log_rotation_requires_writer_handoff(tmp_path):
+    from hermes_cli.doctor_logs import run_doctor_logs
+
+    log = tmp_path / "Library" / "Application Support" / "oMLX" / "logs" / "server.log"
+    log.parent.mkdir(parents=True)
+    control = tmp_path / "reopen"
+    log.write_text("before\n", encoding="utf-8")
+    writer = textwrap.dedent(
+        """
+        import pathlib, signal, sys, time
+        path = pathlib.Path(sys.argv[1]); control = pathlib.Path(sys.argv[2])
+        handle = path.open('a', encoding='utf-8'); handle.write('writer before\\n'); handle.flush()
+        def reopen(*_):
+            global handle
+            handle.close(); handle = path.open('a', encoding='utf-8')
+            handle.write('writer after\\n'); handle.flush()
+        signal.signal(signal.SIGHUP, reopen)
+        while not control.exists(): time.sleep(.02)
+        handle.close()
+        """
+    )
+    proc = subprocess.Popen([sys.executable, "-c", writer, str(log), str(control)])
+    try:
+        deadline = time.monotonic() + 3
+        while "writer before" not in log.read_text(encoding="utf-8"):
+            assert time.monotonic() < deadline
+            time.sleep(0.02)
+        rc = run_doctor_logs(
+            argparse.Namespace(
+                path=str(log), max_bytes=None, backups=3, force=True,
+                reopen_command=["/bin/kill", "-HUP", str(proc.pid)], reopen_timeout=3,
+            )
+        )
+        assert rc == 0
+        assert "writer after" in log.read_text(encoding="utf-8")
+        assert "writer after" not in log.with_suffix(".log.1").read_text(encoding="utf-8")
+    finally:
+        control.touch()
+        proc.wait(timeout=3)

--- a/tests/hermes_cli/test_doctor_logs.py
+++ b/tests/hermes_cli/test_doctor_logs.py
@@ -1,0 +1,89 @@
+"""Tests for ``hermes doctor logs`` one-shot log rotation (t_57aac3e7 fix 1)."""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+
+def _build_doctor_parser():
+    """Build just the doctor subparser via the real builder."""
+    from hermes_cli.subcommands.doctor import build_doctor_parser
+
+    root = argparse.ArgumentParser(prog="hermes")
+    sub = root.add_subparsers(dest="command")
+    build_doctor_parser(sub, cmd_doctor=lambda args: None)
+    return root
+
+
+def test_doctor_logs_parser_wiring():
+    """``doctor logs <path> --force --backups N --max-bytes M`` parses."""
+    root = _build_doctor_parser()
+    ns = root.parse_args(
+        ["doctor", "logs", "/tmp/x.log", "--force", "--backups", "2", "--max-bytes", "100"]
+    )
+    assert ns.command == "doctor"
+    assert ns.doctor_command == "logs"
+    assert ns.path == "/tmp/x.log"
+    assert ns.force is True
+    assert ns.backups == 2
+    assert ns.max_bytes == 100
+
+
+def test_plain_doctor_has_no_logs_subcommand():
+    """Bare ``hermes doctor`` still parses (no doctor_command attr set)."""
+    root = _build_doctor_parser()
+    ns = root.parse_args(["doctor"])
+    assert ns.command == "doctor"
+    assert getattr(ns, "doctor_command", None) is None
+
+
+def test_run_doctor_logs_forced_rotation(tmp_path):
+    """--force rotates an existing file even under the cap; .1 appears."""
+    from hermes_cli.doctor_logs import run_doctor_logs
+
+    log = tmp_path / "server.log"
+    log.write_text("x" * 100, encoding="utf-8")
+    args = argparse.Namespace(path=str(log), max_bytes=None, backups=3, force=True)
+    rc = run_doctor_logs(args)
+    assert rc == 0
+    # The original inode was renamed to .1
+    assert log.with_suffix(".log.1").exists()
+    content = log.with_suffix(".log.1").read_text(encoding="utf-8")
+    assert len(content) == 100
+
+
+def test_run_doctor_logs_noop_under_cap_without_force(tmp_path):
+    """Without --force, a small file is left alone (size-gated)."""
+    from hermes_cli.doctor_logs import run_doctor_logs
+
+    log = tmp_path / "small.log"
+    log.write_text("tiny", encoding="utf-8")
+    args = argparse.Namespace(path=str(log), max_bytes=None, backups=3, force=False)
+    rc = run_doctor_logs(args)
+    assert rc == 0
+    assert not log.with_suffix(".log.1").exists()
+    assert log.exists()
+
+
+def test_run_doctor_logs_missing_path_is_clean(tmp_path):
+    """A missing path reports cleanly and exits 0 (nothing to do)."""
+    from hermes_cli.doctor_logs import run_doctor_logs
+
+    args = argparse.Namespace(
+        path=str(tmp_path / "nope.log"), max_bytes=None, backups=3, force=True
+    )
+    rc = run_doctor_logs(args)
+    assert rc == 0
+
+
+def test_run_doctor_logs_bad_args_exit_2(tmp_path):
+    """Negative --backups is a usage error (exit 2)."""
+    from hermes_cli.doctor_logs import run_doctor_logs
+
+    log = tmp_path / "x.log"
+    log.write_text("data", encoding="utf-8")
+    args = argparse.Namespace(path=str(log), max_bytes=None, backups=-1, force=True)
+    rc = run_doctor_logs(args)
+    assert rc == 2

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -17,6 +17,9 @@ import pytest
 import hermes_state
 from hermes_cli import kanban_db as kb
 
+# Repo root (tests/hermes_cli/test_kanban_db.py -> up 3 levels).
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
 
 @pytest.fixture
 def kanban_home(tmp_path, monkeypatch):
@@ -1614,3 +1617,173 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# D1 self-kill guard (t_57aac3e7, severity-critical)
+#
+# complete_task / block_task run IN-PROCESS inside the worker, so the
+# worker_pid they pass to _reap_task_orphans is os.getpid(). A blind
+# os.killpg(worker_pid) SIGTERMs the completing worker mid-completion. The
+# guard must let the completer survive while still reaping the worker's
+# direct children.
+# ---------------------------------------------------------------------------
+
+
+def test_reap_self_does_not_kill_completer_but_reaps_child(tmp_path):
+    """Completing in-process must not SIGTERM itself; its child must die."""
+    script = tmp_path / "worker.py"
+    child_pid_file = tmp_path / "child.pid"
+    done_marker = tmp_path / "done"
+    script.write_text(
+        "import os, sys, time\n"
+        "from pathlib import Path\n"
+        "sys.path.insert(0, %r)\n"
+        "from hermes_cli import kanban_db as kb\n"
+        "# Become a session leader (mirrors start_new_session=True workers),\n"
+        "# so our pgid == our pid and a blind killpg(self) would self-terminate.\n"
+        "os.setsid()\n"
+        "child = __import__('subprocess').Popen(['sleep', '30'])\n"
+        "Path(%r).write_text(str(child.pid))\n"
+        "time.sleep(0.4)\n"
+        "kb._reap_task_orphans(os.getpid())\n"
+        "Path(%r).write_text('alive')\n"
+        "print('SURVIVED')\n" % (str(REPO_ROOT), str(child_pid_file), str(done_marker)),
+    )
+    proc = subprocess.run(
+        [sys.executable, str(script)], capture_output=True, text=True, timeout=60,
+    )
+    # The completer must have survived its own reap (no SIGTERM self-kill).
+    assert proc.returncode == 0, f"completer died: rc={proc.returncode} err={proc.stderr}"
+    assert "SURVIVED" in proc.stdout
+    assert done_marker.exists(), "completer did not finish after reaping itself"
+    # The worker's direct child must have been reaped.
+    child_pid = int(child_pid_file.read_text())
+    time.sleep(0.6)
+    try:
+        os.kill(child_pid, 0)
+        child_alive = True
+    except ProcessLookupError:
+        child_alive = False
+    assert not child_alive, "worker's direct child was not reaped"
+
+
+def test_reap_self_no_child_returns_zero():
+    """Reaping ourselves with no children is a no-op that never throws."""
+    import signal as _sig
+    n = kb._reap_task_orphans(os.getpid())
+    assert isinstance(n, int)
+    assert n >= 0
+    # Sanity: the helper is present and callable.
+    assert callable(kb._kill_direct_children)
+    assert hasattr(_sig, "SIGTERM")
+
+
+# ---------------------------------------------------------------------------
+# D4 — container-aware reaper (_reap_container_task_processes)
+# ---------------------------------------------------------------------------
+# NOTE: this sandbox mounts /tmp noexec, so we cannot run a real fake ``docker``
+# shell script. Instead we mock ``subprocess.run`` at the Python level and assert
+# on the exact docker invocations the reaper issues. This exercises the
+# orchestration (ps -> probe -> TERM -> KILL, never stop/rm) which is what D4
+# guarantees; the live end-to-end container kill is covered by host-ops t_b00b5cc1.
+
+
+def _fake_docker_run(pids):
+    """Return ``(fake_run, calls)`` where ``fake_run`` emulates docker for one task.
+
+    - ``docker ps ...``          -> one container id.
+    - ``docker exec <cid> sh -c <probe>`` -> the orphan PIDs (always — the
+      processes are treated as stubborn so every probe sees them).
+    - ``docker exec <cid> sh -c 'kill -SIG ...'`` -> success, no output.
+
+    ``calls`` records ``(subcommand, script)`` for every invocation so tests can
+    assert ordering and that stop/rm were never issued.
+    """
+    cid = "fakecid123"
+    calls: list[tuple[str, str]] = []
+
+    def _run(args, *a, **k):
+        sub = args[1] if len(args) > 1 else ""
+        script = args[-1] if args else ""
+        calls.append((sub, script))
+        if sub == "ps":
+            return subprocess.CompletedProcess(args, 0, stdout=f"{cid}\n", stderr="")
+        if sub == "exec":
+            if "kill -TERM" in script or "kill -KILL" in script:
+                return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+            # probe
+            return subprocess.CompletedProcess(
+                args, 0, stdout="\n".join(pids) + "\n", stderr="",
+            )
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    return _run, calls
+
+
+def test_reap_container_kills_orphans_not_container(monkeypatch):
+    """Layer B signals the task's orphan PIDs (TERM then KILL) but never stops
+    or removes the shared container."""
+    fake_run, calls = _fake_docker_run(["4242", "4243"])
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    n = kb._reap_container_task_processes("t_d4test", docker_exe="/usr/bin/docker")
+    assert n == 2, f"expected 2 orphans signalled, got {n}"
+    scripts = [s for _, s in calls]
+    joined = "\n".join(scripts)
+    assert "kill -TERM 4242 4243" in joined
+    assert "kill -KILL 4242 4243" in joined
+    # TERM must precede KILL.
+    term_idx = next(i for i, s in enumerate(scripts) if "kill -TERM" in s)
+    kill_idx = next(i for i, s in enumerate(scripts) if "kill -KILL" in s)
+    assert term_idx < kill_idx
+    # Only ps + exec were ever invoked — the container was NEVER stopped/removed.
+    subs = {sub for sub, _ in calls}
+    assert subs <= {"ps", "exec"}, f"unexpected docker subcommands: {subs}"
+    assert "stop" not in subs and "rm" not in subs
+
+
+def test_reap_container_no_docker_returns_zero():
+    """No docker binary -> best-effort no-op returning 0 (never throws)."""
+    n = kb._reap_container_task_processes("t_nodocker", docker_exe=None)
+    assert n == 0
+
+
+def test_reap_container_no_matching_container_returns_zero(monkeypatch):
+    """Docker present but no container carries the task label -> 0, no execs."""
+    calls: list[tuple[str, str]] = []
+
+    def _run(args, *a, **k):
+        sub = args[1] if len(args) > 1 else ""
+        calls.append((sub, args[-1] if args else ""))
+        # ps finds nothing
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _run)
+    n = kb._reap_container_task_processes("t_nomatch", docker_exe="/usr/bin/docker")
+    assert n == 0
+    # No exec was issued because no container matched.
+    assert all(sub == "ps" for sub, _ in calls)
+
+
+def test_reap_task_processes_records_event(kanban_home, monkeypatch):
+    """The combined terminal-transition reap records a
+    ``reaped_container_processes`` event when Layer B kills something."""
+    fake_run, _calls = _fake_docker_run(["7777"])
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    # _reap_task_processes -> _reap_container_task_processes(task_id) with no
+    # docker_exe, so it resolves docker via find_docker(); point that at a fake.
+    import tools.environments.docker as dmod
+    monkeypatch.setattr(dmod, "find_docker", lambda: "/usr/bin/docker")
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="d4-event", assignee="a")
+        result = kb._reap_task_processes(conn, tid)
+        assert result["container"] >= 1
+        row = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'reaped_container_processes'",
+            (tid,),
+        ).fetchone()
+        assert row is not None, "reaped_container_processes event not recorded"
+        import json as _json
+        payload = _json.loads(row["payload"])
+        assert payload.get("container", 0) >= 1

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1488,3 +1488,35 @@ def test_extra_args_set_shm_size_helper():
     assert docker_env._extra_args_set_shm_size(None) is False
     # non-string entries must not crash (config.yaml can be malformed)
     assert docker_env._extra_args_set_shm_size([42, None, "--shm-size=1g"]) is True
+
+
+def test_persistent_mount_sanitizes_session_task_id_with_colon(monkeypatch, tmp_path):
+    """Interactive chat sessions use task_id='session:<key>'. The persistent
+    volume mount path must sanitize colons to underscores so Docker does not
+    parse the source path as a volume separator (exit 125 'invalid mode: /root').
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr("tools.environments.base.get_sandbox_dir", lambda: tmp_path / "sandboxes")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    env = _make_dummy_env(
+        task_id="session:20260823_140621_59dd51",
+        persistent_filesystem=True,
+    )
+
+    assert ":" not in env._home_dir
+    assert "session_20260823_140621_59dd51" in env._home_dir
+
+    run_args = _run_args_from_calls(calls)
+    mount_sources = []
+    for i, arg in enumerate(run_args):
+        if arg == "-v" and i + 1 < len(run_args):
+            mount_sources.append(run_args[i + 1])
+
+    home_mounts = [m for m in mount_sources if m.endswith(":/root")]
+    assert len(home_mounts) == 1
+    home_mount = home_mounts[0]
+    host_src, target = home_mount.split(":/root")[0], "/root"
+    assert ":" not in host_src
+    assert "session_20260823_140621_59dd51/home" in host_src
+

--- a/tests/tools/test_docker_sanitize_path_component.py
+++ b/tests/tools/test_docker_sanitize_path_component.py
@@ -1,0 +1,41 @@
+"""Regression coverage for Docker sandbox path components."""
+
+from tools.environments.docker import _sanitize_path_component
+
+
+def test_sanitize_path_component_preserves_safe_kanban_id():
+    assert _sanitize_path_component("t_50621cac") == "t_50621cac"
+
+
+def test_sanitize_path_component_replaces_docker_mount_delimiters():
+    component = _sanitize_path_component("session:20260822_232116_cef735/child")
+
+    assert component == "session_20260822_232116_cef735_child"
+    assert ":" not in component
+    assert "/" not in component
+
+
+def test_sanitize_path_component_replaces_interactive_chat_session_colon():
+    component = _sanitize_path_component("session:20260823_140621_59dd51")
+
+    assert component == "session_20260823_140621_59dd51"
+    assert ":" not in component
+    assert "/" not in component
+
+
+def test_sanitize_path_component_uses_hash_suffix_for_long_distinct_inputs():
+    first = _sanitize_path_component("a" * 80)
+    second = _sanitize_path_component("a" * 79 + "b")
+
+    assert len(first) == 64
+    assert len(second) == 64
+    assert first != second
+    assert first[:51] == "a" * 51
+    assert len(first.rsplit("_", 1)[1]) == 12
+    assert ":" not in first
+    assert "/" not in first
+
+
+def test_sanitize_path_component_uses_default_for_empty_value():
+    assert _sanitize_path_component("") == "default"
+    assert _sanitize_path_component(None) == "default"  # type: ignore[arg-type]

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -130,6 +130,27 @@ def _sanitize_label_value(value: str) -> str:
     return cleaned
 
 
+def _sanitize_path_component(value: str) -> str:
+    """Sanitize a task/session ID for use as a single filesystem path segment.
+
+    NOT interchangeable with _sanitize_label_value(): a label collision is
+    harmless, but a collision here would merge two sessions' sandbox home
+    directories. So this never drops information:
+      - every character outside [A-Za-z0-9._-] becomes '_'
+        (fixes the ':' that breaks docker -v host:container parsing)
+      - if the result exceeds 64 chars, keep a stable prefix plus a 12-char
+        sha256 of the ORIGINAL value, so distinct inputs always map to
+        distinct components (hash the overflow, never just drop it).
+    """
+    safe = re.sub(r"[^A-Za-z0-9._-]", "_", value or "")
+    if not safe:
+        return "default"
+    if len(safe) > 64:
+        digest = hashlib.sha256((value or "").encode("utf-8")).hexdigest()[:12]
+        safe = safe[: 64 - 13] + "_" + digest
+    return safe
+
+
 def _get_active_profile_name() -> str:
     """Return the active Hermes profile name, or ``"default"`` on any error.
 
@@ -980,7 +1001,7 @@ class DockerEnvironment(BaseEnvironment):
         self._home_dir: Optional[str] = None
         writable_args = []
         if self._persistent:
-            sandbox = get_sandbox_dir() / "docker" / task_id
+            sandbox = get_sandbox_dir() / "docker" / _sanitize_path_component(task_id)
             self._home_dir = str(sandbox / "home")
             os.makedirs(self._home_dir, exist_ok=True)
             writable_args.extend([


### PR DESCRIPTION
## Summary

Re-lands reviewed, tested work for kanban ticket t_57aac3e7 (three independent host-hygiene defects found 2026-08-20 on a live Hermes install). The original deploy landed as a local-only commit directly on a live checkout and was silently wiped by a subsequent `hermes update` (see the companion PR for the durable fix to that).

- **Log rotation**: `hermes doctor logs` one-shot rotator. oMLX's app-managed `server.log` refuses silent rotation without an explicit `--reopen-command`, and only reports success once the fresh path has a verified new writer (checked via `lsof`) — rename-only rotation previously left the owning process appending forever to the renamed backup inode. Ordinary foreign logs (dashboard.error.log) keep bounded rename-rotation via new size-capped primitives in `stderr_timestamp.py`, which this branch also had to port in since main never had that feature merged.
- **Bind conflicts**: `web_server.py`'s dashboard startup now fails loudly (clean exit + a `bind_conflict.json` status file surfaced via `hermes gateway status`) on `EADDRINUSE` instead of the process retrying/looping silently. Note: main had already reverted `KeepAlive.SuccessfulExit=false` (#37388) for an unrelated graceful-restart reason, so this PR does **not** reinstate that — the loud status surfacing lands, but stopping the launchd respawn loop itself needs a separate follow-up that's compatible with the SIGUSR1 drain protocol.
- **Sandbox reaping**: `kanban_db.py` now reaps a task worker's full process tree (session-group SIGTERM/SIGKILL) and its sandbox-container processes on every terminal transition (complete/block/reclaim), fixing orphaned children (`os.walk("/")`, stray vitest workers) that previously outlived their task by hours.

## Test plan
- `tests/hermes_cli/test_kanban_db.py`, `test_doctor_logs.py`, `test_stderr_timestamp.py`, `test_gateway_service.py`: 142 passed, 2 skipped, 0 failed.
- Held-open-FD regression test spawns a real writer process, rotates, sends the reopen command, and asserts new writes land in the fresh file, not the backup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)