### PR TITLE
fix(buzz): run periodic DM discovery on the WebSocket transport

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -822,10 +822,14 @@ class BuzzAdapter(BasePlatformAdapter):
             subscriptions[_WS_MEMBERSHIP_SUB_ID] = None
         return subscriptions
 
-    async def _handle_membership_event(self, websocket, subscriptions: Dict[str, Optional[str]], event: dict) -> None:
-        """A membership event p-tagged to us: rediscover conversations and
-        subscribe to any new ones (fresh DMs dispatch from their beginning)."""
-        self._membership_since = max(self._membership_since, int(event.get("created_at") or 0))
+    async def _discover_and_subscribe_new(self, websocket, subscriptions: Dict[str, Optional[str]]) -> None:
+        """Discover conversations and subscribe to new ones on the live socket.
+
+        Shared by the kind-44100 membership path and the WS loop's periodic
+        discovery sweep: some relays never emit a membership event for a
+        fresh DM (#93557), so the sweep gives the WebSocket transport the
+        same _DM_DISCOVERY_EVERY cadence the poll loop already has.
+        """
         before = set(self._channel_state)
         await self._discover_dms(seed=False)
         for channel_id in self._channel_state:
@@ -835,6 +839,12 @@ class BuzzAdapter(BasePlatformAdapter):
             subscriptions[subscription_id] = channel_id
             await self._send_channel_subscription(websocket, subscription_id, channel_id)
             logger.info("Buzz: subscribed to new conversation %s", channel_id)
