### PR TITLE
fix(batch_runner): write a discard tombstone so resume skips no-reasoning prompts

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -457,6 +457,17 @@ def _process_batch_worker(args: Tuple) -> Dict[str, Any]:
                 print(f"   🚫 Prompt {prompt_index} discarded (no reasoning in any turn)")
                 discarded_no_reasoning += 1
                 completed_in_batch.append(prompt_index)
+                # Write a tombstone row so the content-based resume scan (which
+                # only reads batch_*.jsonl) can see this prompt was already
+                # processed and discarded, not just left unprocessed.
+                with open(batch_output_file, 'a', encoding='utf-8') as f:
+                    f.write(json.dumps({
+                        "prompt_index": prompt_index,
+                        "conversations": result["trajectory"],
+                        "discarded": "no_reasoning",
+                    }, ensure_ascii=False) + "\n")
+                    f.flush()
+                    os.fsync(f.fileno())
                 continue
             
             # Get and normalize tool stats for consistent schema across all entries
@@ -995,8 +1006,11 @@ class BatchRunner:
         
         # Aggregate all batch statistics and update checkpoint
         total_reasoning_stats = {"total_assistant_turns": 0, "turns_with_reasoning": 0, "turns_without_reasoning": 0}
+        total_discarded_no_reasoning = 0
 
         for batch_result in results:
+            total_discarded_no_reasoning += batch_result.get("discarded_no_reasoning", 0)
+
             # Aggregate tool stats
             for tool_name, stats in batch_result.get("tool_stats", {}).items():
                 if tool_name not in total_tool_stats:
@@ -1043,6 +1057,7 @@ class BatchRunner:
         
         total_entries = 0
         filtered_entries = 0
+        discarded_tombstones = 0
         batch_files_found = 0
         
         # Find ALL batch files in the output directory (handles resume merging old + new)
@@ -1058,8 +1073,16 @@ class BatchRunner:
                         total_entries += 1
                         try:
                             data = json.loads(line)
+
+                            # Discard tombstones exist only so resume can see
+                            # these prompts as done; they carry no full
+                            # trajectory and must not enter the training file.
+                            if data.get("discarded"):
+                                discarded_tombstones += 1
+                                continue
+
                             tool_stats = data.get('tool_stats', {})
-                            
+
                             # Check for invalid tool names (model hallucinations)
                             invalid_tools = [k for k in tool_stats if k not in VALID_TOOLS]
                             
@@ -1076,7 +1099,9 @@ class BatchRunner:
         
         if filtered_entries > 0:
             print(f"⚠️  Filtered {filtered_entries} corrupted entries out of {total_entries} total")
-        print(f"✅ Combined {batch_files_found} batch files into trajectories.jsonl ({total_entries - filtered_entries} entries)")
+        if discarded_tombstones > 0:
+            print(f"ℹ️  Excluded {discarded_tombstones} discarded (no-reasoning) tombstone rows out of {total_entries} total")
+        print(f"✅ Combined {batch_files_found} batch files into trajectories.jsonl ({total_entries - filtered_entries - discarded_tombstones} entries)")
         
         # Save final statistics
         final_stats = {
@@ -1090,6 +1115,7 @@ class BatchRunner:
             "duration_seconds": round(time.time() - start_time, 2),
             "tool_statistics": total_tool_stats,
             "reasoning_statistics": total_reasoning_stats,
+            "discarded_no_reasoning": total_discarded_no_reasoning,
         }
         
         with open(self.stats_file, 'w', encoding='utf-8') as f:

--- a/tests/test_batch_runner_checkpoint.py
+++ b/tests/test_batch_runner_checkpoint.py
@@ -153,7 +153,8 @@ class TestBatchWorkerResumeBehavior:
         batch_file = tmp_path / "batch_1.jsonl"
         prompt_result = {
             "success": True,
-            "trajectory": [{"role": "assistant", "content": "x"}],
+            "trajectory": [{"from": "human", "value": "hi"},
+                            {"role": "assistant", "content": "x"}],
             "reasoning_stats": {"has_any_reasoning": False},
             "tool_stats": {},
             "metadata": {},
@@ -174,7 +175,52 @@ class TestBatchWorkerResumeBehavior:
 
         assert result["discarded_no_reasoning"] == 1
         assert result["completed_prompts"] == [0]
-        assert not batch_file.exists() or batch_file.read_text() == ""
+
+        # A tombstone row must be written so the content-based resume scan
+        # can see this prompt was already processed and discarded.
+        assert batch_file.exists()
+        lines = [l for l in batch_file.read_text(encoding="utf-8").strip().split("\n") if l]
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert entry["discarded"] == "no_reasoning"
+
+    def test_resume_after_all_discarded_batch_reruns_zero_prompts(self, tmp_path, monkeypatch):
+        """Regression for the issue: a resumed run must not re-execute
+        prompts that were already processed and discarded for having no
+        reasoning — the content-based scan must see the discard tombstone.
+        """
+        prompt_result = {
+            "success": True,
+            "trajectory": [{"from": "human", "value": "hi"},
+                            {"role": "assistant", "content": "x"}],
+            "reasoning_stats": {"has_any_reasoning": False},
+            "tool_stats": {},
+            "metadata": {},
+            "completed": True,
+            "api_calls": 1,
+            "toolsets_used": [],
+        }
+        monkeypatch.setattr("batch_runner._process_single_prompt", lambda *args, **kwargs: prompt_result)
+
+        # First run: prompt 0 gets processed and discarded, writing its
+        # tombstone row into batch_1.jsonl.
+        _process_batch_worker((1, [(0, {"prompt": "hi"})], tmp_path, set(), {"verbose": False}))
+
+        # Simulate a fresh resume: scan batch files by content, exactly as
+        # BatchRunner.run() does.
+        r = BatchRunner.__new__(BatchRunner)
+        r.output_dir = tmp_path
+        completed_prompt_texts = r._scan_completed_prompts_by_content()
+
+        assert "hi" in completed_prompt_texts, (
+            "discarded prompt is invisible to the content-based resume scan"
+        )
+
+        r.dataset = [{"prompt": "hi"}]
+        filtered_entries, skipped_indices = r._filter_dataset_by_completed(completed_prompt_texts)
+
+        assert filtered_entries == [], "discarded prompt was rescheduled on resume"
+        assert skipped_indices == [0]
 
 
 class TestFinalCheckpointNoDuplicates:


### PR DESCRIPTION
## What does this PR do?

Fixes #93527. The "no reasoning in any turn" discard path in
`_process_batch_worker()` marked the prompt as completed in the
in-memory/checkpoint tracking but never wrote a row to `batch_N.jsonl`.
`--resume`'s only dataset filter, `_scan_completed_prompts_by_content()`,
scans exclusively those `batch_*.jsonl` files for prompt text — so any
discarded prompt whose batch hadn't yet returned from the worker pool
(e.g. the run was interrupted mid-batch, a very normal way for a long
batch job to end) is invisible to it. On `--resume` it gets reprocessed
at full agent/API cost and discarded again, repeating indefinitely.

The fix: write a lightweight tombstone row for each discarded prompt
(`{"prompt_index": N, "conversations": ..., "discarded": "no_reasoning"}`)
into the same `batch_N.jsonl` file used for real trajectories, so the
existing content-based scan naturally picks it up as already processed
(it only special-cases `failed` rows for retry; anything else with a
human-turn goes into the completed-prompts set). Two follow-on gaps
called out in the issue are fixed too:

- The trajectory-combine step that builds `trajectories.jsonl` now
  explicitly skips these tombstones, so they never leak into the
  training data.
- `statistics.json` now reports `discarded_no_reasoning` (previously
  only printed to stdout, so totals couldn't be reconciled after the
  fact).

## Related Issue

Fixes #93527

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `batch_runner.py`: `_process_batch_worker()` writes a discard tombstone
  row (with `fsync`, matching the durability of the success path) instead
  of writing nothing.
- `batch_runner.py`: the batch-file combine step in `BatchRunner.run()`
  skips rows with a `discarded` key before they can reach
  `trajectories.jsonl`.
- `batch_runner.py`: `discarded_no_reasoning` is aggregated across batches
  and included in `statistics.json`.
- `tests/test_batch_runner_checkpoint.py`: updated the existing
  `test_discarded_no_reasoning_prompts_are_marked_completed` (which
  asserted the *old*, buggy behavior — no row written) to assert the
  tombstone is written instead, and added
  `test_resume_after_all_discarded_batch_reruns_zero_prompts`, a direct
  regression test for the issue: it drives `_process_batch_worker()` to
  discard a prompt, then drives `_scan_completed_prompts_by_content()` and
  `_filter_dataset_by_completed()` exactly as `run()` does, and asserts
  the discarded prompt is (a) visible to the content scan and (b) not
  rescheduled on resume.

## How to Test

Verified the new/updated tests fail without the fix and pass with it, by
diffing out the `batch_runner.py` change and rerunning:

```
$ git stash push -- batch_runner.py   # (only the fix, tests unstaged)
$ python3 -m pytest tests/test_batch_runner_checkpoint.py -q
...
FAILED tests/test_batch_runner_checkpoint.py::TestBatchWorkerResumeBehavior::test_discarded_no_reasoning_prompts_are_marked_completed
FAILED tests/test_batch_runner_checkpoint.py::TestBatchWorkerResumeBehavior::test_resume_after_all_discarded_batch_reruns_zero_prompts
2 failed, 13 passed in 1.25s

$ git stash pop                       # fix restored
$ python3 -m pytest tests/test_batch_runner_checkpoint.py tests/test_batch_runner_durability.py tests/test_batch_runner_exit_code.py -q
......................                                                   [100%]
22 passed in 6.14s
```

Also ran, both clean:

```
$ python3 -m ruff check batch_runner.py tests/test_batch_runner_checkpoint.py
All checks passed!

$ python3 scripts/check-windows-footguns.py batch_runner.py
✓ No Windows footguns found (1 file(s) scanned).
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` (the specific test files above) and all tests pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Linux, Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no public API/config surface changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — verified with `scripts/check-windows-footguns.py`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## AI assistance disclosure

This PR was prepared with AI assistance (Claude), including the root-cause
analysis, the fix, and the tests. All changes were verified locally
(tests, ruff, windows-footguns check) before submission.
