### PR TITLE
feat(wisdom): add trusted publish and install foundation

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -67,6 +67,12 @@ ORG_PROVENANCE_FILE = ".org-provenance.json"
 # later local edit is detectable and an org pull can refuse to clobber it.
 ORG_BASELINE_FILE = ".org-baseline.json"
 
+# Collective Wisdom managed installs are intentionally separate from the M2
+# whole-org mirror. The only writer of this marker is the Wisdom setup/client
+# path after the Gateway has accepted the profile's installation identity.
+WISDOM_MANAGED_DIR_NAME = "_wisdom"
+WISDOM_ACTIVE_MARKER = ".active_org"
+
 
 def read_active_org_id(skills_dir: Path) -> Optional[str]:
     """The org id whose mirror may resolve, or None (no org skills load)."""
@@ -78,6 +84,27 @@ def read_active_org_id(skills_dir: Path) -> Optional[str]:
         return val or None
     except OSError:
         return None
+
+
+def read_active_wisdom_org_id(skills_dir: Path) -> Optional[str]:
+    """The last Gateway-verified org whose managed Wisdom skills may load."""
+    try:
+        marker = skills_dir / WISDOM_MANAGED_DIR_NAME / WISDOM_ACTIVE_MARKER
+        if not marker.exists():
+            return None
+        value = marker.read_text(encoding="utf-8").strip()
+        return value or None
+    except OSError:
+        return None
+
+
+def is_wisdom_managed_path(path, skills_dir: Path) -> bool:
+    """True when *path* is below ``_wisdom/<org-id>/``."""
+    try:
+        rel = Path(path).resolve().relative_to(Path(skills_dir).resolve())
+    except (OSError, ValueError):
+        return False
+    return bool(rel.parts) and rel.parts[0] == WISDOM_MANAGED_DIR_NAME
 
 
 def is_org_mirror_path(path, skills_dir: Path) -> bool:
@@ -1198,7 +1225,8 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
     ``SKILL.md`` files, but they are progressive-disclosure data loaded through
     ``skill_view(..., file_path=...)`` rather than active skill roots.
 
-    M2 org mirrors (``_org/``): TOKEN-GATED resolution. Only the active org's
+    M2 org mirrors (``_org/``) and Collective Wisdom installs
+    (``_wisdom/``): TOKEN-GATED resolution. Only the active org's
     subdir (per the sync-client-written ``.active_org`` marker) is walked;
     every other ``_org/<id>/`` (stale mirror from a previous org, or no
     marker at all) is pruned — leave an org and its skills stop resolving,
@@ -1206,15 +1234,22 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
     """
     skills_dir_str = str(skills_dir)
     active_org = read_active_org_id(skills_dir)
+    active_wisdom_org = read_active_wisdom_org_id(skills_dir)
     org_root = os.path.join(skills_dir_str, ORG_MIRROR_DIR_NAME)
+    wisdom_root = os.path.join(skills_dir_str, WISDOM_MANAGED_DIR_NAME)
     matches: list[str] = []
     for root, dirs, files in os.walk(skills_dir_str, followlinks=True):
         has_skill_md = "SKILL.md" in files
         if root == skills_dir_str and ORG_MIRROR_DIR_NAME in dirs and active_org is None:
             dirs.remove(ORG_MIRROR_DIR_NAME)
+        if root == skills_dir_str and WISDOM_MANAGED_DIR_NAME in dirs and active_wisdom_org is None:
+            dirs.remove(WISDOM_MANAGED_DIR_NAME)
         elif root == org_root:
             # Inside _org/: descend ONLY into the active org's mirror.
             dirs[:] = [d for d in dirs if d == active_org]
+        elif root == wisdom_root:
+            # Inside _wisdom/: descend ONLY into the last Gateway-verified org.
+            dirs[:] = [d for d in dirs if d == active_wisdom_org]
         dirs[:] = [
             d
             for d in dirs

--- a/docs/COLLECTIVE_WISDOM_AGENT_REQUIREMENTS.md
+++ b/docs/COLLECTIVE_WISDOM_AGENT_REQUIREMENTS.md
@@ -1,0 +1,30 @@
+# Collective Wisdom Agent requirements ledger
+
+This ledger implements the Agent-owned portion of the canonical design in
+[Gateway PR #215](https://github.com/NousResearch/gateway-gateway/pull/215) at
+`ee7b6123a08ef2379ef1641ed8e6defa10329eaa`. The wire contract is Gateway PR
+#213 at `391bf7077c0dee5ca3b818ceff61c31cf14f3efd`; `hermes_wisdom/contract.py`
+pins its OpenAPI, package-manifest schema, and canonical-vector digests.
+
+Local usage, refinement, qualification, ranking, stability, and dismissal
+signals are device-private. They are never part of a Gateway request, log,
+stored row, audit event, Portal response, or publication consent artifact.
+
+| Requirement area | Owning PR | Implementation | Verification | Status / dependency |
+| --- | --- | --- | --- | --- |
+| Profile setup, disclosure, SQLite migrations, installation identity | foundation | `hermes_wisdom/store.py`, `service.py` | `tests/wisdom/test_store.py`, `test_service.py` | complete in foundation |
+| Instruction-only overlay and declarative System Specification | foundation | `hermes_wisdom/package.py`, `contract.py` | `tests/wisdom/test_package.py` | complete; no dependency execution |
+| Canonical content, author-copy, and manifest hashes | foundation | `contract.py`, pinned fixtures | `scripts/verify_wisdom_contract.py`, `test_contract.py` | complete; three-hash consent |
+| Built-in guard plus NVIDIA SkillEvaluator advisory | foundation | `service.py`, existing `tools/skillevaluator_scan.py` | `test_service.py` | complete; advisory is not compatibility or ranking |
+| Owner-private submission, exact server review, receipt, publish recovery | foundation | `client.py`, `service.py` | `test_client.py`, `test_service.py` | complete; Gateway remains authority |
+| Explicit managed install and four deterministic local outcomes | foundation | `compatibility.py`, `service.py` | `test_compatibility.py`, `test_service.py` | complete; local inventory is never uploaded |
+| CLI and natural-language plan/apply install | foundation | `hermes_cli/subcommands/wisdom.py`, built-in skill | `test_cli.py`, `tests/skills` | complete in foundation |
+| Continuous local qualification and durable candidate event | contribution loop | local qualification/event modules | contribution tests | partial until stacked PR 2 |
+| In-chat promotion card and dashboard/native candidate UI | contribution loop | local API and client renderers | web/desktop visual E2E | partial until stacked PR 2 |
+| Update modes, required forks, feed, cadence, Telegram, uninstall | consumption | update/feed modules | failure-injection and feed suites | partial until stacked PR 3 |
+| Completed discovery/detail/install/update dashboard/native UX | consumption | web and desktop capability surfaces | accessibility and visual E2E | partial until stacked PR 3 |
+| Two-identity same-org and negative cross-org live E2E | cross-repo rollout | Agent + Gateway + Portal | live dogfood harness | blocked on deployed pinned stack and sign-off |
+
+The Gateway verifies both the exact `wisdom:*` permission and the signed NAS
+admin containment claim during dogfood. Token claims decoded by Hermes are
+display hints only and never local authorization authority.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2180,6 +2180,20 @@ DEFAULT_CONFIG = {
         "ledger": True,
     },
 
+    # Collective Wisdom — local qualification plus owner-consented sharing.
+    # The sync.base_url transport and existing Nous OAuth token are reused;
+    # no Gateway secret or URL is exposed to renderer clients.
+    "wisdom": {
+        "enabled": False,
+        "portal_url": "https://portal.nousresearch.com",
+        "request_timeout": 30,
+        "notifications": {
+            "decisions": "immediate",
+            "installed_updates": "immediate",
+            "new_skills": "daily",
+        },
+    },
+
     # Curator — background skill maintenance.
     #
     # Periodically reviews AGENT-CREATED skills (never bundled or

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -442,6 +442,7 @@ import functools as _functools
 from hermes_cli.subcommands._shared import add_accept_hooks_flag as _add_accept_hooks_flag
 from hermes_cli.subcommands.cron import build_cron_parser
 from hermes_cli.subcommands.sync import build_sync_parser
+from hermes_cli.subcommands.wisdom import build_wisdom_parser
 from hermes_cli.subcommands.gateway import build_gateway_parser
 from hermes_cli.subcommands.profile import build_profile_parser
 from hermes_cli.subcommands.model import build_model_parser
@@ -13033,6 +13034,7 @@ def main():
     # =========================================================================
     build_cron_parser(subparsers, cmd_cron=cmd_cron)
     build_sync_parser(subparsers, cmd_sync=cmd_sync)
+    build_wisdom_parser(subparsers)
 
     # =========================================================================
     # webhook command  (parser built in hermes_cli/subcommands/webhook.py)

--- a/hermes_cli/subcommands/wisdom.py
+++ b/hermes_cli/subcommands/wisdom.py
@@ -1,0 +1,185 @@
+"""`hermes wisdom` command surface."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any, Callable
+
+
+def _emit(value: Any, *, as_json: bool) -> None:
+    if as_json:
+        print(
+            json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False, default=str)
+        )
+    elif isinstance(value, (dict, list)):
+        print(json.dumps(value, indent=2, ensure_ascii=False, default=str))
+    else:
+        print(value)
+
+
+def cmd_wisdom(args: argparse.Namespace) -> int:
+    from hermes_wisdom.client import WisdomError
+    from hermes_wisdom.package import PackagePolicyError
+    from hermes_wisdom.service import WisdomService
+
+    service = WisdomService()
+    command = getattr(args, "wisdom_command", None)
+    try:
+        if command == "setup":
+            result = service.setup()
+        elif command == "status":
+            result = service.status()
+        elif command == "scan":
+            result = service.scan(getattr(args, "skill", None))
+        elif command == "suggest":
+            result = service.suggest(
+                getattr(args, "skill", None),
+                description=getattr(args, "description", None),
+                allow_private_secret_review=getattr(
+                    args, "private_secret_override", False
+                ),
+            )
+        elif command == "candidates":
+            result = {"candidates": service.scan_candidates()}
+        elif command == "review":
+            if not args.portal and not args.acknowledge and not sys.stdin.isatty():
+                raise PackagePolicyError(
+                    "noninteractive review cannot create consent; use --portal or an interactive --acknowledge"
+                )
+            acknowledge = bool(args.acknowledge)
+            if not args.portal and not acknowledge:
+                preview = service.review(args.draft_id, acknowledge=False)
+                _emit(preview, as_json=args.json)
+                answer = input(
+                    "Review every raw file and the three hashes above. Record consent receipt? [y/N] "
+                )
+                if answer.strip().lower() not in {"y", "yes"}:
+                    return 7
+                acknowledge = True
+            result = service.review(
+                args.draft_id, acknowledge=acknowledge, portal=args.portal
+            )
+        elif command == "approve":
+            result = service.approve(args.draft_id)
+        elif command == "decline":
+            result = service.decline(args.draft_id)
+        elif command == "list":
+            result = service.list_skills()
+        elif command == "show":
+            result = service.show(args.skill_id)
+        elif command == "versions":
+            result = {"versions": service.versions(args.skill_id)}
+        elif command == "install":
+            if args.apply_receipt:
+                result = service.install_apply(
+                    args.apply_receipt, accept_partial=args.accept_partial
+                )
+            else:
+                plan = service.install_plan(
+                    args.reference, update_mode=args.update_mode
+                )
+                if args.plan or args.json:
+                    result = plan
+                else:
+                    _emit(plan, as_json=False)
+                    if not sys.stdin.isatty():
+                        raise PackagePolicyError(
+                            "noninteractive install requires --plan then --apply-receipt"
+                        )
+                    answer = input("Apply this authenticated install plan? [y/N] ")
+                    if answer.strip().lower() not in {"y", "yes"}:
+                        return 7
+                    result = service.install_apply(
+                        plan["receipt"], accept_partial=args.accept_partial
+                    )
+        else:
+            args._wisdom_parser.print_help()
+            return 2
+        _emit(result, as_json=bool(getattr(args, "json", False)))
+        return 0
+    except WisdomError as exc:
+        _emit(
+            {"ok": False, "error": str(exc), "category": exc.exit_code},
+            as_json=bool(getattr(args, "json", False)),
+        )
+        return exc.exit_code
+    except PackagePolicyError as exc:
+        _emit(
+            {"ok": False, "error": str(exc), "category": 6},
+            as_json=bool(getattr(args, "json", False)),
+        )
+        return 6
+    except KeyboardInterrupt:
+        return 7
+
+
+def build_wisdom_parser(subparsers) -> None:
+    parser = subparsers.add_parser(
+        "wisdom",
+        help="Collective Wisdom — review, share, and install team skills",
+        description=(
+            "Local qualification stays on this device. Publication uploads only an owner-private "
+            "instruction package and requires a complete, hash-bound owner review."
+        ),
+    )
+    parser.set_defaults(func=cmd_wisdom, _wisdom_parser=parser)
+    commands = parser.add_subparsers(dest="wisdom_command")
+
+    def add(name: str, help_text: str) -> argparse.ArgumentParser:
+        command = commands.add_parser(name, help=help_text)
+        command.add_argument(
+            "--json", action="store_true", help="Emit stable machine-readable JSON"
+        )
+        return command
+
+    add("setup", "Validate entitlement and initialize this profile")
+    add("status", "Show local and Gateway Wisdom status")
+    scan = add("scan", "Run local policy and advisory scans")
+    scan.add_argument("skill", nargs="?")
+    suggest = add("suggest", "Browse candidates or submit an owner-private draft")
+    suggest.add_argument("skill", nargs="?")
+    suggest.add_argument("--description", help="Owner-edited outcome description")
+    suggest.add_argument(
+        "--send-for-owner-only-server-review",
+        dest="private_secret_override",
+        action="store_true",
+        help="Explicitly override a high-confidence local secret pause for owner-private review",
+    )
+    add("candidates", "List all manually selectable local candidates")
+    review = add("review", "Review exact server draft bytes and hashes")
+    review.add_argument("draft_id")
+    review.add_argument(
+        "--portal", action="store_true", help="Open the authenticated Portal review"
+    )
+    review.add_argument(
+        "--acknowledge",
+        action="store_true",
+        help="Record a receipt after complete review",
+    )
+    approve = add("approve", "Approve a freshly reviewed draft and publish")
+    approve.add_argument("draft_id")
+    decline = add("decline", "Decline an owner-private draft")
+    decline.add_argument("draft_id")
+    add("list", "List published Collective Wisdom skills")
+    show = add("show", "Show one published skill")
+    show.add_argument("skill_id")
+    versions = add("versions", "List published versions")
+    versions.add_argument("skill_id")
+    install = add("install", "Plan or apply an authenticated managed install")
+    install.add_argument("reference", nargs="?", default="")
+    install.add_argument(
+        "--plan", action="store_true", help="Create a plan receipt without applying"
+    )
+    install.add_argument(
+        "--apply-receipt", help="Apply a previously reviewed plan receipt"
+    )
+    install.add_argument(
+        "--accept-partial",
+        action="store_true",
+        help="Accept partial/setup-required compatibility",
+    )
+    install.add_argument(
+        "--update-mode", choices=["MANUAL", "AUTO_WITH_NOTICE", "REQUIRED"]
+    )

--- a/hermes_wisdom/__init__.py
+++ b/hermes_wisdom/__init__.py
@@ -1,0 +1,5 @@
+"""Hermes Collective Wisdom local plane and Gateway client."""
+
+from .contract import CONTRACT_PIN
+
+__all__ = ["CONTRACT_PIN"]

