### PR TITLE
fix(desktop): opened files stack as tabs in one preview pane instead of new splits (#93610)

### DIFF
--- a/apps/desktop/src/app/chat/preview-tile.test.ts
+++ b/apps/desktop/src/app/chat/preview-tile.test.ts
@@ -41,3 +41,52 @@ describe('preview tiles in Bot Mode', () => {
     expect(contributesToWorkspace(pane, 'bots', 'bot:connection-a::default')).toBe(true)
   })
 })
+
+type DockData = { dock?: { pane?: string; pos?: string } } | undefined
+
+function dockOf(paneId: string) {
+  return (registry.getArea('panes').find(entry => entry.id === paneId)?.data as DockData)?.dock
+}
+
+const fileTarget = (path: string) =>
+  ({ kind: 'file', label: path.split('/').at(-1) ?? path, path, source: path, url: path }) as const
+
+describe('preview tiles stack, not split (#93610)', () => {
+  it('docks the first preview right and stacks the second as a center tab in the same zone', () => {
+    openPreview(fileTarget('/tmp/a.ts'), 'file-browser')
+
+    const first = dockOf('preview-tile:file:/tmp/a.ts')
+
+    expect(first?.pos).toBe('right')
+
+    openPreview(fileTarget('/tmp/b.ts'), 'file-browser')
+
+    const second = dockOf('preview-tile:file:/tmp/b.ts')
+
+    expect(second?.pos).toBe('center')
+    expect(second?.pane).toBe('preview-tile:file:/tmp/a.ts')
+
+    // The first pane's registration is untouched — one preview zone, two tabs.
+    expect(dockOf('preview-tile:file:/tmp/a.ts')?.pos).toBe('right')
+  })
+
+  it('stacks an artifact opened after a file into the same preview zone', () => {
+    openPreview(fileTarget('/tmp/a.ts'), 'file-browser')
+    openPreview({ kind: 'artifact', label: 'Chart', source: 'artifact-1', url: 'artifact-1' }, 'explicit-link')
+
+    const artifact = dockOf('preview-tile:artifact:artifact-1')
+
+    expect(artifact?.pos).toBe('center')
+    expect(artifact?.pane).toBe('preview-tile:file:/tmp/a.ts')
+  })
+
+  it('lets a lone preview open its own right-docked zone again after all tabs closed', () => {
+    openPreview(fileTarget('/tmp/a.ts'), 'file-browser')
+    openPreview(fileTarget('/tmp/b.ts'), 'file-browser')
+    closeRightRail()
+
+    openPreview(fileTarget('/tmp/c.ts'), 'file-browser')
+
+    expect(dockOf('preview-tile:file:/tmp/c.ts')?.pos).toBe('right')
+  })
+})

--- a/apps/desktop/src/app/chat/preview-tile.tsx
+++ b/apps/desktop/src/app/chat/preview-tile.tsx
@@ -11,7 +11,7 @@
  */
 
 import { findGroup } from '@/components/pane-shell/tree/model'
-import { $activeTreeGroup, $layoutTree, revealTreePane } from '@/components/pane-shell/tree/store'
+import { $activeTreeGroup, $layoutTree, revealTreePane, treePanesWithPrefix } from '@/components/pane-shell/tree/store'
 import { FileTypeIcon } from '@/components/ui/file-type-icon'
 import { ToolIcon } from '@/components/ui/tool-icon'
 import { $rightRailActiveTabId, type RightRailTabId, selectRightRailTab } from '@/store/layout'
@@ -72,6 +72,25 @@ function PreviewTabLead({ tabId }: { tabId: string }) {
 
 const PREVIEW_TILE_PREFIX = 'preview-tile'
 
+const previewPaneId = (tabId: string) => `${PREVIEW_TILE_PREFIX}:${tabId}`
+
+/** The pane a NEW preview tile should stack into: another preview tile already
+ *  in the tree, else another open tab adopted earlier in the same pass (a
+ *  reload restores every tab at once, before any of them is in the tree).
+ *  `undefined` means this is the first preview — it opens its own zone. */
+function existingPreviewAnchor(tabId: string): string | undefined {
+  const own = previewPaneId(tabId)
+  const inTree = treePanesWithPrefix(`${PREVIEW_TILE_PREFIX}:`).find(id => id !== own)
+
+  if (inTree) {
+    return inTree
+  }
+
+  const other = $previewTabs.get().find(tab => tab.id !== tabId)
+
+  return other ? previewPaneId(other.id) : undefined
+}
+
 /** Keep pane contributions mirroring `$previewTabs`, keep the store's selection
  *  and the tree's active pane agreeing, and front a tile when its tab is
  *  selected. Call once from the root. */
@@ -128,11 +147,13 @@ const watchPreviewTileMirror = paneMirror<{ id: string }>({
   // `openPreview` ran and the click looked like a no-op.
   key: tab => tab.id,
   prefix: PREVIEW_TILE_PREFIX,
-  // Identical to route (page) tiles: its own zone docked beside main, sized by
-  // the split weights. NOT anchored to the file tree — the old rail was a
-  // files-adjacent strip, and carrying that over welded preview into the file
-  // browser's zone, so ⌘J (toggle file browser) took the preview with it.
-  dir: () => 'right',
+  // The FIRST preview still opens its own zone docked beside main (identical
+  // to route tiles — NOT anchored to the file tree, so ⌘J can't take it
+  // along). Every SUBSEQUENT preview stacks into that zone as a center tab:
+  // without the anchor each opened file split a new zone off the right edge
+  // (#93610), turning three file opens into three ever-narrower columns.
+  dir: tab => (existingPreviewAnchor(tab.id) ? 'center' : 'right'),
+  anchor: tab => existingPreviewAnchor(tab.id),
   minWidth: '22rem',
   title: previewTitle,
   tabLead: tabId => <PreviewTabLead tabId={tabId} />,


### PR DESCRIPTION
## Summary
Opening several files in the desktop app now stacks them as tabs in one preview pane — previously every file open spawned another right-hand split, shredding the workspace into narrow vertical slivers. Fixes #93610.

## Changes
- `apps/desktop/src/app/chat/preview-tile.tsx`: subsequent preview tiles anchor to an existing `preview-tile:*` pane with dir `center` (stack as tabs); the first preview still docks right; after all previews close, the next one docks right again
- Covers files, artifacts, and the Browser tab alike (all share `openPreview`/`$previewTabs`); session and route tiles untouched

## Validation
| Open two files | Before | After |
|---|---|---|
| Layout | two right splits | one preview group, two tabs |
| Session tiles | — | unaffected (13 tests) |
| Tests | — | preview-tile + pane-mirror 9/9 (3 new), tsc + eslint clean |

## Infographic

![Files open as tabs in one preview pane](https://v3b.fal.media/files/b/0aa798f3/rTAdC_v918nLkRn6OQruG_CXcGf6tS.png)
