### PR TITLE
fix(gateway): secondary-profile allowlists work and allow-all no longer leaks across profiles (#93522, salvage #93545 + #93605)

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -250,6 +250,26 @@ def validate_signal_config(config: PlatformConfig) -> bool:
 # Signal Adapter
 # ---------------------------------------------------------------------------
 
+def _sig_secret(name: str, default: str = "") -> str:
+    """Resolve a per-profile ``SIGNAL_*`` setting honoring the active secret
+    scope (#93522).
+
+    Under ``gateway.multiplex_profiles`` every secondary profile is
+    constructed inside ``_profile_runtime_scope`` (``gateway/run.py``) and
+    its ``.env`` lives in that scope — raw ``os.getenv`` misses it and
+    leaks the default profile's values instead. The primary/active profile
+    is constructed without a scope and legitimately owns ``os.environ``
+    (same canonical shape as QQ's ``_resolve_qq_secret``).
+    """
+    from agent.secret_scope import UnscopedSecretError, get_secret
+
+    try:
+        val = get_secret(name, default)
+    except UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
+
 class SignalAdapter(BasePlatformAdapter):
     """Signal messenger adapter using signal-cli HTTP daemon."""
 
@@ -268,7 +288,10 @@ class SignalAdapter(BasePlatformAdapter):
         self.ignore_stories = extra.get("ignore_stories", True)
 
         # Parse allowlists — group policy is derived from presence of group allowlist
-        group_allowed_str = os.getenv("SIGNAL_GROUP_ALLOWED_USERS", "")
+        # Scoped reads (#93522): allowlists are per-profile authorization
+        # config; raw os.getenv misses secondary profiles' .env values and
+        # leaks the default profile's list into them.
+        group_allowed_str = _sig_secret("SIGNAL_GROUP_ALLOWED_USERS", "")
         self.group_allow_from = set(_parse_comma_list(group_allowed_str))
 
         # Mention filter — only respond in groups when the bot account is @mentioned.
@@ -285,7 +308,7 @@ class SignalAdapter(BasePlatformAdapter):
         # every inbound DM from any contact gets a 👀 reaction).
         # "*" means all users allowed (open mode); empty means no restriction
         # recorded at adapter level (run.py still enforces auth separately).
-        dm_allowed_str = os.getenv("SIGNAL_ALLOWED_USERS", "*")
+        dm_allowed_str = _sig_secret("SIGNAL_ALLOWED_USERS", "*")
         self.dm_allow_from = set(_parse_comma_list(dm_allowed_str))
 
         # HTTP client

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1227,14 +1227,14 @@ class WeixinAdapter(BasePlatformAdapter):
         )
         self._rate_limit_circuit_until = 0.0
         self._rate_limit_events: List[float] = []
-        self._dm_policy = str(extra.get("dm_policy") or os.getenv("WEIXIN_DM_POLICY", "pairing")).strip().lower()
-        self._group_policy = str(extra.get("group_policy") or os.getenv("WEIXIN_GROUP_POLICY", "disabled")).strip().lower()
+        self._dm_policy = str(extra.get("dm_policy") or _wx_secret("WEIXIN_DM_POLICY", "pairing")).strip().lower()
+        self._group_policy = str(extra.get("group_policy") or _wx_secret("WEIXIN_GROUP_POLICY", "disabled")).strip().lower()
         allow_from = extra.get("allow_from")
         if allow_from is None:
-            allow_from = os.getenv("WEIXIN_ALLOWED_USERS", "")
+            allow_from = _wx_secret("WEIXIN_ALLOWED_USERS", "")
         group_allow_from = extra.get("group_allow_from")
         if group_allow_from is None:
-            group_allow_from = os.getenv("WEIXIN_GROUP_ALLOWED_USERS", "")
+            group_allow_from = _wx_secret("WEIXIN_GROUP_ALLOWED_USERS", "")
         self._allow_from = self._coerce_list(allow_from)
         self._group_allow_from = self._coerce_list(group_allow_from)
         self._split_multiline_messages = _coerce_bool(

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1537,9 +1537,11 @@ class WeixinAdapter(BasePlatformAdapter):
             await self.handle_message(event)
 
     def _open_dm_opted_in(self) -> bool:
-        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+        # Scoped reads (#93522): the default profile's allow-all flag must
+        # not leak into a multiplexed secondary profile's admission gate.
+        if (_wx_secret("GATEWAY_ALLOW_ALL_USERS", "") or "").lower() in {"true", "1", "yes"}:
             return True
-        return os.getenv("WEIXIN_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+        return (_wx_secret("WEIXIN_ALLOW_ALL_USERS", "") or "").lower() in {"true", "1", "yes"}
 
     def _is_dm_allowed(self, sender_id: str) -> bool:
         if self._dm_policy == "disabled":

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -97,6 +97,7 @@ from gateway.platforms.yuanbao_proto import (
     next_seq_no,
 )
 from gateway.session import build_session_key
+from gateway.authz_mixin import _platform_gate_env
 
 logger = logging.getLogger(__name__)
 
@@ -1282,9 +1283,9 @@ class AccessPolicy:
         self._group_allow_from = group_allow_from
 
     def _open_dm_opted_in(self) -> bool:
-        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+        if _platform_gate_env("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
             return True
-        return os.getenv("YUANBAO_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+        return _platform_gate_env("YUANBAO_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
 
     def is_dm_allowed(self, sender_id: str) -> bool:
         """Strict DM authorization — pairing does not imply access."""
@@ -4946,23 +4947,23 @@ class YuanbaoAdapter(BasePlatformAdapter):
         # ------------------------------------------------------------------
         dm_policy: str = (
             _extra.get("dm_policy")
-            or os.getenv("YUANBAO_DM_POLICY", "pairing")
+            or _platform_gate_env("YUANBAO_DM_POLICY", "pairing")
         ).strip().lower()
 
         _dm_allow_from_raw: str = (
             _extra.get("dm_allow_from")
-            or os.getenv("YUANBAO_DM_ALLOW_FROM", "")
+            or _platform_gate_env("YUANBAO_DM_ALLOW_FROM", "")
         )
         dm_allow_from: list[str] = [x.strip() for x in _dm_allow_from_raw.split(",") if x.strip()]
 
         group_policy: str = (
             _extra.get("group_policy")
-            or os.getenv("YUANBAO_GROUP_POLICY", "pairing")
+            or _platform_gate_env("YUANBAO_GROUP_POLICY", "pairing")
         ).strip().lower()
 
         _group_allow_from_raw: str = (
             _extra.get("group_allow_from")
-            or os.getenv("YUANBAO_GROUP_ALLOW_FROM", "")
+            or _platform_gate_env("YUANBAO_GROUP_ALLOW_FROM", "")
         )
         group_allow_from: list[str] = [x.strip() for x in _group_allow_from_raw.split(",") if x.strip()]
 

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -97,7 +97,6 @@ from gateway.platforms.yuanbao_proto import (
     next_seq_no,
 )
 from gateway.session import build_session_key
-from gateway.authz_mixin import _platform_gate_env
 
 logger = logging.getLogger(__name__)
 
@@ -1262,6 +1261,27 @@ class ChatRoutingMiddleware(InboundMiddleware):
         await next_fn()
 
 
+def _yb_secret(name: str, default: Optional[str] = None) -> Optional[str]:
+    """Resolve a per-profile ``YUANBAO_*`` / gateway setting honoring the
+    active secret scope (#93522).
+
+    Under ``gateway.multiplex_profiles`` every secondary profile is
+    constructed inside ``_profile_runtime_scope`` (``gateway/run.py``) and
+    its ``.env`` lives in that scope — raw ``os.getenv`` misses it and
+    leaks the default profile's values instead. The primary/active profile
+    is constructed without a scope and legitimately owns ``os.environ``,
+    so fall back to it there (same canonical shape as QQ's
+    ``_resolve_qq_secret``).
+    """
+    from agent.secret_scope import UnscopedSecretError, get_secret
+
+    try:
+        val = get_secret(name, default)
+    except UnscopedSecretError:
+        val = os.getenv(name)
+    return val if val is not None else default
+
+
 class AccessPolicy:
     """Platform-level DM / Group access control policy.
 
@@ -1283,9 +1303,9 @@ class AccessPolicy:
         self._group_allow_from = group_allow_from
 
     def _open_dm_opted_in(self) -> bool:
-        if _platform_gate_env("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+        if (_yb_secret("GATEWAY_ALLOW_ALL_USERS", "") or "").lower() in {"true", "1", "yes"}:
             return True
-        return _platform_gate_env("YUANBAO_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+        return (_yb_secret("YUANBAO_ALLOW_ALL_USERS", "") or "").lower() in {"true", "1", "yes"}
 
     def is_dm_allowed(self, sender_id: str) -> bool:
         """Strict DM authorization — pairing does not imply access."""
@@ -4943,27 +4963,29 @@ class YuanbaoAdapter(BasePlatformAdapter):
 
         # Reply-to dedup: inbound_msg_id -> expire_ts
         # ------------------------------------------------------------------
-        # Access control policy (DM / Group)
+        # Access control policy (DM / Group) — scoped reads (#93522)
         # ------------------------------------------------------------------
         dm_policy: str = (
             _extra.get("dm_policy")
-            or _platform_gate_env("YUANBAO_DM_POLICY", "pairing")
+            or _yb_secret("YUANBAO_DM_POLICY")
+            or "pairing"
         ).strip().lower()
 
         _dm_allow_from_raw: str = (
             _extra.get("dm_allow_from")
-            or _platform_gate_env("YUANBAO_DM_ALLOW_FROM", "")
+            or _yb_secret("YUANBAO_DM_ALLOW_FROM", "")
         )
         dm_allow_from: list[str] = [x.strip() for x in _dm_allow_from_raw.split(",") if x.strip()]
 
         group_policy: str = (
             _extra.get("group_policy")
-            or _platform_gate_env("YUANBAO_GROUP_POLICY", "pairing")
+            or _yb_secret("YUANBAO_GROUP_POLICY")
+            or "pairing"
         ).strip().lower()
 
         _group_allow_from_raw: str = (
             _extra.get("group_allow_from")
-            or _platform_gate_env("YUANBAO_GROUP_ALLOW_FROM", "")
+            or _yb_secret("YUANBAO_GROUP_ALLOW_FROM", "")
         )
         group_allow_from: list[str] = [x.strip() for x in _group_allow_from_raw.split(",") if x.strip()]
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2750,7 +2750,7 @@ def _own_policy_open_startup_violation(config) -> Optional[str]:
         ).strip().lower()
         if dm_policy != "open" and group_policy != "open":
             continue
-        gateway_allow_all = os.getenv(
+        gateway_allow_all = _getenv(
             "GATEWAY_ALLOW_ALL_USERS", ""
         ).lower() in {"true", "1", "yes"}
         platform_opted_in = gateway_allow_all or (

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -185,7 +185,7 @@ class WeComAdapter(BasePlatformAdapter):
             or os.getenv("WECOM_WEBSOCKET_URL", DEFAULT_WS_URL)
         ).strip() or DEFAULT_WS_URL
 
-        self._dm_policy = str(extra.get("dm_policy") or os.getenv("WECOM_DM_POLICY", "pairing")).strip().lower()
+        self._dm_policy = str(extra.get("dm_policy") or _get_scoped_secret("WECOM_DM_POLICY", "pairing")).strip().lower()
         # dm_policy already honors WECOM_DM_POLICY, so the allowlist must honor
         # WECOM_ALLOWED_USERS too. Without the env fallback an env-only setup
         # (dm_policy=allowlist via env, no config extra) runs with an empty
@@ -193,10 +193,10 @@ class WeComAdapter(BasePlatformAdapter):
         self._allow_from = _coerce_list(
             extra.get("allow_from")
             or extra.get("allowFrom")
-            or os.getenv("WECOM_ALLOWED_USERS", "")
+            or _get_scoped_secret("WECOM_ALLOWED_USERS", "")
         )
 
-        self._group_policy = str(extra.get("group_policy") or os.getenv("WECOM_GROUP_POLICY", "pairing")).strip().lower()
+        self._group_policy = str(extra.get("group_policy") or _get_scoped_secret("WECOM_GROUP_POLICY", "pairing")).strip().lower()
         self._group_allow_from = _coerce_list(extra.get("group_allow_from") or extra.get("groupAllowFrom"))
         self._groups = extra.get("groups") if isinstance(extra.get("groups"), dict) else {}
 

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -893,9 +893,11 @@ class WeComAdapter(BasePlatformAdapter):
         return True
 
     def _open_dm_opted_in(self) -> bool:
-        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+        # Scoped reads (#93522): the default profile's allow-all flag must
+        # not leak into a multiplexed secondary profile's admission gate.
+        if (_get_scoped_secret("GATEWAY_ALLOW_ALL_USERS", "") or "").lower() in {"true", "1", "yes"}:
             return True
-        return os.getenv("WECOM_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+        return (_get_scoped_secret("WECOM_ALLOW_ALL_USERS", "") or "").lower() in {"true", "1", "yes"}
 
     def _is_dm_allowed(self, sender_id: str) -> bool:
         if self._dm_policy == "disabled":

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -114,6 +114,42 @@ def test_adapter_auth_check_stamps_secondary_profile(monkeypatch):
     assert captured["profile"] == "coder"
 
 
+def test_startup_guard_gateway_allow_all_reads_scope_not_environ(monkeypatch):
+    """The GATEWAY_ALLOW_ALL_USERS opt-in check inside the startup guard
+    must honor the active profile secret scope (#93522): the default
+    profile's env-only opt-in must not leak into a secondary profile that
+    never opted in, and a secondary profile's own scoped opt-in must be
+    honored."""
+    from agent import secret_scope
+    from gateway.run import _own_policy_open_startup_violation
+
+    _clear_auth_env(monkeypatch)
+    cfg = GatewayConfig(multiplex_profiles=True)
+    cfg.platforms = {
+        Platform.WECOM: PlatformConfig(enabled=True, extra={"dm_policy": "open"}),
+    }
+
+    previous_multiplex = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+    try:
+        token = secret_scope.set_secret_scope({"SOMETHING_ELSE": "x"})
+        try:
+            violation = _own_policy_open_startup_violation(cfg)
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert violation is not None, "default profile's env opt-in must not leak into the scoped secondary profile"
+
+        token = secret_scope.set_secret_scope({"GATEWAY_ALLOW_ALL_USERS": "true"})
+        try:
+            violation = _own_policy_open_startup_violation(cfg)
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert violation is None, "the secondary profile's own scoped opt-in must be honored"
+    finally:
+        secret_scope.set_multiplex_active(previous_multiplex)
+
+
 def test_secondary_open_policy_fails_startup_guard(monkeypatch):
     """Secondary profiles must pass the same open-policy startup guard."""
     from gateway.run import _own_policy_open_startup_violation

--- a/tests/gateway/test_platform_authz_scope.py
+++ b/tests/gateway/test_platform_authz_scope.py
@@ -1,0 +1,212 @@
+"""Platform authorization reads must honor the per-profile secret scope (#93522).
+
+Under ``gateway.multiplex_profiles`` every secondary profile is constructed
+inside ``_profile_runtime_scope`` and its ``.env`` lives in that scope —
+``gateway/run.py`` explicitly does NOT mutate ``os.environ`` with it. Raw
+``os.getenv`` authorization reads therefore (a) silently miss the secondary
+profile's own allowlists (fail-closed no-replies) and (b) leak the default
+profile's ``GATEWAY_ALLOW_ALL_USERS`` / allowlists into secondary profiles
+(fail-open admissions).
+
+Covers the scoped env helpers of weixin / yuanbao / signal / wecom plus the
+``_open_dm_opted_in`` gates built on them. Canonical shape reference:
+QQ's ``_resolve_qq_secret``.
+"""
+
+import contextlib
+import os
+
+import pytest
+
+from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+
+@contextlib.contextmanager
+def _scope(secrets):
+    token = set_secret_scope(secrets)
+    try:
+        yield
+    finally:
+        reset_secret_scope(token)
+
+
+@pytest.fixture
+def profile_scope():
+    """Install a secondary-profile secret scope; os.environ stays 'default'."""
+    with _scope(
+        {
+            "WEIXIN_DM_POLICY": "allowlist",
+            "WEIXIN_ALLOWED_USERS": "wx-alice",
+            "WEIXIN_ALLOW_ALL_USERS": "",
+            "YUANBAO_DM_POLICY": "open",
+            "SIGNAL_ALLOWED_USERS": "sig-bob",
+            "WECOM_DM_POLICY": "allowlist",
+            "WECOM_ALLOWED_USERS": "wecom-carol",
+        }
+    ):
+        yield
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Scoped helpers: read the scope, never leak os.environ past it
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "module_path,helper_name,var",
+    [
+        ("gateway.platforms.weixin", "_wx_secret", "WEIXIN_ALLOWED_USERS"),
+        ("gateway.platforms.yuanbao", "_yb_secret", "YUANBAO_DM_POLICY"),
+        ("gateway.platforms.signal", "_sig_secret", "SIGNAL_ALLOWED_USERS"),
+        ("plugins.platforms.wecom.adapter", "_get_scoped_secret", "WECOM_ALLOWED_USERS"),
+    ],
+)
+def test_helper_reads_profile_scope_first(module_path, helper_name, var, monkeypatch):
+    """Scope value wins over anything in os.environ."""
+    monkeypatch.setenv(var, "FROM-DEFAULT-ENV")
+    module = __import__(module_path, fromlist=[helper_name])
+    helper = getattr(module, helper_name)
+
+    with _scope({var: "from-profile-scope"}):
+        assert helper(var, "") == "from-profile-scope"
+
+
+@pytest.fixture
+def multiplex_on(monkeypatch):
+    """Simulate a multiplexed deployment: scoped misses fail closed.
+
+    With multiplexing off, a scope miss deliberately falls through to
+    os.environ (the cron-overlay contract) — the cross-profile leak only
+    exists while the multiplexer is active, which is exactly the #93522
+    scenario.
+    """
+    monkeypatch.setattr("agent.secret_scope._MULTIPLEX_ACTIVE", True)
+
+
+@pytest.mark.parametrize(
+    "module_path,helper_name",
+    [
+        ("gateway.platforms.weixin", "_wx_secret"),
+        ("gateway.platforms.yuanbao", "_yb_secret"),
+        ("gateway.platforms.signal", "_sig_secret"),
+        ("plugins.platforms.wecom.adapter", "_get_scoped_secret"),
+    ],
+)
+def test_helper_does_not_leak_default_env_into_scoped_miss(
+    module_path, helper_name, multiplex_on, monkeypatch
+):
+    """Scoped miss must return the default, NOT fall through to os.environ.
+
+    This is the fail-closed half of #93522: the default profile's
+    ``*_ALLOW_ALL_USERS=true`` in process env must not answer a secondary
+    profile's gate.
+    """
+    monkeypatch.setenv("WEIXIN_ALLOW_ALL_USERS", "true")
+    monkeypatch.setenv("YUANBAO_ALLOW_ALL_USERS", "true")
+    monkeypatch.setenv("SIGNAL_ALLOWED_USERS", "*")
+    monkeypatch.setenv("WECOM_ALLOW_ALL_USERS", "true")
+
+    module = __import__(module_path, fromlist=[helper_name])
+    helper = getattr(module, helper_name)
+
+    with _scope({}):  # scope installed, keys absent
+        assert helper("WEIXIN_ALLOW_ALL_USERS", "") == ""
+        assert helper("YUANBAO_ALLOW_ALL_USERS", "") == ""
+        assert helper("WECOM_ALLOW_ALL_USERS", "") == ""
+        # signal's "*" default means open at adapter level — the scoped
+        # read must still not see the unscoped value:
+        assert helper("SIGNAL_ALLOWED_USERS", "restricted-default") == "restricted-default"
+
+
+@pytest.mark.parametrize(
+    "module_path,helper_name,var",
+    [
+        ("gateway.platforms.weixin", "_wx_secret", "WEIXIN_ALLOWED_USERS"),
+        ("gateway.platforms.yuanbao", "_yb_secret", "YUANBAO_DM_POLICY"),
+        ("gateway.platforms.signal", "_sig_secret", "SIGNAL_ALLOWED_USERS"),
+        ("plugins.platforms.wecom.adapter", "_get_scoped_secret", "WECOM_ALLOWED_USERS"),
+    ],
+)
+def test_helper_falls_back_to_environ_without_scope(module_path, helper_name, var, monkeypatch):
+    """Single-profile (no scope installed): os.environ remains authoritative."""
+    monkeypatch.setenv(var, "legacy-env-value")
+    module = __import__(module_path, fromlist=[helper_name])
+    helper = getattr(module, helper_name)
+    assert helper(var, "") == "legacy-env-value"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Admission gates built on the helpers
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_weixin_open_gate_ignores_default_env_under_scope(profile_scope, multiplex_on, monkeypatch):
+    """Default profile sets GATEWAY_ALLOW_ALL_USERS=true; secondary scope does
+    NOT carry it — the gate must stay closed."""
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+
+    from gateway.platforms.weixin import WeixinAdapter
+
+    adapter = WeixinAdapter.__new__(WeixinAdapter)
+    assert adapter._open_dm_opted_in() is False
+
+
+def test_weixin_open_gate_honors_scope_opt_in():
+    from gateway.platforms.weixin import WeixinAdapter
+
+    with _scope({"WEIXIN_ALLOW_ALL_USERS": "yes"}):
+        adapter = WeixinAdapter.__new__(WeixinAdapter)
+        assert adapter._open_dm_opted_in() is True
+
+
+def test_yuanbao_access_policy_gate_ignores_default_env(profile_scope, multiplex_on, monkeypatch):
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+
+    from gateway.platforms.yuanbao import AccessPolicy
+
+    policy = AccessPolicy(
+        dm_policy="open", dm_allow_from=[], group_policy="pairing", group_allow_from=[]
+    )
+    assert policy._open_dm_opted_in() is False
+
+
+def test_wecom_open_gate_ignores_default_env_under_scope(profile_scope, multiplex_on, monkeypatch):
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+
+    from plugins.platforms.wecom.adapter import WeComAdapter
+
+    adapter = WeComAdapter.__new__(WeComAdapter)
+    assert adapter._open_dm_opted_in() is False
+
+
+def test_startup_guard_uses_scoped_gateway_flag(multiplex_on):
+    """_own_policy_open_startup_violation must consult the scope for
+    GATEWAY_ALLOW_ALL_USERS, not raw os.environ (#93522)."""
+    from gateway.platforms.base import Platform
+    from gateway.run import _own_policy_open_startup_violation
+
+    class _PlatformConfig:
+        enabled = True
+        extra = {"dm_policy": "open"}
+
+    class _Config:
+        platforms = {Platform.YUANBAO: _PlatformConfig()}
+
+    cfg = _Config()
+    with _scope({"GATEWAY_ALLOW_ALL_USERS": "true"}):
+        # Scope says opted-in even though os.environ doesn't -> no violation.
+        assert _own_policy_open_startup_violation(cfg) is None
+
+    with _scope({}):
+        # Scope lacks the opt-in while os.environ has it -> violation (the
+        # default profile's flag must not satisfy this profile's check).
+        monkey_env_backup = os.environ.get("GATEWAY_ALLOW_ALL_USERS")
+        os.environ["GATEWAY_ALLOW_ALL_USERS"] = "true"
+        try:
+            reason = _own_policy_open_startup_violation(cfg)
+            assert reason is not None and "yuanbao" in reason.lower()
+        finally:
+            if monkey_env_backup is None:
+                os.environ.pop("GATEWAY_ALLOW_ALL_USERS", None)
+            else:
+                os.environ["GATEWAY_ALLOW_ALL_USERS"] = monkey_env_backup

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -30,6 +30,53 @@ class TestWeComAdapterInit:
         assert WeComAdapter.SUPPORTS_MESSAGE_EDITING is False
 
 
+class TestWeComAdapterAuthzScope:
+    """dm_policy/allowlist reads must honor the profile secret scope under
+    multiplexing (#93522): a secondary profile's own scope is authoritative
+    and must not inherit the default profile's process-env authorization."""
+
+    @pytest.fixture()
+    def multiplex_on(self):
+        from agent import secret_scope
+
+        previous = secret_scope.is_multiplex_active()
+        secret_scope.set_multiplex_active(True)
+        try:
+            yield
+        finally:
+            secret_scope.set_multiplex_active(previous)
+
+    def test_scoped_construction_reads_authz_from_scope_not_environ(self, multiplex_on, monkeypatch):
+        from agent import secret_scope
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        monkeypatch.setenv("WECOM_DM_POLICY", "pairing")
+        monkeypatch.setenv("WECOM_ALLOWED_USERS", "default-user")
+        token = secret_scope.set_secret_scope(
+            {"WECOM_DM_POLICY": "allowlist", "WECOM_ALLOWED_USERS": "scoped-user"}
+        )
+        try:
+            adapter = WeComAdapter(PlatformConfig(enabled=True))
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert adapter._dm_policy == "allowlist"
+        assert adapter._allow_from == ["scoped-user"]
+
+    def test_scoped_miss_does_not_admit_default_profiles_allowlist(self, multiplex_on, monkeypatch):
+        from agent import secret_scope
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        monkeypatch.setenv("WECOM_DM_POLICY", "allowlist")
+        monkeypatch.setenv("WECOM_ALLOWED_USERS", "default-user")
+        token = secret_scope.set_secret_scope({"SOMETHING_ELSE": "x"})
+        try:
+            adapter = WeComAdapter(PlatformConfig(enabled=True))
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert adapter._dm_policy == "pairing"
+        assert adapter._allow_from == []
+
+
 class TestWeComConnect:
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_weixin_secret_scope.py
+++ b/tests/gateway/test_weixin_secret_scope.py
@@ -101,3 +101,49 @@ class TestWeixinAdapterConstructionScope:
             secret_scope.reset_secret_scope(token)
         assert adapter._account_id == "env-account"
         assert adapter._token == "env-token"
+
+
+class TestWeixinAdapterAuthzScope:
+    """Authorization reads (dm_policy/allowlists) must follow the same
+    scoped-secret rules as the credential reads above (#93522): a secondary
+    profile's own scope is authoritative, and the default profile's
+    process-env values must not leak into it."""
+
+    def test_scoped_construction_reads_authz_from_scope_not_environ(
+        self, multiplex_on, monkeypatch
+    ):
+        monkeypatch.setenv("WEIXIN_DM_POLICY", "pairing")
+        monkeypatch.setenv("WEIXIN_ALLOWED_USERS", "default-user")
+        monkeypatch.setenv("WEIXIN_GROUP_ALLOWED_USERS", "default-group-user")
+        token = secret_scope.set_secret_scope(
+            {
+                "WEIXIN_DM_POLICY": "allowlist",
+                "WEIXIN_ALLOWED_USERS": "scoped-user",
+                "WEIXIN_GROUP_ALLOWED_USERS": "scoped-group-user",
+            }
+        )
+        try:
+            adapter = WeixinAdapter(PlatformConfig(enabled=True))
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert adapter._dm_policy == "allowlist"
+        assert adapter._allow_from == ["scoped-user"]
+        assert adapter._group_allow_from == ["scoped-group-user"]
+        assert adapter._is_dm_allowed("scoped-user") is True
+        assert adapter._is_dm_allowed("default-user") is False
+
+    def test_scoped_miss_does_not_admit_default_profiles_allow_all(
+        self, multiplex_on, monkeypatch
+    ):
+        """A secondary profile with no allowlist of its own must fail closed,
+        not inherit the default profile's env-only allowlist/opt-in."""
+        monkeypatch.setenv("WEIXIN_DM_POLICY", "allowlist")
+        monkeypatch.setenv("WEIXIN_ALLOWED_USERS", "default-user")
+        token = secret_scope.set_secret_scope({"SOMETHING_ELSE": "x"})
+        try:
+            adapter = WeixinAdapter(PlatformConfig(enabled=True))
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert adapter._dm_policy == "pairing"
+        assert adapter._allow_from == []
+        assert adapter._is_dm_allowed("default-user") is False

--- a/tests/gateway/test_yuanbao_secret_scope.py
+++ b/tests/gateway/test_yuanbao_secret_scope.py
@@ -1,0 +1,72 @@
+"""Yuanbao authorization-scope regression tests (#93522).
+
+``dm_policy``/``group_policy``/allowlist reads and the ``AccessPolicy``
+allow-all opt-in must honor the active profile secret scope under
+multiplexing: a secondary profile's own scope is authoritative and must
+not inherit the default profile's process-env authorization config.
+"""
+
+import pytest
+
+from agent import secret_scope
+from gateway.config import PlatformConfig
+from gateway.platforms.yuanbao import AccessPolicy, YuanbaoAdapter
+
+
+@pytest.fixture()
+def multiplex_on():
+    previous = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+    try:
+        yield
+    finally:
+        secret_scope.set_multiplex_active(previous)
+
+
+class TestYuanbaoAdapterAuthzScope:
+    def test_scoped_construction_reads_authz_from_scope_not_environ(self, multiplex_on, monkeypatch):
+        monkeypatch.setenv("YUANBAO_DM_POLICY", "pairing")
+        monkeypatch.setenv("YUANBAO_DM_ALLOW_FROM", "default-user")
+        token = secret_scope.set_secret_scope(
+            {"YUANBAO_DM_POLICY": "allowlist", "YUANBAO_DM_ALLOW_FROM": "scoped-user"}
+        )
+        try:
+            adapter = YuanbaoAdapter(PlatformConfig(enabled=True))
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert adapter._access_policy._dm_policy == "allowlist"
+        assert adapter._access_policy._dm_allow_from == ["scoped-user"]
+
+    def test_scoped_miss_does_not_admit_default_profiles_allowlist(self, multiplex_on, monkeypatch):
+        monkeypatch.setenv("YUANBAO_DM_POLICY", "allowlist")
+        monkeypatch.setenv("YUANBAO_DM_ALLOW_FROM", "default-user")
+        token = secret_scope.set_secret_scope({"SOMETHING_ELSE": "x"})
+        try:
+            adapter = YuanbaoAdapter(PlatformConfig(enabled=True))
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert adapter._access_policy._dm_policy == "pairing"
+        assert adapter._access_policy._dm_allow_from == []
+
+
+class TestYuanbaoAccessPolicyOpenDmOptIn:
+    def test_scoped_allow_all_admits(self, multiplex_on, monkeypatch):
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("YUANBAO_ALLOW_ALL_USERS", raising=False)
+        policy = AccessPolicy(dm_policy="open", dm_allow_from=[], group_policy="pairing", group_allow_from=[])
+        token = secret_scope.set_secret_scope({"YUANBAO_ALLOW_ALL_USERS": "true"})
+        try:
+            assert policy._open_dm_opted_in() is True
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+    def test_default_profiles_allow_all_does_not_leak_into_scoped_miss(self, multiplex_on, monkeypatch):
+        """The default profile's env-only GATEWAY_ALLOW_ALL_USERS must not
+        admit a secondary profile that never opted in."""
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+        policy = AccessPolicy(dm_policy="open", dm_allow_from=[], group_policy="pairing", group_allow_from=[])
+        token = secret_scope.set_secret_scope({"SOMETHING_ELSE": "x"})
+        try:
+            assert policy._open_dm_opted_in() is False
+        finally:
+            secret_scope.reset_secret_scope(token)


### PR DESCRIPTION
## Summary
Secondary-profile allowlists on weixin/yuanbao/signal/wecom group chats work again, and a default profile's `GATEWAY_ALLOW_ALL_USERS=true` can no longer leak admission into other profiles. Under `gateway.multiplex_profiles`, these four adapters read DM/group policies and allowlists via raw `os.getenv` at construction time — bypassing the per-profile secret scope (which deliberately never mutates `os.environ`), so secondary-profile authz config was invisible (silent drops) and default-profile allow-all was global (fail-open). Fixes #93522.

## Changes
- `gateway/platforms/weixin.py`, `yuanbao.py`, `signal.py`, `plugins/platforms/wecom/adapter.py`: every authorization read (DM/group policy, allowlists, allow-all opt-ins, open-DM opt-in gates) now routes through the profile-scoped secret helpers, matching the existing qqbot pattern
- Yuanbao startup-guard opt-in check and Signal's `__init__`-snapshotted lists included
- `tests/gateway/test_multiplex_profile_authz.py` + `tests/gateway/test_platform_authz_scope.py`: secondary profile env-only allowlist admits its sender; default-profile allow-all does not leak

## Validation
| | Before | After |
|---|---|---|
| Secondary profile allowlist | invisible → messages dropped | admits its sender |
| Default `GATEWAY_ALLOW_ALL_USERS` | leaks into all profiles | scoped to its profile |
| Tests | — | 76 passed + 19/19 live E2E (all four adapters under fake profile scope) |

Salvaged from #93545 (@chelsealong, earliest) with follow-up from #93605 (@aniruddhaadak80 — signal coverage, allow-all gates, cross-adapter suite); both cherry-picked with authorship preserved.

## Infographic

![Profile secret scope now covers platform authorization](https://v3b.fal.media/files/b/0aa79830/PszWLUblZALK19xCdw-UI_Wx19kZhh.png)
