### PR TITLE
fix(config): v15 migration stops reporting a setting it never saved (#93533, salvage #93550 + #93567)

### DIFF
--- a/hermes_cli/config_migrations.py
+++ b/hermes_cli/config_migrations.py
@@ -218,25 +218,6 @@ def _migrate_to_14(results: Dict[str, Any], quiet: bool) -> None:
             print("  ✓ Migrated legacy stt.model to provider-specific config")
 
 
-def _migrate_to_15(results: Dict[str, Any], quiet: bool) -> None:
-    # ── Version 14 → 15: add explicit gateway interim-message gate ──
-    _c = _cfg()
-    read_raw_config = _c.read_raw_config
-    _persist_migration = _c._persist_migration
-
-    config = read_raw_config()
-    display = config.get("display", {})
-    if not isinstance(display, dict):
-        display = {}
-    if "interim_assistant_messages" not in display:
-        display["interim_assistant_messages"] = True
-        config["display"] = display
-        results["config_added"].append("display.interim_assistant_messages=true (default)")
-        _persist_migration(config)
-        if not quiet:
-            print("  ✓ Added display.interim_assistant_messages=true")
-
-
 def _migrate_to_16(results: Dict[str, Any], quiet: bool) -> None:
     # ── Version 15 → 16: migrate tool_progress_overrides into display.platforms ──
     _c = _cfg()
@@ -856,7 +837,8 @@ MIGRATIONS: Tuple[Tuple[int, Callable[[Dict[str, Any], bool], None]], ...] = (
     (12, _migrate_to_12),
     (13, _migrate_to_13),
     (14, _migrate_to_14),
-    (15, _migrate_to_15),
+    # v15 only added a schema default; runtime merging supplies it without a
+    # write. Registering a migration would falsely report or materialise it.
     (16, _migrate_to_16),
     (17, _migrate_to_17),
     (21, _migrate_to_21),

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -957,7 +957,9 @@ class TestInterimAssistantMessageConfig:
     def test_default_config_enables_interim_assistant_messages(self):
         assert DEFAULT_CONFIG["display"]["interim_assistant_messages"] is True
 
-    def test_migrate_to_v15_adds_interim_assistant_message_gate(self, tmp_path):
+    def test_migrate_to_v15_supplies_interim_message_gate_at_read_time(
+        self, tmp_path, capsys
+    ):
         config_path = tmp_path / "config.yaml"
         config_path.write_text(
             yaml.safe_dump({"_config_version": 14, "display": {"tool_progress": "off"}}),
@@ -965,7 +967,7 @@ class TestInterimAssistantMessageConfig:
         )
 
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
-            migrate_config(interactive=False, quiet=True)
+            results = migrate_config(interactive=False, quiet=False)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
             loaded = load_config()
 
@@ -978,6 +980,11 @@ class TestInterimAssistantMessageConfig:
         # was the config-bloat bug). It is still effective via load_config().
         assert "interim_assistant_messages" not in raw.get("display", {})
         assert loaded["display"]["interim_assistant_messages"] is True
+        assert not any(
+            "interim_assistant_messages" in item
+            for item in results["config_added"]
+        )
+        assert "Added display.interim_assistant_messages" not in capsys.readouterr().out
 
 
 class TestCliRefreshIntervalConfig:


### PR DESCRIPTION
## Summary
`hermes update`'s v15 config migration no longer prints "✓ Added display.interim_assistant_messages=true" for a write that never reached disk. The migration wrote a value equal to the schema default, `_persist_migration`'s strip-defaults invariant removed it before saving, yet the report claimed success — reported state and disk state disagreed. Fixes #93533.

## Changes
- `hermes_cli/config_migrations.py`: dead default-equal write removed along with the `(15, ...)` registry entry (read-time deep-merge already supplies the default; comment explains why)
- Regression test: raw disk lacks the key, `load_config()` still resolves True, `results['config_added']` has no interim entry, no "✓ Added" line — reported == persisted

## Validation
| | Before | After |
|---|---|---|
| Migration output | "✓ Added …=true" | no false claim |
| Disk after migration | key absent | key absent (honest) |
| Live repro (temp HERMES_HOME, v14 config) | reported ≠ persisted | reported == persisted |

Salvaged from #93550 (@fangliquanflq, earliest) — maintainer-approved fix shape from the issue thread; #93567 (@aniruddhaadak80) same fix, credited.

## Infographic

![Config migration reports only what it really saved](https://v3b.fal.media/files/b/0aa79844/ibSlQYd_FdBgm6PdbgfWL_fLX6AiUB.png)
