### PR TITLE
fix(terminal): cap watch_patterns notifications over a process's lifetime

### DIFF
--- a/tests/tools/test_watch_patterns.py
+++ b/tests/tools/test_watch_patterns.py
@@ -136,6 +136,46 @@ class TestPerSessionRateLimit:
 
 
 # =========================================================================
+# Lifetime cap: sparsely-spaced matches never trip the consecutive-strike
+# counter, but must still stop eventually (#93513).
+# =========================================================================
+
+class TestLifetimeCap:
+    def test_sparse_matches_disable_after_lifetime_cap(self, registry):
+        """Matches spaced well past the cooldown never strike, but a service
+        restarted over and over must still get disabled instead of forcing a
+        full-context turn forever."""
+        from tools.process_registry import WATCH_LIFETIME_MAX_HITS
+
+        session = _make_session(watch_patterns=["Application started"])
+        for i in range(WATCH_LIFETIME_MAX_HITS):
+            # Force the cooldown to have already expired, simulating a
+            # cleanly-spaced restart (no strikes should ever accumulate).
+            session._watch_cooldown_until = 0.0
+            registry._check_watch_patterns(session, "Application started\n")
+
+        assert session._watch_hits == WATCH_LIFETIME_MAX_HITS
+        assert session._watch_consecutive_strikes == 0  # never struck
+        assert session._watch_disabled is True
+        assert session.notify_on_complete is True
+
+        events = []
+        while not registry.completion_queue.empty():
+            events.append(registry.completion_queue.get_nowait())
+        match_events = [e for e in events if e["type"] == "watch_match"]
+        disabled_events = [e for e in events if e["type"] == "watch_disabled"]
+        assert len(match_events) == WATCH_LIFETIME_MAX_HITS
+        assert len(disabled_events) == 1
+        assert "lifetime cap" in disabled_events[0]["message"]
+
+        # One more restart after the cap: no further turns are forced.
+        session._watch_cooldown_until = 0.0
+        registry._check_watch_patterns(session, "Application started\n")
+        assert registry.completion_queue.empty()
+        assert session._watch_hits == WATCH_LIFETIME_MAX_HITS
+
+
+# =========================================================================
 # Checkpoint persistence
 # =========================================================================
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -73,6 +73,16 @@ MAX_ACTIVE_PROCESS_AGE = 86400  # 24h default — see session_reset.bg_process_m
 WATCH_MIN_INTERVAL_SECONDS = 15   # Minimum spacing between consecutive watch matches
 WATCH_STRIKE_LIMIT = 3            # Strikes in a row → disable watch + promote to notify_on_complete
 
+# Lifetime cap — independent of the strike counter above. A process whose
+# pattern recurs at a cadence just above WATCH_MIN_INTERVAL_SECONDS (e.g. a
+# service restarted repeatedly over a day) never trips the consecutive-strike
+# limit, since each match lands in its own clean cooldown window, yet still
+# forces a full-context agent turn every single time (#93513). watch_patterns
+# is documented as "ONLY for rare one-shot mid-process signals", so once a
+# session has delivered this many matches over its whole life we disable it
+# and fall back to notify_on_complete, same as the strike-limit path.
+WATCH_LIFETIME_MAX_HITS = 8
+
 # Global circuit breaker — across all sessions. Secondary safety net so concurrent
 # siblings can't collectively flood the user even when each is under its own cap.
 WATCH_GLOBAL_MAX_PER_WINDOW = 15
@@ -526,6 +536,12 @@ class ProcessRegistry:
         disabled for this session and the session is promoted to
         notify_on_complete semantics — one notification when the process
         actually exits, no more mid-process spam.
