### PR TITLE
fix(patch): stop weak fuzzy hunks from rewriting nearby content

### DIFF
--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -269,7 +269,7 @@ class TestBlockAnchorThreshold:
     """Tests for the raised block_anchor threshold (Bug 4)."""
 
     def test_high_similarity_matches(self):
-        """A block with >50% middle similarity should match."""
+        """A block with high middle similarity should match."""
         content = "def foo():\n    x = 1\n    y = 2\n    return x + y\n"
         pattern = "def foo():\n    x = 1\n    y = 9\n    return x + y"
         new, count, strategy, err = fuzzy_find_and_replace(content, pattern, "def foo():\n    return 0\n")
@@ -278,7 +278,7 @@ class TestBlockAnchorThreshold:
 
     def test_completely_different_middle_does_not_match(self):
         """A block where only first+last lines match but middle is completely different
-        should NOT match under the raised 0.50 threshold."""
+        should NOT match under the raised threshold."""
         content = (
             "class Foo:\n"
             "    completely = 'unrelated'\n"
@@ -295,11 +295,39 @@ class TestBlockAnchorThreshold:
             "    pass"
         )
         new, count, strategy, err = fuzzy_find_and_replace(content, pattern, "replaced")
-        # With threshold=0.50, this near-zero-similarity middle should not match
+        # A near-zero-similarity middle should not match.
         assert count == 0, (
-            f"Block with unrelated middle should not match under threshold=0.50, "
+            f"Block with unrelated middle should not match, "
             f"but matched via strategy={strategy}"
         )
+
+    def test_unique_markdown_block_with_weak_middle_does_not_match(self):
+        """A unique boundary match must not make a weak middle safe to replace."""
+        content = (
+            "# Tasks\n\n"
+            "- [ ] Publish report\n"
+            "  - Source: [paper](https://example.com/source)\n"
+            "  - Status: queued\n"
+            "  - Owner: Alice\n"
+            "  - Notes: preserve metadata\n"
+            "  <!-- task-end -->\n"
+        )
+        old = (
+            "- [ ] Publish report\n"
+            "  - Source: [pdf](https://files.test/final.pdf)\n"
+            "  - Status: complete\n"
+            "  - Reviewer: Bob\n"
+            "  - Notes: add download\n"
+            "  <!-- task-end -->"
+        )
+
+        new, count, strategy, err = fuzzy_find_and_replace(
+            content, old, "- [x] Publish report\n  <!-- task-end -->"
+        )
+
+        assert count == 0, f"Weak middle matched via strategy={strategy}"
+        assert err is not None
+        assert new == content
 
 
 class TestStrategyNameSurfaced:

--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -1,5 +1,7 @@
 """Tests for the fuzzy matching module."""
 
+from difflib import SequenceMatcher
+
 from tools.fuzzy_match import IDENTICAL_STRINGS_ERROR, fuzzy_find_and_replace
 
 
@@ -380,6 +382,35 @@ class TestEscapeDriftGuard:
         new, count, strategy, err = fuzzy_find_and_replace(content, old_string, new_string)
         assert count == 0
         assert err is not None and "Escape-drift" in err
+
+    def test_backslash_doubling_diagnosed_for_weak_block_candidate(self):
+        """A rejected weak anchor still supplies escape-drift diagnostics."""
+        content_middle = (
+            "path_a = C:\\Users\\alice\n"
+            "path_b = D:\\Temp\\cache\n"
+            "mode = production"
+        )
+        old_middle = (
+            "first = C:\\\\Users\\\\alice\n"
+            "second = D:\\\\Temp\\\\cache\n"
+            "requested = staging"
+        )
+        similarity = SequenceMatcher(None, content_middle, old_middle).ratio()
+        assert 0.50 <= similarity < 0.70
+
+        content = f"settings:\n{content_middle}\nend settings"
+        old_string = f"settings:\n{old_middle}\nend settings"
+        new_string = old_string.replace("staging", "complete")
+
+        new, count, strategy, err = fuzzy_find_and_replace(
+            content, old_string, new_string
+        )
+
+        assert count == 0
+        assert strategy is None
+        assert new == content
+        assert err is not None
+        assert "Escape-drift detected: every backslash run" in err
 
     def test_drift_allowed_when_file_genuinely_has_backslash_escapes(self):
         """If the file already contains \\' (e.g. inside an existing escaped

