### PR TITLE
feat(goals): /goal accepts a GOAL.md file + an autonomous mode

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1132,12 +1132,14 @@ goals:
   max_turns: 20
 
   # Default autonomous mode for new goals. When true, every /goal is created
-  # in autonomous mode without needing the explicit --auto flag. Off by
-  # default so /goal keeps its plain per-turn-judge behaviour. Override for a
-  # single session with the GOAL_AUTONOMOUS=1 env var, or per goal with
-  # `/goal --auto <text>`. Autonomous mode is the trigger the optional engine
-  # expansions (session-recycle, decision log, deception check, council gate)
-  # hang off in follow-up releases; on its own it is an inert marker.
+  # in autonomous mode without needing the explicit switch. Off by default so
+  # /goal keeps its plain per-turn-judge behaviour. Turn it on per goal with a
+  # leading keyword `/goal auto <text-or-file>` (or `/goal autonomous ...`, or
+  # the `--auto` flag); override the default for one session with
+  # GOAL_AUTONOMOUS=1 (or =0 to force off). Autonomous mode is the trigger the
+  # optional engine expansions (session-recycle, decision log, deception check,
+  # council gate) hang off in follow-up releases; on its own it is an inert
+  # marker.
   autonomous: false
 
 # =============================================================================

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1133,9 +1133,9 @@ goals:
 
   # Default autonomous mode for new goals. When true, every /goal is created
   # in autonomous mode without needing the explicit switch. Off by default so
-  # /goal keeps its plain per-turn-judge behaviour. Turn it on per goal with a
-  # leading keyword `/goal auto <text-or-file>` (or `/goal autonomous ...`, or
-  # the `--auto` flag); override the default for one session with
+  # /goal keeps its plain per-turn-judge behaviour. Turn it on per goal with
+  # the explicit `--auto` or `--autonomous` flag; override the default for one
+  # session with
   # GOAL_AUTONOMOUS=1 (or =0 to force off). Autonomous mode is the trigger the
   # optional engine expansions (session-recycle, decision log, deception check,
   # council gate) hang off in follow-up releases; on its own it is an inert

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1120,6 +1120,27 @@ agent:
   #     style: "terse"
 
 # =============================================================================
+# Goals (/goal — persistent cross-turn objectives, the Ralph loop)
+# =============================================================================
+# A /goal is a free-form objective that stays active across turns. After each
+# turn a judge model checks whether it's done; if not, Hermes feeds a
+# continuation prompt back into the same session and keeps working.
+goals:
+  # Max continuation turns before Hermes auto-pauses the goal and asks the
+  # user to /goal resume. Guards against judge false-negatives and unbounded
+  # spend on fuzzy goals.
+  max_turns: 20
+
+  # Default autonomous mode for new goals. When true, every /goal is created
+  # in autonomous mode without needing the explicit --auto flag. Off by
+  # default so /goal keeps its plain per-turn-judge behaviour. Override for a
+  # single session with the GOAL_AUTONOMOUS=1 env var, or per goal with
+  # `/goal --auto <text>`. Autonomous mode is the trigger the optional engine
+  # expansions (session-recycle, decision log, deception check, council gate)
+  # hang off in follow-up releases; on its own it is an inert marker.
+  autonomous: false
+
+# =============================================================================
 # Toolsets
 # =============================================================================
 # Control which tools the agent has access to.

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2990,21 +2990,43 @@ class CLICommandsMixin:
             _cprint("  Usage: /goal gate [list | add <command> | remove <N> | clear]")
             return
 
-        # Otherwise treat the arg as the goal text. Inline `field: value`
-        # lines (verify:, constraints:, boundaries:, stop when:) are parsed
-        # into a completion contract; the remaining prose is the headline.
-        # A plain free-form goal with no such lines behaves exactly as before.
-        from hermes_cli.goals import parse_contract
+        # Otherwise treat the arg as the goal text. First resolve autonomous
+        # mode (`--auto` / `--autonomous`) and optional GOAL.md file loading,
+        # then parse inline `field: value` lines (verify:, constraints:,
+        # boundaries:, stop when:) into a completion contract; the remaining
+        # prose is the headline. A plain free-form goal behaves exactly as
+        # before (autonomous stays off, no file is read).
+        from hermes_cli.goals import parse_contract, resolve_goal_input
 
-        headline, contract = parse_contract(arg)
-        goal_text = headline or arg
+        auto_default = bool(
+            (self.config.get("goals") or {}).get("autonomous", False)
+        )
+        # Single-session override: GOAL_AUTONOMOUS=1 forces autonomous default
+        # on without editing config (mirrors how other goal knobs allow an env
+        # override for one session).
+        _env_auto = os.environ.get("GOAL_AUTONOMOUS", "").strip().lower()
+        if _env_auto in {"1", "true", "yes", "on"}:
+            auto_default = True
+        resolved, autonomous, note = resolve_goal_input(
+            arg, cwd=os.getcwd(), autonomous_default=auto_default
+        )
+        if note:
+            _cprint(f"  {_DIM}{note}{_RST}")
+
+        headline, contract = parse_contract(resolved)
+        goal_text = headline or resolved
         try:
