### PR TITLE
fix(slack): update native stream for rewritten finals

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -258,6 +258,7 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
             meta["expect_edits"] = True
         if final:
             meta["notify"] = True
+            meta["final"] = True
         return meta or None
 
     # Read-only views for the gateway (flag semantics: see _clear_turn_final_flags).

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2299,13 +2299,17 @@ class SlackAdapter(BasePlatformAdapter):
             if text == sent:
                 return SendResult(success=True, message_id=stream["ts"])
             if not text.startswith(sent):
-                # Text was rewritten mid-segment: seal the stream, then fail
-                # the frame so the consumer falls back to the edit path.
-                await self._seal_stream(chat_id, stream)
-                self._active_streams.pop(chat_id, None)
-                return SendResult(success=False, error="stream prefix mismatch")
-            delta = text[len(sent) :]
-            await client.chat_appendStream(channel=chat_id, ts=stream["ts"], markdown_text=delta)
+                if await self._seal_stream(chat_id, stream):
+                    self._active_streams.pop(chat_id, None)
+                return SendResult(
+                    success=False, error="stream prefix mismatch"
+                )
+            delta = text[len(sent):]
+            await client.chat_appendStream(
+                channel=chat_id,
+                ts=stream["ts"],
+                markdown_text=delta,
+            )
             stream["sent"] = text
             return SendResult(success=True, message_id=stream["ts"])
         except Exception as e:  # pragma: no cover - network/API errors
@@ -2398,14 +2402,14 @@ class SlackAdapter(BasePlatformAdapter):
             # Slack message: stop the append-only stream, then replace its
             # contents with the authoritative final text. Plain/interim sends
             # still pass through without touching the live stream.
-            if not metadata or not metadata.get("notify"):
+            if not metadata or not metadata.get("final"):
                 return None
-            self._active_streams.pop(chat_id, None)
             ts = stream["ts"]
             if not await self._seal_stream(chat_id, stream):
                 # The stream may still be live; let the normal send path make
                 # a best-effort delivery rather than swallowing the answer.
                 return None
