### PR TITLE
fix(api_server): scope run-scoped endpoints to the owning profile

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7464,6 +7464,14 @@ class APIServerAdapter(BasePlatformAdapter):
         """Update pollable run status without exposing private agent objects."""
         now = time.time()
         current = self._run_statuses.get(run_id, {})
+        if not current:
+            # Stamp the owning profile at first write (#93689): every creation
+            # path runs inside the request middleware, so the ContextVar holds
+            # the URL-selected profile here. Later updates merge into the
+            # record and never re-stamp. Run-scoped handlers enforce equality
+            # so one served profile's API key cannot read or control another
+            # profile's run.
+            current["profile"] = _api_request_profile.get() or "default"
         current.update({
             "object": "hermes.run",
             "run_id": run_id,
@@ -7474,6 +7482,21 @@ class APIServerAdapter(BasePlatformAdapter):
         current.update(fields)
         self._run_statuses[run_id] = current
         return current
+
+    def _run_visible_to_request(self, run_id: str) -> bool:
+        """Ownership gate for the run-scoped endpoints (#93689).
+
+        A registry record owned by a different profile must be
+        indistinguishable from one that does not exist, so callers return
+        their existing not-found 404 shape (never 403 — that would confirm
+        the run id exists under another profile). Records without a profile
+        stamp cannot occur since first-write stamping, and are treated as
+        not visible (fail closed) rather than trusted.
+        """
+        record = self._run_statuses.get(run_id)
+        if record is None:
+            return True  # caller's not-found branch handles it
+        return record.get("profile") == (_api_request_profile.get() or "default")
 
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
         """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
@@ -8005,12 +8028,15 @@ class APIServerAdapter(BasePlatformAdapter):
 
         run_id = request.match_info["run_id"]
         status = self._run_statuses.get(run_id)
-        if status is None:
+        if status is None or not self._run_visible_to_request(run_id):
             return web.json_response(
                 _openai_error(f"Run not found: {run_id}", code="run_not_found"),
                 status=404,
             )
-        return web.json_response(status)
+        # The ownership stamp is internal bookkeeping, not part of the
+        # public run payload.
+        payload = {k: v for k, v in status.items() if k != "profile"}
+        return web.json_response(payload)
 
     async def _handle_run_events(self, request: "web.Request") -> "web.StreamResponse":
         """GET /v1/runs/{run_id}/events — SSE stream of structured agent lifecycle events."""
@@ -8026,6 +8052,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 break
             await asyncio.sleep(0.05)
         else:
+            return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
+
+        # Ownership gate (#93689): same 404 shape as a run that does not
+        # exist. Inside the creation race window the registry record may not
+        # be written yet; _run_visible_to_request passes unknown ids through
+        # to preserve that window's subscribe-early semantics.
+        if not self._run_visible_to_request(run_id):
             return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
 
         q = self._run_streams[run_id]
@@ -8072,7 +8105,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         run_id = request.match_info["run_id"]
         status = self._run_statuses.get(run_id)
-        if status is None:
+        if status is None or not self._run_visible_to_request(run_id):
             return web.json_response(
                 _openai_error(f"Run not found: {run_id}", code="run_not_found"),
                 status=404,
@@ -8160,7 +8193,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         run_id = request.match_info["run_id"]
         status = self._run_statuses.get(run_id)
-        if status is None:
+        if status is None or not self._run_visible_to_request(run_id):
             return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
         # Only genuinely running runs are steerable.  /stop retains agent/task
         # refs during cooperative shutdown, so the status gate (not the mere
@@ -8219,6 +8252,12 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         run_id = request.match_info["run_id"]
+        # Ownership gate first (#93689): a foreign profile must not learn the
+        # run exists (404 shape) let alone interrupt it. The registry record
+        # is written at creation before agent/task refs activate, so a live
+        # run always carries its stamp here.
+        if not self._run_visible_to_request(run_id):
+            return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
         agent = self._active_run_agents.get(run_id)
         task = self._active_run_tasks.get(run_id)
 

--- a/tests/gateway/test_api_server_run_profile_ownership.py
+++ b/tests/gateway/test_api_server_run_profile_ownership.py
@@ -1,0 +1,214 @@
+"""Run-scoped endpoints must enforce per-profile ownership (#93689).
+
+Under ``gateway.multiplex_profiles`` the five run-scoped api_server
+endpoints authenticated the caller but never asked *which* profile's key
+they held: any served profile's ``API_SERVER_KEY`` could read — and stop /
+steer / approve — any run on the gateway given its ``run_id``. The fix
+stamps the creating request's profile into the run record at first write
+and rejects foreign lookups with the same 404 shape as a run that does not
+exist (403 would confirm the run id exists under another profile).
+
+These tests mirror production wiring: a test middleware binds
+``_api_request_profile`` from a header the way the real one binds it from
+the URL prefix, and the per-profile secret lookup is stubbed so alpha and
+beta each hold their own valid key — the attacker is an authenticated,
+legitimate key holder of a *different* profile.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter, _api_request_profile
+
+
+_PROFILE_KEYS = {
+    "default": "sk-secret",
+    "alpha": "a" * 32,
+    "beta": "b" * 32,
+}
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    config = PlatformConfig(enabled=True, extra={"key": _PROFILE_KEYS["default"]})
+    adapter = APIServerAdapter(config)
+
+    def fake_get_secret(name, default=""):
+        if name != "API_SERVER_KEY":
+            return default
+        return _PROFILE_KEYS.get(_api_request_profile.get() or "default", default)
+
+    # The handlers import these lazily from their modules, so patching the
+    # module attributes is what the call sites actually observe.
+    monkeypatch.setattr("agent.secret_scope.get_secret", fake_get_secret)
+    return adapter
+
+
+def _auth(profile: str) -> dict:
+    return {
+        "Authorization": f"Bearer {_PROFILE_KEYS[profile]}",
+        "X-Test-Profile": profile,
+    }
+
+
+@web.middleware
+async def _profile_mw(request, handler):
+    """Mirror the production middleware: bind the URL-selected profile."""
+    token = _api_request_profile.set(request.headers.get("X-Test-Profile"))
+    try:
+        return await handler(request)
+    finally:
+        _api_request_profile.reset(token)
+
+
+def _create_runs_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application(middlewares=[_profile_mw])
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
+    app.router.add_post("/v1/runs/{run_id}/approval", adapter._handle_run_approval)
+    app.router.add_post("/v1/runs/{run_id}/steer", adapter._handle_steer_run)
+    app.router.add_post("/v1/runs/{run_id}/stop", adapter._handle_stop_run)
+    return app
+
+
+def _stamp_run(adapter: APIServerAdapter, run_id: str, profile: str, status: str = "running"):
+    """Create a registry record as if the named profile had started the run."""
+    token = _api_request_profile.set(profile)
+    try:
+        adapter._set_run_status(run_id, status)
+    finally:
+        _api_request_profile.reset(token)
+
+
+def test_run_records_stamp_profile_at_first_write_only(adapter):
+    token = _api_request_profile.set("alpha")
+    try:
+        adapter._set_run_status("run_a", "queued")
+    finally:
+        _api_request_profile.reset(token)
+
+    assert adapter._run_statuses["run_a"]["profile"] == "alpha"
+    # A later update from a contextless worker (event callback, stop path)
+    # must not re-stamp or clobber the owner.
+    adapter._set_run_status("run_a", "running", last_event="run.started")
+    assert adapter._run_statuses["run_a"]["profile"] == "alpha"
+
+
+def test_visibility_gate_is_fail_closed(adapter):
+    _stamp_run(adapter, "run_a", "alpha")
+
+    token = _api_request_profile.set("alpha")
+    try:
+        assert adapter._run_visible_to_request("run_a") is True
+    finally:
+        _api_request_profile.reset(token)
+
+    token = _api_request_profile.set("beta")
+    try:
+        assert adapter._run_visible_to_request("run_a") is False
+    finally:
+        _api_request_profile.reset(token)
+
+    # No ContextVar = default listener; alpha's run is not visible there.
+    assert adapter._run_visible_to_request("run_a") is False
+    # Unknown ids pass through so callers return their own not-found shape.
+    assert adapter._run_visible_to_request("run_nope") is True
+    # A record without a stamp cannot occur since first-write stamping;
+    # if it ever does, it is NOT visible (fail closed).
+    adapter._run_statuses["run_ghost"] = {"run_id": "run_ghost", "status": "running"}
+    assert adapter._run_visible_to_request("run_ghost") is False
+
+
+@pytest.mark.asyncio
+async def test_get_run_cross_profile_404_is_indistinguishable(adapter):
+    app = _create_runs_app(adapter)
+    _stamp_run(adapter, "run_a", "alpha")
+
+    async with TestClient(TestServer(app)) as cli:
+        owner = await cli.get("/v1/runs/run_a", headers=_auth("alpha"))
+        assert owner.status == 200
+        payload = await owner.json()
+        # The ownership stamp is internal bookkeeping, not API surface.
+        assert "profile" not in payload
+
+        attacker = await cli.get("/v1/runs/run_a", headers=_auth("beta"))
+        assert attacker.status == 404
+        attacker_body = await attacker.json()
+
+        missing = await cli.get("/v1/runs/run_missing", headers=_auth("beta"))
+        missing_body = await missing.json()
+
+    # Same error shape as a nonexistent run (no existence oracle for other
+    # profiles' ids); the message names the queried id, exactly as the
+    # not-found branch would for an id that does not exist for beta.
+    assert attacker_body["error"]["code"] == missing_body["error"]["code"] == "run_not_found"
+    assert set(attacker_body["error"]) == set(missing_body["error"])
+    assert attacker_body["error"]["message"] == "Run not found: run_a"
+
+
+@pytest.mark.asyncio
+async def test_stop_run_cross_profile_is_blocked_and_run_survives(adapter):
+    app = _create_runs_app(adapter)
+    _stamp_run(adapter, "run_a", "alpha")
+    agent = MagicMock()
+    adapter._active_run_agents["run_a"] = agent
+    adapter._active_run_tasks["run_a"] = MagicMock()
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post("/v1/runs/run_a/stop", headers=_auth("beta"))
+        body = await resp.json()
+        owner_view = await cli.get("/v1/runs/run_a", headers=_auth("alpha"))
+
+    assert resp.status == 404
+    assert body["error"]["code"] == "run_not_found"
+    # The attack had no effect: no interrupt, no state transition, and the
+    # owner still sees their run intact.
+    agent.interrupt.assert_not_called()
+    assert adapter._run_statuses["run_a"]["status"] == "running"
+    assert owner_view.status == 200
+
+
+@pytest.mark.asyncio
+async def test_steer_and_approval_cross_profile_return_404(adapter):
+    app = _create_runs_app(adapter)
+    _stamp_run(adapter, "run_a", "alpha", status="waiting_for_approval")
+
+    async with TestClient(TestServer(app)) as cli:
+        steer = await cli.post(
+            "/v1/runs/run_a/steer",
+            json={"input": "inject guidance"},
+            headers=_auth("beta"),
+        )
+        approval = await cli.post(
+            "/v1/runs/run_a/approval",
+            json={"choice": "approve"},
+            headers=_auth("beta"),
+        )
+
+    assert steer.status == 404
+    assert approval.status == 404
+
+
+@pytest.mark.asyncio
+async def test_single_profile_default_flow_is_unchanged(adapter):
+    """No multiplex: runs created and read through the default listener
+    (no profile prefix) keep working exactly as before."""
+    app = _create_runs_app(adapter)
+    adapter._set_run_status("run_d", "running")  # no ContextVar → default
+    adapter._active_run_agents["run_d"] = MagicMock()
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get(
+            "/v1/runs/run_d", headers=_auth("default"))
+        assert resp.status == 200
+        payload = await resp.json()
+        assert payload["status"] == "running"
+        assert "profile" not in payload
+
+        stop = await cli.post(
+            "/v1/runs/run_d/stop", headers=_auth("default"))
+        assert stop.status == 200


### PR DESCRIPTION
## What does this PR do?

Under `gateway.multiplex_profiles`, the five run-scoped `api_server` endpoints authenticated the caller but never asked *which* profile's key they held: any served profile's `API_SERVER_KEY` could read — and stop/steer/approve — any run on the gateway given its `run_id` (#93689's reproduced read + cross-profile cancellation). The run registry (`_run_statuses`) was keyed by `run_id` alone and never recorded an owner, while the execution paths already scoped via `_profile_scope`. This PR adds the missing ownership concept:

- `_set_run_status` stamps the creating request's profile into the record at **first write** — both creation paths (runs + chat-completions) run inside the request middleware, so the `_api_request_profile` ContextVar holds the URL-selected profile there; later contextless updates (event callbacks, the stop path) merge into the record without re-stamping.
- The five handlers (`_handle_get_run`, `_handle_run_events`, `_handle_run_approval`, `_handle_steer_run`, `_handle_stop_run`) enforce equality through a `_run_visible_to_request` gate, returning the **same not-found 404 shape as a nonexistent id** — a 403 would confirm the id exists under another profile, which is exactly the oracle the reporter argued against.
- Records without a stamp cannot occur since first-write stamping, and are treated as **not visible (fail closed)** rather than trusted.
- The stamp is internal bookkeeping: `GET /v1/runs/{id}` excludes `profile` from its payload, so the public API surface is unchanged.
- Single-profile (default listener) flows are unchanged: runs created and read with no profile prefix behave exactly as before.

## Related Issue

Fixes #93689

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `gateway/platforms/api_server.py`:
  - `_set_run_status`: stamp `_api_request_profile` (or `"default"`) on first write, with the mechanism documented in a comment.
  - new `_run_visible_to_request(run_id)`: fail-closed ownership gate; unknown ids pass through so callers keep their not-found branch.
  - `_handle_get_run` / `_handle_run_approval` / `_handle_steer_run`: `status is None or not _run_visible_to_request(...)` → existing 404.
  - `_handle_run_events`: gate after the subscribe-early race window (same 404 shape; window semantics preserved).
  - `_handle_stop_run`: gate before agent/task lookup (a live run always carries its stamp — the registry record is written at creation before refs activate).
- `tests/gateway/test_api_server_run_profile_ownership.py` — new (6 tests): stamp at first write only; fail-closed gate (foreign/unstamped/unknown ids); cross-profile GET returns the same 404 shape as a nonexistent id with the queried-id message; cross-profile STOP is blocked with the agent untouched and the owner still seeing their run; cross-profile steer/approval 404; single-profile default flow regression (read + stop still 200, no `profile` in payloads). The tests mirror production wiring: a test middleware binds the ContextVar from a header the way the real one binds it from the URL prefix, and the per-profile secret lookup is stubbed so alpha and beta each hold their own valid key — the attacker is an authenticated, legitimate key holder of a *different* profile.

## How to Test

- New: `.venv/bin/python -m pytest tests/gateway/test_api_server_run_profile_ownership.py -q` — should pass (6 tests). On unpatched `main`, 5 of 6 fail (no stamp, foreign reads/stops/steers go through), pinning the vulnerability.
- Regression: `.venv/bin/python -m pytest tests/gateway/test_api_server_runs.py tests/gateway/test_api_server.py -q` — should pass (134 tests), confirming the default-listener flows and every existing runs-endpoint behavior are untouched.

Observed result: locally, all 6 new tests pass and the 134 existing api_server runs/core tests stay green; the indistinguishability test pins that beta's view of alpha's run returns the exact not-found shape (`run_not_found`, same error keys, message naming the queried id).

## Checklist

- [x] Code follows project style (no unrelated changes)
- [x] Self-reviewed the diff
- [x] Added/updated tests covering the fix (fail-closed per the security policy)
- [x] All new and existing tests pass locally (6 new + 134 existing)
- [x] PR targets `upstream/main` from a fork branch
