### PR TITLE
feat(bot-mode): add native session goal bridge

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -2121,6 +2121,39 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             tool_duration = time.time() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('message_agent', function_args, tool_duration, result=function_result)}")
+        elif function_name == "goal_manage":
+            # Bot Mode bridge to the existing persistent GoalManager. Like
+            # message_agent, this schema is injected only into canonical Bot
+            # Chat and is not globally registered. The calling session id is
+            # supplied server-side so the model cannot target another session.
+            def _execute(next_args: dict) -> Any:
+                from tools.bot_mode_goal import goal_manage_tool as _goal_manage_tool
+                return _goal_manage_tool(
+                    action=next_args.get("action", ""),
+                    session_id=str(getattr(agent, "session_id", "") or ""),
+                    agent=agent,
+                    goal=next_args.get("goal", ""),
+                    max_turns=next_args.get("max_turns"),
+                    outcome=next_args.get("outcome", ""),
+                    verification=next_args.get("verification", ""),
+                    constraints=next_args.get("constraints", ""),
+                    boundaries=next_args.get("boundaries", ""),
+                    stop_when=next_args.get("stop_when", ""),
+                    criterion=next_args.get("criterion", ""),
+                )
+            function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                execute=_execute,
+                scope_block=_ts_scope_block,
+                display_index=i,
+            ))
+            tool_duration = time.time() - tool_start_time
+            if agent._should_emit_quiet_tool_messages():
+                agent._vprint(f"  {_get_cute_tool_message_impl('goal_manage', function_args, tool_duration, result=function_result)}")
         elif function_name == "session_search":
             def _execute(next_args: dict) -> Any:
                 session_db = agent._get_session_db_for_recall()

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -777,6 +777,13 @@ def build_turn_context(
     except Exception:
         logger.debug("message_agent injection skipped", exc_info=True)
 
+    try:
+        from tools.bot_mode_goal import ensure_goal_manage_tool
+
+        ensure_goal_manage_tool(agent)
+    except Exception:
+        logger.debug("goal_manage injection skipped", exc_info=True)
+
     # Create the DB session row now that _cached_system_prompt is populated, so
     # the persisted snapshot is written non-NULL on the first turn (Issue
     # #45499). Idempotent: _ensure_db_session() no-ops once the row exists.

--- a/cli.py
+++ b/cli.py
@@ -12571,7 +12571,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         session split).
         """
         try:
-            from hermes_cli.goals import GoalManager
+            from hermes_cli.goals import GoalManager, consume_goal_state_dirty
             from hermes_cli.config import load_config
         except Exception as exc:
             logging.debug("goal manager unavailable: %s", exc)
@@ -12581,9 +12581,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if not sid:
             return None
 
+        dirty = consume_goal_state_dirty(sid)
         existing = getattr(self, "_goal_manager", None)
         if existing is not None and getattr(existing, "session_id", None) == sid:
-            return existing
+            if not dirty:
+                return existing
+            # A session-scoped tool mutated the durable GoalManager state
+            # outside this CLI object's cached instance. Rebuild from SessionDB
+            # before the post-turn continuation hook inspects it.
 
         try:
             cfg = load_config() or {}

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -44,6 +44,35 @@ from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
+# In-process cache invalidation for session-scoped goal mutations that happen
+# outside the CLI/gateway command object (for example the Bot Chat
+# ``goal_manage`` bridge). Goal state itself remains durable in SessionDB; this
+# marker only tells a long-lived host to rebuild a cached GoalManager before it
+# reads the state again. It is intentionally process-local and best-effort.
+_GOAL_DIRTY_SESSIONS: set[str] = set()
+_GOAL_DIRTY_LOCK = threading.Lock()
+
+
+def mark_goal_state_dirty(session_id: str) -> None:
+    """Mark *session_id* so a host refreshes its cached GoalManager."""
+    sid = str(session_id or "").strip()
+    if not sid:
+        return
+    with _GOAL_DIRTY_LOCK:
+        _GOAL_DIRTY_SESSIONS.add(sid)
+
+
+def consume_goal_state_dirty(session_id: str) -> bool:
+    """Consume and return the process-local dirty marker for *session_id*."""
+    sid = str(session_id or "").strip()
+    if not sid:
+        return False
+    with _GOAL_DIRTY_LOCK:
+        if sid not in _GOAL_DIRTY_SESSIONS:
+            return False
+        _GOAL_DIRTY_SESSIONS.remove(sid)
+        return True
+
 
 # ──────────────────────────────────────────────────────────────────────
 # Constants & defaults
@@ -2317,6 +2346,8 @@ __all__ = [
     "KANBAN_GOAL_CONTINUATION_TEMPLATE",
     "KANBAN_GOAL_FINALIZE_TEMPLATE",
     "DEFAULT_MAX_TURNS",
+    "mark_goal_state_dirty",
+    "consume_goal_state_dirty",
     "load_goal",
     "save_goal",
     "clear_goal",

--- a/tests/tools/test_bot_mode_goal.py
+++ b/tests/tools/test_bot_mode_goal.py
@@ -1,0 +1,280 @@
+"""Tests for the Bot-Chat-only ``goal_manage`` native GoalManager bridge."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from hermes_cli import goals
+from tools import bot_mode_goal, bot_mode_probe
+
+
+@pytest.fixture(autouse=True)
+def _clean_goal_context():
+    bot_mode_probe._reset_cache_for_tests()
+    goals._DB_CACHE.clear()
+    goals._GOAL_DIRTY_SESSIONS.clear()
+    yield
+    bot_mode_probe._reset_cache_for_tests()
+    goals._DB_CACHE.clear()
+    goals._GOAL_DIRTY_SESSIONS.clear()
+
+
+def _managed_home(tmp_path: Path) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    teammate = home / "profiles" / "researcher"
+    teammate.mkdir(parents=True)
+    (teammate / "profile.yaml").write_text(
+        textwrap.dedent(
+            """\
+            description: teammate for tests
+            ui_meta:
+              hermes-bots:
+                shape: cloud
+            """
+        ),
+        encoding="utf-8",
+    )
+    return home
+
+
+class _FakeDB:
+    def __init__(self, home: Path, title: str):
+        self.db_path = str(home / "state.db")
+        self._title = title
+
+    def get_session_title(self, _sid):
+        return self._title
+
+
+class _FakeAgent:
+    def __init__(self, home: Path, title: str = "Bot Chat", sid: str = "sess-goal"):
+        self._session_db = _FakeDB(home, title)
+        self.session_id = sid
+        self._session_title_hint = None
+        self._bot_mode_protocol = True
+        self.tools: list = []
+        self.valid_tool_names: set = set()
+
+
+def _call(home: Path, agent: _FakeAgent, **kwargs):
+    token = set_hermes_home_override(home)
+    try:
+        raw = bot_mode_goal.goal_manage_tool(
+            session_id=agent.session_id,
+            agent=agent,
+            **kwargs,
+        )
+        return json.loads(raw)
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_injects_only_into_managed_bot_chat(tmp_path):
+    home = _managed_home(tmp_path)
+    agent = _FakeAgent(home)
+    assert bot_mode_goal.ensure_goal_manage_tool(agent) is True
+    assert [t["function"]["name"] for t in agent.tools] == ["goal_manage"]
+    assert "goal_manage" in agent.valid_tool_names
+    assert bot_mode_goal.ensure_goal_manage_tool(agent) is True
+    assert len(agent.tools) == 1
+
+
+@pytest.mark.parametrize("title", ["", "ordinary", "Group: test", "handoff-1"])
+def test_never_injects_outside_canonical_bot_chat(tmp_path, title):
+    home = _managed_home(tmp_path)
+    agent = _FakeAgent(home, title=title)
+    assert bot_mode_goal.ensure_goal_manage_tool(agent) is False
+    assert agent.tools == []
+
+
+def test_never_injects_on_unmanaged_install(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    agent = _FakeAgent(home)
+    assert bot_mode_goal.ensure_goal_manage_tool(agent) is False
+
+
+def test_schema_never_in_global_registry_or_toolsets():
+    from tools.registry import registry
+    import toolsets
+
+    assert bot_mode_goal.GOAL_MANAGE_TOOL_NAME not in getattr(registry, "_tools", {})
+    for names in toolsets.TOOLSETS.values():
+        assert bot_mode_goal.GOAL_MANAGE_TOOL_NAME not in names
+
+
+def test_dispatch_refuses_outside_bot_chat(tmp_path):
+    home = _managed_home(tmp_path)
+    agent = _FakeAgent(home, title="ordinary")
+    result = _call(home, agent, action="set", goal="ship it")
+    assert result["success"] is False
+    assert "Bot Chat" in result["error"]
+
+
+def test_set_uses_native_goal_contract_and_persists(tmp_path):
+    home = _managed_home(tmp_path)
+    agent = _FakeAgent(home, sid="native-contract")
+    result = _call(
+        home,
+        agent,
+        action="set",
+        goal="learn API authorization",
+        max_turns=7,
+        outcome="demonstrate authorization boundary reasoning",
+        verification="pass a novel transfer review",
+        constraints="minimum sufficient instruction",
+        boundaries="learner-local writes only",
+        stop_when="mastered or blocked",
+    )
+    assert result["success"] is True
+    assert result["status"] == "active"
+    assert result["max_turns"] == 7
+    assert result["contract"]["verification"] == "pass a novel transfer review"
+
+    token = set_hermes_home_override(home)
+    try:
+        persisted = goals.GoalManager("native-contract").state
+        assert persisted is not None
+        assert persisted.goal == "learn API authorization"
+        assert persisted.max_turns == 7
+        assert persisted.contract.outcome == "demonstrate authorization boundary reasoning"
+        assert persisted.contract.boundaries == "learner-local writes only"
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_set_cannot_replace_existing_goal(tmp_path):
+    home = _managed_home(tmp_path)
+    agent = _FakeAgent(home, sid="replace-guard")
+    assert _call(home, agent, action="set", goal="first")["success"] is True
+    refused = _call(home, agent, action="set", goal="second")
+    assert refused["success"] is False
+    assert refused["goal"] == "first"
+    assert "cannot replace" in refused["error"]
+
+
+def test_add_subgoal_uses_native_manager(tmp_path):
+    home = _managed_home(tmp_path)
+    agent = _FakeAgent(home, sid="mutations")
+    assert _call(home, agent, action="set", goal="main")["success"] is True
+    added = _call(home, agent, action="add_subgoal", criterion="prove tenant isolation")
+    assert added["subgoals"] == ["prove tenant isolation"]
+
+
+def test_schema_exposes_no_destructive_goal_controls():
+    schema = bot_mode_goal.goal_manage_tool_schema()
+    props = schema["function"]["parameters"]["properties"]
+    actions = set(props["action"]["enum"])
+    assert actions == {"set", "status", "add_subgoal"}
+    assert "replace" not in props
+    assert "reason" not in props
+
+
+def test_dirty_marker_refreshes_cli_cached_goal_manager(tmp_path):
+    """A goal set during an agent turn must wake the CLI's same native loop."""
+    home = _managed_home(tmp_path)
+    sid = "cli-cache-refresh"
+    token = set_hermes_home_override(home)
+    try:
+        from cli import HermesCLI
+
+        cli = HermesCLI.__new__(HermesCLI)
+        cli.session_id = sid
+        cli._goal_manager = None
+        cached = cli._get_goal_manager()
+        assert cached is not None
+        assert cached.state is None
+
+        agent = _FakeAgent(home, sid=sid)
+        raw = bot_mode_goal.goal_manage_tool(
+            action="set",
+            session_id=sid,
+            agent=agent,
+            goal="persist from tool",
+            verification="native state is visible to CLI hook",
+        )
+        assert json.loads(raw)["success"] is True
+
+        refreshed = cli._get_goal_manager()
+        assert refreshed is not cached
+        assert refreshed.is_active()
+        assert refreshed.state.goal == "persist from tool"
+        assert refreshed.state.contract.verification == "native state is visible to CLI hook"
+        assert goals.consume_goal_state_dirty(sid) is False
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_cli_post_turn_hook_judges_goal_created_by_tool(tmp_path, monkeypatch):
+    """The real CLI host hook must consume a goal created during the turn."""
+    import queue
+    from cli import HermesCLI
+
+    home = _managed_home(tmp_path)
+    sid = "cli-post-turn"
+    token = set_hermes_home_override(home)
+    try:
+        cli = HermesCLI.__new__(HermesCLI)
+        cli.session_id = sid
+        cli._goal_manager = None
+        cli._pending_input = queue.Queue()
+        cli._last_turn_interrupted = False
+        cli.conversation_history = [
+            {"role": "assistant", "content": "HOOK_DONE"},
+        ]
+        cached = cli._get_goal_manager()
+        assert cached.state is None
+
+        agent = _FakeAgent(home, sid=sid)
+        result = json.loads(
+            bot_mode_goal.goal_manage_tool(
+                action="set",
+                session_id=sid,
+                agent=agent,
+                goal="prove host hook",
+                verification="assistant response contains HOOK_DONE",
+            )
+        )
+        assert result["success"] is True
+
+        monkeypatch.setattr(
+            "hermes_cli.goals.judge_goal",
+            lambda *args, **kwargs: ("done", "verified", False, None, False),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.goals.gather_background_processes", lambda: []
+        )
+        cli._maybe_continue_goal_after_turn()
+
+        persisted = goals.GoalManager(sid).state
+        assert persisted is not None
+        assert persisted.status == "done"
+        assert persisted.last_verdict == "done"
+        assert cli._pending_input.empty()
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_missing_session_id_is_rejected(tmp_path):
+    home = _managed_home(tmp_path)
+    agent = _FakeAgent(home)
+    token = set_hermes_home_override(home)
+    try:
+        result = json.loads(
+            bot_mode_goal.goal_manage_tool(
+                action="set",
+                session_id="",
+                agent=agent,
+                goal="nope",
+            )
+        )
+    finally:
+        reset_hermes_home_override(token)
+    assert result["success"] is False
+    assert "session id" in result["error"].lower()

--- a/tests/tools/test_bot_mode_goal_upgrade.py
+++ b/tests/tools/test_bot_mode_goal_upgrade.py
@@ -1,0 +1,75 @@
+"""Upgrade regressions for the Bot Chat native goal bridge."""
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from tools import bot_mode_goal, bot_mode_probe
+
+
+@pytest.fixture(autouse=True)
+def _clear_bot_probe_cache():
+    bot_mode_probe._reset_cache_for_tests()
+    yield
+    bot_mode_probe._reset_cache_for_tests()
+
+
+class _FakeDB:
+    def __init__(self, home: Path):
+        self.db_path = str(home / "state.db")
+
+    def get_session_title(self, _sid):
+        return "Bot Chat"
+
+
+class _FakeAgent:
+    def __init__(self, home: Path):
+        self._session_db = _FakeDB(home)
+        self.session_id = "legacy-managed-goal"
+        self._session_title_hint = None
+        self._bot_mode_protocol = True
+        self.tools: list = []
+        self.valid_tool_names: set = set()
+
+
+def _legacy_managed_home(tmp_path: Path) -> Path:
+    """Managed install whose old SOUL already contains the protocol text."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "SOUL.md").write_text(
+        "# Existing profile\n\n## Messaging other agents\nLegacy appended protocol.\n",
+        encoding="utf-8",
+    )
+
+    teammate = home / "profiles" / "researcher"
+    teammate.mkdir(parents=True)
+    (teammate / "profile.yaml").write_text(
+        textwrap.dedent(
+            """\
+            description: teammate for upgrade regression
+            ui_meta:
+              hermes-bots:
+                shape: cloud
+            """
+        ),
+        encoding="utf-8",
+    )
+    return home
+
+
+def test_legacy_protocol_dedupe_does_not_remove_goal_manage(tmp_path):
+    home = _legacy_managed_home(tmp_path)
+    agent = _FakeAgent(home)
+
+    # Prompt rendering correctly stays silent because an older Bot Mode build
+    # already appended the protocol text into SOUL.md. Tool eligibility must
+    # use managed-install state instead of mistaking that empty section for an
+    # unmanaged install.
+    assert bot_mode_probe.get_bot_mode_protocol_section(home, force_refresh=True) == ""
+    assert bot_mode_probe.is_bot_mode_managed(home) is True
+
+    assert bot_mode_goal.ensure_goal_manage_tool(agent) is True
+    assert [tool["function"]["name"] for tool in agent.tools] == ["goal_manage"]
+    assert "goal_manage" in agent.valid_tool_names

--- a/tools/bot_mode_goal.py
+++ b/tools/bot_mode_goal.py
@@ -1,0 +1,217 @@
+"""Bot Mode bridge to Hermes' native persistent GoalManager.
+
+``goal_manage`` exists for one reason: an agent in its canonical Bot Chat may
+need to turn a natural-language standing objective into the same native
+``GoalManager`` state that a human reaches through ``/goal`` and ``/subgoal``.
+
+This module deliberately does NOT implement a second goal loop. It is only a
+thin session-scoped tool wrapper around :mod:`hermes_cli.goals`.
+
+Containment mirrors ``message_agent``:
+- injected only into a Bot-Mode-managed canonical ``Bot Chat``;
+- not registered in the global tool registry/toolsets;
+- execution re-checks the Bot Chat gate;
+- the calling session id is supplied server-side by the tool executor and is
+  never model-controlled.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+GOAL_MANAGE_TOOL_NAME = "goal_manage"
+
+
+def goal_manage_tool_schema() -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": GOAL_MANAGE_TOOL_NAME,
+            "description": (
+                "Manage the CURRENT Bot Chat's real persistent Hermes goal using the native "
+                "GoalManager. Use this when a natural-language objective should persist across "
+                "turns. This does not simulate a goal and cannot target another session. "
+                "For a new standing objective use action='set' with a concrete completion "
+                "contract. Use action='add_subgoal' only for a newly discovered required "
+                "criterion. This tool cannot pause, clear, resume, or replace an existing "
+                "goal; those remain user/host controls."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["set", "status", "add_subgoal"],
+                    },
+                    "goal": {
+                        "type": "string",
+                        "description": "Standing goal text for action=set.",
+                    },
+                    "max_turns": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 500,
+                        "description": "Optional native goal turn budget for action=set.",
+                    },
+                    "outcome": {
+                        "type": "string",
+                        "description": "Optional GoalContract outcome.",
+                    },
+                    "verification": {
+                        "type": "string",
+                        "description": "Optional GoalContract verification evidence required for completion.",
+                    },
+                    "constraints": {
+                        "type": "string",
+                        "description": "Optional GoalContract constraints.",
+                    },
+                    "boundaries": {
+                        "type": "string",
+                        "description": "Optional GoalContract scope/authority boundaries.",
+                    },
+                    "stop_when": {
+                        "type": "string",
+                        "description": "Optional GoalContract blocked/stop conditions.",
+                    },
+                    "criterion": {
+                        "type": "string",
+                        "description": "Required new criterion for action=add_subgoal.",
+                    },
+                },
+                "required": ["action"],
+            },
+        },
+    }
+
+
+def ensure_goal_manage_tool(agent: Any) -> bool:
+    """Inject ``goal_manage`` only into a managed canonical Bot Chat."""
+    try:
+        if not getattr(agent, "_bot_mode_protocol", True):
+            return False
+        tools = getattr(agent, "tools", None)
+        if tools:
+            for tool in tools:
+                if (
+                    isinstance(tool, dict)
+                    and tool.get("function", {}).get("name") == GOAL_MANAGE_TOOL_NAME
+                ):
+                    return True
+
+        from tools.bot_mode_dm import _agent_home, _session_title
+        from tools.bot_mode_probe import BOT_CHAT_TITLE, get_bot_mode_protocol_section
+
+        if _session_title(agent) != BOT_CHAT_TITLE:
+            return False
+        if not get_bot_mode_protocol_section(_agent_home(agent)):
+            return False
+        if agent.tools is None:
+            agent.tools = []
+        agent.tools.append(goal_manage_tool_schema())
+        valid = getattr(agent, "valid_tool_names", None)
+        if isinstance(valid, set):
+            valid.add(GOAL_MANAGE_TOOL_NAME)
+        return True
+    except Exception:  # pragma: no cover - tool injection must never break a turn
+        logger.debug("ensure_goal_manage_tool failed", exc_info=True)
+        return False
+
+
+def _result(payload: dict) -> str:
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _state_payload(manager: Any) -> dict:
+    state = manager.state
+    if state is None:
+        return {"status": "none", "status_line": manager.status_line()}
+    contract = getattr(state, "contract", None)
+    return {
+        "status": state.status,
+        "goal": state.goal,
+        "turns_used": state.turns_used,
+        "max_turns": state.max_turns,
+        "subgoals": list(state.subgoals),
+        "contract": contract.to_dict() if contract is not None else {},
+        "status_line": manager.status_line(),
+    }
+
+
+def goal_manage_tool(
+    *,
+    action: str,
+    session_id: str,
+    agent: Any,
+    goal: str = "",
+    max_turns: Optional[int] = None,
+    outcome: str = "",
+    verification: str = "",
+    constraints: str = "",
+    boundaries: str = "",
+    stop_when: str = "",
+    criterion: str = "",
+) -> str:
+    """Execute one native GoalManager mutation for the calling Bot Chat."""
+    from tools.bot_mode_dm import _agent_home, _session_title
+    from tools.bot_mode_probe import BOT_CHAT_TITLE, get_bot_mode_protocol_section
+
+    if _session_title(agent) != BOT_CHAT_TITLE:
+        return _result({"success": False, "error": "goal_manage is only available in a Bot Mode 'Bot Chat' session."})
+    if not get_bot_mode_protocol_section(_agent_home(agent)):
+        return _result({"success": False, "error": "goal_manage is unavailable because this profile is not Bot-Mode managed."})
+
+    sid = str(session_id or "").strip()
+    if not sid:
+        return _result({"success": False, "error": "No active session id is available for goal_manage."})
+
+    try:
+        from hermes_cli.goals import GoalContract, GoalManager, mark_goal_state_dirty
+
+        manager = GoalManager(session_id=sid)
+        act = str(action or "").strip().lower()
+
+        if act == "status":
+            return _result({"success": True, **_state_payload(manager)})
+
+        if act == "set":
+            text = str(goal or "").strip()
+            if not text:
+                return _result({"success": False, "error": "goal is required for action=set."})
+            if manager.has_goal():
+                return _result({
+                    "success": False,
+                    "error": "An active or paused goal already exists. goal_manage cannot replace it; use the existing goal or let the user change/clear it.",
+                    **_state_payload(manager),
+                })
+            budget = None
+            if max_turns is not None:
+                budget = int(max_turns)
+                if budget < 1 or budget > 500:
+                    return _result({"success": False, "error": "max_turns must be between 1 and 500."})
+            contract = GoalContract(
+                outcome=str(outcome or "").strip(),
+                verification=str(verification or "").strip(),
+                constraints=str(constraints or "").strip(),
+                boundaries=str(boundaries or "").strip(),
+                stop_when=str(stop_when or "").strip(),
+            )
+            manager.set(text, max_turns=budget, contract=contract)
+            mark_goal_state_dirty(sid)
+            return _result({"success": True, "action": "set", **_state_payload(manager)})
+
+        if act == "add_subgoal":
+            text = str(criterion or "").strip()
+            if not text:
+                return _result({"success": False, "error": "criterion is required for action=add_subgoal."})
+            manager.add_subgoal(text)
+            mark_goal_state_dirty(sid)
+            return _result({"success": True, "action": "add_subgoal", **_state_payload(manager)})
+
+        return _result({"success": False, "error": f"Unknown goal_manage action: {action!r}."})
+    except Exception as exc:
+        logger.error("goal_manage failed: %s", exc, exc_info=True)
+        return _result({"success": False, "error": f"goal_manage failed: {exc}"})

