### PR TITLE
fix(desktop): SkillsView tests no longer cascade-fail on slow CI runners

### DIFF
--- a/apps/desktop/src/app/skills/index.test.tsx
+++ b/apps/desktop/src/app/skills/index.test.tsx
@@ -104,7 +104,12 @@ afterEach(() => {
   queryClient.clear()
 })
 
-describe('SkillsView toolset management', () => {
+// SkillsView is a heavy module: the first test pays the whole dynamic-import
+// cost, and the file legitimately runs ~14s on CI runners — right against the
+// global 15s per-test budget, so slow runners cascade-fail all 11 tests
+// (2× in a row on PR #93612, plus a main run the same hour). Give this file
+// headroom; the tests are not slow individually.
+describe('SkillsView toolset management', { timeout: 60_000 }, () => {
   it('renders a switch for each toolset and toggles it off', async () => {
     await renderSkills()
 


### PR DESCRIPTION
## Summary

SkillsView desktop tests no longer cascade-fail on slow CI runners.

`src/app/skills/index.test.tsx` legitimately runs ~14s on CI (the first test pays the whole heavy dynamic import), brushing the global 15s per-test budget. A slow runner tips the first test over and cascade-fails all 11 tests in the file. This hit twice in a row on PR #93612 and a `main` run in the same hour — none of them touching SkillsView.

## Changes

- `apps/desktop/src/app/skills/index.test.tsx`: describe-level `{ timeout: 60_000 }` with a comment explaining why. No test logic changed.

## Validation

| Check | Result |
|---|---|
| `npx vitest run src/app/skills/index.test.tsx` | 11/11 pass (~3.5s locally) |
| Sabotage run (`timeout: 1`) | all 11 fail — option is honored |
| Restored (`timeout: 60_000`) | all 11 pass |

## Infographic

![Flaky test gets a real time budget](https://v3b.fal.media/files/b/0aa79870/-9njM2YDJwJ6da1OFgLev_yRpxKqpn.png)