-            state = mgr.set(goal_text, contract=contract if not contract.is_empty() else None)
+            state = mgr.set(
+                goal_text,
+                contract=contract if not contract.is_empty() else None,
+                autonomous=autonomous,
+            )
         except ValueError as exc:
             _cprint(f"  Invalid goal: {exc}")
             return
 
-        _cprint(f"  ⊙ Goal set ({state.max_turns}-turn budget): {state.goal}")
+        mode = " · autonomous" if state.autonomous else ""
+        _cprint(f"  ⊙ Goal set ({state.max_turns}-turn budget{mode}): {state.goal}")
         if state.has_contract():
             _cprint(f"  {_DIM}Completion contract:{_RST}")
             for line in state.contract.render_block().splitlines():

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -3001,12 +3001,14 @@ class CLICommandsMixin:
         auto_default = bool(
             (self.config.get("goals") or {}).get("autonomous", False)
         )
-        # Single-session override: GOAL_AUTONOMOUS=1 forces autonomous default
-        # on without editing config (mirrors how other goal knobs allow an env
-        # override for one session).
+        # Single-session override: GOAL_AUTONOMOUS forces the autonomous default
+        # on or OFF without editing config. Truthy (1/true/yes/on) and falsy
+        # (0/false/no/off) spellings both override; anything else is ignored.
         _env_auto = os.environ.get("GOAL_AUTONOMOUS", "").strip().lower()
         if _env_auto in {"1", "true", "yes", "on"}:
             auto_default = True
+        elif _env_auto in {"0", "false", "no", "off"}:
+            auto_default = False
         resolved, autonomous, note = resolve_goal_input(
             arg, cwd=os.getcwd(), autonomous_default=auto_default
         )
@@ -3027,6 +3029,11 @@ class CLICommandsMixin:
 
         mode = " · autonomous" if state.autonomous else ""
         _cprint(f"  ⊙ Goal set ({state.max_turns}-turn budget{mode}): {state.goal}")
+        if state.autonomous:
+            _cprint(
+                f"  {_DIM}Autonomous mode is recorded on this goal; on its own "
+                f"it is an inert marker — nothing else changes yet.{_RST}"
+            )
         if state.has_contract():
             _cprint(f"  {_DIM}Completion contract:{_RST}")
             for line in state.contract.render_block().splitlines():

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2078,6 +2078,13 @@ DEFAULT_CONFIG = {
         # negatives (goal actually done but judge says continue) and
         # unbounded model spend on fuzzy / unachievable goals.
         "max_turns": 20,
+        # Default autonomous mode for new goals. When true, every /goal is
+        # created in autonomous mode (opting into the engine expansions:
+        # session-recycle, decision log, deception check, council gate) without
+        # needing the explicit --auto flag. Off by default so /goal keeps its
+        # plain Ralph-loop behaviour; override per session via the GOAL_AUTONOMOUS
+        # env var or per goal with `/goal --auto <text>`.
+        "autonomous": False,
     },
 
 

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -421,8 +421,92 @@ def parse_contract(text: str) -> Tuple[str, GoalContract]:
 
 
 # ──────────────────────────────────────────────────────────────────────
-# Quality gates
+# Autonomous-mode + file-goal input resolution
 # ──────────────────────────────────────────────────────────────────────
+
+# Flags that opt a goal into autonomous mode. Accepted anywhere in the arg
+# (leading or trailing) so both `/goal --auto <text>` and `/goal <text> --auto`
+# work. `autonomous` is the long word form of the same switch.
+_AUTONOMOUS_FLAGS = {"--auto", "--autonomous", "auto", "autonomous"}
+
+# Upper bound on a goal file we will read inline, so a stray huge/binary file
+# path can never flood the goal text. A real GOAL.md is a handful of KB.
+_GOAL_FILE_MAX_BYTES = 64 * 1024
+
+
+def _looks_like_path(token: str) -> bool:
+    """Heuristic: does this single token look like a goal file path?
+
+    True for tokens that carry a path separator or a text-ish extension and
+    contain no whitespace. Kept deliberately conservative so a normal prose
+    goal ("fix the parser") is never mistaken for a file.
+    """
+    if not token or any(c.isspace() for c in token):
+        return False
+    if token.startswith(("/", "./", "../", "~/")):
+        return True
+    lowered = token.lower()
+    return lowered.endswith((".md", ".txt", ".goal"))
+
+
+def resolve_goal_input(
+    arg: str, *, cwd: Optional[str] = None, autonomous_default: bool = False
+) -> Tuple[str, bool, str]:
+    """Resolve a raw `/goal` argument into (goal_text, autonomous, note).
+
+    Two additive behaviours on top of plain goal text:
+
+      * ``--auto`` / ``--autonomous`` (long form ``autonomous``) anywhere in the
+        argument opts the goal into autonomous mode and is stripped from the
+        text. ``autonomous_default`` (from config) seeds the flag when no
+        explicit switch is present.
+      * If what remains is a single path-like token pointing at a readable file,
+        the file's contents become the goal text (the ``GOAL.md`` pattern). A
+        missing/oversized/unreadable file falls back to treating the token
+        literally, so this never raises into the command handler.
+
+    ``note`` is a short human-readable provenance string ('' when the text was
+    used verbatim). Fail-open by construction: any error yields the original
+    text with the resolved autonomous flag.
+    """
+    text = (arg or "").strip()
+    autonomous = bool(autonomous_default)
+
+    tokens = text.split()
+    kept: List[str] = []
+    for tok in tokens:
+        if tok.lower() in _AUTONOMOUS_FLAGS:
+            autonomous = True
+            continue
+        kept.append(tok)
+    text = " ".join(kept).strip()
+
+    note = ""
+    if len(kept) == 1 and _looks_like_path(kept[0]):
+        loaded, note = _read_goal_file(kept[0], cwd=cwd)
+        if loaded is not None:
+            text = loaded
+    return text, autonomous, note
+
+
+def _read_goal_file(token: str, *, cwd: Optional[str] = None) -> Tuple[Optional[str], str]:
+    """Read a goal file, returning (contents, note) or (None, '') on any miss."""
+    try:
+        path = os.path.expanduser(token)
+        if not os.path.isabs(path) and cwd:
+            path = os.path.join(cwd, path)
+        if not os.path.isfile(path):
+            return None, ""
+        if os.path.getsize(path) > _GOAL_FILE_MAX_BYTES:
+            return None, ""
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            contents = fh.read().strip()
+        if not contents:
+            return None, ""
+        return contents, f"loaded goal from {token}"
+    except Exception:  # never raise into the command handler
+        return None, ""
+
 
 
 @dataclass