--- a/tools/bot_mode_goal.py
+++ b/tools/bot_mode_goal.py
@@ -103,11 +103,16 @@ def ensure_goal_manage_tool(agent: Any) -> bool:
                     return True
 
         from tools.bot_mode_dm import _agent_home, _session_title
-        from tools.bot_mode_probe import BOT_CHAT_TITLE, get_bot_mode_protocol_section
+        from tools.bot_mode_probe import BOT_CHAT_TITLE, is_bot_mode_managed
 
         if _session_title(agent) != BOT_CHAT_TITLE:
             return False
-        if not get_bot_mode_protocol_section(_agent_home(agent)):
+        # Match message_agent's managed-install gate rather than the rendered
+        # protocol section. Older Bot Mode builds appended that protocol text
+        # into SOUL.md; current prompt generation correctly deduplicates it to
+        # an empty section, but the install is still managed and must retain
+        # native Bot Chat tools after upgrade.
+        if not is_bot_mode_managed(_agent_home(agent)):
             return False
         if agent.tools is None:
             agent.tools = []
@@ -157,11 +162,11 @@ def goal_manage_tool(
 ) -> str:
     """Execute one native GoalManager mutation for the calling Bot Chat."""
     from tools.bot_mode_dm import _agent_home, _session_title
-    from tools.bot_mode_probe import BOT_CHAT_TITLE, get_bot_mode_protocol_section
+    from tools.bot_mode_probe import BOT_CHAT_TITLE, is_bot_mode_managed
 
     if _session_title(agent) != BOT_CHAT_TITLE:
         return _result({"success": False, "error": "goal_manage is only available in a Bot Mode 'Bot Chat' session."})
