### PR TITLE
fix(cli): keep --reasoning invocations on the plugin fast path

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -11,6 +11,7 @@ because its dispatch is tightly coupled to module-level ``cmd_*`` functions.
 """
 
 import argparse
+from functools import lru_cache
 
 
 # `--profile` / `-p` is consumed by ``main._apply_profile_override`` before
@@ -21,6 +22,20 @@ PRE_ARGPARSE_INHERITED_FLAGS: list[tuple[str, bool]] = [
     ("--profile", True),
     ("-p", True),
 ]
+
+
+@lru_cache(maxsize=1)
+def top_level_value_flag_sets() -> tuple[frozenset[str], frozenset[str]]:
+    """Return required- and optional-value flags from the live parser."""
+    parser = build_top_level_parser()[0]
+    required: set[str] = set()
+    optional: set[str] = set()
+    for action in parser._actions:
+        if not action.option_strings or action.nargs == 0:
+            continue
+        target = optional if action.nargs == "?" else required
+        target.update(action.option_strings)
+    return frozenset(required), frozenset(optional)
 
 
 def _inherited_flag(parser, *args, **kwargs):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -572,17 +572,9 @@ def _apply_profile_override() -> None:
     # 1. Check for explicit -p / --profile flag. Historically this worked even
     # after the subcommand (`hermes chat -p coder`), so keep scanning broadly.
     # The exception is command-argv passthrough regions such as `mcp add --args`.
-    value_flags = {
-        "-z", "--oneshot",
-        "-m", "--model",
-        "--provider",
-        "-t", "--toolsets",
-        "-r", "--resume",
-        "-s", "--skills",
-        "--usage-file",
-        "--in",
-    }
-    optional_value_flags = {"-c", "--continue"}
+    from hermes_cli._parser import top_level_value_flag_sets
+
+    value_flags, optional_value_flags = top_level_value_flag_sets()
     i = 0
     while i < len(argv):
         arg = argv[i]
@@ -11902,33 +11894,6 @@ _BUILTIN_SUBCOMMANDS = frozenset(
 )
 
 
-# Top-level flags that take a value. Needed by ``_first_positional_argv``
-# so that in ``hermes -m gpt5 chat``, ``gpt5`` is correctly skipped as a
-# flag value rather than misclassified as a subcommand. Kept in sync with
-# the top-level flags declared in ``hermes_cli/_parser.py``.
-#
-# Correctness-safe either way: missing an entry here only makes the
-# fast-path bail out too eagerly (we run plugin discovery when we didn't
-# need to); extra entries would make us skip a real positional.
-_TOP_LEVEL_VALUE_FLAGS = frozenset(
-    {
-        "-z", "--oneshot",
-        "-m", "--model",
-        "--provider",
-        "-t", "--toolsets",
-        "-r", "--resume",
-        "-s", "--skills",
-        "--usage-file",
-        "--in",
-        # ``-c / --continue`` is nargs='?' (optional value). Treat it as
-        # value-taking: if the next token is a subcommand-looking word
-        # the user almost certainly meant it as the session name, and
-        # either interpretation keeps us on the safe side.
-        "-c", "--continue",
-    }
-)
-
-
 def _first_positional_argv() -> str | None:
     """Return the first non-flag, non-flag-value token in ``sys.argv[1:]``.
 
