### PR TITLE
feat(profiles): support distribution skill preloads

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -193,7 +193,7 @@ def _extract_bundle_user_instruction(message: str) -> Optional[str]:
 def _resolve_skill_commands_platform() -> Optional[str]:
     """Return the current platform scope used for disabled-skill filtering.
 
-    Used to detect when the active platform has shifted so
+    Used to detect when the active platform scope changes so
     :func:`get_skill_commands` can drop a stale cache that was populated
     for a different platform's ``skills.platform_disabled`` view (#14536).
 
@@ -315,8 +315,15 @@ def _build_skill_message(
     user_instruction: str = "",
     runtime_note: str = "",
     session_id: str | None = None,
+    allow_inline_shell: bool = True,
 ) -> str:
-    """Format a loaded skill into a user/system message payload."""
+    """Format a loaded skill into a user/system message payload.
+
+    ``allow_inline_shell`` preserves the existing behavior for explicit skill
+    invocations and CLI/TUI preloads. Automatic native surfaces can disable
+    inline-shell expansion so loading prompt guidance cannot execute host
+    commands as a side effect of prompt construction.
+    """
     from tools.skills_tool import SKILLS_DIR
 
     content = str(loaded_skill.get("content") or "")
@@ -327,7 +334,7 @@ def _build_skill_message(
     skills_cfg = _load_skills_config()
     if skills_cfg.get("template_vars", True):
         content = _substitute_template_vars(content, skill_dir, session_id)
-    if skills_cfg.get("inline_shell", False):
+    if allow_inline_shell and skills_cfg.get("inline_shell", False):
         timeout = int(skills_cfg.get("inline_shell_timeout", 10) or 10)
         content = _expand_inline_shell(content, skill_dir, timeout)
 
@@ -840,14 +847,23 @@ def build_preloaded_skills_prompt(
     skill_identifiers: list[str],
     task_id: str | None = None,
     activation_note_template: str | None = None,
+    allow_inline_shell: bool | None = None,
 ) -> tuple[str, list[str], list[str]]:
-    """Load one or more skills for session-wide CLI/TUI preloading.
+    """Load one or more skills for session-wide preloading.
 
     Returns (prompt_text, loaded_skill_names, missing_identifiers).
 
     ``activation_note_template`` may override the default CLI activation note.
     It receives ``{skill_name}`` and is used by other native surfaces such as
     profile-distribution preloads without duplicating skill-loading logic.
+
+    ``allow_inline_shell`` preserves existing explicit CLI/TUI preload
+    behavior when true. When omitted, the default CLI activation path keeps
+    inline shell enabled while a custom/native-surface activation template
+    defaults to non-executing rendering. Automatic prompt construction must
+    not gain host-command side effects merely because ``skills.inline_shell``
+    is enabled globally. A future custom surface that represents an explicit
+    user invocation may opt in deliberately with ``allow_inline_shell=True``.
 
     Disabled skills are treated the same as missing ones: this loads via a
     raw identifier straight into ``_load_skill_payload``, bypassing
@@ -856,6 +872,9 @@ def build_preloaded_skills_prompt(
     a deployment's ``HERMES_TUI_SKILLS`` env var could force-load a skill an
     operator disabled via ``skills.disabled``/``skills.platform_disabled``.
     """
+    if allow_inline_shell is None:
+        allow_inline_shell = activation_note_template is None
+
     prompt_parts: list[str] = []
     loaded_names: list[str] = []
     missing: list[str] = []
