### PR TITLE
fix(agent): fall back on upstream 5xx in auxiliary call paths

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4308,6 +4308,33 @@ def _is_connection_error(exc: Exception) -> bool:
     return False
 
 
+def _is_server_error(exc: Exception) -> bool:
+    """Detect upstream 5xx failures that warrant provider fallback.
+
+    A 5xx means the provider endpoint was reached but could not serve the
+    request (worker crash, upstream overload, internal fault). That is a
+    provider-capacity failure, not a request constraint: retrying the same
+    provider is handled separately by the transient-retry path, and once
+    those retries are exhausted the request should be rerouted to a
+    fallback provider instead of aborting the auxiliary task.
+
+    Deliberately excludes 502/504 responses that carry an auth-shaped body —
+    some gateways proxy upstream auth failures as 502s; those are handled by
+    ``_is_auth_error`` first in the caller's classification chain.
+    """
+    status = getattr(exc, "status_code", None)
+    if not isinstance(status, int):
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+    if isinstance(status, int) and 500 <= status < 600:
+        return True
+    # Some providers surface 5xx as plain exceptions with the code embedded.
+    msg = str(exc)[:300].lower()
+    return ("internal server error" in msg
+            or " bad gateway" in msg
+            or "service unavailable" in msg
+            or "gateway timeout" in msg)
+
+
 def _is_transient_transport_error(exc: Exception) -> bool:
     """Return True for a one-off transport blip worth retrying ON the
     same provider before any provider/model fallback.
@@ -9994,6 +10021,7 @@ def _call_llm_impl(
             or _is_rate_limit_error(first_err)
             or _is_model_incompatible_error(first_err)
             or _is_invalid_aux_response_error(first_err)
+            or _is_server_error(first_err)
         )
         # Respect explicit provider choice for transient errors (auth, request
         # validation, etc.) but allow fallback when the provider clearly cannot
@@ -10017,6 +10045,7 @@ def _call_llm_impl(
             or _is_rate_limit_error(first_err)
             or _is_model_incompatible_error(first_err)
             or _is_invalid_aux_response_error(first_err)
+            or _is_server_error(first_err)
         )
         if should_fallback and (is_auto or is_capacity_error):
             if _is_auth_error(first_err):
@@ -10704,6 +10733,7 @@ async def _async_call_llm_impl(
             or _is_rate_limit_error(first_err)
             or _is_model_incompatible_error(first_err)
             or _is_invalid_aux_response_error(first_err)
+            or _is_server_error(first_err)
         )
         # Capacity errors (payment/quota/connection/rate-limit) bypass the
         # explicit-provider gate — the provider cannot serve the request
@@ -10719,6 +10749,7 @@ async def _async_call_llm_impl(
             or _is_rate_limit_error(first_err)
             or _is_model_incompatible_error(first_err)
             or _is_invalid_aux_response_error(first_err)
+            or _is_server_error(first_err)
         )
         if should_fallback and (is_auto or is_capacity_error):
             if _is_auth_error(first_err):

--- a/tests/agent/test_auxiliary_5xx_fallback.py
+++ b/tests/agent/test_auxiliary_5xx_fallback.py
@@ -1,0 +1,152 @@
+"""Tests for upstream 5xx fallback: aux tasks must fall back on server errors.
+
+Regression context: an OpenCode Go endpoint returned HTTP 500
+("Internal server error") for every muse-spark request. 500s survived the
+transient-retry path but were not classified as a fallback-worthy failure,
+so ``should_fallback`` stayed False and user-configured
+``auxiliary.<task>.fallback_chain`` entries were never consulted — auxiliary
+tasks (compression, title generation, approval) failed outright instead of
+rerouting to a healthy provider.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.auxiliary_client import _is_server_error, call_llm
+
+
+def _make_500_err():
+    """An APIStatusError-shaped exception like openai raises on HTTP 500."""
+    class _Err500(Exception):
+        status_code = 500
+    return _Err500("Error code: 500 - {'type': 'error', 'error': "
+                   "{'message': 'Internal server error'}}")
+
+
+def _make_503_err():
+    class _Err503(Exception):
+        status_code = 503
+    return _Err503("Error code: 503 - Service Unavailable")
+
+
+class TestIsServerError:
+    def test_500_status_code_detected(self):
+        assert _is_server_error(_make_500_err()) is True
+
+    def test_503_status_code_detected(self):
+        assert _is_server_error(_make_503_err()) is True
+
+    def test_plain_exception_with_message_detected(self):
+        # Some providers surface 5xx as bare exceptions without status_code.
+        exc = Exception("upstream returned Internal server error")
+        assert _is_server_error(exc) is True
+
+    def test_4xx_not_matched(self):
+        exc = Exception("Error code: 400 - bad request")
+        exc.status_code = 400
+        assert _is_server_error(exc) is False
+
+    def test_unrelated_exception_not_matched(self):
+        assert _is_server_error(Exception("something else went wrong")) is False
+
+    def test_auth_error_body_not_shadowed(self):
+        # A 5xx whose message mentions auth must NOT be force-matched here;
+        # the caller classifies auth first via _is_auth_error.
+        exc = Exception("internal error while validating credentials")
+        exc.status_code = 502
+        assert _is_server_error(exc) is True  # matched, but caller checks auth first
+        assert "auth" not in ("internal server error", )
+
+
+class TestExplicitProvider500FallsBackToChain:
+    """HTTP 500 on an explicit aux provider must consult fallback_chain.
+
+    Mirrors TestAuxiliaryFallbackLayering.test_explicit_provider_rate_limit_
+    triggers_fallback (#52228), extended to 5xx responses.
+    """
+
+    def test_explicit_provider_500_triggers_configured_chain(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = _make_500_err()
+
+        fallback_client = MagicMock()
+        fallback_client.chat.completions.create.return_value = MagicMock(choices=[
+            MagicMock(message=MagicMock(content="from fallback chain"))
+        ])
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "muse-spark-1.2-contributor")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("opencode-go", "muse-spark-1.2-contributor",
+                                 None, None, None)), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain",
+                   return_value=(fallback_client, "deepseek-v4-flash",
+                                 "fallback_chain[0](commandcode)")) as mock_chain, \
+             patch("agent.auxiliary_client._try_main_agent_model_fallback") as mock_main:
+            result = call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "title this"}],
+            )
+
+        mock_chain.assert_called()
+        assert fallback_client.chat.completions.create.called
+        assert result.choices[0].message.content == "from fallback chain"
+        mock_main.assert_not_called()
+
+    def test_explicit_provider_503_triggers_configured_chain(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = _make_503_err()
+
+        fallback_client = MagicMock()
+        fallback_client.chat.completions.create.return_value = MagicMock(choices=[
+            MagicMock(message=MagicMock(content="recovered"))
+        ])
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "m")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("opencode-go", "m", None, None, None)), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain",
+                   return_value=(fallback_client, "fb-model",
+                                 "fallback_chain[0](commandcode)")) as mock_chain, \
+             patch("agent.auxiliary_client._try_main_agent_model_fallback"):
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+
+        mock_chain.assert_called()
+        assert result.choices[0].message.content == "recovered"
+
+    def test_500_with_no_chain_reaches_main_model_safety_net(self, monkeypatch):
+        """When no chain is configured, 500 still falls back to main model."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = _make_500_err()
+
+        main_client = MagicMock()
+        main_client.chat.completions.create.return_value = MagicMock(choices=[
+            MagicMock(message=MagicMock(content="main saved it"))
+        ])
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "m")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("opencode-go", "m", None, None, None)), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain",
+                   return_value=(None, None, "")), \
+             patch("agent.auxiliary_client._try_main_agent_model_fallback",
+                   return_value=(main_client, "stealth/ox-alpha", "main-agent(openrouter)")) as mock_main:
+            result = call_llm(
+                task="approval",
+                messages=[{"role": "user", "content": "approve?"}],
+            )
+
+        mock_main.assert_called()
+        assert result.choices[0].message.content == "main saved it"


### PR DESCRIPTION
## What

Auxiliary tasks (compression, title generation, approval, vision, ...) did not consult `auxiliary.<task>.fallback_chain` when the primary provider returned HTTP 5xx. A 500 is not classified as auth/payment/connection/rate-limit/model-incompatible/invalid-response, so `should_fallback` stayed False and the failure propagated to the caller even when a healthy fallback provider was configured.

### Changes

- Add `_is_server_error()`: matches APIStatusError-style exceptions carrying a 5xx `status_code`, plus plain exceptions whose message embeds the status (some providers raise bare errors without structured status)
- Include it in `should_fallback` and `is_capacity_error` in both the sync (`call_llm`) and async auxiliary paths

Same-provider transient retries are unchanged: `_is_transient_transport_error` already covers 5xx for the retry-once-on-same-provider gate. This change only governs what happens after those retries are exhausted.

## Why

Observed in the wild: an OpenCode Go endpoint returned `500 Internal Server Error` for every request over multiple hours while a user-configured fallback provider was healthy. Consequences:

- Context compression fell back to a deterministic no-summary marker (`Summary generation failed ... Inserted a fallback context marker`) — the session lost its handoff summary entirely
- Title generation and approval aux calls failed all day despite a working fallback chain sitting unused in config

A 5xx is a provider-capacity failure, not a request constraint: the endpoint was reached but could not serve the request. Once same-provider retries are exhausted, rerouting to a healthy fallback is the correct behavior, consistent with how 429/402/connection failures are already treated (#52228, #26803).

## How to test

```bash
python3 -m pytest tests/agent/test_auxiliary_5xx_fallback.py -v
```

9 new tests:

- `_is_server_error` unit coverage (500/503 status codes, plain-exception messages, 4xx rejection, unrelated messages)
- Explicit-provider 500 → configured `fallback_chain` consulted, fallback response returned
- Explicit-provider 503 → same
- 500 with no chain configured → main-agent-model safety net reached

Existing suite: `tests/agent/test_auxiliary_client.py` — 181 passed (1 pre-existing environment-dependent failure in `TestStaleBaseUrlWarning`, fails on clean upstream/main too when `OPENAI_BASE_URL` is set locally; unrelated to this change).

## Platforms

Linux (WSL2). Change is platform-independent error classification.

## Duplicate check

Searched open+merged PRs and issues for "auxiliary 500 fallback" / "should_fallback server error" — no existing PR covers 5xx classification for aux fallback.