### PR TITLE
fix(desktop): Bot Chat refreshes on bot switch instead of painting a stale transcript (#93604)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5300,12 +5300,20 @@ async function openStoredBotChat(owner, storedId, summary) {
   // asks the SDK layer to retry that same wait internally, BEFORE it arms the
   // core stranded-session overlay: a plugin-side retry can't do this because
   // only host.openSession sees the resume-exhausted latch that overlay reads.
+  //
+  // forceResume: an explicit bot switch must never trust a cached transcript.
+  // The SDK's surface-health check passes whenever ANY non-empty transcript is
+  // painted, including a stale snapshot the session-states cache kept from the
+  // previous time this bot was open — which left the pane showing old messages
+  // until an app restart (hermes-agent#93604). A resume is cheap and
+  // idempotent, so on this explicit user navigation we always request one.
   await host.openSession(storedId, {
     ...(route ? { route } : {}),
     profile: name,
     intent: 'tab',
     awaitHydration: true,
     expectHistory,
+    forceResume: true,
     keepAllProfilesScope: true,
     workspaceMode: 'bots',
     workspaceOwnerKey: ownerKey,

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -314,6 +314,15 @@ let openSessionGeneration = 0
 export interface PluginOpenSessionOptions {
   awaitHydration?: boolean
   expectHistory?: boolean
+  /** Always request a sequenced session.resume after the open, even when the
+   *  surface already looks healthy. The healthy check trusts any non-empty
+   *  cached transcript, so an explicit bot-switch re-open can paint a STALE
+   *  snapshot kept by the session-states cache and skip the refresh entirely
+   *  (#93604 — Bot Chat shows old messages until app restart). Resume is
+   *  cheap and idempotent (the route-resume effect consumes redundant
+   *  requests as no-ops), so callers who know the user explicitly navigated
+   *  here set this to guarantee freshness. Only honored with awaitHydration. */
+  forceResume?: boolean
   hydrationTimeoutMs?: number
   intent?: OpenSessionIntent
   keepAllProfilesScope?: boolean
@@ -891,7 +900,12 @@ export const host = {
             Boolean($activeSessionId.get()) &&
             (!expectHistory || $messages.get().length > 0)
 
-          if (options.awaitHydration && !surfaceHealthy) {
+          // surfaceHealthy trusts ANY non-empty cached transcript, so it
+          // cannot distinguish a fresh transcript from a stale snapshot the
+          // session-states cache kept across a bot switch (#93604). Callers
+          // that represent an explicit user navigation pass forceResume to
+          // skip the heuristic entirely; the resume is idempotent either way.
+          if (options.awaitHydration && (options.forceResume || !surfaceHealthy)) {
             requestSessionResume(storedSessionId, ownerRoute || undefined)
           }
 

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -663,6 +663,51 @@ describe('profile-aware plugin session opens', () => {
     expect($gatewaySwapTarget.get()).toBeNull()
   })
 
+  it('forces a resume on an explicit bot switch even when a cached transcript looks healthy (#93604)', async () => {
+    // Bot-switch shape from the field: the previous visit left a non-empty
+    // snapshot in the session-states cache, so the surface passes every
+    // health check while painting STALE messages. The heuristic alone skips
+    // the resume; the explicit-navigation caller must be able to force it.
+    $activeGatewayProfile.set('hyoseob')
+    setMockAtom($selectedStoredSessionId, 'bot-chat')
+    setMockAtom($activeSessionId, 'runtime-stale-snapshot')
+    setMockAtom($messages, [{ id: 'stale-history', parts: [], role: 'assistant' }] as never)
+
+    const opening = host.openSession('bot-chat', {
+      profile: 'hyoseob',
+      awaitHydration: true,
+      expectHistory: true,
+      forceResume: true,
+      hydrationTimeoutMs: 1_000
+    })
+
+    await Promise.resolve()
+    expect(requestSessionResume).toHaveBeenCalledWith('bot-chat', undefined)
+
+    await opening
+    expect($gatewaySwapTarget.get()).toBeNull()
+  })
+
+  it('still trusts a healthy surface when the caller does not force a resume', async () => {
+    $activeGatewayProfile.set('hyoseob')
+    setMockAtom($selectedStoredSessionId, 'bot-chat')
+    setMockAtom($activeSessionId, 'runtime-live')
+    setMockAtom($messages, [{ id: 'live-history', parts: [], role: 'assistant' }] as never)
+
+    const opening = host.openSession('bot-chat', {
+      profile: 'hyoseob',
+      awaitHydration: true,
+      expectHistory: true,
+      hydrationTimeoutMs: 1_000
+    })
+
+    await Promise.resolve()
+    expect(requestSessionResume).not.toHaveBeenCalled()
+
+    await opening
+    expect($gatewaySwapTarget.get()).toBeNull()
+  })
+
   it('resolves a history-bearing wake on transcript paint without waiting for the runtime (paint-first)', async () => {
     vi.mocked(openGatewayForProfile).mockImplementationOnce(async () => undefined)
 


### PR DESCRIPTION
## Summary
Switching bots in the desktop can no longer paint a stale cached Bot Chat transcript until app restart: explicit bot-switch opens now always request a session.resume instead of trusting the "any non-empty transcript = healthy" heuristic. Addresses #93604 (needs-repro — this fixes the most likely mechanism identified from static analysis; issue stays open for reporter confirmation).

## Changes
- `apps/desktop/src/sdk/index.ts`: opt-in `forceResume` on plugin openSession options; resume gate becomes `awaitHydration && (forceResume || !surfaceHealthy)`
- `apps/desktop/src/plugins/hermes-bots/plugin.js`: `openStoredBotChat` — the single funnel for explicit bot-switch navigation — passes `forceResume: true`; new-chat kickoffs and all other openSession callers keep the existing heuristic
- Safe by design: the route-resume effect consumes redundant resume requests as no-ops (documented "cheap and idempotent")

## Validation
| | Before | After |
|---|---|---|
| Bot switch with stale >0-message cache | resume skipped, stale pane | resume forced, fresh transcript |
| Non-bot-switch navigations | — | heuristic unchanged (scope-guard test) |
| Tests | — | sdk suite 66/66 |

## Infographic

![Bot Chat refreshes on every bot switch](https://v3b.fal.media/files/b/0aa798f2/AkGT0fB_BEcc6qKoIeVt0_nbajuFDo.png)
