### PR TITLE
fix(cron): keep live fallback delivery on gateway loop

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2853,6 +2853,37 @@ def _is_channel_dm_topic(
     return is_channel
 
 
+class _GatewayLoopFallbackDispatch:
+    """Coordinate a scheduler timeout with gateway-loop fallback dispatch.
+
+    The loop must authorize under this lock before creating the send coroutine.
+    The scheduler aborts under the same lock, so an abort that wins guarantees a
+    queued callback observes it and makes no network/send call.  A timeout after
+    authorization is intentionally indeterminate: it must not be retried.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._aborted = False
+        self._authorized = False
+
+    def abort_pending(self) -> bool:
+        """Atomically abort only a fallback that the gateway loop has not authorized."""
+        with self._lock:
+            if self._authorized:
+                return False
+            self._aborted = True
+            return True
+
+    async def run(self, send_factory):
+        """Authorize on the gateway loop before constructing/awaiting the send."""
+        with self._lock:
+            if self._aborted:
+                return {"aborted": True}
+            self._authorized = True
+        return await send_factory()
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -3565,60 +3596,112 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 target_errors.append(msg)
                 delivery_errors.extend(target_errors)
                 continue
-            # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
-            try:
-                result = asyncio.run(coro)
-            except RuntimeError as run_err:
-                # asyncio.run() checks for a running loop before awaiting the coroutine;
-                # when it raises, the original coro was never started — close it to
-                # prevent "coroutine was never awaited" RuntimeWarning, then retry in a
-                # fresh thread that has no running loop.
-                coro.close()
-                # If the RuntimeError is the interpreter-finalization signal,
-                # the fresh-thread fallback would fail identically — skip
-                # gracefully instead of logging a shutdown-race traceback.
-                if _interpreter_shutting_down(run_err):
-                    msg = f"delivery to {platform_name}:{chat_id} skipped — interpreter is shutting down"
-                    logger.warning("Job '%s': %s", job["id"], msg)
-                    target_errors.append(msg)
-                    delivery_errors.extend(target_errors)
+            # Matrix's persistent aiohttp/E2EE session is bound to the gateway
+            # loop, so its fallback must not re-await it in this scheduler
+            # thread's fresh asyncio.run() loop. Other live adapters retain the
+            # established standalone retry when this scheduling race loses.
+            if live_adapter_ready and platform == Platform.MATRIX:
+                # Keep gateway-bound adapters on their owning loop.  The
+                # dispatch handshake, not Future.cancel(), determines whether a
+                # timeout was safely aborted before any send could begin.
+                from agent.async_utils import safe_schedule_threadsafe
+
+                dispatch = _GatewayLoopFallbackDispatch()
+                future = safe_schedule_threadsafe(
+                    dispatch.run(
+                        lambda: _send_to_platform(
+                            platform, pconfig, chat_id, cleaned_delivery_content,
+                            thread_id=thread_id, media_files=media_files,
+                        )
+                    ),
+                    loop,
+                )
+                if future is None:
+                    msg = f"delivery to {platform_name}:{chat_id} failed: live adapter event loop scheduling failed"
+                    logger.error("Job '%s': %s", job["id"], msg)
+                    target_errors.append(msg); delivery_errors.extend(target_errors)
                     continue
-                # The thread-pool fallback can itself raise (SMTP ConnectionError,
-                # future.result timeout, etc.). An exception raised inside this
-                # `except RuntimeError` block is NOT caught by the sibling
-                # `except Exception` below — it would escape _deliver_result()
-                # and crash the whole delivery loop, silently skipping every
-                # remaining target (#47163). Wrap the fallback in its own
-                # try/except so a per-target failure is logged and the loop
-                # continues to the next target.
                 try:
-                    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-                    try:
-                        future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
-                        result = future.result(timeout=30)
-                    finally:
-                        pool.shutdown(wait=False)
+                    result = future.result(timeout=30)
+                except TimeoutError:
+                    if dispatch.abort_pending():
+                        # The synchronized abort is the proof a queued callback
+                        # cannot send; let it run and observe the abort cleanly.
+                        msg = (
+                            f"delivery to {platform_name}:{chat_id} failed: live adapter "
+                            "fallback timed out before dispatch authorization"
+                        )
+                        logger.warning("Job '%s': %s", job["id"], msg)
+                        target_errors.append(msg); delivery_errors.extend(target_errors)
+                        continue
+                    logger.warning(
+                        "Job '%s': live adapter fallback to %s:%s timed out after "
+                        "30s after dispatch authorization; outcome indeterminate, "
+                        "not retrying to avoid a duplicate",
+                        job["id"], platform_name, chat_id,
+                    )
+                    delivered = True
+                    continue
                 except Exception as e:
-                    # A shutdown-race here is expected during teardown; downgrade
-                    # to a warning so it doesn't read as a genuine failure.
-                    if _interpreter_shutting_down(e):
+                    msg = f"delivery to {platform_name}:{chat_id} failed: {e}"
+                    logger.error("Job '%s': %s", job["id"], msg, exc_info=True)
+                    target_errors.append(msg); delivery_errors.extend(target_errors)
+                    continue
+            else:
+                # Standalone path: run the async send in a fresh event loop (safe from any thread)
+                coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+                try:
+                    result = asyncio.run(coro)
+                except RuntimeError as run_err:
+                    # asyncio.run() checks for a running loop before awaiting the coroutine;
+                    # when it raises, the original coro was never started — close it to
+                    # prevent "coroutine was never awaited" RuntimeWarning, then retry in a
+                    # fresh thread that has no running loop.
+                    coro.close()
+                    # If the RuntimeError is the interpreter-finalization signal,
+                    # the fresh-thread fallback would fail identically — skip
+                    # gracefully instead of logging a shutdown-race traceback.
+                    if _interpreter_shutting_down(run_err):
                         msg = f"delivery to {platform_name}:{chat_id} skipped — interpreter is shutting down"
                         logger.warning("Job '%s': %s", job["id"], msg)
                         target_errors.append(msg)
                         delivery_errors.extend(target_errors)
                         continue
+                    # The thread-pool fallback can itself raise (SMTP ConnectionError,
+                    # future.result timeout, etc.). An exception raised inside this
+                    # `except RuntimeError` block is NOT caught by the sibling
+                    # `except Exception` below — it would escape _deliver_result()
+                    # and crash the whole delivery loop, silently skipping every
+                    # remaining target (#47163). Wrap the fallback in its own
+                    # try/except so a per-target failure is logged and the loop
+                    # continues to the next target.
+                    try:
+                        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+                        try:
+                            future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                            result = future.result(timeout=30)
+                        finally:
+                            pool.shutdown(wait=False)
+                    except Exception as e:
+                        # A shutdown-race here is expected during teardown; downgrade
+                        # to a warning so it doesn't read as a genuine failure.
+                        if _interpreter_shutting_down(e):
+                            msg = f"delivery to {platform_name}:{chat_id} skipped — interpreter is shutting down"
+                            logger.warning("Job '%s': %s", job["id"], msg)
+                            target_errors.append(msg)
+                            delivery_errors.extend(target_errors)
+                            continue
+                        msg = f"delivery to {platform_name}:{chat_id} failed: {e}"
+                        logger.error("Job '%s': %s", job["id"], msg, exc_info=True)
+                        target_errors.extend([msg])
+                        delivery_errors.extend(target_errors)
+                        continue
+                except Exception as e:
                     msg = f"delivery to {platform_name}:{chat_id} failed: {e}"
                     logger.error("Job '%s': %s", job["id"], msg, exc_info=True)
                     target_errors.extend([msg])
                     delivery_errors.extend(target_errors)
                     continue
-            except Exception as e:
-                msg = f"delivery to {platform_name}:{chat_id} failed: {e}"
-                logger.error("Job '%s': %s", job["id"], msg, exc_info=True)
-                target_errors.extend([msg])
-                delivery_errors.extend(target_errors)
-                continue
 
             if result and result.get("error"):
                 # Include target context (platform/chat) so a bare error string

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -5,6 +5,7 @@ import itertools
 import json
 import logging
 import os
+import warnings
 from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
@@ -511,6 +512,111 @@ class TestDeliverResultWrapping:
         adapter.send_voice.assert_called_once()
         voice_call = adapter.send_voice.call_args
         assert voice_call[1]["audio_path"] == str(media_path)
+
+
+class TestMatrixFallbackGatewayLoop:
+    def test_scheduler_thread_matrix_fallback_reuses_gateway_loop(self):
+        """A failed live Matrix attempt must bridge its persistent adapter back to
+        the owning gateway loop, never await it inside the scheduler's fresh loop.
+        """
+        import asyncio
+        import threading
+        from types import SimpleNamespace
+
+        from gateway.config import Platform
+
+        gateway_loop = asyncio.new_event_loop()
+        gateway_ready = threading.Event()
+        calls = []
+        result_holder = {}
+
+        class LoopBoundMatrixAdapter:
+            async def send(self, chat_id, content, metadata=None):
+                current_loop = asyncio.get_running_loop()
+                calls.append(current_loop)
+                # The primary routed attempt fails, forcing the scheduler fallback.
+                if len(calls) == 1:
+                    return SimpleNamespace(success=False, error="primary failed")
+                if current_loop is not gateway_loop:
+                    raise RuntimeError("Matrix session used on wrong loop")
+                return SimpleNamespace(success=True, message_id="$fallback")
+
+        adapter = LoopBoundMatrixAdapter()
+        runner = SimpleNamespace(adapters={Platform.MATRIX: adapter})
+        pconfig = SimpleNamespace(enabled=True, token="unused", extra={})
+        config = SimpleNamespace(platforms={Platform.MATRIX: pconfig})
+
+        def run_gateway_loop():
+            asyncio.set_event_loop(gateway_loop)
+            gateway_ready.set()
+            try:
+                gateway_loop.run_forever()
+            finally:
+                gateway_loop.close()
+                asyncio.set_event_loop(None)
+
+        gateway_thread = threading.Thread(target=run_gateway_loop)
+        gateway_thread.start()
+        assert gateway_ready.wait(timeout=2)
+
+        job = {
+            "id": "matrix-loop-fallback",
+            "deliver": "origin",
+            "origin": {"platform": "matrix", "chat_id": "!room:example.test"},
+        }
+
+        def invoke_from_scheduler_thread():
+            result_holder["result"] = _deliver_result(
+                job, "scheduled output", adapters=runner.adapters, loop=gateway_loop
+            )
+
+        try:
+            with (
+                patch("gateway.config.load_gateway_config", return_value=config),
+                patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}),
+                patch("gateway.run._gateway_runner_ref", return_value=runner),
+            ):
+                scheduler_thread = threading.Thread(target=invoke_from_scheduler_thread)
+                scheduler_thread.start()
+                scheduler_thread.join(timeout=5)
+                assert not scheduler_thread.is_alive()
+        finally:
+            gateway_loop.call_soon_threadsafe(gateway_loop.stop)
+            gateway_thread.join(timeout=2)
+            gateway_loop.close()
+
+        assert result_holder["result"] is None
+        assert calls == [gateway_loop, gateway_loop]
+
+    def test_without_live_adapter_or_loop_uses_existing_standalone_sender(self):
+        """No-adapter/no-loop delivery stays on the standalone asyncio.run path."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        config = MagicMock()
+        config.platforms = {Platform.MATRIX: pconfig}
+        standalone_calls = []
+
+        async def standalone_send(*_args, **_kwargs):
+            standalone_calls.append(True)
+            return {"success": True}
+
+        job = {
+            "id": "matrix-standalone-unchanged",
+            "deliver": "origin",
+            "origin": {"platform": "matrix", "chat_id": "!room:example.test"},
+        }
+
+        with (
+            patch("gateway.config.load_gateway_config", return_value=config),
+            patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}),
+            patch("tools.send_message_tool._send_to_platform", new=standalone_send),
+        ):
+            result = _deliver_result(job, "scheduled output", adapters=None, loop=None)
+
+        assert result is None
+        assert standalone_calls == [True]
 
 
 class TestDeliverResultErrorReturns:
