### PR TITLE
fix(docs): shrink oversized hero buttons

### DIFF
--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -59,7 +59,9 @@ The self-improving AI agent built by [Nous Research](https://nousresearch.com). 
       borderRadius: "8px",
       textDecoration: "none",
     }}
-  >Download Desktop</a>
+  >
+    Download Desktop
+  </a>
   <a
     href="https://github.com/NousResearch/hermes-agent"
     style={{
@@ -70,7 +72,9 @@ The self-improving AI agent built by [Nous Research](https://nousresearch.com). 
       borderRadius: "8px",
       textDecoration: "none",
     }}
-  >View on GitHub</a>
+  >
+    View on GitHub
+  </a>
 </div>
 
 ## Install

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -33,7 +33,9 @@ The self-improving AI agent built by [Nous Research](https://nousresearch.com). 
       fontWeight: 600,
       textDecoration: "none",
     }}
-  >Get Started →</Link>
+  >
+     Get Started →
+   </Link>
   <Link
     to="/user-guide/bot-mode"
     style={{
@@ -44,7 +46,9 @@ The self-improving AI agent built by [Nous Research](https://nousresearch.com). 
       borderRadius: "8px",
       textDecoration: "none",
     }}
-  >Explore Bot Mode</Link>
+  >
+     Explore Bot Mode →
+    </Link>
   <a
     href="https://hermes-agent.nousresearch.com/"
     style={{

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -33,9 +33,7 @@ The self-improving AI agent built by [Nous Research](https://nousresearch.com). 
       fontWeight: 600,
       textDecoration: "none",
     }}
-  >
-    Get Started →
-  </Link>
+  >Get Started →</Link>
   <Link
     to="/user-guide/bot-mode"
     style={{
@@ -46,9 +44,7 @@ The self-improving AI agent built by [Nous Research](https://nousresearch.com). 
       borderRadius: "8px",
       textDecoration: "none",
     }}
-  >
-    Explore Bot Mode
-  </Link>
+  >Explore Bot Mode</Link>
   <a
     href="https://hermes-agent.nousresearch.com/"
     style={{
@@ -59,9 +55,7 @@ The self-improving AI agent built by [Nous Research](https://nousresearch.com). 
       borderRadius: "8px",
       textDecoration: "none",
     }}
-  >
-    Download Desktop
-  </a>
+  >Download Desktop</a>
   <a
     href="https://github.com/NousResearch/hermes-agent"
     style={{
@@ -72,9 +66,7 @@ The self-improving AI agent built by [Nous Research](https://nousresearch.com). 
       borderRadius: "8px",
       textDecoration: "none",
     }}
-  >
-    View on GitHub
-  </a>
+  >View on GitHub</a>
 </div>
 
 ## Install

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -25,7 +25,7 @@ The self-improving AI agent built by [Nous Research](https://nousresearch.com). 
     to="/getting-started/installation"
     style={{
       display: "inline-block",
-      padding: "0.4rem 0.9rem",
+      padding: "0.4rem 0.7rem",
       fontSize: "0.9rem",
       backgroundColor: "#FFD700",
       color: "#07070d",
@@ -40,7 +40,7 @@ The self-improving AI agent built by [Nous Research](https://nousresearch.com). 
     to="/user-guide/bot-mode"
     style={{
       display: "inline-block",
-      padding: "0.4rem 0.9rem",
+      padding: "0.4rem 0.7rem",
       fontSize: "0.9rem",
       border: "1px solid rgba(255,215,0,0.2)",
       borderRadius: "8px",
@@ -53,7 +53,7 @@ The self-improving AI agent built by [Nous Research](https://nousresearch.com). 
     href="https://hermes-agent.nousresearch.com/"
     style={{
       display: "inline-block",
-      padding: "0.4rem 0.9rem",
+      padding: "0.4rem 0.7rem",
       fontSize: "0.9rem",
       border: "1px solid rgba(255,215,0,0.2)",
       borderRadius: "8px",
@@ -66,7 +66,7 @@ The self-improving AI agent built by [Nous Research](https://nousresearch.com). 
     href="https://github.com/NousResearch/hermes-agent"
     style={{
       display: "inline-block",
-      padding: "0.4rem 0.9rem",
+      padding: "0.4rem 0.7rem",
       fontSize: "0.9rem",
       border: "1px solid rgba(255,215,0,0.2)",
       borderRadius: "8px",

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -25,7 +25,8 @@ The self-improving AI agent built by [Nous Research](https://nousresearch.com). 
     to="/getting-started/installation"
     style={{
       display: "inline-block",
-      padding: "0.6rem 1.2rem",
+      padding: "0.4rem 0.9rem",
+      fontSize: "0.9rem",
       backgroundColor: "#FFD700",
       color: "#07070d",
       borderRadius: "8px",
@@ -39,7 +40,8 @@ The self-improving AI agent built by [Nous Research](https://nousresearch.com). 
     to="/user-guide/bot-mode"
     style={{
       display: "inline-block",
-      padding: "0.6rem 1.2rem",
+      padding: "0.4rem 0.9rem",
+      fontSize: "0.9rem",
       border: "1px solid rgba(255,215,0,0.2)",
       borderRadius: "8px",
       textDecoration: "none",
@@ -51,7 +53,8 @@ The self-improving AI agent built by [Nous Research](https://nousresearch.com). 
     href="https://hermes-agent.nousresearch.com/"
     style={{
       display: "inline-block",
-      padding: "0.6rem 1.2rem",
+      padding: "0.4rem 0.9rem",
+      fontSize: "0.9rem",
       border: "1px solid rgba(255,215,0,0.2)",
       borderRadius: "8px",
       textDecoration: "none",
@@ -63,7 +66,8 @@ The self-improving AI agent built by [Nous Research](https://nousresearch.com). 
     href="https://github.com/NousResearch/hermes-agent"
     style={{
       display: "inline-block",
-      padding: "0.6rem 1.2rem",
+      padding: "0.4rem 0.9rem",
+      fontSize: "0.9rem",
       border: "1px solid rgba(255,215,0,0.2)",
       borderRadius: "8px",
       textDecoration: "none",


### PR DESCRIPTION
Reduced padding and font-size on the 4 hero buttons on the docs landing page — they were too big.