### PR TITLE
fix(cron): stop stale one-shot reminders after downtime

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2952,10 +2952,27 @@ def _machine_id() -> str:
     return f"{host}:{os.getpid()}"
 
 
+_DEFAULT_FIRE_CLAIM_TTL_SECONDS = 300
+
+
+def _claim_is_fresh(
+    claim: Any, now: datetime, claim_ttl_seconds: float
+) -> bool:
+    """Return whether a claim timestamp is valid and inside its bounded lease."""
+    if not isinstance(claim, dict):
+        return False
+    try:
+        claimed_at = _ensure_aware(datetime.fromisoformat(claim["at"]))
+    except (KeyError, TypeError, ValueError):
+        return False
+    age = (now - claimed_at).total_seconds()
+    return 0 <= age < claim_ttl_seconds
+
+
 def claim_job_for_fire(
     job_id: str,
     *,
-    claim_ttl_seconds: int = 300,
+    claim_ttl_seconds: int = _DEFAULT_FIRE_CLAIM_TTL_SECONDS,
     force: bool = False,
     scheduled_fire: bool = True,
     return_job: bool = False,
@@ -2975,7 +2992,7 @@ def claim_job_for_fire(
 def _claim_job_for_fire_locked(
     job_id: str,
     *,
-    claim_ttl_seconds: int = 300,
+    claim_ttl_seconds: int = _DEFAULT_FIRE_CLAIM_TTL_SECONDS,
     force: bool = False,
     scheduled_fire: bool = True,
     return_job: bool = False,
@@ -3018,20 +3035,10 @@ def _claim_job_for_fire_locked(
                 return False
             now = _hermes_now()
             existing = job.get("fire_claim")
-            if existing:
-                try:
-                    claimed_at = _ensure_aware(datetime.fromisoformat(existing["at"]))
-                    # Bounded on BOTH sides (#60703): a claim stamped in the
-                    # future (clock/TZ skew across a restart, or a corrupted
-                    # timestamp) would otherwise have a negative age and stay
-                    # "fresh" forever — the job becomes permanently unfireable
-                    # and every manual `cron run` reports "already being
-                    # fired". Treat future-dated claims as stale/overwritable.
-                    _age = (now - claimed_at).total_seconds()
-                    if 0 <= _age < claim_ttl_seconds:
-                        return False  # someone holds a fresh claim
-                except Exception:
-                    pass  # malformed claim → overwrite
+            # Bounded on BOTH sides (#60703): a claim stamped in the future
+            # must be stale/overwritable rather than permanently blocking fire.
+            if _claim_is_fresh(existing, now, claim_ttl_seconds):
+                return False  # someone holds a fresh claim
             if force:
                 job["enabled"] = True
                 job["state"] = "scheduled"
@@ -3552,6 +3559,17 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                     continue
 
                 if _oneshot_missed_grace(job, next_run_dt, now):
+                    # An explicit Run-now leaves a one-shot's stale schedule in
+                    # place while fire_claim owns the execution. A concurrent
+                    # built-in ticker must not retire that in-flight run or
+                    # clear its ownership fence. Expired/malformed/future-dated
+                    # claims still fall through to normal stale retirement.
+                    if _claim_is_fresh(
+                        job.get("fire_claim"),
+                        now,
+                        _DEFAULT_FIRE_CLAIM_TTL_SECONDS,
+                    ):
+                        continue
                     logger.info(
                         "Job '%s': one-shot missed its scheduled time (%s, grace=%ds); "
                         "retiring without dispatch",

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -865,6 +865,31 @@ def _recoverable_oneshot_run_at(
     return None
 
 
+def _oneshot_missed_grace(
+    job: Dict[str, Any], next_run_dt: datetime, now: datetime
+) -> bool:
+    schedule = job.get("schedule")
+    return (
+        isinstance(schedule, dict)
+        and schedule.get("kind") == "once"
+        and (now - next_run_dt).total_seconds() > ONESHOT_GRACE_SECONDS
+    )
+
+
+def _mark_oneshot_missed(job: Dict[str, Any], now: datetime) -> None:
+    """Retire an expired one-shot without recording a run that never happened."""
+    job["enabled"] = False
+    job["state"] = "completed"
+    job["next_run_at"] = None
+    job["last_status"] = "missed"
+    job["last_error"] = (
+        f"One-shot missed its {ONESHOT_GRACE_SECONDS}-second grace window and was not run"
+    )
+    job["missed_at"] = now.isoformat()
+    job["fire_claim"] = None
+    job["run_claim"] = None
+
+
 def _compute_grace_seconds(schedule: dict) -> int:
     """Compute how late a job can be and still catch up instead of fast-forwarding.
 
@@ -3007,12 +3032,32 @@ def _claim_job_for_fire_locked(
                 job["state"] = "scheduled"
                 job["paused_at"] = None
                 job["paused_reason"] = None
+            kind = job.get("schedule", {}).get("kind")
+            if not force and kind == "once":
+                next_run_at = job.get("next_run_at")
+                try:
+                    next_run_dt = _ensure_aware(datetime.fromisoformat(next_run_at))
+                except (TypeError, ValueError):
+                    next_run_dt = None
+                if next_run_dt is not None and _oneshot_missed_grace(
+                    job, next_run_dt, now
+                ):
+                    _mark_oneshot_missed(job, now)
+                    save_jobs(jobs)
+                    logger.info(
+                        "Job '%s': one-shot missed its scheduled time (%s, grace=%ds); "
+                        "retiring without dispatch",
+                        job.get("name", job_id),
+                        next_run_at,
+                        ONESHOT_GRACE_SECONDS,
+                    )
+                    return False
+
             # Per-acquisition token: a process may legitimately reclaim its own
             # stale lease, and the previous runner must not heartbeat the new
             # claim merely because hostname + PID are unchanged.
             owner = f"{_machine_id()}:{uuid.uuid4().hex}"
             job["fire_claim"] = {"at": now.isoformat(), "by": owner}
-            kind = job.get("schedule", {}).get("kind")
             if kind in {"cron", "interval"}:
                 nxt = compute_next_run(job["schedule"], now.isoformat())
                 if nxt:
@@ -3061,8 +3106,9 @@ def _sweep_completed_oneshots(
     ``save_jobs``'s shrink-merge guard (#80624) allows the intentional delete.
     Only one-shot (``schedule.kind == "once"``) records in the terminal
     completed state are candidates; recurring jobs and non-terminal one-shots
-    are never touched. Age is measured from ``last_run_at`` — a completed
-    record without a parseable ``last_run_at`` is kept (never guess a record
+    are never touched. Age is measured from ``last_run_at`` for executed jobs
+    or ``missed_at`` for one-shots retired without execution. A completed
+    record without either parseable timestamp is kept (never guess a record
     into deletion).
     """
     retention_days = _completed_oneshot_retention_days()
@@ -3078,7 +3124,7 @@ def _sweep_completed_oneshots(
             kind = schedule.get("kind") if isinstance(schedule, dict) else None
             if kind != "once":
                 continue
-            last_run = rj.get("last_run_at")
+            last_run = rj.get("last_run_at") or rj.get("missed_at")
             if not isinstance(last_run, str):
                 continue
             try:
@@ -3498,6 +3544,22 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                                 rj["next_run_at"] = new_next
                                 needs_save = True
                                 break
+                    continue
+
+                if _oneshot_missed_grace(job, next_run_dt, now):
+                    logger.info(
+                        "Job '%s': one-shot missed its scheduled time (%s, grace=%ds); "
+                        "retiring without dispatch",
+                        job.get("name", job.get("id", "?")),
+                        next_run,
+                        ONESHOT_GRACE_SECONDS,
+                    )
+                    _mark_oneshot_missed(job, now)
+                    for rj in raw_jobs:
+                        if rj["id"] == job["id"]:
+                            _mark_oneshot_missed(rj, now)
+                            needs_save = True
+                            break
                     continue
 
                 # For recurring jobs, check if the scheduled time is stale

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2957,6 +2957,7 @@ def claim_job_for_fire(
     *,
     claim_ttl_seconds: int = 300,
     force: bool = False,
+    scheduled_fire: bool = True,
     return_job: bool = False,
 ) -> Union[bool, Dict[str, Any]]:
     with _fire_job_lock(job_id) as acquired:
@@ -2966,6 +2967,7 @@ def claim_job_for_fire(
             job_id,
             claim_ttl_seconds=claim_ttl_seconds,
             force=force,
+            scheduled_fire=scheduled_fire,
             return_job=return_job,
         )
 
@@ -2975,6 +2977,7 @@ def _claim_job_for_fire_locked(
     *,
     claim_ttl_seconds: int = 300,
     force: bool = False,
+    scheduled_fire: bool = True,
     return_job: bool = False,
 ) -> Union[bool, Dict[str, Any]]:
     """Atomically claim a job for a single external 'fire' (multi-machine
@@ -2985,9 +2988,11 @@ def _claim_job_for_fire_locked(
     exactly one wins. Single-machine deployments always win.
 
     Under the file lock: reject if the job is missing/disabled/paused. An
-    explicit manual fire may pass ``force=True`` to atomically enable and
-    resume the job as part of the claim; external scheduler callbacks must
-    leave it false so a stale callback cannot resurrect a paused job. If a
+    explicit manual fire passes ``scheduled_fire=False`` so the one-shot grace
+    window does not turn an intentional Run-now request into a missed run. It
+    may also pass ``force=True`` to atomically enable and resume the job as part
+    of the claim; external scheduler callbacks must leave both defaults intact
+    so a stale callback cannot resurrect a paused job. If a
     fresh claim (younger than ``claim_ttl_seconds``) already exists, lose.
     Otherwise stamp a ``fire_claim`` and, for recurring jobs, advance
     ``next_run_at`` (mirrors ``advance_next_run``'s at-most-once bump so a stale
@@ -3033,7 +3038,7 @@ def _claim_job_for_fire_locked(
                 job["paused_at"] = None
                 job["paused_reason"] = None
             kind = job.get("schedule", {}).get("kind")
-            if not force and kind == "once":
+            if scheduled_fire and not force and kind == "once":
                 next_run_at = job.get("next_run_at")
                 try:
                     next_run_dt = _ensure_aware(datetime.fromisoformat(next_run_at))

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -394,14 +394,6 @@ def fire_overdue_jobs(
         if overdue_seconds < grace_minutes * 60:
             continue
         job_id = str(job.get("id") or "")
-        logger.warning(
-            "Misfire catch-up: job %s (%s) was due %s (%.0f min overdue) and "
-            "no external fire arrived — firing locally.",
-            job_id,
-            job.get("name") or "unnamed",
-            next_run_at,
-            overdue_seconds / 60,
-        )
         try:
             # Two-phase, webhook-style: claim synchronously (fast store
             # CAS — losing means an external retry beat us, which is
@@ -410,6 +402,14 @@ def fire_overdue_jobs(
             claimed = provider.claim_fire(job_id)
             if claimed is None:
                 continue
+            logger.warning(
+                "Misfire catch-up: job %s (%s) was due %s (%.0f min overdue) and "
+                "no external fire arrived — firing locally.",
+                job_id,
+                job.get("name") or "unnamed",
+                next_run_at,
+                overdue_seconds / 60,
+            )
             threading.Thread(
                 target=provider.fire_claimed,
                 args=(claimed,),

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -147,6 +147,11 @@ class CronScheduler(ABC):
         """
         return provider_supports_force_fire(self)
 
+    @property
+    def supports_scheduled_fire(self) -> bool:
+        """Whether manual intent can flow through ``fire_due`` safely."""
+        return provider_supports_scheduled_fire(self)
+
     def fire_due(
         self,
         job_id: str,
@@ -154,6 +159,7 @@ class CronScheduler(ABC):
         adapters: Any = None,
         loop: Any = None,
         force: bool = False,
+        scheduled_fire: bool = True,
     ) -> bool:
         """Run a single job NOW via the shared orchestrator. Called by the
         inbound fire webhook when an external scheduler signals a job is due.
@@ -167,12 +173,22 @@ class CronScheduler(ABC):
         the job itself failed. Returns False only if the claim was lost
         (another machine/retry won it) or the job no longer exists.
         """
-        claimed_job = self.claim_fire(job_id, force=force)
+        claimed_job = self.claim_fire(
+            job_id,
+            force=force,
+            scheduled_fire=scheduled_fire,
+        )
         if claimed_job is None:
             return False
         return self.fire_claimed(claimed_job, adapters=adapters, loop=loop)
 
-    def claim_fire(self, job_id: str, *, force: bool = False) -> dict | None:
+    def claim_fire(
+        self,
+        job_id: str,
+        *,
+        force: bool = False,
+        scheduled_fire: bool = True,
+    ) -> dict | None:
         """Durably claim one fire and create its audit attempt before dispatch.
 
         Webhook transports call this synchronously before acknowledging the
@@ -186,6 +202,8 @@ class CronScheduler(ABC):
         claim_kwargs = {"return_job": True}
         if force:
             claim_kwargs["force"] = True
+        if not scheduled_fire:
+            claim_kwargs["scheduled_fire"] = False
         try:
             claimed_job = claim_job_for_fire(job_id, **claim_kwargs)
         except BaseException as exc:
@@ -252,6 +270,36 @@ def provider_supports_force_fire(provider: Any) -> bool:
         )
         for parameter in parameters
     )
+
+
+def _accepts_keyword(callable_obj: Any, keyword: str) -> bool:
+    try:
+        parameters = inspect.signature(callable_obj).parameters.values()
+    except (TypeError, ValueError):
+        return False
+    return any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        or (
+            parameter.name == keyword
+            and parameter.kind
+            in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+        )
+        for parameter in parameters
+    )
+
+
+def provider_supports_scheduled_fire(provider: Any) -> bool:
+    """Return whether ``scheduled_fire`` reaches the provider claim safely.
+
+    The base ``fire_due`` virtually dispatches through ``claim_fire``, so a
+    provider with a legacy claim override must not receive the new keyword even
+    though its inherited first phase accepts it.
+    """
+    if not _accepts_keyword(provider.fire_due, "scheduled_fire"):
+        return False
+    if type(provider).fire_due is CronScheduler.fire_due:
+        return _accepts_keyword(provider.claim_fire, "scheduled_fire")
+    return True
 
 
 def provider_supports_split_fire(provider: Any) -> bool:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13291,6 +13291,7 @@ def _fire_cron_job_for_profile(
     from cron import jobs as cron_jobs
     from cron.scheduler_provider import (
         provider_supports_force_fire,
+        provider_supports_scheduled_fire,
         resolve_cron_scheduler,
     )
     from hermes_constants import (
@@ -13302,6 +13303,9 @@ def _fire_cron_job_for_profile(
     try:
         with cron_jobs.use_cron_store(home):
             provider = resolve_cron_scheduler()
+            fire_kwargs = {"adapters": None, "loop": None}
+            if provider_supports_scheduled_fire(provider):
+                fire_kwargs["scheduled_fire"] = False
             if force:
                 if not provider_supports_force_fire(provider):
                     raise HTTPException(
@@ -13311,10 +13315,8 @@ def _fire_cron_job_for_profile(
                             "does not support atomic forced firing of paused jobs"
                         ),
                     )
-                return bool(
-                    provider.fire_due(job_id, adapters=None, loop=None, force=True)
-                )
-            return bool(provider.fire_due(job_id, adapters=None, loop=None))
+                fire_kwargs["force"] = True
+            return bool(provider.fire_due(job_id, **fire_kwargs))
     finally:
         reset_hermes_home_override(token)
 

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -112,6 +112,32 @@ def test_manual_run_claims_stale_oneshot_without_marking_it_missed(
     assert persisted.get("missed_at") is None
 
 
+def test_due_scan_preserves_manual_claim_for_stale_oneshot(temp_home, monkeypatch):
+    """A scheduler scan must not retire an in-flight explicit Run-now."""
+    import cron.jobs as jobs
+
+    now = datetime(2026, 6, 22, 20, 0, 0, tzinfo=timezone.utc)
+    run_at = (now - timedelta(hours=1)).isoformat()
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: now)
+    job = jobs.create_job(prompt="x", schedule="1h", name="manual stale")
+    records = jobs.load_jobs()
+    records[0]["schedule"] = {"kind": "once", "run_at": run_at}
+    records[0]["next_run_at"] = run_at
+    jobs.save_jobs(records)
+
+    claimed = jobs.claim_job_for_fire(
+        job["id"], scheduled_fire=False, return_job=True
+    )
+    owner = claimed["fire_claim"]
+
+    assert jobs.get_due_jobs() == []
+    persisted = jobs.get_job(job["id"])
+    assert persisted["enabled"] is True
+    assert persisted["state"] == "scheduled"
+    assert persisted["fire_claim"] == owner
+    assert persisted.get("last_status") != "missed"
+
+
 def test_stale_claim_is_reclaimable(temp_home, monkeypatch):
     """A claim older than the TTL is overwritten — the fire isn't stuck forever
     if the winning machine crashed before mark_job_run cleared the claim."""

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -9,6 +9,7 @@ E2E-over-mocks discipline for file-touching code.
 """
 import threading
 import time
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -74,6 +75,41 @@ def test_forced_claim_atomically_resumes_paused_job(temp_home):
     assert claimed["paused_at"] is None
     assert claimed["paused_reason"] is None
     assert claimed["fire_claim"] is not None
+
+
+def test_manual_run_claims_stale_oneshot_without_marking_it_missed(
+    temp_home, monkeypatch
+):
+    """Run-now is intentional execution, not a delayed scheduled fire."""
+    import cron.jobs as jobs
+    import tools.cronjob_tools as cronjob_tools
+
+    now = datetime(2026, 6, 22, 20, 0, 0, tzinfo=timezone.utc)
+    run_at = (now - timedelta(hours=1)).isoformat()
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: now)
+    job = jobs.create_job(prompt="x", schedule="1h", name="manual stale")
+    records = jobs.load_jobs()
+    records[0]["schedule"] = {"kind": "once", "run_at": run_at}
+    records[0]["next_run_at"] = run_at
+    jobs.save_jobs(records)
+    monkeypatch.setattr(
+        cronjob_tools,
+        "_run_claimed_job",
+        lambda claimed_job, extra_prompt=None: {
+            "claimed": True,
+            "success": True,
+            "error": None,
+        },
+    )
+
+    result = cronjob_tools._execute_job_now(job)
+
+    assert result["claimed"] is True
+    persisted = jobs.get_job(job["id"])
+    assert persisted["enabled"] is True
+    assert persisted["state"] == "scheduled"
+    assert persisted.get("last_status") != "missed"
+    assert persisted.get("missed_at") is None
 
 
 def test_stale_claim_is_reclaimable(temp_home, monkeypatch):

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -138,6 +138,37 @@ class TestNaiveScheduleTimezoneDivergence:
             f"one-shot should be due; next_run_at={job['next_run_at']}"
         )
 
+    def test_stale_stored_oneshot_is_retired_without_firing(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        """A persisted one-shot beyond the miss grace must not fire on restart."""
+        now = datetime(2026, 6, 22, 20, 0, 0, tzinfo=timezone.utc)
+        run_at = (now - timedelta(hours=1)).isoformat()
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        save_jobs(
+            [{
+                "id": "stale-oneshot",
+                "name": "Stale reminder",
+                "prompt": "old reminder",
+                "schedule": {"kind": "once", "run_at": run_at},
+                "next_run_at": run_at,
+                "repeat": {"times": 1, "completed": 0},
+                "enabled": True,
+                "state": "scheduled",
+            }]
+        )
+
+        assert get_due_jobs() == []
+
+        retired = get_job("stale-oneshot")
+        assert retired["enabled"] is False
+        assert retired["state"] == "completed"
+        assert retired["last_status"] == "missed"
+        assert retired["next_run_at"] is None
+        assert retired.get("last_run_at") is None
+        assert retired["missed_at"] == now.isoformat()
+        assert retired["repeat"]["completed"] == 0
+
 
 # =========================================================================
 # compute_next_run
@@ -1573,6 +1604,24 @@ class TestCompletedOneshotRetentionSweep:
         assert kept is not None
         assert kept["state"] == "completed"
         assert kept["last_delivery_error"] == "boom"
+
+    def test_sweep_ages_missed_oneshot_from_missed_at(self, tmp_cron_dir):
+        missed_at = (
+            datetime.now(timezone.utc) - timedelta(days=30)
+        ).isoformat()
+        save_jobs([{
+            "id": "old-missed",
+            "schedule": {"kind": "once", "run_at": missed_at},
+            "enabled": False,
+            "state": "completed",
+            "next_run_at": None,
+            "last_status": "missed",
+            "missed_at": missed_at,
+        }])
+
+        get_due_jobs()
+
+        assert get_job("old-missed") is None
 
     def test_sweep_ignores_recurring_jobs(self, tmp_cron_dir):
         """Old recurring jobs are never candidates, whatever their history."""

--- a/tests/cron/test_misfire_catchup.py
+++ b/tests/cron/test_misfire_catchup.py
@@ -82,6 +82,32 @@ class TestFireOverdueJobs:
         assert provider.wait_fired()
         assert provider.fired == [job["id"]]
 
+    def test_retires_stale_oneshot_instead_of_firing(self, tmp_cron_dir):
+        job = create_job(prompt="p", schedule="1h")
+        _park_in_past(job["id"], minutes=60)
+        provider = RecordingProvider()
+
+        assert fire_overdue_jobs(provider) == 0
+        assert provider.fired == []
+
+        retired = get_job(job["id"])
+        assert retired["enabled"] is False
+        assert retired["state"] == "completed"
+        assert retired["last_status"] == "missed"
+        assert retired["next_run_at"] is None
+
+    def test_fires_oneshot_within_its_grace(self, tmp_cron_dir, monkeypatch):
+        monkeypatch.setattr(
+            "cron.scheduler_provider._misfire_grace_minutes", lambda: 1.0
+        )
+        job = create_job(prompt="p", schedule="1h")
+        _park_in_past(job["id"], minutes=1.5)
+        provider = RecordingProvider()
+
+        assert fire_overdue_jobs(provider) == 1
+        assert provider.wait_fired()
+        assert provider.fired == [job["id"]]
+
     def test_respects_grace_window(self, tmp_cron_dir):
         """A job only a few minutes overdue is still the external
         scheduler's to retry — the backstop must not race it."""

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -162,6 +162,30 @@ def test_force_fire_capability_detects_legacy_override():
     assert KeywordSink().supports_force_fire is True
 
 
+def test_scheduled_fire_capability_detects_legacy_claim_override():
+    from cron.scheduler_provider import CronScheduler
+
+    class Current(CronScheduler):
+        @property
+        def name(self):
+            return "current"
+
+        def start(self, stop_event, **kw):
+            pass
+
+    class LegacyClaim(Current):
+        def claim_fire(self, job_id, *, force=False):
+            return None
+
+    class KeywordSink(Current):
+        def claim_fire(self, job_id, **kwargs):
+            return None
+
+    assert Current().supports_scheduled_fire is True
+    assert LegacyClaim().supports_scheduled_fire is False
+    assert KeywordSink().supports_scheduled_fire is True
+
+
 def test_inprocess_provider_ticks_and_stops():
     """The built-in provider drives cron.scheduler.tick(sync=False) on a loop
     and exits promptly when stop_event is set — same contract as the raw
@@ -436,8 +460,15 @@ def test_fire_due_forwards_manual_force_to_store_claim(monkeypatch):
     )
     monkeypatch.setattr(sched, "run_one_job", lambda job, **kw: True)
 
-    assert InProcessCronScheduler().fire_due("j1", force=True) is True
-    assert claims == [("j1", {"force": True, "return_job": True})]
+    assert InProcessCronScheduler().fire_due(
+        "j1", force=True, scheduled_fire=False
+    ) is True
+    assert claims == [
+        (
+            "j1",
+            {"force": True, "scheduled_fire": False, "return_job": True},
+        )
+    ]
 
 
 def test_fire_due_lost_claim_does_not_run(monkeypatch):

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -1,6 +1,7 @@
 """Regression tests for dashboard cron job profile routing."""
 
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
 import json
 from queue import Empty, SimpleQueue
 import threading
@@ -535,12 +536,21 @@ async def test_trigger_cron_job_fires_only_selected_job_and_returns_refreshed_st
     fired = []
 
     class RecordingProvider:
-        def fire_due(self, job_id, *, adapters=None, loop=None, force=False):
+        def fire_due(
+            self,
+            job_id,
+            *,
+            adapters=None,
+            loop=None,
+            force=False,
+            scheduled_fire=True,
+        ):
             fired.append(
                 {
                     "job_id": job_id,
                     "jobs_file": cron_jobs._current_cron_store().jobs_file,
                     "force": force,
+                    "scheduled_fire": scheduled_fire,
                 }
             )
             cron_jobs.mark_job_run(job_id, success=True)
@@ -568,6 +578,7 @@ async def test_trigger_cron_job_fires_only_selected_job_and_returns_refreshed_st
             "job_id": selected["id"],
             "jobs_file": isolated_profiles["worker_alpha"] / "cron" / "jobs.json",
             "force": False,
+            "scheduled_fire": False,
         }
     ]
     assert triggered["last_status"] == "ok"
@@ -578,6 +589,60 @@ async def test_trigger_cron_job_fires_only_selected_job_and_returns_refreshed_st
         sibling["id"],
     )
     assert untouched["last_run_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_trigger_cron_job_runs_stale_oneshot_as_manual_fire(
+    isolated_profiles,
+    monkeypatch,
+):
+    from cron import jobs as cron_jobs
+    from cron.scheduler_provider import CronScheduler
+    from hermes_cli import web_server
+
+    now = datetime(2026, 6, 22, 20, 0, 0, tzinfo=timezone.utc)
+    run_at = (now - timedelta(hours=1)).isoformat()
+    monkeypatch.setattr(cron_jobs, "_hermes_now", lambda: now)
+    job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="run stale one-shot intentionally",
+        schedule="1h",
+        name="stale-manual-trigger",
+    )
+    with cron_jobs.use_cron_store(isolated_profiles["worker_alpha"]):
+        records = cron_jobs.load_jobs()
+        records[0]["schedule"] = {"kind": "once", "run_at": run_at}
+        records[0]["next_run_at"] = run_at
+        cron_jobs.save_jobs(records)
+    fired = []
+
+    class ManualProvider(CronScheduler):
+        @property
+        def name(self):
+            return "manual-test"
+
+        def start(self, stop_event, **kwargs):
+            pass
+
+        def fire_claimed(self, claimed_job, **kwargs):
+            fired.append(claimed_job["id"])
+            cron_jobs.mark_job_run(claimed_job["id"], success=True)
+            return True
+
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler",
+        lambda: ManualProvider(),
+    )
+
+    triggered = await web_server.trigger_cron_job(
+        job["id"],
+        profile="worker_alpha",
+    )
+
+    assert fired == [job["id"]]
+    assert triggered["last_status"] == "ok"
+    assert triggered.get("missed_at") is None
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -79,7 +79,9 @@ class TestBackgroundDispatch:
             assert res["claimed"] is True
             assert res["dispatched"] is True
             assert res["delegation_id"]
-            m_claim.assert_called_once_with("job-bg-01", return_job=True)
+            m_claim.assert_called_once_with(
+                "job-bg-01", scheduled_fire=False, return_job=True
+            )
             # The job actually starts on the daemon executor.
             assert run_started.wait(timeout=5.0), "job never started in background"
         finally:
@@ -304,5 +306,7 @@ class TestCronjobRunToolIntegration:
         assert out["success"] is True
         assert out["job"]["executed"] is True
         assert out["job"]["execution_success"] is True
-        m_claim.assert_called_once_with("job-bg-13", return_job=True)
+        m_claim.assert_called_once_with(
+            "job-bg-13", scheduled_fire=False, return_job=True
+        )
         m_run.assert_called_once()

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -39,7 +39,9 @@ class TestCronjobRunExecutesImmediately:
         assert out["success"] is True
         assert out["job"]["executed"] is True
         assert out["job"]["execution_success"] is True
-        m_claim.assert_called_once_with("job-run-1", return_job=True)
+        m_claim.assert_called_once_with(
+            "job-run-1", scheduled_fire=False, return_job=True
+        )
         m_run.assert_called_once_with(claimed, adapters=None, loop=None, extra_prompt=None)
 
     def test_run_reconciles_external_provider_after_claimed_execution(self):

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -741,7 +741,13 @@ def _execute_job_now(
     claimed_job = None
     try:
         # At-most-once claim: bail without running if a tick/other fire owns it.
-        claimed_job = claim_job_for_fire(job_id, return_job=True)
+        # This is an explicit Run-now request, so a past schedule does not make
+        # the requested execution a stale scheduled fire.
+        claimed_job = claim_job_for_fire(
+            job_id,
+            scheduled_fire=False,
+            return_job=True,
+        )
         if not isinstance(claimed_job, dict):
             # claim_job_for_fire returns False for paused/disabled/missing
             # jobs too — don't mislabel those as "already being fired"
@@ -1081,9 +1087,14 @@ def _try_dispatch_background_run(
         except Exception:
             pass
 
-        # Same snapshot claim as _execute_job_now: carry the owner-bearing
-        # record into the run so terminal writes stay fenced by this owner.
-        claimed_job = claim_job_for_fire(job_id, return_job=True)
+        # Same manual snapshot claim as _execute_job_now: carry the
+        # owner-bearing record into the run so terminal writes stay fenced by
+        # this owner without treating Run-now as a stale scheduled fire.
+        claimed_job = claim_job_for_fire(
+            job_id,
+            scheduled_fire=False,
+            return_job=True,
+        )
         if not isinstance(claimed_job, dict):
             refreshed = get_job(job_id)
             if refreshed is None:


### PR DESCRIPTION
## What does this PR do?

Prevents one-shot cron jobs missed by more than the documented 120-second grace window from firing stale reminders after gateway or machine downtime. The fix retires expired one-shots as inspectable `completed` records with `last_status: missed`, while preserving recent one-shots and recurring catch-up behavior.

### Symptom

A stored one-shot with a past `next_run_at` fired on the next scheduler tick even when it was hours or days late.

### Impact

Users could receive obsolete reminders and pay for an unnecessary agent run after restarting Hermes following downtime.

### Bug Cause

**Trigger:** `cron/jobs.py` / `_get_due_jobs_locked()` when `next_run_at <= now`

**Causal chain:**
1. A machine or gateway remains offline past a one-shot job's scheduled time.
2. The persisted `next_run_at` remains present and past, so the missing-value recovery guard is bypassed.
3. The due scan applies stale-run grace only to recurring jobs and dispatches the one-shot regardless of age. The external-provider backstop reaches the same unbounded claim path.

**Why it is wrong:** One-shot creation, update, resume, and missing-`next_run_at` recovery enforce `ONESHOT_GRACE_SECONDS`, but normal stored due jobs did not.

**Working sibling / contrast:** One-shots whose `next_run_at` is missing already use `_recoverable_oneshot_run_at()` and stop being eligible after 120 seconds.

**Ruled out:** This is not a timezone parsing failure; the failing branch compares two aware datetimes correctly but omits the one-shot staleness condition.

### Fix

- Centralize the one-shot grace check and terminal missed-state transition.
- Retire expired one-shots in the built-in due scan without incrementing their run count or setting `last_run_at`.
- Reject stale non-manual external fire claims through the shared atomic claim path, while preserving explicit force-runs.
- Retain missed records for the same configured period as executed one-shots, using `missed_at` for retention age.
- Log external misfire dispatch only after the claim succeeds.

## Related Issue

Closes #93526

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/jobs.py` - enforce one-shot grace in built-in and external claim paths and persist missed outcomes.
- `cron/scheduler_provider.py` - avoid reporting an external catch-up fire when its claim was rejected.
- `tests/cron/test_jobs.py` - cover stored overdue retirement and missed-record retention.
- `tests/cron/test_misfire_catchup.py` - cover external stale retirement and within-grace dispatch.

## How to Test

1. Store an enabled one-shot with `next_run_at` one hour in the past and run the due scan; verify it is not returned and is marked `completed` / `missed`.
2. Run the external misfire backstop against the same state; verify no provider fire occurs.
3. Run:

```bash
scripts/run_tests.sh tests/cron/test_jobs.py tests/cron/test_misfire_catchup.py tests/cron/test_claim_job_for_fire.py
```

Result: 105 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior matches the existing documented grace window
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - platform-independent datetime and store logic
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - covered by deterministic cron store and scheduler tests.