--- a/tests/tools/test_patch_parser.py
+++ b/tests/tools/test_patch_parser.py
@@ -231,6 +231,50 @@ class TestApplyUpdate:
             '    return result + 1'
         )
 
+    def test_rejects_unique_markdown_anchor_with_weak_middle(self):
+        """A real V4A hunk must not rewrite a weak same-boundary block."""
+        patch = """\
+*** Begin Patch
+*** Update File: tasks.md
+@@ Publish report @@
+ - [ ] Publish report
+   - Source: [pdf](https://files.test/final.pdf)
+   - Status: complete
+   - Reviewer: Bob
+   - Notes: add download
+-  <!-- task-end -->
++  - PDF: [download](https://files.test/final.pdf)
++  <!-- task-end -->
+*** End Patch"""
+        operations, err = parse_v4a_patch(patch)
+        assert err is None
+
+        original = (
+            "# Tasks\n\n"
+            "- [ ] Publish report\n"
+            "  - Source: [paper](https://example.com/source)\n"
+            "  - Status: queued\n"
+            "  - Owner: Alice\n"
+            "  - Notes: preserve metadata\n"
+            "  <!-- task-end -->\n"
+        )
+
+        class FakeFileOps:
+            written = None
+
+            def read_file_raw(self, path):
+                return SimpleNamespace(content=original, error=None)
+
+            def write_file(self, path, content, pre_content=None):
+                self.written = content
+                return SimpleNamespace(error=None)
+
+        file_ops = FakeFileOps()
+        result = apply_v4a_operations(operations, file_ops)
+
+        assert result.success is False
+        assert file_ops.written is None
+
 
 class TestAdditionOnlyHunks:
     """Regression tests for #3081 — addition-only hunks were silently dropped."""

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -259,8 +259,7 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
     # A weak block-anchor candidate is no longer safe to replace, but it can
     # still provide the matched file region needed for the more actionable
     # escape-drift diagnostic. Never apply this candidate.
-    if (("\\'" in old_string and "\\'" in new_string)
-            or ('\\"' in old_string and '\\"' in new_string)):
+    if "\\" in old_string:
         weak_matches = _strategy_block_anchor(content, old_string, threshold=0.50)
         if weak_matches:
             drift_err = _detect_escape_drift(

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -256,6 +256,19 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
             )
             return new_content, len(matches), strategy_name, None
 
+    # A weak block-anchor candidate is no longer safe to replace, but it can
+    # still provide the matched file region needed for the more actionable
+    # escape-drift diagnostic. Never apply this candidate.
+    if (("\\'" in old_string and "\\'" in new_string)
+            or ('\\"' in old_string and '\\"' in new_string)):
+        weak_matches = _strategy_block_anchor(content, old_string, threshold=0.50)
+        if weak_matches:
+            drift_err = _detect_escape_drift(
+                content, weak_matches, old_string, new_string
+            )
+            if drift_err:
+                return content, 0, None, drift_err
+
     # No strategy found a match
     return content, 0, None, "Could not find a match for old_string in the file"
 