+
+        Independently, WATCH_LIFETIME_MAX_HITS caps the total number of
+        matches ever delivered for a session, so a pattern that keeps
+        recurring at a cadence just above the cooldown (e.g. a service
+        restarted repeatedly over a day) still gets disabled instead of
+        forcing a full-context agent turn indefinitely.
         """
         if not session.watch_patterns or session._watch_disabled:
             return
@@ -552,6 +568,7 @@ class ProcessRegistry:
 
         now = time.time()
         should_disable = False
+        lifetime_exhausted = False
         with session._lock:
             # Case 1: still inside the cooldown from the last emission.
             # Count this as a strike for the current window (only once per window)
@@ -590,6 +607,13 @@ class ProcessRegistry:
                 suppressed = session._watch_suppressed
                 session._watch_suppressed = 0
                 return_early = False
+                # Lifetime cap: this match is delivered (it already earned it),
+                # but disable further ones regardless of how cleanly spaced
+                # they are — see WATCH_LIFETIME_MAX_HITS above.
+                lifetime_exhausted = session._watch_hits >= WATCH_LIFETIME_MAX_HITS
+                if lifetime_exhausted:
+                    session._watch_disabled = True
+                    session.notify_on_complete = True
 
         if return_early:
             if should_disable:
@@ -644,6 +668,29 @@ class ProcessRegistry:
         }
         _redact_process_result(notification)
         self.completion_queue.put(notification)
+
+        if lifetime_exhausted:
+            # Same "why things went quiet" summary as the strike-limit path,
+            # queued right after the final delivered match.
+            self.completion_queue.put({
+                "session_id": session.id,
+                "session_key": session.session_key,
+                "command": session.command,
+                "type": "watch_disabled",
+                "suppressed": 0,
+                "platform": session.watcher_platform,
+                "chat_id": session.watcher_chat_id,
+                "user_id": session.watcher_user_id,
+                "user_name": session.watcher_user_name,
+                "thread_id": session.watcher_thread_id,
+                "message_id": session.watcher_message_id,
+                "message": (
+                    f"Watch patterns disabled for process {session.id} — "
+                    f"reached the lifetime cap of {WATCH_LIFETIME_MAX_HITS} delivered "
+                    f"matches. Falling back to notify_on_complete semantics; you'll get "
+                    f"exactly one notification when the process exits."
+                ),
+            })
 
     def _global_watch_admit(self, now: float) -> bool:
         """Return True if this watch_match event is allowed through the global breaker.

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3971,7 +3971,7 @@ TERMINAL_SCHEMA = {
             "watch_patterns": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "Strings to watch for in background output. ONLY for rare one-shot mid-process signals on processes that never exit (e.g. ['Application startup complete'] on a server). NOT for end-of-run markers (use notify_on_complete) and NOT for per-iteration patterns like 'ERROR' in loops — rate-limited to 1 notification/15s; repeated over-firing auto-disables it and falls back to notify-on-exit. When in doubt, use notify_on_complete. MUTUALLY EXCLUSIVE with notify_on_complete."
+                "description": "Strings to watch for in background output. ONLY for rare one-shot mid-process signals on processes that never exit (e.g. ['Application startup complete'] on a server). NOT for end-of-run markers (use notify_on_complete) and NOT for per-iteration patterns like 'ERROR' in loops — rate-limited to 1 notification/15s, capped at a small number of matches over the process's lifetime; over-firing auto-disables it and falls back to notify-on-exit. When in doubt, use notify_on_complete. MUTUALLY EXCLUSIVE with notify_on_complete."
             }
         },
         "required": ["command"]


### PR DESCRIPTION
## What does this PR do?

Closes the gap in `watch_patterns` rate limiting that lets a recurring
pattern force an unbounded number of full-context agent turns.

`ProcessRegistry._check_watch_patterns()` already has a per-session rate
limit (1 notification / 15s) plus a 3-consecutive-strikes auto-disable, but
that strike counter only advances when a match is *dropped* inside an
active cooldown window. A match that arrives after the cooldown has already
expired is treated as "clean" and resets the strike counter to 0 — so a
pattern that recurs at a cadence just above the 15s floor (a service
restarted repeatedly over hours/days, for example) never trips the
strike-limit disable. Every one of those matches still synthesizes an
`[IMPORTANT: Background process ... matched watch pattern ...]` message and
forces a brand-new agent turn carrying the *entire* conversation.

