### PR TITLE
fix(auxiliary): honor keyless task base URLs

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8217,14 +8217,16 @@ def _resolve_task_provider_model(
 
     if task:
         # Config.yaml is the primary source for per-task overrides.
-        if cfg_base_url and cfg_api_key:
-            # Both base_url and api_key explicitly set → custom endpoint.
-            return "custom", resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
         if cfg_base_url and cfg_provider and cfg_provider != "auto":
-            # base_url set without api_key but with a known provider — use
-            # the provider so it can resolve credentials from env vars
-            # (e.g. OPENROUTER_API_KEY) instead of locking into "custom".
-            return cfg_provider, resolved_model, cfg_base_url, None, resolved_api_mode
+            # Keep an explicitly named provider so it can resolve credentials
+            # from env vars (e.g. OPENROUTER_API_KEY) and preserve its request
+            # shaping.  A task-scoped api_key still wins when provided.
+            return cfg_provider, resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
+        if cfg_base_url:
+            # A bare task-scoped endpoint is a complete routing override even
+            # when it is keyless (common for localhost proxies).  Falling
+            # through to "auto" here silently sent the task to the main model.
+            return "custom", resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
         if cfg_provider and cfg_provider != "auto":
             return cfg_provider, resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -157,6 +157,24 @@ class TestResolveTaskProviderModel:
         assert model == "meta/llama-3.2-11b-vision-instruct"
         assert api_mode is None
 
+    def test_configured_bare_base_url_routes_to_keyless_custom_endpoint(self):
+        """A local task endpoint must not fall through to the main provider
+        merely because it does not require an API key."""
+        task_config = {
+            "model": "claude-sonnet-5",
+            "base_url": "http://127.0.0.1:9180/v1",
+        }
+        with patch("agent.auxiliary_client._get_auxiliary_task_config", return_value=task_config):
+            resolved_provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+                task="compression",
+            )
+
+        assert resolved_provider == "custom"
+        assert model == "claude-sonnet-5"
+        assert base_url == "http://127.0.0.1:9180/v1"
+        assert api_key is None
+        assert api_mode is None
+
 
 
 


### PR DESCRIPTION
## Summary
- honor a task-scoped bare `base_url` as a keyless custom endpoint
- keep task model and API mode while preventing silent fallback to the main provider
- add regression coverage for localhost compression proxies

## Tests
- `scripts/run_tests.sh tests/agent/test_auxiliary_client.py` (183 passed)