### PR TITLE
fix(agent): honor auxiliary.fallback_chain in review forks

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -27,6 +27,7 @@ import threading
 from typing import Any, Dict, List, Optional
 
 from agent.thread_scoped_output import thread_scoped_silence
+from hermes_cli.fallback_config import resolve_aux_task_fallback_chain
 
 logger = logging.getLogger(__name__)
 
@@ -1240,6 +1241,17 @@ def _run_review_in_thread(
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                 skip_memory=True,
+                # The review fork fails over through run_conversation()'s
+                # _try_activate_fallback(), which only consults
+                # _fallback_chain — built from this argument. Without it a
+                # configured auxiliary.background_review.fallback_chain was
+                # silently ignored and the review died with its primary
+                # (#93592). Per-task entries first, top-level chain as the
+                # last-resort safety net.
+                fallback_model=(
+                    resolve_aux_task_fallback_chain("background_review")
+                    or None
+                ),
                 **_fork_kwargs,
             )
             review_agent._memory_write_origin = "background_review"

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set
 
 from hermes_constants import get_hermes_home
+from hermes_cli.fallback_config import resolve_aux_task_fallback_chain
 from tools import skill_usage
 from utils import atomic_json_write
 
@@ -1937,6 +1938,15 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
             api_mode=_api_mode,
             credential_pool=_credential_pool,
             request_overrides=_request_overrides,
+            # The curator fork fails over through run_conversation()'s
+            # _try_activate_fallback(), which only consults _fallback_chain
+            # — built from this argument. Without it a configured
+            # auxiliary.curator.fallback_chain was silently ignored and the
+            # curation pass died with its primary (#78371). Per-task entries
+            # first, top-level chain as the last-resort safety net.
+            fallback_model=(
+                resolve_aux_task_fallback_chain("curator") or None
+            ),
             **_agent_kwargs,
             enabled_toolsets=["skills", "terminal"],
             # Umbrella-building over a large skill collection is worth a

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 def _normalized_base_url(value: Any) -> str:
@@ -99,3 +102,109 @@ def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
             chain.append(entry)
 
     return chain