This PR adds a lifetime cap independent of the strike counter:
`WATCH_LIFETIME_MAX_HITS` (8). Once a session has delivered that many
`watch_match` notifications over its whole life — regardless of how cleanly
spaced they were — `watch_patterns` is disabled and the session falls back
to `notify_on_complete` semantics (one notification when the process
actually exits), reusing the exact same disable/promotion path the
strike-limit already uses.

This targets the part of #93513 that the existing three-layer defense
(`97d54f0e4d`) doesn't cover: sparse-but-recurring matches. Deeper parts of
that issue — a token-budget guard before triggering a turn at all, and the
separate WebSocket re-attach defect — are larger, architectural changes to
the gateway's turn-triggering and connection-recovery paths and are left
for a maintainer/dedicated follow-up rather than bundled into this small,
mechanical fix.

## Related Issue

Fixes #93513 (partial — see scope note above)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/process_registry.py` — add `WATCH_LIFETIME_MAX_HITS` constant and enforce it in `_check_watch_patterns()`, queuing the same `watch_disabled` summary event used by the strike-limit path.
- `tools/terminal_tool.py` — update the `watch_patterns` tool-schema description to mention the lifetime cap.
- `tests/tools/test_watch_patterns.py` — add `TestLifetimeCap` covering sparsely-spaced matches (cooldown reset before every match, so the strike counter never advances) that must still stop after the cap.

## How to Test

1. `python3 -m pytest tests/tools/test_watch_patterns.py -q`
2. To see the new test fail without the fix: `git checkout HEAD~1 -- tools/process_registry.py tools/terminal_tool.py && python3 -m pytest tests/tools/test_watch_patterns.py -k TestLifetimeCap -q` (fails with `ImportError: cannot import name 'WATCH_LIFETIME_MAX_HITS'`), then `git checkout HEAD -- tools/process_registry.py tools/terminal_tool.py` to restore.

### Actual output

```
$ python3 -m pytest tests/tools/test_watch_patterns.py -q
.....................                                                    [100%]
21 passed in 0.63s

$ git checkout HEAD~1 -- tools/process_registry.py tools/terminal_tool.py
$ python3 -m pytest tests/tools/test_watch_patterns.py -k TestLifetimeCap -q
F                                                                        [100%]
FAILED tests/tools/test_watch_patterns.py::TestLifetimeCap::test_sparse_matches_disable_after_lifetime_cap - ImportError: cannot import name 'WATCH_LIFETIME_MAX_HITS' from 'tools.process_registry'
1 failed, 20 deselected in 0.43s
$ git checkout HEAD -- tools/process_registry.py tools/terminal_tool.py

$ python3 -m ruff check tools/process_registry.py tools/terminal_tool.py tests/tools/test_watch_patterns.py
All checks passed!
```

`tests/tools/test_process_registry.py` and other neighboring suites were
also run; the handful of pre-existing failures there (missing `psutil` /
`ptyprocess` in this sandbox, a live-system-guard block on real `os.kill`)
reproduce identically on unmodified `main` and are unrelated to this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (checked #82561, #89941, #82925, #73351 — none address the lifetime-recurrence gap)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant test suites and all targeted tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (sandboxed CI environment)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring in `_check_watch_patterns` updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new config key
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A, pure in-memory rate-limit logic, no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — updated `watch_patterns` description in `TERMINAL_SCHEMA`

## AI assistance disclosure

This PR was prepared by an autonomous coding agent (Claude, via an
OSS-contribution pipeline) that read the issue, located the relevant rate
limiting code, wrote the fix and the failing-first test, and verified it.
