### PR TITLE
fix(dev-sandbox): export npm_config_nodedir only when it survives the mount plan

### DIFF
--- a/scripts/sandbox/stage2-run.sh
+++ b/scripts/sandbox/stage2-run.sh
@@ -17,6 +17,31 @@
 
 set -euo pipefail
 
+# Does a nodedir resolved on the HOST still exist inside the mount plan built
+# below? Pure string logic over the plan's prefixes, kept free of filesystem
+# access so tests can source this file and table-test it (see the guard after
+# the definition). The caller still has to check the headers are really there.
+#
+#   nodedir_visible <dir> <use_host_runtime>
+#
+# /usr/local is never visible: the sandbox binds its own near-empty copy over
+# it in both modes. In nix mode only /nix is bound in; in host mode the
+# runtime prefixes /usr /bin /sbin /lib /lib64 are. The sandbox HOME is a
+# fresh directory ($DEV_SANDBOX_ROOT/home), NOT the host's, so a node under
+# ~/.nvm or similar is invisible inside no matter what it contains.
+nodedir_visible() {
+  case "$1" in
+    /usr/local|/usr/local/*) return 1 ;;
+    /nix|/nix/*) [ "$2" = false ] ;;
+    /usr|/usr/*|/bin|/bin/*|/sbin|/sbin/*|/lib|/lib/*|/lib64|/lib64/*)
+      [ "$2" = true ] ;;
+    *) return 1 ;;
+  esac
+}
+
+# Sourced (by the tests) rather than executed: expose the function and stop.
+[[ "${BASH_SOURCE[0]}" == "$0" ]] || return 0
+
 : "${DEV_SANDBOX_ROOT:?missing DEV_SANDBOX_ROOT}"
 : "${DEV_SANDBOX_BASH:?missing DEV_SANDBOX_BASH}"
 : "${DEV_SANDBOX_INTERACTIVE:?missing DEV_SANDBOX_INTERACTIVE}"
@@ -109,24 +134,17 @@ else
 fi
 
 # npm_config_nodedir points node-gyp at a Node install's bundled headers
-# (include/node/common.gypi). NODE_DIR was resolved on the HOST, and most host
-# paths do not survive the mount plan above: /usr/local is always shadowed by
-# the sandbox's own near-empty copy, and anything outside the mounted runtime
-# prefixes (/nix, or /usr /bin /sbin /lib /lib64) does not exist inside at
-# all. A nodedir that is empty inside the sandbox breaks every node-gyp build
+# (include/node/common.gypi). NODE_DIR was resolved on the HOST by stage 1
+# (dev-sandbox.sh, from `command -v node`), and most host paths do not
+# survive the mount plan above -- nodedir_visible (top of this file) encodes
+# which ones do, keyed on the USE_HOST_RUNTIME decision made just above. A
+# nodedir that is empty inside the sandbox breaks every node-gyp build
 # ("gyp: <nodedir>/common.gypi not found" while compiling node-pty), whereas
 # with no nodedir node-gyp fetches version-matched headers through the proxy
 # -- exactly what a real install does. So pass the nodedir through only when
 # the directory is visible inside the sandbox and really contains the headers.
-nodedir_visible=false
-case "${DEV_SANDBOX_NODE_DIR:-}" in
-  '') ;;
-  /usr/local|/usr/local/*) ;;
-  /nix|/nix/*) [ "$USE_HOST_RUNTIME" = false ] && nodedir_visible=true ;;
-  /usr|/usr/*|/bin|/bin/*|/sbin|/sbin/*|/lib|/lib/*|/lib64|/lib64/*)
-    [ "$USE_HOST_RUNTIME" = true ] && nodedir_visible=true ;;
-esac
-if [ "$nodedir_visible" = true ] \
+if [ -n "${DEV_SANDBOX_NODE_DIR:-}" ] \
+  && nodedir_visible "$DEV_SANDBOX_NODE_DIR" "$USE_HOST_RUNTIME" \
   && [ -f "$DEV_SANDBOX_NODE_DIR/include/node/common.gypi" ]; then
   node_env+=(--setenv npm_config_nodedir "$DEV_SANDBOX_NODE_DIR")
 fi

--- a/scripts/sandbox/stage2-run.sh
+++ b/scripts/sandbox/stage2-run.sh
@@ -48,9 +48,6 @@ fi
 home_mounts+=(--bind "$DEV_SANDBOX_ROOT/home" "$DEV_SANDBOX_HOME")
 
 node_env=()
-if [ -n "${DEV_SANDBOX_NODE_DIR:-}" ]; then
-  node_env+=(--setenv npm_config_nodedir "$DEV_SANDBOX_NODE_DIR")
-fi
 electron_env=()
 if [ -n "${DEV_SANDBOX_ELECTRON_LD_LIBRARY_PATH:-}" ]; then
   electron_env+=(
@@ -109,6 +106,29 @@ else
   # The git-upload-pack shim standing in for github.com is the only file that
   # must beat the host's copy; sh/ls/env are already there for real.
   shim_mounts+=(--bind "$DEV_SANDBOX_ROOT/root/usr/bin/ssh" /usr/bin/ssh)
+fi
+
+# npm_config_nodedir points node-gyp at a Node install's bundled headers
+# (include/node/common.gypi). NODE_DIR was resolved on the HOST, and most host
+# paths do not survive the mount plan above: /usr/local is always shadowed by
+# the sandbox's own near-empty copy, and anything outside the mounted runtime
+# prefixes (/nix, or /usr /bin /sbin /lib /lib64) does not exist inside at
+# all. A nodedir that is empty inside the sandbox breaks every node-gyp build
+# ("gyp: <nodedir>/common.gypi not found" while compiling node-pty), whereas
+# with no nodedir node-gyp fetches version-matched headers through the proxy
+# -- exactly what a real install does. So pass the nodedir through only when
+# the directory is visible inside the sandbox and really contains the headers.
+nodedir_visible=false
+case "${DEV_SANDBOX_NODE_DIR:-}" in
+  '') ;;
+  /usr/local|/usr/local/*) ;;
+  /nix|/nix/*) [ "$USE_HOST_RUNTIME" = false ] && nodedir_visible=true ;;
+  /usr|/usr/*|/bin|/bin/*|/sbin|/sbin/*|/lib|/lib/*|/lib64|/lib64/*)
+    [ "$USE_HOST_RUNTIME" = true ] && nodedir_visible=true ;;
+esac
+if [ "$nodedir_visible" = true ] \
+  && [ -f "$DEV_SANDBOX_NODE_DIR/include/node/common.gypi" ]; then
+  node_env+=(--setenv npm_config_nodedir "$DEV_SANDBOX_NODE_DIR")
 fi
 
 # /etc: start from a copy of the host's and overwrite only the files we fake.

--- a/tests/test_sandbox_stage2_nodedir.py
+++ b/tests/test_sandbox_stage2_nodedir.py
@@ -16,8 +16,11 @@ version-matched headers through the sandbox proxy -- what a real install
 does -- so the fix is to pass the nodedir through only when the directory
 is actually visible inside the sandbox and contains the bundled headers.
 
-These tests drive the real stage2-run.sh with a fake ``bwrap`` on PATH that
-records its argv, and assert on the --setenv plan it would have executed.
+The visibility decision itself is a pure function (``nodedir_visible``) at
+the top of stage2-run.sh, table-tested here by sourcing the script. The
+end-to-end tests drive the real stage2-run.sh with a fake ``bwrap`` on PATH
+that records its argv, and assert on the --setenv plan it would have
+executed.
 """
 
 import os
@@ -32,7 +35,9 @@ STAGE2 = REPO_ROOT / "scripts" / "sandbox" / "stage2-run.sh"
 pytestmark = pytest.mark.linux_only
 
 
-def _run_stage2(tmp_path: Path, node_dir: str) -> tuple[list[str], subprocess.CompletedProcess]:
+def _run_stage2(
+    tmp_path: Path, node_dir: str
+) -> tuple[list[str], subprocess.CompletedProcess]:
     """Run stage2-run.sh against a minimal sandbox root and a fake bwrap.
 
     The fake bwrap dumps its argv (one arg per line) and exits, so the test
@@ -41,7 +46,16 @@ def _run_stage2(tmp_path: Path, node_dir: str) -> tuple[list[str], subprocess.Co
     """
     sandbox = tmp_path / "sandbox"
     root = sandbox / "root"
-    for sub in ("logs", "usr/local", "usr/bin", "bin", "lib64", "repo", "certs", "http"):
+    for sub in (
+        "logs",
+        "usr/local",
+        "usr/bin",
+        "bin",
+        "lib64",
+        "repo",
+        "certs",
+        "http",
+    ):
         (root / sub).mkdir(parents=True)
     # Non-empty ready file skips the wait for the (absent) network helper.
     (root / "logs" / "slirp.ready").write_text("1\n", encoding="utf-8")
@@ -91,6 +105,56 @@ def _nodedir_settings(argv: list[str]) -> list[str]:
     ]
 
 
+def _nodedir_visible(node_dir: str, use_host_runtime: bool) -> bool:
+    """Call stage2-run.sh's nodedir_visible without running stage 2."""
+    proc = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$1" && nodedir_visible "$2" "$3"',
+            "_",
+            str(STAGE2),
+            node_dir,
+            "true" if use_host_runtime else "false",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode in (0, 1), proc.stderr
+    return proc.returncode == 0
+
+
+@pytest.mark.parametrize(
+    ("node_dir", "host_runtime", "visible"),
+    [
+        # /usr/local: shadowed by the sandbox's own copy in both modes.
+        ("/usr/local", True, False),
+        ("/usr/local", False, False),
+        ("/usr/local/n/versions/22", True, False),
+        # Host mode ro-binds the runtime prefixes; nix mode does not.
+        ("/usr", True, True),
+        ("/usr/lib/node", True, True),
+        ("/usr", False, False),
+        # Nix mode binds /nix; host mode does not.
+        ("/nix/store/abc-nodejs-22", False, True),
+        ("/nix/store/abc-nodejs-22", True, False),
+        # Nothing binds the host HOME (the sandbox HOME is a fresh directory),
+        # hostedtoolcache, Homebrew, or a bare prefix that only shares a name.
+        ("/home/dev/.nvm/versions/node/v22.0.0", True, False),
+        ("/opt/hostedtoolcache/node/22.0.0/x64", True, False),
+        ("/home/linuxbrew/.linuxbrew", True, False),
+        ("/usrlocal", True, False),
+        ("/nixos", False, False),
+    ],
+)
+def test_nodedir_visible_table(
+    node_dir: str, host_runtime: bool, visible: bool
+) -> None:
+    """Both branches of the visibility decision, hermetically."""
+    assert _nodedir_visible(node_dir, host_runtime) is visible
+
+
 def test_usr_local_nodedir_is_dropped(tmp_path: Path) -> None:
     """/usr/local is always shadowed inside the sandbox; a host node living
     there (GitHub runners) must not become npm_config_nodedir."""
@@ -129,6 +193,10 @@ def test_empty_nodedir_stays_absent(tmp_path: Path) -> None:
 )
 def test_visible_nodedir_with_headers_is_kept(tmp_path: Path) -> None:
     """A distro node under /usr is ro-bound into the sandbox and its headers
-    are real: that nodedir must survive, preserving the offline build path."""
+    are real: that nodedir must survive, preserving the offline build path.
+
+    Opportunistic: needs root-owned headers, so it only runs on hosts that
+    have them. The keep branch of the decision itself is covered
+    hermetically by test_nodedir_visible_table; this proves the wiring."""
     argv, _ = _run_stage2(tmp_path, "/usr")
     assert _nodedir_settings(argv) == ["/usr"]

--- a/tests/test_sandbox_stage2_nodedir.py
+++ b/tests/test_sandbox_stage2_nodedir.py
@@ -1,0 +1,134 @@
+"""Regression tests for stage2-run.sh not exporting a dead npm_config_nodedir.
+
+stage 1 (dev-sandbox.sh) resolves NODE_DIR from the HOST's ``command -v
+node`` and stage 2 exported it as ``npm_config_nodedir`` unconditionally.
+But stage 2's own mount plan hides most host paths: /usr/local is always
+shadowed by the sandbox's near-empty copy, and anything outside the mounted
+runtime prefixes (/nix, or /usr /bin /sbin /lib /lib64) does not exist
+inside at all. On GitHub runners the host node is /usr/local/bin/node, so
+every node-gyp build inside the sandbox failed with
+
+    gyp: /usr/local/common.gypi not found (cwd: .../node_modules/node-pty)
+
+which kept the Install & Update E2E installer legs red (see the
+verification thread on #87635). With no nodedir at all, node-gyp downloads
+version-matched headers through the sandbox proxy -- what a real install
+does -- so the fix is to pass the nodedir through only when the directory
+is actually visible inside the sandbox and contains the bundled headers.
+
+These tests drive the real stage2-run.sh with a fake ``bwrap`` on PATH that
+records its argv, and assert on the --setenv plan it would have executed.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+STAGE2 = REPO_ROOT / "scripts" / "sandbox" / "stage2-run.sh"
+
+pytestmark = pytest.mark.linux_only
+
+
+def _run_stage2(tmp_path: Path, node_dir: str) -> tuple[list[str], subprocess.CompletedProcess]:
+    """Run stage2-run.sh against a minimal sandbox root and a fake bwrap.
+
+    The fake bwrap dumps its argv (one arg per line) and exits, so the test
+    observes exactly the mount/setenv plan stage 2 execs -- no namespaces,
+    no network, no real bubblewrap needed.
+    """
+    sandbox = tmp_path / "sandbox"
+    root = sandbox / "root"
+    for sub in ("logs", "usr/local", "usr/bin", "bin", "lib64", "repo", "certs", "http"):
+        (root / sub).mkdir(parents=True)
+    # Non-empty ready file skips the wait for the (absent) network helper.
+    (root / "logs" / "slirp.ready").write_text("1\n", encoding="utf-8")
+    (sandbox / "etc").mkdir()
+    (sandbox / "home").mkdir()
+
+    bindir = tmp_path / "fakebin"
+    bindir.mkdir()
+    argv_file = tmp_path / "bwrap-argv"
+    fake_bwrap = bindir / "bwrap"
+    fake_bwrap.write_text(
+        '#!/bin/sh\nprintf "%s\\n" "$@" > ' + str(argv_file) + "\nexit 0\n",
+        encoding="utf-8",
+    )
+    fake_bwrap.chmod(0o755)
+
+    env = {
+        "PATH": f"{bindir}:/usr/bin:/bin",
+        "HOME": str(tmp_path),
+        "DEV_SANDBOX_ROOT": str(sandbox),
+        "DEV_SANDBOX_BASH": "/usr/bin/bash",
+        "DEV_SANDBOX_INTERACTIVE": "false",
+        "DEV_SANDBOX_USER": "hermes",
+        "DEV_SANDBOX_HOME": "/home/hermes",
+        "DEV_SANDBOX_NODE_DIR": node_dir,
+    }
+    proc = subprocess.run(
+        ["bash", str(STAGE2), "true"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert argv_file.exists(), (
+        f"stage2-run.sh never reached its bwrap exec "
+        f"(rc={proc.returncode}):\n{proc.stderr}"
+    )
+    return argv_file.read_text(encoding="utf-8").splitlines(), proc
+
+
+def _nodedir_settings(argv: list[str]) -> list[str]:
+    """The values stage 2 planned to --setenv npm_config_nodedir to."""
+    return [
+        argv[i + 2]
+        for i, arg in enumerate(argv)
+        if arg == "--setenv" and argv[i + 1] == "npm_config_nodedir"
+    ]
+
+
+def test_usr_local_nodedir_is_dropped(tmp_path: Path) -> None:
+    """/usr/local is always shadowed inside the sandbox; a host node living
+    there (GitHub runners) must not become npm_config_nodedir."""
+    argv, _ = _run_stage2(tmp_path, "/usr/local")
+    assert _nodedir_settings(argv) == [], (
+        "stage 2 exported npm_config_nodedir=/usr/local, but the sandbox "
+        "bind-mounts its own near-empty directory over /usr/local -- inside, "
+        "node-gyp fails with 'gyp: /usr/local/common.gypi not found'"
+    )
+
+
+def test_unmounted_prefix_nodedir_is_dropped(tmp_path: Path) -> None:
+    """A host node outside the mounted runtime prefixes (nvm, Homebrew,
+    hostedtoolcache...) is invisible inside the sandbox, headers or not."""
+    fake_node = tmp_path / "node-install"
+    (fake_node / "include" / "node").mkdir(parents=True)
+    (fake_node / "include" / "node" / "common.gypi").write_text(
+        "{}\n", encoding="utf-8"
+    )
+    argv, _ = _run_stage2(tmp_path, str(fake_node))
+    assert _nodedir_settings(argv) == [], (
+        "stage 2 exported an npm_config_nodedir that no mount in its own "
+        "plan makes visible inside the sandbox"
+    )
+
+
+def test_empty_nodedir_stays_absent(tmp_path: Path) -> None:
+    """No host node resolved -> no nodedir, before and after the fix."""
+    argv, _ = _run_stage2(tmp_path, "")
+    assert _nodedir_settings(argv) == []
+
+
+@pytest.mark.skipif(
+    not os.path.isfile("/usr/include/node/common.gypi"),
+    reason="host has no node headers under /usr (libnode-dev not installed)",
+)
+def test_visible_nodedir_with_headers_is_kept(tmp_path: Path) -> None:
+    """A distro node under /usr is ro-bound into the sandbox and its headers
+    are real: that nodedir must survive, preserving the offline build path."""
+    argv, _ = _run_stage2(tmp_path, "/usr")
+    assert _nodedir_settings(argv) == ["/usr"]


### PR DESCRIPTION
## What does this PR do?

Stops `stage2-run.sh` from exporting an `npm_config_nodedir` that is dead inside the sandbox.

Stage 1 resolves `NODE_DIR` from the **host's** `command -v node`; stage 2 exported it unconditionally. But stage 2's own mount plan hides most host paths — `/usr/local` is always shadowed by the sandbox's near-empty copy, and anything outside the mounted runtime prefixes (`/nix`, or `/usr /bin /sbin /lib /lib64`) doesn't exist inside at all. On GitHub runners the host node is `/usr/local/bin/node`, so the release installer provisions its own Node into `~/.hermes/node` and every node-gyp build dies against the empty nodedir:

```
npm error gyp: /usr/local/common.gypi not found (cwd: .../node_modules/node-pty) while reading includes of binding.gyp
npm error gyp ERR! configure error
```

This is the failure that keeps the **Install & Update E2E** installer legs red once the Node CA mismatch (#87635) is fixed — masked until then by that TLS failure and by `npm --silent` (#88383). First isolated by @lioand in [#87635's verification thread](https://github.com/NousResearch/hermes-agent/pull/87635#issuecomment-5388944874).

The fix passes the nodedir through only when the directory is visible under the mount plan stage 2 itself builds **and** really contains `include/node/common.gypi`. With no nodedir, node-gyp downloads version-matched headers through the sandbox proxy — official Node builds ship `use_prefix_to_find_headers=false`, so that download is exactly what a real user install does. A `/nix` store node (the environment this plumbing was written for, `84874c58a5`) and a distro node under `/usr` keep the offline header path.

**Verification.** With this change plus #87635's CA fix, `tests/install/install-update-e2e.sh --route installer --install-ref v2026.7.20` passes locally (first green run of that leg I'm aware of): `node-pty`'s `pty.node` builds in both phases, and `~/.cache/node-gyp/{20.20.2,26.7.0}/` inside the kept sandbox shows both installers took the header-download path. Baselines from lioand's fork: CA fix alone still fails on the gyp error ([32670780755](https://github.com/lioand/hermes-agent/actions/runs/32670780755)); without the CA fix, 44 `SSLEOFError` lines ([32661905260](https://github.com/lioand/hermes-agent/actions/runs/32661905260)). The two fixes are mechanically independent, so this PR deliberately does not duplicate #87635 — the E2E goes green with both merged.

Related: #88420 overlaps #87635 (CA + proxy keep-alive), not this. Sibling found during the same investigation: the stage-2 launch was also being swallowed by uv's `env` shim on developer machines — separate mechanism, separate PR: #93667.

## Related Issue

No standalone issue — surfaced and documented in #87635's verification thread (comment linked above).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/sandbox/stage2-run.sh` — build `node_env` after the mount plan is known; export `npm_config_nodedir` only for a visible directory with real headers
- `tests/test_sandbox_stage2_nodedir.py` — drives the real `stage2-run.sh` with an argv-recording fake `bwrap` and asserts on the `--setenv` plan

## How to Test

1. `pytest tests/test_sandbox_stage2_nodedir.py -q` — 4 pass here; on `main` the two regression cases fail (host node in `/usr/local`; host node outside the mounted prefixes)
2. Full path (needs bubblewrap/slirp4netns, ~15 min): apply this + #87635, then `tests/install/install-update-e2e.sh --route installer --install-ref v2026.7.20`
3. Or dispatch `install-e2e.yml` (`route=installer`) on a fork carrying both

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the added tests plus `tests/test_install_sh_node_npm_check.py` and `tests/test_install_sh_node_deps_failure.py` (all pass); the full suite needs the project venv I didn't build on this machine
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behaviour documented in the script comment
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the dev sandbox is Linux-only; new tests are marked `linux_only`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Green leg tail (local, this + #87635):

```
✓ installer re-run completed
✓ installer re-run landed on <head>
✓ hermes runs after installer re-run
✓ install/update E2E passed (route: installer, from: v2026.7.20)
```