@@ -599,6 +683,11 @@ class GoalState:
     # must ALL pass before the judge may declare the goal done. Empty by
     # default — a goal with no gates behaves exactly as before.
     gates: List[GoalGate] = field(default_factory=list)
+    # Autonomous mode (/goal --auto <text>): opts this goal into the autonomous
+    # engine expansions (session-recycle, decision log, deception check, council
+    # gate) that layer on top of the base Ralph loop. Off by default so a plain
+    # goal behaves exactly as before; back-compatible with old state_meta rows.
+    autonomous: bool = False
 
     def to_json(self) -> str:
         data = asdict(self)
@@ -636,6 +725,7 @@ class GoalState:
                 for g in (data.get("gates") or [])
                 if isinstance(g, dict) and str(g.get("command") or "").strip()
             ],
+            autonomous=bool(data.get("autonomous", False)),
         )
 
     # --- contract helpers -------------------------------------------------
@@ -1473,7 +1563,7 @@ class GoalManager:
 
     # --- mutation -----------------------------------------------------
 
-    def set(self, goal: str, *, max_turns: Optional[int] = None, contract: Optional[GoalContract] = None) -> GoalState:
+    def set(self, goal: str, *, max_turns: Optional[int] = None, contract: Optional[GoalContract] = None, autonomous: bool = False) -> GoalState:
         goal = (goal or "").strip()
         if not goal:
             raise ValueError("goal text is empty")
@@ -1485,6 +1575,7 @@ class GoalManager:
             created_at=time.time(),
             last_turn_at=0.0,
             contract=contract if contract is not None else GoalContract(),
+            autonomous=bool(autonomous),
         )
         self._state = state
         save_goal(self.session_id, state)

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -424,13 +424,14 @@ def parse_contract(text: str) -> Tuple[str, GoalContract]:
 # Autonomous-mode + file-goal input resolution
 # ──────────────────────────────────────────────────────────────────────
 
-# Flags that opt a goal into autonomous mode. Accepted anywhere in the arg
-# (leading or trailing) so both `/goal --auto <text>` and `/goal <text> --auto`
-# work. Only the DASHED forms are flags: bare words like "auto"/"autonomous"
-# are indistinguishable from English (e.g. "autonomous drone pipeline") and are
-# treated as ordinary goal text. The config default / GOAL_AUTONOMOUS env cover
-# hands-free use without an explicit flag.
-_AUTONOMOUS_FLAGS = {"--auto", "--autonomous"}
+# Autonomous-mode switches. The DASHED forms (--auto/--autonomous) are
+# unambiguous and accepted anywhere in the argument. The BARE keywords
+# (auto/autonomous) are accepted ONLY as the leading token — a subcommand-style
+# keyword like `/goal draft ...`, matching the `/fast on` toggle feel — so
+# ordinary prose that merely contains "auto"/"autonomous" later on (e.g.
+# "ship the autonomous drone") is never silently altered.
+_AUTONOMOUS_DASH_FLAGS = {"--auto", "--autonomous"}
+_AUTONOMOUS_BARE_KEYWORDS = {"auto", "autonomous"}
 
 # Upper bound on a goal file we will read inline, so a stray huge/binary file
 # path can never flood the goal text. A real GOAL.md is a handful of KB.
