### PR TITLE
fix(desktop-update): splash stops hijacking Chrome/Edge/Brave and never strands a window (salvage #88418, #84548)

### DIFF
--- a/contributors/emails/jeremy.randria@gmail.com
+++ b/contributors/emails/jeremy.randria@gmail.com
@@ -1,0 +1,1 @@
+jeremyrandria-debug

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -171,15 +171,20 @@ publish() { # terminal event -- the page must render it before teardown
 
 find_browser() {
   local c
+  # No Microsoft Edge, on purpose: Edge's OS-level Microsoft-account
+  # integration signs a fresh throwaway profile into the user's MSA and
+  # renders its own "syncing your data" notification — MSA email included —
+  # inside this window that is titled "Hermes" (#88410). The throwaway
+  # --user-data-dir below cannot block it; the other Chromium-family
+  # browsers carry no OS account integration into a fresh profile.
   if [ "$(uname)" = "Darwin" ]; then
     for c in "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
-             "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge" \
              "/Applications/Chromium.app/Contents/MacOS/Chromium" \
              "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"; do
       [ -x "$c" ] && { echo "$c"; return; }
     done
   else
-    for c in google-chrome google-chrome-stable chromium chromium-browser microsoft-edge brave-browser; do
+    for c in google-chrome google-chrome-stable chromium chromium-browser brave-browser; do
       command -v "$c" 2>/dev/null && return
     done
   fi

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -171,20 +171,22 @@ publish() { # terminal event -- the page must render it before teardown
 
 find_browser() {
   local c
-  # No Microsoft Edge, on purpose: Edge's OS-level Microsoft-account
-  # integration signs a fresh throwaway profile into the user's MSA and
-  # renders its own "syncing your data" notification — MSA email included —
-  # inside this window that is titled "Hermes" (#88410). The throwaway
-  # --user-data-dir below cannot block it; the other Chromium-family
-  # browsers carry no OS account integration into a fresh profile.
+  # No Microsoft Edge and no Brave, on purpose. Edge's OS-level
+  # Microsoft-account integration signs a fresh throwaway profile into the
+  # user's MSA and renders its own "syncing your data" notification — MSA
+  # email included — inside this window that is titled "Hermes" (#88410).
+  # Brave paints its own P3A privacy-notice bar over the progress page in
+  # the same window — cramped to unreadability at the shim's small size
+  # (#88682). The throwaway --user-data-dir below cannot block either; the
+  # remaining Chromium-family browsers carry no first-run chrome of their
+  # own into a fresh profile.
   if [ "$(uname)" = "Darwin" ]; then
     for c in "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
-             "/Applications/Chromium.app/Contents/MacOS/Chromium" \
-             "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"; do
+             "/Applications/Chromium.app/Contents/MacOS/Chromium"; do
       [ -x "$c" ] && { echo "$c"; return; }
     done
   else
-    for c in google-chrome google-chrome-stable chromium chromium-browser brave-browser; do
+    for c in google-chrome google-chrome-stable chromium chromium-browser; do
       command -v "$c" 2>/dev/null && return
     done
   fi

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -229,12 +229,20 @@ start_ui() {
   log "shim: app window on 127.0.0.1:$port"
 }
 
-stop_ui() { # error state leaves the window up for the user to read
+stop_ui() { # error/manual outcomes keep the window up briefly so a watching
+  # user can read the message, then close it. The outcome is also durably
+  # written to the result file and surfaced in a dialog on the next Desktop
+  # boot (handoff-result.ts), so the shim window never lingers indefinitely —
+  # before this, each aborted update left another orphan browser window on
+  # screen until the user closed it by hand.
+  if [ "${1:-}" = "leave-window" ]; then
+    sleep "${HERMES_UPDATE_SHIM_GRACE_SECONDS:-15}"
+  fi
   if [ -n "$UI_SERVER_PID" ]; then
     # The server ignores TERM/HUP (see start_ui) — KILL is its off switch.
     { kill -9 "$UI_SERVER_PID" && wait "$UI_SERVER_PID"; } 2>/dev/null
   fi
-  if [ "${1:-}" != "leave-window" ] && [ -n "$UI_BROWSER_PID" ]; then
+  if [ -n "$UI_BROWSER_PID" ]; then
     { kill "$UI_BROWSER_PID" && wait "$UI_BROWSER_PID"; } 2>/dev/null
   fi
   UI_SERVER_PID="" UI_BROWSER_PID=""

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -192,12 +192,55 @@ find_browser() {
   fi
 }
 
+# The shim is decoration; launching a browser the user does NOT use is not.
+# A Safari/Firefox/Helium user who merely has Chrome installed watched Chrome
+# open on every update — a "why is Chrome opening?" surprise (community
+# report, Aug 2026). Only render the shim when the system DEFAULT browser is
+# itself Chromium-family; otherwise skip the window and let notify_fallback +
+# the durable result file carry the outcome. Best-effort on purpose: any
+# detection failure keeps today's behavior (0 = allowed).
+default_browser_is_chromium() {
+  local py="$1" handler=""
+  if [ "$(uname)" = "Darwin" ]; then
+    local plist="$HOME/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist"
+    # No explicit https handler registered = the OS default (Safari).
+    [ -f "$plist" ] || return 1
+    handler="$("$py" -c '
+import plistlib, sys
+with open(sys.argv[1], "rb") as f:
+    data = plistlib.load(f)
+for entry in data.get("LSHandlers", []):
+    if entry.get("LSHandlerURLScheme") == "https":
+        print(entry.get("LSHandlerRoleAll", ""))
+        break
+' "$plist" 2>/dev/null)" || return 0
+    # Parsed but empty = no https override = Safari default.
+    [ -n "$handler" ] || return 1
+    case "$handler" in
+      com.google.[Cc]hrome*|org.chromium.[Cc]hromium*) return 0 ;;
+      *) return 1 ;;
+    esac
+  fi
+  # Linux: xdg-settings is the authority; missing tool = permissive.
+  command -v xdg-settings >/dev/null 2>&1 || return 0
+  handler="$(xdg-settings get default-web-browser 2>/dev/null)" || return 0
+  [ -n "$handler" ] || return 0
+  case "$handler" in
+    *chrome*|*chromium*|*Chrome*|*Chromium*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 start_ui() {
   [ "$NO_UI" -eq 1 ] && return
   local html="$SCRIPT_DIR/ui.html" py browser port="" i
   py="${INSTALL_ROOT:+$INSTALL_ROOT/venv/bin/python3}"
   [ -x "${py:-/nonexistent}" ] || py="$(command -v python3 2>/dev/null)"
   browser="$(find_browser)"
+  if [ -n "$browser" ] && [ -n "$py" ] && ! default_browser_is_chromium "$py"; then
+    log "shim: default browser is not Chromium-family; skipping UI window"
+    browser=""
+  fi
   { [ -f "$html" ] && [ -n "$py" ] && [ -n "$browser" ]; } || { log "shim: no renderer; skipping UI"; return; }
 
   publish_stage ""


### PR DESCRIPTION
## Summary

The desktop update splash no longer launches Chrome for users whose default browser isn't Chromium-family, no longer renders in Edge or Brave at all, and never leaves an orphan window on screen after a failed update. Salvages PR #88418 by @liuhao1024 and PR #84548 by @jeremyrandria-debug, plus a default-browser gate for the community-reported "why is Chrome opening with the update splash?" on macOS (Helium/Safari user with Chrome merely installed).

## Changes

All in `scripts/desktop-update/posix.sh`:

- `find_browser()` drops Microsoft Edge (signs the throwaway profile into the user's MSA and paints their real email over the "Hermes" progress window, #88410) and Brave (P3A privacy bar crushes the 280px shim, #88682) — from #88418.
- New `default_browser_is_chromium()` gate: the shim only renders when the system default browser is itself Chromium-family (LaunchServices https handler on macOS, `xdg-settings` on Linux). Safari/Firefox/Helium users get no surprise Chrome window; `notify_fallback` + the durable result file still carry the outcome. Best-effort: any detection failure keeps the old behavior.
- `stop_ui()` always closes the shim window; error/manual outcomes keep it up for a readable grace period (`HERMES_UPDATE_SHIM_GRACE_SECONDS`, default 15s) instead of forever — from #84548. The next-boot dialog (handoff-result.ts) remains the durable surface.

## Validation

| scenario | Before | After |
|---|---|---|
| macOS default Helium/Safari, Chrome installed | Chrome opens on every update | shim skipped (plist E2E: helium/safari-no-override → skip, chrome → open) |
| Linux default firefox.desktop | shim opens in Chrome | skipped (fake xdg-settings E2E) |
| Linux default google-chrome.desktop | opens | still opens |
| Edge-only / Brave-only system | MSA leak / P3A bar | no shim (headless path) |
| Update aborts | orphan window per attempt | closes after 15s grace |
| `bash -n` | — | clean |

Credit: @liuhao1024 (#88418, earliest, Edge/Brave exclusions) and @jeremyrandria-debug (#84548, orphan-window close). PR #89708 (@zhentouers) proposed `--no-ui` for everyone — kept the UI instead, gated to the user's own browser family.

Reported by @tiny__edge (desktop feedback #3).

## Infographic

![Update window: play in your own browser](https://v3b.fal.media/files/b/0aa79984/oUujEkBGX9CpDtps-aoa1_w6KcNSq3.png)
