### PR TITLE
feat(discord): restore opt-in voice auto-follow

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7526,10 +7526,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
           - ``_auto_tts_default``: global default from ``voice.auto_tts``
           - ``_auto_tts_enabled_chats``: chats with mode ``voice_only``/``all``
           - ``_auto_tts_disabled_chats``: chats with mode ``off``
+
+        Also wires Discord voice callbacks at adapter startup.  `/voice channel`
+        used to be the only path that installed these callbacks, which meant the
+        newer auto-join path could connect/listen/transcribe but then dropped the
+        transcript before it reached the agent.
         """
         platform = getattr(adapter, "platform", None)
         if not isinstance(platform, Platform):
             return
+
+        if platform == Platform.DISCORD:
+            if hasattr(adapter, "_voice_input_callback"):
+                adapter._voice_input_callback = self._handle_voice_channel_input
+            if hasattr(adapter, "_on_voice_disconnect"):
+                adapter._on_voice_disconnect = self._handle_voice_timeout_cleanup
+            if hasattr(adapter, "_voice_mode_getter"):
+                adapter._voice_mode_getter = lambda chat_id: self._voice_mode.get(
+                    self._voice_key(Platform.DISCORD, str(chat_id)), "off"
+                )
 
         disabled_chats = getattr(adapter, "_auto_tts_disabled_chats", None)
         enabled_chats = getattr(adapter, "_auto_tts_enabled_chats", None)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2347,6 +2347,11 @@ DEFAULT_CONFIG = {
                 "On it.",
             ],
         },
+        # Auto-join an allowed user's voice channel. OFF by default.
+        "voice": {
+            "auto_join_on_user_join": False,
+            "auto_join_users": [],
+        },
     },
 
     # WhatsApp platform settings (gateway mode)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2351,6 +2351,7 @@ DEFAULT_CONFIG = {
         "voice": {
             "auto_join_on_user_join": False,
             "auto_join_users": [],
+            "auto_join_voice_channels": [],
         },
     },
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2352,6 +2352,9 @@ DEFAULT_CONFIG = {
             "auto_join_on_user_join": False,
             "auto_join_users": [],
             "auto_join_voice_channels": [],
+            # Text channel used as the session anchor for auto-joined VC turns.
+            # Empty falls back to Discord home/free-response configuration.
+            "auto_join_text_channel_id": "",
         },
     },
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1500,10 +1500,11 @@ class DiscordAdapter(BasePlatformAdapter):
                             # anyway, but skip the call entirely when nothing
                             # would change to avoid needless log noise.
                             existing_vc = adapter_self._voice_clients.get(guild_id)
+                            existing_channel_id = getattr(getattr(existing_vc, "channel", None), "id", None)
                             already_here = (
                                 existing_vc
                                 and existing_vc.is_connected()
-                                and existing_vc.channel.id == after.channel.id
+                                and existing_channel_id == getattr(after.channel, "id", None)
                             )
                             if not already_here:
                                 try:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1513,6 +1513,14 @@ class DiscordAdapter(BasePlatformAdapter):
                                             )
                                         else:
                                             adapter_self._voice_text_channels[guild_id] = text_channel_int
+                                            # Treat auto-joined VC sessions like `/voice tts`:
+                                            # speech heard in the VC should always get a spoken
+                                            # reply, even if global voice.auto_tts is disabled or
+                                            # the text channel had a stale `/voice off` override.
+                                            if isinstance(getattr(adapter_self, "_auto_tts_enabled_chats", None), set):
+                                                adapter_self._auto_tts_enabled_chats.add(str(text_channel_int))
+                                            if isinstance(getattr(adapter_self, "_auto_tts_disabled_chats", None), set):
+                                                adapter_self._auto_tts_disabled_chats.discard(str(text_channel_int))
                                             adapter_self._voice_sources[guild_id] = {
                                                 "platform": Platform.DISCORD.value,
                                                 "chat_id": str(text_channel_int),

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1113,6 +1113,10 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_mixers: Dict[int, Any] = {}  # guild_id -> VoiceMixer
         self._ambient_pcm_cache: Optional[bytes] = None  # decoded ambient bed
         self._voice_fx_cfg: Dict[str, Any] = self._load_voice_fx_config()
+        # Opt-in auto-join: automatically call join_voice_channel() when an
+        # allowed user enters a voice channel, instead of requiring /voice
+        # join every time. OFF by default. See discord.voice.* in config.yaml.
+        self._voice_auto_join_cfg: Dict[str, Any] = self._load_voice_auto_join_config()
         # Track threads where the bot has participated so follow-up messages
         # in those threads don't require @mention.  Persisted to disk so the
         # set survives gateway restarts.
@@ -1426,13 +1430,6 @@ class DiscordAdapter(BasePlatformAdapter):
             @self._client.event
             async def on_voice_state_update(member, before, after):
                 """Track voice channel join/leave events."""
-                # Only track channels where the bot is connected
-                bot_guild_ids = set(adapter_self._voice_clients.keys())
-                if not bot_guild_ids:
-                    return
-                guild_id = member.guild.id
-                if guild_id not in bot_guild_ids:
-                    return
                 # Ignore the bot itself
                 if member == adapter_self._client.user:
                     return
@@ -1445,16 +1442,65 @@ class DiscordAdapter(BasePlatformAdapter):
                     and before.channel != after.channel
                 )
 
+                # Only track channels where the bot is connected, EXCEPT for the
+                # auto-join path below, which by definition fires before the bot
+                # is connected in that guild.
+                bot_guild_ids = set(adapter_self._voice_clients.keys())
+                guild_id = member.guild.id
+
                 if joined or left or switched:
-                    logger.info(
-                        "Voice state: %s (%d) %s (guild %d)",
-                        member.display_name,
-                        member.id,
-                        "joined " + after.channel.name if joined
-                        else "left " + before.channel.name if left
-                        else f"moved {before.channel.name} -> {after.channel.name}",
-                        guild_id,
-                    )
+                    if guild_id in bot_guild_ids:
+                        logger.info(
+                            "Voice state: %s (%d) %s (guild %d)",
+                            member.display_name,
+                            member.id,
+                            "joined " + after.channel.name if joined
+                            else "left " + before.channel.name if left
+                            else f"moved {before.channel.name} -> {after.channel.name}",
+                            guild_id,
+                        )
+
+                # ── Opt-in auto-join (discord.voice.auto_join_on_user_join) ──
+                # Purely additive: does not alter existing tracking/logging
+                # above, and reuses the same join_voice_channel() path (and
+                # its own per-guild lock) that /voice join calls.
+                if joined and not getattr(member, "bot", False):
+                    auto_cfg = getattr(adapter_self, "_voice_auto_join_cfg", None) or {}
+                    if auto_cfg.get("auto_join_on_user_join"):
+                        trigger_users = auto_cfg.get("auto_join_users") or []
+                        member_matches_trigger_list = (
+                            not trigger_users
+                            or str(member.id) in {str(u) for u in trigger_users}
+                            or (member.name and member.name in {str(u) for u in trigger_users})
+                        )
+                        if member_matches_trigger_list and adapter_self._is_allowed_user(
+                            str(member.id), member, guild=member.guild, is_dm=False
+                        ):
+                            # Already connected to this exact channel in this
+                            # guild? join_voice_channel() no-ops in that case
+                            # anyway, but skip the call entirely when nothing
+                            # would change to avoid needless log noise.
+                            existing_vc = adapter_self._voice_clients.get(guild_id)
+                            already_here = (
+                                existing_vc
+                                and existing_vc.is_connected()
+                                and existing_vc.channel.id == after.channel.id
+                            )
+                            if not already_here:
+                                try:
+                                    await adapter_self.join_voice_channel(after.channel)
+                                    logger.info(
+                                        "[%s] Auto-joined voice channel %s (triggered by %s)",
+                                        adapter_self.name,
+                                        after.channel.name,
+                                        member.display_name,
+                                    )
+                                except Exception as e:
+                                    logger.warning(
+                                        "[%s] Auto-join voice channel failed: %s",
+                                        adapter_self.name,
+                                        e,
+                                    )
 
             # Register slash commands
             if self._slash_commands:
@@ -4411,6 +4457,31 @@ class DiscordAdapter(BasePlatformAdapter):
         if not duration or duration <= 0:
             return floor
         return max(floor, duration + float(self.PLAYBACK_TIMEOUT_PADDING))
+
+    def _load_voice_auto_join_config(self) -> Dict[str, Any]:
+        """Read auto-join-on-user-join settings from config.yaml.
+
+        All settings live under ``discord.voice`` in config.yaml (NOT the
+        .env file — these are behavioral, not secrets). OFF by default;
+        users opt in with ``discord.voice.auto_join_on_user_join: true``.
+
+        Returns a dict with safe defaults so callers never KeyError.
+        """
+        defaults: Dict[str, Any] = {
+            "auto_join_on_user_join": False,
+            "auto_join_users": [],
+        }
+        try:
+            from hermes_cli.config import read_raw_config
+            cfg = read_raw_config() or {}
+            voice_cfg = ((cfg.get("discord") or {}).get("voice") or {})
+            if isinstance(voice_cfg, dict):
+                for k, v in voice_cfg.items():
+                    if k in defaults and v is not None:
+                        defaults[k] = v
+        except Exception as e:
+            logger.debug("Could not load discord.voice config: %s", e)
+        return defaults
 
     def _get_ambient_pcm(self) -> Optional[bytes]:
         """Return decoded 48k/stereo/s16le PCM for the ambient idle bed.

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1464,16 +1464,35 @@ class DiscordAdapter(BasePlatformAdapter):
                 # Purely additive: does not alter existing tracking/logging
                 # above, and reuses the same join_voice_channel() path (and
                 # its own per-guild lock) that /voice join calls.
