### PR TITLE
fix(pairing): prune expired rate-limit entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,8 @@ wandb/
 testlogs
 playwright-report/
 test-results/
+/log.txt
+/sqlite_leak_fix.png
 # Playwright visual regression baselines — cached from main in CI, not committed
 *-snapshots/
 

--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -869,7 +869,7 @@ class PairingStore:
     # ----- Cleanup -----
 
     def _cleanup_expired(self, platform: str) -> None:
-        """Remove expired pending codes.
+        """Remove expired pending codes and stale per-user rate-limit keys.
 
         Tolerant of malformed / legacy entries — anything without a numeric
         ``created_at`` is treated as expired (it's effectively unusable
@@ -893,6 +893,31 @@ class PairingStore:
             for entry_id in expired:
                 del pending[entry_id]
             self._save_json(path, pending)
+
+        # The rate-limit file is shared across platforms. Prune only the
+        # current platform's per-user timestamps so failed-attempt counters
+        # for other platforms remain untouched. Malformed timestamps are
+        # unusable and are safe to discard.
+        rate_path = self._rate_limit_path()
+        limits = self._load_json(rate_path)
+        prefix = f"{platform}:"
+        stale_keys = [
+            key
+            for key, timestamp in limits.items()
+            if key.startswith(prefix)
+            and (
+                not isinstance(timestamp, (int, float))
+                or (now - timestamp) >= RATE_LIMIT_SECONDS
+            )
+        ]
+        lockout_key = f"_lockout:{platform}"
+        lockout_until = limits.get(lockout_key)
+        if isinstance(lockout_until, (int, float)) and lockout_until <= now:
+            stale_keys.append(lockout_key)
+        if stale_keys:
+            for key in stale_keys:
+                limits.pop(key, None)
+            self._save_json(rate_path, limits)
 
     def _all_platforms(self, suffix: str) -> list:
         """List all platforms that have data files of a given suffix."""

--- a/tests/hermes_cli/test_pairing.py
+++ b/tests/hermes_cli/test_pairing.py
@@ -1,7 +1,7 @@
 from argparse import Namespace
 from unittest.mock import patch
 
-from gateway.pairing import PairingStore
+from gateway.pairing import RATE_LIMIT_SECONDS, PairingStore
 from hermes_cli.pairing import pairing_command
 
 
@@ -41,3 +41,33 @@ def test_cli_listed_request_id_and_bot_code_can_be_approved(tmp_path, capsys):
     assert "listed-user" in request_approval_output
     assert "code-user" in code_approval_output
     assert approved_ids == {"listed-user", "code-user"}
+
+
+def test_cleanup_expired_prunes_stale_rate_limit_keys(tmp_path):
+    now = 10_000.0
+    with patch("gateway.pairing.PAIRING_DIR", tmp_path), patch(
+        "gateway.pairing.time.time", return_value=now
+    ):
+        store = PairingStore()
+        rate_path = store._rate_limit_path()
+        store._save_json(
+            rate_path,
+            {
+                "telegram:stale-user": now - RATE_LIMIT_SECONDS - 1,
+                "telegram:fresh-user": now - RATE_LIMIT_SECONDS + 1,
+                "telegram:malformed": "not-a-timestamp",
+                "discord:stale-user": now - RATE_LIMIT_SECONDS - 1,
+                "_lockout:telegram": now - 1,
+                "_failures:telegram": 2,
+            },
+        )
+
+        store._cleanup_expired("telegram")
+        remaining = store._load_json(rate_path)
+
+    assert "telegram:stale-user" not in remaining
+    assert "telegram:malformed" not in remaining
+    assert "_lockout:telegram" not in remaining
+    assert remaining["telegram:fresh-user"] == now - RATE_LIMIT_SECONDS + 1
+    assert "discord:stale-user" in remaining
+    assert remaining["_failures:telegram"] == 2


### PR DESCRIPTION
## Summary
- prune expired or malformed per-user pairing rate-limit timestamps
- prune expired platform lockouts without touching failure counters or other platforms
- add regression coverage
- ignore legacy root artifacts already absent from current main

## Verification
- uv run --extra dev python -m pytest -q tests/hermes_cli/test_pairing.py
- uv run --extra dev ruff check gateway/pairing.py tests/hermes_cli/test_pairing.py
- git diff --check

Ox Alpha remediation: OX-SEC-004.