### PR TITLE
fix(dev-sandbox): launch stage 2 with prefix assignments, not PATH-resolved env

### DIFF
--- a/scripts/dev-sandbox.sh
+++ b/scripts/dev-sandbox.sh
@@ -534,7 +534,6 @@ slirp_log="$SANDBOX_ROOT/root/logs/slirp.log"
 : > "$sandbox_pid_file"
 : > "$slirp_ready"
 
-env \
   DEV_SANDBOX_ROOT="$SANDBOX_ROOT" \
   DEV_SANDBOX_BASH="$(command -v bash)" \
   DEV_SANDBOX_REAL_CA_CERT="$REAL_CA_CERT" \

--- a/tests/test_sandbox_env_shadowing.py
+++ b/tests/test_sandbox_env_shadowing.py
@@ -1,0 +1,107 @@
+"""The dev-sandbox scripts must not invoke a PATH-resolved ``env``.
+
+Same hazard #88385 fixed in install.sh: uv's installer writes
+``~/.local/bin/env`` -- a PATH helper meant to be *sourced*, which ignores
+its arguments and exits 0 -- and puts ``~/.local/bin`` ahead of /usr/bin.
+On any machine where that shim exists, ``env VAR=... cmd`` resolves to it,
+runs nothing, and reports success.
+
+dev-sandbox.sh launched its entire stage 2 through exactly that shape
+(``env DEV_SANDBOX_...=... unshare ...``), so on a shim-bearing developer
+machine every sandbox invocation printed its banner, executed nothing, and
+exited 0 -- including the Install & Update E2E driver, which then failed
+with the payload's output nowhere to be found.
+
+The scan here differs from install.sh's in one way the sandbox scripts
+need: the offending call spelled ``env`` on its own line with the variables
+on backslash-continued lines, so continuations are joined before matching.
+"""
+
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SANDBOX_SCRIPTS = [
+    REPO_ROOT / "scripts" / "dev-sandbox.sh",
+    REPO_ROOT / "scripts" / "sandbox" / "stage2-run.sh",
+    REPO_ROOT / "scripts" / "sandbox" / "pick-release-tags.sh",
+    REPO_ROOT / "tests" / "install" / "install-update-e2e.sh",
+]
+
+# `env FOO=bar cmd` (or bare `env` before continued assignments) where env is
+# resolved through PATH. Excludes /usr/bin/env and other absolute or relative
+# paths, and words merely ending in "env" (--setenv, printenv).
+BARE_ENV_PREFIX = re.compile(r"(?:^|[^./\w-])env\s+[A-Z_]+=")
+COMMENT = re.compile(r"(?:^|\s)#.*$")
+
+
+def _logical_lines(text: str) -> list[str]:
+    """Comment-stripped lines with backslash continuations joined."""
+    joined = re.sub(r"\\\n", " ", text)
+    return [COMMENT.sub("", line) for line in joined.splitlines()]
+
+
+def test_no_path_resolved_env_in_sandbox_scripts() -> None:
+    """No sandbox-side script may set variables via a PATH-resolved `env`."""
+    offenders = [
+        (script.name, number, line.rstrip())
+        for script in SANDBOX_SCRIPTS
+        for number, line in enumerate(
+            _logical_lines(script.read_text(encoding="utf-8")), 1
+        )
+        if BARE_ENV_PREFIX.search(line)
+    ]
+    assert not offenders, (
+        "sandbox scripts must not prefix commands with a PATH-resolved "
+        "`env` -- a shadowing ~/.local/bin/env (written by uv) swallows the "
+        "command and returns 0. Use bash prefix assignments "
+        "(`VAR=... cmd`) instead. Offending logical lines: " + repr(offenders)
+    )
+
+
+def _write_env_shim(directory: Path) -> None:
+    """Drop in a no-op `env` matching the one uv installs."""
+    shim = directory / "env"
+    shim.write_text(
+        textwrap.dedent(
+            """\
+            #!/bin/sh
+            # add binaries to PATH if they aren't added yet
+            case ":${PATH}:" in
+                *:"$HOME/.local/bin":*) ;;
+                *) export PATH="$HOME/.local/bin:$PATH" ;;
+            esac
+            """
+        ),
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+
+
+def test_prefix_assignments_survive_the_env_shim(tmp_path: Path) -> None:
+    """Behavioural proof: with the shim first on PATH, the old launch shape
+    silently succeeds without running anything; bash prefix assignments both
+    run the command and deliver the variables."""
+    _write_env_shim(tmp_path)
+    path = f"{tmp_path}:/usr/bin:/bin"
+
+    def run(script: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["bash", "-c", script],
+            env={"PATH": path, "HOME": str(tmp_path)},
+            capture_output=True,
+            text=True,
+        )
+
+    # The old shape: `false` never runs, yet the caller sees success -- a
+    # stage 2 launched this way vanishes without an error.
+    assert run("env FOO=bar false").returncode == 0
+
+    # The new shape: the command really runs (failure propagates)...
+    assert run("FOO=bar false").returncode != 0
+    # ...and the environment still arrives, including for multi-variable,
+    # continuation-style prefixes like the stage 2 launch uses.
+    delivered = run('FOO=bar \\\n  BAR=baz \\\n  sh -c \'printf "%s %s" "$FOO" "$BAR"\'')
+    assert delivered.stdout == "bar baz"

--- a/tests/test_sandbox_env_shadowing.py
+++ b/tests/test_sandbox_env_shadowing.py
@@ -15,6 +15,12 @@ with the payload's output nowhere to be found.
 The scan here differs from install.sh's in one way the sandbox scripts
 need: the offending call spelled ``env`` on its own line with the variables
 on backslash-continued lines, so continuations are joined before matching.
+
+Scope: only the ``env VAR=... cmd`` shape is flagged, because that is the
+one these scripts use and the one with a drop-in replacement (bash prefix
+assignments). Argument-less forms (``env -i cmd``, a bare ``env cmd``) are
+swallowed by the shim just the same, but have no assignment to key on and
+no equivalent rewrite -- if one is ever needed, spell it /usr/bin/env.
 """
 
 import re
@@ -32,15 +38,34 @@ SANDBOX_SCRIPTS = [
 
 # `env FOO=bar cmd` (or bare `env` before continued assignments) where env is
 # resolved through PATH. Excludes /usr/bin/env and other absolute or relative
-# paths, and words merely ending in "env" (--setenv, printenv).
-BARE_ENV_PREFIX = re.compile(r"(?:^|[^./\w-])env\s+[A-Z_]+=")
+# paths, and words merely ending in "env" (--setenv, printenv). The assignment
+# target accepts any shell identifier, not just the uppercase convention.
+BARE_ENV_PREFIX = re.compile(r"(?:^|[^./\w-])env\s+[A-Za-z_][A-Za-z0-9_]*=")
 COMMENT = re.compile(r"(?:^|\s)#.*$")
 
 
-def _logical_lines(text: str) -> list[str]:
-    """Comment-stripped lines with backslash continuations joined."""
-    joined = re.sub(r"\\\n", " ", text)
-    return [COMMENT.sub("", line) for line in joined.splitlines()]
+def _logical_lines(text: str) -> list[tuple[int, str]]:
+    """(physical start line, comment-stripped text) per logical line.
+
+    Backslash continuations are joined into their opening line, and the
+    number reported is that opening line's position in the file -- not its
+    index in the joined text, which drifts by one per continuation.
+    """
+    lines: list[tuple[int, str]] = []
+    start = 1
+    pending: list[str] = []
+    for number, line in enumerate(text.splitlines(), 1):
+        if not pending:
+            start = number
+        if line.endswith("\\"):
+            pending.append(line[:-1])
+            continue
+        pending.append(line)
+        lines.append((start, COMMENT.sub("", " ".join(pending))))
+        pending = []
+    if pending:
+        lines.append((start, COMMENT.sub("", " ".join(pending))))
+    return lines
 
 
 def test_no_path_resolved_env_in_sandbox_scripts() -> None:
@@ -48,9 +73,7 @@ def test_no_path_resolved_env_in_sandbox_scripts() -> None:
     offenders = [
         (script.name, number, line.rstrip())
         for script in SANDBOX_SCRIPTS
-        for number, line in enumerate(
-            _logical_lines(script.read_text(encoding="utf-8")), 1
-        )
+        for number, line in _logical_lines(script.read_text(encoding="utf-8"))
         if BARE_ENV_PREFIX.search(line)
     ]
     assert not offenders, (
@@ -59,6 +82,18 @@ def test_no_path_resolved_env_in_sandbox_scripts() -> None:
         "command and returns 0. Use bash prefix assignments "
         "(`VAR=... cmd`) instead. Offending logical lines: " + repr(offenders)
     )
+
+
+def test_scan_matches_lowercase_and_continued_assignments() -> None:
+    """The scanner's own edge cases: lowercase targets, continuation-split
+    calls, and the physical line number of a multi-line offender."""
+    text = "#!/bin/sh\nenv foo=bar cmd\n/usr/bin/env FOO=bar ok\nenv \\\n  X=1 \\\n  cmd\nprintenv X=1\n"
+    hits = [
+        (number, line)
+        for number, line in _logical_lines(text)
+        if BARE_ENV_PREFIX.search(line)
+    ]
+    assert [number for number, _ in hits] == [2, 4], hits
 
 
 def _write_env_shim(directory: Path) -> None:
@@ -103,5 +138,7 @@ def test_prefix_assignments_survive_the_env_shim(tmp_path: Path) -> None:
     assert run("FOO=bar false").returncode != 0
     # ...and the environment still arrives, including for multi-variable,
     # continuation-style prefixes like the stage 2 launch uses.
-    delivered = run('FOO=bar \\\n  BAR=baz \\\n  sh -c \'printf "%s %s" "$FOO" "$BAR"\'')
+    delivered = run(
+        'FOO=bar \\\n  BAR=baz \\\n  sh -c \'printf "%s %s" "$FOO" "$BAR"\''
+    )
     assert delivered.stdout == "bar baz"


### PR DESCRIPTION
## What does this PR do?

Deletes the PATH-resolved `env` from the stage-2 launch in `dev-sandbox.sh` — the same hazard #88385 fixes in `install.sh`, one layer down.

uv's installer writes `~/.local/bin/env` — a PATH helper meant to be *sourced*, which ignores its arguments and exits 0 — and places `~/.local/bin` ahead of `/usr/bin`. `dev-sandbox.sh` launched its entire stage 2 through exactly that shape (`env DEV_SANDBOX_...=... unshare ...`), so on any machine carrying the shim every sandbox invocation printed its banner, ran nothing, and reported success. Captured verbatim on a shim-bearing machine, pristine `main`:

```
$ type -a env | head -1
env is /home/lxman/.local/bin/env

$ scripts/dev-sandbox.sh echo PROBE-BEFORE; echo rc=$?
[sandbox] fake main: current folder (7e67f64fce...)
[sandbox] root: /tmp/hermes-sandbox.63tdDn
[sandbox] identity: hermes (uid 1000) — installs are user-level under /home/hermes
[sandbox] ephemeral
rc=0                    ← no PROBE-BEFORE, no error, nothing ran
```

The E2E driver on such a machine fails with `✗ ... did not report a completed install` over an empty log: proxy, installer and payload never started; the empty `sandbox.pid`/`slirp.ready` under `root/logs/` are the only trace. Since the shim ships with uv — which `install.sh` itself installs — any contributor who has run the real installer on their dev box is likely to have it. (Also a live confirmation of the reviewer note on #88385 about scanning the other shell scripts.)

Bash prefix assignments do the same job with no PATH lookup, so the fix is deleting the `env` line — the assignments bind directly to `unshare`. After the change, same machine: `PROBE-AFTER` prints, and a full `tests/install/install-update-e2e.sh --route installer --install-ref v2026.7.20` leg runs to completion (alongside the unrelated sandbox fixes #87635 + #93666, #93666).

## Related Issue

No standalone issue; mechanism documented in #88385 for `install.sh`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/dev-sandbox.sh` — drop the `env \` line; the `DEV_SANDBOX_*` assignments now prefix `unshare` directly
- `tests/test_sandbox_env_shadowing.py` — extends #88385's scan to the sandbox-side scripts, joining backslash-continued logical lines first (this offender spelled `env` on its own line); plus a behavioural proof that the shim swallows `env FOO=bar false` while `FOO=bar false` propagates failure and continuation-style prefixes still deliver the variables

## How to Test

1. `pytest tests/test_sandbox_env_shadowing.py -q` — 2 pass here; on `main` the scan test fails, naming `dev-sandbox.sh`'s launch line
2. On a machine with uv's `~/.local/bin/env` first on PATH: `scripts/dev-sandbox.sh echo PROBE` — silent `rc=0` on `main`, prints `PROBE` with this change

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the added tests plus `tests/test_install_sh_node_npm_check.py` and `tests/test_install_sh_node_deps_failure.py` (all pass); the full suite needs the project venv I didn't build on this machine
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the dev sandbox is Linux-only; test style follows #88385's
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

After the fix, same machine and command:

```
$ scripts/dev-sandbox.sh echo PROBE-AFTER; echo rc=$?
[sandbox] fake main: current folder (...)
[sandbox] ephemeral
PROBE-AFTER
rc=0
```
