### PR TITLE
fix(model-metadata): 1M-context local endpoints no longer detected at their output cap (#93412, salvage #65574 + #71442 + #93423)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1152,6 +1152,25 @@ def _extract_first_int(payload: Dict[str, Any], keys: tuple[str, ...]) -> Option
     return None
 
 
+def _extract_flat_context_length(payload: Dict[str, Any]) -> Optional[int]:
+    """Read a context WINDOW from the top level of a model-describe payload.
+
+    Same key vocabulary as :func:`_extract_context_length` (the module's single
+    source of truth for what counts as a context window), but WITHOUT the
+    nested-dict walk — for callers that hold a specific model object and must
+    not pick up a same-named key from an unrelated nested section.
+
+    Critically, ``max_tokens`` is NOT in ``_CONTEXT_LENGTH_KEYS``: it lives in
+    ``_MAX_COMPLETION_KEYS`` because on an OpenAI-compatible ``/v1/models``
+    passthrough it is the max *output* tokens, not the context window.
+    """
+    for key in _CONTEXT_LENGTH_KEYS:
+        coerced = _coerce_reasonable_int(payload.get(key))
+        if coerced is not None:
+            return coerced
+    return None
+
+
 def _extract_context_length(payload: Dict[str, Any]) -> Optional[int]:
     return _extract_first_int(payload, _CONTEXT_LENGTH_KEYS)
 
@@ -1164,7 +1183,7 @@ def _context_length_from_model_payload(payload: Dict[str, Any]) -> Optional[int]
     """Extract a context *window* from a ``/v1/models`` model object.
 
     Prefers input-window keys (``max_model_len``, ``max_input_tokens``,
-    ``context_length``, …) via :func:`_extract_context_length`. Falls back to
+    ``context_length``, …) via :func:`_extract_flat_context_length`. Falls back to
     ``max_tokens`` only when no input-window field is present.
 
     Anthropic (and Anthropic-compatible proxies such as local reverse
@@ -1176,7 +1195,7 @@ def _context_length_from_model_payload(payload: Dict[str, Any]) -> Optional[int]
     """
     if not isinstance(payload, dict):
         return None
-    ctx = _extract_context_length(payload)
+    ctx = _extract_flat_context_length(payload)
     if ctx is not None:
         return ctx
     # Last resort for OpenAI-compat servers that only report max_tokens as
@@ -2341,8 +2360,15 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
             if resp.status_code == 200:
                 data = resp.json()
                 if isinstance(data, dict):
-                    # Prefer max_model_len / max_input_tokens / context_length
-                    # over max_tokens (Anthropic max_tokens = max OUTPUT).
+                    # Context-WINDOW keys only (canonical _CONTEXT_LENGTH_KEYS
+                    # vocabulary). `max_tokens` is the max *output* tokens on
+                    # OpenAI-compatible passthroughs (LiteLLM, Anthropic-compat
+                    # shims, cloud proxies) — e.g. 393216 for a 1M-context
+                    # model — so reading it ahead of real window keys collapses
+                    # the window to the output cap and poisons the context
+                    # cache. It is consulted only as an explicit last resort
+                    # inside _context_length_from_model_payload, for servers
+                    # that report nothing else.
                     ctx = _context_length_from_model_payload(data)
                     if ctx is not None:
                         return ctx
@@ -2380,10 +2406,11 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                         if isinstance(val, (int, float)) and val:
                             return int(val)
                     # Canonical context-WINDOW keys (via _CONTEXT_LENGTH_KEYS)
-                    # with max_tokens demoted to an explicit last resort — see
-                    # _context_length_from_model_payload for why max_tokens
-                    # must never win over a real window key (it is the max
-                    # OUTPUT cap on Anthropic/OpenAI-compatible passthroughs).
+                    # with max_tokens demoted to an explicit last resort —
+                    # sibling of the /v1/models/{id} path above; see that
+                    # comment for why max_tokens must never win over a real
+                    # window key (it is the max OUTPUT cap on
+                    # Anthropic/OpenAI-compatible passthroughs).
                     for source in sources:
                         ctx = _context_length_from_model_payload(source)
                         if ctx is not None:

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1160,6 +1160,36 @@ def _extract_max_completion_tokens(payload: Dict[str, Any]) -> Optional[int]:
     return _extract_first_int(payload, _MAX_COMPLETION_KEYS)
 
 
+def _context_length_from_model_payload(payload: Dict[str, Any]) -> Optional[int]:
+    """Extract a context *window* from a ``/v1/models`` model object.
+
+    Prefers input-window keys (``max_model_len``, ``max_input_tokens``,
+    ``context_length``, …) via :func:`_extract_context_length`. Falls back to
+    ``max_tokens`` only when no input-window field is present.
+
+    Anthropic (and Anthropic-compatible proxies such as local reverse
+    proxies) expose both ``max_input_tokens`` (context window, e.g. 1M) and
+    ``max_tokens`` (max *output* length, e.g. 128k). Using ``max_tokens`` as
+    the context window under-reports the real limit, persists a stale value
+    into ``context_length_cache.yaml``, and makes the compressor fire far too
+    early (e.g. at 75% of 128k instead of 75% of 1M).
+    """
+    if not isinstance(payload, dict):
+        return None
+    ctx = _extract_context_length(payload)
+    if ctx is not None:
+        return ctx
+    # Last resort for OpenAI-compat servers that only report max_tokens as
+    # the window. Safe for Anthropic shapes because max_input_tokens is
+    # present and already handled above.
+    raw = payload.get("max_tokens")
+    if isinstance(raw, (int, float)):
+        ivalue = int(raw)
+        if ivalue > 0:
+            return ivalue
+    return None
+
+
 def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
     novita_input = payload.get("input_token_price_per_m")
     novita_output = payload.get("output_token_price_per_m")
@@ -2305,14 +2335,17 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                                     return int(ctx)
                             break
 
-            # LM Studio / vLLM / llama.cpp: try /v1/models/{model}
+            # LM Studio / vLLM / llama.cpp / Anthropic-compat proxies:
+            # try /v1/models/{model}
             resp = client.get(f"{server_url}/v1/models/{model}")
             if resp.status_code == 200:
                 data = resp.json()
-                # vLLM returns max_model_len
-                ctx = data.get("max_model_len") or data.get("context_length") or data.get("max_tokens")
-                if ctx and isinstance(ctx, (int, float)):
-                    return int(ctx)
+                if isinstance(data, dict):
+                    # Prefer max_model_len / max_input_tokens / context_length
+                    # over max_tokens (Anthropic max_tokens = max OUTPUT).
+                    ctx = _context_length_from_model_payload(data)
+                    if ctx is not None:
+                        return ctx
 
             # Try /v1/models and find the model in the list.
             # Use _model_id_matches to handle "publisher/slug" vs bare "slug".
@@ -2325,6 +2358,8 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                 # so fall back to the sole model when nothing matches.
                 matched = None
                 for m in models_list:
+                    if not isinstance(m, dict):
+                        continue
                     if _model_id_matches(m.get("id", ""), model):
                         matched = m
                         break
@@ -2335,21 +2370,24 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                     # vLLM/OpenAI keys are also checked. Runtime n_ctx is
                     # preferred over n_ctx_train (the training maximum, which
                     # can be larger than what the server actually allocates).
-                    for source in (matched, matched.get("meta") or {}):
-                        if not isinstance(source, dict):
-                            continue
-                        for key in (
-                            "n_ctx",
-                            "context_length",
-                            "context_window",
-                            "max_model_len",
-                            "max_context_length",
-                            "max_tokens",
-                            "n_ctx_train",
-                        ):
-                            val = source.get(key)
-                            if isinstance(val, (int, float)) and val:
-                                return int(val)
+                    sources = [
+                        s
+                        for s in (matched, matched.get("meta") or {})
+                        if isinstance(s, dict)
+                    ]
+                    for source in sources:
+                        val = source.get("n_ctx")
+                        if isinstance(val, (int, float)) and val:
+                            return int(val)
+                    # Canonical context-WINDOW keys (via _CONTEXT_LENGTH_KEYS)
+                    # with max_tokens demoted to an explicit last resort — see
+                    # _context_length_from_model_payload for why max_tokens
+                    # must never win over a real window key (it is the max
+                    # OUTPUT cap on Anthropic/OpenAI-compatible passthroughs).
+                    for source in sources:
+                        ctx = _context_length_from_model_payload(source)
+                        if ctx is not None:
+                            return ctx
     except Exception as exc:
         if _is_connect_timeout(exc):
             _note_endpoint_blackholed(server_url)

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -130,6 +130,94 @@ class TestQueryLocalContextLengthVllm:
 
         assert result == 32768
 
+    def test_detail_branch_reads_context_window_not_output_cap(self):
+        """A payload carrying BOTH a context window and an output cap must
+        resolve to the context window.
+
+        An OpenAI-compatible ``/v1/models/{id}`` passthrough (LiteLLM, an
+        Anthropic-compat shim, a cloud proxy) returns ``max_input_tokens`` —
+        the context window — alongside ``max_tokens``, the max *output*
+        tokens.  Reading ``max_tokens`` collapses a 1M-context model to its
+        128K output cap and drives premature auto-compaction.
+
+        Contract asserted: when a describe payload contains both classes of
+        key, the resolver returns the ``_CONTEXT_LENGTH_KEYS`` value, never
+        the ``_MAX_COMPLETION_KEYS`` one.
+        """
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(200, {
+            "type": "model",
+            "id": "some-model",
+            "max_input_tokens": 1000000,   # context window
+            "max_tokens": 128000,          # max OUTPUT tokens — not a window
+        })
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.return_value = detail_resp
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="vllm"), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("some-model", "http://localhost:8000/v1")
+
+        assert result == 1000000, (
+            f"must resolve the context window, not the output cap; got {result}"
+        )
+
+    def test_list_branch_reads_context_window_not_output_cap(self):
+        """Same contract on the sibling ``/v1/models`` LIST branch.
+
+        Both probe branches must share one definition of "context window";
+        fixing only the detail branch would leave the identical bug reachable
+        whenever the per-model describe endpoint 404s.
+        """
+        from agent.model_metadata import _query_local_context_length
+
+        detail_miss = self._make_resp(404, {})
+        list_resp = self._make_resp(200, {"data": [
+            {"id": "some-model", "max_input_tokens": 1000000, "max_tokens": 128000},
+        ]})
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        # first GET is /v1/models/{model} (miss), second is /v1/models (list)
+        client_mock.get.side_effect = [detail_miss, list_resp]
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="vllm"), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("some-model", "http://localhost:8000/v1")
+
+        assert result == 1000000, (
+            f"list branch must resolve the context window, not the output cap; got {result}"
+        )
+
+    def test_probe_agrees_with_the_module_key_vocabulary(self):
+        """Invariant: the probe's notion of a context window is the module's.
+
+        ``_CONTEXT_LENGTH_KEYS`` / ``_MAX_COMPLETION_KEYS`` are the single
+        source of truth for this distinction.  Asserting the relation (rather
+        than a frozen key list) keeps the guard correct as the vocabulary
+        grows, and fails if a probe branch ever re-hardcodes its own keys.
+        """
+        from agent import model_metadata as mm
+
+        assert "max_tokens" in mm._MAX_COMPLETION_KEYS
+        assert "max_tokens" not in mm._CONTEXT_LENGTH_KEYS
+        # No key may be classified as both a window and an output cap.
+        assert not (set(mm._CONTEXT_LENGTH_KEYS) & set(mm._MAX_COMPLETION_KEYS))
+
+        # Every context key the module recognises is honoured by the flat
+        # reader the probe branches use, and no completion key ever is.
+        for key in mm._CONTEXT_LENGTH_KEYS:
+            assert mm._extract_flat_context_length({key: 123456}) == 123456, key
+        for key in mm._MAX_COMPLETION_KEYS:
+            assert mm._extract_flat_context_length({key: 123456}) is None, key
+
 
 class TestQueryLocalContextLengthModelsList:
     """_query_local_context_length: falls back to /v1/models list."""

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -272,6 +272,126 @@ class TestQueryLocalContextLengthModelsList:
         assert result == 256000
 
 
