### PR TITLE
fix(mem0): give the search guidance explicit stop conditions

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -122,7 +122,12 @@ SEARCH_SCHEMA = {
         "what you know about the user (preferences, facts, history, people, "
         "projects, past decisions). For multi-part or multi-hop questions, "
         "call it several times — vary the wording and run follow-up searches "
-        "on what earlier results reveal; one search is rarely enough."
+        "on what earlier results reveal. Stop as soon as results stop being "
+        "useful: if the top results are unrelated to the question or their "
+        "scores are low, do NOT keep rephrasing and re-searching — answer "
+        "from general knowledge and, when it helps, note that memory had "
+        "nothing relevant. Also never call this tool again once the user "
+        "asks you to stop searching."
     ),
     "parameters": {
         "type": "object",
@@ -405,8 +410,11 @@ class Mem0MemoryProvider(MemoryProvider):
             "alone, and do not assume you have no memory.\n"
             "For multi-part or multi-hop questions, run several searches with "
             "different wording/angles and follow-up searches on what the first "
-            "results surface; one search is rarely enough. Keep searching until "
-            "you have every fact the question needs before you answer.\n"
+            "results surface. Stop when the results stop being relevant: if "
+            "searches return unrelated records or low scores, do not keep "
+            "rephrasing — answer from general knowledge and, when it helps, "
+            "note that memory had nothing relevant. Also stop immediately "
+            "when the user asks you to stop searching.\n"
             "Tools: mem0_search to find memories, mem0_add to store facts, "
             f"mem0_update and mem0_delete to manage by ID.{rerank_note}"
         )

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -260,6 +260,27 @@ class TestMem0V3Config:
         assert "mem0_profile" not in block
         assert "mem0_conclude" not in block
 
+    def test_search_guidance_has_stop_conditions(self):
+        """#93485: the search guidance must tell the agent when to STOP.
+
+        The old text ended with imperatives that encouraged retrying ("vary
+        the wording", "keep searching until you have every fact") with no
+        relevance qualifier, so low-relevance results produced a rephrase-
+        and-research loop that ignored the user's stop instruction.
+        """
+        provider = Mem0MemoryProvider()
+        provider._user_id = "test"
+        block = provider.system_prompt_block()
+        search_schema = provider.get_tool_schemas()[0]
+
+        for text in (block, search_schema["description"]):
+            assert "do NOT keep rephrasing" in text or \
+                "do not keep rephrasing" in text
+            assert "asks you to stop" in text
+        # The unconditional continuation imperative is gone from both sites.
+        assert "Keep searching until" not in block
+        assert "one search is rarely enough" not in search_schema["description"]
+
 
 class TestMem0ModeSwitch:
 


### PR DESCRIPTION
## What does this PR do?

Stops the mem0_search rephrase-and-research loop on low-relevance results by giving the search guidance the stop conditions it was missing.

Both instruction sites **only** encouraged retrying: the tool description ended with "vary the wording and run follow-up searches on what earlier results reveal; one search is rarely enough", and the system-prompt block went further — "Keep searching until you have every fact the question needs before you answer." Neither had any relevance qualifier or stop condition. When a search returned unrelated low-score records (in #93485: a question about gold prices matching a memory about "Jinhe Bio-Engineering" on the single shared character 金, scores 0.25–0.55), the model's natural reading of its own instructions was "the wording was wrong — rephrase and search again". The result: 10+ consecutive mem0_search calls returning the same irrelevant records, surviving three explicit user interventions to stop.

The fix adds mirrored stop conditions at both sites:

- **Relevance stop**: as soon as the top results are unrelated or their scores are low, do NOT keep rephrasing and re-searching — answer from general knowledge, optionally noting that memory had nothing relevant.
- **User stop**: never call the tool again once the user asks to stop searching.

The multi-hop encouragement ("call it several times, vary the wording") is kept — it is correct when results ARE relevant; only the unbounded continuation is now bounded. Search behavior itself (backend call, scoring, payload) is untouched.

## Related Issue

Fixes #93485

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/mem0/__init__.py` — `SEARCH_SCHEMA` description and `system_prompt_block()`'s search paragraph each gain the two stop conditions (relevance stop + user stop); the unconditional "keep searching until you have every fact" imperative is removed.
- `tests/plugins/memory/test_mem0_v3.py` — `test_search_guidance_has_stop_conditions` pins both sites: the rephrase-stop and user-stop phrasing must be present in the system block and the tool description, and the old unbounded-continuation strings must be gone.

## How to Test

`pytest tests/plugins/memory/test_mem0_v3.py -q` — should pass (24 tests).

Observed result: with the fix, all 24 pass. With the plugin change stashed (fix reverted, test kept), `test_search_guidance_has_stop_conditions` fails — the stop phrasing is absent and the old "Keep searching until" imperative is still there, which is exactly the loop configuration from the issue. The 7 failures elsewhere in `tests/plugins/memory/` (hindsight/openviking providers) reproduce identically on unpatched main and are environment-local, unrelated to this change.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (none needed beyond the guidance text itself)
- [x] Tests added that prove the fix works
- [x] New and existing unit tests pass locally (mem0 suite 24/24)
- [x] Platform: macOS (pure guidance-text change, platform-independent)
