### PR TITLE
fix(cli): hard-exit the Windows update hand-off child once work is durable

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10379,6 +10379,10 @@ def cmd_update(args):
         _finalize_update_output(_update_io_state)
         sys.exit(UPDATE_EXIT_CONCURRENT)
 
+    # Exit code for the Windows hand-off child's hard exit (see finally).
+    # None = not a SystemExit-shaped outcome; real exceptions keep the
+    # normal raise path so their traceback still prints.
+    _update_handoff_exit_code: int | None = None
     try:
         _self()._cmd_update_impl(args, gateway_mode=gateway_mode)
     except SystemExit as _update_exit:
@@ -10395,6 +10399,9 @@ def cmd_update(args):
             finalize_pending_update_receipt(_code, f"sys.exit({_code})")
         except Exception:
             pass
+        _update_handoff_exit_code = (
+            _update_exit.code if isinstance(_update_exit.code, int) else 0
+        )
         raise
     except BaseException as _update_exc:
         try:
@@ -10413,9 +10420,29 @@ def cmd_update(args):
             finalize_pending_update_receipt(0, "completed at command boundary")
         except Exception:
             pass
+        _update_handoff_exit_code = 0
     finally:
         _update_lock.release()
         _finalize_update_output(_update_io_state)
+        # Windows hand-off child (#93581): the re-exec'd venv child cannot
+        # rely on graceful interpreter shutdown — a leftover non-daemon
+        # thread from the update tail keeps the console busy long after
+        # the receipt is durable (success, exit 0, "completed at command
+        # boundary"), freezing the PowerShell window for minutes. By this
+        # point every durable step is done (receipt finalized above, lock
+        # released, stdio restored), so on the hand-off path only, flush
+        # and exit hard instead of waiting for the interpreter to unwind
+        # — the same treatment #79040's cron workaround applies. No-op on
+        # every non-hand-off invocation: the marker env is set solely by
+        # _reexec_dependency_sync_off_windows_shim when it spawns the child.
+        if _update_handoff_exit_code is not None and os.environ.get(_UPDATE_REEXEC_ENV) == "1":
+            logger.debug(
+                "Update hand-off child %s exiting via os._exit(%s)",
+                os.getpid(), _update_handoff_exit_code,
+            )
+            sys.stdout.flush()
+            sys.stderr.flush()
+            os._exit(_update_handoff_exit_code)
 
 
 def _coalesce_session_name_args(argv: list) -> list:

--- a/tests/hermes_cli/test_update_handoff_exit.py
+++ b/tests/hermes_cli/test_update_handoff_exit.py
@@ -1,0 +1,133 @@
+"""Windows hand-off child must hard-exit once the update is durably done (#93581).
+
+The re-exec'd venv child (spawned by
+``_reexec_dependency_sync_off_windows_shim`` with ``HERMES_UPDATE_REEXEC=1``)
+completes all update work — the receipt records ``success`` / ``completed at
+command boundary`` — but then hangs in interpreter shutdown on a leftover
+non-daemon thread, freezing the PowerShell window for minutes. The fix: on
+the hand-off path only, after the receipt is finalized, the lock released,
+and stdio restored, flush and ``os._exit(code)`` instead of unwinding.
+
+These tests pin: the hard exit fires (with the right code) only when the
+re-exec marker env is set, it happens after lock release + stdio restore,
+early ``SystemExit`` codes propagate to it, and real exceptions keep the
+normal raise path (traceback intact, no hard exit).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import hermes_cli.main as main_mod
+from hermes_cli.main import cmd_update
+
+
+class _FakeLock:
+    def __init__(self, events):
+        self._events = events
+
+    def acquire(self):
+        self._events.append("acquire")
+        return True
+
+    def release(self):
+        self._events.append("release")
+
+
+# Events from the most recent _run_cmd_update call, also filled in when
+# cmd_update propagates an exception (the return value is unreachable then).
+_LAST = {}
+
+
+def _run_cmd_update(monkeypatch, impl, *, reexec: bool):
+    """Run cmd_update with everything external mocked; return the events."""
+    events = {"order": [], "exit_codes": [], "receipts": []}
+
+    def fake_impl(args, gateway_mode=False):
+        events["order"].append("impl")
+        impl(args, gateway_mode=gateway_mode)
+
+    def fake_finalize_io(state):
+        events["order"].append("restore-stdio")
+
+    def fake_receipt(code, reason):
+        events["receipts"].append((code, reason))
+
+    def fake_exit(code):
+        events["order"].append("hard-exit")
+        events["exit_codes"].append(code)
+
+    monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
+    monkeypatch.setattr("hermes_cli.config.detect_install_method", lambda root: "git")
+    monkeypatch.setattr("hermes_cli.update_lock.UpdateLock", lambda: _FakeLock(events["order"]))
+    monkeypatch.setattr(main_mod, "_cmd_update_impl", fake_impl)
+    monkeypatch.setattr(main_mod, "_install_hangup_protection", lambda gateway_mode=False: None)
+    monkeypatch.setattr(main_mod, "_finalize_update_output", fake_finalize_io)
+    monkeypatch.setattr("hermes_cli.update_receipt.finalize_pending_update_receipt", fake_receipt)
+    monkeypatch.setattr("os._exit", fake_exit)
+    if reexec:
+        monkeypatch.setenv("HERMES_UPDATE_REEXEC", "1")
+    else:
+        monkeypatch.delenv("HERMES_UPDATE_REEXEC", raising=False)
+
+    args = SimpleNamespace(plan=False, check=False, gateway=False, branch=None)
+    try:
+        cmd_update(args)
+    finally:
+        _LAST.clear()
+        _LAST.update(events)
+    return events
+
+
+def _noop_impl(args, gateway_mode=False):
+    return None
+
+
+def test_handoff_child_hard_exits_zero_after_success(monkeypatch):
+    events = _run_cmd_update(monkeypatch, _noop_impl, reexec=True)
+    assert events["exit_codes"] == [0]
+    assert events["receipts"] == [(0, "completed at command boundary")]
+    # The hard exit is the last thing, after lock release and stdio restore.
+    assert events["order"] == ["acquire", "impl", "release", "restore-stdio", "hard-exit"]
+
+
+def test_non_handoff_run_never_hard_exits(monkeypatch):
+    events = _run_cmd_update(monkeypatch, _noop_impl, reexec=False)
+    assert events["exit_codes"] == []
+    assert "hard-exit" not in events["order"]
+    assert events["receipts"] == [(0, "completed at command boundary")]
+
+
+def test_handoff_child_propagates_early_systemexit_code(monkeypatch):
+    def early_refusal(args, gateway_mode=False):
+        raise SystemExit(3)
+
+    with pytest.raises(SystemExit) as excinfo:
+        _run_cmd_update(monkeypatch, early_refusal, reexec=True)
+    assert excinfo.value.code == 3
+    # The finally-block hard exit ran (before the re-raise propagated)
+    # and carried the early exit's code, not a blanket 0.
+    assert _LAST["exit_codes"] == [3]
+
+
+def test_handoff_child_systemexit_none_means_zero(monkeypatch):
+    def bare_exit(args, gateway_mode=False):
+        raise SystemExit(None)
+
+    with pytest.raises(SystemExit):
+        _run_cmd_update(monkeypatch, bare_exit, reexec=True)
+    assert _LAST["exit_codes"] == [0]
+
+
+def test_unhandled_exception_keeps_raise_path_no_hard_exit(monkeypatch):
+    def boom(args, gateway_mode=False):
+        raise RuntimeError("update tail exploded")
+
+    # With os._exit patched to record, the re-raised RuntimeError reaches
+    # pytest with the finally block already run — and no hard exit fires.
+    with pytest.raises(RuntimeError, match="update tail exploded"):
+        _run_cmd_update(monkeypatch, boom, reexec=True)
+    assert "hard-exit" not in _LAST["order"]
+    assert _LAST["receipts"] == [(1, "RuntimeError: update tail exploded")]


### PR DESCRIPTION
## What does this PR do?

On Windows, `hermes update` from the `hermes.exe` console shim hands the dependency install to a re-exec'd child under the venv Python (the #90192 self-lock fix). That child completes every update step — the receipt records `"outcome": "success"`, `"exit_code": 0`, `"stop_reason": "completed at command boundary"` — and then hangs in interpreter shutdown on a leftover non-daemon thread, so the PowerShell window never regains its prompt (frozen ~15 minutes until Ctrl+C in the report). This PR makes the hand-off child hard-exit (`os._exit(code)`) at the command boundary once everything durable is done, instead of relying on graceful interpreter shutdown.

## Related Issue

Fixes #93581

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `hermes_cli/main.py` (`cmd_update`): track the SystemExit-shaped outcome (success → 0; early `sys.exit(n)` refusals → n; bare `sys.exit()` → 0), and in the existing `finally` — after the receipt finalizer has run, the update lock is released, and stdio is restored — when the re-exec marker `HERMES_UPDATE_REEXEC=1` is set, log (PID + code), flush stdout/stderr, and `os._exit(code)`. Real (non-SystemExit) exceptions deliberately keep the normal raise path so tracebacks still print. The marker env is set solely by `_reexec_dependency_sync_off_windows_shim` when it spawns the child, so every non-hand-off invocation — including all non-Windows updates and direct venv runs — is untouched.
- `tests/hermes_cli/test_update_handoff_exit.py` — new: hard exit fires with code 0 after success in strict order (impl → release → restore-stdio → hard-exit); no hard exit without the marker env; early `SystemExit(3)` propagates its code to the hard exit; bare `SystemExit(None)` maps to 0; unhandled `RuntimeError` keeps the raise path with no hard exit and the failure receipt still finalized.

## How to Test

- New: `.venv/bin/python -m pytest tests/hermes_cli/test_update_handoff_exit.py -q` — should pass (5 tests). On unpatched `main`, the three hand-off-exit assertions fail (no hard exit exists), pinning the regression; the fix is platform-independent in its decision condition (env marker, not platform check), so it is fully testable on macOS/Linux CI.
- Regression: `.venv/bin/python -m pytest tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_cmd_update_docker.py tests/hermes_cli/test_cmd_update_apt.py -q` — the 8 failures there (`test_branch_flag_pulls_against_named_branch`, `test_wsl_update_skips_windows_npm_build_paths`, …) are identical on clean `main` in this environment (verified via `git stash` comparison); they exercise real git/network flows and are unrelated to this change.

Observed result: locally, all 5 new tests pass; the order-pinning test shows the hard exit is the final event after lock release and stdio restore, and the no-marker control run shows zero `os._exit` calls — the pre-fix behavior of every non-hand-off invocation is byte-identical.

## Checklist

- [x] Code follows project style (no unrelated changes)
- [x] Self-reviewed the diff
- [x] Added/updated tests covering the fix
- [x] All new and existing tests pass locally (new suite 5/5; the 8 pre-existing update-suite failures are identical on clean `main` — environment git/network tests, unrelated)
- [x] PR targets `upstream/main` from a fork branch
