### PR TITLE
fix(gateway): persist cwd for messaging sessions

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -31,7 +31,12 @@ def _now() -> datetime:
 def _gateway_session_cwd() -> str:
     """Return the workspace persisted for gateway-created session rows."""
     configured = (os.environ.get("TERMINAL_CWD") or "").strip()
-    return os.path.expanduser(configured) if configured else str(Path.home())
+    if not configured:
+        return str(Path.home())
+    backend = (os.environ.get("TERMINAL_ENV") or "local").strip().lower()
+    if backend != "local":
+        return configured
+    return str(Path(os.path.expandvars(configured)).expanduser().resolve())
 
 
 # Default auto-continue freshness window in seconds (1 hour).  A session

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -28,6 +28,12 @@ def _now() -> datetime:
     return datetime.now()
 
 
+def _gateway_session_cwd() -> str:
+    """Return the workspace persisted for gateway-created session rows."""
+    configured = (os.environ.get("TERMINAL_CWD") or "").strip()
+    return os.path.expanduser(configured) if configured else str(Path.home())
+
+
 # Default auto-continue freshness window in seconds (1 hour).  A session
 # interrupted by a restart is only auto-resumed — and only returned by
 # ``get_or_create_session`` — while it stays within this window of when
@@ -2318,6 +2324,7 @@ class SessionStore:
                 chat_id=source.chat_id,
                 chat_type=source.chat_type,
                 thread_id=source.thread_id,
+                cwd=_gateway_session_cwd(),
                 display_name=display_name or source.chat_name,
                 origin_json=origin_json,
                 include_compression_ancestors=include_compression_ancestors,
@@ -2932,6 +2939,7 @@ class SessionStore:
                     "chat_id": source.chat_id,
                     "chat_type": source.chat_type,
                     "thread_id": source.thread_id,
+                    "cwd": _gateway_session_cwd(),
                     "profile_name": source.profile,
                     # Identity lands atomically in the INSERT (#82616): a
                     # crash after this write can no longer strand the row
@@ -3444,6 +3452,7 @@ class SessionStore:
                 "chat_id": old_entry.origin.chat_id if old_entry.origin else None,
                 "chat_type": old_entry.origin.chat_type if old_entry.origin else None,
                 "thread_id": old_entry.origin.thread_id if old_entry.origin else None,
+                "cwd": _gateway_session_cwd(),
                 "profile_name": old_entry.origin.profile if old_entry.origin else None,
                 # Identity + lineage land atomically in the INSERT (#82616,
                 # #12857) — see the get_or_create twin path.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5782,6 +5782,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         chat_id: str = None,
         chat_type: str = None,
         thread_id: str = None,
+        cwd: str = None,
         display_name: str = None,
         origin_json: str = None,
         include_compression_ancestors: bool = False,
@@ -5846,6 +5847,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     chat_id,
                     chat_type,
                     thread_id,
+                    cwd,
                     display_name,
                     origin_json,
                 )
@@ -5857,6 +5859,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                    UPDATE sessions
                    SET session_key = ?, source = ?, user_id = ?, chat_id = ?,
                        chat_type = ?, thread_id = ?,
+                       cwd = CASE
+                           WHEN TRIM(COALESCE(cwd, '')) = '' THEN ?
+                           ELSE cwd
+                       END,
                        display_name = COALESCE(?, display_name),
                        origin_json = COALESCE(?, origin_json)
                    {target_clause}""",
@@ -5875,15 +5881,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     conn.execute(
                         """INSERT INTO sessions (
                                id, source, user_id, session_key, chat_id,
-                               chat_type, thread_id, display_name, origin_json,
-                               started_at
+                               chat_type, thread_id, cwd, display_name,
+                               origin_json, started_at
                            )
-                           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                            ON CONFLICT(id) DO UPDATE SET
                                session_key = COALESCE(sessions.session_key, excluded.session_key),
                                chat_id = COALESCE(sessions.chat_id, excluded.chat_id),
                                chat_type = COALESCE(sessions.chat_type, excluded.chat_type),
                                thread_id = COALESCE(sessions.thread_id, excluded.thread_id),
