### PR TITLE
feat(goals): surface-neutral goal-turn protocol for embedders

### DIFF
--- a/hermes_cli/goal_session.py
+++ b/hermes_cli/goal_session.py
@@ -1,0 +1,369 @@
+"""Surface-neutral goal-turn protocol for embedders (Stage 1 of the HAC extraction).
+
+Why this exists
+---------------
+``GoalManager`` (:mod:`hermes_cli.goals`) is the semantic owner of the
+persistent-goal loop, and every in-tree surface drives it directly: the gateway
+at ``gateway/run.py`` (``_post_turn_goal_continuation``), the TUI gateway, and
+the CLI. An EMBEDDER — a console that runs Hermes as a child process and owns
+its own turn loop — has no such entry point, so it must reach in from outside:
+resolve the manager, call ``evaluate_after_turn``, and reassemble a decision
+envelope itself.
+
+Doing that across a process boundary is where embedded goal loops actually
+fail. Measured in one embedder's production telemetry over 5,001 mission events:
+the operator-facing noise was almost entirely bridge faults, not judgments about
+the work — ``no active goal`` (51), judge transport errors (33), raw
+``RuntimeError`` (80), and ``invalid turn count`` (10). None of those are
+decisions; they are an outside caller failing to keep a goal it cannot see.
+
+This module is the supported entry point, so that logic lives in ONE place,
+next to the state it describes:
+
+    from hermes_cli.goal_session import run_goal_turn
+    envelope = run_goal_turn("sess-123", "evaluate", response=answer)
+
+It is deliberately transport-free: no argparse, no JSON on stdout, no exit
+codes. A caller in-process gets a dict; a caller over a gateway or a subprocess
+serializes that same dict. The envelope shape is stable and versioned.
+
+What it fixes relative to reaching in from outside
+--------------------------------------------------
+1. **``goal_not_found`` on evaluate is impossible when an objective is known.**
+   ``evaluate`` accepts ``goal=`` and starts the goal itself if the session has
+   none, rather than returning an error the caller has to recognize and repair
+   with a second round-trip. The repair is reported honestly in
+   ``envelope["restarted"]`` so an audit trail does not silently claim
+   continuity that never existed.
+2. **A judge outage is classified once, here.** It arrives from the judge as an
+   ordinary ``failed``/``paused``, which reads identically to "this work is
+   wrong". Embedders that cannot tell them apart park missions behind a button
+   for an infrastructure fault. The envelope tags it ``failure_kind =
+   'judge_unavailable'`` so an embedder may self-heal an outage while a real
+   ``failed`` verdict still reaches the operator immediately.
+3. **The turn counters are internally consistent by construction**, because the
+   state is read after the evaluation that advanced it rather than being
+   re-derived by a caller comparing two snapshots.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+PROTOCOL_VERSION = 1
+
+ACTIONS = ("start", "evaluate", "resume", "pause", "cancel", "status")
+
+# Verdicts an embedder may act on. Anything else is a protocol violation and is
+# normalized to ``failed`` rather than passed through — an unrecognized verdict
+# driving another agent turn is how a loop runs on a decision nobody made.
+#
+# ``inactive`` is deliberately present. ``evaluate_after_turn`` returns it when
+# the goal is not active — a goal that was completed, cleared, or paused between
+# turns — and that is an ORDINARY, expected condition, not a malformed verdict.
+# Normalizing it to ``failed`` (as this module first did) turns a quiet
+# "nothing to supervise" into a mission failure the operator has to resume:
+# production showed three such resumes within minutes of the first deployment,
+# each reading "The goal supervisor returned an unrecognized verdict".
+_KNOWN_VERDICTS = frozenset({"done", "continue", "wait", "waiting", "failed", "inactive"})
+
+
+def _state_payload(state: Any, *, status: Optional[str] = None) -> Dict[str, Any]:
+    return {
+        "status": status or state.status,
+        "turns_used": int(state.turns_used),
+        "max_turns": int(state.max_turns),
+    }
+
+
+def _error(session_id: str, code: str, message: str) -> Dict[str, Any]:
+    return {
+        "protocol_version": PROTOCOL_VERSION,
+        "session_id": session_id,
+        "state": None,
+        "decision": None,
+        "error": {"code": code, "message": message},
+    }
+
+
+def _judge_unavailable(state: Any, decision: Dict[str, Any]) -> bool:
+    """Detect a judge OUTAGE from every source that can report one.
+
+    The judge's failure surfaces either as a ``paused_reason`` on the state or
+    as an already-resolved reason on the decision, and only ever as a
+    ``judge error:`` prefix. Checking one spelling silently returns the loop.
+    """
+    candidates = (getattr(state, "paused_reason", "") or "", decision.get("reason") or "")
+    return any(str(item).strip().startswith("judge error:") for item in candidates)
+
+
+def _judge_detail(state: Any, decision: Dict[str, Any]) -> str:
+    raw = str(getattr(state, "paused_reason", "") or decision.get("reason") or "")
+    return raw.removeprefix("judge error:").strip() or "unknown error"
+
+
+def publication_continuation(reason: str, remedy: str, attempts_left: int, paths: Iterable[str] = ()) -> str:
+    """Build the continuation that asks the agent to clear its own publication blocker.
+
+    An embedder that owns a publication step (promoting verified work to a
+    branch, uploading an artifact, filing a release) can find the work DONE and
+    still be unable to publish it. That is not a decision for a human — it is
+    the next step, and usually one the agent that did the work can take.
+
+    Routing it back through the goal loop rather than the embedder's own state
+    machine matters: the loop already owns continuations, attempt budgets, and
+    the boundary between "the agent should act" and "a human must". An embedder
+    that reimplements those grows a second supervisor that drifts from this one.
+
+    The prompt states the verdict already reached, so the agent does not restart
+    finished work; names the blocker and its remedy concretely; and forbids new
+    work, the failure mode being an agent that reads "blocked" as "keep going"
+    and grows the diff instead of shipping it.
+    """
+    listed = [str(item).strip() for item in paths if str(item).strip()]
+    blocker = str(reason or "").strip() or "publication was blocked"
+    if listed:
+        blocker = f"{blocker}:\n" + "\n".join(f"  - {item}" for item in listed)
+    remaining = max(0, int(attempts_left))
+    # A bulleted path list must not be followed by the sentence's period — it
+    # reads as part of the final filename.
+    blocked_sentence = f"Publication was blocked because {blocker}" + ("\n" if listed else ".")
+    return (
+        "[Publication] The goal supervisor has already verified this work as DONE. "
+        f"{blocked_sentence}\n"
+        f"{str(remedy or '').strip() or 'Resolve the blocker so the verified work can be published.'}\n\n"
+        "Do NOT start new work, expand the change, or re-verify what is already done — "
+        "the only remaining task is to clear this blocker so the finished work can be published. "
+        "If it is something you genuinely cannot resolve, say so plainly and stop rather than forcing it. "
+        f"Publication will be attempted {remaining} more time(s) before asking the operator."
+    )
+
+
+def run_goal_turn(
+    session_id: str,
+    action: str = "evaluate",
+    *,
+    goal: str = "",
+    response: str = "",
+    contract: Optional[Dict[str, str]] = None,
+    gates: Iterable[str] = (),
+    max_turns: Optional[int] = None,
+    reason: str = "",
+    default_max_turns: int = 90,
+    blocked_reason: str = "",
+    blocked_remedy: str = "",
+    blocked_paths: Iterable[str] = (),
+    blocked_attempts_left: int = 0,
+) -> Dict[str, Any]:
+    """Drive one goal-protocol action for ``session_id`` and return an envelope.
+
+    ``action`` is one of :data:`ACTIONS`. ``evaluate`` is the interesting one:
+    it grades ``response`` and returns the decision that may drive another turn.
+
+    Passing ``goal`` alongside ``evaluate`` makes the call SELF-HEALING — if the
+    session holds no goal (a cancelled turn, a cleared session, a crash between
+    turns), it is started from that objective instead of failing. The envelope
+    then carries ``restarted: True``.
+
+    ``blocked_reason`` reports an embedder-side PUBLICATION precondition that
+    failed after the work was already judged done. It short-circuits the judge —
+    there is nothing new to grade, and grading it again wastes an auxiliary call
+    to re-reach a verdict that already exists — and returns a ``continue``
+    carrying a continuation that names the blocker and its remedy. When the
+    attempt budget is spent it returns ``hard_pause`` instead, because by then
+    the obstacle is not what the reason code claims and a human should see it.
+
+    Never raises for an ordinary protocol condition: a missing goal, an unknown
+    action, or an unavailable judge all come back as a structured envelope. Only
+    a genuine programming error propagates.
+    """
+    session_id = str(session_id or "").strip()
+    if not session_id:
+        return _error("", "invalid_session", "A session id is required")
+    if action not in ACTIONS:
+        return _error(session_id, "invalid_action", f"Unknown goal action {action!r}")
+
+    try:
+        from hermes_cli.goals import GoalManager
+    except Exception as exc:  # noqa: BLE001 — an embedder must get an envelope, not a traceback
+        return _error(session_id, "goals_unavailable", f"goals module unavailable: {exc}")
+
+    manager = GoalManager(session_id, default_max_turns=int(max_turns or default_max_turns))
+    restarted = False
+
+    def _start() -> Any:
+        built = None
+        if contract:
+            from hermes_cli.goals import GoalContract
+
+            fields = {key: str(contract.get(key) or "").strip() for key in
+                      ("outcome", "verification", "constraints", "boundaries", "stop_when")}
+            if any(fields.values()):
+                built = GoalContract(**fields)
+        state = manager.set(goal, max_turns=max_turns, contract=built)
+        # Gates are appended after `set` because add_gate requires an active
+        # goal. They run at the turn boundary BEFORE the judge and short-circuit
+        # it on failure, which is the deterministic half of "done".
+        for command in (str(item).strip() for item in gates):
+            if command:
+                manager.add_gate(command)
+        return state
+
+    if action == "start":
+        if not str(goal or "").strip():
+            return _error(session_id, "invalid_goal", "A goal is required to start")
+        return {
+            "protocol_version": PROTOCOL_VERSION,
+            "session_id": session_id,
+            "state": _state_payload(_start()),
+            "decision": None,
+            "error": None,
+            "restarted": False,
+        }
+
+    if manager.state is None:
+        # The self-healing path. An embedder that knows the objective should
+        # never have to recognize `goal_not_found`, issue a `start`, and retry —
+        # that round-trip is the single commonest bridge fault in production.
+        if action == "evaluate" and str(goal or "").strip():
+            _start()
+            restarted = True
+            logger.info("goal_session: restarted a missing goal for session %s", session_id)
+        else:
+            return _error(session_id, "goal_not_found", "No persistent goal exists for this session")
+
+    if action in {"resume", "pause", "cancel", "status"}:
+        if action == "resume":
+            state = manager.resume(reset_budget=False)
+        elif action == "pause":
+            state = manager.pause(reason or "user-paused")
+        elif action == "cancel":
+            state = manager.state
+            manager.clear()
+            return {
+                "protocol_version": PROTOCOL_VERSION,
+                "session_id": session_id,
+                "state": _state_payload(state, status="cancelled"),
+                "decision": None,
+                "error": None,
+                "restarted": restarted,
+            }
+        else:
+            state = manager.state
+        assert state is not None
+        return {
+            "protocol_version": PROTOCOL_VERSION,
+            "session_id": session_id,
+            "state": _state_payload(state),
+            "decision": None,
+            "error": None,
+            "restarted": restarted,
+        }
+
+    # --- evaluate -----------------------------------------------------------
+    if str(blocked_reason or "").strip():
+        # A publication precondition failed on work the judge already passed.
+        # Do NOT call the judge again: the verdict exists, the response has not
+        # changed, and re-grading it would spend an auxiliary call to reach the
+        # same answer. The mission's next step is the blocker, not a re-judgment.
+        state = manager.state
+        assert state is not None
+        attempts_left = int(blocked_attempts_left)
+        if attempts_left <= 0:
+            return {
+                "protocol_version": PROTOCOL_VERSION,
+                "session_id": session_id,
+                "state": _state_payload(state, status="hard_paused"),
+                "decision": {
+                    "verdict": "hard_pause",
+                    "reason": f"Publication remained blocked ({blocked_reason}) after every attempt.",
+                    "should_continue": False,
+                    "continuation_prompt": None,
+                    "failure_kind": "",
+                },
+                "error": None,
+                "restarted": restarted,
+            }
+        return {
+            "protocol_version": PROTOCOL_VERSION,
+            "session_id": session_id,
+            "state": _state_payload(state, status="active"),
+            "decision": {
+                "verdict": "continue",
+                "reason": f"Publication is blocked ({blocked_reason}); the agent must clear it.",
+                "should_continue": True,
+                "continuation_prompt": publication_continuation(
+                    blocked_reason, blocked_remedy, attempts_left, blocked_paths,
+                ),
+                "failure_kind": "",
+            },
+            "error": None,
+            "restarted": restarted,
+        }
+
+    try:
+        from hermes_cli.goals import gather_background_processes
+
+        background = gather_background_processes()
+    except Exception:  # noqa: BLE001 — the live process list is an optimization
+        background = None
+
+    decision = manager.evaluate_after_turn(response, background_processes=background)
+    state = manager.state
+    assert state is not None
+
+    verdict = str(decision.get("verdict") or "failed")
+    status = str(decision.get("status") or state.status)
+    should_continue = bool(decision.get("should_continue"))
+    continuation = decision.get("continuation_prompt")
+    failure_kind = ""
+
+    if _judge_unavailable(state, decision):
+        # An OUTAGE, not a verdict about the work. Reported as `failed` so a
+        # caller that ignores `failure_kind` still stops safely, but tagged so a
+        # caller that understands it may continue unsupervised rather than
+        # parking a healthy mission behind a button.
+        verdict, status, should_continue, continuation = "failed", "failed", False, None
+        failure_kind = "judge_unavailable"
+        decision["reason"] = (
+            f"The goal supervisor is unavailable ({_judge_detail(state, decision)}); "
+            "progress cannot be verified."
+        )
+    elif verdict == "inactive":
+        # There is nothing left to supervise. Resolve it against the goal's own
+        # status rather than reporting a verdict no embedder can act on: a goal
+        # that reached `done` between turns IS done, and one that was paused is
+        # a pause. Neither is a failure, and neither should cost the operator a
+        # Resume.
+        should_continue, continuation = False, None
+        if str(state.status) == "paused":
+            verdict, status = "hard_pause", "hard_paused"
+            decision["reason"] = decision.get("reason") or "The goal is paused; there is nothing to supervise."
+        else:
+            verdict, status = "done", "done"
+            decision["reason"] = decision.get("reason") or "The goal is no longer active; nothing remains to supervise."
+    elif status == "paused":
+        verdict, status, should_continue, continuation = "hard_pause", "hard_paused", False, None
+    elif verdict == "waiting":
+        status = "active"
+    elif verdict not in _KNOWN_VERDICTS:
+        decision["reason"] = f"The goal supervisor returned an unrecognized verdict ({verdict!r})"
+        verdict, status, should_continue, continuation = "failed", "failed", False, None
+
+    return {
+        "protocol_version": PROTOCOL_VERSION,
+        "session_id": session_id,
+        "state": _state_payload(state, status=status),
+        "decision": {
+            "verdict": verdict,
+            "reason": str(decision.get("reason") or "No goal decision reason was returned"),
+            "should_continue": should_continue,
+            "continuation_prompt": continuation,
+            "failure_kind": failure_kind,
+        },
+        "error": None,
+        "restarted": restarted,
+    }

--- a/tests/hermes_cli/test_goal_session.py
+++ b/tests/hermes_cli/test_goal_session.py
@@ -1,0 +1,313 @@
+"""Contract tests for the embedder goal-turn protocol (``hermes_cli.goal_session``).
+
+These pin the properties an EMBEDDER depends on. Each one corresponds to a
+failure class measured in a real embedded deployment, where the same logic was
+reimplemented outside the process and drifted.
+"""
+
+import sys
+import types
+
+import pytest
+
+
+def _install_fake_goals(monkeypatch, manager_cls, contract_cls=None):
+    module = types.SimpleNamespace(
+        GoalManager=manager_cls,
+        GoalContract=contract_cls or (lambda **kw: dict(kw)),
+        gather_background_processes=lambda: [],
+    )
+    monkeypatch.setitem(sys.modules, "hermes_cli.goals", module)
+    return module
+
+
+class _State:
+    def __init__(self, status="active", turns_used=1, max_turns=10, paused_reason=""):
+        self.status = status
+        self.turns_used = turns_used
+        self.max_turns = max_turns
+        self.paused_reason = paused_reason
+
+
+def test_unknown_action_is_an_envelope_not_an_exception():
+    from hermes_cli.goal_session import run_goal_turn
+
+    result = run_goal_turn("s1", "teleport")
+    assert result["error"]["code"] == "invalid_action"
+    assert result["state"] is None
+
+
+def test_missing_session_id_is_rejected():
+    from hermes_cli.goal_session import run_goal_turn
+
+    assert run_goal_turn("  ", "status")["error"]["code"] == "invalid_session"
+
+
+def test_evaluate_restarts_a_vanished_goal_when_the_objective_is_supplied(monkeypatch):
+    """The single commonest embedded failure: `goal_not_found` on evaluate.
+
+    An embedder that knows the objective should never have to recognize the
+    error, issue a `start`, and retry — that round-trip is the bug.
+    """
+    started = {}
+
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = None
+
+        def set(self, goal, *, max_turns=None, contract=None):
+            started["goal"] = goal
+            self.state = _State()
+            return self.state
+
+        def add_gate(self, command):
+            started.setdefault("gates", []).append(command)
+
+        def evaluate_after_turn(self, response, background_processes=None):
+            return {"verdict": "continue", "reason": "keep going",
+                    "should_continue": True, "continuation_prompt": "next"}
+
+    _install_fake_goals(monkeypatch, Manager)
+    from hermes_cli.goal_session import run_goal_turn
+
+    result = run_goal_turn("s1", "evaluate", response="did a thing", goal="Ship it")
+
+    assert started["goal"] == "Ship it"
+    assert result["restarted"] is True
+    assert result["decision"]["verdict"] == "continue"
+
+
+def test_evaluate_without_an_objective_still_reports_goal_not_found(monkeypatch):
+    """Self-healing must not invent a goal out of nothing."""
+
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = None
+
+    _install_fake_goals(monkeypatch, Manager)
+    from hermes_cli.goal_session import run_goal_turn
+
+    assert run_goal_turn("s1", "evaluate", response="x")["error"]["code"] == "goal_not_found"
+
+
+@pytest.mark.parametrize("where", ["state", "decision"])
+def test_a_judge_outage_is_tagged_rather_than_read_as_a_failed_verdict(monkeypatch, where):
+    """An outage and a real `failed` both arrive as `failed`; only one may self-heal.
+
+    The reason can surface on the state OR on the decision. Checking one
+    spelling silently returns the loop, so both are pinned.
+    """
+
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = _State(paused_reason="judge error: BadRequestError" if where == "state" else "")
+
+        def evaluate_after_turn(self, response, background_processes=None):
+            reason = "judge error: BadRequestError" if where == "decision" else "the work is wrong"
+            return {"verdict": "failed", "reason": reason,
+                    "should_continue": False, "continuation_prompt": None}
+
+    _install_fake_goals(monkeypatch, Manager)
+    from hermes_cli.goal_session import run_goal_turn
+
+    decision = run_goal_turn("s1", "evaluate", response="x")["decision"]
+    assert decision["verdict"] == "failed"
+    assert decision["failure_kind"] == "judge_unavailable"
+    assert "BadRequestError" in decision["reason"]
+
+
+def test_a_genuine_failed_verdict_is_not_tagged_as_an_outage(monkeypatch):
+    """A real judgment about the work must reach the operator immediately."""
+
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = _State()
+
+        def evaluate_after_turn(self, response, background_processes=None):
+            return {"verdict": "failed", "reason": "the tests do not pass",
+                    "should_continue": False, "continuation_prompt": None}
+
+    _install_fake_goals(monkeypatch, Manager)
+    from hermes_cli.goal_session import run_goal_turn
+
+    assert run_goal_turn("s1", "evaluate", response="x")["decision"]["failure_kind"] == ""
+
+
+def test_an_unrecognized_verdict_is_normalized_to_failed(monkeypatch):
+    """A verdict nobody defined must never drive another agent turn."""
+
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = _State()
+
+        def evaluate_after_turn(self, response, background_processes=None):
+            return {"verdict": "vibes", "reason": "?", "should_continue": True,
+                    "continuation_prompt": "go"}
+
+    _install_fake_goals(monkeypatch, Manager)
+    from hermes_cli.goal_session import run_goal_turn
+
+    decision = run_goal_turn("s1", "evaluate", response="x")["decision"]
+    assert decision["verdict"] == "failed"
+    assert decision["should_continue"] is False
+    assert decision["continuation_prompt"] is None
+    assert "vibes" in decision["reason"]
+
+
+def test_an_inactive_goal_resolves_rather_than_failing(monkeypatch):
+    """`inactive` is an ordinary condition, not a malformed verdict.
+
+    ``evaluate_after_turn`` returns it when the goal is no longer active — done,
+    cleared, or paused between turns. Normalizing it to `failed` cost the
+    operator a Resume for a mission that had simply finished: production showed
+    three such resumes within minutes of the first deployment.
+    """
+
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = _State(status="done")
+
+        def evaluate_after_turn(self, response, background_processes=None):
+            return {"verdict": "inactive", "reason": "no active goal",
+                    "should_continue": False, "continuation_prompt": None}
+
+    _install_fake_goals(monkeypatch, Manager)
+    from hermes_cli.goal_session import run_goal_turn
+
+    result = run_goal_turn("s1", "evaluate", response="x")
+    assert result["decision"]["verdict"] == "done"
+    assert result["decision"]["failure_kind"] == ""
+    assert result["decision"]["should_continue"] is False
+
+
+def test_an_inactive_goal_that_was_paused_reports_a_pause(monkeypatch):
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = _State(status="paused")
+
+        def evaluate_after_turn(self, response, background_processes=None):
+            return {"verdict": "inactive", "reason": "no active goal",
+                    "should_continue": False, "continuation_prompt": None}
+
+    _install_fake_goals(monkeypatch, Manager)
+    from hermes_cli.goal_session import run_goal_turn
+
+    result = run_goal_turn("s1", "evaluate", response="x")
+    assert result["decision"]["verdict"] == "hard_pause"
+    assert result["state"]["status"] == "hard_paused"
+
+
+def test_a_publication_blocker_returns_a_continuation_without_re_judging(monkeypatch):
+    """The verdict already exists; re-grading it would spend an aux call for nothing."""
+    judged = []
+
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = _State()
+
+        def evaluate_after_turn(self, response, background_processes=None):
+            judged.append(response)
+            return {"verdict": "continue", "reason": "x", "should_continue": True,
+                    "continuation_prompt": "y"}
+
+    _install_fake_goals(monkeypatch, Manager)
+    from hermes_cli.goal_session import run_goal_turn
+
+    result = run_goal_turn(
+        "s1", "evaluate", response="done", blocked_reason="branch-not-pushed",
+        blocked_remedy="Push it.", blocked_paths=["a.py"], blocked_attempts_left=2,
+    )
+
+    assert judged == [], "the judge must not run again for a publication blocker"
+    decision = result["decision"]
+    assert decision["verdict"] == "continue"
+    assert "branch-not-pushed" in decision["continuation_prompt"]
+    assert "Push it." in decision["continuation_prompt"]
+    assert "a.py" in decision["continuation_prompt"]
+    assert "2 more time" in decision["continuation_prompt"]
+
+
+def test_a_publication_blocker_hard_pauses_once_the_budget_is_spent(monkeypatch):
+    """If naming the blocker did not clear it, a human must see it."""
+
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = _State()
+
+        def evaluate_after_turn(self, response, background_processes=None):
+            raise AssertionError("the judge must not be called")
+
+    _install_fake_goals(monkeypatch, Manager)
+    from hermes_cli.goal_session import run_goal_turn
+
+    result = run_goal_turn("s1", "evaluate", response="done",
+                           blocked_reason="worktree-dirty", blocked_attempts_left=0)
+
+    assert result["decision"]["verdict"] == "hard_pause"
+    assert result["decision"]["should_continue"] is False
+    assert result["state"]["status"] == "hard_paused"
+
+
+def test_the_publication_continuation_forbids_new_work():
+    """The failure mode is an agent that reads 'blocked' as 'keep going'."""
+    from hermes_cli.goal_session import publication_continuation
+
+    text = publication_continuation("branch-not-pushed", "Push the branch.", 1)
+    assert "already verified this work as DONE" in text
+    assert "Do NOT start new work" in text
+    # A bulleted path list must not run into the sentence's period.
+    listed = publication_continuation("worktree-dirty", "Commit it.", 1, ["x.py", "  "])
+    assert listed.count("- x.py") == 1
+    assert "  - x.py." not in listed
+
+
+def test_a_paused_state_becomes_a_hard_pause(monkeypatch):
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = _State(status="paused")
+
+        def evaluate_after_turn(self, response, background_processes=None):
+            return {"verdict": "continue", "status": "paused", "reason": "budget",
+                    "should_continue": True, "continuation_prompt": "go"}
+
+    _install_fake_goals(monkeypatch, Manager)
+    from hermes_cli.goal_session import run_goal_turn
+
+    result = run_goal_turn("s1", "evaluate", response="x")
+    assert result["decision"]["verdict"] == "hard_pause"
+    assert result["decision"]["should_continue"] is False
+    assert result["state"]["status"] == "hard_paused"
+
+
+def test_a_broken_background_process_list_never_fails_the_turn(monkeypatch):
+    """The live process list is an optimization, not a precondition."""
+
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = _State()
+
+        def evaluate_after_turn(self, response, background_processes=None):
+            assert background_processes is None
+            return {"verdict": "continue", "reason": "ok", "should_continue": True,
+                    "continuation_prompt": "next"}
+
+    def explode():
+        raise RuntimeError("process registry is down")
+
+    module = _install_fake_goals(monkeypatch, Manager)
+    module.gather_background_processes = explode
+
+    from hermes_cli.goal_session import run_goal_turn
+
+    assert run_goal_turn("s1", "evaluate", response="x")["decision"]["verdict"] == "continue"
+
+
+def test_start_requires_a_goal(monkeypatch):
+    class Manager:
+        def __init__(self, session_id, *, default_max_turns):
+            self.state = None
+
+    _install_fake_goals(monkeypatch, Manager)
+    from hermes_cli.goal_session import run_goal_turn
+
+    assert run_goal_turn("s1", "start", goal="   ")["error"]["code"] == "invalid_goal"


### PR DESCRIPTION
## What this adds

A surface-neutral entry point, `hermes_cli.goal_session.run_goal_turn()`, that lets an **embedder** — a console, a web app, any process that runs Hermes as a child — drive the persistent-goal loop without reaching across the process boundary to repair agent state.

Purely additive: one new module, one new test file, no existing surface changed.

## Why

An embedder that supervises Hermes from outside has to ask, then act, then handle the race between the two. In practice that means it grows a second supervision loop — retries, verdict validation, goal repair — and the two drift.

We measured this in a production console over a month: **201 mission resumes and 121 failures**, dominated not by disagreements about the work but by *plumbing* — `no active goal` (51), invalid turn counts, raw `RuntimeError`s. The single commonest fault was a goal vanishing between turns (a cancelled turn, a cleared session, a crash), which the embedder could only fix by asking whether a goal existed and conditionally calling `start` — a destructive call that overwrites a live goal if the read was wrong.

After switching that console to this module, those reason codes fell to **zero** and have stayed there across several days and multiple releases.

## What it does

- **`run_goal_turn(session_id, action, ...)`** returns a structured envelope for every ordinary protocol condition — a missing goal, an unknown action, an unavailable judge — instead of raising. Callers get `failure_kind` to distinguish a supervisor outage from a judgment about the work.
- **Self-healing.** Passing `goal=` alongside `evaluate` re-establishes a vanished goal *in the same call that grades the turn*. It cannot clobber a live goal, because it only sets one when none exists — which is strictly safer than the ask-then-start dance it replaces. The envelope reports `restarted: True`.
- **Publication blockers.** An embedder that owns a publication step (promoting to a branch, uploading an artifact) can find work DONE and still be unable to publish it. `blocked_reason`/`blocked_remedy`/`blocked_paths`/`blocked_attempts_left` report that into the loop, which returns an ordinary `continue` carrying a continuation naming the blocker — or `hard_pause` once the budget is spent. It short-circuits the judge, since the verdict already exists and the response has not changed, so re-grading would spend an auxiliary call to reach the same answer.

## Notes

- `PROTOCOL_VERSION` is declared so an embedder can detect capability and fall back to its legacy path against an older Hermes.
- Verdict normalization treats `inactive` as a resolution rather than an unrecognized verdict — folding it into `failed` turns a finished mission into an operator prompt.
- 16 tests, covering the self-heal, the blocker paths, the budget boundary, and judge-unavailable degradation.
