### PR TITLE
fix(cli): prevent secrets subcommand recursion via set_defaults inheritance (#92799)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12852,6 +12852,14 @@ def main():
     _secrets_cli.register_cli(secrets_bw)
     _op_secrets_cli.register_cli(secrets_op)
 
+    # Set fallback func on each sub-subparser so argparse does not inherit
+    # _dispatch_secrets from the parent secrets_parser via set_defaults
+    # propagation.  Without this, ``hermes secrets onepassword`` (no
+    # sub-subcommand) resolves args.func = _dispatch_secrets, which calls
+    # args.func(args) = itself → RecursionError (#92799).
+    secrets_bw.set_defaults(func=lambda a: (secrets_bw.print_help(), 0)[-1])
+    secrets_op.set_defaults(func=lambda a: (secrets_op.print_help(), 0)[-1])
+
     def _dispatch_secrets(args):  # noqa: ANN001
         sub = getattr(args, "secrets_command", None)
         if sub is None:


### PR DESCRIPTION
## Summary

Fixes #92799. `hermes secrets onepassword` (without a sub-subcommand) causes `RecursionError` because argparse propagates `set_defaults(func=_dispatch_secrets)` from the parent `secrets_parser` to the child `onepassword` parser. When `_dispatch_secrets` runs, it calls `args.func(args)` which is itself, recursing until Python raises `RecursionError`.

## Root Cause

argparse `set_defaults` on a parent parser propagates to child parsers that don't define their own default for the same key. The `onepassword` and `bitwarden` sub-subparsers had `func` set on their leaf commands (setup, status, token, etc.) but NOT on the parser itself. When no sub-subcommand is given, argparse applies the parent's `func=_dispatch_secrets` default.

## Changes

- `hermes_cli/main.py`: Set explicit `func` defaults on `secrets_bw` and `secrets_op` parsers that print help and return 0, preventing inheritance of `_dispatch_secrets` from the parent.

## Testing

```bash
# Before fix: RecursionError
hermes secrets onepassword  # maximum recursion depth exceeded

# After fix: prints help
hermes secrets onepassword  # shows onepassword subcommand help

# Subcommands still work normally
hermes secrets onepassword status  # shows 1Password status
hermes secrets op setup  # alias works too
```
