### PR TITLE
fix(gateway): expose trusted destination context to hooks

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -660,6 +660,23 @@ def init_agent(
     agent._chat_type = chat_type
     agent._thread_id = thread_id
     agent._gateway_session_key = gateway_session_key  # Stable per-chat key (e.g. agent:main:telegram:dm:123)
+    # A gateway AIAgent owns one provider destination for its entire model
+    # conversation.  Keep the original, provider-sourced route immutable so a
+    # cached transcript (including plugin-injected private context) cannot be
+    # reused after an accidental in-place destination mutation.
+    agent._destination_binding = (
+        (
+            platform or "",
+            user_id or "",
+            user_id_alt or "",
+            chat_id or "",
+            chat_type or "",
+            thread_id or "",
+            gateway_session_key or "",
+        )
+        if gateway_session_key
+        else None
+    )
     # Pluggable print function — CLI replaces this with _cprint so that
     # raw ANSI status lines are routed through prompt_toolkit's renderer
     # instead of going directly to stdout where patch_stdout's StdoutProxy

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -51,6 +51,33 @@ from agent.model_metadata import (
 logger = logging.getLogger(__name__)
 
 
+def assert_destination_binding(agent) -> None:
+    """Refuse to reuse a gateway model conversation for another destination.
+
+    Gateway agents are cached and their transcript can contain destination-
+    specific plugin context.  The provider route captured at construction is
+    therefore a security boundary, not mutable per-turn metadata.  CLI and
+    legacy test agents without a gateway session key have no binding.
+    """
+    expected = getattr(agent, "_destination_binding", None)
+    if expected is None:
+        return
+    current = (
+        getattr(agent, "platform", None) or "",
+        getattr(agent, "_user_id", None) or "",
+        getattr(agent, "_user_id_alt", None) or "",
+        getattr(agent, "_chat_id", None) or "",
+        getattr(agent, "_chat_type", None) or "",
+        getattr(agent, "_thread_id", None) or "",
+        getattr(agent, "_gateway_session_key", None) or "",
+    )
+    if current != expected:
+        raise RuntimeError(
+            "Agent destination binding changed during the conversation; "
+            "start a fresh destination-bound agent instead"
+        )
+
+
 def compose_user_api_content(
     content: Any,
     ext_prefetch_cache: str,
@@ -473,6 +500,12 @@ def build_turn_context(
     ``conversation_loop`` module are passed in explicitly to keep this module
     free of an import cycle with ``agent.conversation_loop``.
     """
+    # This must precede hooks, memory prefetch, persistence, compaction, and
+    # every provider call.  A drifted agent may already contain private or
+    # private-derived prior turns, so merely disabling fresh hydration is not
+    # sufficient.
+    assert_destination_binding(agent)
+
     # Guard stdio against OSError from broken pipes (systemd/headless/daemon).
     install_safe_stdio()
 
@@ -1279,6 +1312,8 @@ def build_turn_context(
             platform=getattr(agent, "platform", None) or "",
             parent_session_id=getattr(agent, "_parent_session_id", None) or "",
             sender_id=getattr(agent, "_user_id", None) or "",
+            destination_chat_id=getattr(agent, "_chat_id", None) or "",
+            destination_chat_type=getattr(agent, "_chat_type", None) or "",
         )
         _ctx_parts: list[str] = []
         # Spill oversized per-hook context to disk so a runaway plugin

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -104,6 +104,15 @@ _DEFAULT_SIDECAR_BIND = "127.0.0.1"
 # size to ~16 KB.  Keep a conservative cap that matches BlueBubbles.
 _MAX_MESSAGE_LENGTH = 8000
 
+
+def _normalize_space_chat_type(value: Any) -> str:
+    """Return a trusted Photon destination class without guessing privacy."""
+    if value == "dm":
+        return "dm"
+    if value == "group":
+        return "group"
+    return "unknown"
+
 # ---------------------------------------------------------------------------
 # Sidecar runtime record
 #
@@ -1234,7 +1243,9 @@ class PhotonAdapter(BasePlatformAdapter):
             return
 
         # iMessage spaces carry their type directly — no id string-sniffing.
-        chat_type = "group" if space.get("type") == "group" else "dm"
+        # Unknown future or malformed values must not be promoted to a trusted
+        # private destination.
+        chat_type = _normalize_space_chat_type(space.get("type"))
         sender_id = sender.get("id") or space.get("phone") or space_id
 
         ts_str = event.get("timestamp") or ""

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -446,13 +446,26 @@ def wire_env():
     db = SessionDB(db_path=Path(test_home) / "state.db")
     sid = "sess-wire"
 
-    def make_agent():
+    def make_agent(**route_overrides):
+        route = {
+            "platform": "cli",
+            "user_id": None,
+            "chat_id": None,
+            "chat_type": None,
+            "gateway_session_key": None,
+        }
+        route.update(route_overrides)
         agent = AIAgent(
             api_key="test-key", base_url=f"http://127.0.0.1:{port}/v1",
             provider="openai-compat", model="test-model",
             max_iterations=10, enabled_toolsets=[],
             quiet_mode=True, skip_context_files=True, skip_memory=True,
-            save_trajectories=False, platform="cli",
+            save_trajectories=False,
+            platform=route["platform"],
+            user_id=route["user_id"],
+            chat_id=route["chat_id"],
+            chat_type=route["chat_type"],
+            gateway_session_key=route["gateway_session_key"],
             session_db=db, session_id=sid,
         )
         agent.valid_tool_names = {"read_file"}
@@ -487,6 +500,72 @@ def _user_messages(req: dict) -> list:
 
 
 class TestWireInvariant:
+    def test_pre_llm_hook_receives_bound_destination_context(self, wire_env):
+        make_agent, handler, _db, _sid = wire_env
+        agent = make_agent(
+            platform="photon",
+            user_id="provider-sender",
+            chat_id="provider-space",
+            chat_type="dm",
+            gateway_session_key="agent:main:photon:dm:provider-space",
+        )
+        handler.response_queue.append(_text_resp("done"))
+        seen = {}
+
+        def capture(hook, **kwargs):
+            if hook == "pre_llm_call":
+                seen.update(kwargs)
+            return []
+
+        with patch("hermes_cli.plugins.invoke_hook", side_effect=capture):
+            agent.run_conversation("hello", conversation_history=[], task_id="t")
+
+        assert seen["platform"] == "photon"
+        assert seen["sender_id"] == "provider-sender"
+        assert seen["destination_chat_id"] == "provider-space"
+        assert seen["destination_chat_type"] == "dm"
+
+    @pytest.mark.parametrize(
+        ("field", "changed_value"),
+        [
+            ("_chat_type", "group"),
+            ("_chat_type", "unknown"),
+            ("_chat_id", "different-space"),
+        ],
+    )
+    def test_destination_drift_fails_before_hook_or_model_call(
+        self, wire_env, field, changed_value
+    ):
+        make_agent, handler, _db, _sid = wire_env
+        agent = make_agent(
+            platform="photon",
+            user_id="provider-sender",
+            chat_id="private-space",
+            chat_type="dm",
+            gateway_session_key="agent:main:photon:dm:private-space",
+        )
+        hook_calls = []
+
+        def capture(hook, **kwargs):
+            if hook == "pre_llm_call":
+                hook_calls.append(kwargs)
+                return [{"context": "PRIVATE-CONTEXT"}]
+            return []
+
+        handler.response_queue.append(_text_resp("private answer"))
+        with patch("hermes_cli.plugins.invoke_hook", side_effect=capture):
+            agent.run_conversation("private turn", conversation_history=[], task_id="t1")
+            model_calls_before_drift = len(_chat_requests(handler))
+            hook_calls_before_drift = len(hook_calls)
+
+            setattr(agent, field, changed_value)
+
+            with pytest.raises(RuntimeError, match="destination binding changed"):
+                agent.run_conversation("reuse attempt", conversation_history=[], task_id="t2")
+
+        assert len(_chat_requests(handler)) == model_calls_before_drift
+        assert len(hook_calls) == hook_calls_before_drift
+
     def test_injection_sent_stamped_and_stable_within_turn(self, wire_env):
         """The current turn's user message goes out with the injected context,
         the sidecar equals the sent bytes exactly, the field never reaches the

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -719,6 +719,23 @@ class TestWhatsAppSessionKeyConsistency:
         assert build_session_key(second) == "agent:main:telegram:dm:100"
         assert build_session_key(first) != build_session_key(second)
 
+    def test_photon_destination_boundaries_get_distinct_session_keys(self):
+        """Photon DM, group, and different-chat routes cannot share an agent."""
+        photon = Platform("photon")
+        private = SessionSource(
+            platform=photon,
+            chat_id="space-1",
+            chat_type="dm",
+            user_id="provider-sender",
+        )
+        group = replace(private, chat_type="group")
+        different_private = replace(private, chat_id="space-2")
+
+        assert build_session_key(private) == "agent:main:photon:dm:space-1"
+        assert build_session_key(group).startswith("agent:main:photon:group:space-1")
+        assert build_session_key(private) != build_session_key(group)
+        assert build_session_key(private) != build_session_key(different_private)
+
 
     def test_dm_without_chat_id_distinct_users_do_not_collide(self):
         """Two different DM senders without chat_id must not share one
@@ -1642,5 +1659,4 @@ class TestGatewayRoutingTable:
         recovered = restarted.get_or_create_session(self._source())
         assert recovered.session_id == entry.session_id
         restarted._db.close()
-
 

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -67,6 +67,26 @@ async def test_dispatch_text_dm(monkeypatch: pytest.MonkeyPatch) -> None:
     assert src.user_id == "+15551234567"
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("space_type", [None, "", "private", "future-type"])
+async def test_unknown_space_type_never_becomes_dm(
+    monkeypatch: pytest.MonkeyPatch, space_type: str | None
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+    event = _dm_event("hello")
+    if space_type is None:
+        event["space"].pop("type")
+    else:
+        event["space"]["type"] = space_type
+
+    await adapter._dispatch_inbound(event)
+
+    assert len(captured) == 1
+    assert captured[0].source is not None
+    assert captured[0].source.chat_type == "unknown"
+
+
 # A real 1x1 transparent PNG (passes base.py's _looks_like_image magic check).
 _PNG_1X1_B64 = (
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhf"

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -927,7 +927,7 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 |------|-----------|-------------------|---------|
 | [`pre_tool_call`](/user-guide/features/hooks#pre_tool_call) | Before any tool executes | `tool_name: str, args: dict, task_id: str` | optional directive: `{"action": "block", "message": ...}` vetoes the call; `{"action": "approve", "message": ...}` escalates to the human-approval gate |
 | [`post_tool_call`](/user-guide/features/hooks#post_tool_call) | After any tool returns | `tool_name: str, args: dict, result: str, task_id: str, duration_ms: int` | ignored |
-| [`pre_llm_call`](/user-guide/features/hooks#pre_llm_call) | Once per turn, before the tool-calling loop | `session_id: str, user_message: str, conversation_history: list, is_first_turn: bool, model: str, platform: str` | [context injection](#pre_llm_call-context-injection) |
+| [`pre_llm_call`](/user-guide/features/hooks#pre_llm_call) | Once per turn, before the tool-calling loop | `session_id: str, user_message: str, conversation_history: list, is_first_turn: bool, model: str, platform: str, sender_id: str, destination_chat_id: str, destination_chat_type: str` | [context injection](#pre_llm_call-context-injection) |
 | [`post_llm_call`](/user-guide/features/hooks#post_llm_call) | Once per turn, after the tool-calling loop (successful turns only) | `session_id: str, user_message: str, assistant_response: str, conversation_history: list, model: str, platform: str` | ignored |
 | `pre_api_request` | Before each raw provider API request (several per turn when the model calls tools) | `session_id: str, model: str, provider: str, base_url: str, api_mode: str, api_call_count: int, message_count: int, tool_count: int, approx_input_tokens: int, max_tokens: int, request: dict` | ignored |
 | `post_api_request` | After each raw provider API request returns | `pre_api_request` fields plus `api_duration: float, finish_reason: str, response_model: str \| None, usage: dict, response: dict, assistant_content_chars: int, assistant_tool_call_count: int` | ignored |
@@ -952,6 +952,15 @@ The **API request hooks** are observers for the raw provider request, one level 
 ### `pre_llm_call` context injection
 
 This is the only hook whose return value matters. When a `pre_llm_call` callback returns a dict with a `"context"` key (or a plain string), Hermes injects that text into the **current turn's user message**. This is the mechanism for memory plugins, RAG integrations, guardrails, and any plugin that needs to provide the model with additional context.
+
+Gateway turns also provide source-bound `sender_id`, `destination_chat_id`, and
+`destination_chat_type` fields. Plugins may use all three together for
+destination-aware policy. Treat missing or unrecognized destination types as
+unknown; do not infer that a destination is private from an empty value.
+Hermes binds each gateway agent and model conversation to its original
+provider route. If that destination identity changes in place, the next turn
+fails before hooks, memory retrieval, persistence, or a provider request.
+Start a fresh destination-bound agent instead of reusing the conversation.
 
 #### Return format
 


### PR DESCRIPTION
## Summary
- pass source-bound destination chat ID and type to `pre_llm_call` hooks
- make Photon classify missing or unrecognized space types as `unknown` instead of private DMs
- bind every gateway `AIAgent` and model conversation immutably to its original provider route
- refuse route drift before hooks, memory retrieval, compaction, persistence, or provider traffic
- document the additive hook fields and fail-closed expectation

## Why
Destination-aware memory and policy plugins currently receive `platform` and `sender_id` but cannot distinguish a private conversation from a group. Photon also treats every non-group space type as a DM, so an unknown future provider value is incorrectly promoted to private.

Fresh session keys already isolate Photon DMs, groups, and distinct chat IDs. The additional immutable binding closes the in-process hazard: a cached transcript that may contain private or private-derived turns cannot be reused if route metadata changes in place.

The hook fields are additive and preserve narrow legacy callbacks through the existing signature-filtering compatibility path.

## Tests
- red regression: destination drift made three cases reach the hook/model before the patch
- `scripts/run_tests.sh tests/plugins/platforms/photon/test_inbound.py tests/agent/test_api_content_sidecar.py tests/gateway/test_session.py tests/hermes_cli/test_plugins.py -q` (173 passed)
- `.venv/bin/ruff check agent/agent_init.py agent/turn_context.py plugins/platforms/photon/adapter.py tests/agent/test_api_content_sidecar.py tests/gateway/test_session.py tests/plugins/platforms/photon/test_inbound.py`
- `git diff --check`

No live gateway, provider, memory, or user configuration was changed.
