### PR TITLE
fix(compression): keep lean tail budget through runtime recalibration

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1790,6 +1790,18 @@ class ContextCompressor(MicroCompactionMixin, ContextEngine):
     def tail_token_budget(self, value: int) -> None:
         self._tail_token_budget = value
 
+    def recalibrate_tail_budget(self) -> None:
+        """Drop the cached tail budget so the mode-aware property re-derives it.
+
+        Runtime recalibration paths that change the threshold (e.g. the aux
+        compression-model threshold sync) must call this instead of writing
+        ``threshold_tokens * summary_target_ratio`` themselves: that legacy
+        formula is only one branch of the ``tail_token_budget`` property, and
+        caching it unconditionally overwrites the lean clamp while
+        ``tail_mode`` still claims "lean".
+        """
+        self._tail_token_budget = None
+
     @property
     def max_summary_tokens(self) -> int:
         if self._max_summary_tokens is None:

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1701,9 +1701,10 @@ def _lower_threshold_to_aux_context(
     compressor = agent.context_compressor
     old_threshold = compressor.threshold_tokens
     new_threshold = compressor.threshold_tokens = aux_context
-    summary_target_ratio = getattr(compressor, "summary_target_ratio", None)
-    if isinstance(summary_target_ratio, (int, float)):
-        compressor.tail_token_budget = int(new_threshold * summary_target_ratio)
+    # Re-derive the tail through the mode-aware property (legacy recomputes
+    # threshold*ratio; lean keeps its clamped window-based budget) — writing
+    # the legacy formula here directly would overwrite the lean clamp.
+    compressor.recalibrate_tail_budget()
     main_ctx = compressor.context_length
     if main_ctx:
         compressor.threshold_percent = new_threshold / main_ctx

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from run_agent import AIAgent
-from agent.context_compressor import ContextCompressor
+from agent.context_compressor import ContextCompressor, LEAN_TAIL_CAP_TOKENS
 
 
 @pytest.fixture(autouse=True)
@@ -31,8 +31,16 @@ def _make_agent(
     compression_enabled: bool = True,
     threshold_percent: float = 0.50,
     main_context: int = 200_000,
+    tail_mode: str = "legacy",
+    real_compressor: bool = False,
 ) -> AIAgent:
-    """Build a minimal AIAgent with a compressor, skipping __init__."""
+    """Build a minimal AIAgent with a compressor, skipping __init__.
+
+    The default MagicMock compressor is enough for warning/message tests.
+    ``real_compressor=True`` builds a REAL ContextCompressor so the
+    mode-aware tail policy is exercised end to end — a mock would silently
+    accept any budget the aux-context sync writes.
+    """
     agent = AIAgent.__new__(AIAgent)
     agent.model = "test-main-model"
     agent.provider = "openrouter"
@@ -61,6 +69,22 @@ def _make_agent(
     compressor.tail_token_budget = int(
         compressor.threshold_tokens * compressor.summary_target_ratio
     )
+    # Mimic the real legacy policy: recalibration re-derives the tail
+    # from the CURRENT threshold at the configured ratio (the real
+    # method invalidates a cache the mode-aware property re-fills).
+    compressor.recalibrate_tail_budget.side_effect = lambda: setattr(
+        compressor, "tail_token_budget",
+        int(compressor.threshold_tokens * compressor.summary_target_ratio),
+    )
+    if real_compressor:
+        compressor = ContextCompressor(
+            model="test-main-model",
+            threshold_percent=threshold_percent,
+            summary_target_ratio=0.20,
+            config_context_length=main_context,
+            tail_mode=tail_mode,
+            quiet_mode=True,
+        )
     agent.context_compressor = compressor
 
     return agent
@@ -108,8 +132,74 @@ def test_auto_corrects_threshold_when_aux_context_below_threshold(mock_get_clien
     # Every threshold-derived budget must move with it. Keeping the original
     # 20K tail here would protect 25% of the lowered threshold instead of the
     # configured 20%, and larger real-world mismatches can make the tail's 1.5x
-    # soft ceiling wider than the entire compression trigger.
+    # soft ceiling wider than the entire compression trigger. The sync goes
+    # through the canonical mode-aware hook; the mock's side_effect re-derives
+    # the legacy budget from the lowered threshold.
+    agent.context_compressor.recalibrate_tail_budget.assert_called_once()
     assert agent.context_compressor.tail_token_budget == 16_000
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_aux_sync_keeps_lean_tail_policy(mock_get_client, mock_ctx_len):
+    """Regression: the aux-context threshold sync must not cache a legacy
+    threshold*ratio tail when tail_mode is lean.
+
+    Real compressor, 1M main window (lean tail = 25K cap), aux context 80K
+    lowers the live threshold to 80K. The legacy formula would write
+    80K * 0.20 = 16K into the tail budget; lean must stay at its canonical
+    clamp (25K on a 1M window) and keep tail_mode == "lean".
+    """
+    agent = _make_agent(
+        main_context=1_000_000,
+        threshold_percent=0.65,
+        tail_mode="lean",
+        real_compressor=True,
+    )
+    comp = agent.context_compressor
+    assert comp.tail_token_budget == LEAN_TAIL_CAP_TOKENS  # 25K on 1M
+
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+    agent._emit_status = lambda message: None
+
+    agent._check_compression_model_feasibility()
+
+    # The threshold was lowered to the aux context...
+    assert comp.threshold_tokens == 80_000
+    # ...but the lean tail policy survived the sync.
+    assert comp.tail_mode == "lean"
+    assert comp.tail_token_budget == LEAN_TAIL_CAP_TOKENS
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_aux_sync_legacy_tail_follows_lowered_threshold(mock_get_client, mock_ctx_len):
+    """Legacy behavior on the same sync path is unchanged: the tail budget
+    follows the lowered threshold at the configured ratio (80K * 0.20)."""
+    agent = _make_agent(
+        main_context=1_000_000,
+        threshold_percent=0.65,
+        tail_mode="legacy",
+        real_compressor=True,
+    )
+    comp = agent.context_compressor
+    before = comp.tail_token_budget
+    assert before == int(comp.threshold_tokens * comp.summary_target_ratio)
+
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+    agent._emit_status = lambda message: None
+
+    agent._check_compression_model_feasibility()
+
+    assert comp.threshold_tokens == 80_000
+    assert comp.tail_mode == "legacy"
+    assert comp.tail_token_budget == int(80_000 * comp.summary_target_ratio)
 
 
 @patch("agent.model_metadata.get_model_context_length", return_value=32_768)


### PR DESCRIPTION
## Problem

The `tail_token_budget` property (`agent/context_compressor.py`) is mode-aware: in `lean` mode it derives a clamped 2.5%-of-window budget; in legacy mode it computes `threshold_tokens * summary_target_ratio`. The result is cached in `_tail_token_budget`.

The aux compression-model threshold-sync path in `agent/conversation_compression.py::_lower_threshold_to_aux_context` wrote the LEGACY formula directly into the cached field, unconditionally. After it runs while `tail_mode` is `"lean"`, the cached budget permanently reflects the legacy formula — the tail's 1.5x soft ceiling widens past the lowered trigger, compression preserves nearly the entire request, and compaction re-fires repeatedly. The session keeps claiming `tail_mode: lean` while behaving legacy.

Note: this PR deliberately does NOT touch `update_model()`. Current upstream `main` already invalidates the cache there (`self._tail_token_budget = None`, mode-aware recompute), verified by `test_update_model_preserves_lean_mode` on main. Related #92738 (still open) proposes a lean/legacy branch inside `update_model()` — that outcome is already what main produces unconditionally, so #92738 is redundant for `update_model()`; this PR addresses the remaining live writer, the aux-sync path.

## Fix

Add a policy-neutral `ContextCompressor.recalibrate_tail_budget()` hook whose only responsibility is invalidating `_tail_token_budget`. `_lower_threshold_to_aux_context()` calls it unconditionally after lowering the threshold and lets the existing `tail_token_budget` property remain the single owner of lean-vs-legacy policy:

* legacy re-derives `threshold * ratio` (behavior unchanged),
* lean re-derives its context-window clamp,
* no cross-module private cache mutation, no duplicated `tail_mode` branching,
* future tail policies stay localized to `ContextCompressor`.

## Testing

Live repro on current main before fix (real compressor, 1M window, aux 80K): lean 25K -> 16K (bug), legacy 130K -> 16K (correct). After fix: lean 25K -> 25K, legacy unchanged.

```bash
pytest tests/run_agent/test_compression_feasibility.py  # 12 passed (10 existing + 2 new)
pytest tests/agent/test_context_compressor.py           # 152 passed (unchanged behavior)
```

New regression tests use a REAL compressor end to end through `_check_compression_model_feasibility()`: `test_aux_sync_keeps_lean_tail_policy` (lean survives the sync) and `test_aux_sync_legacy_tail_follows_lowered_threshold` (legacy follows 80K * ratio). The pre-existing MagicMock test now asserts the sync goes through the hook (`recalibrate_tail_budget.assert_called_once()`), with a mock side-effect mimicking the real legacy re-derivation.
