### PR TITLE
feat(goals): surface-neutral goal-turn protocol for embedders

### DIFF
--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -353,26 +353,17 @@ def _extract_file_mutation_targets(tool_name: str, args: Dict[str, Any]) -> List
         body = args.get("patch") or ""
         if not isinstance(body, str) or not body:
             return []
+        from tools.patch_parser import parse_v4a_patch
+
+        operations, parse_error = parse_v4a_patch(body)
+        if parse_error:
+            return []
         paths: List[str] = []
-        for _m in re.finditer(
-            r'^\*\*\*\s+(?:Update|Add|Delete)\s+File:\s*(.+)$',
-            body,
-            re.MULTILINE,
-        ):
-            p = _m.group(1).strip()
-            if p:
-                paths.append(p)
-        for _m in re.finditer(
-            r'^\*\*\*\s+Move\s+File:\s*(.+?)\s*->\s*(.+)$',
-            body,
-            re.MULTILINE,
-        ):
-            src = _m.group(1).strip()
-            dst = _m.group(2).strip()
-            if src:
-                paths.append(src)
-            if dst:
-                paths.append(dst)
+        for op in operations:
+            if op.file_path:
+                paths.append(op.file_path)
+            if op.operation.value == "move" and op.new_path:
+                paths.append(op.new_path)
         return paths
     return []
 

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -260,6 +260,23 @@ class ToolCallGuardrailController:
             self._halt_decision = decision
             return decision
 
+        same_tool_count = self._same_tool_failure_counts.get(tool_name, 0)
+        if same_tool_count >= self.config.same_tool_failure_halt_after:
+            decision = ToolGuardrailDecision(
+                action="block",
+                code="same_tool_failure_block",
+                message=(
+                    f"Blocked {tool_name}: it failed {same_tool_count} times this turn. "
+                    "The last failure was delivered to the model; stop using this tool "
+                    "for the turn and choose a different approach."
+                ),
+                tool_name=tool_name,
+                count=same_tool_count,
+                signature=signature,
+            )
+            self._halt_decision = decision
+            return decision
+
         if self._is_idempotent(tool_name):
             record = self._no_progress.get(signature)
             if record is not None:
@@ -302,21 +319,6 @@ class ToolCallGuardrailController:
 
             same_count = self._same_tool_failure_counts.get(tool_name, 0) + 1
             self._same_tool_failure_counts[tool_name] = same_count
