### PR TITLE
fix(cli): add --reasoning to top-level value-flag sets (#93530)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -581,6 +581,7 @@ def _apply_profile_override() -> None:
         "-s", "--skills",
         "--usage-file",
         "--in",
+        "--reasoning",
     }
     optional_value_flags = {"-c", "--continue"}
     i = 0
@@ -11920,6 +11921,7 @@ _TOP_LEVEL_VALUE_FLAGS = frozenset(
         "-s", "--skills",
         "--usage-file",
         "--in",
+        "--reasoning",
         # ``-c / --continue`` is nargs='?' (optional value). Treat it as
         # value-taking: if the next token is a subcommand-looking word
         # the user almost certainly meant it as the session name, and


### PR DESCRIPTION
## Summary

Fixes #93530. The `--reasoning` flag takes a value (`metavar="LEVEL"`) but was missing from both hand-maintained top-level value-flag sets, causing `hermes --reasoning high chat "msg"` to treat `"high"` as the first positional argument and trigger unnecessary plugin discovery.

## Changes

- `hermes_cli/main.py`: Add `"--reasoning"` to `_TOP_LEVEL_VALUE_FLAGS` (used by `_first_positional_argv()`) and to `value_flags` inside `_apply_profile_override()` (used for profile resolution before argparse).

## Testing

```bash
# Before fix: "high" is treated as a subcommand, triggers plugin discovery
hermes --reasoning high chat "hello"  # slow startup due to unnecessary plugin scan

# After fix: "high" is correctly skipped as --reasoning's value
hermes --reasoning high chat "hello"  # normal startup, no plugin scan
```
