### PR TITLE
fix(cron): rescheduled one-shot jobs fire again instead of being silently deleted (#93524, salvage #93543 + #93585)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -3648,13 +3648,38 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                                     times,
                                 )
                                 continue
-                            logger.info(
-                                "Job '%s': one-shot dispatch limit reached (%d/%d) "
-                                "— removing stale due entry",
-                                job.get("name", job.get("id", "?")),
-                                completed,
-                                times,
-                            )
+                            if job.get("last_run_at") is not None:
+                                # A record with last_run_at completed a real
+                                # run and was later re-armed without a budget
+                                # reset (e.g. a schedule edit before the
+                                # #93524 fix, or a hand-edited store). This is
+                                # NOT the dead-tick recovery case this guard
+                                # was built for, and the wedged-oneshot
+                                # diagnostic below will (correctly) not fire
+                                # — so removing it silently at INFO would
+                                # vanish the user's rescheduled run without a
+                                # trace. Make it operator-visible.
+                                logger.warning(
+                                    "Job '%s': one-shot dispatch limit reached "
+                                    "(%d/%d) on a record that already completed "
+                                    "a run (last_run_at=%s) — removing it "
+                                    "WITHOUT firing. If this job was recently "
+                                    "re-armed via a schedule edit or trigger, "
+                                    "its repeat.completed budget was never "
+                                    "reset (#93524).",
+                                    job.get("name", job.get("id", "?")),
+                                    completed,
+                                    times,
+                                    job.get("last_run_at"),
+                                )
+                            else:
+                                logger.info(
+                                    "Job '%s': one-shot dispatch limit reached (%d/%d) "
+                                    "— removing stale due entry",
+                                    job.get("name", job.get("id", "?")),
+                                    completed,
+                                    times,
+                                )
                             for rj in raw_jobs:
                                 if rj["id"] == job["id"]:
                                     raw_jobs.remove(rj)

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2267,6 +2267,24 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     "schedule_display",
                     updated_schedule.get("display", updated.get("schedule_display")),
                 )
+                # Re-arming a consumed finite one-shot via a schedule edit
+                # (#93524): "reschedule my report to tomorrow" means a fresh
+                # run. Without resetting the budget, the record re-enables
+                # with completed >= times and the due-scan's stale-entry
+                # guard silently deletes it at the new fire time instead of
+                # firing — and its last_run_at suppresses the wedged-oneshot
+                # diagnostic, so the run just vanishes.
+                _repeat = updated.get("repeat")
+                if isinstance(_repeat, dict):
+                    _times = _repeat.get("times")
+                    if (
+                        _times is not None
+                        and _times > 0
+                        and _repeat.get("completed", 0) >= _times
+                    ):
+                        _fresh = dict(_repeat)
+                        _fresh["completed"] = 0
+                        updated["repeat"] = _fresh
                 if updated.get("state") != "paused":
                     updated_next_run = compute_next_run(updated_schedule)
                     # Same guard as create_job: an UPDATE that sets a one-shot
@@ -2364,16 +2382,25 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
     job = resolve_job_ref(job_id)
     if not job:
         return None
-    return update_job(
-        job["id"],
-        {
-            "enabled": True,
-            "state": "scheduled",
-            "paused_at": None,
-            "paused_reason": None,
-            "next_run_at": _hermes_now().isoformat(),
-        },
-    )
+    updates: Dict[str, Any] = {
+        "enabled": True,
+        "state": "scheduled",
+        "paused_at": None,
+        "paused_reason": None,
+        "next_run_at": _hermes_now().isoformat(),
+    }
+    # An explicit trigger of a consumed finite one-shot is a request for a
+    # fresh run (#93524): without resetting the budget, the due-scan's
+    # stale-entry guard would delete the re-armed record at fire time
+    # instead of running it.
+    _repeat = job.get("repeat")
+    if isinstance(_repeat, dict):
+        _times = _repeat.get("times")
+        if _times is not None and _times > 0 and _repeat.get("completed", 0) >= _times:
+            _fresh = dict(_repeat)
+            _fresh["completed"] = 0
+            updates["repeat"] = _fresh
+    return update_job(job["id"], updates)
 
 
 def remove_job(job_id: str) -> bool:

--- a/tests/cron/test_oneshot_rearm_budget.py
+++ b/tests/cron/test_oneshot_rearm_budget.py
@@ -144,3 +144,117 @@ def test_edited_consumed_oneshot_passes_the_stale_entry_guard(temp_home):
     assert not (times is not None and times > 0 and completed >= times), (
         "due-scan would remove this entry instead of firing it"
     )
+
+
+def test_full_cycle_edited_consumed_oneshot_fires_exactly_once(temp_home):
+    """End-to-end regression for #93524: consume a one-shot via the real
+    dispatch path, edit its schedule to a (near) future time, and assert the
+    scheduler fires it exactly once at the new time and then RETAINS the
+    record as completed — instead of silently deleting it."""
+    import time
+
+    from cron.jobs import (
+        claim_dispatch,
+        create_job,
+        get_due_jobs,
+        load_jobs,
+        mark_job_run,
+        update_job,
+    )
+
+    job = create_job(
+        prompt="write the report",
+        schedule=(datetime.now().astimezone() + timedelta(seconds=2)).isoformat(),
+        name="report-e2e",
+        repeat=1,
+        deliver="local",
+    )
+    jid = job["id"]
+    # Real consumption path: claim the dispatch, then record the run.
+    assert claim_dispatch(jid)
+    mark_job_run(jid, success=True, status="ok")
+    consumed = next(j for j in load_jobs() if j["id"] == jid)
+    assert consumed["repeat"]["completed"] >= 1
+    assert consumed.get("last_run_at") is not None
+
+    # Edit the schedule to a near-future time (what "move my report to
+    # tomorrow" does, compressed for the test) and re-enable.
+    new_time = (datetime.now().astimezone() + timedelta(seconds=1)).isoformat()
+    updated = update_job(
+        jid, {"schedule": new_time, "enabled": True, "state": "scheduled"}
+    )
+    assert updated is not None
+    assert updated["repeat"]["completed"] == 0, "budget must be fresh after edit"
+
+    time.sleep(1.5)
+    due = get_due_jobs()
+    due_ids = [d["id"] for d in due]
+    assert due_ids.count(jid) == 1, (
+        f"edited one-shot must be dispatched exactly once, got due={due_ids} "
+        f"(pre-fix behavior: the due-scan guard deleted it instead)"
+    )
+    # Record must survive the scan (get_due_jobs claims it, doesn't delete it).
+    assert any(j["id"] == jid for j in load_jobs())
+
+    # Complete the fire; the record is retained as a terminal completed
+    # one-shot — not deleted.
+    mark_job_run(jid, success=True, status="ok")
+    final = next((j for j in load_jobs() if j["id"] == jid), None)
+    assert final is not None, "completed one-shot record must be retained"
+    assert final["state"] == "completed"
+    assert final["repeat"]["completed"] >= 1
+
+    # And it must not fire a second time.
+    assert jid not in [d["id"] for d in get_due_jobs()]
+
+
+def test_due_scan_guard_warns_on_record_with_last_run_at(temp_home, caplog):
+    """If a consumed record with last_run_at somehow reaches the due-scan
+    guard (pre-fix stores, hand edits), removal must log at WARNING with a
+    diagnostic — never a silent INFO delete (#93524)."""
+    import logging
+    import time
+
+    from cron.jobs import (
+        claim_dispatch,
+        create_job,
+        get_due_jobs,
+        load_jobs,
+        mark_job_run,
+        save_jobs,
+    )
+
+    job = create_job(
+        prompt="x",
+        schedule=(datetime.now().astimezone() + timedelta(seconds=1)).isoformat(),
+        name="warn-guard",
+        repeat=1,
+        deliver="local",
+    )
+    jid = job["id"]
+    assert claim_dispatch(jid)
+    mark_job_run(jid, success=True, status="ok")
+
+    # Simulate a pre-fix re-arm: enabled+scheduled+due but budget still spent.
+    jobs = load_jobs()
+    for j in jobs:
+        if j["id"] == jid:
+            j["enabled"] = True
+            j["state"] = "scheduled"
+            j["next_run_at"] = (
+                datetime.now().astimezone() - timedelta(seconds=1)
+            ).isoformat()
+    save_jobs(jobs)
+    time.sleep(0.1)
+
+    with caplog.at_level(logging.INFO, logger="cron.jobs"):
+        due = get_due_jobs()
+
+    assert jid not in [d["id"] for d in due]
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno >= logging.WARNING and "dispatch limit" in r.getMessage()
+    ]
+    assert warnings, "removal of a record with last_run_at must log at WARNING"
+    assert "93524" in warnings[0].getMessage()

