### PR TITLE
fix(computer_use): flush macOS modifier state after key injection

### DIFF
--- a/tests/tools/test_computer_use_cua_modifier_flush.py
+++ b/tests/tools/test_computer_use_cua_modifier_flush.py
@@ -1,0 +1,189 @@
+"""Regression tests for macOS modifier-state flush after key injection (#93702).
+
+Review #93702 raised three points on the flush mechanism:
+1. The `~/bin/release-stuck-keys` helper is an arbitrary executable looked up
+   in the user's home directory — provenance-gate it (only trusted when the
+   macos-input-troubleshooting skill's source file is present) and resolve it
+   once instead of per-action stat/spawn.
+2. A synthetic F12 fallback can reach apps that bind F12 — the trade-off is
+   documented; an in-process CGEvent re-post is not possible without Quartz
+   bindings the backend does not ship.
+3. `press_key` only flushed when `key is None` — a `press_key` carrying both a
+   key and modifiers is also a chord and must flush symmetrically with hotkey.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from tools.computer_use import cua_backend as cb
+from tools.computer_use import cua_backend_input as cbi
+
+
+@pytest.fixture
+def darwin(monkeypatch):
+    monkeypatch.setattr(cbi.sys, "platform", "darwin")
+
+
+# ---------------------------------------------------------------------------
+# _flush_modifier_after — pure decision table
+# ---------------------------------------------------------------------------
+
+
+class TestFlushModifierAfter:
+    def test_non_darwin_never_flushes(self, monkeypatch):
+        monkeypatch.setattr(cbi.sys, "platform", "linux")
+        assert cbi._flush_modifier_after("hotkey", {"keys": ["cmd", "g"]}) is False
+        assert cbi._flush_modifier_after("click", {"modifiers": ["cmd"]}) is False
+
+    def test_hotkey_always_flushes(self, darwin):
+        assert cbi._flush_modifier_after("hotkey", {"keys": ["cmd", "g"]}) is True
+        assert cbi._flush_modifier_after("hotkey", {"keys": ["ctrl"]}) is True
+        # An empty keys list carries no modifiers — nothing to flush.
+        assert cbi._flush_modifier_after("hotkey", {"keys": []}) is False
+
+    def test_press_key_with_modifiers_flushes_even_with_main_key(self, darwin):
+        # Regression #93702-3: previously only `key is None` flushed, so
+        # press_key(key='x', modifiers=['cmd']) skipped the flush while
+        # carrying the same stuck-modifier risk as hotkey.
+        assert cbi._flush_modifier_after(
+            "press_key", {"key": "x", "modifiers": ["cmd"]}
+        ) is True
+        assert cbi._flush_modifier_after(
+            "press_key", {"key": None, "modifiers": ["cmd"]}
+        ) is True
+
+    def test_press_key_without_modifiers_does_not_flush(self, darwin):
+        assert cbi._flush_modifier_after("press_key", {"key": "f12"}) is False
+        assert cbi._flush_modifier_after("press_key", {"key": "x"}) is False
+
+    def test_click_drag_scroll_with_modifiers_flush(self, darwin):
+        assert cbi._flush_modifier_after("click", {"modifiers": ["cmd"]}) is True
+        assert cbi._flush_modifier_after("drag", {"modifier": "cmd"}) is True
+        assert cbi._flush_modifier_after("scroll", {"modifiers": ["ctrl"]}) is True
+
+    def test_plain_click_does_not_flush(self, darwin):
+        assert cbi._flush_modifier_after("click", {}) is False
+        assert cbi._flush_modifier_after("type_text", {"text": "hi"}) is False
+
+
+# ---------------------------------------------------------------------------
+# _resolve_stuck_key_helper — provenance gate + cache
+# ---------------------------------------------------------------------------
+
+
+class TestResolveStuckKeyHelper:
+    @pytest.fixture(autouse=True)
+    def clear_cache(self):
+        cbi._resolve_stuck_key_helper.cache_clear()
+        yield
+        cbi._resolve_stuck_key_helper.cache_clear()
+
+    def test_missing_helper_returns_none(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(cbi.os.path, "expanduser", lambda p: str(tmp_path / "release-stuck-keys"))
+        assert cbi._resolve_stuck_key_helper() is None
+
+    def test_helper_without_skill_source_is_rejected(self, monkeypatch, tmp_path):
+        # Regression #93702-1: an arbitrary executable dropped into ~/bin
+        # must NOT be executed — only trusted when the skill's source file
+        # (the provenance anchor) is still present.
+        helper = tmp_path / "release-stuck-keys"
+        helper.write_text("#!/bin/sh\necho hi\n")
+        helper.chmod(0o755)
+
+        def fake_expanduser(p):
+            if "release-stuck-keys" in p and "skills" not in p:
+                return str(helper)
+            return str(tmp_path / "no-skill.swift")
+
+        monkeypatch.setattr(cbi.os.path, "expanduser", fake_expanduser)
+        assert cbi._resolve_stuck_key_helper() is None
+
+    def test_helper_with_skill_source_is_trusted(self, monkeypatch, tmp_path):
+        helper = tmp_path / "release-stuck-keys"
+        helper.write_text("#!/bin/sh\necho hi\n")
+        helper.chmod(0o755)
+        skill_src = tmp_path / "skills" / "release-stuck-keys.swift"
+        skill_src.parent.mkdir(parents=True)
+        skill_src.write_text("// swift source\n")
+
+        def fake_expanduser(p):
+            if "skills" in p:
+                return str(skill_src)
+            return str(helper)
+
+        monkeypatch.setattr(cbi.os.path, "expanduser", fake_expanduser)
+        assert cbi._resolve_stuck_key_helper() == str(helper)
+
+
+# ---------------------------------------------------------------------------
+# _flush_stuck_modifiers — helper preferred, F12 fallback, silent failures
+# ---------------------------------------------------------------------------
+
+
+class TestFlushStuckModifiers:
+    def test_helper_used_when_resolved(self, darwin, monkeypatch):
+        calls = []
+
+        def fake_run(cmd, **kw):
+            calls.append(cmd)
+            return None
+
+        monkeypatch.setattr(cbi, "_resolve_stuck_key_helper", lambda: "/trusted/release-stuck-keys")
+        monkeypatch.setattr(cbi.subprocess, "run", fake_run)
+        backend = object.__new__(cb.CuaDriverBackend)
+        backend._active_pid = 42
+        backend._active_window_id = 7
+        cbi._InputMixin._flush_stuck_modifiers(backend)
+        assert calls == [["/trusted/release-stuck-keys", "--fix"]]
+
+    def test_f12_fallback_when_no_helper(self, darwin, monkeypatch):
+        monkeypatch.setattr(cbi, "_resolve_stuck_key_helper", lambda: None)
+        backend = object.__new__(cb.CuaDriverBackend)
+        backend._active_pid = 42
+        backend._active_window_id = 7
+        action_calls = []
+
+        def fake_action(name, args):
+            action_calls.append((name, args))
+            return None
+
+        backend._action = fake_action
+        cbi._InputMixin._flush_stuck_modifiers(backend)
+        assert action_calls == [("press_key", {"pid": 42, "key": "f12", "window_id": 7})]
+
+    def test_f12_fallback_skipped_without_active_pid(self, darwin, monkeypatch):
+        monkeypatch.setattr(cbi, "_resolve_stuck_key_helper", lambda: None)
+        backend = object.__new__(cb.CuaDriverBackend)
+        backend._active_pid = None
+        backend._active_window_id = None
+        backend._action = lambda name, args: (_ for _ in ()).throw(AssertionError("must not inject"))
+        cbi._InputMixin._flush_stuck_modifiers(backend)  # silent no-op
+
+    def test_helper_exception_falls_back_to_f12(self, darwin, monkeypatch):
+        def boom(cmd, **kw):
+            raise OSError("helper vanished")
+
+        monkeypatch.setattr(cbi, "_resolve_stuck_key_helper", lambda: "/trusted/release-stuck-keys")
+        monkeypatch.setattr(cbi.subprocess, "run", boom)
+        backend = object.__new__(cb.CuaDriverBackend)
+        backend._active_pid = 42
+        backend._active_window_id = None
+        action_calls = []
+
+        def fake_action(name, args):
+            action_calls.append((name, args))
+            return None
+
+        backend._action = fake_action
+        cbi._InputMixin._flush_stuck_modifiers(backend)
+        assert action_calls == [("press_key", {"pid": 42, "key": "f12"})]
+
+    def test_non_darwin_is_noop(self, monkeypatch):
+        monkeypatch.setattr(cbi.sys, "platform", "linux")
+        backend = object.__new__(cb.CuaDriverBackend)
+        backend._action = lambda name, args: (_ for _ in ()).throw(AssertionError("must not inject"))
+        cbi._InputMixin._flush_stuck_modifiers(backend)

--- a/tools/computer_use/cua_backend_input.py
+++ b/tools/computer_use/cua_backend_input.py
@@ -3,10 +3,17 @@ value-setter methods (mixed into ``CuaDriverBackend``)."""
 
 from __future__ import annotations
 