@@ -11941,6 +11906,10 @@ def _first_positional_argv() -> str | None:
     bar`` flags degrade gracefully (``bar`` may be wrongly classified as
     a positional, which at worst forces a one-time plugin discovery).
     """
+    from hermes_cli._parser import top_level_value_flag_sets
+
+    required_value_flags, optional_value_flags = top_level_value_flag_sets()
+    value_flags = required_value_flags | optional_value_flags
     argv = sys.argv[1:]
     i = 0
     while i < len(argv):
@@ -11955,7 +11924,7 @@ def _first_positional_argv() -> str | None:
             if "=" in tok:
                 i += 1
                 continue
-            if tok in _TOP_LEVEL_VALUE_FLAGS and i + 1 < len(argv):
+            if tok in value_flags and i + 1 < len(argv):
                 i += 2
                 continue
             i += 1

--- a/tests/hermes_cli/test_startup_plugin_gating.py
+++ b/tests/hermes_cli/test_startup_plugin_gating.py
@@ -28,6 +28,7 @@ from unittest.mock import patch
 
 import pytest
 
+from hermes_cli._parser import build_top_level_parser, top_level_value_flag_sets
 from hermes_cli.main import (
     _BUILTIN_SUBCOMMANDS,
     _first_positional_argv,
@@ -67,6 +68,27 @@ def _live_subcommand_names() -> set[str]:
 
 
 # ── _first_positional_argv ─────────────────────────────────────────────────
+
+
+def test_value_flag_sets_match_top_level_parser():
+    required, optional = top_level_value_flag_sets()
+
+    for action in build_top_level_parser()[0]._actions:
+        if not action.option_strings or action.nargs == 0:
+            continue
+        expected = optional if action.nargs == "?" else required
+        assert set(action.option_strings) <= expected
+
+
+def test_reasoning_value_is_not_misclassified_as_subcommand(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "--reasoning", "high", "chat", "hello"],
+    )
+
+    assert _first_positional_argv() == "chat"
+    assert _plugin_cli_discovery_needed() is False
 
 
 


### PR DESCRIPTION
## What does this PR do?

Keeps built-in CLI invocations that use the top-level `--reasoning` override on the fast startup path instead of eagerly discovering every plugin. The fix derives value-taking flags from the live top-level parser, so future parser additions cannot silently reintroduce the same drift.

### Symptom

`hermes --reasoning high chat "hello"` treated `high` as the first positional token during startup gating. Because `high` is not a built-in subcommand, Hermes unnecessarily ran full plugin CLI discovery before parsing the command.

### Impact

Every CLI invocation using the top-level reasoning override paid the eager plugin import cost even when it targeted a built-in command. Command correctness was preserved, but startup was unnecessarily delayed.

### Bug Cause

**Trigger:** `hermes_cli/main.py` in `_first_positional_argv()` when `--reasoning LEVEL` appears before a built-in subcommand.

**Causal chain:**
1. The top-level parser declares `--reasoning` as a value-taking option.
2. Two independent hand-maintained scanner sets omitted that option, so the startup scanner returned its value as the first positional token.
3. `_plugin_cli_discovery_needed()` interpreted that unknown token as a possible plugin command and selected eager discovery.

**Why it is wrong:** Startup classification duplicated parser metadata in handwritten sets that could drift whenever top-level options changed.

**Working sibling / contrast:** `--model VALUE chat` stayed on the fast path because `--model` happened to be present in both handwritten sets.

**Ruled out:** The parser declaration itself is correct; direct inspection shows `--reasoning` consumes one value. The failure was confined to the pre-parse scanners.

### Fix

Add a cached parser-introspection helper that separates required-value and optional-value top-level flags. Both profile pre-scanning and plugin startup gating now consume that shared metadata. Regression coverage verifies parser parity and the reported `--reasoning high chat` path.

## Related Issue

Closes #93530

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/_parser.py` - derive and cache top-level value flag sets from argparse actions.
- `hermes_cli/main.py` - use the derived sets in both pre-parse scanners.
- `tests/hermes_cli/test_startup_plugin_gating.py` - cover parser parity and the reasoning fast path.

## How to Test

1. Run the focused startup gating suite:

```bash
scripts/run_tests.sh tests/hermes_cli/test_startup_plugin_gating.py -q
```

2. Verify the reported invocation is classified as `chat` without plugin discovery:

```bash
C:/workspace/hermes-agent/.venv/Scripts/python.exe -c "import sys; from hermes_cli import main as m; sys.argv=['hermes','--reasoning','high','chat','hello']; print(m._first_positional_argv(), m._plugin_cli_discovery_needed())"
```

Expected output: `chat False`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all focused tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updates: N/A
- [x] `cli-config.yaml.example` updates: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` updates: N/A - no architecture or workflow changed
- [x] I've considered cross-platform impact per the compatibility guide; the parser logic is platform-independent
- [x] Tool description/schema updates: N/A - no tool behavior changed

## Screenshots / Logs

Focused regression suite: 4 passed. Manual startup classification: `chat False`.
