### PR TITLE
fix(desktop): stop idle bot relay from reconnecting every four seconds

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1394,10 +1394,74 @@ let relayRosterBusy = false
 let relayDrainBusy = false
 let relayPushUnsub = null
 let relayPushDebounceTimer = null
+const relayConnectionLeases = new Map()
+let relayLeaseSync = Promise.resolve()
 // A push landing while a drain is ALREADY running would be lost forever —
 // the gateway signature is monotone (one event per new envelope, never
 // re-broadcast) — so remember it and re-schedule after the drain finishes.
 let relayDrainRerun = false
+
+const relayRouteIdentity = route =>
+  [route?.connectionId, route?.profile, route?.targetProfile].map(String).join('\u0000')
+
+function releaseRelayConnectionLease(entry) {
+  try {
+    entry?.release?.()
+  } catch {
+    // A lease disposer must never break relay teardown.
+  }
+}
+
+async function reconcileRelayConnectionLeases(connections) {
+  if (relayDisposed || typeof host.retainProfile !== 'function') {
+    return
+  }
+
+  const desired = new Map(connections.map(connection => [String(connection.id), connection]))
+
+  for (const [id, entry] of relayConnectionLeases) {
+    const connection = desired.get(id)
+
+    if (!connection || relayRouteIdentity(connection.route) !== entry.routeIdentity) {
+      relayConnectionLeases.delete(id)
+      releaseRelayConnectionLease(entry)
+    }
+  }
+
+  await Promise.all(
+    [...desired].map(async ([id, connection]) => {
+      if (relayConnectionLeases.has(id)) {
+        return
+      }
+
+      const entry = { release: null, routeIdentity: relayRouteIdentity(connection.route) }
+      relayConnectionLeases.set(id, entry)
+
+      try {
+        const release = await host.retainProfile(connection.route)
+
+        if (relayDisposed || relayConnectionLeases.get(id) !== entry) {
+          releaseRelayConnectionLease({ release })
+        } else {
+          entry.release = release
+        }
+      } catch {
+        if (relayConnectionLeases.get(id) === entry) {
+          relayConnectionLeases.delete(id)
+        }
+      }
+    })
+  )
+}
+
+function syncRelayConnectionLeases(connections) {
+  relayLeaseSync = relayLeaseSync.then(
+    () => reconcileRelayConnectionLeases(connections),
+    () => reconcileRelayConnectionLeases(connections)
+  )
+
+  return relayLeaseSync
+}
 
 /** One representative route per reachable connection id. */
 async function relayConnections() {
@@ -1417,7 +1481,10 @@ async function relayConnections() {
       }
     }
 
-    return [...byConnection.entries()].map(([id, route]) => ({ id, route }))
+    const connections = [...byConnection.entries()].map(([id, route]) => ({ id, route }))
+    await syncRelayConnectionLeases(connections.length >= 2 ? connections : [])
+
+    return connections
   } catch {
     return []
   }