@@ -459,10 +460,13 @@ def resolve_goal_input(
 
     Two additive behaviours on top of plain goal text:
 
-      * ``--auto`` / ``--autonomous`` (long form ``autonomous``) anywhere in the
-        argument opts the goal into autonomous mode and is stripped from the
-        text. ``autonomous_default`` (from config) seeds the flag when no
-        explicit switch is present.
+      * Autonomous mode: a leading bare keyword (``auto`` / ``autonomous``,
+        subcommand-style like ``/goal auto ship it``) or a ``--auto`` /
+        ``--autonomous`` flag anywhere in the argument opts the goal in and is
+        stripped from the text. A bare keyword that is NOT leading stays part of
+        the goal (so "ship the autonomous drone" is untouched).
+        ``autonomous_default`` (from config) seeds the flag when no explicit
+        switch is present.
       * If what remains is a single path-like token pointing at a readable file,
         the file's contents become the goal text (the ``GOAL.md`` pattern). A
         missing/oversized/unreadable file falls back to treating the token
@@ -476,9 +480,18 @@ def resolve_goal_input(
     autonomous = bool(autonomous_default)
 
     tokens = text.split()
+    # Bare keyword only counts as a switch when it's the LEADING token, so a
+    # subcommand-style `/goal auto ship it` or `/goal autonomous ./GOAL.md`
+    # enables autonomous mode while prose like "ship the autonomous drone" does
+    # not. The token is consumed only in the leading position.
+    if tokens and tokens[0].lower() in _AUTONOMOUS_BARE_KEYWORDS:
+        autonomous = True
+        tokens = tokens[1:]
+
+    # Dashed flags (--auto/--autonomous) are unambiguous and stripped anywhere.
     kept: List[str] = []
     for tok in tokens:
-        if tok.lower() in _AUTONOMOUS_FLAGS:
+        if tok.lower() in _AUTONOMOUS_DASH_FLAGS:
             autonomous = True
             continue
         kept.append(tok)

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -424,12 +424,9 @@ def parse_contract(text: str) -> Tuple[str, GoalContract]:
 # Autonomous-mode + file-goal input resolution
 # ──────────────────────────────────────────────────────────────────────
 
-# Autonomous-mode switches. The DASHED forms (--auto/--autonomous) are
-# unambiguous and accepted anywhere in the argument. The BARE keywords
-# (auto/autonomous) are accepted ONLY as the leading token — a subcommand-style
-# keyword like `/goal draft ...`, matching the `/fast on` toggle feel — so
-# ordinary prose that merely contains "auto"/"autonomous" later on (e.g.
-# "ship the autonomous drone") is never silently altered.
+# Autonomous-mode switches. The dashed forms (--auto/--autonomous) are
+# unambiguous and accepted anywhere in the argument. A bare keyword is accepted
+# only when it is the entire argument. It must never consume part of goal prose.
 _AUTONOMOUS_DASH_FLAGS = {"--auto", "--autonomous"}
 _AUTONOMOUS_BARE_KEYWORDS = {"auto", "autonomous"}
 
@@ -460,11 +457,11 @@ def resolve_goal_input(
 
     Two additive behaviours on top of plain goal text:
 
-      * Autonomous mode: a leading bare keyword (``auto`` / ``autonomous``,
-        subcommand-style like ``/goal auto ship it``) or a ``--auto`` /
-        ``--autonomous`` flag anywhere in the argument opts the goal in and is
-        stripped from the text. A bare keyword that is NOT leading stays part of
-        the goal (so "ship the autonomous drone" is untouched).
+      * Autonomous mode: a ``--auto`` / ``--autonomous`` flag anywhere in the
+        argument opts the goal in and is stripped from the text. For backwards
+        compatibility, a bare ``auto`` / ``autonomous`` keyword is also accepted
+        when it is the entire argument. A bare keyword in goal prose always stays
+        in the goal, including in the leading position.
         ``autonomous_default`` (from config) seeds the flag when no explicit
         switch is present.
       * If what remains is a single path-like token pointing at a readable file,
@@ -480,11 +477,9 @@ def resolve_goal_input(
     autonomous = bool(autonomous_default)
 
     tokens = text.split()
-    # Bare keyword only counts as a switch when it's the LEADING token, so a
-    # subcommand-style `/goal auto ship it` or `/goal autonomous ./GOAL.md`
-    # enables autonomous mode while prose like "ship the autonomous drone" does
-    # not. The token is consumed only in the leading position.
-    if tokens and tokens[0].lower() in _AUTONOMOUS_BARE_KEYWORDS:
+    # A bare keyword is a switch only when it is the entire argument. This keeps
+    # the old shorthand without consuming a leading word from normal goal prose.
+    if len(tokens) == 1 and tokens[0].lower() in _AUTONOMOUS_BARE_KEYWORDS:
         autonomous = True
         tokens = tokens[1:]
 

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -426,8 +426,11 @@ def parse_contract(text: str) -> Tuple[str, GoalContract]:
 
 # Flags that opt a goal into autonomous mode. Accepted anywhere in the arg
 # (leading or trailing) so both `/goal --auto <text>` and `/goal <text> --auto`
-# work. `autonomous` is the long word form of the same switch.
-_AUTONOMOUS_FLAGS = {"--auto", "--autonomous", "auto", "autonomous"}
+# work. Only the DASHED forms are flags: bare words like "auto"/"autonomous"
+# are indistinguishable from English (e.g. "autonomous drone pipeline") and are
+# treated as ordinary goal text. The config default / GOAL_AUTONOMOUS env cover
+# hands-free use without an explicit flag.
+_AUTONOMOUS_FLAGS = {"--auto", "--autonomous"}
 
 # Upper bound on a goal file we will read inline, so a stray huge/binary file
 # path can never flood the goal text. A real GOAL.md is a handful of KB.
@@ -490,19 +493,31 @@ def resolve_goal_input(
 
 
 def _read_goal_file(token: str, *, cwd: Optional[str] = None) -> Tuple[Optional[str], str]:
-    """Read a goal file, returning (contents, note) or (None, '') on any miss."""
+    """Read a goal file, returning (contents, note).
+
+    On success returns (contents, "loaded goal from <token>"). On a miss returns
+    (None, note): when the token looked like a path but no file was found the
+    note says so (so a typo like ``GOL.md`` is diagnosable rather than silently
+    becoming the literal goal); other misses return (None, "").
+    """
     try:
         path = os.path.expanduser(token)
         if not os.path.isabs(path) and cwd:
             path = os.path.join(cwd, path)
         if not os.path.isfile(path):
-            return None, ""
+            return None, (
+                f"'{token}' looks like a file path but no such file was "
+                "found — using it as the goal text instead."
+            )
         if os.path.getsize(path) > _GOAL_FILE_MAX_BYTES:
-            return None, ""
+            return None, (
+                f"'{token}' exceeds the {_GOAL_FILE_MAX_BYTES // 1024} KB goal-"
+                "file cap — using it as the goal text instead."
+            )
         with open(path, "r", encoding="utf-8", errors="replace") as fh:
             contents = fh.read().strip()
         if not contents:
-            return None, ""
+            return None, f"'{token}' is empty — using it as the goal text instead."
         return contents, f"loaded goal from {token}"
     except Exception:  # never raise into the command handler
         return None, ""

--- a/tests/hermes_cli/test_goal_autonomous_pr0.py
+++ b/tests/hermes_cli/test_goal_autonomous_pr0.py
@@ -44,24 +44,33 @@ class TestResolveGoalInputFlags:
         assert text == "ship the widget"
         assert autonomous is True
 
-    def test_long_autonomous_flag_word(self):
+    def test_leading_bare_keyword_auto_enables(self):
+        # Subcommand-style: `/goal auto ship it` enables autonomous mode and
+        # consumes the leading keyword (like `/goal draft ...`).
         from hermes_cli.goals import resolve_goal_input
 
-        text, autonomous, _ = resolve_goal_input("--autonomous do the thing")
+        text, autonomous, _ = resolve_goal_input("auto ship the widget")
+        assert text == "ship the widget"
+        assert autonomous is True
+
+    def test_leading_bare_keyword_autonomous_enables(self):
+        from hermes_cli.goals import resolve_goal_input
+
+        text, autonomous, _ = resolve_goal_input("autonomous do the thing")
         assert text == "do the thing"
         assert autonomous is True
 
-    def test_bare_word_autonomous_is_NOT_a_flag(self):
-        # Regression: bare "autonomous"/"auto" are English, not flags — a goal
-        # like "autonomous drone pipeline" must keep its first word and stay
-        # non-autonomous. Only the dashed forms toggle the mode.
+    def test_non_leading_bare_autonomous_is_NOT_a_switch(self):
+        # Regression: a bare keyword that is not the leading token stays part of
+        # the goal — "ship the autonomous drone" keeps every word and is not
+        # autonomous. Only a LEADING bare keyword (or a dashed flag) toggles.
         from hermes_cli.goals import resolve_goal_input
 
-        text, autonomous, _ = resolve_goal_input("autonomous drone pipeline")
-        assert text == "autonomous drone pipeline"
+        text, autonomous, _ = resolve_goal_input("ship the autonomous drone")
+        assert text == "ship the autonomous drone"
         assert autonomous is False
 
-    def test_bare_word_auto_trailing_is_NOT_a_flag(self):
+    def test_non_leading_bare_auto_trailing_is_NOT_a_switch(self):
         from hermes_cli.goals import resolve_goal_input
 
         text, autonomous, _ = resolve_goal_input("wire the relay to auto")
@@ -119,6 +128,18 @@ class TestResolveGoalInputFile:
             "--auto GOAL.md", cwd=str(tmp_path)
         )
         assert text == "autonomous file goal"
+        assert autonomous is True
+        assert "loaded goal from" in note
+
+    def test_leading_keyword_plus_file_loads_and_sets_autonomous(self, tmp_path):
+        # The user-facing combined form: `/goal auto ./GOAL.md`.
+        from hermes_cli.goals import resolve_goal_input
+
+        (tmp_path / "GOAL.md").write_text("keyword file goal")
+        text, autonomous, note = resolve_goal_input(
+            "auto GOAL.md", cwd=str(tmp_path)
+        )
+        assert text == "keyword file goal"
         assert autonomous is True
         assert "loaded goal from" in note
 

--- a/tests/hermes_cli/test_goal_autonomous_pr0.py
+++ b/tests/hermes_cli/test_goal_autonomous_pr0.py
@@ -51,6 +51,23 @@ class TestResolveGoalInputFlags:
         assert text == "do the thing"
         assert autonomous is True
 
+    def test_bare_word_autonomous_is_NOT_a_flag(self):
+        # Regression: bare "autonomous"/"auto" are English, not flags — a goal
+        # like "autonomous drone pipeline" must keep its first word and stay
+        # non-autonomous. Only the dashed forms toggle the mode.
+        from hermes_cli.goals import resolve_goal_input
+
+        text, autonomous, _ = resolve_goal_input("autonomous drone pipeline")
+        assert text == "autonomous drone pipeline"
+        assert autonomous is False
+
+    def test_bare_word_auto_trailing_is_NOT_a_flag(self):
+        from hermes_cli.goals import resolve_goal_input
+
+        text, autonomous, _ = resolve_goal_input("wire the relay to auto")
+        assert text == "wire the relay to auto"
+        assert autonomous is False
+
     def test_autonomous_default_seeds_flag_without_explicit_switch(self):
         from hermes_cli.goals import resolve_goal_input
 
@@ -107,13 +124,14 @@ class TestResolveGoalInputFile:
 
     def test_missing_file_path_falls_back_to_literal_text(self):
         # A path-looking token that does not resolve to a file is treated as
-        # literal goal text (fail-open, never raises).
+        # literal goal text (fail-open, never raises), and the note diagnoses
+        # the miss so a typo like GOL.md is visible rather than silent.
         from hermes_cli.goals import resolve_goal_input
 
         text, autonomous, note = resolve_goal_input("./nonexistent-goal.md")
         assert text == "./nonexistent-goal.md"
         assert autonomous is False
-        assert note == ""
+        assert "no such file" in note.lower()
 
     def test_oversized_file_is_not_loaded(self, tmp_path):
         from hermes_cli.goals import resolve_goal_input
@@ -121,9 +139,10 @@ class TestResolveGoalInputFile:
         big = tmp_path / "HUGE.md"
         big.write_text("x" * (64 * 1024 + 10))
         text, _autonomous, note = resolve_goal_input(str(big))
-        # Falls back to the literal token; the giant body is never inlined.
+        # Falls back to the literal token; the giant body is never inlined, and
+        # the note explains why (over the cap) rather than failing silently.
         assert text == str(big)
-        assert note == ""
+        assert "cap" in note.lower()
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/hermes_cli/test_goal_autonomous_pr0.py
+++ b/tests/hermes_cli/test_goal_autonomous_pr0.py
@@ -1,0 +1,198 @@
+"""Tests for PR0: /goal file-loading + autonomous mode (hermes_cli/goals.py).
+
+Covers the additive surfaces PR0 introduces on top of the native Ralph-loop
+/goal:
+  * ``resolve_goal_input`` — parses ``--auto`` / ``--autonomous`` flags and
+    loads a GOAL.md-style file when the argument is a single path token;
+  * ``GoalState.autonomous`` — persists through to_json/from_json and is
+    back-compatible with pre-PR0 state rows that lack the field;
+  * ``GoalManager.set(autonomous=...)`` — records the flag on the state.
+
+All offline; no judge calls, no network.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+# --------------------------------------------------------------------------- #
+# resolve_goal_input: flag parsing                                            #
+# --------------------------------------------------------------------------- #
+class TestResolveGoalInputFlags:
+    def test_plain_goal_is_unchanged_and_not_autonomous(self):
+        from hermes_cli.goals import resolve_goal_input
+
+        text, autonomous, note = resolve_goal_input("fix the parser")
+        assert text == "fix the parser"
+        assert autonomous is False
+        assert note == ""
+
+    def test_leading_auto_flag_sets_autonomous_and_is_stripped(self):
+        from hermes_cli.goals import resolve_goal_input
+
+        text, autonomous, _ = resolve_goal_input("--auto ship the widget")
+        assert text == "ship the widget"
+        assert autonomous is True
+
+    def test_trailing_auto_flag_also_works(self):
+        from hermes_cli.goals import resolve_goal_input
+
+        text, autonomous, _ = resolve_goal_input("ship the widget --auto")
+        assert text == "ship the widget"
+        assert autonomous is True
+
+    def test_long_autonomous_flag_word(self):
+        from hermes_cli.goals import resolve_goal_input
+
+        text, autonomous, _ = resolve_goal_input("--autonomous do the thing")
+        assert text == "do the thing"
+        assert autonomous is True
+
+    def test_autonomous_default_seeds_flag_without_explicit_switch(self):
+        from hermes_cli.goals import resolve_goal_input
+
+        text, autonomous, _ = resolve_goal_input(
+            "do the thing", autonomous_default=True
+        )
+        assert text == "do the thing"
+        assert autonomous is True
+
+    def test_colon_in_prose_goal_is_not_treated_as_a_path(self):
+        # A normal goal with an incidental colon/word must not be mistaken for
+        # a file path (guards the file heuristic's conservatism).
+        from hermes_cli.goals import resolve_goal_input
+
+        text, autonomous, note = resolve_goal_input("Fix bug: the parser")
+        assert text == "Fix bug: the parser"
+        assert autonomous is False
+        assert note == ""
+
+
+# --------------------------------------------------------------------------- #
+# resolve_goal_input: GOAL.md file loading                                    #
+# --------------------------------------------------------------------------- #
+class TestResolveGoalInputFile:
+    def test_loads_goal_from_absolute_file(self, tmp_path):
+        from hermes_cli.goals import resolve_goal_input
+
+        goal_file = tmp_path / "GOAL.md"
+        goal_file.write_text("Migrate auth to JWT\nverify: the auth suite passes\n")
+        text, autonomous, note = resolve_goal_input(str(goal_file))
+        assert "Migrate auth to JWT" in text
+        assert "verify: the auth suite passes" in text
+        assert autonomous is False
+        assert "loaded goal from" in note
+
+    def test_loads_relative_file_against_cwd(self, tmp_path):
+        from hermes_cli.goals import resolve_goal_input
+
+        (tmp_path / "GOAL.md").write_text("do the relative thing")
+        text, _autonomous, note = resolve_goal_input("GOAL.md", cwd=str(tmp_path))
+        assert text == "do the relative thing"
+        assert "loaded goal from" in note
+
+    def test_file_plus_auto_flag_loads_and_sets_autonomous(self, tmp_path):
+        from hermes_cli.goals import resolve_goal_input
+
+        (tmp_path / "GOAL.md").write_text("autonomous file goal")
+        text, autonomous, note = resolve_goal_input(
+            "--auto GOAL.md", cwd=str(tmp_path)
+        )
+        assert text == "autonomous file goal"
+        assert autonomous is True
+        assert "loaded goal from" in note
+
+    def test_missing_file_path_falls_back_to_literal_text(self):
+        # A path-looking token that does not resolve to a file is treated as
+        # literal goal text (fail-open, never raises).
+        from hermes_cli.goals import resolve_goal_input
+
+        text, autonomous, note = resolve_goal_input("./nonexistent-goal.md")
+        assert text == "./nonexistent-goal.md"
+        assert autonomous is False
+        assert note == ""
+
+    def test_oversized_file_is_not_loaded(self, tmp_path):
+        from hermes_cli.goals import resolve_goal_input
+
+        big = tmp_path / "HUGE.md"
+        big.write_text("x" * (64 * 1024 + 10))
+        text, _autonomous, note = resolve_goal_input(str(big))
+        # Falls back to the literal token; the giant body is never inlined.
+        assert text == str(big)
+        assert note == ""
+
+
+# --------------------------------------------------------------------------- #
+# GoalState.autonomous persistence + back-compat                             #
+# --------------------------------------------------------------------------- #
+class TestGoalStateAutonomous:
+    def test_autonomous_round_trips_through_json(self):
+        from hermes_cli.goals import GoalState
+
+        state = GoalState(goal="ship it", autonomous=True)
+        restored = GoalState.from_json(state.to_json())
+        assert restored.autonomous is True
+
+    def test_default_autonomous_is_false(self):
+        from hermes_cli.goals import GoalState
+
+        assert GoalState(goal="ship it").autonomous is False
+
+    def test_pre_pr0_row_without_autonomous_loads_as_false(self):
+        """A goal serialized BEFORE the autonomous field existed must load with
+        autonomous=False, not crash (back-compat, mirrors the subgoals case)."""
+        from hermes_cli.goals import GoalState
+
+        legacy = json.dumps({
+            "goal": "do a thing",
+            "status": "active",
+            "turns_used": 2,
+            "max_turns": 20,
+            "created_at": 1.0,
+            "last_turn_at": 2.0,
+            "consecutive_parse_failures": 0,
+        })
+        state = GoalState.from_json(legacy)
+        assert state.goal == "do a thing"
+        assert state.autonomous is False
+
+
+# --------------------------------------------------------------------------- #
+# GoalManager.set persists the flag                                          #
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    from pathlib import Path
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from hermes_cli import goals
+
+    goals._DB_CACHE.clear()
+    yield home
+    goals._DB_CACHE.clear()
+
+
+class TestGoalManagerSetAutonomous:
+    def test_set_records_autonomous_and_persists(self, hermes_home):
+        from hermes_cli.goals import GoalManager, load_goal
+
+        mgr = GoalManager(session_id="auto-sid")
+        state = mgr.set("ship the PR", autonomous=True)
+        assert state.autonomous is True
+        # Reloaded from the durable store, the flag survives.
+        reloaded = load_goal("auto-sid")
+        assert reloaded is not None and reloaded.autonomous is True
+
+    def test_set_defaults_to_non_autonomous(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="plain-sid")
+        state = mgr.set("ordinary goal")
+        assert state.autonomous is False

--- a/tests/hermes_cli/test_goal_autonomous_pr0.py
+++ b/tests/hermes_cli/test_goal_autonomous_pr0.py
@@ -44,21 +44,31 @@ class TestResolveGoalInputFlags:
         assert text == "ship the widget"
         assert autonomous is True
 
-    def test_leading_bare_keyword_auto_enables(self):
-        # Subcommand-style: `/goal auto ship it` enables autonomous mode and
-        # consumes the leading keyword (like `/goal draft ...`).
+    @pytest.mark.parametrize("keyword", ["auto", "autonomous"])
+    def test_bare_keyword_only_enables_when_it_is_the_entire_argument(self, keyword):
         from hermes_cli.goals import resolve_goal_input
 
-        text, autonomous, _ = resolve_goal_input("auto ship the widget")
-        assert text == "ship the widget"
+        text, autonomous, _ = resolve_goal_input(keyword)
+        assert text == ""
         assert autonomous is True
 
-    def test_leading_bare_keyword_autonomous_enables(self):
+    def test_autonomous_goal_prose_is_literal_and_non_autonomous(self):
         from hermes_cli.goals import resolve_goal_input
 
-        text, autonomous, _ = resolve_goal_input("autonomous do the thing")
-        assert text == "do the thing"
-        assert autonomous is True
+        text, autonomous, note = resolve_goal_input(
+            "autonomous drone surveillance pipeline"
+        )
+        assert text == "autonomous drone surveillance pipeline"
+        assert autonomous is False
+        assert note == ""
+
+    def test_auto_goal_prose_is_literal_and_non_autonomous(self):
+        from hermes_cli.goals import resolve_goal_input
+
+        text, autonomous, note = resolve_goal_input("auto remediation workflow")
+        assert text == "auto remediation workflow"
+        assert autonomous is False
+        assert note == ""
 
     def test_non_leading_bare_autonomous_is_NOT_a_switch(self):
         # Regression: a bare keyword that is not the leading token stays part of
@@ -131,17 +141,16 @@ class TestResolveGoalInputFile:
         assert autonomous is True
         assert "loaded goal from" in note
 
-    def test_leading_keyword_plus_file_loads_and_sets_autonomous(self, tmp_path):
-        # The user-facing combined form: `/goal auto ./GOAL.md`.
+    def test_leading_keyword_plus_file_remains_literal_goal_prose(self, tmp_path):
         from hermes_cli.goals import resolve_goal_input
 
         (tmp_path / "GOAL.md").write_text("keyword file goal")
         text, autonomous, note = resolve_goal_input(
             "auto GOAL.md", cwd=str(tmp_path)
         )
-        assert text == "keyword file goal"
-        assert autonomous is True
-        assert "loaded goal from" in note
+        assert text == "auto GOAL.md"
+        assert autonomous is False
+        assert note == ""
 
     def test_missing_file_path_falls_back_to_literal_text(self):
         # A path-looking token that does not resolve to a file is treated as


### PR DESCRIPTION
## Problem

The existing `/goal` command accepts only inline text. Repeatable goals stored in a repository must be pasted manually, and there is no persisted per goal marker for explicitly opting into later autonomous goal behavior.

## Solution

This PR extends the existing `GoalManager` and `GoalState` rather than adding a parallel goal system.

A single path shaped argument such as `/goal ./GOAL.md` loads a UTF 8 text file and passes its contents through the existing completion contract parser. Relative paths resolve from the current working directory. Missing, unreadable, empty, or oversized files produce a diagnostic where possible and fall back to treating the original token as literal goal text.

Autonomous mode can be selected with `--auto` or `--autonomous`. Those explicit dashed switches may appear in the argument and are removed before the goal text is parsed. A bare `auto` or `autonomous` is recognized only when it is the entire argument. Bare words inside prose, including a leading phrase such as `autonomous drone pipeline`, remain literal goal text.

The default comes from `goals.autonomous` in `config.yaml`, which remains false. `GOAL_AUTONOMOUS` accepts explicit true and false spellings as a session override. The resolved Boolean is persisted in `GoalState`, and older state rows without the field continue to load as nonautonomous.

## Scope and overlap

The autonomous value added here is an inert persisted marker. This PR does not add session recycling, deception checks, Council gates, decision logs, or a new completion loop. Existing plain `/goal <text>` behavior and completion contract parsing remain unchanged.

## Trust and input limits

File loading occurs only for one explicit path shaped token after switch parsing. Goal files are capped at 64 KiB to prevent an accidental large or binary file from flooding the goal context. Decode errors use replacement characters, file errors do not escape the command handler, and a miss remains visible as literal goal text rather than discarding the user's input.

The autonomous marker changes no execution or approval behavior in this PR. It records intent for consumers which may be added separately.

## Validation

The current focused rerun passed all cases in `tests/hermes_cli/test_goal_autonomous_pr0.py`: `22 passed`.

Coverage includes plain goal compatibility, dashed switch parsing, bare prose collisions, file loading and completion contracts, missing and oversized files, configuration and environment precedence, persisted state round trips, and compatibility with old rows.