+            self._active_streams.pop(chat_id, None)
             replaced = await self.edit_message(
                 chat_id,
                 ts,
@@ -2417,12 +2421,12 @@ class SlackAdapter(BasePlatformAdapter):
                 await self.stop_typing(chat_id)
                 return replaced
             return None
-        self._active_streams.pop(chat_id, None)
         ts = stream["ts"]
         ok = await self._seal_stream(chat_id, stream, final_text=text)
         if not ok:
             # Stop failed — post normally; the dangling stream times out on Slack's side.
             return None
+        self._active_streams.pop(chat_id, None)
         # Streams render markdown natively; rich blocks are applied via
         # chat_update on the sealed message (mirrors edit_message finalize).
         blocks = self._maybe_blocks(text)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2398,10 +2398,12 @@ class SlackAdapter(BasePlatformAdapter):
         if not sent or not text.startswith(sent):
             # A turn-final payload can legitimately differ from the streamed
             # draft after markdown conversion, verifier/footer augmentation,
-            # or a final answer rewrite. Keep delivery on the already-created
-            # Slack message: stop the append-only stream, then replace its
-            # contents with the authoritative final text. Plain/interim sends
-            # still pass through without touching the live stream.
+            # or a final answer rewrite. Slack retains a native stream's rich
+            # text after chat.stopStream, so chat.update would render that
+            # text alongside the replacement markdown. Remove the incomplete
+            # stream before allowing the normal final-send path to post once.
+            # Plain/interim sends still pass through without touching the
+            # live stream.
             if not metadata or not metadata.get("final"):
                 return None
             ts = stream["ts"]
@@ -2410,17 +2412,21 @@ class SlackAdapter(BasePlatformAdapter):
                 # a best-effort delivery rather than swallowing the answer.
                 return None
             self._active_streams.pop(chat_id, None)
-            replaced = await self.edit_message(
-                chat_id,
+            if await self.delete_message(chat_id, ts):
+                # Returning None lets send() post the authoritative final
+                # message exactly once.
+                return None
+            logger.warning(
+                "[Slack] Could not delete incomplete native stream %s in channel %s; "
+                "suppressing rewritten final to avoid a duplicate message",
                 ts,
-                text,
-                finalize=True,
-                metadata=metadata,
+                chat_id,
             )
-            if replaced.success:
-                await self.stop_typing(chat_id)
-                return replaced
-            return None
+            # A deleted stream is normally followed by a new post. If the
+            # deletion fails, the best available user-visible result is the
+            # sealed prefix rather than two competing answer bodies.
+            await self.stop_typing(chat_id)
+            return SendResult(success=True, message_id=ts)
         ts = stream["ts"]
         ok = await self._seal_stream(chat_id, stream, final_text=text)
         if not ok:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2032,7 +2032,7 @@ class SlackAdapter(BasePlatformAdapter):
                 return await self._send_slash_reply(chat_id, slash_ctx, content, metadata)
             # An active native stream that this content finalizes IS the final
             # message: seal it instead of posting a duplicate.
-            stream_result = await self._try_finalize_stream(chat_id, content)
+            stream_result = await self._try_finalize_stream(chat_id, content, metadata=metadata)
             if stream_result is not None:
                 return stream_result
             formatted = self.format_message(content)
@@ -2372,17 +2372,50 @@ class SlackAdapter(BasePlatformAdapter):
                 "[Slack] chat.stopStream failed for %s/%s: %s", chat_id, stream.get("ts"), e)
             return False
 
-    async def _try_finalize_stream(self, chat_id: str, content: str) -> Optional[SendResult]:
-        """Seal the active native stream if ``content`` is its final text: SendResult when the
-        stream IS the final message; None when unrelated (interim commentary), leaving it open."""
+    async def _try_finalize_stream(
+        self,
+        chat_id: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[SendResult]:
+        """Finalize a native stream when this send owns the turn-final content."""
         stream = self._active_streams.get(chat_id)
         if stream is None:
+            return None
+        # Commentary/status sends are allowed to happen while the answer is
+        # streaming. They must never claim the native stream, even when their
+        # text happens to share a prefix with the answer.
+        if metadata and metadata.get("_interim_send"):
             return None
         sent = stream.get("sent", "")
         text = self._strip_stream_cursor(content)
         # Only claim sends that extend what was streamed; an empty ``sent``
         # prefix would match everything.
         if not sent or not text.startswith(sent):
+            # A turn-final payload can legitimately differ from the streamed
+            # draft after markdown conversion, verifier/footer augmentation,
+            # or a final answer rewrite. Keep delivery on the already-created
+            # Slack message: stop the append-only stream, then replace its
+            # contents with the authoritative final text. Plain/interim sends
+            # still pass through without touching the live stream.
+            if not metadata or not metadata.get("notify"):
+                return None
+            self._active_streams.pop(chat_id, None)
+            ts = stream["ts"]
+            if not await self._seal_stream(chat_id, stream):
+                # The stream may still be live; let the normal send path make
+                # a best-effort delivery rather than swallowing the answer.
+                return None
+            replaced = await self.edit_message(
+                chat_id,
+                ts,
+                text,
+                finalize=True,
+                metadata=metadata,
+            )
+            if replaced.success:
+                await self.stop_typing(chat_id)
+                return replaced
             return None
         self._active_streams.pop(chat_id, None)
         ts = stream["ts"]

--- a/tests/gateway/test_slack_native_streaming.py
+++ b/tests/gateway/test_slack_native_streaming.py
@@ -199,6 +199,54 @@ class TestSendFinalization:
         assert "D1" in adapter._active_streams
 
     @pytest.mark.asyncio
+    async def test_rewritten_final_updates_stream_message_without_duplicate(self):
+        """A final answer that is not a raw prefix still owns the stream.
+
+        Slack markdown formatting and post-stream finalization can change the
+        completed text. The adapter must update the existing stream message,
+        rather than post a second answer.
+        """
+        adapter, client = _make_adapter()
+        await adapter.send_draft("D1", 7, "Draft answer", metadata=META)
+
+        result = await adapter.send(
+            "D1",
+            "Final answer with the completed details.",
+            metadata={**META, "notify": True},
+        )
+
+        assert result.success
+        assert result.message_id == "123.456"
+        client.chat_stopStream.assert_awaited_once_with(
+            channel="D1",
+            ts="123.456",
+        )
+        client.chat_update.assert_awaited_once()
+        update = client.chat_update.await_args.kwargs
+        assert update["channel"] == "D1"
+        assert update["ts"] == "123.456"
+        assert update["text"] == "Final answer with the completed details."
+        client.chat_postMessage.assert_not_awaited()
+        assert "D1" not in adapter._active_streams
+
+    @pytest.mark.asyncio
+    async def test_interim_send_cannot_replace_stream_message(self):
+        adapter, client = _make_adapter()
+        await adapter.send_draft("D1", 7, "Streaming text here", metadata=META)
+
+        result = await adapter.send(
+            "D1",
+            "Unrelated notice",
+            metadata={**META, "_interim_send": True, "notify": True},
+        )
+
+        assert result.success
+        client.chat_stopStream.assert_not_awaited()
+        client.chat_update.assert_not_awaited()
+        client.chat_postMessage.assert_awaited_once()
+        assert "D1" in adapter._active_streams
+
+    @pytest.mark.asyncio
     async def test_stop_stream_failure_falls_back_to_post(self):
         adapter, client = _make_adapter()
         await adapter.send_draft("D1", 7, "Hello", metadata=META)

--- a/tests/gateway/test_slack_native_streaming.py
+++ b/tests/gateway/test_slack_native_streaming.py
@@ -36,6 +36,7 @@ def _make_adapter(extra=None):
     client.chat_startStream = AsyncMock(return_value={"ok": True, "ts": "123.456"})
     client.chat_appendStream = AsyncMock(return_value={"ok": True})
     client.chat_stopStream = AsyncMock(return_value={"ok": True})
+    client.chat_delete = AsyncMock(return_value={"ok": True})
     a._get_client = MagicMock(return_value=client)
     a.stop_typing = AsyncMock()
     a._running = True
@@ -210,16 +211,38 @@ class TestSendFinalization:
         assert "D1" in adapter._active_streams
 
     @pytest.mark.asyncio
-    async def test_rewritten_final_updates_stream_message_without_duplicate(self):
-        """A final answer that is not a raw prefix still owns the stream.
-
-        Slack markdown formatting and post-stream finalization can change the
-        completed text. The adapter must update the existing stream message,
-        rather than post a second answer.
-        """
+    async def test_rewritten_final_deletes_stream_then_posts_once(self):
+        """A rewritten final replaces an incomplete native stream safely."""
         adapter, client = _make_adapter()
         await adapter.send_draft("D1", 7, "Draft answer", metadata=META)
-        adapter.edit_message = AsyncMock(wraps=adapter.edit_message)
+
+        result = await adapter.send(
+            "D1",
+            "Final answer with the completed details.",
+            metadata={**META, "final": True},
+        )
+
+        assert result.success
+        assert result.message_id == "999.111"
+        client.chat_stopStream.assert_awaited_once_with(
+            channel="D1",
+            ts="123.456",
+        )
+        client.chat_delete.assert_awaited_once_with(channel="D1", ts="123.456")
+        client.chat_update.assert_not_awaited()
+        client.chat_postMessage.assert_awaited_once()
+        assert client.chat_postMessage.await_args.kwargs["text"] == (
+            "Final answer with the completed details."
+        )
+        assert "D1" not in adapter._active_streams
+
+    @pytest.mark.asyncio
+    async def test_rewritten_final_keeps_prefix_when_stream_delete_fails(self):
+        adapter, client = _make_adapter()
+        await adapter.send_draft("D1", 7, "Draft answer", metadata=META)
+        client.chat_delete = AsyncMock(
+            return_value={"ok": False, "error": "cant_delete_message"}
+        )
 
         result = await adapter.send(
             "D1",
@@ -233,12 +256,8 @@ class TestSendFinalization:
             channel="D1",
             ts="123.456",
         )
-        client.chat_update.assert_awaited_once()
-        update = client.chat_update.await_args.kwargs
-        assert update["channel"] == "D1"
-        assert update["ts"] == "123.456"
-        assert update["text"] == "Final answer with the completed details."
-        assert adapter.edit_message.await_args.kwargs["finalize"] is True
+        client.chat_delete.assert_awaited_once_with(channel="D1", ts="123.456")
+        client.chat_update.assert_not_awaited()
         client.chat_postMessage.assert_not_awaited()
         assert "D1" not in adapter._active_streams
 

--- a/tests/gateway/test_slack_native_streaming.py
+++ b/tests/gateway/test_slack_native_streaming.py
@@ -127,6 +127,17 @@ class TestSendDraft:
         assert "D1" not in adapter._active_streams
 
     @pytest.mark.asyncio
+    async def test_prefix_mismatch_keeps_stream_when_sealing_fails(self):
+        adapter, client = _make_adapter()
+        await adapter.send_draft("D1", 7, "Hello", metadata=META)
+        client.chat_stopStream = AsyncMock(side_effect=Exception("boom"))
+
+        result = await adapter.send_draft("D1", 7, "Rewritten text", metadata=META)
+
+        assert not result.success
+        assert "D1" in adapter._active_streams
+
+    @pytest.mark.asyncio
     async def test_no_thread_ts_fails_cleanly(self):
         adapter, client = _make_adapter()
         result = await adapter.send_draft("D1", 7, "Hello", metadata={})
@@ -208,11 +219,12 @@ class TestSendFinalization:
         """
         adapter, client = _make_adapter()
         await adapter.send_draft("D1", 7, "Draft answer", metadata=META)
+        adapter.edit_message = AsyncMock(wraps=adapter.edit_message)
 
         result = await adapter.send(
             "D1",
             "Final answer with the completed details.",
-            metadata={**META, "notify": True},
+            metadata={**META, "final": True},
         )
 
         assert result.success
@@ -226,6 +238,7 @@ class TestSendFinalization:
         assert update["channel"] == "D1"
         assert update["ts"] == "123.456"
         assert update["text"] == "Final answer with the completed details."
+        assert adapter.edit_message.await_args.kwargs["finalize"] is True
         client.chat_postMessage.assert_not_awaited()
         assert "D1" not in adapter._active_streams
 
@@ -237,7 +250,7 @@ class TestSendFinalization:
         result = await adapter.send(
             "D1",
             "Unrelated notice",
-            metadata={**META, "_interim_send": True, "notify": True},
+            metadata={**META, "_interim_send": True, "final": True},
         )
 
         assert result.success
@@ -254,6 +267,41 @@ class TestSendFinalization:
         result = await adapter.send("D1", "Hello world", metadata=META)
         assert result.success
         client.chat_postMessage.assert_awaited()
+        assert "D1" in adapter._active_streams
+
+    @pytest.mark.asyncio
+    async def test_notify_only_send_does_not_finalize_rewritten_stream(self):
+        adapter, client = _make_adapter()
+        await adapter.send_draft("D1", 7, "Draft answer", metadata=META)
+
+        result = await adapter.send(
+            "D1",
+            "Unrelated notification",
+            metadata={**META, "notify": True},
+        )
+
+        assert result.success
+        client.chat_stopStream.assert_not_awaited()
+        client.chat_update.assert_not_awaited()
+        client.chat_postMessage.assert_awaited_once()
+        assert "D1" in adapter._active_streams
+
+    @pytest.mark.asyncio
+    async def test_rewritten_final_keeps_stream_when_sealing_fails(self):
+        adapter, client = _make_adapter()
+        await adapter.send_draft("D1", 7, "Draft answer", metadata=META)
+        client.chat_stopStream = AsyncMock(side_effect=Exception("boom"))
+
+        result = await adapter.send(
+            "D1",
+            "Final answer with the completed details.",
+            metadata={**META, "final": True},
+        )
+
+        assert result.success
+        client.chat_update.assert_not_awaited()
+        client.chat_postMessage.assert_awaited_once()
+        assert "D1" in adapter._active_streams
 
     @pytest.mark.asyncio
     async def test_rich_blocks_applied_after_seal(self):

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -22,6 +22,7 @@ def test_stream_send_metadata_carries_original_reply_anchor():
     assert consumer._metadata_for_send(final=True) == {
         "reply_to_message_id": "456",
         "notify": True,
+        "final": True,
     }
 
 
@@ -1487,4 +1488,3 @@ class TestFlushPendingSync:
 
         consumer.finish()
         await task
-

--- a/tests/gateway/test_stream_consumer_draft.py
+++ b/tests/gateway/test_stream_consumer_draft.py
@@ -138,6 +138,7 @@ class TestDraftStreamingHappyPath:
         assert sent_content == "Hello world!"
         final_metadata = final_call.kwargs.get("metadata") or {}
         assert final_metadata.get("notify") is True
+        assert final_metadata.get("final") is True
         assert "expect_edits" not in final_metadata
 
     @pytest.mark.asyncio
@@ -195,6 +196,7 @@ class TestDraftStreamingHappyPath:
         send_mock = adapter.__dict__["send"]
         metadata = send_mock.call_args.kwargs.get("metadata") or {}
         assert metadata.get("notify") is True
+        assert metadata.get("final") is True
         assert "expect_edits" not in metadata
 
 
@@ -448,4 +450,3 @@ class TestRichAwareOverflow:
         adapter.edit_message.assert_not_called()
         adapter.delete_message.assert_awaited_once_with("12345", "preview1")
         assert consumer.final_response_sent is True
-


### PR DESCRIPTION
Slack native streaming only closes the stream when the final text starts with the text already streamed. That check fails when the final response is reformatted or changed before delivery, so send() posts a second message.

This keeps the existing append path for normal responses. When a final send does not match the streamed prefix, the adapter now stops the stream and updates that same Slack message. Interim sends are ignored by the finalizer.

Tests:

- pytest -q tests/gateway/test_slack_native_streaming.py tests/gateway/test_stream_final_contract.py
- pytest -q tests/gateway/test_slack.py tests/gateway/test_slack_native_streaming.py tests/gateway/test_stream_final_contract.py

193 tests passed.

Related issue: #93648