### PR TITLE
feat(memory): add hindsight_update_memory tool to set occurred_* on stored facts

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -262,6 +262,56 @@ def _fetch_hindsight_api_version(api_url: str, api_key: str | None = None,
     return str(version) if version else None
 
 
+async def _patch_memory_via_client(
+    client, bank_id: str, memory_id: str, fields: dict, timeout: float
+) -> dict:
+    """PATCH a single memory's fields through the SDK's request pipeline.
+
+    hindsight-client 0.6.1's generated ``MemoryApi`` has no per-memory PATCH
+    method, so this drives ``ApiClient.param_serialize``/``call_api`` with a
+    constant resource path — the exact channel the generated methods use.
+    The target host, auth, and timeout all come from the client's own
+    ``Configuration`` (same source as every aretain/arecall call), so no
+    request can reach anything but the configured Hindsight server. Both
+    client shapes work: the cloud facade exposes ``_api_client`` directly,
+    and ``HindsightEmbedded`` forwards attribute access to its inner
+    facade via ``__getattr__``.
+    """
+    api_client = getattr(client, "_api_client", None)
+    if api_client is None:
+        raise RuntimeError("Hindsight client does not expose an ApiClient")
+    _param = api_client.param_serialize(
+        method="PATCH",
+        resource_path="/v1/default/banks/{bank_id}/memories/{memory_id}",
+        path_params={"bank_id": bank_id, "memory_id": memory_id},
+        query_params=[],
+        header_params={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+        body=fields,
+        post_params=[],
+        auth_settings=[],
+    )
+    response = await api_client.call_api(*_param, _request_timeout=timeout)
+    await response.read()
+    if response.status not in (200, 204):
+        detail = ""
+        try:
+            detail = response.data.decode("utf-8", errors="replace").strip()
+        except Exception:
+            pass
+        # Surface the server's own rejection body — for observation facts
+        # it names the actual reason ("only world/experience facts can be
+        # curated. Observations are derived…").
+        raise RuntimeError(f"HTTP {response.status}: {detail or response.reason}")
+    try:
+        data = json.loads(response.data.decode("utf-8", errors="replace")) if response.data else {}
+    except ValueError:
+        data = {}
+    return data if isinstance(data, dict) else {}
+
+
 def _check_api_supports_update_mode_append(api_url: str,
                                            api_key: str | None = None) -> bool:
     """Cached capability check for ``update_mode='append'`` on *api_url*.
@@ -398,6 +448,40 @@ REFLECT_SCHEMA = {
             "query": {"type": "string", "description": "The question to reflect on."},
         },
         "required": ["query"],
+    },
+}
+
+UPDATE_SCHEMA = {
+    "name": "hindsight_update_memory",
+    "description": (
+        "Update a stored memory — most importantly its event-time anchors "
+        "occurred_start/occurred_end, which Hindsight timelines and "
+        "time-filtered recall are built on and which retained memories land "
+        "with as null. Only world/experience facts can be updated; the "
+        "server rejects derived observation facts."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {"type": "string", "description": "ID of the stored memory to update."},
+            "occurred_start": {
+                "type": "string",
+                "description": (
+                    "ISO-8601 start of the event (Z / +00:00 / naive UTC all accepted). "
+                    'Empty string clears the field; omitting it leaves it unchanged.'
+                ),
+            },
+            "occurred_end": {
+                "type": "string",
+                "description": (
+                    "ISO-8601 end of the event. Empty string clears the field; "
+                    "omitting it leaves it unchanged."
+                ),
+            },
+            "text": {"type": "string", "description": "Replacement memory text."},
+            "context": {"type": "string", "description": "Replacement context label."},
+        },
+        "required": ["memory_id"],
     },
 }
 
@@ -2170,7 +2254,7 @@ class HindsightMemoryProvider(MemoryProvider):
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         if self._memory_mode == "context":
             return []
-        return [RETAIN_SCHEMA, RECALL_SCHEMA, REFLECT_SCHEMA]
+        return [RETAIN_SCHEMA, RECALL_SCHEMA, REFLECT_SCHEMA, UPDATE_SCHEMA]
 
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
         if tool_name == "hindsight_retain":
@@ -2242,6 +2326,43 @@ class HindsightMemoryProvider(MemoryProvider):
             except Exception as e:
                 logger.warning("hindsight_reflect failed: %s", e, exc_info=True)
                 return tool_error(f"Failed to reflect: {e}")
+
+        elif tool_name == "hindsight_update_memory":
+            memory_id = str(args.get("memory_id") or "").strip()
+            if not memory_id:
+                return tool_error("Missing required parameter: memory_id")
+            # Only keys the caller provided go on the patch body — an empty
+            # string is meaningful (it clears the field server-side).
+            fields: Dict[str, str] = {}
+            for key in ("occurred_start", "occurred_end", "text", "context"):
+                value = args.get(key)
+                if value is not None:
+                    fields[key] = str(value)
+            if not fields:
+                return tool_error(
+                    "Provide at least one field to update: occurred_start, "
+                    "occurred_end, text, or context"
+                )
+            try:
+                logger.debug("Tool hindsight_update_memory: bank=%s, memory=%s, fields=%s",
+                             self._bank_id, memory_id, sorted(fields))
+                self._run_hindsight_operation(
+                    lambda client: _patch_memory_via_client(
+                        client,
+                        bank_id=self._bank_id,
+                        memory_id=memory_id,
+                        fields=fields,
+                        timeout=float(self._timeout or _DEFAULT_TIMEOUT),
+                    )
+                )
+                return json.dumps({
+                    "result": "Memory updated successfully.",
+                    "memory_id": memory_id,
+                    "updated_fields": sorted(fields),
+                })
+            except Exception as e:
+                logger.warning("hindsight_update_memory failed: %s", e, exc_info=True)
+                return tool_error(f"Failed to update memory: {e}")
 
         return tool_error(f"Unknown tool: {tool_name}")
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -233,11 +233,16 @@ class TestSchemas:
         assert "content" in RETAIN_SCHEMA["parameters"]["required"]
 
 
-    def test_get_tool_schemas_returns_three(self, provider):
+    def test_get_tool_schemas_returns_four(self, provider):
         schemas = provider.get_tool_schemas()
-        assert len(schemas) == 3
+        assert len(schemas) == 4
         names = {s["name"] for s in schemas}
-        assert names == {"hindsight_retain", "hindsight_recall", "hindsight_reflect"}
+        assert names == {
+            "hindsight_retain",
+            "hindsight_recall",
+            "hindsight_reflect",
+            "hindsight_update_memory",
+        }
 
     def test_context_mode_returns_no_tools(self, provider_with_config):
         p = provider_with_config(memory_mode="context")

--- a/tests/plugins/memory/test_hindsight_update_memory.py
+++ b/tests/plugins/memory/test_hindsight_update_memory.py
@@ -1,0 +1,178 @@
+"""hindsight_update_memory: the missing write path for occurred_* fields (#93568).
+
+Retained memories land with occurred_start/occurred_end = null and no Hermes
+tool could ever set them — the plugin's only write tool was hindsight_retain,
+and the SDK's generated MemoryApi (0.6.1) has no per-memory PATCH method.
+The new tool drives ApiClient.param_serialize/call_api directly with the
+constant resource path the generated methods use, so host/auth/timeout stay
+in the SDK Configuration's domain.
+
+These tests use a fake ApiClient (no hindsight-client import needed) to pin:
+schema registration, provided-fields-only patch bodies with empty-string
+passthrough, the missing-argument guards, and rejection-body surfacing.
+"""
+
+import json
+
+import pytest
+
+from plugins.memory.hindsight import HindsightMemoryProvider, UPDATE_SCHEMA
+
+
+class _FakeResponse:
+    def __init__(self, status: int, data: bytes):
+        self.status = status
+        self.data = data
+        self.reason = f"reason-{status}"
+
+    async def read(self):
+        pass
+
+
+class _FakeApiClient:
+    """Stands in for hindsight_client_api.ApiClient.
+
+    param_serialize echoes back a RequestSerialized-shaped tuple whose URL
+    prefix represents the Configuration-owned host; call_api returns a
+    canned response. Everything the plugin is responsible for — method,
+    resource path, path params, header params, body — is captured for
+    assertions. Auth is Configuration-owned and deliberately not faked
+    here.
+    """
+
+    def __init__(self, status: int = 200, body: bytes = b'{"ok": true}'):
+        self.serialize_calls = []
+        self.call_api_calls = []
+        self.status = status
+        self.body = body
+
+    def param_serialize(self, **kwargs):
+        self.serialize_calls.append(kwargs)
+        # Mirror the real ApiClient: path params are interpolated (and
+        # URL-quoted) into the resource path at this layer.
+        resource_path = kwargs["resource_path"]
+        for key, value in (kwargs.get("path_params") or {}).items():
+            resource_path = resource_path.replace("{" + key + "}", str(value))
+        url = "https://configured-server.test" + resource_path
+        return (kwargs["method"], url, dict(kwargs.get("header_params") or {}),
+                kwargs.get("body"), kwargs.get("post_params") or [])
+
+    async def call_api(self, *args, **request_kwargs):
+        self.call_api_calls.append((args, request_kwargs))
+        return _FakeResponse(self.status, self.body)
+
+
+class _FakeClient:
+    def __init__(self, api_client):
+        self._api_client = api_client
+
+
+def _make_provider(tmp_path, monkeypatch, fake_api_client) -> HindsightMemoryProvider:
+    config = {
+        "mode": "cloud",
+        "api_url": "https://configured-server.test",
+        "bank_id": "test-bank",
+        "budget": "mid",
+        "memory_mode": "hybrid",
+    }
+    config_path = tmp_path / "hindsight" / "config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(config))
+    monkeypatch.setattr(
+        "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+    )
+    provider = HindsightMemoryProvider()
+    provider.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+    provider._client = _FakeClient(fake_api_client)
+    return provider
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for key in (
+        "HINDSIGHT_API_KEY", "HINDSIGHT_API_URL", "HINDSIGHT_BANK_ID",
+        "HINDSIGHT_MODE", "HINDSIGHT_TIMEOUT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_update_tool_registered_in_schemas(tmp_path, monkeypatch):
+    provider = _make_provider(tmp_path, monkeypatch, _FakeApiClient())
+    schemas = {s["name"]: s for s in provider.get_tool_schemas()}
+    assert "hindsight_update_memory" in schemas
+    schema = schemas["hindsight_update_memory"]
+    assert schema["parameters"]["required"] == ["memory_id"]
+    for prop in ("occurred_start", "occurred_end", "text", "context"):
+        assert prop in schema["parameters"]["properties"]
+    # The tool description must carry the server's curatability caveat so
+    # the model doesn't burn calls on derived observation facts.
+    assert "world/experience" in schema["description"]
+    assert UPDATE_SCHEMA["name"] == "hindsight_update_memory"
+
+
+def test_update_patches_only_provided_fields(tmp_path, monkeypatch):
+    api = _FakeApiClient()
+    provider = _make_provider(tmp_path, monkeypatch, api)
+    result = json.loads(provider.handle_tool_call("hindsight_update_memory", {
+        "memory_id": "mem-42",
+        "occurred_start": "2026-08-24T03:48:54Z",
+        "occurred_end": "",  # explicit clear must pass through, not drop
+    }))
+    assert result["result"] == "Memory updated successfully."
+    assert result["memory_id"] == "mem-42"
+    assert result["updated_fields"] == ["occurred_end", "occurred_start"]
+
+    assert len(api.serialize_calls) == 1
+    call = api.serialize_calls[0]
+    assert call["method"] == "PATCH"
+    assert call["resource_path"] == "/v1/default/banks/{bank_id}/memories/{memory_id}"
+    assert call["path_params"] == {"bank_id": "test-bank", "memory_id": "mem-42"}
+    # Provided keys only — text/context were omitted and must not appear.
+    assert call["body"] == {
+        "occurred_start": "2026-08-24T03:48:54Z",
+        "occurred_end": "",
+    }
+    assert call["header_params"]["Content-Type"] == "application/json"
+
+    args, request_kwargs = api.call_api_calls[0]
+    assert args[0] == "PATCH"
+    assert args[1] == "https://configured-server.test/v1/default/banks/test-bank/memories/mem-42"
+    assert request_kwargs["_request_timeout"] > 0
+
+
+def test_update_requires_memory_id(tmp_path, monkeypatch):
+    provider = _make_provider(tmp_path, monkeypatch, _FakeApiClient())
+    out = provider.handle_tool_call("hindsight_update_memory", {"occurred_start": "2026-01-01T00:00:00Z"})
+    assert "memory_id" in out
+
+
+def test_update_requires_at_least_one_field(tmp_path, monkeypatch):
+    provider = _make_provider(tmp_path, monkeypatch, _FakeApiClient())
+    out = provider.handle_tool_call("hindsight_update_memory", {"memory_id": "mem-42"})
+    assert "at least one field" in out
+
+
+def test_update_surfaces_server_rejection_detail(tmp_path, monkeypatch):
+    api = _FakeApiClient(
+        status=400,
+        body=b'{"detail":"only world/experience facts can be curated. '
+             b'Observations are derived and regenerate from their sources."}',
+    )
+    provider = _make_provider(tmp_path, monkeypatch, api)
+    out = provider.handle_tool_call("hindsight_update_memory", {
+        "memory_id": "mem-42",
+        "occurred_start": "2026-08-24T03:48:54Z",
+    })
+    assert "Failed to update memory" in out
+    assert "HTTP 400" in out
+    assert "world/experience" in out
+
+
+def test_update_accepts_empty_204_body(tmp_path, monkeypatch):
+    api = _FakeApiClient(status=204, body=b"")
+    provider = _make_provider(tmp_path, monkeypatch, api)
+    result = json.loads(provider.handle_tool_call("hindsight_update_memory", {
+        "memory_id": "mem-42",
+        "context": "project decision",
+    }))
+    assert result["result"] == "Memory updated successfully."


### PR DESCRIPTION
## What does this PR do?

Adds the missing write path for `occurred_start`/`occurred_end`: a fourth Hindsight plugin tool, `hindsight_update_memory`. Every fact written through the plugin currently lands with `occurred_*` = null (the basis of Hindsight timelines and time-filtered recall), `hindsight_retain` takes no temporal argument, and the only endpoint that writes those columns — `PATCH /v1/default/banks/{bank}/memories/{id}` — was reachable from no Hermes tool because the SDK 0.6.1 `MemoryApi` has no per-memory PATCH method.

## Related Issue

Fixes #93568

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `plugins/memory/hindsight/__init__.py`:
  - `UPDATE_SCHEMA` — `memory_id` (required) plus optional `occurred_start`/`occurred_end` (ISO-8601; empty string clears, omitting leaves unchanged), `text`, `context`. The description carries the server's curatability caveat (only world/experience facts; derived observations are rejected) so the model doesn't burn calls on them.
  - `_patch_memory_via_client()` — module-level async helper that drives `ApiClient.param_serialize`/`call_api` with the same constant resource path the generated methods use. Host/auth/timeout come from the client's own `Configuration` (same source as every aretain/arecall call), so no request can target anything but the configured Hindsight server. Both client shapes work: the cloud facade exposes `_api_client` directly, and `HindsightEmbedded` forwards attribute access to its inner facade via `__getattr__` (verified in vectorize-io/hindsight `embedded.py`). Non-2xx raises with the server's own rejection body.
  - `handle_tool_call` branch + `get_tool_schemas` registration — validates `memory_id` and "at least one field", passes only provided keys on the patch body (empty strings preserved — they clear server-side), and routes through `_run_hindsight_operation` so the embedded reconnect-retry path is reused.
- `tests/plugins/memory/test_hindsight_update_memory.py` — new: schema registration + description caveat, provided-fields-only body with empty-string passthrough and URL assembly, both missing-argument guards, rejection-body surfacing (HTTP 400 observation-fact case), empty 204 body. Uses a fake ApiClient — no `hindsight-client` import needed, so CI runs it without the optional dep.
- `tests/plugins/memory/test_hindsight_provider.py` — `test_get_tool_schemas_returns_three` → `returns_four` (the tool surface intentionally widens).

## How to Test

- New: `.venv/bin/python -m pytest tests/plugins/memory/test_hindsight_update_memory.py -q` — should pass (6 tests). On unpatched `main` the file fails at collection (`UPDATE_SCHEMA` does not exist), pinning the regression.
- Regression: `.venv/bin/python -m pytest tests/plugins/memory -q` — should pass except one pre-existing unrelated failure (`test_openviking_provider.py::test_describe_local_port_listener_reports_process` fails identically on clean `main` in this environment; process-table probing).
- SDK-compatibility smoke (no network): with `hindsight-client==0.6.1` installed, calling `_patch_memory_via_client` against a real `Hindsight` client with `call_api` stubbed confirms `method=PATCH`, `url=<Configuration.host>/v1/default/banks/{bank}/memories/{id}` interpolated, `Content-Type: application/json`, `Authorization` present via default-header merge, body dict passed through for the rest layer to JSON-encode, and `_request_timeout` forwarded.

Observed result: locally, all 6 new tests pass, the full memory-plugin suite is green apart from the pre-existing openviking process-probe failure, and the real-SDK smoke shows the request is assembled exactly as the issue's verified PATCH route expects.

## Checklist

- [x] Code follows project style (no unrelated changes)
- [x] Self-reviewed the diff
- [x] Added/updated tests covering the fix
- [x] All new and existing tests pass locally (memory-plugin suite: 345 passed; one pre-existing openviking failure is identical on clean `main`)
- [x] PR targets `upstream/main` from a fork branch