--- a/tests/cron/test_oneshot_rearm_budget.py
+++ b/tests/cron/test_oneshot_rearm_budget.py
@@ -1,0 +1,146 @@
+"""Re-arming a consumed finite one-shot must reset its run budget (#93524).
+
+A finished one-shot is retained as a terminal record (``repeat.completed``
+>= ``repeat.times``, ``state="completed"``, ``enabled=False``) so its
+outcome stays inspectable. Editing its schedule or explicitly triggering
+it used to re-enable the record **without** resetting the budget — and at
+the new fire time the due-scan's stale-entry guard saw ``completed >=
+times`` and silently deleted the job instead of running it (the wedged-
+oneshot diagnostic was suppressed because ``last_run_at`` was already
+set). "Move my report to tomorrow 9am" did nothing tomorrow.
+
+Real store against a temp ``HERMES_HOME`` (no mocks), matching the
+file-touching-code discipline in this directory.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+
+@pytest.fixture
+def temp_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield tmp_path
+
+
+def _consumed_oneshot():
+    """Create a finite one-shot and drive it to its terminal state."""
+    from cron.jobs import create_job, load_jobs, mark_job_run, save_jobs
+
+    job = create_job(
+        prompt="write the report",
+        schedule=(datetime.now().astimezone() + timedelta(seconds=5)).isoformat(),
+        name="report",
+        repeat=1,
+        deliver="local",
+    )
+    # Simulate the fire completing: mark_job_run retires it with
+    # completed >= times while retaining the record.
+    mark_job_run(job["id"], success=True, status="ok")
+    jobs = load_jobs()
+    stored = next(j for j in jobs if j["id"] == job["id"])
+    assert stored["repeat"]["completed"] >= 1, "test setup: one-shot not consumed"
+    assert stored["state"] == "completed"
+    return job["id"]
+
+
+def test_schedule_edit_resets_consumed_budget(temp_home):
+    from cron.jobs import get_job, update_job
+
+    jid = _consumed_oneshot()
+    future = (datetime.now().astimezone() + timedelta(days=1)).replace(
+        microsecond=0
+    ).isoformat()
+
+    # Mirror what the edit callers do (hermes cron edit / cronjob update):
+    # re-enable alongside the new schedule.
+    updated = update_job(
+        jid,
+        {"schedule": future, "enabled": True, "state": "scheduled"},
+    )
+
+    assert updated is not None
+    assert updated["enabled"] is True
+    assert updated["state"] == "scheduled"
+    # The budget must be fresh — otherwise the due-scan's stale-entry
+    # guard deletes the record instead of firing it (#93524).
+    assert updated["repeat"]["completed"] == 0
+    assert updated["next_run_at"] is not None
+
+    persisted = get_job(jid)
+    assert persisted["repeat"]["completed"] == 0
+
+
+def test_trigger_resets_consumed_budget(temp_home):
+    from cron.jobs import get_job, trigger_job
+
+    jid = _consumed_oneshot()
+
+    triggered = trigger_job(jid)
+
+    assert triggered is not None
+    assert triggered["repeat"]["completed"] == 0
+    assert triggered["next_run_at"] is not None
+    persisted = get_job(jid)
+    assert persisted["repeat"]["completed"] == 0
+
+
+def test_edit_of_unconsumed_one_shot_keeps_zero_budget(temp_home):
+    """A not-yet-consumed one-shot edit must stay at completed=0."""
+    from cron.jobs import create_job, update_job
+
+    job = create_job(
+        prompt="x",
+        schedule=(datetime.now().astimezone() + timedelta(hours=2)).isoformat(),
+        name="fresh",
+        repeat=1,
+        deliver="local",
+    )
+    future = (datetime.now().astimezone() + timedelta(days=1)).replace(
+        microsecond=0
+    ).isoformat()
+
+    updated = update_job(job["id"], {"schedule": future})
+
+    assert updated["repeat"]["completed"] == 0
+    assert updated["state"] == "scheduled"
+
+
+def test_recurring_job_edit_is_not_disturbed(temp_home):
+    """The budget reset must apply only to consumed finite one-shots."""
+    from cron.jobs import create_job, load_jobs, save_jobs, update_job
+
+    job = create_job(prompt="x", schedule="every 60m", name="rec", repeat=10)
+    jobs = load_jobs()
+    for j in jobs:
+        if j["id"] == job["id"]:
+            j["repeat"]["completed"] = 3
+    save_jobs(jobs)
+
+    updated = update_job(job["id"], {"schedule": "every 90m"})
+
+    assert updated["repeat"]["completed"] == 3, (
+        "recurring jobs track their own progress; edits must not reset it"
+    )
+
+
+def test_edited_consumed_oneshot_passes_the_stale_entry_guard(temp_home):
+    """End-to-end shape: after the fix, an edited consumed one-shot no
+    longer satisfies the due-scan's dispatch-limit predicate when due."""
+    from cron.jobs import get_job, update_job
+
+    jid = _consumed_oneshot()
+    soon = (datetime.now().astimezone() + timedelta(seconds=30)).replace(
+        microsecond=0
+    ).isoformat()
+    update_job(jid, {"schedule": soon})
+
+    stored = get_job(jid)
+    times = stored["repeat"]["times"]
+    completed = stored["repeat"]["completed"]
+    assert not (times is not None and times > 0 and completed >= times), (
+        "due-scan would remove this entry instead of firing it"
+    )