--- a/hermes_wisdom/client.py
+++ b/hermes_wisdom/client.py
@@ -1,0 +1,501 @@
+"""Bounded, schema-validated Gateway client for Collective Wisdom."""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import quote
+
+import requests
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from tools.skills_sync_client import (
+    KIND_BLOB,
+    KIND_COMMIT,
+    KIND_TREE,
+    ObjectSet,
+    SyncClient,
+)
+from tools.skills_sync_client import (
+    resolve_identity,
+    resolve_sync_base_url,
+    wire_address,
+)
+
+from .contract import ContentFile, PackageManifest, SystemSpecification
+from .package import PackagePolicyError, verify_content_files
+
+logger = logging.getLogger(__name__)
+
+
+class WisdomError(RuntimeError):
+    exit_code = 8
+
+    def __init__(
+        self, message: str, *, status: int | None = None, code: str | None = None
+    ):
+        super().__init__(message)
+        self.status = status
+        self.code = code
+
+
+class WisdomAuthError(WisdomError):
+    exit_code = 3
+
+
+class WisdomNotFound(WisdomError):
+    exit_code = 4
+
+
+class WisdomConflict(WisdomError):
+    exit_code = 5
+
+
+class WisdomValidationError(WisdomError):
+    exit_code = 6
+
+
+class WireModel(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
+class Draft(WireModel):
+    id: str
+    orgId: str
+    ownerUserId: str
+    slug: str
+    draftCommit: str
+    contentHash: str
+    authorDescription: str | None
+    authorDescriptionHash: str | None
+    state: str
+    packageManifestHash: str | None
+    packageManifestSchemaVersion: int | None
+    systemSpec: SystemSpecification | None
+    scan: dict[str, Any] | None
+    scanVerdict: str | None
+    explanation: str | None
+    updatedAt: str
+
+
+class DraftDetail(WireModel):
+    draft: Draft
+    effective_policy: dict[str, Any]
+
+
+class DraftResponse(WireModel):
+    draft: Draft
+
+
+class DraftList(WireModel):
+    drafts: list[Draft]
+
+
+class SkillSummary(WireModel):
+    id: str
+    slug: str
+    state: str
+    created_by_user_id: str
+    latest_version: int | None
+    author_description: str | None
+    verified_facts: dict[str, Any] | None
+    explanation: str | None
+    install_count: int
+    takedown_generation: int
+    system_spec: SystemSpecification | None
+
+
+class SkillList(WireModel):
+    skills: list[SkillSummary]
+    next_cursor: str | None
+
+
+class SkillDetail(WireModel):
+    skill: dict[str, Any]
+    versions: list[dict[str, Any]]
+
+
+class VersionDetail(WireModel):
+    skill: dict[str, Any]
+    version: dict[str, Any]
+
+
+class VersionContent(WireModel):
+    commit: str
+    content_hash: str
+    files: list[dict[str, Any]]
+
+
+class InstallationRecord(WireModel):
+    installed_version: int
+    effective_update_mode: str
+
+
+class Feed(WireModel):
+    events: list[dict[str, Any]]
+    next_cursor: str
+    has_more: bool
+
+
+@dataclass(frozen=True)
+class ReconstructedDraft:
+    detail: DraftDetail
+    files: list[tuple[str, str, bytes]]
+    content_files: list[ContentFile]
+    content_hash: str
+
+
+def _walk_private_commit(
+    sync: SyncClient, commit_hash: str
+) -> list[tuple[str, str, bytes]]:
+    kind, body = sync.get_object(commit_hash)
+    if wire_address(body) != commit_hash or kind != KIND_COMMIT:
+        raise WisdomValidationError(
+            "owner-private draft commit failed integrity validation"
+        )
+    try:
+        commit = json.loads(body.decode("utf-8"))
+        tree_hash = str(commit["tree"])
+    except (
+        KeyError,
+        TypeError,
+        ValueError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+    ) as exc:
+        raise WisdomValidationError("owner-private draft commit is malformed") from exc
+    out: list[tuple[str, str, bytes]] = []
+    seen_nodes: set[tuple[str, str]] = set()
+
+    def walk(tree: str, prefix: str) -> None:
+        node_key = (tree, prefix)
+        if node_key in seen_nodes:
+            raise WisdomValidationError("owner-private draft contains a tree cycle")
+        seen_nodes.add(node_key)
+        node_kind, node_body = sync.get_object(tree)
+        if node_kind != KIND_TREE or wire_address(node_body) != tree:
+            raise WisdomValidationError(
+                "owner-private draft tree failed integrity validation"
+            )
+        try:
+            parsed = json.loads(node_body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise WisdomValidationError(
+                "owner-private draft tree is malformed"
+            ) from exc
+        entries = parsed.get("entries")
+        if not isinstance(entries, list):
+            raise WisdomValidationError("owner-private draft tree has no entries")
+        for entry in entries:
+            if not isinstance(entry, dict):
+                raise WisdomValidationError(
+                    "owner-private draft tree entry is malformed"
+                )
+            name = entry.get("name")
+            address = entry.get("hash")
+            entry_kind = entry.get("kind")
+            if not isinstance(name, str) or not isinstance(address, str):
+                raise WisdomValidationError(
+                    "owner-private draft tree entry is malformed"
+                )
+            path = f"{prefix}{name}"
+            if entry_kind == KIND_TREE:
+                walk(address, path + "/")
+            elif entry_kind == KIND_BLOB:
+                blob_kind, blob = sync.get_object(address)
+                if blob_kind != KIND_BLOB or wire_address(blob) != address:
+                    raise WisdomValidationError(
+                        f"draft blob failed integrity validation: {path}"
+                    )
+                out.append((
+                    path,
+                    "exec" if entry.get("mode") == "exec" else "file",
+                    blob,
+                ))
+            else:
+                raise WisdomValidationError(f"unsupported draft object kind at {path}")
+
+    walk(tree_hash, "")
+    return out
+
+
+class WisdomClient:
+    def __init__(self, *, timeout: float = 30.0) -> None:
+        identity = resolve_identity()
+        base = resolve_sync_base_url()
+        if not base:
+            raise WisdomAuthError("Collective Wisdom Gateway is not configured")
+        self.identity = identity
+        self.base = base.rstrip("/")
+        self.timeout = timeout
+        self.session = requests.Session()
+        self.session.headers.update({
+            "Authorization": f"Bearer {identity['api_key']}",
+            "Accept": "application/json",
+        })
+        self.sync = SyncClient(self.base, identity["api_key"], timeout=timeout)
+
+    @property
+    def display_scopes(self) -> tuple[str, ...]:
+        scopes = self.identity.get("claims", {}).get("wisdom_scopes")
+        return (
+            tuple(item for item in scopes if isinstance(item, str))
+            if isinstance(scopes, list)
+            else ()
+        )
+
+    @property
+    def display_org_id(self) -> str | None:
+        claims = self.identity.get("claims", {})
+        value = claims.get("org_id") or claims.get("orgId")
+        return str(value) if value else None
+
+    def _url(self, path: str) -> str:
+        return f"{self.base}/v1/sync/wisdom/{path.lstrip('/')}"
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        model: type[BaseModel] | None = None,
+        json_body: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        try:
+            response = self.session.request(
+                method,
+                self._url(path),
+                json=json_body,
+                params=params,
+                timeout=self.timeout,
+            )
+        except requests.Timeout as exc:
+            raise WisdomError("Collective Wisdom Gateway timed out") from exc
+        except requests.RequestException as exc:
+            raise WisdomError("Collective Wisdom Gateway is unavailable") from exc
+        body: Any = None
+        if response.content:
+            try:
+                body = response.json()
+            except ValueError as exc:
+                raise WisdomError(
+                    "Collective Wisdom Gateway returned a malformed response"
+                ) from exc
+        code = body.get("error") if isinstance(body, dict) else None
+        if response.status_code in (401, 403):
+            raise WisdomAuthError(
+                "Collective Wisdom is unavailable for this account",
+                status=response.status_code,
+                code=code,
+            )
+        if response.status_code == 404:
+            raise WisdomNotFound(
+                "Collective Wisdom item not found", status=404, code=code
+            )
+        if response.status_code == 409:
+            raise WisdomConflict(
+                str(code or "Collective Wisdom state changed; refresh and retry"),
+                status=409,
+                code=code,
+            )
+        if response.status_code == 422:
+            raise WisdomValidationError(
+                str(code or "Collective Wisdom rejected invalid content"),
+                status=422,
+                code=code,
+            )
+        if response.status_code < 200 or response.status_code >= 300:
+            raise WisdomError(
+                f"Collective Wisdom Gateway failed ({response.status_code})",
+                status=response.status_code,
+                code=code,
+            )
+        if model is None:
+            return body
+        try:
+            return model.model_validate(body)
+        except ValidationError as exc:
+            raise WisdomError(
+                "Collective Wisdom Gateway response failed schema validation"
+            ) from exc
+
+    def capability(self) -> dict[str, Any]:
+        try:
+            response = self.session.get(
+                f"{self.base}/v1/sync/capabilities", timeout=self.timeout
+            )
+            response.raise_for_status()
+            body = response.json()
+        except (requests.RequestException, ValueError) as exc:
+            raise WisdomError("Gateway capabilities are unavailable") from exc
+        if "wisdom" not in (body.get("capabilities") or []):
+            raise WisdomAuthError("Gateway does not advertise Collective Wisdom")
+        return body
+
+    def register_identity(self, installation_id: str) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            "installation-identities",
+            json_body={"installation_id": installation_id},
+        )
+
+    def upload_private_objects(self, objects: ObjectSet) -> None:
+        self.sync.put_objects(objects.objects)
+
+    def submit_draft(
+        self, *, slug: str, commit: str, content_hash: str, description: str
+    ) -> Draft:
+        body = self._request(
+            "POST",
+            "drafts",
+            model=DraftResponse,
+            json_body={
+                "slug": slug,
+                "draft_commit": commit,
+                "content_hash": content_hash,
+                "author_description": description,
+            },
+        )
+        return body.draft
+
+    def list_drafts(self) -> list[Draft]:
+        return self._request("GET", "drafts", model=DraftList).drafts
+
+    def draft(self, draft_id: str) -> DraftDetail:
+        return self._request(
+            "GET", f"drafts/{quote(draft_id, safe='')}", model=DraftDetail
+        )
+
+    def reconstruct_draft(self, draft_id: str) -> ReconstructedDraft:
+        detail = self.draft(draft_id)
+        files = _walk_private_commit(self.sync, detail.draft.draftCommit)
+        records, content_hash = verify_content_files(files)
+        if content_hash != detail.draft.contentHash:
+            raise WisdomValidationError(
+                "server draft content does not match its authoritative hash"
+            )
+        return ReconstructedDraft(
+            detail=detail, files=files, content_files=records, content_hash=content_hash
+        )
+
+    def approve(
+        self,
+        draft_id: str,
+        *,
+        content_hash: str,
+        description_hash: str,
+        manifest_hash: str,
+    ) -> Draft:
+        body = self._request(
+            "POST",
+            f"drafts/{quote(draft_id, safe='')}/approve",
+            json_body={
+                "content_hash": content_hash,
+                "author_description_hash": description_hash,
+                "package_manifest_hash": manifest_hash,
+            },
+        )
+        return Draft.model_validate(body.get("draft", body))
+
+    def publish(self, draft_id: str, *, content_hash: str) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            f"drafts/{quote(draft_id, safe='')}/publish",
+            json_body={"content_hash": content_hash, "base_commit": None},
+        )
+
+    def decline(self, draft_id: str) -> dict[str, Any]:
+        return self._request("POST", f"drafts/{quote(draft_id, safe='')}/decline")
+
+    def list_skills(self, *, cursor: str | None = None) -> SkillList:
+        return self._request(
+            "GET",
+            "skills",
+            model=SkillList,
+            params={"cursor": cursor} if cursor else None,
+        )
+
+    def skill(self, skill_id: str) -> SkillDetail:
+        return self._request(
+            "GET", f"skills/{quote(skill_id, safe='')}", model=SkillDetail
+        )
+
+    def version(self, skill_id: str, version: int) -> VersionDetail:
+        return self._request(
+            "GET",
+            f"skills/{quote(skill_id, safe='')}/versions/{version}",
+            model=VersionDetail,
+        )
+
+    def content(
+        self, skill_id: str, version: int
+    ) -> tuple[VersionContent, list[tuple[str, str, bytes]]]:
+        response = self._request(
+            "GET",
+            f"skills/{quote(skill_id, safe='')}/versions/{version}/content",
+            model=VersionContent,
+        )
+        decoded: list[tuple[str, str, bytes]] = []
+        for item in response.files:
+            try:
+                raw = base64.b64decode(item["content_base64"], validate=True)
+            except (KeyError, TypeError, ValueError) as exc:
+                raise WisdomValidationError(
+                    "version content contains malformed base64"
+                ) from exc
+            if wire_address(raw) != item.get("hash"):
+                raise WisdomValidationError(
+                    f"version blob failed integrity validation: {item.get('path', '?')}"
+                )
+            decoded.append((str(item["path"]), str(item["mode"]), raw))
+        records, derived = verify_content_files(decoded)
+        if derived != response.content_hash:
+            raise WisdomValidationError(
+                "version content hash failed integrity validation"
+            )
+        manifest_body = next(
+            (body for path, _, body in decoded if path == "skill.manifest.json"), None
+        )
+        if manifest_body is None:
+            raise WisdomValidationError("version content has no package manifest")
+        try:
+            PackageManifest.model_validate_json(manifest_body)
+        except ValidationError as exc:
+            raise WisdomValidationError("version package manifest is invalid") from exc
+        return response, decoded
+
+    def record_install(
+        self,
+        *,
+        skill_id: str,
+        installation_id: str,
+        version: int,
+        takedown_generation: int,
+        update_mode: str | None,
+    ) -> InstallationRecord:
+        payload: dict[str, Any] = {
+            "skill_id": skill_id,
+            "installation_id": installation_id,
+            "version": version,
+            "takedown_generation": takedown_generation,
+        }
+        if update_mode:
+            payload["update_mode"] = update_mode
+        return self._request(
+            "POST", "installations", model=InstallationRecord, json_body=payload
+        )
+
+    def installations(self, installation_id: str) -> list[dict[str, Any]]:
+        result = self._request(
+            "GET", "installations", params={"installation_id": installation_id}
+        )
+        return list((result or {}).get("installations") or [])
+
+    def feed(self, cursor: str | None = None) -> Feed:
+        return self._request(
+            "GET", "feed", model=Feed, params={"cursor": cursor} if cursor else None
+        )

