### PR TITLE
feat(kanban): add atomic weekly graph facade

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2664,6 +2664,10 @@ DEFAULT_CONFIG = {
     # each claimable ready task. One dispatcher per profile is sufficient;
     # running more than one on the same kanban.db will race for claims.
     "kanban": {
+        # Opt-in host facade for one closed, authenticated weekly graph route.
+        # Disabled by default: deployment must also provide the pinned
+        # hermes-overseer-hardening board and private plugin auth provider.
+        "atomic_graph_enabled": False,
         # Auto-subscribe the originating gateway/TUI session to task
         # completion + block events when ``kanban_create`` is called from
         # inside a session that has a persistent delivery channel. The

--- a/hermes_cli/kanban_atomic_graph.py
+++ b/hermes_cli/kanban_atomic_graph.py
@@ -1,0 +1,507 @@
+"""Host-owned atomic Kanban graph capability for the weekly Overseer route.
+
+The private plugin owns authentication and transport. This module owns the
+closed domain contract, board resolution, preflight, transaction, and durable
+receipt. It deliberately has no caller-selectable board or database path.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from collections.abc import Callable, Mapping
+from hashlib import sha256
+from pathlib import Path
+from typing import Any, Final, cast
+
+from hermes_cli import kanban_db as kb
+
+CAPABILITY_ID: Final = "hermes.kanban.atomic-graph"
+CAPABILITY_VERSION: Final = 1
+TARGET_BOARD: Final = "hermes-overseer-hardening"
+REQUIRED_PROVIDER: Final = "overseer-weekly-token"
+REQUIRED_PRINCIPAL: Final = "overseer-weekly"
+REQUIRED_SCOPE: Final = "kanban.atomic-graph.apply"
+
+_OPERATIONS: Final = frozenset(
+    {"verify_collector_report", "preflight", "apply_weekly_graphs", "reconcile_weekly_graphs"}
+)
+_COMMON_FIELDS: Final = {
+    "schema_version", "capability", "capability_version", "operation", "board", "request_digest"
+}
+_OPERATION_FIELDS: Final = {
+    "verify_collector_report": {"report", "report_digest"},
+    "preflight": {"report_digest", "profiles", "workspace"},
+    "apply_weekly_graphs": {"report_digest", "profiles", "workspace", "idempotency_key", "graphs"},
+    "reconcile_weekly_graphs": {"idempotency_key", "apply_request_digest"},
+}
+_GRAPH_FIELDS: Final = {
+    "kind", "idempotency_key", "proposal_key", "expected_metric", "evidence",
+    "implementation", "qa", "release_note", "release_compatibility", "recurrence_check",
+}
+_CARD_NAMES: Final = (
+    "evidence", "implementation", "qa", "release_note", "release_compatibility", "recurrence_check"
+)
+_CARD_FIELDS: Final = {"key", "title", "assignee", "parents", "body"}
+_BODY_FIELDS: Final = {
+    "proposal_key", "failure_scope", "collector_report_digest", "evidence_ids", "expected_metric"
+}
+_EXPECTED_ASSIGNEES: Final = {
+    "evidence": {"developer"},
+    "implementation": {"developer", "senior_developer"},
+    "qa": {"reviewer_qa"},
+    "release_note": {"writer_docs"},
+    "release_compatibility": {"developer"},
+    "recurrence_check": {"reviewer_qa"},
+}
+_EXPECTED_METRIC: Final = "reduced recurrence in the next closed weekly window"
+_MAX_ENVELOPE_BYTES: Final = 256 * 1024
+_MAX_TEXT: Final = 4096
+_MAX_CACHE_ENTRIES: Final = 32
+
+
+class _ContractError(ValueError):
+    pass
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _canonical_digest(value: object) -> str:
+    return sha256(_canonical_json(value).encode()).hexdigest()
+
+
+def _digest(value: object, field: str) -> str:
+    if not isinstance(value, str) or len(value) != 64 or any(c not in "0123456789abcdef" for c in value):
+        raise _ContractError(f"invalid {field}")
+    return value
+
+
+def _text(value: object, field: str, *, maximum: int = _MAX_TEXT) -> str:
+    if not isinstance(value, str) or not value or len(value) > maximum:
+        raise _ContractError(f"invalid {field}")
+    return value
+
+
+def _bounded_strings(
+    value: object,
+    field: str,
+    *,
+    maximum_items: int,
+    allow_empty: bool = False,
+) -> list[str]:
+    if (
+        not isinstance(value, list)
+        or (not allow_empty and not value)
+        or len(value) > maximum_items
+        or any(not isinstance(item, str) or not item or len(item) > _MAX_TEXT for item in value)
+        or len(set(value)) != len(value)
+    ):
+        raise _ContractError(f"invalid {field}")
+    return value
+
+
+def _profiles(value: object) -> list[str]:
+    profiles = _bounded_strings(value, "profiles", maximum_items=16)
+    if profiles != sorted(profiles) or any(len(profile) > 64 for profile in profiles):
+        raise _ContractError("invalid profiles")
+    return profiles
+
+
+def _card(
+    value: object,
+    name: str,
+    *,
+    report_digest: str,
+    proposal_key: str,
+) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise _ContractError("invalid card")
+    expected_fields = _CARD_FIELDS | ({"window_start"} if name == "recurrence_check" else set())
+    if set(value) != expected_fields:
+        raise _ContractError("invalid card fields")
+    _text(value.get("key"), f"{name}.key")
+    _text(value.get("title"), f"{name}.title")
+    assignee = _text(value.get("assignee"), f"{name}.assignee", maximum=64)
+    if assignee not in _EXPECTED_ASSIGNEES[name]:
+        raise _ContractError("invalid assignee")
+    _bounded_strings(value.get("parents"), f"{name}.parents", maximum_items=2, allow_empty=True)
+    body = value.get("body")
+    if not isinstance(body, Mapping):
+        raise _ContractError("invalid body")
+    body_fields = set(_BODY_FIELDS)
+    if name == "implementation":
+        body_fields |= {"routing_reason", "developer_failure_count"}
+    if name == "recurrence_check":
+        body_fields.add("window_start")
+    if set(body) != body_fields:
+        raise _ContractError("invalid body fields")
+    if _text(body.get("proposal_key"), "body.proposal_key") != proposal_key:
+        raise _ContractError("mismatched proposal")
+    _text(body.get("failure_scope"), "body.failure_scope")
+    if _digest(body.get("collector_report_digest"), "collector_report_digest") != report_digest:
+        raise _ContractError("mismatched report")
+    _bounded_strings(body.get("evidence_ids"), "body.evidence_ids", maximum_items=100)
+    if body.get("expected_metric") != _EXPECTED_METRIC:
+        raise _ContractError("invalid metric")
+    if name == "implementation":
+        _text(body.get("routing_reason"), "routing_reason", maximum=256)
+        failure_count = body.get("developer_failure_count")
+        if type(failure_count) is not int or not 0 <= failure_count <= 1_000_000:
+            raise _ContractError("invalid failure count")
+    if name == "recurrence_check":
+        window_start = _text(value.get("window_start"), "window_start", maximum=32)
+        if body.get("window_start") != window_start:
+            raise _ContractError("mismatched window")
+    return value
+
+
+def _graphs(value: object, *, report_digest: str, profiles: list[str]) -> list[Mapping[str, object]]:
+    if not isinstance(value, list) or not 1 <= len(value) <= 3:
+        raise _ContractError("invalid graphs")
+    graphs: list[Mapping[str, object]] = []
+    bundle_keys: set[str] = set()
+    proposal_keys: set[str] = set()
+    task_keys: set[str] = set()
+    for graph in value:
+        if not isinstance(graph, Mapping) or set(graph) != _GRAPH_FIELDS or graph.get("kind") != "improvement":
+            raise _ContractError("invalid graph")
+        bundle_key = _text(graph.get("idempotency_key"), "graph.idempotency_key")
+        proposal_key = _text(graph.get("proposal_key"), "graph.proposal_key")
+        if not bundle_key.startswith("bundle:weekly:") or bundle_key in bundle_keys or proposal_key in proposal_keys:
+            raise _ContractError("duplicate graph identity")
+        bundle_keys.add(bundle_key)
+        proposal_keys.add(proposal_key)
+        if graph.get("expected_metric") != _EXPECTED_METRIC:
+            raise _ContractError("invalid graph metric")
+        cards: dict[str, Mapping[str, object]] = {}
+        for name in _CARD_NAMES:
+            card = _card(graph.get(name), name, report_digest=report_digest, proposal_key=proposal_key)
+            task_key = str(card["key"])
+            if task_key in task_keys:
+                raise _ContractError("duplicate task key")
+            task_keys.add(task_key)
+            if str(card["assignee"]) not in profiles:
+                raise _ContractError("assignee outside preflight profiles")
+            cards[name] = card
+        expected_parents = {
+            "evidence": [],
+            "implementation": [cards["evidence"]["key"]],
+            "qa": [cards["implementation"]["key"]],
+            "release_note": [cards["qa"]["key"]],
+            "release_compatibility": [cards["qa"]["key"], cards["release_note"]["key"]],
+            "recurrence_check": [cards["release_compatibility"]["key"]],
+        }
+        if any(cards[name]["parents"] != expected for name, expected in expected_parents.items()):
+            raise _ContractError("invalid graph dependencies")
+        graphs.append(graph)
+    return graphs
+
+
+def _validate_report(value: object, expected_digest: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping) or set(value) != {
+        "schema_version", "window", "records", "proposals", "scorecards", "digest"
+    }:
+        raise _ContractError("invalid collector report")
+    if value.get("schema_version") != 1 or value.get("digest") != expected_digest:
+        raise _ContractError("invalid collector report identity")
+    material = dict(value)
+    del material["digest"]
+    if _canonical_digest(material) != expected_digest:
+        raise _ContractError("invalid collector report digest")
+    if not isinstance(value.get("window"), Mapping) or set(value["window"]) != {"start", "end"}:
+        raise _ContractError("invalid collector report window")
+    if not isinstance(value.get("records"), list) or not isinstance(value.get("proposals"), list):
+        raise _ContractError("invalid collector report lists")
+    scorecards = value.get("scorecards")
+    if not isinstance(scorecards, Mapping) or set(scorecards) != {"boards", "profiles"}:
+        raise _ContractError("invalid collector report scorecards")
+    scorecards = cast(Mapping[str, object], scorecards)
+    if any(not isinstance(scorecards[name], list) for name in ("boards", "profiles")):
+        raise _ContractError("invalid collector report scorecards")
+    return value
+
+
+def _validate_envelope(value: object) -> dict[str, object]:
+    if not isinstance(value, Mapping):
+        raise _ContractError("invalid envelope")
+    try:
+        if len(_canonical_json(value).encode()) > _MAX_ENVELOPE_BYTES:
+            raise _ContractError("oversized envelope")
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise _ContractError("unserializable envelope") from exc
+    operation = value.get("operation")
+    if not isinstance(operation, str) or operation not in _OPERATIONS:
+        raise _ContractError("invalid operation")
+    if set(value) != _COMMON_FIELDS | _OPERATION_FIELDS[operation]:
+        raise _ContractError("invalid envelope fields")
+    if (
+        value.get("schema_version") != 1
+        or value.get("capability") != CAPABILITY_ID
+        or value.get("capability_version") != CAPABILITY_VERSION
+        or value.get("board") != TARGET_BOARD
+    ):
+        raise _ContractError("invalid capability identity")
+    request_digest = _digest(value.get("request_digest"), "request_digest")
+    material = dict(value)
+    del material["request_digest"]
+    if _canonical_digest(material) != request_digest:
+        raise _ContractError("invalid request digest")
+    if operation == "verify_collector_report":
+        report_digest = _digest(value.get("report_digest"), "report_digest")
+        _validate_report(value.get("report"), report_digest)
+    elif operation == "preflight":
+        _digest(value.get("report_digest"), "report_digest")
+        _profiles(value.get("profiles"))
+        _text(value.get("workspace"), "workspace")
+    elif operation == "apply_weekly_graphs":
+        report_digest = _digest(value.get("report_digest"), "report_digest")
+        profiles = _profiles(value.get("profiles"))
+        _text(value.get("workspace"), "workspace")
+        key = _text(value.get("idempotency_key"), "idempotency_key")
+        if not key.startswith("weekly-plan:"):
+            raise _ContractError("invalid idempotency namespace")
+        _graphs(value.get("graphs"), report_digest=report_digest, profiles=profiles)
+    else:
+        key = _text(value.get("idempotency_key"), "idempotency_key")
+        if not key.startswith("weekly-plan:"):
+            raise _ContractError("invalid idempotency namespace")
+        _digest(value.get("apply_request_digest"), "apply_request_digest")
+    return dict(value)
+
+
+def _configured_enabled() -> bool:
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        config = load_config_readonly()
+        kanban = config.get("kanban", {})
+        return isinstance(kanban, Mapping) and kanban.get("atomic_graph_enabled") is True
+    except Exception:
+        return False
+
+
+def _default_live_profiles() -> list[str]:
+    return kb.list_profiles_on_disk()
+
+
+def _pinned_workspace() -> Path:
+    metadata = kb.read_board_metadata(TARGET_BOARD)
+    configured = metadata.get("default_workdir")
+    if not isinstance(configured, str) or not configured:
+        raise _ContractError("pinned workspace unavailable")
+    workspace = Path(configured).expanduser()
+    if not workspace.is_absolute() or not workspace.is_dir():
+        raise _ContractError("pinned workspace unavailable")
+    return workspace.resolve()
+
+
+def _rejected(code: str = "preflight_rejected") -> dict[str, object]:
+    return {"outcome": "confirmed_not_applied", "error": {"code": code}}
+
+
+class _AtomicGraphCapabilityV1:
+    """Closed v1 facade; callers cannot select its board or storage path."""
+
+    def __init__(
+        self,
+        *,
+        db_path: Path | None = None,
+        live_profiles: Callable[[], list[str]] = _default_live_profiles,
+        workspace_root: Path | None = None,
+    ) -> None:
+        self._db_path = db_path or (kb.board_dir(TARGET_BOARD) / "kanban.db")
+        self._live_profiles = live_profiles
+        self._workspace_root = (workspace_root or _pinned_workspace()).resolve()
+        if not self._workspace_root.is_absolute() or not self._workspace_root.is_dir():
+            raise _ContractError("pinned workspace unavailable")
+        self._verified_reports: dict[str, None] = {}
+        self._preflights: dict[tuple[str, tuple[str, ...], str], None] = {}
+        self._state_lock = threading.Lock()
+        # Force the additive receipt migration once when the capability is
+        # activated. This deliberately bypasses connect()'s steady-state path
+        # cache, which may have been populated before a hot-loaded plugin first
+        # asks for this newer optional table.
+        kb.init_db(self._db_path)
+
+    def _remember(self, cache: dict[Any, None], key: Any) -> None:
+        cache[key] = None
+        while len(cache) > _MAX_CACHE_ENTRIES:
+            del cache[next(iter(cache))]
+
+    def _live_preflight(self, envelope: Mapping[str, object]) -> tuple[str, tuple[str, ...], str]:
+        digest = str(envelope["report_digest"])
+        profiles = tuple(str(item) for item in cast(list[object], envelope["profiles"]))
+        raw_workspace = Path(str(envelope["workspace"])).expanduser()
+        if not raw_workspace.is_absolute() or not raw_workspace.is_dir():
+            raise _ContractError("workspace unavailable")
+        workspace = str(raw_workspace.resolve())
+        if workspace != str(self._workspace_root):
+            raise _ContractError("workspace is not the pinned board workdir")
+        live = set(self._live_profiles())
+        if not profiles or any(profile not in live for profile in profiles):
+            raise _ContractError("profile unavailable")
+        with self._state_lock:
+            if digest not in self._verified_reports:
+                raise _ContractError("report not verified")
+        return digest, profiles, workspace
+
+    def _receipt(self, key: str) -> tuple[str, dict[str, object]] | None:
+        with kb.connect_closing(self._db_path) as conn:
+            row = conn.execute(
+                "SELECT apply_request_digest, receipt_json FROM atomic_graph_receipts WHERE idempotency_key = ?",
+                (key,),
+            ).fetchone()
+        if row is None:
+            return None
+        receipt = json.loads(row["receipt_json"])
+        if not isinstance(receipt, dict):
+            raise _ContractError("invalid stored receipt")
+        return str(row["apply_request_digest"]), receipt
+
+    def _reconcile(self, envelope: Mapping[str, object]) -> dict[str, object]:
+        try:
+            existing = self._receipt(str(envelope["idempotency_key"]))
+        except Exception:
+            return {"outcome": "indeterminate"}
+        if existing is None:
+            return {"outcome": "confirmed_not_applied"}
+        stored_digest, receipt = existing
+        if stored_digest != envelope["apply_request_digest"]:
+            return _rejected("idempotency_conflict")
+        return {"outcome": "confirmed_applied", "receipt": {**receipt, "idempotent": True}}
+
+    def _apply(self, envelope: Mapping[str, object]) -> dict[str, object]:
+        key = str(envelope["idempotency_key"])
+        request_digest = str(envelope["request_digest"])
+        try:
+            existing = self._receipt(key)
+        except Exception:
+            return {"outcome": "indeterminate"}
+        if existing is not None:
+            stored_digest, receipt = existing
+            if stored_digest != request_digest:
+                return _rejected("idempotency_conflict")
+            return {"outcome": "confirmed_applied", "receipt": {**receipt, "idempotent": True}}
+
+        try:
+            preflight_key = self._live_preflight(envelope)
+            with self._state_lock:
+                if preflight_key not in self._preflights:
+                    raise _ContractError("preflight not confirmed")
+            graphs = cast(list[Mapping[str, Any]], envelope["graphs"])
+            task_keys = [str(graph[name]["key"]) for graph in graphs for name in _CARD_NAMES]
+            with kb.connect_closing(self._db_path) as conn, kb.write_txn(conn):
+                placeholders = ",".join("?" for _ in task_keys)
+                if task_keys and conn.execute(
+                    f"SELECT 1 FROM tasks WHERE idempotency_key IN ({placeholders}) LIMIT 1",
+                    task_keys,
+                ).fetchone() is not None:
+                    raise _ContractError("task key already exists")
+                task_ids_by_bundle: dict[str, list[str]] = {}
+                graph_keys_by_bundle: dict[str, list[str]] = {}
+                for graph in graphs:
+                    bundle_key = str(graph["idempotency_key"])
+                    ids_by_key: dict[str, str] = {}
+                    bundle_ids: list[str] = []
+                    bundle_graph_keys: list[str] = []
+                    for name in _CARD_NAMES:
+                        card = graph[name]
+                        parent_ids = [ids_by_key[str(parent_key)] for parent_key in card["parents"]]
+                        task_id = kb.create_task(
+                            conn,
+                            title=str(card["title"]),
+                            body=_canonical_json(card["body"]),
+                            assignee=str(card["assignee"]),
+                            created_by=REQUIRED_PRINCIPAL,
+                            workspace_kind="dir",
+                            workspace_path=preflight_key[2],
+                            parents=parent_ids,
+                            idempotency_key=str(card["key"]),
+                            board=TARGET_BOARD,
+                        )
+                        ids_by_key[str(card["key"])] = task_id
+                        bundle_ids.append(task_id)
+                        bundle_graph_keys.append(str(card["key"]))
+                    task_ids_by_bundle[bundle_key] = bundle_ids
+                    graph_keys_by_bundle[bundle_key] = bundle_graph_keys
+                created = [task_id for ids in task_ids_by_bundle.values() for task_id in ids]
+                receipt: dict[str, object] = {
+                    "receipt_id": f"receipt:{request_digest}",
+                    "idempotency_key": key,
+                    "stable_bundle_keys": list(task_ids_by_bundle),
+                    "created_task_ids": created,
+                    "created_task_ids_by_bundle": task_ids_by_bundle,
+                    "graph_task_keys_by_bundle": graph_keys_by_bundle,
+                    "idempotent": False,
+                }
+                conn.execute(
+                    "INSERT INTO atomic_graph_receipts "
+                    "(idempotency_key, apply_request_digest, receipt_json, created_at) VALUES (?, ?, ?, ?)",
+                    (key, request_digest, _canonical_json(receipt), int(time.time())),
+                )
+            return {"outcome": "confirmed_applied", "receipt": receipt}
+        except Exception:
+            # COMMIT can succeed before a response-path failure. Re-read the
+            # durable receipt before claiming the batch was not applied.
+            try:
+                committed = self._receipt(key)
+            except Exception:
+                return {"outcome": "indeterminate"}
+            if committed is not None:
+                stored_digest, receipt = committed
+                if stored_digest == request_digest:
+                    return {"outcome": "confirmed_applied", "receipt": {**receipt, "idempotent": True}}
+                return _rejected("idempotency_conflict")
+            return _rejected()
+
+    def execute(
+        self,
+        *,
+        envelope: object,
+        principal: object,
+        provider: object,
+    ) -> dict[str, object]:
+        if principal != REQUIRED_PRINCIPAL or provider != REQUIRED_PROVIDER:
+            return _rejected()
+        try:
+            closed = _validate_envelope(envelope)
+        except Exception:
+            return _rejected()
+        operation = str(closed["operation"])
+        if operation == "verify_collector_report":
+            digest = str(closed["report_digest"])
+            with self._state_lock:
+                self._remember(self._verified_reports, digest)
+            return {"outcome": "confirmed_not_applied", "report_digest": digest}
+        if operation == "preflight":
+            try:
+                key = self._live_preflight(closed)
+            except Exception:
+                return _rejected()
+            with self._state_lock:
+                self._remember(self._preflights, key)
+            return {"outcome": "confirmed_not_applied", "preflight": "confirmed"}
+        if operation == "reconcile_weekly_graphs":
+            return self._reconcile(closed)
+        return self._apply(closed)
+
+
+_CAPABILITY: _AtomicGraphCapabilityV1 | None = None
+_CAPABILITY_LOCK = threading.Lock()
+
+
+def get_capability_v1() -> _AtomicGraphCapabilityV1 | None:
+    """Return the enabled v1 facade, or ``None`` when unavailable/disabled."""
+    global _CAPABILITY
+    if not _configured_enabled() or not kb.board_exists(TARGET_BOARD):
+        return None
+    with _CAPABILITY_LOCK:
+        if _CAPABILITY is None:
+            try:
+                _CAPABILITY = _AtomicGraphCapabilityV1()
+            except Exception:
+                return None
+        return _CAPABILITY

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1448,6 +1448,16 @@ CREATE TABLE IF NOT EXISTS task_events (
     created_at INTEGER NOT NULL
 );
 
+-- Durable outcome for the host-owned hermes.kanban.atomic-graph v1 facade.
+-- The weekly idempotency key is the lookup identity, while the original full
+-- apply digest prevents a caller from reusing that key for different work.
+CREATE TABLE IF NOT EXISTS atomic_graph_receipts (
+    idempotency_key      TEXT PRIMARY KEY,
+    apply_request_digest TEXT NOT NULL,
+    receipt_json         TEXT NOT NULL,
+    created_at           INTEGER NOT NULL
+);
+
 -- Historical attempt record. Each time the dispatcher claims a task, a
 -- new row is created here; claim state, PID, heartbeat, runtime cap,
 -- and structured summary all live on the run, not the task. Multiple

--- a/tests/hermes_cli/test_kanban_atomic_graph.py
+++ b/tests/hermes_cli/test_kanban_atomic_graph.py
@@ -1,0 +1,315 @@
+"""Behavior contract for the host-owned weekly atomic Kanban graph facade."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_atomic_graph as atomic
+
+
+CARD_NAMES = (
+    "evidence",
+    "implementation",
+    "qa",
+    "release_note",
+    "release_compatibility",
+    "recurrence_check",
+)
+
+
+def _digest(value: object) -> str:
+    return sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def _envelope(operation: str, **payload: object) -> dict[str, object]:
+    material = {
+        "schema_version": 1,
+        "capability": atomic.CAPABILITY_ID,
+        "capability_version": 1,
+        "operation": operation,
+        "board": atomic.TARGET_BOARD,
+        **payload,
+    }
+    return {**material, "request_digest": _digest(material)}
+
+
+def _report() -> dict[str, object]:
+    material: dict[str, object] = {
+        "schema_version": 1,
+        "window": {"start": "2026-08-10T00:00:00Z", "end": "2026-08-17T00:00:00Z"},
+        "records": [],
+        "proposals": [],
+        "scorecards": {"boards": [], "profiles": []},
+    }
+    return {**material, "digest": _digest(material)}
+
+
+def _graph(report_digest: str, proposal: str = "proposal_aaaaaaaaaaaaaaaaaaaa") -> dict[str, Any]:
+    prefix = f"weekly:2026-08-10T00:00:00Z:{proposal}"
+    common = {
+        "proposal_key": proposal,
+        "failure_scope": "failure_scope_bbbbbbbbbbbbbbbbbbbb",
+        "collector_report_digest": report_digest,
+        "evidence_ids": ["evidence_cccccccccccccccccccc"],
+        "expected_metric": "reduced recurrence in the next closed weekly window",
+    }
+    return {
+        "kind": "improvement",
+        "idempotency_key": f"bundle:{prefix}",
+        "proposal_key": proposal,
+        "expected_metric": "reduced recurrence in the next closed weekly window",
+        "evidence": {"key": f"{prefix}:evidence", "title": "Weekly evidence/spec: scope", "assignee": "developer", "parents": [], "body": common},
+        "implementation": {"key": f"{prefix}:implementation", "title": "Implement weekly hardening: scope", "assignee": "developer", "parents": [f"{prefix}:evidence"], "body": {**common, "routing_reason": "developer_first", "developer_failure_count": 0}},
+        "qa": {"key": f"{prefix}:qa", "title": "Independent QA: scope", "assignee": "reviewer_qa", "parents": [f"{prefix}:implementation"], "body": common},
+        "release_note": {"key": f"{prefix}:release-notes", "title": "Release note decision: scope", "assignee": "writer_docs", "parents": [f"{prefix}:qa"], "body": common},
+        "release_compatibility": {"key": f"{prefix}:release-compatibility", "title": "Release/compatibility tail: scope", "assignee": "developer", "parents": [f"{prefix}:qa", f"{prefix}:release-notes"], "body": common},
+        "recurrence_check": {"key": f"{prefix}:recurrence", "title": "Next-window recurrence check: scope", "assignee": "reviewer_qa", "parents": [f"{prefix}:release-compatibility"], "body": {**common, "window_start": "2026-08-17T00:00:00Z"}, "window_start": "2026-08-17T00:00:00Z"},
+    }
+
+
+def _capability(tmp_path: Path) -> tuple[atomic._AtomicGraphCapabilityV1, Path, Path]:
+    board_db = tmp_path / "target.db"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    capability = atomic._AtomicGraphCapabilityV1(
+        db_path=board_db,
+        live_profiles=lambda: ["default", "developer", "reviewer_qa", "writer_docs"],
+        workspace_root=workspace,
+    )
+    return capability, board_db, workspace
+
+
+def _prepare(capability: atomic._AtomicGraphCapabilityV1, workspace: Path) -> tuple[str, dict[str, Any]]:
+    report = _report()
+    digest = str(report["digest"])
+    verify = capability.execute(
+        envelope=_envelope("verify_collector_report", report=report, report_digest=digest),
+        principal=atomic.REQUIRED_PRINCIPAL,
+        provider=atomic.REQUIRED_PROVIDER,
+    )
+    assert verify == {"outcome": "confirmed_not_applied", "report_digest": digest}
+    preflight = capability.execute(
+        envelope=_envelope(
+            "preflight",
+            report_digest=digest,
+            profiles=["developer", "reviewer_qa", "writer_docs"],
+            workspace=str(workspace),
+        ),
+        principal=atomic.REQUIRED_PRINCIPAL,
+        provider=atomic.REQUIRED_PROVIDER,
+    )
+    assert preflight == {"outcome": "confirmed_not_applied", "preflight": "confirmed"}
+    return digest, _graph(digest)
+
+
+def _execute(capability: atomic._AtomicGraphCapabilityV1, envelope: dict[str, object]) -> dict[str, Any]:
+    return capability.execute(
+        envelope=envelope,
+        principal=atomic.REQUIRED_PRINCIPAL,
+        provider=atomic.REQUIRED_PROVIDER,
+    )
+
+
+def test_factory_is_disabled_by_default_and_requires_the_pinned_board(monkeypatch, tmp_path):
+    monkeypatch.setattr(atomic, "_configured_enabled", lambda: False)
+    assert atomic.get_capability_v1() is None
+
+    monkeypatch.setattr(atomic, "_configured_enabled", lambda: True)
+    monkeypatch.setattr(kb, "kanban_home", lambda: tmp_path)
+    assert atomic.get_capability_v1() is None
+
+
+def test_facade_rejects_identity_and_malformed_envelopes_without_writes(tmp_path):
+    capability, board_db, workspace = _capability(tmp_path)
+    report = _report()
+    valid = _envelope("verify_collector_report", report=report, report_digest=report["digest"])
+    mutations = [
+        ({**valid, "capability_version": 2}, atomic.REQUIRED_PRINCIPAL, atomic.REQUIRED_PROVIDER),
+        ({**valid, "board": "other-board"}, atomic.REQUIRED_PRINCIPAL, atomic.REQUIRED_PROVIDER),
+        ({**valid, "operation": "run_cli"}, atomic.REQUIRED_PRINCIPAL, atomic.REQUIRED_PROVIDER),
+        ({**valid, "request_digest": "b" * 64}, atomic.REQUIRED_PRINCIPAL, atomic.REQUIRED_PROVIDER),
+        (valid, "wrong-principal", atomic.REQUIRED_PROVIDER),
+        (valid, atomic.REQUIRED_PRINCIPAL, "wrong-provider"),
+    ]
+    for envelope, principal, provider in mutations:
+        result = capability.execute(envelope=envelope, principal=principal, provider=provider)
+        assert result == {"outcome": "confirmed_not_applied", "error": {"code": "preflight_rejected"}}
+    with sqlite3.connect(board_db) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM atomic_graph_receipts").fetchone()[0] == 0
+    assert workspace.exists()
+
+
+def test_verify_rejects_a_report_whose_digest_is_not_canonical(tmp_path):
+    capability, board_db, _ = _capability(tmp_path)
+    report = _report()
+    report["window"] = {"start": "changed", "end": "changed"}
+    result = _execute(
+        capability,
+        _envelope("verify_collector_report", report=report, report_digest=report["digest"]),
+    )
+    assert result == {"outcome": "confirmed_not_applied", "error": {"code": "preflight_rejected"}}
+    with sqlite3.connect(board_db) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+
+
+def test_apply_commits_six_cards_links_events_and_receipt_atomically(tmp_path):
+    capability, board_db, workspace = _capability(tmp_path)
+    report_digest, graph = _prepare(capability, workspace)
+    key = "weekly-plan:" + "b" * 64
+    apply = _envelope(
+        "apply_weekly_graphs",
+        report_digest=report_digest,
+        profiles=["developer", "reviewer_qa", "writer_docs"],
+        workspace=str(workspace),
+        idempotency_key=key,
+        graphs=[graph],
+    )
+
+    result = _execute(capability, apply)
+
+    assert result["outcome"] == "confirmed_applied"
+    receipt = result["receipt"]
+    assert receipt["stable_bundle_keys"] == [graph["idempotency_key"]]
+    assert receipt["graph_task_keys_by_bundle"] == {
+        graph["idempotency_key"]: [graph[name]["key"] for name in CARD_NAMES]
+    }
+    assert receipt["created_task_ids"] == receipt["created_task_ids_by_bundle"][graph["idempotency_key"]]
+    assert receipt["idempotent"] is False
+    with sqlite3.connect(board_db) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 6
+        assert conn.execute("SELECT COUNT(*) FROM task_links").fetchone()[0] == 6
+        assert conn.execute("SELECT COUNT(*) FROM task_events WHERE kind = 'created'").fetchone()[0] == 6
+        stored = conn.execute(
+            "SELECT apply_request_digest, receipt_json FROM atomic_graph_receipts WHERE idempotency_key = ?",
+            (key,),
+        ).fetchone()
+    assert stored[0] == apply["request_digest"]
+    assert json.loads(stored[1]) == receipt
+
+
+def test_exact_replay_is_a_noop_and_digest_collision_is_confirmed_not_applied(tmp_path):
+    capability, board_db, workspace = _capability(tmp_path)
+    report_digest, graph = _prepare(capability, workspace)
+    key = "weekly-plan:" + "b" * 64
+    apply = _envelope("apply_weekly_graphs", report_digest=report_digest, profiles=["developer", "reviewer_qa", "writer_docs"], workspace=str(workspace), idempotency_key=key, graphs=[graph])
+    first = _execute(capability, apply)
+    replay = _execute(capability, deepcopy(apply))
+    changed: dict[str, Any] = deepcopy(apply)
+    changed["graphs"][0]["evidence"]["title"] = "Different valid title"
+    changed["request_digest"] = _digest({k: v for k, v in changed.items() if k != "request_digest"})
+    conflict = _execute(capability, changed)
+
+    assert replay == {"outcome": "confirmed_applied", "receipt": {**first["receipt"], "idempotent": True}}
+    assert conflict == {"outcome": "confirmed_not_applied", "error": {"code": "idempotency_conflict"}}
+    with sqlite3.connect(board_db) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 6
+        assert conn.execute("SELECT COUNT(*) FROM atomic_graph_receipts").fetchone()[0] == 1
+
+
+def test_reconcile_uses_original_key_and_apply_digest_after_response_loss(tmp_path):
+    capability, _, workspace = _capability(tmp_path)
+    report_digest, graph = _prepare(capability, workspace)
+    key = "weekly-plan:" + "b" * 64
+    apply = _envelope("apply_weekly_graphs", report_digest=report_digest, profiles=["developer", "reviewer_qa", "writer_docs"], workspace=str(workspace), idempotency_key=key, graphs=[graph])
+    applied = _execute(capability, apply)
+
+    reconcile = _execute(capability, _envelope("reconcile_weekly_graphs", idempotency_key=key, apply_request_digest=apply["request_digest"]))
+    wrong_digest = _execute(capability, _envelope("reconcile_weekly_graphs", idempotency_key=key, apply_request_digest="c" * 64))
+    missing = _execute(capability, _envelope("reconcile_weekly_graphs", idempotency_key="weekly-plan:" + "d" * 64, apply_request_digest="e" * 64))
+
+    assert reconcile == {"outcome": "confirmed_applied", "receipt": {**applied["receipt"], "idempotent": True}}
+    assert wrong_digest == {"outcome": "confirmed_not_applied", "error": {"code": "idempotency_conflict"}}
+    assert missing == {"outcome": "confirmed_not_applied"}
+
+
+def test_injected_crash_before_commit_rolls_back_every_graph_row(tmp_path, monkeypatch):
+    capability, board_db, workspace = _capability(tmp_path)
+    report_digest, graph = _prepare(capability, workspace)
+    original = kb.create_task
+    calls = 0
+
+    def crash_on_fourth(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 4:
+            raise RuntimeError("private crash marker")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(kb, "create_task", crash_on_fourth)
+    apply = _envelope("apply_weekly_graphs", report_digest=report_digest, profiles=["developer", "reviewer_qa", "writer_docs"], workspace=str(workspace), idempotency_key="weekly-plan:" + "b" * 64, graphs=[graph])
+    result = _execute(capability, apply)
+
+    assert result == {"outcome": "confirmed_not_applied", "error": {"code": "preflight_rejected"}}
+    assert "private crash marker" not in json.dumps(result)
+    with sqlite3.connect(board_db) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM task_links").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM atomic_graph_receipts").fetchone()[0] == 0
+
+
+def test_preflight_checks_live_profiles_workspace_and_all_graph_keys_before_writes(tmp_path):
+    capability, board_db, workspace = _capability(tmp_path)
+    report_digest, graph = _prepare(capability, workspace)
+    malformed = deepcopy(graph)
+    malformed["qa"]["parents"] = ["unknown-key"]
+    apply = _envelope("apply_weekly_graphs", report_digest=report_digest, profiles=["developer", "reviewer_qa", "writer_docs"], workspace=str(workspace), idempotency_key="weekly-plan:" + "b" * 64, graphs=[malformed])
+    assert _execute(capability, apply) == {"outcome": "confirmed_not_applied", "error": {"code": "preflight_rejected"}}
+
+    missing_workspace = _envelope("preflight", report_digest=report_digest, profiles=["developer", "reviewer_qa", "writer_docs"], workspace=str(tmp_path / "missing"))
+    assert _execute(capability, missing_workspace) == {"outcome": "confirmed_not_applied", "error": {"code": "preflight_rejected"}}
+    arbitrary_workspace = tmp_path / "other-existing-directory"
+    arbitrary_workspace.mkdir()
+    redirected = _envelope("preflight", report_digest=report_digest, profiles=["developer", "reviewer_qa", "writer_docs"], workspace=str(arbitrary_workspace))
+    assert _execute(capability, redirected) == {"outcome": "confirmed_not_applied", "error": {"code": "preflight_rejected"}}
+    with sqlite3.connect(board_db) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+
+
+def test_pinned_board_ignores_ambient_board_current_and_db_overrides(tmp_path, monkeypatch):
+    target_dir = tmp_path / "kanban" / "boards" / atomic.TARGET_BOARD
+    target_dir.mkdir(parents=True)
+    (target_dir / "board.json").write_text("{}", encoding="utf-8")
+    ambient_db = tmp_path / "ambient.db"
+    monkeypatch.setattr(kb, "kanban_home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "other-board")
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(ambient_db))
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    capability = atomic._AtomicGraphCapabilityV1(
+        live_profiles=lambda: ["developer", "reviewer_qa", "writer_docs"],
+        workspace_root=workspace,
+    )
+    report_digest, graph = _prepare(capability, workspace)
+    apply = _envelope("apply_weekly_graphs", report_digest=report_digest, profiles=["developer", "reviewer_qa", "writer_docs"], workspace=str(workspace), idempotency_key="weekly-plan:" + "b" * 64, graphs=[graph])
+
+    assert _execute(capability, apply)["outcome"] == "confirmed_applied"
+    assert (target_dir / "kanban.db").exists()
+    assert not ambient_db.exists()
+
+
+def test_receipt_schema_upgrades_legacy_boards_and_concurrent_initialization(tmp_path):
+    db_path = tmp_path / "legacy.db"
+    initialized = kb.connect(db_path)
+    initialized.execute("DROP TABLE atomic_graph_receipts")
+    initialized.commit()
+    initialized.close()
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    def initialize(_: int) -> None:
+        connection = kb.connect(db_path)
+        connection.close()
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        list(pool.map(initialize, range(8)))
+
+    with sqlite3.connect(db_path) as upgraded:
+        columns = {row[1] for row in upgraded.execute("PRAGMA table_info(atomic_graph_receipts)")}
+    assert columns == {"idempotency_key", "apply_request_digest", "receipt_json", "created_at"}

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -245,6 +245,28 @@ the old standalone daemon alive for one release cycle, but running both
 a gateway-embedded dispatcher AND a standalone daemon against the same
 `kanban.db` causes claim races and is not supported.
 
+### Atomic graph host facade
+
+Hermes includes an opt-in, host-owned `hermes.kanban.atomic-graph` v1
+facade for authenticated automation that must create a complete dependency
+graph or create nothing. It is disabled by default and intentionally pinned
+to the `hermes-overseer-hardening` board; caller input, the active-board
+pointer, and `HERMES_KANBAN_BOARD` / `HERMES_KANBAN_DB` cannot redirect its
+writes. Enable it only when the matching private token-auth route is installed:
+
+```yaml
+kanban:
+  atomic_graph_enabled: true
+```
+
+The facade validates the complete closed envelope and live profiles/workspace
+before opening one `BEGIN IMMEDIATE` transaction. Tasks, links, creation events,
+and a durable digest-bound receipt commit together. Exact retries return the
+original ordered receipt without new writes; reusing an idempotency key for a
+different request is rejected. Disable the flag to roll back access; the
+additive receipt table may remain in place and existing graph tasks are not
+deleted automatically.
+
 ### Idempotent create (for automation / webhooks)
 
 ```bash


### PR DESCRIPTION
## Summary
- add the opt-in host-owned hermes.kanban.atomic-graph v1 facade for the authenticated weekly Overseer route
- pin board and workspace resolution to host-owned metadata, validate the complete closed envelope, and create 1-3 six-card graphs in one BEGIN IMMEDIATE transaction
- persist digest-bound ordered receipts for exact replay and reconciliation, with additive legacy-board migration coverage

## Security and containment
- disabled by default via kanban.atomic_graph_enabled
- rejects wrong capability/version/operation/board/principal/provider and malformed or oversized envelopes
- ignores ambient current board, HERMES_KANBAN_BOARD, and HERMES_KANBAN_DB
- never returns database paths, SQL, tokens, raw payloads, or raw exceptions

## Verification
- uvx ruff check: passed
- uvx pyright on facade and focused tests: passed
- compileall: passed
- git diff --check: passed
- pytest was intentionally not run in the production Hermes container; GitHub Actions is the approved disposable test executor for this immutable commit

## Migration / rollback
The migration adds atomic_graph_receipts(idempotency_key PK, apply_request_digest, receipt_json, created_at) through the existing idempotent schema initialization path. Roll back access by setting kanban.atomic_graph_enabled=false and removing/disabling the private route. The additive table can remain; reverting this commit does not delete created tasks or receipts.