### PR TITLE
test(desktop): pin auto-speak silence across an Edge TTS fallback id rewrite (#93515)

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx
@@ -1,0 +1,132 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { atom } from 'nanostores'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { assistantTextPart, type ChatMessage, chatMessageText } from '@/lib/chat-messages'
+import { clearSpokenRepliesForTests, markAssistantIdSpoken, resolveSpokenReply } from '@/lib/spoken-reply'
+import { playSpeechText } from '@/lib/voice-playback'
+import { $voicePlayback, setVoicePlaybackState } from '@/store/voice-playback'
+import { $autoSpeakReplies } from '@/store/voice-prefs'
+
+import { ComposerScopeProvider, MAIN_COMPOSER_SCOPE } from '../scope'
+
+import { useAutoSpeakReplies } from './use-auto-speak-replies'
+
+vi.mock('@/lib/voice-playback', () => ({
+  playSpeechText: vi.fn()
+}))
+
+const SESSION_ID = 'session-under-test'
+const IDLE_STATE = { audioElement: null, messageId: null, sequence: 0, source: null, status: 'idle' as const }
+
+function assistantMessage(id: string, text: string): ChatMessage {
+  return { id, parts: [assistantTextPart(text)], role: 'assistant' }
+}
+
+// #93515 — Edge TTS has no chunked-PCM API, so the WS attempt in
+// playSpeechText's fallback ladder settles 'fallback' before any audio plays
+// and the client retries over the POST endpoint. While that POST round-trip
+// is in flight, the backend can rewrite the just-completed reply's renderer
+// id (`assistant-stream-*`) to its durable id. The issue claims
+// `resolveSpokenReply()` fails to follow that rewrite and the reply gets
+// spoken a second time once `$voicePlayback` goes idle.
+describe('useAutoSpeakReplies — Edge TTS fallback chain (#93515)', () => {
+  afterEach(() => {
+    cleanup()
+    clearSpokenRepliesForTests()
+    $autoSpeakReplies.set(false)
+    setVoicePlaybackState({ ...IDLE_STATE })
+    vi.clearAllMocks()
+  })
+
+  it('does not re-speak the reply once playback goes idle after an id rewrite mid-fallback', async () => {
+    $autoSpeakReplies.set(true)
+
+    const $messages = atom<ChatMessage[]>([])
+
+    // The exact pendingReply/markSpoken contract use-composer-voice.ts wires
+    // up for this hook, backed by the real ordinal-anchored dedupe.
+    const pendingReply = () => {
+      const messages = $messages.get()
+      const last = messages.findLast(m => m.role === 'assistant' && !m.hidden)
+      const spoken = resolveSpokenReply(SESSION_ID, messages)
+
+      if (!last || last.id === spoken?.id) {
+        return null
+      }
+
+      return { id: last.id, pending: Boolean(last.pending), text: chatMessageText(last) }
+    }
+
+    const markSpoken = () => {
+      const messages = $messages.get()
+      const last = messages.findLast(m => m.role === 'assistant' && !m.hidden)
+
+      if (last) {
+        markAssistantIdSpoken(SESSION_ID, messages, last.id)
+      }
+    }
+
+    let settleFallback: (() => void) | null = null
+
+    vi.mocked(playSpeechText).mockImplementation(async () => {
+      setVoicePlaybackState({
+        audioElement: null,
+        messageId: 'assistant-stream-1',
+        sequence: 0,
+        source: 'read-aloud',
+        status: 'preparing'
+      })
+
+      // Holds mid-ladder — the WS-fallback-then-POST round trip the issue
+      // describes — until the test rewrites the message id underneath it.
+      await new Promise<void>(resolve => {
+        settleFallback = resolve
+      })
+
+      $messages.set([assistantMessage('durable-42', 'hello there')])
+
+      setVoicePlaybackState({
+        audioElement: null,
+        messageId: 'durable-42',
+        sequence: 0,
+        source: 'read-aloud',
+        status: 'idle'
+      })
+
+      return true
+    })
+
+    renderHook(
+      () =>
+        useAutoSpeakReplies({
+          conversationActive: false,
+          failureLabel: 'read-aloud failed',
+          markSpoken,
+          pendingReply,
+          sessionId: SESSION_ID
+        }),
+      {
+        wrapper: ({ children }) => (
+          <ComposerScopeProvider value={{ ...MAIN_COMPOSER_SCOPE, $messages }}>{children}</ComposerScopeProvider>
+        )
+      }
+    )
+
+    act(() => {
+      $messages.set([assistantMessage('assistant-stream-1', 'hello there')])
+    })
+
+    await waitFor(() => expect(playSpeechText).toHaveBeenCalledTimes(1))
+
+    await act(async () => {
+      settleFallback?.()
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect($voicePlayback.get().status).toBe('idle')
+    expect(playSpeechText).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
Fixes #93515 (already fixed — this pins it with a test, no source change)

## What #93515 reports

Auto-speak reads each assistant reply aloud twice when the desktop's TTS
provider (Edge TTS in the report) has no chunked-PCM streaming API. The
`/api/audio/speak-stream` WebSocket attempt in `playSpeechText`'s fallback
ladder settles `{"type": "fallback"}` before any audio plays, so the client
retries over the POST `/api/audio/speak` endpoint. The issue's claim: while
that POST round-trip is in flight, the backend can rewrite the
just-completed reply's renderer id (`assistant-stream-*`) to its durable
id, `resolveSpokenReply()` fails to follow that rewrite, and the reply gets
spoken a second time once `$voicePlayback` goes idle.

## Why this doesn't reproduce on current `main`

That was true before `63565fa26b` ("fix(desktop): keep auto-speak silent
across the stream-id rewrite", merged 2026-08-19 — five days before this
issue was filed, superseding #75649/#86637/#87672/#88642 and closing
#86601/#87652/#87823). That commit replaced the plain `lastSpokenIdRef ===
id` dedupe with `resolveSpokenReply()` in `apps/desktop/src/lib/spoken-reply.ts`,
which anchors "already spoken" on the assistant reply's **ordinal position**
and migrates the anchor across an id rewrite at the same ordinal
(`absorbSpokenReplyRewrite`). That's exactly the id-rewrite case #93515
describes.

`spoken-reply.test.ts` already unit-tests that migration in isolation. This
adds a test one layer up, at the `useAutoSpeakReplies` hook + `$voicePlayback`
store integration, reproducing the exact sequence from the report: reply
completes → `playSpeechText` starts (WS-fallback-then-POST held mid-flight)
→ the message id is rewritten to its durable form *while still in flight* →
the fallback POST completes and `$voicePlayback` goes idle. It asserts
`playSpeechText` is called exactly once.

## Proof this test is discriminating, not a no-op

I temporarily swapped the test's `pendingReply`/`markSpoken` pair for the
pre-fix plain id-ref dedupe (matching `use-composer-voice.ts` before
`63565fa26b`) and reran it — it failed with `playSpeechText` invoked twice
(the reported double-speak), confirming the harness actually catches the
bug when the ordinal-anchored dedupe isn't in play. I did not commit that
variant; I'm describing it here as the "would fail without the fix" check,
since the actual fix already lives on `main` and there's no source change
in this PR to revert.

## Test plan

```
$ npx vitest run src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx
 Test Files  1 passed (1)
      Tests  1 passed (1)

$ npx vitest run src/app/chat/composer   # full composer/hooks suite, no regressions
 Test Files  46 passed (46)
      Tests  372 passed (372)

$ npx eslint src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx
(clean)

$ npx tsc -p . --noEmit
(clean)
```

## AI assistance disclosure

Investigated and written with Claude Code (Anthropic), including reading
the issue, tracing `playSpeechText`'s fallback ladder and `spoken-reply.ts`,
and authoring/running the test (including the temporary pre-fix variant
used only to validate the test itself, not committed).
