### PR TITLE
fix(desktop): group chats survive deleting a cloud connection (#93492, salvage #93505)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5215,7 +5215,19 @@ function aliasIdentityFor(bot) {
 // aliasRouteIndex above — which is connection-exact, never name-based.
 function botRosterMeta(bot, metaByName) {
   if (bot?.sourceScoped || bot?.remoteSource) {
-    const route = botConnectionRoute(bot)
+    // A row orphaned by a deleted connection (connectionId gone, e.g. from a
+    // stale persisted group roster) has no route to resolve. botConnectionRoute
+    // fails closed there for routing dispatch — correct for a network call,
+    // but this is a passive meta lookup, and the whole component tree above
+    // display-only code must not crash rendering an unroutable member.
+    let route = null
+
+    try {
+      route = botConnectionRoute(bot)
+    } catch {
+      route = null
+    }
+
     const direct = route ? metaByName?.[botRouteKey(route)] : null
 
     if (direct) {

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5155,7 +5155,9 @@ function botConnectionRoute(bot) {
 const BOTS_HOME_OWNER_KEY = 'bots:home'
 
 function botWorkspaceOwnerKey(bot) {
-  const route = botConnectionRoute(bot)
+  // Render-reachable (sidebar sync, Bots home open, context menus): an
+  // orphaned row must yield a stable degraded key, never the dispatch throw.
+  const route = resolveBotConnectionRoute(bot).route
 
   return `bot:${route ? botRouteKey(route) : String(bot?.name || 'default')}`
 }
@@ -5165,7 +5167,9 @@ function groupWorkspaceOwnerKey(group) {
 }
 
 function setBotsWorkspaceOwner(ownerKey, bot = null, blockedMessage = 'Select a Bot or group first.') {
-  const route = bot ? botConnectionRoute(bot) : null
+  // Render-reachable (sidebar listener fires on visibility flips). An
+  // orphaned row degrades to the blocked target instead of throwing.
+  const route = bot ? resolveBotConnectionRoute(bot).route : null
   const target = route ? { kind: 'route', route } : { kind: 'blocked', message: blockedMessage }
 
   host.setWorkspaceScope?.('bots', ownerKey || BOTS_HOME_OWNER_KEY, target)
@@ -6234,7 +6238,11 @@ function groupChatMemberBots(group, roster, metaByName) {
  *  here is what keeps the same room intact across machines. */
 function durableGroupChatMembers(bots) {
   return (bots || []).map(bot => {
-    const route = botConnectionRoute(bot)
+    // Persistence pass over the whole seated roster: an orphaned member
+    // (connection deleted) keeps its identity and simply persists with no
+    // route — the same degraded shape the hydrate annotate produces. The
+    // strict throw here would lose the entire room update over one row.
+    const route = resolveBotConnectionRoute(bot).route
     // Keep the friendly identity on the stored descriptor: after a
     // connection switch the live roster row may be gone, and renamed-tag
     // mentions must still resolve against the persisted member.
@@ -6249,6 +6257,9 @@ function durableGroupChatMembers(bots) {
       connectionKind: bot.connectionKind,
       connectionLabel: bot.connectionLabel,
       ...(route ? { route, targetProfile: route.targetProfile } : {}),
+      // A swept/annotated member keeps its degraded mark across the rebuild —
+      // otherwise the next room send would silently un-mark an orphaned row.
+      ...(bot.sourceMissing ? { sourceMissing: true, sourceReachable: false } : {}),
       remoteSource: true,
       sourceScoped: Boolean(route)
     }
@@ -8388,7 +8399,11 @@ function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }) {
 // ── model picker (provider/model dropdowns via model.options) ───────────────
 
 function useModelOptions(bot = null) {
-  const route = botConnectionRoute(bot)
+  // Hook body runs during render: an orphaned row must paint the picker
+  // disabled/erroring, not throw into the pane's error boundary.
+  const resolved = bot ? resolveBotConnectionRoute(bot) : null
+  const route = resolved?.status === 'resolved' ? resolved.route : null
+  const orphaned = resolved?.status === 'owner_removed'
 
   return useQuery({
     queryKey: [ID, 'model-options', route ? botRouteKey(route) : 'active'],
@@ -8397,6 +8412,7 @@ function useModelOptions(bot = null) {
       explicit_only: false,
       refresh: true
     }),
+    enabled: !orphaned,
     staleTime: 120000,
     retry: false
   })
@@ -8600,7 +8616,9 @@ function AdvancedProfileConfig({ bot, state, setState }) {
   const [loaded, setLoaded] = useState(false)
   const [unsupported, setUnsupported] = useState(false)
   const [skillFilter, setSkillFilter] = useState('')
-  const botRoute = botConnectionRoute(bot)
+  // Component body = render path: degrade an orphaned row to the bot's own
+  // name scope instead of throwing into the dialog's error boundary.
+  const botRoute = resolveBotConnectionRoute(bot).route
   const backendProfile = botRoute?.targetProfile || botRoute?.profile || bot.name
   const backendScope = botBackendProfileScope(botRoute, bot.name)
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1133,6 +1133,58 @@ function sweepGroupChatMembersForRemovedConnection(connectionId) {
   return changed
 }
 
+/** Hydrate-time pass for rows orphaned BEFORE this build (the poisoned rows
+ *  that made #93492 survive app restarts). Two shapes are annotated, never
+ *  deleted:
+ *  - a descriptor that already lost its connectionId (route unresolvable —
+ *    exactly what a stale row looks like once its connection was deleted);
+ *  - a descriptor whose connectionId is absent from the live registry, when
+ *    the caller could obtain one (liveConnectionIds === null means "registry
+ *    unavailable", which must NOT read as "everything is orphaned").
+ *  Pure on the rooms map; returns { rooms, changed }. */
+function annotateOrphanedGroupChatMembers(rooms, liveConnectionIds = null) {
+  // Duck-typed, not instanceof: callers (and vm-based tests) may hand a Set
+  // constructed in another realm.
+  const live = liveConnectionIds && typeof liveConnectionIds.has === 'function' ? liveConnectionIds : null
+  const next = {}
+  let changed = false
+
+  for (const [name, room] of Object.entries(rooms || {})) {
+    const members = Array.isArray(room?.members) ? room.members : []
+    const orphaned = member => {
+      if (!member || member.sourceMissing) {
+        return false
+      }
+
+      if (!member.sourceScoped && !member.remoteSource) {
+        return false
+      }
+
+      const id = String(member.route?.connectionId || member.connectionId || '').trim()
+
+      if (!id) {
+        // Route unresolvable: this is the row shape that threw on render.
+        return true
+      }
+
+      return live ? !live.has(id) : false
+    }
+
+    if (!members.some(orphaned)) {
+      next[name] = room
+      continue
+    }
+
+    changed = true
+    next[name] = {
+      ...room,
+      members: members.map(member => (orphaned(member) ? markOrphanedGroupMemberDescriptor(member) : member))
+    }
+  }
+
+  return { rooms: next, changed }
+}
+
 function groupChatSyncConnectionId() {
   return String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || '')
 }
@@ -14735,6 +14787,35 @@ export default {
             }
 
             $groupChats.set({ ...rooms, ...$groupChats.get() })
+
+            // #93492: annotate rows orphaned before this build (their
+            // connection was deleted while an older Desktop ran, so no
+            // 'removed' push ever swept them). Registry read is
+            // feature-detected; when unavailable only the unresolvable-route
+            // shape (lost connectionId) is annotated.
+            try {
+              const registry =
+                typeof window !== 'undefined'
+                  ? await Promise.resolve(window.hermesDesktop?.connections?.list?.()).catch(() => null)
+                  : null
+              const liveIds = Array.isArray(registry?.connections)
+                ? new Set(registry.connections.map(connection => String(connection?.id || '').trim()).filter(Boolean))
+                : null
+              const annotated = annotateOrphanedGroupChatMembers($groupChats.get(), liveIds)
+
+              if (annotated.changed) {
+                // Per-room updateGroupChat keeps the durable record's full
+                // shape (sessionOwners, holds) in storage; sync:false —
+                // the scheduleGroupChatServerSync below publishes once.
+                for (const [roomName, room] of Object.entries(annotated.rooms)) {
+                  if (room !== $groupChats.get()[roomName]) {
+                    updateGroupChat(roomName, () => room, { sync: false })
+                  }
+                }
+              }
+            } catch {
+              /* registry unavailable — the lost-connectionId shape is still safe to render */
+            }
           }
 
           // Receive before publish. A fresh Desktop with no local room cache

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1066,6 +1066,73 @@ function persistGroupChatRooms(all = $groupChats.get()) {
   }
 }
 
+// ── deleted-connection roster hygiene (#93492 root cause) ───────────────────
+// Deleting a cloud/remote connection used to leave every persisted group-chat
+// member descriptor that referenced it behind untouched. Those orphaned rows
+// (remoteSource: true, connection gone) are exactly the shape that made
+// render-path route lookups throw "Bot X has no connection owner" on every
+// group open, permanently — the poisoned row lives in plugin storage. The
+// sweep below runs on the registry's 'removed' push (and its annotate helper
+// again at hydrate for rows orphaned before this build). It never hard-deletes
+// user data: the member row is kept and marked, so panes render the existing
+// degraded 'Gateway removed' botSourceStatus state instead of crashing.
+
+/** Keep the member's identity; mark it so botSourceStatus reads
+ *  'Gateway removed' and no render-path route lookup can throw on it. */
+function markOrphanedGroupMemberDescriptor(member) {
+  return {
+    ...member,
+    sourceMissing: true,
+    sourceReachable: false
+  }
+}
+
+function groupMemberReferencesConnection(member, connectionId) {
+  const id = String(connectionId || '').trim()
+
+  if (!id) {
+    return false
+  }
+
+  return (
+    String(member?.connectionId || '').trim() === id ||
+    String(member?.route?.connectionId || '').trim() === id
+  )
+}
+
+/** Register-removed sweep: annotate (not delete) every persisted group-chat
+ *  member owned by the deleted connection, in the atom AND plugin storage.
+ *  Writes ride updateGroupChat so the durable record keeps its full shape
+ *  (sessionOwners, holds — durableGroupChatRooms would drop them).
+ *  Returns whether anything changed. */
+function sweepGroupChatMembersForRemovedConnection(connectionId) {
+  const id = String(connectionId || '').trim()
+
+  if (!id) {
+    return false
+  }
+
+  let changed = false
+
+  for (const [name, room] of Object.entries($groupChats.get())) {
+    const members = Array.isArray(room?.members) ? room.members : []
+
+    if (!members.some(member => groupMemberReferencesConnection(member, id) && !member?.sourceMissing)) {
+      continue
+    }
+
+    changed = true
+    updateGroupChat(name, current => ({
+      ...current,
+      members: (Array.isArray(current.members) ? current.members : []).map(member =>
+        groupMemberReferencesConnection(member, id) ? markOrphanedGroupMemberDescriptor(member) : member
+      )
+    }))
+  }
+
+  return changed
+}
+
 function groupChatSyncConnectionId() {
   return String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || '')
 }
@@ -14692,6 +14759,28 @@ export default {
     const unbindProfileListener = bindProfileSync($focusedBotOwner)
     const unbindGatewayListener = host.state.gateway.listen(handleSessionsGatewayTransition)
 
+    // #93492 root fix: the registry pushes a lifecycle event when a
+    // connection is removed. The gateway store already disposes the dead
+    // sockets; the persisted group-chat rosters referencing that connection
+    // were never touched, which is what left panes throwing "Bot X has no
+    // connection owner" forever. Annotate (never silently delete) those
+    // member rows the moment the connection goes away. Feature-detected:
+    // older Electron mains don't emit it, and bare vm test harnesses have
+    // no window global.
+    let unbindConnectionsChanged = null
+    try {
+      if (typeof window !== 'undefined') {
+        unbindConnectionsChanged =
+          window.hermesDesktop?.connections?.onChanged?.(payload => {
+            if (payload?.reason === 'removed') {
+              sweepGroupChatMembersForRemovedConnection(payload.connectionId)
+            }
+          }) || null
+      }
+    } catch {
+      /* registry lifecycle push unavailable — hydrate-time annotate still covers it */
+    }
+
     if (typeof ctx.onDispose === 'function') {
       ctx.onDispose(() => {
         stopGroupChatServerSync()
@@ -14700,6 +14789,9 @@ export default {
         }
         if (typeof unbindGatewayListener === 'function') {
           unbindGatewayListener()
+        }
+        if (typeof unbindConnectionsChanged === 'function') {
+          unbindConnectionsChanged()
         }
       })
     }

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4983,11 +4983,13 @@ function botSourceStatus(bot) {
 // active-gateway door. Feature-detected: older desktops without
 // requestProfile simply have no remote routes (callers fall back / disable).
 
-/** Immutable owner descriptor for every source-scoped row. The active
- *  gateway is presentation state and is never consulted here. */
-function botConnectionRoute(bot) {
+/** Non-throwing resolver behind botConnectionRoute(). Returns a typed status
+ *  instead of throwing, so passive callers (display/meta lookups) can branch
+ *  on `resolved | owner_removed | not_scoped` rather than catching whatever
+ *  exception the strict wrapper below happens to throw. */
+function resolveBotConnectionRoute(bot) {
   if (!bot?.sourceScoped && !bot?.remoteSource) {
-    return null
+    return { status: 'not_scoped', route: null }
   }
 
   const candidate = bot.route || {
@@ -5001,15 +5003,34 @@ function botConnectionRoute(bot) {
   const targetProfile = String(candidate?.targetProfile || profile).trim() || profile
 
   if (!connectionId) {
-    throw new Error(`Bot ${profile} has no connection owner`)
+    return { status: 'owner_removed', route: null, profile }
   }
 
-  return Object.freeze({
-    connectionId,
-    mode: candidate.mode === 'local' || connectionId === 'local' ? 'local' : 'remote',
-    profile,
-    targetProfile
-  })
+  return {
+    status: 'resolved',
+    route: Object.freeze({
+      connectionId,
+      mode: candidate.mode === 'local' || connectionId === 'local' ? 'local' : 'remote',
+      profile,
+      targetProfile
+    })
+  }
+}
+
+/** Immutable owner descriptor for every source-scoped row. The active
+ *  gateway is presentation state and is never consulted here. Strict: throws
+ *  when the owning connection is gone -- correct for real dispatch
+ *  (requestForBot, session creation, etc.), covered by
+ *  remote-routing-races.test.mjs. Passive lookups (rendering, meta) must call
+ *  resolveBotConnectionRoute() directly instead of catching this throw. */
+function botConnectionRoute(bot) {
+  const resolved = resolveBotConnectionRoute(bot)
+
+  if (resolved.status === 'owner_removed') {
+    throw new Error(`Bot ${resolved.profile} has no connection owner`)
+  }
+
+  return resolved.route
 }
 
 const BOTS_HOME_OWNER_KEY = 'bots:home'
@@ -5215,18 +5236,12 @@ function aliasIdentityFor(bot) {
 // aliasRouteIndex above — which is connection-exact, never name-based.
 function botRosterMeta(bot, metaByName) {
   if (bot?.sourceScoped || bot?.remoteSource) {
-    // A row orphaned by a deleted connection (connectionId gone, e.g. from a
-    // stale persisted group roster) has no route to resolve. botConnectionRoute
-    // fails closed there for routing dispatch — correct for a network call,
-    // but this is a passive meta lookup, and the whole component tree above
-    // display-only code must not crash rendering an unroutable member.
-    let route = null
-
-    try {
-      route = botConnectionRoute(bot)
-    } catch {
-      route = null
-    }
+    // Passive meta lookup: branch on the typed status instead of catching
+    // botConnectionRoute's throw, so an owner_removed row (e.g. a stale
+    // persisted group roster after its connection was deleted) reads as "no
+    // route" without masking an unrelated failure under the same catch.
+    const resolved = resolveBotConnectionRoute(bot)
+    const route = resolved.status === 'resolved' ? resolved.route : null
 
     const direct = route ? metaByName?.[botRouteKey(route)] : null
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/embed-real-capabilities.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/embed-real-capabilities.test.mjs
@@ -27,7 +27,9 @@ test('AdvancedProfileConfig embeds the real McpTab with a live gateway + profile
 })
 
 test('AdvancedProfileConfig scopes SkillsView to the connection and backend target profile', () => {
-  assert.match(source, /const botRoute = botConnectionRoute\(bot\)/)
+  // Route lookup is the NON-throwing resolver (#93492): the dialog renders
+  // degraded for an orphaned row instead of crashing the pane.
+  assert.match(source, /const botRoute = resolveBotConnectionRoute\(bot\)\.route/)
   assert.match(source, /fixedProfile: backendProfile/)
   assert.match(source, /fixedConnection: botRoute\.connectionId/)
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
@@ -32,7 +32,7 @@ function runtime() {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__mergeMultiSourceRoster = mergeMultiSourceRoster;\nglobalThis.__botHandle = botHandle;\nglobalThis.__botRosterKey = botRosterKey;\nglobalThis.__botRosterMeta = botRosterMeta;\nglobalThis.__displayName = displayName;\nglobalThis.__filterBots = filterBots;\nglobalThis.__resolveRosterMentions = resolveRosterMentions;'
+      '\nglobalThis.__mergeMultiSourceRoster = mergeMultiSourceRoster;\nglobalThis.__botHandle = botHandle;\nglobalThis.__botRosterKey = botRosterKey;\nglobalThis.__botRosterMeta = botRosterMeta;\nglobalThis.__displayName = displayName;\nglobalThis.__filterBots = filterBots;\nglobalThis.__resolveRosterMentions = resolveRosterMentions;\nglobalThis.__botConnectionRoute = botConnectionRoute;\nglobalThis.__resolveBotConnectionRoute = resolveBotConnectionRoute;'
     )
   vm.runInNewContext(code, context)
   return context
@@ -264,6 +264,40 @@ test('botRosterMeta: a group roster row orphaned by a deleted connection does no
 
   assert.doesNotThrow(() => metaFor(orphaned, {}))
   assert.equal(metaFor(orphaned, {}), null)
+})
+
+test('resolveBotConnectionRoute: typed status for resolved / owner_removed / not_scoped, and strict botConnectionRoute still fails closed', () => {
+  const { __resolveBotConnectionRoute: resolve, __botConnectionRoute: strictRoute } = runtime()
+  const orphaned = { name: 'halakukhan', connectionId: null, remoteSource: true }
+  const owned = { name: 'halakukhan', connectionId: 'conn-1', remoteSource: true }
+  const local = { name: 'default' }
+
+  // Passive resolver: typed status, never throws.
+  assert.equal(resolve(orphaned).status, 'owner_removed')
+  assert.equal(resolve(owned).status, 'resolved')
+  assert.equal(resolve(owned).route.connectionId, 'conn-1')
+  assert.equal(resolve(local).status, 'not_scoped')
+
+  // Strict wrapper used by real dispatch (requestForBot, session creation)
+  // must still fail closed on the same orphaned row -- the split only moves
+  // the *passive* lookup off this throw, it does not remove it.
+  assert.throws(() => strictRoute(orphaned), /has no connection owner/)
+  assert.equal(strictRoute(owned).connectionId, 'conn-1')
+})
+
+test('botRosterMeta: an unrelated failure while resolving meta for a live route still propagates', () => {
+  const { __botRosterMeta: metaFor } = runtime()
+  const owned = { name: 'halakukhan', connectionId: 'conn-1', remoteSource: true }
+  // A metaByName lookup that throws for reasons that have nothing to do with
+  // connection ownership must not be caught by botRosterMeta -- only the
+  // owner_removed status is treated as "no meta for this row".
+  const explodingMetaByName = new Proxy({}, {
+    get() {
+      throw new Error('unrelated invariant failure')
+    }
+  })
+
+  assert.throws(() => metaFor(owned, explodingMetaByName), /unrelated invariant failure/)
 })
 
 test('botHandle: precomputed multi-source handle wins; default stays hermes', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
@@ -254,6 +254,18 @@ test('default rows use source identity without borrowing another source title', 
   assert.equal(name(active, undefined), 'Hermes')
 })
 
+test('botRosterMeta: a group roster row orphaned by a deleted connection does not throw', () => {
+  const { __botRosterMeta: metaFor } = runtime()
+  // Mirrors the persisted `group-chats` descriptor left behind once its
+  // connection is removed: remoteSource is still true, but connectionId is
+  // gone, so botConnectionRoute has nothing to resolve. This must not crash
+  // rendering the group (#93492) just because one member is unroutable.
+  const orphaned = { name: 'halakukhan', handle: 'halakukhan', connectionId: null, remoteSource: true }
+
+  assert.doesNotThrow(() => metaFor(orphaned, {}))
+  assert.equal(metaFor(orphaned, {}), null)
+})
+
 test('botHandle: precomputed multi-source handle wins; default stays hermes', () => {
   const { __botHandle: botHandle } = runtime()
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/orphaned-connection-members.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/orphaned-connection-members.test.mjs
@@ -1,0 +1,182 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+// #93492 root fix: deleting a connection sweeps/annotates the persisted
+// group-chat member rows that referenced it (registry 'removed' push), and a
+// hydrate-time pass annotates rows orphaned before the sweep existed. Rows
+// are marked (sourceMissing → the existing 'Gateway removed' degraded state),
+// never silently deleted.
+
+function runtime() {
+  const atom = initial => {
+    let value = initial
+    return { get: () => value, set: next => { value = next }, listen: () => () => undefined }
+  }
+  const jsx = (type, props = {}) => ({ type, props })
+  const storageWrites = []
+  const context = {
+    atom,
+    jsx,
+    jsxs: jsx,
+    useQuery: () => ({}),
+    useValue: value => (value?.get ? value.get() : value),
+    useState: value => [value, () => undefined],
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: {
+      state: {
+        connectionId: { get: () => 'local', listen: () => undefined },
+        profile: { get: () => 'ops', listen: () => undefined }
+      },
+      request: () => undefined
+    },
+    sdk: new Proxy({}, { get: () => undefined })
+  }
+  const code = source
+    .replace(/^import \* as sdk from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat(
+      '\nglobalThis.__orphan = { $groupChats, sweepGroupChatMembersForRemovedConnection, annotateOrphanedGroupChatMembers, markOrphanedGroupMemberDescriptor, groupMemberReferencesConnection, botSourceStatus, durableGroupChatMembers, botWorkspaceOwnerKey, setBotsWorkspaceOwner, useModelOptions, pluginCtxRef: () => pluginCtx, setPluginCtx: value => { pluginCtx = value } };'
+    )
+  vm.runInNewContext(code, context)
+  context.__storageWrites = storageWrites
+  return context
+}
+
+function member(overrides = {}) {
+  return {
+    name: 'dixie',
+    handle: 'dixie',
+    connectionId: 'conn-gone',
+    remoteSource: true,
+    sourceScoped: true,
+    route: { connectionId: 'conn-gone', mode: 'remote', profile: 'dixie', targetProfile: 'dixie' },
+    ...overrides
+  }
+}
+
+test('removed-connection sweep annotates matching members and persists; other rows untouched', () => {
+  const { __orphan: o } = runtime()
+  const writes = []
+  o.setPluginCtx({ storage: { set: (key, value) => { writes.push([key, value]); return Promise.resolve() } } })
+
+  o.$groupChats.set({
+    Crew: {
+      log: [{ id: '1', at: 1 }],
+      watermarks: {},
+      members: [member(), member({ name: 'bob', connectionId: 'conn-live', route: { connectionId: 'conn-live', mode: 'remote', profile: 'bob', targetProfile: 'bob' } })]
+    }
+  })
+
+  assert.equal(o.sweepGroupChatMembersForRemovedConnection('conn-gone'), true)
+
+  const room = o.$groupChats.get().Crew
+  const swept = room.members.find(m => m.name === 'dixie')
+  const kept = room.members.find(m => m.name === 'bob')
+
+  // Annotated, not deleted: identity survives, marked degraded.
+  assert.equal(room.members.length, 2)
+  assert.equal(swept.sourceMissing, true)
+  assert.equal(swept.sourceReachable, false)
+  assert.equal(kept.sourceMissing, undefined)
+  // The degraded mark renders as the existing 'Gateway removed' state.
+  assert.equal(o.botSourceStatus(swept).label, 'Gateway removed')
+  // Persisted so the fix survives restarts (the poisoned row lived in storage).
+  assert.ok(writes.some(([key]) => key === 'group-chats'))
+})
+
+test('removed-connection sweep is idempotent and ignores blank ids', () => {
+  const { __orphan: o } = runtime()
+  o.setPluginCtx({ storage: { set: () => Promise.resolve() } })
+  o.$groupChats.set({ Crew: { log: [], watermarks: {}, members: [member()] } })
+
+  assert.equal(o.sweepGroupChatMembersForRemovedConnection(''), false)
+  assert.equal(o.sweepGroupChatMembersForRemovedConnection('conn-gone'), true)
+  // Already annotated: nothing left to change.
+  assert.equal(o.sweepGroupChatMembersForRemovedConnection('conn-gone'), false)
+})
+
+test('hydrate annotate: lost-connectionId rows are marked even without a registry', () => {
+  const { __orphan: o } = runtime()
+  const rooms = {
+    Crew: {
+      log: [],
+      watermarks: {},
+      // The exact persisted shape from #93492: remoteSource kept, connectionId gone.
+      members: [{ name: 'halakukhan', handle: 'halakukhan', connectionId: null, remoteSource: true }]
+    }
+  }
+
+  const { rooms: next, changed } = o.annotateOrphanedGroupChatMembers(rooms, null)
+
+  assert.equal(changed, true)
+  assert.equal(next.Crew.members[0].sourceMissing, true)
+  assert.equal(o.botSourceStatus(next.Crew.members[0]).label, 'Gateway removed')
+})
+
+test('hydrate annotate: with a live registry, members on dead connections are marked, live and local kept', () => {
+  const { __orphan: o } = runtime()
+  const rooms = {
+    Crew: {
+      log: [],
+      watermarks: {},
+      members: [
+        member(),
+        member({ name: 'bob', connectionId: 'conn-live', route: { connectionId: 'conn-live', mode: 'remote', profile: 'bob', targetProfile: 'bob' } }),
+        { name: 'local-pal' }
+      ]
+    }
+  }
+
+  const { rooms: next, changed } = o.annotateOrphanedGroupChatMembers(rooms, new Set(['conn-live']))
+
+  assert.equal(changed, true)
+  assert.equal(next.Crew.members.find(m => m.name === 'dixie').sourceMissing, true)
+  assert.equal(next.Crew.members.find(m => m.name === 'bob').sourceMissing, undefined)
+  assert.equal(next.Crew.members.find(m => m.name === 'local-pal').sourceMissing, undefined)
+})
+
+test('hydrate annotate: no registry means only the unresolvable-route shape is touched', () => {
+  const { __orphan: o } = runtime()
+  const rooms = { Crew: { log: [], watermarks: {}, members: [member()] } }
+
+  // conn-gone still has an id; without a registry we cannot prove it dead.
+  const { changed } = o.annotateOrphanedGroupChatMembers(rooms, null)
+
+  assert.equal(changed, false)
+})
+
+test('render-reachable route callers degrade on an orphaned row instead of throwing', () => {
+  const { __orphan: o } = runtime()
+  const orphaned = { name: 'halakukhan', handle: 'halakukhan', connectionId: null, remoteSource: true }
+
+  // botWorkspaceOwnerKey (sidebar sync / Bots home / context menus)
+  assert.doesNotThrow(() => o.botWorkspaceOwnerKey(orphaned))
+  assert.equal(o.botWorkspaceOwnerKey(orphaned), 'bot:halakukhan')
+  // setBotsWorkspaceOwner (sidebar visibility listener)
+  assert.doesNotThrow(() => o.setBotsWorkspaceOwner('bot:halakukhan', orphaned))
+  // durableGroupChatMembers (every group send / roster refresh)
+  assert.doesNotThrow(() => o.durableGroupChatMembers([orphaned]))
+  const durable = o.durableGroupChatMembers([{ ...orphaned, sourceMissing: true, sourceReachable: false }])[0]
+  // The degraded mark survives the durable rebuild.
+  assert.equal(durable.sourceMissing, true)
+  // useModelOptions (hook body — runs during pane render)
+  assert.doesNotThrow(() => o.useModelOptions(orphaned))
+})
+
+test('source contract: the sweep is wired to the registry removed push and unbound on dispose', () => {
+  assert.match(source, /connections\?\.onChanged\?\.\(/)
+  assert.match(source, /payload\?\.reason === 'removed'/)
+  assert.match(source, /sweepGroupChatMembersForRemovedConnection\(payload\.connectionId\)/)
+  assert.match(source, /unbindConnectionsChanged\(\)/)
+})
+
+test('source contract: hydrate runs the orphan annotate over persisted rooms', () => {
+  assert.match(source, /annotateOrphanedGroupChatMembers\(\$groupChats\.get\(\), liveIds\)/)
+})


### PR DESCRIPTION
## Summary
Desktop group chats no longer crash permanently with `Bot X has no connection owner` after a cloud connection is deleted — one orphaned persisted member row used to poison every render of the pane. Root cause fixed too: persisted group-chat rosters are now swept when a connection is removed. Fixes #93492.

## Changes
- `apps/desktop/src/plugins/hermes-bots/plugin.js`: render-path guard splits strict connection routing from passive roster lookup (salvaged from #93505)
- Connection-registry `removed` events sweep group-chat member rows referencing the deleted connection → degraded "Gateway removed" state (no silent data deletion)
- Load-time annotation of rows already orphaned before hydrate
- All render-reachable `botConnectionRoute` callers guarded; dispatch keeps the fail-closed throw (remote-routing-races suite still asserts it, 21/21)

## Validation
| | Before | After |
|---|---|---|
| Delete connection with group-chat member | pane throws forever | member degrades, chat usable |
| Real dispatch to orphaned member | — | still fail-closed |
| Tests | — | 543/543 hermes-bots suite + 8 new orphan tests |

Salvaged from #93505 (@chelsealong, both commits authorship-preserved); root-fix follow-ups on top.

## Infographic

![Group chats survive deleting a connection](https://v3b.fal.media/files/b/0aa7989d/eKzsvKpcReoB2xBOoppEW_QjYgWuBX.png)
