### PR TITLE
fix(desktop): keep bots workspace when sidebar folds to rail

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/pane-toggle-visibility.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/pane-toggle-visibility.test.ts
@@ -9,6 +9,7 @@ import {
   $hiddenTreePanes,
   $layoutTree,
   bindPaneVisibility,
+  isPaneMinimized,
   isPaneVisible,
   setTreeGroupMinimized,
   togglePaneVisible
@@ -94,6 +95,61 @@ describe('a hide-style pane inside a minimized zone', () => {
     togglePaneVisible('files')
 
     expect(isPaneVisible('files')).toBe(true)
+  })
+})
+
+describe('minimized vs. hidden — the rail-collapse distinction', () => {
+  it('reports a zone folded to its rail as minimized, not visible', () => {
+    $layoutTree.set(
+      split('row', [
+        group(['workspace'], { active: 'workspace', id: 'g-main' }),
+        group(['files'], { active: 'files', id: 'g-files' })
+      ])
+    )
+
+    const $files = atom(true)
+    bindVisibility('files', $files)
+
+    // On screen and active: neither minimized nor hidden.
+    expect(isPaneMinimized('files')).toBe(false)
+    expect(isPaneVisible('files')).toBe(true)
+
+    // Fold the zone to its rail (the header chevron): the pane is off screen
+    // but still in the tree and reachable — a layout gesture, not a removal.
+    setTreeGroupMinimized('g-files', true)
+
+    expect(isPaneMinimized('files'), 'rail-folded pane reports minimized').toBe(true)
+    expect(isPaneVisible('files'), 'rail-folded pane is not on screen').toBe(false)
+  })
+
+  it('reports a dismissed pane as neither minimized nor visible', () => {
+    $layoutTree.set(
+      split('row', [
+        group(['workspace'], { active: 'workspace', id: 'g-main' }),
+        group(['files'], { active: 'files', id: 'g-files' })
+      ])
+    )
+
+    $dismissedPanes.set(new Set(['files']))
+
+    expect(isPaneMinimized('files'), 'a dismissed pane is not a rail fold').toBe(false)
+    expect(isPaneVisible('files')).toBe(false)
+  })
+
+  it('reports a chrome-hidden pane as neither minimized nor visible', () => {
+    $layoutTree.set(
+      split('row', [
+        group(['workspace'], { active: 'workspace', id: 'g-main' }),
+        group(['files'], { active: 'files', id: 'g-files' })
+      ])
+    )
+
+    const $files = atom(true)
+    bindVisibility('files', $files)
+    $files.set(false)
+
+    expect(isPaneMinimized('files'), 'a chrome-hidden pane is not a rail fold').toBe(false)
+    expect(isPaneVisible('files')).toBe(false)
   })
 })
 

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -1726,6 +1726,37 @@ export function $paneVisible(paneId: string): ReadableAtom<boolean> {
   return cached
 }
 
+/** Is a pane's ZONE folded to its rail (minimized) while the pane itself is
+ *  still in the tree and reachable? Distinct from being hidden/dismissed: a
+ *  minimized zone keeps its tab on the rail, so the pane's surface is a
+ *  click away rather than gone. Chrome that must tell "collapsed to a rail"
+ *  apart from "removed from the layout" (a plugin deciding whether its
+ *  workspace still owns the center) reads this instead of `isPaneVisible`,
+ *  which folds both cases into `false`. */
+export function isPaneMinimized(paneId: string): boolean {
+  if ($dismissedPanes.get().has(paneId) || $hiddenTreePanes.get().has(paneId)) {
+    return false
+  }
+
+  const group = paneGroup(paneId)
+
+  return Boolean(group && group.minimized)
+}
+
+const paneMinimizedCache = new Map<string, ReadableAtom<boolean>>()
+
+/** Reactive `isPaneMinimized` — memoized per pane id like `$paneVisible`. */
+export function $paneMinimized(paneId: string): ReadableAtom<boolean> {
+  let cached = paneMinimizedCache.get(paneId)
+
+  if (!cached) {
+    cached = computed([$layoutTree, $dismissedPanes, $hiddenTreePanes], () => isPaneMinimized(paneId))
+    paneMinimizedCache.set(paneId, cached)
+  }
+
+  return cached
+}
+
 /**
  * HIDE-STYLE PANES (files, review, preview): bind a pane's visibility STORE to
  * the tree so its toggle HIDES the pane — its zone collapses while the content

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -14767,6 +14767,13 @@ export default {
             group ? null : selected,
             group ? 'New group conversations start in the group composer.' : 'Select a Bot or group first.'
           )
+        } else if (host.paneMinimized?.(`${ID}:pane`)?.get()) {
+          // The Bots zone folded to its RAIL (the header chevron / a narrow
+          // edge collapse) — the tab is still reachable, so Bot Mode is still
+          // on screen. Keep the workspace owned by the current bot rather than
+          // stranding it: folding the sidebar is a layout gesture, not a
+          // deliberate return to Sessions.
+          $botsPaneVisible.set(true)
         } else {
           // Strand any owner wake still dialing. Its SDK open will fail the
           // workspace token too; this plugin generation prevents that expected

--- a/apps/desktop/src/plugins/hermes-bots/tests/bots-home.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bots-home.test.mjs
@@ -758,8 +758,19 @@ test('an explicit Bots-home gesture fronts the selected owner over a Sessions co
 
 test('source contract: sidebar entry and boot restore reconcile passively after layout hydration', () => {
   assert.match(pluginSource, /const syncWorkspaceSurfaces = \(\) =>/)
-  assert.match(pluginSource, /stopSidebarSync = \$sidebarVisible\.listen\(visible => \{[\s\S]{0,1500}?syncWorkspaceSurfaces\(\)/)
-  assert.doesNotMatch(pluginSource, /stopSidebarSync = \$sidebarVisible\.listen\(visible => \{[\s\S]{0,1500}?syncWorkspaceSurfaces\(Boolean\(visible\)\)/)
+  // The sidebar-visibility listener must reconcile PASSIVELY: it may keep the
+  // bots workspace alive (a zone folded to its rail is still reachable) but
+  // must never swallow the sync call. 2000 chars headroom covers the
+  // paneMinimized guard added for the rail-collapse case.
+  assert.match(pluginSource, /stopSidebarSync = \$sidebarVisible\.listen\(visible => \{[\s\S]{0,2000}?syncWorkspaceSurfaces\(\)/)
+  assert.doesNotMatch(pluginSource, /stopSidebarSync = \$sidebarVisible\.listen\(visible => \{[\s\S]{0,2000}?syncWorkspaceSurfaces\(Boolean\(visible\)\)/)
+  // Rail-collapse (zone minimized, tab still on the rail) is a layout gesture,
+  // not a return to Sessions: the listener must check paneMinimized before
+  // stranding the workspace, and keep $botsPaneVisible true in that case.
+  assert.match(
+    pluginSource,
+    /stopSidebarSync = \$sidebarVisible\.listen\(visible => \{[\s\S]{0,2000}?host\.paneMinimized\?\.\(`\$\{ID\}:pane`\)\?\.get\(\)[\s\S]{0,600}?\$botsPaneVisible\.set\(true\)/
+  )
   assert.match(
     pluginSource,
     /\$botChatFocused\.set\(sessionOwnsWorkspace\(\)\)[\s\S]{0,500}?syncWorkspaceSurfaces\(\)[\s\S]{0,120}?scheduleSurfaceSync\(\)/

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -27,6 +27,7 @@ import type { ClientSessionState } from '@/app/types'
 import {
   $narrowViewport,
   $newSessionTabAction,
+  $paneMinimized,
   $paneVisible,
   registerPaneCloser,
   removeTreePane,
@@ -1088,6 +1089,16 @@ export const host = {
    *  safe to call in render. Feature-detect on older desktops
    *  (`typeof host.paneVisibility === 'function'`). */
   paneVisibility: (paneId: string): ReadableAtom<boolean> => $paneVisible(paneId),