@@ -1934,80 +2040,194 @@ class TestParallelTick:
         assert start_s2 >= end_s1, "Jobs ran concurrently despite max_parallel=1"
 
 
-class TestDeliverResultTimeoutCancelsFuture:
-    """When future.result(timeout=60) raises TimeoutError in the live adapter
-    delivery path, the outcome depends on whether the coroutine was already
-    running.  future.cancel() returning False means it is in flight on the wire
-    (cannot be un-sent) → treat as DELIVERED and skip the standalone fallback to
-    avoid a duplicate (#38922).  future.cancel() returning True means it never
-    started (wedged loop) → nothing was sent, so fall through to standalone or
-    the message is silently dropped.  Regression for #38922.
+class TestDeliverResultTimeoutDispatchContract:
+    """The fallback's timeout result comes from its loop-side authorization,
+    never from ``Future.cancel()``.  These tests run its second scheduling leg
+    on a real gateway loop; mock Futures cannot model this race.
     """
 
-    def test_live_adapter_timeout_assumes_delivered_no_duplicate(self):
-        """End-to-end: live adapter confirmation times out past the 60s budget.
-        The fix (#38922) treats the send as already-dispatched/delivered and
-        does NOT run the standalone fallback — otherwise the message is sent
-        twice."""
+    @staticmethod
+    def _context():
         from gateway.config import Platform
-        from concurrent.futures import Future
-
-        # Live adapter whose send() coroutine never resolves within the budget
-        adapter = AsyncMock()
-        adapter.send.return_value = MagicMock(success=True)
 
         pconfig = MagicMock()
         pconfig.enabled = True
-        mock_cfg = MagicMock()
-        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
-
-        loop = MagicMock()
-        loop.is_running.return_value = True
-
-        # A real concurrent.futures.Future, but we override .result() to raise
-        # TimeoutError exactly like the 60s wait firing in production.  We make
-        # .cancel() return False to simulate the coroutine being ALREADY RUNNING
-        # on the gateway loop (in flight on the wire) — the case where the send
-        # cannot be un-sent and a standalone resend would be a duplicate.
-        captured_future = Future()
-        cancel_calls = []
-
-        def in_flight_cancel():
-            cancel_calls.append(True)
-            return False  # already running — cannot be cancelled
-
-        captured_future.cancel = in_flight_cancel
-        captured_future.result = MagicMock(side_effect=TimeoutError("timed out"))
-
-        def fake_run_coro(coro, _loop):
-            coro.close()
-            return captured_future
-
+        config = MagicMock()
+        config.platforms = {Platform.MATRIX: pconfig}
         job = {
             "id": "timeout-job",
             "deliver": "origin",
-            "origin": {"platform": "telegram", "chat_id": "123"},
+            "origin": {"platform": "matrix", "chat_id": "!room:example.test"},
         }
+        return Platform, config, job
 
+    def test_pending_fallback_aborted_at_timeout_never_enters_sender(self):
+        """Abort wins before the loop starts the fallback, so releasing the
+        blocked loop afterwards cannot invoke ``_send_to_platform``.
+        """
+        import asyncio
+        import threading
+        from concurrent.futures import Future
+        from agent.async_utils import safe_schedule_threadsafe
+
+        Platform, config, job = self._context()
+        gateway_loop = asyncio.new_event_loop()
+        loop_ready = threading.Event()
+        blocker_started = threading.Event()
+        release_loop = threading.Event()
+        sent = AsyncMock(return_value={"success": True})
         standalone_send = AsyncMock(return_value={"success": True})
 
-        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
-             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
-             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro), \
-             patch("tools.send_message_tool._send_to_platform", new=standalone_send):
-            result = _deliver_result(
-                job,
-                "Hello world",
-                adapters={Platform.TELEGRAM: adapter},
-                loop=loop,
-            )
+        def run_loop():
+            asyncio.set_event_loop(gateway_loop)
+            loop_ready.set()
+            try:
+                gateway_loop.run_forever()
+            finally:
+                gateway_loop.close()
+                asyncio.set_event_loop(None)
 
-        # 1. cancel() was attempted (returned False = in flight).
-        assert cancel_calls == [True], "future.cancel() should be attempted on TimeoutError"
-        # 2. Delivery is reported successful (no error string returned).
-        assert result is None, f"expected successful delivery, got error: {result!r}"
-        # 3. The standalone fallback must NOT run — that is the #38922 fix:
-        #    an in-flight confirmation timeout is assume-delivered, not a resend.
+        def block_loop():
+            blocker_started.set()
+            release_loop.wait(timeout=2)
+
+        gateway_thread = threading.Thread(target=run_loop)
+        gateway_thread.start()
+        assert loop_ready.wait(timeout=2)
+        gateway_loop.call_soon_threadsafe(block_loop)
+        assert blocker_started.wait(timeout=2)
+
+        primary = Future()
+        primary.set_result(None)
+        scheduled = []
+        fallback_future = None
+
+        class ImmediateTimeout:
+            def __init__(self, future):
+                self.future = future
+
+            def result(self, timeout=None):
+                raise TimeoutError("timed out")
+
+            def cancel(self):
+                return self.future.cancel()
+
+        def schedule(coro, loop):
+            nonlocal fallback_future
+            scheduled.append(coro)
+            if len(scheduled) == 1:
+                coro.close()
+                return primary
+            fallback_future = safe_schedule_threadsafe(coro, loop)
+            return ImmediateTimeout(fallback_future)
+
+        try:
+            with (
+                patch("gateway.config.load_gateway_config", return_value=config),
+                patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}),
+                patch("agent.async_utils.safe_schedule_threadsafe", side_effect=schedule),
+                patch("tools.send_message_tool._send_to_platform", new=sent),
+            ):
+                result = _deliver_result(
+                    job, "Hello", adapters={Platform.MATRIX: AsyncMock()}, loop=gateway_loop
+                )
+        finally:
+            release_loop.set()
+            assert fallback_future is not None
+            try:
+                fallback_future.result(timeout=2)
+            except Exception:
+                pass
+            gateway_loop.call_soon_threadsafe(gateway_loop.stop)
+            gateway_thread.join(timeout=2)
+            gateway_loop.close()
+
+        assert "before dispatch authorization" in result
+        assert len(scheduled) == 2
+        sent.assert_not_awaited()
+        standalone_send.assert_not_awaited()
+
+    def test_authorized_fallback_timeout_is_indeterminate_not_safely_unsent(self):
+        """Once the loop authorizes the fallback, a timeout must not be called
+        an unsent cancellation even when ``Future.cancel()`` would say True.
+        """
+        import asyncio
+        import threading
+        from concurrent.futures import Future
+        from agent.async_utils import safe_schedule_threadsafe
+
+        Platform, config, job = self._context()
+        gateway_loop = asyncio.new_event_loop()
+        loop_ready = threading.Event()
+        entered_sender = threading.Event()
+        release_sender = asyncio.Event()
+        standalone_send = AsyncMock(return_value={"success": True})
+
+        async def blocked_sender(*_args, **_kwargs):
+            entered_sender.set()
+            await release_sender.wait()
+            return {"success": True}
+
+        def run_loop():
+            asyncio.set_event_loop(gateway_loop)
+            loop_ready.set()
+            try:
+                gateway_loop.run_forever()
+            finally:
+                gateway_loop.close()
+                asyncio.set_event_loop(None)
+
+        gateway_thread = threading.Thread(target=run_loop)
+        gateway_thread.start()
+        assert loop_ready.wait(timeout=2)
+        primary = Future()
+        primary.set_result(None)
+        scheduled = []
+        fallback_future = None
+        cancel_calls = []
+
+        class StartedTimeout:
+            def __init__(self, future):
+                self.future = future
+
+            def result(self, timeout=None):
+                assert entered_sender.wait(timeout=2)
+                raise TimeoutError("timed out")
+
+            def cancel(self):
+                cancel_calls.append(True)
+                return self.future.cancel()
+
+        def schedule(coro, loop):
+            nonlocal fallback_future
+            scheduled.append(coro)
+            if len(scheduled) == 1:
+                coro.close()
+                return primary
+            fallback_future = safe_schedule_threadsafe(coro, loop)
+            return StartedTimeout(fallback_future)
+
+        try:
+            with (
+                patch("gateway.config.load_gateway_config", return_value=config),
+                patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}),
+                patch("agent.async_utils.safe_schedule_threadsafe", side_effect=schedule),
+                patch("tools.send_message_tool._send_to_platform", new=blocked_sender),
+            ):
+                result = _deliver_result(
+                    job, "Hello", adapters={Platform.MATRIX: AsyncMock()}, loop=gateway_loop
+                )
+        finally:
+            gateway_loop.call_soon_threadsafe(release_sender.set)
+            assert fallback_future is not None
+            fallback_future.result(timeout=2)
+            gateway_loop.call_soon_threadsafe(gateway_loop.stop)
+            gateway_thread.join(timeout=2)
+            gateway_loop.close()
+
+        assert result is None
+        assert len(scheduled) == 2
+        assert cancel_calls == []
         standalone_send.assert_not_awaited()
 
 
@@ -2034,43 +2254,145 @@ class TestDeliverResultLiveAdapterUnconfirmed:
         pconfig = MagicMock()
         pconfig.enabled = True
         mock_cfg = MagicMock()
-        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+        mock_cfg.platforms = {Platform.MATRIX: pconfig}
 
         loop = MagicMock()
         loop.is_running.return_value = True
 
-        completed_future = Future()
-        completed_future.set_result(send_value)
+        primary_future = Future()
+        primary_future.set_result(send_value)
+        fallback_future = Future()
+        fallback_future.set_result({"success": True})
+        scheduled = []
+        futures = iter((primary_future, fallback_future))
 
-        def fake_run_coro(coro, _loop):
+        def fake_schedule(coro, _loop):
+            scheduled.append(coro)
             coro.close()
-            return completed_future
+            return next(futures)
 
         job = {
             "id": "unconfirmed-job",
             "deliver": "origin",
-            "origin": {"platform": "telegram", "chat_id": "123"},
+            "origin": {"platform": "matrix", "chat_id": "!room:example.test"},
         }
 
         standalone_send = AsyncMock(return_value={"success": True})
 
         with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
              patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
-             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro), \
+             patch("agent.async_utils.safe_schedule_threadsafe", side_effect=fake_schedule), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=AssertionError("direct scheduling is not allowed")), \
              patch("tools.send_message_tool._send_to_platform", new=standalone_send):
             result = _deliver_result(
                 job,
                 "Hello world",
-                adapters={Platform.TELEGRAM: adapter},
+                adapters={Platform.MATRIX: adapter},
                 loop=loop,
             )
-        return result, standalone_send
+        return result, standalone_send, scheduled
 
-    def test_none_result_falls_through_to_standalone(self):
-        """send() returning None must trigger the standalone fallback, not a
-        silent "delivered" log."""
-        result, standalone_send = self._run(None)
-        assert result is None, f"standalone should have delivered, got: {result!r}"
+    def test_none_result_uses_gateway_loop_bridge_for_fallback(self):
+        """An unconfirmed live result must use the safe gateway-loop bridge."""
+        result, standalone_send, scheduled = self._run(None)
+        assert result is None, f"gateway-loop fallback should have delivered, got: {result!r}"
+        # Both the primary and fallback coroutines are scheduled on the live
+        # gateway loop; _send_to_platform must not run in a fresh local loop.
+        assert len(scheduled) == 2
+        standalone_send.assert_not_awaited()
+
+
+class TestDeliverResultLiveFallbackLoopBridge:
+    """Loop-close fallback coverage for Matrix and other live adapters."""
+
+    def test_fallback_schedule_failure_closes_authorization_wrapper(self):
+        from agent.async_utils import safe_schedule_threadsafe
+        from concurrent.futures import Future
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        config = MagicMock()
+        config.platforms = {Platform.MATRIX: pconfig}
+        loop = MagicMock()
+        loop.is_running.return_value = True
+        job = {
+            "id": "live-fallback-review",
+            "deliver": "origin",
+            "origin": {"platform": "matrix", "chat_id": "!room:example.test"},
+        }
+        primary = Future()
+        primary.set_result(None)
+        scheduled = []
+
+        def run_coroutine_threadsafe(coro, _loop):
+            scheduled.append(coro)
+            if len(scheduled) == 1:
+                coro.close()
+                return primary
+            raise RuntimeError("event loop is closed")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", RuntimeWarning)
+            with (
+                patch("gateway.config.load_gateway_config", return_value=config),
+                patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}),
+                patch("agent.async_utils.safe_schedule_threadsafe", wraps=safe_schedule_threadsafe) as schedule,
+                patch("agent.async_utils.asyncio.run_coroutine_threadsafe", side_effect=run_coroutine_threadsafe),
+                patch("tools.send_message_tool._send_to_platform", new=AsyncMock()),
+            ):
+                result = _deliver_result(
+                    job, "Hello", adapters={Platform.MATRIX: AsyncMock()}, loop=loop
+                )
+
+        assert "live adapter event loop scheduling failed" in result
+        assert schedule.call_count == 2
+        assert scheduled[1].cr_frame is None
+        assert not [warning for warning in caught if "was never awaited" in str(warning.message)]
+
+    def test_non_matrix_schedule_failure_uses_standalone_sender(self):
+        """A Telegram loop-close race keeps the pre-existing standalone retry."""
+        from agent.async_utils import safe_schedule_threadsafe
+        from concurrent.futures import Future
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        config = MagicMock()
+        config.platforms = {Platform.TELEGRAM: pconfig}
+        loop = MagicMock()
+        loop.is_running.return_value = True
+        job = {
+            "id": "telegram-loop-close-fallback",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+        }
+        primary = Future()
+        primary.set_result(None)
+        scheduled = []
+        standalone_send = AsyncMock(return_value={"success": True})
+
+        def run_coroutine_threadsafe(coro, _loop):
+            scheduled.append(coro)
+            if len(scheduled) == 1:
+                coro.close()
+                return primary
+            raise RuntimeError("event loop is closed")
+
+        with (
+            patch("gateway.config.load_gateway_config", return_value=config),
+            patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}),
+            patch("agent.async_utils.safe_schedule_threadsafe", wraps=safe_schedule_threadsafe) as schedule,
+            patch("agent.async_utils.asyncio.run_coroutine_threadsafe", side_effect=run_coroutine_threadsafe),
+            patch("tools.send_message_tool._send_to_platform", new=standalone_send),
+        ):
+            result = _deliver_result(
+                job, "Hello", adapters={Platform.TELEGRAM: AsyncMock()}, loop=loop
+            )
+
+        assert result is None
+        assert schedule.call_count == 1
+        assert scheduled[0].cr_frame is None
         standalone_send.assert_awaited_once()
 
 
@@ -2718,7 +3040,13 @@ class TestMultiTargetDeliveryContinuesOnFailure:
             fail_future.result.side_effect = ConnectionError("SMTP connection refused")
             ok_future = MagicMock()
             ok_future.result.return_value = {"success": True}
-            mock_pool.submit.side_effect = [fail_future, ok_future]
+            futures = iter((fail_future, ok_future))
+
+            def submit(_runner, coro):
+                coro.close()
+                return next(futures)
+
+            mock_pool.submit.side_effect = submit
 
             result = _deliver_result(job, "Report content")
 


### PR DESCRIPTION
## Summary

Fix the cron fallback lane when a ready live adapter returns an unconfirmed or failed result.

The scheduler previously ran the fallback through a fresh `asyncio.run()` loop. That can re-enter a gateway-owned Matrix aiohttp/E2EE session from the wrong loop and raise:

```text
Timeout context manager should be used inside a task
```

This patch keeps that fallback on the owning gateway loop.

## Timeout safety

A loop-side, lock-protected dispatch handshake avoids inferring send state from `Future.cancel()`:

- if the scheduler abort wins before gateway-loop authorization, a delayed callback observes the abort and does not construct or call the sender;
- if authorization wins, the outcome is treated as indeterminate and is not retried as safely unsent, avoiding duplicate delivery.

## Scope

Only:

- `cron/scheduler.py`
- `tests/cron/test_scheduler.py`

This is an alternative to #62956’s ephemeral-adapter approach: it preserves the existing gateway-owned live adapter/E2EE path for the fallback while fixing its event-loop affinity.

## Verification

On current `main` base `7e67f64fce`:

```text
6 focused Matrix/fallback tests passed with RuntimeWarnings promoted to errors
107 scheduler tests passed
107 scheduler tests collected
python -m py_compile passed
git diff --check passed
```

The targeted regressions cover:

- gateway-loop reuse after a failed/unconfirmed live-adapter send;
- pending fallback abort before sender entry;
- authorized/in-flight timeout treated as indeterminate with no retry;
- schedule-failure coroutine closure without an unawaited-coroutine warning;
- unchanged standalone behavior without a live adapter/loop.

Note: the existing broad scheduler test file still emits an end-of-run unawaited `_send_to_platform` warning outside these focused paths; the focused changed-path suite is warning-free.