+
+
+def _normalize_aux_fallback_entries(raw: Any) -> list[dict[str, Any]]:
+    """Normalize raw ``auxiliary.<task>.fallback_chain`` entries.
+
+    The per-task chain format mirrors the top-level one, but the aux
+    resolvers historically accepted looser shapes. Normalize to the exact
+    contract ``agent_init`` expects for ``fallback_model`` list entries
+    (non-empty string ``provider`` + non-empty ``model``, optional
+    ``base_url`` / ``api_mode`` / ``key_env``), dropping invalid entries
+    instead of failing the whole chain.
+    """
+    if isinstance(raw, dict):
+        candidates = [raw]
+    elif isinstance(raw, list):
+        candidates = raw
+    else:
+        return []
+    entries: list[dict[str, Any]] = []
+    for entry in candidates:
+        if not isinstance(entry, dict):
+            continue
+        provider = str(entry.get("provider") or "").strip()
+        model = str(entry.get("model") or "").strip()
+        if not provider or not model:
+            continue
+        normalized = dict(entry)
+        normalized["provider"] = provider
+        normalized["model"] = model
+        base_url = _normalized_base_url(entry.get("base_url"))
+        if base_url:
+            normalized["base_url"] = base_url
+        # Parity with the call_llm fallback path (_resolve_fallback_entry,
+        # auxiliary_client.py): entries may declare the wire format as
+        # ``transport``, but the conversation-loop failover consumer
+        # (_try_activate_fallback) reads only ``api_mode`` — alias it so
+        # both paths honor either spelling.
+        if not str(normalized.get("api_mode") or "").strip():
+            transport = str(entry.get("transport") or "").strip()
+            if transport:
+                normalized["api_mode"] = transport
+        entries.append(normalized)
+    return entries
+
+
+def _dedupe_aux_by_backend_identity(
+    entries: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Drop later entries that resolve to an earlier backend identity."""
+    seen: set[tuple[str, str, str]] = set()
+    out: list[dict[str, Any]] = []
+    for entry in entries:
+        key = (
+            entry["provider"].lower(),
+            entry["model"].lower(),
+            str(entry.get("base_url") or "").lower(),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(entry)
+    return out
+
+
+def resolve_aux_task_fallback_chain(
+    task: str,
+    config: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Effective fallback chain for an ``AIAgent``-fork auxiliary review task.
+
+    Review forks spawned by background_review (#93592) and the curator pass
+    (#78371) run through ``run_conversation()``, whose failover consults only
+    the constructor-provided chain. This builds it: per-task
+    ``auxiliary.<task>.fallback_chain`` entries first, then the top-level
+    chain (:func:`get_fallback_chain`) as the last-resort safety net —
+    mirroring how ``call_llm``-based aux tasks layer their chains.
+    Duplicates across both sources are dropped by backend identity
+    (provider+model+base_url). Returns fresh dicts; safe against a shared
+    cached config object.
+
+    Plugin-registered task default layering (``_get_auxiliary_task_config``
+    in agent/auxiliary_client.py) is intentionally not applied: both
+    consumers are built-in tasks, and importing the auxiliary client from
+    this low-level module would add a heavy import edge for no behavioral
+    change.
+    """
+    cfg = config
+    if cfg is None:
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            cfg = load_config_readonly()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("aux fallback-chain read failed (%s); empty chain", exc)
+            return []
+
+    aux = cfg.get("auxiliary", {}) if isinstance(cfg.get("auxiliary"), dict) else {}
+    task_cfg = aux.get(task, {}) if isinstance(aux.get(task), dict) else {}
+    chain: list[dict[str, Any]] = []
+    chain.extend(_normalize_aux_fallback_entries(task_cfg.get("fallback_chain")))
+    try:
+        chain.extend(get_fallback_chain(cfg))
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("top-level fallback chain read failed (%s)", exc)
+
+    return _dedupe_aux_by_backend_identity(chain)

--- a/tests/agent/test_aux_review_fallback_chain.py
+++ b/tests/agent/test_aux_review_fallback_chain.py
@@ -1,0 +1,291 @@
+"""Regression tests: auxiliary review forks must honor configured fallback chains.
+
+``_run_review_in_thread()`` (background_review) and ``_run_llm_review()``
+(curator) spawn forked ``AIAgent`` objects whose failover runs through
+``run_conversation()`` → ``_try_activate_fallback()``, which consults only
+``agent._fallback_chain`` — built from the constructor's ``fallback_model``
+argument. Neither fork passed one, so ``auxiliary.<task>.fallback_chain``
+was silently ignored and a primary-provider failure killed the whole review
+with zero fallback attempts (#93592 background_review, #78371 curator).
+
+What these tests pin down:
+
+A. The chain resolver returns per-task entries first, then the top-level
+   chain as safety net, deduplicated by backend identity.
+B. The background-review fork is CONSTRUCTED with that chain (wiring).
+C. The curator fork is CONSTRUCTED with its own chain (wiring).
+
+Construction-time wiring is asserted through a fake agent class because the
+fork's post-construction flow (tool whitelist, usage accounting) is already
+covered by dedicated suites; here every fake method is inert by contract.
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+import sys
+import types
+
+import pytest
+
+REPO_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from hermes_cli.fallback_config import resolve_aux_task_fallback_chain
+
+
+def _entry(provider: str, model: str, **extra) -> dict:
+    out = {"provider": provider, "model": model}
+    out.update(extra)
+    return out
+
+
+def _patch_config(monkeypatch, cfg: dict) -> None:
+    """Route every ``load_config_readonly()`` call to an in-memory config."""
+    from hermes_cli import config as hermes_config
+
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config_readonly",
+        lambda: copy.deepcopy(cfg),
+    )
+
+
+# ---------------------------------------------------------------------------
+# A. resolve_aux_task_fallback_chain
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAuxTaskFallbackChain:
+    def test_task_entries_first_then_top_level(self):
+        cfg = {
+            "auxiliary": {
+                "background_review": {
+                    "fallback_chain": [_entry("custom:a", "model-a")]
+                }
+            },
+            "fallback_providers": [_entry("nous", "m1")],
+        }
+        chain = resolve_aux_task_fallback_chain("background_review", config=cfg)
+        assert [e["provider"] for e in chain] == ["custom:a", "nous"]
+
+    def test_deduplicates_by_backend_identity(self):
+        cfg = {
+            "auxiliary": {
+                "curator": {
+                    "fallback_chain": [_entry("nous", "m1")]
+                }
+            },
+            "fallback_providers": [
+                _entry("NOUS", "M1"),  # same identity, different case
+                _entry("cohere", "c1"),
+            ],
+        }
+        chain = resolve_aux_task_fallback_chain("curator", config=cfg)
+        assert [(e["provider"], e["model"]) for e in chain] == [
+            ("nous", "m1"),
+            ("cohere", "c1"),
+        ]
+
+    def test_invalid_entries_dropped_not_fatal(self):
+        cfg = {
+            "auxiliary": {
+                "background_review": {
+                    "fallback_chain": [
+                        "junk",
+                        {"provider": "x"},  # missing model
+                        _entry("ok", "fine"),
+                    ]
+                }
+            },
+        }
+        chain = resolve_aux_task_fallback_chain("background_review", config=cfg)
+        assert chain == [_entry("ok", "fine")]
+
+    def test_no_config_anywhere_yields_empty_list(self):
+        assert resolve_aux_task_fallback_chain("background_review", config={}) == []
+
+    def test_returns_fresh_dicts(self):
+        entry = _entry("nous", "m1")
+        cfg = {
+            "auxiliary": {"background_review": {"fallback_chain": [entry]}},
+        }
+        chain = resolve_aux_task_fallback_chain("background_review", config=cfg)
+        chain[0]["provider"] = "mutated"
+        assert entry["provider"] == "nous"
+
+    def test_entry_fields_survive_resolution(self):
+        cfg = {
+            "auxiliary": {
+                "background_review": {
+                    "fallback_chain": [
+                        _entry(
+                            "custom:x",
+                            "mx",
+                            base_url="https://api.x.com/v1/",
+                            key_env="X_API_KEY",
+                            transport="anthropic_messages",
+                        )
+                    ]
+                }
+            },
+        }
+        chain = resolve_aux_task_fallback_chain("background_review", config=cfg)
+        assert len(chain) == 1
+        got = chain[0]
+        # base_url normalized (trailing slash stripped), credentials and
+        # wire format preserved for the conversation-loop failover consumer.
+        assert got["base_url"] == "https://api.x.com/v1"
+        assert got["key_env"] == "X_API_KEY"
+        # ``transport`` is aliased to api_mode — the only spelling
+        # _try_activate_fallback reads.
+        assert got["api_mode"] == "anthropic_messages"
+
+
+# ---------------------------------------------------------------------------
+# B/C. Construction wiring for both forks
+# ---------------------------------------------------------------------------
+
+
+class _FakeReviewFork:
+    """Inert stand-in capturing constructor kwargs."""
+
+    def __init__(self, **kwargs):
+        self.constructor_kwargs = kwargs
+        self._memory_enabled = False
+        self._user_profile_enabled = False
+        self._session_messages = []
+
+    def run_conversation(self, *args, **kwargs):
+        return {"final_response": ""}
+
+    def shutdown_memory_provider(self):
+        pass
+
+    def close(self):
+        pass
+
+
+@pytest.fixture()
+def fake_fork(monkeypatch):
+    captured = {}
+
+    class _CapturingFork(_FakeReviewFork):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            captured.update(kwargs)
+
+    import run_agent
+
+    monkeypatch.setattr(run_agent, "AIAgent", _CapturingFork)
+    return captured
+
+
+def _fake_parent(**extra) -> types.SimpleNamespace:
+    base = dict(
+        model="parent-model",
+        provider="parent-prov",
+        platform="cli",
+        session_id="s-parent",
+        session_start="2026-08-24T00:00:00",
+        enabled_toolsets=None,
+        disabled_toolsets=None,
+        reasoning_config=None,
+        ephemeral_system_prompt=None,
+        prefill_messages=None,
+        memory_notifications="on",
+        cached_system_prompt=None,
+        _current_main_runtime=lambda: {},
+        _credential_pool=None,
+        request_overrides={},
+        _memory_store=None,
+        _cached_system_prompt=None,
+        # Memory/profile flags copied onto the fork after construction.
+        _memory_enabled=False,
+        _user_profile_enabled=False,
+        # User-facing surfaces the worker touches on completion paths.
+        background_review_callback=None,
+        _safe_print=lambda *args, **kwargs: None,
+        _emit_auxiliary_failure=lambda *args, **kwargs: None,
+    )
+    base.update(extra)
+    return types.SimpleNamespace(**base)
+
+
+class TestBackgroundReviewWiring:
+    def test_fork_constructed_with_configured_chain(self, tmp_path, monkeypatch, fake_fork):
+        # Same provider/model as the parent -> _resolve_review_runtime takes
+        # the non-routed shortcut and no real provider resolution happens.
+        task_block = {
+            "provider": "parent-prov",
+            "model": "parent-model",
+            "fallback_chain": [
+                _entry("working", "m1"),
+                _entry("backup", "m2"),
+            ],
+        }
+        _patch_config(monkeypatch, {"auxiliary": {"background_review": task_block}})
+
+        from agent.background_review import _run_review_in_thread
+
+        _run_review_in_thread(
+            _fake_parent(),
+            [{"role": "user", "content": "hi"}],
+            "review prompt",
+            task_cfg=task_block,
+        )
+        assert fake_fork["fallback_model"] == [
+            _entry("working", "m1"),
+            _entry("backup", "m2"),
+        ]
+
+    def test_fork_without_any_chain_gets_none(self, monkeypatch, fake_fork):
+        _patch_config(monkeypatch, {})
+        from agent.background_review import _run_review_in_thread
+
+        _run_review_in_thread(
+            _fake_parent(),
+            [{"role": "user", "content": "hi"}],
+            "p",
+            task_cfg={},
+        )
+        assert fake_fork["fallback_model"] is None
+
+
+class TestCuratorWiring:
+    def test_curator_fork_constructed_with_configured_chain(self, monkeypatch, fake_fork):
+        cfg = {
+            "model": {"provider": "nous", "default": "main-m"},
+            "auxiliary": {
+                "curator": {
+                    "fallback_chain": [_entry("working", "c1")],
+                }
+            },
+        }
+        _patch_config(monkeypatch, cfg)
+
+        from agent.curator import _run_llm_review
+
+        result = _run_llm_review("curator prompt")
+        assert fake_fork["fallback_model"] == [_entry("working", "c1")]
+        # With an inert fake fork the pass completes cleanly.
+        assert result["error"] is None
+
+
+class TestChainReadsLiveConfig:
+    def test_resolver_reads_live_config_when_none_passed(self, monkeypatch):
+        cfg = {
+            "auxiliary": {
+                "background_review": {
+                    "fallback_chain": [_entry("live", "l1")]
+                }
+            },
+        }
+        _patch_config(monkeypatch, cfg)
+        # No explicit config -> resolver loads through load_config_readonly().
+        chain = resolve_aux_task_fallback_chain("background_review")
+        assert chain == [_entry("live", "l1")]


### PR DESCRIPTION
## What does this PR do?

When `auxiliary.background_review.provider` fails, the per-task
`fallback_chain` configured under `auxiliary.background_review.fallback_chain`
is never consulted: the review retries its primary 3 times and then dies
silently with `calls=0`, even though working fallback entries are configured.

Root cause: `_run_review_in_thread()` spawns the review fork without a
`fallback_model` argument, so `agent._fallback_chain` starts empty and
`_try_activate_fallback()` gives up immediately. Every other auxiliary
sub-module goes through `call_llm()` (`_try_configured_fallback_chain`)
and honors its chain — the two `run_conversation()`-based forks were the
only ones that ignored it.

This wires both forks through the same layering the rest of the aux tasks
get: per-task `auxiliary.<task>.fallback_chain` entries first, then the
top-level chain as the last-resort safety net, deduplicated by backend
identity. The user-facing documentation already promises this behavior
("Each task can also declare its own `fallback_chain`"), and #78371
describes exactly this wiring for the curator.

## Related Issue

Fixes #93592
Fixes #78371

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/fallback_config.py`: add
  `resolve_aux_task_fallback_chain(task, config=None)` — builds the
  effective chain for an AIAgent-fork review task: normalized
  `auxiliary.<task>.fallback_chain` entries first, top-level chain
  (`get_fallback_chain`) appended as safety net, deduplicated by backend
  identity (provider+model+base_url). Entry normalization preserves
  `base_url`/`key_env`/`api_key` and aliases `transport` -> `api_mode`
  for parity with the `call_llm` fallback path, which accepts either
  spelling while `_try_activate_fallback()` only reads `api_mode`.
- `agent/background_review.py`: pass the resolved chain to the review
  fork's `AIAgent(...)` constructor as `fallback_model`.
- `agent/curator.py`: same wiring for the curation-pass fork.
- `tests/agent/test_aux_review_fallback_chain.py`: behavior-contract
  tests — task-first ordering, cross-source dedupe (case-insensitive),
  invalid-entry tolerance, fresh-dict guarantees, entry-field
  preservation, live-config resolution, and construction-time wiring of
  both forks.

Users with no `auxiliary.<task>.fallback_chain` and no top-level chain get
byte-identical behavior (empty chain -> `None` -> empty `_fallback_chain`,
as before).

## How to Test

1. Targeted suites (CI-parity wrapper):

       HERMES_PYTHON=$(which python3) scripts/run_tests.sh \
         tests/agent/test_aux_review_fallback_chain.py \
         tests/hermes_cli/test_fallback_config.py
   -> 15 passed.

2. Regression proof (fails on code before this PR): revert the two
   constructor hunks in `agent/background_review.py` / `agent/curator.py`
   — `TestBackgroundReviewWiring::*` and `TestCuratorWiring::*` fail;
   restore them and all pass.

3. Manual: configure `auxiliary.background_review.{provider,model}` pointing
   at a failing provider plus a working `fallback_chain` entry; trigger a
   background review. Before: `Background review complete: calls=0 ...
   result=none`. After: the loop walks the configured entries (and then the
   top-level chain) exactly like the main agent does.

Note on the full suite: on this host, `scripts/run_tests.sh` shows
environment-dependent failures unrelated to this change (terminal-width and
env-gate tests such as `tests/cli/test_prompt_stash_cli.py` and
`tests/hermes_cli/test_ignore_user_config_flags.py`). Both sets were
verified to fail identically on pristine `origin/main` without this branch
(via stash / scratch-worktree runs); every suite touching the modified
subsystems passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian GNU/Linux 13 (trixie), x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

(No new config keys and no behavior beyond what the existing fallback-providers
documentation already describes, so the documentation boxes are N/A.)

---

**🛠️ Dev:** Halldrix
**🤖 Sidekick:** Hermes Agent v0.20.5
**🐞 Reproduction:** ✅ Confirmed
