### PR TITLE
One-shot cron jobs no longer fire hours late after downtime (#93526, salvage #89571)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2714,6 +2714,38 @@ def _write_wedged_oneshot_diagnostic(job: Dict[str, Any]) -> None:
         )
 
 
+def _write_missed_oneshot_diagnostic(job: Dict[str, Any], next_run: str) -> None:
+    """Leave an operator-visible trace when a never-ran one-shot is retired
+    because its persisted run time fell outside the grace window.
+
+    The record is removed because the scheduler will never fire it (see the
+    grace gate in ``_get_due_jobs_locked``); without a diagnostic the job
+    would just vanish. Best-effort: a diagnostic failure never blocks the
+    removal itself.
+    """
+    try:
+        text = (
+            "# Cron job removed before firing (run time outside grace window)\n\n"
+            f"- job id: {job.get('id')}\n"
+            f"- name: {job.get('name')}\n"
+            f"- scheduled run time: {next_run}\n"
+            f"- grace window: {ONESHOT_GRACE_SECONDS}s\n"
+            f"- removed at: {_hermes_now().isoformat()}\n\n"
+            "This one-shot's run time is more than the grace window in the "
+            "past (scheduler down past the window, host asleep, or jobs.json "
+            "edited), which is outside the 'will never fire' contract "
+            "enforced at create/update/resume time. The job was removed "
+            "without running; recreate it (or use the Run button) to "
+            "schedule it again.\n"
+        )
+        save_job_output(job.get("id", ""), text)
+    except Exception as e:
+        logger.debug(
+            "Failed to write missed-oneshot diagnostic for job %r: %s",
+            job.get("id"), e,
+        )
+
+
 def claim_dispatch(job_id: str) -> bool:
     """Atomically claim a finite one-shot job dispatch BEFORE execution.
 
@@ -3534,6 +3566,30 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                                 break
                         record_catch_up_occurrence()
                         # Fall through to due.append(job) — execute once now
+
+                # One-shot grace gate: a one-shot whose persisted run time is
+                # beyond the grace window must never fire. create_job /
+                # update_job / resume_job all reject such schedules ("will
+                # never fire") and _recoverable_oneshot_run_at never recovers
+                # them — only the due-scan acted differently and dispatched a
+                # wall-clock one-shot hours late (gateway down past the
+                # window, host asleep, hand-edited jobs.json).
+                if kind == "once" and (now - next_run_dt).total_seconds() > ONESHOT_GRACE_SECONDS:
+                    if not (job.get("run_claim") or job.get("fire_claim")):
+                        # Nothing was ever dispatched — retire the record with
+                        # a diagnostic so it stops being scanned and the miss
+                        # is operator-visible (retire-not-silently-delete).
+                        _write_missed_oneshot_diagnostic(job, next_run)
+                        for rj in raw_jobs:
+                            if rj["id"] == job["id"]:
+                                raw_jobs.remove(rj)
+                                intentionally_removed.add(str(job["id"]))
+                                needs_save = True
+                                break
+                    # A (possibly stale) claim may mean a run is still in
+                    # flight in another process — skip this scan but keep the
+                    # record so its mark_job_run can still land.
+                    continue
 
                 # One-shot dispatch-limit guard (issue #38758): a finite one-shot
                 # claimed via claim_dispatch() but whose tick died before

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -394,6 +394,27 @@ def fire_overdue_jobs(
         if overdue_seconds < grace_minutes * 60:
             continue
         job_id = str(job.get("id") or "")
+        # One-shot jobs share the module-wide policy: more than
+        # ONESHOT_GRACE_SECONDS past their run time means "will never fire"
+        # (create/update/resume/recovery and, since #89571, the due-scan all
+        # enforce it). The misfire backstop must not resurrect them hours
+        # late after downtime — that's #93526.
+        schedule = job.get("schedule") or {}
+        if str(schedule.get("kind") or "") == "once":
+            from cron.jobs import ONESHOT_GRACE_SECONDS
+
+            if overdue_seconds > ONESHOT_GRACE_SECONDS:
+                logger.warning(
+                    "Misfire catch-up: one-shot job %s (%s) was due %s "
+                    "(%.0f min overdue) — outside the %ss one-shot grace "
+                    "window, not firing.",
+                    job_id,
+                    job.get("name") or "unnamed",
+                    next_run_at,
+                    overdue_seconds / 60,
+                    ONESHOT_GRACE_SECONDS,
+                )
+                continue
         logger.warning(
             "Misfire catch-up: job %s (%s) was due %s (%.0f min overdue) and "
             "no external fire arrived — firing locally.",

--- a/tests/cron/test_misfire_backstop_oneshot_grace.py
+++ b/tests/cron/test_misfire_backstop_oneshot_grace.py
@@ -1,0 +1,96 @@
+"""Misfire-backstop grace gate for one-shot cron jobs (#93526).
+
+``fire_overdue_jobs`` in ``cron/scheduler_provider.py`` is the hosted-provider
+misfire catch-up: any runnable job whose ``next_run_at`` is older than
+``cron.misfire_grace_minutes`` gets fired locally. Before the fix it applied
+no one-shot grace check, so a stored past-due one-shot bypassed
+ONESHOT_GRACE_SECONDS and fired arbitrarily late after downtime — the exact
+"will never fire" contract violation the due-scan gate (#89571) closes on the
+built-in scheduler path.
+
+Pins:
+  - one-shot beyond ONESHOT_GRACE_SECONDS -> backstop skips it (no claim)
+  - recurring job equally overdue          -> backstop still fires it
+"""
+
+from datetime import timedelta
+
+from cron.jobs import ONESHOT_GRACE_SECONDS, _hermes_now
+from cron.scheduler_provider import fire_overdue_jobs
+
+
+class _RecordingProvider:
+    """Non-InProcess provider double that records claim attempts."""
+
+    def __init__(self):
+        self.claimed = []
+
+    def claim_fire(self, job_id):
+        self.claimed.append(job_id)
+        return None  # decline the claim so no thread is spawned
+
+    def fire_claimed(self, *a, **k):  # pragma: no cover - never reached
+        raise AssertionError("fire_claimed must not run when claim declined")
+
+
+def _job(jid, kind, run_at_dt):
+    schedule = {"kind": kind}
+    if kind == "once":
+        schedule["run_at"] = run_at_dt.isoformat()
+    else:
+        schedule["expr"] = "*/5 * * * *"
+    return {
+        "id": jid,
+        "name": jid,
+        "prompt": "x",
+        "schedule": schedule,
+        "next_run_at": run_at_dt.isoformat(),
+        "last_run_at": None,
+        "enabled": True,
+        "state": "scheduled",
+        "repeat": {"times": 1 if kind == "once" else None, "completed": 0},
+        "deliver": "local",
+    }
+
+
+def _run_backstop(monkeypatch, jobs):
+    provider = _RecordingProvider()
+    monkeypatch.setattr("cron.jobs.load_jobs", lambda: jobs)
+    monkeypatch.setattr("cron.jobs.is_job_runnable", lambda j: True)
+    monkeypatch.setattr(
+        "cron.scheduler_provider._misfire_grace_minutes", lambda: 5.0
+    )
+    fired = fire_overdue_jobs(provider)
+    return provider, fired
+
+
+class TestMisfireBackstopOneShotGrace:
+    def test_stale_oneshot_beyond_grace_is_not_fired(self, monkeypatch):
+        now = _hermes_now()
+        stale = _job("stale-once", "once", now - timedelta(hours=2))
+        provider, fired = _run_backstop(monkeypatch, [stale])
+        assert fired == 0
+        assert provider.claimed == []
+
+    def test_overdue_recurring_job_still_fires(self, monkeypatch):
+        now = _hermes_now()
+        overdue = _job("overdue-cron", "cron", now - timedelta(hours=2))
+        provider, fired = _run_backstop(monkeypatch, [overdue])
+        assert provider.claimed == ["overdue-cron"]
+
+    def test_oneshot_within_oneshot_grace_but_past_misfire_grace(
+        self, monkeypatch
+    ):
+        # misfire grace patched to ~0 so a 60s-late one-shot is "overdue" for
+        # the backstop but still inside ONESHOT_GRACE_SECONDS -> must fire.
+        assert ONESHOT_GRACE_SECONDS > 60
+        now = _hermes_now()
+        recent = _job("recent-once", "once", now - timedelta(seconds=60))
+        provider = _RecordingProvider()
+        monkeypatch.setattr("cron.jobs.load_jobs", lambda: [recent])
+        monkeypatch.setattr("cron.jobs.is_job_runnable", lambda j: True)
+        monkeypatch.setattr(
+            "cron.scheduler_provider._misfire_grace_minutes", lambda: 0.5
+        )
+        fire_overdue_jobs(provider)
+        assert provider.claimed == ["recent-once"]

--- a/tests/cron/test_oneshot_grace_due_scan.py
+++ b/tests/cron/test_oneshot_grace_due_scan.py
@@ -1,0 +1,132 @@
+"""Due-scan grace gate for one-shot cron jobs.
+
+create_job / update_job / resume_job all reject a one-shot whose run time is
+more than ONESHOT_GRACE_SECONDS in the past ("will never fire"), and
+``_recoverable_oneshot_run_at`` never recovers such a schedule — but the
+due-scan (``_get_due_jobs_locked``) used to dispatch any one-shot whose
+*persisted* ``next_run_at`` was in the past, even hours later (gateway down
+past the window, host asleep, hand-edited jobs.json). That fired a
+wall-clock one-shot late, contradicting the "will never fire" contract.
+
+These tests pin the due-scan grace gate:
+  - beyond grace  -> not due; record retired with a diagnostic
+  - within grace  -> still due (legitimate catch-up)
+  - beyond grace + claim -> not due, but the record is kept (a run may be
+    in flight in another process; its mark_job_run must still land)
+  - re-triggered  -> due again (the Run button still works)
+"""
+
+import pytest
+from datetime import datetime, timedelta, timezone
+
+from cron.jobs import (
+    get_due_jobs,
+    load_jobs,
+    save_jobs,
+    save_job_output,
+    trigger_job,
+    _hermes_now,
+    ONESHOT_GRACE_SECONDS,
+)
+
+FIXED_NOW = datetime(2026, 6, 22, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture()
+def cron_store(tmp_path, monkeypatch):
+    """Redirect cron storage to a temp dir and pin the clock."""
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: FIXED_NOW)
+    return tmp_path
+
+
+def _oneshot(jid, run_at_dt, *, completed=0, run_claim=None, fire_claim=None):
+    return {
+        "id": jid,
+        "name": jid,
+        "prompt": "x",
+        "schedule": {"kind": "once", "run_at": run_at_dt.isoformat()},
+        "next_run_at": run_at_dt.isoformat(),
+        "last_run_at": None,
+        "enabled": True,
+        "state": "scheduled",
+        "repeat": {"times": 1, "completed": completed},
+        "deliver": "local",
+        "run_claim": run_claim,
+        "fire_claim": fire_claim,
+    }
+
+
+class TestOneShotGraceDueScan:
+    def test_stale_beyond_grace_not_due_and_retired_with_diagnostic(self, cron_store):
+        stale = _oneshot("stale", FIXED_NOW - timedelta(hours=3))
+        save_jobs([stale])
+
+        due = get_due_jobs()
+
+        assert [d["id"] for d in due] == []
+        # Record is retired (removed) so it stops being scanned — with a
+        # diagnostic left behind so the miss is operator-visible.
+        assert [j["id"] for j in load_jobs()] == []
+        out_dir = cron_store / "cron" / "output" / "stale"
+        diag = list(out_dir.glob("*.md")) if out_dir.exists() else []
+        assert diag, "expected a diagnostic file for the retired stale one-shot"
+        assert "outside grace window" in diag[0].read_text(encoding="utf-8")
+
+    def test_within_grace_still_due(self, cron_store):
+        recent = _oneshot("recent", FIXED_NOW - timedelta(seconds=60))
+        save_jobs([recent])
+
+        due = get_due_jobs()
+        assert [d["id"] for d in due] == ["recent"]
+        # Still stored (dispatch proceeds normally).
+        assert [j["id"] for j in load_jobs()] == ["recent"]
+
+    def test_stale_with_claim_skipped_but_record_kept(self, cron_store):
+        # A (possibly stale) run_claim means a run may still be in flight in
+        # another process — the due-scan must not fire OR retire the record,
+        # so mark_job_run can still land.
+        claimed = _oneshot(
+            "claimed",
+            FIXED_NOW - timedelta(hours=3),
+            completed=1,
+            run_claim={"at": (FIXED_NOW - timedelta(hours=3)).isoformat(), "by": "other"},
+        )
+        save_jobs([claimed])
+
+        due = get_due_jobs()
+        assert [d["id"] for d in due] == []
+        # Record preserved (not retired) despite being beyond grace.
+        assert [j["id"] for j in load_jobs()] == ["claimed"]
+
+    def test_retriggered_stale_oneshot_is_due(self, cron_store):
+        # A user can still explicitly re-run a stale one-shot: trigger_job
+        # sets next_run_at=now, which is inside the grace window -> due.
+        stale = _oneshot("stale", FIXED_NOW - timedelta(hours=3))
+        save_jobs([stale])
+        trigger_job("stale")
+
+        due = get_due_jobs()
+        assert [d["id"] for d in due] == ["stale"]
+
+    def test_recurring_jobs_unaffected(self, cron_store):
+        # The grace gate is once-kind only; a stale recurring job keeps its
+        # existing execute-now catch-up behavior.
+        interval = {
+            "id": "int",
+            "name": "int",
+            "prompt": "x",
+            "schedule": {"kind": "interval", "minutes": 60},
+            "next_run_at": (FIXED_NOW - timedelta(hours=2)).isoformat(),
+            "last_run_at": None,
+            "enabled": True,
+            "state": "scheduled",
+            "repeat": {"times": None, "completed": 0},
+            "deliver": "local",
+        }
+        save_jobs([interval])
+        due = get_due_jobs()
+        # Recurring stale handling still executes once now (existing behavior).
+        assert [d["id"] for d in due] == ["int"]


### PR DESCRIPTION
## Summary
One-shot cron jobs stored before downtime no longer fire hours late: the misfire backstop now enforces the same 120s one-shot grace window the rest of the module already promises ("will never fire"), and the due-scan gate from the original contributor PR retires past-grace one-shots with an operator-visible diagnostic instead of dispatching them. Fixes #93526, salvages #89571.

Root cause: two dispatch-time paths never checked `ONESHOT_GRACE_SECONDS` — the built-in due-scan (`cron/jobs.py::_get_due_jobs_locked`) and the hosted-provider misfire catch-up (`cron/scheduler_provider.py::fire_overdue_jobs`) — while create/update/resume/recovery all enforce it.

## Changes
- `cron/jobs.py`: due-scan grace gate for `once` jobs — beyond grace → not due, record retired with diagnostic; claim present → kept (in-flight run may still land); re-trigger still works (cherry-picked from #89571 by @spfcraze)
- `cron/scheduler_provider.py`: misfire backstop skips one-shots beyond `ONESHOT_GRACE_SECONDS` with a warning log (sibling site, our follow-up)
- `tests/cron/test_oneshot_grace_due_scan.py`: 5 tests pinning the due-scan gate (contributor's)
- `tests/cron/test_misfire_backstop_oneshot_grace.py`: 3 tests pinning the backstop gate incl. recurring-still-fires and within-grace-still-fires

## Validation
| | Before | After |
|---|---|---|
| Live repro: one-shot due 2h ago, due-scan | dispatched (`due ids: ['repro-oneshot-1']`) | not dispatched, record retired |
| Backstop test vs origin/main (sabotage run) | `test_stale_oneshot_beyond_grace_is_not_fired` FAILS | passes |
| `tests/cron` targeted (8 tests) | — | 8 passed |

## Infographic

![oneshot grace infographic](https://v3b.fal.media/files/b/0aa7948f/So9P_YiSERAIpdfD-DOFX_bnv3AXRj.png)
