### PR TITLE
fix(cli): post-update fleet check fails closed when a running gateway yields zero rows (#93406, salvage #93410)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4903,6 +4903,7 @@ _LAZY_COMMAND_EXPORTS = {
         "_ensure_fhs_path_guard",
         "_ensure_uv_for_termux",
         "_finish_dashboard_update_cleanup",
+        "_fleet_probe_expected_runtimes",
         "_for_each_systemd_gateway_unit",
         "_format_concurrent_instances_message",
         "_format_time_ago",

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -8317,6 +8317,19 @@ def _cmd_update_impl(args, gateway_mode: bool):
             )
             if print_fleet_version_matrix(_fleet_snapshot):
                 gateway_fleet_restart_incomplete = True
+            elif not _fleet_snapshot and (restarted_services or killed_pids):
+                # Fleet probe returned zero rows even though the restart
+                # phase touched live gateways.  Every failure path inside
+                # collect_fleet_versions() is swallowed via logger.debug(),
+                # so an empty list is indistinguishable from a healthy fleet
+                # in the current output.  Treat it as verification failure
+                # so the receipt records "partial" and the exit code is 1
+                # (#93406).
+                print(
+                    "\n⚠ Fleet version check returned no rows even though"
+                    " gateways were restarted — verification incomplete."
+                )
+                gateway_fleet_restart_incomplete = True
         except Exception as _fleet_exc:
             logger.debug("Fleet version verification failed: %s", _fleet_exc)
 

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -8303,11 +8303,22 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 print_fleet_version_matrix,
             )
 
-            # A brief settle window: freshly restarted gateways need a
-            # moment to rewrite gateway_state.json with their new identity.
+            # Cross-platform "we expected fleet rows" signal (#93406). The
+            # old (restarted_services or killed_pids) condition never fires
+            # on Windows: the pause/resume phase populates neither list, so
+            # a healthy resumed gateway yielded zero rows and exit 0.
+            _fleet_rows_expected = _m()._fleet_probe_expected_runtimes(
+                _pre_update_plan,
+                _pre_restart_gateway_pids,
+                _windows_gateway_resume,
+                restarted_services,
+                killed_pids,
+            )
+            # A brief settle window: freshly restarted/resumed gateways need
+            # a moment to rewrite gateway_state.json with their new identity.
             # Skipped when the restart phase touched nothing (no gateways
             # were running) — nothing to settle.
-            if restarted_services or killed_pids:
+            if _fleet_rows_expected:
                 _time.sleep(2.0)
             # Pass the pre-restart PID snapshot so a gateway the restart
             # phase stopped WITHOUT a verified replacement shows as a DOWN
@@ -8317,9 +8328,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
             )
             if print_fleet_version_matrix(_fleet_snapshot):
                 gateway_fleet_restart_incomplete = True
-            elif not _fleet_snapshot and (restarted_services or killed_pids):
-                # Fleet probe returned zero rows even though the restart
-                # phase touched live gateways.  Every failure path inside
+            elif not _fleet_snapshot and _fleet_rows_expected:
+                # Fleet probe returned zero rows even though at least one
+                # gateway runtime was (or may have been) live pre-update —
+                # POSIX restart bookkeeping, the pre-restart PID snapshot,
+                # the pre-update plan inventory, or the Windows pause/resume
+                # token all count as that signal.  Every failure path inside
                 # collect_fleet_versions() is swallowed via logger.debug(),
                 # so an empty list is indistinguishable from a healthy fleet
                 # in the current output.  Treat it as verification failure
@@ -8327,7 +8341,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 # (#93406).
                 print(
                     "\n⚠ Fleet version check returned no rows even though"
-                    " gateways were restarted — verification incomplete."
+                    " gateway runtimes were expected — verification incomplete."
                 )
                 gateway_fleet_restart_incomplete = True
         except Exception as _fleet_exc:
@@ -8445,6 +8459,61 @@ def _restart_phase_failure_is_incomplete(surviving, pre_restart_pids) -> bool:
         return True
     # surviving == []: safe only if we know nothing was running beforehand.
     return pre_restart_pids is None or bool(pre_restart_pids)