-
-            if self.config.hard_stop_enabled and same_count >= self.config.same_tool_failure_halt_after:
-                decision = ToolGuardrailDecision(
-                    action="halt",
-                    code="same_tool_failure_halt",
-                    message=(
-                        f"Stopped {tool_name}: it failed {same_count} times this turn. "
-                        "Stop retrying the same failing tool path and choose a different approach."
-                    ),
-                    tool_name=tool_name,
-                    count=same_count,
-                    signature=signature,
-                )
-                self._halt_decision = decision
-                return decision
 
             if self.config.warnings_enabled and exact_count >= self.config.exact_failure_warn_after:
                 return ToolGuardrailDecision(

--- a/hermes_cli/goal_session.py
+++ b/hermes_cli/goal_session.py
@@ -105,6 +105,43 @@ def _judge_detail(state: Any, decision: Dict[str, Any]) -> str:
     return raw.removeprefix("judge error:").strip() or "unknown error"
 
 
+def publication_continuation(reason: str, remedy: str, attempts_left: int, paths: Iterable[str] = ()) -> str:
+    """Build the continuation that asks the agent to clear its own publication blocker.
+
+    An embedder that owns a publication step (promoting verified work to a
+    branch, uploading an artifact, filing a release) can find the work DONE and
+    still be unable to publish it. That is not a decision for a human — it is
+    the next step, and usually one the agent that did the work can take.
+
+    Routing it back through the goal loop rather than the embedder's own state
+    machine matters: the loop already owns continuations, attempt budgets, and
+    the boundary between "the agent should act" and "a human must". An embedder
+    that reimplements those grows a second supervisor that drifts from this one.
+
+    The prompt states the verdict already reached, so the agent does not restart
+    finished work; names the blocker and its remedy concretely; and forbids new
+    work, the failure mode being an agent that reads "blocked" as "keep going"
+    and grows the diff instead of shipping it.
+    """
+    listed = [str(item).strip() for item in paths if str(item).strip()]
+    blocker = str(reason or "").strip() or "publication was blocked"
+    if listed:
+        blocker = f"{blocker}:\n" + "\n".join(f"  - {item}" for item in listed)
+    remaining = max(0, int(attempts_left))
+    # A bulleted path list must not be followed by the sentence's period — it
+    # reads as part of the final filename.
+    blocked_sentence = f"Publication was blocked because {blocker}" + ("\n" if listed else ".")
+    return (
+        "[Publication] The goal supervisor has already verified this work as DONE. "
+        f"{blocked_sentence}\n"
+        f"{str(remedy or '').strip() or 'Resolve the blocker so the verified work can be published.'}\n\n"
+        "Do NOT start new work, expand the change, or re-verify what is already done — "
+        "the only remaining task is to clear this blocker so the finished work can be published. "
+        "If it is something you genuinely cannot resolve, say so plainly and stop rather than forcing it. "
+        f"Publication will be attempted {remaining} more time(s) before asking the operator."
+    )
+
+
 def run_goal_turn(
     session_id: str,
     action: str = "evaluate",
@@ -116,6 +153,10 @@ def run_goal_turn(
     max_turns: Optional[int] = None,
     reason: str = "",
     default_max_turns: int = 90,
+    blocked_reason: str = "",
+    blocked_remedy: str = "",
+    blocked_paths: Iterable[str] = (),
+    blocked_attempts_left: int = 0,
 ) -> Dict[str, Any]:
     """Drive one goal-protocol action for ``session_id`` and return an envelope.
 
@@ -126,6 +167,14 @@ def run_goal_turn(
     session holds no goal (a cancelled turn, a cleared session, a crash between
     turns), it is started from that objective instead of failing. The envelope
     then carries ``restarted: True``.
+
+    ``blocked_reason`` reports an embedder-side PUBLICATION precondition that
+    failed after the work was already judged done. It short-circuits the judge —
+    there is nothing new to grade, and grading it again wastes an auxiliary call
+    to re-reach a verdict that already exists — and returns a ``continue``
+    carrying a continuation that names the blocker and its remedy. When the
+    attempt budget is spent it returns ``hard_pause`` instead, because by then
+    the obstacle is not what the reason code claims and a human should see it.
 
     Never raises for an ordinary protocol condition: a missing goal, an unknown
     action, or an unavailable judge all come back as a structured envelope. Only
@@ -215,6 +264,46 @@ def run_goal_turn(
         }
 
     # --- evaluate -----------------------------------------------------------
+    if str(blocked_reason or "").strip():
+        # A publication precondition failed on work the judge already passed.
+        # Do NOT call the judge again: the verdict exists, the response has not
+        # changed, and re-grading it would spend an auxiliary call to reach the
+        # same answer. The mission's next step is the blocker, not a re-judgment.
+        state = manager.state
+        assert state is not None
+        attempts_left = int(blocked_attempts_left)
+        if attempts_left <= 0:
+            return {
+                "protocol_version": PROTOCOL_VERSION,
+                "session_id": session_id,
+                "state": _state_payload(state, status="hard_paused"),
+                "decision": {
+                    "verdict": "hard_pause",
+                    "reason": f"Publication remained blocked ({blocked_reason}) after every attempt.",
+                    "should_continue": False,
+                    "continuation_prompt": None,
+                    "failure_kind": "",
+                },
+                "error": None,
+                "restarted": restarted,
+            }
+        return {
+            "protocol_version": PROTOCOL_VERSION,
+            "session_id": session_id,
+            "state": _state_payload(state, status="active"),
+            "decision": {
+                "verdict": "continue",
+                "reason": f"Publication is blocked ({blocked_reason}); the agent must clear it.",
+                "should_continue": True,
+                "continuation_prompt": publication_continuation(
+                    blocked_reason, blocked_remedy, attempts_left, blocked_paths,
+                ),
+                "failure_kind": "",
+            },
+            "error": None,
+            "restarted": restarted,
+        }
+
     try:
         from hermes_cli.goals import gather_background_processes
 

--- a/hermes_cli/goal_session.py
+++ b/hermes_cli/goal_session.py
@@ -60,7 +60,15 @@ ACTIONS = ("start", "evaluate", "resume", "pause", "cancel", "status")
 # Verdicts an embedder may act on. Anything else is a protocol violation and is
 # normalized to ``failed`` rather than passed through — an unrecognized verdict
 # driving another agent turn is how a loop runs on a decision nobody made.
-_KNOWN_VERDICTS = frozenset({"done", "continue", "wait", "waiting", "failed"})
+#
+# ``inactive`` is deliberately present. ``evaluate_after_turn`` returns it when
+# the goal is not active — a goal that was completed, cleared, or paused between
+# turns — and that is an ORDINARY, expected condition, not a malformed verdict.
+# Normalizing it to ``failed`` (as this module first did) turns a quiet
+# "nothing to supervise" into a mission failure the operator has to resume:
+# production showed three such resumes within minutes of the first deployment,
+# each reading "The goal supervisor returned an unrecognized verdict".
+_KNOWN_VERDICTS = frozenset({"done", "continue", "wait", "waiting", "failed", "inactive"})
 
 
 def _state_payload(state: Any, *, status: Optional[str] = None) -> Dict[str, Any]:
@@ -235,6 +243,19 @@ def run_goal_turn(
             f"The goal supervisor is unavailable ({_judge_detail(state, decision)}); "
             "progress cannot be verified."
         )
+    elif verdict == "inactive":
+        # There is nothing left to supervise. Resolve it against the goal's own
+        # status rather than reporting a verdict no embedder can act on: a goal
+        # that reached `done` between turns IS done, and one that was paused is
+        # a pause. Neither is a failure, and neither should cost the operator a
+        # Resume.
+        should_continue, continuation = False, None
+        if str(state.status) == "paused":
+            verdict, status = "hard_pause", "hard_paused"
+            decision["reason"] = decision.get("reason") or "The goal is paused; there is nothing to supervise."
+        else:
+            verdict, status = "done", "done"
+            decision["reason"] = decision.get("reason") or "The goal is no longer active; nothing remains to supervise."
     elif status == "paused":
         verdict, status, should_continue, continuation = "hard_pause", "hard_paused", False, None
     elif verdict == "waiting":

--- a/hermes_cli/goal_session.py
+++ b/hermes_cli/goal_session.py
@@ -1,0 +1,259 @@
+"""Surface-neutral goal-turn protocol for embedders (Stage 1 of the HAC extraction).
+
+Why this exists
+---------------
+``GoalManager`` (:mod:`hermes_cli.goals`) is the semantic owner of the
+persistent-goal loop, and every in-tree surface drives it directly: the gateway
+at ``gateway/run.py`` (``_post_turn_goal_continuation``), the TUI gateway, and
+the CLI. An EMBEDDER — a console that runs Hermes as a child process and owns
+its own turn loop — has no such entry point, so it must reach in from outside:
+resolve the manager, call ``evaluate_after_turn``, and reassemble a decision
+envelope itself.
+
+Doing that across a process boundary is where embedded goal loops actually
+fail. Measured in one embedder's production telemetry over 5,001 mission events:
+the operator-facing noise was almost entirely bridge faults, not judgments about
+the work — ``no active goal`` (51), judge transport errors (33), raw
+``RuntimeError`` (80), and ``invalid turn count`` (10). None of those are
+decisions; they are an outside caller failing to keep a goal it cannot see.
+
+This module is the supported entry point, so that logic lives in ONE place,
+next to the state it describes:
+
+    from hermes_cli.goal_session import run_goal_turn
+    envelope = run_goal_turn("sess-123", "evaluate", response=answer)
+
+It is deliberately transport-free: no argparse, no JSON on stdout, no exit
+codes. A caller in-process gets a dict; a caller over a gateway or a subprocess
+serializes that same dict. The envelope shape is stable and versioned.
+
+What it fixes relative to reaching in from outside
+--------------------------------------------------
+1. **``goal_not_found`` on evaluate is impossible when an objective is known.**
+   ``evaluate`` accepts ``goal=`` and starts the goal itself if the session has
+   none, rather than returning an error the caller has to recognize and repair
+   with a second round-trip. The repair is reported honestly in
+   ``envelope["restarted"]`` so an audit trail does not silently claim
+   continuity that never existed.
+2. **A judge outage is classified once, here.** It arrives from the judge as an
+   ordinary ``failed``/``paused``, which reads identically to "this work is
+   wrong". Embedders that cannot tell them apart park missions behind a button
+   for an infrastructure fault. The envelope tags it ``failure_kind =
+   'judge_unavailable'`` so an embedder may self-heal an outage while a real
+   ``failed`` verdict still reaches the operator immediately.
+3. **The turn counters are internally consistent by construction**, because the
+   state is read after the evaluation that advanced it rather than being
+   re-derived by a caller comparing two snapshots.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+PROTOCOL_VERSION = 1
+
+ACTIONS = ("start", "evaluate", "resume", "pause", "cancel", "status")
+
+# Verdicts an embedder may act on. Anything else is a protocol violation and is
+# normalized to ``failed`` rather than passed through — an unrecognized verdict
+# driving another agent turn is how a loop runs on a decision nobody made.
+_KNOWN_VERDICTS = frozenset({"done", "continue", "wait", "waiting", "failed"})
+
+
+def _state_payload(state: Any, *, status: Optional[str] = None) -> Dict[str, Any]:
+    return {
+        "status": status or state.status,
+        "turns_used": int(state.turns_used),
+        "max_turns": int(state.max_turns),
+    }
+
+
+def _error(session_id: str, code: str, message: str) -> Dict[str, Any]:
+    return {
+        "protocol_version": PROTOCOL_VERSION,
+        "session_id": session_id,
+        "state": None,
+        "decision": None,
+        "error": {"code": code, "message": message},
+    }
+
+
+def _judge_unavailable(state: Any, decision: Dict[str, Any]) -> bool:
+    """Detect a judge OUTAGE from every source that can report one.
+
+    The judge's failure surfaces either as a ``paused_reason`` on the state or
+    as an already-resolved reason on the decision, and only ever as a
+    ``judge error:`` prefix. Checking one spelling silently returns the loop.
+    """
+    candidates = (getattr(state, "paused_reason", "") or "", decision.get("reason") or "")
+    return any(str(item).strip().startswith("judge error:") for item in candidates)
+
+
+def _judge_detail(state: Any, decision: Dict[str, Any]) -> str:
+    raw = str(getattr(state, "paused_reason", "") or decision.get("reason") or "")
+    return raw.removeprefix("judge error:").strip() or "unknown error"
+
+
+def run_goal_turn(
+    session_id: str,
+    action: str = "evaluate",
+    *,
+    goal: str = "",
+    response: str = "",
+    contract: Optional[Dict[str, str]] = None,
+    gates: Iterable[str] = (),
+    max_turns: Optional[int] = None,
+    reason: str = "",
+    default_max_turns: int = 90,
+) -> Dict[str, Any]:
+    """Drive one goal-protocol action for ``session_id`` and return an envelope.
+
+    ``action`` is one of :data:`ACTIONS`. ``evaluate`` is the interesting one:
+    it grades ``response`` and returns the decision that may drive another turn.
+
+    Passing ``goal`` alongside ``evaluate`` makes the call SELF-HEALING — if the
+    session holds no goal (a cancelled turn, a cleared session, a crash between
+    turns), it is started from that objective instead of failing. The envelope
+    then carries ``restarted: True``.
+
+    Never raises for an ordinary protocol condition: a missing goal, an unknown
+    action, or an unavailable judge all come back as a structured envelope. Only
+    a genuine programming error propagates.
+    """
+    session_id = str(session_id or "").strip()
+    if not session_id:
+        return _error("", "invalid_session", "A session id is required")
+    if action not in ACTIONS:
+        return _error(session_id, "invalid_action", f"Unknown goal action {action!r}")
+
+    try:
+        from hermes_cli.goals import GoalManager
+    except Exception as exc:  # noqa: BLE001 — an embedder must get an envelope, not a traceback
+        return _error(session_id, "goals_unavailable", f"goals module unavailable: {exc}")
+
+    manager = GoalManager(session_id, default_max_turns=int(max_turns or default_max_turns))
+    restarted = False
+
+    def _start() -> Any:
+        built = None
+        if contract:
+            from hermes_cli.goals import GoalContract
+
+            fields = {key: str(contract.get(key) or "").strip() for key in
+                      ("outcome", "verification", "constraints", "boundaries", "stop_when")}
+            if any(fields.values()):
+                built = GoalContract(**fields)
+        state = manager.set(goal, max_turns=max_turns, contract=built)
+        # Gates are appended after `set` because add_gate requires an active
+        # goal. They run at the turn boundary BEFORE the judge and short-circuit
+        # it on failure, which is the deterministic half of "done".
+        for command in (str(item).strip() for item in gates):
+            if command:
+                manager.add_gate(command)
+        return state
+
+    if action == "start":
+        if not str(goal or "").strip():
+            return _error(session_id, "invalid_goal", "A goal is required to start")
+        return {
+            "protocol_version": PROTOCOL_VERSION,
+            "session_id": session_id,
+            "state": _state_payload(_start()),
+            "decision": None,
+            "error": None,
+            "restarted": False,
+        }
+
+    if manager.state is None:
+        # The self-healing path. An embedder that knows the objective should
+        # never have to recognize `goal_not_found`, issue a `start`, and retry —
+        # that round-trip is the single commonest bridge fault in production.
+        if action == "evaluate" and str(goal or "").strip():
+            _start()
+            restarted = True
+            logger.info("goal_session: restarted a missing goal for session %s", session_id)
+        else:
+            return _error(session_id, "goal_not_found", "No persistent goal exists for this session")
+
+    if action in {"resume", "pause", "cancel", "status"}:
+        if action == "resume":
+            state = manager.resume(reset_budget=False)
+        elif action == "pause":
+            state = manager.pause(reason or "user-paused")
+        elif action == "cancel":
+            state = manager.state
+            manager.clear()
+            return {
+                "protocol_version": PROTOCOL_VERSION,
+                "session_id": session_id,
+                "state": _state_payload(state, status="cancelled"),
+                "decision": None,
+                "error": None,
+                "restarted": restarted,
+            }
+        else:
+            state = manager.state
+        assert state is not None
+        return {
+            "protocol_version": PROTOCOL_VERSION,
+            "session_id": session_id,
+            "state": _state_payload(state),
+            "decision": None,
+            "error": None,
+            "restarted": restarted,
+        }
+
+    # --- evaluate -----------------------------------------------------------
+    try:
+        from hermes_cli.goals import gather_background_processes
+
+        background = gather_background_processes()
+    except Exception:  # noqa: BLE001 — the live process list is an optimization
+        background = None
+
+    decision = manager.evaluate_after_turn(response, background_processes=background)
+    state = manager.state
+    assert state is not None
+
+    verdict = str(decision.get("verdict") or "failed")
+    status = str(decision.get("status") or state.status)
+    should_continue = bool(decision.get("should_continue"))
+    continuation = decision.get("continuation_prompt")
+    failure_kind = ""
+
+    if _judge_unavailable(state, decision):
+        # An OUTAGE, not a verdict about the work. Reported as `failed` so a
+        # caller that ignores `failure_kind` still stops safely, but tagged so a
+        # caller that understands it may continue unsupervised rather than
+        # parking a healthy mission behind a button.
+        verdict, status, should_continue, continuation = "failed", "failed", False, None
+        failure_kind = "judge_unavailable"
+        decision["reason"] = (
+            f"The goal supervisor is unavailable ({_judge_detail(state, decision)}); "
+            "progress cannot be verified."
+        )
+    elif status == "paused":
+        verdict, status, should_continue, continuation = "hard_pause", "hard_paused", False, None
+    elif verdict == "waiting":
+        status = "active"
+    elif verdict not in _KNOWN_VERDICTS:
+        decision["reason"] = f"The goal supervisor returned an unrecognized verdict ({verdict!r})"
+        verdict, status, should_continue, continuation = "failed", "failed", False, None
+
+    return {
+        "protocol_version": PROTOCOL_VERSION,
+        "session_id": session_id,
+        "state": _state_payload(state, status=status),
+        "decision": {
+            "verdict": verdict,
+            "reason": str(decision.get("reason") or "No goal decision reason was returned"),
+            "should_continue": should_continue,
+            "continuation_prompt": continuation,
+            "failure_kind": failure_kind,
+        },
+        "error": None,
+        "restarted": restarted,
+    }

--- a/run_agent.py
+++ b/run_agent.py
@@ -3049,44 +3049,30 @@ class AIAgent:
 
     @classmethod
     def _format_file_mutation_failure_footer(cls, failed: Dict[str, Dict[str, Any]]) -> str:
-        """Render the per-turn failed-mutation dict as a user-facing footer.
+        """Render a safe aggregate advisory for failed file mutations.
 
-        Displays up to 10 paths with their first error preview, then a
-        count of any additional failures.  Returns an empty string when
-        the dict is empty so callers can concatenate unconditionally.
-
-        Every file path that reaches the user-facing text — both the bullet
-        path and any path echoed inside the tool's error preview — is
-        backtick-wrapped via ``_neutralize_footer_paths`` so the gateway's
-        bare-path media extractor can never auto-attach a protected file
-        (e.g. ``~/.hermes/config.yaml``) to a messaging channel (#35584).
+        Tool-call arguments and error previews are untrusted model/provider data:
+        a corrupted argument can contain a plausible but false path.  Keep those
+        details in the tool transcript rather than echoing them after an otherwise
+        complete final answer.  The footer reports only aggregate counts by tool.
         """
         if not failed:
             return ""
-        lines = [
+        tool_counts: Dict[str, int] = {}
+        for info in failed.values():
+            tool = str(info.get("tool") or "file mutation")
+            tool_counts[tool] = tool_counts.get(tool, 0) + 1
+        breakdown = ", ".join(
+            f"{count} {tool}" for tool, count in sorted(tool_counts.items())
+        )
+        return (
             "⚠️ File-mutation verifier: "
             f"{len(failed)} file-mutation target(s) failed and were not later "
             "confirmed successful under the same path. Other edits may still "
-            "have succeeded this turn. Run `git status` or `read_file` to confirm."
-        ]
-        shown = 0
-        for path, info in failed.items():
-            if shown >= 10:
-                break
-            preview = (info.get("error_preview") or "").strip()
-            tool = info.get("tool") or "patch"
-            if preview:
-                lines.append(f"  • `{path}` — [{tool}] {preview}")
-            else:
-                lines.append(f"  • `{path}` — [{tool}] failed")
-            shown += 1
-        remaining = len(failed) - shown
-        if remaining > 0:
-            lines.append(f"  • … and {remaining} more")
-        # Neutralize any path the preview text echoed (the bullet path is
-        # already backticked above; the lookbehind keeps it from being
-        # double-wrapped).
-        return cls._neutralize_footer_paths("\n".join(lines))
+            "have succeeded this turn. Inspect the tool transcript, then run "
+            "`git status` or `read_file` to confirm. "
+            f"Failed calls by tool: {breakdown}."
+        )
 
     def _turn_completion_explainer_enabled(self) -> bool:
         """Check whether the end-of-turn completion explainer footer is on.

--- a/run_agent.py
+++ b/run_agent.py
@@ -3065,9 +3065,9 @@ class AIAgent:
             return ""
         lines = [
             "⚠️ File-mutation verifier: "
-            f"{len(failed)} file(s) were NOT modified this turn despite any "
-            "wording above that may suggest otherwise. Run `git status` or "
-            "`read_file` to confirm."
+            f"{len(failed)} file-mutation target(s) failed and were not later "
+            "confirmed successful under the same path. Other edits may still "
+            "have succeeded this turn. Run `git status` or `read_file` to confirm."
         ]
         shown = 0
         for path, info in failed.items():

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -167,7 +167,7 @@ def test_same_tool_varying_args_warns_by_default_without_halting():
     assert controller.halt_decision is None
 
 
-def test_hard_stop_enabled_halts_same_tool_varying_args_failure_streak():
+def test_hard_stop_enabled_warns_at_same_tool_threshold_then_blocks_next_call():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(
             hard_stop_enabled=True,
@@ -183,9 +183,14 @@ def test_hard_stop_enabled_halts_same_tool_varying_args_failure_streak():
     assert second.action == "warn"
     assert second.code == "same_tool_failure_warning"
     third = controller.after_call("terminal", {"command": "cmd-3"}, '{"exit_code":1}', failed=True)
-    assert third.action == "halt"
-    assert third.code == "same_tool_failure_halt"
+    assert third.action == "warn"
+    assert third.code == "same_tool_failure_warning"
     assert third.count == 3
+
+    blocked = controller.before_call("terminal", {"command": "cmd-4"})
+    assert blocked.action == "block"
+    assert blocked.code == "same_tool_failure_block"
+    assert blocked.count == 3
 
 
 def test_idempotent_no_progress_repeated_result_warns_without_blocking_by_default():

--- a/tests/hermes_cli/test_goal_session.py
+++ b/tests/hermes_cli/test_goal_session.py
@@ -154,6 +154,49 @@ def test_an_unrecognized_verdict_is_normalized_to_failed(monkeypatch):
     assert "vibes" in decision["reason"]
 
 
+def test_an_inactive_goal_resolves_rather_than_failing(monkeypatch):
+    """`inactive` is an ordinary condition, not a malformed verdict.
+
+    ``evaluate_after_turn`` returns it when the goal is no longer active — done,
+    cleared, or paused between turns. Normalizing it to `failed` cost the
+    operator a Resume for a mission that had simply finished: production showed
+    three such resumes within minutes of the first deployment.
+    """
+
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = _State(status="done")
+
+        def evaluate_after_turn(self, response, background_processes=None):
+            return {"verdict": "inactive", "reason": "no active goal",
+                    "should_continue": False, "continuation_prompt": None}
+
+    _install_fake_goals(monkeypatch, Manager)
+    from hermes_cli.goal_session import run_goal_turn
+
+    result = run_goal_turn("s1", "evaluate", response="x")
+    assert result["decision"]["verdict"] == "done"
+    assert result["decision"]["failure_kind"] == ""
+    assert result["decision"]["should_continue"] is False
+
+
+def test_an_inactive_goal_that_was_paused_reports_a_pause(monkeypatch):
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = _State(status="paused")
+
+        def evaluate_after_turn(self, response, background_processes=None):
+            return {"verdict": "inactive", "reason": "no active goal",
+                    "should_continue": False, "continuation_prompt": None}
+
+    _install_fake_goals(monkeypatch, Manager)
+    from hermes_cli.goal_session import run_goal_turn
+
+    result = run_goal_turn("s1", "evaluate", response="x")
+    assert result["decision"]["verdict"] == "hard_pause"
+    assert result["state"]["status"] == "hard_paused"
+
+
 def test_a_paused_state_becomes_a_hard_pause(monkeypatch):
     class Manager:
         def __init__(self, session_id, *, default_max_turns):

--- a/tests/hermes_cli/test_goal_session.py
+++ b/tests/hermes_cli/test_goal_session.py
@@ -197,6 +197,70 @@ def test_an_inactive_goal_that_was_paused_reports_a_pause(monkeypatch):
     assert result["state"]["status"] == "hard_paused"
 
 
+def test_a_publication_blocker_returns_a_continuation_without_re_judging(monkeypatch):
+    """The verdict already exists; re-grading it would spend an aux call for nothing."""
+    judged = []
+
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = _State()
+
+        def evaluate_after_turn(self, response, background_processes=None):
+            judged.append(response)
+            return {"verdict": "continue", "reason": "x", "should_continue": True,
+                    "continuation_prompt": "y"}
+
+    _install_fake_goals(monkeypatch, Manager)
+    from hermes_cli.goal_session import run_goal_turn
+
+    result = run_goal_turn(
+        "s1", "evaluate", response="done", blocked_reason="branch-not-pushed",
+        blocked_remedy="Push it.", blocked_paths=["a.py"], blocked_attempts_left=2,
+    )
+
+    assert judged == [], "the judge must not run again for a publication blocker"
+    decision = result["decision"]
+    assert decision["verdict"] == "continue"
+    assert "branch-not-pushed" in decision["continuation_prompt"]
+    assert "Push it." in decision["continuation_prompt"]
+    assert "a.py" in decision["continuation_prompt"]
+    assert "2 more time" in decision["continuation_prompt"]
+
+
+def test_a_publication_blocker_hard_pauses_once_the_budget_is_spent(monkeypatch):
+    """If naming the blocker did not clear it, a human must see it."""
+
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = _State()
+
+        def evaluate_after_turn(self, response, background_processes=None):
+            raise AssertionError("the judge must not be called")
+
+    _install_fake_goals(monkeypatch, Manager)
+    from hermes_cli.goal_session import run_goal_turn
+
+    result = run_goal_turn("s1", "evaluate", response="done",
+                           blocked_reason="worktree-dirty", blocked_attempts_left=0)
+
+    assert result["decision"]["verdict"] == "hard_pause"
+    assert result["decision"]["should_continue"] is False
+    assert result["state"]["status"] == "hard_paused"
+
+
+def test_the_publication_continuation_forbids_new_work():
+    """The failure mode is an agent that reads 'blocked' as 'keep going'."""
+    from hermes_cli.goal_session import publication_continuation
+
+    text = publication_continuation("branch-not-pushed", "Push the branch.", 1)
+    assert "already verified this work as DONE" in text
+    assert "Do NOT start new work" in text
+    # A bulleted path list must not run into the sentence's period.
+    listed = publication_continuation("worktree-dirty", "Commit it.", 1, ["x.py", "  "])
+    assert listed.count("- x.py") == 1
+    assert "  - x.py." not in listed
+
+
 def test_a_paused_state_becomes_a_hard_pause(monkeypatch):
     class Manager:
         def __init__(self, session_id, *, default_max_turns):

--- a/tests/hermes_cli/test_goal_session.py
+++ b/tests/hermes_cli/test_goal_session.py
@@ -1,0 +1,206 @@
+"""Contract tests for the embedder goal-turn protocol (``hermes_cli.goal_session``).
+
+These pin the properties an EMBEDDER depends on. Each one corresponds to a
+failure class measured in a real embedded deployment, where the same logic was
+reimplemented outside the process and drifted.
+"""
+
+import sys
+import types
+
+import pytest
+
+
+def _install_fake_goals(monkeypatch, manager_cls, contract_cls=None):
+    module = types.SimpleNamespace(
+        GoalManager=manager_cls,
+        GoalContract=contract_cls or (lambda **kw: dict(kw)),
+        gather_background_processes=lambda: [],
+    )
+    monkeypatch.setitem(sys.modules, "hermes_cli.goals", module)
+    return module
+
+
+class _State:
+    def __init__(self, status="active", turns_used=1, max_turns=10, paused_reason=""):
+        self.status = status
+        self.turns_used = turns_used
+        self.max_turns = max_turns
+        self.paused_reason = paused_reason
+
+
+def test_unknown_action_is_an_envelope_not_an_exception():
+    from hermes_cli.goal_session import run_goal_turn
+
+    result = run_goal_turn("s1", "teleport")
+    assert result["error"]["code"] == "invalid_action"
+    assert result["state"] is None
+
+
+def test_missing_session_id_is_rejected():
+    from hermes_cli.goal_session import run_goal_turn
+
+    assert run_goal_turn("  ", "status")["error"]["code"] == "invalid_session"
+
+
+def test_evaluate_restarts_a_vanished_goal_when_the_objective_is_supplied(monkeypatch):
+    """The single commonest embedded failure: `goal_not_found` on evaluate.
+
+    An embedder that knows the objective should never have to recognize the
+    error, issue a `start`, and retry — that round-trip is the bug.
+    """
+    started = {}
+
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = None
+
+        def set(self, goal, *, max_turns=None, contract=None):
+            started["goal"] = goal
+            self.state = _State()
+            return self.state
+
+        def add_gate(self, command):
+            started.setdefault("gates", []).append(command)
+
+        def evaluate_after_turn(self, response, background_processes=None):
+            return {"verdict": "continue", "reason": "keep going",
+                    "should_continue": True, "continuation_prompt": "next"}
+
+    _install_fake_goals(monkeypatch, Manager)
+    from hermes_cli.goal_session import run_goal_turn
+
+    result = run_goal_turn("s1", "evaluate", response="did a thing", goal="Ship it")
+
+    assert started["goal"] == "Ship it"
+    assert result["restarted"] is True
+    assert result["decision"]["verdict"] == "continue"
+
+
+def test_evaluate_without_an_objective_still_reports_goal_not_found(monkeypatch):
+    """Self-healing must not invent a goal out of nothing."""
+
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = None
+
+    _install_fake_goals(monkeypatch, Manager)
+    from hermes_cli.goal_session import run_goal_turn
+
+    assert run_goal_turn("s1", "evaluate", response="x")["error"]["code"] == "goal_not_found"
+
+
+@pytest.mark.parametrize("where", ["state", "decision"])
+def test_a_judge_outage_is_tagged_rather_than_read_as_a_failed_verdict(monkeypatch, where):
+    """An outage and a real `failed` both arrive as `failed`; only one may self-heal.
+
+    The reason can surface on the state OR on the decision. Checking one
+    spelling silently returns the loop, so both are pinned.
+    """
+
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = _State(paused_reason="judge error: BadRequestError" if where == "state" else "")
+
+        def evaluate_after_turn(self, response, background_processes=None):
+            reason = "judge error: BadRequestError" if where == "decision" else "the work is wrong"
+            return {"verdict": "failed", "reason": reason,
+                    "should_continue": False, "continuation_prompt": None}
+
+    _install_fake_goals(monkeypatch, Manager)
+    from hermes_cli.goal_session import run_goal_turn
+
+    decision = run_goal_turn("s1", "evaluate", response="x")["decision"]
+    assert decision["verdict"] == "failed"
+    assert decision["failure_kind"] == "judge_unavailable"
+    assert "BadRequestError" in decision["reason"]
+
+
+def test_a_genuine_failed_verdict_is_not_tagged_as_an_outage(monkeypatch):
+    """A real judgment about the work must reach the operator immediately."""
+
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = _State()
+
+        def evaluate_after_turn(self, response, background_processes=None):
+            return {"verdict": "failed", "reason": "the tests do not pass",
+                    "should_continue": False, "continuation_prompt": None}
+
+    _install_fake_goals(monkeypatch, Manager)
+    from hermes_cli.goal_session import run_goal_turn
+
+    assert run_goal_turn("s1", "evaluate", response="x")["decision"]["failure_kind"] == ""
+
+
+def test_an_unrecognized_verdict_is_normalized_to_failed(monkeypatch):
+    """A verdict nobody defined must never drive another agent turn."""
+
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = _State()
+
+        def evaluate_after_turn(self, response, background_processes=None):
+            return {"verdict": "vibes", "reason": "?", "should_continue": True,
+                    "continuation_prompt": "go"}
+
+    _install_fake_goals(monkeypatch, Manager)
+    from hermes_cli.goal_session import run_goal_turn
+
+    decision = run_goal_turn("s1", "evaluate", response="x")["decision"]
+    assert decision["verdict"] == "failed"
+    assert decision["should_continue"] is False
+    assert decision["continuation_prompt"] is None
+    assert "vibes" in decision["reason"]
+
+
+def test_a_paused_state_becomes_a_hard_pause(monkeypatch):
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = _State(status="paused")
+
+        def evaluate_after_turn(self, response, background_processes=None):
+            return {"verdict": "continue", "status": "paused", "reason": "budget",
+                    "should_continue": True, "continuation_prompt": "go"}
+
+    _install_fake_goals(monkeypatch, Manager)
+    from hermes_cli.goal_session import run_goal_turn
+
+    result = run_goal_turn("s1", "evaluate", response="x")
+    assert result["decision"]["verdict"] == "hard_pause"
+    assert result["decision"]["should_continue"] is False
+    assert result["state"]["status"] == "hard_paused"
+
+
+def test_a_broken_background_process_list_never_fails_the_turn(monkeypatch):
+    """The live process list is an optimization, not a precondition."""
+
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = _State()
+
+        def evaluate_after_turn(self, response, background_processes=None):
+            assert background_processes is None
+            return {"verdict": "continue", "reason": "ok", "should_continue": True,
+                    "continuation_prompt": "next"}
+
+    def explode():
+        raise RuntimeError("process registry is down")
+
+    module = _install_fake_goals(monkeypatch, Manager)
+    module.gather_background_processes = explode
+
+    from hermes_cli.goal_session import run_goal_turn
+
+    assert run_goal_turn("s1", "evaluate", response="x")["decision"]["verdict"] == "continue"
+
+
+def test_start_requires_a_goal(monkeypatch):
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = None
+
+    _install_fake_goals(monkeypatch, Manager)
+    from hermes_cli.goal_session import run_goal_turn
+
+    assert run_goal_turn("s1", "start", goal="   ")["error"]["code"] == "invalid_goal"

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -311,26 +311,39 @@ class TestFormatFooter:
         )
         assert "1 file-mutation target(s) failed" in out
         assert "file(s) were NOT modified" not in out
-        assert "/tmp/a.md" in out
-        assert "Could not find old_string" in out
+        assert "/tmp/a.md" not in out
+        assert "Could not find old_string" not in out
+        assert "Failed calls by tool: 1 patch" in out
         assert "git status" in out  # user-actionable hint
 
-    def test_truncation_at_10_entries(self):
+    def test_corrupted_tool_arguments_are_not_echoed(self):
+        corrupted_path = (
+            "/Usershashed/karthik/GDrive - 33rd Avenue JR/"
+            "hermes-agent_jeeves/projects/jarvis-san-pdf -gmail-incident/PROGRESS.md"
+        )
+        corrupted_preview = f"Failed to write {corrupted_path}"
+
+        out = AIAgent._format_file_mutation_failure_footer(
+            {corrupted_path: {"tool": "write_file", "error_preview": corrupted_preview}},
+        )
+
+        assert "1 file-mutation target(s) failed" in out
+        assert corrupted_path not in out
+        assert corrupted_preview not in out
+
+    def test_many_failures_are_aggregated_without_untrusted_details(self):
         failed = {
             f"/tmp/f{i}.md": {"tool": "patch", "error_preview": "err"}
             for i in range(15)
         }
         out = AIAgent._format_file_mutation_failure_footer(failed)
         assert "15 file-mutation target(s) failed" in out
-        assert "… and 5 more" in out
-        # Ten file bullets + header + "and X more" line
-        lines = out.split("\n")
-        bullet_lines = [ln for ln in lines if ln.lstrip().startswith("•")]
-        assert len(bullet_lines) == 11  # 10 shown + 1 summary
+        assert "Failed calls by tool: 15 patch" in out
+        assert "/tmp/f0.md" not in out
+        assert "err" not in out
 
-    def test_paths_are_backtick_wrapped(self):
-        """Footer paths must be inline-code wrapped so the gateway's bare-path
-        media extractor can't auto-attach them (#35584 defense-in-depth)."""
+    def test_sensitive_paths_and_error_previews_are_not_rendered(self):
+        """Untrusted details cannot leak or become gateway attachments."""
         out = AIAgent._format_file_mutation_failure_footer(
             {"/home/u/.hermes/config.yaml": {
                 "tool": "patch",
@@ -340,16 +353,9 @@ class TestFormatFooter:
                 ),
             }},
         )
-        # Path still human-readable.
-        assert "/home/u/.hermes/config.yaml" in out
-        # Bullet path is backticked.
-        assert "`/home/u/.hermes/config.yaml`" in out
-        # The path echoed inside the preview is ALSO backticked (the real
-        # file_operations.py denial message embeds it in single quotes, which
-        # do NOT block the gateway extractor's regex).
-        assert "'`/home/u/.hermes/config.yaml`'" in out
-        # No double-backticking anywhere.
-        assert "``" not in out
+        assert "/home/u/.hermes/config.yaml" not in out
+        assert "protected system/credential file" not in out
+        assert "Failed calls by tool: 1 patch" in out
 
     def test_footer_path_not_extracted_by_gateway(self):
         """End-to-end: the gateway's extract_local_files must NOT pull a

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -309,7 +309,8 @@ class TestFormatFooter:
         out = AIAgent._format_file_mutation_failure_footer(
             {"/tmp/a.md": {"tool": "patch", "error_preview": "Could not find old_string"}},
         )
-        assert "1 file(s) were NOT modified" in out
+        assert "1 file-mutation target(s) failed" in out
+        assert "file(s) were NOT modified" not in out
         assert "/tmp/a.md" in out
         assert "Could not find old_string" in out
         assert "git status" in out  # user-actionable hint
@@ -320,7 +321,7 @@ class TestFormatFooter:
             for i in range(15)
         }
         out = AIAgent._format_file_mutation_failure_footer(failed)
-        assert "15 file(s) were NOT modified" in out
+        assert "15 file-mutation target(s) failed" in out
         assert "… and 5 more" in out
         # Ten file bullets + header + "and X more" line
         lines = out.split("\n")

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -89,6 +89,17 @@ class TestExtractFileMutationTargets:
         assert _extract_file_mutation_targets("patch", {"mode": "patch"}) == []
         assert _extract_file_mutation_targets("patch", {"mode": "patch", "patch": ""}) == []
 
+    def test_malformed_patch_header_without_hunks_is_not_a_mutation_target(self):
+        body = (
+            "*** Begin" " Patch\n"
+            "*** Update" " File: /tmp/grep app Wilt?\n"
+            "*** End" " Patch\n"
+        )
+
+        assert _extract_file_mutation_targets(
+            "patch", {"mode": "patch", "patch": body},
+        ) == []
+
 
 # ---------------------------------------------------------------------------
 # _extract_error_preview

--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -37,6 +37,25 @@ class TestExactMatch:
 
 
 class TestWhitespaceDifference:
+    def test_corrupted_single_line_anchor_is_rejected(self):
+        """A similar single line must not authorize a destructive replacement."""
+        content = '    file_path = "/data/_workspaces/lit-822/inputs/thread.pdf"'
+        corrupted = (
+            '    file_pathchl = "/usz data/_work AH spaces/'
+            'lit-Х sunset822/inputs/thread.pdf"'
+        )
+
+        new, count, strategy, err = fuzzy_find_and_replace(
+            content,
+            corrupted,
+            '    file_path = "/data/_workspaces/workspace/inputs/thread.pdf"',
+        )
+
+        assert new == content
+        assert count == 0
+        assert strategy is None
+        assert err is not None
+
     def test_extra_spaces_match(self):
         content = "def  foo(  x,  y  ):"
         new, count, _, err = fuzzy_find_and_replace(content, "def foo( x, y ):", "def bar(x, y):")
@@ -83,6 +102,71 @@ class TestWhitespaceDifference:
         # "foo   +" normalized to "foo +" matches; trailing spaces consumed
         # Result: "a = XY bar"
         assert "XY" in new and "bar" in new
+
+
+class TestSingleLineCompatibility:
+    """Corpus for safe normalization and unsafe approximate single-line edits."""
+
+    def test_safe_normalization_strategies_remain_available(self):
+        cases = [
+            ("value = 1", "value = 1", "exact"),
+            ("    value = 1", "  value = 1  ", "line_trimmed"),
+            ("value  =  1", "value = 1", "whitespace_normalized"),
+            ("\tvalue = 1", "\\tvalue = 1", "escape_normalized"),
+            ("value—fallback", "value--fallback", "unicode_normalized"),
+        ]
+
+        for content, old_string, expected_strategy in cases:
+            new, count, strategy, err = fuzzy_find_and_replace(
+                content, old_string, "updated = True",
+            )
+
+            assert err is None, (content, old_string, err)
+            assert count == 1, (content, old_string, strategy)
+            assert strategy == expected_strategy
+            assert "updated = True" in new
+
+    def test_approximate_corruption_is_rejected(self):
+        cases = [
+            (
+                '    file_path = "/data/_workspaces/lit-822/inputs/thread.pdf"',
+                '    file_pathchl = "/usz data/_work AH spaces/'
+                'lit-Х sunset822/inputs/thread.pdf"',
+            ),
+            (
+                "    assert response.status_code == 413",
+                "    assert response Ghoul.status_code ==shire 413",
+            ),
+            (
+                '    assert payload["error"] == "path_outside_allowed_roots"',
+                '    assert payload["error cumin"] == "path_outside_allowed_roots/gl"',
+            ),
+        ]
+
+        for content, corrupted in cases:
+            new, count, strategy, err = fuzzy_find_and_replace(
+                content, corrupted, "CORRUPTED REPLACEMENT",
+            )
+
+            assert new == content
+            assert count == 0
+            assert strategy is None
+            assert err is not None
+
+
+class TestContextAwareCompatibility:
+    def test_multiline_approximate_match_remains_available(self):
+        content = "alpha_value = 1\nbeta_value = 2"
+        old_string = "alpha_value = 1;\nbeta_value = 2;"
+
+        new, count, strategy, err = fuzzy_find_and_replace(
+            content, old_string, "updated = True",
+        )
+
+        assert err is None
+        assert count == 1
+        assert strategy == "context_aware"
+        assert new == "updated = True"
 
 
 class TestIndentDifference:

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -696,13 +696,16 @@ def _strategy_block_anchor(content: str, pattern: str) -> List[Tuple[int, int]]:
 def _strategy_context_aware(content: str, pattern: str) -> List[Tuple[int, int]]:
     """
     Strategy 9: Line-by-line similarity with 50% threshold.
-    
+
     Finds blocks where at least 50% of lines have high similarity.
+    Single-line patterns are excluded: earlier normalization strategies cover
+    safe formatting drift, while approximate one-line matches provide too
+    little context to authorize a replacement.
     """
     pattern_lines = pattern.split('\n')
     content_lines = content.split('\n')
-    
-    if not pattern_lines:
+
+    if len(pattern_lines) < 2:
         return []
     
     matches = []

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1411,7 +1411,7 @@ For unattended gateway / server deployments, enable hard stops so a stuck agent 
 ```yaml
 tool_loop_guardrails:
   warnings_enabled: true       # inject warnings into tool results (default: true)
-  hard_stop_enabled: false     # also BLOCK the call past the hard-stop threshold (default: false)
+  hard_stop_enabled: false     # also BLOCK the next call past the threshold (default: false)
   warn_after:
     exact_failure: 2           # identical failing call repeated N times
     same_tool_failure: 3       # same tool failing N times (different args)
@@ -1422,7 +1422,7 @@ tool_loop_guardrails:
     idempotent_no_progress: 5
 ```
 
-`hard_stop_enabled` defaults to `false` because interactive sessions have a human in the loop. In unattended deployments (gateway, cron, kanban workers) set it to `true` so repeated failures are blocked rather than only warned. See also [Docker / unattended deployments](docker.md).
+`hard_stop_enabled` defaults to `false` because interactive sessions have a human in the loop. In unattended deployments (gateway, cron, kanban workers) set it to `true` so repeated failures are blocked rather than only warned. The failure that reaches a hard-stop threshold is still returned to the model; if it attempts that tool again, the next call is blocked before execution. This gives the model one chance to choose a different tool or report the blocker. See also [Docker / unattended deployments](docker.md).
 
 ## TTS Configuration
 


### PR DESCRIPTION
## What this adds

A surface-neutral entry point, `hermes_cli.goal_session.run_goal_turn()`, that lets an **embedder** — a console, a web app, any process that runs Hermes as a child — drive the persistent-goal loop without reaching across the process boundary to repair agent state.

Purely additive: one new module, one new test file, no existing surface changed.

## Why

An embedder that supervises Hermes from outside has to ask, then act, then handle the race between the two. In practice that means it grows a second supervision loop — retries, verdict validation, goal repair — and the two drift.

We measured this in a production console over a month: **201 mission resumes and 121 failures**, dominated not by disagreements about the work but by *plumbing* — `no active goal` (51), invalid turn counts, raw `RuntimeError`s. The single commonest fault was a goal vanishing between turns (a cancelled turn, a cleared session, a crash), which the embedder could only fix by asking whether a goal existed and conditionally calling `start` — a destructive call that overwrites a live goal if the read was wrong.

After switching that console to this module, those reason codes fell to **zero** and have stayed there across several days and multiple releases.

## What it does

- **`run_goal_turn(session_id, action, ...)`** returns a structured envelope for every ordinary protocol condition — a missing goal, an unknown action, an unavailable judge — instead of raising. Callers get `failure_kind` to distinguish a supervisor outage from a judgment about the work.
- **Self-healing.** Passing `goal=` alongside `evaluate` re-establishes a vanished goal *in the same call that grades the turn*. It cannot clobber a live goal, because it only sets one when none exists — which is strictly safer than the ask-then-start dance it replaces. The envelope reports `restarted: True`.
- **Publication blockers.** An embedder that owns a publication step (promoting to a branch, uploading an artifact) can find work DONE and still be unable to publish it. `blocked_reason`/`blocked_remedy`/`blocked_paths`/`blocked_attempts_left` report that into the loop, which returns an ordinary `continue` carrying a continuation naming the blocker — or `hard_pause` once the budget is spent. It short-circuits the judge, since the verdict already exists and the response has not changed, so re-grading would spend an auxiliary call to reach the same answer.

## Notes

- `PROTOCOL_VERSION` is declared so an embedder can detect capability and fall back to its legacy path against an older Hermes.
- Verdict normalization treats `inactive` as a resolution rather than an unrecognized verdict — folding it into `failed` turns a finished mission into an operator prompt.
- 16 tests, covering the self-heal, the blocker paths, the budget boundary, and judge-unavailable degradation.
