### PR TITLE
fix(agent): do not retry Ctrl+C or SystemExit

### DIFF
--- a/agent/error_surface.py
+++ b/agent/error_surface.py
@@ -169,7 +169,9 @@ def build_error_surface_from_exception(exc: BaseException, provider: str = "", m
         if _disk_full(exc):
             return _surface(LAYER_DISK, "disk_full", False, provider, model)
         api_like = (type(exc).__module__ or "").split(".")[0] in _API_EXC_MODULE_PREFIXES or hasattr(exc, "status_code")
-        if not api_like or not isinstance(exc, Exception):
+        if not isinstance(exc, Exception):
+            return _surface(LAYER_GATEWAY, type(exc).__name__, False, provider, model)
+        if not api_like:
             return _surface(LAYER_GATEWAY, type(exc).__name__, True, provider, model)
 
         from agent.error_classifier import classify_api_error

--- a/tests/agent/test_error_surface.py
+++ b/tests/agent/test_error_surface.py
@@ -177,6 +177,16 @@ def test_exception_non_api_is_gateway_layer():
     assert surface["retryable"] is True
 
 
+@pytest.mark.parametrize("exc_type", [KeyboardInterrupt, SystemExit])
+def test_control_flow_exceptions_are_not_retryable(exc_type):
+    surface = build_error_surface_from_exception(exc_type())
+    assert surface == {
+        "layer": LAYER_GATEWAY,
+        "code": exc_type.__name__,
+        "retryable": False,
+    }
+
+
 def test_exception_disk_full_is_disk_layer():
     surface = build_error_surface_from_exception(OSError(28, "No space left on device"))
     assert surface["layer"] == LAYER_DISK


### PR DESCRIPTION
KeyboardInterrupt and SystemExit are BaseException subclasses, but the error-surface code treated them as retryable gateway failures. That can send a user interrupt into recovery logic instead of letting the turn stop.

Keep ordinary gateway exceptions retryable. Mark only the two control-flow exceptions as non-retryable and cover both cases with regression tests.

Tests:

- pytest -q tests/agent/test_error_surface.py tests/run_agent/test_interpreter_shutdown_turn_exit.py tests/run_agent/test_exit_cleanup_interrupt.py

31 tests passed.

Related issue: #93627