### PR TITLE
feat(sessions): expose bounded lineage metadata

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -9757,8 +9757,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     JOIN sessions child ON child.parent_session_id = parent.id
                     WHERE parent.id = ?
                       AND parent.end_reason = 'compression'
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
+                      AND COALESCE(json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from'), '')
+                          != child.parent_session_id
+                      AND COALESCE(json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from'), '')
+                          != child.parent_session_id
                       AND COALESCE(child.source, '') != 'tool'
                     ORDER BY
                       CASE
@@ -9782,6 +9784,153 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             seen.add(child_id)
             current = child_id
         return current
+
+    def session_list_branch_parent_roots(
+        self,
+        sessions: List[Dict[str, Any]],
+        *,
+        max_rows: int = 200,
+        max_hops: int = 100,
+    ) -> Dict[str, str]:
+        """Return normalized visible-parent roots for listable branch rows.
+
+        ``parent_session_id`` records the exact segment that was live when a
+        branch was created. If that conversation compresses again, the exact
+        segment becomes an intermediate hidden row. Session-list consumers
+        need the compression root instead so the branch remains attached to
+        the one projected parent row.
+
+        The walk deliberately follows only compression edges, using the same
+        explicit-fork discriminator as :meth:`get_compression_lineage`. It is
+        batch-loaded and hard-bounded before traversal: at most ``max_rows``
+        seeds and ``max_hops`` ancestor frontiers are inspected. Missing,
+        malformed, cyclic, or over-depth ancestry simply omits the normalized
+        field; callers keep every admitted session row.
+        """
+        admitted = list(sessions[: max(0, min(int(max_rows), 200))])
+        hop_limit = max(1, min(int(max_hops), 100))
+        if not admitted:
+            return {}
+
+        def _config(row: Dict[str, Any]) -> Dict[str, Any]:
+            raw = row.get("model_config")
+            if not raw:
+                return {}
+            try:
+                parsed = json.loads(raw) if isinstance(raw, str) else raw
+            except (TypeError, json.JSONDecodeError):
+                return {}
+            return parsed if isinstance(parsed, dict) else {}
+
+        # Do not seed this cache from projected list rows. A projected row uses
+        # the compression tip's ``id`` but intentionally retains the root's
+        # ``parent_session_id``/model_config; treating that synthetic shape as
+        # the real tip would stop an ancestor walk one segment too early.
+        cache: Dict[str, Dict[str, Any]] = {}
+        frontier = {
+            str(row["parent_session_id"])
+            for row in admitted
+            if isinstance(row.get("parent_session_id"), str)
+            and row.get("parent_session_id")
+        }
+        with self._read_ctx() as conn:
+            for _ in range(hop_limit + 1):
+                missing = sorted(sid for sid in frontier if sid not in cache)
+                if missing:
+                    placeholders = ",".join("?" for _ in missing)
+                    rows = conn.execute(
+                        "SELECT id, parent_session_id, source, model_config, "
+                        "started_at, ended_at, end_reason FROM sessions "
+                        f"WHERE id IN ({placeholders})",
+                        missing,
+                    ).fetchall()
+                    for row in rows:
+                        cache[str(row["id"])] = dict(row)
+                frontier = {
+                    str(cache[sid]["parent_session_id"])
+                    for sid in frontier
+                    if sid in cache
+                    and isinstance(cache[sid].get("parent_session_id"), str)
+                    and cache[sid].get("parent_session_id")
+                    and str(cache[sid]["parent_session_id"]) not in cache
+                }
+                if not frontier:
+                    break
+
+        def _branch_origin(row: Dict[str, Any]) -> Optional[str]:
+            parent_id = row.get("parent_session_id")
+            if not isinstance(parent_id, str) or not parent_id:
+                return None
+            cfg = _config(row)
+            if "_branched_from" in cfg:
+                marker = cfg.get("_branched_from")
+                # Current writers bind the marker to the exact direct parent.
+                # A mismatched marker is corrupt evidence, not authority.
+                return parent_id if marker == parent_id else None
+
+            # Legacy branch rows predate the marker. Mirror
+            # _BRANCH_CHILD_SQL's end-reason/timestamp fallback exactly.
+            parent = cache.get(parent_id)
+            if not parent or parent.get("end_reason") != "branched":
+                return None
+            child_started = row.get("started_at")
+            parent_ended = parent.get("ended_at")
+            if child_started is None or parent_ended is None:
+                return None
+            try:
+                return parent_id if child_started >= parent_ended else None
+            except TypeError:
+                return None
+
+        def _compression_root(origin: str) -> Optional[str]:
+            current = origin
+            seen: set[str] = set()
+            for _ in range(hop_limit):
+                if not current or current in seen:
+                    return None
+                seen.add(current)
+                child = cache.get(current)
+                if child is None:
+                    return None
+                parent_id = child.get("parent_session_id")
+                if not isinstance(parent_id, str) or not parent_id:
+                    return current
+                # A branch/delegate/tool root starts its own conversation; do
+                # not cross that edge while normalizing its compression root.
+                if self._is_explicit_fork_child_row(child):
+                    return current
+                parent = cache.get(parent_id)
+                if parent is None:
+                    return None
+                if parent.get("end_reason") != "compression":
+                    return current
+                current = parent_id
+            return None
+
+        normalized: Dict[str, str] = {}
+        for row in admitted:
+            visible_id = row.get("id")
+            if not isinstance(visible_id, str) or not visible_id:
+                continue
+            origin = _branch_origin(row)
+            root = _compression_root(origin) if origin else None
+            if root:
+                normalized[visible_id] = root
+        return normalized
+
+    def session_last_active(self, session_id: str) -> Optional[float]:
+        """Return the list-order activity timestamp for one exact session row."""
+        if not session_id:
+            return None
+        with self._read_ctx() as conn:
+            row = conn.execute(
+                f"SELECT {_sql_session_last_active('s')} AS last_active "
+                "FROM sessions s WHERE s.id = ?",
+                (session_id,),
+            ).fetchone()
+        if row is None or row["last_active"] is None:
+            return None
+        return float(row["last_active"])
 
     # Columns excluded from compact_rows projections: only the payload-heavy
     # blob no list consumer renders. Everything else — including gateway
@@ -9932,8 +10081,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             params.append(session_key)
         if exclude_sources:
             placeholders = ",".join("?" for _ in exclude_sources)
-            where_clauses.append(f"s.source NOT IN ({placeholders})")
-            params.extend(exclude_sources)
+            where_clauses.append(
+                f"LOWER(COALESCE(s.source, '')) NOT IN ({placeholders})"
+            )
+            params.extend(str(value).lower() for value in exclude_sources)
         if cwd_prefix:
             clause, clause_params = _cwd_prefix_clause(cwd_prefix)
             where_clauses.append(clause)
@@ -10042,8 +10193,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     JOIN sessions parent ON parent.id = c.cur_id
                     JOIN sessions child ON child.parent_session_id = c.cur_id
                     WHERE parent.end_reason = 'compression'
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
+                      AND COALESCE(json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from'), '')
+                          != child.parent_session_id
+                      AND COALESCE(json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from'), '')
+                          != child.parent_session_id
                       AND COALESCE(child.source, '') != 'tool'
                 ),
                 chain_max AS (
@@ -12298,6 +12451,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         archived_only: bool = False,
         exclude_children: bool = False,
         exclude_sources: List[str] = None,
+        include_hidden: Optional[bool] = None,
     ) -> int:
         """Count sessions, optionally filtered by source.
 
@@ -12312,6 +12466,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         (e.g. ``["cron"]`` so the recents "load more" total matches a
         cron-excluded ``list_sessions_rich`` page and doesn't keep "load more"
         stuck on for buried scheduler sessions).
+
+        ``include_hidden`` is tri-state for compatibility: ``None`` preserves
+        the historical all-row count, while an explicit false mirrors a normal
+        list and true admits hidden rows.
         """
         where_clauses = []
         params = []
@@ -12329,8 +12487,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             params.extend(include_sources)
         if exclude_sources:
             placeholders = ",".join("?" for _ in exclude_sources)
-            where_clauses.append(f"s.source NOT IN ({placeholders})")
-            params.extend(exclude_sources)
+            where_clauses.append(
+                f"LOWER(COALESCE(s.source, '')) NOT IN ({placeholders})"
+            )
+            params.extend(str(value).lower() for value in exclude_sources)
         if cwd_prefix:
             clause, clause_params = _cwd_prefix_clause(cwd_prefix)
             where_clauses.append(clause)
@@ -12342,6 +12502,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             where_clauses.append("s.archived = 1")
         elif not include_archived:
             where_clauses.append("s.archived = 0")
+        # ``None`` preserves the historical count contract for callers that do
+        # not pair this with a visibility-scoped listing. session.list passes
+        # an explicit boolean so its total describes the exact same row set.
+        if include_hidden is False:
+            where_clauses.append("s.hidden = 0")
 
         where_sql = f" WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
 

--- a/tests/tui_gateway/test_session_list_lineage_rpc.py
+++ b/tests/tui_gateway/test_session_list_lineage_rpc.py
@@ -1,0 +1,300 @@
+"""Behavior contract for durable lineage metadata on ``session.list``."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from hermes_state import SessionDB
+import tui_gateway.methods_session  # noqa: F401  (registers RPC methods)
+import tui_gateway.server as srv
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    database = SessionDB(tmp_path / "state.db")
+    monkeypatch.setattr(srv, "_get_db", lambda: database)
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+def _seed(
+    db: SessionDB,
+    sid: str,
+    *,
+    parent: str | None = None,
+    branch_from: str | None = None,
+    source: str = "desktop",
+    started_at: float = 1.0,
+) -> None:
+    model_config = {"_branched_from": branch_from} if branch_from is not None else None
+    db.create_session(
+        sid,
+        source=source,
+        model_config=model_config,
+        parent_session_id=parent,
+    )
+    db._conn.execute(
+        "UPDATE sessions SET title = ?, started_at = ?, last_activity_at = ?, "
+        "message_count = 1 WHERE id = ?",
+        (sid, started_at, started_at, sid),
+    )
+    db._conn.commit()
+
+
+def _compress(db: SessionDB, parent: str, child: str, *, started_at: float) -> None:
+    parent_row = db.get_session(parent)
+    inherited = (
+        json.loads(parent_row["model_config"])
+        if parent_row.get("model_config")
+        else None
+    )
+    db._conn.execute(
+        "UPDATE sessions SET ended_at = ?, end_reason = 'compression' WHERE id = ?",
+        (started_at - 0.5, parent),
+    )
+    _seed(db, child, parent=parent, started_at=started_at)
+    if inherited:
+        db._conn.execute(
+            "UPDATE sessions SET model_config = ? WHERE id = ?",
+            (json.dumps(inherited), child),
+        )
+        db._conn.commit()
+
+
+def _list(**params) -> dict:
+    envelope = srv._methods["session.list"](1, params)
+    assert "error" not in envelope, envelope
+    return envelope["result"]
+
+
+def _by_id(result: dict) -> dict[str, dict]:
+    return {row["id"]: row for row in result["sessions"]}
+
+
+def test_plain_branch_adds_compatible_optional_lineage_fields(db):
+    _seed(db, "parent", started_at=1)
+    _seed(db, "branch", parent="parent", branch_from="parent", started_at=2)
+
+    result = _list()
+    rows = _by_id(result)
+
+    assert rows["branch"]["parent_session_id"] == "parent"
+    assert rows["branch"]["branch_parent_root_id"] == "parent"
+    assert rows["branch"]["last_active"] == 2
+    assert set((
+        "id",
+        "title",
+        "preview",
+        "started_at",
+        "message_count",
+        "source",
+    )) <= set(rows["branch"])
+    assert "model_config" not in rows["branch"]
+    assert "_branched_from" not in rows["branch"]
+    assert result["total"] == 2
+    assert result["has_more"] is False
+
+
+def test_legacy_branch_uses_the_same_listable_fallback(db):
+    _seed(db, "legacy-parent", started_at=1)
+    db._conn.execute(
+        "UPDATE sessions SET ended_at = 1.5, end_reason = 'branched' "
+        "WHERE id = 'legacy-parent'"
+    )
+    db._conn.commit()
+    _seed(db, "legacy-child", parent="legacy-parent", started_at=2)
+
+    row = _by_id(_list())["legacy-child"]
+
+    assert row["parent_session_id"] == "legacy-parent"
+    assert row["branch_parent_root_id"] == "legacy-parent"
+
+
+def test_exact_title_lookup_keeps_root_tip_shape_and_adds_lineage(db):
+    _seed(db, "parent-root", started_at=1)
+    _compress(db, "parent-root", "parent-tip", started_at=2)
+    _seed(
+        db,
+        "named-branch",
+        parent="parent-tip",
+        branch_from="parent-tip",
+        started_at=3,
+    )
+
+    result = _list(title="named-branch")
+    row = result["sessions"][0]
+
+    assert row["id"] == "named-branch"
+    assert row["resolved_id"] == "named-branch"
+    assert row["parent_session_id"] == "parent-tip"
+    assert row["branch_parent_root_id"] == "parent-root"
+    assert row["last_active"] == 3
+    assert result["total"] == 1
+    assert result["has_more"] is False
+
+
+def test_branch_parent_normalizes_through_later_parent_compression(db):
+    _seed(db, "parent-root", started_at=1)
+    _compress(db, "parent-root", "parent-tip-1", started_at=2)
+    _seed(
+        db,
+        "branch",
+        parent="parent-tip-1",
+        branch_from="parent-tip-1",
+        started_at=3,
+    )
+    _compress(db, "parent-tip-1", "parent-tip-2", started_at=4)
+
+    rows = _by_id(_list())
+
+    assert rows["parent-tip-2"]["_lineage_root_id"] == "parent-root"
+    assert rows["branch"]["parent_session_id"] == "parent-tip-1"
+    assert rows["branch"]["branch_parent_root_id"] == "parent-root"
+
+
+def test_compressed_branch_keeps_original_conversation_parent(db):
+    _seed(db, "parent", started_at=1)
+    _seed(
+        db,
+        "branch-root",
+        parent="parent",
+        branch_from="parent",
+        started_at=2,
+    )
+    _compress(db, "branch-root", "branch-tip", started_at=3)
+
+    rows = _by_id(_list())
+
+    assert "branch-root" not in rows
+    assert rows["branch-tip"]["_lineage_root_id"] == "branch-root"
+    assert rows["branch-tip"]["parent_session_id"] == "parent"
+    assert rows["branch-tip"]["branch_parent_root_id"] == "parent"
+
+
+def test_deleted_parent_leaves_branch_visible_as_an_orphan(db):
+    _seed(db, "parent", started_at=1)
+    _seed(db, "branch", parent="parent", branch_from="parent", started_at=2)
+    assert db.delete_session("parent") is True
+
+    rows = _by_id(_list())
+
+    assert set(rows) == {"branch"}
+    assert "parent_session_id" not in rows["branch"]
+    assert "branch_parent_root_id" not in rows["branch"]
+
+
+def test_cycle_and_depth_exhaustion_omit_only_normalized_parent(db):
+    _seed(db, "cycle-a", started_at=1)
+    _seed(db, "cycle-b", started_at=2)
+    db._conn.execute(
+        "UPDATE sessions SET parent_session_id = CASE id "
+        "WHEN 'cycle-a' THEN 'cycle-b' ELSE 'cycle-a' END, "
+        "ended_at = started_at + 0.1, end_reason = 'compression' "
+        "WHERE id IN ('cycle-a', 'cycle-b')"
+    )
+    db._conn.commit()
+    _seed(
+        db,
+        "cycle-branch",
+        parent="cycle-a",
+        branch_from="cycle-a",
+        started_at=3,
+    )
+
+    _seed(db, "deep-root", started_at=10)
+    previous = "deep-root"
+    for index in range(1, 102):
+        child = f"deep-{index}"
+        _compress(db, previous, child, started_at=10 + index)
+        previous = child
+    _seed(
+        db,
+        "deep-branch",
+        parent=previous,
+        branch_from=previous,
+        started_at=200,
+    )
+
+    rows = _by_id(_list())
+
+    assert rows["cycle-branch"]["parent_session_id"] == "cycle-a"
+    assert "branch_parent_root_id" not in rows["cycle-branch"]
+    assert rows["deep-branch"]["parent_session_id"] == previous
+    assert "branch_parent_root_id" not in rows["deep-branch"]
+
+
+def test_pagination_carries_off_page_parent_and_truthful_bounds(db):
+    _seed(db, "parent", started_at=1)
+    _seed(db, "branch", parent="parent", branch_from="parent", started_at=2)
+
+    first = _list(limit=1, offset=0)
+    assert [row["id"] for row in first["sessions"]] == ["branch"]
+    assert first["sessions"][0]["branch_parent_root_id"] == "parent"
+    assert first["total"] == 2
+    assert first["has_more"] is True
+
+    second = _list(limit=1, offset=1)
+    assert [row["id"] for row in second["sessions"]] == ["parent"]
+    assert second["total"] == 2
+    assert second["has_more"] is False
+
+
+def test_total_uses_the_same_hidden_visibility_as_the_page(db):
+    _seed(db, "visible", started_at=1)
+    _seed(db, "hidden", started_at=2)
+    assert db.set_session_hidden("hidden", True) is True
+
+    default = _list()
+    owning = _list(include_hidden=True)
+
+    assert set(_by_id(default)) == {"visible"}
+    assert default["total"] == 1
+    assert set(_by_id(owning)) == {"visible", "hidden"}
+    assert owning["total"] == 2
+
+
+def test_limit_is_clamped_and_internal_sources_do_not_inflate_total(db):
+    for index in range(205):
+        _seed(db, f"row-{index:03d}", started_at=index + 1)
+    _seed(db, "internal-tool", source="tool", started_at=999)
+    _seed(db, "internal-tool-uppercase", source="TOOL", started_at=996)
+    _seed(db, "internal-kanban", source="kanban", started_at=998)
+
+    result = _list(limit=999)
+
+    assert len(result["sessions"]) == 200
+    assert result["total"] == 205
+    assert result["has_more"] is True
+    assert not {"internal-tool", "internal-tool-uppercase", "internal-kanban"} & set(
+        _by_id(result)
+    )
+
+
+def test_requested_profile_remains_the_database_authority(tmp_path, monkeypatch):
+    launch = SessionDB(tmp_path / "launch.db")
+    work = SessionDB(tmp_path / "work.db")
+    _seed(launch, "launch-only")
+    _seed(work, "work-parent")
+    _seed(
+        work,
+        "work-branch",
+        parent="work-parent",
+        branch_from="work-parent",
+        started_at=2,
+    )
+
+    def db_for_profile(profile):
+        return (work, False) if profile == "work" else (launch, False)
+
+    monkeypatch.setattr(srv, "_db_for_profile", db_for_profile)
+    try:
+        result = _list(profile="work")
+        assert set(_by_id(result)) == {"work-parent", "work-branch"}
+        assert _by_id(result)["work-branch"]["branch_parent_root_id"] == "work-parent"
+    finally:
+        launch.close()
+        work.close()

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -177,6 +177,30 @@ def _(rid, params: dict) -> dict:
             # their own source.
             deny = frozenset({"kanban", "tool"})
 
+            def _wire_row(session, branch_parent_roots, *, last_active=None):
+                """Project a rich row without leaking model_config markers."""
+                projected = {
+                    "id": session["id"],
+                    "title": session.get("title") or "",
+                    "preview": session.get("preview") or "",
+                    "started_at": session.get("started_at") or 0,
+                    "message_count": session.get("message_count") or 0,
+                    "source": session.get("source") or "",
+                }
+                lineage_root = session.get("_lineage_root_id")
+                if isinstance(lineage_root, str) and lineage_root:
+                    projected["_lineage_root_id"] = lineage_root
+                parent = session.get("parent_session_id")
+                if isinstance(parent, str) and parent:
+                    projected["parent_session_id"] = parent
+                branch_parent_root = branch_parent_roots.get(session["id"])
+                if branch_parent_root:
+                    projected["branch_parent_root_id"] = branch_parent_root
+                activity = session.get("last_active") if last_active is None else last_active
+                if isinstance(activity, (int, float)):
+                    projected["last_active"] = activity
+                return projected
+
             # ``title``: EXACT-title registry lookup, not a listing. The core
             # UNIQUE title index means at most one session per db carries a
             # given exact title, so callers that treat a title as an identity
@@ -213,64 +237,74 @@ def _(rid, params: dict) -> dict:
                     or row.get("archived")
                     or (row.get("source") or "").strip().lower() in deny
                 ):
-                    return _ok(rid, {"sessions": []})
+                    return _ok(
+                        rid,
+                        {"sessions": [], "total": 0, "has_more": False},
+                    )
                 try:
                     tip = db.resolve_resume_session_id(row["id"]) or row["id"]
                 except Exception:
                     tip = row["id"]
                 tip_row = (db.get_session(tip) or row) if tip != row["id"] else row
+                normalize = getattr(db, "session_list_branch_parent_roots", None)
+                branch_parent_roots = normalize([row]) if callable(normalize) else {}
+                last_active_fn = getattr(db, "session_last_active", None)
+                last_active = last_active_fn(tip) if callable(last_active_fn) else None
+                wire_row = _wire_row(row, branch_parent_roots, last_active=last_active)
+                wire_row["resolved_id"] = tip
+                wire_row["preview"] = tip_row.get("preview") or ""
+                wire_row["message_count"] = tip_row.get("message_count") or 0
                 return _ok(
                     rid,
                     {
-                        "sessions": [
-                            {
-                                "id": row["id"],
-                                "resolved_id": tip,
-                                "title": row.get("title") or "",
-                                "preview": tip_row.get("preview") or "",
-                                "started_at": row.get("started_at") or 0,
-                                "message_count": tip_row.get("message_count") or 0,
-                                "source": row.get("source") or "",
-                            }
-                        ]
+                        "sessions": [wire_row],
+                        "total": 1,
+                        "has_more": False,
                     },
                 )
 
-            limit = int(params.get("limit", 200) or 200)
+            limit = max(1, min(int(params.get("limit", 200) or 200), 200))
+            offset = max(0, min(int(params.get("offset", 0) or 0), 1_000_000))
             # ``include_hidden``: surfaces that OWN hidden sessions (the Bots
             # pane's per-profile browser, plugin session pickers) need to list
             # them; the flag stays off for the resume picker and every other
             # global caller so `hidden` keeps meaning "not in shared lists".
             include_hidden = is_truthy_value(params.get("include_hidden", False))
-            # Over-fetch modestly so per-source filtering doesn't leave us
-            # short; the compression-tip projection in ``list_sessions_rich``
-            # can also merge rows.
-            fetch_limit = max(limit * 2, 200)
+            # Push the deny-list into SQL so LIMIT/OFFSET and total describe the
+            # same visible row set. Keep the small Python check as defense for
+            # older/custom SessionDB implementations that ignore the kwarg.
             rows = [
                 s
                 for s in db.list_sessions_rich(
                     source=None,
-                    limit=fetch_limit,
+                    exclude_sources=sorted(deny),
+                    limit=limit,
+                    offset=offset,
                     order_by_last_active=True,
                     compact_rows=True,
                     include_hidden=include_hidden,
                 )
                 if (s.get("source") or "").strip().lower() not in deny
             ][:limit]
+            normalize = getattr(db, "session_list_branch_parent_roots", None)
+            branch_parent_roots = normalize(rows) if callable(normalize) else {}
+            count = getattr(db, "session_count", None)
+            if callable(count):
+                total = count(
+                    exclude_children=True,
+                    exclude_sources=sorted(deny),
+                    include_hidden=include_hidden,
+                )
+            else:
+                # Compatibility for lightweight third-party/test SessionDB
+                # implementations. The real SessionDB always supplies count.
+                total = offset + len(rows)
             return _ok(
                 rid,
                 {
-                    "sessions": [
-                        {
-                            "id": s["id"],
-                            "title": s.get("title") or "",
-                            "preview": s.get("preview") or "",
-                            "started_at": s.get("started_at") or 0,
-                            "message_count": s.get("message_count") or 0,
-                            "source": s.get("source") or "",
-                        }
-                        for s in rows
-                    ]
+                    "sessions": [_wire_row(s, branch_parent_roots) for s in rows],
+                    "total": total,
+                    "has_more": offset + len(rows) < total,
                 },
             )
         except Exception as e:


### PR DESCRIPTION
## Summary

- extend JSON-RPC `session.list` with optional durable-lineage metadata while preserving every existing row field and exact-title identity shape
- normalize a branch visible parent to the parent conversation compression root so later parent compression cannot orphan the branch in clients
- add bounded ordinary-list pagination (`limit <= 200`, bounded `offset`, truthful `total` / `has_more`) over the same visibility/source predicate

## Contract

Ordinary rows continue to project compression roots as their current tip (`id=tip`, optional `_lineage_root_id=root`). Exact-title registry lookup intentionally keeps its existing stable-root shape (`id=root`, `resolved_id=tip`). Both shapes may now include:

- `parent_session_id`
- `branch_parent_root_id`
- `_lineage_root_id`
- `last_active`

`model_config`, `_branched_from`, and `_delegate_from` never cross the RPC boundary.

The normalizer proves branches from the exact current marker or the existing legacy branch heuristic, then walks only compression edges. It batch-loads at most 200 seeds over at most 100 ancestor frontiers. Missing, malformed, cyclic, or over-depth ancestry omits only `branch_parent_root_id`; the admitted session row remains visible.

Compression traversal binds inherited branch/delegate markers to the direct parent. This lets a branch or delegate conversation compress without mistaking its continuation for another fork, matching the existing `_is_explicit_fork_child_row` contract.

## Verification

- rebased onto current upstream main `dc50f020905d5bdca5d5f683a5898f85b9c07dbd`
- focused lineage contract: 11 passed
- TUI/session + Hermes-state regression: 849 passed
- the same broader suite on untouched current main: 838 passed with the same three failures (Desktop toolset order dependency, subprocess live-system guard cleanup, SQLite trace-callback assertion)
- Ruff on touched files
- diff check clean

Exact implementation head: `7fb8f5723581ab8741ecd5bff9af6acf11f6fe39`.

No live gateway deployment claim is included. Independent QA is intentionally not self-posted.