@@ -1669,6 +1736,11 @@ function stopBotRelay() {
   // A rerun remembered mid-drain must not leak into the next start —
   // it would fire one stale drain after restart.
   relayDrainRerun = false
+
+  for (const entry of relayConnectionLeases.values()) {
+    releaseRelayConnectionLease(entry)
+  }
+  relayConnectionLeases.clear()
 
   if (relayRosterTimer !== null) {
     clearInterval(relayRosterTimer)

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -49,6 +49,7 @@ import {
   openGatewayForProfile,
   requestGatewayForAgent,
   requestGatewayForProfile,
+  retainGatewayForAgent,
   retireLocalProfileGateways
 } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
@@ -256,6 +257,14 @@ async function requestPluginProfile<T>(
   throw new Error(
     `Profile "${profile}" requires a route descriptor from host.profileRoutes(); profile-only routing is limited to legacy/local profiles.`
   )
+}
+
+async function retainPluginProfile(route: PluginProfileRoute): Promise<() => void> {
+  if (!route.connectionId.trim() || !route.profile.trim() || !route.targetProfile.trim()) {
+    throw new Error('Profile route must include connectionId, profile, and targetProfile')
+  }
+
+  return retainGatewayForAgent(route.connectionId, route.profile)
 }
 
 /** Re-read Electron's current registry before retrying an exact-owner wake.
@@ -1131,6 +1140,10 @@ export const host = {
     method: string,
     params: Record<string, unknown> = {}
   ): Promise<T> => requestPluginProfile<T>(route, method, params),
+
+  /** Hold a route's pooled socket across repeated background RPCs. The
+   *  disposer releases this owner without disturbing foreground/live work. */
+  retainProfile: async (route: PluginProfileRoute): Promise<() => void> => retainPluginProfile(route),
 
   /** Gateway JSON-RPC — sessions, config, skills, cron, kanban, everything
    *  the app itself uses. Lazy: resolves the LIVE socket per call. */

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -86,6 +86,7 @@ vi.mock('@/store/gateway', async () => {
     ensureGatewayForAgent: vi.fn(),
     openGatewayForAgent: vi.fn(),
     openGatewayForProfile: vi.fn(),
+    retainGatewayForAgent: vi.fn(async () => vi.fn()),
     requestGatewayForAgent: vi.fn(
       async (connectionId: string, profile: string, method: string, params: Record<string, unknown>) => ({
         connectionId,
@@ -110,6 +111,7 @@ const { deleteProfile } = await import('@/hermes')
 const {
   openGatewayForAgent,
   openGatewayForProfile,
+  retainGatewayForAgent,
   requestGatewayForAgent,
   requestGatewayForProfile,
   retireLocalProfileGateways
@@ -253,6 +255,21 @@ describe('connection-aware plugin host APIs', () => {
       include_sessions: true
     })
     expect(requestGatewayForProfile).not.toHaveBeenCalled()
+  })
+
+  it('retains a targeted route and returns the transport disposer', async () => {
+    const release = vi.fn()
+    vi.mocked(retainGatewayForAgent).mockResolvedValueOnce(release)
+
+    const route = {
+      connectionId: 'source-a',
+      mode: 'remote' as const,
+      profile: 'remote-worker',
+      targetProfile: 'backend-worker'
+    }
+
+    await expect(host.retainProfile(route)).resolves.toBe(release)
+    expect(retainGatewayForAgent).toHaveBeenCalledWith('source-a', 'remote-worker')
   })
 
   it('fails closed when a descriptor omits connection or target profile identity', async () => {

--- a/apps/desktop/src/store/gateway-profile-request.test.ts
+++ b/apps/desktop/src/store/gateway-profile-request.test.ts
@@ -55,6 +55,7 @@ const {
   disposeSecondariesForConnection,
   openGatewayForAgent,
   pruneSecondaryGateways,
+  retainGatewayForAgent,
   requestGatewayForAgent,
   requestGatewayForProfile,
   setPrimaryGateway
@@ -190,6 +191,49 @@ describe('requestGatewayForProfile', () => {
 })
 
 describe('requestGatewayForAgent', () => {
+  it('reuses a retained registry socket until the final owner releases it', async () => {
+    const primary = makePrimary()
+    const getConnectionFor = vi.fn(async ({ connectionId, profile }) => ({ connectionId, port: 5151, profile }))
+
+    setPrimaryGateway(primary as never, 'default')
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+      getConnection: vi.fn(),
+      getConnectionFor,
+      getGatewayWsUrlFor: vi.fn(async ({ connectionId, profile }) => ({
+        ok: true as const,
+        wsUrl: `ws://${connectionId}/${profile}`
+      })),
+      touchBackend: vi.fn(async () => undefined)
+    }
+
+    const releaseFirst = await retainGatewayForAgent('source-a', 'research')
+    const releaseSecond = await retainGatewayForAgent('source-a', 'research')
+
+    await requestGatewayForAgent('source-a', 'research', 'bot_relay.outbox.drain')
+    await requestGatewayForAgent('source-a', 'research', 'bot_relay.outbox.drain')
+    pruneSecondaryGateways(new Set())
+
+    expect(secondaryGateways).toHaveLength(1)
+    expect(secondaryGateways[0].connect).toHaveBeenCalledOnce()
+    expect(secondaryGateways[0].request).toHaveBeenCalledTimes(2)
+    expect(secondaryGateways[0].close).not.toHaveBeenCalled()
+
+    disposeSecondariesForConnection('source-a', { redial: true })
+    await vi.waitFor(() => expect(secondaryGateways[1]?.connect).toHaveBeenCalledOnce())
+    await requestGatewayForAgent('source-a', 'research', 'bot_relay.outbox.drain')
+    pruneSecondaryGateways(new Set())
+
+    expect(secondaryGateways).toHaveLength(2)
+    expect(secondaryGateways[0].close).toHaveBeenCalledOnce()
+    expect(secondaryGateways[1].request).toHaveBeenCalledOnce()
+    expect(secondaryGateways[1].close).not.toHaveBeenCalled()
+
+    releaseFirst()
+    expect(secondaryGateways[1].close).not.toHaveBeenCalled()
+    releaseSecond()
+    expect(secondaryGateways[1].close).toHaveBeenCalledOnce()
+  })
+
   it('leases separate registry sockets for duplicate profile names without changing the active gateway', async () => {
     const primary = makePrimary()
     const getConnection = vi.fn(async (profile: null | string) => ({ port: 4242, profile, token: 'legacy-token' }))

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -48,6 +48,8 @@ interface Secondary {
   connection: HermesConnection | null
   gateway: HermesGateway
   activeRequests: number
+  /** Long-lived background consumers that explicitly own this socket. */
+  retainers: number
   connectPromise: Promise<void> | null
   offEvent: () => void
   offState: () => void
@@ -479,6 +481,7 @@ function createSecondary(profile: string, connectionId: null | string = null): S
     connection: null,
     gateway,
     activeRequests: 0,
+    retainers: 0,
     connectPromise: null,
     offEvent: () => {},
     offState: () => {},
@@ -637,6 +640,67 @@ export async function requestGatewayForProfile<T>(
 }
 
 /**
+ * Keep one registry-scoped socket alive for a background consumer without
+ * foregrounding it. The returned disposer releases exactly one ownership
+ * lease; the socket closes once no request, foreground owner, or retainer
+ * still needs it.
+ */
+export async function retainGatewayForAgent(connectionId: string, profile: string): Promise<() => void> {
+  const key = normKey(profile)
+  const id = String(connectionId || '').trim()
+
+  if (!id || !window.hermesDesktop?.getConnectionFor) {
+    throw new Error('A registry connection is required to retain an agent gateway')
+  }
+
+  const scope = registryBackendScopeKey(id, key)
+  const entry = g.secondaries.get(scope) ?? createSecondary(key, id)
+
+  if (!Number.isFinite(entry.retainers)) {
+    entry.retainers = 0
+  }
+
+  entry.retainers += 1
+  entry.wantOpen = true
+  let released = false
+
+  const release = () => {
+    if (released) {
+      return
+    }
+
+    released = true
+    // A material connection edit replaces the pool entry in-place. Ownership
+    // follows that replacement so the original disposer still releases the
+    // re-dialed socket instead of leaking it.
+    const ownedEntry = g.secondaries.get(scope) ?? entry
+    ownedEntry.retainers = Math.max(0, Number(ownedEntry.retainers) - 1)
+
+    if (
+      ownedEntry.retainers === 0 &&
+      ownedEntry.activeRequests === 0 &&
+      !ownedEntry.retained &&
+      g.activeKey !== ownedEntry.scope &&
+      g.secondaries.get(ownedEntry.scope) === ownedEntry
+    ) {
+      disposeSecondary(ownedEntry)
+      g.secondaries.delete(ownedEntry.scope)
+    }
+  }
+
+  try {
+    if (!isOpen(entry.gateway)) {
+      await openSecondary(entry)
+    }
+  } catch (error) {
+    release()
+    throw error
+  }
+
+  return release
+}
+
+/**
  * Send a gateway RPC through one registry source without activating it. The
  * composite (connectionId, profile) pool key prevents same-named agents on two
  * sources from sharing a socket. Only null/empty ids retain the v1 profile
@@ -686,7 +750,12 @@ export async function requestGatewayForAgent<T>(
   } finally {
     entry.activeRequests = Math.max(0, entry.activeRequests - 1)
 
-    if (entry.activeRequests === 0 && !entry.retained && g.activeKey !== entry.scope) {
+    if (
+      entry.activeRequests === 0 &&
+      !(Number.isFinite(entry.retainers) && entry.retainers > 0) &&
+      !entry.retained &&
+      g.activeKey !== entry.scope
+    ) {
       disposeSecondary(entry)
 
       if (g.secondaries.get(entry.scope) === entry) {
@@ -959,6 +1028,7 @@ export function pruneSecondaryGateways(keep: Set<string>): void {
       keep.has(key) ||
       (!entry.connectionId && keep.has(entry.profile)) ||
       entry.activeRequests > 0 ||
+      (Number.isFinite(entry.retainers) && entry.retainers > 0) ||
       // Mid-dial activation target: the profile being switched TO is not yet
       // active and has no live work, so without this lease any recompute
       // during its cold spawn disposed the entry and the click died silently
@@ -1042,6 +1112,8 @@ export function disposeSecondariesForConnection(connectionId: string, opts: { re
     }
 
     const wasActive = key === g.activeKey
+    const retainers = Number.isFinite(entry.retainers) ? entry.retainers : 0
+    const retained = entry.retained
     activeInvalidated ||= wasActive
 
     disposeSecondary(entry)
@@ -1051,6 +1123,13 @@ export function disposeSecondariesForConnection(connectionId: string, opts: { re
       const reopen = wasActive
         ? ensureGatewayForAgent(entry.connectionId, entry.profile)
         : openGatewayForAgent(entry.connectionId, entry.profile)
+
+      const replacement = g.secondaries.get(key)
+
+      if (replacement) {
+        replacement.retainers = retainers
+        replacement.retained = retained
+      }
 
       void reopen.catch(() => undefined)
     }


### PR DESCRIPTION
## What does this PR do?

Desktop Bot Mode no longer opens and closes a fresh WebSocket for every four-second relay drain on each registered connection. The relay now holds one explicit transport lease per reachable connection, reuses that socket for roster, drain, delivery, and reply RPCs, and releases the lease when the route disappears or the plugin stops.

### Symptom

With at least two Desktop connections registered, an idle app polls `bot_relay.outbox.drain` every four seconds. Each poll previously created a secondary socket for one RPC and immediately disposed it, producing a steady stream of WebSocket accepts and closes in gateway logs.

### Impact

The reported two-connection setup observed about 16 accepts per minute while idle. Remote gateways repeatedly paid connection and authentication setup costs, and shared gateway logs accumulated transport noise even though relay delivery itself succeeded.

### Bug Cause

**Trigger:** `apps/desktop/src/plugins/hermes-bots/plugin.js` / `relayConnections()` and `apps/desktop/src/store/gateway.ts` / `requestGatewayForAgent()`

**Causal chain:**
1. Bot Mode discovers at least two routes and starts its four-second relay drain.
2. `host.requestProfile()` enters the connection-scoped secondary pool with only a request lease.
3. The request finishes with zero active requests, no retained owner, and a non-active scope, so the pool disposes the socket after one RPC.
4. The next poll repeats connection resolution, WebSocket setup, authentication, and teardown.

**Why it is wrong:** The relay is a long-lived background consumer, but it used a one-shot request API without owning the transport for its lifetime.

**Working sibling / contrast:** Foreground and prewarmed profile routes mark their secondary entries as retained, so repeated RPCs reuse an existing open socket.

**Ruled out:** The churn is not caused by failed relay delivery or gateway-side disconnect handling. The one-shot pool release path closes a healthy socket after a successful request.

### Fix

- Add reference-counted background transport leases to connection-scoped secondary gateways without foregrounding them.
- Preserve lease ownership across material connection edits so the existing redial path targets the new endpoint without reverting to one-shot churn.
- Reconcile one relay lease per current connection, serialize concurrent roster/drain reconciliation, and release leases on route removal or plugin disposal.
- Keep older Desktop hosts compatible by feature-detecting the new lease API and falling back to the existing request behavior.

## Related Issue
N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/gateway.ts` - add reference-counted connection-scoped gateway retention with prune, redial, and final-release handling.
- `apps/desktop/src/sdk/index.ts` - expose a credential-free route retention API to Desktop plugins.
- `apps/desktop/src/plugins/hermes-bots/plugin.js` - retain and reconcile one socket per active relay connection, then release all relay ownership on teardown.
- `apps/desktop/src/store/gateway-profile-request.test.ts` - verify one dial serves repeated drain RPCs, survives pruning and redial, and closes after the final release.
- `apps/desktop/src/sdk/profile-routing.test.ts` - verify route identity is forwarded to the retention seam and the disposer is returned.

## How to Test

1. Run the focused gateway and SDK tests:

```bash
cd apps/desktop
npx vitest run --project ui src/store/gateway-profile-request.test.ts src/store/gateway-connection-lifecycle.test.ts src/store/gateway-agent-scope.test.ts src/store/gateway-activation-prune-lease.test.ts src/sdk/profile-routing.test.ts
```

2. Run all Desktop plugin contract tests:

```bash
cd apps/desktop
npm run check:test:plugins
```

3. Run the renderer type and lint checks:

```bash
cd apps/desktop
npx tsc -p . --noEmit
npx eslint src/store/gateway.ts src/store/gateway-profile-request.test.ts src/sdk/index.ts src/sdk/profile-routing.test.ts --max-warnings=0
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant repository tests and all selected tests pass
- [x] I've added tests for this bug fix
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A; this fixes internal transport ownership without changing user-facing configuration
- [x] `cli-config.yaml.example` changes are N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` changes are N/A; no project workflow changed
- [x] Cross-platform impact was considered; the renderer lease logic is platform-neutral and the tests run without OS branching
- [x] Tool descriptions and schemas are N/A; no agent tool behavior changed
