### PR TITLE
fix(cli): exclude gateway.sock from backup archive (#93347)

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -115,6 +115,7 @@ _EXCLUDED_NAMES = {
     ".backup.lock",
     "gateway.pid",
     "cron.pid",
+    "gateway.sock",
 }
 
 # File names that ``hermes import`` must never overwrite, matched by basename so


### PR DESCRIPTION
## Summary

Fixes #93347. Since the control socket feature (#92447), a running gateway creates a Unix domain socket at `$HERMES_HOME/gateway.sock`. The backup walker tries to archive it, `zipfile.write()` fails with `OSError: [Errno 102] Operation not supported on socket`, and the error lands in the errors list — flagging every backup taken while the gateway runs as "Backup incomplete".

## Changes

- `hermes_cli/backup.py`: Add `"gateway.sock"` to `_EXCLUDED_NAMES` alongside the existing `gateway.pid` and `cron.pid` exclusions.

## Testing

```bash
# Start gateway (creates gateway.sock)
hermes gateway start

# Run backup — should complete without "incomplete" warning
hermes backup

# Verify gateway.sock is not in the archive
python3 -c "import zipfile; z=zipfile.ZipFile('backup.zip'); print([n for n in z.namelist() if 'sock' in n])"
```
