### PR TITLE
fix(desktop): remote reconnect can't latch frozen after a liveness trip (#93454, salvage #93476, prior art #40008)

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -479,6 +479,48 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect(callCount).toBeGreaterThanOrEqual(3)
   })
 
+  it('a revalidateConnection() that hangs on reconnect does not permanently latch the backoff loop (#93454)', async () => {
+    // Same failure mode as the getConnection() repro above, but for the OTHER
+    // unbounded IPC await in the same try block: a wedged revalidation after a
+    // liveness-probe trip (the PR's own named trigger) must also unlatch.
+    const desktop = fakeDesktop()
+    let revalidateCallCount = 0
+
+    desktop.revalidateConnection = vi.fn(() => {
+      revalidateCallCount += 1
+
+      // Every reconnect attempt after the drop hangs indefinitely; getConnection
+      // itself stays fast so this isolates the revalidate call specifically.
+      return new Promise(() => undefined)
+    })
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+    const callsBeforeDrop = desktop.getConnection.mock.calls.length
+
+    act(() => FakeWebSocket.instances[0].drop())
+    await advanceBackoff()
+
+    expect(revalidateCallCount).toBe(1)
+    expect($gatewayState.get()).not.toBe('open')
+    // Still stuck behind the hung revalidate — execution never reached
+    // getConnection() at all.
+    expect(desktop.getConnection.mock.calls.length).toBe(callsBeforeDrop)
+
+    // Advance past the internal reconnect-attempt timeout (20s) — the stalled
+    // revalidate await must reject (swallowed, as it always was for a genuine
+    // rejection) so execution proceeds to getConnection() and the socket
+    // reopens, instead of latching on the still-pending revalidate forever.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000)
+    })
+
+    expect(desktop.getConnection.mock.calls.length).toBeGreaterThan(callsBeforeDrop)
+    expect($gatewayState.get()).toBe('open')
+  })
+
   it('rebinds Bot tabs owned by the restarted primary without touching another gateway', async () => {
     render(<Harness />)
     await flushAsync()

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -435,6 +435,50 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect($desktopBoot.get().error).toBeNull()
   })
 