--- a/hermes_wisdom/compatibility.py
+++ b/hermes_wisdom/compatibility.py
@@ -1,0 +1,137 @@
+"""Deterministic local compatibility evaluation for Wisdom packages."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import platform
+import shutil
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from packaging.version import InvalidVersion, Version
+
+from hermes_cli import __version__ as HERMES_VERSION
+
+from .contract import SystemSpecification
+
+
+CompatibilityOutcome = Literal[
+    "compatible", "compatible_after_setup", "partial", "blocked_pending_action"
+]
+
+
+@dataclass(frozen=True)
+class LocalCapabilities:
+    hermes_version: str
+    os: str
+    architecture: str
+    model_capabilities: frozenset[str] = frozenset()
+    context_window: int | None = None
+    enabled_tools: dict[str, str | None] = field(default_factory=dict)
+    plugins: dict[str, str | None] = field(default_factory=dict)
+    credentials: frozenset[str] = frozenset()
+    connections: frozenset[str] = frozenset()
+    runtime: dict[str, bool] = field(default_factory=dict)
+    hardware: frozenset[str] = frozenset()
+    is_admin: bool = False
+
+
+@dataclass(frozen=True)
+class CompatibilityResult:
+    outcome: CompatibilityOutcome
+    satisfied: tuple[str, ...]
+    setup_actions: tuple[str, ...]
+    limitations: tuple[str, ...]
+    blocked: tuple[str, ...]
+
+
+def detect_local_capabilities() -> LocalCapabilities:
+    runtime = {
+        "shell": shutil.which("sh") is not None or platform.system() == "Windows",
+        "browser": False,
+        "code": True,
+        "sandbox": True,
+    }
+    return LocalCapabilities(
+        hermes_version=HERMES_VERSION,
+        os=platform.system().lower(),
+        architecture=platform.machine().lower(),
+        runtime=runtime,
+    )
+
+
+def _version_at_least(actual: str | None, minimum: str | None) -> bool:
+    if minimum is None:
+        return actual is not None
+    if actual is None:
+        return False
+    try:
+        return Version(actual) >= Version(minimum)
+    except InvalidVersion:
+        return actual == minimum
+
+
+def evaluate(
+    spec: SystemSpecification, local: LocalCapabilities
+) -> CompatibilityResult:
+    satisfied: list[str] = []
+    setup: list[str] = []
+    partial: list[str] = list(spec.known_limitations)
+    blocked: list[str] = []
+    if _version_at_least(local.hermes_version, spec.hermes.minimum_version):
+        satisfied.append(f"Hermes >= {spec.hermes.minimum_version}")
+    else:
+        blocked.append(f"Hermes >= {spec.hermes.minimum_version}")
+    if spec.platforms and local.os not in {item.lower() for item in spec.platforms}:
+        blocked.append(f"platform in {', '.join(spec.platforms)}")
+    if spec.architectures and local.architecture not in {
+        item.lower() for item in spec.architectures
+    }:
+        blocked.append(f"architecture in {', '.join(spec.architectures)}")
+    missing_caps = sorted(set(spec.model.capabilities) - set(local.model_capabilities))
+    if missing_caps:
+        partial.append("model capabilities: " + ", ".join(missing_caps))
+    if spec.model.minimum_context_window and (
+        local.context_window is None
+        or local.context_window < spec.model.minimum_context_window
+    ):
+        partial.append(f"model context window >= {spec.model.minimum_context_window}")
+    for requirement in spec.tools:
+        actual = local.enabled_tools.get(requirement.name)
+        label = requirement.name + (
+            f">={requirement.minimum_version}" if requirement.minimum_version else ""
+        )
+        if requirement.requires_admin and not local.is_admin:
+            blocked.append(f"administrator approval for tool {label}")
+        elif not _version_at_least(actual, requirement.minimum_version):
+            setup.append(f"enable tool {label}")
+    for requirement in spec.plugins:
+        actual = local.plugins.get(requirement.id)
+        if not _version_at_least(actual, requirement.minimum_version):
+            (setup if requirement.required else partial).append(
+                f"install plugin {requirement.id}"
+            )
+    setup.extend(
+        f"configure credential {item}"
+        for item in spec.credentials
+        if item not in local.credentials
+    )
+    setup.extend(
+        f"connect {item}" for item in spec.connections if item not in local.connections
+    )
+    for capability, required in spec.runtime.model_dump().items():
+        if required and not local.runtime.get(capability, False):
+            blocked.append(f"runtime capability {capability}")
+    missing_hw = sorted(set(spec.hardware) - set(local.hardware))
+    blocked.extend(f"hardware {item}" for item in missing_hw)
+    if blocked:
+        outcome: CompatibilityOutcome = "blocked_pending_action"
+    elif setup:
+        outcome = "compatible_after_setup"
+    elif partial:
+        outcome = "partial"
+    else:
+        outcome = "compatible"
+    return CompatibilityResult(
+        outcome, tuple(satisfied), tuple(setup), tuple(partial), tuple(blocked)
+    )

--- a/hermes_wisdom/contract.py
+++ b/hermes_wisdom/contract.py
@@ -1,0 +1,188 @@
+"""Pinned Collective Wisdom wire contract and canonicalization helpers.
+
+The Gateway remains authoritative for authorization and publication. Claims
+decoded by this package are display hints only; every mutation is rechecked by
+the Gateway.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import html
+import json
+import re
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+@dataclass(frozen=True)
+class ContractPin:
+    gateway_commit: str
+    openapi_sha256: str
+    manifest_schema_sha256: str
+    canonical_vectors_sha256: str
+    requirements_pr: str
+    requirements_commit: str
+
+
+CONTRACT_PIN = ContractPin(
+    gateway_commit="391bf7077c0dee5ca3b818ceff61c31cf14f3efd",
+    openapi_sha256="e2ce2025daff7470791b8080a3ace884f3ca5115047d8bf30183cc2e1d1f66c2",
+    manifest_schema_sha256="64d0010eada1d79fa16309e9fd715faf77b6186360ea0b095182b2bdaeec5714",
+    canonical_vectors_sha256="e2b28c708f69e99b342de1df48498d96efde68867857391590bc964a609a730b",
+    requirements_pr="NousResearch/gateway-gateway#215",
+    requirements_commit="ee7b6123a08ef2379ef1641ed8e6defa10329eaa",
+)
+
+PACKAGE_MANIFEST_SCHEMA_VERSION = 1
+AUTHOR_DESCRIPTION_SCHEMA_VERSION = 1
+SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class HermesRequirement(StrictModel):
+    minimum_version: str
+
+
+class ModelRequirement(StrictModel):
+    capabilities: list[str] = Field(default_factory=list, max_length=64)
+    minimum_context_window: int | None = Field(default=None, ge=1)
+
+
+class ToolRequirement(StrictModel):
+    name: str
+    minimum_version: str | None = None
+    auto_install: Literal[False] = False
+    requires_admin: bool = False
+
+
+class PluginRequirement(StrictModel):
+    id: str
+    minimum_version: str | None = None
+    required: bool = True
+
+
+class FilesystemRequirement(StrictModel):
+    read: list[str] = Field(default_factory=list, max_length=64)
+    write: list[str] = Field(default_factory=list, max_length=64)
+
+
+class NetworkRequirement(StrictModel):
+    destinations: list[str] = Field(default_factory=list, max_length=64)
+
+
+class RuntimeRequirement(StrictModel):
+    shell: bool = False
+    browser: bool = False
+    code: bool = False
+    sandbox: bool = True
+
+
+class SystemSpecification(StrictModel):
+    hermes: HermesRequirement
+    platforms: list[str] = Field(default_factory=list, max_length=64)
+    architectures: list[str] = Field(default_factory=list, max_length=64)
+    model: ModelRequirement = Field(default_factory=ModelRequirement)
+    tools: list[ToolRequirement] = Field(default_factory=list, max_length=64)
+    plugins: list[PluginRequirement] = Field(default_factory=list, max_length=64)
+    credentials: list[str] = Field(default_factory=list, max_length=64)
+    connections: list[str] = Field(default_factory=list, max_length=64)
+    filesystem: FilesystemRequirement = Field(default_factory=FilesystemRequirement)
+    network: NetworkRequirement = Field(default_factory=NetworkRequirement)
+    runtime: RuntimeRequirement = Field(default_factory=RuntimeRequirement)
+    hardware: list[str] = Field(default_factory=list, max_length=64)
+    known_limitations: list[str] = Field(default_factory=list, max_length=64)
+
+    @field_validator(
+        "platforms",
+        "architectures",
+        "credentials",
+        "connections",
+        "hardware",
+        "known_limitations",
+    )
+    @classmethod
+    def _bounded_strings(cls, values: list[str]) -> list[str]:
+        if any(not value or len(value.encode("utf-8")) > 512 for value in values):
+            raise ValueError("requirement values must be 1..512 UTF-8 bytes")
+        return values
+
+
+class PackageManifest(StrictModel):
+    schema_version: Literal[1] = 1
+    name: str = Field(min_length=1, max_length=512)
+    requirements: SystemSpecification
+
+
+class ContentFile(StrictModel):
+    path: str
+    hash: str
+    mode: Literal["file", "exec"]
+    content_base64: str | None = None
+
+    @field_validator("hash")
+    @classmethod
+    def _hash(cls, value: str) -> str:
+        if not SHA256_RE.fullmatch(value):
+            raise ValueError("invalid sha256 address")
+        return value
+
+
+def sha256_address(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+
+
+def canonical_content_manifest(files: list[ContentFile]) -> bytes:
+    lines = sorted(f"{item.path} {item.mode} {item.hash}\n" for item in files)
+    return "".join(lines).encode("utf-8")
+
+
+def derive_content_hash(files: list[ContentFile]) -> str:
+    return sha256_address(canonical_content_manifest(files))
+
+
+def sanitize_author_description(raw: str) -> str:
+    # Mirror gateway descriptionSanitizer.ts. html.unescape is intentionally
+    # not used: the Gateway strips tags but does not decode entities.
+    value = re.sub(r"<[^>]*>", "", raw)
+    value = "".join(
+        ch
+        for ch in value
+        if ord(ch) in (0x09, 0x0A, 0x0D) or (ord(ch) > 0x1F and ord(ch) != 0x7F)
+    )
+    value = unicodedata.normalize(
+        "NFC", value.replace("\r\n", "\n").replace("\r", "\n")
+    )
+    value = "\n".join(line.rstrip() for line in value.split("\n")).strip()
+    if not value or len(value.encode("utf-8")) > 4096:
+        raise ValueError("author description must be 1..4096 canonical UTF-8 bytes")
+    return value
+
+
+def author_description_hash(canonical_description: str) -> str:
+    return sha256_address(canonical_description.encode("utf-8"))
+
+
+def load_manifest(path: Path) -> tuple[PackageManifest, bytes]:
+    raw = path.read_bytes()
+    parsed = PackageManifest.model_validate_json(raw)
+    # The bytes themselves are consented. We validate but never rewrite them.
+    return parsed, raw
+
+
+def escape_for_display(value: str) -> str:
+    """Escape untrusted server/skill text for HTML-based surfaces."""
+    return html.escape(value, quote=True)

--- a/hermes_wisdom/contracts/canonical-hash-vectors.v1.json
+++ b/hermes_wisdom/contracts/canonical-hash-vectors.v1.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "files": [
+    {
+      "path": "SKILL.md",
+      "mode": "file",
+      "content_utf8": "# Canonical Example\n\nFollow these steps.\n",
+      "content_base64": "IyBDYW5vbmljYWwgRXhhbXBsZQoKRm9sbG93IHRoZXNlIHN0ZXBzLgo=",
+      "hash": "sha256:52321eb89a8f2c22e8436c9f1ba0bf2d2f8c557674a2bcecad4c63d9a0a26f3e"
+    },
+    {
+      "path": "refs/notes.txt",
+      "mode": "file",
+      "content_utf8": "Use exact bytes.\n",
+      "content_base64": "VXNlIGV4YWN0IGJ5dGVzLgo=",
+      "hash": "sha256:aa73904fc874145cafd576ced9ace72bf34a07a9e5c178e3ba419dd175f155d4"
+    },
+    {
+      "path": "skill.manifest.json",
+      "mode": "file",
+      "content_utf8": "{\"schema_version\":1,\"name\":\"Canonical example\",\"requirements\":{\"hermes\":{\"minimum_version\":\"1.0.0\"},\"platforms\":[],\"architectures\":[],\"model\":{\"capabilities\":[],\"minimum_context_window\":null},\"tools\":[],\"plugins\":[],\"credentials\":[],\"connections\":[],\"filesystem\":{\"read\":[],\"write\":[]},\"network\":{\"destinations\":[]},\"runtime\":{\"shell\":false,\"browser\":false,\"code\":false,\"sandbox\":true},\"hardware\":[],\"known_limitations\":[]}}",
+      "content_base64": "eyJzY2hlbWFfdmVyc2lvbiI6MSwibmFtZSI6IkNhbm9uaWNhbCBleGFtcGxlIiwicmVxdWlyZW1lbnRzIjp7Imhlcm1lcyI6eyJtaW5pbXVtX3ZlcnNpb24iOiIxLjAuMCJ9LCJwbGF0Zm9ybXMiOltdLCJhcmNoaXRlY3R1cmVzIjpbXSwibW9kZWwiOnsiY2FwYWJpbGl0aWVzIjpbXSwibWluaW11bV9jb250ZXh0X3dpbmRvdyI6bnVsbH0sInRvb2xzIjpbXSwicGx1Z2lucyI6W10sImNyZWRlbnRpYWxzIjpbXSwiY29ubmVjdGlvbnMiOltdLCJmaWxlc3lzdGVtIjp7InJlYWQiOltdLCJ3cml0ZSI6W119LCJuZXR3b3JrIjp7ImRlc3RpbmF0aW9ucyI6W119LCJydW50aW1lIjp7InNoZWxsIjpmYWxzZSwiYnJvd3NlciI6ZmFsc2UsImNvZGUiOmZhbHNlLCJzYW5kYm94Ijp0cnVlfSwiaGFyZHdhcmUiOltdLCJrbm93bl9saW1pdGF0aW9ucyI6W119fQ==",
+      "hash": "sha256:0fb917e5e5641cd16612323e2873fcdbe755e38b306cd6f9b676564116629b4f"
+    }
+  ],
+  "canonical_content_manifest_utf8": "SKILL.md file sha256:52321eb89a8f2c22e8436c9f1ba0bf2d2f8c557674a2bcecad4c63d9a0a26f3e\nrefs/notes.txt file sha256:aa73904fc874145cafd576ced9ace72bf34a07a9e5c178e3ba419dd175f155d4\nskill.manifest.json file sha256:0fb917e5e5641cd16612323e2873fcdbe755e38b306cd6f9b676564116629b4f\n",
+  "content_hash": "sha256:885e321f65a7eb41ba90830aad694b9d4a881a31e49cf4c77045e85e39284569",
+  "package_manifest_hash": "sha256:0fb917e5e5641cd16612323e2873fcdbe755e38b306cd6f9b676564116629b4f",
+  "author_description_input": "  <b>Reuses</b> a proven deployment checklist.  \r\n",
+  "canonical_author_description": "Reuses a proven deployment checklist.",
+  "author_description_hash": "sha256:6b6736801941addd7dd16b6030f5202f33f52540605c8c1e2ee8110014651cd1"
+}

--- a/hermes_wisdom/contracts/skill-manifest.schema.v1.json
+++ b/hermes_wisdom/contracts/skill-manifest.schema.v1.json
@@ -1,0 +1,163 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gateway.nousresearch.com/contracts/collective-wisdom/skill-manifest.schema.v1.json",
+  "title": "Hermes Collective Wisdom skill manifest V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "name", "requirements"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "x-max-utf8-bytes": 512
+    },
+    "requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "hermes",
+        "platforms",
+        "architectures",
+        "model",
+        "tools",
+        "plugins",
+        "credentials",
+        "connections",
+        "filesystem",
+        "network",
+        "runtime",
+        "hardware",
+        "known_limitations"
+      ],
+      "properties": {
+        "hermes": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["minimum_version"],
+          "properties": {
+            "minimum_version": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 512,
+              "x-max-utf8-bytes": 512
+            }
+          }
+        },
+        "platforms": { "$ref": "#/$defs/stringList" },
+        "architectures": { "$ref": "#/$defs/stringList" },
+        "model": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["capabilities", "minimum_context_window"],
+          "properties": {
+            "capabilities": { "$ref": "#/$defs/stringList" },
+            "minimum_context_window": {
+              "type": ["integer", "null"],
+              "minimum": 1
+            }
+          }
+        },
+        "tools": {
+          "type": "array",
+          "maxItems": 64,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "minimum_version",
+              "auto_install",
+              "requires_admin"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 512,
+                "x-max-utf8-bytes": 512
+              },
+              "minimum_version": {
+                "type": ["string", "null"],
+                "minLength": 1,
+                "maxLength": 512,
+                "x-max-utf8-bytes": 512
+              },
+              "auto_install": { "const": false },
+              "requires_admin": { "type": "boolean" }
+            }
+          }
+        },
+        "plugins": {
+          "type": "array",
+          "maxItems": 64,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "minimum_version", "required"],
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 512,
+                "x-max-utf8-bytes": 512
+              },
+              "minimum_version": {
+                "type": ["string", "null"],
+                "minLength": 1,
+                "maxLength": 512,
+                "x-max-utf8-bytes": 512
+              },
+              "required": { "type": "boolean" }
+            }
+          }
+        },
+        "credentials": { "$ref": "#/$defs/stringList" },
+        "connections": { "$ref": "#/$defs/stringList" },
+        "filesystem": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["read", "write"],
+          "properties": {
+            "read": { "$ref": "#/$defs/stringList" },
+            "write": { "$ref": "#/$defs/stringList" }
+          }
+        },
+        "network": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["destinations"],
+          "properties": {
+            "destinations": { "$ref": "#/$defs/stringList" }
+          }
+        },
+        "runtime": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["shell", "browser", "code", "sandbox"],
+          "properties": {
+            "shell": { "type": "boolean" },
+            "browser": { "type": "boolean" },
+            "code": { "type": "boolean" },
+            "sandbox": { "type": "boolean" }
+          }
+        },
+        "hardware": { "$ref": "#/$defs/stringList" },
+        "known_limitations": { "$ref": "#/$defs/stringList" }
+      }
+    }
+  },
+  "$defs": {
+    "stringList": {
+      "type": "array",
+      "maxItems": 64,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 512,
+        "x-max-utf8-bytes": 512
+      }
+    }
+  }
+}

