### PR TITLE
fix(bot-mode): suppress duplicate in-flight DMs

### DIFF
--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -217,6 +217,126 @@ def _runner_parts(command):
     return parts[marker + 1], parts[marker + 2], parts[marker + 3 :]
 
 
+
+
+def _mock_tracked_delivery(monkeypatch, command, *, proc_id="proc_pending", exited=False):
+    import tools.process_registry as process_registry_module
+
+    class _Process:
+        def __init__(self):
+            self.command = command
+            self.exited = exited
+
+    monkeypatch.setattr(
+        process_registry_module.process_registry,
+        "list_sessions",
+        lambda **_kwargs: [
+            {
+                "session_id": proc_id,
+                "status": "running",
+                "command": command[:80],
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        process_registry_module.process_registry,
+        "get",
+        lambda session_id: _Process() if session_id == proc_id else None,
+    )
+
+
+def test_same_target_delivery_is_rejected_while_in_flight(tmp_path, monkeypatch):
+    calls = _capture_spawn(monkeypatch)
+    home = _managed_home(tmp_path, teammates=("researcher",))
+    agent = _FakeAgent(home, title="Bot Chat")
+    transport_argv = [
+        "hermes", "-p", "researcher", "chat", "--in", "~", "-c", "Bot Chat",
+        "--create-if-missing", "-Q",
+    ]
+    command = bot_mode_dm._delivery_command(
+        transport_argv, "/tmp/hermes-dm/already-running.txt", stdin_file=False
+    )
+    _mock_tracked_delivery(monkeypatch, command)
+
+    result = json.loads(
+        bot_mode_dm.message_agent_tool(target="researcher", message="second send", agent=agent)
+    )
+
+    assert "error" in result
+    assert "already in flight" in result["error"]
+    assert "proc_pending" in result["error"]
+    assert "Do not retry" in result["error"]
+    assert calls == []
+
+
+def test_different_target_delivery_is_allowed_while_other_target_is_in_flight(
+    tmp_path, monkeypatch
+):
+    calls = _capture_spawn(monkeypatch)
+    home = _managed_home(tmp_path, teammates=("researcher", "coder"))
+    agent = _FakeAgent(home, title="Bot Chat")
+    coder_argv = [
+        "hermes", "-p", "coder", "chat", "--in", "~", "-c", "Bot Chat",
+        "--create-if-missing", "-Q",
+    ]
+    command = bot_mode_dm._delivery_command(
+        coder_argv, "/tmp/hermes-dm/coder-running.txt", stdin_file=False
+    )
+    _mock_tracked_delivery(monkeypatch, command, proc_id="proc_coder")
+
+    result = json.loads(
+        bot_mode_dm.message_agent_tool(
+            target="researcher", message="independent send", agent=agent
+        )
+    )
+
+    assert result["status"] == "sent"
+    assert len(calls) == 1
+
+
+def test_finished_same_target_delivery_does_not_block_new_send(tmp_path, monkeypatch):
+    calls = _capture_spawn(monkeypatch)
+    home = _managed_home(tmp_path, teammates=("researcher",))
+    agent = _FakeAgent(home, title="Bot Chat")
+    transport_argv = [
+        "hermes", "-p", "researcher", "chat", "--in", "~", "-c", "Bot Chat",
+        "--create-if-missing", "-Q",
+    ]
+    command = bot_mode_dm._delivery_command(
+        transport_argv, "/tmp/hermes-dm/finished.txt", stdin_file=False
+    )
+    _mock_tracked_delivery(monkeypatch, command, proc_id="proc_done", exited=True)
+
+    result = json.loads(
+        bot_mode_dm.message_agent_tool(target="researcher", message="new send", agent=agent)
+    )
+
+    assert result["status"] == "sent"
+    assert len(calls) == 1
+
+
+def test_peer_same_target_delivery_is_rejected_while_in_flight(tmp_path, monkeypatch):
+    calls = _capture_spawn(monkeypatch)
+    home = _managed_home(tmp_path, peers=("spark",))
+    agent = _FakeAgent(home, title="Bot Chat")
+    transport_argv = ["hermes", "peer", "dm", "spark/researcher"]
+    command = bot_mode_dm._delivery_command(
+        transport_argv, "/tmp/hermes-dm/peer-running.txt", stdin_file=True
+    )
+    _mock_tracked_delivery(monkeypatch, command, proc_id="proc_peer")
+
+    result = json.loads(
+        bot_mode_dm.message_agent_tool(
+            target="spark/researcher", message="duplicate peer send", agent=agent
+        )
+    )
+
+    assert "error" in result
+    assert "already in flight" in result["error"]
+    assert "proc_peer" in result["error"]
+    assert calls == []
+
+
 def test_local_delivery_command_and_ack(tmp_path, monkeypatch):
     calls = _capture_spawn(monkeypatch)
     home = _managed_home(tmp_path, teammates=("researcher",))

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -238,6 +238,44 @@ def _err(message: str, *, roster: list[str] | None = None, peers: list[str] | No
     return json.dumps(payload)
 
 
+def _command_contains_tokens(command: str, expected: list[str]) -> bool:
+    """Return whether *expected* appears contiguously in a shell command."""
+    if not command or not expected:
+        return False
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return False
+    width = len(expected)
+    return any(parts[index : index + width] == expected for index in range(len(parts) - width + 1))
+
+
+def _active_delivery_to_target(agent: Any, transport_argv: list[str]) -> str | None:
+    """Return a running DM process id for this Bot Chat + transport target."""
+    session_key = str(getattr(agent, "session_id", "") or "").strip()
+    if not session_key:
+        return None
+    try:
+        from tools.process_registry import process_registry
+
+        for entry in process_registry.list_sessions(session_key=session_key):
+            if entry.get("status") != "running":
+                continue
+            proc_id = str(entry.get("session_id") or "").strip()
+            process = process_registry.get(proc_id) if proc_id else None
+            if process is not None and process.exited:
+                continue
+            # list_sessions intentionally truncates commands for display. Use
+            # the registry object when available so long install/temp paths do
+            # not hide the transport target beyond that preview boundary.
+            command = str(getattr(process, "command", "") or entry.get("command") or "")
+            if _command_contains_tokens(command, transport_argv):
+                return proc_id or "running"
+    except Exception:
+        logger.debug("message_agent in-flight lookup failed", exc_info=True)
+    return None
+
+
 def message_agent_tool(
     target: str = "",
     message: str = "",
@@ -303,8 +341,16 @@ def message_agent_tool(
             )
         dm_target = f"{peer_name}/{peer_profile}" if peer_profile else peer_name
         label = f"@{peer_profile or peer_name} on peer '{peer_name}'"
+        transport_argv = ["hermes", "peer", "dm", dm_target]
+        active = _active_delivery_to_target(agent, transport_argv)
+        if active:
+            return _err(
+                f"A message to {label} is already in flight ({active}). "
+                "Do not retry or duplicate it; finish this turn and wait for the "
+                "completion notification."
+            )
         return _start_delivery(
-            ["hermes", "peer", "dm", dm_target],
+            transport_argv,
             prefix + body,
             label,
             stdin_file=True,
@@ -344,21 +390,31 @@ def message_agent_tool(
             return relayed
         return _err("You can't message yourself. Pick a teammate from the roster.")
 
+    transport_argv = [
+        "hermes",
+        "-p",
+        resolved,
+        "chat",
+        "--in",
+        "~",
+        "-c",
+        "Bot Chat",
+        "--create-if-missing",
+        "-Q",
+    ]
+    label = f"@{_handle(resolved)}"
+    active = _active_delivery_to_target(agent, transport_argv)
+    if active:
+        return _err(
+            f"A message to {label} is already in flight ({active}). "
+            "Do not retry or duplicate it; finish this turn and wait for the "
+            "completion notification."
+        )
+
     return _start_delivery(
-        [
-            "hermes",
-            "-p",
-            resolved,
-            "chat",
-            "--in",
-            "~",
-            "-c",
-            "Bot Chat",
-            "--create-if-missing",
-            "-Q",
-        ],
+        transport_argv,
         prefix + body,
-        f"@{_handle(resolved)}",
+        label,
         stdin_file=False,
         task_id=task_id,
         agent=agent,


### PR DESCRIPTION
## Summary

Prevents a Bot Chat from dispatching a second `message_agent` delivery to the same target while the first background delivery is still running.

`message_agent` is intentionally fire-and-forget. Without a same-target in-flight guard, a goal loop or repeated model turn can dispatch duplicate inference before the first reply arrives, producing duplicate work and out-of-order completion notifications.

This version is adapted to the current cleanup-owning DM runner:

- reuses the existing `ProcessRegistry` as the source of running-delivery truth
- scopes lookup to the calling Bot Chat session
- resolves the authoritative full registered command with `ProcessRegistry.get()` rather than relying on the truncated display preview
- matches the actual local or peer transport argv inside the runner command
- blocks only the same target; a different target can still be messaged independently
- finished deliveries do not block later sends
- covers both local teammates and registered peer targets
- adds no new persistence or queue

The error explicitly tells the agent not to retry and to wait for the normal completion notification.

## Validation

- `python -m pytest -q tests/tools/test_bot_mode_dm.py tests/tools/test_bot_mode_probe.py` → **57 passed**
- Python compile checks for touched modules → **PASS**
- `git diff --check` → **PASS**
