### PR TITLE
fix(cron): skip the delivery credential check on route_only deployments

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4769,6 +4769,13 @@ def _preflight_check_delivery(job: dict) -> Optional[str]:
     the same source `cron_delivery_targets` uses). Gateway-config load
     failures fail OPEN so a transient config hiccup never wedges delivery
     that would have worked.
+
+    A ``route_only`` deployment holds no platform credentials of its own by
+    design — ingress and egress belong to the fronting gateway — so the
+    credential half of the check is skipped there (the unknown-platform half
+    still applies). Without that carve-out every route_only profile blocks
+    every platform target, including ones whose delivery demonstrably
+    succeeds through the fronting gateway's live adapter.
     """
     deliver_value = _normalize_deliver_value(job.get("deliver", "local"))
     platform_parts: list[str] = []
@@ -4786,6 +4793,7 @@ def _preflight_check_delivery(job: dict) -> Optional[str]:
         return None
 
     connected: Optional[set] = None
+    credentials_fronted = False
     for platform_name in platform_parts:
         if not _is_known_delivery_platform(platform_name):
             return (
@@ -4793,11 +4801,28 @@ def _preflight_check_delivery(job: dict) -> Optional[str]:
                 "delivery target. Fix the job's `deliver` value or configure "
                 "the platform's gateway credentials."
             )
+        if credentials_fronted:
+            continue
         if connected is None:
             try:
                 from gateway.config import load_gateway_config
 
                 gateway_config = load_gateway_config()
+                if getattr(gateway_config, "route_only", False):
+                    # Route-only deployment: this config intentionally carries
+                    # no platform credentials — the fronting gateway owns them,
+                    # and fire-time delivery resolves through ITS live adapter
+                    # (`resolve_delivery_transport`). get_connected_platforms()
+                    # is empty here for every platform, so the credential check
+                    # can only produce false blocks. Same carve-out rationale
+                    # as the relay-fronted set below.
+                    logger.debug(
+                        "preflight: route_only deployment — delivery "
+                        "credentials belong to the fronting gateway; "
+                        "skipping the credential check"
+                    )
+                    credentials_fronted = True
+                    continue
                 connected = {
                     p.value for p in gateway_config.get_connected_platforms()
                 }

--- a/tests/cron/test_cron_relay_delivery_guards.py
+++ b/tests/cron/test_cron_relay_delivery_guards.py
@@ -104,6 +104,10 @@ def _gateway_config(connected_values):
     config.get_connected_platforms.return_value = [
         MagicMock(value=v) for v in connected_values
     ]
+    # GatewayConfig.route_only is a real bool; a bare MagicMock attribute is
+    # truthy and would silently opt these native/relay topologies into the
+    # route_only carve-out, hiding the strictness they exist to prove.
+    config.route_only = False
     return config
 
 

--- a/tests/cron/test_preflight_config.py
+++ b/tests/cron/test_preflight_config.py
@@ -340,3 +340,44 @@ class TestDeliveryPlatform:
 
         assert success is True
         assert agent_constructed is True
+
+    def test_route_only_skips_credential_check(self):
+        """A route_only deployment fronts delivery — an empty set must not block.
+
+        route_only configs hold no platform credentials by design: the
+        fronting gateway owns them and fire-time delivery resolves through
+        ITS live adapter. get_connected_platforms() is empty there for every
+        platform, so without the carve-out the credential check blocks every
+        concrete platform target on every multi-profile host.
+        """
+        gateway_config = MagicMock()
+        gateway_config.route_only = True
+        gateway_config.get_connected_platforms.return_value = []
+        with patch("gateway.config.load_gateway_config",
+                   return_value=gateway_config):
+            assert sched._preflight_check_delivery(
+                {"deliver": "discord:123"}) is None
+
+    def test_route_only_still_blocks_unknown_platform(self):
+        """The carve-out covers credentials only — a typo'd target still blocks."""
+        gateway_config = MagicMock()
+        gateway_config.route_only = True
+        gateway_config.get_connected_platforms.return_value = []
+        with patch("gateway.config.load_gateway_config",
+                   return_value=gateway_config), \
+                patch("cron.scheduler._is_known_delivery_platform",
+                      return_value=False):
+            reason = sched._preflight_check_delivery({"deliver": "notaplatform"})
+
+        assert reason is not None and "not a known cron" in reason
+
+    def test_native_deployment_keeps_strict_credential_check(self):
+        """Non-route_only topologies must keep blocking unconfigured platforms."""
+        gateway_config = MagicMock()
+        gateway_config.route_only = False
+        gateway_config.get_connected_platforms.return_value = []
+        with patch("gateway.config.load_gateway_config",
+                   return_value=gateway_config):
+            reason = sched._preflight_check_delivery({"deliver": "discord:123"})
+
+        assert reason is not None and "no gateway credentials" in reason


