### PR TITLE
fix(cron): editing or triggering a consumed one-shot must give it a fresh run budget

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2267,6 +2267,24 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     "schedule_display",
                     updated_schedule.get("display", updated.get("schedule_display")),
                 )
+                # Re-arming a consumed finite one-shot via a schedule edit
+                # (#93524): "reschedule my report to tomorrow" means a fresh
+                # run. Without resetting the budget, the record re-enables
+                # with completed >= times and the due-scan's stale-entry
+                # guard silently deletes it at the new fire time instead of
+                # firing — and its last_run_at suppresses the wedged-oneshot
+                # diagnostic, so the run just vanishes.
+                _repeat = updated.get("repeat")
+                if isinstance(_repeat, dict):
+                    _times = _repeat.get("times")
+                    if (
+                        _times is not None
+                        and _times > 0
+                        and _repeat.get("completed", 0) >= _times
+                    ):
+                        _fresh = dict(_repeat)
+                        _fresh["completed"] = 0
+                        updated["repeat"] = _fresh
                 if updated.get("state") != "paused":
                     updated_next_run = compute_next_run(updated_schedule)
                     # Same guard as create_job: an UPDATE that sets a one-shot
@@ -2364,16 +2382,25 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
     job = resolve_job_ref(job_id)
     if not job:
         return None
-    return update_job(
-        job["id"],
-        {
-            "enabled": True,
-            "state": "scheduled",
-            "paused_at": None,
-            "paused_reason": None,
-            "next_run_at": _hermes_now().isoformat(),
-        },
-    )
+    updates: Dict[str, Any] = {
+        "enabled": True,
+        "state": "scheduled",
+        "paused_at": None,
+        "paused_reason": None,
+        "next_run_at": _hermes_now().isoformat(),
+    }
+    # An explicit trigger of a consumed finite one-shot is a request for a
+    # fresh run (#93524): without resetting the budget, the due-scan's
+    # stale-entry guard would delete the re-armed record at fire time
+    # instead of running it.
+    _repeat = job.get("repeat")
+    if isinstance(_repeat, dict):
+        _times = _repeat.get("times")
+        if _times is not None and _times > 0 and _repeat.get("completed", 0) >= _times:
+            _fresh = dict(_repeat)
+            _fresh["completed"] = 0
+            updates["repeat"] = _fresh
+    return update_job(job["id"], updates)
 
 
 def remove_job(job_id: str) -> bool:

--- a/tests/cron/test_oneshot_rearm_budget.py
+++ b/tests/cron/test_oneshot_rearm_budget.py
@@ -1,0 +1,146 @@
+"""Re-arming a consumed finite one-shot must reset its run budget (#93524).
+
+A finished one-shot is retained as a terminal record (``repeat.completed``
+>= ``repeat.times``, ``state="completed"``, ``enabled=False``) so its
+outcome stays inspectable. Editing its schedule or explicitly triggering
+it used to re-enable the record **without** resetting the budget — and at
+the new fire time the due-scan's stale-entry guard saw ``completed >=
+times`` and silently deleted the job instead of running it (the wedged-
+oneshot diagnostic was suppressed because ``last_run_at`` was already
+set). "Move my report to tomorrow 9am" did nothing tomorrow.
+
+Real store against a temp ``HERMES_HOME`` (no mocks), matching the
+file-touching-code discipline in this directory.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+
+@pytest.fixture
+def temp_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield tmp_path
+
+
+def _consumed_oneshot():
+    """Create a finite one-shot and drive it to its terminal state."""
+    from cron.jobs import create_job, load_jobs, mark_job_run, save_jobs
+
+    job = create_job(
+        prompt="write the report",
+        schedule=(datetime.now().astimezone() + timedelta(seconds=5)).isoformat(),
+        name="report",
+        repeat=1,
+        deliver="local",
+    )
+    # Simulate the fire completing: mark_job_run retires it with
+    # completed >= times while retaining the record.
+    mark_job_run(job["id"], success=True, status="ok")
+    jobs = load_jobs()
+    stored = next(j for j in jobs if j["id"] == job["id"])
+    assert stored["repeat"]["completed"] >= 1, "test setup: one-shot not consumed"
+    assert stored["state"] == "completed"
+    return job["id"]
+
+
+def test_schedule_edit_resets_consumed_budget(temp_home):
+    from cron.jobs import get_job, update_job
+
+    jid = _consumed_oneshot()
+    future = (datetime.now().astimezone() + timedelta(days=1)).replace(
+        microsecond=0
+    ).isoformat()
+
+    # Mirror what the edit callers do (hermes cron edit / cronjob update):
+    # re-enable alongside the new schedule.
+    updated = update_job(
+        jid,
+        {"schedule": future, "enabled": True, "state": "scheduled"},
+    )
+
+    assert updated is not None
+    assert updated["enabled"] is True
+    assert updated["state"] == "scheduled"
+    # The budget must be fresh — otherwise the due-scan's stale-entry
+    # guard deletes the record instead of firing it (#93524).
+    assert updated["repeat"]["completed"] == 0
+    assert updated["next_run_at"] is not None
+
+    persisted = get_job(jid)
+    assert persisted["repeat"]["completed"] == 0
+
+
+def test_trigger_resets_consumed_budget(temp_home):
+    from cron.jobs import get_job, trigger_job
+
+    jid = _consumed_oneshot()
+
+    triggered = trigger_job(jid)
+
+    assert triggered is not None
+    assert triggered["repeat"]["completed"] == 0
+    assert triggered["next_run_at"] is not None
+    persisted = get_job(jid)
+    assert persisted["repeat"]["completed"] == 0
+
+
+def test_edit_of_unconsumed_one_shot_keeps_zero_budget(temp_home):
+    """A not-yet-consumed one-shot edit must stay at completed=0."""
+    from cron.jobs import create_job, update_job
+
+    job = create_job(
+        prompt="x",
+        schedule=(datetime.now().astimezone() + timedelta(hours=2)).isoformat(),
+        name="fresh",
+        repeat=1,
+        deliver="local",
+    )
+    future = (datetime.now().astimezone() + timedelta(days=1)).replace(
+        microsecond=0
+    ).isoformat()
+
+    updated = update_job(job["id"], {"schedule": future})
+
+    assert updated["repeat"]["completed"] == 0
+    assert updated["state"] == "scheduled"
+
+
+def test_recurring_job_edit_is_not_disturbed(temp_home):
+    """The budget reset must apply only to consumed finite one-shots."""
+    from cron.jobs import create_job, load_jobs, save_jobs, update_job
+
+    job = create_job(prompt="x", schedule="every 60m", name="rec", repeat=10)
+    jobs = load_jobs()
+    for j in jobs:
+        if j["id"] == job["id"]:
+            j["repeat"]["completed"] = 3
+    save_jobs(jobs)
+
+    updated = update_job(job["id"], {"schedule": "every 90m"})
+
+    assert updated["repeat"]["completed"] == 3, (
+        "recurring jobs track their own progress; edits must not reset it"
+    )
+
+
+def test_edited_consumed_oneshot_passes_the_stale_entry_guard(temp_home):
+    """End-to-end shape: after the fix, an edited consumed one-shot no
+    longer satisfies the due-scan's dispatch-limit predicate when due."""
+    from cron.jobs import get_job, update_job
+
+    jid = _consumed_oneshot()
+    soon = (datetime.now().astimezone() + timedelta(seconds=30)).replace(
+        microsecond=0
+    ).isoformat()
+    update_job(jid, {"schedule": soon})
+
+    stored = get_job(jid)
+    times = stored["repeat"]["times"]
+    completed = stored["repeat"]["completed"]
+    assert not (times is not None and times > 0 and completed >= times), (
+        "due-scan would remove this entry instead of firing it"
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes a silent job-loss trap in the cron lifecycle: **editing the schedule of an already-consumed finite one-shot** (or explicitly triggering it) re-enabled the retained terminal record **without resetting its run budget** — and at the new fire time, the due-scan's stale-entry guard (cron/jobs.py, added for #38758) saw epeat.completed >= repeat.times and **removed the job instead of firing it**. The #73973 wedged-oneshot diagnostic was suppressed because the record's last_run_at (from its first run) made it look like a normal completion race.

User-visible shape: /cron set a report for 09:00 today → it ran → user says *"move it to tomorrow 9am"* → edit reports success and shows a future next-run → next day at 09:00 the tick logs info-level "one-shot dispatch limit reached (1/1) — removing stale due entry", deletes the record, produces no output, no delivery, no diagnostic. The run silently never happens.

The fix resets the budget (completed = 0) in both re-arm paths:

1. update_job() — when the update changes the schedule ("reschedule my report" means a fresh run);
2. 	rigger_job() — an explicit "run now" on a consumed one-shot is by definition a fresh-run request.

Recurring jobs' progress counters are untouched (their completed tracks real cadence progress and must survive edits).

## Related Issue

Fixes #93524

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Tests

## Changes Made

- cron/jobs.py
  - update_job(): inside the schedule_changed branch, if the merged record is a finite one-shot with completed >= times, reset completed to 0 (comment documents why — the stale-entry guard would otherwise delete the re-armed record);
  - 	rigger_job(): same budget reset before handing updates to update_job() (trigger re-arms via 
ext_run_at=now without a schedule change, so it needs its own reset).
- 	ests/cron/test_oneshot_rearm_budget.py — new regression suite driving the **real store** against a temp HERMES_HOME:
  - schedule-edit of a consumed one-shot resets completed to 0, re-enables, sets a future 
ext_run_at (in-memory + persisted);
  - explicit trigger of a consumed one-shot does the same;
  - editing a not-yet-consumed one-shot keeps completed == 0;
  - recurring-job edits do NOT reset their progress counter;
  - end-to-end predicate check: after the fix, the edited record no longer satisfies the due-scan's dispatch-limit removal condition when due.

## How to Test

1. uv run python -m pytest tests/cron/test_oneshot_rearm_budget.py -q → 5 passed.
2. Adjacent cron suites stay green: uv run python -m pytest tests/cron/test_jobs.py tests/cron/test_due_stale_cron_edit.py tests/cron/test_oneshot_rearm_budget.py -q → 89 passed.
3. uff check cron/jobs.py tests/cron/test_oneshot_rearm_budget.py → clean.
4. Manual: create a one-shot with --repeat 1, let it fire, hermes cron edit <id> --schedule "<future>" → hermes cron list shows scheduled; at the new time it fires (previously: silently removed).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (ix(scope):, eat(scope):, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls?q=is%3Apr) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run targeted test suites locally and they pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Docs N/A (edit semantics now match what users expect "reschedule" to mean)
- [x] cli-config.yaml.example N/A
- [x] CONTRIBUTING/AGENTS N/A
- [x] Cross-platform impact: none (pure scheduling logic) → N/A
- [x] No tool schema change (cronjob tool params unchanged) → N/A

## Screenshots / Logs

N/A