### PR TITLE
fix(config): stop v15 upgrades from reporting settings they did not save

### DIFF
--- a/hermes_cli/config_migrations.py
+++ b/hermes_cli/config_migrations.py
@@ -218,25 +218,6 @@ def _migrate_to_14(results: Dict[str, Any], quiet: bool) -> None:
             print("  ✓ Migrated legacy stt.model to provider-specific config")
 
 
-def _migrate_to_15(results: Dict[str, Any], quiet: bool) -> None:
-    # ── Version 14 → 15: add explicit gateway interim-message gate ──
-    _c = _cfg()
-    read_raw_config = _c.read_raw_config
-    _persist_migration = _c._persist_migration
-
-    config = read_raw_config()
-    display = config.get("display", {})
-    if not isinstance(display, dict):
-        display = {}
-    if "interim_assistant_messages" not in display:
-        display["interim_assistant_messages"] = True
-        config["display"] = display
-        results["config_added"].append("display.interim_assistant_messages=true (default)")
-        _persist_migration(config)
-        if not quiet:
-            print("  ✓ Added display.interim_assistant_messages=true")
-
-
 def _migrate_to_16(results: Dict[str, Any], quiet: bool) -> None:
     # ── Version 15 → 16: migrate tool_progress_overrides into display.platforms ──
     _c = _cfg()
@@ -856,7 +837,8 @@ MIGRATIONS: Tuple[Tuple[int, Callable[[Dict[str, Any], bool], None]], ...] = (
     (12, _migrate_to_12),
     (13, _migrate_to_13),
     (14, _migrate_to_14),
-    (15, _migrate_to_15),
+    # v15 only added a schema default; runtime merging supplies it without a
+    # write. Registering a migration would falsely report or materialise it.
     (16, _migrate_to_16),
     (17, _migrate_to_17),
     (21, _migrate_to_21),

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -957,7 +957,9 @@ class TestInterimAssistantMessageConfig:
     def test_default_config_enables_interim_assistant_messages(self):
         assert DEFAULT_CONFIG["display"]["interim_assistant_messages"] is True
 
-    def test_migrate_to_v15_adds_interim_assistant_message_gate(self, tmp_path):
+    def test_migrate_to_v15_supplies_interim_message_gate_at_read_time(
+        self, tmp_path, capsys
+    ):
         config_path = tmp_path / "config.yaml"
         config_path.write_text(
             yaml.safe_dump({"_config_version": 14, "display": {"tool_progress": "off"}}),
@@ -965,7 +967,7 @@ class TestInterimAssistantMessageConfig:
         )
 
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
-            migrate_config(interactive=False, quiet=True)
+            results = migrate_config(interactive=False, quiet=False)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
             loaded = load_config()
 
@@ -978,6 +980,11 @@ class TestInterimAssistantMessageConfig:
         # was the config-bloat bug). It is still effective via load_config().
         assert "interim_assistant_messages" not in raw.get("display", {})
         assert loaded["display"]["interim_assistant_messages"] is True
+        assert not any(
+            "interim_assistant_messages" in item
+            for item in results["config_added"]
+        )
+        assert "Added display.interim_assistant_messages" not in capsys.readouterr().out
 
 
 class TestCliRefreshIntervalConfig:


### PR DESCRIPTION
## What does this PR do?

Stops the v14-to-v15 config migration from claiming that `display.interim_assistant_messages=true` was saved when the migration write invariant strips that schema-default value. Existing installs still receive the enabled value through runtime config merging, while their lean on-disk config remains unchanged.

### Symptom

A v14 config without `display.interim_assistant_messages` prints a successful addition and includes the setting in `config_added`, but the setting is absent from the resulting `config.yaml`.

### Impact

Operators and update automation receive a false success report for a write that did not occur. The persisted config and the migration report disagree.

### Bug Cause

**Trigger:** `hermes_cli/config_migrations.py` / `_migrate_to_15` when a v14 config omits `display.interim_assistant_messages`.

**Causal chain:**
1. The v15 migration inserts `display.interim_assistant_messages=true` into its in-memory config and unconditionally records a successful addition.
2. `_persist_migration` routes the config through default stripping, which correctly removes the value because it equals the current schema default.
3. The migration still prints and returns a successful write report even though no such key reached disk.

**Why it is wrong:** Migration result entries and success output must describe persisted changes, not values removed by the migration write invariant.

**Working sibling / contrast:** Runtime `load_config()` deep-merges schema defaults and already supplies `interim_assistant_messages=true` without materializing it in `config.yaml`.

**Ruled out:** Forcing the value onto disk was rejected because it would violate the default-stripping invariant, bloat user configs, and shadow future default changes.

### Fix

Remove the unnecessary v15 migration registry entry. Keep the schema default as the sole source for read-time behavior, and extend the migration regression test to assert that the key is effective without appearing in the persisted config, `config_added`, or success output.

## Related Issue

Closes #93533

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config_migrations.py` - remove the no-op-but-successful v15 default migration.
- `tests/hermes_cli/test_config.py` - verify read-time behavior and migration report/disk consistency.

## How to Test

1. Start with a v14 config that omits `display.interim_assistant_messages`.
2. Run the config migration and verify the loaded value is `true` while the raw config and migration report omit it.
3. Run the focused migration tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_config.py -k 'TestInterimAssistantMessageConfig' -q
scripts/run_tests.sh tests/hermes_cli/test_sibling_config_migration.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo test entry on the relevant tests and all selected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - no user-facing behavior or config key changed
- [x] `cli-config.yaml.example` update: N/A - no config key changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered: migration logic is platform-independent
- [x] Tool descriptions/schemas update: N/A - no tool behavior changed
