### PR TITLE
fix(desktop): keep Windows startup off an occupied shared backend port

### DIFF
--- a/apps/desktop/electron/backend-command.test.ts
+++ b/apps/desktop/electron/backend-command.test.ts
@@ -5,15 +5,24 @@ import { test } from 'vitest'
 import { dashboardFallbackArgs, serveBackendArgs, sourceDeclaresServe } from './backend-command'
 
 test('serveBackendArgs builds a headless serve invocation', () => {
-  assert.deepEqual(serveBackendArgs(), ['serve', '--host', '127.0.0.1', '--port', '0'])
+  assert.deepEqual(serveBackendArgs(), ['serve', '--isolated', '--host', '127.0.0.1', '--port', '0'])
 })
 
 test('serveBackendArgs pins a profile when provided', () => {
-  assert.deepEqual(serveBackendArgs('worker'), ['--profile', 'worker', 'serve', '--host', '127.0.0.1', '--port', '0'])
+  assert.deepEqual(serveBackendArgs('worker'), [
+    '--profile',
+    'worker',
+    'serve',
+    '--isolated',
+    '--host',
+    '127.0.0.1',
+    '--port',
+    '0'
+  ])
 })
 
 test('dashboardFallbackArgs rewrites serve -> dashboard --no-open, keeping the -m prefix', () => {
-  const serve = ['-m', 'hermes_cli.main', 'serve', '--host', '127.0.0.1', '--port', '0']
+  const serve = ['-m', 'hermes_cli.main', 'serve', '--isolated', '--host', '127.0.0.1', '--port', '0']
   assert.deepEqual(dashboardFallbackArgs(serve), [
     '-m',
     'hermes_cli.main',
@@ -27,7 +36,19 @@ test('dashboardFallbackArgs rewrites serve -> dashboard --no-open, keeping the -
 })
 
 test('dashboardFallbackArgs preserves a --profile flag ahead of serve', () => {
-  const serve = ['-m', 'hermes_cli.main', '--profile', 'worker', 'serve', '--host', '127.0.0.1', '--port', '0']
+  const serve = [
+    '-m',
+    'hermes_cli.main',
+    '--profile',
+    'worker',
+    'serve',
+    '--isolated',
+    '--host',
+    '127.0.0.1',
+    '--port',
+    '0'
+  ]
+
   assert.deepEqual(dashboardFallbackArgs(serve), [
     '-m',
     'hermes_cli.main',

--- a/apps/desktop/electron/backend-command.ts
+++ b/apps/desktop/electron/backend-command.ts
@@ -18,14 +18,21 @@
 export function serveBackendArgs(profile?: string) {
   const head = profile ? ['--profile', profile] : []
 
-  return [...head, 'serve', '--host', '127.0.0.1', '--port', '0']
+  // Desktop owns this child and needs its announced ephemeral port. Make the
+  // per-process topology explicit instead of relying on HERMES_DESKTOP to
+  // bypass the CLI's named-profile routing to the machine-level server. That
+  // keeps startup away from the shared 9119 bind even across version-skewed
+  // runtimes and the legacy dashboard fallback.
+  return [...head, 'serve', '--isolated', '--host', '127.0.0.1', '--port', '0']
 }
 
 /**
  * Rewrite a resolved backend argv from `serve` to the legacy
- * `dashboard --no-open` form, preserving every other argument (incl. a leading
- * `-m hermes_cli.main` and any `--profile <name>`). Returns a copy; if there is
- * no `serve` token the argv is returned unchanged.
+ * `dashboard --no-open` form, preserving the common arguments (incl. a leading
+ * `-m hermes_cli.main` and any `--profile <name>`). The newer `--isolated`
+ * flag is removed because runtimes old enough to lack `serve` may predate that
+ * dashboard flag too. Returns a copy; if there is no `serve` token the argv is
+ * returned unchanged.
  */
 export function dashboardFallbackArgs(args) {
   const i = args.indexOf('serve')
@@ -34,7 +41,7 @@ export function dashboardFallbackArgs(args) {
     return args.slice()
   }
 
-  return [...args.slice(0, i), 'dashboard', '--no-open', ...args.slice(i + 1)]
+  return [...args.slice(0, i), 'dashboard', '--no-open', ...args.slice(i + 1).filter(arg => arg !== '--isolated')]
 }
 
 /**

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -33,7 +33,7 @@ import {
 import { classifyActiveRuntime } from './active-runtime-state'
 import { destroyKeepaliveAgents, downloadAgentFor, jsonAgentFor, withRetry } from './api-transport'
 import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
-import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
+import { dashboardFallbackArgs, serveBackendArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
 import {
@@ -10479,7 +10479,7 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   // --profile wins over the inherited HERMES_HOME env (see _apply_profile_override
   // step 3 in hermes_cli/main.py), so the child re-homes to this profile.
   // --port 0: the OS assigns an ephemeral port; the child announces it on stdout.
-  const backendArgs = ['--profile', profile, 'serve', '--host', '127.0.0.1', '--port', '0']
+  const backendArgs = serveBackendArgs(profile)
   const backend = await ensureRuntime(resolveHermesBackend(backendArgs))
   // Route old runtimes (no `serve`) through the legacy `dashboard --no-open`.
   backend.args = getBackendArgsForRuntime(backend)
@@ -10533,10 +10533,13 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
 
   entry.process = child
   entry.token = token
-  await claimBackendChild(child, `${backend.command} ${backend.args.join(' ')}`, profile, backendNonce)
 
+  // Observe output before the Windows ownership marker probe. A child that
+  // exits during that probe must leave its real startup error in desktop.log
+  // instead of being masked by the follow-up Get-Process failure.
   child.stdout.on('data', rememberLog)
   child.stderr.on('data', rememberLog)
+  await claimBackendChild(child, `${backend.command} ${backend.args.join(' ')}`, profile, backendNonce)
 
   let ready = false
   let rejectStart = null
@@ -10814,7 +10817,7 @@ async function startHermes() {
 
     const token = crypto.randomBytes(32).toString('base64url')
     // --port 0: the OS assigns an ephemeral port; the child announces it on stdout.
-    const backendArgs = ['serve', '--host', '127.0.0.1', '--port', '0']
+    const backendArgs = serveBackendArgs()
     // Pin the desktop's chosen profile via the global --profile flag. This is
     // deterministic (it wins over the sticky ~/.hermes/active_profile file) and
     // resolves HERMES_HOME the same way `hermes -p <name>` does on the CLI. An
@@ -10909,6 +10912,12 @@ async function startHermes() {
       })
     )
 
+    // Start logging before ownership persistence: on Windows an immediately
+    // exiting child can disappear while processStartMarker() starts PowerShell.
+    // Its stderr remains the actionable failure even if that marker probe then
+    // reports only that the PID no longer exists.
+    hermesProcess.stdout.on('data', rememberLog)
+    hermesProcess.stderr.on('data', rememberLog)
     await claimBackendChild(hermesProcess, `${backend.command} ${backend.args.join(' ')}`, profile, backendNonce)
     const processOwner = backendConnectionState.attachProcess(connectionAttempt, hermesProcess)
 
@@ -10919,8 +10928,6 @@ async function startHermes() {
       throw new Error('Hermes backend start was superseded by a newer connection attempt.')
     }
 
-    hermesProcess.stdout.on('data', rememberLog)
-    hermesProcess.stderr.on('data', rememberLog)
     let backendReady = false
     let rejectBackendStart = null
 


### PR DESCRIPTION
## What does this PR do?

Windows Desktop now launches every managed local backend as an explicitly isolated server on an OS-assigned port. This keeps Desktop startup independent of the shared machine-level server bind and preserves the backend's real stderr when a child exits during the Windows ownership probe.

### Symptom

After an update, Desktop can repeatedly fail startup with `Could not persist ownership for the Hermes backend` while the child process has already exited. The ownership error can mask the child's earlier bind failure in the Desktop log.

### Impact

Affected users cannot reach the Desktop renderer until the conflicting server state clears, while the CLI and messaging gateway may remain available.

### Bug Cause

**Trigger:** `apps/desktop/electron/main.ts` / the primary and pooled local backend spawn paths

**Causal chain:**
1. Desktop built a generic `serve --host 127.0.0.1 --port 0` command and relied on `HERMES_DESKTOP=1` to keep the CLI out of unified machine-server routing.
2. If startup crossed that shared-server routing boundary during an update/version handoff, the Desktop-owned child could contend with the machine-level server instead of retaining its dedicated ephemeral bind.
3. On Windows, the child could exit while the slower PowerShell process-marker probe was running, so the later missing-PID error replaced the actionable child stderr in the visible failure.

**Why it is wrong:** Desktop owns and authenticates a dedicated child process, waits for that child's announced ephemeral port, and records ownership for that exact PID. Its required isolated topology should be explicit in argv rather than inferred from an environment flag.

**Working sibling / contrast:** Explicit `--isolated --port 0` startup binds a dedicated OS-assigned port and never needs the machine-level server's shared port. The legacy `dashboard --no-open` fallback remains compatible by removing `--isolated` for runtimes old enough not to support that flag.

**Ruled out:** The renderer is not the source of the bind failure; the failure occurs before the local backend announces a usable connection. The CLI and gateway can remain healthy because they do not depend on the Desktop-owned child.

### Fix

Centralize Desktop backend argv construction in `serveBackendArgs()`, add `--isolated` for both primary and pooled children, retain `--port 0`, and keep the legacy dashboard fallback compatible. Register stdout/stderr logging immediately after spawn, before ownership persistence, so an early Windows child exit leaves its real startup error in `desktop.log`.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/backend-command.ts` - make isolated ephemeral startup the canonical Desktop backend command while preserving old-dashboard fallback compatibility.
- `apps/desktop/electron/main.ts` - use the canonical command for primary and pooled backends and capture output before the ownership marker probe.
- `apps/desktop/electron/backend-command.test.ts` - cover primary/profile argv and legacy fallback behavior.

## How to Test

1. Run the focused Desktop command tests.
2. Run Desktop Electron type checking and lint the changed files.
3. Run the dashboard lifecycle tests through the repository test wrapper.

```bash
cd apps/desktop && npx vitest run electron/backend-command.test.ts
npm run typecheck --workspace apps/desktop
cd apps/desktop && npx eslint electron/backend-command.ts electron/backend-command.test.ts electron/main.ts --max-warnings=0
scripts/run_tests.sh tests/hermes_cli/test_dashboard_lifecycle_flags.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested the automated paths on Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation changes are N/A
- [x] Config example changes are N/A
- [x] Contributor guide changes are N/A
- [x] I've considered Windows and legacy-runtime compatibility
- [x] Tool description/schema changes are N/A

## Screenshots / Logs

N/A - backend startup and diagnostic behavior are covered by focused automated tests and the phase-B Windows runtime verification.
