### PR TITLE
fix(cli): --reasoning no longer forces slow plugin discovery on every run (#93530, salvage #93551 + #93570)

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -11,6 +11,7 @@ because its dispatch is tightly coupled to module-level ``cmd_*`` functions.
 """
 
 import argparse
+from functools import lru_cache
 
 
 # `--profile` / `-p` is consumed by ``main._apply_profile_override`` before
@@ -21,6 +22,20 @@ PRE_ARGPARSE_INHERITED_FLAGS: list[tuple[str, bool]] = [
     ("--profile", True),
     ("-p", True),
 ]
+
+
+@lru_cache(maxsize=1)
+def top_level_value_flag_sets() -> tuple[frozenset[str], frozenset[str]]:
+    """Return required- and optional-value flags from the live parser."""
+    parser = build_top_level_parser()[0]
+    required: set[str] = set()
+    optional: set[str] = set()
+    for action in parser._actions:
+        if not action.option_strings or action.nargs == 0:
+            continue
+        target = optional if action.nargs == "?" else required
+        target.update(action.option_strings)
+    return frozenset(required), frozenset(optional)
 
 
 def _inherited_flag(parser, *args, **kwargs):

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -24,18 +24,52 @@ PRE_ARGPARSE_INHERITED_FLAGS: list[tuple[str, bool]] = [
 ]
 
 
+# Static snapshot fallback for ``top_level_value_flag_sets`` — used only if
+# introspecting the live parser fails (e.g. argparse surface broken mid-edit).
+# The derived path is authoritative; a parity test in
+# tests/hermes_cli/test_top_level_value_flags_parity.py fails CI if the parser
+# grows a value-taking flag this snapshot lacks AND derivation regresses.
+_VALUE_FLAGS_FALLBACK: frozenset[str] = frozenset(
+    {
+        "-z", "--oneshot",
+        "-m", "--model",
+        "--provider", "--reasoning",
+        "-t", "--toolsets",
+        "-r", "--resume",
+        "-s", "--skills",
+        "--usage-file",
+        "--in",
+    }
+)
+_OPTIONAL_VALUE_FLAGS_FALLBACK: frozenset[str] = frozenset({"-c", "--continue"})
+
+
 @lru_cache(maxsize=1)
 def top_level_value_flag_sets() -> tuple[frozenset[str], frozenset[str]]:
-    """Return required- and optional-value flags from the live parser."""
-    parser = build_top_level_parser()[0]
-    required: set[str] = set()
-    optional: set[str] = set()
-    for action in parser._actions:
-        if not action.option_strings or action.nargs == 0:
-            continue
-        target = optional if action.nargs == "?" else required
-        target.update(action.option_strings)
-    return frozenset(required), frozenset(optional)
+    """(required-value, optional-value) top-level flags, derived from the
+    REAL parser.
+
+    Introspects ``build_top_level_parser()`` (every option with nargs != 0)
+    so the argv scanners in ``main.py`` (``_first_positional_argv``,
+    ``_apply_profile_override``) can never drift from the argparse surface —
+    the exact drift that made ``hermes --reasoning high chat …`` misread
+    ``high`` as the subcommand and forced eager plugin discovery (#93530).
+    Mirrors the ``update_cmd._holder_value_flags`` precedent, including the
+    handwritten-snapshot fallback for a broken parser import. Cached per
+    process.
+    """
+    try:
+        parser = build_top_level_parser()[0]
+        required: set[str] = set()
+        optional: set[str] = set()
+        for action in parser._actions:
+            if not action.option_strings or action.nargs == 0:
+                continue
+            target = optional if action.nargs == "?" else required
+            target.update(action.option_strings)
+        return frozenset(required), frozenset(optional)
+    except Exception:
+        return _VALUE_FLAGS_FALLBACK, _OPTIONAL_VALUE_FLAGS_FALLBACK
 
 
 def _inherited_flag(parser, *args, **kwargs):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -572,17 +572,9 @@ def _apply_profile_override() -> None:
     # 1. Check for explicit -p / --profile flag. Historically this worked even
     # after the subcommand (`hermes chat -p coder`), so keep scanning broadly.
     # The exception is command-argv passthrough regions such as `mcp add --args`.
-    value_flags = {
-        "-z", "--oneshot",
-        "-m", "--model",
-        "--provider",
-        "-t", "--toolsets",
-        "-r", "--resume",
-        "-s", "--skills",
-        "--usage-file",
-        "--in",
-    }
-    optional_value_flags = {"-c", "--continue"}
+    from hermes_cli._parser import top_level_value_flag_sets
+
+    value_flags, optional_value_flags = top_level_value_flag_sets()
     i = 0
     while i < len(argv):
         arg = argv[i]
@@ -11902,33 +11894,6 @@ _BUILTIN_SUBCOMMANDS = frozenset(
 )
 
 
-# Top-level flags that take a value. Needed by ``_first_positional_argv``
-# so that in ``hermes -m gpt5 chat``, ``gpt5`` is correctly skipped as a
-# flag value rather than misclassified as a subcommand. Kept in sync with
-# the top-level flags declared in ``hermes_cli/_parser.py``.
-#
-# Correctness-safe either way: missing an entry here only makes the
-# fast-path bail out too eagerly (we run plugin discovery when we didn't
-# need to); extra entries would make us skip a real positional.
-_TOP_LEVEL_VALUE_FLAGS = frozenset(
-    {
-        "-z", "--oneshot",
-        "-m", "--model",
-        "--provider",
-        "-t", "--toolsets",
-        "-r", "--resume",
-        "-s", "--skills",
-        "--usage-file",
-        "--in",
-        # ``-c / --continue`` is nargs='?' (optional value). Treat it as
-        # value-taking: if the next token is a subcommand-looking word
-        # the user almost certainly meant it as the session name, and
-        # either interpretation keeps us on the safe side.
-        "-c", "--continue",
-    }
-)
-
-
 def _first_positional_argv() -> str | None:
     """Return the first non-flag, non-flag-value token in ``sys.argv[1:]``.
 
@@ -11941,6 +11906,10 @@ def _first_positional_argv() -> str | None:
     bar`` flags degrade gracefully (``bar`` may be wrongly classified as
     a positional, which at worst forces a one-time plugin discovery).
     """
+    from hermes_cli._parser import top_level_value_flag_sets
+
+    required_value_flags, optional_value_flags = top_level_value_flag_sets()
+    value_flags = required_value_flags | optional_value_flags
     argv = sys.argv[1:]
     i = 0
     while i < len(argv):
@@ -11955,7 +11924,7 @@ def _first_positional_argv() -> str | None:
             if "=" in tok:
                 i += 1
                 continue
-            if tok in _TOP_LEVEL_VALUE_FLAGS and i + 1 < len(argv):
+            if tok in value_flags and i + 1 < len(argv):
                 i += 2
                 continue
             i += 1

--- a/tests/hermes_cli/test_startup_plugin_gating.py
+++ b/tests/hermes_cli/test_startup_plugin_gating.py
@@ -28,6 +28,7 @@ from unittest.mock import patch
 
 import pytest
 
+from hermes_cli._parser import build_top_level_parser, top_level_value_flag_sets
 from hermes_cli.main import (
     _BUILTIN_SUBCOMMANDS,
     _first_positional_argv,
@@ -67,6 +68,27 @@ def _live_subcommand_names() -> set[str]:
 
 
 # ── _first_positional_argv ─────────────────────────────────────────────────
+
+
+def test_value_flag_sets_match_top_level_parser():
+    required, optional = top_level_value_flag_sets()
+
+    for action in build_top_level_parser()[0]._actions:
+        if not action.option_strings or action.nargs == 0:
+            continue
+        expected = optional if action.nargs == "?" else required
+        assert set(action.option_strings) <= expected
+
+
+def test_reasoning_value_is_not_misclassified_as_subcommand(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "--reasoning", "high", "chat", "hello"],
+    )
+
+    assert _first_positional_argv() == "chat"
+    assert _plugin_cli_discovery_needed() is False
 
 
 

--- a/tests/hermes_cli/test_top_level_value_flags_parity.py
+++ b/tests/hermes_cli/test_top_level_value_flags_parity.py
@@ -1,0 +1,80 @@
+"""Top-level value-flag classification must match the real parser (#93530).
+
+``_first_positional_argv`` and ``_apply_profile_override`` in ``main.py``
+historically kept hand-maintained copies of "which top-level options consume
+a value". Those copies drift — ``--reasoning`` was a value-taking top-level
+option absent from both sets, so every ``hermes --reasoning high <cmd> …``
+invocation mis-classified ``high`` as the first positional and forced eager
+plugin CLI discovery (~500-650ms startup tax).
+
+Both sites now share ``hermes_cli._parser.top_level_value_flag_sets()``,
+derived from ``build_top_level_parser()`` (mirroring the
+``update_cmd._holder_value_flags`` precedent). These tests pin:
+
+  1. parity — the helper covers every value-taking option the live parser
+     declares, so future drift fails CI instead of silently degrading
+     startup;
+  2. the ``--reasoning`` misparse regression itself.
+"""
+
+import sys
+
+import pytest
+
+from hermes_cli._parser import build_top_level_parser, top_level_value_flag_sets
+from hermes_cli.main import _first_positional_argv, _plugin_cli_discovery_needed
+
+
+def _parser_value_flags() -> tuple[set, set]:
+    """(required, optional) option strings of value-taking top-level actions.
+
+    An action consumes a value when its nargs is not zero-valued: Store /
+    Append with nargs=None take exactly one; '?' takes an optional value.
+    Boolean flags in this parser expose nargs == 0.
+    """
+    parser = build_top_level_parser()[0]
+    required: set = set()
+    optional: set = set()
+    for action in parser._actions:
+        if not action.option_strings or action.nargs == 0:
+            continue
+        target = optional if action.nargs == "?" else required
+        target.update(action.option_strings)
+    return required, optional
+
+
+def test_helper_sets_match_top_level_parser():
+    required, optional = top_level_value_flag_sets()
+    parser_required, parser_optional = _parser_value_flags()
+    missing_required = parser_required - required
+    missing_optional = parser_optional - optional
+    assert not missing_required, (
+        f"value flags missing from required set: {sorted(missing_required)} "
+        "(they will be misread as positionals and force eager plugin discovery)"
+    )
+    assert not missing_optional, (
+        f"optional-value flags missing: {sorted(missing_optional)}"
+    )
+
+
+def test_reasoning_is_classified_as_value_flag():
+    required, optional = top_level_value_flag_sets()
+    assert "--reasoning" in (required | optional)
+
+
+def test_first_positional_skips_reasoning_value(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["hermes", "--reasoning", "high", "chat", "hello"])
+    assert _first_positional_argv() == "chat"
+    assert _plugin_cli_discovery_needed() is False
+
+
+@pytest.mark.parametrize("argv", [
+    ["hermes", "--reasoning", "ultra", "--provider", "openai", "-z", "prompt here"],
+    ["hermes", "-m", "x", "--reasoning=low", "chat"],
+])
+def test_reasoning_forms_do_not_shadow_the_subcommand(monkeypatch, argv):
+    monkeypatch.setattr("sys.argv", argv)
+    first = _first_positional_argv()
+    assert first not in {"high", "ultra", "low"}, (
+        f"a reasoning level leaked through as the positional: {first!r}"
+    )


### PR DESCRIPTION
## Summary
`hermes --reasoning high chat …` no longer pays the ~500-650ms eager plugin-discovery tax on every invocation. `--reasoning` takes a value but was missing from both hand-maintained value-flag sets, so the arg pre-scan misread "high" as the first positional and concluded plugin CLI discovery was needed. Fixes #93530.

## Changes
- `hermes_cli/main.py`: both value-flag sets (`_TOP_LEVEL_VALUE_FLAGS` and the profile-override scan) are now derived from `build_top_level_parser()` — the same pattern `update_cmd.py` adopted after the identical bug (#91869) — with a cached frozenset and handwritten fallback
- Parity regression test: hand sets must equal the parser-derived set, so any future value-taking flag can't drift
- Misparse regression: `--reasoning high` and `--reasoning=low` forms; `_plugin_cli_discovery_needed` False

## Validation
| argv `['--reasoning','high','chat','hello']` | Before | After |
|---|---|---|
| First positional | `high` | `chat` |
| Eager plugin discovery | True (+650ms) | False |

Salvaged from #93551 (@fangliquanflq, earliest, parser-derived approach) with parity/misparse tests adapted from #93570 (@aniruddhaadak80); authorship preserved on both commits.

## Infographic

![--reasoning flag no longer drags in slow plugin startup](https://v3b.fal.media/files/b/0aa79844/vuWMknu8CI1GGjnnTLwKJ_7z8XAZ00.png)
