### PR TITLE
fix(desktop): cron jobs on sleeping profiles no longer stop firing (#69377 desktop sibling)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -271,16 +271,45 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
     scheduler provider here (no live adapters; delivery falls back to the
     per-platform send path).
 
+    Every local profile's store is ticked, not just this backend's own
+    (#69377's desktop sibling): the desktop pools per-profile backends and
+    reaps them after ~10 idle minutes, so a secondary profile's ticker dies
+    with its backend and that profile's jobs silently stop firing until the
+    user next opens it ("tasks on the sleeping profile could be idle" —
+    community report, Aug 2026). The primary backend outlives the pool, so it
+    owns every profile's tick, exactly like a multiplex gateway. External
+    providers keep the single-store behavior — their registries are not
+    profile-scoped (see _notify_cron_provider_for_profile).
+
     Cross-process safe: the built-in provider's ``cron.scheduler.tick`` takes
-    the ``cron/.tick.lock`` file lock, so this never double-fires alongside a
-    real gateway on the same HERMES_HOME — whichever process grabs the lock
-    first wins the tick.
+    the per-store ``cron/.tick.lock`` file lock, so this never double-fires
+    alongside a real gateway or a live pool backend on the same profile home —
+    whichever process grabs the lock first wins the tick.
     """
-    from cron.scheduler_provider import resolve_cron_scheduler
+    from cron.scheduler_provider import InProcessCronScheduler, resolve_cron_scheduler
 
     provider = resolve_cron_scheduler()
+
+    start_kwargs: dict = {"interval": interval}
+    if isinstance(provider, InProcessCronScheduler):
+        try:
+            from hermes_cli.profiles import profiles_to_serve
+
+            profile_homes = list(profiles_to_serve(multiplex=True))
+            if len(profile_homes) > 1:
+                start_kwargs["profile_homes"] = profile_homes
+                _log.info(
+                    "Desktop cron scheduler will tick %d profile(s): %s",
+                    len(profile_homes),
+                    [name for name, _home in profile_homes],
+                )
+        except Exception:
+            # Fail open to the single-store ticker — the active profile's
+            # jobs must keep firing even if profile enumeration breaks.
+            _log.exception("Desktop cron: profile enumeration failed; ticking active profile only")
+
     _log.info("Desktop cron scheduler started (provider=%s, interval=%ds)", provider.name, interval)
-    provider.start(stop_event, interval=interval)
+    provider.start(stop_event, **start_kwargs)
 
 
 def _warm_gateway_module() -> None:

--- a/tests/hermes_cli/test_desktop_cron_ticker_profiles.py
+++ b/tests/hermes_cli/test_desktop_cron_ticker_profiles.py
@@ -1,0 +1,120 @@
+"""Desktop cron ticker: every local profile's store must be ticked.
+
+The desktop app pools per-profile backends and reaps them after ~10 idle
+minutes, so a secondary profile's in-backend ticker dies with its backend and
+that profile's cron jobs silently stop firing until the user next opens the
+profile. The PRIMARY desktop backend outlives the pool, so its ticker must own
+every profile's store — the desktop sibling of the multiplex-gateway fix for
+#69377.
+"""
+
+from pathlib import Path
+import threading
+
+import pytest
+
+import hermes_cli.web_server as ws
+
+
+class _RecordingBuiltin:
+    """Stands in for InProcessCronScheduler; records start() kwargs."""
+
+    name = "builtin"
+
+    def __init__(self):
+        self.start_kwargs = None
+
+    def start(self, stop_event, **kwargs):
+        self.start_kwargs = kwargs
+
+
+class _RecordingExternal:
+    """External provider double — must NOT receive profile_homes."""
+
+    name = "chronos-test"
+
+    def __init__(self):
+        self.start_kwargs = None
+
+    def start(self, stop_event, **kwargs):
+        self.start_kwargs = kwargs
+
+
+@pytest.fixture()
+def _providers(monkeypatch):
+    import cron.scheduler_provider as sp
+
+    builtin = _RecordingBuiltin()
+    # isinstance(provider, InProcessCronScheduler) gate: register our double
+    # as that class for the module under test.
+    monkeypatch.setattr(ws, "_log", ws._log)
+    monkeypatch.setattr(sp, "resolve_cron_scheduler", lambda: builtin)
+    monkeypatch.setattr(sp, "InProcessCronScheduler", _RecordingBuiltin)
+    return sp, builtin
+
+
+def test_multi_profile_homes_passed_to_builtin(monkeypatch, _providers, tmp_path):
+    _sp, builtin = _providers
+    homes = [
+        ("default", tmp_path / "root"),
+        ("coder", tmp_path / "profiles" / "coder"),
+    ]
+    import hermes_cli.profiles as profiles_mod
+
+    monkeypatch.setattr(profiles_mod, "profiles_to_serve", lambda **_kw: list(homes))
+
+    ws._start_desktop_cron_ticker(threading.Event(), interval=7)
+
+    assert builtin.start_kwargs is not None
+    assert builtin.start_kwargs["interval"] == 7
+    assert builtin.start_kwargs["profile_homes"] == homes
+
+
+def test_single_profile_keeps_legacy_path(monkeypatch, _providers, tmp_path):
+    _sp, builtin = _providers
+    import hermes_cli.profiles as profiles_mod
+
+    monkeypatch.setattr(
+        profiles_mod,
+        "profiles_to_serve",
+        lambda **_kw: [("default", tmp_path / "root")],
+    )
+
+    ws._start_desktop_cron_ticker(threading.Event(), interval=9)
+
+    assert builtin.start_kwargs == {"interval": 9}
+
+
+def test_enumeration_failure_fails_open(monkeypatch, _providers):
+    """The active profile's jobs keep firing even if profile listing breaks."""
+    _sp, builtin = _providers
+    import hermes_cli.profiles as profiles_mod
+
+    def _boom(**_kw):
+        raise RuntimeError("profiles dir unreadable")
+
+    monkeypatch.setattr(profiles_mod, "profiles_to_serve", _boom)
+
+    ws._start_desktop_cron_ticker(threading.Event(), interval=11)
+
+    assert builtin.start_kwargs == {"interval": 11}
+
+
+def test_external_provider_never_gets_profile_homes(monkeypatch, tmp_path):
+    """External registries are not profile-scoped; keep single-store semantics."""
+    import cron.scheduler_provider as sp
+
+    external = _RecordingExternal()
+    monkeypatch.setattr(sp, "resolve_cron_scheduler", lambda: external)
+
+    import hermes_cli.profiles as profiles_mod
+
+    monkeypatch.setattr(
+        profiles_mod,
+        "profiles_to_serve",
+        lambda **_kw: [("default", tmp_path / "a"), ("b", tmp_path / "b")],
+    )
+
+    ws._start_desktop_cron_ticker(threading.Event(), interval=13)
+
+    assert external.start_kwargs == {"interval": 13}

--- a/website/docs/guides/cron-troubleshooting.md
+++ b/website/docs/guides/cron-troubleshooting.md
@@ -40,6 +40,8 @@ Cron jobs are fired by the gateway's background ticker thread, which ticks every
 
 If you're expecting jobs to fire automatically, you need a running gateway (`hermes gateway` for foreground, or `hermes gateway start` for the installed service). For one-off debugging, you can manually trigger a tick with `hermes cron tick`.
 
+**Desktop app:** the desktop's primary backend runs its own ticker, and it ticks **every local profile's** cron store — so jobs on a secondary profile keep firing even while that profile's backend is asleep (the desktop puts idle profile backends to sleep after ~10 minutes). You do not need to keep a profile open for its scheduled jobs to run.
+
 ### Check 4: Check the system clock and timezone
 
 Jobs use the local timezone. If your machine's clock is wrong or in a different timezone than expected, jobs will fire at the wrong times. Verify:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/cron-troubleshooting.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/cron-troubleshooting.md
@@ -40,6 +40,8 @@ Cron 任务由 gateway 的后台 ticker 线程触发，该线程每 60 秒 tick 
 
 如果你期望任务自动触发，需要运行一个 gateway（前台运行用 `hermes gateway`，安装为服务用 `hermes gateway start`）。如需单次调试，可手动触发一次 tick：`hermes cron tick`。
 
+**桌面应用：** 桌面端的主后端自带 ticker，并且会 tick **本机每个 profile** 的 cron 存储——因此即使某个次要 profile 的后端处于休眠状态（桌面端会在约 10 分钟空闲后让 profile 后端休眠），该 profile 上的任务也会照常触发。你不需要保持某个 profile 打开来让它的定时任务运行。
+
 ### 检查 4：检查系统时钟和时区
 
 任务使用本地时区。若机器时钟有误或时区与预期不符，任务将在错误的时间触发。验证方法：


### PR DESCRIPTION
## Summary

Cron jobs on a "sleeping" desktop profile no longer stop firing. The desktop pools per-profile backends and puts them to sleep after ~10 idle minutes — and a reaped backend took its cron ticker with it, so a secondary profile's scheduled jobs silently froze until the user next opened that profile ("I have a feeling some tasks on that sleeping profile could be idle" — community report, and they were right).

This is the desktop sibling of #69377 (multiplex gateway ticking only the default profile's store).

## Changes

- `hermes_cli/web_server.py` (`_start_desktop_cron_ticker`): the primary desktop backend — which outlives the pool — now enumerates every local profile via `profiles_to_serve(multiplex=True)` and hands the ticker `profile_homes`, reusing the existing multiplex tick loop (per-profile home scoping, heartbeats, recovery). External cron providers keep single-store semantics (their registries are not profile-scoped, same guard as `_notify_cron_provider_for_profile`); enumeration failure fails open to the active profile.
- Docs: desktop note in `guides/cron-troubleshooting.md` (+ zh-Hans mirror) — you don't need to keep a profile open for its jobs to run.
- Tests: `tests/hermes_cli/test_desktop_cron_ticker_profiles.py` — multi-profile homes passed to the built-in, single-profile keeps the legacy path, enumeration failure fails open, external provider never receives `profile_homes`.

No double-fire risk: `cron.scheduler.tick` takes the per-store `cron/.tick.lock`, so a live pool backend (or real gateway) on the same profile home and the primary's multiplex tick can never both fire a job.

## Validation

| | Result |
|---|---|
| New tests | 4/4 green |
| Sabotage run (fix reverted to origin/main) | multi-profile test FAILS, others pass — test exercises the bug |
| Restored fix | 4/4 green |

Reported by @tiny__edge (desktop feedback #4).

## Infographic

![Cron never sleeps](https://v3b.fal.media/files/b/0aa799b2/62XorOvIrQDwSFNW0e_I0_Hlds9G6H.png)