+
+  /** Reactive minimized state of a contributed pane: true while the pane is
+   *  still in the layout tree (not dismissed/hidden) but its zone is folded
+   *  to a rail. Complements `paneVisibility` — a plugin that treats "zone
+   *  collapsed to a rail" differently from "removed from the layout" (e.g.
+   *  whether its workspace still owns the center) can tell the two apart.
+   *  Contribution-scoped pane id `<pluginId>:<paneId>`. Memoized per id.
+   *  Feature-detect on older desktops
+   *  (`typeof host.paneMinimized === 'function'`). */
+  paneMinimized: (paneId: string): ReadableAtom<boolean> => $paneMinimized(paneId),
 
   /** HEAR the gateway stream (message deltas, session lifecycle, tool
    *  activity, …) by event type — `'*'` for everything. Returns a disposer.


### PR DESCRIPTION
## Problem

Clicking the **sidebar zone minimize chevron** (the small down-triangle next to the Bots tab in the left sessions/Bots strip) while a Bot Chat session owns the center folds the zone to a narrow rail — and the main chat surface turns **gray**.

Root cause chain:
1. `collapseTreePane` → `setTreeGroupMinimized` folds the zone; `isPaneVisible('hermes-bots:pane')` now returns `false` (a minimized zone is not on screen).
2. The Bots plugin listens to that visibility flip and interprets `false` as "Bot Mode left the screen".
3. It answers with `host.setWorkspaceScope('sessions')` + `closeBotsHomeWorkspace()`, switching the workspace away from the bot.
4. The workspace pane is `sessions`-scoped while the Bot Chat session tile is `bots`-scoped, so `contributesToWorkspace` filters the chat pane out of the render → the dialog gray.

Folding a zone to its rail is a **layout gesture** — the tab stays reachable on the rail, so Bot Mode is still on screen. Only a real hide (dismissed / chrome-hidden pane) should strand the workspace and return to Sessions.

## Fix

- **`store.ts`**: add `isPaneMinimized` / `$paneMinimized` — true while the pane is still in the tree (not dismissed/hidden) but its zone is folded to a rail. Distinct from `isPaneVisible`, which folds both cases into `false`.
- **`sdk/index.ts`**: expose `host.paneMinimized(paneId)` (feature-detected, memoized like `paneVisibility`).
- **`plugin.js`**: the sidebar-visibility listener now checks `paneMinimized` before stranding the workspace: a rail fold keeps the current bot owner and `$botsPaneVisible` stays `true`; only a real hide returns to Sessions.

## Tests

- `pane-toggle-visibility.test.ts`: new "minimized vs. hidden" suite — rail-folded pane reports minimized (not visible); dismissed and chrome-hidden panes report neither.
- `bots-home.test.mjs`: source-contract test updated for the new guard (and asserts the `paneMinimized` check + `$botsPaneVisible.set(true)` branch exist).
- All 530 hermes-bots plugin tests pass; SDK + tree-store UI tests pass; `tsc --noEmit` clean.

Verified live in an isolated dev instance: clicking the chevron folds the zone to a 28px rail with the workspace intact and no gray overlay on the chat surface.