### PR TITLE
fix(batch_runner): make no-reasoning discarded samples visible to --resume (tombstone rows)

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -457,6 +457,21 @@ def _process_batch_worker(args: Tuple) -> Dict[str, Any]:
                 print(f"   🚫 Prompt {prompt_index} discarded (no reasoning in any turn)")
                 discarded_no_reasoning += 1
                 completed_in_batch.append(prompt_index)
+                # Tombstone row (#93527): resume filters exclusively by
+                # scanning batch_*.jsonl rows for prompt content, so a
+                # discarded sample without a row is invisible to --resume
+                # and gets re-run at full cost on every restart. The
+                # tombstone carries just enough for the scan; the merge
+                # step excludes it from trajectories.jsonl.
+                tombstone = {
+                    "prompt_index": prompt_index,
+                    "discarded": "no_reasoning",
+                    "prompt": _entry_prompt_text(prompt_data),
+                }
+                with open(batch_output_file, 'a', encoding='utf-8') as f:
+                    f.write(json.dumps(tombstone, ensure_ascii=False) + "\n")
+                    f.flush()
+                    os.fsync(f.fileno())
                 continue
             
             # Get and normalize tool stats for consistent schema across all entries
@@ -524,6 +539,31 @@ def _process_batch_worker(args: Tuple) -> Dict[str, Any]:
         "discarded_no_reasoning": discarded_no_reasoning,
         "completed_prompts": completed_in_batch
     }
+
+
+def _entry_prompt_text(entry: Dict) -> str:
+    """Extract the human prompt text from a dataset or trajectory entry.
+
+    Handles the shapes that appear across batch_runner: a flat
+    ``entry["prompt"]``, ShareGPT-style ``conversations`` (``from``/``value``),
+    chat-style ``conversations``/``messages`` (``role``/``content``), and the
+    discard tombstones written by the no-reasoning discard path.
+    """
+    if not isinstance(entry, dict):
+        return ""
+    text = str(entry.get("prompt") or "").strip()
+    if text:
+        return text
+    for key in ("conversations", "messages"):
+        for msg in entry.get(key, []) or []:
+            if not isinstance(msg, dict):
+                continue
+            role = msg.get("role") or msg.get("from")
+            if role in {"user", "human"}:
+                text = str(msg.get("content") or msg.get("value") or "").strip()
+                if text:
+                    return text
+    return ""
 
 
 class BatchRunner:
@@ -755,19 +795,17 @@ class BatchRunner:
                     for line in f:
                         try:
                             entry = json.loads(line.strip())
-                            
+
                             # Skip failed entries - we want to retry these
                             if entry.get("failed", False):
                                 continue
-                            
-                            # Extract the human/user prompt from conversations
-                            conversations = entry.get("conversations", [])
-                            for msg in conversations:
-                                if msg.get("from") == "human":
-                                    prompt_text = msg.get("value", "").strip()
-                                    if prompt_text:
-                                        completed_prompts.add(prompt_text)
-                                    break  # Only need the first human message
+
+                            # Discard tombstones count as completed — the
+                            # prompt was processed and deliberately dropped
+                            # (#93527); re-running it would just re-discard.
+                            prompt_text = _entry_prompt_text(entry)
+                            if prompt_text:
+                                completed_prompts.add(prompt_text)
                         except json.JSONDecodeError:
                             continue
             except Exception as e:
@@ -1043,6 +1081,7 @@ class BatchRunner:
         
         total_entries = 0
         filtered_entries = 0
+        tombstone_entries = 0
         batch_files_found = 0
         
         # Find ALL batch files in the output directory (handles resume merging old + new)
@@ -1058,6 +1097,14 @@ class BatchRunner:
                         total_entries += 1
                         try:
                             data = json.loads(line)
+
+                            # Discard tombstones are resume bookkeeping, not
+                            # training data (#93527) — never enter the merged
+                            # trajectories file.
+                            if data.get("discarded"):
+                                tombstone_entries += 1
+                                continue
+
                             tool_stats = data.get('tool_stats', {})
                             
                             # Check for invalid tool names (model hallucinations)