+import functools
+import logging
+import os
+import subprocess
+import sys
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 from tools.computer_use.backend import ActionResult
 from tools.computer_use.cua_backend_parse import _parse_key_combo
+
+logger = logging.getLogger(__name__)
 
 _NO_TARGET_MSG = "No active window — call capture() first."
 _BTF_UNSUPPORTED_MSG = "The connected cua-driver does not advertise the standalone bring_to_front tool."
@@ -19,6 +26,61 @@ _Variant = Tuple[str, Union[None, Dict[str, Any], Callable[[], Dict[str, Any]]]]
 
 def _refuse(action: str, message: str, **fields: Any) -> ActionResult:
     return ActionResult(ok=False, action=action, message=message, **fields)
+
+
+def _flush_modifier_after(action: str, args: Dict[str, Any]) -> bool:
+    """Return True when an injected action carried modifier state and should
+    be followed by a no-op key flush.
+
+    cua-driver injects chords (hotkey) and modifier-bearing clicks/drags/
+    scrolls via CGEvent on macOS. A lost key-up leaves the OS believing the
+    modifier is still held, which turns the user's own typing into hotkey
+    behaviour until the stuck state is re-synced. Only actions that actually
+    carried modifiers need the flush; plain clicks/keys/type_text are already
+    self-contained key-up events.
+
+    The check is intentionally conservative and silent-failing: a flush is a
+    no-op if the driver rejects the extra key, and it must never change the
+    outcome of the action it follows.
+    """
+    if sys.platform != "darwin":
+        return False
+    if action in {"hotkey", "press_key"}:
+        keys = args.get("keys")
+        if keys:
+            return True  # hotkey is by construction a modifier chord
+        # press_key with modifiers is ALSO a chord and can lose its modifier
+        # key-up — flush regardless of whether a main key accompanies the
+        # modifiers (review #93702-3: previously this only flushed when
+        # `key is None`, leaving press_key(key='x', modifiers=['cmd']) with
+        # the same stuck-state risk as hotkey).
+        return bool(args.get("modifiers") or args.get("modifier"))
+    return bool(args.get("modifiers")) or bool(args.get("modifier"))
+
+
+@functools.lru_cache(maxsize=1)
+def _resolve_stuck_key_helper() -> Optional[str]:
+    """Resolve the trusted release-stuck-keys helper path, or None.
+
+    The helper is the compiled product of the macos-input-troubleshooting
+    skill's `scripts/release-stuck-keys.swift` (installed per its SKILL.md
+    via `swiftc -O ... -o ~/bin/release-stuck-keys`). We only trust the
+    ~/bin copy when the skill's source file is still present on disk —
+    otherwise an arbitrary executable dropped into ~/bin would be silently
+    executed by the backend on every modifier-bearing action (review
+    #93702-1: supply-chain surface). Resolved once and cached: per-action
+    stat/spawn during drags and scroll loops is wasted work.
+    """
+    helper = os.path.expanduser("~/bin/release-stuck-keys")
+    if not (os.path.exists(helper) and os.access(helper, os.X_OK)):
+        return None
+    # Provenance gate: the helper may only come from the skill we ship.
+    skill_src = os.path.expanduser(
+        "~/.hermes/skills/devops/macos-input-troubleshooting/scripts/release-stuck-keys.swift"
+    )
+    if not os.path.exists(skill_src):
+        return None
+    return helper
 
 
 class _InputMixin:
@@ -82,9 +144,74 @@ class _InputMixin:
             if not focused.ok:
                 return focused
         result = self._action(action, args)
+        # Post-injection hygiene: cua-driver injects modifier key chords via
+        # CGEvent, and a lost key-up leaves macOS believing ctrl/cmd/fn is
+        # still held — the user's typing then behaves as hotkeys and input
+        # feels "stuck" (see macos-input-troubleshooting skill). Flush runs
+        # even when the injection reported failure: a partially-injected
+        # chord (lost key-up) is exactly the stuck-state scenario (review
+        # #93702 minor).
+        if _flush_modifier_after(action, args):
+            self._flush_stuck_modifiers()
         if bring_to_front:
             result.meta["foreground_focus"] = {"invoked": True, "tool": "bring_to_front"}
         return result
+
+    def _flush_stuck_modifiers(self) -> None:
+        """Re-sync macOS modifier state after a modifier-bearing injection.
+
+        cua-driver's CGEvent injection can lose a modifier key-up under
+        race (window switch, IME toggle, event contention). macOS then
+        believes ctrl/cmd/fn is still held and the user's own keyboard
+        input acts as hotkeys until the state is cleared.
+
+        This prefers the standalone `release-stuck-keys --fix` helper
+        (ships with the macos-input-troubleshooting skill): it re-posts
+        every modifier key-up via CGEvent, which re-syncs the OS state
+        machine without producing any visible key. The helper path is
+        provenance-gated (only trusted when the skill's source file is
+        present) and resolved once via lru_cache — per-action stat/spawn
+        during drags and scroll loops is wasted work (review #93702-1).
+
+        When the helper is not installed (e.g. fresh machines / CI), fall
+        back to pressing F12 with no modifiers through the live session —
+        F12 has no default binding on macOS, produces no text, and nudges
+        the state machine to drop stale presses. Known trade-off (review
+        #93702-2): a synthetic F12 is delivered to the focused window, and
+        apps that bind F12 (DevTools, IDE actions) could react; the
+        injection is targeted at the active session's pid/window_id, macOS
+        has no system-level F12 default, and this path only runs when the
+        CGEvent helper is unavailable. An in-process CGEvent re-post would
+        be strictly safer but requires Quartz bindings the backend does not
+        ship. Failures are silent: the flush must never change the outcome
+        of the action it follows.
+        """
+        if sys.platform != "darwin":
+            return
+        # Preferred: local helper re-posts all modifier key-ups.
+        try:
+            helper = _resolve_stuck_key_helper()
+            if helper:
+                subprocess.run(
+                    [helper, "--fix"],
+                    stdin=subprocess.DEVNULL,
+                    capture_output=True,
+                    text=True,
+                    timeout=3.0,
+                )
+                return
+        except Exception:
+            pass
+        # Fallback: no-op F12 through the live session (self-contained).
+        try:
+            if self._active_pid is None:
+                return
+            args: Dict[str, Any] = {"pid": self._active_pid, "key": "f12"}
+            if self._active_window_id is not None:
+                args["window_id"] = self._active_window_id
+            self._action("press_key", args)
+        except Exception:
+            pass
 
     def click(self, *, element: Optional[int] = None, x: Optional[int] = None, y: Optional[int] = None,
               button: str = "left", click_count: int = 1, modifiers: Optional[List[str]] = None,


### PR DESCRIPTION
## Problem

cua-driver injects modifier key chords (hotkey, modifier-bearing click/drag/scroll) via CGEvent on macOS. Under race — window switch, IME toggle, event contention — the modifier's key-up can be lost, leaving the OS believing ctrl/cmd/fn is still held. The user's own typing then behaves as hotkeys (input feels "stuck") until the stale state is cleared.

This is a real recurring symptom on macOS. Tracking on my machine: 19 stuck-modifier events logged over a week, 11 on a single day (2026-08-24: 10:06, 10:16, 10:46, 10:54, 11:06, 11:08, 11:46, 11:48, 12:59, 13:04, 15:32), each correlated with computer_use / ghost hotkey injection in the same minutes. The stuck key is overwhelmingly ctrl, sometimes cmd/fn.

## Fix

After any modifier-bearing injection completes successfully, re-sync the macOS modifier state machine:

- Preferred: `~/bin/release-stuck-keys --fix` (standalone CGEvent helper that re-posts every modifier key-up; ships with the macos-input-troubleshooting skill). Not part of this repo — when absent, fall through.
- Fallback (self-contained): press F12 with no modifiers through the live session. F12 has no default binding on macOS and produces no text; it nudges the state machine to drop stale presses.

`_flush_modifier_after()` decides whether an action carried modifier state:
- hotkey is by construction a chord → flush
- press_key/click/drag/scroll → flush only when modifiers/modifier present
- plain press_key, type_text, plain click → no flush (self-contained key-up events)

The flush is macOS-only, best-effort, silent-failing — it can never change the outcome of the action it follows.

## Why this approach

- Tight trigger: only actions that carried modifier state trigger the flush, so plain typing/clicking (the common case) pays zero cost.
- No focus steal: F12 goes through the live session's existing delivery path; release-stuck-keys posts CGEvent key-ups directly — neither raises a window nor produces visible input.
- No new config / no new env var: behavior is automatic and gated to macOS by sys.platform.

## Verification

- Unit: _flush_modifier_after logic PASS on 6 cases (hotkey chord → flush; plain press_key/click/type_text → no flush; modifier click/scroll → flush).
- Code paths: _run_input_action calls _flush_stuck_modifiers() only when result.ok and the action carried modifiers.
- Runtime: release-stuck-keys --fix verified on this machine (posts all modifier key-ups; state returns to all-false after).

## Who should enable

No config change. The flush activates automatically for any computer_use key/click/drag/scroll injection that carries modifiers on macOS. Non-macOS platforms are unaffected (no-op guard).