--- a/hermes_wisdom/package.py
+++ b/hermes_wisdom/package.py
@@ -1,0 +1,294 @@
+"""Instruction-only package preparation and exact-byte verification."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import stat
+import tempfile
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+from tools.skills_sync_client import ObjectSet, build_commit, build_tree
+
+from .contract import (
+    ContentFile,
+    FilesystemRequirement,
+    HermesRequirement,
+    ModelRequirement,
+    NetworkRequirement,
+    PackageManifest,
+    RuntimeRequirement,
+    SystemSpecification,
+    author_description_hash,
+    derive_content_hash,
+    load_manifest,
+    sanitize_author_description,
+    sha256_address,
+)
+
+
+MAX_FILE_BYTES = 25 * 1024 * 1024
+MAX_TREE_BYTES = 50 * 1024 * 1024
+ALLOWED_ROOT_FILES = frozenset({"SKILL.md", "skill.manifest.json"})
+ALLOWED_SUPPORT_DIRS = frozenset({"refs", "assets"})
+FORBIDDEN_REFERENCE_RE = re.compile(
+    r"(?i)(?:^|[\s(`'\"])(?:scripts?|templates?)/[^\s)`'\"]+"
+)
+PACKAGE_MANAGER_FILES = frozenset({
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "requirements.txt",
+    "pyproject.toml",
+    "poetry.lock",
+    "Pipfile",
+    "Cargo.toml",
+    "Cargo.lock",
+    "go.mod",
+    "go.sum",
+    "Gemfile",
+    "Gemfile.lock",
+})
+
+
+class PackagePolicyError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class PreparedPackage:
+    source: Path
+    overlay: Path
+    source_hash: str
+    content_hash: str
+    description: str
+    description_hash: str
+    manifest_hash: str
+    manifest: PackageManifest
+    files: list[ContentFile]
+    objects: ObjectSet
+    commit: str
+
+
+def _safe_relative(path: Path, root: Path) -> str:
+    rel = path.relative_to(root).as_posix()
+    pure = PurePosixPath(rel)
+    if pure.is_absolute() or any(part in ("", ".", "..") for part in pure.parts):
+        raise PackagePolicyError(f"unsafe package path: {rel!r}")
+    if unicodedata.normalize("NFC", rel) != rel or "\x00" in rel or "\\" in rel:
+        raise PackagePolicyError(f"non-canonical package path: {rel!r}")
+    return rel
+
+
+def _validate_tree(root: Path, *, require_manifest: bool = True) -> list[Path]:
+    if not root.is_dir() or root.is_symlink():
+        raise PackagePolicyError("skill root must be a regular directory")
+    entries: list[Path] = []
+    collision_keys: set[str] = set()
+    total = 0
+    for path in sorted(root.rglob("*")):
+        rel = _safe_relative(path, root)
+        if path.is_symlink():
+            raise PackagePolicyError(f"symlinks are not supported: {rel}")
+        parts = PurePosixPath(rel).parts
+        if len(parts) == 1:
+            if path.is_file() and parts[0] not in ALLOWED_ROOT_FILES:
+                raise PackagePolicyError(
+                    f"unsupported root file {rel}; create an explicit instruction-only fork"
+                )
+            if path.is_dir() and parts[0] not in ALLOWED_SUPPORT_DIRS:
+                raise PackagePolicyError(
+                    f"unsupported directory {rel}; scripts/templates cannot be silently omitted"
+                )
+        elif parts[0] not in ALLOWED_SUPPORT_DIRS:
+            raise PackagePolicyError(f"unsupported package path: {rel}")
+        key = "/".join(
+            unicodedata.normalize("NFC", part).rstrip(". ").casefold() for part in parts
+        )
+        if key in collision_keys:
+            raise PackagePolicyError(f"install-target path collision: {rel}")
+        collision_keys.add(key)
+        if path.is_file():
+            if path.name in PACKAGE_MANAGER_FILES:
+                raise PackagePolicyError(
+                    f"package-manager manifest is not allowed: {rel}"
+                )
+            size = path.stat().st_size
+            if size > MAX_FILE_BYTES:
+                raise PackagePolicyError(f"file too large: {rel}")
+            total += size
+            if total > MAX_TREE_BYTES:
+                raise PackagePolicyError("package exceeds 50 MiB")
+            if path.stat().st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH):
+                raise PackagePolicyError(f"executable content is not allowed: {rel}")
+            try:
+                path.read_bytes().decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise PackagePolicyError(f"binary content is not allowed: {rel}")
+            entries.append(path)
+    if not (root / "SKILL.md").is_file():
+        raise PackagePolicyError("package requires exactly one root SKILL.md")
+    if require_manifest and not (root / "skill.manifest.json").is_file():
+        raise PackagePolicyError(
+            "package requires exactly one root skill.manifest.json"
+        )
+    skill_text = (root / "SKILL.md").read_text(encoding="utf-8")
+    if FORBIDDEN_REFERENCE_RE.search(skill_text):
+        raise PackagePolicyError(
+            "SKILL.md references active scripts/templates; create an explicit instruction-only fork"
+        )
+    return entries
+
+
+def _source_fingerprint(source: Path) -> str:
+    records: list[str] = []
+    for path in sorted(source.rglob("*")):
+        if path.is_file() and not path.is_symlink():
+            records.append(
+                f"{path.relative_to(source).as_posix()} {sha256_address(path.read_bytes())}\n"
+            )
+    return sha256_address("".join(records).encode("utf-8"))
+
+
+def prepare_package(
+    source: Path,
+    *,
+    overlay_root: Path,
+    author_description: str,
+    owner: str,
+    installation_id: str,
+) -> PreparedPackage:
+    source = source.resolve()
+    source_hash = _source_fingerprint(source)
+    target = overlay_root / source_hash.removeprefix("sha256:")
+    if target.exists():
+        shutil.rmtree(target)
+    target.mkdir(parents=True, mode=0o700)
+    # Copy only validated allowlisted bytes. Validation happens first so an
+    # unsupported referenced file never disappears silently from the package.
+    _validate_tree(source, require_manifest=False)
+    for path in sorted(source.rglob("*")):
+        rel = path.relative_to(source)
+        dest = target / rel
+        if path.is_dir():
+            dest.mkdir(parents=True, exist_ok=True)
+        elif path.is_file():
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(path.read_bytes())
+            dest.chmod(0o600)
+    if not (target / "skill.manifest.json").exists():
+        from hermes_cli import __version__ as hermes_version
+
+        generated = PackageManifest(
+            name=source.name,
+            requirements=SystemSpecification(
+                hermes=HermesRequirement(minimum_version=hermes_version),
+                model=ModelRequirement(),
+                filesystem=FilesystemRequirement(),
+                network=NetworkRequirement(),
+                runtime=RuntimeRequirement(),
+            ),
+        )
+        (target / "skill.manifest.json").write_bytes(
+            json.dumps(
+                generated.model_dump(mode="json"),
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+            ).encode("utf-8")
+        )
+        (target / "skill.manifest.json").chmod(0o600)
+    paths = _validate_tree(target)
+    manifest, manifest_bytes = load_manifest(target / "skill.manifest.json")
+    description = sanitize_author_description(author_description)
+    files = [
+        ContentFile(
+            path=_safe_relative(path, target),
+            mode="file",
+            hash=sha256_address(path.read_bytes()),
+        )
+        for path in paths
+    ]
+    content_hash = derive_content_hash(files)
+    objects = ObjectSet()
+    tree = build_tree(target, objects, max_object_bytes=MAX_FILE_BYTES)
+    commit = build_commit(
+        tree,
+        [],
+        owner=owner,
+        device=installation_id,
+        message="Collective Wisdom owner-private draft",
+        objects=objects,
+    )
+    return PreparedPackage(
+        source=source,
+        overlay=target,
+        source_hash=source_hash,
+        content_hash=content_hash,
+        description=description,
+        description_hash=author_description_hash(description),
+        manifest_hash=sha256_address(manifest_bytes),
+        manifest=manifest,
+        files=files,
+        objects=objects,
+        commit=commit,
+    )
+
+
+def verify_content_files(
+    files: list[tuple[str, str, bytes]],
+) -> tuple[list[ContentFile], str]:
+    """Validate downloaded paths/modes/blobs and derive the content hash."""
+    records: list[ContentFile] = []
+    keys: set[str] = set()
+    for raw_path, mode, body in files:
+        pure = PurePosixPath(raw_path)
+        if (
+            pure.is_absolute()
+            or not pure.parts
+            or any(p in ("", ".", "..") for p in pure.parts)
+        ):
+            raise PackagePolicyError(f"unsafe server path: {raw_path!r}")
+        if (
+            "\\" in raw_path
+            or "\x00" in raw_path
+            or unicodedata.normalize("NFC", raw_path) != raw_path
+        ):
+            raise PackagePolicyError(f"non-canonical server path: {raw_path!r}")
+        key = "/".join(
+            unicodedata.normalize("NFC", p).rstrip(". ").casefold() for p in pure.parts
+        )
+        if key in keys:
+            raise PackagePolicyError(f"install-target collision: {raw_path}")
+        keys.add(key)
+        if mode != "file":
+            raise PackagePolicyError(f"executable/unknown mode rejected: {raw_path}")
+        if pure.name in PACKAGE_MANAGER_FILES:
+            raise PackagePolicyError(
+                f"package-manager manifest is not allowed: {raw_path}"
+            )
+        if len(pure.parts) == 1 and pure.name not in ALLOWED_ROOT_FILES:
+            raise PackagePolicyError(f"unsupported root file: {raw_path}")
+        if len(pure.parts) > 1 and pure.parts[0] not in ALLOWED_SUPPORT_DIRS:
+            raise PackagePolicyError(f"unsupported package path: {raw_path}")
+        try:
+            body.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise PackagePolicyError(
+                f"binary content is not allowed: {raw_path}"
+            ) from exc
+        records.append(
+            ContentFile(path=raw_path, mode="file", hash=sha256_address(body))
+        )
+    required = {record.path for record in records}
+    if "SKILL.md" not in required or "skill.manifest.json" not in required:
+        raise PackagePolicyError("download is not a complete Wisdom package")
+    skill_body = next(body for path, _, body in files if path == "SKILL.md")
+    if FORBIDDEN_REFERENCE_RE.search(skill_body.decode("utf-8")):
+        raise PackagePolicyError("SKILL.md references unsupported active content")
+    return records, derive_content_hash(records)

--- a/hermes_wisdom/service.py
+++ b/hermes_wisdom/service.py
@@ -1,0 +1,709 @@
+"""Application service shared by Wisdom CLI, dashboard, and desktop APIs."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+import uuid
+import webbrowser
+from dataclasses import asdict
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import urlparse
+
+from hermes_constants import get_hermes_home, get_skills_dir
+from tools.skill_usage import _find_skill_dir, is_bundled, is_hub_installed
+from tools.skills_guard import scan_skill, should_allow_install
+from tools.skillevaluator_scan import run_tier1_scan, tier1_advisory_enabled
+
+from .client import WisdomClient, WisdomValidationError
+from .compatibility import CompatibilityResult, detect_local_capabilities, evaluate
+from .contract import (
+    CONTRACT_PIN,
+    PackageManifest,
+    author_description_hash,
+    sha256_address,
+)
+from .package import (
+    PackagePolicyError,
+    PreparedPackage,
+    prepare_package,
+    verify_content_files,
+)
+from .store import WisdomStore
+
+
+SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$")
+
+
+def _config() -> dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        value = (load_config() or {}).get("wisdom") or {}
+        return value if isinstance(value, dict) else {}
+    except Exception:
+        return {}
+
+
+def portal_base_url() -> str:
+    value = _config().get("portal_url")
+    return (
+        str(value).rstrip("/")
+        if isinstance(value, str) and value.strip()
+        else "https://portal.nousresearch.com"
+    )
+
+
+def _slug(value: str) -> str:
+    candidate = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")[:64]
+    if not SLUG_RE.fullmatch(candidate):
+        raise PackagePolicyError(
+            "skill name cannot be converted to a valid Wisdom slug"
+        )
+    return candidate
+
+
+def _source_fingerprint(source: Path) -> str:
+    rows: list[str] = []
+    for path in sorted(source.rglob("*")):
+        if path.is_file() and not path.is_symlink():
+            rows.append(
+                f"{path.relative_to(source).as_posix()} {sha256_address(path.read_bytes())}\n"
+            )
+    return sha256_address("".join(rows).encode("utf-8"))
+
+
+def _scan_summary(path: Path) -> dict[str, Any]:
+    guard = scan_skill(path, source="community")
+    allowed, reason = should_allow_install(guard)
+    tier1 = run_tier1_scan(path) if tier1_advisory_enabled() else None
+    return {
+        "guard": {
+            "verdict": guard.verdict,
+            "allowed": allowed,
+            "reason": reason,
+            "findings": [
+                {
+                    "severity": finding.severity,
+                    "category": finding.category,
+                    "file": finding.file,
+                    "line": finding.line,
+                    "match": finding.match,
+                }
+                for finding in guard.findings
+            ],
+        },
+        "skill_evaluator": (
+            {
+                "status": "available",
+                "passed": tier1.passed,
+                "findings": [
+                    {
+                        "check": finding.check,
+                        "severity": finding.severity,
+                        "file": finding.file,
+                        "line": finding.line,
+                        "message": finding.message,
+                        "secrets_class": finding.is_secrets_class,
+                    }
+                    for finding in tier1.findings
+                ],
+                "incomplete_checks": tier1.incomplete_checks,
+            }
+            if tier1 and tier1.available
+            else {
+                "status": "disabled" if tier1 is None else "unavailable",
+                "passed": None,
+                "findings": [],
+            }
+        ),
+    }
+
+
+def _has_high_confidence_secret(scan: dict[str, Any]) -> bool:
+    return any(
+        item.get("secrets_class") and item.get("severity") in {"critical", "high"}
+        for item in scan["skill_evaluator"]["findings"]
+    )
+
+
+def _extract_model_text(response: Any) -> str:
+    from agent.auxiliary_client import extract_content_or_reasoning
+
+    return extract_content_or_reasoning(response).strip()
+
+
+def draft_description(skill_md: str) -> str:
+    """Draft author copy with the configured model under normal routing rules."""
+    from agent.auxiliary_client import call_llm
+
+    response = call_llm(
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "Write one concise, outcome-oriented plain-text description of this Hermes skill. "
+                    "Do not claim quality, safety, usage, popularity, or platform verification. "
+                    "Return only the description, at most 600 characters."
+                ),
+            },
+            {"role": "user", "content": skill_md[:24000]},
+        ],
+        temperature=0.2,
+        max_tokens=220,
+        timeout=60,
+    )
+    text = _extract_model_text(response)
+    if not text:
+        raise PackagePolicyError(
+            "the configured model did not return an author description"
+        )
+    return text
+
+
+class WisdomService:
+    def __init__(
+        self, *, store: WisdomStore | None = None, client: WisdomClient | None = None
+    ) -> None:
+        self.store = store or WisdomStore()
+        self._client = client
+
+    @property
+    def client(self) -> WisdomClient:
+        if self._client is None:
+            self._client = WisdomClient(
+                timeout=float(_config().get("request_timeout", 30))
+            )
+        return self._client
+
+    def setup(self) -> dict[str, Any]:
+        installation_id = self.store.installation_identity()
+        capability = self.client.capability()
+        registered = self.client.register_identity(installation_id)
+        org_id = self.client.display_org_id
+        if not org_id:
+            raise WisdomValidationError(
+                "team organization identity is missing from the current token"
+            )
+        self.store.verify_installation_identity(org_id)
+        managed = get_skills_dir() / "_wisdom"
+        managed.mkdir(parents=True, exist_ok=True, mode=0o700)
+        marker = managed / ".active_org"
+        marker.write_text(org_id + "\n", encoding="utf-8")
+        try:
+            marker.chmod(0o600)
+        except OSError:
+            pass
+        recovered = self.reconcile_pending_install_records()
+        candidates = self.scan_candidates()
+        return {
+            "ok": True,
+            "installation_id": installation_id,
+            "organization_id": org_id,
+            "registered": registered,
+            "capabilities": capability.get("capabilities", []),
+            "display_scopes": list(self.client.display_scopes),
+            "database": str(self.store.path),
+            "managed_directory": str(managed / org_id),
+            "candidate_count": len(candidates),
+            "recovered_gateway_records": recovered,
+            "disclosure": (
+                "Candidate signals stay on this profile. Only owner-approved private draft bytes, "
+                "author copy, manifest metadata, and managed-install state reach the Gateway."
+            ),
+        }
+
+    def reconcile_pending_install_records(self) -> list[str]:
+        """Retry final Gateway install records after a local commit succeeded."""
+        recovered: list[str] = []
+        installation_id = self.store.installation_identity()
+        for operation in self.store.pending_operations():
+            if (
+                operation["kind"] != "install"
+                or operation["phase"] != "local_ledger_committed"
+            ):
+                continue
+            try:
+                plan = json.loads(operation["payload_json"])
+                self.client.record_install(
+                    skill_id=plan["skill_id"],
+                    installation_id=installation_id,
+                    version=int(plan["version"]),
+                    takedown_generation=int(plan["takedown_generation"]),
+                    update_mode=plan.get("update_mode"),
+                )
+            except Exception:
+                continue
+            self.store.advance(operation["id"], "gateway_recorded", done=True)
+            recovered.append(str(operation["entity_id"]))
+        return recovered
+
+    def status(self) -> dict[str, Any]:
+        try:
+            client = self.client
+            live = True
+            capability = client.capability()
+            scopes = list(client.display_scopes)
+            admin_gate = (
+                client.identity.get("claims", {}).get("tool_gateway_admin") is True
+            )
+        except Exception as exc:
+            live = False
+            capability = {}
+            scopes = []
+            admin_gate = False
+            error = str(exc)
+        return {
+            "configured": bool(_config().get("enabled", False)),
+            "gateway_available": live,
+            "error": None if live else error,
+            "capability_advertised": "wisdom" in (capability.get("capabilities") or []),
+            "display_scopes": scopes,
+            "dogfood_admin_claim": admin_gate,
+            "installation_id": self.store.installation_identity(),
+            "verified_org_id": self.store.active_org_id(),
+            "pending_operations": self.store.pending_operations(),
+            "contract": asdict(CONTRACT_PIN),
+        }
+
+    def _eligible_paths(self) -> list[Path]:
+        root = get_skills_dir().resolve()
+        if not root.exists():
+            return []
+        paths: list[Path] = []
+        for skill_md in sorted(root.rglob("SKILL.md")):
+            try:
+                rel = skill_md.relative_to(root)
+            except ValueError:
+                continue
+            if any(
+                part in {".archive", "_org", "_wisdom", ".hub"} for part in rel.parts
+            ):
+                continue
+            path = skill_md.parent
+            name = path.name
+            if is_bundled(name) or is_hub_installed(name):
+                continue
+            paths.append(path)
+        return paths
+
+    def scan_candidates(self) -> list[dict[str, Any]]:
+        candidates: list[dict[str, Any]] = []
+        eligible_paths = self._eligible_paths()
+        self.store.mark_missing_skills({str(path.resolve()) for path in eligible_paths})
+        for path in eligible_paths:
+            source_hash = _source_fingerprint(path)
+            skill_id = self.store.register_skill(
+                path, content_hash=source_hash, source_kind="local"
+            )
+            try:
+                # Preparation remains manual; this dry structural pass rejects
+                # scripts/templates/unsupported bytes without uploading anything.
+                prepare_package(
+                    path,
+                    overlay_root=self.store.root / "scan-overlays",
+                    author_description=f"Local skill {path.name}.",
+                    owner="local-scan",
+                    installation_id=self.store.installation_identity(),
+                )
+                eligibility = "eligible"
+                reason = None
+            except PackagePolicyError as exc:
+                eligibility = "instruction_only_fork_required"
+                reason = str(exc)
+            candidates.append({
+                "local_skill_id": skill_id,
+                "name": path.name,
+                "path": str(path),
+                "content_hash": source_hash,
+                "eligibility": eligibility,
+                "reason": reason,
+                "qualification": "manual_selection",
+            })
+        return candidates
+
+    def scan(self, skill_name: str | None = None) -> dict[str, Any]:
+        selected = self.scan_candidates()
+        if skill_name:
+            selected = [item for item in selected if item["name"] == skill_name]
+            if not selected:
+                raise PackagePolicyError(f"local skill not found: {skill_name}")
+        return {
+            "candidates": [
+                {**item, "local_scan": _scan_summary(Path(item["path"]))}
+                for item in selected
+            ]
+        }
+
+    def suggest(
+        self,
+        skill_name: str | None = None,
+        *,
+        description: str | None = None,
+        allow_private_secret_review: bool = False,
+    ) -> dict[str, Any]:
+        if not skill_name:
+            return {"candidates": self.scan_candidates(), "network_submission": False}
+        source = _find_skill_dir(skill_name)
+        if source is None or source.resolve() not in {
+            path.resolve() for path in self._eligible_paths()
+        }:
+            raise PackagePolicyError("skill is not eligible for Collective Wisdom")
+        source_hash = _source_fingerprint(source)
+        skill_id = self.store.register_skill(
+            source, content_hash=source_hash, source_kind="local"
+        )
+        prepared = self.store.prepared_draft(skill_id, source_hash)
+        if prepared is None:
+            author_copy = description or draft_description(
+                (source / "SKILL.md").read_text(encoding="utf-8")
+            )
+            local_package = prepare_package(
+                source,
+                overlay_root=self.store.root / "drafts",
+                author_description=author_copy,
+                owner=str(self.client.identity.get("owner")),
+                installation_id=self.store.installation_identity(),
+            )
+            local_id = f"local:{skill_id}:{source_hash.removeprefix('sha256:')[:16]}"
+            self.store.record_draft({
+                "id": local_id,
+                "skill_id": skill_id,
+                "source_hash": source_hash,
+                "overlay_path": str(local_package.overlay),
+                "state": "prepared",
+                "description": local_package.description,
+                "content_hash": local_package.content_hash,
+                "description_hash": local_package.description_hash,
+                "manifest_hash": local_package.manifest_hash,
+            })
+            return {
+                "network_submission": False,
+                "local_draft_id": local_id,
+                "overlay_path": str(local_package.overlay),
+                "drafted_description": local_package.description,
+                "system_specification": local_package.manifest.requirements.model_dump(
+                    mode="json"
+                ),
+                "next_step": (
+                    "Edit the author description and skill.manifest.json in the overlay, review every "
+                    "file, then rerun `hermes wisdom suggest <skill> --description <approved-copy>`."
+                ),
+            }
+        if description is None:
+            return {
+                "network_submission": False,
+                "local_draft_id": prepared["id"],
+                "overlay_path": prepared["overlay_path"],
+                "drafted_description": prepared["description"],
+                "next_step": "Provide the owner-approved description to submit the edited overlay.",
+            }
+        package = prepare_package(
+            Path(prepared["overlay_path"]),
+            overlay_root=self.store.root / "submissions",
+            author_description=description,
+            owner=str(self.client.identity.get("owner")),
+            installation_id=self.store.installation_identity(),
+        )
+        local_scan = _scan_summary(package.overlay)
+        if local_scan["guard"]["allowed"] is False:
+            raise PackagePolicyError(
+                f"built-in guard blocked the exact staged package: {local_scan['guard']['reason']}"
+            )
+        if _has_high_confidence_secret(local_scan) and not allow_private_secret_review:
+            raise PackagePolicyError(
+                "high-confidence local secret finding paused upload; rerun with the explicit "
+                "--send-for-owner-only-server-review confirmation"
+            )
+        if _source_fingerprint(source) != source_hash:
+            raise PackagePolicyError(
+                "source changed while the review overlay was being prepared"
+            )
+        self.client.upload_private_objects(package.objects)
+        server = self.client.submit_draft(
+            slug=_slug(skill_name),
+            commit=package.commit,
+            content_hash=package.content_hash,
+            description=package.description,
+        )
+        self.store.set_draft_state(str(prepared["id"]), "submitted")
+        self.store.record_draft({
+            "id": server.id,
+            "skill_id": skill_id,
+            "source_hash": source_hash,
+            "overlay_path": str(package.overlay),
+            "draft_commit": server.draftCommit,
+            "server_revision": server.updatedAt,
+            "state": server.state,
+            "description": server.authorDescription or "",
+            "content_hash": server.contentHash,
+            "description_hash": server.authorDescriptionHash
+            or package.description_hash,
+            "manifest_hash": server.packageManifestHash or package.manifest_hash,
+        })
+        return {
+            "draft": server.model_dump(mode="json"),
+            "local_scan": local_scan,
+            "notice": "Draft bytes are owner-private; nothing is published until hash-bound approval.",
+        }
+
+    def review(
+        self, draft_id: str, *, acknowledge: bool, portal: bool = False
+    ) -> dict[str, Any]:
+        reconstructed = self.client.reconstruct_draft(draft_id)
+        draft = reconstructed.detail.draft
+        manifest_body = next(
+            body
+            for path, _, body in reconstructed.files
+            if path == "skill.manifest.json"
+        )
+        manifest_hash = sha256_address(manifest_body)
+        if manifest_hash != draft.packageManifestHash:
+            raise WisdomValidationError(
+                "server draft package manifest hash does not match exact bytes"
+            )
+        description_hash = author_description_hash(draft.authorDescription or "")
+        if description_hash != draft.authorDescriptionHash:
+            raise WisdomValidationError(
+                "server draft author description hash does not match displayed copy"
+            )
+        result = {
+            "draft": draft.model_dump(mode="json"),
+            "effective_policy": reconstructed.detail.effective_policy,
+            "files": [
+                {
+                    "path": path,
+                    "mode": mode,
+                    "hash": sha256_address(body),
+                    "content_utf8": body.decode("utf-8", errors="replace"),
+                }
+                for path, mode, body in reconstructed.files
+            ],
+            "hashes": {
+                "content": reconstructed.content_hash,
+                "author_description": description_hash,
+                "package_manifest": manifest_hash,
+            },
+            "receipt": None,
+        }
+        if portal:
+            url = f"{portal_base_url()}/wisdom/review/{draft_id}"
+            webbrowser.open(url)
+            result["portal_url"] = url
+        if acknowledge:
+            result["receipt"] = self.store.save_receipt(
+                draft_id=draft_id,
+                server_revision=draft.updatedAt,
+                content_hash=reconstructed.content_hash,
+                description_hash=description_hash,
+                manifest_hash=manifest_hash,
+            )
+        return result
+
+    def approve(self, draft_id: str) -> dict[str, Any]:
+        receipt = self.store.receipt(draft_id)
+        if not receipt:
+            raise PackagePolicyError(
+                "approval requires a fresh complete-package review receipt"
+            )
+        current = self.client.reconstruct_draft(draft_id)
+        draft = current.detail.draft
+        manifest_body = next(
+            body for path, _, body in current.files if path == "skill.manifest.json"
+        )
+        expected = (
+            current.content_hash,
+            author_description_hash(draft.authorDescription or ""),
+            sha256_address(manifest_body),
+            draft.updatedAt,
+        )
+        received = (
+            receipt["content_hash"],
+            receipt["description_hash"],
+            receipt["manifest_hash"],
+            receipt["server_revision"],
+        )
+        if expected != received:
+            raise PackagePolicyError(
+                "review receipt is stale; review the complete server draft again"
+            )
+        approved = self.client.approve(
+            draft_id,
+            content_hash=receipt["content_hash"],
+            description_hash=receipt["description_hash"],
+            manifest_hash=receipt["manifest_hash"],
+        )
+        published = self.client.publish(draft_id, content_hash=receipt["content_hash"])
+        self.store.consume_receipt(draft_id)
+        return {"approved": approved.model_dump(mode="json"), "publication": published}
+
+    def decline(self, draft_id: str) -> dict[str, Any]:
+        result = self.client.decline(draft_id)
+        self.store.consume_receipt(draft_id)
+        return result
+
+    def list_skills(self) -> dict[str, Any]:
+        response = self.client.list_skills()
+        return response.model_dump(mode="json")
+
+    def show(self, skill_id: str) -> dict[str, Any]:
+        return self.client.skill(skill_id).model_dump(mode="json")
+
+    def versions(self, skill_id: str) -> list[dict[str, Any]]:
+        return self.client.skill(skill_id).versions
+
+    def _resolve_install_ref(self, reference: str) -> tuple[str, int | None]:
+        parsed = urlparse(reference)
+        raw = (
+            parsed.path.rstrip("/").split("/")[-1]
+            if parsed.scheme in {"http", "https"}
+            else reference
+        )
+        if "@v" in raw:
+            skill_id, raw_version = raw.rsplit("@v", 1)
+            if not raw_version.isdigit() or int(raw_version) < 1:
+                raise PackagePolicyError("invalid Wisdom version selector")
+            return skill_id, int(raw_version)
+        return raw, None
+
+    def install_plan(
+        self, reference: str, *, update_mode: str | None = None
+    ) -> dict[str, Any]:
+        skill_id, selected_version = self._resolve_install_ref(reference)
+        detail = self.client.skill(skill_id)
+        if detail.skill.get("state") != "active":
+            raise PackagePolicyError("only active Wisdom skills can be installed")
+        versions = detail.versions
+        if not versions:
+            raise PackagePolicyError("Wisdom skill has no published versions")
+        version_number = selected_version or max(
+            int(item["version"]) for item in versions
+        )
+        version_detail = self.client.version(skill_id, version_number)
+        spec = PackageManifest.model_validate({
+            "schema_version": 1,
+            "name": str(detail.skill.get("slug") or skill_id),
+            "requirements": version_detail.version.get("system_spec"),
+        }).requirements
+        compatibility = evaluate(spec, detect_local_capabilities())
+        if compatibility.outcome == "blocked_pending_action":
+            allowed = False
+        else:
+            allowed = True
+        receipt = "wip_" + uuid.uuid4().hex
+        plan = {
+            "receipt": receipt,
+            "skill_id": skill_id,
+            "slug": str(detail.skill.get("slug") or skill_id),
+            "version": version_number,
+            "takedown_generation": int(detail.skill.get("takedown_generation", 0)),
+            "update_mode": update_mode,
+            "compatibility": asdict(compatibility),
+            "allowed": allowed,
+        }
+        plan_dir = self.store.root / "plans"
+        plan_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        plan_path = plan_dir / f"{receipt}.json"
+        plan_path.write_text(json.dumps(plan, sort_keys=True), encoding="utf-8")
+        plan_path.chmod(0o600)
+        return plan
+
+    def install_apply(
+        self, receipt: str, *, accept_partial: bool = False
+    ) -> dict[str, Any]:
+        plan_path = self.store.root / "plans" / f"{receipt}.json"
+        try:
+            plan = json.loads(plan_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise PackagePolicyError(
+                "install plan receipt is missing or invalid"
+            ) from exc
+        outcome = plan["compatibility"]["outcome"]
+        if not plan.get("allowed") or outcome == "blocked_pending_action":
+            raise PackagePolicyError(
+                "blocked compatibility requirements prevent activation"
+            )
+        if outcome in {"partial", "compatible_after_setup"} and not accept_partial:
+            raise PackagePolicyError(
+                "compatibility action is required; explicitly accept the plan"
+            )
+        response, files = self.client.content(plan["skill_id"], int(plan["version"]))
+        exact_records, exact_hash = verify_content_files(files)
+        if exact_hash != response.content_hash:
+            raise WisdomValidationError("download changed after install planning")
+        org_id = self.store.active_org_id()
+        if not org_id:
+            raise PackagePolicyError("run `hermes wisdom setup` before installing")
+        managed_root = (get_skills_dir() / "_wisdom" / org_id).resolve()
+        managed_root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        target = (managed_root / plan["slug"]).resolve()
+        try:
+            target.relative_to(managed_root)
+        except ValueError as exc:
+            raise PackagePolicyError(
+                "managed install target escaped the Wisdom root"
+            ) from exc
+        operation = self.store.journal("install", plan["skill_id"], "downloaded", plan)
+        staging = Path(tempfile.mkdtemp(prefix=f".{plan['slug']}-", dir=managed_root))
+        try:
+            for raw_path, mode, body in files:
+                destination = staging.joinpath(*PurePosixPath(raw_path).parts)
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                destination.write_bytes(body)
+                destination.chmod(0o600)
+            local_scan = _scan_summary(staging)
+            if local_scan["guard"]["allowed"] is False:
+                raise PackagePolicyError(
+                    f"built-in guard blocked installation: {local_scan['guard']['reason']}"
+                )
+            self.store.advance(operation, "staged")
+            backup = managed_root / f".{plan['slug']}.previous"
+            if backup.exists():
+                shutil.rmtree(backup)
+            if target.exists():
+                os.replace(target, backup)
+            os.replace(staging, target)
+            self.store.advance(operation, "files_committed")
+            baseline = {record.path: record.hash for record in exact_records}
+            self.store.record_install({
+                "skill_id": plan["skill_id"],
+                "org_id": org_id,
+                "slug": plan["slug"],
+                "version": plan["version"],
+                "content_hash": exact_hash,
+                "baseline": baseline,
+                "target_path": str(target),
+                "update_mode": plan.get("update_mode") or "MANUAL",
+            })
+            self.store.advance(operation, "local_ledger_committed")
+            installation_id = self.store.installation_identity()
+            server = self.client.record_install(
+                skill_id=plan["skill_id"],
+                installation_id=installation_id,
+                version=int(plan["version"]),
+                takedown_generation=int(plan["takedown_generation"]),
+                update_mode=plan.get("update_mode"),
+            )
+            self.store.advance(operation, "gateway_recorded", done=True)
+            plan_path.unlink(missing_ok=True)
+            if backup.exists():
+                shutil.rmtree(backup)
+            return {
+                "installed": True,
+                "skill_id": plan["skill_id"],
+                "version": plan["version"],
+                "path": str(target),
+                "content_hash": exact_hash,
+                "effective_update_mode": server.effective_update_mode,
+                "compatibility": plan["compatibility"],
+                "local_scan": local_scan,
+            }
+        finally:
+            if staging.exists():
+                shutil.rmtree(staging)

--- a/hermes_wisdom/store.py
+++ b/hermes_wisdom/store.py
@@ -1,0 +1,420 @@
+"""Profile-scoped crash-safe SQLite state for Collective Wisdom."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+from hermes_constants import get_hermes_home
+
+
+SCHEMA_VERSION = 1
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class WisdomStore:
+    def __init__(self, root: Path | None = None) -> None:
+        self.root = root or (get_hermes_home() / "wisdom")
+        self.path = self.root / "wisdom.db"
+        self._lock = threading.RLock()
+        self._prepare()
+
+    def _prepare(self) -> None:
+        self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        try:
+            self.root.chmod(0o700)
+        except OSError:
+            pass
+        with self.transaction() as db:
+            db.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS schema_meta (
+                  key TEXT PRIMARY KEY,
+                  value TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS local_skill (
+                  id TEXT PRIMARY KEY,
+                  canonical_path TEXT NOT NULL,
+                  fs_identity TEXT,
+                  current_hash TEXT,
+                  source_kind TEXT NOT NULL,
+                  deleted_at TEXT,
+                  created_at TEXT NOT NULL,
+                  updated_at TEXT NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS local_skill_fs_identity
+                  ON local_skill(fs_identity) WHERE fs_identity IS NOT NULL;
+                CREATE UNIQUE INDEX IF NOT EXISTS local_skill_active_path
+                  ON local_skill(canonical_path) WHERE deleted_at IS NULL;
+                CREATE TABLE IF NOT EXISTS snapshot (
+                  skill_id TEXT NOT NULL,
+                  content_hash TEXT NOT NULL,
+                  captured_at TEXT NOT NULL,
+                  PRIMARY KEY(skill_id, content_hash),
+                  FOREIGN KEY(skill_id) REFERENCES local_skill(id) ON DELETE CASCADE
+                );
+                CREATE TABLE IF NOT EXISTS candidate (
+                  skill_id TEXT NOT NULL,
+                  content_hash TEXT NOT NULL,
+                  qualification TEXT NOT NULL,
+                  state TEXT NOT NULL,
+                  suggested_at TEXT,
+                  dismissed_at TEXT,
+                  PRIMARY KEY(skill_id, content_hash),
+                  FOREIGN KEY(skill_id) REFERENCES local_skill(id) ON DELETE CASCADE
+                );
+                CREATE TABLE IF NOT EXISTS local_draft (
+                  id TEXT PRIMARY KEY,
+                  skill_id TEXT NOT NULL,
+                  source_hash TEXT NOT NULL,
+                  overlay_path TEXT NOT NULL,
+                  draft_commit TEXT,
+                  server_revision TEXT,
+                  state TEXT NOT NULL,
+                  description TEXT NOT NULL,
+                  content_hash TEXT NOT NULL,
+                  description_hash TEXT NOT NULL,
+                  manifest_hash TEXT NOT NULL,
+                  created_at TEXT NOT NULL,
+                  updated_at TEXT NOT NULL,
+                  FOREIGN KEY(skill_id) REFERENCES local_skill(id) ON DELETE CASCADE
+                );
+                CREATE TABLE IF NOT EXISTS review_receipt (
+                  id TEXT PRIMARY KEY,
+                  draft_id TEXT NOT NULL UNIQUE,
+                  server_revision TEXT NOT NULL,
+                  content_hash TEXT NOT NULL,
+                  description_hash TEXT NOT NULL,
+                  manifest_hash TEXT NOT NULL,
+                  reviewed_at TEXT NOT NULL,
+                  consumed_at TEXT,
+                  FOREIGN KEY(draft_id) REFERENCES local_draft(id) ON DELETE CASCADE
+                );
+                CREATE TABLE IF NOT EXISTS installation_identity (
+                  singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+                  installation_id TEXT NOT NULL,
+                  verified_org_id TEXT,
+                  verified_at TEXT,
+                  disclosure_at TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS managed_install (
+                  skill_id TEXT PRIMARY KEY,
+                  org_id TEXT NOT NULL,
+                  slug TEXT NOT NULL,
+                  version INTEGER NOT NULL CHECK(version > 0),
+                  content_hash TEXT NOT NULL,
+                  baseline_json TEXT NOT NULL,
+                  target_path TEXT NOT NULL UNIQUE,
+                  update_mode TEXT NOT NULL,
+                  state TEXT NOT NULL,
+                  installed_at TEXT NOT NULL,
+                  updated_at TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS operation_journal (
+                  id TEXT PRIMARY KEY,
+                  kind TEXT NOT NULL,
+                  entity_id TEXT NOT NULL,
+                  phase TEXT NOT NULL,
+                  payload_json TEXT NOT NULL,
+                  state TEXT NOT NULL,
+                  created_at TEXT NOT NULL,
+                  updated_at TEXT NOT NULL,
+                  UNIQUE(kind, entity_id, state)
+                );
+                """
+            )
+            db.execute(
+                "INSERT INTO schema_meta(key,value) VALUES('schema_version',?) "
+                "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+                (str(SCHEMA_VERSION),),
+            )
+        try:
+            self.path.chmod(0o600)
+        except OSError:
+            pass
+
+    @contextmanager
+    def transaction(self) -> Iterator[sqlite3.Connection]:
+        with self._lock:
+            db = sqlite3.connect(self.path, timeout=30, isolation_level=None)
+            db.row_factory = sqlite3.Row
+            db.execute("PRAGMA foreign_keys=ON")
+            db.execute("PRAGMA journal_mode=WAL")
+            db.execute("BEGIN IMMEDIATE")
+            try:
+                yield db
+                if db.in_transaction:
+                    db.execute("COMMIT")
+            except BaseException:
+                if db.in_transaction:
+                    db.execute("ROLLBACK")
+                raise
+            finally:
+                db.close()
+
+    def register_skill(
+        self, path: Path, *, content_hash: str | None, source_kind: str
+    ) -> str:
+        resolved = path.resolve()
+        stat = resolved.stat()
+        fs_identity = f"{stat.st_dev}:{stat.st_ino}" if stat.st_ino else None
+        now = utc_now()
+        with self.transaction() as db:
+            row = db.execute(
+                "SELECT id FROM local_skill WHERE canonical_path=? AND deleted_at IS NULL",
+                (str(resolved),),
+            ).fetchone()
+            if row is None and fs_identity:
+                matches = db.execute(
+                    "SELECT id FROM local_skill WHERE fs_identity=? AND deleted_at IS NULL",
+                    (fs_identity,),
+                ).fetchall()
+                row = matches[0] if len(matches) == 1 else None
+            skill_id = str(row["id"]) if row else str(uuid.uuid4())
+            if row:
+                db.execute(
+                    "UPDATE local_skill SET canonical_path=?,fs_identity=?,current_hash=?,"
+                    "source_kind=?,deleted_at=NULL,updated_at=? WHERE id=?",
+                    (
+                        str(resolved),
+                        fs_identity,
+                        content_hash,
+                        source_kind,
+                        now,
+                        skill_id,
+                    ),
+                )
+            else:
+                db.execute(
+                    "INSERT INTO local_skill VALUES(?,?,?,?,?,?,?,?)",
+                    (
+                        skill_id,
+                        str(resolved),
+                        fs_identity,
+                        content_hash,
+                        source_kind,
+                        None,
+                        now,
+                        now,
+                    ),
+                )
+            if content_hash:
+                db.execute(
+                    "INSERT OR IGNORE INTO snapshot VALUES(?,?,?)",
+                    (skill_id, content_hash, now),
+                )
+        return skill_id
+
+    def mark_missing_skills(self, seen_paths: set[str]) -> None:
+        """Tombstone disappeared paths so delete/recreate gets a new identity."""
+        now = utc_now()
+        with self.transaction() as db:
+            rows = db.execute(
+                "SELECT id,canonical_path FROM local_skill WHERE deleted_at IS NULL"
+            ).fetchall()
+            for row in rows:
+                if str(row["canonical_path"]) not in seen_paths:
+                    db.execute(
+                        "UPDATE local_skill SET deleted_at=?,updated_at=? WHERE id=?",
+                        (now, now, row["id"]),
+                    )
+
+    def installation_identity(self) -> str:
+        with self.transaction() as db:
+            row = db.execute(
+                "SELECT installation_id FROM installation_identity WHERE singleton=1"
+            ).fetchone()
+            if row:
+                return str(row["installation_id"])
+            installation_id = "hwi_" + uuid.uuid4().hex
+            db.execute(
+                "INSERT INTO installation_identity VALUES(1,?,?,?,?)",
+                (installation_id, None, None, utc_now()),
+            )
+            return installation_id
+
+    def verify_installation_identity(self, org_id: str) -> None:
+        with self.transaction() as db:
+            db.execute(
+                "UPDATE installation_identity SET verified_org_id=?,verified_at=? WHERE singleton=1",
+                (org_id, utc_now()),
+            )
+
+    def active_org_id(self) -> str | None:
+        with self.transaction() as db:
+            row = db.execute(
+                "SELECT verified_org_id FROM installation_identity WHERE singleton=1"
+            ).fetchone()
+            return str(row[0]) if row and row[0] else None
+
+    def record_draft(self, values: dict[str, str]) -> None:
+        now = utc_now()
+        with self.transaction() as db:
+            db.execute(
+                """INSERT INTO local_draft(
+                   id,skill_id,source_hash,overlay_path,draft_commit,server_revision,state,
+                   description,content_hash,description_hash,manifest_hash,created_at,updated_at
+                 ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)
+                 ON CONFLICT(id) DO UPDATE SET draft_commit=excluded.draft_commit,
+                   server_revision=excluded.server_revision,state=excluded.state,
+                   description=excluded.description,content_hash=excluded.content_hash,
+                   description_hash=excluded.description_hash,manifest_hash=excluded.manifest_hash,
+                   updated_at=excluded.updated_at""",
+                (
+                    values["id"],
+                    values["skill_id"],
+                    values["source_hash"],
+                    values["overlay_path"],
+                    values.get("draft_commit"),
+                    values.get("server_revision"),
+                    values["state"],
+                    values["description"],
+                    values["content_hash"],
+                    values["description_hash"],
+                    values["manifest_hash"],
+                    now,
+                    now,
+                ),
+            )
+
+    def draft(self, draft_id: str) -> dict[str, Any] | None:
+        with self.transaction() as db:
+            row = db.execute(
+                "SELECT * FROM local_draft WHERE id=?", (draft_id,)
+            ).fetchone()
+            return dict(row) if row else None
+
+    def prepared_draft(self, skill_id: str, source_hash: str) -> dict[str, Any] | None:
+        with self.transaction() as db:
+            row = db.execute(
+                "SELECT * FROM local_draft WHERE skill_id=? AND source_hash=? "
+                "AND state='prepared' ORDER BY updated_at DESC LIMIT 1",
+                (skill_id, source_hash),
+            ).fetchone()
+            return dict(row) if row else None
+
+    def set_draft_state(self, draft_id: str, state: str) -> None:
+        with self.transaction() as db:
+            db.execute(
+                "UPDATE local_draft SET state=?,updated_at=? WHERE id=?",
+                (state, utc_now(), draft_id),
+            )
+
+    def save_receipt(
+        self,
+        *,
+        draft_id: str,
+        server_revision: str,
+        content_hash: str,
+        description_hash: str,
+        manifest_hash: str,
+    ) -> str:
+        receipt_id = str(uuid.uuid4())
+        with self.transaction() as db:
+            db.execute("DELETE FROM review_receipt WHERE draft_id=?", (draft_id,))
+            db.execute(
+                "INSERT INTO review_receipt VALUES(?,?,?,?,?,?,?,NULL)",
+                (
+                    receipt_id,
+                    draft_id,
+                    server_revision,
+                    content_hash,
+                    description_hash,
+                    manifest_hash,
+                    utc_now(),
+                ),
+            )
+        return receipt_id
+
+    def receipt(self, draft_id: str) -> dict[str, Any] | None:
+        with self.transaction() as db:
+            row = db.execute(
+                "SELECT * FROM review_receipt WHERE draft_id=? AND consumed_at IS NULL",
+                (draft_id,),
+            ).fetchone()
+            return dict(row) if row else None
+
+    def consume_receipt(self, draft_id: str) -> None:
+        with self.transaction() as db:
+            db.execute(
+                "UPDATE review_receipt SET consumed_at=? WHERE draft_id=?",
+                (utc_now(), draft_id),
+            )
+
+    def journal(
+        self, kind: str, entity_id: str, phase: str, payload: dict[str, Any]
+    ) -> str:
+        operation_id = str(uuid.uuid4())
+        with self.transaction() as db:
+            db.execute(
+                "INSERT INTO operation_journal VALUES(?,?,?,?,?,'pending',?,?)",
+                (
+                    operation_id,
+                    kind,
+                    entity_id,
+                    phase,
+                    json.dumps(payload, sort_keys=True),
+                    utc_now(),
+                    utc_now(),
+                ),
+            )
+        return operation_id
+
+    def advance(self, operation_id: str, phase: str, *, done: bool = False) -> None:
+        with self.transaction() as db:
+            db.execute(
+                "UPDATE operation_journal SET phase=?,state=?,updated_at=? WHERE id=?",
+                (phase, "done" if done else "pending", utc_now(), operation_id),
+            )
+
+    def pending_operations(self) -> list[dict[str, Any]]:
+        with self.transaction() as db:
+            return [
+                dict(row)
+                for row in db.execute(
+                    "SELECT * FROM operation_journal WHERE state='pending' ORDER BY created_at"
+                ).fetchall()
+            ]
+
+    def record_install(self, values: dict[str, Any]) -> None:
+        now = utc_now()
+        with self.transaction() as db:
+            db.execute(
+                """INSERT INTO managed_install VALUES(?,?,?,?,?,?,?,?,?,?,?)
+                 ON CONFLICT(skill_id) DO UPDATE SET org_id=excluded.org_id,
+                   slug=excluded.slug,version=excluded.version,content_hash=excluded.content_hash,
+                   baseline_json=excluded.baseline_json,target_path=excluded.target_path,
+                   update_mode=excluded.update_mode,state=excluded.state,updated_at=excluded.updated_at""",
+                (
+                    values["skill_id"],
+                    values["org_id"],
+                    values["slug"],
+                    int(values["version"]),
+                    values["content_hash"],
+                    json.dumps(values["baseline"], sort_keys=True),
+                    values["target_path"],
+                    values["update_mode"],
+                    values.get("state", "active"),
+                    now,
+                    now,
+                ),
+            )
+
+    def installations(self) -> list[dict[str, Any]]:
+        with self.transaction() as db:
+            return [
+                dict(row)
+                for row in db.execute(
+                    "SELECT * FROM managed_install ORDER BY slug"
+                ).fetchall()
+            ]