@@ -1076,7 +1123,7 @@ class BatchRunner:
         
         if filtered_entries > 0:
             print(f"⚠️  Filtered {filtered_entries} corrupted entries out of {total_entries} total")
-        print(f"✅ Combined {batch_files_found} batch files into trajectories.jsonl ({total_entries - filtered_entries} entries)")
+        print(f"✅ Combined {batch_files_found} batch files into trajectories.jsonl ({total_entries - filtered_entries - tombstone_entries} entries)")
         
         # Save final statistics
         final_stats = {
@@ -1090,6 +1137,9 @@ class BatchRunner:
             "duration_seconds": round(time.time() - start_time, 2),
             "tool_statistics": total_tool_stats,
             "reasoning_statistics": total_reasoning_stats,
+            "discarded_no_reasoning": sum(
+                r.get("discarded_no_reasoning", 0) for r in results
+            ),
         }
         
         with open(self.stats_file, 'w', encoding='utf-8') as f:
@@ -1100,7 +1150,7 @@ class BatchRunner:
         print("📊 BATCH PROCESSING COMPLETE")
         print("=" * 70)
         print(f"✅ Prompts processed this run: {sum(r.get('processed', 0) for r in results)}")
-        print(f"✅ Total trajectories in merged file: {total_entries - filtered_entries}")
+        print(f"✅ Total trajectories in merged file: {total_entries - filtered_entries - tombstone_entries}")
         print(f"✅ Total batch files merged: {batch_files_found}")
         print(f"⏱️  Total duration: {round(time.time() - start_time, 2)}s")
         print("\n📈 Tool Usage Statistics:")

--- a/tests/test_batch_runner_checkpoint.py
+++ b/tests/test_batch_runner_checkpoint.py
@@ -174,7 +174,17 @@ class TestBatchWorkerResumeBehavior:
 
         assert result["discarded_no_reasoning"] == 1
         assert result["completed_prompts"] == [0]
