### PR TITLE
fix(auth): malformed OpenRouter env key no longer shadows a valid credential-pool key (#93593)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -684,6 +684,42 @@ def has_usable_secret(value: Any, *, min_length: int = 4) -> bool:
     return True
 
 
+# Known API-key prefixes per provider.  Only providers listed here get
+# prefix validation; everyone else is fail-open (unknown formats pass).
+# This exists so an obviously malformed key in .env (truncated paste, wrong
+# provider's key in the wrong var, etc.) doesn't silently shadow a valid
+# credential-pool entry and produce opaque 401s (#93593).
+KNOWN_PROVIDER_KEY_PREFIXES: Dict[str, tuple] = {
+    # All OpenRouter keys are issued as sk-or-... (currently sk-or-v1-).
+    "openrouter": ("sk-or-",),
+}
+
+
+def _secret_matches_declared_prefix(provider_id: str, value: str) -> bool:
+    """Return False only when the provider declares key prefixes and none match.
+
+    Providers without a declared prefix always pass (fail-open): we never
+    hard-reject unknown key formats, only skip values that provably don't
+    belong to a provider whose key format we know.
+    """
+    prefixes = KNOWN_PROVIDER_KEY_PREFIXES.get(provider_id)
+    if not prefixes:
+        return True
+    return any(value.startswith(p) for p in prefixes)
+
+
+def _warn_malformed_secret(provider_id: str, source: str) -> None:
+    prefixes = KNOWN_PROVIDER_KEY_PREFIXES.get(provider_id, ())
+    logger.warning(
+        "Ignoring %s for provider %r: value does not match the expected key "
+        "prefix (%s). Falling back to the next credential source. Fix or "
+        "remove the malformed key to silence this warning.",
+        source,
+        provider_id,
+        " or ".join(prefixes),
+    )
+
+
 def _resolve_api_key_provider_secret(
     provider_id: str, pconfig: ProviderConfig
 ) -> tuple[str, str]:
@@ -708,20 +744,42 @@ def _resolve_api_key_provider_secret(
         # in the user's .env file isn't shadowed by a stale shell export
         # inherited from a parent process (Codex CLI, test runners, etc.).
         val = (get_env_value_prefer_dotenv(env_var) or "").strip()
-        if has_usable_secret(val):
-            return val, env_var
+        if not has_usable_secret(val):
+            continue
+        if not _secret_matches_declared_prefix(provider_id, val):
+            # A provably malformed key (declared prefix mismatch) must not
+            # shadow a valid credential-pool entry (#93593). Warn and keep
+            # looking instead of returning it.
+            _warn_malformed_secret(provider_id, env_var)
+            continue
+        return val, env_var
 
     # Fallback: try credential pool (e.g. zai key stored via auth.json)
     try:
         from agent.credential_pool import load_pool
         pool = load_pool(provider_id)
         if pool and pool.has_credentials():
+            # Prefer the pool's own selection (peek), but iterate the rest of
+            # the entries too so one malformed entry doesn't block a valid one.
+            candidates = []
             entry = pool.peek()
-            if entry:
+            if entry is not None:
+                candidates.append(entry)
+            try:
+                for extra in pool.entries():
+                    if extra is not None and all(extra is not c for c in candidates):
+                        candidates.append(extra)
+            except Exception:
+                pass
+            for entry in candidates:
                 key = getattr(entry, "access_token", "") or getattr(entry, "runtime_api_key", "")
                 key = str(key).strip()
-                if has_usable_secret(key):
-                    return key, f"credential_pool:{provider_id}"
+                if not has_usable_secret(key):
+                    continue
+                if not _secret_matches_declared_prefix(provider_id, key):
+                    _warn_malformed_secret(provider_id, f"credential_pool:{provider_id}")
+                    continue
+                return key, f"credential_pool:{provider_id}"
     except Exception:
         pass
 

--- a/tests/hermes_cli/test_auth_key_prefix_skip.py
+++ b/tests/hermes_cli/test_auth_key_prefix_skip.py
@@ -1,0 +1,176 @@
+"""Regression tests for #93593: a malformed provider key in .env must not
+silently shadow a valid credential-pool key.
+
+Before the fix, ``_resolve_api_key_provider_secret`` returned the FIRST env
+value that passed ``has_usable_secret`` (length + placeholder check only), so
+an obviously malformed OPENROUTER_API_KEY (e.g. a truncated paste or another
+provider's key) in ~/.hermes/.env won over a valid pool entry and produced
+opaque ``401 Missing Authentication header`` errors.
+
+The fix:
+- providers with a declared key prefix (KNOWN_PROVIDER_KEY_PREFIXES) skip
+  env values that don't match, with a WARNING naming the env var, and fall
+  through to the next env var / credential pool;
+- the credential-pool fallback iterates entries instead of only peek(), so a
+  malformed pool entry doesn't block a valid one either;
+- providers WITHOUT a declared prefix are fail-open (unchanged behavior);
+- a VALID env key still wins over the pool (precedence unchanged).
+"""
+
+import logging
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_pconfig(provider_id, env_vars=None):
+    from hermes_cli.auth import ProviderConfig
+    return ProviderConfig(
+        id=provider_id,
+        name=provider_id.title(),
+        auth_type="api_key",
+        api_key_env_vars=tuple(env_vars or [f"{provider_id.upper()}_API_KEY"]),
+    )
+
+
+@pytest.fixture
+def isolated_hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for key in ["OPENROUTER_API_KEY", "DEEPSEEK_API_KEY", "OPENAI_API_KEY"]:
+        monkeypatch.delenv(key, raising=False)
+    return home
+
+
+def _write_env_file(home: Path, **kwargs) -> None:
+    lines = [f"{k}={v}" for k, v in kwargs.items()]
+    (home / ".env").write_text("\n".join(lines) + "\n")
+
+
+def _mock_pool(*entries):
+    pool = MagicMock()
+    pool.has_credentials.return_value = bool(entries)
+    pool.peek.return_value = entries[0] if entries else None
+    pool.entries.return_value = list(entries)
+    return pool
+
+
+def _entry(token):
+    e = MagicMock()
+    e.access_token = token
+    e.runtime_api_key = ""
+    return e
+
+
+class TestMalformedEnvKeySkipped:
+    """Declared-prefix mismatch in .env → warn + fall through to pool."""
+
+    def test_malformed_openrouter_env_key_falls_back_to_pool(
+        self, isolated_hermes_home, caplog
+    ):
+        _write_env_file(isolated_hermes_home, OPENROUTER_API_KEY="not-a-real-openrouter-key")
+        pool = _mock_pool(_entry("sk-or-v1-valid-pool-key-abc123"))
+
+        from hermes_cli.auth import _resolve_api_key_provider_secret
+        with patch("agent.credential_pool.load_pool", return_value=pool):
+            with caplog.at_level(logging.WARNING):
+                key, source = _resolve_api_key_provider_secret(
+                    provider_id="openrouter",
+                    pconfig=_make_pconfig("openrouter"),
+                )
+        assert key == "sk-or-v1-valid-pool-key-abc123"
+        assert source == "credential_pool:openrouter"
+        warnings = [r for r in caplog.records if "OPENROUTER_API_KEY" in r.getMessage()]
+        assert warnings, "expected a WARNING naming the malformed env var"
+        assert "sk-or-" in warnings[0].getMessage()
+
+    def test_malformed_env_key_with_empty_pool_returns_empty(
+        self, isolated_hermes_home, caplog
+    ):
+        """Malformed env key + no pool → empty result, never the bad key."""
+        _write_env_file(isolated_hermes_home, OPENROUTER_API_KEY="sk-proj-wrong-provider-key")
+        pool = _mock_pool()
+
+        from hermes_cli.auth import _resolve_api_key_provider_secret
+        with patch("agent.credential_pool.load_pool", return_value=pool):
+            with caplog.at_level(logging.WARNING):
+                key, source = _resolve_api_key_provider_secret(
+                    provider_id="openrouter",
+                    pconfig=_make_pconfig("openrouter"),
+                )
+        assert key == ""
+        assert source == ""
+
+    def test_malformed_pool_entry_skipped_for_valid_one(self, isolated_hermes_home):
+        """Pool iteration: a malformed first entry must not block a valid second."""
+        pool = _mock_pool(
+            _entry("garbage-pool-entry"),
+            _entry("sk-or-v1-second-entry-good"),
+        )
+
+        from hermes_cli.auth import _resolve_api_key_provider_secret
+        with patch("agent.credential_pool.load_pool", return_value=pool):
+            key, source = _resolve_api_key_provider_secret(
+                provider_id="openrouter",
+                pconfig=_make_pconfig("openrouter"),
+            )
+        assert key == "sk-or-v1-second-entry-good"
+        assert source == "credential_pool:openrouter"
+
+
+class TestNoDeclaredPrefixUnaffected:
+    """Providers without a declared prefix keep today's fail-open behavior."""
+
+    def test_undeclared_provider_env_key_returned_verbatim(self, isolated_hermes_home):
+        _write_env_file(isolated_hermes_home, DEEPSEEK_API_KEY="totally-unknown-format-key")
+
+        from hermes_cli.auth import _resolve_api_key_provider_secret
+        pool = _mock_pool(_entry("pool-key-should-not-win"))
+        with patch("agent.credential_pool.load_pool", return_value=pool) as mp:
+            key, source = _resolve_api_key_provider_secret(
+                provider_id="deepseek",
+                pconfig=_make_pconfig("deepseek"),
+            )
+        assert key == "totally-unknown-format-key"
+        assert source == "DEEPSEEK_API_KEY"
+        mp.assert_not_called()
+
+
+class TestValidEnvKeyStillWins:
+    """Precedence unchanged: a valid env key beats the credential pool."""
+
+    def test_valid_openrouter_env_key_wins_over_pool(self, isolated_hermes_home):
+        _write_env_file(isolated_hermes_home, OPENROUTER_API_KEY="sk-or-v1-env-key-wins")
+        pool = _mock_pool(_entry("sk-or-v1-pool-key-loses"))
+
+        from hermes_cli.auth import _resolve_api_key_provider_secret
+        with patch("agent.credential_pool.load_pool", return_value=pool) as mp:
+            key, source = _resolve_api_key_provider_secret(
+                provider_id="openrouter",
+                pconfig=_make_pconfig("openrouter"),
+            )
+        assert key == "sk-or-v1-env-key-wins"
+        assert source == "OPENROUTER_API_KEY"
+        mp.assert_not_called()
+
+    def test_second_env_var_wins_when_first_is_malformed(self, isolated_hermes_home):
+        """Malformed first env var falls through to a valid SECOND env var."""
+        _write_env_file(
+            isolated_hermes_home,
+            OPENROUTER_API_KEY="malformed-first-var",
+            OPENROUTER_KEY="sk-or-v1-second-var-good",
+        )
+
+        from hermes_cli.auth import _resolve_api_key_provider_secret
+        key, source = _resolve_api_key_provider_secret(
+            provider_id="openrouter",
+            pconfig=_make_pconfig(
+                "openrouter", env_vars=["OPENROUTER_API_KEY", "OPENROUTER_KEY"]
+            ),
+        )
+        assert key == "sk-or-v1-second-var-good"
+        assert source == "OPENROUTER_KEY"


### PR DESCRIPTION
## Summary
A malformed `OPENROUTER_API_KEY` in `.env` can no longer silently shadow a valid credential-pool key — users hit an opaque "401 Missing Authentication header" because the resolver returned the first env value that merely looked non-empty, never reaching the pool. Fixes #93593 (the malformed-env case #42130's fix didn't cover).

## Changes
- `hermes_cli/auth.py`: `KNOWN_PROVIDER_KEY_PREFIXES` (openrouter: `sk-or-`); env values mismatching a declared prefix are skipped with a WARNING naming the env var and expected prefix, resolution continues to the next env var / pool
- Pool fallback iterates entries instead of peek-only, so one malformed pool entry can't block a valid sibling
- Fail-open by design: providers with no declared prefix are untouched; a VALID env key still wins (precedence unchanged); aux/vision paths fixed automatically (shared resolver)

## Validation
| Scenario (real temp HERMES_HOME, no mocks) | Before | After |
|---|---|---|
| Malformed env + valid pool | malformed key → 401 | warns, pool key used |
| Valid env key | wins | wins (unchanged) |
| Provider w/o declared prefix | — | unaffected |
| Tests | — | 6 new regressions green |

## Infographic

![Bad env key can't shadow a good pool key](https://v3b.fal.media/files/b/0aa798e4/BH0XSq1VwmGvHhkKTdsxR_CLpTYgxB.png)
