### PR TITLE
fix(desktop): remote Git artifacts no longer 403 from the wrong backend (#89916, salvage #89918)

### DIFF
--- a/apps/desktop/src/lib/desktop-git.test.ts
+++ b/apps/desktop/src/lib/desktop-git.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { setApiRequestConnection } from '@/hermes'
 import { $connection } from '@/store/session'
 
 import { desktopGit } from './desktop-git'
@@ -37,6 +38,7 @@ describe('desktop git facade', () => {
   })
 
   afterEach(() => {
+    setApiRequestConnection(null)
     vi.unstubAllGlobals()
     vi.clearAllMocks()
     $connection.set(null)
@@ -87,6 +89,27 @@ describe('desktop git facade', () => {
       method: 'POST',
       path: '/api/git/review/stage',
       profile: 'remote-docker'
+    })
+  })
+
+  it('routes remote git reads and writes through the active registered gateway', async () => {
+    setApiRequestConnection('remote-user')
+    $connection.set({ mode: 'remote', profile: 'default' } as never)
+
+    await desktopGit()?.repoStatus('/srv/work')
+    await desktopGit()?.review.stage('/srv/work', 'a.txt')
+
+    expect(api).toHaveBeenCalledWith({
+      connectionId: 'remote-user',
+      path: '/api/git/status?path=%2Fsrv%2Fwork',
+      profile: 'default'
+    })
+    expect(api).toHaveBeenCalledWith({
+      body: { file: 'a.txt', path: '/srv/work' },
+      connectionId: 'remote-user',
+      method: 'POST',
+      path: '/api/git/review/stage',
+      profile: 'default'
     })
   })
 

--- a/apps/desktop/src/lib/desktop-git.ts
+++ b/apps/desktop/src/lib/desktop-git.ts
@@ -7,6 +7,7 @@ import type {
   HermesReviewList,
   HermesReviewShipInfo
 } from '@/global'
+import { hermesApi } from '@/hermes'
 
 import { desktopFsProfile, isDesktopFsRemoteMode } from './desktop-fs'
 
@@ -25,7 +26,7 @@ function desktopApi<T>(path: string, body?: Record<string, unknown>): Promise<T>
     throw new Error('Hermes Desktop bridge is unavailable')
   }
 
-  return desktop.api<T>(
+  return hermesApi<T>(
     body ? { body, method: 'POST', path, profile: desktopFsProfile() } : { path, profile: desktopFsProfile() }
   )
 }


### PR DESCRIPTION
## Summary

Salvages the remaining half of PR #89918 by @frizikk. Fixes the leftover scope of #89916.

Clicking a Git-backed artifact (file diffs, review data) in a session owned by a registered remote gateway no longer returns `403: File is not readable` from the wrong machine: the remote Git facade now routes through the connection-aware `hermesApi()` seam, so requests reach the gateway that owns the session instead of the local backend.

The filesystem half of #89918 already landed on main via #93547 (same `hermesApi()` routing in `desktop-fs.ts`); this PR completes the contributor's fix with the sibling `desktop-git.ts` facade.

## Changes

- `src/lib/desktop-git.ts`: `desktopApi()` routes through `hermesApi()` (active registry `connectionId` attached) instead of calling the Electron bridge directly.
- `src/lib/desktop-git.test.ts`: covers registered-gateway Git reads and mutations, including profile preservation.

## Validation

| Check | Result |
|---|---|
| `npx vitest run` desktop-git + desktop-fs tests | 19/19 pass |
| `npm run typecheck` (3 tsconfigs) | pass |
| eslint on changed files | pass |

Authorship preserved: cherry-picked from #89918 (fs-half conflict resolved in favor of main, which already carries it via #93547).

## Infographic

![Git requests follow the connection](https://v3b.fal.media/files/b/0aa79527/iWmltAZZpcEi6LjJM_Sol_lCdY6Ihb.png)
