### PR TITLE
fix(desktop): remote gateway update no longer strands the app on a dead socket (salvage #90769)

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -49,6 +49,12 @@ class FakeWebSocket {
   // errors (a dead remote). Mirrors a VPS going away after the first connect.
   static mode: 'open' | 'fail' = 'open'
   static instances: FakeWebSocket[] = []
+  // Ping behavior: 'pong' answers with a healthy pong frame; 'silent' swallows
+  // the request (the half-open-socket simulation — connection looks OPEN but
+  // every RPC hangs until its per-call timeout); 'method-not-found' answers
+  // the JSON-RPC error a PRE-ping backend returns (a healthy, version-skewed
+  // response that must NOT trigger a reconnect).
+  static pingMode: 'pong' | 'silent' | 'method-not-found' = 'pong'
 
   readyState = 0
   private listeners: Record<string, Set<Listener>> = {}
@@ -86,6 +92,35 @@ class FakeWebSocket {
   drop() {
     this.readyState = FakeWebSocket.CLOSED
     this.emit('close', {})
+  }
+
+  send(data: string) {
+    let frame: { id?: unknown; method?: string }
+
+    try {
+      frame = JSON.parse(data) as { id?: unknown; method?: string }
+    } catch {
+      return
+    }
+
+    if (frame.method !== 'ping') {
+      return
+    }
+
+    if (FakeWebSocket.pingMode === 'pong') {
+      this.emit('message', {
+        data: JSON.stringify({ jsonrpc: '2.0', id: frame.id, result: { pong: true } })
+      })
+    } else if (FakeWebSocket.pingMode === 'method-not-found') {
+      this.emit('message', {
+        data: JSON.stringify({
+          jsonrpc: '2.0',
+          id: frame.id,
+          error: { code: -32601, message: 'Method not found' }
+        })
+      })
+    }
+    // 'silent': swallow — a healthy socket answers, a half-open one never does.
   }
 
   private emit(type: string, ev: unknown) {
@@ -204,6 +239,7 @@ beforeEach(() => {
   vi.useFakeTimers()
   FakeWebSocket.mode = 'open'
   FakeWebSocket.instances = []
+  FakeWebSocket.pingMode = 'pong'
   connectionApplied = null
   powerResume = null
   ;(globalThis as { WebSocket: unknown }).WebSocket = FakeWebSocket
@@ -760,5 +796,67 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     // Still no retry later: a missing capability is not a transient failure.
     await advanceBackoff()
     expect(desktop.getConnection).toHaveBeenCalledTimes(1)
+  })
+
+  it('wake probe: an open-looking but unresponsive socket is force-closed and reconnected', async () => {
+    render(<Harness />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+    const socketCountBefore = FakeWebSocket.instances.length
+
+    // Half-open socket: connectionState reads 'open' (no close event) but the
+    // backend never answers — the sleep/wake TCP black hole.
+    FakeWebSocket.pingMode = 'silent'
+
+    // A wake signal (power resume / network online / window visible) nudges
+    // reconnectNow. With the socket still reporting open it must PROBE rather
+    // than skip; the swallowed ping times out and forces the socket down.
+    act(() => window.dispatchEvent(new Event('online')))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_100)
+    })
+    // The probe timeout (5s) force-closed the socket → 'closed' → the backoff
+    // timer schedules a reconnect; let it fire and re-dial.
+    await advanceBackoff()
+
+    // A fresh socket was dialed.
+    expect(FakeWebSocket.instances.length).toBeGreaterThan(socketCountBefore)
+    expect($gatewayState.get()).toBe('open')
+  })
+
+  it('wake probe: a healthy socket answers the ping and stays untouched', async () => {
+    render(<Harness />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+    const socketCountBefore = FakeWebSocket.instances.length
+
+    // Default FakeWebSocket behavior: answer pings with a pong frame.
+    act(() => window.dispatchEvent(new Event('online')))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_100)
+    })
+
+    // Probe succeeded → no forced close, no reconnect, connection untouched.
+    expect(FakeWebSocket.instances.length).toBe(socketCountBefore)
+    expect($gatewayState.get()).toBe('open')
+  })
+
+  it('wake probe: a pre-ping backend (-32601) is healthy, not reconnected', async () => {
+    render(<Harness />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+    const socketCountBefore = FakeWebSocket.instances.length
+
+    // Version skew: this gateway predates the ping method. The error response
+    // proves the socket is alive; forcing a reconnect would loop forever.
+    FakeWebSocket.pingMode = 'method-not-found'
+
+    act(() => window.dispatchEvent(new Event('online')))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_100)
+    })
+
+    expect(FakeWebSocket.instances.length).toBe(socketCountBefore)
+    expect($gatewayState.get()).toBe('open')
   })
 })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -545,12 +545,20 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect(powerResume).not.toBeNull()
 
     // macOS can discard the TCP connection during sleep without updating the