--- a/scripts/verify_wisdom_contract.py
+++ b/scripts/verify_wisdom_contract.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Fail CI when pinned Wisdom artifacts or canonical algorithms drift."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+
+from hermes_wisdom.contract import (
+    CONTRACT_PIN,
+    ContentFile,
+    author_description_hash,
+    derive_content_hash,
+    sanitize_author_description,
+    sha256_address,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACTS = ROOT / "hermes_wisdom" / "contracts"
+
+
+def digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def main() -> int:
+    schema = CONTRACTS / "skill-manifest.schema.v1.json"
+    vectors_path = CONTRACTS / "canonical-hash-vectors.v1.json"
+    assert digest(schema) == CONTRACT_PIN.manifest_schema_sha256
+    assert digest(vectors_path) == CONTRACT_PIN.canonical_vectors_sha256
+    vectors = json.loads(vectors_path.read_text(encoding="utf-8"))
+    files: list[ContentFile] = []
+    for item in vectors["files"]:
+        body = base64.b64decode(item["content_base64"], validate=True)
+        assert sha256_address(body) == item["hash"]
+        files.append(
+            ContentFile(path=item["path"], mode=item["mode"], hash=item["hash"])
+        )
+    assert derive_content_hash(files) == vectors["content_hash"]
+    canonical = sanitize_author_description(vectors["author_description_input"])
+    assert canonical == vectors["canonical_author_description"]
+    assert author_description_hash(canonical) == vectors["author_description_hash"]
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "gateway_commit": CONTRACT_PIN.gateway_commit,
+                "openapi_sha256": CONTRACT_PIN.openapi_sha256,
+                "manifest_schema_sha256": digest(schema),
+                "canonical_vectors_sha256": digest(vectors_path),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/productivity/collective-wisdom-install/SKILL.md
+++ b/skills/productivity/collective-wisdom-install/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: collective-wisdom-install
+description: Install a shared team skill with explicit consent.
+version: 0.1.0
+author: Shannon (Shannon), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [skills, collective-wisdom, install, team]
+    related_skills: []
+---
+
+# Collective Wisdom Install Skill
+
+Resolve a copied Collective Wisdom install request into a local compatibility
+plan, then apply it only after explicit user confirmation. This skill never
+adds a core tool, changes the active toolset, or installs dependencies.
+
+## When to Use
+
+- The user pastes `Install this Collective Wisdom skill: <portal-link>`.
+- The user asks to install a Collective Wisdom skill ID or version.
+- Don't use for Hub skills or the legacy `_org` Skill Sync mirror.
+
+## Prerequisites
+
+- The profile must already be signed into Nous Portal.
+- `hermes wisdom setup` must have verified a team organization and installation
+  identity for this profile.
+
+## Procedure
+
+1. Extract only the authenticated Portal URL, skill ID, or `skill-id@vN` from
+   the user's request. Do not infer another organization or version.
+2. Use `terminal(command="hermes wisdom install '<reference>' --plan --json")`.
+   Treat a not-found response as opaque; never probe nearby identifiers.
+3. Present the returned version, author copy, local compatibility outcome,
+   setup actions, permissions, and known limitations. State that
+   SkillEvaluator is advisory and separate from compatibility.
+4. Use `clarify` to ask whether to apply this exact receipt. Do not treat the
+   original natural-language request as the apply confirmation.
+5. Only after an affirmative answer, use
+   `terminal(command="hermes wisdom install --apply-receipt '<receipt>' --accept-partial --json")`.
+   Omit `--accept-partial` unless the user explicitly accepted a partial or
+   setup-required outcome.
+6. Report the managed path, installed version, content hash, and effective
+   update mode from the apply response.
+
+## Pitfalls
+
+- Never pass a browser-supplied organization, generation, content hash, or
+  Gateway token. The CLI re-fetches authoritative state.
+- Never convert a blocked compatibility result into a force install.
+- Never say an unavailable advisory scan passed.
+- A Portal raw copy is an unmanaged fork, not a managed install.
+
+## Verification
+
+The apply response must say `installed: true`, include the pinned version and
+content hash, and point below the active profile's `_wisdom/<org-id>/` root.

--- a/tests/agent/test_wisdom_skill_namespace.py
+++ b/tests/agent/test_wisdom_skill_namespace.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+from agent import skill_utils
+
+
+def create_skill(root: Path, org: str, name: str) -> Path:
+    path = root / "_wisdom" / org / name / "SKILL.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"---\nname: {name}\ndescription: Test.\n---\n# {name}\n", encoding="utf-8"
+    )
+    return path
+
+
+def test_no_verified_marker_means_no_managed_wisdom_skills(tmp_path: Path):
+    create_skill(tmp_path, "org-a", "shared-a")
+    assert list(skill_utils.iter_skill_index_files(tmp_path, "SKILL.md")) == []
+
+
+def test_only_last_verified_org_managed_tree_loads(tmp_path: Path):
+    first = create_skill(tmp_path, "org-a", "shared-a")
+    second = create_skill(tmp_path, "org-b", "shared-b")
+    marker = tmp_path / "_wisdom" / ".active_org"
+    marker.write_text("org-a\n", encoding="utf-8")
+    assert list(skill_utils.iter_skill_index_files(tmp_path, "SKILL.md")) == [first]
+    marker.write_text("org-b\n", encoding="utf-8")
+    assert list(skill_utils.iter_skill_index_files(tmp_path, "SKILL.md")) == [second]
+
+
+def test_wisdom_managed_path_is_distinct_from_org_mirror(tmp_path: Path):
+    managed = create_skill(tmp_path, "org-a", "shared-a")
+    assert skill_utils.is_wisdom_managed_path(managed, tmp_path)
+    assert not skill_utils.is_org_mirror_path(managed, tmp_path)

