### PR TITLE
fix(display): don't flag null-valued error keys as tool failures

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -1332,6 +1332,14 @@ def _trim_error(msg: str) -> str:
     return msg
 
 
+# Null/empty-valued "error"/"failed" keys inside JSON payloads are part of
+# normal success shapes (web_extract, crawl results), not failures.
+_JSON_NULLISH_ERROR_RE = re.compile(
+    r'"((?:error|failed))"\s*:\s*(?:null|""|\[\]|\{\}|false)(?=[\s,}\]\)]|$)',
+    re.IGNORECASE,
+)
+
+
 def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]:
     """Inspect a tool result string for signs of failure.
 
@@ -1376,6 +1384,11 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
     if not isinstance(result, str):
         return False, ""
     lower = result[:500].lower()
+    # Success payloads often carry null-valued "error"/"failed" keys
+    # (e.g. web_extract emits {"results": [{"url": ..., "error": null}, ...]}
+    # per entry even when every URL succeeded). Neutralise the nullish
+    # forms before the substring scan so they are not misread as failures.
+    lower = _JSON_NULLISH_ERROR_RE.sub(r"\1_present", lower)
     if '"error"' in lower or '"failed"' in lower or result.startswith("Error"):
         return True, " [error]"
 

--- a/tests/agent/test_display_tool_failure_nullish.py
+++ b/tests/agent/test_display_tool_failure_nullish.py
@@ -1,0 +1,72 @@
+"""Regression tests: null-valued "error"/"failed" keys are not tool failures."""
+
+import json
+
+from agent.display import _detect_tool_failure
+
+
+class TestDetectToolFailureNullishErrorKeys:
+    """Null-valued "error"/"failed" keys in success payloads are not failures."""
+
+    def test_nested_null_error_key_not_flagged(self):
+        # web_extract success shape: every entry carries "error": null even
+        # when the extraction succeeded.
+        result = json.dumps(
+            {
+                "results": [
+                    {
+                        "url": "https://example.com",
+                        "title": "Example Domain",
+                        "content": "# Example Domain",
+                        "error": None,
+                    }
+                ]
+            }
+        )
+        assert _detect_tool_failure("web_extract", result) == (False, "")
+
+    def test_nested_empty_string_error_not_flagged(self):
+        result = json.dumps({"results": [{"url": "https://example.com", "error": ""}]})
+        assert _detect_tool_failure("web_extract", result) == (False, "")
+
+    def test_failed_false_not_flagged(self):
+        result = json.dumps({"attempts": 1, "failed": False, "content": "ok"})
+        assert _detect_tool_failure("some_tool", result) == (False, "")
+
+    def test_null_error_key_with_spaces_not_flagged(self):
+        result = '{"results": [{"url": "https://example.com", "error" : null}]}'
+        assert _detect_tool_failure("web_extract", result) == (False, "")
+
+    def test_real_nested_error_string_still_flagged(self):
+        result = json.dumps(
+            {"results": [{"url": "https://blocked.example", "error": "HTTP 500"}]}
+        )
+        is_failure, suffix = _detect_tool_failure("web_extract", result)
+        assert is_failure is True
+        assert suffix == " [error]"
+
+    def test_failed_true_still_flagged(self):
+        result = json.dumps({"failed": True, "content": ""})
+        assert _detect_tool_failure("some_tool", result) == (True, " [error]")
+
+    def test_empty_error_array_not_flagged(self):
+        result = json.dumps({"results": [{"url": "https://example.com", "error": []}]})
+        assert _detect_tool_failure("web_extract", result) == (False, "")
+
+    def test_empty_error_object_not_flagged(self):
+        result = json.dumps({"results": [{"url": "https://example.com", "error": {}}]})
+        assert _detect_tool_failure("web_extract", result) == (False, "")
+
+    def test_nested_structured_error_object_still_flagged(self):
+        result = json.dumps(
+            {"results": [{"url": "https://x.example", "error": {"code": 500}}]}
+        )
+        is_failure, suffix = _detect_tool_failure("web_extract", result)
+        assert is_failure is True
+        assert suffix == " [error]"
+
+    def test_nullish_prefix_word_continuation_not_masked(self):
+        # Not valid JSON, but the heuristic must not strip a partial match:
+        # "nullPointerException" is not the nullish "null" value.
+        result = '{"results": [{"url": "u", "error": nullPointerException}]}'
+        assert _detect_tool_failure("web_extract", result) == (True, " [error]")


### PR DESCRIPTION
## Problem

`_detect_tool_failure`'s generic fallback flags any tool result whose first
500 characters contain the literal `"error"` or `"failed"`. Success payloads
routinely carry null-valued keys with those exact names - `web_extract` emits
`{"results": [{"url": ..., "error": null}, ...]}` per entry even when every
URL extracted cleanly, and crawl/API results include `"failed": false`.

Consequence beyond a red line in the UI: `is_failure` feeds the tool-guardrail
`after_call(failed=...)` counters, so every successful extraction increments
the same-tool failure count. Guardrails then inject false "web_extract has
failed N times" warnings mid-turn and can hard-stop a working tool path
(`same_tool_failure_halt`). Reproduced live: a clean extraction logged
"Tool web_extract returned error" and bumped the failure counters.

## Fix

Neutralise nullish forms (`null`, `""`, `[]`, `{}`, `false`) of
`"error"`/`"failed"` keys before the substring scan, with a terminator
lookahead so partial matches (e.g. `"error": nullPointerException` in log
text) are not masked. Real error values (strings, `true`) still match and are
still flagged.

## Changes

- `agent/display.py`: add `_JSON_NULLISH_ERROR_RE` (key-name capture group,
  nullish value alternatives with a terminator lookahead, IGNORECASE) and
  apply it to the lowercased prefix in the generic heuristic.
- `tests/agent/test_display_tool_failure_nullish.py`: 10 regression tests -
  null / empty-string / spaced-null / `failed: false` / empty `[]` / empty
  `{}` not flagged; real error string, `failed: true`, nested structured
  error object, and word-continuation text still flagged.

## Verification

- 21/21 tests pass (11 pre-existing in `test_display_tool_failure.py` + 10 new).
- Sanity against real payloads: successful web_extract result -> `(False, "")`,
  failed extraction -> `(True, " [error]")`.

## Notes

- The structured-JSON branch above the heuristic already requires a truthy
  top-level `error`/`message`, so no change there.
- Terminal/memory branches untouched.
- Accepted narrowing: `{"ok": false, "error": null}` was previously flagged
  only by luck; a null-valued error key carries no failure information.