+
+    async def _handle_membership_event(self, websocket, subscriptions: Dict[str, Optional[str]], event: dict) -> None:
+        """A membership event p-tagged to us: rediscover conversations and
+        subscribe to any new ones (fresh DMs dispatch from their beginning)."""
+        self._membership_since = max(self._membership_since, int(event.get("created_at") or 0))
+        await self._discover_and_subscribe_new(websocket, subscriptions)
 
     async def _websocket_loop(self) -> None:
         """Persistent authenticated subscription with bounded reconnect
@@ -862,32 +872,73 @@ class BuzzAdapter(BasePlatformAdapter):
                         if self._ws_ready is not None:
                             self._ws_ready.set()
                         backoff = 1.0
-                        async for raw in websocket:
+                        # Periodic DM discovery on the WS transport (#93557):
+                        # some relays never emit kind-44100 membership events
+                        # for a fresh DM, and the WS loop relied on them
+                        # alone — a mid-session DM stayed invisible until the
+                        # next reconnect. The poll loop already re-runs
+                        # discovery every _DM_DISCOVERY_EVERY sweeps; give
+                        # this loop the same cadence by bounding each receive
+                        # with the remaining time to the next sweep.
+                        _discovery_every = self.poll_interval * _DM_DISCOVERY_EVERY
+                        _next_dm_discovery = time.monotonic() + _discovery_every
+                        stream = websocket.__aiter__()
+                        while True:
+                            _recv_timeout = min(
+                                max(_next_dm_discovery - time.monotonic(), 1.0),
+                                30.0,
+                            )
                             try:
-                                message = json.loads(raw)
-                            except (ValueError, TypeError):
-                                logger.warning("Buzz: ignoring malformed WebSocket frame")
-                                continue
-                            if not isinstance(message, list) or not message:
-                                continue
-                            if message[0] == "EVENT" and len(message) >= 3:
-                                subscription_id = str(message[1])
-                                event = message[2]
-                                if not isinstance(event, dict):
+                                raw = await asyncio.wait_for(
+                                    stream.__anext__(), timeout=_recv_timeout
+                                )
+                            except asyncio.TimeoutError:
+                                # Quiet interval — fall through to the sweep
+                                # check below without a frame to process.
+                                raw = None
+                            except StopAsyncIteration:
+                                break
+                            if raw is not None:
+                                try:
+                                    message = json.loads(raw)
+                                except (ValueError, TypeError):
+                                    logger.warning("Buzz: ignoring malformed WebSocket frame")
                                     continue
-                                if subscription_id == _WS_MEMBERSHIP_SUB_ID:
-                                    await self._handle_membership_event(websocket, subscriptions, event)
+                                if not isinstance(message, list) or not message:
                                     continue
-                                channel_id = subscriptions.get(subscription_id)
-                                state = self._channel_state.get(channel_id or "")
-                                if channel_id and state is not None:
-                                    await self._handle_event(channel_id, state, event)
-                                    self._trim_seen(state)
-                            elif message[0] == "CLOSED":
-                                detail = message[-1] if len(message) > 2 else "subscription closed"
-                                raise ConnectionError(str(detail))
-                            elif message[0] == "NOTICE":
-                                logger.warning("Buzz: relay notice: %s", message[-1])
+                                if message[0] == "EVENT" and len(message) >= 3:
+                                    subscription_id = str(message[1])
+                                    event = message[2]
+                                    if not isinstance(event, dict):
+                                        continue
+                                    if subscription_id == _WS_MEMBERSHIP_SUB_ID:
+                                        await self._handle_membership_event(websocket, subscriptions, event)
+                                        continue
+                                    channel_id = subscriptions.get(subscription_id)
+                                    state = self._channel_state.get(channel_id or "")
+                                    if channel_id and state is not None:
+                                        await self._handle_event(channel_id, state, event)
+                                        self._trim_seen(state)
+                                elif message[0] == "CLOSED":
+                                    detail = message[-1] if len(message) > 2 else "subscription closed"
+                                    raise ConnectionError(str(detail))
+                                elif message[0] == "NOTICE":
+                                    logger.warning("Buzz: relay notice: %s", message[-1])
+                            if time.monotonic() >= _next_dm_discovery:
+                                _next_dm_discovery = (
+                                    time.monotonic() + _discovery_every
+                                )
+                                try:
+                                    await self._discover_and_subscribe_new(
+                                        websocket, subscriptions
+                                    )
+                                except asyncio.CancelledError:
+                                    raise
+                                except Exception:
+                                    logger.debug(
+                                        "Buzz: WS DM discovery sweep failed",
+                                        exc_info=True,
+                                    )
                 except asyncio.CancelledError:
                     raise
                 except Exception as e:

--- a/tests/gateway/test_buzz_ws_dm_discovery.py
+++ b/tests/gateway/test_buzz_ws_dm_discovery.py
@@ -1,0 +1,180 @@
+"""Periodic DM discovery on the Buzz WebSocket transport (#93557).
+
+Some relays never emit a kind-44100 membership event for a fresh DM, and
+the WS loop relied on those events alone — a conversation opened while the
+gateway was running stayed invisible (nothing subscribed, nothing
+dispatched) until the next WS reconnect. The poll loop already re-runs
+discovery every _DM_DISCOVERY_EVERY sweeps; the WS loop now runs the same
+sweep at the same cadence by bounding each receive with the remaining time
+to the next sweep.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+_buzz_mod = load_plugin_adapter("buzz")
+BuzzAdapter = _buzz_mod.BuzzAdapter
+
+SELF_PUBKEY = "9fd5c7ba6d3ef224da78f541e0fcb9c50f72cc63edb19aae76ac6a0474dfa860"
+TEST_PRIVATE_KEY = "00" * 31 + "03"
+CHANNEL = "ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd"
+NEW_DM = "ddd2bc1a-7a82-5a8f-8c4e-57a070cbe7cd"
+
+
+def _make_adapter(extra=None):
+    from gateway.config import PlatformConfig
+
+    cfg = PlatformConfig(
+        enabled=True,
+        extra={
+            "relay_url": "https://test.relay",
+            "poll_interval": 0.05,  # discovery every 5 * 0.05s = 0.25s
+            **(extra or {}),
+        },
+    )
+    adapter = BuzzAdapter(cfg)
+    adapter._self_pubkey = SELF_PUBKEY
+    adapter._private_key = TEST_PRIVATE_KEY
+    adapter._display_name = "Chip"
+    return adapter
+
+
+class _QuietWebSocket:
+    """A websocket whose frame stream never yields and records sends."""
+
+    def __init__(self):
+        self.sent = []
+        self._done = asyncio.Event()
+
+    async def recv(self):
+        await self._done.wait()
+        raise ConnectionError("test shutdown")
+
+    async def send(self, raw):
+        self.sent.append(json.loads(raw))
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        await self._done.wait()
+        raise ConnectionError("test shutdown")
+
+
+@pytest.mark.asyncio
+async def test_ws_loop_discovers_midsession_dm_without_membership_events(monkeypatch):
+    """A DM opened mid-session is discovered and subscribed even when the
+    relay emits no kind-44100 membership event for it (#93557)."""
+    adapter = _make_adapter()
+    adapter.poll_interval = 0.2  # discovery every 5 * 0.2s = 1s in the test
+    ws = _QuietWebSocket()
+    discovery_calls = []
+
+    async def fake_discover_dms(*, seed):
+        discovery_calls.append(seed)
+        if len(discovery_calls) >= 2:
+            # Mid-session shape: first sweep at connect found nothing new;
+            # by the second sweep the user opened a DM.
+            adapter._channel_state[NEW_DM] = {
+                "chat_type": "dm", "last_ts": 0, "seen": {},
+            }
+
+    async def fake_auth(websocket):
+        return None
+
+    async def fake_subscribe(websocket):
+        # Watched-channel + membership subscription map at connect time.
+        return {"hermes-buzz-0": CHANNEL, _buzz_mod._WS_MEMBERSHIP_SUB_ID: None}
+
+    async def fake_send_sub(websocket, sub_id, channel_id):
+        ws.sent.append(["REQ", sub_id, channel_id])
+
+    monkeypatch.setattr(adapter, "_discover_dms", fake_discover_dms)
+    monkeypatch.setattr(adapter, "_authenticate_websocket", fake_auth)
+    monkeypatch.setattr(adapter, "_subscribe_websocket", fake_subscribe)
+    monkeypatch.setattr(adapter, "_send_channel_subscription", fake_send_sub)
+    monkeypatch.setattr(adapter, "_websocket_url", lambda: "wss://test.relay")
+
+    import hermes_cli  # noqa: F401  (ensure package import works under loader)
+
+    real_connect = None
+    try:
+        import websockets
+        real_connect = websockets.connect
+
+        # The real websockets.connect returns an async-context-manager
+        # object, not a coroutine — mirror that shape so `async with` in
+        # _websocket_loop binds straight to the fake websocket.
+        def fake_connect(*a, **kw):
+            return ws
+
+        websockets.connect = fake_connect
+    except ImportError:
+        pytest.skip("websockets not installed")
+
+    try:
+        task = asyncio.create_task(adapter._websocket_loop())
+        await asyncio.wait_for(_wait_for_condition(
+            lambda: any(
+                cmd and len(cmd) > 2 and cmd[2] == NEW_DM for cmd in ws.sent
+            )
+        ), timeout=8)
+    finally:
+        if real_connect is not None:
+            websockets.connect = real_connect
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, ConnectionError):
+            pass
+
+    # Discovery ran more than once (periodic, not connect-only) and a
+    # subscription frame for the new DM was sent on the live socket.
+    assert len(discovery_calls) >= 2
+    subscribed = [cmd[2] for cmd in ws.sent if cmd and len(cmd) > 2]
+    assert NEW_DM in subscribed
+
+
+async def _wait_for_condition(predicate, poll_s: float = 0.02):
+    while not predicate():
+        await asyncio.sleep(poll_s)
+
+
+@pytest.mark.asyncio
+async def test_discover_and_subscribe_new_only_touches_new_channels(monkeypatch):
+    """The shared sweep helper subscribes ONLY channels discovery added —
+    already-watched channels are not re-subscribed."""
+    adapter = _make_adapter()
+    ws = _QuietWebSocket()
+    subscriptions = {"hermes-buzz-0": CHANNEL}
+    adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+
+    async def fake_discover_dms(*, seed):
+        adapter._channel_state[NEW_DM] = {
+            "chat_type": "dm", "last_ts": 0, "seen": {},
+        }
+
+    sent = []
+
+    async def fake_send_sub(websocket, sub_id, channel_id):
+        sent.append(channel_id)
+
+    monkeypatch.setattr(adapter, "_discover_dms", fake_discover_dms)
+    monkeypatch.setattr(adapter, "_send_channel_subscription", fake_send_sub)
+
+    await adapter._discover_and_subscribe_new(ws, subscriptions)
+
+    assert sent == [NEW_DM]
+    assert any(v == NEW_DM for v in subscriptions.values())


