### PR TITLE
fix(camofox): recreate tabs after browser restart

### DIFF
--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -3,6 +3,7 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import requests
 
 from tools.browser_camofox import (
     camofox_back,
@@ -106,6 +107,42 @@ class TestCamofoxNavigate:
         assert result["success"] is True
         assert result["url"] == "https://example.com"
 
+
+    def test_recovers_from_stale_tab_410_after_camofox_restart(self, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        stale_response = _mock_response(status=410)
+        stale_response.raise_for_status.side_effect = requests.HTTPError(
+            "Gone", response=stale_response
+        )
+
+        with (
+            patch(
+                "tools.browser_camofox.requests.get",
+                return_value=_mock_response(
+                    json_data={"snapshot": "", "refsCount": 0}
+                ),
+            ),
+            patch(
+                "tools.browser_camofox.requests.post",
+                side_effect=[
+                    _mock_response(
+                        json_data={"tabId": "stale-tab", "url": "https://a.com"}
+                    ),
+                    stale_response,
+                    _mock_response(
+                        json_data={"tabId": "fresh-tab", "url": "https://b.com"}
+                    ),
+                ],
+            ) as mock_post,
+        ):
+            first = json.loads(camofox_navigate("https://a.com", task_id="restart-410"))
+            second = json.loads(camofox_navigate("https://b.com", task_id="restart-410"))
+
+        assert first["success"] is True
+        assert second["success"] is True
+        assert second["url"] == "https://b.com"
+        assert "/tabs/stale-tab/navigate" in mock_post.call_args_list[1].args[0]
+        assert mock_post.call_args_list[2].args[0].endswith("/tabs")
 
     def test_connection_error_returns_helpful_message(self, monkeypatch):
         monkeypatch.setenv("CAMOFOX_URL", "http://localhost:19999")

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -521,7 +521,8 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
             session = _ensure_tab(task_id, browser_url)
             data = {"ok": True, "url": browser_url}
         else:
-            # Navigate existing tab — recover from stale tab 404
+            # Recover when Camofox no longer knows the locally cached tab.
+            # The tab reaper returns 404; a container restart returns 410.
             try:
                 data = _post(
                     f"/tabs/{session['tab_id']}/navigate",
@@ -529,11 +530,13 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
                     timeout=60,
                 )
             except requests.HTTPError as e:
-                if e.response is not None and e.response.status_code == 404:
+                status = e.response.status_code if e.response is not None else None
+                if status in (404, 410):
                     logger.warning(
-                        "Camofox tab %s returned 404 — tab was garbage collected. "
+                        "Camofox tab %s returned %s — tab is stale. "
                         "Creating a fresh tab.",
                         session["tab_id"],
+                        status,
                     )
                     session["tab_id"] = None
                     session = _ensure_tab(task_id, browser_url)


### PR DESCRIPTION
## Summary

Camofox deliberately returns `410 Gone` with `browser_restarted` when a client references a tab UUID that was lost during a recent browser restart. Hermes already recovers from stale `404` tab IDs, but treated this equivalent restart signal as a navigation failure.

This change classifies `410` as stale-tab recovery too: clear the cached tab ID, create a fresh tab, and continue navigation. A persisted Camofox profile can then restore browser storage into the fresh session.

## Validation

- Added a regression test for the cached-tab → Camofox restart → `410` → fresh-tab flow.
- `uv run --locked --extra dev --extra messaging python -m pytest tests/tools/test_browser_camofox.py -q`
- Result: `21 passed`
