### PR TITLE
chore(design): add Codex graphite Superdesign context

### DIFF
--- a/.superdesign/design-system.md
+++ b/.superdesign/design-system.md
@@ -1,0 +1,83 @@
+# Hermes Codex Graphite Design System
+
+## Product context
+
+Hermes is a local-first AI agent dashboard with a persistent embedded TUI chat, session history, files, models, logs, automation, integrations, configuration, and system controls. The redesign must preserve the native information architecture, route hierarchy, compact operator workflow, accessibility, and responsive navigation. It changes presentation only.
+
+## Visual direction
+
+Codex-inspired dark productivity UI: calm, matte graphite surfaces; precise spacing; crisp typography; restrained blue interaction color; subtle borders instead of decorative effects. Borrow only the useful layered-dark hierarchy from the selected Neural Noir reference. Do not use its gold palette, serif typography, marketing composition, glowing nodes, glass blur, gradients, or ornamental animation.
+
+## Color tokens
+
+- Canvas: `#0d0f12`
+- Sidebar: `#090b0e`
+- Elevated surface: `#13161b`
+- Card: `#161a20`
+- Hover surface: `#1b2028`
+- Input surface: `#111419`
+- Primary text: `#f2f4f7`
+- Secondary text: `#a3acb9`
+- Tertiary text: `#737e8e`
+- Disabled text: `#535d6b`
+- Border: `#282e38`
+- Subtle border: `rgba(255,255,255,0.07)`
+- Primary blue: `#4c8dff`
+- Primary blue hover: `#6aa0ff`
+- Primary blue wash: `rgba(76,141,255,0.12)`
+- Focus ring: `rgba(76,141,255,0.55)`
+- Success: `#32d583`
+- Warning: `#fdb022`
+- Destructive: `#f97066`
+- Terminal background: `#080a0d`
+- Terminal foreground: `#e6eaf0`
+- Input-series accent: `#8aaeff`
+- Output-series accent: `#32d583`
+
+## Typography
+
+- UI sans: `Inter`, followed by the native system UI stack.
+- Technical and terminal: `JetBrains Mono`, followed by the native monospace stack.
+- Base size: 14px; line height: 1.5; letter spacing: -0.005em.
+- Headings use 600 weight, sentence case, and tight spacing.
+- Navigation and controls use 500 weight. Avoid wide uppercase labels except where Hermes already requires compact status metadata.
+
+## Geometry and spacing
+
+- Base radius: 10px; controls 7-9px; large dialogs/cards 12px.
+- Comfortable density with compact operator controls.
+- Sidebar remains 256px expanded and 56px collapsed.
+- Use 1px borders and small tonal changes to establish hierarchy.
+- Shadows are rare and restrained: `0 10px 30px rgba(0,0,0,0.28)` only for floating menus/dialogs.
+- No glassmorphism, bevels, neon, grain, or large glow effects.
+
+## Components
+
+- Sidebar: distinct darkest surface, thin right border, blue-tinted active row, 3px active indicator, muted icons, stronger text on hover.
+- Cards: matte elevated surface, subtle border, no heavy shadow, 10-12px radius.
+- Buttons: primary blue solid; secondary graphite; ghost controls use tonal hover. Preserve destructive/status semantics.
+- Inputs/selects: dark recessed surface, visible border, blue focus ring, high-contrast placeholder.
+- Tabs/segmented controls: compact graphite track with the selected segment one tonal step brighter.
+- Dialogs/popovers: elevated graphite, crisp border, soft shadow, clear hierarchy.
+- Tables/lists: low-contrast row separators, blue-tinted selection, visible keyboard focus.
+- Status indicators: semantic colors only; no ambient pulsing except an existing live state.
+- Embedded TUI: use the terminal colors above; retain JetBrains Mono and all terminal behavior.
+
+## Motion
+
+- Transitions: 140-180ms, `cubic-bezier(0.2, 0, 0, 1)`.
+- Limit motion to hover, focus, menu/dialog entrance, and sidebar width changes.
+- Respect `prefers-reduced-motion` and disable non-essential animation.
+
+## Responsive behavior
+
+- Preserve the existing 1024px sidebar-to-drawer transition and 768px document overflow behavior.
+- Keep touch targets at least 40px on mobile.
+- Avoid horizontal overflow on Sessions, Chat, Models, and Config.
+
+## Hard constraints
+
+- Preserve all Hermes routes, controls, icons, information, and plugin slots.
+- Keep the native embedded TUI as the primary chat surface.
+- Use only the colors, fonts, spacing, and component styles defined here.
+- Do not introduce gold, purple, teal, decorative serif fonts, gradients, translucent glass panels, marketing sections, or invented product features.