+
+
+def _fleet_probe_expected_runtimes(
+    pre_update_plan,
+    pre_restart_pids,
+    windows_resume_token,
+    restarted_services,
+    killed_pids,
+) -> bool:
+    """Whether the post-update fleet probe should have produced rows.
+
+    The zero-rows fail-open (#93406): ``collect_fleet_versions()`` swallows
+    every probe failure via ``logger.debug()`` and ``print_fleet_version_matrix([])``
+    early-returns ``False``, so an empty snapshot reads as \"healthy fleet\" and
+    the update exits 0.  An empty snapshot is only proof-of-safety when NOTHING
+    says a gateway existed before the update.  Any of these signals means at
+    least one runtime was (or may have been) live pre-update, so zero rows is
+    verification failure, not health:
+
+    * ``restarted_services`` / ``killed_pids`` — the POSIX restart phase
+      touched live gateways.
+    * ``pre_restart_pids`` non-empty, or ``None`` (pre-state unreadable —
+      cannot prove nothing was running; same contract as
+      ``_restart_phase_failure_is_incomplete``, #78574).
+    * the pre-update plan inventoried ≥1 runtime.
+    * the Windows pause/resume token carries paused ``profiles`` or
+      ``unmapped`` entries — ``_pause_windows_gateways_for_update`` /
+      ``_resume_windows_gateways_after_update`` populate NEITHER
+      ``restarted_services`` NOR ``killed_pids``, which is exactly why the
+      original ``(restarted_services or killed_pids)`` guard never fires on
+      Windows.
+
+    The same condition gates the 2.0s settle sleep: a freshly resumed Windows
+    gateway needs the settle window to rewrite ``gateway_state.json`` just
+    like a systemd-restarted one.
+
+    Note this keys ONLY on zero-rows-despite-expected-runtimes.  A non-empty
+    snapshot — including rows in ``unknown`` state — is still judged solely by
+    ``print_fleet_version_matrix``.
+    """
+    if restarted_services or killed_pids:
+        return True
+    if pre_restart_pids is None or pre_restart_pids:
+        return True
+    try:
+        if pre_update_plan is not None and pre_update_plan.runtimes:
+            return True
+    except Exception:
+        pass
+    if isinstance(windows_resume_token, dict) and (
+        windows_resume_token.get("profiles")
+        or windows_resume_token.get("unmapped")
+    ):
+        return True
+    return False
 
 
 def _print_items(items, label, key, fallback_key=None):

