### PR TITLE
test(tui_gateway): isolate model options test from Anthropic OAuth

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -15492,6 +15492,10 @@ def test_model_options_preserves_canonical_custom_row_after_agent_init(monkeypat
         "hermes_cli.auth.is_provider_explicitly_configured",
         lambda _slug: False,
     )
+    monkeypatch.setattr(
+        "hermes_cli.inventory._anthropic_oauth_credentials_present",
+        lambda: False,
+    )
     monkeypatch.setattr("hermes_cli.inventory._apply_pricing", lambda *_args, **_kwargs: None)
     monkeypatch.setattr("hermes_cli.inventory._apply_capabilities", lambda *_args, **_kwargs: None)
 


### PR DESCRIPTION
## Summary

- isolate the custom-provider model-options test from ambient Anthropic OAuth credentials
- keep the test focused on preserving the canonical custom provider row after agent initialization

## Why

`test_model_options_preserves_canonical_custom_row_after_agent_init` already mocks `is_provider_explicitly_configured()` to return false, but the inventory path also treats Hermes or Claude Code OAuth credentials on the host as explicit Anthropic authentication. On a developer machine with those credentials, the test unexpectedly includes the Anthropic row and fails even though the behavior under test is unrelated.

## Test plan

```text
python -m pytest -q \
  tests/test_tui_gateway_server.py::test_model_options_preserves_canonical_custom_row_after_agent_init \
  tests/hermes_cli/test_inventory.py

19 passed
```