--- a/tests/cron/test_update_consumed_oneshot.py
+++ b/tests/cron/test_update_consumed_oneshot.py
@@ -1,0 +1,119 @@
+"""Re-arming a consumed finite one-shot via a schedule edit (#93524).
+
+A consumed one-shot is retained as a terminal record (repeat.completed >=
+repeat.times, enabled=False, next_run_at=None) so outcomes stay
+inspectable. Editing its schedule re-enables the job with a future
+next_run_at — but without resetting repeat.completed, the due scan's
+dispatch-limit guard removes the job at the new fire time without firing:
+the rescheduled run silently never happens and the record is gone.
+
+A schedule edit is an explicit re-arm gesture, so the spent quota resets.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+
+import pytest
+
+
+@pytest.fixture
+def temp_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME so jobs.json doesn't touch the real store."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield tmp_path
+
+
+def _seed_consumed_oneshot(home, name="spent") -> str:
+    """Persist a consumed finite one-shot (the terminal retention shape)."""
+    from cron.jobs import create_job, save_jobs, load_jobs
+
+    job = create_job(prompt="done", schedule="2026-08-25T09:00", name=name)
+    jobs = load_jobs()
+    for j in jobs:
+        if j["id"] == job["id"]:
+            j["enabled"] = False
+            j["state"] = "completed"
+            j["next_run_at"] = None
+            j["repeat"] = {"times": 1, "completed": 1}
+    save_jobs(jobs)
+    return job["id"]
+
+
+def _update(temp_home, job_id: str, **kwargs):
+    from tools.cronjob_tools import cronjob
+
+    defaults = {"action": "update", "job_id": job_id}
+    defaults.update(kwargs)
+    return json.loads(cronjob(**defaults))
+
+
+def test_schedule_edit_rearms_consumed_oneshot(temp_home):
+    """Editing the schedule of a consumed one-shot resets the spent quota —
+    the job is enabled with a future next_run_at and completed back to 0."""
+    from cron.jobs import get_job
+
+    jid = _seed_consumed_oneshot(temp_home)
+
+    result = _update(temp_home, jid, schedule="2030-01-01T09:00")
+
+    assert result["success"] is True
+    job = get_job(jid)
+    assert job["enabled"] is True
+    assert job["state"] == "scheduled"
+    assert job["next_run_at"] is not None
+    assert job["next_run_at"].startswith("2030-01-01")
+    assert job["repeat"]["completed"] == 0
+    assert job["repeat"]["times"] == 1
+
+
+def test_schedule_edit_leaves_unconsumed_quota_alone(temp_home):
+    """Control: an unconsumed one-shot's completed counter is untouched."""
+    from cron.jobs import create_job, get_job
+
+    job = create_job(prompt="fresh", schedule="2030-01-01T09:00", name="fresh")
+
+    result = _update(temp_home, job["id"], schedule="2030-02-01T09:00")
+
+    assert result["success"] is True
+    stored = get_job(job["id"])
+    assert stored["repeat"]["completed"] == 0
+    assert stored["next_run_at"].startswith("2030-02-01")
+
+
+def test_schedule_edit_with_new_repeat_resets_under_new_quota(temp_home):
+    """--repeat alongside the schedule edit composes: the quota resets under
+    the operator's new times value."""
+    from cron.jobs import get_job
+
+    jid = _seed_consumed_oneshot(temp_home, name="multi")
+
+    result = _update(temp_home, jid, schedule="2030-01-01T09:00", repeat=3)
+
+    assert result["success"] is True
+    job = get_job(jid)
+    assert job["repeat"] == {"times": 3, "completed": 0}
+    assert job["enabled"] is True
+
+
+def test_paused_consumed_oneshot_not_rearmed(temp_home):
+    """A paused record's schedule edit does not re-enable — the reset must
+    not fire either (the re-arm block is gated on state != paused)."""
+    from cron.jobs import create_job, save_jobs, load_jobs, get_job
+
+    job = create_job(prompt="p", schedule="2030-01-01T09:00", name="paused")
+    jobs = load_jobs()
+    for j in jobs:
+        if j["id"] == job["id"]:
+            j["enabled"] = False
+            j["state"] = "paused"
+            j["repeat"] = {"times": 1, "completed": 1}
+    save_jobs(jobs)
+
+    result = _update(temp_home, job["id"], schedule="2030-02-01T09:00")
+
+    assert result["success"] is True
+    stored = get_job(job["id"])
+    assert stored["state"] == "paused"
+    assert stored["enabled"] is False

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1664,6 +1664,28 @@ def cronjob(
                 if job.get("state") != "paused":
                     updates["state"] = "scheduled"
                     updates["enabled"] = True
+                    # Re-arming a consumed finite one-shot must reset the
+                    # spent quota. The terminal record keeps
+                    # repeat.completed >= repeat.times; re-enabling without
+                    # resetting makes the edit report success with a future
+                    # next_run_at, then the due scan's dispatch-limit guard
+                    # removes the job at the new fire time without firing
+                    # — the rescheduled run silently never happens (#93524).
+                    # Consumption is judged on the STORED record (not the
+                    # merged quota — a --repeat bump in the same edit that
+                    # leaves completed < times is not a consumed record).
+                    if parsed_schedule.get("kind") == "once":
+                        stored_repeat = dict(job.get("repeat") or {})
+                        if (
+                            (stored_repeat.get("times") or 0) > 0
+                            and stored_repeat.get("completed", 0)
+                            >= stored_repeat["times"]
+                        ):
+                            repeat_state = dict(
+                                updates.get("repeat") or stored_repeat
+                            )
+                            repeat_state["completed"] = 0
+                            updates["repeat"] = repeat_state
             if not updates:
                 return tool_error("No updates provided.", success=False)
             updated = update_job(job_id, updates)


### PR DESCRIPTION
## Summary
Editing a finished one-shot cron job's schedule now makes it fire exactly once at the new time — previously the edit "resurrected" the job in the UI but the scheduler silently deleted it at fire time, so the run never happened and nothing was logged. Root cause: the re-arm paths (`update_job` schedule change, `trigger_job`) never reset `repeat.completed`, so the due-scan's dispatch-limit guard saw 1/1 consumed and removed the record. Fixes #93524.

## Changes
- `tools/cronjob_tools.py` + `cron/jobs.py`: re-arming a consumed finite one-shot (schedule edit or manual trigger) resets its budget
- `cron/jobs.py`: the due-scan dispatch-limit guard now logs at WARNING with a diagnostic when it removes a record that has `last_run_at` (no more silent delete)
- Regression tests: consume → edit → exactly one fire at the new time, record retained as completed; WARNING-path test via caplog

## Validation
| | Before | After |
|---|---|---|
| Consumed one-shot, schedule edited | silently deleted, zero fires | fires once at new time |
| Live repro (temp HERMES_HOME, real cron store) | job vanishes from store | job fires, retained as completed |
| tests/cron/ | — | 904 passed |

Salvaged from #93543 (@liuhao1024, tool layer) and #93585 (@aniruddhaadak80, issue reporter — core update/trigger paths), authorship preserved; earliest diagnosis of the class credited to @LeonardoLGDS (#89649/#93615, alternative explicit-re-arm design not taken).

## Infographic

![Rescheduled one-shot jobs fire again](https://v3b.fal.media/files/b/0aa79845/zz8QTDbfE28mwvZ44UfZA_qKzpwrA1.png)
