### PR TITLE
fix(buzz): rediscover new conversations while WebSocket transport is live

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -95,6 +95,12 @@ _SEEN_CAP = 500
 # Re-run DM discovery (``dms list`` plus the channels-list fallback) every
 # N poll sweeps to pick up conversations opened mid-run.
 _DM_DISCOVERY_EVERY = 5
+# WebSocket transport: re-run conversation discovery after every N
+# poll-interval periods of quiet. Some relays materialize new DMs in
+# ``dms list``/``channels list`` without ever emitting the kind-44100
+# membership event that normally wakes this transport, so discovery cannot
+# rely on membership events alone (see _refresh_conversation_subscriptions).
+_WS_REDISCOVERY_EVERY = 5
 
 _DEFAULT_POLL_INTERVAL = 4.0
 _MIN_POLL_INTERVAL = 1.0
@@ -826,15 +832,67 @@ class BuzzAdapter(BasePlatformAdapter):
         """A membership event p-tagged to us: rediscover conversations and
         subscribe to any new ones (fresh DMs dispatch from their beginning)."""
         self._membership_since = max(self._membership_since, int(event.get("created_at") or 0))
-        before = set(self._channel_state)
+        await self._refresh_conversation_subscriptions(websocket, subscriptions)
+
+    async def _refresh_conversation_subscriptions(
+        self, websocket, subscriptions: Dict[str, Optional[str]]
+    ) -> None:
+        """Re-run conversation discovery and subscribe the live socket to any
+        watched conversation it does not cover yet.
+
+        Freshly discovered conversations dispatch from their beginning. The
+        poll transport rediscovers periodically (``_DM_DISCOVERY_EVERY``); the
+        WebSocket transport originally relied on kind-44100 membership events
+        alone. Relays have been observed materializing new DMs in ``dms
+        list``/``channels list`` without emitting that event, which left a DM
+        opened mid-session invisible until the next reconnect. Sharing this
+        helper gives both transports one discovery+subscription path, keyed
+        on what the socket is actually subscribed to (idempotent across
+        repeated refreshes and reconnects).
+        """
+        subscribed = {channel_id for channel_id in subscriptions.values() if channel_id}
         await self._discover_dms(seed=False)
         for channel_id in self._channel_state:
-            if channel_id in before:
+            if channel_id in subscribed:
                 continue
-            subscription_id = f"hermes-buzz-dm-{len(subscriptions)}"
+            subscription_id = f"hermes-buzz-conversation-{len(subscriptions)}"
             subscriptions[subscription_id] = channel_id
             await self._send_channel_subscription(websocket, subscription_id, channel_id)
             logger.info("Buzz: subscribed to new conversation %s", channel_id)