@@ -905,6 +924,7 @@ def build_preloaded_skills_prompt(
                 skill_dir,
                 activation_note,
                 session_id=task_id,
+                allow_inline_shell=bool(allow_inline_shell),
             )
         )
         loaded_names.append(skill_name)

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -839,10 +839,15 @@ def build_stacked_skill_invocation_message(
 def build_preloaded_skills_prompt(
     skill_identifiers: list[str],
     task_id: str | None = None,
+    activation_note_template: str | None = None,
 ) -> tuple[str, list[str], list[str]]:
     """Load one or more skills for session-wide CLI/TUI preloading.
 
     Returns (prompt_text, loaded_skill_names, missing_identifiers).
+
+    ``activation_note_template`` may override the default CLI activation note.
+    It receives ``{skill_name}`` and is used by other native surfaces such as
+    profile-distribution preloads without duplicating skill-loading logic.
 
     Disabled skills are treated the same as missing ones: this loads via a
     raw identifier straight into ``_load_skill_payload``, bypassing
@@ -886,11 +891,14 @@ def build_preloaded_skills_prompt(
         except Exception:
             pass  # Non-critical
 
-        activation_note = (
-            f'[IMPORTANT: The user launched this CLI session with the "{skill_name}" skill '
-            "preloaded. Treat its instructions as active guidance for the duration of this "
-            "session unless the user overrides them.]"
-        )
+        if activation_note_template:
+            activation_note = activation_note_template.format(skill_name=skill_name)
+        else:
+            activation_note = (
+                f'[IMPORTANT: The user launched this CLI session with the "{skill_name}" skill '
+                "preloaded. Treat its instructions as active guidance for the duration of this "
+                "session unless the user overrides them.]"
+            )
         prompt_parts.append(
             _build_skill_message(
                 loaded_skill,

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -310,6 +310,57 @@ def _agent_home(agent: Any) -> Optional[Path]:
     return None
 
 
+def _distribution_preloaded_skills_prompt(agent: Any) -> str:
+    """Render skills declared by this profile distribution as always-active.
+
+    The distribution owns the profile payload already, so preloading one of its
+    installed skills adds prompt context only; it grants no extra tools or
+    permissions. Resolve against the agent's own profile home so multiplexed
+    gateway/Desktop sessions cannot leak another profile's preload contract.
+    """
+    home = _agent_home(agent)
+    if home is None:
+        return ""
+    try:
+        from hermes_cli.profile_distribution import read_manifest
+
+        manifest = read_manifest(home)
+    except Exception as exc:
+        logger.debug("profile preload manifest unavailable for %s: %s", home, exc)
+        return ""
+    identifiers = list(getattr(manifest, "preload_skills", None) or []) if manifest else []
+    if not identifiers:
+        return ""
+
+    try:
+        from agent.skill_commands import build_preloaded_skills_prompt
+        from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+
+        token = set_hermes_home_override(home)
+        try:
+            prompt, _loaded, missing = build_preloaded_skills_prompt(
+                identifiers,
+                task_id=str(getattr(agent, "session_id", "") or "") or None,
+                activation_note_template=(
+                    '[IMPORTANT: This profile distribution preloads the "{skill_name}" skill. '
+                    "Treat its instructions as active guidance for this profile on every turn "
+                    "unless the user explicitly overrides them.]"
+                ),
+            )
+        finally:
+            reset_hermes_home_override(token)
+        if missing:
+            logger.warning(
+                "Profile distribution preload missing/disabled skill(s) for %s: %s",
+                home,
+                ", ".join(missing),
+            )
+        return prompt or ""
+    except Exception as exc:
+        logger.warning("Could not render profile distribution preloads for %s: %s", home, exc)
+        return ""
+
+
 def _agent_skills_dir(agent: Any) -> Optional[Path]:
     """The agent's own ``<home>/skills`` dir, or None to use ambient home."""
     home = _agent_home(agent)
@@ -816,6 +867,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # system message is one cache unit regardless of internal order.)
     if skills_prompt:
         volatile_parts.append(skills_prompt)
+
+    distribution_preloads = _distribution_preloaded_skills_prompt(agent)
+    if distribution_preloads:
+        volatile_parts.append(distribution_preloads)
 
     if agent._memory_store:
         if agent._memory_enabled:

--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -47,6 +47,12 @@ Manifest format (``distribution.yaml`` at the profile root)::
       - skills/
       - cron/
       - mcp.json
+    preload_skills:          # optional; always-active profile guidance
+      - security-review
+
+``preload_skills`` loads full instructions from skills already installed in
+that profile whenever the normal agent system prompt is built. It does not
+grant tools, permissions, or access to skills that are missing or disabled.
 
 Update semantics:
 
@@ -176,6 +182,10 @@ class DistributionManifest:
     license: str = ""
     env_requires: List[EnvRequirement] = field(default_factory=list)
     distribution_owned: List[str] = field(default_factory=list)
+    # Skills this distribution wants loaded into every session for this profile.
+    # This is prompt/context activation only: it grants no extra tools or
+    # permissions, and disabled/missing skills remain unavailable.
+    preload_skills: List[str] = field(default_factory=list)
     # Tracked after install — where we pulled from, so ``update`` can re-pull.
     source: str = ""
     # ISO-8601 UTC timestamp written on install / update, so ``info`` and
@@ -200,6 +210,10 @@ class DistributionManifest:
         if dist_owned_raw and not isinstance(dist_owned_raw, list):
             raise DistributionError("distribution_owned must be a list")
         distribution_owned = [str(p).strip().strip("/") for p in dist_owned_raw if str(p).strip()]
+        preload_raw = data.get("preload_skills") or []
+        if preload_raw and not isinstance(preload_raw, list):
+            raise DistributionError("preload_skills must be a list")
+        preload_skills = [str(s).strip() for s in preload_raw if str(s).strip()]
         return cls(
             name=name,
             version=str(data.get("version") or "0.1.0"),
@@ -209,6 +223,7 @@ class DistributionManifest:
             license=str(data.get("license") or ""),
             env_requires=env_requires,
             distribution_owned=distribution_owned,
+            preload_skills=preload_skills,
             source=str(data.get("source") or ""),
             installed_at=str(data.get("installed_at") or ""),
         )
@@ -230,6 +245,8 @@ class DistributionManifest:
             out["env_requires"] = [e.to_dict() for e in self.env_requires]
         if self.distribution_owned:
             out["distribution_owned"] = self.distribution_owned
+        if self.preload_skills:
+            out["preload_skills"] = self.preload_skills
         if self.source:
             out["source"] = self.source
         if self.installed_at:

--- a/tests/agent/test_profile_distribution_preloads.py
+++ b/tests/agent/test_profile_distribution_preloads.py
@@ -1,0 +1,59 @@
+"""Profile-distribution preloaded-skill system-prompt tests."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from agent import system_prompt
+from hermes_cli.profile_distribution import DistributionManifest, write_manifest
+
+
+def _profile_with_preload(tmp_path, *, preload=True):
+    home = tmp_path / "profile"
+    skill_dir = home / "skills" / "always-on-test"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: always-on-test\n"
+        "description: Always active test skill.\n"
+        "---\n"
+        "# Always On Test\n\n"
+        "PROFILE_PRELOAD_MARKER\n",
+        encoding="utf-8",
+    )
+    write_manifest(
+        home,
+        DistributionManifest(
+            name="preload-profile",
+            version="0.1.0",
+            preload_skills=["always-on-test"] if preload else [],
+        ),
+    )
+    return home
+
+
+def _agent(home):
+    db = SimpleNamespace(db_path=str(home / "state.db"))
+    return SimpleNamespace(_session_db=db, session_id="preload-session")
+
+
+def test_distribution_preload_renders_full_skill_from_profile_home(tmp_path):
+    home = _profile_with_preload(tmp_path)
+    prompt = system_prompt._distribution_preloaded_skills_prompt(_agent(home))
+
+    assert 'profile distribution preloads the "always-on-test" skill' in prompt
+    assert "PROFILE_PRELOAD_MARKER" in prompt
+    assert "Treat its instructions as active guidance for this profile on every turn" in prompt
+
+
+def test_distribution_without_preloads_adds_no_prompt(tmp_path):
+    home = _profile_with_preload(tmp_path, preload=False)
+    assert system_prompt._distribution_preloaded_skills_prompt(_agent(home)) == ""
+
+
+def test_distribution_preload_does_not_resolve_from_ambient_profile(tmp_path, monkeypatch):
+    target = _profile_with_preload(tmp_path / "target")
+    ambient = _profile_with_preload(tmp_path / "ambient", preload=False)
+    monkeypatch.setenv("HERMES_HOME", str(ambient))
+
+    prompt = system_prompt._distribution_preloaded_skills_prompt(_agent(target))
+    assert "PROFILE_PRELOAD_MARKER" in prompt

--- a/tests/agent/test_profile_distribution_preloads.py
+++ b/tests/agent/test_profile_distribution_preloads.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from agent import system_prompt
+from agent import skill_commands, system_prompt
 from hermes_cli.profile_distribution import DistributionManifest, write_manifest
 
 
-def _profile_with_preload(tmp_path, *, preload=True):
+def _profile_with_preload(tmp_path, *, preload=True, extra_content=""):
     home = tmp_path / "profile"
     skill_dir = home / "skills" / "always-on-test"
     skill_dir.mkdir(parents=True)
@@ -17,7 +17,8 @@ def _profile_with_preload(tmp_path, *, preload=True):
         "description: Always active test skill.\n"
         "---\n"
         "# Always On Test\n\n"
-        "PROFILE_PRELOAD_MARKER\n",
+        "PROFILE_PRELOAD_MARKER\n"
+        f"{extra_content}",
         encoding="utf-8",
     )
     write_manifest(
@@ -57,3 +58,56 @@ def test_distribution_preload_does_not_resolve_from_ambient_profile(tmp_path, mo
 
     prompt = system_prompt._distribution_preloaded_skills_prompt(_agent(target))
     assert "PROFILE_PRELOAD_MARKER" in prompt
+
+
+def test_distribution_preload_never_executes_inline_shell_during_prompt_build(tmp_path, monkeypatch):
+    literal = "!`printf PROFILE_PRELOAD_MUST_NOT_EXECUTE`"
+    home = _profile_with_preload(tmp_path, extra_content=f"{literal}\n")
+
+    monkeypatch.setattr(
+        skill_commands,
+        "_load_skills_config",
+        lambda: {
+            "template_vars": True,
+            "inline_shell": True,
+            "inline_shell_timeout": 10,
+        },
+    )
+
+    def _unexpected_inline_shell(*_args, **_kwargs):
+        raise AssertionError("automatic profile preload attempted inline shell execution")
+
+    monkeypatch.setattr(skill_commands, "_expand_inline_shell", _unexpected_inline_shell)
+
+    prompt = system_prompt._distribution_preloaded_skills_prompt(_agent(home))
+    assert literal in prompt
+    assert "PROFILE_PRELOAD_MARKER" in prompt
+
+
+def test_explicit_skill_render_can_still_opt_into_existing_inline_shell_behavior(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        skill_commands,
+        "_load_skills_config",
+        lambda: {
+            "template_vars": False,
+            "inline_shell": True,
+            "inline_shell_timeout": 7,
+        },
+    )
+
+    def _expand(content, skill_dir, timeout):
+        calls.append((content, skill_dir, timeout))
+        return "EXPANDED_INLINE_SHELL"
+
+    monkeypatch.setattr(skill_commands, "_expand_inline_shell", _expand)
+
+    rendered = skill_commands._build_skill_message(
+        {"content": "!`printf explicit`"},
+        None,
+        "explicit preload",
+        allow_inline_shell=True,
+    )
+
+    assert "EXPANDED_INLINE_SHELL" in rendered
+    assert calls == [("!`printf explicit`", None, 7)]

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -87,6 +87,22 @@ def _prompt_parts(agent):
         return build_system_prompt_parts(agent)
 
 
+def test_distribution_preload_prompt_is_in_volatile_tier():
+    agent = _make_agent()
+    with (
+        patch("run_agent.load_soul_md", return_value=""),
+        patch("run_agent.build_nous_subscription_prompt", return_value=""),
+        patch("run_agent.build_environment_hints", return_value=""),
+        patch("run_agent.build_context_files_prompt", return_value=""),
+        patch(
+            "agent.system_prompt._distribution_preloaded_skills_prompt",
+            return_value="DISTRIBUTION_PRELOAD_MARKER",
+        ),
+    ):
+        parts = build_system_prompt_parts(agent)
+    assert "DISTRIBUTION_PRELOAD_MARKER" in parts["volatile"]
+
+
 def _init_code_repo(path):
     """A git repo that actually holds code — the coding posture requires a source
     file (or manifest), not a bare ``.git`` (a prose/notes repo stays general)."""

--- a/tests/hermes_cli/test_profile_distribution.py
+++ b/tests/hermes_cli/test_profile_distribution.py
@@ -106,6 +106,9 @@ class TestManifestParsing:
             "distribution_owned:\n"
             "  - SOUL.md\n"
             "  - skills/\n"
+            "preload_skills:\n"
+            "  - api-design\n"
+            "  - auth-integration\n"
         )
         m = read_manifest(tmp_path)
         assert m.name == "telem"
@@ -118,6 +121,7 @@ class TestManifestParsing:
         assert m.env_requires[1].required is False
         assert m.env_requires[1].default == "http://127.0.0.1:8000"
         assert m.distribution_owned == ["SOUL.md", "skills"]
+        assert m.preload_skills == ["api-design", "auth-integration"]
 
 
 
@@ -130,11 +134,13 @@ class TestManifestParsing:
             version="1.0.0",
             description="roundtrip",
             env_requires=[EnvRequirement(name="FOO", description="foo")],
+            preload_skills=["api-design"],
         )
         write_manifest(tmp_path, original)
         parsed = read_manifest(tmp_path)
         assert parsed.name == "rt"
         assert parsed.env_requires[0].name == "FOO"
+        assert parsed.preload_skills == ["api-design"]
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Adds a generic `preload_skills` field to Hermes profile distributions so profile-defining skills can be present in the normal agent system prompt deterministically rather than depending on routing-time skill discovery.

- parsed and round-tripped in `distribution.yaml`
- rendered through the existing native skill-loading path
- respects disabled or missing skills
- resolves from the active agent profile home under multiplexed gateway/Desktop contexts
- adds prompt context only; grants no tools, permissions, or authority
- **automatic distribution preloads are non-executing even when global `skills.inline_shell` is enabled**
- applies at the shared system-prompt boundary, so normal AIAgent surfaces share the behavior
- existing explicit `-s/--skills` / CLI-TUI preload behavior remains unchanged, including its existing inline-shell opt-in behavior

This is a generic profile-distribution capability with no domain-specific coupling.

## Security boundary

During review, I found that reusing `build_preloaded_skills_prompt()` verbatim would also inherit optional inline-shell expansion from explicit user-invoked skill preloads. That would make automatic profile activation capable of host-side command execution during prompt construction when `skills.inline_shell` is enabled, contradicting the intended prompt-context-only boundary.

The branch now makes inline-shell execution an explicit rendering capability:
- `_build_skill_message(..., allow_inline_shell=True)` preserves existing invocation behavior by default
- `build_preloaded_skills_prompt(..., allow_inline_shell=None)` keeps inline shell for the default explicit CLI/TUI activation path
- any custom/native-surface activation template, including profile-distribution preloads, defaults to `allow_inline_shell=False`
- a future explicit user-driven custom surface may opt in deliberately with `allow_inline_shell=True`
- template-variable substitution remains available; only host-command execution is suppressed for automatic preloads

Regression coverage proves an automatically preloaded skill containing literal `!\`...\`` syntax does not call the inline-shell executor even when the global feature is enabled, while an explicit skill render can still opt into the prior behavior.

## Validation

Original focused gate before the security hardening:
- `python -m pytest -q tests/agent/test_profile_distribution_preloads.py tests/agent/test_system_prompt.py tests/hermes_cli/test_profile_distribution.py` → **89 passed**
- Python compile checks for touched modules → **PASS**
- `git diff --check` → **PASS**

The current head adds two focused authority-boundary regressions to `tests/agent/test_profile_distribution_preloads.py`. Fork-triggered upstream Actions remain subject to Nous workflow approval, so the new head should be re-run by upstream CI before merge.