### PR TITLE
fix(telegram): stop restart backlogs from silently wedging dispatch

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -320,6 +320,12 @@ _TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
 # froze inbound on every platform (#91969).
 _FLOOD_INLINE_WAIT_CAP_SECS = 5.0
 
+# PTB processes updates sequentially by default. Optional Bot API enrichment
+# must therefore be bounded: getUpdates has already advanced its offset before
+# these awaits run, so one orphaned request would otherwise park every later
+# update while Telegram's server-side pending count falls to zero (#93506).
+_INBOUND_PREPROCESS_TIMEOUT_SECS = 30.0
+
 
 def _flood_cap_result(wait: float) -> "SendResult":
     """The shared fail-closed SendResult for an over-cap flood wait."""
@@ -9438,6 +9444,28 @@ class TelegramAdapter(BasePlatformAdapter):
         )
         logger.info("[Telegram] Cached replied-to %s at %s", cached.kind, cached.path)
 
+    async def _await_inbound_preprocess(self, awaitable: Any, *, stage: str) -> bool:
+        """Bound optional enrichment that runs on PTB's update processor."""
+        timeout = float(
+            getattr(
+                self,
+                "_inbound_preprocess_timeout_seconds",
+                _INBOUND_PREPROCESS_TIMEOUT_SECS,
+            )
+        )
+        try:
+            await _await_with_thread_deadline(awaitable, timeout=timeout)
+            return True
+        except asyncio.TimeoutError:
+            logger.error(
+                "[Telegram] Inbound %s timed out after %.0fs; continuing "
+                "without optional enrichment so later updates can dispatch",
+                stage,
+                timeout,
+                exc_info=True,
+            )
+            return False
+
     def _observed_media_source(self, msg: Message):
         """Return (telegram_file_source, filename, mime, default_kind) or Nones."""
         if msg.photo:
@@ -9708,11 +9736,17 @@ class TelegramAdapter(BasePlatformAdapter):
             if self._should_observe_unmentioned_group_message(msg):
                 self._observe_unmentioned_group_message(msg, MessageType.TEXT, update_id=update.update_id)
             return
-        await self._ensure_forum_commands(update.message)
+        await self._await_inbound_preprocess(
+            self._ensure_forum_commands(msg),
+            stage="forum-command registration",
+        )
 
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
-        await self._cache_replied_media(msg, event)
+        await self._await_inbound_preprocess(
+            self._cache_replied_media(msg, event),
+            stage="replied-media lookup",
+        )
         event = self._apply_telegram_group_observe_attribution(event)
         self._enqueue_text_event(event)
 
@@ -9730,11 +9764,17 @@ class TelegramAdapter(BasePlatformAdapter):
                 getattr(getattr(msg, "chat", None), "id", None),
             )
             return
