### PR TITLE
fix(codex): avoid persisting app-server user echo

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -827,7 +827,23 @@ def run_codex_app_server_turn(
     if turn.projected_messages:
         from agent.message_metadata import append_message
 
-        for projected_message in turn.projected_messages:
+        projected_messages = turn.projected_messages
+        # ``turn/start`` materializes the submitted input as the leading
+        # ``userMessage`` item.  That item is a transport echo, not a second
+        # user action: build_turn_context already appended and persisted the
+        # same input before this early-return runtime was entered.  Drop only
+        # that exact leading echo.  Later/non-matching user projections remain
+        # intact so a distinct user event (for example a future turn/steer
+        # projection) is never erased by broad role- or content-based dedupe.
+        first_projected = projected_messages[0]
+        if (
+            isinstance(first_projected, dict)
+            and first_projected.get("role") == "user"
+            and first_projected.get("content") == user_message
+        ):
+            projected_messages = projected_messages[1:]
+
+        for projected_message in projected_messages:
             append_message(messages, projected_message)
 
         # Persist the newly-projected assistant/tool messages ourselves.
@@ -938,8 +954,8 @@ def run_codex_app_server_turn(
         # The codex app-server runtime IS an early-return path that bypasses
         # conversation_loop, but we flush the projected assistant/tool messages
         # ourselves above (see the _flush_messages_to_session_db call after
-        # messages.extend). The inbound user turn was already flushed at turn
-        # start (turn_context._persist_session) and the flush dedups via
+        # the projection splice). The inbound user turn was already flushed at
+        # turn start (turn_context._persist_session) and the flush dedups via
         # _DB_PERSISTED_MARKER, so state.db ends up with each real message
         # exactly once and session_search / conversation-distill see the full
         # gateway conversation. Report agent_persisted=True so the gateway

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -678,7 +678,7 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
 def run_codex_app_server_turn(
     agent,
     *,
-    user_message: str,
+    user_message: Any,
     original_user_message: Any,
     messages: List[Dict[str, Any]],
     effective_task_id: str,
@@ -831,15 +831,21 @@ def run_codex_app_server_turn(
         # ``turn/start`` materializes the submitted input as the leading
         # ``userMessage`` item.  That item is a transport echo, not a second
         # user action: build_turn_context already appended and persisted the
-        # same input before this early-return runtime was entered.  Drop only
-        # that exact leading echo.  Later/non-matching user projections remain
-        # intact so a distinct user event (for example a future turn/steer
-        # projection) is never erased by broad role- or content-based dedupe.
+        # same input before this early-return runtime was entered. ``run_turn``
+        # records the exact text it serialized into the wire input after rich
+        # content coercion; use that value rather than the original Hermes
+        # shape. Drop only an exact match — normalization here could erase a
+        # distinct user event such as a future turn/steer projection.
         first_projected = projected_messages[0]
+        submitted_user_text = getattr(turn, "submitted_user_text", None)
+        if submitted_user_text is None and isinstance(user_message, str):
+            # Compatibility for older/mocked TurnResult shapes. Live sessions
+            # always return submitted_user_text.
+            submitted_user_text = user_message
         if (
             isinstance(first_projected, dict)
             and first_projected.get("role") == "user"
-            and first_projected.get("content") == user_message
+            and first_projected.get("content") == submitted_user_text
         ):
             projected_messages = projected_messages[1:]
 

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -72,6 +72,9 @@ class TurnResult:
     error: Optional[str] = None  # Set if turn ended in a non-recoverable error
     turn_id: Optional[str] = None
     thread_id: Optional[str] = None
+    # Exact text serialized into the turn/start input item. The runtime uses
+    # this to distinguish Codex's transport echo from a separate user event.
+    submitted_user_text: Optional[str] = None
     token_usage_last: Optional[dict[str, Any]] = None
     token_usage_total: Optional[dict[str, Any]] = None
     model_context_window: Optional[int] = None
@@ -515,6 +518,7 @@ class CodexAppServerSession:
         projector = CodexEventProjector()
 
         user_input_text = _coerce_turn_input_text(user_input)
+        result.submitted_user_text = user_input_text
 
         # Send turn/start with the user input. Text-only for now (codex
         # supports rich content but Hermes' text path is the common case).

--- a/tests/agent/test_codex_app_server_persist.py
+++ b/tests/agent/test_codex_app_server_persist.py
@@ -14,13 +14,19 @@ The fix has the codex runtime flush its own projected messages via
 skips its own ``append_to_transcript`` DB write. This is critical: the inbound
 user turn is already flushed at turn start (``turn_context._persist_session``),
 and ``append_message`` is a raw INSERT with no dedup — a gateway re-write would
-duplicate the user turn (#860 / #42039). This test locks in:
+duplicate the user turn (#860 / #42039).
+
+Codex also projects the submitted input as a fresh leading ``userMessage``
+dict. The persistence marker cannot identify that semantically equal copy, so
+the runtime must discard the exact leading transport echo before splicing the
+remaining projected messages. This test locks in:
 
 1. ``run_codex_app_server_turn`` flushes projected messages and returns
    ``agent_persisted=True``.
 2. Exactly-once persistence: the already-flushed user turn is NOT re-written,
-   and the new projected assistant message lands once.
-3. The gateway resolution expression preserves standard-runtime behaviour.
+   the projected input echo is NOT inserted, and the assistant lands once.
+3. A later distinct user projection is preserved.
+4. The gateway resolution expression preserves standard-runtime behaviour.
 """
 
 import tempfile
@@ -33,13 +39,17 @@ from hermes_state import SessionDB
 from run_agent import AIAgent
 
 
-def _make_turn():
+def _make_turn(*, user_echo=None):
+    projected_messages = []
+    if user_echo is not None:
+        projected_messages.append({"role": "user", "content": user_echo})
+    projected_messages.append({"role": "assistant", "content": "CODEX_ASSISTANT"})
     return SimpleNamespace(
         interrupted=False,
         error=None,
         thread_id="thread-1",
         turn_id="turn-1",
-        projected_messages=[{"role": "assistant", "content": "CODEX_ASSISTANT"}],
+        projected_messages=projected_messages,
         tool_iterations=0,
         final_text="CODEX_ASSISTANT",
         should_retire=False,
@@ -105,12 +115,41 @@ def test_codex_user_interrupt_is_reported_and_cleared():
     assert agent._interrupt_requested is False
 
 
+def test_codex_drops_only_the_leading_matching_user_echo():
+    """A later distinct user projection must survive the input-echo filter."""
+    agent = _make_agent(session_db=None)
+    turn = _make_turn()
+    turn.projected_messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "INTERIM"},
+        {"role": "user", "content": "STEER"},
+        {"role": "assistant", "content": "CODEX_ASSISTANT"},
+    ]
+    agent._codex_session.run_turn.return_value = turn
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message="hello",
+        original_user_message="hello",
+        messages=[{"role": "user", "content": "hello"}],
+        effective_task_id="task-1",
+    )
+
+    assert [(message["role"], message.get("content")) for message in result["messages"]] == [
+        ("user", "hello"),
+        ("assistant", "INTERIM"),
+        ("user", "STEER"),
+        ("assistant", "CODEX_ASSISTANT"),
+    ]
+
+
 def test_codex_turn_persists_each_message_exactly_once():
     """The user turn (flushed at turn start) must not be duplicated; the
     projected assistant message must land once.  Uses a real SessionDB and the
     real AIAgent._flush_messages_to_session_db to prove no #860/#42039
     duplicate-write regression on the codex path."""
     tmp = tempfile.mkdtemp(prefix="codex_persist_")
+    db = None
     try:
         db = SessionDB(Path(tmp) / "state.db")
         sid = "sess-codex-once"
@@ -128,7 +167,11 @@ def test_codex_turn_persists_each_message_exactly_once():
         )
         agent._session_db_created = True
         agent._codex_session = MagicMock()
-        agent._codex_session.run_turn.return_value = _make_turn()
+        # A real app-server turn projects the submitted input back as a
+        # leading userMessage before the assistant response.  Hermes already
+        # owns and flushed that input at turn start, so the transport echo
+        # must not become a second durable user row.
+        agent._codex_session.run_turn.return_value = _make_turn(user_echo="USER_TURN")
         agent.tool_progress_callback = None
 
         # Model the real flow: the inbound user turn is flushed at turn start
@@ -163,6 +206,8 @@ def test_codex_turn_persists_each_message_exactly_once():
     finally:
         import shutil
 
+        if db is not None:
+            db.close()
         shutil.rmtree(tmp)
 
 

--- a/tests/agent/test_codex_app_server_persist.py
+++ b/tests/agent/test_codex_app_server_persist.py
@@ -16,17 +16,18 @@ user turn is already flushed at turn start (``turn_context._persist_session``),
 and ``append_message`` is a raw INSERT with no dedup — a gateway re-write would
 duplicate the user turn (#860 / #42039).
 
-Codex also projects the submitted input as a fresh leading ``userMessage``
-dict. The persistence marker cannot identify that semantically equal copy, so
-the runtime must discard the exact leading transport echo before splicing the
-remaining projected messages. This test locks in:
+The projection-splice comment in ``run_codex_app_server_turn`` documents why
+Codex's leading ``userMessage`` is a transport echo rather than a second user
+action. These tests lock in:
 
 1. ``run_codex_app_server_turn`` flushes projected messages and returns
    ``agent_persisted=True``.
 2. Exactly-once persistence: the already-flushed user turn is NOT re-written,
    the projected input echo is NOT inserted, and the assistant lands once.
-3. A later distinct user projection is preserved.
-4. The gateway resolution expression preserves standard-runtime behaviour.
+3. Assistant-only and non-matching leading projections are preserved.
+4. A later distinct user projection is preserved.
+5. Rich input is matched against the exact text submitted on the wire.
+6. The gateway resolution expression preserves standard-runtime behaviour.
 """
 
 import tempfile
@@ -39,7 +40,7 @@ from hermes_state import SessionDB
 from run_agent import AIAgent
 
 
-def _make_turn(*, user_echo=None):
+def _make_turn(*, user_echo=None, submitted_user_text=None):
     projected_messages = []
     if user_echo is not None:
         projected_messages.append({"role": "user", "content": user_echo})
@@ -49,6 +50,7 @@ def _make_turn(*, user_echo=None):
         error=None,
         thread_id="thread-1",
         turn_id="turn-1",
+        submitted_user_text=submitted_user_text,
         projected_messages=projected_messages,
         tool_iterations=0,
         final_text="CODEX_ASSISTANT",
@@ -82,7 +84,11 @@ def test_codex_success_flushes_and_reports_persisted():
         effective_task_id="task-1",
     )
     assert result["completed"] is True
-    assert isinstance(result["messages"][-1]["timestamp"], float)
+    assert [(message["role"], message.get("content")) for message in result["messages"]] == [
+        ("user", "hello"),
+        ("assistant", "CODEX_ASSISTANT"),
+    ]
+    assert isinstance(result["messages"][1]["timestamp"], float)
     # With the agent as sole persister, the gateway must SKIP its DB write.
     assert result["agent_persisted"] is True
 
@@ -125,6 +131,7 @@ def test_codex_drops_only_the_leading_matching_user_echo():
         {"role": "user", "content": "STEER"},
         {"role": "assistant", "content": "CODEX_ASSISTANT"},
     ]
+    turn.submitted_user_text = "hello"
     agent._codex_session.run_turn.return_value = turn
 
     result = run_codex_app_server_turn(
@@ -139,6 +146,52 @@ def test_codex_drops_only_the_leading_matching_user_echo():
         ("user", "hello"),
         ("assistant", "INTERIM"),
         ("user", "STEER"),
+        ("assistant", "CODEX_ASSISTANT"),
+    ]
+
+
+def test_codex_preserves_nonmatching_leading_user_projection():
+    agent = _make_agent(session_db=None)
+    turn = _make_turn(user_echo="DIFFERENT", submitted_user_text="hello")
+    agent._codex_session.run_turn.return_value = turn
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message="hello",
+        original_user_message="hello",
+        messages=[{"role": "user", "content": "hello"}],
+        effective_task_id="task-1",
+    )
+
+    assert [(message["role"], message.get("content")) for message in result["messages"]] == [
+        ("user", "hello"),
+        ("user", "DIFFERENT"),
+        ("assistant", "CODEX_ASSISTANT"),
+    ]
+
+
+def test_codex_drops_echo_of_coerced_rich_wire_text():
+    rich_input = [
+        {"type": "text", "text": "caption"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+    ]
+    submitted_text = "caption\n\n[image attached]"
+    agent = _make_agent(session_db=None)
+    agent._codex_session.run_turn.return_value = _make_turn(
+        user_echo=submitted_text,
+        submitted_user_text=submitted_text,
+    )
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message=rich_input,
+        original_user_message=rich_input,
+        messages=[{"role": "user", "content": rich_input}],
+        effective_task_id="task-1",
+    )
+
+    assert [(message["role"], message.get("content")) for message in result["messages"]] == [
+        ("user", rich_input),
         ("assistant", "CODEX_ASSISTANT"),
     ]
 
@@ -171,7 +224,10 @@ def test_codex_turn_persists_each_message_exactly_once():
         # leading userMessage before the assistant response.  Hermes already
         # owns and flushed that input at turn start, so the transport echo
         # must not become a second durable user row.
-        agent._codex_session.run_turn.return_value = _make_turn(user_echo="USER_TURN")
+        agent._codex_session.run_turn.return_value = _make_turn(
+            user_echo="USER_TURN",
+            submitted_user_text="USER_TURN",
+        )
         agent.tool_progress_callback = None
 
         # Model the real flow: the inbound user turn is flushed at turn start

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -209,6 +209,32 @@ class TestRunTurn:
         # turn_id propagated for downstream session-DB linkage
         assert r.turn_id == "turn-fake-001"
 
+    def test_rich_input_records_exact_submitted_wire_text(self):
+        client = FakeClient()
+        client.queue_notification(
+            "item/completed",
+            item={"type": "agentMessage", "id": "m1", "text": "done"},
+            threadId="t",
+            turnId="tu1",
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        rich_input = [
+            {"type": "text", "text": "caption"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+        ]
+
+        result = make_session(client).run_turn(rich_input, turn_timeout=2.0)
+
+        _, params = next(request for request in client.requests if request[0] == "turn/start")
+        assert params["input"] == [
+            {"type": "text", "text": "caption\n\n[image attached]"}
+        ]
+        assert result.submitted_user_text == "caption\n\n[image attached]"
+
 
 
     def test_foreign_completion_in_server_request_drain_is_ignored(self):
@@ -895,4 +921,3 @@ class TestClassifyOAuthFailure:
         assert _classify_oauth_failure() is None
         assert _classify_oauth_failure("") is None
         assert _classify_oauth_failure("", None) is None  # type: ignore[arg-type]
-


### PR DESCRIPTION
## What does this PR do?

Prevents the Codex app-server runtime from persisting the submitted user input twice.

Hermes already appends and flushes the inbound user message in `build_turn_context()` before entering the `codex_app_server` early-return path. Codex then emits the same submitted input as the leading projected `userMessage`. Because that projection is a fresh dict, Hermes' `_DB_PERSISTED_MARKER` identity guard correctly treats it as a new row, producing `[user, user, assistant]` in `state.db` from one accepted prompt.

The fix removes only the leading projected user message when its role and content exactly match the text actually serialized into `turn/start`. `CodexAppServerSession` records that post-coercion wire text on `TurnResult`, so rich/list input is handled without fuzzy normalization. Non-matching or later user projections remain untouched, preserving distinct events such as future `turn/steer` projections. The projector and SQLite layer remain protocol-faithful and content-agnostic.

This fixes the writer boundary rather than adding storage-level content deduplication. Legitimate identical active messages exist, so a database uniqueness rule cannot infer caller intent; see the withdrawn approach in #74855.

Historical duplicate rows are not rewritten. This PR prevents new duplicates on the affected runtime path.

## Related work

- #38254 contains the original exact root-cause report and a live duplicated-row example from @gitszabolcs.
- #43127 contains the first implementation of the user-echo filter by @vectorcmd (submitted by @vashkartik). This PR is the focused salvage requested in that PR's maintainer review, rebased onto current `main` with the missing real-`userMessage` regression coverage.
- No new issue was opened because the bug and proposed boundary fix were already documented in those threads.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/codex_runtime.py`
  - drops only the exact leading Codex input echo by comparing against the submitted wire text;
  - preserves later/non-matching user projections;
  - leaves projector and SessionDB semantics unchanged.
- `agent/transports/codex_app_server_session.py`
  - records the exact post-coercion text serialized into `turn/start` on `TurnResult`.
- `tests/agent/test_codex_app_server_persist.py`
  - makes the real SessionDB persistence fixture include the `userMessage` shape emitted by a real app-server turn;
  - asserts one durable user row and one durable assistant row;
  - asserts assistant-only and non-matching leading projections are preserved;
  - asserts that a later distinct user projection survives filtering and rich input matches its wire form;
  - closes the SessionDB before temporary-directory cleanup.
- `tests/agent/transports/test_codex_app_server_session.py`
  - asserts the recorded submitted text exactly matches the `turn/start` payload for rich input.

## Reproduction and evidence

On current `main`, the realistic persistence regression failed with:

```text
['USER_TURN', 'USER_TURN', 'CODEX_ASSISTANT']
```

The second `USER_TURN` was the Codex projection, not a second accepted prompt.

After the fix, a real `gpt-5.6-sol` Codex app-server turn on macOS 26.5.2 / Python 3.12.11 / `codex-cli 0.146.0`, using commit `18c8348ef5bc120a1911d06267823c55b4f5a38b`, returned:

```json
{
  "completed": true,
  "final_response": "CODEX_ECHO_REVIEW_OK",
  "roles": ["user", "assistant"],
  "user_rows": 1,
  "assistant_rows": 1
}
```

## How to Test

```bash
scripts/run_tests.sh \
  tests/agent/test_codex_app_server_event_bridge.py \
  tests/agent/test_codex_app_server_persist.py \
  tests/agent/test_codex_runtime_live_events.py \
  tests/agent/transports/test_codex_app_server_runtime.py \
  tests/agent/transports/test_codex_app_server_session.py \
  tests/agent/transports/test_codex_event_projector.py \
  tests/run_agent/test_codex_app_server_compaction.py \
  tests/run_agent/test_codex_app_server_integration.py \
  tests/run_agent/test_codex_app_server_lifecycle.py \
  tests/tui_gateway/test_codex_app_server_live_events.py -q
```

Result: **143 passed, 0 failed**.

```bash
ruff check \
  agent/codex_runtime.py \
  agent/transports/codex_app_server_session.py \
  tests/agent/test_codex_app_server_persist.py \
  tests/agent/transports/test_codex_app_server_session.py
```

Result: **passed**.

The complete repository suite was not rerun after rebasing onto the latest `main`; the affected Codex matrix and static checks above were rerun on the current head. CI remains the authoritative cross-platform gate.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit follows Conventional Commits.
- [x] I searched open and closed issues/PRs and credited the existing work.
- [x] The PR contains only the Codex user-echo persistence fix and its regression coverage.
- [ ] The entire local repository suite was rerun after the latest rebase; see the explicit validation boundary above.
- [x] Added real-SessionDB, negative-arm, rich-input wire-text, and later-user-event preservation tests.
- [x] Tested on macOS 26.5.2 with Python 3.12.11 and a real Codex app-server turn.

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing behavior or configuration surface changed.
- [x] `cli-config.yaml.example`: N/A.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; architecture and workflow are unchanged.
- [x] Cross-platform impact considered: pure list/dict filtering, no OS-specific APIs.
- [x] Tool descriptions/schemas: N/A.

## Contributor credit

The focused filter is salvaged from #43127. @vectorcmd is preserved as a co-author on the commit; @vashkartik and @gitszabolcs are credited above for the original PR and root-cause report.