-        assert not batch_file.exists() or batch_file.read_text() == ""
+        # Tombstone row (#93527): the resume content-scan only sees
+        # batch_*.jsonl rows, so a discard must leave one — otherwise every
+        # --resume re-runs the sample at full cost.
+        rows = [
+            json.loads(line)
+            for line in batch_file.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert len(rows) == 1
+        assert rows[0]["discarded"] == "no_reasoning"
+        assert rows[0]["prompt"] == "hi"
 
 
 class TestFinalCheckpointNoDuplicates:

--- a/tests/test_batch_runner_discard_resume.py
+++ b/tests/test_batch_runner_discard_resume.py
@@ -1,0 +1,175 @@
+"""Discarded samples must be visible to --resume (#93527).
+
+The no-reasoning discard path used to mark prompts completed only in the
+checkpoint index while writing no batch_*.jsonl row. Resume filters
+exclusively by scanning those files for prompt content, so every
+discarded sample was re-run at full cost on each restart. The fix writes
+a tombstone row that the content scan treats as completed and the
+trajectories.jsonl merge excludes.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import batch_runner
+from batch_runner import (
+    BatchRunner,
+    _entry_prompt_text,
+    _process_batch_worker,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Worker: discard leaves a tombstone row
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _discarded_result():
+    return {
+        "success": True,
+        "trajectory": [{"role": "assistant", "content": "x"}],
+        "reasoning_stats": {"has_any_reasoning": False},
+        "tool_stats": {},
+        "metadata": {},
+        "completed": True,
+        "api_calls": 1,
+        "toolsets_used": [],
+    }
+
+
+def test_discard_writes_tombstone_row(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "batch_runner._process_single_prompt", lambda *a, **kw: _discarded_result()
+    )
+
+    _process_batch_worker((1, [(0, {"prompt": "hi"})], tmp_path, set(), {"verbose": False}))
+
+    batch_file = tmp_path / "batch_1.jsonl"
+    rows = [json.loads(line) for line in batch_file.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert len(rows) == 1
+    assert rows[0]["discarded"] == "no_reasoning"
+    assert rows[0]["prompt_index"] == 0
+    assert rows[0]["prompt"] == "hi"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Content scan: tombstones count as completed
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _scan_runner(tmp_path):
+    runner = BatchRunner.__new__(BatchRunner)
+    runner.output_dir = tmp_path
+    return runner
+
+
+def test_content_scan_treats_tombstone_as_completed(tmp_path):
+    (tmp_path / "batch_1.jsonl").write_text(
+        json.dumps({"prompt_index": 0, "discarded": "no_reasoning", "prompt": "tombstoned q"})
+        + "\n"
+        + json.dumps({
+            "conversations": [{"from": "human", "value": "normal q"}],
+            "completed": True,
+        })
+        + "\n",
+        encoding="utf-8",
+    )
+
+    completed = _scan_runner(tmp_path)._scan_completed_prompts_by_content()
+
+    assert completed == {"tombstoned q", "normal q"}
+
+
+def test_content_scan_still_skips_failed_rows(tmp_path):
+    (tmp_path / "batch_1.jsonl").write_text(
+        json.dumps({"failed": True, "conversations": [{"from": "human", "value": "retry me"}]})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert _scan_runner(tmp_path)._scan_completed_prompts_by_content() == set()
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Merge: tombstones never enter trajectories.jsonl
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _make_real_runner(tmp_path, monkeypatch):
+    dataset = tmp_path / "dataset.jsonl"
+    dataset.write_text(json.dumps({"prompt": "hi"}) + "\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    return BatchRunner(
+        dataset_file=str(dataset),
+        batch_size=1,
+        run_name="discard-resume-test",
+        num_workers=1,
+    )
+
+
+def _fake_pool(batch_results):
+    pool = MagicMock()
+    pool.imap_unordered.return_value = iter(batch_results)
+    pool_cm = MagicMock()
+    pool_cm.__enter__ = MagicMock(return_value=pool)
+    pool_cm.__exit__ = MagicMock(return_value=False)
+    return pool_cm
+
+
+def test_merge_excludes_tombstones_from_trajectories(tmp_path, monkeypatch):
+    # Pre-existing output from an earlier session: one real trajectory +
+    # one tombstone. run(resume=False) re-processes its batches through the
+    # patched Pool, then merges ALL batch files on disk.
+    out_dir = tmp_path / "data" / "discard-resume-test"
+    out_dir.mkdir(parents=True)
+    (out_dir / "batch_1.jsonl").write_text(
+        json.dumps({
+            "prompt_index": 0,
+            "conversations": [{"from": "human", "value": "real q"}],
+            "completed": True,
+            "tool_stats": {},
+        })
+        + "\n"
+        + json.dumps({"prompt_index": 1, "discarded": "no_reasoning", "prompt": "dropped q"})
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("sys.argv", ["batch_runner.py"])
+
+    runner = _make_real_runner(tmp_path, monkeypatch)
+    # Point the runner at the pre-populated directory instead of cwd/data.
+    runner.output_dir = out_dir
+
+    batch_result = {
+        "batch_num": 1,
+        "processed": 0,
+        "skipped": 0,
+        "tool_stats": {},
+        "reasoning_stats": {},
+        "discarded_no_reasoning": 0,
+        "completed_prompts": [],
+    }
+    with patch.object(batch_runner, "Pool", return_value=_fake_pool([batch_result])):
+        runner.run()
+
+    merged = (out_dir / "trajectories.jsonl").read_text(encoding="utf-8").splitlines()
+    parsed = [json.loads(line) for line in merged if line.strip()]
+    assert len(parsed) == 1
+    assert "discarded" not in parsed[0]
+    stats = json.loads((out_dir / "statistics.json").read_text(encoding="utf-8"))
+    assert "discarded_no_reasoning" in stats
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Prompt-text extraction shapes
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_entry_prompt_text_shapes():
+    assert _entry_prompt_text({"prompt": "flat"}) == "flat"
+    assert _entry_prompt_text({"conversations": [{"from": "human", "value": "sharegpt"}]}) == "sharegpt"
+    assert _entry_prompt_text({"conversations": [{"role": "user", "content": "chat"}]}) == "chat"
+    assert _entry_prompt_text({"messages": [{"role": "user", "content": "msgs"}]}) == "msgs"
+    assert _entry_prompt_text({"prompt": "  padded  ", "discarded": "x"}) == "padded"
+    assert _entry_prompt_text({}) == ""
+    assert _entry_prompt_text("not-a-dict") == ""


### PR DESCRIPTION
## What does this PR do?

Fixes a silent re-spend leak in batch processing: the "no reasoning in any turn" discard path (atch_runner.py worker) marked prompts as completed **only** in checkpoint.json while writing no row to atch_N.jsonl. But un(resume=True) filters exclusively by scanning those JSONL files for prompt content (_scan_completed_prompts_by_content()), so every discarded sample was invisible to resume and **re-ran at full token cost on every restart** — only to be discarded again. On long RL-data batches this is a repeated, unbounded spend leak on exactly the samples already paid for.

The fix writes a lightweight **tombstone row** at discard time:

`json
{"prompt_index": 0, "discarded": "no_reasoning", "prompt": "<human text>"}
`

- _scan_completed_prompts_by_content() now counts tombstones as completed (the prompt was processed; re-running would just re-discard);
- the final 	rajectories.jsonl merge **excludes** tombstones, so they never enter training data (and the combined-entries log count stays accurate);
- statistics.json gains discarded_no_reasoning, so post-hoc accounting can finally reconcile 	otal_prompts vs trajectories + failures (previously this counter existed only on stdout).

## Related Issue

Fixes #93527

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Tests

## Changes Made

- atch_runner.py:
  - discard branch writes an fsync'd tombstone row to the batch file;
  - new _entry_prompt_text() helper extracting the human prompt across all shapes seen in this file (flat prompt, ShareGPT conversations from/value, chat-style role/content, tombstones) — the content scan and _filter_dataset_by_completed's shape assumptions are now unified;
  - _scan_completed_prompts_by_content() uses the helper (tombstone-aware, failed-row skip preserved);
  - merge loop skips tombstone rows and reports accurate entry counts;
  - statistics.json includes discarded_no_reasoning.
- 	ests/test_batch_runner_checkpoint.py: updated 	est_discarded_no_reasoning_prompts_are_marked_completed, which previously **pinned the old no-row behavior**.
- 	ests/test_batch_runner_discard_resume.py — new regression coverage: worker writes exactly one tombstone with the right prompt text; scan treats tombstones as completed; failed rows still skipped; a real un() merge excludes tombstones from 	rajectories.jsonl; extraction-shape table.

## How to Test

1. uv run python -m pytest tests/test_batch_runner_discard_resume.py tests/test_batch_runner_checkpoint.py tests/test_batch_runner_durability.py -q → 22 passed.
2. uff check batch_runner.py tests/test_batch_runner_discard_resume.py → clean.
3. Manual: run a small batch against a no-reasoning model, Ctrl-C, resume → discarded prompts are skipped ("Found N already-completed prompts by content matching" now includes them).

(Note: 	ests/test_batch_runner_exit_code.py fails identically on clean main under Windows-local subprocess runs — pre-existing, unrelated to this diff.)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (ix(scope):, eat(scope):, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls?q=is%3Apr) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run targeted test suites locally and they pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Docs N/A (behavior now matches the resume docstring's promise)
- [x] cli-config.yaml.example N/A
- [x] CONTRIBUTING/AGENTS N/A
- [x] Cross-platform impact: none (file formats unchanged) → N/A
- [x] No tool schema/behavior change → N/A

## Screenshots / Logs

N/A