### PR TITLE
fix(kanban): signal undeclared scratch content before workspace rmtree

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5875,6 +5875,58 @@ def _is_managed_scratch_path(p: Path) -> bool:
     return is_managed
 
 
+#: Files below this size in a scratch workspace about to be removed are
+#: considered trivial scaffolding and never trigger the discard signal
+#: (#93164). Threshold kept identical to operator-deployed parachutes.
+WORKSPACE_DISCARD_SIGNAL_MIN_BYTES = 64
+#: How many file names the warning/event carries; the rest is a count.
+WORKSPACE_DISCARD_SIGNAL_MAX_NAMES = 10
+
+
+def _warn_undeclared_workspace_content(
+    conn: sqlite3.Connection, task_id: str, wp: Path
+) -> None:
+    """Before rmtree, surface non-trivial undeclared content (#93164).
+
+    Declared artifacts are already preserved by ``complete_task`` (copied to
+    the board attachment store, #63619); anything still sitting in the
+    workspace at cleanup time is undeclared and is about to be destroyed.
+    Fires on every ``_cleanup_workspace`` path that rmtree's a scratch dir
+    (task completion and archive). Best-effort like the rest of cleanup: a
+    scan failure never blocks the rmtree, and the signal is a WARNING + task
+    event, not a preservation.
+    """
+    try:
+        files = []
+        for f in sorted(wp.rglob("*")):
+            if not f.is_file():
+                continue
+            size = f.stat().st_size  # one stat per file, reused below
+            if size >= WORKSPACE_DISCARD_SIGNAL_MIN_BYTES:
+                files.append((str(f.relative_to(wp)), size))
+    except OSError:
+        return
+    if not files:
+        return
+    names = [name for name, _ in files[:WORKSPACE_DISCARD_SIGNAL_MAX_NAMES]]
+    total = sum(size for _, size in files)
+    _log.warning(
+        "Removing scratch workspace for task %s with %d undeclared file(s) "
+        "(%d bytes) not listed in kanban_complete artifacts: %s%s — declared "
+        "artifacts are already preserved; these files will be deleted.",
+        task_id, len(files), total, ", ".join(names),
+        f" (+{len(files) - len(names)} more)" if len(files) > len(names) else "",
+    )
+    try:
+        with write_txn(conn):
+            _append_event(
+                conn, task_id, "workspace_discarded_content",
+                {"files": names, "file_count": len(files), "total_bytes": total},
+            )
+    except Exception:  # noqa: BLE001 — signal is best-effort, never blocks cleanup
+        _log.debug("workspace_discarded_content event append failed", exc_info=True)
+
+
 def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
     """Remove a task's scratch workspace dir and kill its stale tmux session.
 
@@ -5933,6 +5985,7 @@ def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
             # completion would unconditionally ``shutil.rmtree`` that path
             # and silently delete the user's source data.
             if _is_managed_scratch_path(wp):
+                _warn_undeclared_workspace_content(conn, task_id, wp)
                 shutil.rmtree(wp, ignore_errors=True)
                 _log.debug("Removed scratch workspace: %s", wp)
             else:
@@ -6059,6 +6112,7 @@ def _try_cleanup_parent_workspaces(conn: sqlite3.Connection, task_id: str) -> No
             import shutil
             wp = Path(row["workspace_path"])
             if wp.is_dir() and _is_managed_scratch_path(wp):
+                _warn_undeclared_workspace_content(conn, parent_id, wp)
                 shutil.rmtree(wp, ignore_errors=True)
                 _log.debug("Deferred cleanup: removed parent %s scratch workspace: %s", parent_id, wp)
     except Exception:

--- a/tests/hermes_cli/test_kanban_workspace_discard_signal.py
+++ b/tests/hermes_cli/test_kanban_workspace_discard_signal.py
@@ -1,0 +1,117 @@
+"""Undeclared scratch-workspace content must not vanish silently (#93164)."""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+import hermes_cli.kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB (same shape as the
+    fixture local to test_kanban_db.py, which a sibling file cannot see)."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _scratch_task_with_file(kanban_home, tmp_path, name, size):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="undeclared content task")
+        t = kb.get_task(conn, tid)
+        ws = kb.resolve_workspace(t)
+        kb.set_workspace_path(conn, tid, ws)
+        ws.mkdir(parents=True, exist_ok=True)
+        if size:
+            (ws / name).write_text("x" * size)
+        return tid, ws
+
+
+def test_undeclared_content_warns_and_events(kanban_home, tmp_path, caplog):
+    tid, ws = _scratch_task_with_file(kanban_home, tmp_path, "report.md", 2048)
+    with caplog.at_level(logging.WARNING, logger=kb._log.name):
+        with kb.connect() as conn:
+            kb._cleanup_workspace(conn, tid)
+    assert "report.md" in caplog.text
+    with kb.connect() as conn:
+        rows = conn.execute(
+            "SELECT payload FROM task_events WHERE kind = 'workspace_discarded_content'"
+        ).fetchall()
+    assert rows and "report.md" in rows[0][0]
+
+
+def test_trivial_content_stays_silent(kanban_home, tmp_path, caplog):
+    tid, ws = _scratch_task_with_file(kanban_home, tmp_path, ".keep", 8)
+    with kb.connect() as conn:
+        kb._cleanup_workspace(conn, tid)
+    assert "workspace_discarded_content" not in caplog.text
+    with kb.connect() as conn:
+        assert conn.execute(
+            "SELECT 1 FROM task_events WHERE kind = 'workspace_discarded_content'"
+        ).fetchone() is None
+
+
+def test_signal_never_blocks_cleanup(kanban_home, tmp_path):
+    tid, ws = _scratch_task_with_file(kanban_home, tmp_path, "big.bin", 4096)
+    with kb.connect() as conn:
+        kb._cleanup_workspace(conn, tid)
+    assert not ws.exists(), "best-effort semantics unchanged: dir still removed"
+
+
+def test_many_files_event_bounded_and_counts_accurate(kanban_home, tmp_path, caplog):
+    """11+ undeclared files: event lists 10 names, counts stay exact (#93164)."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="many files")
+        ws = kb.resolve_workspace(kb.get_task(conn, tid))
+        kb.set_workspace_path(conn, tid, ws)
+        ws.mkdir(parents=True, exist_ok=True)  # resolve_workspace may already have
+        for i in range(12):
+            (ws / f"f{i:02}.dat").write_text("z" * 100)
+    with caplog.at_level(logging.WARNING, logger=kb._log.name):
+        with kb.connect() as conn:
+            kb._cleanup_workspace(conn, tid)
+    assert "f00.dat" in caplog.text and "f09.dat" in caplog.text
+    assert "f10.dat" not in caplog.text and "+2 more" in caplog.text
+    with kb.connect() as conn:
+        payload = conn.execute(
+            "SELECT payload FROM task_events WHERE kind = 'workspace_discarded_content'"
+        ).fetchone()
+    assert payload
+    body = json.loads(payload[0])
+    assert body["file_count"] == 12 and body["total_bytes"] == 1200
+    assert len(body["files"]) == 10
+
+
+def test_deferred_parent_cleanup_also_signals(kanban_home, tmp_path, caplog):
+    """The deferred parent-sweep rmtree must emit the same signal (#93164):
+    a parent whose cleanup waited on children would otherwise destroy its
+    undeclared files silently on the second rmtree path."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="scratch parent")
+        child = kb.create_task(conn, title="dir child",
+                               workspace_kind="dir", workspace_path=str(tmp_path / "c"))
+        (tmp_path / "c").mkdir()
+        kb.link_tasks(conn, parent, child)
+        ws = kb.resolve_workspace(kb.get_task(conn, parent))
+        kb.set_workspace_path(conn, parent, ws)
+        (ws / "undeclared.md").write_text("q" * 512)  # resolve_workspace made the dir
+
+    with caplog.at_level(logging.WARNING, logger=kb._log.name):
+        kb.complete_task(conn, parent, result="handoff")  # deferred: child active
+        assert "undeclared.md" not in caplog.text
+        kb.complete_task(conn, child, result="built")     # triggers parent sweep
+
+    assert "undeclared.md" in caplog.text
+    with kb.connect() as conn:
+        payloads = [p for (p,) in conn.execute(
+            "SELECT payload FROM task_events"
+            " WHERE kind = 'workspace_discarded_content'"
+        ).fetchall() if p]
+    assert any("undeclared.md" in p for p in payloads)


### PR DESCRIPTION
Fixes #93164.

## Problem

`complete_task` → `_cleanup_workspace` unconditionally `rmtree`s a scratch workspace after the completion commit. Declared artifacts are safe (#63619 copies them to the board attachment store first), but anything the worker wrote and did NOT declare in `kanban_complete(artifacts=[...])` is destroyed silently: no warning, no event, no trace on the board. Observed in production (report in the issue): a worker wrote an 8KB report, completed without declaring it, lost the only copy.

## Change

Adds `_warn_undeclared_workspace_content(conn, task_id, wp)`, called immediately before **every** scratch rmtree in the cleanup paths:

- the direct scratch branch of `_cleanup_workspace` (task completion and archive), and
- the deferred parent sweep in `_try_cleanup_parent_workspaces` (#33774) — found by an adversarial self-review: the second rmtree path would otherwise keep the exact silent-loss bug this fixes.

Behavior:

- scans the workspace for files >= 64 bytes (trivial scaffolding stays silent — threshold matches the operator-deployed parachute the issue describes);
- emits a WARNING with up to 10 file names, exact counts and total bytes;
- appends a `workspace_discarded_content` task event (bounded payload: 10 names + counts) so the board retains what was destroyed;
- purely a signal: never a preservation, never a blocker. Scan failure returns silently, event failure is swallowed, and the rmtree semantics (including `ignore_errors`) are byte-for-byte unchanged.

## Verification

- RED→GREEN: 5 new tests in `tests/hermes_cli/test_kanban_workspace_discard_signal.py` — signal fires with event; trivial content silent; cleanup never blocked; 11+ files bounded with exact counts; **deferred-parent path also signals** (fails without the parent-sweep call).
- Regression: `tests/hermes_cli/test_kanban_db.py` full suite — 35 passed, 1 skipped (pre-existing), together with the new file.
- `ruff check` on both touched files: clean.
- Adversarial review (refutation-first) on the safety claims: confirmed no nested-txn/deadlock risk at either call site (both strictly post-commit), no crash path from special files/symlink loops (whole scan inside `try/except`, outer cleanup guard unchanged), no partial transactions (write_txn rollback semantics), TOCTOU can only suppress the signal, never misfire.
