### PR TITLE
fix(computer-use): keep Windows CLI Cua sessions startable

### DIFF
--- a/tests/computer_use/test_cua_stdio_stderr.py
+++ b/tests/computer_use/test_cua_stdio_stderr.py
@@ -1,0 +1,80 @@
+"""Regression coverage for cua-driver MCP stderr ownership on Windows."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+import sys
+from types import SimpleNamespace
+
+from tools.computer_use import cua_backend
+
+
+class _DeniedStderr:
+    """Model prompt_toolkit's non-inheritable Windows output proxy."""
+
+    def fileno(self) -> int:
+        raise PermissionError(5, "Access is denied")
+
+
+class _FakeClientSession:
+    def __init__(self, _read, _write) -> None:
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc) -> None:
+        return None
+
+    async def initialize(self) -> None:
+        return None
+
+    async def list_tools(self):
+        return SimpleNamespace(tools=[])
+
+
+async def _run_lifecycle(session: cua_backend._CuaDriverSession) -> None:
+    task = asyncio.create_task(session._lifecycle_coro())
+    while session._shutdown_event is None:
+        await asyncio.sleep(0)
+    session._shutdown_event.set()
+    await task
+
+
+def test_stdio_spawn_uses_owned_real_stderr_when_process_stderr_is_denied(
+    monkeypatch,
+) -> None:
+    captured = {}
+
+    @asynccontextmanager
+    async def fake_stdio_client(_params, *, errlog):
+        captured["errlog"] = errlog
+        assert errlog.fileno() >= 0
+        yield object(), object()
+
+    monkeypatch.setattr(cua_backend, "resolve_cua_driver_cmd", lambda: "cua-driver")
+    monkeypatch.setattr(
+        cua_backend,
+        "_resolve_mcp_invocation",
+        lambda _driver: ("cua-driver", ["mcp"]),
+    )
+    monkeypatch.setattr(
+        cua_backend,
+        "_standard_runtime_launch_args",
+        lambda args, **_kwargs: (args, None),
+    )
+
+    import mcp
+    import mcp.client.stdio
+
+    monkeypatch.setattr(mcp, "ClientSession", _FakeClientSession)
+    monkeypatch.setattr(mcp.client.stdio, "stdio_client", fake_stdio_client)
+
+    session = cua_backend._CuaDriverSession(cua_backend._AsyncBridge())
+    with monkeypatch.context() as stderr_patch:
+        stderr_patch.setattr(sys, "stderr", _DeniedStderr())
+        asyncio.run(_run_lifecycle(session))
+
+    assert captured["errlog"] is not sys.stderr
+    assert captured["errlog"].closed

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -398,6 +398,37 @@ def cua_driver_child_env(base_env: Optional[Dict[str, str]] = None) -> Dict[str,
     return env
 
 
+def _open_cua_driver_stderr_log() -> Any:
+    """Open a real file descriptor for the cua-driver MCP child's stderr.
+
+    The interactive CLI runs tool calls inside prompt_toolkit's
+    ``patch_stdout()`` context. On Windows that replaces ``sys.stderr`` with
+    an output proxy whose console handle is not necessarily inheritable by
+    ``CreateProcess``. The MCP SDK otherwise captures that proxy as its
+    default ``errlog`` and the stdio spawn can fail with ``WinError 5``.
+
+    An owned file handle is stable across every Hermes surface and keeps the
+    driver's startup diagnostics available without writing through the TUI.
+    """
+    try:
+        from hermes_constants import get_hermes_home
+
+        log_dir = get_hermes_home() / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        handle = open(
+            log_dir / "cua-driver-stderr.log",
+            "a",
+            encoding="utf-8",
+            errors="replace",
+            buffering=1,
+        )
+        handle.fileno()
+        return handle
+    except Exception:
+        logger.debug("could not open cua-driver stderr log", exc_info=True)
+        return open(os.devnull, "w", encoding="utf-8")
+
+
 def _linux_session_locked() -> Optional[bool]:
     """Best-effort: is the graphical session locked? (Linux only.)
 
@@ -1622,30 +1653,31 @@ class _CuaDriverSession:
                 env=_sanitize_subprocess_env(child_env),
             )
 
-            async with stdio_client(params) as (read, write):
-                self._startup_phase = "mcp-initialize"
-                async with ClientSession(read, write) as session:
-                    await session.initialize()
-                    _t_init = _time.monotonic()
-                    # Populate capabilities + capability_version BEFORE
-                    # exposing the session to callers, so the first
-                    # tool call already sees them.
-                    self._startup_phase = "capability-discovery"
-                    await self._populate_capabilities(session)
-                    self._session = session
-                    self._startup_phase = "ready"
-                    self._ready_event.set()
-                    logger.info(
-                        "cua-driver session ready in %.1fs "
-                        "(manifest=%.1fs, mcp_init=%.1fs)",
-                        _time.monotonic() - _t0,
-                        _t_manifest - _t0,
-                        _t_init - _t_manifest,
-                    )
-                    # Hold the contexts open until stop() / restart asks
-                    # us to wind down. Tool calls run as their own tasks
-                    # on the same loop and touch self._session directly.
-                    await self._shutdown_event.wait()
+            with _open_cua_driver_stderr_log() as errlog:
+                async with stdio_client(params, errlog=errlog) as (read, write):
+                    self._startup_phase = "mcp-initialize"
+                    async with ClientSession(read, write) as session:
+                        await session.initialize()
+                        _t_init = _time.monotonic()
+                        # Populate capabilities + capability_version BEFORE
+                        # exposing the session to callers, so the first
+                        # tool call already sees them.
+                        self._startup_phase = "capability-discovery"
+                        await self._populate_capabilities(session)
+                        self._session = session
+                        self._startup_phase = "ready"
+                        self._ready_event.set()
+                        logger.info(
+                            "cua-driver session ready in %.1fs "
+                            "(manifest=%.1fs, mcp_init=%.1fs)",
+                            _time.monotonic() - _t0,
+                            _t_manifest - _t0,
+                            _t_init - _t_manifest,
+                        )
+                        # Hold the contexts open until stop() / restart asks
+                        # us to wind down. Tool calls run as their own tasks
+                        # on the same loop and touch self._session directly.
+                        await self._shutdown_event.wait()
         except BaseException as e:
             # Capture both ordinary errors and anyio CancelledError.
             # The caller (start()) inspects this to surface setup


### PR DESCRIPTION
## What does this PR do?

Windows CLI sessions can now start the `computer_use` Cua MCP transport while prompt_toolkit is patching process output. Without this fix, a capture-only tool call can fail before MCP initialization with `[WinError 5] Access is denied`, leaving computer use unavailable even though the signed driver and direct backend calls work.

### Symptom

A standard-mode `computer_use` call from the full Hermes CLI reports `cua-driver session setup failed: [WinError 5] Access is denied`. Direct `CuaDriverBackend.start()` and lower-level Cua calls work in the same account.

### Impact

Affected Windows CLI sessions cannot use any `computer_use` action, including read-only capture, because the MCP subprocess never reaches initialization.

### Bug Cause

**Trigger:** `tools/computer_use/cua_backend.py:_CuaDriverSession._lifecycle_coro`

**Causal chain:**
1. The interactive CLI runs agent tool dispatch inside prompt_toolkit's `patch_stdout()` context.
2. The Cua MCP lifecycle calls `stdio_client(params)` without an explicit `errlog`, so the MCP SDK uses the process `sys.stderr`, which can be prompt_toolkit's Windows output proxy rather than an owned inheritable file handle.
3. Windows subprocess setup attempts to use that proxy for the child's stderr and can fail with access denied before MCP initialization.

**Why it is wrong:** A long-lived background MCP child must not depend on a UI framework's temporary output proxy as an inheritable OS handle.

**Working sibling / contrast:** Direct backend startup outside the patched CLI output context receives a normal process stderr handle, so the same driver command and permission mode succeed.

**Ruled out:** The signed Cua binary, UIAccess worker, default daemon, named pipe, and standard permission mode are not the failing layer; the issue's direct driver and direct backend controls all succeed.

### Fix

Open a profile-scoped `cua-driver-stderr.log` with a real OS file descriptor for each Cua MCP lifecycle, pass it explicitly to `stdio_client`, and close it with the transport context. Fall back to `os.devnull` if the profile log cannot be opened. The existing sanitized child environment and permission-mode arguments are unchanged.

## Related Issue
N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/computer_use/cua_backend.py` - give the Cua MCP child an owned, profile-scoped stderr file handle.
- `tests/computer_use/test_cua_stdio_stderr.py` - exercise the lifecycle with a process stderr proxy that raises `PermissionError(5)` and require an explicit real descriptor.

## How to Test

1. Run the targeted Windows stderr ownership regression and the adjacent Cua spawn environment tests.
2. Confirm all targeted tests pass.

```bash
scripts/run_tests.sh tests/computer_use/test_cua_stdio_stderr.py tests/computer_use/test_cua_spawn_env_sanitization.py tests/computer_use/test_cua_cli_fallback_env.py -q
```

Local result: 8 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo test entry on the relevant tests and all targeted tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; the implementation docstring records the Windows handle contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; the public schema is unchanged

## Screenshots / Logs

N/A. The automated regression exercises the failed Windows handle boundary directly.