+
+    async def _handle_websocket_message(
+        self,
+        websocket,
+        subscriptions: Dict[str, Optional[str]],
+        # websockets yields either str or bytes; json.loads accepts both.
+        raw: Any,
+    ) -> None:
+        """Decode and route a single WebSocket frame."""
+        try:
+            message = json.loads(raw)
+        except (ValueError, TypeError):
+            logger.warning("Buzz: ignoring malformed WebSocket frame")
+            return
+        if not isinstance(message, list) or not message:
+            return
+        if message[0] == "EVENT" and len(message) >= 3:
+            subscription_id = str(message[1])
+            event = message[2]
+            if not isinstance(event, dict):
+                return
+            if subscription_id == _WS_MEMBERSHIP_SUB_ID:
+                await self._handle_membership_event(websocket, subscriptions, event)
+                return
+            channel_id = subscriptions.get(subscription_id)
+            state = self._channel_state.get(channel_id or "")
+            if channel_id and state is not None:
+                await self._handle_event(channel_id, state, event)
+                self._trim_seen(state)
+        elif message[0] == "CLOSED":
+            detail = message[-1] if len(message) > 2 else "subscription closed"
+            raise ConnectionError(str(detail))
+        elif message[0] == "NOTICE":
+            logger.warning("Buzz: relay notice: %s", message[-1])
 
     async def _websocket_loop(self) -> None:
         """Persistent authenticated subscription with bounded reconnect
@@ -862,32 +920,32 @@ class BuzzAdapter(BasePlatformAdapter):
                         if self._ws_ready is not None:
                             self._ws_ready.set()
                         backoff = 1.0
-                        async for raw in websocket:
+                        while True:
+                            # Bound each recv so quiet periods still reach the
+                            # periodic conversation rediscovery below: some
+                            # relays materialize new DMs without ever sending
+                            # the kind-44100 membership event. A timeout means
+                            # the socket has been idle for a full window, so
+                            # the rediscovery awaits cannot race inbound
+                            # frames; anything delivered meanwhile stays
+                            # buffered and is consumed by the next recv().
                             try:
-                                message = json.loads(raw)
-                            except (ValueError, TypeError):
-                                logger.warning("Buzz: ignoring malformed WebSocket frame")
+                                raw = await asyncio.wait_for(
+                                    websocket.recv(),
+                                    timeout=self.poll_interval * _WS_REDISCOVERY_EVERY,
+                                )
+                            except asyncio.TimeoutError:
+                                await self._refresh_conversation_subscriptions(
+                                    websocket, subscriptions
+                                )
                                 continue
-                            if not isinstance(message, list) or not message:
-                                continue
-                            if message[0] == "EVENT" and len(message) >= 3:
-                                subscription_id = str(message[1])
-                                event = message[2]
-                                if not isinstance(event, dict):
-                                    continue
-                                if subscription_id == _WS_MEMBERSHIP_SUB_ID:
-                                    await self._handle_membership_event(websocket, subscriptions, event)
-                                    continue
-                                channel_id = subscriptions.get(subscription_id)
-                                state = self._channel_state.get(channel_id or "")
-                                if channel_id and state is not None:
-                                    await self._handle_event(channel_id, state, event)
-                                    self._trim_seen(state)
-                            elif message[0] == "CLOSED":
-                                detail = message[-1] if len(message) > 2 else "subscription closed"
-                                raise ConnectionError(str(detail))
-                            elif message[0] == "NOTICE":
-                                logger.warning("Buzz: relay notice: %s", message[-1])
+                            except asyncio.CancelledError:
+                                raise
+                            except Exception as e:
+                                # Surface transport errors (connection closed,
+                                # protocol violation, …) to the reconnect loop.
+                                raise ConnectionError(f"receive failed: {e}") from e
+                            await self._handle_websocket_message(websocket, subscriptions, raw)
                 except asyncio.CancelledError:
                     raise
                 except Exception as e:

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -538,3 +538,209 @@ class TestStandaloneSend:
         assert all("nsec1x" not in str(a) for a in captured["args"])
 
 
+# ── WebSocket conversation (re)discovery ──────────────────────────────────
+
+
+class _FrameWebSocket:
+    """Scripted recv()/send() double: replays queued frames, records sends."""
+
+    def __init__(self, frames):
+        self._frames = list(frames)
+        self.sent = []
+
+    async def recv(self):
+        if not self._frames:
+            await asyncio.sleep(3600)
+        return self._frames.pop(0)
+
+    async def send(self, raw):
+        self.sent.append(json.loads(raw))
+
+
+def _ws_event_frame(event_id, channel=CHANNEL, content="hi", created_at=1000):
+    event = _event(event_id, content=content, created_at=created_at)
+    event["tags"] = [["h", channel]]
+    return json.dumps(["EVENT", "hermes-buzz-0", event])
+
+
+class TestRefreshConversationSubscriptions:
+    """_refresh_conversation_subscriptions: one idempotent
+    discovery+subscription path shared by the membership-event and periodic
+    WebSocket refreshes."""
+
+    @pytest.mark.asyncio
+    async def test_subscribes_newly_discovered_conversation(self):
+        a = _make_adapter()
+        subscriptions = {"hermes-buzz-0": CHANNEL}
+        websocket = object()
+
+        async def discover(*, seed):
+            assert seed is False
+            a._channel_state[DM_CHANNEL] = {
+                "chat_type": "group",
+                "last_ts": 0,
+                "seen": {},
+            }
+
+        sent = []
+
+        async def subscribe(ws, subscription_id, channel_id):
+            sent.append((ws, subscription_id, channel_id))
+
+        a._discover_dms = discover
+        a._send_channel_subscription = subscribe
+
+        await a._refresh_conversation_subscriptions(websocket, subscriptions)
+
+        assert list(subscriptions.values()) == [CHANNEL, DM_CHANNEL]
+        assert sent == [(websocket, "hermes-buzz-conversation-1", DM_CHANNEL)]
+
+    @pytest.mark.asyncio
+    async def test_idempotent_when_conversation_already_subscribed(self):
+        a = _make_adapter()
+        # DM already watched AND already covered by the socket's subscription
+        # map — a repeated refresh must not send a duplicate REQ.
+        a._channel_state[DM_CHANNEL] = {"chat_type": "dm", "last_ts": 0, "seen": {}}
+        subscriptions = {
+            "hermes-buzz-0": CHANNEL,
+            "hermes-buzz-1": DM_CHANNEL,
+        }
+        sent = []
+
+        async def discover(*, seed):
+            return
+
+        async def subscribe(ws, subscription_id, channel_id):
+            sent.append((subscription_id, channel_id))
+
+        a._discover_dms = discover
+        a._send_channel_subscription = subscribe
+
+        await a._refresh_conversation_subscriptions(object(), subscriptions)
+
+        assert sent == []
+        assert list(subscriptions.values()) == [CHANNEL, DM_CHANNEL]
+
+    @pytest.mark.asyncio
+    async def test_membership_event_shares_refresh_helper(self):
+        """The membership path must go through the same discovery+subscribe
+        helper so both transports stay behaviorally identical."""
+        a = _make_adapter()
+        subscriptions = {"hermes-buzz-0": CHANNEL}
+
+        calls = []
+
+        async def refresh(websocket, subs):
+            calls.append((websocket, subs))
+
+        a._refresh_conversation_subscriptions = refresh
+        await a._handle_membership_event(
+            object(), subscriptions, {"created_at": 1234}
+        )
+
+        assert a._membership_since == 1234
+        assert len(calls) == 1
+
+
+class TestWebsocketLoopConversationRediscovery:
+    """Integration coverage for the bounded-recv loop in
+    _websocket_loop(): a quiet socket must still trigger periodic conversation
+    discovery, without cancelling an in-flight recv() (which could drop a
+    frame delivered mid-refresh)."""
+
+    @staticmethod
+    def _fake_connect(monkeypatch, ws):
+        """Replace websockets.connect with a context manager over ``ws``."""
+
+        class _CM:
+            async def __aenter__(self):
+                return ws
+
+            async def __aexit__(self, *exc):
+                return False
+
+        monkeypatch.setattr("websockets.connect", lambda *a, **k: _CM())
+
+    @staticmethod
+    def _wire(adapter, monkeypatch, initial_subscriptions):
+        """Stub the handshake so the loop reaches its recv pump directly."""
+        adapter.poll_interval = 0.05  # discovery window = interval * 5
+        adapter._authenticate_websocket = AsyncMock()
+        adapter._subscribe_websocket = AsyncMock(return_value=dict(initial_subscriptions))
+
+    @pytest.mark.asyncio
+    async def test_quiet_socket_triggers_periodic_rediscovery(self, monkeypatch):
+        a = _make_adapter()
+        ws = _FrameWebSocket([])
+        self._fake_connect(monkeypatch, ws)
+        initial = {"hermes-buzz-0": CHANNEL}
+        self._wire(a, monkeypatch, initial)
+
+        refresh_calls = []
+
+        async def refresh(websocket, subscriptions):
+            refresh_calls.append((websocket, subscriptions))
+            if len(refresh_calls) >= 3:
+                # The only way out of the reconnect loop from inside.
+                raise asyncio.CancelledError
+
+        a._refresh_conversation_subscriptions = refresh
+
+        task = asyncio.create_task(a._websocket_loop())
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=10)
+
+        assert len(refresh_calls) == 3
+        # Every refresh sees the live socket and the current subscription map.
+        assert all(call[0] is ws for call in refresh_calls)
+        assert all(
+            call[1] is initial or call[1] == initial for call in refresh_calls
+        )
+
+    @pytest.mark.asyncio
+    async def test_frames_dispatch_through_real_decoder_then_refresh_fires(
+        self, monkeypatch
+    ):
+        a = _make_adapter()
+        a._channel_state[CHANNEL] = {
+            "chat_type": "group",
+            "last_ts": 0,
+            "seen": {},
+            "chat_type_locked": True,
+        }
+        frames = [
+            _ws_event_frame("e-ws-1"),
+            _ws_event_frame("e-ws-2", created_at=1001),
+        ]
+        ws = _FrameWebSocket(frames)
+        self._fake_connect(monkeypatch, ws)
+        initial = {"hermes-buzz-0": CHANNEL}
+        self._wire(a, monkeypatch, initial)
+
+        dispatched = []
+
+        async def handle_event(channel_id, state, event):
+            dispatched.append((channel_id, event["id"]))
+
+        a._handle_event = handle_event
+
+        refreshed = []
+
+        async def refresh(websocket, subscriptions):
+            refreshed.append(True)
+            raise asyncio.CancelledError
+
+        a._refresh_conversation_subscriptions = refresh
+
+        task = asyncio.create_task(a._websocket_loop())
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=10)
+
+        # Both frames flowed through the real decoder/subscription routing.
+        assert dispatched == [
+            (CHANNEL, "e-ws-1"),
+            (CHANNEL, "e-ws-2"),
+        ]
+        # …and the quiet period after them still reached the periodic refresh.
+        assert refreshed == [True]
+


### PR DESCRIPTION
## What does this PR do?

Fixes #93557 — a DM opened **while the gateway is running** was never discovered when the WebSocket transport was active: `_websocket_loop()` relied on kind-44100 membership events alone, and relays have been observed materializing new DMs in `dms list`/`channels list` without ever emitting that event. The conversation stayed invisible until the next WS reconnect. The poll transport was unaffected (`_poll_loop()` re-runs discovery every `_DM_DISCOVERY_EVERY` sweeps).

## Related Issue

Fixes #93557

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

`plugins/platforms/buzz/adapter.py`:

- Extract `_refresh_conversation_subscriptions(websocket, subscriptions)` — one idempotent discovery+subscription path shared by both transports. It re-runs `_discover_dms(seed=False)` and subscribes the live socket to any watched conversation missing from the subscription map. Keying on what the socket *actually covers* (instead of the old before/after diff over `_channel_state`) makes repeated refreshes and reconnects safe from duplicate REQs.
- Bound each `recv()` at `poll_interval * _WS_REDISCOVERY_EVERY` (5 quiet windows ≈ 20s at defaults) instead of `async for raw in websocket`; on timeout, run the refresh and continue receiving.
  - **recv() is never cancelled mid-flight**: the timeout can only fire after a fully idle window, so refresh awaits cannot race inbound frames; anything delivered during a refresh stays buffered in the transport and is consumed by the next `recv()`.
  - Transport errors surface to the existing reconnect/backoff path as `ConnectionError("receive failed: …")`.
- Frame decoding moves verbatim into `_handle_websocket_message()` so the pump stays readable; routing for EVENT / membership / CLOSED / NOTICE frames is unchanged.
- Freshly discovered conversations dispatch from their beginning, matching the poll transport's documented mid-run behavior.

`tests/gateway/test_buzz_adapter.py`:

- Refresh subscribes a newly discovered conversation; idempotent no-op when already covered.
- Membership-event path routes through the same helper (behavioral parity between transports).
- Loop integration tests via a fake `websockets.connect`: quiet socket triggers periodic rediscovery (3 refreshes observed, same socket object + live subscription map), and frames flow through the real decoder/subscription routing with the refresh firing after traffic resumes-then-quiets.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py -q` → 32 passed.
2. Live check on a self-hosted relay with WS established: open a new DM to the agent mid-session → it dispatches within ~`poll_interval × _WS_REDISCOVERY_EVERY` without any reconnect or membership event (previously: never, until reconnect).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (aarch64 homelab, gateway mode against a self-hosted closed-membership relay)

Full `tests/gateway/` run: 6146 passed, 8 failed — those 8 reproduce identically on untouched `origin/main` in this environment (missing `xml.etree.CDATA` alias affecting WeCom tests, Discord fixture drift) and are unrelated to Buzz. Checkbox left unchecked intentionally per that baseline.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior documented in adapter comments, no config keys changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (none added)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure asyncio, platform-neutral; no encoding or path changes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