-    if not get_bot_mode_protocol_section(_agent_home(agent)):
+    if not is_bot_mode_managed(_agent_home(agent)):
         return _result({"success": False, "error": "goal_manage is unavailable because this profile is not Bot-Mode managed."})
 
     sid = str(session_id or "").strip()


### PR DESCRIPTION
## Summary

Adds a minimal Bot-Chat-only bridge from agent tool calls to the existing persistent `GoalManager`.

`/goal` is already a native session primitive, but Bot Mode models currently cannot invoke that same session goal handler themselves. This patch exposes a narrow `goal_manage` tool only in a managed canonical Bot Chat, mirroring the existing dynamic `message_agent` exposure.

- dynamically injected only into managed canonical Bot Chat sessions
- never globally registered or added to a general toolset
- session ID is supplied server-side and cannot be model-controlled
- wraps the existing `GoalManager` / `GoalContract`; no parallel loop or persistence
- supports only `set`, `status`, and `add_subgoal`
- refuses `set` when a standing goal already exists
- preserves the native structured completion contract and turn budget
- refreshes a long-lived host's cached GoalManager after a session-scoped mutation while SessionDB remains the durable source of truth
- uses the same managed-install eligibility boundary as `message_agent`, so upgraded Bot Mode installs whose legacy `SOUL.md` already contains the messaging protocol do not silently lose `goal_manage` when prompt rendering correctly deduplicates that text

No domain-specific behavior is included; unused stock behavior is unchanged.

## Validation

Original focused gate:
- `python -m pytest -q tests/tools/test_bot_mode_goal.py tests/cli/test_cli_goal_interrupt.py tests/hermes_cli/test_goals.py` → **55 passed**
- Python compile checks for touched modules → **PASS**
- `git diff --check` → **PASS**

Additional upgrade regression:
- `tests/tools/test_bot_mode_goal_upgrade.py` constructs a Bot-managed install whose legacy `SOUL.md` already contains `## Messaging other agents`, proves `get_bot_mode_protocol_section(...) == ""` while `is_bot_mode_managed(...) is True`, and requires `goal_manage` to remain injected in canonical Bot Chat.

This keeps tool eligibility independent from protocol-text rendering, matching the existing `message_agent` upgrade behavior.