### PR TITLE
fix(cron): honor ONESHOT_GRACE_SECONDS for stored past-due one-shots (no more hours-late fires)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -3471,6 +3471,42 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
 
             if next_run_dt <= now:
 
+                # One-shot lateness bound (#93526): ONESHOT_GRACE_SECONDS is
+                # the documented miss-grace for one-shots — it is enforced on
+                # the create/update/resume validators and on the missing-
+                # next_run_at recovery path, but a stored past-due one-shot
+                # (machine off across its fire time) reached this branch and
+                # fired arbitrarily late. Retain the record as a terminal
+                # miss instead of running a stale alert hours later.
+                if kind == "once":
+                    late_by = (now - next_run_dt).total_seconds()
+                    if late_by > ONESHOT_GRACE_SECONDS:
+                        logger.warning(
+                            "Job '%s' (%s): one-shot missed its fire time %s by "
+                            "%ds (> %ss grace) while the scheduler was down; "
+                            "marking it completed without running so a stale "
+                            "alert is not delivered.",
+                            job.get("name", job.get("id", "?")),
+                            kind,
+                            next_run,
+                            int(late_by),
+                            ONESHOT_GRACE_SECONDS,
+                        )
+                        for rj in raw_jobs:
+                            if rj["id"] == job["id"]:
+                                rj["enabled"] = False
+                                rj["state"] = "completed"
+                                rj["next_run_at"] = None
+                                rj["last_status"] = "missed"
+                                if not rj.get("last_error"):
+                                    rj["last_error"] = (
+                                        f"Missed fire time by {int(late_by)}s "
+                                        f"(> {ONESHOT_GRACE_SECONDS}s grace); not run."
+                                    )
+                                needs_save = True
+                                break
+                        continue
+
                 # Stale-schedule guard (#93049): a direct jobs.json edit that
                 # changed schedule.expr leaves next_run_at computed under the
                 # old expression, so the job would fire at an instant the

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -374,7 +374,14 @@ def fire_overdue_jobs(
     if grace_minutes <= 0:
         return 0
 
-    from cron.jobs import _ensure_aware, _hermes_now, is_job_runnable, load_jobs
+    from cron.jobs import (
+        ONESHOT_GRACE_SECONDS,
+        _ensure_aware,
+        _hermes_now,
+        is_job_runnable,
+        load_jobs,
+        save_jobs,
+    )
 
     if now is None:
         now = _hermes_now()
@@ -393,6 +400,34 @@ def fire_overdue_jobs(
         overdue_seconds = (now - due_dt).total_seconds()
         if overdue_seconds < grace_minutes * 60:
             continue
+        # One-shot lateness bound (#93526): the 120s miss-grace applies to
+        # one-shots everywhere else; this backstop must not fire a stored
+        # past-due one-shot hours late either. Mark it terminal-missed like
+        # the built-in tick's due-scan does.
+        if (job.get("schedule") or {}).get("kind") == "once":
+            if overdue_seconds > ONESHOT_GRACE_SECONDS:
+                logger.warning(
+                    "Misfire catch-up skips one-shot job %s: overdue by %.0f min "
+                    "(> %ss one-shot grace); marking completed without running.",
+                    str(job.get("id") or ""),
+                    overdue_seconds / 60,
+                    ONESHOT_GRACE_SECONDS,
+                )
+                jobs_now = load_jobs()
+                for j in jobs_now:
+                    if j.get("id") == job.get("id"):
+                        j["enabled"] = False
+                        j["state"] = "completed"
+                        j["next_run_at"] = None
+                        j["last_status"] = "missed"
+                        if not j.get("last_error"):
+                            j["last_error"] = (
+                                f"Missed fire time by {int(overdue_seconds)}s "
+                                f"(> {ONESHOT_GRACE_SECONDS}s grace); not run."
+                            )
+                        save_jobs(jobs_now)
+                        break
+                continue
         job_id = str(job.get("id") or "")
         logger.warning(
             "Misfire catch-up: job %s (%s) was due %s (%.0f min overdue) and "

--- a/tests/cron/test_oneshot_late_grace.py
+++ b/tests/cron/test_oneshot_late_grace.py
@@ -1,0 +1,132 @@
+"""One-shot lateness must honor ONESHOT_GRACE_SECONDS on every path (#93526).
+
+The 120s one-shot miss-grace was enforced by the create/update/resume
+validators and the missing-next_run_at recovery helper — but a stored
+past-due one-shot (machine off across its fire time) fired arbitrarily
+late from the due scan, and the external-provider misfire backstop had no
+one-shot bound at all. A 5-hour-stale reminder ran in full and delivered.
+
+Real store against a temp ``HERMES_HOME``; the provider backstop test
+drives ``fire_overdue_jobs`` with a fake provider, mirroring its own
+test style.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+
+@pytest.fixture
+def temp_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield tmp_path
+
+
+def _past_oneshot(minutes_late: int):
+    """Persist a one-shot whose stored next_run_at is minutes in the past."""
+    from cron.jobs import create_job, load_jobs, save_jobs
+
+    future = (datetime.now().astimezone() + timedelta(days=3650)).replace(microsecond=0)
+    job = create_job(
+        prompt="stale reminder",
+        schedule=future.isoformat(),
+        name="late-reminder",
+        deliver="local",
+    )
+    past = (datetime.now().astimezone() - timedelta(minutes=minutes_late)).replace(
+        microsecond=0
+    )
+    jobs = load_jobs()
+    for j in jobs:
+        if j["id"] == job["id"]:
+            j["next_run_at"] = past.isoformat()
+    save_jobs(jobs)
+    return job["id"], past
+
+
+class TestDueScanGraceBound:
+    def test_one_shot_past_grace_is_not_fired(self, temp_home):
+        from cron.jobs import get_due_jobs, get_job
+
+        jid, _past = _past_oneshot(minutes_late=30)
+
+        due = get_due_jobs()
+
+        assert all(j["id"] != jid for j in due), (
+            "a one-shot missed beyond ONESHOT_GRACE_SECONDS must not fire"
+        )
+        stored = get_job(jid)
+        assert stored["enabled"] is False
+        assert stored["state"] == "completed"
+        assert stored["next_run_at"] is None
+        assert stored.get("last_status") == "missed"
+
+    def test_one_shot_within_grace_still_fires(self, temp_home):
+        from cron.jobs import get_due_jobs
+
+        jid, _past = _past_oneshot(minutes_late=1)  # 60s < 120s grace
+
+        due = get_due_jobs()
+
+        assert any(j["id"] == jid for j in due), (
+            "within-grace one-shots keep firing (existing contract)"
+        )
+
+
+class TestProviderMisfireBackstopBound:
+    def test_backstop_skips_and_retires_past_grace_one_shot(self, temp_home):
+        from cron.jobs import get_job
+        from cron.scheduler_provider import fire_overdue_jobs
+
+        jid, _past = _past_oneshot(minutes_late=60)
+
+        class _FakeProvider:
+            def __init__(self):
+                self.claimed = []
+
+            def claim_fire(self, job_id, **kwargs):
+                self.claimed.append(job_id)
+                return {"id": job_id}
+
+            def fire_claimed(self, *args, **kwargs):
+                pass
+
+        provider = _FakeProvider()
+
+        fired = fire_overdue_jobs(provider)
+
+        assert fired == 0
+        assert provider.claimed == [], "one-shot must not be claimed/fired late"
+        stored = get_job(jid)
+        assert stored["state"] == "completed"
+        assert stored.get("last_status") == "missed"
+
+    @pytest.mark.usefixtures("temp_home")
+    def test_backstop_still_fires_recurring_overdue(self):
+        """Recurring misfire catch-up behavior is unchanged."""
+        from cron.jobs import create_job, load_jobs, save_jobs
+        from cron.scheduler_provider import fire_overdue_jobs
+
+        create_job(prompt="x", schedule="every 60m", name="rec", deliver="local")
+
+        class _FakeProvider:
+            def claim_fire(self, job_id, **kwargs):
+                return {"id": job_id}
+
+            def fire_claimed(self, *args, **kwargs):
+                pass
+
+        # The recurring job's next_run_at is in the future; force it past.
+        jobs = load_jobs()
+        past = datetime.now().astimezone() - timedelta(hours=5)
+        for j in jobs:
+            if j["name"] == "rec":
+                j["next_run_at"] = past.isoformat()
+        save_jobs(jobs)
+
+        provider = _FakeProvider()
+        fired = fire_overdue_jobs(provider)
+
+        assert fired >= 1


### PR DESCRIPTION
## What does this PR do?

Makes the documented **120s one-shot miss-grace** (ONESHOT_GRACE_SECONDS, cron/jobs.py) actually hold on every fire path. It was already enforced by the create/update/resume validators ("…is more than 120s in the past and cannot be scheduled") and by the missing-
ext_run_at recovery helper — but the **main due-scan** applied its staleness fast-forward only to {"cron", "interval"}, so a stored past-due one-shot fell through to the fire list no matter how late it was. The external-provider misfire backstop (ire_overdue_jobs in cron/scheduler_provider.py, firing anything >10 min overdue) had no one-shot bound at all.

User-visible shape: set a one-shot reminder for 09:00, shut the laptop at 08:55, boot at 14:00 → on the first tick the job ran a full agent turn and delivered a 5-hour-stale alert. Whether a missed one-shot fired depended purely on which code path encountered it (missing vs. present 
ext_run_at).

With this fix, an overdue one-shot is retained as a terminal completion — enabled=false, state="completed", 
ext_run_at=null, last_status="missed", plus a last_error explaining the skip ("Missed fire time by Ns (> 120s grace); not run.") — so it stays inspectable in cron list output and ages out via the existing completed-one-shot retention sweep, instead of delivering stale output.

## Related Issue

Fixes #93526

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Tests

## Changes Made

- cron/jobs.py (get_due_jobs): inside 
ext_run_dt <= now, a kind == "once" branch bounded by ONESHOT_GRACE_SECONDS runs before the recurring catch-up logic; past-grace one-shots are retired terminal-missed (with warning log) instead of being appended to due.
- cron/scheduler_provider.py (ire_overdue_jobs): the misfire backstop now skips past-grace one-shots with the same retire-terminal-missed handling; recurring jobs' catch-up behavior is unchanged.
- 	ests/cron/test_oneshot_late_grace.py — new suite against the real store (temp HERMES_HOME):
  - due scan: 30-min-late one-shot is not fired and is retired missed;
  - due scan: 60s-late one-shot still fires (within-grace contract preserved);
  - provider backstop: 60-min-late one-shot is skipped, never claimed/fired, record retired;
  - provider backstop: recurring overdue jobs still fire (unchanged behavior).

## How to Test

1. uv run python -m pytest tests/cron/test_oneshot_late_grace.py -q -W error::pytest.PytestUnhandledThreadExceptionWarning → 4 passed.
2. Full cron directory: uv run python -m pytest tests/cron/ -q → 842 passed / 16 failed locally, all 16 pre-existing POSIX-only failures (chmod 0700/0600 bits, bash monitors, tilde workdir) that fail identically on clean main under Windows and pass in CI's Linux lane. My two touched files' suites are green.
3. uff check cron/jobs.py cron/scheduler_provider.py tests/cron/test_oneshot_late_grace.py → clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (ix(scope):, eat(scope):, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls?q=is%3Apr) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run targeted test suites locally and they pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Docs N/A (behavior now matches the documented grace-window invariant)
- [x] cli-config.yaml.example N/A
- [x] CONTRIBUTING/AGENTS N/A
- [x] Cross-platform impact: none (pure scheduling logic) → N/A
- [x] No tool schema change → N/A

## Screenshots / Logs

N/A