+                               cwd = CASE
+                                   WHEN TRIM(COALESCE(sessions.cwd, '')) = ''
+                                   THEN excluded.cwd
+                                   ELSE sessions.cwd
+                               END,
                                display_name = COALESCE(sessions.display_name, excluded.display_name),
                                origin_json = COALESCE(sessions.origin_json, excluded.origin_json)""",
                         (
@@ -5894,6 +5905,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                             chat_id,
                             chat_type,
                             thread_id,
+                            cwd,
                             display_name,
                             origin_json,
                             time.time(),

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -470,9 +470,10 @@ class TestGatewaySessionCwdPersistence:
         assert store._db.get_session(entry.session_id)["cwd"] == str(home)
 
     def test_peer_refresh_heals_blank_cwd_without_overwriting_explicit_cwd(
-        self, store, tmp_path
+        self, store, tmp_path, monkeypatch
     ):
         healed_cwd = str(tmp_path / "workspace")
+        monkeypatch.setenv("TERMINAL_CWD", healed_cwd)
         db = store._db
         db.create_session("blank", source="slack", session_key="blank-key", cwd="")
         db.create_session(
@@ -480,12 +481,7 @@ class TestGatewaySessionCwdPersistence:
         )
 
         for session_id, session_key in (("blank", "blank-key"), ("explicit", "explicit-key")):
-            db.record_gateway_session_peer(
-                session_id,
-                source="slack",
-                session_key=session_key,
-                cwd=healed_cwd,
-            )
+            store._record_gateway_session_peer(session_id, session_key, self._source())
 
         assert db.get_session("blank")["cwd"] == healed_cwd
         assert db.get_session("explicit")["cwd"] == "/original"

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -433,6 +433,64 @@ class TestSessionStoreRewriteTranscript:
         assert reloaded[1]["content"] == "hi"
 
 
+class TestGatewaySessionCwdPersistence:
+    @pytest.fixture()
+    def store(self, tmp_path, monkeypatch):
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        return SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+
+    @staticmethod
+    def _source():
+        return SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_type="channel",
+            user_id="U123",
+        )
+
+    def test_new_gateway_session_records_configured_terminal_cwd(
+        self, store, tmp_path, monkeypatch
+    ):
+        configured_cwd = tmp_path / "workspace"
+        monkeypatch.setenv("TERMINAL_CWD", str(configured_cwd))
+
+        entry = store.get_or_create_session(self._source())
+
+        assert store._db.get_session(entry.session_id)["cwd"] == str(configured_cwd)
+
+    def test_new_gateway_session_falls_back_to_home(self, store, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        monkeypatch.setattr("gateway.session.Path.home", lambda: home)
+
+        entry = store.get_or_create_session(self._source())
+
+        assert store._db.get_session(entry.session_id)["cwd"] == str(home)
+
+    def test_peer_refresh_heals_blank_cwd_without_overwriting_explicit_cwd(
+        self, store, tmp_path
+    ):
+        healed_cwd = str(tmp_path / "workspace")
+        db = store._db
+        db.create_session("blank", source="slack", session_key="blank-key", cwd="")
+        db.create_session(
+            "explicit", source="slack", session_key="explicit-key", cwd="/original"
+        )
+
+        for session_id, session_key in (("blank", "blank-key"), ("explicit", "explicit-key")):
+            db.record_gateway_session_peer(
+                session_id,
+                source="slack",
+                session_key=session_key,
+                cwd=healed_cwd,
+            )
+
+        assert db.get_session("blank")["cwd"] == healed_cwd
+        assert db.get_session("explicit")["cwd"] == "/original"
+
+
 class TestLoadTranscriptDBOnly:
     """After spec 002, load_transcript reads only from state.db."""
 

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -460,6 +460,29 @@ class TestGatewaySessionCwdPersistence:
 
         assert store._db.get_session(entry.session_id)["cwd"] == str(configured_cwd)
 
+    def test_local_relative_terminal_cwd_is_persisted_as_absolute(
+        self, store, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setenv("TERMINAL_CWD", "workspace")
+
+        entry = store.get_or_create_session(self._source())
+
+        assert store._db.get_session(entry.session_id)["cwd"] == str(
+            (tmp_path / "workspace").resolve()
+        )
+
+    def test_remote_terminal_cwd_preserves_remote_tilde(
+        self, store, monkeypatch
+    ):
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setenv("TERMINAL_CWD", "~/workspace")
+
+        entry = store.get_or_create_session(self._source())
+
+        assert store._db.get_session(entry.session_id)["cwd"] == "~/workspace"
+
     def test_new_gateway_session_falls_back_to_home(self, store, tmp_path, monkeypatch):
         home = tmp_path / "home"
         monkeypatch.delenv("TERMINAL_CWD", raising=False)
@@ -485,6 +508,18 @@ class TestGatewaySessionCwdPersistence:
 
         assert db.get_session("blank")["cwd"] == healed_cwd
         assert db.get_session("explicit")["cwd"] == "/original"
+
+    def test_peer_refresh_inserts_missing_row_with_cwd(
+        self, store, tmp_path, monkeypatch
+    ):
+        configured_cwd = str(tmp_path / "workspace")
+        monkeypatch.setenv("TERMINAL_CWD", configured_cwd)
+
+        store._record_gateway_session_peer("missing", "missing-key", self._source())
+
+        inserted = store._db.get_session("missing")
+        assert inserted is not None
+        assert inserted["cwd"] == configured_cwd
 
 
 class TestLoadTranscriptDBOnly:


### PR DESCRIPTION
## Summary

- persist the configured gateway working directory on newly created messaging sessions
- fall back to the user home directory when no gateway working directory is configured
- repair blank `cwd` values when active legacy gateway sessions refresh their routing metadata, without overwriting an existing value

## Testing

- `scripts/run_tests.sh tests/gateway/test_session.py tests/test_hermes_state.py -q` (311 passed, 2 skipped)

## Related Issue

Closes #93625
