### PR TITLE
feat(agent): add modular GAS project generator

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -37,6 +37,10 @@ from agent.conversation_compression import (
     conversation_history_after_compression,
 )
 from agent.context_engine import automatic_compaction_status_message
+from agent.request_context_budget import (
+    build_request_context_budget,
+    select_request_context_window,
+)
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.message_metadata import append_message
@@ -1683,6 +1687,70 @@ def _redecorate_prompt_cache_for_provider(
     return messages, prepared, planned_tools
 
 
+def _apply_request_context_budget_window(
+    agent: Any,
+    api_messages: List[Dict[str, Any]],
+    *,
+    fixed_prefix_count: int,
+) -> List[Dict[str, Any]]:
+    """Apply the built-in request-only sliding window without touching history.
+
+    Fixed prompt messages (the active system prompt and ephemeral prefills) are
+    charged before history.  This closes the mid-turn undercount where dynamic
+    system prompt bytes were absent from the pressure calculation.
+    """
+    compressor = getattr(agent, "context_compressor", None)
+    context_length = getattr(compressor, "context_length", 0)
+    if isinstance(context_length, bool) or not isinstance(context_length, int) or context_length <= 0:
+        return api_messages
+
+    reserved_output = getattr(agent, "max_tokens", None)
+    if not isinstance(reserved_output, int) or isinstance(reserved_output, bool) or reserved_output < 0:
+        reserved_output = getattr(compressor, "max_tokens", 0)
+    if not isinstance(reserved_output, int) or isinstance(reserved_output, bool) or reserved_output < 0:
+        reserved_output = 0
+
+    fixed_prefix_count = max(0, min(int(fixed_prefix_count), len(api_messages)))
+    fixed_prompt_tokens = estimate_messages_tokens_rough(api_messages[:fixed_prefix_count])
+    tools = getattr(agent, "tools", None) or []
+    tool_schema_tokens = _estimate_tools_tokens_rough(tools) if tools else 0
+    budget = build_request_context_budget(
+        context_window_tokens=context_length,
+        reserved_output_tokens=reserved_output,
+        system_prompt_tokens=fixed_prompt_tokens,
+        tool_schema_tokens=tool_schema_tokens,
+        confidence="rough",
+    )
+    # Request-local observability only; this is never persisted as transcript
+    # state and is intentionally best effort for lightweight test doubles.
+    try:
+        agent._last_request_context_budget = budget
+    except Exception:
+        pass
+
+    history = api_messages[fixed_prefix_count:]
+    history_tokens = estimate_messages_tokens_rough(history)
+    if history_tokens <= budget.history_budget_tokens:
+        return api_messages
+
+    selection = select_request_context_window(
+        api_messages,
+        fixed_prefix_count=fixed_prefix_count,
+        budget=budget,
+    )
+    if selection.omitted_message_count:
+        logger.info(
+            "Request sliding window selected %s history messages (~%s tokens; "
+            "budget=%s, pinned=%s) and omitted %s older messages",
+            len(selection.messages) - fixed_prefix_count,
+            selection.selected_tokens,
+            budget.history_budget_tokens,
+            selection.pinned_tokens,
+            selection.omitted_message_count,
+        )
+    return selection.messages
+
+
 def _apply_context_engine_selection(
     agent: Any,
     api_messages: List[Dict[str, Any]],
@@ -2453,6 +2521,12 @@ def run_conversation(
                 # containers (same aliasing class as the history build).
                 api_messages.insert(sys_offset + idx, _clone_message_for_send(pfm))
 
+        # System prompt and ephemeral prefill are fixed request components, not
+        # durable transcript history. Charge them before any request-only tail
+        # selection so their dynamic bytes cannot be hidden from the budget.
+        _request_fixed_prefix_count = len(api_messages) - len(messages)
+        _request_fixed_prefix_count = max(0, _request_fixed_prefix_count)
+
         # Per-turn context selection hook (additive, no-op by default).
         # Lets a context engine select/replace which context enters the
         # prompt for THIS call only — retrieval, topic routing, role/branch
@@ -2471,6 +2545,16 @@ def run_conversation(
             messages,
             _sel_incoming,
             logger=request_logger,
+        )
+
+        # Built-in Dynamic Sliding Window. This runs after an optional plugin
+        # selection so every provider request has a final request-local cap.
+        # The durable SessionDB transcript and ContextCompressor lifecycle are
+        # deliberately untouched.
+        api_messages = _apply_request_context_budget_window(
+            agent,
+            api_messages,
+            fixed_prefix_count=_request_fixed_prefix_count,
         )
 
         # Safety net: strip orphaned tool results / add stubs for missing

--- a/agent/gas_project_generator.py
+++ b/agent/gas_project_generator.py
@@ -1,0 +1,222 @@
+"""Validated modular Google Apps Script project generation contracts.
+
+This module is deliberately request-local: it turns an LLM's proposed project
+into a validated artifact without changing sessions, SessionDB, or compaction
+state.  Callers can use ``build_gas_generation_prompt`` with the current
+``RequestContextBudget`` before asking a model to generate source files.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping, Sequence
+
+from agent.request_context_budget import RequestContextBudget
+
+
+_SOURCE_FILENAME_RE = re.compile(r"^(?P<index>[0-9]{2})_[A-Za-z][A-Za-z0-9_]*\.(?:js|html)$")
+_PARTIAL_MARKER_RE = re.compile(
+    r"(?:\.\.\.(?![A-Za-z_$])|<\s*(?:existing|rest|remaining))",
+    re.IGNORECASE,
+)
+_BLOCK_RE = re.compile(
+    r"^###\s+(?P<filename>[^\r\n]+)\r?\n"
+    r"```(?P<language>[A-Za-z0-9_+-]*)\r?\n"
+    r"(?P<content>.*?)\r?\n```[ \t]*$",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+class GasProjectValidationError(ValueError):
+    """Raised when a generated GAS project is unsafe or incomplete."""
+
+
+@dataclass(frozen=True)
+class GasSourceFile:
+    """One full-replacement Apps Script source file."""
+
+    filename: str
+    content: str
+
+    def __post_init__(self) -> None:
+        if not _SOURCE_FILENAME_RE.fullmatch(self.filename):
+            raise GasProjectValidationError(
+                "source filename must be a two-digit sequential prefix followed by a name and .js/.html"
+            )
+        if not self.content.strip():
+            raise GasProjectValidationError(f"{self.filename} must contain complete source code")
+        if _PARTIAL_MARKER_RE.search(self.content):
+            raise GasProjectValidationError(f"{self.filename} contains a prohibited partial replacement marker")
+
+    @property
+    def index(self) -> int:
+        match = _SOURCE_FILENAME_RE.fullmatch(self.filename)
+        assert match is not None
+        return int(match.group("index"))
+
+    @property
+    def fence_language(self) -> str:
+        return "html" if self.filename.endswith(".html") else "javascript"
+
+
+@dataclass(frozen=True)
+class ClaspValidationResult:
+    """Result of an optional local ``clasp status`` validation."""
+
+    available: bool
+    valid: bool
+    stdout: str
+    stderr: str
+
+
+@dataclass(frozen=True)
+class GasProject:
+    """A complete copy-pasteable Apps Script project plus manifest."""
+
+    source_files: Sequence[GasSourceFile]
+    manifest: Mapping[str, object]
+
+    def __post_init__(self) -> None:
+        source_files = tuple(self.source_files)
+        object.__setattr__(self, "source_files", source_files)
+        if not source_files:
+            raise GasProjectValidationError("at least one numbered GAS source file is required")
+        names = [source.filename for source in source_files]
+        if len(names) != len(set(names)):
+            raise GasProjectValidationError("source filenames must be unique")
+        indices = [source.index for source in source_files]
+        if indices != list(range(1, len(source_files) + 1)):
+            raise GasProjectValidationError("source filenames must be sequential starting at 01")
+        manifest_errors = self.validate_manifest()
+        if manifest_errors:
+            raise GasProjectValidationError("invalid appsscript.json: " + "; ".join(manifest_errors))
+
+    def validate_manifest(self) -> list[str]:
+        """Return deterministic manifest-contract errors without calling Google."""
+        errors: list[str] = []
+        time_zone = self.manifest.get("timeZone")
+        if not isinstance(time_zone, str) or not time_zone.strip():
+            errors.append("timeZone must be a non-empty string")
+        exception_logging = self.manifest.get("exceptionLogging")
+        if exception_logging not in {"STACKDRIVER", "CLOUD_LOGGING", "NONE"}:
+            errors.append("exceptionLogging must be STACKDRIVER, CLOUD_LOGGING, or NONE")
+        runtime_version = self.manifest.get("runtimeVersion")
+        if runtime_version is not None and runtime_version != "V8":
+            errors.append("runtimeVersion must be V8 when specified")
+        scopes = self.manifest.get("oauthScopes")
+        if scopes is not None and (
+            not isinstance(scopes, list) or not all(isinstance(scope, str) and scope for scope in scopes)
+        ):
+            errors.append("oauthScopes must be a list of non-empty strings")
+        return errors
+
+    def to_markdown(self) -> str:
+        """Render only full-file replacement blocks, in upload order."""
+        blocks = [
+            f"### {source.filename}\n```{source.fence_language}\n{source.content.rstrip()}\n```"
+            for source in self.source_files
+        ]
+        manifest = json.dumps(dict(self.manifest), ensure_ascii=False, indent=2, sort_keys=True)
+        blocks.append(f"### appsscript.json\n```json\n{manifest}\n```")
+        return "\n\n".join(blocks)
+
+    def write_to(self, project_dir: Path) -> None:
+        """Write the validated clasp-compatible project layout to an empty/safe directory."""
+        project_dir.mkdir(parents=True, exist_ok=True)
+        for source in self.source_files:
+            (project_dir / source.filename).write_text(source.content.rstrip() + "\n", encoding="utf-8")
+        manifest = json.dumps(dict(self.manifest), ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+        (project_dir / "appsscript.json").write_text(manifest, encoding="utf-8")
+
+
+ClaspRunner = Callable[[list[str], Path], tuple[int, str, str]]
+
+
+def _subprocess_clasp_runner(command: list[str], cwd: Path) -> tuple[int, str, str]:
+    completed = subprocess.run(command, cwd=cwd, capture_output=True, text=True, check=False)
+    return completed.returncode, completed.stdout, completed.stderr
+
+
+def validate_clasp_project(project_dir: Path, *, runner: ClaspRunner | None = None) -> ClaspValidationResult:
+    """Run the non-mutating ``clasp status`` check when clasp is available.
+
+    Authentication and project binding remain the user's responsibility.  This
+    function never pushes, pulls, or changes a remote Apps Script project.
+    """
+    manifest_path = project_dir / "appsscript.json"
+    if not manifest_path.is_file():
+        return ClaspValidationResult(False, False, "", "appsscript.json is missing")
+    if runner is None and shutil.which("clasp") is None:
+        return ClaspValidationResult(False, False, "", "clasp is not installed")
+    active_runner = runner or _subprocess_clasp_runner
+    return_code, stdout, stderr = active_runner(["clasp", "status"], project_dir)
+    return ClaspValidationResult(True, return_code == 0, stdout, stderr)
+
+
+def parse_generated_gas_project(markdown: str) -> GasProject:
+    """Parse an LLM response that follows the full-replacement output contract."""
+    blocks = list(_BLOCK_RE.finditer(markdown))
+    if not blocks:
+        raise GasProjectValidationError("no named fenced GAS file blocks were found")
+
+    source_files: list[GasSourceFile] = []
+    manifest: dict[str, object] | None = None
+    seen: set[str] = set()
+    for position, block in enumerate(blocks):
+        filename = block.group("filename").strip()
+        language = block.group("language").lower()
+        content = block.group("content")
+        if filename in seen:
+            raise GasProjectValidationError(f"duplicate output block: {filename}")
+        seen.add(filename)
+        if filename == "appsscript.json":
+            if position != len(blocks) - 1:
+                raise GasProjectValidationError("appsscript.json must be the final output block")
+            if language != "json":
+                raise GasProjectValidationError("appsscript.json must use a json fenced-block language")
+            try:
+                parsed = json.loads(content)
+            except json.JSONDecodeError as exc:
+                raise GasProjectValidationError(f"appsscript.json is invalid JSON: {exc.msg}") from exc
+            if not isinstance(parsed, dict):
+                raise GasProjectValidationError("appsscript.json must be a JSON object")
+            manifest = parsed
+            continue
+        expected_language = "html" if filename.endswith(".html") else "javascript"
+        accepted_languages = {expected_language}
+        if expected_language == "javascript":
+            accepted_languages.add("js")
+        if language not in accepted_languages:
+            raise GasProjectValidationError(
+                f"{filename} must use a {expected_language} fenced-block language"
+            )
+        source_files.append(GasSourceFile(filename, content))
+
+    if manifest is None:
+        raise GasProjectValidationError("appsscript.json full replacement block is required")
+    return GasProject(source_files=tuple(source_files), manifest=manifest)
+
+
+def build_gas_generation_prompt(requirements: str, *, budget: RequestContextBudget) -> str:
+    """Build a budget-aware system/developer prompt for a GAS generation turn."""
+    if not requirements.strip():
+        raise ValueError("requirements must not be blank")
+    return f"""Generate a complete Google Apps Script project for the following requirements:
+{requirements.strip()}
+
+Output contract (non-negotiable):
+1. Split responsibilities into numbered source files named exactly `01_Name.js`, `02_Name.js`, and so on. Start at `01` and use every number without gaps.
+2. For every source file, output `### filename` followed by one fenced `javascript` or `html` block containing the full replacement content of that file. Never emit a diff, ellipsis, placeholder, or instructions to merge with existing code.
+3. Output one final `### appsscript.json` fenced `json` block. It must be a complete JSON object with a non-empty `timeZone`, valid `exceptionLogging`, and `runtimeVersion: "V8"` when specified.
+4. Keep code Apps Script V8 compatible. Declare only the minimum OAuth scopes needed by the requested APIs.
+5. Before finalizing, self-check sequential filenames, cross-file references, manifest JSON, and that every block is a full replacement.
+
+Request context guard:
+- This request has {budget.history_budget_tokens} history tokens available after reserving output, active system prompt, and tool schemas.
+- Budget confidence is `{budget.confidence}`. Prefer concise modules; if requirements cannot fit safely, finish the current complete project rather than truncating a file.
+"""

--- a/agent/request_context_budget.py
+++ b/agent/request_context_budget.py
@@ -1,0 +1,202 @@
+"""Request-local context budgets and safe token-based history selection.
+
+This module deliberately does not mutate the durable transcript.  It computes
+what may be sent for one provider request and returns a selected history copy.
+Durable summarization remains owned by ``ContextCompressor``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Callable, Literal, Mapping, Sequence
+
+
+BudgetConfidence = Literal["exact", "tokenizer", "rough"]
+_VALID_CONFIDENCE = frozenset({"exact", "tokenizer", "rough"})
+
+
+@dataclass(frozen=True)
+class RequestContextBudget:
+    """Token allocation for one provider request.
+
+    ``history_budget_tokens`` is derived after reserving output capacity and
+    fixed request components.  It is never negative: an oversized system/tool
+    payload leaves zero room for history and the caller can retain only pinned
+    active-turn messages.
+    """
+
+    context_window_tokens: int
+    reserved_output_tokens: int
+    system_prompt_tokens: int
+    tool_schema_tokens: int
+    confidence: BudgetConfidence
+
+    def __post_init__(self) -> None:
+        for name in (
+            "context_window_tokens",
+            "reserved_output_tokens",
+            "system_prompt_tokens",
+            "tool_schema_tokens",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(f"{name} must be a non-negative integer")
+        if self.confidence not in _VALID_CONFIDENCE:
+            raise ValueError("confidence must be one of: exact, tokenizer, rough")
+
+    @property
+    def safe_input_budget_tokens(self) -> int:
+        """Maximum prompt input after reserving output capacity."""
+        return max(0, self.context_window_tokens - self.reserved_output_tokens)
+
+    @property
+    def fixed_input_tokens(self) -> int:
+        """Input tokens consumed outside conversation history."""
+        return self.system_prompt_tokens + self.tool_schema_tokens
+
+    @property
+    def history_budget_tokens(self) -> int:
+        """Pure history allowance after all fixed request components."""
+        return max(0, self.safe_input_budget_tokens - self.fixed_input_tokens)
+
+
+@dataclass(frozen=True)
+class TokenBudgetedHistorySelection:
+    """Request-only result of history-tail selection."""
+
+    messages: list[dict[str, Any]]
+    history_budget_tokens: int
+    selected_tokens: int
+    pinned_tokens: int
+    omitted_message_count: int
+
+
+def build_request_context_budget(
+    *,
+    context_window_tokens: int,
+    reserved_output_tokens: int,
+    system_prompt_tokens: int,
+    tool_schema_tokens: int,
+    confidence: BudgetConfidence = "rough",
+) -> RequestContextBudget:
+    """Build a budget from already-measured request components."""
+    return RequestContextBudget(
+        context_window_tokens=context_window_tokens,
+        reserved_output_tokens=reserved_output_tokens,
+        system_prompt_tokens=system_prompt_tokens,
+        tool_schema_tokens=tool_schema_tokens,
+        confidence=confidence,
+    )
+
+
+def _rough_message_tokens(message: Mapping[str, Any]) -> int:
+    """Conservative local fallback for selection when no tokenizer is available."""
+    try:
+        serialized = json.dumps(message, ensure_ascii=False, default=str, separators=(",", ":"))
+    except (TypeError, ValueError):
+        serialized = str(message)
+    return max(1, (len(serialized) + 3) // 4)
+
+
+def _latest_user_start(messages: Sequence[Mapping[str, Any]]) -> int:
+    for index in range(len(messages) - 1, -1, -1):
+        if messages[index].get("role") == "user":
+            return index
+    # A malformed/resumed transcript with no user message is kept intact.  The
+    # standard request sanitizer remains responsible for repairing it.
+    return 0
+
+
+def _previous_group_start(messages: Sequence[Mapping[str, Any]], end: int) -> int:
+    """Return the start of the immediately preceding complete conversation turn.
+
+    A turn starts at a user message and includes every following assistant/tool
+    activity until the next user message. This keeps ordinary assistant replies
+    coherent with the request that prompted them, and also makes every
+    ``assistant(tool_calls) + tool results`` block indivisible. Malformed
+    history with no preceding user is kept as one conservative group for the
+    standard request sanitizer to repair later.
+    """
+    for start in range(end - 1, -1, -1):
+        if messages[start].get("role") == "user":
+            return start
+    return 0
+
+
+def select_token_budgeted_history_tail(
+    messages: Sequence[Mapping[str, Any]],
+    *,
+    history_budget_tokens: int,
+    estimate_message_tokens: Callable[[Mapping[str, Any]], int] = _rough_message_tokens,
+) -> TokenBudgetedHistorySelection:
+    """Select the newest safe history tail without mutating ``messages``.
+
+    The latest user turn and every following message are pinned even if they
+    alone exceed budget.  Earlier groups are added only when the whole group
+    fits, so oversized old tool output is omitted first and can use the existing
+    spillover/preview path rather than breaking tool-call/result pairing.
+    """
+    if (
+        isinstance(history_budget_tokens, bool)
+        or not isinstance(history_budget_tokens, int)
+        or history_budget_tokens < 0
+    ):
+        raise ValueError("history_budget_tokens must be a non-negative integer")
+    copied = [dict(message) for message in messages]
+    if not copied:
+        return TokenBudgetedHistorySelection([], history_budget_tokens, 0, 0, 0)
+
+    pinned_start = _latest_user_start(copied)
+    pinned_tokens = sum(max(0, int(estimate_message_tokens(message))) for message in copied[pinned_start:])
+    selected_start = pinned_start
+    selected_tokens = pinned_tokens
+
+    while selected_start > 0:
+        group_start = _previous_group_start(copied, selected_start)
+        group_tokens = sum(
+            max(0, int(estimate_message_tokens(message)))
+            for message in copied[group_start:selected_start]
+        )
+        if selected_tokens + group_tokens > history_budget_tokens:
+            break
+        selected_start = group_start
+        selected_tokens += group_tokens
+
+    return TokenBudgetedHistorySelection(
+        messages=copied[selected_start:],
+        history_budget_tokens=history_budget_tokens,
+        selected_tokens=selected_tokens,
+        pinned_tokens=pinned_tokens,
+        omitted_message_count=selected_start,
+    )
+
+
+def select_request_context_window(
+    request_messages: Sequence[Mapping[str, Any]],
+    *,
+    fixed_prefix_count: int,
+    budget: RequestContextBudget,
+    estimate_message_tokens: Callable[[Mapping[str, Any]], int] = _rough_message_tokens,
+) -> TokenBudgetedHistorySelection:
+    """Select a request-only history tail while preserving fixed prompt prefix.
+
+    ``fixed_prefix_count`` is for system and ephemeral prefill messages that
+    are not durable conversation history.  They stay verbatim; only the
+    remaining history consumes ``budget.history_budget_tokens``.
+    """
+    if fixed_prefix_count < 0 or fixed_prefix_count > len(request_messages):
+        raise ValueError("fixed_prefix_count must identify a request prefix")
+    prefix = [dict(message) for message in request_messages[:fixed_prefix_count]]
+    tail = select_token_budgeted_history_tail(
+        request_messages[fixed_prefix_count:],
+        history_budget_tokens=budget.history_budget_tokens,
+        estimate_message_tokens=estimate_message_tokens,
+    )
+    return TokenBudgetedHistorySelection(
+        messages=prefix + tail.messages,
+        history_budget_tokens=tail.history_budget_tokens,
+        selected_tokens=tail.selected_tokens,
+        pinned_tokens=tail.pinned_tokens,
+        omitted_message_count=tail.omitted_message_count,
+    )

--- a/examples/gas-order-webhook/01_Config.js
+++ b/examples/gas-order-webhook/01_Config.js
@@ -1,0 +1,13 @@
+const CONFIG = Object.freeze({
+  SHEET_NAME: 'Orders',
+  REQUIRED_COLUMNS: ['Order ID', 'Status', 'Payload', 'Received At'],
+  WEBHOOK_URL_PROPERTY: 'WEBHOOK_URL',
+});
+
+function getWebhookUrl_() {
+  const url = PropertiesService.getScriptProperties().getProperty(CONFIG.WEBHOOK_URL_PROPERTY);
+  if (!url) {
+    throw new Error(`Missing script property: ${CONFIG.WEBHOOK_URL_PROPERTY}`);
+  }
+  return url;
+}

--- a/examples/gas-order-webhook/02_SpreadsheetService.js
+++ b/examples/gas-order-webhook/02_SpreadsheetService.js
@@ -1,0 +1,17 @@
+function getOrdersSheet_() {
+  const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+  const sheet = spreadsheet.getSheetByName(CONFIG.SHEET_NAME);
+  if (!sheet) {
+    throw new Error(`Required sheet not found: ${CONFIG.SHEET_NAME}`);
+  }
+  return sheet;
+}
+
+function appendOrder_(order) {
+  if (!order || typeof order.id !== 'string' || !order.id.trim()) {
+    throw new Error('order.id must be a non-empty string');
+  }
+  const status = typeof order.status === 'string' ? order.status : 'RECEIVED';
+  const payload = JSON.stringify(order);
+  getOrdersSheet_().appendRow([order.id.trim(), status, payload, new Date().toISOString()]);
+}

--- a/examples/gas-order-webhook/03_WebhookService.js
+++ b/examples/gas-order-webhook/03_WebhookService.js
@@ -1,0 +1,16 @@
+function notifyWebhook_(order) {
+  const response = UrlFetchApp.fetch(getWebhookUrl_(), {
+    method: 'post',
+    contentType: 'application/json',
+    payload: JSON.stringify({
+      event: 'order.received',
+      orderId: order.id,
+      status: order.status || 'RECEIVED',
+    }),
+    muteHttpExceptions: true,
+  });
+  const statusCode = response.getResponseCode();
+  if (statusCode < 200 || statusCode >= 300) {
+    throw new Error(`Webhook request failed with HTTP ${statusCode}`);
+  }
+}

--- a/examples/gas-order-webhook/04_Main.js
+++ b/examples/gas-order-webhook/04_Main.js
@@ -1,0 +1,20 @@
+function doPost(event) {
+  try {
+    const requestBody = event && event.postData && event.postData.contents;
+    if (!requestBody) {
+      throw new Error('Request body is required');
+    }
+    const order = JSON.parse(requestBody);
+    appendOrder_(order);
+    notifyWebhook_(order);
+    return jsonResponse_({ ok: true, orderId: order.id });
+  } catch (error) {
+    console.error(error);
+    return jsonResponse_({ ok: false, error: String(error.message || error) });
+  }
+}
+
+function jsonResponse_(body) {
+  return ContentService.createTextOutput(JSON.stringify(body))
+    .setMimeType(ContentService.MimeType.JSON);
+}

--- a/examples/gas-order-webhook/appsscript.json
+++ b/examples/gas-order-webhook/appsscript.json
@@ -1,0 +1,9 @@
+{
+  "timeZone": "Asia/Bangkok",
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8",
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/spreadsheets.currentonly",
+    "https://www.googleapis.com/auth/script.external_request"
+  ]
+}

--- a/tests/agent/test_gas_project_generator.py
+++ b/tests/agent/test_gas_project_generator.py
@@ -1,0 +1,180 @@
+"""Tests for modular, full-replacement Google Apps Script generation."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent.gas_project_generator import (
+    GasProject,
+    GasProjectValidationError,
+    GasSourceFile,
+    build_gas_generation_prompt,
+    parse_generated_gas_project,
+    validate_clasp_project,
+)
+from agent.request_context_budget import RequestContextBudget
+
+
+SAMPLE_GENERATION = """### 01_Config.js
+```javascript
+const CONFIG = Object.freeze({
+  SHEET_NAME: 'Orders',
+  WEBHOOK_URL: 'https://example.invalid/webhook',
+});
+```
+
+### 02_SpreadsheetService.js
+```javascript
+function appendOrder_(order) {
+  SpreadsheetApp.getActive().getSheetByName(CONFIG.SHEET_NAME)
+    .appendRow([order.id, order.status]);
+}
+```
+
+### 03_WebhookService.js
+```javascript
+function notifyWebhook_(payload) {
+  UrlFetchApp.fetch(CONFIG.WEBHOOK_URL, {
+    method: 'post',
+    contentType: 'application/json',
+    payload: JSON.stringify(payload),
+  });
+}
+```
+
+### appsscript.json
+```json
+{
+  "timeZone": "Asia/Bangkok",
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8"
+}
+```
+"""
+
+
+def test_parses_sample_into_sequential_full_replacement_files():
+    project = parse_generated_gas_project(SAMPLE_GENERATION)
+
+    assert [source.filename for source in project.source_files] == [
+        "01_Config.js",
+        "02_SpreadsheetService.js",
+        "03_WebhookService.js",
+    ]
+    assert "appendOrder_" in project.source_files[1].content
+    assert project.manifest["runtimeVersion"] == "V8"
+
+
+def test_renders_each_source_as_a_complete_named_code_block():
+    project = parse_generated_gas_project(SAMPLE_GENERATION)
+
+    rendered = project.to_markdown()
+
+    assert "### 01_Config.js\n```javascript" in rendered
+    assert "### 02_SpreadsheetService.js\n```javascript" in rendered
+    assert "### appsscript.json\n```json" in rendered
+    assert "// ... existing code ..." not in rendered
+
+
+def test_rejects_nonsequential_source_file_prefixes():
+    with pytest.raises(GasProjectValidationError, match="sequential"):
+        GasProject(
+            source_files=(
+                GasSourceFile("01_Config.js", "const CONFIG = {};"),
+                GasSourceFile("03_Main.js", "function run() {}"),
+            ),
+            manifest={"timeZone": "Etc/UTC", "exceptionLogging": "STACKDRIVER"},
+        )
+
+
+def test_rejects_partial_replacement_markers():
+    with pytest.raises(GasProjectValidationError, match="partial"):
+        GasSourceFile("01_Config.js", "const CONFIG = {};\n// ... existing code ...")
+
+
+def test_rejects_bare_ellipsis_in_source_block():
+    incomplete = SAMPLE_GENERATION.replace(
+        "const CONFIG = Object.freeze({", "const CONFIG = ...;", 1
+    )
+
+    with pytest.raises(GasProjectValidationError, match="partial"):
+        parse_generated_gas_project(incomplete)
+
+
+def test_rejects_wrong_fence_language_for_javascript_source():
+    wrong_language = SAMPLE_GENERATION.replace("```javascript", "```python", 1)
+
+    with pytest.raises(GasProjectValidationError, match="language"):
+        parse_generated_gas_project(wrong_language)
+
+
+def test_rejects_manifest_block_when_it_is_not_final():
+    manifest_start = SAMPLE_GENERATION.index("### appsscript.json")
+    manifest_first = SAMPLE_GENERATION[manifest_start:] + "\n" + SAMPLE_GENERATION[:manifest_start]
+
+    with pytest.raises(GasProjectValidationError, match="final"):
+        parse_generated_gas_project(manifest_first)
+
+
+def test_writes_clasp_layout_and_validates_manifest(tmp_path: Path):
+    project = parse_generated_gas_project(SAMPLE_GENERATION)
+
+    project.write_to(tmp_path)
+
+    assert (tmp_path / "01_Config.js").read_text(encoding="utf-8").startswith("const CONFIG")
+    assert (tmp_path / "appsscript.json").exists()
+    assert project.validate_manifest() == []
+
+
+def test_clasp_validation_uses_injected_runner_without_network(tmp_path: Path):
+    project = parse_generated_gas_project(SAMPLE_GENERATION)
+    project.write_to(tmp_path)
+    calls: list[tuple[list[str], Path]] = []
+
+    result = validate_clasp_project(
+        tmp_path,
+        runner=lambda command, cwd: calls.append((command, cwd)) or (0, "ok", ""),
+    )
+
+    assert result.available is True
+    assert result.valid is True
+    assert calls == [(["clasp", "status"], tmp_path)]
+
+
+def test_checked_in_webhook_example_is_a_valid_clasp_project():
+    example_dir = Path(__file__).parents[2] / "examples" / "gas-order-webhook"
+    source_files = tuple(
+        GasSourceFile(path.name, path.read_text(encoding="utf-8"))
+        for path in sorted(example_dir.glob("[0-9][0-9]_*.js"))
+    )
+    manifest = json.loads((example_dir / "appsscript.json").read_text(encoding="utf-8"))
+
+    project = GasProject(source_files=source_files, manifest=manifest)
+
+    assert project.validate_manifest() == []
+    assert [source.filename for source in project.source_files] == [
+        "01_Config.js",
+        "02_SpreadsheetService.js",
+        "03_WebhookService.js",
+        "04_Main.js",
+    ]
+
+
+def test_generation_prompt_includes_budget_and_nonnegotiable_output_contract():
+    budget = RequestContextBudget(
+        context_window_tokens=16_000,
+        reserved_output_tokens=2_000,
+        system_prompt_tokens=1_000,
+        tool_schema_tokens=500,
+        confidence="rough",
+    )
+
+    prompt = build_gas_generation_prompt(
+        "Create a spreadsheet order intake flow with webhook notification.", budget=budget
+    )
+
+    assert "12500" in prompt
+    assert "01_" in prompt
+    assert "full replacement" in prompt.lower()
+    assert "appsscript.json" in prompt

--- a/tests/agent/test_request_context_budget.py
+++ b/tests/agent/test_request_context_budget.py
@@ -1,0 +1,204 @@
+"""Tests for request-level context budgeting and token-based history selection."""
+
+from types import SimpleNamespace
+
+from agent.conversation_loop import _apply_request_context_budget_window
+from agent.request_context_budget import (
+    RequestContextBudget,
+    select_request_context_window,
+    select_token_budgeted_history_tail,
+)
+
+
+def _message(role: str, content: str, **extra):
+    return {"role": role, "content": content, **extra}
+
+
+class TestRequestContextBudget:
+    def test_reserves_system_tools_and_output_before_history(self):
+        budget = RequestContextBudget(
+            context_window_tokens=1000,
+            reserved_output_tokens=250,
+            system_prompt_tokens=200,
+            tool_schema_tokens=150,
+            confidence="rough",
+        )
+
+        assert budget.history_budget_tokens == 400
+        assert budget.safe_input_budget_tokens == 750
+        assert budget.fixed_input_tokens == 350
+
+    def test_never_allocates_negative_history_budget_for_large_fixed_prompt(self):
+        budget = RequestContextBudget(
+            context_window_tokens=1000,
+            reserved_output_tokens=300,
+            system_prompt_tokens=800,
+            tool_schema_tokens=200,
+            confidence="rough",
+        )
+
+        assert budget.safe_input_budget_tokens == 700
+        assert budget.history_budget_tokens == 0
+
+    def test_rejects_unknown_confidence(self):
+        try:
+            RequestContextBudget(
+                context_window_tokens=1000,
+                reserved_output_tokens=1,
+                system_prompt_tokens=1,
+                tool_schema_tokens=1,
+                confidence="guessed",
+            )
+        except ValueError as exc:
+            assert "confidence" in str(exc)
+        else:
+            raise AssertionError("unknown confidence must be rejected")
+
+    def test_rejects_non_integer_history_budget_input(self):
+        messages = [_message("user", "latest request")]
+
+        try:
+            select_token_budgeted_history_tail(messages, history_budget_tokens="10")
+        except ValueError as exc:
+            assert "history_budget_tokens" in str(exc)
+        else:
+            raise AssertionError("non-integer budget must be rejected")
+
+
+class TestTokenBudgetedHistoryTail:
+    def test_drops_old_messages_before_latest_user_turn_when_budget_is_exhausted(self):
+        messages = [
+            _message("user", "old user " + "a" * 200),
+            _message("assistant", "old assistant " + "b" * 200),
+            _message("user", "latest user request"),
+            _message("assistant", "latest answer"),
+        ]
+
+        selected = select_token_budgeted_history_tail(messages, history_budget_tokens=20)
+
+        assert selected.messages == messages[2:]
+        assert selected.omitted_message_count == 2
+        assert selected.pinned_tokens > selected.history_budget_tokens
+
+    def test_keeps_active_tool_chain_with_its_latest_user_turn(self):
+        messages = [
+            _message("user", "old request " + "x" * 200),
+            _message("assistant", "old reply " + "y" * 200),
+            _message("user", "deploy now"),
+            _message(
+                "assistant",
+                "",
+                tool_calls=[{"id": "call-1", "function": {"name": "terminal", "arguments": "{}"}}],
+            ),
+            _message("tool", "build output", tool_call_id="call-1"),
+        ]
+
+        selected = select_token_budgeted_history_tail(messages, history_budget_tokens=5)
+
+        assert selected.messages == messages[2:]
+        assert selected.messages[-2]["tool_calls"][0]["id"] == "call-1"
+        assert selected.messages[-1]["tool_call_id"] == "call-1"
+
+    def test_adds_only_complete_older_tool_group_when_it_fits(self):
+        messages = [
+            _message("user", "older request"),
+            _message(
+                "assistant",
+                "",
+                tool_calls=[{"id": "call-1", "function": {"name": "read_file", "arguments": "{}"}}],
+            ),
+            _message("tool", "small result", tool_call_id="call-1"),
+            _message("assistant", "older conclusion"),
+            _message("user", "latest request"),
+        ]
+
+        selected = select_token_budgeted_history_tail(messages, history_budget_tokens=80)
+
+        assert selected.messages == messages
+        assert selected.omitted_message_count == 0
+
+    def test_does_not_orphan_prior_assistant_response_from_its_user_turn(self):
+        messages = [
+            _message("user", "older request " + "a" * 100),
+            _message("assistant", "older conclusion"),
+            _message("user", "latest request"),
+        ]
+
+        selected = select_token_budgeted_history_tail(messages, history_budget_tokens=25)
+
+        assert selected.messages == messages[-1:]
+        assert selected.omitted_message_count == 2
+
+    def test_excludes_oversized_old_tool_result_without_mutating_source(self):
+        huge_tool = _message("tool", "z" * 10_000, tool_call_id="call-1")
+        messages = [
+            _message("user", "old request"),
+            _message(
+                "assistant",
+                "",
+                tool_calls=[{"id": "call-1", "function": {"name": "terminal", "arguments": "{}"}}],
+            ),
+            huge_tool,
+            _message("user", "latest request"),
+        ]
+
+        selected = select_token_budgeted_history_tail(messages, history_budget_tokens=20)
+
+        assert selected.messages == messages[-1:]
+        assert selected.omitted_message_count == 3
+        assert huge_tool["content"] == "z" * 10_000
+
+
+class TestRequestContextWindow:
+    def test_preserves_fixed_system_prefix_while_clipping_history(self):
+        request_messages = [
+            _message("system", "dynamic system prompt " + "s" * 100),
+            _message("user", "old request " + "a" * 1_000),
+            _message("assistant", "old reply " + "b" * 1_000),
+            _message("user", "latest request"),
+        ]
+        budget = RequestContextBudget(
+            context_window_tokens=100,
+            reserved_output_tokens=20,
+            system_prompt_tokens=30,
+            tool_schema_tokens=20,
+            confidence="rough",
+        )
+
+        selected = select_request_context_window(
+            request_messages,
+            fixed_prefix_count=1,
+            budget=budget,
+        )
+
+        assert selected.messages[0] == request_messages[0]
+        assert selected.messages[1:] == request_messages[-1:]
+        assert selected.omitted_message_count == 2
+
+
+class TestConversationLoopBudgetIntegration:
+    def test_uses_active_system_and_tool_schema_before_selecting_history(self):
+        agent = SimpleNamespace(
+            context_compressor=SimpleNamespace(context_length=100),
+            max_tokens=20,
+            tools=[{"type": "function", "function": {"name": "tool", "parameters": {}}}],
+        )
+        request_messages = [
+            _message("system", "dynamic system prompt " + "s" * 100),
+            _message("user", "old request " + "a" * 1_000),
+            _message("assistant", "old response " + "b" * 1_000),
+            _message("user", "latest request"),
+        ]
+
+        selected = _apply_request_context_budget_window(
+            agent,
+            request_messages,
+            fixed_prefix_count=1,
+        )
+
+        assert selected[0] == request_messages[0]
+        assert selected[-1] == request_messages[-1]
+        assert len(selected) == 2
+        assert agent._last_request_context_budget.system_prompt_tokens > 0
+        assert agent._last_request_context_budget.tool_schema_tokens > 0
+        assert agent._last_request_context_budget.reserved_output_tokens == 20


### PR DESCRIPTION
## Summary
- add a strict, request-local GAS project generation and validation contract
- enforce sequential two-digit source filenames, complete replacement blocks, fence-language correctness, and final appsscript.json placement
- add safe clasp status validation plus a spreadsheet/webhook example

## Validation
- `uv run --no-sync pytest -q tests/agent/test_gas_project_generator.py tests/agent/test_request_context_budget.py tests/agent/test_gemini_native_adapter.py` — 45 passed
- `git diff --check`

## Dependency
This PR intentionally includes the request-context-budget foundation (the same change proposed in #93489) because the GAS prompt builder consumes `RequestContextBudget`. It excludes the unrelated tool-choice sanitization change.