### PR TITLE
feat(skills): optimize deterministic BM25 routing

### DIFF
--- a/agent/skill_routing.py
+++ b/agent/skill_routing.py
@@ -13,16 +13,26 @@ from typing import Any, Iterable, Mapping
 
 
 _TOKEN_RE = re.compile(r"[^\W_]+", re.UNICODE)
-_SCALAR_FIELDS = ("qualified_name", "name", "category", "description")
-_SEQUENCE_FIELDS = (
+_FIELDS = (
+    "qualified_name",
+    "name",
+    "category",
+    "description",
     "triggers",
     "tags",
     "related_skills",
     "required_commands",
     "required_environment_variables",
 )
+_SCALAR_FIELDS = frozenset({"qualified_name", "name", "category", "description"})
+_SEQUENCE_FIELDS = frozenset(_FIELDS) - _SCALAR_FIELDS
 _K1 = 1.5
 _B = 0.75
+_DEFAULT_LIMIT = 8
+# A default query is considered separated when its best score clears the
+# runner-up by this ratio. Separated intent needs only a compact handoff set.
+_STRONG_SCORE_RATIO = 1.2
+_STRONG_DEPTH = 3
 
 
 def _tokenize(value: str) -> list[str]:
@@ -43,20 +53,27 @@ def _normalized_values(value: Any) -> list[str]:
     return sorted(cleaned, key=lambda item: (item.casefold(), item))
 
 
-def _canonical_document(skill: Mapping[str, Any]) -> dict[str, Any]:
+def build_routing_card(skill: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a deterministic internal card hashed only from ranking fields."""
     document: dict[str, Any] = {
         field: str(skill.get(field) or "").strip() for field in _SCALAR_FIELDS
     }
     for field in _SEQUENCE_FIELDS:
         document[field] = _normalized_values(skill.get(field))
+    canonical_source = json.dumps(
+        document, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    )
+    document["source_fingerprint"] = hashlib.sha256(
+        canonical_source.encode("utf-8")
+    ).hexdigest()
     return document
 
 
-def _document_tokens(document: Mapping[str, Any]) -> list[str]:
+def _document_tokens(document: Mapping[str, Any]) -> tuple[str, ...]:
     text: list[str] = [str(document[field]) for field in _SCALAR_FIELDS]
     for field in _SEQUENCE_FIELDS:
         text.extend(document[field])
-    return _tokenize(" ".join(text))
+    return tuple(_tokenize(" ".join(text)))
 
 
 def _tie_key(document: Mapping[str, Any]) -> tuple[str, ...]:
@@ -88,9 +105,9 @@ def _build_index(
     float,
     str,
 ]:
-    """Build and cache one immutable BM25 corpus from canonical metadata."""
+    """Build and cache one immutable BM25 corpus from source-hashed cards."""
     documents = tuple(json.loads(serialized_documents))
-    tokenized = tuple(tuple(_document_tokens(document)) for document in documents)
+    tokenized = tuple(_document_tokens(document) for document in documents)
     document_frequencies: Counter[str] = Counter()
     for tokens in tokenized:
         document_frequencies.update(set(tokens))
@@ -112,7 +129,7 @@ def rank_skills(
 ) -> dict[str, Any]:
     """Rank canonical skill metadata with deterministic Okapi BM25."""
     skill_list = list(skills)
-    canonical_documents = [_canonical_document(skill) for skill in skill_list]
+    canonical_documents = [build_routing_card(skill) for skill in skill_list]
     serialized_documents = _serialize_documents(canonical_documents)
     (
         documents,
@@ -160,7 +177,15 @@ def rank_skills(
         )
         for skill, document in zip(skill_list, canonical_documents)
     }
-    for rank, (_, score, document) in enumerate(scored[: max(0, limit)], start=1):
+    depth = min(max(0, limit), total)
+    if limit == _DEFAULT_LIMIT and scored:
+        if scored[0][1] > 0.0:
+            runner_up = scored[1][1] if len(scored) > 1 else 0.0
+            if runner_up <= 0.0 or scored[0][1] >= runner_up * _STRONG_SCORE_RATIO:
+                exact_name_count = sum(exact_name for exact_name, _, _ in scored)
+                depth = min(depth, max(_STRONG_DEPTH, exact_name_count))
+
+    for rank, (_, score, document) in enumerate(scored[:depth], start=1):
         ranked.append({
             "rank": rank,
             "name": document["name"],

--- a/agent/skill_routing.py
+++ b/agent/skill_routing.py
@@ -177,15 +177,18 @@ def rank_skills(
         )
         for skill, document in zip(skill_list, canonical_documents)
     }
-    depth = min(max(0, limit), total)
-    if limit == _DEFAULT_LIMIT and scored:
-        if scored[0][1] > 0.0:
-            runner_up = scored[1][1] if len(scored) > 1 else 0.0
-            if runner_up <= 0.0 or scored[0][1] >= runner_up * _STRONG_SCORE_RATIO:
-                exact_name_count = sum(exact_name for exact_name, _, _ in scored)
-                depth = min(depth, max(_STRONG_DEPTH, exact_name_count))
+    rankable = scored
+    if limit == _DEFAULT_LIMIT:
+        rankable = [item for item in scored if item[1] > 0.0]
 
-    for rank, (_, score, document) in enumerate(scored[:depth], start=1):
+    depth = min(max(0, limit), len(rankable))
+    if limit == _DEFAULT_LIMIT and rankable:
+        runner_up = rankable[1][1] if len(rankable) > 1 else 0.0
+        if runner_up <= 0.0 or rankable[0][1] >= runner_up * _STRONG_SCORE_RATIO:
+            exact_name_count = sum(exact_name for exact_name, _, _ in rankable)
+            depth = min(depth, max(_STRONG_DEPTH, exact_name_count))
+
+    for rank, (_, score, document) in enumerate(rankable[:depth], start=1):
         ranked.append({
             "rank": rank,
             "name": document["name"],

--- a/agent/skill_routing.py
+++ b/agent/skill_routing.py
@@ -1,0 +1,176 @@
+"""Deterministic, local BM25 ranking for skill routing metadata."""
+
+from __future__ import annotations
+
+from collections import Counter
+from functools import lru_cache
+import hashlib
+import json
+import math
+import re
+import unicodedata
+from typing import Any, Iterable, Mapping
+
+
+_TOKEN_RE = re.compile(r"[^\W_]+", re.UNICODE)
+_SCALAR_FIELDS = ("qualified_name", "name", "category", "description")
+_SEQUENCE_FIELDS = (
+    "triggers",
+    "tags",
+    "related_skills",
+    "required_commands",
+    "required_environment_variables",
+)
+_K1 = 1.5
+_B = 0.75
+
+
+def _tokenize(value: str) -> list[str]:
+    normalized = unicodedata.normalize("NFKC", value).casefold()
+    return _TOKEN_RE.findall(normalized)
+
+
+def _normalized_values(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        values: Iterable[Any] = [value]
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        values = value
+    else:
+        return []
+    cleaned = {str(item).strip() for item in values if str(item).strip()}
+    return sorted(cleaned, key=lambda item: (item.casefold(), item))
+
+
+def _canonical_document(skill: Mapping[str, Any]) -> dict[str, Any]:
+    document: dict[str, Any] = {
+        field: str(skill.get(field) or "").strip() for field in _SCALAR_FIELDS
+    }
+    for field in _SEQUENCE_FIELDS:
+        document[field] = _normalized_values(skill.get(field))
+    return document
+
+
+def _document_tokens(document: Mapping[str, Any]) -> list[str]:
+    text: list[str] = [str(document[field]) for field in _SCALAR_FIELDS]
+    for field in _SEQUENCE_FIELDS:
+        text.extend(document[field])
+    return _tokenize(" ".join(text))
+
+
+def _tie_key(document: Mapping[str, Any]) -> tuple[str, ...]:
+    values = (
+        str(document["qualified_name"]),
+        str(document["category"]),
+        str(document["name"]),
+    )
+    return tuple(part for value in values for part in (value.casefold(), value))
+
+
+def _serialize_documents(documents: list[dict[str, Any]]) -> str:
+    ordered = sorted(documents, key=_tie_key)
+    return json.dumps(
+        ordered,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+@lru_cache(maxsize=1)
+def _build_index(
+    serialized_documents: str,
+) -> tuple[
+    tuple[dict[str, Any], ...],
+    tuple[tuple[str, ...], ...],
+    tuple[tuple[str, int], ...],
+    float,
+    str,
+]:
+    """Build and cache one immutable BM25 corpus from canonical metadata."""
+    documents = tuple(json.loads(serialized_documents))
+    tokenized = tuple(tuple(_document_tokens(document)) for document in documents)
+    document_frequencies: Counter[str] = Counter()
+    for tokens in tokenized:
+        document_frequencies.update(set(tokens))
+    average_length = (
+        sum(len(tokens) for tokens in tokenized) / len(tokenized) if tokenized else 0.0
+    )
+    fingerprint = hashlib.sha256(serialized_documents.encode("utf-8")).hexdigest()[:16]
+    return (
+        documents,
+        tokenized,
+        tuple(sorted(document_frequencies.items())),
+        average_length,
+        fingerprint,
+    )
+
+
+def rank_skills(
+    skills: Iterable[Mapping[str, Any]], query: str, limit: int
+) -> dict[str, Any]:
+    """Rank canonical skill metadata with deterministic Okapi BM25."""
+    skill_list = list(skills)
+    canonical_documents = [_canonical_document(skill) for skill in skill_list]
+    serialized_documents = _serialize_documents(canonical_documents)
+    (
+        documents,
+        tokenized,
+        document_frequency_items,
+        average_length,
+        index_fingerprint,
+    ) = _build_index(serialized_documents)
+    query_tokens = _tokenize(query)
+    total = len(documents)
+    document_frequencies = dict(document_frequency_items)
+
+    query_frequencies = Counter(query_tokens)
+    scored: list[tuple[bool, float, dict[str, Any]]] = []
+    normalized_query_name = " ".join(query_tokens)
+    for document, tokens in zip(documents, tokenized):
+        frequencies = Counter(tokens)
+        score = 0.0
+        for term, query_frequency in query_frequencies.items():
+            frequency = frequencies[term]
+            if not frequency:
+                continue
+            document_frequency = document_frequencies[term]
+            inverse_document_frequency = math.log(
+                1.0 + (total - document_frequency + 0.5) / (document_frequency + 0.5)
+            )
+            length_normalization = 1.0 - _B
+            if average_length:
+                length_normalization += _B * len(tokens) / average_length
+            score += (
+                query_frequency
+                * inverse_document_frequency
+                * (frequency * (_K1 + 1.0))
+                / (frequency + _K1 * length_normalization)
+            )
+
+        exact_name = " ".join(_tokenize(str(document["name"]))) == normalized_query_name
+        scored.append((exact_name, score, document))
+
+    scored.sort(key=lambda item: (not item[0], -item[1], _tie_key(item[2])))
+    ranked = []
+    display_descriptions = {
+        _tie_key(document): str(
+            skill.get("display_description", document["description"])
+        )
+        for skill, document in zip(skill_list, canonical_documents)
+    }
+    for rank, (_, score, document) in enumerate(scored[: max(0, limit)], start=1):
+        ranked.append({
+            "rank": rank,
+            "name": document["name"],
+            "category": document["category"] or None,
+            "description": display_descriptions[_tie_key(document)],
+            "score": round(score, 6),
+        })
+
+    return {
+        "skills": ranked,
+        "total_candidates": total,
+        "index_fingerprint": index_fingerprint,
+    }

--- a/contributors/emails/danny@dannyrosen.net
+++ b/contributors/emails/danny@dannyrosen.net
@@ -1,0 +1,2 @@
+Dannyzen
+# PR #93591 contributor attribution

--- a/contributors/emails/scribe@sovereign.local
+++ b/contributors/emails/scribe@sovereign.local
@@ -1,0 +1,2 @@
+Dannyzen
+# PR #93591 local author identity owned by Dannyzen

--- a/scripts/benchmark_skill_routing.py
+++ b/scripts/benchmark_skill_routing.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Run the deterministic public-safe skill-routing relevance benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+import sys
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from agent.skill_routing import rank_skills
+
+
+def evaluate(fixture: dict) -> dict:
+    """Return deterministic aggregate metrics and public-safe result rows."""
+    rows = []
+    for case in fixture["queries"]:
+        ranking = rank_skills(fixture["skills"], case["query"], limit=8)
+        names = [item["name"] for item in ranking["skills"]]
+        relevant = case["relevant"]
+        ranks = [names.index(name) + 1 for name in relevant if name in names]
+        reciprocal_rank = 1.0 / min(ranks) if ranks else (1.0 if not relevant else 0.0)
+        recall = len(ranks) / len(relevant) if relevant else 1.0
+        dcg = sum(1.0 / math.log2(rank + 1) for rank in ranks)
+        ideal = sum(1.0 / math.log2(rank + 1) for rank in range(1, len(relevant) + 1))
+        ndcg = dcg / ideal if ideal else 1.0
+        rows.append({
+            "depth": len(names),
+            "ndcg": ndcg,
+            "query": case["query"],
+            "ranked": names,
+            "recall": recall,
+            "reciprocal_rank": reciprocal_rank,
+            "relevant": relevant,
+        })
+
+    count = len(rows)
+    return {
+        "average_depth": round(sum(row["depth"] for row in rows) / count, 6),
+        "mean_ndcg": round(sum(row["ndcg"] for row in rows) / count, 6),
+        "mrr": round(sum(row["reciprocal_rank"] for row in rows) / count, 6),
+        "query_count": count,
+        "recall": round(sum(row["recall"] for row in rows) / count, 6),
+        "rows": rows,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("fixture", type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    fixture = json.loads(args.fixture.read_text(encoding="utf-8"))
+    result = evaluate(fixture)
+    rendered = json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+    sys.stderr.write(f"sha256={hashlib.sha256(rendered.encode()).hexdigest()}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent/test_skill_routing.py
+++ b/tests/agent/test_skill_routing.py
@@ -1,0 +1,169 @@
+"""Behavioral tests for deterministic local skill routing."""
+
+import json
+
+import pytest
+
+
+def _skill(skill_name: str, **overrides):
+    skill = {
+        "qualified_name": f"testing/{skill_name}",
+        "name": skill_name,
+        "category": "testing",
+        "description": "Generic skill description",
+        "triggers": [],
+        "tags": [],
+        "related_skills": [],
+        "required_commands": [],
+        "required_environment_variables": [],
+    }
+    skill.update(overrides)
+    return skill
+
+
+def test_ranking_uses_routing_metadata_deterministically():
+    from agent import skill_routing
+
+    candidates = [
+        _skill("other"),
+        _skill("deployment-helper", triggers=["deploy kubernetes workloads"]),
+    ]
+
+    first = skill_routing.rank_skills(candidates, "kubernetes", limit=2)
+    second = skill_routing.rank_skills(
+        list(reversed(candidates)), "kubernetes", limit=2
+    )
+
+    assert first == second
+    assert [item["name"] for item in first["skills"]] == [
+        "deployment-helper",
+        "other",
+    ]
+    assert first["skills"][0]["score"] > first["skills"][1]["score"]
+    assert first["total_candidates"] == 2
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("qualified_name", "testing/needle-route"),
+        ("name", "needle-helper"),
+        ("category", "needle-category"),
+        ("description", "Handles the needle workflow"),
+        ("triggers", ["route needle requests"]),
+        ("tags", ["needle"]),
+        ("related_skills", ["needle-companion"]),
+        ("required_commands", ["needle-cli"]),
+        ("required_environment_variables", ["NEEDLE_TOKEN"]),
+    ],
+)
+def test_every_canonical_routing_field_contributes_to_ranking(field, value):
+    from agent import skill_routing
+
+    relevant = _skill("relevant", **{field: value})
+    result = skill_routing.rank_skills(
+        [_skill("irrelevant"), relevant], "needle", limit=2
+    )
+
+    assert result["skills"][0]["name"] == relevant["name"]
+    assert result["skills"][0]["score"] > 0
+
+
+def test_exact_normalized_skill_name_precedes_higher_bm25_score():
+    from agent import skill_routing
+
+    result = skill_routing.rank_skills(
+        [
+            _skill("code-review"),
+            _skill(
+                "review-expert",
+                description="code review code review code review code review",
+                tags=["code", "review"],
+            ),
+        ],
+        "  CODE_review  ",
+        limit=2,
+    )
+
+    assert result["skills"][0]["name"] == "code-review"
+
+
+def test_equal_scores_use_qualified_name_tie_breaker():
+    from agent import skill_routing
+
+    result = skill_routing.rank_skills(
+        [
+            _skill("alpha", qualified_name="plugin-b:alpha"),
+            _skill("zeta", qualified_name="plugin-a:zeta"),
+        ],
+        "unmatched",
+        limit=2,
+    )
+
+    assert [item["name"] for item in result["skills"]] == ["zeta", "alpha"]
+    assert [item["score"] for item in result["skills"]] == [0.0, 0.0]
+
+
+def test_fingerprint_and_ranked_output_ignore_paths_and_input_order():
+    from agent import skill_routing
+
+    first_candidates = [
+        _skill("alpha", source_path="/private/one/SKILL.md"),
+        _skill("beta", tags=["needle"], source_path="/private/two/SKILL.md"),
+    ]
+    second_candidates = [
+        dict(first_candidates[1], source_path="/different/private/two/SKILL.md"),
+        dict(first_candidates[0], source_path="/different/private/one/SKILL.md"),
+    ]
+
+    first = skill_routing.rank_skills(first_candidates, "needle", limit=2)
+    second = skill_routing.rank_skills(second_candidates, "needle", limit=2)
+
+    assert first == second
+    assert len(first["index_fingerprint"]) == 16
+    serialized = json.dumps(first)
+    assert "/private/" not in serialized
+    assert "source_path" not in serialized
+
+
+def test_ranked_output_keeps_display_description_with_its_skill():
+    from agent import skill_routing
+
+    result = skill_routing.rank_skills(
+        [
+            _skill("zeta", display_description="Display for zeta"),
+            _skill("alpha", display_description="Display for alpha"),
+        ],
+        "unmatched",
+        limit=2,
+    )
+
+    assert [(item["name"], item["description"]) for item in result["skills"]] == [
+        ("alpha", "Display for alpha"),
+        ("zeta", "Display for zeta"),
+    ]
+
+
+def test_index_cache_reuses_corpus_and_invalidates_on_routing_change():
+    from agent import skill_routing
+
+    candidates = [_skill("alpha"), _skill("beta", tags=["needle"])]
+    skill_routing._build_index.cache_clear()
+    try:
+        first = skill_routing.rank_skills(candidates, "needle", limit=2)
+        after_first = skill_routing._build_index.cache_info()
+
+        skill_routing.rank_skills(list(reversed(candidates)), "other", limit=2)
+        after_second = skill_routing._build_index.cache_info()
+
+        changed = [dict(candidates[0]), dict(candidates[1], tags=["changed"])]
+        third = skill_routing.rank_skills(changed, "changed", limit=2)
+        after_third = skill_routing._build_index.cache_info()
+
+        assert after_first.misses == 1
+        assert after_second.hits == 1
+        assert after_second.misses == 1
+        assert after_third.misses == 2
+        assert first["index_fingerprint"] != third["index_fingerprint"]
+    finally:
+        skill_routing._build_index.cache_clear()

--- a/tests/agent/test_skill_routing_benchmark.py
+++ b/tests/agent/test_skill_routing_benchmark.py
@@ -1,0 +1,47 @@
+"""Frozen public-safe relevance and determinism gate for skill routing."""
+
+import json
+import math
+from pathlib import Path
+
+
+FIXTURE = Path(__file__).parents[1] / "fixtures" / "skill_routing_benchmark.json"
+
+
+def _metrics(payload, skills):
+    from agent.skill_routing import rank_skills
+
+    rows = []
+    for case in payload["queries"]:
+        result = rank_skills(skills, case["query"], limit=8)
+        names = [item["name"] for item in result["skills"]]
+        relevant = case["relevant"]
+        ranks = [names.index(name) + 1 for name in relevant if name in names]
+        reciprocal_rank = 1.0 / min(ranks) if ranks else (1.0 if not relevant else 0.0)
+        recall = len(ranks) / len(relevant) if relevant else 1.0
+        dcg = sum(1.0 / math.log2(rank + 1) for rank in ranks)
+        ideal = sum(1.0 / math.log2(rank + 1) for rank in range(1, len(relevant) + 1))
+        ndcg = dcg / ideal if ideal else 1.0
+        rows.append((names, reciprocal_rank, ndcg, recall))
+    count = len(rows)
+    return {
+        "rows": rows,
+        "mrr": sum(row[1] for row in rows) / count,
+        "mean_ndcg": sum(row[2] for row in rows) / count,
+        "recall": sum(row[3] for row in rows) / count,
+        "average_depth": sum(len(row[0]) for row in rows) / count,
+    }
+
+
+def test_frozen_benchmark_thresholds_and_reversed_order_determinism():
+    payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    forward = _metrics(payload, payload["skills"])
+    reverse = _metrics(payload, list(reversed(payload["skills"])))
+
+    assert forward == reverse
+    assert forward["mrr"] >= 0.95
+    assert forward["mean_ndcg"] >= 0.96
+    assert forward["recall"] == 1.0
+    assert forward["average_depth"] <= 6.0
+    assert 1 <= len(forward["rows"][-2][0]) <= 3
+    assert len(forward["rows"][-1][0]) == 8

--- a/tests/agent/test_skill_routing_benchmark.py
+++ b/tests/agent/test_skill_routing_benchmark.py
@@ -44,4 +44,4 @@ def test_frozen_benchmark_thresholds_and_reversed_order_determinism():
     assert forward["recall"] == 1.0
     assert forward["average_depth"] <= 6.0
     assert 1 <= len(forward["rows"][-2][0]) <= 3
-    assert len(forward["rows"][-1][0]) == 8
+    assert forward["rows"][-1][0] == []

--- a/tests/agent/test_skill_routing_production.py
+++ b/tests/agent/test_skill_routing_production.py
@@ -1,0 +1,176 @@
+"""Production behavior contracts for deterministic BM25 skill routing."""
+
+from copy import deepcopy
+import json
+
+import pytest
+
+
+def _skill(name: str, **overrides):
+    skill = {
+        "qualified_name": f"testing/{name}",
+        "name": name,
+        "category": "testing",
+        "description": "generic helper",
+        "display_description": "generic helper",
+        "triggers": [],
+        "tags": [],
+        "related_skills": [],
+        "required_commands": [],
+        "required_environment_variables": [],
+    }
+    skill.update(overrides)
+    return skill
+
+
+def test_routing_card_fingerprint_is_stable_private_and_source_bound():
+    from agent import skill_routing
+
+    make_card = getattr(skill_routing, "build_routing_card", None)
+    assert callable(make_card), (
+        "build_routing_card must create internal source-hashed cards"
+    )
+    source = _skill("deploy-helper", triggers=["deploy workloads"])
+    first = make_card(source)
+    second = make_card(dict(source))
+
+    assert first == second
+    assert len(first["source_fingerprint"]) == 64
+    assert first["source_fingerprint"] == first["source_fingerprint"].lower()
+    assert set(first["source_fingerprint"]) <= set("0123456789abcdef")
+
+    for excluded, changed in {
+        "display_description": "presentation changed",
+        "path": "/private/secret/SKILL.md",
+        "source_path": "/private/other/SKILL.md",
+        "body": "private body material",
+    }.items():
+        variant = dict(source, **{excluded: changed})
+        assert make_card(variant)["source_fingerprint"] == first["source_fingerprint"]
+
+    for field, changed in {
+        "name": "changed-name",
+        "qualified_name": "changed/qualified",
+        "category": "changed-category",
+        "description": "changed description",
+        "triggers": ["changed trigger"],
+        "tags": ["changed-tag"],
+        "related_skills": ["changed-related"],
+        "required_commands": ["changed-command"],
+        "required_environment_variables": ["CHANGED_ENV"],
+    }.items():
+        variant = deepcopy(source)
+        variant[field] = changed
+        assert make_card(variant)["source_fingerprint"] != first["source_fingerprint"]
+
+
+def test_approved_bm25_description_signal_beats_name_only_distractor():
+    from agent.skill_routing import rank_skills
+
+    candidates = [
+        _skill(
+            "git-recovery",
+            description="repair orphaned branch pruning behavior safely",
+            triggers=["repair stale branches"],
+            tags=["git"],
+        ),
+        _skill(
+            "orphaned-branch-pruning",
+            description="format a status label",
+            triggers=["format status"],
+            tags=["formatting"],
+        ),
+        _skill("repair", description="generic repair helper", triggers=["repair data"]),
+    ]
+
+    result = rank_skills(candidates, "repair orphaned branch pruning behavior", limit=8)
+
+    assert result["skills"][0]["name"] == "git-recovery"
+
+
+def test_duplicate_exact_names_keep_all_ambiguity_candidates():
+    from agent.skill_routing import rank_skills
+
+    candidates = [
+        _skill(
+            "duplicate",
+            qualified_name="testing/duplicate-strong",
+            description="duplicate duplicate duplicate duplicate duplicate",
+        ),
+        *[
+            _skill("duplicate", qualified_name=f"testing/duplicate-{index}")
+            for index in range(4)
+        ],
+    ]
+
+    result = rank_skills(candidates, "duplicate", limit=8)
+
+    assert len(result["skills"]) == 5
+
+
+def test_default_adaptive_depth_and_non_default_exact_limits():
+    from agent.skill_routing import rank_skills
+
+    candidates = [_skill(f"other-{index:02d}") for index in range(9)]
+    candidates.append(_skill("deploy-helper", triggers=["deploy kubernetes workload"]))
+
+    exact = rank_skills(candidates, "DEPLOY_helper", limit=8)
+    strong = rank_skills(candidates, "deploy kubernetes workload", limit=8)
+    ambiguous = rank_skills(candidates, "generic", limit=8)
+    unmatched = rank_skills(candidates, "quantum orchard", limit=8)
+
+    assert 1 <= len(exact["skills"]) <= 3
+    assert exact["skills"][0]["name"] == "deploy-helper"
+    assert 1 <= len(strong["skills"]) <= 3
+    assert strong["skills"][0]["name"] == "deploy-helper"
+    assert len(ambiguous["skills"]) == 8
+    assert len(unmatched["skills"]) == 8
+    assert len(rank_skills(candidates, "deploy-helper", limit=4)["skills"]) == 4
+    assert len(rank_skills(candidates[:2], "unmatched", limit=8)["skills"]) == 2
+    assert rank_skills([], "unmatched", limit=8)["skills"] == []
+
+
+def test_index_cache_reuse_isolation_and_fingerprint_invalidation():
+    from agent import skill_routing
+
+    candidates = [_skill("alpha"), _skill("beta", tags=["needle"])]
+    skill_routing._build_index.cache_clear()
+    try:
+        first = skill_routing.rank_skills(candidates, "needle", limit=2)
+        info_one = skill_routing._build_index.cache_info()
+        reversed_result = skill_routing.rank_skills(
+            list(reversed(candidates)), "other", limit=2
+        )
+        info_two = skill_routing._build_index.cache_info()
+        presentation = deepcopy(candidates)
+        presentation[1]["display_description"] = "changed display"
+        display_result = skill_routing.rank_skills(presentation, "needle", limit=2)
+        info_three = skill_routing._build_index.cache_info()
+        changed = deepcopy(candidates)
+        changed[1]["tags"] = ["changed"]
+        changed_result = skill_routing.rank_skills(changed, "changed", limit=2)
+        info_four = skill_routing._build_index.cache_info()
+
+        assert info_one.misses == 1
+        assert info_two.hits == 1
+        assert info_three.hits == 2
+        assert info_four.misses == 2
+        assert first["index_fingerprint"] == reversed_result["index_fingerprint"]
+        assert first["index_fingerprint"] == display_result["index_fingerprint"]
+        assert first["index_fingerprint"] != changed_result["index_fingerprint"]
+        assert "source_fingerprint" not in json.dumps(first)
+    finally:
+        skill_routing._build_index.cache_clear()
+
+
+@pytest.mark.parametrize("query", ["café", "CAFE\u0301"])
+def test_unicode_normalization_and_input_order_are_deterministic(query):
+    from agent.skill_routing import rank_skills
+
+    candidates = [_skill("zeta"), _skill("café")]
+    forward = rank_skills(candidates, query, limit=8)
+    reverse = rank_skills(list(reversed(candidates)), query, limit=8)
+
+    assert forward == reverse
+    assert forward["skills"][0]["name"] == "café"
+    assert len(forward["skills"]) == 2

--- a/tests/agent/test_skill_routing_production.py
+++ b/tests/agent/test_skill_routing_production.py
@@ -121,12 +121,13 @@ def test_default_adaptive_depth_and_non_default_exact_limits():
 
     assert 1 <= len(exact["skills"]) <= 3
     assert exact["skills"][0]["name"] == "deploy-helper"
-    assert 1 <= len(strong["skills"]) <= 3
+    assert len(strong["skills"]) == 1
     assert strong["skills"][0]["name"] == "deploy-helper"
+    assert all(skill["score"] > 0.0 for skill in strong["skills"])
     assert len(ambiguous["skills"]) == 8
-    assert len(unmatched["skills"]) == 8
+    assert unmatched["skills"] == []
     assert len(rank_skills(candidates, "deploy-helper", limit=4)["skills"]) == 4
-    assert len(rank_skills(candidates[:2], "unmatched", limit=8)["skills"]) == 2
+    assert rank_skills(candidates[:2], "unmatched", limit=8)["skills"] == []
     assert rank_skills([], "unmatched", limit=8)["skills"] == []
 
 
@@ -173,4 +174,4 @@ def test_unicode_normalization_and_input_order_are_deterministic(query):
 
     assert forward == reverse
     assert forward["skills"][0]["name"] == "café"
-    assert len(forward["skills"]) == 2
+    assert len(forward["skills"]) == 1

--- a/tests/fixtures/skill_routing_benchmark.json
+++ b/tests/fixtures/skill_routing_benchmark.json
@@ -1,0 +1,228 @@
+{
+  "schema_version": 1,
+  "description": "Synthetic public-safe skill routing benchmark with hard negatives.",
+  "skills": [
+    {
+      "qualified_name": "research/grounded-citations",
+      "name": "grounded-citations",
+      "category": "research",
+      "description": "Ground answers in cited verifiable sources.",
+      "triggers": ["verify claims and citations", "trace evidence to primary sources"],
+      "tags": ["citations", "provenance"],
+      "related_skills": ["research-source-intelligence"],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "research/research-source-intelligence",
+      "name": "research-source-intelligence",
+      "category": "research",
+      "description": "Source-grounded web research and synthesis.",
+      "triggers": ["research a topic across authoritative sources"],
+      "tags": ["research", "sources"],
+      "related_skills": ["grounded-citations"],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "research/generic-research-notes",
+      "name": "generic-research-notes",
+      "category": "research",
+      "description": "Verify claims citations citations evidence primary sources and citations for broad research notes.",
+      "triggers": ["organize generic notes"],
+      "tags": ["notes"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "github/github-pr-workflow",
+      "name": "github-pr-workflow",
+      "category": "github",
+      "description": "Manage the GitHub pull request lifecycle.",
+      "triggers": ["open a pull request and monitor CI", "merge a reviewed branch"],
+      "tags": ["github", "pull-request", "ci"],
+      "related_skills": ["requesting-code-review"],
+      "required_commands": ["gh", "git"],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "github/release-notes-helper",
+      "name": "release-notes-helper",
+      "category": "github",
+      "description": "Open pull request pull request and monitor CI checks before merge for release notes.",
+      "triggers": ["draft release notes"],
+      "tags": ["writing"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "devops/hermes-gateway-operations",
+      "name": "hermes-gateway-operations",
+      "category": "devops",
+      "description": "Operate and troubleshoot Hermes messaging gateway channels.",
+      "triggers": ["restart WhatsApp gateway and prove channel health", "repair Telegram gateway"],
+      "tags": ["gateway", "whatsapp", "telegram"],
+      "related_skills": ["hermes-agent"],
+      "required_commands": ["systemctl"],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "devops/service-status-report",
+      "name": "service-status-report",
+      "category": "devops",
+      "description": "Restart WhatsApp gateway gateway channel health status and Telegram gateway reporting.",
+      "triggers": ["write a service status summary"],
+      "tags": ["report"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "software-development/beads-work-ledger",
+      "name": "beads-work-ledger",
+      "category": "software-development",
+      "description": "Durable work tracking for nontrivial development.",
+      "triggers": ["track nontrivial development work", "record durable implementation status"],
+      "tags": ["beads", "ledger"],
+      "related_skills": ["beads-kanban-workflow"],
+      "required_commands": ["bd"],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "productivity/daily-task-manager",
+      "name": "daily-task-manager",
+      "category": "productivity",
+      "description": "Track nontrivial development work and record durable implementation status in daily task notes.",
+      "triggers": ["manage today's tasks"],
+      "tags": ["tasks"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "quality-engineering/mr-tester-handoff",
+      "name": "mr-tester-handoff",
+      "category": "quality-engineering",
+      "description": "Route substantive testing judgment to the named QA profile.",
+      "triggers": ["independent release QA", "adversarial verification and test design"],
+      "tags": ["testing", "qa", "review"],
+      "related_skills": ["source-bound-release-gates"],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "writing/release-summary",
+      "name": "release-summary",
+      "category": "writing",
+      "description": "Independent release QA testing review adversarial verification and test design summary.",
+      "triggers": ["write a release summary"],
+      "tags": ["writing"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "productivity/maps",
+      "name": "maps",
+      "category": "productivity",
+      "description": "Geocode places and find nearby points of interest.",
+      "triggers": ["find a nearby restaurant", "calculate a route"],
+      "tags": ["maps", "nearby", "route"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "leisure/travel-itinerary-planning",
+      "name": "travel-itinerary-planning",
+      "category": "leisure",
+      "description": "Find a nearby restaurant restaurant and calculate a route while planning a trip.",
+      "triggers": ["fit activities into a trip"],
+      "tags": ["travel"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "productivity/product-price-monitor",
+      "name": "product-price-monitor",
+      "category": "productivity",
+      "description": "Watch listings and alert on a target price.",
+      "triggers": ["alert when a product price drops", "monitor a listing price"],
+      "tags": ["price", "monitor", "alert"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "productivity/shop",
+      "name": "shop",
+      "category": "productivity",
+      "description": "Alert when product price drops and monitor listing price while searching products.",
+      "triggers": ["search a product catalog"],
+      "tags": ["shopping"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "media/youtube-content",
+      "name": "youtube-content",
+      "category": "media",
+      "description": "Turn YouTube transcripts into summaries and articles.",
+      "triggers": ["summarize a YouTube transcript", "extract a video transcript"],
+      "tags": ["youtube", "transcript"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "writing/blog-post-editing",
+      "name": "blog-post-editing",
+      "category": "writing",
+      "description": "Summarize YouTube transcript transcript content into an article and edit the draft.",
+      "triggers": ["edit a technical blog post"],
+      "tags": ["writing"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "mcp/skill-surface-mining",
+      "name": "skill-surface-mining",
+      "category": "mcp",
+      "description": "Mine source trees for recurring workflows suitable for skills.",
+      "triggers": ["mine a codebase for reusable skill workflows"],
+      "tags": ["skills", "source", "mining"],
+      "related_skills": ["hermes-agent-skill-authoring"],
+      "required_commands": [],
+      "required_environment_variables": []
+    },
+    {
+      "qualified_name": "github/codebase-inspection",
+      "name": "codebase-inspection",
+      "category": "github",
+      "description": "Mine a codebase source tree for reusable skill workflows and inspect language statistics.",
+      "triggers": ["count lines of code"],
+      "tags": ["codebase"],
+      "related_skills": [],
+      "required_commands": [],
+      "required_environment_variables": []
+    }
+  ],
+  "queries": [
+    {"query": "verify claims and citations against primary sources", "relevant": ["grounded-citations"]},
+    {"query": "open a pull request and monitor CI", "relevant": ["github-pr-workflow"]},
+    {"query": "restart WhatsApp gateway and prove channel health", "relevant": ["hermes-gateway-operations"]},
+    {"query": "track nontrivial development work in a durable ledger", "relevant": ["beads-work-ledger"]},
+    {"query": "independent release QA and adversarial test design", "relevant": ["mr-tester-handoff"]},
+    {"query": "find a nearby restaurant and calculate a route", "relevant": ["maps"]},
+    {"query": "alert when a product price drops", "relevant": ["product-price-monitor"]},
+    {"query": "summarize a YouTube transcript", "relevant": ["youtube-content"]},
+    {"query": "mine a codebase for reusable skill workflows", "relevant": ["skill-surface-mining"]},
+    {"query": "github-pr-workflow", "relevant": ["github-pr-workflow"]},
+    {"query": "completely unmatched quantum orchard phrase", "relevant": []}
+  ]
+}

--- a/tests/tools/test_skills_routing.py
+++ b/tests/tools/test_skills_routing.py
@@ -1,0 +1,311 @@
+"""Focused integration tests for BM25 routing through ``skills_list``."""
+
+import inspect
+import json
+
+import pytest
+
+from tools.registry import registry
+import tools.skills_tool as skills_tool
+
+
+class _PluginManager:
+    def __init__(self, skills):
+        self.skills = skills
+
+    def list_plugin_skill_metadata(self):
+        return [dict(skill) for skill in self.skills]
+
+
+@pytest.fixture(autouse=True)
+def _isolated_catalog(tmp_path, monkeypatch):
+    plugin_skills = []
+    skills_tool._SKILLS_CACHE.clear()
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", tmp_path / "skills")
+    monkeypatch.setattr("agent.skill_utils.get_external_skills_dirs", lambda: [])
+    monkeypatch.setattr(skills_tool, "_get_disabled_skill_names", lambda: set())
+    monkeypatch.setattr(skills_tool, "_is_skill_disabled", lambda name: False)
+    monkeypatch.setattr(skills_tool, "skill_matches_platform", lambda metadata: True)
+    monkeypatch.setattr(skills_tool, "skill_matches_environment", lambda metadata: True)
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_manager",
+        lambda: _PluginManager(plugin_skills),
+    )
+    yield plugin_skills
+    skills_tool._SKILLS_CACHE.clear()
+
+
+def _write_skill(
+    root,
+    name,
+    *,
+    category=None,
+    description=None,
+    frontmatter="",
+    body="Step 1: Do the thing.",
+):
+    skill_dir = root / "skills"
+    if category:
+        skill_dir /= category
+    skill_dir /= name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    description = description or f"Description for {name}."
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        f"description: {description}\n"
+        f"{frontmatter}"
+        "---\n\n"
+        f"# {name}\n\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def test_no_query_output_remains_byte_compatible(tmp_path):
+    _write_skill(tmp_path, "alpha", category="testing")
+
+    actual = skills_tool.skills_list()
+
+    expected = json.dumps(
+        {
+            "success": True,
+            "skills": [
+                {
+                    "name": "alpha",
+                    "description": "Description for alpha.",
+                    "category": "testing",
+                }
+            ],
+            "categories": ["testing"],
+            "count": 1,
+            "hint": "Use skill_view(name) to see full content, tags, and linked files",
+        },
+        ensure_ascii=False,
+    )
+    assert actual == expected
+
+
+def test_whitespace_query_preserves_listing_even_with_invalid_limit(tmp_path):
+    _write_skill(tmp_path, "alpha", category="testing")
+
+    assert (
+        skills_tool.skills_list(query=" \t\n", limit=False) == skills_tool.skills_list()
+    )
+
+
+def test_malformed_routing_metadata_does_not_remove_eligible_skill(tmp_path):
+    _write_skill(
+        tmp_path,
+        "alpha",
+        category="testing",
+        frontmatter="prerequisites:\n  commands: 1\n",
+    )
+
+    listing = json.loads(skills_tool.skills_list())
+    ranking = json.loads(skills_tool.skills_list(query="alpha"))
+
+    assert [skill["name"] for skill in listing["skills"]] == ["alpha"]
+    assert [skill["name"] for skill in ranking["skills"]] == ["alpha"]
+    assert ranking["total_candidates"] == 1
+
+
+def test_query_mode_is_compact_path_free_and_does_not_index_body(tmp_path):
+    _write_skill(
+        tmp_path,
+        "zeta",
+        category="testing",
+        body="This full body contains bodyneedle but must not be indexed.",
+    )
+    _write_skill(tmp_path, "alpha", category="testing")
+
+    result = json.loads(skills_tool.skills_list(query="bodyneedle", limit=2))
+
+    assert list(result) == [
+        "success",
+        "mode",
+        "skills",
+        "count",
+        "total_candidates",
+        "index_fingerprint",
+        "hint",
+    ]
+    assert result["success"] is True
+    assert result["mode"] == "bm25"
+    assert [skill["name"] for skill in result["skills"]] == ["alpha", "zeta"]
+    assert set(result["skills"][0]) == {
+        "rank",
+        "name",
+        "category",
+        "description",
+        "score",
+    }
+    assert result["count"] == 2
+    assert result["total_candidates"] == 2
+    assert len(result["index_fingerprint"]) == 16
+    assert "skill_view(name)" in result["hint"]
+    serialized = json.dumps(result)
+    assert str(tmp_path) not in serialized
+    assert "bodyneedle" not in serialized
+    assert "query" not in result
+
+
+def test_query_does_not_index_body_fallback_for_missing_description(tmp_path):
+    skill_dir = tmp_path / "skills" / "testing" / "zeta"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: zeta\n"
+        "---\n\n"
+        "# zeta\n\n"
+        "bodyfallbackneedle must remain display-only.\n",
+        encoding="utf-8",
+    )
+    _write_skill(tmp_path, "alpha", category="testing")
+
+    result = json.loads(skills_tool.skills_list(query="bodyfallbackneedle", limit=2))
+
+    assert [skill["name"] for skill in result["skills"]] == ["alpha", "zeta"]
+    assert [skill["score"] for skill in result["skills"]] == [0.0, 0.0]
+    assert result["skills"][1]["description"] == (
+        "bodyfallbackneedle must remain display-only."
+    )
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "triggerneedle",
+        "tagneedle",
+        "relatedneedle",
+        "commandneedle",
+        "envneedle",
+        "legacycommandneedle",
+        "legacyenvneedle",
+        "descriptionneedle",
+    ],
+)
+def test_query_indexes_declared_routing_metadata(tmp_path, query):
+    long_description = "x" * 1050 + " descriptionneedle"
+    _write_skill(
+        tmp_path,
+        "zeta",
+        category="testing",
+        description=long_description,
+        frontmatter=(
+            "triggers: [triggerneedle]\n"
+            "metadata:\n"
+            "  hermes:\n"
+            "    tags: [tagneedle]\n"
+            "    related_skills: [relatedneedle]\n"
+            "required_commands: [commandneedle]\n"
+            "required_environment_variables:\n"
+            "  - name: ENVNEEDLE\n"
+            "prerequisites:\n"
+            "  commands: [legacycommandneedle]\n"
+            "  env_vars: [LEGACYENVNEEDLE]\n"
+        ),
+    )
+    _write_skill(tmp_path, "alpha", category="testing")
+
+    result = json.loads(skills_tool.skills_list(query=query, limit=2))
+
+    assert result["skills"][0]["name"] == "zeta"
+    assert result["skills"][0]["score"] > 0
+
+
+def test_query_applies_category_filter_before_ranking(tmp_path):
+    _write_skill(
+        tmp_path, "devops-match", category="devops", frontmatter="tags: [needle]\n"
+    )
+    _write_skill(
+        tmp_path, "mlops-match", category="mlops", frontmatter="tags: [needle]\n"
+    )
+    _write_skill(tmp_path, "devops-other", category="devops")
+
+    result = json.loads(
+        skills_tool.skills_list(category="devops", query="needle", limit=8)
+    )
+
+    assert {skill["name"] for skill in result["skills"]} == {
+        "devops-match",
+        "devops-other",
+    }
+    assert result["total_candidates"] == 2
+
+
+def test_query_includes_eligible_plugin_skill_metadata(_isolated_catalog):
+    _isolated_catalog.append({
+        "name": "demo:router",
+        "description": "Routes generic work",
+        "category": "plugin",
+        "frontmatter": {"metadata": {"hermes": {"tags": ["pluginneedle"]}}},
+    })
+
+    result = json.loads(skills_tool.skills_list(query="pluginneedle"))
+
+    assert result["skills"][0]["name"] == "demo:router"
+    assert result["skills"][0]["category"] == "plugin"
+    assert result["total_candidates"] == 1
+
+
+@pytest.mark.parametrize("limit", [True, False, 0, -1, 51, 1.5, "2"])
+def test_query_rejects_invalid_limit(limit):
+    result = json.loads(skills_tool.skills_list(query="needle", limit=limit))
+
+    assert result == {
+        "error": "limit must be an integer between 1 and 50",
+        "success": False,
+    }
+
+
+def test_query_honors_default_and_explicit_limit(tmp_path):
+    for index in range(10):
+        _write_skill(tmp_path, f"skill-{index:02d}", category="testing")
+
+    default = json.loads(skills_tool.skills_list(query="unmatched"))
+    explicit = json.loads(skills_tool.skills_list(query="unmatched", limit=3))
+
+    assert default["count"] == 8
+    assert explicit["count"] == 3
+    assert default["total_candidates"] == explicit["total_candidates"] == 10
+
+
+def test_signature_schema_and_handler_expose_query_limit_and_task_id(monkeypatch):
+    signature = inspect.signature(skills_tool.skills_list)
+    assert list(signature.parameters) == ["category", "query", "limit", "task_id"]
+    assert signature.parameters["query"].default is None
+    assert signature.parameters["limit"].default == 8
+    assert signature.parameters["task_id"].default is None
+
+    properties = skills_tool.SKILLS_LIST_SCHEMA["parameters"]["properties"]
+    assert properties["query"]["type"] == "string"
+    assert properties["limit"] == {
+        "type": "integer",
+        "description": "Maximum ranked skills to return in query mode",
+        "default": 8,
+        "minimum": 1,
+        "maximum": 50,
+    }
+
+    captured = {}
+
+    def fake_skills_list(**kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr(skills_tool, "skills_list", fake_skills_list)
+    entry = registry.get_entry("skills_list")
+    assert (
+        entry.handler(
+            {"category": "testing", "query": "needle", "limit": 3},
+            task_id="task-123",
+        )
+        == "ok"
+    )
+    assert captured == {
+        "category": "testing",
+        "query": "needle",
+        "limit": 3,
+        "task_id": "task-123",
+    }

--- a/tests/tools/test_skills_routing.py
+++ b/tests/tools/test_skills_routing.py
@@ -227,10 +227,7 @@ def test_query_applies_category_filter_before_ranking(tmp_path):
         skills_tool.skills_list(category="devops", query="needle", limit=8)
     )
 
-    assert {skill["name"] for skill in result["skills"]} == {
-        "devops-match",
-        "devops-other",
-    }
+    assert {skill["name"] for skill in result["skills"]} == {"devops-match"}
     assert result["total_candidates"] == 2
 
 
@@ -266,7 +263,7 @@ def test_query_honors_default_and_explicit_limit(tmp_path):
     default = json.loads(skills_tool.skills_list(query="unmatched"))
     explicit = json.loads(skills_tool.skills_list(query="unmatched", limit=3))
 
-    assert default["count"] == 8
+    assert default["count"] == 0
     assert explicit["count"] == 3
     assert default["total_candidates"] == explicit["total_candidates"] == 10
 

--- a/tests/tools/test_skills_routing_production.py
+++ b/tests/tools/test_skills_routing_production.py
@@ -1,0 +1,130 @@
+"""Production integration contracts for query-aware ``skills_list``."""
+
+import json
+
+import pytest
+
+from tools.registry import registry
+import tools.skills_tool as skills_tool
+
+
+class _PluginManager:
+    def __init__(self, skills):
+        self.skills = skills
+
+    def list_plugin_skill_metadata(self):
+        return [dict(skill) for skill in self.skills]
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path, monkeypatch):
+    plugins = []
+    skills_tool._SKILLS_CACHE.clear()
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", tmp_path / "skills")
+    monkeypatch.setattr("agent.skill_utils.get_external_skills_dirs", lambda: [])
+    monkeypatch.setattr(skills_tool, "_get_disabled_skill_names", lambda: set())
+    monkeypatch.setattr(skills_tool, "_is_skill_disabled", lambda name: False)
+    monkeypatch.setattr(skills_tool, "skill_matches_platform", lambda metadata: True)
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_manager", lambda: _PluginManager(plugins)
+    )
+    yield plugins
+    skills_tool._SKILLS_CACHE.clear()
+
+
+def _write_skill(root, name, *, description="public description", body="private body"):
+    path = root / "skills" / "testing" / name / "SKILL.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def test_environment_ineligible_plugin_is_omitted_in_both_modes(_isolated, monkeypatch):
+    _isolated.extend([
+        {
+            "name": "demo:eligible",
+            "description": "eligible needle",
+            "category": "plugin",
+            "frontmatter": {"environment": "eligible"},
+        },
+        {
+            "name": "demo:private-secret-name",
+            "description": "ineligible needle",
+            "category": "plugin",
+            "frontmatter": {"environment": "ineligible"},
+        },
+    ])
+    monkeypatch.setattr(
+        skills_tool,
+        "skill_matches_environment",
+        lambda metadata: metadata.get("environment") != "ineligible",
+    )
+
+    listing = json.loads(skills_tool.skills_list())
+    ranking = json.loads(skills_tool.skills_list(query="needle"))
+
+    assert [skill["name"] for skill in listing["skills"]] == ["demo:eligible"]
+    assert [skill["name"] for skill in ranking["skills"]] == ["demo:eligible"]
+
+
+def test_public_shapes_and_privacy_are_unchanged(tmp_path, monkeypatch):
+    private_path = str(tmp_path / "private-location")
+    private_body = "private-body-token"
+    credential_value = "credential-value-token"
+    environment_value = "environment-value-token"
+    raw_query = "raw-query-token"
+    monkeypatch.setenv("ROUTING_SECRET", environment_value)
+    _write_skill(tmp_path, "alpha", body=private_body)
+
+    listing = json.loads(skills_tool.skills_list())
+    ranking = json.loads(skills_tool.skills_list(query=raw_query))
+    serialized = json.dumps({"listing": listing, "ranking": ranking})
+
+    assert list(listing) == ["success", "skills", "categories", "count", "hint"]
+    assert set(listing["skills"][0]) == {"name", "description", "category"}
+    assert list(ranking) == [
+        "success",
+        "mode",
+        "skills",
+        "count",
+        "total_candidates",
+        "index_fingerprint",
+        "hint",
+    ]
+    assert set(ranking["skills"][0]) == {
+        "rank",
+        "name",
+        "category",
+        "description",
+        "score",
+    }
+    for private in (
+        private_path,
+        private_body,
+        credential_value,
+        environment_value,
+        raw_query,
+        "source_fingerprint",
+        "_routing",
+    ):
+        assert private not in serialized
+    assert registry.get_entry("skills_list") is not None
+
+
+def test_ranking_does_not_load_skill_body(tmp_path, monkeypatch):
+    _write_skill(tmp_path, "alpha", body="body-only-secret")
+    called = False
+
+    def forbidden_view(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("skill_view must remain the explicit loading entrypoint")
+
+    monkeypatch.setattr(skills_tool, "skill_view", forbidden_view)
+    result = json.loads(skills_tool.skills_list(query="alpha"))
+
+    assert result["skills"][0]["name"] == "alpha"
+    assert called is False

--- a/tests/tools/test_skills_routing_production.py
+++ b/tests/tools/test_skills_routing_production.py
@@ -75,7 +75,7 @@ def test_public_shapes_and_privacy_are_unchanged(tmp_path, monkeypatch):
     private_body = "private-body-token"
     credential_value = "credential-value-token"
     environment_value = "environment-value-token"
-    raw_query = "raw-query-token"
+    raw_query = "alpha raw-query-token"
     monkeypatch.setenv("ROUTING_SECRET", environment_value)
     _write_skill(tmp_path, "alpha", body=private_body)
 

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -670,13 +670,82 @@ def _is_skill_disabled(name: str, platform: str = None) -> bool:
         return False
 
 
-def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
+def _routing_metadata_values(frontmatter: Dict[str, Any], key: str) -> List[str]:
+    """Return stable string values for a routing-only frontmatter field."""
+    metadata = frontmatter.get("metadata")
+    hermes_metadata = (
+        metadata.get("hermes", {}) if isinstance(metadata, dict) else {}
+    )
+    nested = hermes_metadata.get(key) if isinstance(hermes_metadata, dict) else None
+    values = _parse_tags(nested) + _parse_tags(frontmatter.get(key))
+    return sorted(set(values), key=lambda value: (value.casefold(), value))
+
+
+def _routing_document(
+    *,
+    name: str,
+    description: str,
+    display_description: str,
+    category: str | None,
+    frontmatter: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Build a path-free routing document from declared skill metadata."""
+    try:
+        legacy_environment, legacy_commands = _collect_prerequisite_values(
+            frontmatter
+        )
+    except (TypeError, ValueError):
+        legacy_environment, legacy_commands = [], []
+    required_environment = _get_required_environment_variables(
+        frontmatter, legacy_environment
+    )
+    required_commands = _routing_metadata_values(frontmatter, "required_commands")
+    required_commands.extend(legacy_commands)
+    required_command_names = sorted(
+        {value for value in required_commands if value},
+        key=lambda value: (value.casefold(), value),
+    )
+    qualified_name = (
+        name if ":" in name else "/".join(filter(None, (category, name)))
+    )
+    return {
+        "qualified_name": qualified_name,
+        "name": name,
+        "category": category,
+        "description": description,
+        "display_description": display_description,
+        "triggers": _routing_metadata_values(frontmatter, "triggers"),
+        "tags": _routing_metadata_values(frontmatter, "tags"),
+        "related_skills": _routing_metadata_values(frontmatter, "related_skills"),
+        "required_commands": required_command_names,
+        "required_environment_variables": [
+            item["name"] for item in required_environment if item.get("name")
+        ],
+    }
+
+
+def _copy_skill_catalog(
+    skills: List[Dict[str, Any]], *, include_routing: bool
+) -> List[Dict[str, Any]]:
+    copied = [dict(skill) for skill in skills]
+    if not include_routing:
+        for skill in copied:
+            skill.pop("_routing", None)
+    return copied
+
+
+def _find_all_skills(
+    *, skip_disabled: bool = False, include_routing: bool = False
+) -> List[Dict[str, Any]]:
     """Recursively find all skills in ~/.hermes/skills/ and external dirs.
 
     Args:
         skip_disabled: If True, return ALL skills regardless of disabled
             state (used by ``hermes skills`` config UI). Default False
             filters out disabled skills.
+        include_routing: Include private, path-free routing metadata for the
+            ``skills_list`` query path. Default False preserves the public
+            catalog shape.
 
     Returns:
         List of skill metadata dicts (name, description, category).
@@ -692,7 +761,10 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
         iter_skill_index_files,
     )
 
-    cache_key = _SKILLS_CACHE_KEY_DISABLED if skip_disabled else _SKILLS_CACHE_KEY_FILTERED
+    visibility_key = (
+        _SKILLS_CACHE_KEY_DISABLED if skip_disabled else _SKILLS_CACHE_KEY_FILTERED
+    )
+    cache_key = (visibility_key, include_routing)
 
     # Load disabled set once (not per-skill). Part of the cache signature:
     # disabling a skill is a config change with no filesystem mtime bump.
@@ -722,7 +794,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
         # Per-call shallow copies: callers mutate the returned dicts
         # (e.g. web_server annotates s["enabled"]/s["usage"]) — handing
         # out the cached objects would poison the cache for everyone else.
-        return [dict(s) for s in cached[2]]
+        return _copy_skill_catalog(cached[2], include_routing=include_routing)
 
     skills = []
     seen_names: set = set()
@@ -759,7 +831,8 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                 if name in disabled:
                     continue
 
-                description = frontmatter.get("description", "")
+                frontmatter_description = frontmatter.get("description", "")
+                description = frontmatter_description
                 if not description:
                     for line in body.strip().split("\n"):
                         line = line.strip()
@@ -773,11 +846,20 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                 category = _get_category_from_path(skill_md)
 
                 seen_names.add(name)
-                skills.append({
+                skill = {
                     "name": name,
                     "description": description,
                     "category": category,
-                })
+                }
+                if include_routing:
+                    skill["_routing"] = _routing_document(
+                        name=name,
+                        description=frontmatter_description,
+                        display_description=description,
+                        category=category,
+                        frontmatter=frontmatter,
+                    )
+                skills.append(skill)
 
             except (UnicodeDecodeError, PermissionError) as e:
                 logger.debug("Failed to read skill file %s: %s", skill_md, e)
@@ -793,7 +875,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     # re-scans rather than serving the torn result past the TTL). Same
     # shallow-copy contract as the hit path — the caller may mutate.
     _SKILLS_CACHE[cache_key] = (signature, now, skills)
-    return [dict(s) for s in skills]
+    return _copy_skill_catalog(skills, include_routing=include_routing)
 
 
 def _sort_skills(skills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -801,7 +883,12 @@ def _sort_skills(skills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return sorted(skills, key=lambda s: (s.get("category") or "", s["name"]))
 
 
-def skills_list(category: str = None, task_id: str = None) -> str:
+def skills_list(
+    category: str | None = None,
+    query: str | None = None,
+    limit: int = 8,
+    task_id: str | None = None,
+) -> str:
     """
     List all available skills (progressive disclosure tier 1 - minimal metadata).
 
@@ -810,18 +897,33 @@ def skills_list(category: str = None, task_id: str = None) -> str:
 
     Args:
         category: Optional category filter (e.g., "mlops")
+        query: Optional natural-language routing query
+        limit: Maximum ranked candidates in query mode (1-50)
         task_id: Optional task identifier used to probe the active backend
 
     Returns:
         JSON string with minimal skill info: name, description, category
     """
     try:
+        if query is not None and not isinstance(query, str):
+            return tool_error("query must be a string", success=False)
+        routing_query = query.strip() if query is not None else ""
+        query_mode = bool(routing_query)
+        if query_mode and (
+            isinstance(limit, bool)
+            or not isinstance(limit, int)
+            or not 1 <= limit <= 50
+        ):
+            return tool_error(
+                "limit must be an integer between 1 and 50", success=False
+            )
+
         active_skills_dir = _skills_dir()
         if not active_skills_dir.exists():
             active_skills_dir.mkdir(parents=True, exist_ok=True)
 
         # Find all skills
-        all_skills = _find_all_skills()
+        all_skills = _find_all_skills(include_routing=query_mode)
         try:
             from hermes_cli.plugins import discover_plugins, get_plugin_manager
 
@@ -832,11 +934,19 @@ def skills_list(category: str = None, task_id: str = None) -> str:
                     continue
                 if _is_skill_disabled(plugin_skill["name"]):
                     continue
+                if query_mode:
+                    plugin_skill["_routing"] = _routing_document(
+                        name=plugin_skill["name"],
+                        description=plugin_skill.get("description", ""),
+                        display_description=plugin_skill.get("description", ""),
+                        category=plugin_skill.get("category"),
+                        frontmatter=frontmatter,
+                    )
                 all_skills.append(plugin_skill)
         except Exception:
             logger.debug("Plugin skill listing failed", exc_info=True)
 
-        if not all_skills:
+        if not all_skills and not query_mode:
             return json.dumps(
                 {
                     "success": True,
@@ -850,6 +960,26 @@ def skills_list(category: str = None, task_id: str = None) -> str:
         # Filter by category if specified
         if category:
             all_skills = [s for s in all_skills if s.get("category") == category]
+
+        if query_mode:
+            from agent.skill_routing import rank_skills
+
+            ranking = rank_skills(
+                [skill["_routing"] for skill in all_skills], routing_query, limit
+            )
+            ranked_skills = ranking["skills"]
+            return json.dumps(
+                {
+                    "success": True,
+                    "mode": "bm25",
+                    "skills": ranked_skills,
+                    "count": len(ranked_skills),
+                    "total_candidates": ranking["total_candidates"],
+                    "index_fingerprint": ranking["index_fingerprint"],
+                    "hint": "Use skill_view(name) to load a candidate skill",
+                },
+                ensure_ascii=False,
+            )
 
         # Sort by category then name
         all_skills = _sort_skills(all_skills)
@@ -1975,7 +2105,20 @@ SKILLS_LIST_SCHEMA = {
             "category": {
                 "type": "string",
                 "description": "Optional category filter to narrow results",
-            }
+            },
+            "query": {
+                "type": "string",
+                "description": (
+                    "Optional query for deterministic local BM25 skill routing"
+                ),
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum ranked skills to return in query mode",
+                "default": 8,
+                "minimum": 1,
+                "maximum": 50,
+            },
         },
         "required": [],
     },
@@ -2005,7 +2148,10 @@ registry.register(
     toolset="skills",
     schema=SKILLS_LIST_SCHEMA,
     handler=lambda args, **kw: skills_list(
-        category=args.get("category"), task_id=kw.get("task_id")
+        category=args.get("category"),
+        query=args.get("query"),
+        limit=args.get("limit", 8),
+        task_id=kw.get("task_id"),
     ),
     check_fn=check_skills_requirements,
     emoji="📚",

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -932,6 +932,8 @@ def skills_list(
                 frontmatter = plugin_skill.pop("frontmatter", {})
                 if not skill_matches_platform(frontmatter):
                     continue
+                if not skill_matches_environment(frontmatter):
+                    continue
                 if _is_skill_disabled(plugin_skill["name"]):
                     continue
                 if query_mode:


### PR DESCRIPTION
## Summary

- add deterministic BM25 candidate routing to `skills_list(query, limit)` while keeping `skill_view(name)` as the explicit content-loading boundary
- prune zero-score tails and use calibrated adaptive depth only for the default limit; explicit non-default limits remain exact
- add internal source fingerprints over declared routing metadata and align plugin environment eligibility with local skills
- add public-safe relevance, determinism, ambiguity, privacy, and compatibility coverage

## Compatibility

- no-query `skills_list()` response is unchanged
- tool schema and prompt construction are unchanged
- ranking does not read skill bodies or expose source fingerprints
- BM25F is not used in production scoring

## Verification

- routing and adjacent tool tests: 161 passed
- prompt-cache and system-prompt tests: 187 passed
- Ruff, formatting, type, bytecode, diff, and privacy checks passed
- public benchmark: MRR >= 0.95, nDCG >= 0.96, recall 1.0
- broader local suite: 37,599 passed, 340 skipped; five unrelated failures reproduced unchanged on the base revision
