### PR TITLE
fix(gateway): serve /context in-process for local sessions

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -544,6 +544,88 @@ def test_slash_exec_compress_flag_on_applies_host_control_mirror(monkeypatch):
     assert server._session_info(None, session)["model"] == "host-model"
 
 
+def test_slash_exec_context_served_in_process_for_local_session(monkeypatch, tmp_path):
+    """Local (non-compute-host) sessions must answer /context in-process.
+
+    /context is a pure session-scoped read (db + history + usage snapshot,
+    no live agent), so gating it behind compute-host isolation — the reason
+    it was routed to the slash worker, which has no agent and replied
+    "No active agent -- send a message first." (#93280) — is wrong.
+    """
+
+    class _ExplodingWorker:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("slash worker should not run for /context")
+
+    session = _session(
+        agent=None,
+        history=[{"role": "user", "content": "hello"}],
+        _metadata_mirror={"model": "test-model", "provider": "test-provider"},
+    )
+    server._sessions["sid"] = session
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(server, "_SlashWorker", _ExplodingWorker)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "slash.exec",
+                "params": {"command": "context", "session_id": "sid"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert "error" not in resp
+    output = resp["result"]["output"]
+    assert "No active agent" not in output
+    assert "Conversation: 1 messages" in output
+    assert "test-model" in output
+
+
+def test_slash_exec_context_still_works_for_compute_host_session(monkeypatch, tmp_path):
+    """Moving "context" to the direct set must not regress compute hosts.
+
+    Regression guard for the #93280 fix: compute-host sessions answer
+    /context from the metadata mirror because their agent is remote; the
+    fix must keep that path working.
+    """
+
+    class _ExplodingWorker:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("slash worker should not run for /context")
+
+    session = _session(
+        agent=None,
+        agent_ready=True,
+        _compute_host_active=True,
+        history=[{"role": "user", "content": "hello"}],
+        _metadata_mirror={"model": "host-model", "usage": {"context_used": 100}},
+    )
+    server._sessions["sid"] = session
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
+    monkeypatch.setattr(server, "_SlashWorker", _ExplodingWorker)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "slash.exec",
+                "params": {"command": "context", "session_id": "sid"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert "error" not in resp
+    output = resp["result"]["output"]
+    assert "No active agent" not in output
+    assert "Conversation: 1 messages" in output
+    assert "host-model" in output
+
+
 def test_prompt_submit_golden_transcript_matches_flag_off_and_on(monkeypatch):
     class _ImmediateThread:
         def __init__(self, target=None, daemon=None, **_kwargs):
@@ -17462,7 +17544,7 @@ def test_slash_exec_concurrent_first_use_spawns_single_worker(monkeypatch):
             {
                 "id": str(n),
                 "method": "slash.exec",
-                "params": {"command": "/context", "session_id": "race-spawn"},
+                "params": {"command": "/version", "session_id": "race-spawn"},
             }
         )
         results.append(resp)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -14381,6 +14381,7 @@ _LIVE_SESSION_DIRECT_COMMANDS = frozenset(
     {
         "clear",
         "compress",
+        "context",
         "effort",
         "history",
         "models",
@@ -14392,7 +14393,7 @@ _LIVE_SESSION_DIRECT_COMMANDS = frozenset(
     }
 )
 
-_ISOLATED_SESSION_READ_COMMANDS = frozenset({"context", "tools", "help"})
+_ISOLATED_SESSION_READ_COMMANDS = frozenset({"tools", "help"})
 
 
 def _format_live_review_output(session: Optional[dict], arg: str) -> str:


### PR DESCRIPTION
## Problem

Fixes #93280

In local desktop/TUI sessions (no compute host), "/context" answered
"No active agent -- send a message first." even when the session was
active. The status-bar context gauge was affected the same way.

Root cause: /context was in _ISOLATED_SESSION_READ_COMMANDS, so the
gateway only served it in-process for compute-host sessions and routed
every local session to the forked slash worker, which has no live
agent. But the handler is a pure session-scoped read (session db +
history + usage snapshot + metadata mirror, zero agent access) — the
comment above it says "Same session-scoped read as /history", and
/history (like /usage) was already in the direct set.

## Solution

Move "context" from _ISOLATED_SESSION_READ_COMMANDS to
_LIVE_SESSION_DIRECT_COMMANDS (2 lines). Compute-host behavior is
unchanged: both paths already converge on the same formatter. The
status-bar half is already fixed on main by the agent=None fallback in
session.context_breakdown (PR #92821); this covers the remaining
slash-command path.

## Result

- /context works in-process for local sessions with zero agent
  dependency; output identical to before for compute hosts.
- 2 new regression tests (local + compute-host, both assert the slash
  worker never runs) and the concurrent-spawn test now uses /version
  as its vehicle since /context no longer routes to the worker.
- Local: tests/test_tui_gateway_server.py 609/609 green; all other
  tui_gateway/slash suites match a clean main baseline (the 2 failing
  tests fail identically on main without this change).