### PR TITLE
fix(curator): read-before-write mark must survive the tool-executor thread hop

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -1073,6 +1073,19 @@ def _run_review_in_thread(
         finish_background_review_run(agent, review_run)
         return
 
+    # Identify this review turn so the skill read-before-write guard can scope
+    # its marks to it: a skill_view here must authorise a skill_manage here,
+    # and nothing in a later review run. Bound on the worker thread, which is
+    # the context every tool call for this review is copied from.
+    _turn_token = None
+    try:
+        from tools.skill_provenance import begin_review_turn
+        _turn_token = begin_review_turn(
+            f"{id(review_run)}-{threading.get_ident()}-{id(messages_snapshot)}"
+        )
+    except Exception:
+        logger.debug("Could not bind review turn id", exc_info=True)
+
     # Local import to avoid a hard circular dep at module load.
     from run_agent import AIAgent
     from tools.terminal_tool import set_approval_callback as _set_approval_callback
@@ -1590,6 +1603,21 @@ def _run_review_in_thread(
             _set_approval_callback(None)
         except Exception:
             pass
+        # Drop this review turn's read-before-write marks and unbind its id,
+        # so a recycled worker thread cannot inherit either.
+        try:
+            from tools.skill_manager_tool import (
+                _reset_background_review_read_marks,
+            )
+            _reset_background_review_read_marks()
+        except Exception:
+            pass
+        if _turn_token is not None:
+            try:
+                from tools.skill_provenance import reset_review_turn
+                reset_review_turn(_turn_token)
+            except Exception:
+                pass
 
 
 def spawn_background_review_thread(

--- a/tests/tools/test_skill_curator_thread_hop.py
+++ b/tests/tools/test_skill_curator_thread_hop.py
@@ -1,0 +1,201 @@
+"""Regression: the curator's read-before-write mark must survive the thread hop.
+
+Every tool call runs on its own worker thread via
+``tools.thread_context.propagate_context_to_thread``, which does a
+``contextvars.copy_context()``. When the read-before-write mark lived in a
+ContextVar, ``skill_view``'s worker wrote the mark into *its own copy* of the
+context and that copy was discarded when the call returned. The later
+``skill_manage`` worker started from a fresh copy, never saw the mark, and the
+guard refused the write — every time, for every skill.
+
+The user-visible failure was an infinite curator loop: read the skill, try to
+patch it, get refused, retry. One observed run burned 5.4M cache-read tokens
+over 34 minutes and made the CLI appear frozen.
+
+These tests pin both halves of the invariant:
+  * a read in the *same review turn* authorises the write even across threads;
+  * a write with no read — or with a read from a *different* turn — is still
+    refused, so the fix does not weaken the guard.
+"""
+
+import json
+
+import pytest
+
+from tools.daemon_pool import DaemonThreadPoolExecutor
+from tools.thread_context import propagate_context_to_thread
+
+
+VALID_SKILL_CONTENT = """---
+name: my-skill
+description: test skill
+---
+
+# My Skill
+
+Original body.
+"""
+
+
+@pytest.fixture
+def curator_env(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME + skills dir, as in test_skill_ledger."""
+    from agent import skill_utils
+    from tools import skill_ledger, skill_manager_tool, skill_usage
+
+    home = tmp_path / "home"
+    skills_dir = home / "skills"
+    skills_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(skill_ledger, "get_hermes_home", lambda: home)
+    monkeypatch.setattr(skill_usage, "get_hermes_home", lambda: home)
+    monkeypatch.setattr(skill_manager_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(skill_utils, "get_all_skills_dirs", lambda: [skills_dir])
+    return {"home": home, "skills": skills_dir}
+
+
+def _in_worker(fn, *args, **kwargs):
+    """Run *fn* the way the tool executor does: own thread, copied context."""
+    executor = DaemonThreadPoolExecutor(max_workers=1)
+    try:
+        future = executor.submit(
+            propagate_context_to_thread(lambda: fn(*args, **kwargs))
+        )
+        return future.result(timeout=30)
+    finally:
+        executor.shutdown(wait=False)
+
+
+def test_read_mark_survives_thread_hop(curator_env):
+    """skill_view on one worker authorises skill_manage on another."""
+    from tools.skill_manager_tool import (
+        mark_background_review_skill_read,
+        skill_manage,
+    )
+    from tools.skill_provenance import (
+        BACKGROUND_REVIEW,
+        begin_review_turn,
+        reset_current_write_origin,
+        reset_review_turn,
+        set_current_write_origin,
+    )
+
+    origin = set_current_write_origin(BACKGROUND_REVIEW)
+    turn = begin_review_turn("turn-1")
+    try:
+        assert json.loads(
+            skill_manage(action="create", name="my-skill", content=VALID_SKILL_CONTENT)
+        )["success"] is True
+        skill_md = curator_env["skills"] / "my-skill" / "SKILL.md"
+
+        # Worker A: what skill_view does after returning file content.
+        _in_worker(mark_background_review_skill_read, skill_md)
+
+        # Worker B: the write. Before the fix this was refused unconditionally.
+        result = json.loads(
+            _in_worker(
+                skill_manage,
+                action="patch",
+                name="my-skill",
+                old_string="Original body.",
+                new_string="Curated body.",
+            )
+        )
+        assert result.get("success") is True, result.get("error")
+        assert "Curated body." in skill_md.read_text(encoding="utf-8")
+    finally:
+        reset_review_turn(turn)
+        reset_current_write_origin(origin)
+
+
+def test_write_without_read_is_still_refused(curator_env):
+    """The guard must not be weakened: no read in this turn → no write."""
+    from tools.skill_manager_tool import skill_manage
+    from tools.skill_provenance import (
+        BACKGROUND_REVIEW,
+        begin_review_turn,
+        reset_current_write_origin,
+        reset_review_turn,
+        set_current_write_origin,
+    )
+
+    origin = set_current_write_origin(BACKGROUND_REVIEW)
+    turn = begin_review_turn("turn-1")
+    try:
+        assert json.loads(
+            skill_manage(action="create", name="my-skill", content=VALID_SKILL_CONTENT)
+        )["success"] is True
+
+        result = json.loads(
+            _in_worker(
+                skill_manage,
+                action="patch",
+                name="my-skill",
+                old_string="Original body.",
+                new_string="Unread edit.",
+            )
+        )
+        assert result.get("success") is False
+        assert "has not been loaded" in result.get("error", "")
+    finally:
+        reset_review_turn(turn)
+        reset_current_write_origin(origin)
+
+
+def test_read_does_not_leak_across_review_turns(curator_env):
+    """A read in turn 1 must not authorise a write in turn 2."""
+    from tools.skill_manager_tool import (
+        mark_background_review_skill_read,
+        skill_manage,
+    )
+    from tools.skill_provenance import (
+        BACKGROUND_REVIEW,
+        begin_review_turn,
+        reset_current_write_origin,
+        reset_review_turn,
+        set_current_write_origin,
+    )
+
+    origin = set_current_write_origin(BACKGROUND_REVIEW)
+    first = begin_review_turn("turn-1")
+    try:
+        assert json.loads(
+            skill_manage(action="create", name="my-skill", content=VALID_SKILL_CONTENT)
+        )["success"] is True
+        skill_md = curator_env["skills"] / "my-skill" / "SKILL.md"
+        _in_worker(mark_background_review_skill_read, skill_md)
+    finally:
+        reset_review_turn(first)
+
+    second = begin_review_turn("turn-2")
+    try:
+        result = json.loads(
+            _in_worker(
+                skill_manage,
+                action="patch",
+                name="my-skill",
+                old_string="Original body.",
+                new_string="Stale-turn edit.",
+            )
+        )
+        assert result.get("success") is False
+        assert "has not been loaded" in result.get("error", "")
+
+        # Re-reading inside this turn restores the authorisation.
+        _in_worker(
+            mark_background_review_skill_read,
+            curator_env["skills"] / "my-skill" / "SKILL.md",
+        )
+        ok = json.loads(
+            _in_worker(
+                skill_manage,
+                action="patch",
+                name="my-skill",
+                old_string="Original body.",
+                new_string="Fresh-turn edit.",
+            )
+        )
+        assert ok.get("success") is True, ok.get("error")
+    finally:
+        reset_review_turn(second)
+        reset_current_write_origin(origin)

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -36,6 +36,7 @@ import json
 import logging
 import re
 import shutil
+import threading
 import contextvars as _ctxvars
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -52,9 +53,33 @@ from agent.skill_utils import (
 
 logger = logging.getLogger(__name__)
 
-_background_review_read_paths: "_ctxvars.ContextVar[frozenset[str]]" = _ctxvars.ContextVar(
-    "background_review_read_paths", default=frozenset()
-)
+# Read-before-write marks for the background-review (curator) fork.
+#
+# NOT a ContextVar: every tool call runs on its own worker thread via
+# ``tools.thread_context.propagate_context_to_thread``, which does a
+# ``contextvars.copy_context()``.  A ContextVar written inside skill_view's
+# worker lands in that worker's *copy* and is discarded when the call returns,
+# so the later skill_manage worker — running off its own fresh copy — never
+# saw the mark and the guard below refused every single write.  That made the
+# curator loop forever: read the skill, try to patch it, get refused, retry.
+#
+# The mark therefore lives in a plain dict keyed by review-run id, guarded by
+# a lock, so it survives the thread hop while still being scoped to one review
+# run (a new run starts with an empty set).
+_background_review_read_lock = threading.Lock()
+_background_review_read_paths: Dict[str, set] = {}
+
+
+def _background_review_run_key() -> str:
+    """Identify the current review run so marks never leak between runs."""
+    try:
+        from tools.skill_provenance import current_background_review_id
+        rid = current_background_review_id()
+        if rid:
+            return str(rid)
+    except Exception:
+        pass
+    return "default"
 
 
 def mark_background_review_skill_read(path: Path) -> None:
@@ -77,9 +102,14 @@ def mark_background_review_skill_read(path: Path) -> None:
         resolved = str(path.resolve())
     except Exception:
         resolved = str(path)
-    current = set(_background_review_read_paths.get())
-    current.add(resolved)
-    _background_review_read_paths.set(frozenset(current))
+    key = _background_review_run_key()
+    with _background_review_read_lock:
+        # Bound the table: a long-lived process runs many review turns and
+        # each one would otherwise leave its set behind forever.
+        if len(_background_review_read_paths) > 32:
+            for stale in list(_background_review_read_paths)[:-8]:
+                _background_review_read_paths.pop(stale, None)
+        _background_review_read_paths.setdefault(key, set()).add(resolved)
 
 
 def _background_review_has_read(path: Path) -> bool:
@@ -87,12 +117,17 @@ def _background_review_has_read(path: Path) -> bool:
         resolved = str(path.resolve())
     except Exception:
         resolved = str(path)
-    return resolved in _background_review_read_paths.get()
+    key = _background_review_run_key()
+    with _background_review_read_lock:
+        return resolved in _background_review_read_paths.get(key, ())
 
 
 def _reset_background_review_read_marks() -> None:
     """Test helper: clear read-before-write marks for the current context."""
-    _background_review_read_paths.set(frozenset())
+    key = _background_review_run_key()
+    with _background_review_read_lock:
+        _background_review_read_paths.pop(key, None)
+
 
 # Import security scanner — external hub installs always get scanned;
 # agent-created skills only get scanned when skills.guard_agent_created is on.

--- a/tools/skill_provenance.py
+++ b/tools/skill_provenance.py
@@ -76,3 +76,32 @@ def is_background_review() -> bool:
     """Convenience: True iff the current write origin is the background
     review fork."""
     return get_current_write_origin() == BACKGROUND_REVIEW
+
+
+# --- Review-turn identity -------------------------------------------------
+#
+# The read-before-write guard in skill_manager_tool needs to know *which*
+# review turn is running, so a skill_view in turn N cannot authorise a write
+# in turn N+1. This is a ContextVar and is only ever READ from worker threads
+# (contextvars.copy_context() copies current values in, so reads are correct);
+# the guard's own bookkeeping must not live in a ContextVar because writes
+# made inside a worker's copied context are discarded when that tool call
+# returns. See the comment on _background_review_read_paths.
+_review_turn_id: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "skill_review_turn_id",
+    default="",
+)
+
+
+def begin_review_turn(turn_id: str) -> contextvars.Token[str]:
+    """Bind an identifier for the review turn about to run."""
+    return _review_turn_id.set(turn_id or "")
+
+
+def reset_review_turn(token: contextvars.Token[str]) -> None:
+    _review_turn_id.reset(token)
+
+
+def current_background_review_id() -> str:
+    """Identifier of the active review turn ("" when not in one)."""
+    return _review_turn_id.get()


### PR DESCRIPTION
## What's broken

The background review fork (the curator) can never patch a skill. Not "sometimes" — never, for any skill.

Its read-before-write guard is sound in intent: before the curator mutates a skill it must have loaded that exact file in the current review turn, so it can't patch content it only inferred from the transcript. The mark is recorded by `skill_view` and checked by `skill_manage`.

The mark lived in a `ContextVar`. But every tool call runs on its own worker thread via `tools.thread_context.propagate_context_to_thread`, which does a `contextvars.copy_context()`. So `skill_view` wrote the mark into **its own worker's copy** of the context, and that copy was discarded the moment the call returned. The `skill_manage` worker then started from a fresh copy, never saw the mark, and refused the write.

## Why it's worse than a no-op

The refusal message tells the model to call `skill_view(name)` and retry — which is precisely what it had just done. So the curator loops: read, patch, refused, read, patch, refused.

From my logs, one review run made 16 API calls over 34 minutes and burned 5.4M cache-read tokens before I killed the session. The CLI appears frozen the whole time — there is no output, just a background thread spinning. The same refusal appears 132 times across my logs:

```
Refusing background curator patch for skill 'change-effect-verification': the current
SKILL.md content has not been loaded in this review turn. Call skill_view(name) for
SKILL.md, ...
```

Three different skills, three consecutive review runs, same outcome each time.

## Reproducing it

Independent of the test suite, the mechanism is directly observable:

```
CASO A — same thread, no copy_context (what the guard assumes)
  skill_view marked the file?   True
  skill_manage sees the mark?   True

CASO B — each tool call on its own thread via propagate_context_to_thread (REAL)
  skill_view marked the file?   True
  skill_manage sees the mark?   False

CASO C — the real guard, after a real skill_view
  guard: REFUSES -> Refusing background curator patch ...
```

## The fix

Move the marks out of the `ContextVar` into a lock-guarded dict keyed by review-turn id, so they survive the thread hop while staying scoped to a single review turn.

The turn id itself *is* a new `ContextVar` in `skill_provenance` — that's correct here because it is only ever **read** from workers, and `copy_context()` copies current values in faithfully. It's bound in `_run_review_in_thread` and released in that function's `finally`, together with the turn's marks, so a recycled worker thread can't inherit either. The dict is bounded so a long-lived process doesn't accumulate one set per review turn forever.

## The guard is not weakened

That was the thing worth getting right — it would be easy to "fix" this by opening the gate. Three tests pin both directions:

- a read in the same turn authorises the write across threads;
- a write with **no** read is still refused;
- a read in turn 1 does **not** authorise a write in turn 2, and re-reading inside turn 2 restores it.

I verified the tests actually detect the bug rather than just passing: with the `ContextVar` behaviour reinstated, the two bug tests fail with the original production error message, while `test_write_without_read_is_still_refused` keeps passing.

```
2 failed, 1 passed   # bug reinstated
3 passed             # with the fix
```

## Test runs

- `tests/tools/test_skill_curator_thread_hop.py` — 3 passed (new)
- `test_skill_ledger`, `test_skill_manager_tool`, `test_skill_provenance`, `test_skills_tool`, `test_skill_improvements`, `test_background_review_list_shapes`, `test_background_review_session_isolation` — **141 passed** together with the new file

I also exercised it end-to-end through the real tools rather than only in tests: created a skill, marked it curator-managed, then ran `skill_view` and `skill_manage` on separate worker threads the way the executor does. The patch landed and the edit was confirmed on disk.

## Not covered here

`test_skill_ledger.py::test_background_review_patch_ledgers_and_rolls_back` passes both before and after, because it calls `mark_background_review_skill_read` directly on the test's own thread — the same-thread path (CASO A above), which was never broken. That's why the bug survived the suite. The new file is the one that exercises the thread hop.