--- a/tests/hermes_cli/test_wisdom_parser.py
+++ b/tests/hermes_cli/test_wisdom_parser.py
@@ -1,0 +1,45 @@
+import argparse
+
+from hermes_cli.subcommands.wisdom import build_wisdom_parser
+
+
+def parser():
+    value = argparse.ArgumentParser()
+    build_wisdom_parser(value.add_subparsers(dest="command"))
+    return value
+
+
+def test_all_foundation_commands_are_registered():
+    value = parser()
+    commands = {
+        "setup": [],
+        "status": [],
+        "scan": [],
+        "suggest": [],
+        "candidates": [],
+        "review": ["draft"],
+        "approve": ["draft"],
+        "decline": ["draft"],
+        "list": [],
+        "show": ["skill"],
+        "install": ["skill"],
+        "versions": ["skill"],
+    }
+    for command, trailing in commands.items():
+        args = value.parse_args(["wisdom", command, *trailing])
+        assert args.wisdom_command == command
+
+
+def test_install_plan_apply_arguments_are_stable():
+    value = parser()
+    plan = value.parse_args(["wisdom", "install", "skill-1@v2", "--plan", "--json"])
+    assert plan.reference == "skill-1@v2"
+    assert plan.plan is True
+    apply = value.parse_args([
+        "wisdom",
+        "install",
+        "--apply-receipt",
+        "wip_123",
+        "--accept-partial",
+    ])
+    assert apply.apply_receipt == "wip_123"

