### PR TITLE
fix(desktop): bots group chat sends message on IME composition Enter

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -8867,6 +8867,10 @@ function HubSkillsSection({ forProfile, onInstalled }) {
             value: query,
             onChange: event => setQuery(event.target.value),
             onKeyDown: event => {
+              // IME guard: Enter confirming a composed word must not search.
+              if (event.nativeEvent?.isComposing || event.keyCode === 229) {
+                return
+              }
               if (event.key === 'Enter') {
                 event.preventDefault()
                 void search()
@@ -11775,6 +11779,14 @@ function GroupMentionInput({ members, onChange, onSubmitDraft, value, ...inputPr
         },
         onClick: event => refreshToken(event.target),
         onKeyDown: event => {
+          // IME composition guard (same as the core composer): Enter here
+          // confirms the composed Chinese/Japanese/Korean text — it must not
+          // insert a mention nor submit the draft. nativeEvent.isComposing
+          // covers Chromium; keyCode 229 covers macOS Chinese IMEs that fire
+          // Enter after compositionend with isComposing already false.
+          if (event.nativeEvent?.isComposing || event.keyCode === 229) {
+            return
+          }
           if (open) {
             if (event.key === 'ArrowDown') {
               event.preventDefault()
@@ -11961,6 +11973,10 @@ function GroupClarifyCard({ entry, members }) {
                     setDrafts(prev => ({ ...prev, [q.qid]: value }))
                   },
                   onKeyDown: event => {
+                    // IME guard: Enter confirming a composed word must not submit.
+                    if (event.nativeEvent?.isComposing || event.keyCode === 229) {
+                      return
+                    }
                     if (event.key === 'Enter' && questions.length === 1) {
                       event.preventDefault()
                       void submit()

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-room-ux.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-room-ux.test.mjs
@@ -31,6 +31,33 @@ test('room composer is a textarea with Enter=submit, Shift+Enter=newline (#89884
   assert.match(component, /insert\(options\[active\]\.handle\)/)
 })
 
+test('room composer swallows IME composition Enters before submit/mention (#93528)', () => {
+  // macOS Chinese IME: Enter that confirms a candidate word fires a keydown
+  // the composer mistook for a send — the message went out mid-composition.
+  // The guard must run BEFORE the popover branch AND the submit branch, and
+  // cover both Chromium's isComposing flag and the keyCode 229 legacy
+  // VK_PROCESSKEY that macOS IMEs emit after compositionend.
+  const start = source.indexOf('function GroupMentionInput')
+  const nextFn = source.indexOf('\nfunction ', start + 1)
+  const component = source.slice(start, nextFn)
+
+  const guard = component.indexOf('event.nativeEvent?.isComposing || event.keyCode === 229')
+  assert.ok(guard >= 0, 'IME guard present in GroupMentionInput')
+  const afterGuard = component.slice(guard)
+  // Guard returns immediately (no mention insert, no submit)...
+  assert.match(afterGuard.slice(0, 80), /return/)
+  // ...and it sits before both the popover branch and the submit branch.
+  assert.ok(afterGuard.indexOf('if (open) {') > 0, 'guard precedes popover branch')
+  assert.ok(component.indexOf("event.key === 'Enter' && !event.shiftKey") > guard, 'guard precedes submit branch')
+})
+
+test('clarify free-text input swallows IME composition Enters (#93528)', () => {
+  const clarify = source.slice(source.indexOf('function GroupClarifyCard'), source.indexOf('function openGroupChat'))
+  const guard = clarify.indexOf('event.nativeEvent?.isComposing || event.keyCode === 229')
+  assert.ok(guard >= 0, 'IME guard present in GroupClarifyCard')
+  assert.ok(clarify.indexOf("event.key === 'Enter' && questions.length === 1") > guard, 'guard precedes submit branch')
+})
+
 test('both room composers wire onSubmitDraft (#89884)', () => {
   assert.match(source, /onSubmitDraft: submit,/)
   assert.match(source, /onSubmitDraft: \(\) => submitReply\(id\),/)


### PR DESCRIPTION
## What
Pressing Enter to confirm a candidate word with a macOS Chinese pinyin IME in the **Bots** tab group chat sent the draft as a message mid-composition. The group-chat composer (`GroupMentionInput` in `apps/desktop/src/plugins/hermes-bots/plugin.js`) submitted on `event.key === 'Enter' && !event.shiftKey` with no IME guard.

## Fix
Add the same guard the core composer already uses (#44135 — `isComposing` + legacy `keyCode 229`) to the three Enter handlers in the bots plugin:
- `GroupMentionInput` onKeyDown — group composer + reply box (the reported bug)
- `GroupClarifyCard` free-text answer input — same premature-submit class
- skill-hub search input — same premature-trigger class

Guard runs before both the @-mention popover branch and the submit branch, so an IME confirmation Enter never inserts a mention nor sends.

## Tests
Two new behavior-contract tests in `group-room-ux.test.mjs` assert the guard is present and ordered before the popover/submit branches in `GroupMentionInput` and `GroupClarifyCard`. All 530 hermes-bots tests pass.

Closes #93528