### PR TITLE
fix(desktop): preserve readable update blocker errors

### DIFF
--- a/apps/desktop/src/app/updates-overlay.blockers.test.tsx
+++ b/apps/desktop/src/app/updates-overlay.blockers.test.tsx
@@ -115,6 +115,7 @@ describe('BlockerView', () => {
     expect(screen.getByText('Close other processes to update Hermes')).toBeTruthy()
     expect(screen.getByText('python.exe')).toBeTruthy()
     expect(screen.queryByText('Update didn’t finish')).toBeNull()
+    expect(document.querySelector('[data-slot="dialog-content"]')?.className).toContain('max-w-2xl')
   })
 
   it('identifies foreign blockers without offering automatic termination', async () => {

--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -106,8 +106,8 @@ export function UpdatesOverlay() {
       {/* This dialog has no inputs, so Radix's default autofocus would land on
           the close button and trigger its tooltip immediately on open. */}
       <DialogContent
-        bodyClassName="overflow-hidden p-0 gap-0"
-        className="max-w-sm"
+        bodyClassName="overflow-x-hidden p-0 gap-0"
+        className="max-w-2xl"
         onOpenAutoFocus={preventCloseButtonAutoFocus}
         showCloseButton={phase !== 'applying'}
       >
@@ -538,7 +538,7 @@ function ErrorView({ message, onDismiss, onRetry }: { message: string; onDismiss
     <ErrorState
       className="px-6 pb-6 pt-7 pr-8"
       description={
-        <DialogDescription className="max-w-prose text-center text-sm leading-5 text-muted-foreground">
+        <DialogDescription className="max-w-prose whitespace-pre-line break-words text-center text-sm leading-5 text-muted-foreground">
           {message || u.errorBody}
         </DialogDescription>
       }

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -1214,4 +1214,45 @@ describe('startUpdatePoller', () => {
 
     expect(checkMock).toHaveBeenCalled()
   })
+
+  it('keeps structured blocker metadata when a late error progress frame arrives', async () => {
+    startUpdatePoller()
+    await vi.advanceTimersByTimeAsync(0)
+
+    const progress = onProgressMock.mock.calls[0]?.[0] as ((payload: unknown) => void) | undefined
+    expect(progress).toBeTypeOf('function')
+
+    $updateApply.set({
+      applying: false,
+      stage: 'error',
+      message: 'Update aborted: another Hermes process is using this installation.',
+      percent: null,
+      error: 'venv-blocked',
+      command: null,
+      blockers: [
+        {
+          pid: 3528,
+          name: 'python.exe',
+          cmdline: 'python.exe -m hermes_cli.main gateway run',
+          kind: 'other',
+          safeToStop: false
+        }
+      ],
+      log: []
+    })
+
+    progress?.({
+      stage: 'error',
+      message: 'Update aborted: another Hermes process is using this installation.',
+      percent: null,
+      error: null,
+      at: Date.now()
+    })
+
+    expect($updateApply.get()).toMatchObject({
+      stage: 'error',
+      error: 'venv-blocked',
+      blockers: [{ pid: 3528 }]
+    })
+  })
 })

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -931,9 +931,16 @@ function ingestProgress(payload: DesktopUpdateProgress): void {
     // Streamed log lines carry percent: null; keep the last milestone percent
     // (10/60/…) instead of resetting the bar to indeterminate on every line.
     percent: payload.percent ?? current.percent,
-    error: payload.error,
+    // IPC progress and the resolved apply result travel on separate Electron
+    // channels. A late terminal progress frame can therefore arrive *after*
+    // applyUpdates() has already stored structured failure metadata (for
+    // example `venv-blocked` + its blocker list). Keep that metadata while we
+    // remain on the same error terminal state; a fresh apply resets the store
+    // to IDLE before any new progress arrives.
+    error: payload.error ?? (payload.stage === 'error' ? current.error : null),
     // 'manual' carries the command to run in its message field.
     command: payload.stage === 'manual' ? payload.message : current.command,
+    blockers: payload.stage === 'error' ? (current.blockers ?? null) : null,
     log
   })
 }


### PR DESCRIPTION
## What does this PR do?

Fixes a Desktop updater failure mode where a structured `venv-blocked` result is briefly available, then a later terminal progress frame overwrites its `error`/`blockers` metadata. The renderer consequently falls back to the generic "Update didn't finish" state instead of the actionable blocker view.

It also makes the update overlay readable for long Windows process command lines: the dialog is wider, can scroll vertically, and multiline errors wrap instead of collapsing into a narrow/tall column.

## Related Issue

No linked issue; reproduced on current Desktop update flow while a Windows Hermes process held the managed install.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] 🧪 Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🧩 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/updates.ts`: preserve structured error and blocker metadata when a late `error` progress frame arrives for the same terminal state.
- `apps/desktop/src/store/updates.test.ts`: add a regression test for the progress/apply-result ordering race.
- `apps/desktop/src/app/updates-overlay.tsx`: widen the update dialog, retain vertical scrolling, and wrap multiline error text.
- `apps/desktop/src/app/updates-overlay.blockers.test.tsx`: cover the blocker dialog width used for long process details.

## How to Test

1. Run `npx vitest run --project ui src/app/updates-overlay.blockers.test.tsx src/store/updates.test.ts` from `apps/desktop`.
2. Run `npm run lint -- --quiet` and `npm run typecheck` from `apps/desktop`.
3. On Windows, trigger an update failure that returns `venv-blocked`, then deliver a later `error` progress frame with no structured error. The blocker UI should remain selected and long command lines should remain readable.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (JS/Desktop-only change; targeted Desktop checks below were run instead)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] `cli-config.yaml.example` update N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update N/A
- [x] Cross-platform impact considered: layout/store behavior is platform-neutral; reproduction was Windows-specific
- [x] Tool descriptions/schemas update N/A

## Screenshots / Logs

Local verification on the rebased head:

- Prettier check: pass for all four changed files
- Desktop ESLint: pass (`npm run lint -- --quiet`)
- Targeted UI tests: 63/63 pass
- TypeScript typecheck: pass (`npm run typecheck`)