### PR TITLE
fix(cli): map Shift+symbol sequences to the shifted character under modifyOtherKeys=2

### DIFF
--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -321,9 +321,10 @@ def install_modify_other_keys_aliases() -> int:
     # combo is broken" symptom (#87711).
     # Map Shift+letter to the uppercase character so typing works normally.
     # This is safe across all Latin keyboard layouts: Shift always uppercases
-    # letters.  Shift+digit symbols are layout-specific (US: '!', AZERTY: '¹',
-    # etc.) so they are NOT mapped here — if the terminal sends those under
-    # modifyOtherKeys, they will leak, but that's better than wrong input.
+    # letters.  Shift+digit *base* codepoints (ESC[27;2;50~ for Shift+2) are
+    # layout-specific (US: '@', AZERTY: '²', etc.) so they are NOT mapped —
+    # leaking is better than wrong input.  See the punctuation block below for
+    # why *shifted* codepoints are safe to map.
     # Map both the lowercase and uppercase codepoints — some terminals send
     # the already-shifted codepoint (65 for 'A') with modifier=2.
     shift_map: dict[int, str] = {}
@@ -331,6 +332,19 @@ def install_modify_other_keys_aliases() -> int:
         upper_char = chr(ch - 32)  # 'A'..'Z'
         shift_map[ch] = upper_char
         shift_map[ch - 32] = upper_char
+    # Shift+punctuation: modifyOtherKeys=2 emitters (Ghostty, VS Code,
+    # iTerm2) report the *shifted* codepoint for symbol keys — Shift+2 (US:
+    # '@') arrives as ESC[27;2;64~ where 64 IS '@'.  Mapping the codepoint
+    # to itself is layout-safe: whatever character the terminal reports is
+    # by definition the character the layout produced, so no layout table is
+    # needed.  Without this, every Shift+symbol leaks as literal
+    # "[27;2;NN~]" in the prompt.  Digits are excluded: a base-digit
+    # codepoint under Shift (ESC[27;2;50~ for Shift+2) is layout-dependent
+    # and must keep leaking rather than insert a wrong character.
+    for cp in range(33, 127):
+        if cp in shift_map or chr(cp).isdigit():
+            continue
+        shift_map[cp] = chr(cp)
     _install_paired(2, shift_map)
 
     # -- Multi-modifier letters: Shift+Alt (4), Ctrl+Shift (6),

--- a/tests/cli/test_modify_other_keys_aliases.py
+++ b/tests/cli/test_modify_other_keys_aliases.py
@@ -273,6 +273,54 @@ def test_does_not_clobber_shift_enter_alias():
     assert ANSI_SEQUENCES["\x1b[13;2u"] == (Keys.Escape, Keys.ControlM)
 
 
+# ---------------------------------------------------------------------------
+# Shift+punctuation → the shifted character itself
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "codepoint,char",
+    [
+        (64, "@"),   # Shift+2 on US layout — the original 'leak' report
+        (33, "!"),   # Shift+1
+        (36, "$"),   # Shift+4
+        (38, "&"),   # Shift+7
+        (95, "_"),   # Shift+minus
+        (126, "~"),  # Shift+backtick
+        (60, "<"),   # Shift+comma
+        (62, ">"),   # Shift+period
+        (63, "?"),   # Shift+slash
+        (34, '"'),   # Shift+quote
+    ],
+)
+def test_modify_other_keys_shift_punctuation_produces_character(codepoint, char):
+    """Shift+<symbol> under modifyOtherKeys=2 must produce the character the
+    terminal reported (the shifted codepoint), not leak as literal
+    '[27;2;NN~' text.  modifyOtherKeys=2 emitters (Ghostty, VS Code, iTerm2)
+    send the *shifted* codepoint — 64 IS '@' — so mapping it to itself is
+    layout-safe."""
+    mok_seq = f"\x1b[27;2;{codepoint}~"
+    assert _parse(mok_seq) == [char], (
+        f"modifyOtherKeys Shift codepoint {codepoint} ({mok_seq!r}) should"
+        f" produce {char!r}"
+    )
+    csiu_seq = f"\x1b[{codepoint};2u"
+    assert _parse(csiu_seq) == [char], (
+        f"CSI-u Shift codepoint {codepoint} ({csiu_seq!r}) should produce"
+        f" {char!r}"
+    )
+
+
+@pytest.mark.parametrize("digit", list("0123456789"))
+def test_shift_base_digit_codepoint_stays_unmapped(digit):
+    """A *base*-digit codepoint under Shift (ESC[27;2;50~ for Shift+2) is
+    layout-dependent (US: '@', AZERTY: '²') and must keep leaking rather
+    than insert a wrong character — digits are excluded from the symbol
+    self-mapping."""
+    cp = ord(digit)
+    assert ANSI_SEQUENCES.get(f"\x1b[27;2;{cp}~") is None
+    assert ANSI_SEQUENCES.get(f"\x1b[{cp};2u") is None
+
+
 def test_does_not_clobber_ctrl_enter_alias():
     """install_modify_other_keys_aliases must not overwrite mappings
     installed by install_ctrl_enter_alias (which maps Ctrl+Enter)."""