--- a/tests/skills/test_collective_wisdom_install_skill.py
+++ b/tests/skills/test_collective_wisdom_install_skill.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+import yaml
+
+
+SKILL = Path("skills/productivity/collective-wisdom-install/SKILL.md")
+
+
+def test_collective_wisdom_install_skill_contract():
+    text = SKILL.read_text(encoding="utf-8")
+    _, frontmatter, body = text.split("---", 2)
+    metadata = yaml.safe_load(frontmatter)
+    assert metadata["name"] == "collective-wisdom-install"
+    assert metadata["description"].endswith(".")
+    assert len(metadata["description"]) <= 60
+    assert "--plan --json" in body
+    assert "--apply-receipt" in body
+    assert "`clarify`" in body
+    assert "changes the active toolset" in body

--- a/tests/wisdom/test_client.py
+++ b/tests/wisdom/test_client.py
@@ -1,0 +1,92 @@
+import json
+
+import pytest
+
+from hermes_wisdom.client import WisdomClient, WisdomNotFound, WisdomValidationError
+
+
+class Response:
+    def __init__(self, status: int, body):
+        self.status_code = status
+        self._body = body
+        self.content = json.dumps(body).encode() if body is not None else b""
+
+    def json(self):
+        return self._body
+
+
+class Session:
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    def request(self, method, url, **kwargs):
+        self.calls.append((method, url, kwargs))
+        return self.response
+
+
+def client(response):
+    value = WisdomClient.__new__(WisdomClient)
+    value.base = "https://gateway.example"
+    value.timeout = 7
+    value.session = Session(response)
+    return value
+
+
+def test_submit_body_has_no_local_candidate_or_activity_signals():
+    body = {
+        "draft": {
+            "id": "d1",
+            "orgId": "o1",
+            "ownerUserId": "u1",
+            "slug": "my-skill",
+            "draftCommit": "sha256:" + "a" * 64,
+            "contentHash": "sha256:" + "b" * 64,
+            "authorDescription": "Does a task.",
+            "authorDescriptionHash": "sha256:" + "c" * 64,
+            "state": "ready",
+            "packageManifestHash": "sha256:" + "d" * 64,
+            "packageManifestSchemaVersion": 1,
+            "systemSpec": None,
+            "scan": None,
+            "scanVerdict": "pass",
+            "explanation": None,
+            "updatedAt": "now",
+        }
+    }
+    value = client(Response(201, body))
+    value.submit_draft(
+        slug="my-skill",
+        commit="sha256:" + "a" * 64,
+        content_hash="sha256:" + "b" * 64,
+        description="Does a task.",
+    )
+    payload = value.session.calls[0][2]["json"]
+    assert payload == {
+        "slug": "my-skill",
+        "draft_commit": "sha256:" + "a" * 64,
+        "content_hash": "sha256:" + "b" * 64,
+        "author_description": "Does a task.",
+    }
+    assert not (
+        {"usage", "refinement", "candidate", "ranking", "stability", "dismissal"}
+        & payload.keys()
+    )
+
+
+def test_not_found_is_opaque():
+    value = client(Response(404, {"error": "not_found"}))
+    with pytest.raises(WisdomNotFound, match="item not found"):
+        value._request("GET", "skills/secret")
+
+
+def test_approve_exact_three_hash_body():
+    value = client(Response(200, {"draft": {"id": "invalid"}}))
+    with pytest.raises(Exception):
+        value.approve("d1", content_hash="c", description_hash="d", manifest_hash="m")
+    payload = value.session.calls[0][2]["json"]
+    assert payload == {
+        "content_hash": "c",
+        "author_description_hash": "d",
+        "package_manifest_hash": "m",
+    }

--- a/tests/wisdom/test_compatibility.py
+++ b/tests/wisdom/test_compatibility.py
@@ -1,0 +1,53 @@
+from hermes_wisdom.compatibility import LocalCapabilities, evaluate
+from hermes_wisdom.contract import (
+    HermesRequirement,
+    PluginRequirement,
+    RuntimeRequirement,
+    SystemSpecification,
+    ToolRequirement,
+)
+
+
+def spec(**updates):
+    values = {"hermes": HermesRequirement(minimum_version="0.1.0")}
+    values.update(updates)
+    return SystemSpecification(**values)
+
+
+def local(**updates):
+    values = {
+        "hermes_version": "1.0.0",
+        "os": "darwin",
+        "architecture": "arm64",
+        "runtime": {"shell": True, "browser": False, "code": True, "sandbox": True},
+    }
+    values.update(updates)
+    return LocalCapabilities(**values)
+
+
+def test_all_four_compatibility_outcomes_are_deterministic():
+    assert evaluate(spec(), local()).outcome == "compatible"
+    assert (
+        evaluate(
+            spec(
+                tools=[
+                    ToolRequirement(name="git", minimum_version="2", auto_install=False)
+                ]
+            ),
+            local(),
+        ).outcome
+        == "compatible_after_setup"
+    )
+    assert (
+        evaluate(spec(known_limitations=["manual replay only"]), local()).outcome
+        == "partial"
+    )
+    assert (
+        evaluate(spec(runtime=RuntimeRequirement(browser=True)), local()).outcome
+        == "blocked_pending_action"
+    )
+
+
+def test_skill_evaluator_is_not_a_compatibility_input():
+    result = evaluate(spec(), local())
+    assert not hasattr(result, "skill_evaluator")

--- a/tests/wisdom/test_contract.py
+++ b/tests/wisdom/test_contract.py
@@ -1,0 +1,41 @@
+import base64
+import json
+from pathlib import Path
+
+from hermes_wisdom.contract import (
+    ContentFile,
+    author_description_hash,
+    derive_content_hash,
+    sanitize_author_description,
+    sha256_address,
+)
+
+
+VECTORS = Path("hermes_wisdom/contracts/canonical-hash-vectors.v1.json")
+
+
+def test_gateway_canonical_vectors_match_exactly():
+    vectors = json.loads(VECTORS.read_text(encoding="utf-8"))
+    files = []
+    for item in vectors["files"]:
+        body = base64.b64decode(item["content_base64"], validate=True)
+        assert sha256_address(body) == item["hash"]
+        files.append(
+            ContentFile(path=item["path"], mode=item["mode"], hash=item["hash"])
+        )
+    assert derive_content_hash(files) == vectors["content_hash"]
+    canonical = sanitize_author_description(vectors["author_description_input"])
+    assert canonical == vectors["canonical_author_description"]
+    assert author_description_hash(canonical) == vectors["author_description_hash"]
+
+
+def test_content_hash_commits_to_mode_and_path():
+    blob = sha256_address(b"same")
+    plain = derive_content_hash([ContentFile(path="SKILL.md", mode="file", hash=blob)])
+    executable = derive_content_hash([
+        ContentFile(path="SKILL.md", mode="exec", hash=blob)
+    ])
+    moved = derive_content_hash([
+        ContentFile(path="refs/SKILL.md", mode="file", hash=blob)
+    ])
+    assert len({plain, executable, moved}) == 3

