### PR TITLE
fix(retry): Z.AI coding overload backoff covers all GLM models, not just glm-5.2

### DIFF
--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -154,7 +154,7 @@ def is_zai_coding_overload_error(*, base_url: str | None, model: str | None, err
     return (
         status == 429
         and "api.z.ai/api/coding/paas/v4" in base
-        and "glm-5.2" in model_name
+        and model_name.startswith("glm-")
         and ("1305" in text or "temporarily overloaded" in text)
     )
 

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -113,6 +113,35 @@ def _zai_overload_error():
     )
 
 
+def test_zai_overload_matches_all_glm_coding_models():
+    """The overload backoff must fire for every GLM model on the coding-plan
+    endpoint, not just glm-5.2 — glm-5.3 fell through to the plain 429 path
+    (3 fast retries, dead in ~10s) while the provider overload lasted minutes.
+    """
+    from agent.retry_utils import is_zai_coding_overload_error
+
+    err = _zai_overload_error()
+    for model in ("glm-5.2", "glm-5.3", "glm-4.5", "glm-4.5-air"):
+        assert is_zai_coding_overload_error(
+            base_url="https://api.z.ai/api/coding/paas/v4",
+            model=model,
+            error=err,
+        ), f"overload handler missing for {model}"
+
+    # non-GLM models on the same endpoint keep the plain 429 path
+    assert not is_zai_coding_overload_error(
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        model="deepseek-v3",
+        error=err,
+    )
+    # GLM model on a different endpoint stays untouched
+    assert not is_zai_coding_overload_error(
+        base_url="https://openrouter.ai/api/v1",
+        model="glm-5.3",
+        error=err,
+    )
+
+
 
 
 


### PR DESCRIPTION
## Problem

Z.AI Coding Plan reports transient overload as HTTP 429 (body code 1305, "The service may be temporarily overloaded"). Hermes has a purpose-built adaptive backoff for this — short retries, then 30/60/90/120s long waits — but the matcher in `agent/retry_utils.py` required `"glm-5.2" in model_name`. Anyone on glm-5.3 (or any other GLM model) fell through to the generic 429 path: 3 retries in ~10 seconds, then the turn fails, while the overload lasts minutes. The long-backoff schedule was dead code for them.

Saw this live on 2026-08-24: glm-5.3 on the coding endpoint, two 429 bursts (code 1305), both ended in `API call failed after 3 retries` with waits of 2.5s/5s.

## Fix

Widen the model check from `"glm-5.2" in model_name` to `model_name.startswith("glm-")`. Scope unchanged otherwise: still requires the coding-plan base URL, status 429, and the 1305/overload text — ordinary quota/billing 429s still fail fast through the existing classifier.

## Testing

- Added `test_zai_overload_matches_all_glm_coding_models`: pins glm-5.2/5.3/4.5/4.5-air to the matcher, and pins the negatives (non-GLM model on the same endpoint, GLM on a different endpoint).
- `tests/test_retry_utils.py`: 12 passed (11 existing + 1 new).