### PR TITLE
fix(desktop): titlebar unread badge stops counting cron runs (#93552)

### DIFF
--- a/apps/desktop/src/store/session-dot-state.test.ts
+++ b/apps/desktop/src/store/session-dot-state.test.ts
@@ -3,10 +3,20 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import type { SessionInfo } from '@/types/hermes'
 
-import { $sessions, $unreadFinishedSessionIds, setSessions } from './session'
+import {
+  $cronSessions,
+  $messagingSessions,
+  $sessions,
+  $unreadFinishedSessionIds,
+  markAllSessionsRead,
+  setCronSessions,
+  setMessagingSessions,
+  setSessions
+} from './session'
 import {
   $delegatingSessionIds,
   $sessionDotStateById,
+  $unreadSessionCount,
   hasLiveTurn,
   showsRunningArc,
   unreadSessionCount
@@ -169,5 +179,64 @@ describe('unreadSessionCount', () => {
 
   it('does not count alias keys that are not listed rows', () => {
     expect(unreadSessionCount({ tip: 'unread', root: 'unread' }, [{ id: 'tip' }])).toBe(1)
+  })
+})
+
+describe('$unreadSessionCount (titlebar badge)', () => {
+  beforeEach(() => {
+    clearAllSessionStates()
+    $sessions.set([])
+    $cronSessions.set([])
+    $messagingSessions.set([])
+    $unreadFinishedSessionIds.set([])
+    $unreadWriteGuard.set(new Map())
+  })
+
+  afterEach(() => {
+    clearAllSessionStates()
+    $sessions.set([])
+    $cronSessions.set([])
+    $messagingSessions.set([])
+    $unreadFinishedSessionIds.set([])
+    $unreadWriteGuard.set(new Map())
+  })
+
+  it('does not count an unread cron session — cron runs finish unwatched by design (#93552)', () => {
+    setCronSessions([storedRow('cron-1', { source: 'cron' })])
+    $unreadFinishedSessionIds.set(['cron-1'])
+
+    // The cron row itself still paints unread in the sidebar cron section...
+    expect($sessionDotStateById.get()['cron-1']).toBe('unread')
+    // ...but the titlebar badge stays quiet.
+    expect($unreadSessionCount.get()).toBe(0)
+  })
+
+  it('counts an unread regular session', () => {
+    setSessions([storedRow('reg-1', { unread: true })])
+
+    expect($unreadSessionCount.get()).toBe(1)
+  })
+
+  it('counts regular + messaging but never cron', () => {
+    setSessions([storedRow('reg-1', { unread: true })])
+    setMessagingSessions([storedRow('msg-1')])
+    setCronSessions([storedRow('cron-1', { source: 'cron' })])
+    $unreadFinishedSessionIds.set(['msg-1', 'cron-1'])
+
+    expect($unreadSessionCount.get()).toBe(2)
+  })
+
+  it('mark-all-read clears regular and cron unread alike', () => {
+    setSessions([storedRow('reg-1')])
+    setCronSessions([storedRow('cron-1', { source: 'cron' })])
+    $unreadFinishedSessionIds.set(['reg-1', 'cron-1'])
+
+    expect($unreadSessionCount.get()).toBe(1)
+    expect($sessionDotStateById.get()['cron-1']).toBe('unread')
+
+    markAllSessionsRead()
+
+    expect($unreadSessionCount.get()).toBe(0)
+    expect($sessionDotStateById.get()['cron-1']).not.toBe('unread')
   })
 })

--- a/apps/desktop/src/store/session-dot-state.ts
+++ b/apps/desktop/src/store/session-dot-state.ts
@@ -28,7 +28,7 @@ import { computed } from 'nanostores'
 import { stableArray, stableRecord } from '@/lib/stable-array'
 
 import { $backgroundRunningSessionIds } from './composer-status'
-import { $cronSessions, $messagingSessions, $sessions, $unreadFinishedSessionIds, lineageAliases } from './session'
+import { $messagingSessions, $sessions, $unreadFinishedSessionIds, lineageAliases } from './session'
 import {
   $attentionSessionIds,
   $draftSessionIds,
@@ -202,7 +202,12 @@ export function unreadSessionCount(
   return n
 }
 
+/** The titlebar badge. Cron sessions are deliberately EXCLUDED: cron runs
+ *  finish unwatched by design, so counting them turns the badge into a cron
+ *  run counter that is permanently lit (#93552). Their unread state stays
+ *  visible where it belongs — the sidebar's cron section rows — and
+ *  "mark all as read" still acks them (ackAllSessionsRead iterates cron rows). */
 export const $unreadSessionCount = computed(
-  [$sessionDotStateById, $sessions, $cronSessions, $messagingSessions],
-  (byId, sessions, cron, messaging) => unreadSessionCount(byId, sessions, cron, messaging)
+  [$sessionDotStateById, $sessions, $messagingSessions],
+  (byId, sessions, messaging) => unreadSessionCount(byId, sessions, messaging)
 )


### PR DESCRIPTION
## Summary
The desktop titlebar's "unread conversations" badge stops counting cron-run sessions — a user with ~23 cron jobs saw a badge of ~23 with zero actual unread chats, because every unwatched cron run lit an unread dot that fed the same counter. Fixes #93552.

## Changes
- `apps/desktop/src/store/session-dot-state.ts`: `$unreadSessionCount` excludes `$cronSessions`; cron unread dots still paint inside the sidebar cron section
- `markAllSessionsRead` verified to clear regular AND cron watermarks; pet-overlay consumer stays consistent (same corrected atom)

## Validation
| | Before | After |
|---|---|---|
| Unread cron run | +1 titlebar badge | badge unchanged, cron section dot only |
| Unread conversation | +1 | +1 (unchanged) |
| Tests | — | 20 passed (4 new) |

## Infographic

![Badge counts conversations, not cron](https://v3b.fal.media/files/b/0aa798de/-dDSXDFxBqy6dX3M2634G_7jBq73Kt.png)
