### PR TITLE
fix(desktop): remember local-pool profile in lastProfileByConnection

### DIFF
--- a/apps/desktop/src/store/connections.test.ts
+++ b/apps/desktop/src/store/connections.test.ts
@@ -254,3 +254,75 @@ describe('selectConnection', () => {
     expect(setLastUsed).not.toHaveBeenCalled()
   })
 })
+
+describe('profile memory per source', () => {
+  const LAST_PROFILE_STORAGE_KEY = 'hermes.desktop.lastProfileByConnection'
+
+  const remembered = (): Record<string, string> =>
+    JSON.parse(localStorage.getItem(LAST_PROFILE_STORAGE_KEY) ?? '{}') as Record<string, string>
+
+  it('remembers a local-pool switch under the reserved key', () => {
+    $connection.set({ mode: 'local' })
+    $activeGatewayProfile.set('xiaolu')
+
+    expect(remembered()).toEqual({ __local_pool__: 'xiaolu' })
+  })
+
+  it('remembers a remote source under its connection id', () => {
+    $connection.set({ connectionId: 'homelab', mode: 'remote', profile: 'research', registryScoped: true })
+    $activeGatewayProfile.set('research')
+
+    expect(remembered()).toEqual({ homelab: 'research' })
+  })
+
+  it('rejects a pooled secondary whose descriptor profile mismatches the live gateway', () => {
+    $connection.set({ mode: 'local', profile: 'research', registryScoped: true })
+    $activeGatewayProfile.set('default')
+
+    expect(remembered()).toEqual({})
+  })
+
+  it('does not record when there is no connection record to attribute', () => {
+    $connection.set(null)
+    $activeGatewayProfile.set('xiaolu')
+
+    expect(remembered()).toEqual({})
+  })
+
+  it('suppresses the in-flight window and records the settled state once pending clears', () => {
+    // A connection switch is in flight: pending is set before the target
+    // profile/descriptor land.
+    $pendingConnectionId.set('homelab')
+    $activeGatewayProfile.set('xiaoma')
+    $connection.set({ mode: 'local' })
+
+    expect(remembered()).toEqual({})
+
+    // The descriptor settles on the remote source, still pending.
+    $connection.set({ connectionId: 'homelab', mode: 'remote', profile: 'xiaoma', registryScoped: true })
+
+    expect(remembered()).toEqual({})
+
+    // Pending clears (the finally block). Deriving it into the computed makes
+    // that edge re-emit, recording the settled state with no further
+    // $connection/$activeGatewayProfile change.
+    $pendingConnectionId.set(null)
+
+    expect(remembered()).toEqual({ homelab: 'xiaoma' })
+  })
+
+  it('keeps the local-pool key disjoint from a same-named connection id', () => {
+    // A remote source could in principle be registered with id "local".
+    $connection.set({ connectionId: 'local', mode: 'remote', profile: 'research', registryScoped: true })
+    $activeGatewayProfile.set('research')
+
+    expect(remembered()).toEqual({ local: 'research' })
+
+    // The local pool still keys under the reserved name, so the two writers
+    // never stomp each other's remembered profile.
+    $connection.set({ mode: 'local' })
+    $activeGatewayProfile.set('xiaolu')
+
+    expect(remembered()).toEqual({ local: 'research', __local_pool__: 'xiaolu' })
+  })
+})

--- a/apps/desktop/src/store/connections.ts
+++ b/apps/desktop/src/store/connections.ts
@@ -44,29 +44,57 @@ const $activeConnectionProfile = computed(
     connectionId,
     descriptorProfile: normalizeProfileKey(connection?.profile),
     profile: normalizeProfileKey(profile),
-    registryScoped: connection?.registryScoped === true
+    registryScoped: connection?.registryScoped === true,
+    mode: connection?.mode,
+    // Distinguish "primary backend has no profile field" (undefined → record
+    // the live gateway profile directly) from a pooled secondary or a stale
+    // startup descriptor that DOES carry a profile but must still match.
+    hasDescriptorProfile: connection?.profile != null
   })
 )
 
 // Remember one profile per source, so switching machines is a re-home rather
 // than a reset to `default`. The map is local UI preference only; Electron
 // remains the authority for the connection registry and all secrets.