@@ -813,7 +826,8 @@ def _strategy_unicode_normalized(content: str, pattern: str) -> List[Tuple[int, 
     return _map_positions_norm_to_orig(orig_to_norm, norm_matches)
 
 
-def _strategy_block_anchor(content: str, pattern: str) -> List[Tuple[int, int]]:
+def _strategy_block_anchor(content: str, pattern: str,
+                           threshold: float = 0.70) -> List[Tuple[int, int]]:
     """
     Strategy 8: Match by anchoring on first and last lines.
     Adjusted with permissive thresholds and unicode normalization.
@@ -843,12 +857,10 @@ def _strategy_block_anchor(content: str, pattern: str) -> List[Tuple[int, int]]:
             potential_matches.append(i)
             
     matches = []
-    candidate_count = len(potential_matches)
-    
-    # Thresholding logic: 0.50 for unique matches, 0.70 for multiple candidates.
-    # Previous values (0.10 / 0.30) were dangerously loose — a 10% middle-section
-    # similarity could match completely unrelated blocks.
-    threshold = 0.50 if candidate_count == 1 else 0.70
+    # Uniqueness is not evidence that an approximate block is the intended
+    # target. A nearby block can be the only one with matching boundary lines
+    # while its middle describes different content, so the default confidence
+    # floor is the same regardless of the number of anchored candidates.
 
     for i in potential_matches:
         if pattern_line_count <= 2:


### PR DESCRIPTION
## What does this PR do?

Prevents the patch tool from silently rewriting a nearby Markdown or code block when only the first and last lines match and the middle is weakly similar. A unique block-anchor candidate now needs the same confidence as multiple candidates, so unsafe approximate hunks fail closed instead of corrupting unrelated content.

### Symptom

A V4A update hunk can report success after binding to the only nearby block with matching boundary lines, even when the middle describes different content.

### Impact

The patch can silently replace unrelated file content. The affected blast radius is limited to approximate block-anchor matches, but the unintended rewrite can remove or alter user data before the mismatch is noticed in the diff.

### Bug Cause

**Trigger:** `tools/fuzzy_match.py:_strategy_block_anchor` when exactly one block shares the pattern's first and last lines.

**Causal chain:**
1. Exact and normalization-based strategies do not match the supplied hunk.
2. `block_anchor` finds one same-boundary window and accepts its middle at a 0.50 similarity threshold.
3. The tool replaces that window and reports success even though its middle is not the requested content.

**Why it is wrong:** Candidate uniqueness only establishes that one block has matching boundaries. It does not increase confidence that a weakly similar middle is the intended target.

**Working sibling / contrast:** Multiple block-anchor candidates already require 0.70 similarity, and the final `context_aware` strategy requires every nonblank aligned line to reach 0.80 similarity.

**Ruled out:** Ambiguous multi-match selection is not the cause. `replace_all=False` already rejects multiple accepted matches rather than choosing one.

### Fix

Use a 0.70 block-anchor confidence floor for both unique and repeated candidates. Weak candidates remain available only for the existing escape-drift diagnostic and are never applied. Added direct matcher coverage and an end-to-end V4A hunk regression proving the target file is not written.

## Related Issue

Fixes #93698

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/fuzzy_match.py` - require uniform confidence for approximate block anchors while preserving escape-drift diagnostics.
- `tests/tools/test_fuzzy_match.py` - cover a unique Markdown block with a weakly matching middle.
- `tests/tools/test_patch_parser.py` - verify a real V4A hunk fails without writing the file.

## How to Test

1. Apply a V4A hunk whose first and last Markdown lines match one block but whose middle has only moderate similarity.
2. Confirm the patch fails and the file remains unchanged.
3. Run the focused automated suites:

```bash
scripts/run_tests.sh tests/tools/test_fuzzy_match.py -q
scripts/run_tests.sh tests/tools/test_patch_parser.py tests/tools/test_patch_multimatch_locations.py tests/tools/test_patch_ws_diagnosis.py tests/tools/test_patch_failure_tracking.py tests/tools/test_patch_already_applied.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant test suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A
- [x] Cross-platform impact considered: matching logic is platform-independent
- [x] Tool description/schema update: N/A

## Screenshots / Logs

N/A