### PR DESCRIPTION
## What does this PR do?

The Buzz WebSocket transport never discovered DM conversations opened while the gateway was running on relays that don't emit a kind-44100 membership event for a fresh DM. The WS receive loop (`async for raw in websocket`) relied on those membership events alone to notice new conversations, so a mid-session DM stayed invisible — nothing was subscribed and nothing dispatched — until the next WS reconnect. The poll loop already re-runs DM discovery every `_DM_DISCOVERY_EVERY` sweeps; this PR gives the WS loop the same periodic sweep at the same cadence.

## Related Issue

Fixes #93557

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `plugins/platforms/buzz/adapter.py`:
  - Extracted the discover-and-subscribe-new-channels tail of `_handle_membership_event` into a shared `_discover_and_subscribe_new(websocket, subscriptions)` helper (the membership path now calls it unchanged in behavior).
  - Replaced the unbounded `async for raw in websocket:` receive in `_websocket_loop` with a bounded receive (`asyncio.wait_for(stream.__anext__(), ...)`, timeout capped at 30s) plus a periodic sweep that runs `_discover_and_subscribe_new` every `poll_interval * _DM_DISCOVERY_EVERY` seconds — the exact cadence `_poll_loop` already uses. Sweep failures are logged at debug and retried on the next cadence; `CancelledError` is re-raised. CLOSED → `ConnectionError`, NOTICE logging, and malformed-frame skipping are preserved.

## How to Test

- New: `.venv/bin/python -m pytest tests/gateway/test_buzz_ws_dm_discovery.py -q` — should pass (2 tests). Both tests fail on unpatched `main` (verified via `git stash push -- plugins/platforms/buzz/adapter.py`), pinning the regression.
- Regression: `.venv/bin/python -m pytest tests/gateway/test_buzz_websocket.py tests/gateway/test_buzz_adapter.py -q` — should pass (27 tests).

Observed result: on `main`, the WS loop test times out with zero discovery sweeps because a quiet socket yields no frames and the loop has no cadence of its own; with this PR the new DM is discovered on the second sweep and a `REQ` subscription frame for it is sent on the live socket.

## Checklist

- [x] Code follows project style (no unrelated changes)
- [x] Self-reviewed the diff
- [x] Added/updated tests covering the fix
- [x] All new and existing tests pass locally (the 27 existing buzz tests pass; the 5 known process-tree-kill tests elsewhere in the suite fail identically on clean `main` in this environment and are unrelated)
- [x] PR targets `upstream/main` from a fork branch