--- a/tests/wisdom/test_package.py
+++ b/tests/wisdom/test_package.py
@@ -1,0 +1,97 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_wisdom.package import (
+    PackagePolicyError,
+    prepare_package,
+    verify_content_files,
+)
+
+
+def make_skill(root: Path) -> Path:
+    skill = root / "my-skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\nname: my-skill\ndescription: Test.\n---\n\n# Test\n", encoding="utf-8"
+    )
+    refs = skill / "refs"
+    refs.mkdir()
+    (refs / "notes.txt").write_text("Exact notes.\n", encoding="utf-8")
+    return skill
+
+
+def test_preparation_creates_only_instruction_overlay_and_hashes(tmp_path: Path):
+    skill = make_skill(tmp_path)
+    package = prepare_package(
+        skill,
+        overlay_root=tmp_path / "overlays",
+        author_description="  <b>Does</b> the useful thing. \r\n",
+        owner="owner",
+        installation_id="installation-123456",
+    )
+    assert package.description == "Does the useful thing."
+    assert {item.path for item in package.files} == {
+        "SKILL.md",
+        "refs/notes.txt",
+        "skill.manifest.json",
+    }
+    manifest = json.loads(
+        (package.overlay / "skill.manifest.json").read_text(encoding="utf-8")
+    )
+    assert manifest["requirements"]["tools"] == []
+    assert package.content_hash.startswith("sha256:")
+
+
+@pytest.mark.parametrize(
+    "relative,content",
+    [
+        ("scripts/run.sh", "echo nope"),
+        ("templates/active.md", "active"),
+        ("package.json", "{}"),
+        ("refs/package.json", "{}"),
+    ],
+)
+def test_unsupported_content_is_rejected_not_silently_omitted(
+    tmp_path: Path, relative: str, content: str
+):
+    skill = make_skill(tmp_path)
+    target = skill / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    with pytest.raises(PackagePolicyError):
+        prepare_package(
+            skill,
+            overlay_root=tmp_path / "overlays",
+            author_description="A valid description.",
+            owner="owner",
+            installation_id="installation-123456",
+        )
+
+
+def test_download_rejects_hostile_paths_modes_and_binary():
+    manifest = b'{"schema_version":1}'
+    base = [("SKILL.md", "file", b"# test"), ("skill.manifest.json", "file", manifest)]
+    with pytest.raises(PackagePolicyError):
+        verify_content_files(base + [("../escape", "file", b"x")])
+    with pytest.raises(PackagePolicyError):
+        verify_content_files([
+            (name, "exec" if name == "SKILL.md" else mode, body)
+            for name, mode, body in base
+        ])
+    with pytest.raises(PackagePolicyError):
+        verify_content_files(base + [("assets/image.bin", "file", b"\xff\xfe")])
+
+
+def test_referenced_script_requires_explicit_instruction_only_fork(tmp_path: Path):
+    skill = make_skill(tmp_path)
+    (skill / "SKILL.md").write_text("Run scripts/deploy.sh now.", encoding="utf-8")
+    with pytest.raises(PackagePolicyError, match="instruction-only fork"):
+        prepare_package(
+            skill,
+            overlay_root=tmp_path / "overlays",
+            author_description="A valid description.",
+            owner="owner",
+            installation_id="installation-123456",
+        )

--- a/tests/wisdom/test_service.py
+++ b/tests/wisdom/test_service.py
@@ -1,0 +1,78 @@
+import json
+from pathlib import Path
+
+from hermes_wisdom.client import Draft
+from hermes_wisdom.service import WisdomService
+from hermes_wisdom.store import WisdomStore
+
+
+class FakeClient:
+    identity = {"owner": "user-1"}
+
+    def __init__(self):
+        self.uploaded = 0
+        self.submissions = []
+
+    def upload_private_objects(self, objects):
+        self.uploaded += len(objects)
+
+    def submit_draft(self, **payload):
+        self.submissions.append(payload)
+        return Draft(
+            id="draft-1",
+            orgId="org-1",
+            ownerUserId="user-1",
+            slug=payload["slug"],
+            draftCommit=payload["commit"],
+            contentHash=payload["content_hash"],
+            authorDescription=payload["description"],
+            authorDescriptionHash=None,
+            state="ready",
+            packageManifestHash=None,
+            packageManifestSchemaVersion=1,
+            systemSpec=None,
+            scan=None,
+            scanVerdict="pass",
+            explanation=None,
+            updatedAt="revision-1",
+        )
+
+
+def test_prepare_requires_local_owner_edit_before_any_network(
+    monkeypatch, tmp_path: Path
+):
+    skill = tmp_path / "skills" / "my-skill"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text(
+        "---\nname: my-skill\ndescription: Test.\n---\n# Test\n", encoding="utf-8"
+    )
+    fake = FakeClient()
+    service = WisdomService(store=WisdomStore(tmp_path / "state"), client=fake)
+    monkeypatch.setattr("hermes_wisdom.service._find_skill_dir", lambda _name: skill)
+    monkeypatch.setattr(service, "_eligible_paths", lambda: [skill])
+    monkeypatch.setattr(
+        "hermes_wisdom.service.draft_description", lambda _body: "Drafted locally."
+    )
+
+    prepared = service.suggest("my-skill")
+    assert prepared["network_submission"] is False
+    assert fake.uploaded == 0
+    overlay = Path(prepared["overlay_path"])
+    manifest = json.loads((overlay / "skill.manifest.json").read_text(encoding="utf-8"))
+    manifest["requirements"]["known_limitations"] = ["Owner reviewed limitation"]
+    (overlay / "skill.manifest.json").write_text(
+        json.dumps(manifest, sort_keys=True, separators=(",", ":")), encoding="utf-8"
+    )
+
+    submitted = service.suggest("my-skill", description="Owner-approved copy.")
+    assert submitted["draft"]["id"] == "draft-1"
+    assert fake.uploaded > 0
+    assert fake.submissions[0].keys() == {
+        "slug",
+        "commit",
+        "content_hash",
+        "description",
+    }
+    serialized = json.dumps(fake.submissions[0])
+    for forbidden in ("usage", "refinement", "candidate", "ranking", "stability"):
+        assert forbidden not in serialized

--- a/tests/wisdom/test_store.py
+++ b/tests/wisdom/test_store.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+from hermes_wisdom.store import WisdomStore
+
+
+def test_profile_store_permissions_identity_and_rename(tmp_path: Path):
+    store = WisdomStore(tmp_path / "wisdom")
+    skill = tmp_path / "skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("hello", encoding="utf-8")
+    first = store.register_skill(skill, content_hash="sha256:a", source_kind="local")
+    moved = tmp_path / "renamed"
+    skill.rename(moved)
+    second = store.register_skill(moved, content_hash="sha256:b", source_kind="local")
+    assert first == second
+    assert store.installation_identity() == store.installation_identity()
+    assert store.root.stat().st_mode & 0o777 == 0o700
+    assert store.path.stat().st_mode & 0o777 == 0o600
+
+
+def test_delete_recreate_does_not_inherit_identity(tmp_path: Path):
+    store = WisdomStore(tmp_path / "wisdom")
+    path = tmp_path / "skill"
+    path.mkdir()
+    (path / "SKILL.md").write_text("one", encoding="utf-8")
+    first = store.register_skill(path, content_hash="sha256:a", source_kind="local")
+    (path / "SKILL.md").unlink()
+    path.rmdir()
+    path.mkdir()
+    (path / "SKILL.md").write_text("two", encoding="utf-8")
+    store.mark_missing_skills(set())
+    second = store.register_skill(path, content_hash="sha256:b", source_kind="local")
+    assert first != second
+
+
+def test_operation_journal_survives_restart(tmp_path: Path):
+    root = tmp_path / "wisdom"
+    store = WisdomStore(root)
+    operation = store.journal("install", "skill-1", "downloaded", {"version": 1})
+    store.advance(operation, "files_committed")
+    resumed = WisdomStore(root).pending_operations()
+    assert resumed[0]["id"] == operation
+    assert resumed[0]["phase"] == "files_committed"

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -100,6 +100,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | Skill | Description | Path |
 |-------|-------------|------|
 | [`airtable`](/docs/user-guide/skills/bundled/productivity/productivity-airtable) | Airtable REST API via curl. Records CRUD, filters, upserts. | `productivity/airtable` |
+| [`collective-wisdom-install`](/docs/user-guide/skills/bundled/productivity/productivity-collective-wisdom-install) | Install a shared team skill with explicit consent. | `productivity/collective-wisdom-install` |
 | [`box`](/docs/user-guide/skills/bundled/productivity/productivity-box) | Box manages cloud files, sharing, search, and metadata. | `productivity/box` |
 | [`document-to-action-items`](/docs/user-guide/skills/bundled/productivity/productivity-document-to-action-items) | Extract cited obligations, deadlines, tasks from documents. | `productivity/document-to-action-items` |
 | [`docx`](/docs/user-guide/skills/bundled/productivity/productivity-docx) | Create, read, edit, and template Word .docx files. | `productivity/docx` |

--- a/website/docs/user-guide/skills/bundled/productivity/productivity-collective-wisdom-install.md
+++ b/website/docs/user-guide/skills/bundled/productivity/productivity-collective-wisdom-install.md
@@ -1,0 +1,78 @@
+---
+title: "Collective Wisdom Install — Install a shared team skill with explicit consent"
+sidebar_label: "Collective Wisdom Install"
+description: "Install a shared team skill with explicit consent"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Collective Wisdom Install
+
+Install a shared team skill with explicit consent.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/productivity/collective-wisdom-install` |
+| Version | `0.1.0` |
+| Author | Shannon (Shannon), Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `skills`, `collective-wisdom`, `install`, `team` |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Collective Wisdom Install Skill
+
+Resolve a copied Collective Wisdom install request into a local compatibility
+plan, then apply it only after explicit user confirmation. This skill never
+adds a core tool, changes the active toolset, or installs dependencies.
+
+## When to Use
+
+- The user pastes `Install this Collective Wisdom skill: <portal-link>`.
+- The user asks to install a Collective Wisdom skill ID or version.
+- Don't use for Hub skills or the legacy `_org` Skill Sync mirror.
+
+## Prerequisites
+
+- The profile must already be signed into Nous Portal.
+- `hermes wisdom setup` must have verified a team organization and installation
+  identity for this profile.
+
+## Procedure
+
+1. Extract only the authenticated Portal URL, skill ID, or `skill-id@vN` from
+   the user's request. Do not infer another organization or version.
+2. Use `terminal(command="hermes wisdom install '<reference>' --plan --json")`.
+   Treat a not-found response as opaque; never probe nearby identifiers.
+3. Present the returned version, author copy, local compatibility outcome,
+   setup actions, permissions, and known limitations. State that
+   SkillEvaluator is advisory and separate from compatibility.
+4. Use `clarify` to ask whether to apply this exact receipt. Do not treat the
+   original natural-language request as the apply confirmation.
+5. Only after an affirmative answer, use
+   `terminal(command="hermes wisdom install --apply-receipt '<receipt>' --accept-partial --json")`.
+   Omit `--accept-partial` unless the user explicitly accepted a partial or
+   setup-required outcome.
+6. Report the managed path, installed version, content hash, and effective
+   update mode from the apply response.
+
+## Pitfalls
+
+- Never pass a browser-supplied organization, generation, content hash, or
+  Gateway token. The CLI re-fetches authoritative state.
+- Never convert a blocked compatibility result into a force install.
+- Never say an unavailable advisory scan passed.
+- A Portal raw copy is an unmanaged fork, not a managed install.
+
+## Verification
+
+The apply response must say `installed: true`, include the pinned version and
+content hash, and point below the active profile's `_wisdom/<org-id>/` root.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -263,6 +263,7 @@ const sidebars: SidebarsConfig = {
                   collapsed: true,
                   items: [
                     'user-guide/skills/bundled/productivity/productivity-airtable',
+                    'user-guide/skills/bundled/productivity/productivity-collective-wisdom-install',
                     'user-guide/skills/bundled/productivity/productivity-box',
                     'user-guide/skills/bundled/productivity/productivity-document-to-action-items',
                     'user-guide/skills/bundled/productivity/productivity-docx',


### PR DESCRIPTION
## Summary

First of three stacked Hermes Collective Wisdom Agent V1 PRs. This foundation delivers the independently shippable dogfood slice: local setup/state, strict instruction-only package preparation, model-assisted but owner-edited author copy, exact three-hash consent, owner-private Gateway drafts, explicit managed installation, deterministic local compatibility, CLI, and a built-in natural-language install workflow.

The implementation is pinned to:

- canonical requirements: gateway-gateway PR #215 at `ee7b6123a08ef2379ef1641ed8e6defa10329eaa`
- Gateway implementation: PR #213 at `391bf7077c0dee5ca3b818ceff61c31cf14f3efd`
- OpenAPI SHA-256: `e2ce2025daff7470791b8080a3ace884f3ca5115047d8bf30183cc2e1d1f66c2`
- manifest schema SHA-256: `64d0010eada1d79fa16309e9fd715faf77b6186360ea0b095182b2bdaeec5714`
- canonical vectors SHA-256: `e2b28c708f69e99b342de1df48498d96efde68867857391590bc964a609a730b`

## What landed

- profile-scoped `wisdom/wisdom.db` with restrictive permissions, transactional migrations, stable local identities, delete/recreate tombstones, drafts/receipts, managed installs, and crash-recovery journal
- `hermes wisdom setup|status|scan|suggest|candidates|review|approve|decline|list|show|install|versions`, including stable JSON and exit categories
- owner-local prepare/edit checkpoint before any network submission; local usage/refinement/candidate/ranking/stability signals never enter the wire payload
- exact HSP object upload to the owner-private namespace, authoritative draft re-fetch, full closure re-hash, and three-hash review receipts
- instruction-only allowlist: one root `SKILL.md`, one root `skill.manifest.json`, inert UTF-8 `refs/`/`assets/`; scripts, templates, package-manager manifests, binaries, executables, hostile paths, and collisions fail closed
- built-in guard enforcement plus NVIDIA SkillEvaluator advisory with explicit unavailable state and high-confidence secret pause
- `_wisdom/<org-id>/<slug>` managed namespace, separate from `_org`, with last-Gateway-verified-org discovery gating and offline retention
- deterministic local System Specification evaluation with `compatible`, `compatible_after_setup`, `partial`, and `blocked_pending_action`; no local inventory upload or dependency action
- two-phase natural-language plan/apply built-in skill using the existing CLI and `clarify`
- checked-in requirements ledger and contract drift verifier

## Requirement traceability

See `docs/COLLECTIVE_WISDOM_AGENT_REQUIREMENTS.md`. Foundation rows are complete in this PR. Continuous qualification/in-chat candidate UI remains explicitly partial until stacked PR 2; update/feed/uninstall and completed dashboard/native consumption UI remain partial until stacked PR 3.

## Validation

- canonical contract drift verifier: passed
- Ruff on all changed Python: passed
- ty on all new/changed isolated modules: passed
- focused Wisdom, CLI, built-in skill, and managed namespace suites: 24 passed
- combined Wisdom + legacy skill discovery, M2 org namespace, Skill Sync client, and skill-usage suites: 161 passed
- real CLI parser smoke: `hermes wisdom --help` passed

The repository-wide `ty check hermes_cli/main.py` still reports its existing diagnostics; the new modules and touched import-light modules are clean.

## Stacked follow-ups

1. #93637 — local day buckets/refinements/stability, durable candidate events, dashboard/native/in-chat contribution UI
2. #94266 — update modes, required forks, feed/notifications, uninstall, and completed dashboard/native consumption UI

Rollout remains disabled pending the reconciled Gateway/Portal stack, live two-identity E2E, and product-owner dogfood sign-off.

Model: GPT-5.6
Harness: Codex desktop
