### PR TITLE
fix(desktop): reduce bot relay socket churn

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1381,7 +1381,10 @@ function handleSessionsGatewayTransition() {
 // Older backends without the RPCs fail per-call and are skipped — the
 // relay degrades to whatever subset of connections supports it.
 const RELAY_ROSTER_INTERVAL_MS = 60_000
-const RELAY_DRAIN_INTERVAL_MS = 4_000
+// Push notifications are the normal low-latency path. Keep polling as a
+// compatibility backstop for older gateways, but avoid opening a one-shot
+// secondary socket every few seconds when no envelope is pending.
+const RELAY_DRAIN_INTERVAL_MS = 30_000
 // Push path (#93091): the gateway broadcasts `bot_relay.outbox.pending` when
 // an envelope lands on disk; a burst of signals inside this window collapses
 // to ONE drain. The interval poll above stays as the backstop for older
@@ -1657,8 +1660,8 @@ function startBotRelay() {
 
   // Push path: the gateway change watcher broadcasts when an envelope hits
   // the outbox; drain immediately (debounced) instead of waiting the poll
-  // out. Feature-detected — older shells have no host.onEvent — and the 4s
-  // poll above stays untouched as the backstop either way.
+  // out. Feature-detected — older shells have no host.onEvent — and the 30s
+  // poll above stays as the compatibility backstop either way.
   if (relayPushUnsub === null && typeof host.onEvent === 'function') {
     relayPushUnsub = host.onEvent('bot_relay.outbox.pending', () => scheduleRelayPushDrain())
   }

--- a/apps/desktop/src/plugins/hermes-bots/tests/relay-push-drain.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/relay-push-drain.test.mjs
@@ -5,12 +5,12 @@ import vm from 'node:vm'
 
 // Push-notified relay drain (#93091, motivated by #92760 slow replies): the
 // gateway broadcasts `bot_relay.outbox.pending` when an envelope lands in the
-// outbox; the plugin drains immediately instead of waiting out the 4s poll.
+// outbox; the plugin drains immediately instead of waiting out the 30s poll.
 // Contracts:
 // - a burst of signals inside RELAY_PUSH_DEBOUNCE_MS collapses to ONE drain;
 // - after the debounce fires, a later signal schedules a fresh drain;
 // - the subscription is feature-detected (host.onEvent) and disposed, and the
-//   4s interval poll remains untouched as the backstop.
+//   30s interval poll remains as the compatibility backstop.
 
 const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
@@ -78,9 +78,9 @@ test('subscription is feature-detected, disposed, and the poll backstop stays', 
   const block = pluginSource.slice(start - 400, start + 400)
   assert.match(block, /typeof host\.onEvent === 'function'/)
   assert.match(pluginSource, /relayPushUnsub\(\)/)
-  // The 4s interval poll is untouched — push is an accelerator, not a
-  // replacement (older backends never emit the event).
-  assert.match(pluginSource, /RELAY_DRAIN_INTERVAL_MS = 4_000/)
+  // The 30s interval poll remains as a compatibility backstop — push is the
+  // low-latency path, while older backends never emit the event.
+  assert.match(pluginSource, /RELAY_DRAIN_INTERVAL_MS = 30_000/)
   assert.match(pluginSource, /setInterval\(\(\) => void drainRelayOutboxes\(\), RELAY_DRAIN_INTERVAL_MS\)/)
 })
 


### PR DESCRIPTION
## Summary

Fixes #93594. The bot-relay push notification is the low-latency path, but the 4-second polling loop opens a one-shot secondary WebSocket for every registered connection even when no envelope is pending.

Increase the compatibility backstop to 30 seconds. Push-capable gateways still drain after the existing debounce window, while older gateways and missed events retain periodic recovery. This substantially reduces idle handshake and gateway log churn without changing delivery behavior or retaining sockets past their normal request lifecycle.

## Tests

- `node --test apps/desktop/src/plugins/hermes-bots/tests/relay-push-drain.test.mjs`
- `git diff --check`

All focused checks pass.