### PR TITLE
fix(gateway): scope multiplex-profile authorization reads (weixin/yuanbao/wecom)

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1227,14 +1227,14 @@ class WeixinAdapter(BasePlatformAdapter):
         )
         self._rate_limit_circuit_until = 0.0
         self._rate_limit_events: List[float] = []
-        self._dm_policy = str(extra.get("dm_policy") or os.getenv("WEIXIN_DM_POLICY", "pairing")).strip().lower()
-        self._group_policy = str(extra.get("group_policy") or os.getenv("WEIXIN_GROUP_POLICY", "disabled")).strip().lower()
+        self._dm_policy = str(extra.get("dm_policy") or _wx_secret("WEIXIN_DM_POLICY", "pairing")).strip().lower()
+        self._group_policy = str(extra.get("group_policy") or _wx_secret("WEIXIN_GROUP_POLICY", "disabled")).strip().lower()
         allow_from = extra.get("allow_from")
         if allow_from is None:
-            allow_from = os.getenv("WEIXIN_ALLOWED_USERS", "")
+            allow_from = _wx_secret("WEIXIN_ALLOWED_USERS", "")
         group_allow_from = extra.get("group_allow_from")
         if group_allow_from is None:
-            group_allow_from = os.getenv("WEIXIN_GROUP_ALLOWED_USERS", "")
+            group_allow_from = _wx_secret("WEIXIN_GROUP_ALLOWED_USERS", "")
         self._allow_from = self._coerce_list(allow_from)
         self._group_allow_from = self._coerce_list(group_allow_from)
         self._split_multiline_messages = _coerce_bool(

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -97,6 +97,7 @@ from gateway.platforms.yuanbao_proto import (
     next_seq_no,
 )
 from gateway.session import build_session_key
+from gateway.authz_mixin import _platform_gate_env
 
 logger = logging.getLogger(__name__)
 
@@ -1282,9 +1283,9 @@ class AccessPolicy:
         self._group_allow_from = group_allow_from
 
     def _open_dm_opted_in(self) -> bool:
-        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+        if _platform_gate_env("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
             return True
-        return os.getenv("YUANBAO_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+        return _platform_gate_env("YUANBAO_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
 
     def is_dm_allowed(self, sender_id: str) -> bool:
         """Strict DM authorization — pairing does not imply access."""
@@ -4946,23 +4947,23 @@ class YuanbaoAdapter(BasePlatformAdapter):
         # ------------------------------------------------------------------
         dm_policy: str = (
             _extra.get("dm_policy")
-            or os.getenv("YUANBAO_DM_POLICY", "pairing")
+            or _platform_gate_env("YUANBAO_DM_POLICY", "pairing")
         ).strip().lower()
 
         _dm_allow_from_raw: str = (
             _extra.get("dm_allow_from")
-            or os.getenv("YUANBAO_DM_ALLOW_FROM", "")
+            or _platform_gate_env("YUANBAO_DM_ALLOW_FROM", "")
         )
         dm_allow_from: list[str] = [x.strip() for x in _dm_allow_from_raw.split(",") if x.strip()]
 
         group_policy: str = (
             _extra.get("group_policy")
-            or os.getenv("YUANBAO_GROUP_POLICY", "pairing")
+            or _platform_gate_env("YUANBAO_GROUP_POLICY", "pairing")
         ).strip().lower()
 
         _group_allow_from_raw: str = (
             _extra.get("group_allow_from")
-            or os.getenv("YUANBAO_GROUP_ALLOW_FROM", "")
+            or _platform_gate_env("YUANBAO_GROUP_ALLOW_FROM", "")
         )
         group_allow_from: list[str] = [x.strip() for x in _group_allow_from_raw.split(",") if x.strip()]
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2750,7 +2750,7 @@ def _own_policy_open_startup_violation(config) -> Optional[str]:
         ).strip().lower()
         if dm_policy != "open" and group_policy != "open":
             continue
-        gateway_allow_all = os.getenv(
+        gateway_allow_all = _getenv(
             "GATEWAY_ALLOW_ALL_USERS", ""
         ).lower() in {"true", "1", "yes"}
         platform_opted_in = gateway_allow_all or (

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -185,7 +185,7 @@ class WeComAdapter(BasePlatformAdapter):
             or os.getenv("WECOM_WEBSOCKET_URL", DEFAULT_WS_URL)
         ).strip() or DEFAULT_WS_URL
 
-        self._dm_policy = str(extra.get("dm_policy") or os.getenv("WECOM_DM_POLICY", "pairing")).strip().lower()
+        self._dm_policy = str(extra.get("dm_policy") or _get_scoped_secret("WECOM_DM_POLICY", "pairing")).strip().lower()
         # dm_policy already honors WECOM_DM_POLICY, so the allowlist must honor
         # WECOM_ALLOWED_USERS too. Without the env fallback an env-only setup
         # (dm_policy=allowlist via env, no config extra) runs with an empty
@@ -193,10 +193,10 @@ class WeComAdapter(BasePlatformAdapter):
         self._allow_from = _coerce_list(
             extra.get("allow_from")
             or extra.get("allowFrom")
-            or os.getenv("WECOM_ALLOWED_USERS", "")
+            or _get_scoped_secret("WECOM_ALLOWED_USERS", "")
         )
 
-        self._group_policy = str(extra.get("group_policy") or os.getenv("WECOM_GROUP_POLICY", "pairing")).strip().lower()
+        self._group_policy = str(extra.get("group_policy") or _get_scoped_secret("WECOM_GROUP_POLICY", "pairing")).strip().lower()
         self._group_allow_from = _coerce_list(extra.get("group_allow_from") or extra.get("groupAllowFrom"))
         self._groups = extra.get("groups") if isinstance(extra.get("groups"), dict) else {}
 

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -114,6 +114,42 @@ def test_adapter_auth_check_stamps_secondary_profile(monkeypatch):
     assert captured["profile"] == "coder"
 
 
+def test_startup_guard_gateway_allow_all_reads_scope_not_environ(monkeypatch):
+    """The GATEWAY_ALLOW_ALL_USERS opt-in check inside the startup guard
+    must honor the active profile secret scope (#93522): the default
+    profile's env-only opt-in must not leak into a secondary profile that
+    never opted in, and a secondary profile's own scoped opt-in must be
+    honored."""
+    from agent import secret_scope
+    from gateway.run import _own_policy_open_startup_violation
+
+    _clear_auth_env(monkeypatch)
+    cfg = GatewayConfig(multiplex_profiles=True)
+    cfg.platforms = {
+        Platform.WECOM: PlatformConfig(enabled=True, extra={"dm_policy": "open"}),
+    }
+
+    previous_multiplex = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+    try:
+        token = secret_scope.set_secret_scope({"SOMETHING_ELSE": "x"})
+        try:
+            violation = _own_policy_open_startup_violation(cfg)
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert violation is not None, "default profile's env opt-in must not leak into the scoped secondary profile"
+
+        token = secret_scope.set_secret_scope({"GATEWAY_ALLOW_ALL_USERS": "true"})
+        try:
+            violation = _own_policy_open_startup_violation(cfg)
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert violation is None, "the secondary profile's own scoped opt-in must be honored"
+    finally:
+        secret_scope.set_multiplex_active(previous_multiplex)
+
+
 def test_secondary_open_policy_fails_startup_guard(monkeypatch):
     """Secondary profiles must pass the same open-policy startup guard."""
     from gateway.run import _own_policy_open_startup_violation

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -30,6 +30,53 @@ class TestWeComAdapterInit:
         assert WeComAdapter.SUPPORTS_MESSAGE_EDITING is False
 
 
+class TestWeComAdapterAuthzScope:
+    """dm_policy/allowlist reads must honor the profile secret scope under
+    multiplexing (#93522): a secondary profile's own scope is authoritative
+    and must not inherit the default profile's process-env authorization."""
+
+    @pytest.fixture()
+    def multiplex_on(self):
+        from agent import secret_scope
+
+        previous = secret_scope.is_multiplex_active()
+        secret_scope.set_multiplex_active(True)
+        try:
+            yield
+        finally:
+            secret_scope.set_multiplex_active(previous)
+
+    def test_scoped_construction_reads_authz_from_scope_not_environ(self, multiplex_on, monkeypatch):
+        from agent import secret_scope
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        monkeypatch.setenv("WECOM_DM_POLICY", "pairing")
+        monkeypatch.setenv("WECOM_ALLOWED_USERS", "default-user")
+        token = secret_scope.set_secret_scope(
+            {"WECOM_DM_POLICY": "allowlist", "WECOM_ALLOWED_USERS": "scoped-user"}
+        )
+        try:
+            adapter = WeComAdapter(PlatformConfig(enabled=True))
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert adapter._dm_policy == "allowlist"
+        assert adapter._allow_from == ["scoped-user"]
+
+    def test_scoped_miss_does_not_admit_default_profiles_allowlist(self, multiplex_on, monkeypatch):
+        from agent import secret_scope
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        monkeypatch.setenv("WECOM_DM_POLICY", "allowlist")
+        monkeypatch.setenv("WECOM_ALLOWED_USERS", "default-user")
+        token = secret_scope.set_secret_scope({"SOMETHING_ELSE": "x"})
+        try:
+            adapter = WeComAdapter(PlatformConfig(enabled=True))
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert adapter._dm_policy == "pairing"
+        assert adapter._allow_from == []
+
+
 class TestWeComConnect:
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_weixin_secret_scope.py
+++ b/tests/gateway/test_weixin_secret_scope.py
@@ -101,3 +101,49 @@ class TestWeixinAdapterConstructionScope:
             secret_scope.reset_secret_scope(token)
         assert adapter._account_id == "env-account"
         assert adapter._token == "env-token"
+
+
+class TestWeixinAdapterAuthzScope:
+    """Authorization reads (dm_policy/allowlists) must follow the same
+    scoped-secret rules as the credential reads above (#93522): a secondary
+    profile's own scope is authoritative, and the default profile's
+    process-env values must not leak into it."""
+
+    def test_scoped_construction_reads_authz_from_scope_not_environ(
+        self, multiplex_on, monkeypatch
+    ):
+        monkeypatch.setenv("WEIXIN_DM_POLICY", "pairing")
+        monkeypatch.setenv("WEIXIN_ALLOWED_USERS", "default-user")
+        monkeypatch.setenv("WEIXIN_GROUP_ALLOWED_USERS", "default-group-user")
+        token = secret_scope.set_secret_scope(
+            {
+                "WEIXIN_DM_POLICY": "allowlist",
+                "WEIXIN_ALLOWED_USERS": "scoped-user",
+                "WEIXIN_GROUP_ALLOWED_USERS": "scoped-group-user",
+            }
+        )
+        try:
+            adapter = WeixinAdapter(PlatformConfig(enabled=True))
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert adapter._dm_policy == "allowlist"
+        assert adapter._allow_from == ["scoped-user"]
+        assert adapter._group_allow_from == ["scoped-group-user"]
+        assert adapter._is_dm_allowed("scoped-user") is True
+        assert adapter._is_dm_allowed("default-user") is False
+
+    def test_scoped_miss_does_not_admit_default_profiles_allow_all(
+        self, multiplex_on, monkeypatch
+    ):
+        """A secondary profile with no allowlist of its own must fail closed,
+        not inherit the default profile's env-only allowlist/opt-in."""
+        monkeypatch.setenv("WEIXIN_DM_POLICY", "allowlist")
+        monkeypatch.setenv("WEIXIN_ALLOWED_USERS", "default-user")
+        token = secret_scope.set_secret_scope({"SOMETHING_ELSE": "x"})
+        try:
+            adapter = WeixinAdapter(PlatformConfig(enabled=True))
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert adapter._dm_policy == "pairing"
+        assert adapter._allow_from == []
+        assert adapter._is_dm_allowed("default-user") is False

--- a/tests/gateway/test_yuanbao_secret_scope.py
+++ b/tests/gateway/test_yuanbao_secret_scope.py
@@ -1,0 +1,72 @@
+"""Yuanbao authorization-scope regression tests (#93522).
+
+``dm_policy``/``group_policy``/allowlist reads and the ``AccessPolicy``
+allow-all opt-in must honor the active profile secret scope under
+multiplexing: a secondary profile's own scope is authoritative and must
+not inherit the default profile's process-env authorization config.
+"""
+
+import pytest
+
+from agent import secret_scope
+from gateway.config import PlatformConfig
+from gateway.platforms.yuanbao import AccessPolicy, YuanbaoAdapter
+
+
+@pytest.fixture()
+def multiplex_on():
+    previous = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+    try:
+        yield
+    finally:
+        secret_scope.set_multiplex_active(previous)
+
+
+class TestYuanbaoAdapterAuthzScope:
+    def test_scoped_construction_reads_authz_from_scope_not_environ(self, multiplex_on, monkeypatch):
+        monkeypatch.setenv("YUANBAO_DM_POLICY", "pairing")
+        monkeypatch.setenv("YUANBAO_DM_ALLOW_FROM", "default-user")
+        token = secret_scope.set_secret_scope(
+            {"YUANBAO_DM_POLICY": "allowlist", "YUANBAO_DM_ALLOW_FROM": "scoped-user"}
+        )
+        try:
+            adapter = YuanbaoAdapter(PlatformConfig(enabled=True))
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert adapter._access_policy._dm_policy == "allowlist"
+        assert adapter._access_policy._dm_allow_from == ["scoped-user"]
+
+    def test_scoped_miss_does_not_admit_default_profiles_allowlist(self, multiplex_on, monkeypatch):
+        monkeypatch.setenv("YUANBAO_DM_POLICY", "allowlist")
+        monkeypatch.setenv("YUANBAO_DM_ALLOW_FROM", "default-user")
+        token = secret_scope.set_secret_scope({"SOMETHING_ELSE": "x"})
+        try:
+            adapter = YuanbaoAdapter(PlatformConfig(enabled=True))
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert adapter._access_policy._dm_policy == "pairing"
+        assert adapter._access_policy._dm_allow_from == []
+
+
+class TestYuanbaoAccessPolicyOpenDmOptIn:
+    def test_scoped_allow_all_admits(self, multiplex_on, monkeypatch):
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("YUANBAO_ALLOW_ALL_USERS", raising=False)
+        policy = AccessPolicy(dm_policy="open", dm_allow_from=[], group_policy="pairing", group_allow_from=[])
+        token = secret_scope.set_secret_scope({"YUANBAO_ALLOW_ALL_USERS": "true"})
+        try:
+            assert policy._open_dm_opted_in() is True
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+    def test_default_profiles_allow_all_does_not_leak_into_scoped_miss(self, multiplex_on, monkeypatch):
+        """The default profile's env-only GATEWAY_ALLOW_ALL_USERS must not
+        admit a secondary profile that never opted in."""
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+        policy = AccessPolicy(dm_policy="open", dm_allow_from=[], group_policy="pairing", group_allow_from=[])
+        token = secret_scope.set_secret_scope({"SOMETHING_ELSE": "x"})
+        try:
+            assert policy._open_dm_opted_in() is False
+        finally:
+            secret_scope.reset_secret_scope(token)


### PR DESCRIPTION
## Summary

Under `gateway.multiplex_profiles`, several platform adapters read their **authorization configuration** (DM/group policies, user allowlists, allow-all opt-ins) through raw `os.getenv` at adapter-construction time, bypassing the per-profile secret scope installed by `_profile_runtime_scope`. The credential reads in these same adapters were already migrated to scoped helpers (e.g. `_wx_secret`, `_get_scoped_secret`); the adjacent authorization reads were missed. This produces two failure modes for any non-default profile:

1. **Fail-closed silent rejection** — a secondary profile's own env-only `WEIXIN_ALLOWED_USERS` (etc.) is invisible, so the intake gate drops every DM/group message with no error.
2. **Fail-open cross-profile leak** — the default profile's `GATEWAY_ALLOW_ALL_USERS=true` / allowlists live in the shared process env and leak into a secondary profile, admitting senders it never allowed.

Addresses part of #93522 — the construction-time authorization reads for Weixin/Yuanbao/WeCom and the startup guard. **Does not close #93522.** The remaining fail-open consumers named in that issue are still live on `main` after this PR: `gateway/platforms/weixin.py::_open_dm_opted_in()` and `plugins/platforms/wecom/adapter.py::_open_dm_opted_in()` still read `GATEWAY_ALLOW_ALL_USERS`/`*_ALLOW_ALL_USERS` via raw `os.getenv`, and `gateway/platforms/signal.py::__init__()` still reads `SIGNAL_GROUP_ALLOWED_USERS` / `SIGNAL_REQUIRE_MENTION` / `SIGNAL_ALLOWED_USERS` unscoped. Those sites exist, unmerged, on #88559 (currently 1,091 commits behind `main`). #93522 should stay open until those sites are ported onto current `main` (here or in a follow-up) or #88559 lands.

## What changed

- `gateway/platforms/weixin.py`: `WEIXIN_DM_POLICY` / `WEIXIN_GROUP_POLICY` / `WEIXIN_ALLOWED_USERS` / `WEIXIN_GROUP_ALLOWED_USERS` now read through the existing `_wx_secret` scoped helper (already used for the adjacent credential reads in this file).
- `gateway/platforms/yuanbao.py`: `YUANBAO_DM_POLICY` / `YUANBAO_DM_ALLOW_FROM` / `YUANBAO_GROUP_POLICY` / `YUANBAO_GROUP_ALLOW_FROM`, plus `AccessPolicy._open_dm_opted_in`'s `GATEWAY_ALLOW_ALL_USERS` / `YUANBAO_ALLOW_ALL_USERS` reads, now go through `gateway.authz_mixin._platform_gate_env` (the canonical scoped gate-env reader used elsewhere in the gateway).
- `plugins/platforms/wecom/adapter.py`: `WECOM_DM_POLICY` / `WECOM_ALLOWED_USERS` / `WECOM_GROUP_POLICY` now read through the existing `_get_scoped_secret` helper (already used for `WECOM_SECRET` in the same `__init__`).
- `gateway/run.py`: `_own_policy_open_startup_violation`'s `GATEWAY_ALLOW_ALL_USERS` check now uses the already-imported scoped `_getenv` (the sibling `dm_env`/`group_env`/`allow_all_env` reads two lines above it were already scoped; only this one was still raw).

Not touched (out of scope for this PR, see dependency note above): weixin/wecom `_open_dm_opted_in` and Signal's construction-time allowlist/mention reads. The previously-open PR #88559 covers those, but is 1,091 commits behind `main` and unmerged, so it cannot be relied on to satisfy #93522 as-is.

## Test plan

Added regression tests proving the scoped-vs-leaked behavior (each fails on the pre-fix code, verified via `git checkout HEAD~1 -- <file>`):

- `tests/gateway/test_weixin_secret_scope.py` — new `TestWeixinAdapterAuthzScope` class: a scoped `dm_policy`/allowlist is honored, and a scoped miss does not admit the default profile's env-only allowlist.
- `tests/gateway/test_wecom.py` — new `TestWeComAdapterAuthzScope` class: same shape for WeCom.
- `tests/gateway/test_yuanbao_secret_scope.py` — new file: `AccessPolicy` construction and `_open_dm_opted_in` scoping.
- `tests/gateway/test_multiplex_profile_authz.py` — new `test_startup_guard_gateway_allow_all_reads_scope_not_environ`: the startup guard's allow-all check respects the scope in both directions (no leak-in, and a legitimate scoped opt-in is honored).

```
$ python -m pytest tests/gateway/test_weixin.py tests/gateway/test_weixin_secret_scope.py \
    tests/gateway/test_wecom.py tests/gateway/test_wecom_callback.py \
    tests/gateway/test_wecom_plugin_setup.py tests/gateway/test_yuanbao_secret_scope.py \
    tests/gateway/test_yuanbao_forwarded_heartbeat.py tests/gateway/test_yuanbao_media_ssrf.py \
    tests/gateway/test_multiplex_profile_authz.py tests/gateway/test_qqbot_scope_paths.py -q
92 passed, 1 warning in 3.87s
```

Also ran via the canonical runner:
```
$ scripts/run_tests.sh tests/gateway/test_weixin_secret_scope.py tests/gateway/test_wecom.py \
    tests/gateway/test_yuanbao_secret_scope.py tests/gateway/test_multiplex_profile_authz.py -q
=== Summary: 4 files, 39 tests passed, 0 failed (100% complete) in 1.8s (8 workers) ===
```

`ruff check` on all changed files passed. `python -m py_compile` on all changed files passed. `git diff --check` passed.

## AI-assistance disclosure

This fix, its tests, and this description were prepared by an autonomous Claude Code agent, and reviewed against the repo's existing scoped-secret patterns (`_wx_secret`, `_get_scoped_secret`, `_platform_gate_env`, `gateway.config._getenv`) before being applied.