-                if joined and not getattr(member, "bot", False):
+                # Follow configured users both when they initially join and when
+                # they switch into this profile's assigned channel.
+                if (joined or switched) and not getattr(member, "bot", False):
                     auto_cfg = getattr(adapter_self, "_voice_auto_join_cfg", None) or {}
                     if auto_cfg.get("auto_join_on_user_join"):
-                        trigger_users = auto_cfg.get("auto_join_users") or []
-                        member_matches_trigger_list = (
-                            not trigger_users
-                            or str(member.id) in {str(u) for u in trigger_users}
-                            or (member.name and member.name in {str(u) for u in trigger_users})
+                        configured_channels = auto_cfg.get("auto_join_voice_channels") or []
+                        if not isinstance(configured_channels, (list, tuple, set)):
+                            configured_channels = [configured_channels]
+                        configured_channel_keys = {
+                            str(channel).strip().casefold()
+                            for channel in configured_channels
+                            if str(channel).strip()
+                        }
+                        destination_channel = after.channel
+                        channel_matches = (
+                            not configured_channel_keys
+                            or str(getattr(destination_channel, "id", "")).casefold() in configured_channel_keys
+                            or str(getattr(destination_channel, "name", "")).casefold() in configured_channel_keys
                         )
-                        if member_matches_trigger_list and adapter_self._is_allowed_user(
+                        trigger_users = auto_cfg.get("auto_join_users") or []
+                        if not isinstance(trigger_users, (list, tuple, set)):
+                            trigger_users = [trigger_users]
+                        trigger_user_keys = {str(user) for user in trigger_users}
+                        member_matches_trigger_list = (
+                            not trigger_user_keys
+                            or str(member.id) in trigger_user_keys
+                            or (member.name and member.name in trigger_user_keys)
+                        )
+                        if channel_matches and member_matches_trigger_list and adapter_self._is_allowed_user(
                             str(member.id), member, guild=member.guild, is_dm=False
                         ):
                             # Already connected to this exact channel in this
@@ -4516,6 +4535,9 @@ class DiscordAdapter(BasePlatformAdapter):
         defaults: Dict[str, Any] = {
             "auto_join_on_user_join": False,
             "auto_join_users": [],
+            # Optional voice channel IDs or names assigned to this profile.
+            # Empty means any destination channel.
+            "auto_join_voice_channels": [],
             # Optional text channel used as the session anchor for automatic VC
             # joins. Without an anchor, auto-join could hear/transcribe but had
             # nowhere to route the synthetic MessageEvent.

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1507,7 +1507,14 @@ class DiscordAdapter(BasePlatformAdapter):
                             )
                             if not already_here:
                                 try:
-                                    await adapter_self.join_voice_channel(after.channel)
+                                    success = await adapter_self.join_voice_channel(after.channel)
+                                    if not success:
+                                        logger.warning(
+                                            "[%s] Auto-join voice channel %s returned failure",
+                                            adapter_self.name,
+                                            getattr(after.channel, "name", "unknown"),
+                                        )
+                                        return
 
                                     # Auto-join does not originate from a slash command, so
                                     # there is no event.source to bind as the text/session

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1489,11 +1489,49 @@ class DiscordAdapter(BasePlatformAdapter):
                             if not already_here:
                                 try:
                                     await adapter_self.join_voice_channel(after.channel)
+
+                                    # Auto-join does not originate from a slash command, so
+                                    # there is no event.source to bind as the text/session
+                                    # anchor. Pick an explicit configured channel first, then
+                                    # fall back to Discord home/free-response config. This is
+                                    # what lets the gateway turn future VC transcripts into a
+                                    # real MessageEvent and route the agent's TTS reply back to
+                                    # this voice connection.
+                                    text_channel_id = str(
+                                        auto_cfg.get("auto_join_text_channel_id")
+                                        or os.getenv("DISCORD_HOME_CHANNEL")
+                                        or os.getenv("DISCORD_FREE_RESPONSE_CHANNELS", "").split(",")[0].strip()
+                                    ).strip()
+                                    if text_channel_id:
+                                        try:
+                                            text_channel_int = int(text_channel_id)
+                                        except (TypeError, ValueError):
+                                            logger.warning(
+                                                "[%s] Ignoring invalid discord.voice.auto_join_text_channel_id=%r",
+                                                adapter_self.name,
+                                                text_channel_id,
+                                            )
+                                        else:
+                                            adapter_self._voice_text_channels[guild_id] = text_channel_int
+                                            adapter_self._voice_sources[guild_id] = {
+                                                "platform": Platform.DISCORD.value,
+                                                "chat_id": str(text_channel_int),
+                                                "chat_name": getattr(after.channel, "name", None),
+                                                "chat_type": "channel",
+                                                "user_id": str(member.id),
+                                                "user_name": getattr(member, "display_name", None) or getattr(member, "name", None) or str(member.id),
+                                                "thread_id": None,
+                                                "chat_topic": None,
+                                                "scope_id": str(guild_id),
+                                                "guild_id": str(guild_id),
+                                            }
+
                                     logger.info(
-                                        "[%s] Auto-joined voice channel %s (triggered by %s)",
+                                        "[%s] Auto-joined voice channel %s (triggered by %s, text_channel=%s)",
                                         adapter_self.name,
                                         after.channel.name,
                                         member.display_name,
+                                        text_channel_id or "none",
                                     )
                                 except Exception as e:
                                     logger.warning(
@@ -4470,6 +4508,10 @@ class DiscordAdapter(BasePlatformAdapter):
         defaults: Dict[str, Any] = {
             "auto_join_on_user_join": False,
             "auto_join_users": [],
+            # Optional text channel used as the session anchor for automatic VC
+            # joins. Without an anchor, auto-join could hear/transcribe but had
+            # nowhere to route the synthetic MessageEvent.
+            "auto_join_text_channel_id": "",
         }
         try:
             from hermes_cli.config import read_raw_config

--- a/tests/gateway/test_discord_voice_auto_join.py
+++ b/tests/gateway/test_discord_voice_auto_join.py
@@ -120,6 +120,8 @@ async def test_auto_join_binds_configured_text_channel_for_transcript_routing(mo
 
     adapter.join_voice_channel.assert_awaited_once_with(channel)
     assert adapter._voice_text_channels[guild.id] == 123456789
+    assert "123456789" in adapter._auto_tts_enabled_chats
+    assert "123456789" not in adapter._auto_tts_disabled_chats
     assert adapter._voice_sources[guild.id]["platform"] == "discord"
     assert adapter._voice_sources[guild.id]["chat_id"] == "123456789"
     assert adapter._voice_sources[guild.id]["user_id"] == "42"

--- a/tests/gateway/test_discord_voice_auto_join.py
+++ b/tests/gateway/test_discord_voice_auto_join.py
@@ -91,6 +91,43 @@ async def test_auto_join_called_when_enabled_and_user_allowed(monkeypatch, adapt
 
 
 @pytest.mark.asyncio
+async def test_auto_join_binds_configured_text_channel_for_transcript_routing(monkeypatch, adapter):
+    """Auto-join must bind a text/session anchor.
+
+    Without this, the adapter can join the VC and transcribe speech, but
+    GatewayRunner._handle_voice_channel_input has no chat to route the
+    synthetic VOICE MessageEvent through.
+    """
+    adapter._voice_auto_join_cfg = {
+        "auto_join_on_user_join": True,
+        "auto_join_users": [],
+        "auto_join_text_channel_id": "123456789",
+    }
+    adapter._allowed_user_ids = {"42"}
+    bot = await _connect_adapter(monkeypatch, adapter)
+
+    adapter.join_voice_channel = AsyncMock(return_value=True)
+
+    guild = SimpleNamespace(id=1)
+    member = _make_member(42, guild, name="mxu")
+    channel = SimpleNamespace(id=99, name="General")
+
+    await bot._events["on_voice_state_update"](
+        member,
+        _make_voice_state(None),
+        _make_voice_state(channel),
+    )
+
+    adapter.join_voice_channel.assert_awaited_once_with(channel)
+    assert adapter._voice_text_channels[guild.id] == 123456789
+    assert adapter._voice_sources[guild.id]["platform"] == "discord"
+    assert adapter._voice_sources[guild.id]["chat_id"] == "123456789"
+    assert adapter._voice_sources[guild.id]["user_id"] == "42"
+    assert adapter._voice_sources[guild.id]["scope_id"] == "1"
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_auto_join_not_called_when_flag_off(monkeypatch, adapter):
     adapter._voice_auto_join_cfg = {"auto_join_on_user_join": False, "auto_join_users": []}
     adapter._allowed_user_ids = {"42"}

--- a/tests/gateway/test_discord_voice_auto_join.py
+++ b/tests/gateway/test_discord_voice_auto_join.py
@@ -1,0 +1,224 @@
+"""Tests for opt-in "auto-join voice channel on user join" (discord.voice.*).
+
+Registers the real ``connect()`` event handlers against a FakeBot (same
+pattern as test_discord_connect.py), then invokes the captured
+``on_voice_state_update`` handler directly with a simulated voice-state
+event to exercise the auto-join branch without a live discord.py gateway.
+"""
+
+import asyncio
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+# Reuse the same discord.py mock bootstrap as test_discord_connect.py so this
+# file works standalone regardless of test collection order.
+if "discord" not in sys.modules or not hasattr(sys.modules.get("discord"), "__file__"):
+    from tests.gateway.test_discord_connect import _ensure_discord_mock
+    _ensure_discord_mock()
+
+import plugins.platforms.discord.adapter as discord_platform  # noqa: E402
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+from tests.gateway.test_discord_connect import FakeBot  # noqa: E402
+
+
+def _make_voice_state(channel):
+    return SimpleNamespace(channel=channel)
+
+
+def _make_member(user_id, guild, *, name="testuser", bot=False):
+    return SimpleNamespace(
+        id=user_id,
+        name=name,
+        display_name=name,
+        guild=guild,
+        bot=bot,
+    )
+
+
+async def _connect_adapter(monkeypatch, adapter):
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    intents = SimpleNamespace(
+        message_content=False, dm_messages=False, guild_messages=False,
+        members=False, voice_states=False,
+    )
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+
+    created = {}
+
+    def fake_bot_factory(*, command_prefix, intents, proxy=None, allowed_mentions=None, **_):
+        created["bot"] = FakeBot(intents=intents, allowed_mentions=allowed_mentions)
+        return created["bot"]
+
+    monkeypatch.setattr(discord_platform.commands, "Bot", fake_bot_factory)
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+
+    ok = await adapter.connect()
+    assert ok is True
+    return created["bot"]
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    a = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    yield a
+
+
+@pytest.mark.asyncio
+async def test_auto_join_called_when_enabled_and_user_allowed(monkeypatch, adapter):
+    adapter._voice_auto_join_cfg = {"auto_join_on_user_join": True, "auto_join_users": []}
+    adapter._allowed_user_ids = {"42"}
+    bot = await _connect_adapter(monkeypatch, adapter)
+
+    adapter.join_voice_channel = AsyncMock(return_value=True)
+
+    guild = SimpleNamespace(id=1)
+    member = _make_member(42, guild)
+    channel = SimpleNamespace(id=99, name="General")
+    before = _make_voice_state(None)
+    after = _make_voice_state(channel)
+
+    await bot._events["on_voice_state_update"](member, before, after)
+
+    adapter.join_voice_channel.assert_awaited_once_with(channel)
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_auto_join_not_called_when_flag_off(monkeypatch, adapter):
+    adapter._voice_auto_join_cfg = {"auto_join_on_user_join": False, "auto_join_users": []}
+    adapter._allowed_user_ids = {"42"}
+    bot = await _connect_adapter(monkeypatch, adapter)
+
+    adapter.join_voice_channel = AsyncMock(return_value=True)
+
+    guild = SimpleNamespace(id=1)
+    member = _make_member(42, guild)
+    channel = SimpleNamespace(id=99, name="General")
+    before = _make_voice_state(None)
+    after = _make_voice_state(channel)
+
+    await bot._events["on_voice_state_update"](member, before, after)
+
+    adapter.join_voice_channel.assert_not_awaited()
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_auto_join_not_called_for_bot_member(monkeypatch, adapter):
+    adapter._voice_auto_join_cfg = {"auto_join_on_user_join": True, "auto_join_users": []}
+    adapter._allowed_user_ids = {"*"}
+    bot = await _connect_adapter(monkeypatch, adapter)
+
+    adapter.join_voice_channel = AsyncMock(return_value=True)
+
+    guild = SimpleNamespace(id=1)
+    member = _make_member(7, guild, bot=True)
+    channel = SimpleNamespace(id=99, name="General")
+    before = _make_voice_state(None)
+    after = _make_voice_state(channel)
+
+    await bot._events["on_voice_state_update"](member, before, after)
+
+    adapter.join_voice_channel.assert_not_awaited()
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_auto_join_not_called_when_user_not_allowed(monkeypatch, adapter):
+    adapter._voice_auto_join_cfg = {"auto_join_on_user_join": True, "auto_join_users": []}
+    adapter._allowed_user_ids = {"999"}  # 42 is not in the allowlist
+    bot = await _connect_adapter(monkeypatch, adapter)
+
+    adapter.join_voice_channel = AsyncMock(return_value=True)
+
+    guild = SimpleNamespace(id=1)
+    member = _make_member(42, guild)
+    channel = SimpleNamespace(id=99, name="General")
+    before = _make_voice_state(None)
+    after = _make_voice_state(channel)
+
+    await bot._events["on_voice_state_update"](member, before, after)
+
+    adapter.join_voice_channel.assert_not_awaited()
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_auto_join_respects_trigger_user_list(monkeypatch, adapter):
+    """When auto_join_users is non-empty, only listed users trigger auto-join
+    even if other users pass the general allowlist."""
+    adapter._voice_auto_join_cfg = {
+        "auto_join_on_user_join": True,
+        "auto_join_users": ["42"],
+    }
+    adapter._allowed_user_ids = {"42", "43"}
+    bot = await _connect_adapter(monkeypatch, adapter)
+
+    adapter.join_voice_channel = AsyncMock(return_value=True)
+
+    guild = SimpleNamespace(id=1)
+    channel = SimpleNamespace(id=99, name="General")
+
+    # User 43 is allowed generally but not in the trigger list -> no auto-join.
+    member_43 = _make_member(43, guild)
+    await bot._events["on_voice_state_update"](member_43, _make_voice_state(None), _make_voice_state(channel))
+    adapter.join_voice_channel.assert_not_awaited()
+
+    # User 42 is in the trigger list -> auto-join fires.
+    member_42 = _make_member(42, guild)
+    await bot._events["on_voice_state_update"](member_42, _make_voice_state(None), _make_voice_state(channel))
+    adapter.join_voice_channel.assert_awaited_once_with(channel)
+
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_auto_join_skipped_when_already_connected_to_that_channel(monkeypatch, adapter):
+    adapter._voice_auto_join_cfg = {"auto_join_on_user_join": True, "auto_join_users": []}
+    adapter._allowed_user_ids = {"42"}
+    bot = await _connect_adapter(monkeypatch, adapter)
+
+    adapter.join_voice_channel = AsyncMock(return_value=True)
+
+    guild = SimpleNamespace(id=1)
+    channel = SimpleNamespace(id=99, name="General")
+    existing_vc = MagicMock()
+    existing_vc.is_connected.return_value = True
+    existing_vc.channel = channel
+    adapter._voice_clients[guild.id] = existing_vc
+
+    member = _make_member(42, guild)
+    await bot._events["on_voice_state_update"](member, _make_voice_state(None), _make_voice_state(channel))
+
+    adapter.join_voice_channel.assert_not_awaited()
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_manual_voice_join_path_unaffected(monkeypatch, adapter):
+    """Sanity: with auto-join disabled (the default), on_voice_state_update
+    must still run its existing join/leave/switch tracking without raising,
+    keeping /voice join as the only trigger.
+    """
+    adapter._voice_auto_join_cfg = {"auto_join_on_user_join": False, "auto_join_users": []}
+    bot = await _connect_adapter(monkeypatch, adapter)
+
+    guild = SimpleNamespace(id=1)
+    channel_a = SimpleNamespace(id=1, name="A")
+    channel_b = SimpleNamespace(id=2, name="B")
+    member = _make_member(1, guild)
+
+    # join, switch, leave — should not raise even though the bot has no
+    # voice client tracked in this guild.
+    await bot._events["on_voice_state_update"](member, _make_voice_state(None), _make_voice_state(channel_a))
+    await bot._events["on_voice_state_update"](member, _make_voice_state(channel_a), _make_voice_state(channel_b))
+    await bot._events["on_voice_state_update"](member, _make_voice_state(channel_b), _make_voice_state(None))
+
+    await adapter.disconnect()

--- a/tests/gateway/test_discord_voice_auto_join.py
+++ b/tests/gateway/test_discord_voice_auto_join.py
@@ -292,6 +292,35 @@ async def test_auto_join_ignores_unconfigured_voice_channel(monkeypatch, adapter
 
 
 @pytest.mark.asyncio
+async def test_auto_join_failure_does_not_install_routing_state(monkeypatch, adapter):
+    adapter._voice_auto_join_cfg = {
+        "auto_join_on_user_join": True,
+        "auto_join_users": ["42"],
+        "auto_join_voice_channels": ["General"],
+        "auto_join_text_channel_id": "123456789",
+    }
+    adapter._allowed_user_ids = {"42"}
+    bot = await _connect_adapter(monkeypatch, adapter)
+    adapter.join_voice_channel = AsyncMock(return_value=False)
+
+    guild = SimpleNamespace(id=1)
+    member = _make_member(42, guild)
+    channel = SimpleNamespace(id=99, name="General")
+
+    await bot._events["on_voice_state_update"](
+        member,
+        _make_voice_state(None),
+        _make_voice_state(channel),
+    )
+
+    adapter.join_voice_channel.assert_awaited_once_with(channel)
+    assert guild.id not in adapter._voice_text_channels
+    assert guild.id not in adapter._voice_sources
+    assert "123456789" not in adapter._auto_tts_enabled_chats
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_auto_join_accepts_scalar_user_and_channel_config(monkeypatch, adapter):
     adapter._voice_auto_join_cfg = {
         "auto_join_on_user_join": True,

--- a/tests/gateway/test_discord_voice_auto_join.py
+++ b/tests/gateway/test_discord_voice_auto_join.py
@@ -251,6 +251,28 @@ async def test_auto_join_skipped_when_already_connected_to_that_channel(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_auto_join_handles_connected_client_without_channel(monkeypatch, adapter):
+    adapter._voice_auto_join_cfg = {"auto_join_on_user_join": True, "auto_join_users": []}
+    adapter._allowed_user_ids = {"42"}
+    bot = await _connect_adapter(monkeypatch, adapter)
+    adapter.join_voice_channel = AsyncMock(return_value=True)
+
+    guild = SimpleNamespace(id=1)
+    channel = SimpleNamespace(id=99, name="General")
+    existing_vc = MagicMock()
+    existing_vc.is_connected.return_value = True
+    existing_vc.channel = None
+    adapter._voice_clients[guild.id] = existing_vc
+
+    await bot._events["on_voice_state_update"](
+        _make_member(42, guild), _make_voice_state(None), _make_voice_state(channel)
+    )
+
+    adapter.join_voice_channel.assert_awaited_once_with(channel)
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_auto_join_follows_allowed_user_when_switching_channels(monkeypatch, adapter):
     adapter._voice_auto_join_cfg = {
         "auto_join_on_user_join": True,

--- a/tests/gateway/test_discord_voice_auto_join.py
+++ b/tests/gateway/test_discord_voice_auto_join.py
@@ -41,6 +41,13 @@ def _make_member(user_id, guild, *, name="testuser", bot=False):
 
 
 async def _connect_adapter(monkeypatch, adapter):
+    # connect() refreshes the adapter's config-derived authorization state.
+    # Preserve per-test overrides so the captured event handler is exercised
+    # against the intended auto-join policy rather than the test process config.
+    auto_join_cfg = dict(adapter._voice_auto_join_cfg)
+    allowed_user_ids = set(adapter._allowed_user_ids)
+    allowed_role_ids = set(adapter._allowed_role_ids)
+
     monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
     monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
 
@@ -61,6 +68,9 @@ async def _connect_adapter(monkeypatch, adapter):
 
     ok = await adapter.connect()
     assert ok is True
+    adapter._voice_auto_join_cfg = auto_join_cfg
+    adapter._allowed_user_ids = allowed_user_ids
+    adapter._allowed_role_ids = allowed_role_ids
     return created["bot"]
 
 

--- a/tests/gateway/test_discord_voice_auto_join.py
+++ b/tests/gateway/test_discord_voice_auto_join.py
@@ -241,6 +241,82 @@ async def test_auto_join_skipped_when_already_connected_to_that_channel(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_auto_join_follows_allowed_user_when_switching_channels(monkeypatch, adapter):
+    adapter._voice_auto_join_cfg = {
+        "auto_join_on_user_join": True,
+        "auto_join_users": ["42"],
+        "auto_join_voice_channels": ["Development"],
+    }
+    adapter._allowed_user_ids = {"42"}
+    bot = await _connect_adapter(monkeypatch, adapter)
+    adapter.join_voice_channel = AsyncMock(return_value=True)
+
+    guild = SimpleNamespace(id=1)
+    member = _make_member(42, guild)
+    general = SimpleNamespace(id=98, name="General")
+    development = SimpleNamespace(id=99, name="Development")
+
+    await bot._events["on_voice_state_update"](
+        member,
+        _make_voice_state(general),
+        _make_voice_state(development),
+    )
+
+    adapter.join_voice_channel.assert_awaited_once_with(development)
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_auto_join_ignores_unconfigured_voice_channel(monkeypatch, adapter):
+    adapter._voice_auto_join_cfg = {
+        "auto_join_on_user_join": True,
+        "auto_join_users": ["42"],
+        "auto_join_voice_channels": ["Development"],
+    }
+    adapter._allowed_user_ids = {"42"}
+    bot = await _connect_adapter(monkeypatch, adapter)
+    adapter.join_voice_channel = AsyncMock(return_value=True)
+
+    guild = SimpleNamespace(id=1)
+    member = _make_member(42, guild)
+    general = SimpleNamespace(id=98, name="General")
+
+    await bot._events["on_voice_state_update"](
+        member,
+        _make_voice_state(None),
+        _make_voice_state(general),
+    )
+
+    adapter.join_voice_channel.assert_not_awaited()
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_auto_join_accepts_scalar_user_and_channel_config(monkeypatch, adapter):
+    adapter._voice_auto_join_cfg = {
+        "auto_join_on_user_join": True,
+        "auto_join_users": 42,
+        "auto_join_voice_channels": "Development",
+    }
+    adapter._allowed_user_ids = {"42"}
+    bot = await _connect_adapter(monkeypatch, adapter)
+    adapter.join_voice_channel = AsyncMock(return_value=True)
+
+    guild = SimpleNamespace(id=1)
+    member = _make_member(42, guild)
+    development = SimpleNamespace(id=99, name="Development")
+
+    await bot._events["on_voice_state_update"](
+        member,
+        _make_voice_state(None),
+        _make_voice_state(development),
+    )
+
+    adapter.join_voice_channel.assert_awaited_once_with(development)
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_manual_voice_join_path_unaffected(monkeypatch, adapter):
     """Sanity: with auto-join disabled (the default), on_voice_state_update
     must still run its existing join/leave/switch tracking without raising,

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -394,20 +394,23 @@ By default the bot only joins a voice channel when you run `/voice join`. If you
 ```yaml
 discord:
   voice:
-    auto_join_on_user_join: true   # default: false — opt-in only
-    auto_join_users: []            # optional allowlist; empty = any allowed user
+    auto_join_on_user_join: true       # default: false — opt-in only
+    auto_join_users: []                # optional IDs/usernames; scalar also accepted
+    auto_join_voice_channels: []       # optional channel IDs/names; empty = any
 ```
 
 | Key | Default | Description |
 |-----|---------|-------------|
 | `auto_join_on_user_join` | `false` | When `true`, the bot calls the same join logic as `/voice join` as soon as a qualifying user enters a voice channel it isn't already in. |
-| `auto_join_users` | `[]` | Optional list of Discord user IDs or usernames. Empty means any user who already passes `DISCORD_ALLOWED_USERS` / `DISCORD_ALLOWED_ROLES` can trigger auto-join. Non-empty restricts triggering to just these users (they must still pass the existing allowlist). |
+| `auto_join_users` | `[]` | Optional Discord user ID or username, or a list of them. Empty means any user who already passes `DISCORD_ALLOWED_USERS` / `DISCORD_ALLOWED_ROLES` can trigger auto-join. Non-empty restricts triggering to those users (they must still pass the existing allowlist). |
+| `auto_join_voice_channels` | `[]` | Optional voice channel ID or name, or a list of them. Empty allows any voice channel. Assigning channels per profile prevents every profile from following the same user into the same VC. |
 
 Notes:
 
 - The bot **never** auto-joins in response to another bot joining a voice channel.
 - Auto-join reuses the exact `join_voice_channel()` path (and its per-guild lock) used by `/voice join` — it does not open a second connection or bypass any existing voice permission checks.
-- If the bot is already connected to the channel the user joined, nothing happens (no-op).
+- The bot follows a qualifying user both on their initial join and when they switch into a configured destination channel.
+- If the bot is already connected to the destination channel, nothing happens (no-op).
 - This is purely additive: `/voice join` and `/voice leave` keep working exactly as before, whether or not auto-join is enabled.
 
 ### How It Works

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -397,6 +397,7 @@ discord:
     auto_join_on_user_join: true       # default: false — opt-in only
     auto_join_users: []                # optional IDs/usernames; scalar also accepted
     auto_join_voice_channels: []       # optional channel IDs/names; empty = any
+    auto_join_text_channel_id: ""      # text/session anchor for transcripts and replies
 ```
 
 | Key | Default | Description |
@@ -404,6 +405,7 @@ discord:
 | `auto_join_on_user_join` | `false` | When `true`, the bot calls the same join logic as `/voice join` as soon as a qualifying user enters a voice channel it isn't already in. |
 | `auto_join_users` | `[]` | Optional Discord user ID or username, or a list of them. Empty means any user who already passes `DISCORD_ALLOWED_USERS` / `DISCORD_ALLOWED_ROLES` can trigger auto-join. Non-empty restricts triggering to those users (they must still pass the existing allowlist). |
 | `auto_join_voice_channels` | `[]` | Optional voice channel ID or name, or a list of them. Empty allows any voice channel. Assigning channels per profile prevents every profile from following the same user into the same VC. |
+| `auto_join_text_channel_id` | `""` | Text channel used as the session anchor for auto-joined transcripts and replies. If empty, Hermes falls back to `DISCORD_HOME_CHANNEL`, then the first `DISCORD_FREE_RESPONSE_CHANNELS` entry. Auto-joined speech cannot be routed without one of these anchors. |
 
 Notes:
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -387,6 +387,29 @@ Use these in the Discord text channel where the bot is present:
 You must be in a voice channel before running `/voice join`. The bot joins the same VC you're in.
 :::
 
+### Auto-Join
+
+By default the bot only joins a voice channel when you run `/voice join`. If you'd rather have it join automatically the moment an allowed user enters a voice channel, opt in via `discord.voice` in `config.yaml`:
+
+```yaml
+discord:
+  voice:
+    auto_join_on_user_join: true   # default: false — opt-in only
+    auto_join_users: []            # optional allowlist; empty = any allowed user
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `auto_join_on_user_join` | `false` | When `true`, the bot calls the same join logic as `/voice join` as soon as a qualifying user enters a voice channel it isn't already in. |
+| `auto_join_users` | `[]` | Optional list of Discord user IDs or usernames. Empty means any user who already passes `DISCORD_ALLOWED_USERS` / `DISCORD_ALLOWED_ROLES` can trigger auto-join. Non-empty restricts triggering to just these users (they must still pass the existing allowlist). |
+
+Notes:
+
+- The bot **never** auto-joins in response to another bot joining a voice channel.
+- Auto-join reuses the exact `join_voice_channel()` path (and its per-guild lock) used by `/voice join` — it does not open a second connection or bypass any existing voice permission checks.
+- If the bot is already connected to the channel the user joined, nothing happens (no-op).
+- This is purely additive: `/voice join` and `/voice leave` keep working exactly as before, whether or not auto-join is enabled.
+
 ### How It Works
 
 When the bot joins a voice channel, it:


### PR DESCRIPTION
## Summary
- restores the opt-in Discord voice auto-follow flow on current `main`
- follows an allowed, configured user when they join or switch into a configured VC
- anchors auto-joined voice transcripts to a configured Discord text channel and enables TTS replies there
- keeps the feature disabled by default and preserves manual `/voice join` behavior
- updates the recovered test harness for current connection-time config refresh behavior

## Configuration
```yaml
discord:
  voice:
    auto_join_on_user_join: true
    auto_join_users: ["<Discord user ID>"]
    auto_join_voice_channels: ["<voice channel name or ID>"]
    auto_join_text_channel_id: "<text channel ID>"
```

## Validation
- `uv run --locked --extra dev --extra messaging python -m pytest tests/gateway/test_discord_voice_auto_join.py tests/gateway/test_discord_connect.py tests/gateway/test_discord_voice_mixer.py tests/integration/test_voice_channel_flow.py -q`
- Result: `25 passed, 1 skipped, 34 deselected`
