### PR TITLE
fix(terminal): watch_patterns notifications hit a lifetime cap instead of firing forever (#93513, salvage #93532)

### DIFF
--- a/tests/tools/test_watch_patterns.py
+++ b/tests/tools/test_watch_patterns.py
@@ -174,6 +174,55 @@ class TestLifetimeCap:
         assert registry.completion_queue.empty()
         assert session._watch_hits == WATCH_LIFETIME_MAX_HITS
 
+    def test_suppressed_matches_do_not_count_toward_lifetime_cap(self, registry):
+        """Only DELIVERED notifications consume the lifetime budget — matches
+        suppressed inside the cooldown window must not increment the counter
+        (they never forced an agent turn)."""
+        from tools.process_registry import WATCH_LIFETIME_MAX_HITS
+
+        session = _make_session(watch_patterns=["E"])
+        registry._check_watch_patterns(session, "E emit\n")
+        assert session._watch_hits == 1
+
+        # Flood inside the cooldown: all suppressed, none delivered.
+        for _ in range(WATCH_LIFETIME_MAX_HITS * 3):
+            registry._check_watch_patterns(session, "E drop\n")
+        assert session._watch_hits == 1  # unchanged
+        # Strike-limit disable may or may not have tripped depending on
+        # WATCH_STRIKE_LIMIT vs the single window here; assert it did NOT,
+        # since all drops land in ONE window (one strike max).
+        assert session._watch_consecutive_strikes == 1
+        assert session._watch_disabled is False
+
+    def test_cap_trips_exactly_at_nth_delivery_and_promotes(self, registry):
+        """The Nth delivered match is still delivered, then the session is
+        promoted to notify_on_complete in the same call, with the
+        watch_disabled summary queued right after the final match."""
+        from tools.process_registry import WATCH_LIFETIME_MAX_HITS
+
+        session = _make_session(watch_patterns=["ready"])
+        for i in range(WATCH_LIFETIME_MAX_HITS - 1):
+            session._watch_cooldown_until = 0.0
+            registry._check_watch_patterns(session, "ready\n")
+            assert session._watch_disabled is False
+            assert session.notify_on_complete is False
+
+        # Nth delivery trips the cap.
+        session._watch_cooldown_until = 0.0
+        registry._check_watch_patterns(session, "ready\n")
+        assert session._watch_disabled is True
+        assert session.notify_on_complete is True
+
+        events = []
+        while not registry.completion_queue.empty():
+            events.append(registry.completion_queue.get_nowait())
+        # Last two events: the Nth delivered match, then the summary.
+        assert events[-2]["type"] == "watch_match"
+        assert events[-1]["type"] == "watch_disabled"
+        assert "lifetime cap" in events[-1]["message"]
+        assert str(WATCH_LIFETIME_MAX_HITS) in events[-1]["message"]
+        assert "notify_on_complete" in events[-1]["message"]
+
 
 # =========================================================================
 # Checkpoint persistence

--- a/tests/tools/test_watch_patterns.py
+++ b/tests/tools/test_watch_patterns.py
@@ -136,6 +136,46 @@ class TestPerSessionRateLimit:
 
 
 # =========================================================================
+# Lifetime cap: sparsely-spaced matches never trip the consecutive-strike
+# counter, but must still stop eventually (#93513).
+# =========================================================================
+
+class TestLifetimeCap:
+    def test_sparse_matches_disable_after_lifetime_cap(self, registry):
+        """Matches spaced well past the cooldown never strike, but a service
+        restarted over and over must still get disabled instead of forcing a
+        full-context turn forever."""
+        from tools.process_registry import WATCH_LIFETIME_MAX_HITS
+
+        session = _make_session(watch_patterns=["Application started"])
+        for i in range(WATCH_LIFETIME_MAX_HITS):
+            # Force the cooldown to have already expired, simulating a
+            # cleanly-spaced restart (no strikes should ever accumulate).
+            session._watch_cooldown_until = 0.0
+            registry._check_watch_patterns(session, "Application started\n")
+
+        assert session._watch_hits == WATCH_LIFETIME_MAX_HITS
+        assert session._watch_consecutive_strikes == 0  # never struck
+        assert session._watch_disabled is True
+        assert session.notify_on_complete is True
+
+        events = []
+        while not registry.completion_queue.empty():
+            events.append(registry.completion_queue.get_nowait())
+        match_events = [e for e in events if e["type"] == "watch_match"]
+        disabled_events = [e for e in events if e["type"] == "watch_disabled"]
+        assert len(match_events) == WATCH_LIFETIME_MAX_HITS
+        assert len(disabled_events) == 1
+        assert "lifetime cap" in disabled_events[0]["message"]
+
+        # One more restart after the cap: no further turns are forced.
+        session._watch_cooldown_until = 0.0
+        registry._check_watch_patterns(session, "Application started\n")
+        assert registry.completion_queue.empty()
+        assert session._watch_hits == WATCH_LIFETIME_MAX_HITS
+
+
+# =========================================================================
 # Checkpoint persistence
 # =========================================================================
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -73,6 +73,16 @@ MAX_ACTIVE_PROCESS_AGE = 86400  # 24h default — see session_reset.bg_process_m
 WATCH_MIN_INTERVAL_SECONDS = 15   # Minimum spacing between consecutive watch matches
 WATCH_STRIKE_LIMIT = 3            # Strikes in a row → disable watch + promote to notify_on_complete
 
+# Lifetime cap — independent of the strike counter above. A process whose
+# pattern recurs at a cadence just above WATCH_MIN_INTERVAL_SECONDS (e.g. a
+# service restarted repeatedly over a day) never trips the consecutive-strike
+# limit, since each match lands in its own clean cooldown window, yet still
+# forces a full-context agent turn every single time (#93513). watch_patterns
+# is documented as "ONLY for rare one-shot mid-process signals", so once a
+# session has delivered this many matches over its whole life we disable it
+# and fall back to notify_on_complete, same as the strike-limit path.
+WATCH_LIFETIME_MAX_HITS = 8
+
 # Global circuit breaker — across all sessions. Secondary safety net so concurrent
 # siblings can't collectively flood the user even when each is under its own cap.
 WATCH_GLOBAL_MAX_PER_WINDOW = 15
@@ -526,6 +536,12 @@ class ProcessRegistry:
         disabled for this session and the session is promoted to
         notify_on_complete semantics — one notification when the process
         actually exits, no more mid-process spam.
+
+        Independently, WATCH_LIFETIME_MAX_HITS caps the total number of
+        matches ever delivered for a session, so a pattern that keeps
+        recurring at a cadence just above the cooldown (e.g. a service
+        restarted repeatedly over a day) still gets disabled instead of
+        forcing a full-context agent turn indefinitely.
         """
         if not session.watch_patterns or session._watch_disabled:
             return
@@ -552,6 +568,7 @@ class ProcessRegistry:
 
         now = time.time()
         should_disable = False
+        lifetime_exhausted = False
         with session._lock:
             # Case 1: still inside the cooldown from the last emission.
             # Count this as a strike for the current window (only once per window)
@@ -590,6 +607,13 @@ class ProcessRegistry:
                 suppressed = session._watch_suppressed
                 session._watch_suppressed = 0
                 return_early = False
+                # Lifetime cap: this match is delivered (it already earned it),
+                # but disable further ones regardless of how cleanly spaced
+                # they are — see WATCH_LIFETIME_MAX_HITS above.
+                lifetime_exhausted = session._watch_hits >= WATCH_LIFETIME_MAX_HITS
+                if lifetime_exhausted:
+                    session._watch_disabled = True
+                    session.notify_on_complete = True
 
         if return_early:
             if should_disable:
@@ -644,6 +668,29 @@ class ProcessRegistry:
         }
         _redact_process_result(notification)
         self.completion_queue.put(notification)
+
+        if lifetime_exhausted:
+            # Same "why things went quiet" summary as the strike-limit path,
+            # queued right after the final delivered match.
+            self.completion_queue.put({
+                "session_id": session.id,
+                "session_key": session.session_key,
+                "command": session.command,
+                "type": "watch_disabled",
+                "suppressed": 0,
+                "platform": session.watcher_platform,
+                "chat_id": session.watcher_chat_id,
+                "user_id": session.watcher_user_id,
+                "user_name": session.watcher_user_name,
+                "thread_id": session.watcher_thread_id,
+                "message_id": session.watcher_message_id,
+                "message": (
+                    f"Watch patterns disabled for process {session.id} — "
+                    f"reached the lifetime cap of {WATCH_LIFETIME_MAX_HITS} delivered "
+                    f"matches. Falling back to notify_on_complete semantics; you'll get "
+                    f"exactly one notification when the process exits."
+                ),
+            })
 
     def _global_watch_admit(self, now: float) -> bool:
         """Return True if this watch_match event is allowed through the global breaker.

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -648,6 +648,12 @@ class ProcessRegistry:
 
         # Global circuit breaker — across all sessions (secondary safety net).
         if not self._global_watch_admit(now):
+            if lifetime_exhausted:
+                # The final match was dropped by the global breaker, but the
+                # session is already disabled — still tell the user why things
+                # went quiet (the strike path emits its summary unconditionally
+                # too).
+                self._emit_lifetime_watch_disabled(session)
             return
 
         notification = {
@@ -672,25 +678,29 @@ class ProcessRegistry:
         if lifetime_exhausted:
             # Same "why things went quiet" summary as the strike-limit path,
             # queued right after the final delivered match.
-            self.completion_queue.put({
-                "session_id": session.id,
-                "session_key": session.session_key,
-                "command": session.command,
-                "type": "watch_disabled",
-                "suppressed": 0,
-                "platform": session.watcher_platform,
-                "chat_id": session.watcher_chat_id,
-                "user_id": session.watcher_user_id,
-                "user_name": session.watcher_user_name,
-                "thread_id": session.watcher_thread_id,
-                "message_id": session.watcher_message_id,
-                "message": (
-                    f"Watch patterns disabled for process {session.id} — "
-                    f"reached the lifetime cap of {WATCH_LIFETIME_MAX_HITS} delivered "
-                    f"matches. Falling back to notify_on_complete semantics; you'll get "
-                    f"exactly one notification when the process exits."
-                ),
-            })
+            self._emit_lifetime_watch_disabled(session)
+
+    def _emit_lifetime_watch_disabled(self, session: ProcessSession) -> None:
+        """Queue the watch_disabled summary for the lifetime-cap path (#93513)."""
+        self.completion_queue.put({
+            "session_id": session.id,
+            "session_key": session.session_key,
+            "command": session.command,
+            "type": "watch_disabled",
+            "suppressed": 0,
+            "platform": session.watcher_platform,
+            "chat_id": session.watcher_chat_id,
+            "user_id": session.watcher_user_id,
+            "user_name": session.watcher_user_name,
+            "thread_id": session.watcher_thread_id,
+            "message_id": session.watcher_message_id,
+            "message": (
+                f"Watch patterns disabled for process {session.id} — "
+                f"reached the lifetime cap of {WATCH_LIFETIME_MAX_HITS} delivered "
+                f"matches. Falling back to notify_on_complete semantics; you'll get "
+                f"exactly one notification when the process exits."
+            ),
+        })
 
     def _global_watch_admit(self, now: float) -> bool:
         """Return True if this watch_match event is allowed through the global breaker.

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2686,7 +2686,7 @@ def terminal_tool(
         workdir: Working directory for this command (optional, uses session cwd if not set)
         pty: If True, use pseudo-terminal for interactive CLI tools (local backend only)
         notify_on_complete: If True and background=True, you'll be notified exactly once when the process exits. The right choice for almost every long task. MUTUALLY EXCLUSIVE with watch_patterns.
-        watch_patterns: List of strings to watch for in background output. HARD rate limit: 1 notification per 15s per process. After 3 strike windows in a row, watch_patterns is disabled and the session is auto-promoted to notify_on_complete. Use ONLY for rare, one-shot mid-process signals on long-lived processes (server readiness, migration-done markers). NEVER use in loops/batch jobs — error patterns there will hit the strike limit and get disabled. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both.
+        watch_patterns: List of strings to watch for in background output. HARD rate limit: 1 notification per 15s per process. After 3 strike windows in a row — or after a small lifetime cap of delivered matches, however cleanly spaced — watch_patterns is disabled and the session is auto-promoted to notify_on_complete. Use ONLY for rare, one-shot mid-process signals on long-lived processes (server readiness, migration-done markers). NEVER use in loops/batch jobs — error patterns there will hit the strike limit and get disabled. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both.
 
     Returns:
         str: JSON string with output, exit_code, and error fields

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3971,7 +3971,7 @@ TERMINAL_SCHEMA = {
             "watch_patterns": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "Strings to watch for in background output. ONLY for rare one-shot mid-process signals on processes that never exit (e.g. ['Application startup complete'] on a server). NOT for end-of-run markers (use notify_on_complete) and NOT for per-iteration patterns like 'ERROR' in loops — rate-limited to 1 notification/15s; repeated over-firing auto-disables it and falls back to notify-on-exit. When in doubt, use notify_on_complete. MUTUALLY EXCLUSIVE with notify_on_complete."
+                "description": "Strings to watch for in background output. ONLY for rare one-shot mid-process signals on processes that never exit (e.g. ['Application startup complete'] on a server). NOT for end-of-run markers (use notify_on_complete) and NOT for per-iteration patterns like 'ERROR' in loops — rate-limited to 1 notification/15s, capped at a small number of matches over the process's lifetime; over-firing auto-disables it and falls back to notify-on-exit. When in doubt, use notify_on_complete. MUTUALLY EXCLUSIVE with notify_on_complete."
             }
         },
         "required": ["command"]


### PR DESCRIPTION
## Summary
A watch_pattern matching slower than the 15s cooldown could fire full-context agent turns forever — the strike counter reset on every out-of-cooldown match, so auto-disable never tripped (52 triggers/day reported, stalling gateway and detaching desktop sessions). Watches now hit a lifetime delivery cap that disables the watch and promotes it to notify-on-exit. Fixes the unbounded-turns half of #93513.

## Changes
- `tools/process_registry.py`: `WATCH_LIFETIME_MAX_HITS` cap enforced in `_check_watch_patterns`, reusing the existing disable+promotion path and emitting the `watch_disabled` summary event with a clear reason (salvaged from #93532)
- Hardening: only DELIVERED notifications count toward the cap (suppressed ones don't); terminal_tool schema text and run_command docstring document the cap

## Validation
| | Before | After |
|---|---|---|
| Pattern recurring every >15s | unbounded full-context turns | disabled at Nth delivery, promoted |
| Suppressed matches | — | don't consume the cap |
| Tests | — | 109 passed (TestLifetimeCap sabotage-proven; one deselected failure is pre-existing on main) |

Follow-ups per the issue (not in this PR): token-budget context guard for watch-triggered turns; desktop WS re-attach after code-1006 detach. Salvaged from #93532 (@chelsealong), authorship preserved.

## Infographic

![Runaway watch patterns hit a hard ceiling](https://v3b.fal.media/files/b/0aa7989d/mZSTaqvwo21JxlPnPi9-w_tSMOt9YT.png)
