### PR TITLE
fix(gateway): route platform authorization reads through the profile secret scope

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -250,6 +250,26 @@ def validate_signal_config(config: PlatformConfig) -> bool:
 # Signal Adapter
 # ---------------------------------------------------------------------------
 
+def _sig_secret(name: str, default: str = "") -> str:
+    """Resolve a per-profile ``SIGNAL_*`` setting honoring the active secret
+    scope (#93522).
+
+    Under ``gateway.multiplex_profiles`` every secondary profile is
+    constructed inside ``_profile_runtime_scope`` (``gateway/run.py``) and
+    its ``.env`` lives in that scope — raw ``os.getenv`` misses it and
+    leaks the default profile's values instead. The primary/active profile
+    is constructed without a scope and legitimately owns ``os.environ``
+    (same canonical shape as QQ's ``_resolve_qq_secret``).
+    """
+    from agent.secret_scope import UnscopedSecretError, get_secret
+
+    try:
+        val = get_secret(name, default)
+    except UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
+
 class SignalAdapter(BasePlatformAdapter):
     """Signal messenger adapter using signal-cli HTTP daemon."""
 
@@ -268,7 +288,10 @@ class SignalAdapter(BasePlatformAdapter):
         self.ignore_stories = extra.get("ignore_stories", True)
 
         # Parse allowlists — group policy is derived from presence of group allowlist
-        group_allowed_str = os.getenv("SIGNAL_GROUP_ALLOWED_USERS", "")
+        # Scoped reads (#93522): allowlists are per-profile authorization
+        # config; raw os.getenv misses secondary profiles' .env values and
+        # leaks the default profile's list into them.
+        group_allowed_str = _sig_secret("SIGNAL_GROUP_ALLOWED_USERS", "")
         self.group_allow_from = set(_parse_comma_list(group_allowed_str))
 
         # Mention filter — only respond in groups when the bot account is @mentioned.
@@ -285,7 +308,7 @@ class SignalAdapter(BasePlatformAdapter):
         # every inbound DM from any contact gets a 👀 reaction).
         # "*" means all users allowed (open mode); empty means no restriction
         # recorded at adapter level (run.py still enforces auth separately).
-        dm_allowed_str = os.getenv("SIGNAL_ALLOWED_USERS", "*")
+        dm_allowed_str = _sig_secret("SIGNAL_ALLOWED_USERS", "*")
         self.dm_allow_from = set(_parse_comma_list(dm_allowed_str))
 
         # HTTP client

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1227,14 +1227,18 @@ class WeixinAdapter(BasePlatformAdapter):
         )
         self._rate_limit_circuit_until = 0.0
         self._rate_limit_events: List[float] = []
-        self._dm_policy = str(extra.get("dm_policy") or os.getenv("WEIXIN_DM_POLICY", "pairing")).strip().lower()
-        self._group_policy = str(extra.get("group_policy") or os.getenv("WEIXIN_GROUP_POLICY", "disabled")).strip().lower()
+        # Authorization reads go through the scoped resolver (#93522):
+        # under gateway.multiplex_profiles each profile's .env lives in its
+        # secret scope, NOT in os.environ — raw getenv silently misses the
+        # secondary profile's allowlists and leaks the default profile's.
+        self._dm_policy = str(extra.get("dm_policy") or _wx_secret("WEIXIN_DM_POLICY") or "pairing").strip().lower()
+        self._group_policy = str(extra.get("group_policy") or _wx_secret("WEIXIN_GROUP_POLICY") or "disabled").strip().lower()
         allow_from = extra.get("allow_from")
         if allow_from is None:
-            allow_from = os.getenv("WEIXIN_ALLOWED_USERS", "")
+            allow_from = _wx_secret("WEIXIN_ALLOWED_USERS", "")
         group_allow_from = extra.get("group_allow_from")
         if group_allow_from is None:
-            group_allow_from = os.getenv("WEIXIN_GROUP_ALLOWED_USERS", "")
+            group_allow_from = _wx_secret("WEIXIN_GROUP_ALLOWED_USERS", "")
         self._allow_from = self._coerce_list(allow_from)
         self._group_allow_from = self._coerce_list(group_allow_from)
         self._split_multiline_messages = _coerce_bool(
@@ -1537,9 +1541,11 @@ class WeixinAdapter(BasePlatformAdapter):
             await self.handle_message(event)
 
     def _open_dm_opted_in(self) -> bool:
-        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+        # Scoped reads (#93522): the default profile's allow-all flag must
+        # not leak into a multiplexed secondary profile's admission gate.
+        if (_wx_secret("GATEWAY_ALLOW_ALL_USERS", "") or "").lower() in {"true", "1", "yes"}:
             return True
-        return os.getenv("WEIXIN_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+        return (_wx_secret("WEIXIN_ALLOW_ALL_USERS", "") or "").lower() in {"true", "1", "yes"}
 
     def _is_dm_allowed(self, sender_id: str) -> bool:
         if self._dm_policy == "disabled":

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -1261,6 +1261,27 @@ class ChatRoutingMiddleware(InboundMiddleware):
         await next_fn()
 
 
+def _yb_secret(name: str, default: Optional[str] = None) -> Optional[str]:
+    """Resolve a per-profile ``YUANBAO_*`` / gateway setting honoring the
+    active secret scope (#93522).
+
+    Under ``gateway.multiplex_profiles`` every secondary profile is
+    constructed inside ``_profile_runtime_scope`` (``gateway/run.py``) and
+    its ``.env`` lives in that scope — raw ``os.getenv`` misses it and
+    leaks the default profile's values instead. The primary/active profile
+    is constructed without a scope and legitimately owns ``os.environ``,
+    so fall back to it there (same canonical shape as QQ's
+    ``_resolve_qq_secret``).
+    """
+    from agent.secret_scope import UnscopedSecretError, get_secret
+
+    try:
+        val = get_secret(name, default)
+    except UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
+
 class AccessPolicy:
     """Platform-level DM / Group access control policy.
 
@@ -1282,9 +1303,9 @@ class AccessPolicy:
         self._group_allow_from = group_allow_from
 
     def _open_dm_opted_in(self) -> bool:
-        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+        if (_yb_secret("GATEWAY_ALLOW_ALL_USERS", "") or "").lower() in {"true", "1", "yes"}:
             return True
-        return os.getenv("YUANBAO_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+        return (_yb_secret("YUANBAO_ALLOW_ALL_USERS", "") or "").lower() in {"true", "1", "yes"}
 
     def is_dm_allowed(self, sender_id: str) -> bool:
         """Strict DM authorization — pairing does not imply access."""
@@ -4942,27 +4963,29 @@ class YuanbaoAdapter(BasePlatformAdapter):
 
         # Reply-to dedup: inbound_msg_id -> expire_ts
         # ------------------------------------------------------------------
-        # Access control policy (DM / Group)
+        # Access control policy (DM / Group) — scoped reads (#93522)
         # ------------------------------------------------------------------
         dm_policy: str = (
             _extra.get("dm_policy")
-            or os.getenv("YUANBAO_DM_POLICY", "pairing")
+            or _yb_secret("YUANBAO_DM_POLICY")
+            or "pairing"
         ).strip().lower()
 
         _dm_allow_from_raw: str = (
             _extra.get("dm_allow_from")
-            or os.getenv("YUANBAO_DM_ALLOW_FROM", "")
+            or _yb_secret("YUANBAO_DM_ALLOW_FROM", "")
         )
         dm_allow_from: list[str] = [x.strip() for x in _dm_allow_from_raw.split(",") if x.strip()]
 
         group_policy: str = (
             _extra.get("group_policy")
-            or os.getenv("YUANBAO_GROUP_POLICY", "pairing")
+            or _yb_secret("YUANBAO_GROUP_POLICY")
+            or "pairing"
         ).strip().lower()
 
         _group_allow_from_raw: str = (
             _extra.get("group_allow_from")
-            or os.getenv("YUANBAO_GROUP_ALLOW_FROM", "")
+            or _yb_secret("YUANBAO_GROUP_ALLOW_FROM", "")
         )
         group_allow_from: list[str] = [x.strip() for x in _group_allow_from_raw.split(",") if x.strip()]
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2750,8 +2750,11 @@ def _own_policy_open_startup_violation(config) -> Optional[str]:
         ).strip().lower()
         if dm_policy != "open" and group_policy != "open":
             continue
-        gateway_allow_all = os.getenv(
-            "GATEWAY_ALLOW_ALL_USERS", ""
+        # Scoped read (#93522): under multiplex, each profile validates its
+        # own opt-in — the default profile's env flag must not satisfy (or
+        # veto) a secondary profile's open-policy startup check.
+        gateway_allow_all = (
+            _getenv("GATEWAY_ALLOW_ALL_USERS", "") or ""
         ).lower() in {"true", "1", "yes"}
         platform_opted_in = gateway_allow_all or (
             allow_all_env

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -185,18 +185,21 @@ class WeComAdapter(BasePlatformAdapter):
             or os.getenv("WECOM_WEBSOCKET_URL", DEFAULT_WS_URL)
         ).strip() or DEFAULT_WS_URL
 
-        self._dm_policy = str(extra.get("dm_policy") or os.getenv("WECOM_DM_POLICY", "pairing")).strip().lower()
-        # dm_policy already honors WECOM_DM_POLICY, so the allowlist must honor
-        # WECOM_ALLOWED_USERS too. Without the env fallback an env-only setup
-        # (dm_policy=allowlist via env, no config extra) runs with an empty
-        # allowlist and drops every authorized DM at intake.
+        # Authorization reads go through the scoped resolver (#93522):
+        # under multiplex, secondary profiles' .env lives in the secret
+        # scope, not os.environ — raw getenv misses their allowlists and
+        # leaks the default profile's values into them. (dm_policy already
+        # honors WECOM_DM_POLICY so the allowlist must honor
+        # WECOM_ALLOWED_USERS too; without an env fallback an env-only
+        # setup runs with an empty allowlist and drops every authorized DM.)
+        self._dm_policy = str(extra.get("dm_policy") or _get_scoped_secret("WECOM_DM_POLICY", "") or "pairing").strip().lower()
         self._allow_from = _coerce_list(
             extra.get("allow_from")
             or extra.get("allowFrom")
-            or os.getenv("WECOM_ALLOWED_USERS", "")
+            or _get_scoped_secret("WECOM_ALLOWED_USERS", "")
         )
 
-        self._group_policy = str(extra.get("group_policy") or os.getenv("WECOM_GROUP_POLICY", "pairing")).strip().lower()
+        self._group_policy = str(extra.get("group_policy") or _get_scoped_secret("WECOM_GROUP_POLICY", "") or "pairing").strip().lower()
         self._group_allow_from = _coerce_list(extra.get("group_allow_from") or extra.get("groupAllowFrom"))
         self._groups = extra.get("groups") if isinstance(extra.get("groups"), dict) else {}
 
@@ -893,9 +896,11 @@ class WeComAdapter(BasePlatformAdapter):
         return True
 
     def _open_dm_opted_in(self) -> bool:
-        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+        # Scoped reads (#93522): the default profile's allow-all flag must
+        # not leak into a multiplexed secondary profile's admission gate.
+        if (_get_scoped_secret("GATEWAY_ALLOW_ALL_USERS", "") or "").lower() in {"true", "1", "yes"}:
             return True
-        return os.getenv("WECOM_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+        return (_get_scoped_secret("WECOM_ALLOW_ALL_USERS", "") or "").lower() in {"true", "1", "yes"}
 
     def _is_dm_allowed(self, sender_id: str) -> bool:
         if self._dm_policy == "disabled":

--- a/tests/gateway/test_platform_authz_scope.py
+++ b/tests/gateway/test_platform_authz_scope.py
@@ -1,0 +1,212 @@
+"""Platform authorization reads must honor the per-profile secret scope (#93522).
+
+Under ``gateway.multiplex_profiles`` every secondary profile is constructed
+inside ``_profile_runtime_scope`` and its ``.env`` lives in that scope —
+``gateway/run.py`` explicitly does NOT mutate ``os.environ`` with it. Raw
+``os.getenv`` authorization reads therefore (a) silently miss the secondary
+profile's own allowlists (fail-closed no-replies) and (b) leak the default
+profile's ``GATEWAY_ALLOW_ALL_USERS`` / allowlists into secondary profiles
+(fail-open admissions).
+
+Covers the scoped env helpers of weixin / yuanbao / signal / wecom plus the
+``_open_dm_opted_in`` gates built on them. Canonical shape reference:
+QQ's ``_resolve_qq_secret``.
+"""
+
+import contextlib
+import os
+
+import pytest
+
+from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+
+@contextlib.contextmanager
+def _scope(secrets):
+    token = set_secret_scope(secrets)
+    try:
+        yield
+    finally:
+        reset_secret_scope(token)
+
+
+@pytest.fixture
+def profile_scope():
+    """Install a secondary-profile secret scope; os.environ stays 'default'."""
+    with _scope(
+        {
+            "WEIXIN_DM_POLICY": "allowlist",
+            "WEIXIN_ALLOWED_USERS": "wx-alice",
+            "WEIXIN_ALLOW_ALL_USERS": "",
+            "YUANBAO_DM_POLICY": "open",
+            "SIGNAL_ALLOWED_USERS": "sig-bob",
+            "WECOM_DM_POLICY": "allowlist",
+            "WECOM_ALLOWED_USERS": "wecom-carol",
+        }
+    ):
+        yield
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Scoped helpers: read the scope, never leak os.environ past it
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "module_path,helper_name,var",
+    [
+        ("gateway.platforms.weixin", "_wx_secret", "WEIXIN_ALLOWED_USERS"),
+        ("gateway.platforms.yuanbao", "_yb_secret", "YUANBAO_DM_POLICY"),
+        ("gateway.platforms.signal", "_sig_secret", "SIGNAL_ALLOWED_USERS"),
+        ("plugins.platforms.wecom.adapter", "_get_scoped_secret", "WECOM_ALLOWED_USERS"),
+    ],
+)
+def test_helper_reads_profile_scope_first(module_path, helper_name, var, monkeypatch):
+    """Scope value wins over anything in os.environ."""
+    monkeypatch.setenv(var, "FROM-DEFAULT-ENV")
+    module = __import__(module_path, fromlist=[helper_name])
+    helper = getattr(module, helper_name)
+
+    with _scope({var: "from-profile-scope"}):
+        assert helper(var, "") == "from-profile-scope"
+
+
+@pytest.fixture
+def multiplex_on(monkeypatch):
+    """Simulate a multiplexed deployment: scoped misses fail closed.
+
+    With multiplexing off, a scope miss deliberately falls through to
+    os.environ (the cron-overlay contract) — the cross-profile leak only
+    exists while the multiplexer is active, which is exactly the #93522
+    scenario.
+    """
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+
+
+@pytest.mark.parametrize(
+    "module_path,helper_name",
+    [
+        ("gateway.platforms.weixin", "_wx_secret"),
+        ("gateway.platforms.yuanbao", "_yb_secret"),
+        ("gateway.platforms.signal", "_sig_secret"),
+        ("plugins.platforms.wecom.adapter", "_get_scoped_secret"),
+    ],
+)
+def test_helper_does_not_leak_default_env_into_scoped_miss(
+    module_path, helper_name, multiplex_on, monkeypatch
+):
+    """Scoped miss must return the default, NOT fall through to os.environ.
+
+    This is the fail-closed half of #93522: the default profile's
+    ``*_ALLOW_ALL_USERS=true`` in process env must not answer a secondary
+    profile's gate.
+    """
+    monkeypatch.setenv("WEIXIN_ALLOW_ALL_USERS", "true")
+    monkeypatch.setenv("YUANBAO_ALLOW_ALL_USERS", "true")
+    monkeypatch.setenv("SIGNAL_ALLOWED_USERS", "*")
+    monkeypatch.setenv("WECOM_ALLOW_ALL_USERS", "true")
+
+    module = __import__(module_path, fromlist=[helper_name])
+    helper = getattr(module, helper_name)
+
+    with _scope({}):  # scope installed, keys absent
+        assert helper("WEIXIN_ALLOW_ALL_USERS", "") == ""
+        assert helper("YUANBAO_ALLOW_ALL_USERS", "") == ""
+        assert helper("WECOM_ALLOW_ALL_USERS", "") == ""
+        # signal's "*" default means open at adapter level — the scoped
+        # read must still not see the unscoped value:
+        assert helper("SIGNAL_ALLOWED_USERS", "restricted-default") == "restricted-default"
+
+
+@pytest.mark.parametrize(
+    "module_path,helper_name,var",
+    [
+        ("gateway.platforms.weixin", "_wx_secret", "WEIXIN_ALLOWED_USERS"),
+        ("gateway.platforms.yuanbao", "_yb_secret", "YUANBAO_DM_POLICY"),
+        ("gateway.platforms.signal", "_sig_secret", "SIGNAL_ALLOWED_USERS"),
+        ("plugins.platforms.wecom.adapter", "_get_scoped_secret", "WECOM_ALLOWED_USERS"),
+    ],
+)
+def test_helper_falls_back_to_environ_without_scope(module_path, helper_name, var, monkeypatch):
+    """Single-profile (no scope installed): os.environ remains authoritative."""
+    monkeypatch.setenv(var, "legacy-env-value")
+    module = __import__(module_path, fromlist=[helper_name])
+    helper = getattr(module, helper_name)
+    assert helper(var, "") == "legacy-env-value"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Admission gates built on the helpers
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_weixin_open_gate_ignores_default_env_under_scope(profile_scope, multiplex_on, monkeypatch):
+    """Default profile sets GATEWAY_ALLOW_ALL_USERS=true; secondary scope does
+    NOT carry it — the gate must stay closed."""
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+
+    from gateway.platforms.weixin import WeixinAdapter
+
+    adapter = WeixinAdapter.__new__(WeixinAdapter)
+    assert adapter._open_dm_opted_in() is False
+
+
+def test_weixin_open_gate_honors_scope_opt_in():
+    from gateway.platforms.weixin import WeixinAdapter
+
+    with _scope({"WEIXIN_ALLOW_ALL_USERS": "yes"}):
+        adapter = WeixinAdapter.__new__(WeixinAdapter)
+        assert adapter._open_dm_opted_in() is True
+
+
+def test_yuanbao_access_policy_gate_ignores_default_env(profile_scope, multiplex_on, monkeypatch):
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+
+    from gateway.platforms.yuanbao import AccessPolicy
+
+    policy = AccessPolicy(
+        dm_policy="open", dm_allow_from=[], group_policy="pairing", group_allow_from=[]
+    )
+    assert policy._open_dm_opted_in() is False
+
+
+def test_wecom_open_gate_ignores_default_env_under_scope(profile_scope, multiplex_on, monkeypatch):
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+
+    from plugins.platforms.wecom.adapter import WeComAdapter
+
+    adapter = WeComAdapter.__new__(WeComAdapter)
+    assert adapter._open_dm_opted_in() is False
+
+
+def test_startup_guard_uses_scoped_gateway_flag(multiplex_on):
+    """_own_policy_open_startup_violation must consult the scope for
+    GATEWAY_ALLOW_ALL_USERS, not raw os.environ (#93522)."""
+    from gateway.platforms.base import Platform
+    from gateway.run import _own_policy_open_startup_violation
+
+    class _PlatformConfig:
+        enabled = True
+        extra = {"dm_policy": "open"}
+
+    class _Config:
+        platforms = {Platform.YUANBAO: _PlatformConfig()}
+
+    cfg = _Config()
+    with _scope({"GATEWAY_ALLOW_ALL_USERS": "true"}):
+        # Scope says opted-in even though os.environ doesn't -> no violation.
+        assert _own_policy_open_startup_violation(cfg) is None
+
+    with _scope({}):
+        # Scope lacks the opt-in while os.environ has it -> violation (the
+        # default profile's flag must not satisfy this profile's check).
+        monkey_env_backup = os.environ.get("GATEWAY_ALLOW_ALL_USERS")
+        os.environ["GATEWAY_ALLOW_ALL_USERS"] = "true"
+        try:
+            reason = _own_policy_open_startup_violation(cfg)
+            assert reason is not None and "yuanbao" in reason.lower()
+        finally:
+            if monkey_env_backup is None:
+                os.environ.pop("GATEWAY_ALLOW_ALL_USERS", None)
+            else:
+                os.environ["GATEWAY_ALLOW_ALL_USERS"] = monkey_env_backup


### PR DESCRIPTION
## What does this PR do?

Fixes a **multiplexed-profile isolation break in platform authorization** (issue #93522). Under `gateway.multiplex_profiles`, every secondary profile is constructed inside `_profile_runtime_scope` and its `.env` lives in that profile's secret scope — `gateway/run.py` explicitly does *not* mutate `os.environ` with it. Four adapters still read their **authorization config** via raw `os.getenv`, producing two failure modes for any non-default profile using them:

1. **Fail-closed silent rejection** — profile B sets `WEIXIN_ALLOWED_USERS=alice` (env-only) → raw getenv misses it → intake drops every DM/group message with no error, before the runner-level scoped authz check ever runs.
2. **Fail-open cross-profile leak** — the default profile's `GATEWAY_ALLOW_ALL_USERS=true` / allowlists live in the shared process env and leak into B's admission gates.

### What changed

| Location | Reads routed through the scoped resolver |
|---|---|
| `gateway/platforms/weixin.py` | `WEIXIN_DM_POLICY`, `WEIXIN_ALLOWED_USERS`, `WEIXIN_GROUP_ALLOWED_USERS`, `WEIXIN_ALLOW_ALL_USERS`, `GATEWAY_ALLOW_ALL_USERS` (via existing `_wx_secret`) |
| `gateway/platforms/yuanbao.py` | new `_yb_secret()` helper; `YUANBAO_DM_POLICY`, `YUANBAO_DM_ALLOW_FROM`, `YUANBAO_GROUP_POLICY`, `YUANBAO_GROUP_ALLOW_FROM`; `AccessPolicy._open_dm_opted_in` |
| `gateway/platforms/signal.py` | new `_sig_secret()` helper; `SIGNAL_GROUP_ALLOWED_USERS`, `SIGNAL_ALLOWED_USERS` |
| `plugins/platforms/wecom/adapter.py` | existing `_get_scoped_secret` extended to the authz reads beside the already-scoped credential reads |
| `gateway/run.py::_own_policy_open_startup_violation` | `GATEWAY_ALLOW_ALL_USERS` now via scoped `_getenv`, matching its sibling dm/group reads |

All reads use the canonical fail-closed shape QQ's `_resolve_qq_secret` already established: scope hit wins; with no scope installed (single-profile deployments), legacy `os.environ` behavior is preserved exactly. This is the authorization-axis counterpart of #59662/#59739/#86905's credential work, per AGENTS.md §Profiles rule 7 which names `{PLATFORM}_ALLOW_ALL_USERS` / `{PLATFORM}_ALLOWED_USERS` / `GATEWAY_ALLOW_ALL_USERS` explicitly as must-be-scope-aware.

## Related Issue

Fixes #93522

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Tests

## Changes Made

- Adapter/guard reads listed above; two small module-level helpers (`_yb_secret`, `_sig_secret`) mirroring the canonical shape used across ~16 other call sites. No behavior change for single-profile deployments (covered by tests).
- `tests/gateway/test_platform_authz_scope.py` — 17 regression tests driving the real scope contextvar:
  - each of the four helpers prefers a scope value over `os.environ`;
  - under multiplex (`_MULTIPLEX_ACTIVE=True`), a scoped miss returns the default and never falls through to process env (the leak direction), for all four adapters;
  - without a scope (single-profile), os.environ fallback is preserved;
  - `WeixinAdapter` / wecom `_open_dm_opted_in` and yuanbao `AccessPolicy` gates stay closed when only the default profile's `GATEWAY_ALLOW_ALL_USERS=true` is present, and open on their own scope's opt-in;
  - the yuanbao open-policy startup guard accepts a scope-installed opt-in and rejects when the scope lacks it even though `os.environ` has it.

## How to Test

1. `uv run python -m pytest tests/gateway/test_platform_authz_scope.py -q` → 17 passed.
2. Neighbors: `uv run python -m pytest tests/gateway/test_multiplex_profile_authz.py -q` → 5 passed.
3. `ruff check gateway/platforms/weixin.py gateway/platforms/yuanbao.py gateway/platforms/signal.py plugins/platforms/wecom/adapter.py gateway/run.py tests/gateway/test_platform_authz_scope.py` → clean.
4. Manual (multiplex): configure profiles A+B, put `WEIXIN_ALLOWED_USERS=<id>` in B's `.env` only → B now answers allowlisted senders (previously silent); set `GATEWAY_ALLOW_ALL_USERS=true` in A only → B still denies strangers (previously admitted).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls?q=is%3Apr) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run targeted test suites locally and they pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Docs N/A (matches the documented multiplex contract; comments cite #93522 at each site)
- [x] cli-config.yaml.example N/A (no new config keys)
- [x] CONTRIBUTING/AGENTS N/A
- [x] Cross-platform impact: none (pure env-resolution logic)
- [x] No tool schema change → N/A

## Screenshots / Logs

N/A