--- a/tests/hermes_cli/test_update_fleet_check_fail_closed.py
+++ b/tests/hermes_cli/test_update_fleet_check_fail_closed.py
@@ -1,0 +1,129 @@
+"""Regression for #93406 — post-update fleet version check must fail closed.
+
+``collect_fleet_versions()`` swallows every probe failure via
+``logger.debug()`` and ``print_fleet_version_matrix([])`` early-returns
+``False``, so an empty fleet snapshot used to read as "healthy fleet" and
+``hermes update`` exited 0 with zero rows — even when a gateway was
+verifiably live before the update.
+
+The first guard (PR #93410) keyed on ``(restarted_services or killed_pids)``,
+which never fires on Windows: ``_pause_windows_gateways_for_update`` /
+``_resume_windows_gateways_after_update`` populate neither list, so a healthy
+resumed Windows gateway still yielded zero rows and exit 0.  The fix hoists
+the "should the probe have produced rows?" decision into
+``_fleet_probe_expected_runtimes`` and keys it on every pre-update liveness
+signal: restart-phase bookkeeping, the pre-restart PID snapshot, the
+pre-update plan inventory, and the Windows pause/resume token.  The same
+condition gates the 2.0s settle sleep.
+"""
+
+from __future__ import annotations
+
+import inspect
+import types
+
+from hermes_cli.main import _fleet_probe_expected_runtimes
+
+
+def _plan(runtimes):
+    return types.SimpleNamespace(runtimes=runtimes)
+
+
+class TestEmptySnapshotFailClosed:
+    """Signals under which zero fleet rows means verification failure."""
+
+    def test_incomplete_when_pre_update_plan_saw_runtimes(self):
+        # (a) The plan inventoried a live runtime pre-update but the restart
+        # phase's POSIX bookkeeping is empty (e.g. Windows, or an
+        # externally-supervised gateway). Zero rows must fail closed.
+        assert (
+            _fleet_probe_expected_runtimes(
+                _plan([object()]),
+                [],  # pre_restart_pids: probe saw nothing
+                None,  # no Windows resume token
+                [],  # restarted_services
+                set(),  # killed_pids
+            )
+            is True
+        )
+
+    def test_incomplete_when_windows_resume_token_has_profiles(self):
+        # (c) The Windows pause/resume path: restarted_services and
+        # killed_pids stay empty by construction, so the resume token is the
+        # ONLY signal that a gateway was live. This is exactly the case the
+        # original (restarted_services or killed_pids) guard missed.
+        token = {"resume_needed": False, "profiles": {"default": 4321}}
+        assert (
+            _fleet_probe_expected_runtimes(None, [], token, [], set()) is True
+        )
+
+    def test_incomplete_when_windows_resume_token_has_unmapped(self):
+        # Scheduled-Task gateways land in token["unmapped"], not profiles.
+        token = {"resume_needed": False, "unmapped": [{"pid": 99, "argv": ["x"]}]}
+        assert (
+            _fleet_probe_expected_runtimes(None, [], token, [], set()) is True
+        )
+
+    def test_incomplete_when_restart_phase_touched_gateways(self):
+        # The original #93410 signal still counts.
+        assert (
+            _fleet_probe_expected_runtimes(None, [], None, ["hermes-gateway"], set())
+            is True
+        )
+        assert _fleet_probe_expected_runtimes(None, [], None, [], {4321}) is True
+
+    def test_incomplete_when_pre_restart_pids_seen(self):
+        assert _fleet_probe_expected_runtimes(None, [4321], None, [], set()) is True
+
+    def test_incomplete_when_pre_restart_state_unreadable(self):
+        # None means the pre-state could not be read — cannot prove nothing
+        # was running, same contract as _restart_phase_failure_is_incomplete.
+        assert _fleet_probe_expected_runtimes(None, None, None, [], set()) is True
+
+
+class TestEmptySnapshotGenuinelyIdle:
+    def test_success_when_nothing_was_running_pre_update(self):
+        # (b) Positive control: no plan runtimes, empty PID snapshot, no
+        # Windows token, no restart bookkeeping — zero rows stays a success.
+        assert (
+            _fleet_probe_expected_runtimes(_plan([]), [], None, [], set()) is False
+        )
+
+    def test_success_with_no_plan_at_all(self):
+        assert _fleet_probe_expected_runtimes(None, [], None, [], set()) is False
+
+    def test_success_with_empty_windows_token(self):
+        # A token that paused nothing (e.g. Windows host with no gateways)
+        # is not a liveness signal.
+        token = {"resume_needed": False, "profiles": {}, "unmapped": []}
+        assert _fleet_probe_expected_runtimes(None, [], token, [], set()) is False
+
+
+class TestCallSiteWiring:
+    """The guard AND the settle sleep must both key on the shared signal.
+
+    Sabotage-proof for the wiring itself: reverting the call site to the
+    pre-fix ``(restarted_services or killed_pids)`` condition — while leaving
+    the helper in place — makes these fail.
+    """
+
+    def _impl_source(self):
+        from hermes_cli import update_cmd
+
+        return inspect.getsource(update_cmd._cmd_update_impl)
+
+    def test_settle_sleep_gated_on_expected_runtimes(self):
+        src = self._impl_source()
+        assert "_fleet_rows_expected = _m()._fleet_probe_expected_runtimes(" in src
+        # The 2.0s settle window must key on the cross-platform signal, so a
+        # resumed Windows gateway gets its settle window too (#93406).
+        assert "if _fleet_rows_expected:\n" in src
+        assert "if restarted_services or killed_pids:\n                _time.sleep" not in src
+
+    def test_zero_row_guard_gated_on_expected_runtimes(self):
+        src = self._impl_source()
+        assert "elif not _fleet_snapshot and _fleet_rows_expected:" in src
+        assert (
+            "elif not _fleet_snapshot and (restarted_services or killed_pids):"
+            not in src
+        )


### PR DESCRIPTION
## Summary
`hermes update` can no longer report success while its post-update fleet version check silently produced zero rows for a gateway that was demonstrably running. The success path swallowed probe failures and treated an empty snapshot as "nothing to check" — the fail-closed guard only existed on the restart-failure path, and on Windows the pause/resume phase populates none of the signals the naive guard would key on. Fixes #93406.

## Changes
- `hermes_cli/update_cmd.py`: empty fleet snapshot is treated as incomplete when ANY pre-update liveness signal fired — plan runtimes, pre-restart gateway pids, the Windows resume token's profiles/unmapped entries, or restarted_services/killed_pids (salvaged guard from #93410 widened cross-platform)
- The 2.0s settle window is gated on the same condition, so freshly resumed Windows gateways get their settle before the probe
- Zero-rows-despite-expected-runtimes keying preserves 'unknown'-state rows passing

## Validation
| Scenario | Before | After |
|---|---|---|
| Empty snapshot, gateway was running | exit 0, no rows | INCOMPLETE (fail-closed) |
| Empty snapshot, nothing ran pre-update | success | success (unchanged) |
| Windows resume path | guard never fired | guard + settle window fire |
| Tests | — | 11 new regressions (sabotage-proven), 107 passed |

Salvaged from #93410 (@RelaxJonh), authorship preserved; guard gap identified live by @Halldrix on the PR.

## Infographic

![Post-update fleet check fails closed on empty results](https://v3b.fal.media/files/b/0aa79857/9iV6iXQHTQhVv1hSUgVcc_bOaLManC.png)