-$activeConnectionProfile.subscribe(({ connectionId, descriptorProfile, profile, registryScoped }) => {
-  // A migrated v1 per-profile remote may expose a client-side alias such as
-  // "work" while the registered source's actual profile is "default". Only
-  // remember a source/profile pair after Electron confirms that exact v2
-  // descriptor. This also rejects the brief startup window where the profile
-  // atom still carries the previous app run's alias.
-  if (
-    !connectionId ||
-    !registryScoped ||
-    descriptorProfile !== profile ||
-    $lastProfileByConnection.get()[connectionId] === profile
-  ) {
+$activeConnectionProfile.subscribe(({ connectionId, descriptorProfile, profile, registryScoped, mode, hasDescriptorProfile }) => {
+  // A local-pool switch carries no connectionId (legacy route), but it is
+  // still "This device" — key it under `local` so switching back from a
+  // remote source re-homes to the last-used local profile instead of
+  // resetting to `default`.
+  const key = connectionId ?? (mode === 'local' ? 'local' : null)
+
+  if (!key) {
     return
   }
 
-  $lastProfileByConnection.set({ ...$lastProfileByConnection.get(), [connectionId]: profile })
+  // A connection switch in flight leaves $activeGatewayProfile briefly naming
+  // the TARGET (via onActiveRouteChanged) while $connection still describes the
+  // previous source — recording then would write the wrong profile under the
+  // old key (e.g. `local` ← the remote's profile). Skip until the switch
+  // settles. Profile switches (selectProfile) never set this, so they still
+  // record immediately.
+  if ($pendingConnectionId.get()) {
+    return
+  }
+
+  if (key !== 'local') {
+    // Remote source: keep the full guard (registryScoped + descriptor match),
+    // which also rejects a migrated v1 routing alias.
+    if (!registryScoped || descriptorProfile !== profile) {
+      return
+    }
+  } else if (hasDescriptorProfile && descriptorProfile !== profile) {
+    // A pooled secondary (or a stale startup descriptor) carries a profile and
+    // must still match. Only a profile-less PRIMARY backend records the live
+    // gateway profile directly — its `profile` field is absent by design.
+    return
+  }
+
+  if ($lastProfileByConnection.get()[key] === profile) {
+    return
+  }
+
+  $lastProfileByConnection.set({ ...$lastProfileByConnection.get(), [key]: profile })
 })
 
 /** @internal Reset module-owned preferences and switch coordination for tests. */

--- a/apps/desktop/src/store/connections.ts
+++ b/apps/desktop/src/store/connections.ts
@@ -16,6 +16,13 @@ import { $connection } from '@/store/session'
 
 const LAST_PROFILE_STORAGE_KEY = 'hermes.desktop.lastProfileByConnection'
 
+// The local pool ("This device") is keyed under a reserved name that can never
+// collide with a real connection id. A connection id is user/migration
+// controlled (`import`, `add`, a hand-edited registry) and could in principle
+// be `local`; keeping the pool's remembered profile in a disjoint slot means
+// the two writers can never stomp each other.
+const LOCAL_POOL_KEY = '__local_pool__'
+
 export const $connectionsRegistry = atom<DesktopConnectionsRegistry | null>(null)
 
 // Use only the resolved descriptor identity Electron publishes. `primary`
@@ -39,8 +46,8 @@ export const $pendingConnectionId = atom<null | string>(null)
 $lastProfileByConnection.subscribe(value => persistStringRecord(LAST_PROFILE_STORAGE_KEY, value))
 
 const $activeConnectionProfile = computed(
-  [$activeConnectionId, $activeGatewayProfile, $connection],
-  (connectionId, profile, connection) => ({
+  [$activeConnectionId, $activeGatewayProfile, $connection, $pendingConnectionId],
+  (connectionId, profile, connection, pendingConnectionId) => ({
     connectionId,
     descriptorProfile: normalizeProfileKey(connection?.profile),
     profile: normalizeProfileKey(profile),
@@ -49,35 +56,39 @@ const $activeConnectionProfile = computed(
     // Distinguish "primary backend has no profile field" (undefined → record
     // the live gateway profile directly) from a pooled secondary or a stale
     // startup descriptor that DOES carry a profile but must still match.
-    hasDescriptorProfile: connection?.profile != null
+    hasDescriptorProfile: connection?.profile != null,
+    pendingConnectionId
   })
 )
 
 // Remember one profile per source, so switching machines is a re-home rather
 // than a reset to `default`. The map is local UI preference only; Electron
 // remains the authority for the connection registry and all secrets.
-$activeConnectionProfile.subscribe(({ connectionId, descriptorProfile, profile, registryScoped, mode, hasDescriptorProfile }) => {
+$activeConnectionProfile.subscribe(({ connectionId, descriptorProfile, profile, registryScoped, mode, hasDescriptorProfile, pendingConnectionId }) => {
   // A local-pool switch carries no connectionId (legacy route), but it is
-  // still "This device" — key it under `local` so switching back from a
-  // remote source re-homes to the last-used local profile instead of
-  // resetting to `default`.
-  const key = connectionId ?? (mode === 'local' ? 'local' : null)
+  // still "This device" — key it under a reserved name so switching back from
+  // a remote source re-homes to the last-used local profile instead of
+  // resetting to `default`. Remote sources key under their connectionId.
+  const key = mode === 'local' ? LOCAL_POOL_KEY : connectionId
 
   if (!key) {
+    // No source to attribute yet (the boot window before $connection resolves,
+    // or a descriptor with neither a local mode nor an id).
     return
   }
 
   // A connection switch in flight leaves $activeGatewayProfile briefly naming
   // the TARGET (via onActiveRouteChanged) while $connection still describes the
   // previous source — recording then would write the wrong profile under the
-  // old key (e.g. `local` ← the remote's profile). Skip until the switch
-  // settles. Profile switches (selectProfile) never set this, so they still
-  // record immediately.
-  if ($pendingConnectionId.get()) {
+  // old key (e.g. the local pool ← the remote's profile). Deriving pending into
+  // this computed makes its true→false edge re-emit here, so the settled state
+  // is recorded even when the reset lands after the last $connection update.
+  // Profile switches (selectProfile) never set it, so they record immediately.
+  if (pendingConnectionId) {
     return
   }
 
-  if (key !== 'local') {
+  if (mode !== 'local') {
     // Remote source: keep the full guard (registryScoped + descriptor match),
     // which also rejects a migrated v1 routing alias.
     if (!registryScoped || descriptorProfile !== profile) {
@@ -188,7 +199,8 @@ export async function selectConnection(connectionId: string): Promise<void> {
 
   const currentConnectionId = $activeConnectionId.get()
   const currentProfile = normalizeProfileKey($activeGatewayProfile.get())
-  const targetProfile = normalizeProfileKey($lastProfileByConnection.get()[connectionId] ?? 'default')
+  const rememberKey = targetConnection.kind === 'local' ? LOCAL_POOL_KEY : connectionId
+  const targetProfile = normalizeProfileKey($lastProfileByConnection.get()[rememberKey] ?? 'default')
   const targetKey = `${connectionId}::${targetProfile}`
 
   if (pendingTarget === targetKey) {


### PR DESCRIPTION
## Problem

When the primary profile is set to a non-default name (via `active-profile.json`, e.g. `{"profile":"xiaolu"}`), switching to a remote connection and back to "This device" resets the local pool to `default` instead of the previously selected profile.

## Root cause

`resolveProfileBackendRoute` returns a **profile-less** connection descriptor for the primary backend — the primary profile *is* the backend, so its descriptor carries no `profile` field. The `lastProfileByConnection` subscriber guards writes with a descriptor/profile equality check, and for the primary backend `descriptorProfile = normalizeProfileKey(undefined) = 'default'`, which never equals the real profile. The local-pool selection is therefore never remembered.

## Fix

- Expose `hasDescriptorProfile` (whether the descriptor actually carries a `profile`) from `$activeConnectionProfile`.
- For the local pool (key `local`, no `connectionId`): when the active connection is a profile-less **primary**, record the live gateway profile directly instead of requiring a descriptor match.
- Skip recording while a connection switch is in flight (`$pendingConnectionId` non-empty), to avoid capturing a transient profile during the switch window.

## Tests

`apps/desktop/src/store/connections.test.ts` — 13/13 pass.