+  it('a getConnection() that hangs on reconnect does not permanently latch the backoff loop (#93454)', async () => {
+    // Repro: a remote gateway drops, the backoff loop kicks off a reconnect,
+    // and the IPC round-trip into main (desktop.getConnection) never settles
+    // — e.g. a wedged revalidation after a liveness-probe trip, even though
+    // the backend itself answers fine. Without an internal timeout on that
+    // await, `reconnecting` never clears and every later
+    // scheduleReconnect()/attemptReconnect() early-returns forever, so the UI
+    // stays stuck until the app is restarted.
+    const desktop = fakeDesktop()
+    const originalGetConnection = desktop.getConnection
+    let callCount = 0
+
+    desktop.getConnection = vi.fn((profile?: null | string) => {
+      callCount += 1
+
+      // The initial boot call succeeds; every reconnect attempt after the
+      // drop hangs indefinitely.
+      return callCount === 1 ? originalGetConnection(profile) : new Promise(() => undefined)
+    })
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+    expect(callCount).toBe(1)
+
+    act(() => FakeWebSocket.instances[0].drop())
+    await advanceBackoff()
+
+    expect(callCount).toBe(2)
+    expect($gatewayState.get()).not.toBe('open')
+
+    // Advance past the internal reconnect-attempt timeout (20s) — the stalled
+    // await must reject so the `reconnecting` guard clears and the backoff
+    // loop schedules another attempt, instead of latching forever on the
+    // still-pending first hang.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000)
+    })
+    await advanceBackoff()
+
+    expect(callCount).toBeGreaterThanOrEqual(3)
+  })
+
   it('rebinds Bot tabs owned by the restarted primary without touching another gateway', async () => {
     render(<Harness />)
     await flushAsync()

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -89,6 +89,35 @@ const BOOT_RETRY_MAX_ATTEMPTS = 5
 // loop's 300ms: each attempt may rebuild an SSH master + remote dashboard.
 const BOOT_RETRY_BASE_DELAY_MS = 2_000
 
+// desktop.getConnection() / resolveGatewayWsUrl() are IPC round-trips into the
+// main process with no timeout of their own (#93454). A remote backend that
+// looks alive to a fresh probe but leaves the main-process reconnect path
+// stuck (e.g. a wedged revalidation after a liveness-probe trip) hangs these
+// awaits forever. While either is pending, `reconnecting` never clears, so
+// scheduleReconnect()/attemptReconnect() early-return permanently and the
+// backoff loop is latched — the UI stays "reconnecting" until the app is
+// restarted even though the gateway is reachable again. Bound both so a stall
+// rejects instead, letting the existing catch/finally clear the guard and
+// resume backoff. gateway.connect() already has its own connect timeout.
+const RECONNECT_ATTEMPT_TIMEOUT_MS = 20_000
+
+function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms)
+
+    promise.then(
+      value => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      err => {
+        clearTimeout(timer)
+        reject(err)
+      }
+    )
+  })
+}
+
 /** Registry identity whose runtimes died with the primary connection. */
 export function primaryRuntimeConnectionId(connection: Pick<HermesConnection, 'connectionId' | 'mode'>): null | string {
   const connectionId = connection.connectionId?.trim()
@@ -233,7 +262,11 @@ export function useGatewayBoot({
         // (same as boot/softSwitch). Passing $activeGatewayProfile would retarget
         // this primary socket at a secondary profile's backend after a live swap.
         // Secondaries reconnect via reconnectSecondaryGateways().
-        const conn = await desktop.getConnection()
+        const conn = await withTimeout(
+          desktop.getConnection(),
+          RECONNECT_ATTEMPT_TIMEOUT_MS,
+          'Timed out reconnecting to Hermes backend'
+        )
 
         if (cancelled) {
           return
@@ -254,7 +287,12 @@ export function useGatewayBoot({
         // explicit auth rejection asks for sign-in; transport failures stay in
         // this reconnect loop. For local/token gateways the URL carries a
         // long-lived token and the re-mint is a cheap no-op.
-        const wsUrl = await resolveGatewayWsUrl(desktop, conn)
+        const wsUrl = await withTimeout(
+          resolveGatewayWsUrl(desktop, conn),
+          RECONNECT_ATTEMPT_TIMEOUT_MS,
+          'Timed out re-minting the gateway WebSocket URL'
+        )
+
         await gateway.connect(wsUrl)
 
         if (cancelled) {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -473,7 +473,13 @@ export function useGatewayBoot({
         }
 
         publish(conn)
-        const wsUrl = await resolveGatewayWsUrl(desktop, conn)
+        // Bounded for the same reason as attemptReconnect() (#93454): a wedged
+        // ticket mint would otherwise hang the gateway switch forever.
+        const wsUrl = await withTimeout(
+          resolveGatewayWsUrl(desktop, conn),
+          RECONNECT_ATTEMPT_TIMEOUT_MS,
+          'Timed out re-minting the gateway WebSocket URL'
+        )
         await gateway.connect(wsUrl)
 
         if (cancelled) {
@@ -758,8 +764,14 @@ export function useGatewayBoot({
         // ticket is single-use with a short TTL, so the ticket baked into
         // conn.wsUrl is stale; resolveGatewayWsUrl() re-mints it rather than
         // connecting with a dead ticket. Auth rejection asks for sign-in;
-        // connectivity failures remain retryable.
-        const wsUrl = await resolveGatewayWsUrl(desktop, conn)
+        // connectivity failures remain retryable. Bounded like the reconnect
+        // path (#93454) so a wedged mint fails into boot retry instead of
+        // hanging "Starting Hermes…" forever.
+        const wsUrl = await withTimeout(
+          resolveGatewayWsUrl(desktop, conn),
+          RECONNECT_ATTEMPT_TIMEOUT_MS,
+          'Timed out minting the gateway WebSocket URL'
+        )
         await gateway.connect(wsUrl)
 
         if (cancelled) {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -89,16 +89,17 @@ const BOOT_RETRY_MAX_ATTEMPTS = 5
 // loop's 300ms: each attempt may rebuild an SSH master + remote dashboard.
 const BOOT_RETRY_BASE_DELAY_MS = 2_000
 
-// desktop.getConnection() / resolveGatewayWsUrl() are IPC round-trips into the
-// main process with no timeout of their own (#93454). A remote backend that
-// looks alive to a fresh probe but leaves the main-process reconnect path
-// stuck (e.g. a wedged revalidation after a liveness-probe trip) hangs these
-// awaits forever. While either is pending, `reconnecting` never clears, so
-// scheduleReconnect()/attemptReconnect() early-return permanently and the
-// backoff loop is latched — the UI stays "reconnecting" until the app is
-// restarted even though the gateway is reachable again. Bound both so a stall
-// rejects instead, letting the existing catch/finally clear the guard and
-// resume backoff. gateway.connect() already has its own connect timeout.
+// desktop.revalidateConnection() / getConnection() / resolveGatewayWsUrl() are
+// IPC round-trips into the main process with no timeout of their own (#93454).
+// A remote backend that looks alive to a fresh probe but leaves the
+// main-process reconnect path stuck (e.g. a wedged revalidation after a
+// liveness-probe trip) hangs these awaits forever. While any is pending,
+// `reconnecting` never clears, so scheduleReconnect()/attemptReconnect()
+// early-return permanently and the backoff loop is latched — the UI stays
+// "reconnecting" until the app is restarted even though the gateway is
+// reachable again. Bound all three so a stall rejects instead, letting the
+// existing catch/finally clear the guard and resume backoff. gateway.connect()
+// already has its own connect timeout.
 const RECONNECT_ATTEMPT_TIMEOUT_MS = 20_000
 
 function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
@@ -256,7 +257,13 @@ export function useGatewayBoot({
         // whose 'exit' would clear the main process's cached descriptor — without
         // this the renderer re-dials the same dead endpoint forever and stays on
         // "Starting Hermes…". The probe is a no-op for a healthy or local backend.
-        await desktop.revalidateConnection?.().catch(() => undefined)
+        // Bounded like the two awaits below: a wedged revalidation (#93454) is
+        // the specific hang this loop must survive, not just a rejection.
+        await withTimeout(
+          desktop.revalidateConnection?.() ?? Promise.resolve(),
+          RECONNECT_ATTEMPT_TIMEOUT_MS,
+          'Timed out revalidating the gateway connection'
+        ).catch(() => undefined)
 
         // Primary sleep/wake reconnect must dial the WINDOW-owned primary backend
         // (same as boot/softSwitch). Passing $activeGatewayProfile would retarget


### PR DESCRIPTION
## Summary
The desktop no longer freezes on "Connecting to remote Hermes backend…" forever after a liveness-probe trip — one stuck IPC round-trip used to latch the reconnect loop permanently, requiring an app restart. Fixes #93454.

## Changes
- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts`: all three reconnect awaits (`revalidateConnection`, `getConnection`, `resolveGatewayWsUrl`) are timeout-bounded; on timeout `reconnecting` clears and the existing backoff loop resumes
- Sibling unbounded `resolveGatewayWsUrl` awaits on the boot and gateway-switch paths bounded too (follow-up commit)

## Validation
| | Before | After |
|---|---|---|
| Stuck IPC during reconnect | loop latched forever, restart required | timeout → backoff retries |
| Tests | — | 21/21 (use-gateway-boot suite incl. new bounded-await tests) |

Salvaged from #93476 (@chelsealong), authorship preserved. Prior art: the same fix shape was first proposed in #40008 by @victorftrdba (closed unmerged, June 2026) — credited here.

## Infographic

![Bounded reconnect](https://v3b.fal.media/files/b/0aa79890/huc5rIiG5WrnBSSbisDay_XGTTZMJv.png)
