### PR TITLE
fix(goals): feed judge feedback into continuation

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -2099,9 +2099,30 @@ class GoalManager:
             ),
         }
 
+    def _continuation_judge_feedback(self) -> str:
+        """Return bounded feedback from the previous failed completion check.
+
+        The judge reason is durable goal state, but historically the next agent
+        turn only received the static goal/contract again. That made repeated
+        ``continue`` verdicts easy to loop on: the judge knew what was missing
+        while the agent did not. Feed back only a failed ``continue`` reason;
+        wait/done state must not leak into an unrelated continuation.
+        """
+        if not self._state or self._state.last_verdict != "continue":
+            return ""
+        reason = (self._state.last_reason or "").strip()
+        if not reason:
+            return ""
+        return (
+            "\n\nPrevious completion-check feedback:\n"
+            f"{_truncate(reason, 1200)}\n\n"
+            "Address this specific feedback before claiming the goal is done again."
+        )
+
     def next_continuation_prompt(self) -> Optional[str]:
         if not self._state or self._state.status != "active":
             return None
+        feedback = self._continuation_judge_feedback()
         # Contract takes priority: it carries the verification surface and
         # constraints the agent must target. Subgoals fold in as extra
         # criteria appended to the contract block.
@@ -2113,16 +2134,19 @@ class GoalManager:
                     for i, text in enumerate(self._state.subgoals, start=1)
                 )
                 contract_block = f"{contract_block}\n{extra}"
-            return CONTINUATION_PROMPT_WITH_CONTRACT_TEMPLATE.format(
+            prompt = CONTINUATION_PROMPT_WITH_CONTRACT_TEMPLATE.format(
                 goal=self._state.goal,
                 contract_block=contract_block,
             )
+            return f"{prompt}{feedback}"
         if self._state.subgoals:
-            return CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE.format(
+            prompt = CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE.format(
                 goal=self._state.goal,
                 subgoals_block=self._state.render_subgoals_block(),
             )
-        return CONTINUATION_PROMPT_TEMPLATE.format(goal=self._state.goal)
+            return f"{prompt}{feedback}"
+        prompt = CONTINUATION_PROMPT_TEMPLATE.format(goal=self._state.goal)
+        return f"{prompt}{feedback}"
 
     def render_contract(self) -> str:
         """Public helper for the /goal show + /goal draft slash commands."""

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -137,6 +137,43 @@ class TestGoalManager:
         assert "port goal command to hermes" in prompt
         assert prompt.strip()  # non-empty
 
+    def test_continuation_prompt_includes_failed_judge_reason(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="cont-feedback-sid")
+        mgr.set("prove the result")
+        mgr.state.last_verdict = "continue"
+        mgr.state.last_reason = "Show the actual file excerpt, not only a summary."
+
+        prompt = mgr.next_continuation_prompt()
+        assert "Previous completion-check feedback:" in prompt
+        assert "Show the actual file excerpt" in prompt
+        assert "Address this specific feedback" in prompt
+
+    def test_continuation_feedback_is_bounded(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="cont-feedback-bound-sid")
+        mgr.set("prove the result")
+        mgr.state.last_verdict = "continue"
+        mgr.state.last_reason = "x" * 5000
+
+        prompt = mgr.next_continuation_prompt()
+        feedback = prompt.split("Previous completion-check feedback:\n", 1)[1]
+        assert len(feedback) < 1400
+
+    def test_wait_verdict_is_not_replayed_as_failure_feedback(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="cont-wait-sid")
+        mgr.set("wait for peer")
+        mgr.state.last_verdict = "wait"
+        mgr.state.last_reason = "Waiting for a peer reply."
+
+        prompt = mgr.next_continuation_prompt()
+        assert "Previous completion-check feedback:" not in prompt
+        assert "Waiting for a peer reply." not in prompt
+
 
 # ──────────────────────────────────────────────────────────────────────
 # Smoke: CommandDef is wired


### PR DESCRIPTION
## Summary

Feeds the previous failed goal-judge reason into the next native `/goal` continuation turn.

The judge already persists a precise `continue` reason, but `next_continuation_prompt()` currently sends only the static goal/contract back to the agent. That can make the agent repeat the same incomplete completion claim because the judge knows what evidence is missing while the next turn does not.

- only `continue` verdicts contribute feedback
- feedback is bounded to 1200 characters
- wait/done states are not replayed as failure guidance
- no new state or persistence is introduced
- no domain-specific behavior

## Validation

- `python -m pytest -q tests/hermes_cli/test_goals.py` → **39 passed**
- Python compile check → **PASS**
- `git diff --check` → **PASS**