### PR DESCRIPTION
## Summary

In the classic interactive CLI, **Shift+symbol keys** (`@ ~ ! $ % ^ & * …`) print literal text like `[27;2;64~` into the prompt instead of the symbol, on terminals that emit **xterm modifyOtherKeys level 2** (Ghostty, VS Code terminal, iTerm2). `#87511` fixed Shift+letter; symbols were deliberately left unmapped out of layout caution — but that caution only applies to base-digit codepoints, not the shifted codepoints these terminals actually send.

Fixes #93633.

## Root cause

Under modifyOtherKeys=2, Ghostty/VS Code/iTerm2 re-encode Shift+symbol as `ESC[27;2;<codepoint>~` where the codepoint is the **shifted** one — `Shift+2` (US) → `ESC[27;2;64~`, and 64 **is** `@`. `install_modify_other_keys_aliases()` mapped Shift+letter but skipped symbols, so the sequence fell through the VT100 parser as literal text.

## The fix

Map non-digit codepoints 33–126 to themselves for modifier 2, in both emitted forms (`ESC[27;2;<cp>~` and kitty CSI-u `ESC[<cp>;2u`), inside the existing `shift_map` pass:

```python
for cp in range(33, 127):
    if cp in shift_map or chr(cp).isdigit():
        continue
    shift_map[cp] = chr(cp)
```

**Why self-mapping is layout-safe:** the reported codepoint is already the produced character — the terminal resolved the keyboard layout. `ESC[27;2;64~` means "Shift produced `@`", whether that's Shift+2 on US or Shift+` on UK. No layout table needed.

**Why digits stay excluded:** a **base-digit** codepoint under Shift (`ESC[27;2;50~` = Shift on unshifted `2`) is layout-dependent (US: `@`, AZERTY: `²`) — mapping it would insert wrong characters on non-US layouts. Leaking is better than wrong input; that part of the original caution is preserved.

Existing mappings are never overwritten (`setdefault` semantics), and the lock-bit CSI-u variants are handled by the existing `_install_paired` machinery.

## Testing

- New tests in `tests/cli/test_modify_other_keys_aliases.py`:
  - 10 parametrized symbol cases (both modifyOtherKeys and CSI-u forms) asserting `_parse(seq) == [char]`
  - 10 digit-exclusion cases asserting base-digit sequences stay unmapped
- Targeted suite: **254 passed, 2 skipped** (`test_modify_other_keys_aliases.py`, `test_cli_shift_enter_newline.py`, `test_ctrl_enter_newline.py`, `test_cli_terminal_shortcuts.py`)
- Full `tests/cli/` run: the 10 failures in `test_personality_none` / `test_quick_commands` / `test_resume_quiet_stderr` reproduce identically on clean `origin/main` — pre-existing, unrelated to this change.

## Manual verification

```
ESC[27;2;64~  -> '@'      ESC[64;2u   -> '@'
ESC[27;2;126~ -> '~'      ESC[27;2;33~ -> '!'
ESC[27;2;38~  -> '&'      ESC[27;2;95~ -> '_'
ESC[27;2;97~  -> 'A'   (letters unaffected)
ESC[27;2;50~  -> unmapped (base digit, layout-dependent — by design)
```
