### PR TITLE
fix(config): stop _migrate_to_15 from reporting a write that never lands

### DIFF
--- a/hermes_cli/config_migrations.py
+++ b/hermes_cli/config_migrations.py
@@ -220,21 +220,15 @@ def _migrate_to_14(results: Dict[str, Any], quiet: bool) -> None:
 
 def _migrate_to_15(results: Dict[str, Any], quiet: bool) -> None:
     # ── Version 14 → 15: add explicit gateway interim-message gate ──
-    _c = _cfg()
-    read_raw_config = _c.read_raw_config
-    _persist_migration = _c._persist_migration
-
-    config = read_raw_config()
-    display = config.get("display", {})
-    if not isinstance(display, dict):
-        display = {}
-    if "interim_assistant_messages" not in display:
-        display["interim_assistant_messages"] = True
-        config["display"] = display
-        results["config_added"].append("display.interim_assistant_messages=true (default)")
-        _persist_migration(config)
-        if not quiet:
-            print("  ✓ Added display.interim_assistant_messages=true")
+    # Historical note: this step used to write display.interim_assistant_
+    # messages=true for installs that lacked the key. That value equals the
+    # current schema default, so _persist_migration's strip-defaults
+    # invariant removed it again immediately — the step reported "✓ Added"
+    # while nothing landed on disk, and the intended pin never existed.
+    # Read-time deep-merge already supplies True, so the correct action is
+    # no write at all; the step is kept so the ladder position and the
+    # version bump stay stable.
+    _ = results, quiet
 
 
 def _migrate_to_16(results: Dict[str, Any], quiet: bool) -> None:

--- a/tests/hermes_cli/test_migrate_to_15_noop.py
+++ b/tests/hermes_cli/test_migrate_to_15_noop.py
@@ -1,0 +1,66 @@
+"""_migrate_to_15 must be a faithful no-op (#93533).
+
+The v14→v15 step historically wrote ``display.interim_assistant_messages:
+true`` for installs lacking the key. That value equals the schema default,
+so ``_persist_migration``'s strip-defaults invariant removed it again
+immediately — while the migration printed "✓ Added …" and recorded a
+``config_added`` entry that never landed on disk.
+"""
+
+from pathlib import Path
+
+from hermes_cli import config as c
+from hermes_cli import config_migrations as m
+
+
+def _results():
+    return {
+        "config_added": [],
+        "config_removed": [],
+        "config_changed": [],
+        "errors": [],
+    }
+
+
+def _write_config(text: str) -> Path:
+    path = c.get_hermes_config_path() if hasattr(c, "get_hermes_config_path") else (
+        c.get_hermes_home() / "config.yaml"
+    )
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_v15_migration_persists_nothing_and_reports_nothing():
+    _write_config("_config_version: 14\ndisplay:\n  skin: mono\n")
+    before = c.read_raw_config()
+
+    results = _results()
+    m._migrate_to_15(results, quiet=True)
+
+    after = c.read_raw_config()
+    assert after == before, "migration must not touch a default-equal value"
+    assert results["config_added"] == [], (
+        "must not report a write that never landed on disk"
+    )
+    assert "interim_assistant_messages" not in after.get("display", {})
+
+
+def test_effective_value_still_resolves_true_via_defaults():
+    _write_config("_config_version: 14\ndisplay:\n  skin: mono\n")
+    m._migrate_to_15(_results(), quiet=True)
+
+    cfg = c.load_config_readonly()
+    assert cfg["display"]["interim_assistant_messages"] is True
+
+
+def test_explicit_user_value_is_left_untouched():
+    _write_config(
+        "_config_version: 14\ndisplay:\n"
+        "  interim_assistant_messages: false\n"
+    )
+    results = _results()
+    m._migrate_to_15(results, quiet=True)
+
+    raw = c.read_raw_config()
+    assert raw["display"]["interim_assistant_messages"] is False
+    assert results["config_added"] == []


### PR DESCRIPTION
## What does this PR do?

_migrate_to_15 (the v14→v15 step) wrote display.interim_assistant_messages: true for installs that lacked the key, then persisted through _persist_migration. That helper enforces the repo's migration write invariant — *a migration may only persist values that differ from the current schema default* (hermes_cli/config.py:2270-2291) — and since the written value **equals** DEFAULT_CONFIG["display"]["interim_assistant_messages"], the strip pass removed it immediately. The step nevertheless printed ✓ Added display.interim_assistant_messages=true and appended to esults["config_added"], so hermes update reported a config pin that never existed on disk.

This PR makes the step an explicit, documented no-op: no write, no report. Read-time deep-merge already resolves the effective value to True, which is the invariant-compliant way to supply defaults; materializing them is exactly what the strip-defaults invariant exists to prevent (the historical "hermes update blows up my hand-curated config" reports). The step body is kept in place so the migration ladder position and the v15 version bump remain stable.

Live repro of the old behavior (isolated temp HERMES_HOME, before this fix):

`
before: {'skin': 'mono'}
after : {'skin': 'mono'}          <- nothing persisted
reported: ['display.interim_assistant_messages=true (default)']
`

## Related Issue

Fixes #93533

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- hermes_cli/config_migrations.py — _migrate_to_15():
  - removed the default-equal write + unconditional success print / config_added entry;
  - left a comment documenting why the step is a deliberate no-op (strip-defaults invariant + read-time merge), so nobody reintroduces the write;
  - signature/ladder registration untouched.
- 	ests/hermes_cli/test_migrate_to_15_noop.py — new regression tests:
  - running the step on a v14-style raw config leaves the raw config byte-identical AND reports nothing in config_added;
  - load_config_readonly() still resolves interim_assistant_messages == True via defaults after migration;
  - an explicit user value (e.g. alse) is left untouched and unreported.

## How to Test

1. uv run python -m pytest tests/hermes_cli/test_migrate_to_15_noop.py -q → 3 passed.
2. Related ladder/sibling suites still green: uv run python -m pytest tests/hermes_cli/test_migrate_to_15_noop.py tests/hermes_cli/test_sibling_config_migration.py tests/hermes_cli/test_setup_openclaw_migration.py -q → 18 passed.
3. uff check hermes_cli/config_migrations.py tests/hermes_cli/test_migrate_to_15_noop.py → clean.
4. Manual: point HERMES_HOME at a temp dir with _config_version: 14 + minimal display: block, run the migration — config file unchanged, no "✓ Added" line printed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (ix(scope):, eat(scope):, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls?q=is%3Apr) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run targeted test suites locally and they pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation updated where needed (in-code comments explain the no-op) or N/A
- [x] No config key surface changed → cli-config.yaml.example N/A
- [x] CONTRIBUTING/AGENTS unchanged → N/A
- [x] Cross-platform impact: none (pure Python config logic) → N/A
- [x] No tool schema/behavior change → N/A

## Screenshots / Logs

N/A — no UI output beyond removing a false success line.