-    // renderer WebSocket object. Leave readyState OPEN and emit only resume.
+    // renderer WebSocket object. Leave readyState OPEN, swallow the liveness
+    // ping (a half-open socket never answers), and emit only resume. The wake
+    // path no longer blind-closes an open-looking socket — it probes first and
+    // closes only when the probe times out.
+    FakeWebSocket.pingMode = 'silent'
     act(() => powerResume?.())
-    await flushAsync()
-    await flushAsync()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_100)
+    })
 
     expect(staleSocket.readyState).toBe(FakeWebSocket.CLOSED)
+    // The probe-driven close schedules the regular backoff reconnect, which
+    // revalidates the (possibly dead) remote descriptor before re-dialing.
+    await advanceBackoff()
     expect(desktop.revalidateConnection).toHaveBeenCalledOnce()
     expect(FakeWebSocket.instances).toHaveLength(2)
     expect($gatewayState.get()).toBe('open')

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -353,14 +353,10 @@ export function useGatewayBoot({
       reconnectSecondaryGateways({ forceOpenSockets: forceOpenSocket })
 
       // Browser WebSocket state can remain OPEN after sleep even though the OS
-      // discarded the underlying TCP connection. Strong recovery signals must
-      // retire that half-open socket before the normal reconnect path can run.
-      if (forceOpenSocket && gatewayOpen()) {
-        gateway.close()
-        // close() publishes `closed`, which schedules the regular backoff.
-        // This path reconnects immediately, so remove that redundant timer.
-        clearReconnectTimer()
-      }
+      // discarded the underlying TCP connection. Strong recovery signals used
+      // to blind-close here, but that churned perfectly healthy connections on
+      // every wake/online blip — the liveness probe below now decides, closing
+      // only a socket that is provably dead.
 
       if (!gatewayOpen()) {
         await attemptReconnect()

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -1,4 +1,4 @@
-import { isGatewayReauthRequired, resolveGatewayWsUrl } from '@hermes/shared'
+import { isGatewayReauthRequired, JsonRpcGatewayError, resolveGatewayWsUrl } from '@hermes/shared'
 import { useEffect, useRef } from 'react'
 
 import { shouldApplyPostBootProgressError } from '@/components/boot-failure-reauth'
@@ -74,6 +74,13 @@ import { stashGatewaySurvivor, survivorIsStale, takeGatewaySurvivor } from './ga
 // flaps, sleep/wake, Wi‑Fi blips that self-heal in 1–3 minutes — never even
 // toast. Chat stays readable/draftable the whole time either way.
 const RECONNECT_ESCALATE_AFTER_MS = 300_000
+
+// Bound for the sleep/wake liveness probe (see reconnectNow): long enough to
+// ride out a busy-but-healthy backend's scheduling jitter, short enough that a
+// half-open socket fails fast instead of hanging the wake path. Independent of
+// PROMPT_SUBMIT_REQUEST_TIMEOUT_MS (30 min) — that long timeout is correct for
+// an in-flight turn, but must never be what a dead connection burns.
+const GATEWAY_LIVENESS_PROBE_TIMEOUT_MS = 5_000
 
 // Bounded self-heal for a failed REMOTE boot (#82679): when the primary boot
 // fails on a transient remote fault (dropped SSH/HTTP registered connection,
@@ -357,6 +364,30 @@ export function useGatewayBoot({
 
       if (!gatewayOpen()) {
         await attemptReconnect()
+        return
+      }
+
+      // The socket reports open, but sleep/wake (or a silent network drop)
+      // can leave a half-open TCP connection: no close event fires, so
+      // connectionState stays 'open' while every RPC hangs until its per-call
+      // timeout — prompt.submit's is 30 minutes, which reads as "enter does
+      // nothing until I restart the app". Probe liveness with a short-bounded
+      // ping; on failure force the socket down so the onState handler above
+      // schedules a reconnect (and resetTileRuntimeBindings re-resumes tiles),
+      // instead of letting the user's next submit hang against a dead socket.
+      try {
+        await gateway.request('ping', {}, GATEWAY_LIVENESS_PROBE_TIMEOUT_MS)
+      } catch (probeErr) {
+        // A version-skewed backend that predates the ping method answers
+        // -32601 (method not found) — a HEALTHY response, not a dead socket.
+        // Force-closing on it would spin the reconnect loop forever. Every
+        // other failure (timeout on a swallowed ping, transport error) means
+        // the socket is not actually alive and must be rebuilt.
+        if (probeErr instanceof JsonRpcGatewayError && probeErr.code === -32601) {
+          return
+        }
+
+        gateway.close()
       }
     }
 

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -52,6 +52,16 @@ vi.mock('@/hermes', () => ({
   getActionStatus: (...args: unknown[]) => getActionStatusSpy(...args)
 }))
 
+// A successful backend apply must nudge the gateway reconnect handler — the
+// update restarted the gateway process, and over tunnels the old socket dies
+// without a close event (users force-quit to recover). Mock the tiny registry
+// module so the assertion is direct.
+const reconnectGatewaySpy = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('@/store/gateway-reconnect', () => ({
+  reconnectGateway: (...args: unknown[]) => reconnectGatewaySpy(...args)
+}))
+
 const {
   maybeNotifyUpdateAvailable,
   checkBackendUpdates,
@@ -613,6 +623,24 @@ describe('client nudge after a backend update', () => {
     await new Promise(resolve => setTimeout(resolve, 50))
     const ids = notifySpy.mock.calls.map(call => (call[0] as { id?: string }).id)
     expect(ids).not.toContain('client-update-after-backend')
+  })
+
+  it('nudges a gateway reconnect after the backend caught up (tunnel socket may be dead)', async () => {
+    checkClientMock.mockResolvedValue(status({ behind: 0, updateAvailable: false }))
+    reconnectGatewaySpy.mockClear()
+
+    await applyBackendUpdate()
+
+    expect(reconnectGatewaySpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not nudge a reconnect when the backend apply failed', async () => {
+    reconnectGatewaySpy.mockClear()
+    getActionStatusSpy.mockReset().mockResolvedValue({ lines: [], running: false, exit_code: 1 })
+
+    await applyBackendUpdate()
+
+    expect(reconnectGatewaySpy).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -18,6 +18,7 @@ import { checkHermesUpdate, getActionStatus, updateHermes } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { persistString, storedString } from '@/lib/storage'
 import { $connectionsRegistry, refreshConnectionsRegistry } from '@/store/connections'
+import { reconnectGateway } from '@/store/gateway-reconnect'
 import { dismissNotification, notify } from '@/store/notifications'
 import { $connection } from '@/store/session'
 import type { BackendUpdateCheckResponse } from '@/types/hermes'
@@ -539,6 +540,14 @@ function finishBackendApply(returned: boolean): DesktopUpdateApplyResult {
     $backendUpdateApply.set(IDLE)
     setUpdateOverlayOpen(false)
     void checkBackendUpdates()
+    // The update restarted the gateway process, which strands this window's
+    // WebSocket: over SSH/tailscale tunnels the old TCP connection often dies
+    // without a close event, so connectionState still reads 'open' while every
+    // RPC hangs — users force-quit the app to recover. Nudge the registered
+    // reconnect handler (forceReconnectNow), which retires the half-open
+    // socket and re-dials with a fresh ticket. Best-effort: local installs
+    // whose socket survived treat it as a cheap probe.
+    void reconnectGateway().catch(() => undefined)
     // The backend caught up, but the CLIENT may still be behind — the exact
     // gap that strands remote-mode users on an old GUI forever (every update
     // affordance in remote mode targets the backend, so nothing ever told

--- a/tests/tui_gateway/test_ping_probe.py
+++ b/tests/tui_gateway/test_ping_probe.py
@@ -1,0 +1,31 @@
+"""Tests for the ``ping`` liveness probe (tui_gateway/server.py).
+
+The desktop client probes ``ping`` after sleep/wake to distinguish a
+half-open TCP socket (connectionState still ``open`` while every RPC hangs)
+from a genuinely healthy connection. The contract is minimal on purpose:
+answered synchronously on the WS reader thread, no session, no IO, no agent.
+"""
+
+from __future__ import annotations
+
+import tui_gateway.server as srv
+
+
+def _call(method: str, params: dict) -> dict:
+    """Invoke a registered RPC method and return its result dict."""
+    envelope = srv._methods[method](1, params)
+    return envelope["result"]
+
+
+def test_ping_registered_and_answers_pong():
+    res = _call("ping", {})
+    assert res == {"pong": True}
+
+
+def test_ping_ignores_params_and_returns_ok_envelope():
+    # The probe must be parameter-agnostic: the client sends {} but a stray
+    # future caller must not be able to make it fail.
+    envelope = srv._methods["ping"](7, {"anything": "value"})
+    assert envelope["jsonrpc"] == "2.0"
+    assert envelope["id"] == 7
+    assert envelope["result"] == {"pong": True}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -15318,6 +15318,21 @@ def _persist_wake_enabled(enabled: bool) -> bool:
         return False
 
 
+@method("ping")
+def _(rid, params: dict) -> dict:
+    """Cheapest possible liveness probe for the desktop client.
+
+    Answered synchronously on the WS reader thread, so it works even while
+    every agent is mid-turn or the GIL is contended — the round-trip only
+    measures socket health, not backend load. A desktop client uses it after
+    sleep/wake to distinguish a half-open TCP connection (no close event, so
+    ``connectionState`` still reads ``open`` while every RPC hangs until its
+    per-call timeout) from a genuinely healthy socket, and forces a reconnect
+    in the former case instead of letting the next ``prompt.submit`` hang.
+    """
+    return _ok(rid, {"pong": True})
+
+
 @method("wake.start")
 def _(rid, params: dict) -> dict:
     """Arm the wake-word listener for the calling surface ("tui" | "gui").


### PR DESCRIPTION
## Summary

After a remote (SSH/tailscale) backend update restarts the gateway, the desktop app now reconnects itself instead of hanging until the user force-quits. Salvages PR #90769 by @Owen-narcissus (half-open-socket liveness probe) and wires the backend-update success path into it.

Root cause: the gateway restart kills the tunnel TCP connection without a close event, so the renderer's WebSocket still reads `open` while every RPC hangs — `prompt.submit`'s timeout is 30 minutes, which reads as "app is dead, force-quit". The old wake path skipped reconnect whenever the socket *reported* open.

## Changes

- `tui_gateway/server.py`: new `ping` RPC — cheapest possible liveness probe, answered on the WS reader thread (from #90769).
- `use-gateway-boot.ts`: wake/online/visible signals now probe `ping` (5s bound) on an open-looking socket; only a provably dead socket is force-closed and re-dialed. `-32601` from a pre-ping backend counts as healthy (version-skew safe). The old blind `gateway.close()` on every wake signal is removed — healthy connections are no longer churned.
- `updates.ts` (`finishBackendApply`): a successful backend update nudges `reconnectGateway()`, so the post-update stranded-socket window heals immediately instead of waiting for the next wake signal.
- Tests: 3 probe scenarios (dead socket, healthy socket, version-skewed backend) + 2 update-flow reconnect assertions + server-side ping tests.

## Validation

| | Before | After |
|---|---|---|
| Remote update completes | socket stays half-open, RPCs hang, force-quit | probe fails fast, auto reconnect |
| Wake with healthy socket | blind close + redial churn | ping answers, connection untouched |
| Old backend (no ping) | n/a | -32601 treated as healthy, no loop |
| Desktop vitest | — | 80/80 green (updates + use-gateway-boot) |
| tests/tui_gateway/test_ping_probe.py | — | 2/2 green |

Credit: probe mechanism and server RPC by @Owen-narcissus (#90769); update-flow wiring and blind-close removal added on top.

Reported by @tiny__edge (desktop feedback: "always have to force-quit the local app because it never catches the remote gateway restart") — with the referenced issue #83174.

## Infographic

![The socket that looked alive](https://v3b.fal.media/files/b/0aa79914/1AFeWGJKYRXjAJX4aqT-V_mWQDh88f.png)
