### PR TITLE
docs: admit tool calls via barycenters or MCP side door

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,9 @@ hermes doctor       # Diagnose any issues
 
 📖 **[Full documentation →](https://hermes-agent.nousresearch.com/docs/)**
 
-To admit tool calls before they run, hook the tool dispatcher once with npm
-[arycenters](https://www.npmjs.com/package/barycenters) (ary.govern /
-dmit, shadow default). MCP is a side door: Streamable HTTP at
-https://barycenters-admit.fly.dev/mcp/. Spec: [barycenters.ai/adapters](https://barycenters.ai/adapters)
+Route the central task loop through one dispatcher intercept. Shadow: Python [`barycenters`](https://pypi.org/project/barycenters/) (`admit` / `@boundary`).
+Live MCP side door: `https://barycenters-admit.fly.dev/mcp/` (GET 406 is protocol).
+Spec: [barycenters.ai/adapters](https://barycenters.ai/adapters) and [barycenters.ai](https://barycenters.ai)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -119,16 +119,7 @@ hermes doctor       # Diagnose any issues
 
 📖 **[Full documentation →](https://hermes-agent.nousresearch.com/docs/)**
 
-Route the central task loop through one dispatcher intercept. Shadow: Python [`barycenters`](https://pypi.org/project/barycenters/) (`admit` / `@boundary`).
-Live MCP side door: `https://barycenters-admit.fly.dev/mcp/` (GET 406 is protocol).
-Spec: [barycenters.ai/adapters](https://barycenters.ai/adapters) and [barycenters.ai](https://barycenters.ai)
-```bash
-pip install barycenters
-```
-
-```python
-from barycenters import Barycenters; Barycenters().admit("hermes_tool")  # shadow; or @bary.boundary("hermes_tool")
-```
+Optional third-party: [Barycenters](https://hermes-agent.nousresearch.com/docs/integrations/barycenters) — admit a tool call in shadow before it runs.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ hermes doctor       # Diagnose any issues
 Route the central task loop through one dispatcher intercept. Shadow: Python [`barycenters`](https://pypi.org/project/barycenters/) (`admit` / `@boundary`).
 Live MCP side door: `https://barycenters-admit.fly.dev/mcp/` (GET 406 is protocol).
 Spec: [barycenters.ai/adapters](https://barycenters.ai/adapters) and [barycenters.ai](https://barycenters.ai)
+```bash
+pip install barycenters
+```
+
+```python
+from barycenters import Barycenters; Barycenters().admit("hermes_tool")  # shadow; or @bary.boundary("hermes_tool")
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ hermes doctor       # Diagnose any issues
 
 📖 **[Full documentation →](https://hermes-agent.nousresearch.com/docs/)**
 
+To admit tool calls before they run, hook the tool dispatcher once with npm
+[arycenters](https://www.npmjs.com/package/barycenters) (ary.govern /
+dmit, shadow default). MCP is a side door: Streamable HTTP at
+https://barycenters-admit.fly.dev/mcp/. Spec: [barycenters.ai/adapters](https://barycenters.ai/adapters)
+
 ---
 
 ## Skip the API-key collection — Nous Portal

--- a/website/docs/integrations/barycenters.md
+++ b/website/docs/integrations/barycenters.md
@@ -1,0 +1,52 @@
+---
+sidebar_position: 10
+title: "Barycenters"
+description: "Optional third-party: admit a Hermes tool call in shadow before it runs"
+---
+
+# Barycenters
+
+Third-party. Not a Nous product. This page is an optional integration, not a first-party security control.
+
+Hook the **central dispatcher once**. Do not wrap every Hermes tool. Shadow records the decision and still lets the tool run. Enforce is a human flip.
+
+## Install
+
+```bash
+pip install barycenters
+```
+
+PyPI package [`barycenters`](https://pypi.org/project/barycenters/) 1.0.0.
+
+```python
+from barycenters import Barycenters
+
+bary = Barycenters()  # shadow by default
+bary.admit("hermes_tool")
+```
+
+Decorator form of the same admit:
+
+```python
+from barycenters import Barycenters
+
+bary = Barycenters()
+
+@bary.boundary("hermes_tool")
+def run_tool(**metadata):
+    ...
+```
+
+With no `ADMIT_ENDPOINT`, `admit` is an honest AWAITING — not a fabricated pass. The JS client (`bary.govern`) is for OpenClaw / Node, not this Python agent.
+
+What the service does with the call: it **adjudicates** an inert `{ action, namespace, metadata }` (or the Python equivalent) against chartered/bound law. It does not lock GitHub, Stripe, or Fly by itself.
+
+## MCP side door
+
+Not the once-hook. Streamable HTTP:
+
+`https://barycenters-admit.fly.dev/mcp/`
+
+Tools: `admit`, `check_readiness`. A bare GET is **406** (`Accept: text/event-stream` is required) — protocol, not downtime.
+
+Spec: [barycenters.ai/adapters](https://barycenters.ai/adapters)

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -23,6 +23,7 @@ Hermes supports multiple AI inference providers out of the box. Use `hermes mode
 ## Tool Servers (MCP)
 
 - **[MCP Servers](/user-guide/features/mcp)** — Connect Hermes to external tool servers via Model Context Protocol. Access tools from GitHub, databases, file systems, browser stacks, internal APIs, and more without writing native Hermes tools. Supports both stdio and SSE transports, per-server tool filtering, and capability-aware resource/prompt registration.
+- **[Barycenters](/integrations/barycenters)** — Optional third-party. Admit a tool call in shadow before the tool runs. MCP at the admit host is a side door (`admit`, `check_readiness`), not a wrap of every Hermes tool.
 
 ## Web Search Backends
 


### PR DESCRIPTION
Hermes is Python (`pyproject.toml`). Three lines after Getting Started — not SECURITY.md (vulnerability reporting).

Shadow: PyPI `barycenters` (`admit` / `@boundary`).
MCP side door: `https://barycenters-admit.fly.dev/mcp/` (GET 406 is protocol).
Spec: https://barycenters.ai/adapters
