### PR TITLE
fix(cron): retire stale past-due one-shots instead of firing hours late

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -3500,6 +3500,39 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                                 break
                     continue
 
+                # Stale one-shot guard (#93526): ONESHOT_GRACE_SECONDS is the
+                # one-shot miss-grace, already the enforced contract at the
+                # create/update/resume entry points and in the recovery helper
+                # (_recoverable_oneshot_run_at deems a >grace one-shot
+                # ineligible). But a one-shot stored WITH a past next_run_at —
+                # the normal shape after the machine was off across its fire
+                # time — fell straight through to due.append and fired
+                # arbitrarily late, running a full agent turn to deliver a
+                # stale alert. Skip the fire and retire the record as missed
+                # (terminal retention shape: outcomes stay inspectable, no
+                # last_run_at/last_status write — no run happened), so it
+                # cannot re-evaluate past-due on every tick.
+                if (
+                    kind == "once"
+                    and (now - next_run_dt).total_seconds() > ONESHOT_GRACE_SECONDS
+                ):
+                    logger.info(
+                        "Job '%s': one-shot missed its fire time by %ds "
+                        "(grace=%ds, machine off across it?) — skipping the "
+                        "stale fire and retiring the record as missed",
+                        job.get("name", job.get("id", "?")),
+                        int((now - next_run_dt).total_seconds()),
+                        ONESHOT_GRACE_SECONDS,
+                    )
+                    for rj in raw_jobs:
+                        if rj["id"] == job["id"]:
+                            rj["enabled"] = False
+                            rj["state"] = "completed"
+                            rj["next_run_at"] = None
+                            needs_save = True
+                            break
+                    continue
+
                 # For recurring jobs, check if the scheduled time is stale
                 # (gateway was down and missed the window). Fast-forward to
                 # the next future occurrence instead of firing a stale run.