+class TestContextLengthFromModelPayload:
+    """Anthropic / Anthropic-proxy model objects expose max_input_tokens
+    (context window) and max_tokens (max OUTPUT). The local probe must not
+    treat max_tokens as the context window."""
+
+    def test_prefers_max_input_tokens_over_max_tokens(self):
+        from agent.model_metadata import _context_length_from_model_payload
+
+        # Real Anthropic /v1/models shape for claude-fable-5
+        payload = {
+            "type": "model",
+            "id": "claude-fable-5",
+            "max_input_tokens": 1_000_000,
+            "max_tokens": 128_000,  # output cap, NOT context
+        }
+        assert _context_length_from_model_payload(payload) == 1_000_000
+
+    def test_prefers_max_model_len_over_max_tokens(self):
+        from agent.model_metadata import _context_length_from_model_payload
+
+        payload = {"id": "local-model", "max_model_len": 131072, "max_tokens": 4096}
+        assert _context_length_from_model_payload(payload) == 131072
+
+    def test_falls_back_to_max_tokens_when_no_input_window_field(self):
+        from agent.model_metadata import _context_length_from_model_payload
+
+        # Some OpenAI-compat servers only expose max_tokens for the window.
+        payload = {"id": "odd-server", "max_tokens": 65536}
+        assert _context_length_from_model_payload(payload) == 65536
+
+    def test_returns_none_for_empty_payload(self):
+        from agent.model_metadata import _context_length_from_model_payload
+
+        assert _context_length_from_model_payload({}) is None
+        assert _context_length_from_model_payload(None) is None  # type: ignore[arg-type]
+
+
+class TestQueryLocalContextLengthAnthropicProxy:
+    """Local Anthropic-compatible reverse proxies (e.g. 127.0.0.1:47821)
+    return Anthropic-shaped /v1/models entries. The probe must read
+    max_input_tokens, not max_tokens."""
+
+    def _make_resp(self, status_code, body):
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.json.return_value = body
+        return resp
+
+    def test_models_list_prefers_max_input_tokens(self):
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(404, {})
+        list_resp = self._make_resp(200, {
+            "data": [
+                {
+                    "type": "model",
+                    "id": "claude-fable-5",
+                    "display_name": "Claude Fable 5",
+                    "max_input_tokens": 1_000_000,
+                    "max_tokens": 128_000,
+                },
+                {
+                    "type": "model",
+                    "id": "claude-haiku-4-5-20251001",
+                    "max_input_tokens": 200_000,
+                    "max_tokens": 64_000,
+                },
+            ]
+        })
+
+        call_count = [0]
+
+        def side_effect(url, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return detail_resp  # /v1/models/claude-fable-5
+            return list_resp  # /v1/models
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.side_effect = side_effect
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length(
+                "claude-fable-5", "http://127.0.0.1:47821"
+            )
+
+        assert result == 1_000_000, (
+            f"Expected max_input_tokens (1M), got {result}. "
+            "If Hermes uses Anthropic max_tokens (128k), compression fires ~8x early."
+        )
+
+    def test_model_detail_prefers_max_input_tokens(self):
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(200, {
+            "type": "model",
+            "id": "claude-fable-5",
+            "max_input_tokens": 1_000_000,
+            "max_tokens": 128_000,
+        })
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.return_value = detail_resp
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length(
+                "claude-fable-5", "http://127.0.0.1:47821/v1"
+            )
+
+        assert result == 1_000_000
+
+
 class TestQueryLocalContextLengthLmStudio:
     """_query_local_context_length with LM Studio native /api/v1/models response."""
 

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -951,9 +951,11 @@ class TestQueryLocalContextLengthMaxTokensNotContext:
 
         assert result == 1048576
 
-    def test_models_list_max_tokens_only_returns_none(self):
-        """A model that ONLY exposes `max_tokens` (no real context key) must not
-        be reported as having that output cap as its context length."""
+    def test_models_list_max_tokens_only_falls_back(self):
+        """A model that ONLY exposes `max_tokens` (no real context key) still
+        resolves — max_tokens is preserved as an explicit last-resort fallback
+        because some servers report nothing else. It must only ever win when
+        no genuine context-window key is present."""
         from agent.model_metadata import _query_local_context_length
 
         detail_resp = self._make_resp(404, {})
@@ -983,4 +985,85 @@ class TestQueryLocalContextLengthMaxTokensNotContext:
              patch("httpx.Client", return_value=client_mock):
             result = _query_local_context_length("mystery-model", "http://127.0.0.1:8080/v1")
 
-        assert result is None
+        assert result == 393216, (
+            "max_tokens-only servers must still resolve via the last-resort fallback"
+        )
+
+
+class TestReconcileSelfHealsPoisonedCache:
+    """Cache self-heal: once the probe stops misreading max_tokens, a cache
+    entry poisoned by the old probe (issue #93412: 1M endpoint cached as
+    393216) must be rewritten UPWARD by _reconcile_local_cached_context_length
+    on the next live probe."""
+
+    def _make_resp(self, status_code, body):
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.json.return_value = body
+        return resp
+
+    def test_poisoned_cache_entry_rewritten_upward(self):
+        from agent.model_metadata import _reconcile_local_cached_context_length
+
+        model = "deepseek-v4-flash"
+        base = "http://127.0.0.1:8080/v1"
+        poisoned = 393216      # old probe read the max_tokens output cap
+        real_window = 1048576  # context_size the fixed probe now reports
+
+        with patch(
+            "agent.model_metadata._query_local_context_length",
+            return_value=real_window,
+        ), patch(
+            "agent.model_metadata._invalidate_cached_context_length"
+        ) as mock_invalidate, patch(
+            "agent.model_metadata.save_context_length"
+        ) as mock_save:
+            result = _reconcile_local_cached_context_length(model, base, poisoned)
+
+        assert result == real_window
+        mock_invalidate.assert_called_once_with(model, base)
+        mock_save.assert_called_once_with(model, base, real_window)
+
+    def test_poisoned_cache_heals_end_to_end_from_probe_payload(self):
+        """Full path: live endpoint serves the issue's payload
+        (context_size 1048576 + max_tokens 393216); reconcile must overwrite
+        the poisoned 393216 cache entry with 1048576."""
+        from agent.model_metadata import _reconcile_local_cached_context_length
+
+        detail_resp = self._make_resp(404, {})
+        list_resp = self._make_resp(200, {
+            "data": [
+                {
+                    "id": "deepseek-v4-flash",
+                    "context_size": 1048576,
+                    "max_tokens": 393216,
+                }
+            ]
+        })
+
+        call_count = [0]
+        def side_effect(url, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return detail_resp
+            return list_resp
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.side_effect = side_effect
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("httpx.Client", return_value=client_mock), \
+             patch("agent.model_metadata._invalidate_cached_context_length") as mock_invalidate, \
+             patch("agent.model_metadata.save_context_length") as mock_save:
+            result = _reconcile_local_cached_context_length(
+                "deepseek-v4-flash", "http://127.0.0.1:8080/v1", 393216
+            )
+
+        assert result == 1048576
+        mock_invalidate.assert_called_once()
+        mock_save.assert_called_once_with(
+            "deepseek-v4-flash", "http://127.0.0.1:8080/v1", 1048576
+        )

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -875,3 +875,112 @@ class TestLocalContextProbeTTLCache:
         assert first is None
         assert second is None
         assert detect.call_count == 2, "None result was wrongly cached; retry did not re-probe"
+
+
+class TestQueryLocalContextLengthMaxTokensNotContext:
+    """Regression: `max_tokens` (an output-completion cap) must NOT be treated
+    as a context length.
+
+    OpenAI-compatible gateways (e.g. TokenHub serving DeepSeek V4 Flash)
+    advertise a real context window via `context_size` / `max_input_tokens`
+    while also carrying a smaller `max_tokens` output cap. The probe used to
+    fall through to `max_tokens`, mis-detecting a 1M-window model as 393K.
+    """
+
+    def _make_resp(self, status_code, body):
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.json.return_value = body
+        return resp
+
+    def test_models_list_prefers_context_size_over_max_tokens(self):
+        """/v1/models list: `context_size` wins over `max_tokens`."""
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(404, {})
+        list_resp = self._make_resp(200, {
+            "data": [
+                {
+                    "id": "deepseek-v4-flash",
+                    "context_size": 1048576,
+                    "max_input_tokens": 1048576,
+                    "max_tokens": 393216,
+                }
+            ]
+        })
+
+        call_count = [0]
+        def side_effect(url, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return detail_resp  # /v1/models/deepseek-v4-flash
+            return list_resp  # /v1/models
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.side_effect = side_effect
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("deepseek-v4-flash", "http://127.0.0.1:8080/v1")
+
+        assert result == 1048576
+
+    def test_models_detail_prefers_max_input_tokens_over_max_tokens(self):
+        """/v1/models/{model} detail: `max_input_tokens` wins over `max_tokens`."""
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(200, {
+            "id": "deepseek-v4-flash",
+            "context_size": 1048576,
+            "max_input_tokens": 1048576,
+            "max_tokens": 393216,
+        })
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.return_value = detail_resp
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("deepseek-v4-flash", "http://127.0.0.1:8080/v1")
+
+        assert result == 1048576
+
+    def test_models_list_max_tokens_only_returns_none(self):
+        """A model that ONLY exposes `max_tokens` (no real context key) must not
+        be reported as having that output cap as its context length."""
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(404, {})
+        list_resp = self._make_resp(200, {
+            "data": [
+                {
+                    "id": "mystery-model",
+                    "max_tokens": 393216,
+                }
+            ]
+        })
+
+        call_count = [0]
+        def side_effect(url, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return detail_resp
+            return list_resp
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.side_effect = side_effect
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("mystery-model", "http://127.0.0.1:8080/v1")
+
+        assert result is None


### PR DESCRIPTION
## Summary
Local endpoints with big context windows are detected correctly again: a 1M-context endpoint advertising `context_size: 1048576` alongside `max_tokens: 393216` was detected as 393K because the probe treated the output cap as a context-window candidate — then persisted the wrong value and overwrote a previously-correct cache entry. Fixes #93412. Supersedes #65574, #71442, #72654, #93423 (all salvaged/credited).

## Changes
- `agent/model_metadata.py`: both probe branches reuse the canonical `_CONTEXT_LENGTH_KEYS` (adds `context_size`/`max_input_tokens`); `max_tokens` demoted to explicit last-resort fallback (servers reporting only `max_tokens` still resolve)
- Cache self-heal covered: reconcile rewrites poisoned entries upward once the probe is fixed (tested end-to-end with the issue's exact payload)

## Validation
| Payload | Before | After |
|---|---|---|
| `context_size:1048576 + max_tokens:393216` | 393,216 | 1,048,576 |
| `max_tokens`-only | resolves | still resolves (fallback kept) |
| Tests | — | 150 passed |

Salvage chain with authorship preserved: #65574 (@carlotestor, 2026-07-16, earliest-correct — base), #71442 (@Kyzcreig), #93423 (@re-ITRT, issue author); #72654 (@pju-hoge) credited via Co-authored-by (its never-read-max_tokens policy contradicted the chosen last-resort fallback).

## Infographic

![Context probe reads the real window size](https://v3b.fal.media/files/b/0aa79857/oR9ekQ_I1AbvAzAP7zCvM_DXAXNWu3.png)