--- a/.superdesign/init/components.md
+++ b/.superdesign/init/components.md
@@ -1,0 +1,600 @@
+# Shared UI Components
+
+Framework: React 19 with TypeScript, Vite, React Router, Tailwind CSS v4, and @nous-research/ui.
+
+## ThemeSwitcher
+
+Path: `web/src/components/ThemeSwitcher.tsx`
+
+Full source:
+
+```tsx
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { Palette, Check, Type } from "lucide-react";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { ListItem } from "@nous-research/ui/ui/components/list-item";
+import { BottomSheet } from "@nous-research/ui/ui/components/bottom-sheet";
+import { Typography } from "@nous-research/ui/ui/components/typography/index";
+import { useBelowBreakpoint } from "@nous-research/ui/hooks/use-below-breakpoint";
+import { BUILTIN_THEMES, THEME_DEFAULT_FONT_ID, useTheme } from "@/themes";
+import type { DashboardTheme, FontChoice, ThemeListEntry } from "@/themes";
+import { useI18n } from "@/i18n";
+import { cn } from "@/lib/utils";
+
+/**
+ * Compact theme picker mounted next to the language switcher in the header.
+ * Each dropdown row shows a 3-stop swatch (background / midground / warm
+ * glow) so users can preview the palette before committing. User-defined
+ * themes from `~/.hermes/dashboard-themes/*.yaml` use their API-provided
+ * definitions so they show real palette swatches just like built-ins.
+ *
+ * When placed at the bottom of a container (e.g. the sidebar rail), pass
+ * `dropUp` so the menu opens above the trigger instead of clipping below
+ * the viewport. On viewports below the `sm` breakpoint, `dropUp` uses a
+ * bottom sheet portaled to `document.body` so the picker is not clipped by
+ * the sidebar (same idea as a responsive Drawer).
+ */
+export function ThemeSwitcher({ collapsed = false, dropUp = false }: ThemeSwitcherProps) {
+  const { themeName, availableThemes, setTheme, fontId, fontChoices, setFont } = useTheme();
+  const { t } = useI18n();
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const narrowViewport = useBelowBreakpoint(640);
+  const useMobileSheet = Boolean(dropUp && narrowViewport);
+
+  const close = useCallback(() => setOpen(false), []);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, close]);
+
+  useEffect(() => {
+    if (!open || useMobileSheet) return;
+    const onMouseDown = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (wrapperRef.current?.contains(target)) return;
+      if (dropdownRef.current?.contains(target)) return;
+      close();
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    return () => document.removeEventListener("mousedown", onMouseDown);
+  }, [open, close, useMobileSheet]);
+
+  const current = availableThemes.find((th) => th.name === themeName);
+  const label = current?.label ?? themeName;
+  const sheetTitle = t.theme?.title ?? "Theme";
+
+  return (
+    <div ref={wrapperRef} className="relative">
+      <Button
+        ghost
+        size={collapsed ? "icon" : undefined}
+        onClick={() => setOpen((o) => !o)}
+        className={cn(
+          collapsed
+            ? "text-text-secondary hover:text-foreground hover:bg-transparent"
+            : "px-2 py-1 normal-case tracking-normal font-normal text-xs text-text-secondary hover:text-foreground",
+        )}
+        title={`${t.theme?.switchTheme ?? "Switch theme"}: ${label}`}
+        aria-label={t.theme?.switchTheme ?? "Switch theme"}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+      >
+        <span className="inline-flex items-center gap-1.5">
+          <Palette className="h-3.5 w-3.5" />
+
+          {!collapsed && (
+            <Typography
+              className="hidden sm:inline text-display tracking-wide text-xs"
+            >
+              {label}
+            </Typography>
+          )}
+        </span>
+      </Button>
+
+      {useMobileSheet && (
+        <BottomSheet
+          backdropDismissLabel={t.common.close}
+          onClose={close}
+          open={open}
+          title={sheetTitle}
+        >
+          <div aria-label={sheetTitle} role="listbox">
+            <ThemeSwitcherOptions
+              availableThemes={availableThemes}
+              close={close}
+              setTheme={setTheme}
+              themeName={themeName}
+            />
+            <FontSection
+              fontChoices={fontChoices}
+              fontId={fontId}
+              setFont={setFont}
+            />
+          </div>
+        </BottomSheet>
+      )}
+
+      {open && !useMobileSheet && (() => {
+        const rect = wrapperRef.current?.getBoundingClientRect();
+        const dropdown = (
+          <div
+            ref={dropdownRef}
+            aria-label={sheetTitle}
+            className={cn(
+              "min-w-[240px] max-h-[70dvh] overflow-y-auto",
+              "border border-current/20 bg-background-base/95",
+              "shadow-[0_12px_32px_-8px_rgba(0,0,0,0.6)]",
+              dropUp ? "fixed z-[100]" : "absolute z-50 right-0 top-full mt-1",
+            )}
+            role="listbox"
+            style={
+              dropUp && rect
+                ? { bottom: window.innerHeight - rect.top + 4, left: rect.left }
+                : undefined
+            }
+          >
+            <div className="border-b border-current/20 px-3 py-2">
+              <Typography
+                className="text-display text-xs tracking-[0.12em] text-text-tertiary"
+              >
+                {sheetTitle}
+              </Typography>
+            </div>
+
+            <ThemeSwitcherOptions
+              availableThemes={availableThemes}
+              close={close}
+              setTheme={setTheme}
+              themeName={themeName}
+            />
+            <FontSection
+              fontChoices={fontChoices}
+              fontId={fontId}
+              setFont={setFont}
+            />
+          </div>
+        );
+        return dropUp ? createPortal(dropdown, document.body) : dropdown;
+      })()}
+    </div>
+  );
+}
+
+function ThemeSwitcherOptions({
+  availableThemes,
+  close,
+  setTheme,
+  themeName,
+}: ThemeSwitcherOptionsProps) {
+  return (
+    <>
+      {availableThemes.map((th) => {
+        const isActive = th.name === themeName;
+        const paletteTheme = BUILTIN_THEMES[th.name] ?? th.definition;
+
+        return (
+          <ListItem
+            active={isActive}
+            aria-selected={isActive}
+            className="gap-3"
+            key={th.name}
+            onClick={() => {
+              setTheme(th.name);
+              close();
+            }}
+            role="option"
+          >
+            {paletteTheme ? (
+              <ThemeSwatch theme={paletteTheme} />
+            ) : (
+              <PlaceholderSwatch />
+            )}
+
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+              <Typography
+                className="truncate text-display text-xs tracking-wide"
+              >
+                {th.label}
+              </Typography>
+              {th.description && (
+                <Typography className="truncate text-xs tracking-normal text-text-tertiary">
+                  {th.description}
+                </Typography>
+              )}
+            </div>
+
+            <Check
+              className={cn(
+                "h-3 w-3 shrink-0 text-midground",
+                isActive ? "opacity-100" : "opacity-0",
+              )}
+            />
+          </ListItem>
+        );
+      })}
+    </>
+  );
+}
+
+const FONT_CATEGORY_LABEL_KEY: Record<FontChoice["category"], "fontSans" | "fontSerif" | "fontMono"> = {
+  sans: "fontSans",
+  serif: "fontSerif",
+  mono: "fontMono",
+};
+
+/** Font-override section rendered below the theme list. Lets the user pick
+ *  any catalog font independently of the active theme, or "Theme default"
+ *  to clear the override. Each row previews itself in its own font. */
+function FontSection({ fontChoices, fontId, setFont }: FontSectionProps) {
+  const { t } = useI18n();
+  const order: FontChoice["category"][] = ["sans", "serif", "mono"];
+  return (
+    <>
+      <div className="mt-1 border-t border-current/20 px-3 pb-1 pt-2">
+        <span className="inline-flex items-center gap-1.5">
+          <Type className="h-3 w-3 text-text-tertiary" />
+          <Typography
+            className="text-display text-xs tracking-[0.12em] text-text-tertiary"
+          >
+            {t.theme?.fontTitle ?? "Font"}
+          </Typography>
+        </span>
+      </div>
+
+      {/* Theme-default (clears the override). */}
+      <ListItem
+        active={fontId === THEME_DEFAULT_FONT_ID}
+        aria-selected={fontId === THEME_DEFAULT_FONT_ID}
+        className="gap-3"
+        onClick={() => setFont(THEME_DEFAULT_FONT_ID)}
+        role="option"
+      >
+        <span aria-hidden className="h-4 w-9 shrink-0" />
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <Typography className="truncate text-xs tracking-normal">
+            {t.theme?.fontDefault ?? "Theme default"}
+          </Typography>
+          <Typography className="truncate text-xs tracking-normal text-text-tertiary">
+            {t.theme?.fontDefaultHint ?? "Use the active theme's font"}
+          </Typography>
+        </div>
+        <Check
+          className={cn(
+            "h-3 w-3 shrink-0 text-midground",
+            fontId === THEME_DEFAULT_FONT_ID ? "opacity-100" : "opacity-0",
+          )}
+        />
+      </ListItem>
+
+      {order.map((cat) => {
+        const fonts = fontChoices.filter((f) => f.category === cat);
+        if (fonts.length === 0) return null;
+        const catLabel = t.theme?.[FONT_CATEGORY_LABEL_KEY[cat]] ?? cat;
+        return (
+          <div key={cat}>
+            <div className="px-3 pb-0.5 pt-1.5">
+              <Typography className="text-[0.65rem] uppercase tracking-[0.1em] text-text-tertiary">
+                {catLabel}
+              </Typography>
+            </div>
+            {fonts.map((f) => {
+              const isActive = f.id === fontId;
+              return (
+                <ListItem
+                  active={isActive}
+                  aria-selected={isActive}
+                  className="gap-3"
+                  key={f.id}
+                  onClick={() => setFont(f.id)}
+                  role="option"
+                >
+                  <span aria-hidden className="h-4 w-9 shrink-0" />
+                  <div className="flex min-w-0 flex-1 flex-col">
+                    {/* Preview the font in its own stack. */}
+                    <span
+                      className="truncate text-sm"
+                      style={{ fontFamily: f.stack }}
+                    >
+                      {f.label}
+                    </span>
+                  </div>
+                  <Check
+                    className={cn(
+                      "h-3 w-3 shrink-0 text-midground",
+                      isActive ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                </ListItem>
+              );
+            })}
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+function ThemeSwatch({ theme }: { theme: DashboardTheme }) {
+  const [c1, c2, c3] = theme.swatchColors ?? [
+    theme.palette.background.hex,
+    theme.palette.midground.hex,
+    theme.palette.warmGlow,
+  ];
+  return (
+    <div
+      aria-hidden
+      className="flex h-4 w-9 shrink-0 overflow-hidden border border-current/20"
+    >
+      <span className="flex-1" style={{ background: c1 }} />
+      <span className="flex-1" style={{ background: c2 }} />
+      <span className="flex-1" style={{ background: c3 }} />
+    </div>
+  );
+}
+
+function PlaceholderSwatch() {
+  return (
+    <div
+      aria-hidden
+      className="h-4 w-9 shrink-0 border border-dashed border-current/20"
+    />
+  );
+}
+
+interface ThemeSwitcherOptionsProps {
+  availableThemes: ThemeListEntry[];
+  close: () => void;
+  setTheme: (name: string) => void;
+  themeName: string;
+}
+
+interface FontSectionProps {
+  fontChoices: FontChoice[];
+  fontId: string;
+  setFont: (id: string) => void;
+}
+
+interface ThemeSwitcherProps {
+  collapsed?: boolean;
+  dropUp?: boolean;
+}
+
+```
+
+## ProfileSwitcher
+
+Path: `web/src/components/ProfileSwitcher.tsx`
+
+Full source:
+
+```tsx
+import { useMemo } from "react";
+import { Users } from "lucide-react";
+import {
+  Select,
+  SelectOption,
+} from "@nous-research/ui/ui/components/select";
+import { useProfileScope } from "@/contexts/useProfileScope";
+import { useI18n } from "@/i18n";
+import { cn } from "@/lib/utils";
+
+/**
+ * The machine dashboard's single write-target selector.
+ *
+ * Rendered in the sidebar above the nav. Every management page (Config,
+ * Keys, Skills, MCP, Models) reads/writes the selected profile via the
+ * fetchJSON ?profile= injection. Hidden when only one profile exists.
+ */
+export function ProfileSwitcher({ collapsed }: ProfileSwitcherProps) {
+  const { profile, currentProfile, profiles, setProfile } = useProfileScope();
+  const { t } = useI18n();
+
+  const currentDashboardLabel = useMemo(
+    () =>
+      (t.app.currentProfileOption ?? "this dashboard ({name})").replace(
+        "{name}",
+        currentProfile || "default",
+      ),
+    [currentProfile, t.app.currentProfileOption],
+  );
+
+  if (profiles.length < 2) return null;
+
+  const managed = profile || currentProfile || "default";
+  const isOther = !!profile && profile !== currentProfile;
+  const managingLabel = t.app.managingProfile ?? "Managing profile";
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 border-b border-current/10 px-3 py-2",
+        collapsed && "lg:justify-center lg:px-0",
+      )}
+      title={managingLabel}
+    >
+      <Users
+        className={cn(
+          "h-3.5 w-3.5 shrink-0",
+          isOther ? "text-amber-300" : "text-text-tertiary",
+        )}
+      />
+
+      <Select
+        className={cn(
+          "min-w-0 flex-1",
+          collapsed && "lg:hidden",
+          "[&_button]:h-7 [&_button]:border-border [&_button]:bg-background [&_button]:px-2 [&_button]:text-xs",
+          "[&_button]:font-sans [&_button]:normal-case [&_button]:tracking-normal",
+          "[&_[role=listbox]>div]:font-sans [&_[role=listbox]>div]:text-xs",
+          "[&_[role=listbox]>div]:normal-case [&_[role=listbox]>div]:tracking-normal",
+          isOther &&
+            "[&_button]:border-amber-500/50 [&_button]:text-amber-300",
+        )}
+        id="hermes-profile-switcher"
+        onValueChange={setProfile}
+        value={profile}
+      >
+        <SelectOption value="">{currentDashboardLabel}</SelectOption>
+
+        {profiles
+          .filter((name) => name !== currentProfile)
+          .map((name) => (
+            <SelectOption key={name} value={name}>
+              {name}
+            </SelectOption>
+          ))}
+      </Select>
+
+      {collapsed && <span className="sr-only">{managed}</span>}
+    </div>
+  );
+}
+
+interface ProfileSwitcherProps {
+  collapsed?: boolean;
+}
+
+```
+
+## SidebarStatusStrip
+
+Path: `web/src/components/SidebarStatusStrip.tsx`
+
+Full source:
+
+```tsx
+import { Link } from "react-router";
+import type { StatusResponse } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { useI18n } from "@/i18n";
+
+/** Gateway + session summary for the System sidebar block (no separate strip chrome). */
+export function SidebarStatusStrip({ status }: SidebarStatusStripProps) {
+  const { t } = useI18n();
+
+  if (status === null) {
+    return (
+      <div className="px-5 py-1.5" aria-hidden>
+        <div className="h-2 w-[80%] max-w-full animate-pulse rounded-sm bg-midground/10" />
+      </div>
+    );
+  }
+
+  const gw = gatewayLine(status, t);
+  const { activeSessionsLabel, gatewayStatusLabel } = t.app;
+
+  return (
+    <Link
+      to="/sessions"
+      title={t.app.statusOverview}
+      className={cn(
+        "block text-left",
+        "px-5 pb-2 pt-0.5",
+        "text-text-secondary",
+        "transition-colors hover:text-midground",
+        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-midground/40",
+        "focus-visible:ring-inset",
+      )}
+    >
+      <div className="flex flex-col gap-1 font-sans text-xs leading-snug tracking-[0.08em]">
+        <p className="break-words">
+          <span className="text-text-tertiary">{gatewayStatusLabel}</span>{" "}
+          <span className={cn("font-medium", gw.tone)}>{gw.label}</span>
+        </p>
+
+        <p className="break-words">
+          <span className="text-text-tertiary">{activeSessionsLabel}</span>{" "}
+          <span className="tabular-nums text-text-secondary">
+            {status.active_sessions}
+          </span>
+        </p>
+      </div>
+    </Link>
+  );
+}
+
+export function gatewayLine(
+  status: StatusResponse,
+  t: ReturnType<typeof useI18n>["t"],
+): { label: string; tone: string } {
+  const g = t.app.gatewayStrip;
+  const byState: Record<string, { label: string; tone: string }> = {
+    running: { label: g.running, tone: "text-success" },
+    starting: { label: g.starting, tone: "text-warning" },
+    startup_failed: { label: g.failed, tone: "text-destructive" },
+    stopped: { label: g.stopped, tone: "text-muted-foreground" },
+  };
+  if (status.gateway_state && byState[status.gateway_state]) {
+    return byState[status.gateway_state];
+  }
+  return status.gateway_running
+    ? { label: g.running, tone: "text-success" }
+    : { label: g.off, tone: "text-muted-foreground" };
+}
+
+interface SidebarStatusStripProps {
+  status: StatusResponse | null;
+}
+
+```
+
+## SidebarFooter
+
+Path: `web/src/components/SidebarFooter.tsx`
+
+Full source:
+
+```tsx
+import { Typography } from "@nous-research/ui/ui/components/typography/index";
+import type { StatusResponse } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { useI18n } from "@/i18n";
+
+export function SidebarFooter({ status }: SidebarFooterProps) {
+  const { t } = useI18n();
+
+  return (
+    <div
+      className={cn(
+        "flex shrink-0 items-center justify-between gap-2",
+        "px-5 py-2.5",
+        "border-t border-current/10",
+      )}
+    >
+      <Typography
+        className="font-mono-ui text-xs tabular-nums tracking-[0.08em] text-text-tertiary lowercase"
+      >
+        {status?.version != null ? `v${status.version}` : "—"}
+      </Typography>
+
+      <a
+        href="https://nousresearch.com"
+        target="_blank"
+        rel="noopener noreferrer"
+        className={cn(
+          "font-sans text-display text-xs tracking-[0.12em] text-midground",
+          "transition-opacity hover:opacity-90",
+          "focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-midground/40",
+        )}
+      >
+        {t.app.footer.org}
+      </a>
+    </div>
+  );
+}
+
+interface SidebarFooterProps {
+  status: StatusResponse | null;
+}
+
+```
+

--- a/.superdesign/init/extractable-components.md
+++ b/.superdesign/init/extractable-components.md
@@ -1,0 +1,4 @@
+# Extractable Components
+
+No component extraction is required for this target. The requested redesign is implemented through Hermes' existing user-theme contract, not a new page or altered component hierarchy. The monolithic App shell remains native source and the reusable controls already come from @nous-research/ui; duplicating them as canvas components would not improve this CSS-token-focused design task.
+

--- a/.superdesign/init/layouts.md
+++ b/.superdesign/init/layouts.md
@@ -1,0 +1,1407 @@
+# Shared Layouts
+
+## App shell and router
+
+Path: `web/src/App.tsx`
+
+This is the complete dashboard shell: route table, responsive navigation, sidebar, page header, status strip, profile controls, and persistent chat host.
+
+```tsx
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ComponentType,
+  type FocusEvent,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import {
+  Routes,
+  Route,
+  NavLink,
+  Navigate,
+  useLocation,
+  useNavigate,
+} from "react-router";
+import {
+  Activity,
+  BarChart3,
+  BookOpen,
+  Clock,
+  Code,
+  Cpu,
+  Database,
+  Download,
+  Eye,
+  FolderOpen,
+  FileText,
+  Globe,
+  Heart,
+  KeyRound,
+  Menu,
+  MessageSquare,
+  Package,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Plug,
+  Puzzle,
+  Radio,
+  RotateCw,
+  Settings,
+  Shield,
+  ShieldCheck,
+  Sparkles,
+  Star,
+  Terminal,
+  Users,
+  Webhook,
+  Wrench,
+  X,
+  Zap,
+} from "lucide-react";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { SelectionSwitcher } from "@nous-research/ui/ui/components/selection-switcher";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { Typography } from "@nous-research/ui/ui/components/typography/index";
+import { ConfirmDialog } from "@nous-research/ui/ui/components/confirm-dialog";
+import { cn } from "@/lib/utils";
+import { SidebarFooter } from "@/components/SidebarFooter";
+import { SidebarStatusStrip, gatewayLine } from "@/components/SidebarStatusStrip";
+import { useBelowBreakpoint } from "@nous-research/ui/hooks/use-below-breakpoint";
+import { useSidebarStatus } from "@/hooks/useSidebarStatus";
+import { AuthWidget } from "@/components/AuthWidget";
+import { PageHeaderProvider } from "@/contexts/PageHeaderProvider";
+import { ProfileProvider } from "@/contexts/ProfileProvider";
+import { useProfileScope } from "@/contexts/useProfileScope";
+import { ProfileSwitcher } from "@/components/ProfileSwitcher";
+import { ProfileScopeBanner } from "@/components/ProfileScopeBanner";
+import { MemoryPressureBanner } from "@/components/MemoryPressureBanner";
+import { useSystemActions } from "@/contexts/useSystemActions";
+import type { SystemAction } from "@/contexts/system-actions-context";
+// Route pages are lazy-loaded so the initial dashboard shell does not pay for
+// every admin surface (and heavy deps like xterm) up front.
+const ConfigPage = lazy(() => import("@/pages/ConfigPage"));
+const DocsPage = lazy(() => import("@/pages/DocsPage"));
+const EnvPage = lazy(() => import("@/pages/EnvPage"));
+const FilesPage = lazy(() => import("@/pages/FilesPage"));
+const SessionsPage = lazy(() => import("@/pages/SessionsPage"));
+const LogsPage = lazy(() => import("@/pages/LogsPage"));
+const AnalyticsPage = lazy(() => import("@/pages/AnalyticsPage"));
+const ModelsPage = lazy(() => import("@/pages/ModelsPage"));
+const CronPage = lazy(() => import("@/pages/CronPage"));
+const ProfilesPage = lazy(() => import("@/pages/ProfilesPage"));
+const ProfileBuilderPage = lazy(() => import("@/pages/ProfileBuilderPage"));
+const SkillsPage = lazy(() => import("@/pages/SkillsPage"));
+const PluginsPage = lazy(() => import("@/pages/PluginsPage"));
+const McpPage = lazy(() => import("@/pages/McpPage"));
+const PairingPage = lazy(() => import("@/pages/PairingPage"));
+const ChannelsPage = lazy(() => import("@/pages/ChannelsPage"));
+const WebhooksPage = lazy(() => import("@/pages/WebhooksPage"));
+const SystemPage = lazy(() => import("@/pages/SystemPage"));
+const ChatPage = lazy(() => import("@/pages/ChatPage"));
+import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import { ThemeSwitcher } from "@/components/ThemeSwitcher";
+import { useI18n } from "@/i18n";
+import type { Translations } from "@/i18n/types";
+import { PluginPage, PluginSlot, usePlugins } from "@/plugins";
+import type { PluginManifest } from "@/plugins";
+import { useTheme } from "@/themes";
+import { isDashboardEmbeddedChatEnabled } from "@/lib/dashboard-flags";
+import { latchChatActivation } from "@/lib/chat-activation";
+import { api } from "@/lib/api";
+import type { StatusResponse, UpdateCheckResponse } from "@/lib/api";
+
+function RouteFallback({ label = "Loading…" }: { label?: string }) {
+  return (
+    <div
+      className="flex min-h-[12rem] flex-1 items-center justify-center"
+      aria-busy="true"
+      aria-live="polite"
+    >
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Spinner />
+        <span>{label}</span>
+      </div>
+    </div>
+  );
+}
+
+function RootRedirect() {
+  return <Navigate to="/sessions" replace />;
+}
+
+function UnknownRouteFallback({ pluginsLoading }: { pluginsLoading: boolean }) {
+  if (pluginsLoading) {
+    // Render nothing during the plugin-load window — a spinner here would just flash.
+    return null;
+  }
+  return <Navigate to="/sessions" replace />;
+}
+
+const CHAT_NAV_ITEM: NavItem = {
+  path: "/chat",
+  labelKey: "chat",
+  label: "Chat",
+  icon: Terminal,
+};
+
+/**
+ * Built-in routes except /chat.  Chat is rendered persistently (outside
+ * <Routes>) when embedded — see the persistent chat host block rendered
+ * inline near the bottom of this file — so the PTY child, WebSocket,
+ * and xterm instance survive when the user visits another tab and comes
+ * back.  A `display:none` toggle hides the terminal without unmounting.
+ * The host itself is still deferred until the first /chat visit so the
+ * xterm chunk is not downloaded on unrelated pages.  Routing still owns
+ * the URL so /chat deep-links, browser back/forward, and nav highlight
+ * keep working.
+ */
+const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
+  "/": RootRedirect,
+  "/sessions": SessionsPage,
+  "/files": FilesPage,
+  "/analytics": AnalyticsPage,
+  "/models": ModelsPage,
+  "/logs": LogsPage,
+  "/cron": CronPage,
+  "/skills": SkillsPage,
+  "/plugins": PluginsPage,
+  "/mcp": McpPage,
+  "/pairing": PairingPage,
+  "/channels": ChannelsPage,
+  "/webhooks": WebhooksPage,
+  "/system": SystemPage,
+  "/profiles": ProfilesPage,
+  "/profiles/new": ProfileBuilderPage,
+  "/config": ConfigPage,
+  "/env": EnvPage,
+  "/docs": DocsPage,
+};
+
+// Route placeholder for /chat.  The persistent ChatPage host (rendered
+// outside <Routes> when embedded chat is on) paints on top; this empty
+// element just claims the path so the `*` catch-all redirect doesn't
+// fire when the user navigates to /chat.
+function ChatRouteSink() {
+  return null;
+}
+
+const BUILTIN_NAV_REST: NavItem[] = [
+  {
+    path: "/sessions",
+    labelKey: "sessions",
+    label: "Sessions",
+    icon: MessageSquare,
+  },
+  { path: "/files", label: "Files", icon: FolderOpen },
+  {
+    path: "/analytics",
+    labelKey: "analytics",
+    label: "Analytics",
+    icon: BarChart3,
+  },
+  {
+    path: "/models",
+    labelKey: "models",
+    label: "Models",
+    icon: Cpu,
+  },
+  { path: "/logs", labelKey: "logs", label: "Logs", icon: FileText },
+  { path: "/cron", labelKey: "cron", label: "Cron", icon: Clock },
+  { path: "/skills", labelKey: "skills", label: "Skills", icon: Package },
+  { path: "/plugins", labelKey: "plugins", label: "Plugins", icon: Puzzle },
+  { path: "/mcp", label: "MCP", icon: Plug },
+  { path: "/channels", label: "Channels", icon: Radio },
+  { path: "/webhooks", label: "Webhooks", icon: Webhook },
+  { path: "/pairing", label: "Pairing", icon: ShieldCheck },
+  { path: "/profiles", labelKey: "profiles", label: "Profiles", icon: Users },
+  { path: "/config", labelKey: "config", label: "Config", icon: Settings },
+  { path: "/env", labelKey: "keys", label: "Keys", icon: KeyRound },
+  { path: "/system", label: "System", icon: Wrench },
+  {
+    path: "/docs",
+    labelKey: "documentation",
+    label: "Documentation",
+    icon: BookOpen,
+  },
+];
+
+const ICON_MAP: Record<string, ComponentType<{ className?: string }>> = {
+  Activity,
+  BarChart3,
+  Clock,
+  Cpu,
+  FileText,
+  FolderOpen,
+  KeyRound,
+  MessageSquare,
+  Package,
+  Settings,
+  Puzzle,
+  Sparkles,
+  Terminal,
+  Globe,
+  Database,
+  Shield,
+  Users,
+  Wrench,
+  Zap,
+  Heart,
+  Star,
+  Code,
+  Eye,
+};
+
+function resolveIcon(name: string): ComponentType<{ className?: string }> {
+  return ICON_MAP[name] ?? Puzzle;
+}
+
+function buildNavItems(
+  builtIn: NavItem[],
+  manifests: PluginManifest[],
+): NavItem[] {
+  const items = [...builtIn];
+
+  for (const manifest of manifests) {
+    if (manifest.tab.override) continue;
+    if (manifest.tab.hidden) continue;
+
+    const pluginItem: NavItem = {
+      path: manifest.tab.path,
+      label: manifest.label,
+      icon: resolveIcon(manifest.icon),
+    };
+
+    const pos = manifest.tab.position ?? "end";
+    if (pos === "end") {
+      items.push(pluginItem);
+    } else if (pos.startsWith("after:")) {
+      const target = "/" + pos.slice(6);
+      const idx = items.findIndex((i) => i.path === target);
+      items.splice(idx >= 0 ? idx + 1 : items.length, 0, pluginItem);
+    } else if (pos.startsWith("before:")) {
+      const target = "/" + pos.slice(7);
+      const idx = items.findIndex((i) => i.path === target);
+      items.splice(idx >= 0 ? idx : items.length, 0, pluginItem);
+    } else {
+      items.push(pluginItem);
+    }
+  }
+
+  return items;
+}
+
+/** Split merged nav into built-in sidebar entries vs plugin tabs, preserving plugin order hints. */
+function partitionSidebarNav(
+  builtIn: NavItem[],
+  manifests: PluginManifest[],
+): { coreItems: NavItem[]; pluginItems: NavItem[] } {
+  const merged = buildNavItems(builtIn, manifests);
+  const builtinPaths = new Set(builtIn.map((i) => i.path));
+  const coreItems: NavItem[] = [];
+  const pluginItems: NavItem[] = [];
+  for (const item of merged) {
+    if (builtinPaths.has(item.path)) coreItems.push(item);
+    else pluginItems.push(item);
+  }
+  return { coreItems, pluginItems };
+}
+
+function buildRoutes(
+  builtinRoutes: Record<string, ComponentType>,
+  manifests: PluginManifest[],
+): Array<{
+  key: string;
+  path: string;
+  element: ReactNode;
+}> {
+  const byOverride = new Map<string, PluginManifest>();
+  const addons: PluginManifest[] = [];
+
+  for (const m of manifests) {
+    if (m.tab.override) {
+      byOverride.set(m.tab.override, m);
+    } else {
+      addons.push(m);
+    }
+  }
+
+  const routes: Array<{
+    key: string;
+    path: string;
+    element: ReactNode;
+  }> = [];
+
+  for (const [path, Component] of Object.entries(builtinRoutes)) {
+    const om = byOverride.get(path);
+    if (om) {
+      routes.push({
+        key: `override:${om.name}`,
+        path,
+        element: <PluginPage name={om.name} />,
+      });
+    } else {
+      routes.push({ key: `builtin:${path}`, path, element: <Component /> });
+    }
+  }
+
+  for (const m of addons) {
+    if (m.tab.hidden) continue;
+    if (m.tab.path === "/plugins") continue;
+    if (builtinRoutes[m.tab.path]) continue;
+    routes.push({
+      key: `plugin:${m.name}`,
+      path: m.tab.path,
+      element: <PluginPage name={m.name} />,
+    });
+  }
+
+  for (const m of manifests) {
+    if (!m.tab.hidden) continue;
+    if (m.tab.path === "/plugins") continue;
+    if (builtinRoutes[m.tab.path] || m.tab.override) continue;
+    routes.push({
+      key: `plugin:hidden:${m.name}`,
+      path: m.tab.path,
+      element: <PluginPage name={m.name} />,
+    });
+  }
+
+  return routes;
+}
+
+const SIDEBAR_COLLAPSED_KEY = "hermes-sidebar-collapsed";
+
+export default function App() {
+  const { t } = useI18n();
+  const { pathname } = useLocation();
+  const { manifests, loading: pluginsLoading } = usePlugins();
+  const { theme } = useTheme();
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const closeMobile = useCallback(() => setMobileOpen(false), []);
+
+  const [collapsed, setCollapsed] = useState(() => {
+    try {
+      return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === "true";
+    } catch {
+      return false;
+    }
+  });
+  const toggleCollapsed = useCallback(() => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(next));
+      } catch { /* localStorage may be unavailable in private browsing */ }
+      return next;
+    });
+  }, []);
+  const isMobile = useBelowBreakpoint(1024);
+  const isDesktopCollapsed = collapsed && !isMobile;
+  const tooltipWarmRef = useRef(0);
+  const sidebarStatus = useSidebarStatus();
+  const isDocsRoute = pathname === "/docs" || pathname === "/docs/";
+  const normalizedPath = pathname.replace(/\/$/, "") || "/";
+  const isChatRoute = normalizedPath === "/chat";
+  const embeddedChat = isDashboardEmbeddedChatEnabled();
+  // Defer mounting the persistent chat host (and its xterm chunk) until the
+  // user has actually opened /chat at least once. Sticky after that so the
+  // PTY survives later tab switches.
+  const [chatHostMounted, setChatHostMounted] = useState(isChatRoute);
+  useEffect(() => {
+    setChatHostMounted((prev) => latchChatActivation(prev, isChatRoute));
+  }, [isChatRoute]);
+
+  // `dashboard.show_token_analytics` gates the Analytics nav item.  The
+  // page itself remains reachable by URL (it renders an explanation when
+  // the flag is off — see AnalyticsPage), but hiding the nav entry avoids
+  // surfacing misleading token/cost numbers in the sidebar.  Default off.
+  const [showTokenAnalytics, setShowTokenAnalytics] = useState(false);
+  useEffect(() => {
+    api
+      .getConfig()
+      .then((cfg) => {
+        const dash = (cfg?.dashboard ?? {}) as {
+          show_token_analytics?: unknown;
+        };
+        setShowTokenAnalytics(dash.show_token_analytics === true);
+      })
+      .catch(() => setShowTokenAnalytics(false));
+  }, []);
+
+  // A plugin can replace the built-in /chat page via `tab.override: "/chat"`
+  // in its manifest.  When one does, `buildRoutes` already swaps the route
+  // element for <PluginPage /> — but we also have to suppress the
+  // persistent ChatPage host below, or the plugin's page and the built-in
+  // terminal would paint on top of each other.  The override is niche
+  // (nothing ships overriding /chat today) but it's an advertised
+  // extension point, so preserve the pre-persistence contract: when a
+  // plugin owns /chat, the built-in chat UI is entirely absent.
+  //
+  // Waiting on `pluginsLoading` is load-bearing: manifests arrive
+  // asynchronously from /api/dashboard/plugins, so on initial render
+  // `chatOverriddenByPlugin` is always false.  Without the loading
+  // gate, the persistent host would mount, spawn a PTY, and THEN get
+  // yanked out from under the user when the plugin's manifest resolves
+  // — killing the session mid-paint.  Delaying host mount by the
+  // plugin-load window (typically <50ms, worst case 2s safety timeout)
+  // is the cheaper trade-off.
+  const chatOverriddenByPlugin = useMemo(
+    () => manifests.some((m) => m.tab.override === "/chat"),
+    [manifests],
+  );
+
+  const builtinRoutes = useMemo(
+    () => ({
+      ...BUILTIN_ROUTES_CORE,
+      ...(embeddedChat ? { "/chat": ChatRouteSink } : {}),
+    }),
+    [embeddedChat],
+  );
+
+  const builtinNav = useMemo(() => {
+    const base = embeddedChat
+      ? [CHAT_NAV_ITEM, ...BUILTIN_NAV_REST]
+      : BUILTIN_NAV_REST;
+    return showTokenAnalytics
+      ? base
+      : base.filter((n) => n.path !== "/analytics");
+  }, [embeddedChat, showTokenAnalytics]);
+
+  const sidebarNav = useMemo(
+    () => partitionSidebarNav(builtinNav, manifests),
+    [builtinNav, manifests],
+  );
+  const routes = useMemo(
+    () => buildRoutes(builtinRoutes, manifests),
+    [builtinRoutes, manifests],
+  );
+  const pluginTabMeta = useMemo(
+    () =>
+      manifests
+        .filter((m) => !m.tab.hidden)
+        .map((m) => ({
+          path: m.tab.override ?? m.tab.path,
+          label: m.label,
+        })),
+    [manifests],
+  );
+
+  const layoutVariant = theme.layoutVariant ?? "standard";
+
+  useEffect(() => {
+    if (!mobileOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setMobileOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [mobileOpen]);
+
+  useEffect(() => {
+    const mql = window.matchMedia("(min-width: 1024px)");
+    const onChange = (e: MediaQueryListEvent) => {
+      if (e.matches) setMobileOpen(false);
+    };
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  return (
+    <ProfileProvider>
+    <div
+      data-layout-variant={layoutVariant}
+      className="flex h-dvh max-h-dvh min-h-0 flex-col overflow-hidden bg-background-base text-text-primary antialiased"
+    >
+      <SelectionSwitcher />
+
+      <div
+        aria-hidden
+        className="pointer-events-none fixed inset-0 z-0"
+      >
+        <PluginSlot name="backdrop" />
+      </div>
+
+      <header
+        className={cn(
+          "lg:hidden fixed top-0 left-0 right-0 z-40 min-h-14",
+          "flex items-center gap-2 px-4 py-2",
+          "border-b border-current/20",
+          "bg-background-base",
+        )}
+        style={{
+          background: "var(--component-header-background)",
+          borderImage: "var(--component-header-border-image)",
+          clipPath: "var(--component-header-clip-path)",
+        }}
+      >
+        <Button
+          ghost
+          size="icon"
+          onClick={() => setMobileOpen(true)}
+          aria-label={t.app.openNavigation}
+          aria-expanded={mobileOpen}
+          aria-controls="app-sidebar"
+          className="text-text-secondary hover:text-midground"
+        >
+          <Menu />
+        </Button>
+
+        <Typography className="font-bold text-[0.95rem] leading-[0.95] tracking-[0.05em] text-midground">
+          {t.app.brand}
+        </Typography>
+      </header>
+
+      {mobileOpen && (
+        <Button
+          ghost
+          aria-label={t.app.closeNavigation}
+          onClick={closeMobile}
+          className={cn(
+            "lg:hidden fixed inset-0 z-40 p-0 block",
+            "bg-black/70",
+          )}
+        />
+      )}
+
+      {/* Single mobile header clearance for the banner stack + content. The
+          fixed lg:hidden header is h-14/z-40; previously each banner carried
+          its own mt-14 AND the content kept pt-14, so two visible banners
+          stacked three offsets (NS-656 review P3). One spacer, applied once. */}
+      <div aria-hidden className="h-14 shrink-0 lg:hidden" />
+      <PluginSlot name="header-banner" />
+      <ProfileScopeBanner />
+      <MemoryPressureBanner status={sidebarStatus} />
+
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+        <div className="flex min-h-0 min-w-0 flex-1">
+          <aside
+            id="app-sidebar"
+            aria-label={t.app.navigation}
+            className={cn(
+              "fixed top-0 left-0 z-50 flex h-dvh max-h-dvh w-64 min-h-0 flex-col font-sans",
+              "border-r border-current/20",
+              "bg-background-base",
+              "transition-[transform] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)]",
+              mobileOpen ? "translate-x-0" : "-translate-x-full",
+              "lg:sticky lg:top-0 lg:translate-x-0 lg:shrink-0 lg:overflow-hidden",
+              "lg:transition-[width] lg:duration-300 lg:ease-[cubic-bezier(0.23,1,0.32,1)]",
+              collapsed && "lg:w-14",
+            )}
+            style={{
+              background: "var(--component-sidebar-background)",
+              clipPath: "var(--component-sidebar-clip-path)",
+              borderImage: "var(--component-sidebar-border-image)",
+            }}
+          >
+            <div
+              className={cn(
+                "flex h-14 shrink-0 items-center gap-2",
+                "border-b border-current/20",
+                collapsed ? "lg:justify-center lg:px-0" : "px-4 justify-between",
+              )}
+            >
+              <div
+                className={cn(
+                  "flex items-center gap-2",
+                  collapsed && "lg:hidden",
+                )}
+              >
+                <PluginSlot name="header-left" />
+
+                <Typography className="font-bold text-[1.125rem] leading-[0.95] tracking-[0.0525rem] text-midground uppercase">
+                  Hermes
+                  <br />
+                  Agent
+                </Typography>
+              </div>
+
+              <Button
+                ghost
+                size="icon"
+                onClick={closeMobile}
+                aria-label={t.app.closeNavigation}
+                className="lg:hidden text-text-secondary hover:text-midground"
+              >
+                <X />
+              </Button>
+
+              <Button
+                ghost
+                size="icon"
+                onClick={toggleCollapsed}
+                aria-label={
+                  collapsed ? t.common.expand : t.common.collapse
+                }
+                className="hidden lg:flex text-text-secondary hover:text-midground"
+              >
+                {collapsed ? (
+                  <PanelLeftOpen className="h-4 w-4" />
+                ) : (
+                  <PanelLeftClose className="h-4 w-4" />
+                )}
+              </Button>
+            </div>
+
+            <ProfileSwitcher collapsed={isDesktopCollapsed} />
+
+            <nav
+              className="min-h-0 w-full flex-1 overflow-y-auto overflow-x-hidden border-t border-current/10 py-2"
+              aria-label={t.app.navigation}
+            >
+              <ul className="flex flex-col">
+                {sidebarNav.coreItems.map((item) => (
+                  <SidebarNavLink
+                    closeMobile={closeMobile}
+                    collapsed={isDesktopCollapsed}
+                    item={item}
+                    key={item.path}
+                    t={t}
+                    tooltipWarmRef={tooltipWarmRef}
+                  />
+                ))}
+              </ul>
+
+              {sidebarNav.pluginItems.length > 0 && (
+                <div
+                  aria-labelledby="hermes-sidebar-plugin-nav-heading"
+                  className="flex flex-col border-t border-current/10 pb-2"
+                  role="group"
+                >
+                  <span
+                    className={cn(
+                      "px-5 pt-2.5 pb-1",
+                      "font-sans text-display text-xs tracking-[0.12em] text-text-tertiary",
+                      isDesktopCollapsed && "lg:hidden",
+                    )}
+                    id="hermes-sidebar-plugin-nav-heading"
+                  >
+                    {t.app.pluginNavSection}
+                  </span>
+
+                  <ul className="flex flex-col">
+                    {sidebarNav.pluginItems.map((item) => (
+                      <SidebarNavLink
+                        closeMobile={closeMobile}
+                        collapsed={isDesktopCollapsed}
+                        item={item}
+                        key={item.path}
+                        t={t}
+                        tooltipWarmRef={tooltipWarmRef}
+                      />
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </nav>
+
+            <SidebarSystemActions
+              collapsed={isDesktopCollapsed}
+              onNavigate={closeMobile}
+              status={sidebarStatus}
+              tooltipWarmRef={tooltipWarmRef}
+            />
+
+            <div
+              className={cn(
+                "flex shrink-0 items-center gap-2",
+                "px-3 py-2",
+                "border-t border-current/20",
+                isDesktopCollapsed
+                  ? "lg:flex-col lg:items-start lg:gap-3 lg:py-3"
+                  : "justify-between",
+              )}
+            >
+              <div
+                className={cn(
+                  "flex min-w-0 items-center gap-2",
+                  isDesktopCollapsed && "lg:flex-col lg:items-start",
+                )}
+              >
+                <PluginSlot name="header-right" />
+
+                <SidebarIconWithTooltip
+                  collapsed={isDesktopCollapsed}
+                  label={t.theme?.switchTheme ?? "Switch theme"}
+                  tooltipWarmRef={tooltipWarmRef}
+                >
+                  <ThemeSwitcher collapsed={isDesktopCollapsed} dropUp />
+                </SidebarIconWithTooltip>
+
+                <SidebarIconWithTooltip
+                  collapsed={isDesktopCollapsed}
+                  label={t.language.switchTo}
+                  tooltipWarmRef={tooltipWarmRef}
+                >
+                  <LanguageSwitcher collapsed={isDesktopCollapsed} dropUp />
+                </SidebarIconWithTooltip>
+              </div>
+            </div>
+
+            <div
+              className={cn(
+                "flex shrink-0 flex-col",
+                isDesktopCollapsed && "lg:hidden",
+              )}
+            >
+              <AuthWidget />
+              <SidebarFooter status={sidebarStatus} />
+            </div>
+          </aside>
+
+          <PageHeaderProvider pluginTabs={pluginTabMeta}>
+            <div
+              className={cn(
+                "relative z-2 flex min-w-0 min-h-0 flex-1 flex-col",
+                "px-3 sm:px-6",
+                isChatRoute
+                  ? "pb-0 pt-1 sm:pt-2 lg:pt-4"
+                  : "pt-2 sm:pt-4 lg:pt-6",
+                isDocsRoute && "min-h-0 flex-1",
+              )}
+            >
+              <PluginSlot name="pre-main" />
+              <div
+                className={cn(
+                  "w-full min-w-0",
+                  !isChatRoute &&
+                    "pb-[calc(2rem+env(safe-area-inset-bottom,0px))] lg:pb-8",
+                  (isDocsRoute || isChatRoute) &&
+                    "min-h-0 flex flex-1 flex-col",
+                )}
+              >
+                <ProfileKeyedRoutes>
+                  <Suspense fallback={<RouteFallback />}>
+                    <Routes>
+                      {routes.map(({ key, path, element }) => (
+                        <Route key={key} path={path} element={element} />
+                      ))}
+                      <Route
+                        path="*"
+                        element={
+                          <UnknownRouteFallback pluginsLoading={pluginsLoading} />
+                        }
+                      />
+                    </Routes>
+                  </Suspense>
+                </ProfileKeyedRoutes>
+
+                {embeddedChat &&
+                  !chatOverriddenByPlugin &&
+                  (pluginsLoading ? (
+                    isChatRoute ? (
+                      <RouteFallback label="Loading chat…" />
+                    ) : null
+                  ) : chatHostMounted ? (
+                    <div
+                      data-chat-active={isChatRoute ? "true" : "false"}
+                      className={cn(
+                        "min-h-0 min-w-0",
+                        isChatRoute ? "flex flex-1 flex-col" : "hidden",
+                      )}
+                      aria-hidden={!isChatRoute}
+                    >
+                      <Suspense
+                        fallback={
+                          isChatRoute ? (
+                            <RouteFallback label="Loading chat…" />
+                          ) : null
+                        }
+                      >
+                        <ChatPage isActive={isChatRoute} />
+                      </Suspense>
+                    </div>
+                  ) : isChatRoute ? (
+                    <RouteFallback label="Loading chat…" />
+                  ) : null)}
+              </div>
+              <PluginSlot name="post-main" />
+            </div>
+          </PageHeaderProvider>
+        </div>
+      </div>
+
+      <PluginSlot name="overlay" />
+    </div>
+    </ProfileProvider>
+  );
+}
+
+/**
+ * Remounts the entire routed page tree when the global management profile
+ * changes. Pages load their data on mount; without this, a page opened
+ * under profile A would keep showing A's state while writes (via the
+ * fetchJSON ?profile= injection) silently targeted the newly selected
+ * profile B — the exact stale-target footgun the switcher exists to kill.
+ * Keying by profile resets every page's local state so it refetches under
+ * the new scope. The persistent ChatPage host below handles its own
+ * remount (channel keyed on scopedProfile).
+ */
+function ProfileKeyedRoutes({ children }: { children: ReactNode }) {
+  const { profile } = useProfileScope();
+  return <div key={profile || "__own__"} className="contents">{children}</div>;
+}
+
+function SidebarNavLink({
+  closeMobile,
+  collapsed,
+  item,
+  tooltipWarmRef,
+  t,
+}: SidebarNavLinkProps) {
+  const { path, label, labelKey, icon: Icon } = item;
+  const [hovered, setHovered] = useState(false);
+  const [tooltipAnchor, setTooltipAnchor] = useState<HTMLElement | null>(null);
+
+  const navLabel = labelKey
+    ? ((t.app.nav as Record<string, string>)[labelKey] ?? label)
+    : label;
+  const showTooltip = (event: MouseEvent<HTMLElement> | FocusEvent<HTMLElement>) => {
+    setHovered(true);
+    setTooltipAnchor(event.currentTarget);
+  };
+  const hideTooltip = () => {
+    setHovered(false);
+    setTooltipAnchor(null);
+  };
+
+  return (
+    <li
+      onMouseEnter={collapsed ? showTooltip : undefined}
+      onMouseLeave={collapsed ? hideTooltip : undefined}
+    >
+      <NavLink
+        to={path}
+        end={path === "/sessions"}
+        onClick={closeMobile}
+        aria-label={collapsed ? navLabel : undefined}
+        onFocus={collapsed ? showTooltip : undefined}
+        onBlur={collapsed ? hideTooltip : undefined}
+        className={({ isActive }) =>
+          cn(
+            "group/nav relative flex items-center gap-3",
+            "px-5 py-2.5",
+            "font-sans text-display uppercase text-sm tracking-[0.12em]",
+            "whitespace-nowrap transition-colors cursor-pointer",
+            "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-midground",
+            isActive
+              ? "text-midground"
+              : "text-text-secondary hover:text-midground",
+          )
+        }
+        style={{
+          clipPath: "var(--component-tab-clip-path)",
+        }}
+      >
+        {({ isActive }) => (
+          <>
+            <Icon className="h-3.5 w-3.5 shrink-0" />
+
+            <span
+              className={cn(
+                "truncate transition-opacity duration-300",
+                collapsed ? "lg:opacity-0" : "lg:opacity-100",
+              )}
+            >
+              {navLabel}
+            </span>
+
+            <span
+              aria-hidden
+              className="absolute inset-y-0.5 left-1.5 right-1.5 bg-midground opacity-0 pointer-events-none transition-opacity duration-200 group-hover/nav:opacity-5"
+            />
+
+            {isActive && (
+              <span
+                aria-hidden
+                className="absolute left-0 top-0 bottom-0 w-px bg-midground"
+              />
+            )}
+          </>
+        )}
+      </NavLink>
+
+      {collapsed && hovered && tooltipAnchor && (
+        <SidebarTooltip anchor={tooltipAnchor} label={navLabel} warmRef={tooltipWarmRef} />
+      )}
+    </li>
+  );
+}
+
+function SidebarSystemActions({
+  collapsed,
+  onNavigate,
+  status,
+  tooltipWarmRef,
+}: SidebarSystemActionsProps) {
+  const { t } = useI18n();
+  const navigate = useNavigate();
+  const { activeAction, isBusy, isRunning, pendingAction, runAction } =
+    useSystemActions();
+  const canUpdateHermes = status?.can_update_hermes === true;
+  const [restartConfirmOpen, setRestartConfirmOpen] = useState(false);
+  const [updateConfirmOpen, setUpdateConfirmOpen] = useState(false);
+  const [updateConfirmInfo, setUpdateConfirmInfo] =
+    useState<UpdateCheckResponse | null>(null);
+  const [updateConfirmChecking, setUpdateConfirmChecking] = useState(false);
+
+  useEffect(() => {
+    if (!updateConfirmOpen) {
+      setUpdateConfirmInfo(null);
+      return;
+    }
+    let cancelled = false;
+    setUpdateConfirmChecking(true);
+    api
+      .checkHermesUpdate(false)
+      .then((info) => {
+        if (!cancelled) setUpdateConfirmInfo(info);
+      })
+      .catch(() => {
+        if (!cancelled) setUpdateConfirmInfo(null);
+      })
+      .finally(() => {
+        if (!cancelled) setUpdateConfirmChecking(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [updateConfirmOpen]);
+
+  const updateConfirmDescription = useMemo(() => {
+    if (updateConfirmInfo?.behind && updateConfirmInfo.behind > 0) {
+      const cmd = updateConfirmInfo.update_command;
+      const n = updateConfirmInfo.behind;
+      return `This will run 'hermes update' (${cmd}) and pull ${n} new commit${n === 1 ? "" : "s"}. The gateway restarts when the update finishes; the current session keeps its prompt cache until then.`;
+    }
+    const cmd = updateConfirmInfo?.update_command ?? "hermes update";
+    return (
+      t.status.updateHermesConfirmMessage ??
+      `This will run 'hermes update' (${cmd}) and restart the gateway when it finishes.`
+    );
+  }, [t.status.updateHermesConfirmMessage, updateConfirmInfo]);
+
+  const items: SystemActionItem[] = [
+    {
+      action: "restart",
+      icon: RotateCw,
+      label: t.status.restartGateway,
+      runningLabel: t.status.restartingGateway,
+      spin: true,
+    },
+  ];
+  if (canUpdateHermes) {
+    items.push({
+      action: "update",
+      icon: Download,
+      label: t.status.updateHermes,
+      runningLabel: t.status.updatingHermes,
+      spin: false,
+    });
+  }
+
+  const handleClick = (action: SystemAction) => {
+    if (isBusy) return;
+    if (action === "restart") {
+      setRestartConfirmOpen(true);
+      return;
+    }
+    if (action === "update") {
+      setUpdateConfirmOpen(true);
+      return;
+    }
+    void runAction(action);
+    navigate("/sessions");
+    onNavigate();
+  };
+
+  const confirmRestart = () => {
+    setRestartConfirmOpen(false);
+    void runAction("restart");
+    navigate("/sessions");
+    onNavigate();
+  };
+
+  const confirmUpdate = () => {
+    setUpdateConfirmOpen(false);
+    void runAction("update");
+    navigate("/sessions");
+    onNavigate();
+  };
+
+  return (
+    <>
+    <div
+      className={cn(
+        "shrink-0 flex flex-col",
+        "border-t border-current/10",
+        "py-1",
+      )}
+    >
+      <span
+        className={cn(
+          "px-5 pt-0.5 pb-0.5",
+          "font-sans text-display text-xs tracking-[0.12em] text-text-tertiary",
+          collapsed && "lg:hidden",
+        )}
+      >
+        {t.app.system}
+      </span>
+
+      <div className={cn(collapsed && "lg:hidden")}>
+        <SidebarStatusStrip status={status} />
+      </div>
+
+      <GatewayDot collapsed={collapsed} status={status} tooltipWarmRef={tooltipWarmRef} />
+
+      <ul className="flex flex-col">
+        {items.map((item) => (
+          <SystemActionButton
+            key={item.action}
+            collapsed={collapsed}
+            disabled={isBusy && !(pendingAction === item.action || (activeAction === item.action && isRunning))}
+            tooltipWarmRef={tooltipWarmRef}
+            isPending={pendingAction === item.action}
+            isRunning={activeAction === item.action && isRunning && pendingAction !== item.action}
+            item={item}
+            onClick={() => handleClick(item.action)}
+          />
+        ))}
+      </ul>
+    </div>
+
+    <ConfirmDialog
+      cancelLabel={t.common.cancel}
+      confirmLabel={t.status.restartGateway}
+      description={
+        t.status.restartGatewayConfirmMessage ??
+        "This restarts the Hermes gateway process. Connected channels and active sessions will reconnect afterward."
+      }
+      loading={pendingAction === "restart"}
+      onCancel={() => setRestartConfirmOpen(false)}
+      onConfirm={confirmRestart}
+      open={restartConfirmOpen}
+      title={
+        t.status.restartGatewayConfirmTitle ?? `${t.status.restartGateway}?`
+      }
+    />
+
+    <ConfirmDialog
+      cancelLabel={t.common.cancel}
+      confirmLabel={t.status.updateHermesConfirmNow ?? "Update now"}
+      description={
+        updateConfirmChecking ? t.common.loading : updateConfirmDescription
+      }
+      loading={pendingAction === "update" || updateConfirmChecking}
+      onCancel={() => setUpdateConfirmOpen(false)}
+      onConfirm={confirmUpdate}
+      open={updateConfirmOpen}
+      title={t.status.updateHermesConfirmTitle ?? `${t.status.updateHermes}?`}
+    />
+    </>
+  );
+}
+
+function SystemActionButton({
+  collapsed,
+  disabled,
+  isPending,
+  isRunning: isActionRunning,
+  item,
+  onClick,
+  tooltipWarmRef,
+}: SystemActionButtonProps) {
+  const { icon: Icon, label, runningLabel, spin } = item;
+  const [hovered, setHovered] = useState(false);
+  const [tooltipAnchor, setTooltipAnchor] = useState<HTMLElement | null>(null);
+  const busy = isPending || isActionRunning;
+  const displayLabel = isActionRunning ? runningLabel : label;
+  const showTooltip = (event: MouseEvent<HTMLElement> | FocusEvent<HTMLElement>) => {
+    setHovered(true);
+    setTooltipAnchor(event.currentTarget);
+  };
+  const hideTooltip = () => {
+    setHovered(false);
+    setTooltipAnchor(null);
+  };
+
+  return (
+    <li
+      onMouseEnter={collapsed ? showTooltip : undefined}
+      onMouseLeave={collapsed ? hideTooltip : undefined}
+    >
+      <button
+        onClick={onClick}
+        disabled={disabled}
+        aria-busy={busy}
+        aria-label={collapsed ? displayLabel : undefined}
+        onFocus={collapsed ? showTooltip : undefined}
+        onBlur={collapsed ? hideTooltip : undefined}
+        type="button"
+        className={cn(
+          "group/action relative flex w-full items-center gap-3",
+          "px-5 py-2.5",
+          "font-sans text-display text-xs tracking-[0.1em]",
+          "whitespace-nowrap transition-colors cursor-pointer",
+          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-midground",
+          busy
+            ? "text-midground"
+            : "text-text-secondary hover:text-midground",
+          "disabled:text-text-disabled disabled:cursor-not-allowed",
+        )}
+      >
+        {isPending ? (
+          <Spinner className="shrink-0 text-[0.875rem]" />
+        ) : isActionRunning && spin ? (
+          <Spinner className="shrink-0 text-[0.875rem]" />
+        ) : (
+          <Icon
+            className={cn(
+              "h-3.5 w-3.5 shrink-0",
+              isActionRunning && !spin && "animate-pulse",
+            )}
+          />
+        )}
+
+        <span className={cn(
+          "truncate transition-opacity duration-300",
+          collapsed ? "lg:opacity-0" : "lg:opacity-100",
+        )}>
+          {displayLabel}
+        </span>
+
+        <span
+          aria-hidden
+          className="absolute inset-y-0.5 left-1.5 right-1.5 bg-midground opacity-0 pointer-events-none transition-opacity duration-200 group-hover/action:opacity-5"
+        />
+
+        {busy && (
+          <span
+            aria-hidden
+            className="absolute left-0 top-0 bottom-0 w-px bg-midground"
+          />
+        )}
+      </button>
+
+      {collapsed && hovered && tooltipAnchor && (
+        <SidebarTooltip anchor={tooltipAnchor} label={displayLabel} warmRef={tooltipWarmRef} />
+      )}
+    </li>
+  );
+}
+
+function SidebarIconWithTooltip({
+  children,
+  collapsed,
+  label,
+  tooltipWarmRef,
+}: SidebarIconWithTooltipProps) {
+  const [hovered, setHovered] = useState(false);
+  const [tooltipAnchor, setTooltipAnchor] = useState<HTMLElement | null>(null);
+  const showTooltip = (event: MouseEvent<HTMLDivElement>) => {
+    setHovered(true);
+    setTooltipAnchor(event.currentTarget);
+  };
+  const hideTooltip = () => {
+    setHovered(false);
+    setTooltipAnchor(null);
+  };
+
+  return (
+    <div
+      className={cn(
+        "relative w-fit",
+        collapsed && "group/icon",
+      )}
+      onMouseEnter={collapsed ? showTooltip : undefined}
+      onMouseLeave={collapsed ? hideTooltip : undefined}
+    >
+      {children}
+
+      {collapsed && (
+        <span
+          aria-hidden
+          className="absolute inset-y-0 inset-x-[-0.375rem] bg-midground opacity-0 pointer-events-none transition-opacity duration-200 group-hover/icon:opacity-5 hidden lg:block"
+        />
+      )}
+
+      {collapsed && hovered && tooltipAnchor && (
+        <SidebarTooltip anchor={tooltipAnchor} label={label} warmRef={tooltipWarmRef} />
+      )}
+    </div>
+  );
+}
+
+function GatewayDot({ collapsed, status, tooltipWarmRef }: GatewayDotProps) {
+  const { t } = useI18n();
+  const [hovered, setHovered] = useState(false);
+  const [tooltipAnchor, setTooltipAnchor] = useState<HTMLElement | null>(null);
+
+  const toneToColor: Record<string, string> = {
+    "text-success": "bg-success",
+    "text-warning": "bg-warning",
+    "text-destructive": "bg-destructive",
+    "text-muted-foreground": "bg-muted-foreground",
+  };
+
+  let color: string;
+  let label: string;
+
+  if (!status) {
+    color = "bg-midground/20";
+    label = t.status.gateway;
+  } else {
+    const gw = gatewayLine(status, t);
+    color = toneToColor[gw.tone] ?? "bg-muted-foreground";
+    label = `${t.status.gateway} ${gw.label}`;
+  }
+  const showTooltip = (event: MouseEvent<HTMLDivElement> | FocusEvent<HTMLDivElement>) => {
+    setHovered(true);
+    setTooltipAnchor(event.currentTarget);
+  };
+  const hideTooltip = () => {
+    setHovered(false);
+    setTooltipAnchor(null);
+  };
+
+  return (
+    <div
+      className={cn(
+        "hidden lg:flex py-3 pl-[1.625rem] transition-opacity duration-300",
+        collapsed ? "lg:opacity-100" : "lg:opacity-0 lg:h-0 lg:py-0 lg:overflow-hidden",
+      )}
+      role="status"
+      aria-label={label}
+      tabIndex={collapsed ? 0 : -1}
+      onMouseEnter={collapsed ? showTooltip : undefined}
+      onMouseLeave={collapsed ? hideTooltip : undefined}
+      onFocus={collapsed ? showTooltip : undefined}
+      onBlur={collapsed ? hideTooltip : undefined}
+    >
+      <span
+        aria-hidden
+        className={cn("h-1.5 w-1.5 rounded-full", color)}
+      />
+
+      {hovered && tooltipAnchor && (
+        <SidebarTooltip anchor={tooltipAnchor} label={label} warmRef={tooltipWarmRef} />
+      )}
+    </div>
+  );
+}
+
+function SidebarTooltip({ anchor, label, warmRef }: SidebarTooltipProps) {
+  const rect = anchor.getBoundingClientRect();
+  const sidebar = document.getElementById("app-sidebar");
+  const sidebarRight = sidebar?.getBoundingClientRect().right ?? rect.right;
+  const [isWarm, setIsWarm] = useState(false);
+
+  useEffect(() => {
+    if (!warmRef) {
+      setIsWarm(false);
+      return;
+    }
+    const now = Date.now();
+    setIsWarm(now - warmRef.current < 300);
+    warmRef.current = now;
+    return () => {
+      if (warmRef) warmRef.current = Date.now();
+    };
+  }, [warmRef]);
+
+  return createPortal(
+    <span
+      className={cn(
+        "fixed z-[100] pointer-events-none",
+        "px-2 py-1",
+        "bg-background-base border border-current/20 shadow-lg",
+        "font-sans text-display text-xs tracking-[0.1em] text-midground uppercase",
+      )}
+      style={{
+        top: rect.top + rect.height / 2,
+        left: sidebarRight + 8,
+        transform: "translateY(-50%)",
+        opacity: isWarm ? 1 : undefined,
+        animation: isWarm ? "none" : "sidebar-tooltip-in 120ms ease-out",
+      }}
+    >
+      {label}
+    </span>,
+    document.body,
+  );
+}
+
+type TooltipWarmRef = React.RefObject<number>;
+
+interface GatewayDotProps {
+  collapsed: boolean;
+  status: StatusResponse | null;
+  tooltipWarmRef: TooltipWarmRef;
+}
+
+interface NavItem {
+  icon: ComponentType<{ className?: string }>;
+  label: string;
+  labelKey?: string;
+  path: string;
+}
+
+interface SidebarIconWithTooltipProps {
+  children: ReactNode;
+  collapsed: boolean;
+  label: string;
+  tooltipWarmRef: TooltipWarmRef;
+}
+
+interface SidebarNavLinkProps {
+  closeMobile: () => void;
+  collapsed: boolean;
+  item: NavItem;
+  t: Translations;
+  tooltipWarmRef: TooltipWarmRef;
+}
+
+interface SidebarSystemActionsProps {
+  collapsed: boolean;
+  onNavigate: () => void;
+  status: StatusResponse | null;
+  tooltipWarmRef: TooltipWarmRef;
+}
+
+interface SidebarTooltipProps {
+  anchor: HTMLElement;
+  label: string;
+  warmRef?: TooltipWarmRef;
+}
+
+interface SystemActionButtonProps {
+  collapsed: boolean;
+  disabled: boolean;
+  isPending: boolean;
+  isRunning: boolean;
+  item: SystemActionItem;
+  onClick: () => void;
+  tooltipWarmRef: TooltipWarmRef;
+}
+
+interface SystemActionItem {
+  action: SystemAction;
+  icon: ComponentType<{ className?: string }>;
+  label: string;
+  runningLabel: string;
+  spin: boolean;
+}
+
+```
+

--- a/.superdesign/init/pages.md
+++ b/.superdesign/init/pages.md
@@ -1,0 +1,54 @@
+# Key Page Dependency Trees
+
+## /chat
+Entry: `web/src/pages/ChatPage.tsx`
+Dependencies:
+- web/src/components/ChatSidebar.tsx
+  - web/src/components/ChatSessionList.tsx
+  - web/src/components/ModelPickerDialog.tsx
+  - web/src/components/ReasoningPicker.tsx
+- web/src/lib/api.ts
+- web/src/lib/gatewayClient.ts
+- web/src/lib/pty-reconnect.ts
+- web/src/lib/pty-scroll.ts
+- web/src/themes/context.tsx
+- web/src/App.tsx (persistent shell host)
+
+## /sessions
+Entry: `web/src/pages/SessionsPage.tsx`
+Dependencies:
+- web/src/components/DeleteConfirmDialog.tsx
+- web/src/components/Markdown.tsx
+- web/src/components/ProfileScopeBanner.tsx
+- web/src/lib/api.ts
+- web/src/lib/session-refresh.ts
+- web/src/App.tsx
+
+## /models
+Entry: `web/src/pages/ModelsPage.tsx`
+Dependencies:
+- web/src/components/ModelInfoCard.tsx
+- web/src/components/ModelPickerDialog.tsx
+- web/src/components/ModelReloadConfirm.tsx
+- web/src/lib/api.ts
+- web/src/App.tsx
+
+## /config
+Entry: `web/src/pages/ConfigPage.tsx`
+Dependencies:
+- web/src/components/AutoField.tsx
+- web/src/components/ProfileScopeBanner.tsx
+- web/src/lib/api.ts
+- web/src/lib/nested.ts
+- web/src/App.tsx
+
+## Shared shell dependencies
+- web/src/components/ProfileSwitcher.tsx
+- web/src/components/ThemeSwitcher.tsx
+- web/src/components/SidebarStatusStrip.tsx
+- web/src/components/SidebarFooter.tsx
+- web/src/index.css
+- web/src/themes/context.tsx
+- web/src/themes/presets.ts
+- web/src/themes/types.ts
+

--- a/.superdesign/init/routes.md
+++ b/.superdesign/init/routes.md
@@ -1,0 +1,29 @@
+# Routes
+
+Hermes uses React Router configured in `web/src/App.tsx`.
+
+| Route | Page |
+|---|---|
+| / | Redirect to /sessions |
+| /chat | ChatPage persistent embedded TUI |
+| /sessions | SessionsPage |
+| /files | FilesPage |
+| /analytics | AnalyticsPage |
+| /models | ModelsPage |
+| /logs | LogsPage |
+| /cron | CronPage |
+| /skills | SkillsPage |
+| /plugins | PluginsPage |
+| /mcp | McpPage |
+| /channels | ChannelsPage |
+| /webhooks | WebhooksPage |
+| /pairing | PairingPage |
+| /profiles | ProfilesPage |
+| /profiles/new | ProfileBuilderPage |
+| /config | ConfigPage |
+| /env | EnvPage |
+| /system | SystemPage |
+| /docs | DocsPage |
+
+The full router and shell source is preserved in `layouts.md` to avoid duplicating the 1,395-line file. The route declarations are in `BUILTIN_ROUTES_CORE`, `BUILTIN_NAV_REST`, and the final `Routes` render within that file.
+

--- a/.superdesign/init/theme.md
+++ b/.superdesign/init/theme.md
@@ -1,0 +1,734 @@
+# Theme Context
+
+## Compact token summary
+
+- Framework: Tailwind CSS v4 plus @nous-research/ui semantic tokens.
+- Default canvas: #041c1c; default text/accent: #ffe6cb.
+- Theme layers: background, midground, foreground, each emitted as base/alpha/CSS-mix variables.
+- Typography: theme-controlled sans, mono, display, base size, line height, and letter spacing.
+- Layout: theme-controlled radius and compact/comfortable/spacious density.
+- Components consume shadcn-compatible semantic tokens for card, primary, secondary, muted, accent, border, input, ring, popover, status, and data series.
+- Responsive breakpoint used by the shell: 768px.
+- Custom user themes may supply exact color overrides, terminal colors, component-style variables, and up to 32 KiB of custom CSS.
+
+## Raw web/src/index.css
+
+```css
+@import 'tailwindcss';
+/* `fonts.css` must come BEFORE `globals.css`: as of @nous-research/ui 0.14.x,
+   `globals.css` only declares the `--font-*` CSS variables (Collapse, Rules
+   Compressed/Expanded, Mondwest). The `@font-face` registrations live in
+   `fonts.css`, so without this import the DS variables resolve to font
+   families the browser never loads and components fall back to a system
+   stack (Tabs, Segmented, Typography, Buttons, etc. all look unstyled). */
+@import '@nous-research/ui/styles/fonts.css';
+@import '@nous-research/ui/styles/globals.css';
+
+/* Scan the published design-system bundle so its utility classes survive
+   Tailwind's JIT purge. */
+@source '../node_modules/@nous-research/ui/dist';
+
+/* ------------------------------------------------------------------ */
+/* JetBrains Mono — bundled for the embedded TUI (/chat tab).          */
+/* Gives the terminal a proper monospace font even on systems where    */
+/* the user doesn't have one installed locally; xterm.js picks it up   */
+/* via ChatPage's `fontFamily` option.                                 */
+/* Apache-2.0.                                                         */
+/* ------------------------------------------------------------------ */
+
+@font-face {
+  font-family: 'JetBrains Mono';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('/fonts-terminal/JetBrainsMono-Regular.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'JetBrains Mono';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url('/fonts-terminal/JetBrainsMono-Bold.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'JetBrains Mono';
+  font-style: italic;
+  font-weight: 400;
+  font-display: swap;
+  src: url('/fonts-terminal/JetBrainsMono-Italic.woff2') format('woff2');
+}
+
+/* ------------------------------------------------------------------ */
+/* Hermes Agent — Nous DS with the LENS_0 (Hermes teal) palette applied
+   statically as the default dashboard theme. */
+/* ------------------------------------------------------------------ */
+
+:root {
+  /* LENS_0 — from design-language/src/ui/components/overlays/index.tsx.
+     These are the defaults for the `default` (Hermes Teal) dashboard theme;
+     ThemeProvider rewrites them as inline styles when a user switches themes. */
+  --foreground: color-mix(in srgb, #ffffff 0%, transparent);
+  --foreground-base: #ffffff;
+  --foreground-alpha: 0;
+  --midground: color-mix(in srgb, #ffe6cb 100%, transparent);
+  --midground-base: #ffe6cb;
+  --midground-alpha: 1;
+  --background: color-mix(in srgb, #041c1c 100%, transparent);
+  --background-base: #041c1c;
+  --background-alpha: 1;
+
+  /* Typography tokens — rewritten by ThemeProvider. Defaults match the
+     system stack so themes that don't override look native. */
+  --theme-font-sans: system-ui, -apple-system, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  --theme-font-mono: ui-monospace, "SF Mono", "Cascadia Mono", Menlo,
+    Consolas, monospace;
+  --theme-font-display: var(--theme-font-sans);
+  --theme-base-size: 15px;
+  --theme-line-height: 1.55;
+  --theme-letter-spacing: 0;
+
+  /* Layout tokens. */
+  --radius: 0.5rem;
+  --theme-radius: 0.5rem;
+  --theme-spacing-mul: 1;
+  --theme-density: comfortable;
+
+  /* Data-series accents — consumed by Analytics + Models pages for the
+     input-vs-output token visualisations (chart bars, table values,
+     legend swatches). Defaults are tuned for the Hermes-teal LENS_0
+     look: cream input + emerald-400 output read as warm/cool against
+     the dark canvas. Themes override via ThemeProvider, which emits
+     these as `--series-input-token` / `--series-output-token`. */
+  --series-input-token: #ffe6cb;
+  --series-output-token: #34d399;
+}
+
+/* Theme tokens cascade into the document root so every descendant inherits
+   the font stack, base size, and letter spacing without explicit calls. */
+html {
+  font-family: var(--theme-font-sans);
+  font-size: var(--theme-base-size);
+  line-height: var(--theme-line-height);
+  letter-spacing: var(--theme-letter-spacing);
+  height: 100dvh;
+  max-height: 100dvh;
+  overflow: hidden;
+}
+
+body {
+  font-family: var(--theme-font-sans);
+  min-height: 0;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+}
+
+code, kbd, pre, samp, .font-mono, .font-mono-ui {
+  font-family: var(--theme-font-mono);
+}
+
+/* Density: scale the shadcn spacing utilities via a multiplier. The DS
+   components use `p-N` / `gap-N` / `space-*` classes which resolve against
+   Tailwind's spacing scale; multiplying `--spacing` at :root scales them
+   all proportionally in Tailwind v4. */
+@theme inline {
+  --spacing: calc(0.25rem * var(--theme-spacing-mul, 1));
+  --font-sans: var(--theme-font-sans);
+  --font-mono: var(--theme-font-mono);
+}
+
+#root {
+  min-height: 0;
+  height: 100%;
+  max-height: 100%;
+  overflow: hidden;
+}
+
+@media (max-width: 768px) {
+  html,
+  body,
+  #root {
+    min-height: 100dvh;
+    height: auto;
+    max-height: none;
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+}
+
+/* Nousnet's hermes-agent layout bumps `small` and `code` to readable
+   dashboard sizes. Keep in sync. */
+small { font-size: 1.0625rem; }
+code { font-size: 0.875rem; }
+
+/* Shadcn-compat tokens.
+   The dashboard's page code predates the Nous DS and uses shadcn-style
+   utility classes (bg-card, text-muted-foreground, border-border, etc.)
+   extensively. Rather than rewrite every call site, we expose those
+   tokens on top of the Nous palette so classes continue to resolve. */
+@theme inline {
+  /* Remap foreground to midground so `text-foreground` / `bg-foreground`
+     stay visible — in LENS_0, `--foreground` itself has alpha 0. */
+  --color-foreground: var(--midground);
+
+  --color-card: color-mix(in srgb, var(--midground-base) 4%, var(--background-base));
+  --color-card-foreground: var(--midground);
+  --color-primary: var(--midground);
+  --color-primary-foreground: var(--background-base);
+  --color-secondary: color-mix(in srgb, var(--midground-base) 6%, var(--background-base));
+  --color-secondary-foreground: var(--midground);
+  --color-muted: color-mix(in srgb, var(--midground-base) 8%, var(--background-base));
+  /* Routes the shadcn `muted-foreground` slot through the DS semantic
+     text-secondary token (defaults to midground 80%) so legacy call
+     sites that use `text-muted-foreground` get a readable color
+     instead of the old 55%-transparent default. */
+  --color-muted-foreground: var(--color-text-secondary);
+  --color-accent: color-mix(in srgb, var(--midground-base) 10%, var(--background-base));
+  --color-accent-foreground: var(--midground);
+  --color-destructive: #fb2c36;
+  --color-destructive-foreground: #ffffff;
+  --color-success: #4ade80;
+  --color-warning: #ffbd38;
+  --color-border: color-mix(in srgb, var(--midground-base) 15%, transparent);
+  --color-input: color-mix(in srgb, var(--midground-base) 15%, transparent);
+  --color-ring: var(--midground);
+  --color-popover: color-mix(in srgb, var(--midground-base) 4%, var(--background-base));
+  --color-popover-foreground: var(--midground);
+
+  --radius-sm: calc(var(--theme-radius) - 4px);
+  --radius-md: calc(var(--theme-radius) - 2px);
+  --radius-lg: var(--theme-radius);
+  --radius-xl: calc(var(--theme-radius) + 4px);
+}
+
+
+/* Collapsed sidebar tooltip entrance — skipped when moving between items. */
+@keyframes sidebar-tooltip-in {
+  from { opacity: 0; transform: translateY(-50%) translateX(-4px); }
+  to   { opacity: 1; transform: translateY(-50%) translateX(0); }
+}
+
+/* Toast animations used by `components/Toast.tsx`. */
+@keyframes toast-in {
+  from { opacity: 0; transform: translateX(16px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+@keyframes toast-out {
+  from { opacity: 1; transform: translateX(0); }
+  to   { opacity: 0; transform: translateX(16px); }
+}
+
+/* Generic fade + dialog entrance used by popovers and confirm dialogs. */
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@keyframes dialog-in {
+  from { opacity: 0; transform: translateY(4px) scale(0.98); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* Hide scrollbar utility — used by the header's overflow-x nav row. */
+.scrollbar-none {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-none::-webkit-scrollbar {
+  display: none;
+}
+
+/* System UI-monospace stack — distinct from `font-courier` (Courier
+   Prime), used for dense data readouts where the display font would
+   break the grid. Routes through the theme's mono stack so themes
+   with a different monospace (JetBrains Mono, IBM Plex Mono, etc.)
+   still apply here. */
+.font-mono-ui {
+  font-family: var(--theme-font-mono);
+}
+
+/* Subtle grain overlay for badges. */
+.grain {
+  position: relative;
+}
+.grain::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  opacity: 0.12;
+  pointer-events: none;
+  background: repeating-conic-gradient(currentColor 0% 25%, #0000 0% 50%) 0 0 /
+    2px 2px;
+}
+
+/* RTL support — Arabic and any future right-to-left locale. The i18n provider
+   sets `dir` on <html>; Tailwind v4's logical spacing utilities (ms-/me-,
+   ps-/pe-) and logical properties then flip automatically. Scoped so the
+   default LTR layout is untouched. */
+html[dir="rtl"] {
+  direction: rtl;
+}
+
+
+```
+
+## Raw web/src/themes/presets.ts
+
+```tsx
+import type { DashboardTheme, ThemeTypography, ThemeLayout } from "./types";
+
+/**
+ * Built-in dashboard themes.
+ *
+ * Each theme defines its own palette, typography, and layout so switching
+ * themes produces visible changes beyond just color — fonts, density, and
+ * corner-radius all shift to match the theme's personality.
+ *
+ * Theme names must stay in sync with the backend's
+ * `_BUILTIN_DASHBOARD_THEMES` list in `hermes_cli/web_server.py`.
+ */
+
+// ---------------------------------------------------------------------------
+// Shared typography / layout presets
+// ---------------------------------------------------------------------------
+
+/** Default system stack — neutral, safe fallback for every platform. */
+const SYSTEM_SANS =
+  'system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
+const SYSTEM_MONO =
+  'ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace';
+
+const DEFAULT_TYPOGRAPHY: ThemeTypography = {
+  fontSans: SYSTEM_SANS,
+  fontMono: SYSTEM_MONO,
+  baseSize: "15px",
+  lineHeight: "1.55",
+  letterSpacing: "0",
+};
+
+const DEFAULT_LAYOUT: ThemeLayout = {
+  radius: "0.5rem",
+  density: "comfortable",
+};
+
+// ---------------------------------------------------------------------------
+// Themes
+// ---------------------------------------------------------------------------
+
+export const defaultTheme: DashboardTheme = {
+  name: "default",
+  label: "Hermes Teal",
+  description: "Classic dark teal — the canonical Hermes look",
+  palette: {
+    background: { hex: "#041c1c", alpha: 1 },
+    midground: { hex: "#ffe6cb", alpha: 1 },
+    foreground: { hex: "#ffffff", alpha: 0 },
+    warmGlow: "rgba(255, 189, 56, 0.35)",
+    noiseOpacity: 1,
+  },
+  typography: DEFAULT_TYPOGRAPHY,
+  layout: DEFAULT_LAYOUT,
+  terminalBackground: "#000000",
+};
+
+export const midnightTheme: DashboardTheme = {
+  name: "midnight",
+  label: "Midnight",
+  description: "Deep blue-violet with cool accents",
+  palette: {
+    background: { hex: "#0a0a1f", alpha: 1 },
+    midground: { hex: "#d4c8ff", alpha: 1 },
+    foreground: { hex: "#ffffff", alpha: 0 },
+    warmGlow: "rgba(167, 139, 250, 0.32)",
+    noiseOpacity: 0.8,
+  },
+  typography: {
+    ...DEFAULT_TYPOGRAPHY,
+    fontSans: `"Inter", ${SYSTEM_SANS}`,
+    fontMono: `"JetBrains Mono", ${SYSTEM_MONO}`,
+    fontUrl:
+      "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap",
+    letterSpacing: "-0.005em",
+  },
+  layout: {
+    ...DEFAULT_LAYOUT,
+    radius: "0.75rem",
+  },
+};
+
+export const emberTheme: DashboardTheme = {
+  name: "ember",
+  label: "Ember",
+  description: "Warm crimson and bronze — forge vibes",
+  palette: {
+    background: { hex: "#1a0a06", alpha: 1 },
+    midground: { hex: "#ffd8b0", alpha: 1 },
+    foreground: { hex: "#ffffff", alpha: 0 },
+    warmGlow: "rgba(249, 115, 22, 0.38)",
+    noiseOpacity: 1,
+  },
+  typography: {
+    ...DEFAULT_TYPOGRAPHY,
+    fontSans: `"Spectral", Georgia, "Times New Roman", serif`,
+    fontMono: `"IBM Plex Mono", ${SYSTEM_MONO}`,
+    fontUrl:
+      "https://fonts.googleapis.com/css2?family=Spectral:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;700&display=swap",
+  },
+  layout: {
+    ...DEFAULT_LAYOUT,
+    radius: "0.25rem",
+  },
+  colorOverrides: {
+    destructive: "#c92d0f",
+    warning: "#f97316",
+  },
+};
+
+export const monoTheme: DashboardTheme = {
+  name: "mono",
+  label: "Mono",
+  description: "Clean grayscale — minimal and focused",
+  palette: {
+    background: { hex: "#0e0e0e", alpha: 1 },
+    midground: { hex: "#eaeaea", alpha: 1 },
+    foreground: { hex: "#ffffff", alpha: 0 },
+    warmGlow: "rgba(255, 255, 255, 0.1)",
+    noiseOpacity: 0.6,
+  },
+  typography: {
+    ...DEFAULT_TYPOGRAPHY,
+    fontSans: `"IBM Plex Sans", ${SYSTEM_SANS}`,
+    fontMono: `"IBM Plex Mono", ${SYSTEM_MONO}`,
+    fontUrl:
+      "https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap",
+  },
+  layout: {
+    ...DEFAULT_LAYOUT,
+    radius: "0",
+  },
+};
+
+export const cyberpunkTheme: DashboardTheme = {
+  name: "cyberpunk",
+  label: "Cyberpunk",
+  description: "Neon green on black — matrix terminal",
+  palette: {
+    background: { hex: "#040608", alpha: 1 },
+    midground: { hex: "#9bffcf", alpha: 1 },
+    foreground: { hex: "#ffffff", alpha: 0 },
+    warmGlow: "rgba(0, 255, 136, 0.22)",
+    noiseOpacity: 1.2,
+  },
+  typography: {
+    ...DEFAULT_TYPOGRAPHY,
+    fontSans: `"Share Tech Mono", "JetBrains Mono", ${SYSTEM_MONO}`,
+    fontMono: `"Share Tech Mono", "JetBrains Mono", ${SYSTEM_MONO}`,
+    fontUrl:
+      "https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=JetBrains+Mono:wght@400;700&display=swap",
+  },
+  layout: {
+    ...DEFAULT_LAYOUT,
+    radius: "0",
+  },
+  colorOverrides: {
+    success: "#00ff88",
+    warning: "#ffd700",
+    destructive: "#ff0055",
+  },
+};
+
+export const roseTheme: DashboardTheme = {
+  name: "rose",
+  label: "Rosé",
+  description: "Soft pink and warm ivory — easy on the eyes",
+  palette: {
+    background: { hex: "#1a0f15", alpha: 1 },
+    midground: { hex: "#ffd4e1", alpha: 1 },
+    foreground: { hex: "#ffffff", alpha: 0 },
+    warmGlow: "rgba(249, 168, 212, 0.3)",
+    noiseOpacity: 0.9,
+  },
+  typography: {
+    ...DEFAULT_TYPOGRAPHY,
+    fontSans: `"Fraunces", Georgia, serif`,
+    fontMono: `"DM Mono", ${SYSTEM_MONO}`,
+    fontUrl:
+      "https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=DM+Mono:wght@400;500&display=swap",
+  },
+  layout: {
+    ...DEFAULT_LAYOUT,
+    radius: "1rem",
+  },
+};
+
+/** Light mode — vivid Nous-blue accents on a cream canvas. */
+export const nousBlueTheme: DashboardTheme = {
+  name: "nous-blue",
+  label: "Nous Blue",
+  description: "Light mode — vivid Nous-blue accents on cream canvas",
+  palette: {
+    background: { hex: "#E8F2FD", alpha: 1 },
+    midground: { hex: "#0053FD", alpha: 1 },
+    foreground: { hex: "#170d02", alpha: 0 },
+    warmGlow: "rgba(0, 83, 253, 0.12)",
+    noiseOpacity: 0,
+  },
+  typography: DEFAULT_TYPOGRAPHY,
+  layout: DEFAULT_LAYOUT,
+  terminalBackground: "#f5f8fc",
+  terminalForeground: "#170d02",
+  seriesColors: {
+    inputTokenAccent: "#001934",
+    outputTokenAccent: "#0053fd",
+  },
+  swatchColors: ["#170d02", "#0053FD", "#E8F2FD"],
+};
+
+/**
+ * Same look as ``defaultTheme`` but with a larger root font size, looser
+ * line-height, and ``spacious`` density so every rem-based size in the
+ * dashboard scales up. For users who find the default 15px UI too dense.
+ */
+export const defaultLargeTheme: DashboardTheme = {
+  name: "default-large",
+  label: "Hermes Teal (Large)",
+  description: "Hermes Teal with bigger fonts and roomier spacing",
+  palette: defaultTheme.palette,
+  typography: {
+    ...DEFAULT_TYPOGRAPHY,
+    baseSize: "18px",
+    lineHeight: "1.65",
+  },
+  layout: {
+    ...DEFAULT_LAYOUT,
+    density: "spacious",
+  },
+};
+
+export const BUILTIN_THEMES: Record<string, DashboardTheme> = {
+  default: defaultTheme,
+  "default-large": defaultLargeTheme,
+  "nous-blue": nousBlueTheme,
+  midnight: midnightTheme,
+  ember: emberTheme,
+  mono: monoTheme,
+  cyberpunk: cyberpunkTheme,
+  rose: roseTheme,
+};
+
+```
+
+## Raw web/src/themes/types.ts
+
+```tsx
+/**
+ * Dashboard theme model.
+ *
+ * Themes customise three orthogonal layers:
+ *
+ *   1. `palette`       — the 3-layer color triplet (background/midground/
+ *                         foreground). Legacy `warmGlow` / `noiseOpacity`
+ *                         fields remain for theme YAML compat but are unused
+ *                         by the lightweight shell.
+ *   2. `typography`    — font families, base font size, line height,
+ *                         letter spacing. An optional `fontUrl` is injected
+ *                         as `<link rel="stylesheet">` so self-hosted and
+ *                         Google/Bunny/etc-hosted fonts both work.
+ *   3. `layout`        — corner radius and density (spacing multiplier).
+ *
+ * Plus an optional `colorOverrides` escape hatch for themes that want to
+ * pin specific shadcn tokens to exact values (e.g. a pastel theme that
+ * needs a softer `destructive` red than the derived default).
+ */
+
+/** A color layer: hex base + alpha (0–1). */
+export interface ThemeLayer {
+  alpha: number;
+  hex: string;
+}
+
+export interface ThemePalette {
+  /** Deepest canvas color (typically near-black). */
+  background: ThemeLayer;
+  /** Primary text + accent. Most UI chrome reads this. */
+  midground: ThemeLayer;
+  /** Top-layer highlight. In LENS_0 this is white @ alpha 0 — invisible by
+   *  default but still drives `--color-ring`-style accents. */
+  foreground: ThemeLayer;
+  /** Legacy palette field — kept for theme YAML compat. */
+  warmGlow: string;
+  /** Legacy palette field — kept for theme YAML compat. */
+  noiseOpacity: number;
+}
+
+export interface ThemeTypography {
+  /** CSS font-family stack for sans-serif body copy. */
+  fontSans: string;
+  /** CSS font-family stack for monospace / code blocks. */
+  fontMono: string;
+  /** Optional display/heading font stack. Falls back to `fontSans`. */
+  fontDisplay?: string;
+  /** Optional external stylesheet URL (e.g. Google Fonts, Bunny Fonts,
+   *  self-hosted .woff2 @font-face sheet). Injected as a <link> in <head>
+   *  on theme switch. Same URL is never injected twice. */
+  fontUrl?: string;
+  /** Root font size (controls rem scale). Example: `"14px"`, `"16px"`. */
+  baseSize: string;
+  /** Default line-height. Example: `"1.5"`, `"1.65"`. */
+  lineHeight: string;
+  /** Default letter-spacing. Example: `"0"`, `"0.01em"`, `"-0.01em"`. */
+  letterSpacing: string;
+}
+
+export type ThemeDensity = "compact" | "comfortable" | "spacious";
+
+export interface ThemeLayout {
+  /** Corner-radius token. Example: `"0"`, `"0.25rem"`, `"0.5rem"`,
+   *  `"1rem"`. Maps to `--radius` and cascades into every component. */
+  radius: string;
+  /** Spacing multiplier. `compact` = 0.85, `comfortable` = 1.0 (default),
+   *  `spacious` = 1.2. Applied via the `--spacing-mul` CSS var. */
+  density: ThemeDensity;
+}
+
+/** Overall layout variant the shell renders. `standard` = default single-
+ *  column page layout. `cockpit` = reserves a left sidebar rail for a
+ *  plugin slot (intended for HUD-style themes with persistent status panels).
+ *  `tiled` = relaxes the main content max-width so pages can use the full
+ *  viewport width. Themes set this; plugins react via CSS vars /
+ *  `[data-layout-variant="..."]` selectors. */
+export type ThemeLayoutVariant = "standard" | "cockpit" | "tiled";
+
+/** Named hero/background assets a theme can populate. Each value is
+ *  emitted as a CSS var (`--theme-asset-<name>`). Plugin slots and
+ *  shell chrome may consume these via CSS. */
+export interface ThemeAssets {
+  /** Full-viewport background image URL. Exposed as `--theme-asset-bg` for
+   *  the `backdrop` plugin slot or theme `customCSS`. */
+  bg?: string;
+  /** Hero render (Gundam, mascot, wallpaper) — for plugin sidebars/overlays. */
+  hero?: string;
+  /** Logo mark — header slot consumers use this. */
+  logo?: string;
+  /** Faction/brand crest — header-left decoration. */
+  crest?: string;
+  /** Secondary sidebar illustration. */
+  sidebar?: string;
+  /** Alternate header artwork. */
+  header?: string;
+  /** User-defined named assets. Keyed by [a-zA-Z0-9_-] only.
+   *  Emitted as `--theme-asset-custom-<key>`. */
+  custom?: Record<string, string>;
+}
+
+/** Component-style override buckets. Each bucket's entries become CSS
+ *  vars (`--component-<bucket>-<kebab-property>`) that shell components
+ *  (Card, App header/footer, etc.) read. Values are plain CSS
+ *  strings — we don't parse them, so themes can use `clip-path`,
+ *  `border-image`, `background`, `box-shadow`, and anything else CSS
+ *  accepts. */
+export interface ThemeComponentStyles {
+  card?: Record<string, string>;
+  header?: Record<string, string>;
+  footer?: Record<string, string>;
+  sidebar?: Record<string, string>;
+  tab?: Record<string, string>;
+  progress?: Record<string, string>;
+  badge?: Record<string, string>;
+  backdrop?: Record<string, string>;
+  page?: Record<string, string>;
+}
+
+/** Data-series accent colors for chart + table visualisations (Analytics,
+ *  Models, etc.). Themes provide hex strings; the provider emits them as
+ *  `--series-input-token` / `--series-output-token` CSS vars consumed
+ *  inline by pages that render input-vs-output token flows. Themes can
+ *  omit either field to inherit the default token defined in
+ *  `index.css` (Hermes-teal `#ffe6cb` for input, `#34d399` for output). */
+export interface ThemeSeriesColors {
+  /** Input-tokens series accent (Analytics chart bars + table values). */
+  inputTokenAccent?: string;
+  /** Output-tokens series accent. */
+  outputTokenAccent?: string;
+}
+
+/** Optional hex overrides keyed by shadcn-compat token name (without the
+ *  `--color-` prefix). Any key set here wins over the DS cascade. */
+export interface ThemeColorOverrides {
+  card?: string;
+  cardForeground?: string;
+  popover?: string;
+  popoverForeground?: string;
+  primary?: string;
+  primaryForeground?: string;
+  secondary?: string;
+  secondaryForeground?: string;
+  muted?: string;
+  mutedForeground?: string;
+  accent?: string;
+  accentForeground?: string;
+  destructive?: string;
+  destructiveForeground?: string;
+  success?: string;
+  warning?: string;
+  border?: string;
+  input?: string;
+  ring?: string;
+}
+
+export interface DashboardTheme {
+  description: string;
+  label: string;
+  name: string;
+  palette: ThemePalette;
+  typography: ThemeTypography;
+  layout: ThemeLayout;
+  /** Overall shell layout. Defaults to `"standard"` when absent. */
+  layoutVariant?: ThemeLayoutVariant;
+  /** Named + custom asset URLs exposed as CSS vars on theme apply. */
+  assets?: ThemeAssets;
+  /** Raw CSS injected as a scoped `<style>` tag on theme apply, cleaned up
+   *  on theme switch. Intended for selector-level chrome that's too
+   *  expressive for componentStyles alone (e.g. `::before` pseudo-elements,
+   *  complex animations, media queries). */
+  customCSS?: string;
+  /** Per-component CSS-var overrides. See `ThemeComponentStyles`. */
+  componentStyles?: ThemeComponentStyles;
+  colorOverrides?: ThemeColorOverrides;
+  /** Data-series accent colors for Analytics/Models token charts. */
+  seriesColors?: ThemeSeriesColors;
+  /** Explicit 3-color swatch override for the theme picker. Order matches the
+   *  default swatch cells: [background, midground, warmGlow]. */
+  swatchColors?: [string, string, string];
+  /** Background color for the embedded terminal pane (xterm.js).
+   *  Hex string. Defaults to `"#000000"` when absent. */
+  terminalBackground?: string;
+  /** Default text/cursor color for the embedded terminal pane (xterm.js).
+   *  Hex string. Defaults to `"#f0e6d2"` when absent. */
+  terminalForeground?: string;
+}
+
+/**
+ * Wire response shape for `GET /api/dashboard/themes`.
+ *
+ * The `themes` list is intentionally partial — built-in themes are fully
+ * defined in `presets.ts`; user themes carry their full definition so the
+ * client can apply them without a second round-trip.
+ */
+export interface ThemeListEntry {
+  description: string;
+  label: string;
+  name: string;
+  /** Full theme definition. Present for user-defined themes loaded from
+   *  `~/.hermes/dashboard-themes/*.yaml`; undefined for built-ins (the
+   *  client already has those in `BUILTIN_THEMES`). */
+  definition?: DashboardTheme;
+}
+
+export interface ThemeListResponse {
+  active: string;
+  themes: ThemeListEntry[];
+}
+
+```
+

--- a/.superdesign/resume.json
+++ b/.superdesign/resume.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": 1,
+  "targets": {
+    "/sessions": {
+      "targetKind": "existing-ui",
+      "projectId": "b0f9762b-45d9-46e9-adf4-90b66b56eb8f",
+      "baselineDraftId": "63c21887-afb6-4a23-94b7-05325037a5f4",
+      "activeDraftId": "63c21887-afb6-4a23-94b7-05325037a5f4",
+      "designSystemPath": ".superdesign/design-system.md",
+      "contextFiles": [
+        ".superdesign/design-system.md",
+        ".superdesign/init/theme.md",
+        "web/src/index.css",
+        "web/src/App.tsx:480:860",
+        "web/src/pages/SessionsPage.tsx:1500:2198",
+        "web/src/components/ThemeSwitcher.tsx",
+        "web/src/components/ProfileSwitcher.tsx",
+        "web/src/components/SidebarStatusStrip.tsx",
+        "web/src/components/SidebarFooter.tsx"
+      ],
+      "fingerprints": {
+        ".superdesign/design-system.md": "ab2168d6a5efed675271e76f9942c35e796d352224d5f04fba9720734143b2ec",
+        ".superdesign/init/theme.md": "fa113a7a49ff4ed984d5ec904e27640458a9944917ef4003f0ef4b89f005dcbe",
+        "web/src/index.css": "0f65b06e327494f599d59d57cd0633387a0f0bef11be2917a70cc2ffde60690b",
+        "web/src/App.tsx": "5f72d97b2f3c952118df3920fa6075e9c349dc58d16f9cc00df0dbc9839d3b0e",
+        "web/src/pages/SessionsPage.tsx": "a81346b4538397512dc584ee92e43180496c62134231af653c3a36e2f733db54",
+        "web/src/components/ThemeSwitcher.tsx": "4c5181bb0a89bbf0336ecb9dff4d96736f273607a966ea78eb8704327a939d9e",
+        "web/src/components/ProfileSwitcher.tsx": "41e7041948abaeb7ab726a2e10519a16fb1840995eb98394f3cf63dbfc890319",
+        "web/src/components/SidebarStatusStrip.tsx": "0dd142f12b5b9d4d7d5339a6be46cb52825e2be02f81ecc718493393ebd5522d",
+        "web/src/components/SidebarFooter.tsx": "c070c3c534b7b51bef52b1de94cdeca1d6a2e1e8b357016af8115993e29ad306"
+      },
+      "components": [],
+      "drafts": {
+        "63c21887-afb6-4a23-94b7-05325037a5f4": {
+          "title": "Hermes Agent - Codex Graphite Sessions",
+          "visualDirection": "Codex-inspired matte graphite with restrained blue accents",
+          "currentVersion": 2
+        }
+      },
+      "updatedAt": "2026-08-22T17:52:00Z"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2137,7 +2137,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2154,7 +2153,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2171,7 +2169,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2188,7 +2185,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2205,7 +2201,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2222,7 +2217,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2239,7 +2233,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2256,7 +2249,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2273,7 +2265,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2290,7 +2281,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2307,7 +2297,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2324,7 +2313,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2341,7 +2329,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2358,7 +2345,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2375,7 +2361,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2392,7 +2377,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2409,7 +2393,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2426,7 +2409,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2443,7 +2425,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2460,7 +2441,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2477,7 +2457,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2494,7 +2473,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2511,7 +2489,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2528,7 +2505,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2545,7 +2521,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2562,7 +2537,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18047,7 +18021,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }


### PR DESCRIPTION
## Summary
- add Superdesign context for the existing Hermes dashboard and Sessions route
- capture the Codex-inspired graphite design system and source fingerprints
- normalize npm peer metadata using the currently supported npm release

## Review
- no blocking findings in the current changes
- no runtime product code is changed

## Validation
- `npm install --package-lock-only --ignore-scripts`
- parsed `package-lock.json` and `.superdesign/resume.json`
- verified every stored Superdesign source fingerprint
- `npm run check` was attempted; unrelated workspace checks report missing local modules in bootstrap-installer, desktop, and tests-js, while the web and TUI test suites completed successfully
