### PR TITLE
fix(tools): anchor mkfs hardline pattern to command position (#93392)

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -533,7 +533,7 @@ HARDLINE_PATTERNS = [
     (_RM_FLAG_PREFIX + _hardline_rm_path(_HARDLINE_SYSTEM_DIRS), "recursive delete of system directory"),
     (_RM_FLAG_PREFIX + _hardline_rm_path(r'(?:~|\$\{?HOME\}?)(?:/?|/\*)?'), "recursive delete of home directory"),
     # Filesystem format
-    (r'\bmkfs(\.[a-z0-9]+)?\b', "format filesystem (mkfs)"),
+    (_CMDPOS + r'mkfs(\.[a-z0-9]+)?\b', "format filesystem (mkfs)"),
     # Raw block device overwrites (dd + redirection)
     (r'\bdd\b[^\n]*\bof=/dev/(sd|nvme|hd|mmcblk|vd|xvd)[a-z0-9]*', "dd to raw block device"),
     (r'>\s*/dev/(sd|nvme|hd|mmcblk|vd|xvd)[a-z0-9]*\b', "redirect to raw block device"),


### PR DESCRIPTION
## Summary

Fixes #93392. The `mkfs` hardline pattern in `tools/approval.py` uses a bare `\b` word-boundary anchor that matches `mkfs` anywhere in the command string — including inside quoted arguments like `echo "does this use mkfs?"`.

All sibling hardline patterns for `shutdown`/`reboot`/`init`/`telinit` are anchored to `_CMDPOS` (start-of-command position) to avoid this class of false-positive. The `mkfs` pattern was the only one missing this anchor.

## Changes

- `tools/approval.py`: Add `_CMDPOS` prefix to the `mkfs` hardline pattern so it only triggers when `mkfs` appears as an actual command at a command position, not as a word inside a quoted string argument.

## Testing

```bash
# Before fix: these are incorrectly blocked
echo "does this workflow use mkfs anywhere?"  # BLOCKED (false positive)

# After fix: echo is not blocked (mkfs is inside a quoted argument)
echo "does this workflow use mkfs anywhere?"  # ALLOWED

# Actual mkfs commands are still blocked
mkfs.ext4 /dev/sdb1  # BLOCKED (correct)
sudo mkfs.xfs /dev/sdc  # BLOCKED (correct)
```
