### PR TITLE
fix(dashboard): follow scroll on implicit active-session resume (#93518)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17380,6 +17380,12 @@ async def pty_ws(ws: WebSocket) -> None:
             _forget_active_session_file(active_session_file)
         elif not resume:
             resume = _read_active_session_file(active_session_file)
+            if resume:
+                # The client only knows to pin the viewport to the bottom
+                # when it requested `?resume=`. Tell it a replay is coming
+                # anyway so the implicit active-session fallback gets the
+                # same follow-scroll treatment as an explicit resume (#93518).
+                await ws.send_json({"type": "resume", "id": resume})
 
     resolve_kwargs = {
         "resume": resume,

--- a/tests/hermes_cli/test_web_server_pty_reconnect.py
+++ b/tests/hermes_cli/test_web_server_pty_reconnect.py
@@ -83,6 +83,45 @@ def test_fresh_param_ignores_channel_active_session_file(pty_client, monkeypatch
     assert not active_file.exists()
 
 
+def test_active_session_fallback_sends_resume_control_message(pty_client, monkeypatch):
+    """Implicit resume (no `?resume=`) must tell the client which session.
+
+    Regression for #93518: the dashboard's stick-to-bottom replay logic only
+    fires when the frontend can see a resume id. Without `?resume=` on the URL
+    it previously had no way to learn that `pty_ws` fell back to the
+    per-channel active-session file, so the viewport stayed pinned at the top
+    of the replayed scrollback.
+    """
+    ws, client, token = pty_client
+    channel = "implicit-resume-chan"
+    active_file = ws._active_session_file_for_channel(ws.app, channel)
+    active_file.write_text(json.dumps({"session_id": "sess-old"}), encoding="utf-8")
+
+    monkeypatch.setattr(
+        ws, "_resolve_chat_argv", lambda **kw: (["fake-hermes-tui"], None, None)
+    )
+
+    with client.websocket_connect(_url(token, channel=channel)) as conn:
+        assert conn.receive_json() == {"type": "resume", "id": "sess-old"}
+        assert conn.receive_bytes() == b"ready"
+
+
+def test_explicit_resume_sends_no_control_message(pty_client, monkeypatch):
+    """An explicit `?resume=` already tells the client via the URL param."""
+    ws, client, token = pty_client
+    channel = "explicit-resume-chan"
+
+    monkeypatch.setattr(
+        ws, "_resolve_chat_argv", lambda **kw: (["fake-hermes-tui"], None, None)
+    )
+
+    with client.websocket_connect(
+        _url(token, channel=channel, resume="sess-explicit")
+    ) as conn:
+        # The first (and only) frame is PTY output, not a control message.
+        assert conn.receive_bytes() == b"ready"
+
+
 def test_child_eof_closes_socket_and_bridge(pty_client, monkeypatch):
     """Child EOF must close the WS server-side and reap the PTY.
 

--- a/web/src/lib/pty-scroll.test.ts
+++ b/web/src/lib/pty-scroll.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { isViewportPinnedToBottom, shouldFollowPtyOutput } from "./pty-scroll";
+import {
+	isViewportPinnedToBottom,
+	parseResumeControlMessage,
+	shouldFollowPtyOutput,
+} from "./pty-scroll";
 
 describe("isViewportPinnedToBottom", () => {
 	it("is pinned when the viewport sits on the bottom row", () => {
@@ -45,5 +49,32 @@ describe("shouldFollowPtyOutput", () => {
 
 	it("treats an empty resume param as non-resume", () => {
 		expect(shouldFollowPtyOutput("", true)).toBe(false);
+	});
+});
+
+describe("parseResumeControlMessage", () => {
+	it("extracts the id from a resume control frame", () => {
+		// #93518: the implicit active-session fallback has no `?resume=` on the
+		// URL, so the server names the session it resolved in a control frame.
+		expect(
+			parseResumeControlMessage('{"type":"resume","id":"sess-123"}'),
+		).toBe("sess-123");
+	});
+
+	it("ignores plain ANSI banner text sent as a text frame", () => {
+		// pty_ws also sends "Chat unavailable: ..." error banners as text
+		// frames; those must keep rendering into the terminal, not get
+		// swallowed as a (mis-parsed) control message.
+		expect(
+			parseResumeControlMessage("\r\n\x1b[31mChat unavailable: x\x1b[0m\r\n"),
+		).toBeNull();
+	});
+
+	it("ignores JSON of the wrong shape", () => {
+		expect(parseResumeControlMessage('{"type":"other","id":"x"}')).toBeNull();
+		expect(parseResumeControlMessage('{"type":"resume"}')).toBeNull();
+		expect(parseResumeControlMessage('{"type":"resume","id":""}')).toBeNull();
+		expect(parseResumeControlMessage("null")).toBeNull();
+		expect(parseResumeControlMessage('"resume"')).toBeNull();
 	});
 });

--- a/web/src/lib/pty-scroll.ts
+++ b/web/src/lib/pty-scroll.ts
@@ -48,3 +48,31 @@ export function shouldFollowPtyOutput(
 ): boolean {
 	return Boolean(resumeParam) && stickToBottom;
 }
+
+/**
+ * When `pty_ws` falls back to the per-channel active-session file (no
+ * `?resume=` on the URL), the server sends a one-off JSON text frame naming
+ * the session it resolved before any PTY replay bytes arrive, since the
+ * frontend has no other way to learn a replay is happening (#93518). PTY
+ * output itself always arrives as binary frames, so any text frame is a
+ * candidate; this returns the resume id on a match and `null` for anything
+ * else (including the plain ANSI error banners `pty_ws` still sends as text
+ * on failure, which must keep rendering into the terminal as before).
+ */
+export function parseResumeControlMessage(data: string): string | null {
+	try {
+		const parsed = JSON.parse(data);
+		if (
+			parsed &&
+			typeof parsed === "object" &&
+			parsed.type === "resume" &&
+			typeof parsed.id === "string" &&
+			parsed.id
+		) {
+			return parsed.id;
+		}
+	} catch {
+		/* not JSON — an ANSI banner or other plain-text frame */
+	}
+	return null;
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -68,6 +68,7 @@ import {
 } from "@/lib/pty-keyboard-shortcuts";
 import {
   isViewportPinnedToBottom,
+  parseResumeControlMessage,
   shouldFollowPtyOutput,
 } from "@/lib/pty-scroll";
 import {
@@ -1064,6 +1065,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     // ``return cleanup`` stays at the top level; handlers + disposables
     // are hoisted to ``let`` bindings the cleanup closes over.
     let unmounting = false;
+    // The implicit active-session fallback (no `?resume=` on the URL) only
+    // becomes known once the server's control frame arrives (see
+    // `ws.onmessage` below) — everything gated on "is this a resume replay"
+    // reads this instead of `resumeParam` directly (#93518).
+    let effectiveResume = resumeParam;
     let onDataDisposable: { dispose(): void } | null = null;
     let onResizeDisposable: { dispose(): void } | null = null;
     let onScrollDisposable: { dispose(): void } | null = null;
@@ -1088,7 +1094,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       }
     };
     const noteResumePtyChunk = (chunkText: string) => {
-      if (!resumeParam || unmounting) {
+      if (!effectiveResume || unmounting) {
         return;
       }
       if (shouldFinishResumeHydrationOnChunk(chunkText)) {
@@ -1256,14 +1262,42 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     // in-place redraws through untouched. See pty-resume-sanitizer.ts.
     const decoder = new TextDecoder();
     const sanitizer = new PtyResumeSanitizer();
+    const beginResumeReplay = () => {
+      stickToBottomRef.current = true;
+      if (!eraseSuppressionTimer) {
+        eraseSuppressionTimer = setTimeout(() => {
+          eraseSuppressionTimer = null;
+          sanitizer.endEraseSuppression();
+        }, PTY_RESUME_SANITIZE_WINDOW_MS);
+      }
+      if (!resumeMaxTimer) {
+        setResumeHydrating(true);
+        resumeMaxTimer = setTimeout(
+          finishResumeHydration,
+          PTY_RESUME_LOADING_MAX_MS,
+        );
+      }
+    };
     if (resumeParam) {
-      eraseSuppressionTimer = setTimeout(() => {
-        eraseSuppressionTimer = null;
-        sanitizer.endEraseSuppression();
-      }, PTY_RESUME_SANITIZE_WINDOW_MS);
+      beginResumeReplay();
     }
 
     ws.onmessage = (ev) => {
+      if (typeof ev.data === "string") {
+        // The active-session fallback (no `?resume=` on the URL) tells us
+        // via a one-off JSON control frame that a replay is starting (#93518,
+        // see `pty_ws` in web_server.py). Real PTY output always arrives as
+        // binary frames, so any text frame is a candidate; anything that
+        // isn't this control shape (e.g. the ANSI "Chat unavailable" banners
+        // pty_ws sends as text on failure) falls through to the write path
+        // below unchanged.
+        const resumeId = parseResumeControlMessage(ev.data);
+        if (resumeId) {
+          effectiveResume = resumeId;
+          beginResumeReplay();
+          return;
+        }
+      }
       const text =
         typeof ev.data === "string"
           ? ev.data
@@ -1274,13 +1308,13 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // sanitizer can turn a nonempty erase-only / all-newline / partial-CSI
       // resume frame into "" (pty-resume-sanitizer.ts); keying off raw `text`
       // would hide the wait notice while the terminal is still blank.
-      const rendered = resumeParam ? sanitizer.next(text) : text;
+      const rendered = effectiveResume ? sanitizer.next(text) : text;
       // Resume replay lands over many write chunks; pin the viewport to the
       // bottom as each chunk COMMITS (xterm write callback) instead of
       // guessing with a fixed delay, and release the pin the moment the user
       // scrolls up to read the backlog (#59591).
       const followScroll = shouldFollowPtyOutput(
-        resumeParam,
+        effectiveResume,
         stickToBottomRef.current,
       )
         ? () => termRef.current?.scrollToBottom()
@@ -1293,7 +1327,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // Drain buffered sanitizer state. A buffered partial escape is dropped
       // (writing an unterminated CSI would wedge xterm's parser); a buffered
       // newline run is emitted collapsed.
-      if (resumeParam) {
+      if (effectiveResume) {
         clearEraseSuppressionTimer();
         try {
           term.write(sanitizer.flush());


### PR DESCRIPTION
## What does this PR do?

Opening the dashboard's `/chat` with no `?resume=` query param auto-resumes
the last session server-side via the per-channel active-session file
(`pty_ws` in `hermes_cli/web_server.py`) and replays the whole scrollback
into xterm, but the viewport stayed pinned at the **top** of the replay. The
explicit `?resume=<id>` path already scrolls to the bottom correctly (#59591)
— the frontend's follow-scroll logic keys entirely off the `resume` URL
param, and the implicit fallback path never sets it.

**Root cause:** `pty_ws` resolves the effective resume id server-side
(`_read_active_session_file`) but never tells the client. `ChatPage.tsx`'s
`shouldFollowPtyOutput`/hydration/sanitizer logic all gate on `resumeParam`
(the URL param), which is `null` on the implicit path even though a replay is
happening.

**Fix:**
- `hermes_cli/web_server.py`: when `pty_ws` falls back to the active-session
  file, send a one-off JSON control frame (`{"type": "resume", "id": <id>}`)
  to the client before the PTY is spawned. Real PTY output always arrives as
  binary frames (`send_bytes`), so a text frame is unambiguous — this doesn't
  interfere with the existing ANSI error banners that are also sent as text
  frames on failure.
- `web/src/lib/pty-scroll.ts`: add `parseResumeControlMessage`, a small pure
  helper that extracts the resume id from that control frame and returns
  `null` for anything else (including plain-text banners).
- `web/src/pages/ChatPage.tsx`: track an `effectiveResume` value seeded from
  `resumeParam` and updated when the control frame arrives; the existing
  follow-scroll (`shouldFollowPtyOutput`), sanitizer, and hydration-overlay
  logic now key off `effectiveResume` instead of `resumeParam` directly, so
  the implicit fallback gets the same bottom-pin treatment as an explicit
  resume.

## Related Issue

Fixes #93518

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py` — send `{"type": "resume", "id": ...}` control
  frame when `pty_ws` falls back to the active-session file
- `web/src/lib/pty-scroll.ts` — add `parseResumeControlMessage`
- `web/src/pages/ChatPage.tsx` — track `effectiveResume`, wire the control
  frame into the existing follow-scroll/sanitizer/hydration logic
- `web/src/lib/pty-scroll.test.ts` — unit tests for `parseResumeControlMessage`
- `tests/hermes_cli/test_web_server_pty_reconnect.py` — regression tests for
  the new control frame (present on implicit fallback, absent on explicit
  `?resume=`)

## How to Test

1. `python3 scripts/run_tests.sh tests/hermes_cli/test_web_server_pty_reconnect.py -q`
2. From `web/`: `npx vitest run src/lib/pty-scroll.test.ts`
3. Manually: use dashboard chat for a while, close the tab, reopen `/chat`
   with no query params — the viewport should land at the bottom of the
   replayed transcript instead of the top.

### Test output

Backend (new + existing tests in the same file):
```
tests/hermes_cli/test_web_server_pty_reconnect.py::test_fresh_param_ignores_channel_active_session_file PASSED
tests/hermes_cli/test_web_server_pty_reconnect.py::test_active_session_fallback_sends_resume_control_message PASSED
tests/hermes_cli/test_web_server_pty_reconnect.py::test_explicit_resume_sends_no_control_message PASSED
tests/hermes_cli/test_web_server_pty_reconnect.py::test_child_eof_closes_socket_and_bridge PASSED
4 passed in 1.36s
```

Confirmed the new regression test fails without the fix (`git checkout
HEAD~1 -- hermes_cli/web_server.py`, rerun):
```
FAILED test_active_session_fallback_sends_resume_control_message
KeyError: 'text'   # first frame was PTY binary output, not the control message
```

Full related suites, all green after the fix: `tests/hermes_cli/test_web_server.py`
(166 passed, 1 skipped), `tests/test_pty_keepalive_ws.py` (4 passed).

Frontend: `npx vitest run` — 36 files / 278 tests passed. `tsc -p . --noEmit`
clean. `npx eslint src/pages/ChatPage.tsx src/lib/pty-scroll.ts
src/lib/pty-scroll.test.ts` — 0 errors, same 3 pre-existing warnings as on
`main` (unrelated to this change, verified by diffing eslint output against
unmodified `main`).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant test suites and all tests pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform — tested in a Linux CI sandbox only, not on a physical desktop

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed

## AI assistance disclosure

This change was prepared by an AI coding agent (root-caused against the
issue's description, current `main`, and the existing #59591 follow-scroll
implementation), with the diff, tests, and test output above verified by
running the real test suites before pushing.
