### PR TITLE
fix(cron): reset a consumed one-shot's quota when a schedule edit re-arms it

### DIFF
--- a/tests/cron/test_update_consumed_oneshot.py
+++ b/tests/cron/test_update_consumed_oneshot.py
@@ -1,0 +1,119 @@
+"""Re-arming a consumed finite one-shot via a schedule edit (#93524).
+
+A consumed one-shot is retained as a terminal record (repeat.completed >=
+repeat.times, enabled=False, next_run_at=None) so outcomes stay
+inspectable. Editing its schedule re-enables the job with a future
+next_run_at — but without resetting repeat.completed, the due scan's
+dispatch-limit guard removes the job at the new fire time without firing:
+the rescheduled run silently never happens and the record is gone.
+
+A schedule edit is an explicit re-arm gesture, so the spent quota resets.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+
+import pytest
+
+
+@pytest.fixture
+def temp_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME so jobs.json doesn't touch the real store."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield tmp_path
+
+
+def _seed_consumed_oneshot(home, name="spent") -> str:
+    """Persist a consumed finite one-shot (the terminal retention shape)."""
+    from cron.jobs import create_job, save_jobs, load_jobs
+
+    job = create_job(prompt="done", schedule="2026-08-25T09:00", name=name)
+    jobs = load_jobs()
+    for j in jobs:
+        if j["id"] == job["id"]:
+            j["enabled"] = False
+            j["state"] = "completed"
+            j["next_run_at"] = None
+            j["repeat"] = {"times": 1, "completed": 1}
+    save_jobs(jobs)
+    return job["id"]
+
+
+def _update(temp_home, job_id: str, **kwargs):
+    from tools.cronjob_tools import cronjob
+
+    defaults = {"action": "update", "job_id": job_id}
+    defaults.update(kwargs)
+    return json.loads(cronjob(**defaults))
+
+
+def test_schedule_edit_rearms_consumed_oneshot(temp_home):
+    """Editing the schedule of a consumed one-shot resets the spent quota —
+    the job is enabled with a future next_run_at and completed back to 0."""
+    from cron.jobs import get_job
+
+    jid = _seed_consumed_oneshot(temp_home)
+
+    result = _update(temp_home, jid, schedule="2030-01-01T09:00")
+
+    assert result["success"] is True
+    job = get_job(jid)
+    assert job["enabled"] is True
+    assert job["state"] == "scheduled"
+    assert job["next_run_at"] is not None
+    assert job["next_run_at"].startswith("2030-01-01")
+    assert job["repeat"]["completed"] == 0
+    assert job["repeat"]["times"] == 1
+
+
+def test_schedule_edit_leaves_unconsumed_quota_alone(temp_home):
+    """Control: an unconsumed one-shot's completed counter is untouched."""
+    from cron.jobs import create_job, get_job
+
+    job = create_job(prompt="fresh", schedule="2030-01-01T09:00", name="fresh")
+
+    result = _update(temp_home, job["id"], schedule="2030-02-01T09:00")
+
+    assert result["success"] is True
+    stored = get_job(job["id"])
+    assert stored["repeat"]["completed"] == 0
+    assert stored["next_run_at"].startswith("2030-02-01")
+
+
+def test_schedule_edit_with_new_repeat_resets_under_new_quota(temp_home):
+    """--repeat alongside the schedule edit composes: the quota resets under
+    the operator's new times value."""
+    from cron.jobs import get_job
+
+    jid = _seed_consumed_oneshot(temp_home, name="multi")
+
+    result = _update(temp_home, jid, schedule="2030-01-01T09:00", repeat=3)
+
+    assert result["success"] is True
+    job = get_job(jid)
+    assert job["repeat"] == {"times": 3, "completed": 0}
+    assert job["enabled"] is True
+
+
+def test_paused_consumed_oneshot_not_rearmed(temp_home):
+    """A paused record's schedule edit does not re-enable — the reset must
+    not fire either (the re-arm block is gated on state != paused)."""
+    from cron.jobs import create_job, save_jobs, load_jobs, get_job
+
+    job = create_job(prompt="p", schedule="2030-01-01T09:00", name="paused")
+    jobs = load_jobs()
+    for j in jobs:
+        if j["id"] == job["id"]:
+            j["enabled"] = False
+            j["state"] = "paused"
+            j["repeat"] = {"times": 1, "completed": 1}
+    save_jobs(jobs)
+
+    result = _update(temp_home, job["id"], schedule="2030-02-01T09:00")
+
+    assert result["success"] is True
+    stored = get_job(job["id"])
+    assert stored["state"] == "paused"
+    assert stored["enabled"] is False

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1664,6 +1664,28 @@ def cronjob(
                 if job.get("state") != "paused":
                     updates["state"] = "scheduled"
                     updates["enabled"] = True
+                    # Re-arming a consumed finite one-shot must reset the
+                    # spent quota. The terminal record keeps
+                    # repeat.completed >= repeat.times; re-enabling without
+                    # resetting makes the edit report success with a future
+                    # next_run_at, then the due scan's dispatch-limit guard
+                    # removes the job at the new fire time without firing
+                    # — the rescheduled run silently never happens (#93524).
+                    # Consumption is judged on the STORED record (not the
+                    # merged quota — a --repeat bump in the same edit that
+                    # leaves completed < times is not a consumed record).
+                    if parsed_schedule.get("kind") == "once":
+                        stored_repeat = dict(job.get("repeat") or {})
+                        if (
+                            (stored_repeat.get("times") or 0) > 0
+                            and stored_repeat.get("completed", 0)
+                            >= stored_repeat["times"]
+                        ):
+                            repeat_state = dict(
+                                updates.get("repeat") or stored_repeat
+                            )
+                            repeat_state["completed"] = 0
+                            updates["repeat"] = repeat_state
             if not updates:
                 return tool_error("No updates provided.", success=False)
             updated = update_job(job_id, updates)


### PR DESCRIPTION
## What does this PR do?

Makes editing the schedule of a consumed finite one-shot actually re-arm it, instead of producing a guaranteed silent failure.

A consumed one-shot is retained as a terminal record (`repeat.completed >= repeat.times`, `enabled=False`, `next_run_at=None`) so outcomes stay inspectable (`cron/jobs.py` retention by design). Editing its schedule (`hermes cron edit <id> --schedule ...` or `cronjob(action="update", schedule=...)`) re-enables the job with a future `next_run_at` and reports success — but never resets `repeat.completed`. At the new fire time the due scan's dispatch-limit guard (`kind == "once"` and `completed >= times`, from #38758) removes the job without firing: **the rescheduled run silently never happens and the record is gone** (#93524).

A schedule edit is an explicit re-arm gesture, so the fix resets the spent quota when the update branch re-enables a `kind == "once"` job whose stored record is consumed. Two scope notes:

- Consumption is judged on the **stored** record, not the merged quota — a `--repeat 3` in the same edit on a 1-of-1-consumed record IS consumed (stored 1 >= 1) and resets to `{times: 3, completed: 0}`; a bump on an unconsumed record keeps its counter.
- Paused records are untouched — the re-arm block itself is already gated on `state != paused`.

## Related Issue

Fixes #93524

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/cronjob_tools.py` — in the `update` action's schedule branch, inside the re-enable block, reset `repeat.completed` to 0 when the stored record's finite quota is exhausted (with the stored-vs-merged-quota distinction documented in the comment).
- `tests/cron/test_update_consumed_oneshot.py` — four regressions using the temp-HERMES_HOME real-store pattern: consumed one-shot re-arms (enabled, future `next_run_at`, `completed == 0`); unconsumed control keeps its counter; consumed + `--repeat 3` resets under the new quota (`{times: 3, completed: 0}`); a paused consumed record is not re-armed.

## How to Test

`pytest tests/cron/test_update_consumed_oneshot.py -q` — should pass (4 tests).

Observed result: with the fix, 4/4 pass. With the cronjob_tools.py change stashed (fix reverted, tests kept), the two consumed-record tests fail exactly as the issue reports — `repeat.completed` stays 1, so the edit produces an enabled job with a future `next_run_at` that the due scan's guard will delete without firing — while the two control tests pass on main by design. Full `tests/cron` suite: 880 passed; the 5 failures in `test_script_claim_heartbeat.py` (process-tree kill tests) reproduce identically on unpatched main and are environment-local, unrelated to this change.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (stored-vs-merged quota distinction)
- [x] Tests added that prove the fix works
- [x] New and existing unit tests pass locally (4/4 new; suite 880 passed + 5 pre-existing env failures)
- [x] Platform: macOS (pure scheduler logic, platform-independent)