### PR DESCRIPTION
## What does this PR do?

`_preflight_check_delivery` blocks a cron job when the platform named by its `deliver` target is missing from `load_gateway_config().get_connected_platforms()`. On a **`route_only`** deployment that set is empty for *every* platform by design: such a config intentionally owns no platform credentials, because ingress and egress belong to the fronting gateway and fire-time delivery resolves through **its** live adapter (`resolve_delivery_transport`).

So on a multi-profile host, every cron job with a concrete platform target is refused with `blocked_config` — while delivery through that exact target still works. The logs say both things in the same run:

```
09:00:33 WARNING cron.scheduler: Job 'cloudops-patrol': BLOCKED by pre-dispatch config
         validation — delivery platform 'discord' has no gateway credentials configured
         (not connected). Configure it via `hermes setup` or ...
09:00:34 INFO    cron.scheduler: Job '<id>': delivered to discord:<channel> via live adapter
```

The alert announcing that delivery is impossible was itself delivered, over the very transport it declared unconfigured.

This is the situation the relay carve-out right below already handles: the credential lives one hop away, in the transport that actually sends. So this PR skips the **credential** half of the check when `gateway_config.route_only` is set.

Deliberately narrow:

- the **unknown-platform** half stays strict, so a typo'd `deliver` value is still refused on route_only too;
- **native (non-route_only) topologies are untouched** — an unconfigured platform still blocks exactly as before;
- the check still fails open on gateway-config load errors, as it did.

## Related Issue

No existing issue — found in production on a 13-profile route_only host, first blocked run 2026-08-24. Full reproduction below.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py` — `_preflight_check_delivery()`: skip the credential lookup when `gateway_config.route_only` is set (`credentials_fronted`), keeping the unknown-platform check in the loop. Docstring updated to state the carve-out and why.
- `tests/cron/test_preflight_config.py` — three tests: route_only with an empty connected set passes; route_only still blocks an unknown platform; a native deployment still blocks an unconnected one.
- `tests/cron/test_cron_relay_delivery_guards.py` — `_gateway_config()` built its fake from a bare `MagicMock()`, whose `route_only` attribute is **truthy**. That would have opted the relay/native strictness tests into the new carve-out and silently hidden the behavior they exist to assert. It now models the real bool (`config.route_only = False`).

## How to Test

Reproduce the false block (before this PR):

1. Take a home whose `config.yaml` has `gateway: {route_only: true}` and no `platforms:` credentials — i.e. any profile behind a fronting gateway.
2. Give it a cron job with a concrete platform target, e.g. `deliver: discord:<channel_id>`.
3. Let it fire. It is refused with `last_status=blocked_config` and "has no gateway credentials configured", while the alert about that refusal is delivered to that same channel via the fronting gateway's live adapter.

Confirm the fix:

```
pytest tests/cron/test_preflight_config.py tests/cron/test_cron_relay_delivery_guards.py -q
```

`test_route_only_skips_credential_check` fails on `main` and passes with this change; the other two are regression guards for the halves that must **not** change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **ran `pytest tests/cron/ -q` (the affected package) rather than the whole suite: 888 passed, 1 skipped, on this branch at `ec44116d5`. Happy to post full-suite output in the thread if you want it.**
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring of `_preflight_check_delivery` states the carve-out
- [x] N/A — no config keys added or changed (`cron.preflight` is untouched)
- [x] N/A — no architecture or workflow change
- [x] N/A — pure Python, no file I/O, process, or terminal handling
- [x] N/A — no tool behavior change

## Screenshots / Logs

Production evidence that the blocked target was in fact deliverable (one run, host redacted):

```
2026-08-24 09:00:33,506 INFO  cron.scheduler: Running job 'cloudops-patrol' (ID: <id>)
2026-08-24 09:00:33,525 WARN  cron.scheduler: Job 'cloudops-patrol' (ID: <id>): BLOCKED by
      pre-dispatch config validation — delivery platform 'discord' has no gateway credentials
      configured (not connected).
2026-08-24 09:00:34,194 INFO  cron.scheduler: Job '<id>': delivered to discord:<channel>
      via live adapter
```

That job had completed 44 scheduled runs delivering to that channel before the preflight check landed; nothing about its delivery path changed.