-        await self._ensure_forum_commands(msg)
+        await self._await_inbound_preprocess(
+            self._ensure_forum_commands(msg),
+            stage="forum-command registration",
+        )
 
         event = self._build_message_event(msg, MessageType.COMMAND, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
-        await self._cache_replied_media(msg, event)
+        await self._await_inbound_preprocess(
+            self._cache_replied_media(msg, event),
+            stage="replied-media lookup",
+        )
         event = self._apply_telegram_group_observe_attribution(event)
         # Telegram clients split messages above 4096 chars into multiple
         # updates.  A long command paste (e.g. ``/queue <huge prompt>``)

--- a/tests/gateway/test_telegram_dispatch_timeout.py
+++ b/tests/gateway/test_telegram_dispatch_timeout.py
@@ -1,0 +1,94 @@
+"""Regression tests for bounded Telegram pre-dispatch work (#93506)."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def _event(text: str = "hello") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="42",
+            chat_id="42",
+            chat_type="dm",
+        ),
+    )
+
+
+def _adapter(text: str) -> tuple[TelegramAdapter, SimpleNamespace]:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._inbound_preprocess_timeout_seconds = 0.01
+    adapter._is_user_authorized_from_message = lambda _msg: True
+    adapter._should_process_message = lambda _msg, **_kwargs: True
+    adapter._build_message_event = lambda *_args, **_kwargs: _event(text)
+    adapter._clean_bot_trigger_text = lambda value: value
+    adapter._apply_telegram_group_observe_attribution = lambda event: event
+    message = SimpleNamespace(text=text)
+    update = SimpleNamespace(update_id=1, message=message, effective_message=message)
+    return adapter, update
+
+
+async def _complete(*_args) -> None:
+    return None
+
+
+async def _hang(event: asyncio.Event, *_args) -> None:
+    await event.wait()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("hung_stage", ["forum", "media"])
+async def test_text_dispatch_survives_hung_optional_preprocessing(
+    hung_stage: str,
+) -> None:
+    """Optional Telegram lookups must not serialize-stall update dispatch."""
+    adapter, update = _adapter("hello")
+    never_finishes = asyncio.Event()
+    adapter._ensure_forum_commands = (
+        lambda *args: _hang(never_finishes, *args)
+        if hung_stage == "forum"
+        else _complete(*args)
+    )
+    adapter._cache_replied_media = (
+        lambda *args: _hang(never_finishes, *args)
+        if hung_stage == "media"
+        else _complete(*args)
+    )
+    queued: list[MessageEvent] = []
+    adapter._enqueue_text_event = queued.append
+
+    await asyncio.wait_for(
+        adapter._handle_text_message(update, SimpleNamespace()),
+        timeout=0.25,
+    )
+
+    assert [event.text for event in queued] == ["hello"]
+
+
+@pytest.mark.asyncio
+async def test_command_dispatch_survives_hung_optional_preprocessing() -> None:
+    adapter, update = _adapter("/status")
+    never_finishes = asyncio.Event()
+    adapter._ensure_forum_commands = _complete
+    adapter._cache_replied_media = lambda *args: _hang(never_finishes, *args)
+    dispatched: list[MessageEvent] = []
+
+    async def handle_message(event: MessageEvent) -> None:
+        dispatched.append(event)
+
+    adapter.handle_message = handle_message
+    await asyncio.wait_for(
+        adapter._handle_command(update, SimpleNamespace()),
+        timeout=0.25,
+    )
+
+    assert [event.text for event in dispatched] == ["/status"]


### PR DESCRIPTION
## What does this PR do?

Telegram can consume a restart backlog while never reaching text batching or gateway dispatch, leaving the bot silently unresponsive even though polling and the gateway heartbeat remain healthy.

### Symptom

After restart, `pending_update_count` can fall to zero without a `Flushing text batch` or `inbound message` log. The affected chat receives no response, and later updates remain stuck behind the first unresolved handler await.

### Impact

The gateway looks healthy to supervisors while Telegram messages are acknowledged but not dispatched. Users can remain unable to interact with the bot until another restart discards the already-consumed local update queue.

### Bug Cause

**Trigger:** `plugins/platforms/telegram/adapter.py` in `_handle_text_message` and `_handle_command`.

**Causal chain:**
1. PTB fetches a pending update and advances the Bot API offset.
2. Its sequential update processor awaits optional forum-command registration or replied-media enrichment before Hermes enqueues or dispatches the event.
3. If that Bot API await never resolves, later fetched updates sit behind it while Telegram reports no pending server-side updates, and Hermes emits neither text-batch nor inbound-dispatch logs.

**Why it is wrong:** Optional enrichment had no outer deadline. The request-level transport timeout is not a sufficient bound when an async task becomes orphaned or remains inside a cancellation-shielded path.

**Working sibling / contrast:** Once an event reaches `BasePlatformAdapter.handle_message`, the full agent turn runs in a tracked background task, so long agent work does not block platform update ingestion.

**Ruled out:** The live process dump showed both event loops idle, and killing the MCP child did not release dispatch. The failure is therefore not an MCP child-lifetime wait or a CPU-blocked gateway loop.

### Fix

Run forum-command registration and replied-media enrichment through the existing wall-clock deadline helper. On timeout, Hermes logs the failed stage with a traceback and continues without the optional enrichment, allowing the consumed update and all later updates to reach dispatch. The same guard covers text and command updates.

## Related Issue
N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/telegram/adapter.py` - bound optional pre-dispatch Bot API awaits and fail open to dispatch on timeout.
- `tests/gateway/test_telegram_dispatch_timeout.py` - cover hung forum registration and replied-media lookup for text and command updates.

## How to Test

1. Run the regression test that injects a never-resolving pre-dispatch await and verifies the update still reaches batching or command dispatch.
2. Run the adjacent Telegram authorization, forum-command, and text-batching suites.

```bash
scripts/run_tests.sh tests/gateway/test_telegram_dispatch_timeout.py tests/gateway/test_telegram_auth_check.py tests/gateway/test_telegram_forum_commands.py tests/gateway/test_telegram_text_batching.py -q
```

Result: 39 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repo test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - behavior and diagnostics are covered by code comments and tests
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - asyncio and threading deadline primitives are platform-independent
- [x] Tool descriptions/schemas update: N/A - no tool behavior changed

## Screenshots / Logs

N/A - automated regression coverage exercises the exact never-resolving await boundary.