--- a/tests/cron/test_due_stale_oneshot_grace.py
+++ b/tests/cron/test_due_stale_oneshot_grace.py
@@ -1,0 +1,97 @@
+"""Stale one-shot fire guard in the due scan (#93526).
+
+ONESHOT_GRACE_SECONDS is the one-shot miss-grace — the contract already
+enforced at the create/update/resume entry points and by the recovery
+helper (a >grace one-shot with a MISSING next_run_at is ineligible).
+But a one-shot stored WITH a past next_run_at (machine off across its
+fire time) fell through the due scan's grace check (kind excluded) and
+fired arbitrarily late, burning a full agent turn to deliver a stale
+alert. The guard skips the fire and retires the record as missed, using
+the terminal retention shape (enabled=False, state=completed,
+next_run_at=None, no run-outcome writes — no run happened).
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+
+@pytest.fixture
+def temp_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME so jobs.json doesn't touch the real store."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield tmp_path
+
+
+def _seed_past_due_oneshot(home, hours_past=5, name="stale") -> str:
+    """Persist a one-shot whose stored next_run_at is already hours past."""
+    from cron.jobs import create_job, save_jobs, load_jobs, _hermes_now
+
+    job = create_job(prompt="reminder", schedule="2030-01-01T09:00", name=name)
+    now = _hermes_now()
+    stale = (now - timedelta(hours=hours_past)).isoformat()
+    jobs = load_jobs()
+    for j in jobs:
+        if j["id"] == job["id"]:
+            j["next_run_at"] = stale
+            j["schedule"]["run_at"] = stale.split(".")[0]
+    save_jobs(jobs)
+    return job["id"]
+
+
+def test_past_due_oneshot_beyond_grace_not_fired(temp_home):
+    """A one-shot hours past its fire time is retired as missed, not fired."""
+    from cron.jobs import get_due_jobs, get_job
+    from cron.jobs import ONESHOT_GRACE_SECONDS
+
+    assert ONESHOT_GRACE_SECONDS == 120  # guard uses the one-shot contract
+    jid = _seed_past_due_oneshot(temp_home)
+
+    due = get_due_jobs()
+
+    assert [j["id"] for j in due if j["id"] == jid] == []
+    stored = get_job(jid)
+    assert stored["enabled"] is False
+    assert stored["state"] == "completed"
+    assert stored["next_run_at"] is None
+    # No run happened — the run-outcome fields must not claim one did.
+    assert stored.get("last_run_at") is None
+    assert stored.get("repeat", {}).get("completed", 0) == 0
+
+
+def test_recently_due_oneshot_within_grace_still_fires(temp_home):
+    """Control: a one-shot a few seconds past its time still fires — the
+    grace exists so jobs created just after their requested minute run."""
+    from cron.jobs import create_job, save_jobs, load_jobs, get_due_jobs
+    from cron.jobs import _hermes_now
+
+    job = create_job(prompt="fresh", schedule="2030-01-01T09:00", name="ok")
+    now = _hermes_now()
+    recent = (now - timedelta(seconds=30)).isoformat()
+    jobs = load_jobs()
+    for j in jobs:
+        if j["id"] == job["id"]:
+            j["next_run_at"] = recent
+            j["schedule"]["run_at"] = recent.split(".")[0]
+    save_jobs(jobs)
+
+    due = get_due_jobs()
+
+    assert job["id"] in [j["id"] for j in due]
+
+
+def test_retired_missed_oneshot_not_rediscovered_on_next_tick(temp_home):
+    """The retired record cannot re-evaluate past-due on a later tick."""
+    from cron.jobs import get_due_jobs, get_job
+
+    jid = _seed_past_due_oneshot(temp_home, hours_past=5, name="once-only")
+    get_due_jobs()  # first tick retires it
+
+    due_again = get_due_jobs()  # second tick must be a no-op for it
+
+    assert [j["id"] for j in due_again if j["id"] == jid] == []
+    stored = get_job(jid)
+    assert stored["enabled"] is False
+    assert stored["next_run_at"] is None


### PR DESCRIPTION
## What does this PR do?

Stops a one-shot whose fire time was missed (machine off / gateway down across it) from firing hours or days late — it is now retired as missed, honoring the same grace contract every other one-shot surface already enforces.

`ONESHOT_GRACE_SECONDS` (120s) is the one-shot miss-grace. It is already the enforced contract at the **create/update/resume** entry points (they reject past times beyond 120s) and in the **recovery helper** (`_recoverable_oneshot_run_at` deems a >grace one-shot with a missing `next_run_at` ineligible). But the due scan's catch-up grace check was `kind in {"cron", "interval"}` — **`"once"` was excluded**, so a one-shot stored *WITH* a past `next_run_at` (the normal stored state after the machine was off across its fire time, exactly the report's boot-at-14:00-for-a-09:00-job scenario) fell straight through to `due.append` and fired arbitrarily late, running a full agent turn to deliver a stale alert (#93526).

The guard: a `kind == "once"` more than `ONESHOT_GRACE_SECONDS` past its stored instant is skipped and retired as missed — `enabled=False`, `state="completed"`, `next_run_at=None` (the terminal retention shape, same as the dispatch-limit guard's, so outcomes stay inspectable) — with **no run-outcome writes**: `last_run_at` / `last_status` / `repeat.completed` stay untouched because no run happened. A log line carries the skip reason and the missed-by amount. Retiring also stops the record from re-evaluating past-due on every tick.

Within the grace window (seconds past, e.g. a job created just after its requested minute), the one-shot still fires — that is what the grace exists for.

## Related Issue

Fixes #93526

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/jobs.py` — in `_get_due_jobs_locked()`'s `if next_run_dt <= now:` block, a new stale one-shot guard *before* the recurring catch-up logic: `kind == "once"` more than `ONESHOT_GRACE_SECONDS` past → retire as missed (terminal retention shape, no run-outcome writes) + log + `continue`.
- `tests/cron/test_due_stale_oneshot_grace.py` — three regressions on the temp-HERMES_HOME real-store pattern: a 5-hours-past one-shot is not fired and is retired (`enabled=False` / `state="completed"` / `next_run_at=None` / `last_run_at is None` / `repeat.completed == 0`); a 30-seconds-past one-shot still fires (grace control); the retired record is not rediscovered on a second tick.

## How to Test

`pytest tests/cron/test_due_stale_oneshot_grace.py -q` — should pass (3 tests).

Observed result: with the fix, 3/3 pass. With the cron/jobs.py change stashed (fix reverted, tests kept), the two past-due tests fail — the 5-hours-stale one-shot IS returned due, which is the arbitrarily-late fire from the issue — while the within-grace control passes on main by design. Full `tests/cron` suite: 879 passed; the 5 failures in `test_script_claim_heartbeat.py` (process-tree kill tests) reproduce identically on unpatched main and are environment-local, unrelated to this change.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (grace-contract alignment and no-run-outcome rationale at the guard)
- [x] Tests added that prove the fix works
- [x] New and existing unit tests pass locally (3/3 new; suite 879 passed + 5 pre-existing env failures)
- [x] Platform: macOS (pure scheduler logic, platform-independent)
