### PR TITLE
fix(hermes-bots): stop New Cronjob dialog crash when the owner is a roster object

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5665,6 +5665,12 @@ async function openRosterBot(bot) {
 }
 
 function displayName(bot, meta) {
+  // Defensive: callers have historically passed {name: <object>} here (e.g.
+  // wrapping a roster owner object instead of its .name); a non-string name
+  // must degrade to '' rather than TypeError mid-render.
+  if (bot && typeof bot.name !== 'string') {
+    bot = { ...bot, name: typeof bot.name === 'object' && bot.name !== null ? String(bot.name?.name ?? '') : '' }
+  }
   // A configured alias route claiming this row overrides source-derived
   // identity: the friendly alias name must survive hosted-session
   // activation and Cloud-only rosters (#89131).
@@ -10870,7 +10876,7 @@ function CreateRoutineDialog({ bot, open, onClose }) {
               'Send results to',
               pickerSelect(target, setTarget, [
                 { id: 'history', label: 'Run history only' },
-                { id: 'bot-chat', label: `${displayName({ name: bot }, $botMeta.get()[bot])}\u2019s chat (bot responds)` }
+                { id: 'bot-chat', label: `${displayName(typeof bot === 'string' ? { name: bot } : bot, botRosterMeta(bot, $botMeta.get()))}\u2019s chat (bot responds)` }
               ])
             ),
             jsxs('label', {


### PR DESCRIPTION
## Summary

Clicking **"+ New Cronjob"** in the Cronjobs pane crashes the whole routines pane into its error boundary:

```
[error-boundary:contrib:hermes-bots:routines]
TypeError: (e.name || "").trim is not a function
```

The `bot` prop handed to `CreateRoutineDialog` is a roster-owner **object**: `RoutinesPane.openCreate()` stores the resolved owner from `resolveRoutineOwner()`, which always returns an object. The "Send results to" option label then wraps it unconditionally:

```js
{ id: 'bot-chat', label: `${displayName({ name: bot }, $botMeta.get()[bot])}...` }
```

producing `{ name: <object> }`, so `displayName()` calls `(bot.name || '').trim()` on an object and throws mid-render. The dialog header two lines above already normalizes correctly (`typeof bot === 'string' ? { name: bot } : bot`); this call site does not.

Deterministic: any user opening the dialog with a valid roster owner repros it.

## Fix

- Normalize at the call site, matching the header's existing pattern (and use `botRosterMeta(bot, ...)` so meta lookup works for object owners too).
- Defensive guard in `displayName()`: a non-string `bot.name` degrades to `''` instead of a render-time TypeError.

## Related

This line came in with the same #90006 merge wave that produced the `activeBotRoute()` regression (#92830 / #92878 / fixes #92842, #92811); it is a residual from that refactor that survived the cleanup in #93125.

## Testing

- All hermes-bots test files pass locally; the 2 pre-existing failures in `routine-prompt.test.mjs` are identical on an unmodified checkout (verified via `git stash`) and untouched by this patch.
- Manually verified: dialog renders, creates jobs, and the renderer error no longer appears in desktop logs.