### PR TITLE
feat(gateway): persist ordered transcript parts

### DIFF
--- a/apps/shared/package.json
+++ b/apps/shared/package.json
@@ -8,6 +8,7 @@
     "./billing": "./src/billing-types.ts",
     "./billing-policy": "./src/billing-policy.ts",
     "./charge-settlement": "./src/charge-settlement.ts",
+    "./transcript-parts": "./src/transcript-parts.ts",
     "./skin": "./src/skin.ts"
   },
   "types": "./src/index.ts",

--- a/apps/shared/src/index.ts
+++ b/apps/shared/src/index.ts
@@ -59,6 +59,12 @@ export {
   type WebSocketLike
 } from './json-rpc-gateway'
 export { skillInvocationText } from './skill-scaffold'
+export type {
+  GatewayTranscriptPart,
+  GatewayTranscriptPartKind,
+  GatewayTranscriptPartsFields,
+  GatewayTranscriptPartsMode
+} from './transcript-parts'
 export {
   type HermesSkin,
   SKIN_BRANDING_TOKENS,

--- a/apps/shared/src/transcript-parts.ts
+++ b/apps/shared/src/transcript-parts.ts
@@ -1,0 +1,41 @@
+/** Additive, presentation-only transcript evidence carried beside legacy text. */
+export type GatewayTranscriptPartKind =
+  | 'audio'
+  | 'clipped'
+  | 'file'
+  | 'image'
+  | 'malformed'
+  | 'reasoning'
+  | 'text'
+  | 'tool-call'
+  | 'tool-result'
+  | 'unknown'
+  | (string & {})
+
+export interface GatewayTranscriptPart {
+  arguments?: unknown
+  clipped?: boolean
+  completed_at?: number
+  content_kind?: string
+  evidence?: string
+  id?: string
+  kind: GatewayTranscriptPartKind
+  mime_type?: string
+  name?: string
+  reason?: string
+  ref?: string
+  source_type?: string
+  text?: string
+  timestamp?: number
+  value?: unknown
+}
+
+export type GatewayTranscriptPartsMode = 'append' | 'replace' | 'seal'
+
+/** Optional for compatibility with gateways predating ordered transcript parts. */
+export interface GatewayTranscriptPartsFields {
+  parts?: GatewayTranscriptPart[]
+  parts_clipped?: boolean
+  parts_mode?: GatewayTranscriptPartsMode
+  parts_version?: number
+}

--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -217,6 +217,7 @@ def _append_to_sqlite(session_id: str, message: dict) -> None:
             session_id=session_id,
             role=message.get("role", "assistant"),
             content=message.get("content"),
+            parts=message.get("parts"),
         )
     except Exception as e:
         logger.debug("Mirror SQLite write failed: %s", e)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3879,6 +3879,7 @@ class SessionStore:
             session_id=session_id,
             role=message.get("role", "unknown"),
             content=message.get("content"),
+            parts=message.get("parts"),
             tool_name=message.get("tool_name"),
             tool_calls=message.get("tool_calls"),
             tool_call_id=message.get("tool_call_id"),

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -96,6 +96,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
 from hermes_state_portability import SessionPortabilityMixin
 from hermes_state_schema import SessionSchemaMixin
 from hermes_state_search import SessionSearchMixin
+from transcript_parts import message_parts
 
 try:  # Hard dependency, but tolerate scaffold-phase imports before pip install.
     import psutil
@@ -10472,6 +10473,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         compression_lock_holder: Optional[str] = None,
         turn_lease_holder: Optional[str] = None,
         turn_lease_ttl_seconds: float = 300.0,
+        parts: Any = None,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -10512,6 +10514,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # Multimodal content (list of parts) must be JSON-encoded: sqlite3
         # cannot bind list/dict parameters directly.
         stored_content = self._encode_content(content)
+        stored_parts = self._encode_content(
+            message_parts({"parts": parts})
+            if parts is not None
+            else message_parts({
+                "role": role,
+                "content": content,
+                "tool_name": tool_name,
+                "tool_call_id": tool_call_id,
+                "tool_calls": tool_calls,
+                "reasoning": reasoning,
+                "reasoning_content": reasoning_content,
+            })
+        )
 
         message_timestamp = time.time()
         if timestamp is not None:
@@ -10537,15 +10552,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 turn_lease_ttl_seconds=turn_lease_ttl_seconds,
             )
             cursor = conn.execute(
-                """INSERT INTO messages (session_id, role, content, tool_call_id,
+                """INSERT INTO messages (session_id, role, content, parts, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
                    codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (
+                       ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                       ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+                   )""",
                 (
                     session_id,
                     role,
                     stored_content,
+                    stored_parts,
                     tool_call_id,
                     tool_calls_json,
                     _scrub_surrogates(tool_name),
@@ -10966,17 +10985,22 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
 
             api_content = msg.get("api_content")
+            stored_parts = self._encode_content(message_parts(msg))
 
             cur = conn.execute(
-                """INSERT INTO messages (session_id, role, content, tool_call_id,
+                """INSERT INTO messages (session_id, role, content, parts, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
                    codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (
+                       ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                       ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+                   )""",
                 (
                     session_id,
                     role,
                     self._encode_content(msg.get("content")),
+                    stored_parts,
                     msg.get("tool_call_id"),
                     tool_calls_json,
                     _scrub_surrogates(msg.get("tool_name")),
@@ -11437,6 +11461,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             msg = dict(row)
             if "content" in msg:
                 msg["content"] = self._decode_content(msg["content"])
+            if msg.get("parts") is not None:
+                msg["parts"] = self._decode_content(msg["parts"])
             if msg.get("tool_calls"):
                 try:
                     msg["tool_calls"] = json.loads(msg["tool_calls"])
@@ -11654,6 +11680,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         include_inactive: bool = False,
         repair_alternation: bool = False,
         include_row_ids: bool = False,
+        include_parts: bool = False,
     ) -> List[Dict[str, Any]]:
         """
         Load messages in the OpenAI conversation format (role + content dicts).
@@ -11701,13 +11728,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             include_ancestors=include_ancestors,
             repair_alternation=repair_alternation,
             include_row_ids=include_row_ids,
+            include_parts=include_parts,
         )
 
     # Columns every conversation projection decodes. Shared by
     # get_messages_as_conversation and get_resume_conversations so a single
     # SELECT can feed both the model-fed and display views.
     _CONVERSATION_ROW_COLUMNS = (
-        "id, role, content, tool_call_id, tool_calls, tool_name, effect_disposition, "
+        "id, role, content, parts, tool_call_id, tool_calls, tool_name, effect_disposition, "
         "finish_reason, reasoning, reasoning_content, reasoning_details, "
         "codex_reasoning_items, codex_message_items, platform_message_id, observed, timestamp, "
         "api_content, display_kind, display_metadata"
@@ -11721,6 +11749,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         include_ancestors: bool,
         repair_alternation: bool,
         include_row_ids: bool = False,
+        include_parts: bool = False,
     ) -> List[Dict[str, Any]]:
         """Decode fetched message rows into the OpenAI conversation format.
 
@@ -11735,6 +11764,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if row["role"] in {"user", "assistant"} and isinstance(content, str):
                 content = sanitize_context(content).strip()
             msg = {"role": row["role"], "content": content}
+            if include_parts:
+                raw_parts = row["parts"] if "parts" in row.keys() else None
+                if raw_parts:
+                    decoded_parts = self._decode_content(raw_parts)
+                    if isinstance(decoded_parts, dict) and isinstance(decoded_parts.get("parts"), list):
+                        msg["parts"] = decoded_parts
             # Born durable (#92231): this dict is materialized FROM a durable
             # row, so stamp the persistence marker at the source instead of
             # relying on every restore caller to thread the loaded list back
@@ -11820,6 +11855,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     except (json.JSONDecodeError, TypeError):
                         logger.warning("Failed to deserialize codex_message_items, falling back to None")
                         msg["codex_message_items"] = None
+            # Legacy rows predate the additive envelope. Synthesize a bounded
+            # text/tool projection only for display callers; model history
+            # remains byte/role/tool-identical to the historical projection.
+            if include_parts and "parts" not in msg:
+                msg["parts"] = message_parts(msg)
             if include_ancestors and self._is_duplicate_replayed_user_message(messages, msg):
                 continue
             messages.append(msg)
@@ -11905,6 +11945,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             include_ancestors=False,
             repair_alternation=True,
             include_row_ids=True,
+            include_parts=False,
         )
         display_history = self._rows_to_conversation(
             rows,
@@ -11912,6 +11953,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             include_ancestors=True,
             repair_alternation=False,
             include_row_ids=True,
+            include_parts=True,
         )
         return model_history, display_history
 

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -432,6 +432,7 @@ CREATE TABLE IF NOT EXISTS messages (
     session_id TEXT NOT NULL REFERENCES sessions(id),
     role TEXT NOT NULL,
     content TEXT,
+    parts TEXT,
     tool_call_id TEXT,
     tool_calls TEXT,
     tool_name TEXT,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -435,6 +435,7 @@ py-modules = [
   "hermes_state_portability",
   "hermes_state_schema",
   "hermes_state_search",
+  "transcript_parts",
   "hermes_time",
   "hermes_logging",
   "utils",

--- a/run_agent.py
+++ b/run_agent.py
@@ -220,6 +220,7 @@ from agent.tool_dispatch_helpers import (
     _extract_error_preview,
     _trajectory_normalize_msg,  # noqa: F401  # re-exported for tests that `from run_agent import _trajectory_normalize_msg`
 )
+from transcript_parts import message_parts
 from utils import atomic_json_write, base_url_host_matches, base_url_hostname, env_float, is_truthy_value, model_forces_max_completion_tokens
 
 
@@ -2324,9 +2325,16 @@ class AIAgent:
                     and sanitize_context(content).strip() != content.strip()
                 ):
                     _row_api_content = content
+                # Persist a bounded ordered envelope before the legacy content
+                # fallback below is reduced to a provider-safe text summary.
+                # The envelope is presentation/storage metadata; `content`
+                # remains the historical model-context projection, preserving
+                # prompt-cache bytes and role alternation for existing clients.
+                _row_parts = message_parts({**msg, "content": content})
                 # Persist multimodal tool results as their text summary only —
                 # base64 images would bloat the session DB and aren't useful
-                # for cross-session replay.
+                # for cross-session replay. The ordered envelope above carries
+                # bounded inert media references for display/resume.
                 if _is_multimodal_tool_result(content):
                     content = _multimodal_text_summary(content)
                 elif isinstance(content, list):
@@ -2349,6 +2357,7 @@ class AIAgent:
                 _batch_rows.append({
                     "role": role,
                     "content": content,
+                    "parts": _row_parts,
                     "tool_name": msg.get("tool_name"),
                     "tool_calls": tool_calls_data,
                     "tool_call_id": msg.get("tool_call_id"),

--- a/tests/fixtures/session-resume-active-turn.json
+++ b/tests/fixtures/session-resume-active-turn.json
@@ -8,12 +8,35 @@
   },
   "inflight": {
     "assistant": "partial answer",
+    "parts": [
+      {
+        "kind": "text",
+        "text": "partial answer"
+      }
+    ],
+    "parts_clipped": false,
+    "parts_version": 1,
     "streaming": true,
-    "user": "current prompt"
+    "user": "current prompt",
+    "user_parts": [
+      {
+        "kind": "text",
+        "text": "current prompt"
+      }
+    ],
+    "user_parts_clipped": false
   },
   "message_count": 1,
   "messages": [
     {
+      "parts": [
+        {
+          "kind": "text",
+          "text": "earlier prompt"
+        }
+      ],
+      "parts_clipped": false,
+      "parts_version": 1,
       "role": "user",
       "text": "earlier prompt"
     }

--- a/tests/test_ordered_transcript_parts.py
+++ b/tests/test_ordered_transcript_parts.py
@@ -1,0 +1,378 @@
+"""Gateway-level contract tests for bounded ordered transcript parts."""
+
+import json
+import sqlite3
+import threading
+from pathlib import Path
+
+from hermes_state import SessionDB
+from transcript_parts import MAX_BYTES, MAX_PARTS, message_parts
+from tui_gateway import server
+
+
+def _kinds(envelope):
+    return [part.get("kind") for part in envelope["parts"]]
+
+
+def test_mixed_parts_keep_order_identity_and_redact_media_authority():
+    envelope = message_parts({
+        "role": "assistant",
+        "reasoning": "checking",
+        "content": [
+            {"type": "text", "text": "before", "id": "p-1", "timestamp": 10.0},
+            {"type": "image_url", "image_url": {"url": "https://example.test/a.png?token=secret"}},
+            {"type": "text", "text": "after"},
+            {"type": "input_audio", "input_audio": {"data": "secret-audio"}},
+            {"type": "file", "file": {"file_id": "file-7"}},
+        ],
+        "tool_calls": [{
+            "id": "call-7",
+            "function": {"name": "terminal", "arguments": {"command": "pwd"}},
+        }],
+    })
+
+    assert _kinds(envelope)[:7] == [
+        "reasoning", "text", "image", "text", "audio", "file", "tool-call",
+    ]
+    assert envelope["parts"][1]["id"] == "p-1"
+    assert envelope["parts"][1]["timestamp"] == 10.0
+    encoded = json.dumps(envelope, ensure_ascii=False)
+    assert "token=secret" not in encoded
+    assert "secret-audio" not in encoded
+    local = message_parts({"role": "user", "content": [{"type": "image", "ref": "@image:/Users/alice/private.png"}]})
+    assert "/Users/alice" not in json.dumps(local)
+    assert local["parts"][0]["ref"] == "@image:private.png"
+    assert len(encoded.encode("utf-8")) <= MAX_BYTES
+
+
+def test_hostile_nodes_depth_scalars_and_bytes_are_bounded_with_evidence():
+    nested = "x"
+    for _ in range(40):
+        nested = [nested]
+    envelope = message_parts({
+        "role": "user",
+        "parts": [
+            {"type": "text", "text": "🧑🏽‍💻" * 100_000},
+            {"type": "mystery", "value": nested},
+        ] * 200,
+    })
+
+    assert envelope["clipped"] is True
+    assert any(part.get("kind") in {"unknown", "clipped"} for part in envelope["parts"])
+    assert len(json.dumps(envelope, ensure_ascii=False).encode("utf-8")) <= MAX_BYTES
+
+    numeric = message_parts({
+        "role": "tool",
+        "tool_call_id": "bomb",
+        "content": {"bad": float("nan"), "huge": 10**5000},
+    })
+    assert numeric["clipped"] is True
+    assert len(numeric["parts"]) <= MAX_PARTS
+    assert "nan" not in json.dumps(numeric).lower()
+    unknown_numeric = message_parts({
+        "role": "user",
+        "parts": [{"type": "mystery", "value": 10**5000}],
+    })
+    assert unknown_numeric["clipped"] is True
+    assert "int" in json.dumps(unknown_numeric)
+    surrogate = message_parts({"role": "user", "content": "ok\ud800tail"})
+    assert surrogate["clipped"] is True
+    json.dumps(surrogate, ensure_ascii=False).encode("utf-8")
+    invalid_url = message_parts({
+        "role": "user",
+        "content": [{"type": "image_url", "image_url": {"url": "https://host:99999/path"}}],
+    })
+    assert invalid_url["clipped"] is True
+    assert "99999" not in json.dumps(invalid_url)
+    ipv6 = message_parts({
+        "role": "user",
+        "content": [{"type": "image_url", "image_url": {"url": "https://[::1]:8443/x?q=secret"}}],
+    })
+    assert ipv6["parts"][0]["ref"] == "https://[::1]:8443/x"
+
+
+def test_session_db_round_trip_persists_parts_without_mutating_model_content(tmp_path: Path):
+    db_path = tmp_path / "state.db"
+    content = [
+        {"type": "text", "text": "look"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,hidden"}},
+        {"type": "text", "text": "here"},
+    ]
+    db = SessionDB(db_path=db_path)
+    try:
+        db.create_session("parts-session", "desktop")
+        db.append_message(
+            "parts-session",
+            role="user",
+            # The legacy model-facing value remains exactly what this caller
+            # supplied; the additive envelope is stored in its own column.
+            content="look [image] here",
+            parts=message_parts({"role": "user", "content": content}),
+        )
+        rows = db.get_messages("parts-session")
+        assert rows[0]["content"] == "look [image] here"
+        assert rows[0]["parts"]["parts"][0]["kind"] == "text"
+        assert rows[0]["parts"]["parts"][1]["kind"] == "image"
+        assert "hidden" not in json.dumps(rows[0]["parts"])
+
+        model_rows = db.get_messages_as_conversation(
+            "parts-session", include_row_ids=True, include_parts=True
+        )
+        assert model_rows[0]["content"] == "look [image] here"
+        assert model_rows[0]["parts"]["version"] == 1
+    finally:
+        db.close()
+
+    reopened = SessionDB(db_path=db_path)
+    try:
+        assert reopened.get_messages("parts-session")[0]["parts"]["parts"][2]["text"] == "here"
+    finally:
+        reopened.close()
+
+
+def test_canonical_tool_results_survive_repeated_storage_and_wire_admission():
+    structured = message_parts({
+        "role": "tool",
+        "tool_call_id": "call-json",
+        "tool_name": "inspect",
+        "content": {"ok": True, "rows": [1, 2, 3]},
+    })
+    structured_again = message_parts({"parts": structured})
+    result = structured_again["parts"][0]
+    assert result["kind"] == "tool-result"
+    assert result["id"] == "call-json"
+    assert result["name"] == "inspect"
+    assert result["value"] == {"ok": True, "rows": [1, 2, 3]}
+
+    media = message_parts({
+        "role": "tool",
+        "tool_call_id": "call-image",
+        "tool_name": "render",
+        "content": [{
+            "type": "image_url",
+            "image_url": {"url": "https://example.test/render.png?token=secret"},
+            "mime_type": "image/png",
+        }],
+    })
+    media_again = message_parts({"parts": media})
+    media_result = media_again["parts"][0]
+    assert media_result["kind"] == "tool-result"
+    assert media_result["content_kind"] == "image"
+    assert media_result["ref"] == "https://example.test/render.png"
+    assert media_result["mime_type"] == "image/png"
+    assert "secret" not in json.dumps(media_again)
+
+
+def test_existing_schema_gets_parts_column_and_model_projection_stays_unchanged(tmp_path: Path):
+    db_path = tmp_path / "legacy-state.db"
+    db = SessionDB(db_path=db_path)
+    try:
+        db.create_session("legacy-session", "desktop")
+        db.append_message("legacy-session", "user", "run the tool")
+        db.append_message(
+            "legacy-session",
+            "assistant",
+            "",
+            tool_calls=[{"id": "call-legacy", "function": {"name": "pwd", "arguments": "{}"}}],
+        )
+        db.append_message("legacy-session", "tool", "ok", tool_call_id="call-legacy", tool_name="pwd")
+        db.append_message("legacy-session", "assistant", "done")
+    finally:
+        db.close()
+
+    # Simulate a pre-parts install.  The next writable open must reconcile the
+    # additive column instead of assuming CREATE TABLE IF NOT EXISTS changed it.
+    raw = sqlite3.connect(db_path)
+    try:
+        raw.execute("ALTER TABLE messages DROP COLUMN parts")
+        raw.commit()
+    finally:
+        raw.close()
+
+    reopened = SessionDB(db_path=db_path)
+    try:
+        columns = {
+            row[1]
+            for row in reopened._conn.execute("PRAGMA table_info(messages)").fetchall()
+        }
+        assert "parts" in columns
+        baseline = reopened.get_messages_as_conversation(
+            "legacy-session", repair_alternation=True, include_row_ids=True
+        )
+        model_history, display_history = reopened.get_resume_conversations("legacy-session")
+        assert model_history == baseline
+        assert "parts" not in model_history[0]
+        assert [row["role"] for row in model_history] == ["user", "assistant", "tool", "assistant"]
+        assert [row["role"] for row in display_history] == ["user", "assistant", "tool", "assistant"]
+        assert all("parts" in row for row in display_history)
+        assert display_history[1]["content"] == ""
+        assert display_history[1]["tool_calls"][0]["id"] == "call-legacy"
+    finally:
+        reopened.close()
+
+
+def test_legacy_and_new_rows_project_additive_parts_without_leaking_raw_content():
+    history = [
+        {"role": "user", "content": "old text"},
+        {
+            "role": "assistant",
+            "content": "visible",
+            "parts": message_parts({
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "before"},
+                    {"type": "image_url", "image_url": {"url": "https://e.test/x?key=private"}},
+                    {"type": "text", "text": "after"},
+                ],
+            }),
+        },
+    ]
+
+    projected = server._history_to_messages(history)
+
+    assert projected[0]["text"] == "old text"
+    assert projected[0]["parts"] == [{"kind": "text", "text": "old text"}]
+    assert [part["kind"] for part in projected[1]["parts"][:3]] == ["text", "image", "text"]
+    assert "key=private" not in json.dumps(projected)
+
+
+def test_hydrated_commentary_tool_run_emits_each_invocation_once():
+    projected = server._history_to_messages([
+        {"role": "user", "content": "inspect it"},
+        {
+            "role": "assistant",
+            "content": "I will inspect it.",
+            "tool_calls": [{
+                "id": "call-1",
+                "function": {"name": "terminal", "arguments": {"command": "pwd"}},
+            }],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-1",
+            "tool_name": "terminal",
+            "content": "ok",
+        },
+        {"role": "assistant", "content": "Done."},
+    ])
+
+    kinds = [part["kind"] for row in projected for part in row.get("parts", [])]
+    assert kinds.count("tool-call") == 1
+    assert kinds.count("tool-result") == 1
+    assert projected[2]["args"] == {"command": "pwd"}
+
+
+def test_live_submit_emits_incremental_and_terminal_parts_in_order(monkeypatch, tmp_path):
+    events = []
+
+    class ImmediateThread:
+        def __init__(self, target=None, **_kwargs):
+            self.target = target
+
+        def start(self):
+            if self.target:
+                self.target()
+
+        def join(self, **_kwargs):
+            return None
+
+        def is_alive(self):
+            return False
+
+    class Agent:
+        model = "test-model"
+        provider = "test-provider"
+        api_mode = "chat_completions"
+        base_url = ""
+        api_key = ""
+
+        def clear_interrupt(self):
+            return None
+
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+            stream_callback("live")
+            self.interim_assistant_callback("live", already_streamed=True)
+            self.interim_assistant_callback("new commentary", already_streamed=False)
+            return {
+                "final_response": "after",
+                "messages": [
+                    {"role": "user", "content": prompt},
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "text", "text": "before"},
+                            {"type": "image_url", "image_url": {"url": "https://e.test/a?secret=x"}},
+                            {"type": "text", "text": "after"},
+                        ],
+                        "tool_calls": [{
+                            "id": "call-1",
+                            "function": {"name": "terminal", "arguments": {"command": "pwd"}},
+                        }],
+                    },
+                    {"role": "tool", "tool_call_id": "call-1", "tool_name": "terminal", "content": "ok"},
+                ],
+            }
+
+    session = {
+        "agent": Agent(),
+        "session_key": "parts-live",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": True,
+        "attached_images": [],
+        "image_counter": 0,
+        "cols": 80,
+        "slash_worker": None,
+        "show_reasoning": False,
+        "tool_progress_mode": "all",
+        "tool_started_at": {},
+        "transport": None,
+    }
+    server._sessions["parts-live-sid"] = session
+    monkeypatch.setattr(server.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda event, sid, payload=None: events.append((event, payload)))
+    monkeypatch.setattr(server, "make_stream_renderer", lambda _cols: None)
+    monkeypatch.setattr(server, "render_message", lambda _raw, _cols: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_sync_agent_model_with_config", lambda *_args: None)
+    monkeypatch.setattr(server, "_session_cwd", lambda _session: str(tmp_path))
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+    monkeypatch.setattr(server, "_set_session_context", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+    monkeypatch.setattr(server, "_get_usage", lambda _agent: {})
+    monkeypatch.setattr(server, "_sync_session_key_after_compress", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_drain_queued_prompt", lambda *_args: False)
+    monkeypatch.setattr(server, "_voice_tts_enabled", lambda: False)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_start_usage_ticker", lambda *_args, **_kwargs: (threading.Event(), ImmediateThread()))
+    try:
+        server._run_prompt_submit("parts-live-rid", "parts-live-sid", session, "question")
+    finally:
+        server._sessions.pop("parts-live-sid", None)
+
+    starts = [payload for event, payload in events if event == "message.start"]
+    deltas = [payload for event, payload in events if event == "message.delta"]
+    interims = [payload for event, payload in events if event == "message.interim"]
+    completes = [payload for event, payload in events if event == "message.complete"]
+    assert starts and starts[0]["parts"][0]["kind"] == "text"
+    assert deltas and deltas[0]["parts_mode"] == "append"
+    assert [payload["parts_mode"] for payload in interims] == ["seal", "append"]
+    assert completes
+    assert [part["kind"] for part in completes[-1]["parts"][:5]] == [
+        "text", "image", "text", "tool-call", "tool-result",
+    ]
+    assert "secret=x" not in json.dumps(completes[-1])
+
+
+def test_parts_budget_never_truncates_legacy_inflight_text():
+    legacy_text = "x" * 20_000
+    session = {}
+    server._start_inflight_turn(session, legacy_text)
+    server._append_inflight_delta(session, legacy_text)
+
+    snapshot = server._inflight_snapshot(session)
+    assert snapshot["user"] == legacy_text
+    assert snapshot["assistant"] == legacy_text
+    assert snapshot["parts_clipped"] is True
+    assert snapshot["user_parts_clipped"] is True

--- a/tests/test_ordered_transcript_parts.py
+++ b/tests/test_ordered_transcript_parts.py
@@ -376,3 +376,34 @@ def test_parts_budget_never_truncates_legacy_inflight_text():
     assert snapshot["assistant"] == legacy_text
     assert snapshot["parts_clipped"] is True
     assert snapshot["user_parts_clipped"] is True
+
+
+def test_terminal_parts_keep_the_whole_logical_turn_across_internal_user_nudges():
+    # Repeated identical prompts must not make the collector jump back to the
+    # older turn when locating the current external-user boundary.
+    history = [{"role": "user", "content": "current prompt"},
+               {"role": "assistant", "content": "old answer"}]
+    rows = history + [
+        {"role": "user", "content": "current prompt"},
+        {"role": "assistant", "content": "I will inspect.", "tool_calls": [{
+            "id": "call-1",
+            "function": {"name": "terminal", "arguments": {"command": "pwd"}},
+        }]},
+        {"role": "tool", "tool_call_id": "call-1", "tool_name": "terminal",
+         "content": "ok"},
+        {"role": "user", "content": "[internal continuation nudge]"},
+        {"role": "assistant", "content": "Done."},
+    ]
+
+    envelope = server._assistant_turn_parts(
+        rows,
+        prior_history_count=len(history),
+        turn_user_content="current prompt",
+    )
+
+    assert [part["kind"] for part in envelope["parts"]] == [
+        "text", "tool-call", "tool-result", "text",
+    ]
+    assert [part.get("text") for part in envelope["parts"] if part["kind"] == "text"] == [
+        "I will inspect.", "Done.",
+    ]

--- a/tests/tui_gateway/test_failed_turn_retention.py
+++ b/tests/tui_gateway/test_failed_turn_retention.py
@@ -132,7 +132,15 @@ def test_healthy_snapshot_carries_no_error_keys():
     server._append_inflight_delta(session, "hello")
 
     snapshot = server._inflight_snapshot(session)
-    assert snapshot == {"assistant": "hello", "streaming": True, "user": "hi"}
+    assert snapshot["assistant"] == "hello"
+    assert snapshot["streaming"] is True
+    assert snapshot["user"] == "hi"
+    assert snapshot["parts_version"] == 1
+    assert snapshot["parts"][0]["kind"] == "text"
+    assert snapshot["parts"][0]["text"] == "hello"
+    assert snapshot["user_parts"] == [{"kind": "text", "text": "hi"}]
+    assert "error" not in snapshot
+    assert "status" not in snapshot
 
 
 # ── Returned-error path (run_conversation returns an error result) ────

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -767,9 +767,32 @@ def test_session_resume_returns_hydrated_messages(server, monkeypatch):
     assert "error" not in resp
     assert resp["result"]["message_count"] == 3
     assert resp["result"]["messages"] == [
-        {"role": "user", "text": "hello"},
-        {"role": "assistant", "text": "yo", "reasoning": "thoughts"},
-        {"role": "tool", "name": "tool", "context": ""},
+        {
+            "role": "user",
+            "text": "hello",
+            "parts": [{"kind": "text", "text": "hello"}],
+            "parts_version": 1,
+            "parts_clipped": False,
+        },
+        {
+            "role": "assistant",
+            "text": "yo",
+            "reasoning": "thoughts",
+            "parts": [
+                {"kind": "reasoning", "text": "thoughts"},
+                {"kind": "text", "text": "yo"},
+            ],
+            "parts_version": 1,
+            "parts_clipped": False,
+        },
+        {
+            "role": "tool",
+            "name": "tool",
+            "context": "",
+            "parts": [{"kind": "text", "text": "searched"}],
+            "parts_version": 1,
+            "parts_clipped": False,
+        },
     ]
 
 

--- a/transcript_parts.py
+++ b/transcript_parts.py
@@ -1,0 +1,550 @@
+"""Bounded ordered transcript-part admission.
+
+The model-facing message shape is intentionally left alone.  This module owns
+the small, presentation-safe envelope persisted alongside a message and sent
+on the gateway display/event paths.  Older rows have no envelope and are
+projected to one text part at the edge.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import math
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+
+PARTS_VERSION = 1
+MAX_PARTS = 64
+MAX_NODES = 256
+MAX_DEPTH = 8
+MAX_SCALARS = 65_536
+MAX_BYTES = 256 * 1024
+MAX_STRING_SCALARS = 16_384
+MAX_REFERENCE_SCALARS = 4_096
+MAX_ID_SCALARS = 256
+
+_TEXT_TYPES = frozenset({"text", "input_text", "output_text"})
+_REASONING_TYPES = frozenset({"reasoning", "thinking", "reasoning_text"})
+_IMAGE_TYPES = frozenset({"image", "image_url", "input_image"})
+_AUDIO_TYPES = frozenset({"audio", "input_audio"})
+_FILE_TYPES = frozenset({"file", "input_file", "file_url"})
+
+
+class _Budget:
+    __slots__ = ("nodes", "scalars", "bytes", "clipped")
+
+    def __init__(self) -> None:
+        self.nodes = 0
+        self.scalars = 0
+        self.bytes = 0
+        self.clipped = False
+
+    def node(self) -> bool:
+        if self.nodes >= MAX_NODES:
+            self.clipped = True
+            return False
+        self.nodes += 1
+        return True
+
+    def scalar(self) -> bool:
+        if self.scalars >= MAX_SCALARS:
+            self.clipped = True
+            return False
+        self.scalars += 1
+        return True
+
+    def text(self, value: Any, maximum: int = MAX_STRING_SCALARS) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, bytes):
+            value = value.decode("utf-8", "replace")
+        elif not isinstance(value, str):
+            try:
+                value = str(value)
+            except (TypeError, ValueError, OverflowError):
+                # Python itself can refuse hostile integer/string coercions
+                # (for example the max-int-digit guard). Admission must stay
+                # fail-closed rather than taking down persistence or a live
+                # gateway event.
+                self.clipped = True
+                value = f"<{type(value).__name__}>"
+        # Slice before any encoding so an attacker cannot force an unbounded
+        # temporary string through a hostile scalar.
+        raw = value[: maximum + 1]
+        clipped = len(value) > maximum
+        available_scalars = max(0, MAX_SCALARS - self.scalars)
+        if len(raw) > available_scalars:
+            raw = raw[:available_scalars]
+            clipped = True
+        available_bytes = max(0, MAX_BYTES - self.bytes)
+        encoded = raw.encode("utf-8", "replace")
+        if len(encoded) > available_bytes:
+            # Bound in linear time. Repeatedly slicing one scalar and
+            # re-encoding makes a hostile multibyte string quadratic.
+            raw = encoded[:available_bytes].decode("utf-8", "ignore")
+            encoded = raw.encode("utf-8")
+            clipped = True
+        else:
+            # Replace lone surrogates now so later JSON encoding cannot fail.
+            normalized = encoded.decode("utf-8")
+            if normalized != raw:
+                clipped = True
+            raw = normalized
+        if clipped:
+            self.clipped = True
+        self.scalars += len(raw)
+        self.bytes += len(encoded)
+        return raw
+
+
+def _finite_number(value: Any) -> int | float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    if value < 0 or value > 1_000_000_000_000:
+        return None
+    return value
+
+
+def _identity(value: Any, budget: _Budget) -> str | None:
+    if value is None:
+        return None
+    text = budget.text(value, MAX_ID_SCALARS)
+    # Control characters and bidi controls are not safe durable identities.
+    safe = "".join(
+        ch for ch in text
+        if ch.isprintable() and not (0x202A <= ord(ch) <= 0x202E)
+        and not (0x2066 <= ord(ch) <= 0x2069)
+    )
+    if safe != text:
+        budget.clipped = True
+    return safe or None
+
+
+def _copy_timing(source: Mapping[str, Any], part: dict[str, Any], budget: _Budget) -> None:
+    timestamp = _finite_number(source.get("timestamp", source.get("started_at")))
+    completed = _finite_number(
+        source.get("completed_at", source.get("completedAt", source.get("ended_at")))
+    )
+    if timestamp is not None:
+        part["timestamp"] = timestamp
+    if completed is not None:
+        part["completed_at"] = completed
+    # Keep the admission accounting explicit even though numbers do not consume
+    # scalar/byte text budget. This prevents a future metadata field from
+    # bypassing the node cap by accident.
+    if timestamp is not None or completed is not None:
+        budget.node()
+
+
+def _safe_media_ref(value: Any, budget: _Budget) -> tuple[str | None, bool]:
+    if value is None:
+        return None, False
+    if isinstance(value, Mapping):
+        value = (
+            value.get("url")
+            or value.get("ref")
+            or value.get("file_id")
+            or value.get("file_ref")
+            or value.get("path")
+        )
+    if not isinstance(value, str):
+        return None, True
+    raw = budget.text(value, MAX_REFERENCE_SCALARS).strip()
+    if not raw:
+        return None, False
+    if raw.startswith("data:"):
+        # Inline bytes are content, not a safe durable reference. Keep only the
+        # media header so an event/row cannot leak image/audio bytes or a token.
+        header = raw.split(",", 1)[0]
+        return budget.text(header, MAX_REFERENCE_SCALARS), True
+    if raw.startswith("@image:"):
+        # The gateway uses this marker for local attachments.  Persist only a
+        # harmless basename so a display event/row cannot disclose the
+        # operator's absolute filesystem path.
+        marker_path = raw[len("@image:"):].replace("\\", "/")
+        basename = marker_path.rsplit("/", 1)[-1]
+        if not basename or basename in {".", ".."}:
+            basename = "attachment"
+        safe = "@image:" + basename
+        return budget.text(safe, MAX_REFERENCE_SCALARS), safe != raw
+    if raw.startswith("@"):
+        return budget.text("@attachment", MAX_REFERENCE_SCALARS), True
+    try:
+        parsed = urlsplit(raw)
+    except ValueError:
+        return None, True
+    if parsed.scheme in {"http", "https"} and parsed.hostname:
+        # Strip userinfo, query and fragment. Signed URLs are credentials, and
+        # the display contract carries a ref rather than a fetch authority.
+        host = parsed.hostname
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        try:
+            port = parsed.port
+        except ValueError:
+            return "media:invalid", True
+        if port:
+            host = f"{host}:{port}"
+        safe = urlunsplit((parsed.scheme, host, parsed.path, "", ""))
+        return budget.text(safe, MAX_REFERENCE_SCALARS), safe != raw
+    if parsed.scheme == "file":
+        return "file:local", True
+    if parsed.scheme or raw.startswith("/") or re.match(r"^[A-Za-z]:[\\/]", raw):
+        return "file:local", True
+    # Relative refs are useful for a gateway-managed artifact; arbitrary
+    # opaque strings are retained only as bounded inert references.
+    if ":" not in raw:
+        # Relative references are inert, but avoid carrying path traversal or
+        # an accidental absolute path from a foreign platform.
+        normalized = raw.replace("\\", "/")
+        if normalized.startswith("/") or "/../" in f"/{normalized}/":
+            basename = normalized.rsplit("/", 1)[-1] or "attachment"
+            return budget.text("attachment:" + basename, MAX_REFERENCE_SCALARS), True
+        return raw, False
+    return None, True
+
+
+def _source_type(source: Mapping[str, Any]) -> str:
+    value = source.get("kind", source.get("type"))
+    return value if isinstance(value, str) else ""
+
+
+def _json_value(value: Any, budget: _Budget, depth: int = 0) -> Any:
+    """Copy JSON-like tool evidence without walking an attacker-sized tree."""
+    if depth > MAX_DEPTH:
+        budget.clipped = True
+        return {"clipped": True, "reason": "depth"}
+    if not budget.node():
+        return {"clipped": True, "reason": "nodes"}
+    if value is None or isinstance(value, (bool, int, float)):
+        if not budget.scalar():
+            return {"clipped": True, "reason": "scalars"}
+        if isinstance(value, int) and not isinstance(value, bool) and abs(value) > 1_000_000_000_000:
+            budget.clipped = True
+            return {"clipped": True, "reason": "number"}
+        if isinstance(value, float) and (not math.isfinite(value) or abs(value) > 1_000_000_000_000):
+            budget.clipped = True
+            return {"clipped": True, "reason": "number"}
+        return value
+    if isinstance(value, str):
+        return budget.text(value)
+    if isinstance(value, Mapping):
+        result: dict[str, Any] = {}
+        for index, (key, item) in enumerate(value.items()):
+            if index >= MAX_NODES:
+                budget.clipped = True
+                break
+            name = budget.text(key, MAX_ID_SCALARS)
+            if not name:
+                budget.clipped = True
+                continue
+            result[name] = _json_value(item, budget, depth + 1)
+        return result
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        result = []
+        for item in value:
+            if len(result) >= MAX_PARTS or budget.nodes >= MAX_NODES:
+                budget.clipped = True
+                break
+            result.append(_json_value(item, budget, depth + 1))
+        return result
+    budget.clipped = True
+    return {"clipped": True, "reason": "unsupported"}
+
+
+def _arguments(source: Mapping[str, Any], budget: _Budget) -> Any:
+    value = source.get("arguments", source.get("args", source.get("input")))
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (TypeError, ValueError):
+            return {"text": budget.text(value), "malformed": True}
+    if value is None:
+        return None
+    return _json_value(value, budget)
+
+
+def _base_part(source: Mapping[str, Any], kind: str, budget: _Budget) -> dict[str, Any]:
+    part: dict[str, Any] = {"kind": kind}
+    identity = _identity(
+        source.get("part_id", source.get("id", source.get("tool_call_id", source.get("tool_id")))),
+        budget,
+    )
+    if identity:
+        part["id"] = identity
+    _copy_timing(source, part, budget)
+    return part
+
+
+def _map_part(
+    source: Any,
+    budget: _Budget,
+    *,
+    tool_result_id: str | None = None,
+    tool_result_name: str | None = None,
+) -> dict[str, Any] | None:
+    if isinstance(source, str):
+        source = {"type": "text", "text": source}
+    if not isinstance(source, Mapping):
+        part = {"kind": "malformed", "evidence": budget.text(type(source).__name__, MAX_ID_SCALARS)}
+        part["clipped"] = True
+        budget.clipped = True
+        return part
+    raw_kind = _source_type(source)
+    if raw_kind in _TEXT_TYPES:
+        kind = "text"
+    elif raw_kind in _REASONING_TYPES:
+        kind = "reasoning"
+    elif raw_kind in _IMAGE_TYPES:
+        kind = "image"
+    elif raw_kind in _AUDIO_TYPES:
+        kind = "audio"
+    elif raw_kind in _FILE_TYPES:
+        kind = "file"
+    elif raw_kind in {"tool", "tool_call", "tool-call", "invocation"}:
+        kind = "tool-call"
+    elif raw_kind in {"tool_result", "tool-result", "result"}:
+        kind = "tool-result"
+    elif "text" in source or "content" in source:
+        kind = "text"
+    else:
+        kind = "unknown"
+
+    if tool_result_id is not None:
+        result = _base_part(source, "tool-result", budget)
+        result["id"] = tool_result_id
+        if tool_result_name:
+            result["name"] = tool_result_name
+        result["content_kind"] = kind
+    else:
+        result = _base_part(source, kind, budget)
+
+    if kind in {"text", "reasoning"}:
+        value = source.get("text", source.get("content", ""))
+        result["text"] = budget.text(value)
+    elif kind in {"image", "audio", "file"}:
+        candidate = source.get("url", source.get("ref"))
+        if candidate is None:
+            for nested_key in ("image_url", "input_image", "audio", "input_audio", "file", "input_file"):
+                if nested_key in source:
+                    candidate = source.get(nested_key)
+                    break
+        ref, clipped = _safe_media_ref(candidate, budget)
+        if ref:
+            result["ref"] = ref
+        mime = source.get("mime_type", source.get("mime", source.get("format")))
+        if isinstance(mime, str) and mime:
+            result["mime_type"] = budget.text(mime, MAX_ID_SCALARS)
+        if clipped or not ref:
+            result["clipped"] = True
+            budget.clipped = True
+    elif kind == "tool-call":
+        name = _identity(source.get("name", source.get("tool_name")), budget)
+        if name:
+            result["name"] = name
+        arguments = _arguments(source, budget)
+        if arguments is not None:
+            result["arguments"] = arguments
+    elif kind == "tool-result":
+        # A canonical tool-result can be admitted more than once (DB write,
+        # DB read, resume projection, wire copy). Preserve its evidence on
+        # every pass instead of treating only the provider-native shape as
+        # authoritative.
+        name = _identity(source.get("name", source.get("tool_name")), budget)
+        if name:
+            result["name"] = name
+        content_kind = source.get("content_kind")
+        if isinstance(content_kind, str) and content_kind:
+            result["content_kind"] = budget.text(content_kind, MAX_ID_SCALARS)
+        if content_kind in {"image", "audio", "file"} and source.get("ref") is not None:
+            ref, clipped = _safe_media_ref(source.get("ref"), budget)
+            if ref:
+                result["ref"] = ref
+            mime = source.get("mime_type")
+            if isinstance(mime, str) and mime:
+                result["mime_type"] = budget.text(mime, MAX_ID_SCALARS)
+            if clipped or not ref:
+                result["clipped"] = True
+                budget.clipped = True
+        else:
+            value = source.get(
+                "value",
+                source.get("text", source.get("content", source.get("result", ""))),
+            )
+            if isinstance(value, (Mapping, Sequence)) and not isinstance(value, (str, bytes, bytearray)):
+                result["value"] = _json_value(value, budget)
+            else:
+                result["text"] = budget.text(value)
+    else:
+        result["source_type"] = budget.text(raw_kind or "unknown", MAX_ID_SCALARS)
+        evidence = source.get("text", source.get("content", source.get("value")))
+        if evidence is not None and not isinstance(evidence, (Mapping, Sequence)):
+            result["evidence"] = budget.text(evidence)
+        result["clipped"] = True
+        budget.clipped = True
+    return result
+
+
+def _canonical_envelope(value: Any, budget: _Budget) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    raw_parts = value.get("parts", value.get("items"))
+    if not isinstance(raw_parts, list):
+        return None
+    parts: list[dict[str, Any]] = []
+    for raw in raw_parts:
+        if len(parts) >= MAX_PARTS:
+            budget.clipped = True
+            break
+        # Clipping is envelope evidence, not a second content item.  Drop an
+        # already-materialized marker while normalizing concatenated message
+        # runs; _finish puts one marker at the end so later tool results keep
+        # their original order.
+        if isinstance(raw, Mapping) and raw.get("kind") == "clipped":
+            budget.clipped = True
+            continue
+        mapped = _map_part(raw, budget)
+        if mapped is not None:
+            parts.append(mapped)
+    clipped = bool(value.get("clipped") or value.get("parts_clipped") or budget.clipped)
+    return _finish(parts, clipped, budget)
+
+
+def _finish(parts: list[dict[str, Any]], clipped: bool, budget: _Budget) -> dict[str, Any]:
+    clipped = bool(clipped or budget.clipped)
+    envelope: dict[str, Any] = {"version": PARTS_VERSION, "parts": parts, "clipped": clipped}
+    marker = {"kind": "clipped", "clipped": True, "reason": "budget"}
+    if clipped:
+        # The marker itself consumes one part slot. Replace the last admitted
+        # item at the hard boundary rather than returning MAX_PARTS + 1.
+        if len(parts) >= MAX_PARTS:
+            del parts[MAX_PARTS - 1:]
+        parts.append(marker)
+        envelope["clipped"] = True
+    while _encoded_size(envelope) > MAX_BYTES and len(parts) > 1:
+        # Keep explicit clipping evidence at the tail while dropping the
+        # newest content item atomically.
+        marker_at_tail = parts[-1].get("kind") == "clipped"
+        del parts[-2 if marker_at_tail else -1]
+        envelope["clipped"] = True
+    if len(parts) > MAX_PARTS:
+        del parts[MAX_PARTS:]
+        envelope["clipped"] = True
+    return envelope
+
+
+def _encoded_size(value: Any) -> int:
+    try:
+        return len(json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
+    except (TypeError, ValueError):
+        return MAX_BYTES + 1
+
+
+def message_parts(message: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Build a bounded canonical envelope for one message."""
+    if not isinstance(message, Mapping):
+        return {"version": PARTS_VERSION, "parts": [], "clipped": True}
+    budget = _Budget()
+    supplied = message.get("parts")
+    if isinstance(supplied, Mapping):
+        envelope = _canonical_envelope(supplied, budget)
+        if envelope is not None:
+            return envelope
+    elif isinstance(supplied, list):
+        envelope = _canonical_envelope({"parts": supplied}, budget)
+        if envelope is not None:
+            return envelope
+
+    role = message.get("role")
+    parts: list[dict[str, Any]] = []
+    if role == "assistant":
+        reasoning = message.get("reasoning") or message.get("reasoning_content")
+        if reasoning:
+            mapped = _map_part({"type": "reasoning", "text": reasoning}, budget)
+            if mapped:
+                parts.append(mapped)
+
+    content = message.get("content")
+    if isinstance(content, Mapping) and content.get("_multimodal") is True:
+        content = content.get("content")
+    if isinstance(content, list):
+        for raw in content:
+            if len(parts) >= MAX_PARTS:
+                budget.clipped = True
+                break
+            mapped = _map_part(
+                raw,
+                budget,
+                tool_result_id=_identity(message.get("tool_call_id"), budget) if role == "tool" else None,
+                tool_result_name=_identity(message.get("tool_name", message.get("name")), budget) if role == "tool" else None,
+            )
+            if mapped:
+                parts.append(mapped)
+    elif content is not None:
+        if role == "tool" and isinstance(content, (Mapping, Sequence)) and not isinstance(content, (str, bytes, bytearray)):
+            source = {"type": "tool-result", "result": content}
+        else:
+            source = {"type": "text", "text": content}
+        mapped = _map_part(
+            source,
+            budget,
+            tool_result_id=_identity(message.get("tool_call_id"), budget) if role == "tool" else None,
+            tool_result_name=_identity(message.get("tool_name", message.get("name")), budget) if role == "tool" else None,
+        )
+        if mapped and (mapped.get("text") or mapped.get("kind") not in {"text", "reasoning"}):
+            parts.append(mapped)
+
+    if role == "assistant" and isinstance(message.get("tool_calls"), list):
+        for raw_call in message["tool_calls"][:MAX_PARTS]:
+            if len(parts) >= MAX_PARTS:
+                budget.clipped = True
+                break
+            if not isinstance(raw_call, Mapping):
+                budget.clipped = True
+                continue
+            function = raw_call.get("function")
+            source = dict(function) if isinstance(function, Mapping) else dict(raw_call)
+            source.setdefault("type", "tool-call")
+            source.setdefault("id", raw_call.get("id", raw_call.get("tool_call_id")))
+            mapped = _map_part(source, budget)
+            if mapped:
+                parts.append(mapped)
+    return _finish(parts, budget.clipped, budget)
+
+
+def wire_fields(envelope: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return the additive fields used by display/live gateway payloads."""
+    normalized = message_parts({"parts": envelope}) if envelope is not None else message_parts(None)
+    return {
+        "parts": copy.deepcopy(normalized["parts"]),
+        "parts_version": PARTS_VERSION,
+        "parts_clipped": bool(normalized.get("clipped")),
+    }
+
+
+def stream_text_part(text: Any, *, part_id: str = "assistant-stream", timestamp: Any = None) -> dict[str, Any]:
+    source: dict[str, Any] = {"type": "text", "text": text, "id": part_id}
+    if timestamp is not None:
+        source["timestamp"] = timestamp
+    envelope = message_parts({"role": "assistant", "parts": [source]})
+    return envelope["parts"][0] if envelope["parts"] else {"kind": "clipped", "clipped": True}
+
+
+__all__ = [
+    "MAX_BYTES",
+    "MAX_DEPTH",
+    "MAX_NODES",
+    "MAX_PARTS",
+    "MAX_SCALARS",
+    "MAX_STRING_SCALARS",
+    "PARTS_VERSION",
+    "message_parts",
+    "stream_text_part",
+    "wire_fields",
+]

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -694,7 +694,7 @@ def _(rid, params: dict) -> dict:
             # feeds live replay. Fall back to it if the display read fails.
             try:
                 display_history = db.get_messages_as_conversation(
-                    target, repair_alternation=False, include_row_ids=True
+                    target, repair_alternation=False, include_row_ids=True, include_parts=True
                 )
             except Exception:
                 logger.debug("child-watch display projection read failed", exc_info=True)
@@ -2793,6 +2793,7 @@ def _(rid, params: dict) -> dict:
                         session["session_key"],
                         include_ancestors=True,
                         include_row_ids=True,
+                        include_parts=True,
                     )
                 except Exception:
                     pass

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8245,14 +8245,49 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
 
 
 def _assistant_turn_parts(
-    messages: Any, *, fallback_text: Any = "", reasoning: Any = None
+    messages: Any, *, fallback_text: Any = "", reasoning: Any = None,
+    prior_history_count: int | None = None, turn_user_content: Any = None,
 ) -> dict[str, Any]:
-    """Collect the ordered assistant/tool run after the latest user row."""
+    """Collect the complete assistant/tool run after this turn's user row.
+
+    Conversation-loop recovery can append synthetic user-role nudges inside
+    one logical turn. Using the *latest* user row truncates the terminal
+    replacement at that nudge and discards already-sealed commentary/tools.
+    The caller knows the pre-turn history boundary and exact submitted wire
+    content, so prefer those authorities; retain the old latest-user fallback
+    only for isolated callers that provide neither.
+    """
     rows = messages if isinstance(messages, list) else []
     start = 0
-    for index, row in enumerate(rows):
-        if isinstance(row, dict) and row.get("role") == "user":
-            start = index + 1
+    boundary_found = False
+    if isinstance(prior_history_count, int) and prior_history_count >= 0:
+        for candidate in range(prior_history_count, len(rows)):
+            row = rows[candidate]
+            if (
+                isinstance(row, dict)
+                and row.get("role") == "user"
+                and (
+                    turn_user_content is None
+                    or row.get("content") == turn_user_content
+                )
+            ):
+                start = candidate + 1
+                boundary_found = True
+                break
+    if not boundary_found and turn_user_content is not None:
+        for index in range(len(rows) - 1, -1, -1):
+            row = rows[index]
+            if (
+                isinstance(row, dict)
+                and row.get("role") == "user"
+                and row.get("content") == turn_user_content
+            ):
+                start = index + 1
+                boundary_found = True
+    if not boundary_found and prior_history_count is None and turn_user_content is None:
+        for index, row in enumerate(rows):
+            if isinstance(row, dict) and row.get("role") == "user":
+                start = index + 1
     parts: list[dict[str, Any]] = []
     for row in rows[start:]:
         if not isinstance(row, dict) or row.get("role") not in {"assistant", "tool"}:
@@ -11885,6 +11920,8 @@ def _run_prompt_submit(
                 result.get("messages") if isinstance(result, dict) else None,
                 fallback_text=raw,
                 reasoning=last_reasoning,
+                prior_history_count=len(history),
+                turn_user_content=run_message,
             )
             payload.update(_wire_part_fields(_assistant_envelope))
             payload["parts_mode"] = "replace"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -140,6 +140,11 @@ except Exception:
     pass
 
 from tui_gateway.render import make_stream_renderer, render_diff, render_message
+from transcript_parts import (
+    message_parts as _message_parts,
+    stream_text_part as _stream_text_part,
+    wire_fields as _wire_part_fields,
+)
 
 _sessions: dict[str, dict] = {}
 _methods: dict[str, callable] = {}
@@ -6433,6 +6438,15 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
             args_text = _tool_args_text(args)
             if args_text:
                 payload["args_text"] = args_text
+        payload.update(_wire_part_fields(_message_parts({
+            "role": "assistant",
+            "parts": [{
+                "kind": "tool-call",
+                "id": tool_call_id,
+                "name": name,
+                "arguments": args,
+            }],
+        })))
         # tool.complete is the source of truth for todos (full list from the
         # tool result). args.todos here may be a partial merge update.
         _emit("tool.start", sid, payload)
@@ -6460,6 +6474,12 @@ def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result
         result_text = _tool_result_text(result)
         if result_text:
             payload["result_text"] = result_text
+    payload.update(_wire_part_fields(_message_parts({
+        "role": "tool",
+        "content": payload.get("result"),
+        "tool_call_id": tool_call_id,
+        "tool_name": name,
+    })))
     if name == "todo":
         try:
             data = json.loads(result)
@@ -8088,6 +8108,7 @@ def _legacy_display_kind(role: str, text: str) -> str | None:
 def _history_to_messages(history: list[dict]) -> list[dict]:
     messages = []
     tool_call_args = {}
+    tool_calls_projected_with_assistant: set[str] = set()
 
     for m in history:
         if not isinstance(m, dict):
@@ -8106,26 +8127,46 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
         if m.get("display_kind") == "hidden":
             continue
         content_text = _coerce_message_text(m.get("content"))
+        parts_envelope = _message_parts(m)
         if _is_display_hidden_marker(role, content_text):
             continue
         if role == "assistant" and m.get("tool_calls"):
+            row_tool_call_ids: list[str] = []
             for tc in m["tool_calls"]:
                 fn = tc.get("function", {})
                 tc_id = tc.get("id", "")
                 if tc_id and fn.get("name"):
                     try:
-                        args = json.loads(fn.get("arguments", "{}"))
+                        raw_args = fn.get("arguments", "{}")
+                        args = raw_args if isinstance(raw_args, dict) else json.loads(raw_args)
                     except (json.JSONDecodeError, TypeError):
                         args = {}
                     tool_call_args[tc_id] = (fn["name"], args)
+                    row_tool_call_ids.append(tc_id)
             if not content_text.strip():
                 continue
+            # This row will carry its own tool-call parts alongside the
+            # assistant commentary. The later tool row must not prepend the
+            # same invocation a second time.
+            tool_calls_projected_with_assistant.update(row_tool_call_ids)
         if role == "tool":
             tc_id = m.get("tool_call_id", "")
             tc_info = tool_call_args.get(tc_id) if tc_id else None
             name = (tc_info[0] if tc_info else None) or m.get("tool_name") or "tool"
             args = (tc_info[1] if tc_info else None) or {}
             tool_msg = {"role": "tool", "name": name, "context": _tool_ctx(name, args)}
+            if tc_id and tc_info and tc_id not in tool_calls_projected_with_assistant:
+                invocation = _message_parts({
+                    "role": "assistant",
+                    "tool_calls": [{
+                        "id": tc_id,
+                        "function": {"name": name, "arguments": args},
+                    }],
+                })
+                parts_envelope = _message_parts({
+                    "parts": invocation["parts"] + parts_envelope["parts"],
+                })
+            tool_msg.update(_wire_part_fields(parts_envelope))
             # This is the display projection, so keep it faithful. `context`
             # is an 80-char preview for collapsed row titles. A renderer that
             # shows the full call (the expanded `$` transcript in the desktop)
@@ -8151,9 +8192,18 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
         has_reasoning = role == "assistant" and any(
             m.get(key) for key in reasoning_keys
         )
-        if not content_text.strip() and not has_reasoning:
+        visible_parts = [
+            part for part in parts_envelope["parts"]
+            if part.get("kind") != "tool-call"
+            and (
+                part.get("kind") not in {"text", "reasoning"}
+                or bool(str(part.get("text") or "").strip())
+            )
+        ]
+        if not content_text.strip() and not has_reasoning and not visible_parts:
             continue
         msg = {"role": role, "text": content_text}
+        msg.update(_wire_part_fields(parts_envelope))
         # Persisted authoring time (Unix seconds) for display.timestamps
         # renderers (#41531). Display-only: never fed back into model context.
         ts = m.get("timestamp")
@@ -8174,6 +8224,9 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
                 # turn by ordinal, so no client needs it.
                 msg["text"] = invocation
                 msg["display_kind"] = "skill_invocation"
+                msg.update(_wire_part_fields(_message_parts({
+                    "role": "user", "content": invocation,
+                })))
         if role == "assistant":
             for key in reasoning_keys:
                 if key in m and m.get(key) is not None:
@@ -8189,6 +8242,37 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
         messages.append(msg)
 
     return messages
+
+
+def _assistant_turn_parts(
+    messages: Any, *, fallback_text: Any = "", reasoning: Any = None
+) -> dict[str, Any]:
+    """Collect the ordered assistant/tool run after the latest user row."""
+    rows = messages if isinstance(messages, list) else []
+    start = 0
+    for index, row in enumerate(rows):
+        if isinstance(row, dict) and row.get("role") == "user":
+            start = index + 1
+    parts: list[dict[str, Any]] = []
+    for row in rows[start:]:
+        if not isinstance(row, dict) or row.get("role") not in {"assistant", "tool"}:
+            continue
+        envelope = _message_parts(row)
+        parts.extend(envelope.get("parts") or [])
+    if not parts:
+        parts = _message_parts({
+            "role": "assistant",
+            "content": fallback_text,
+            "reasoning": reasoning,
+        }).get("parts") or []
+    return _message_parts({"parts": parts})
+
+
+def _set_inflight_assistant_parts(session: dict, envelope: dict[str, Any]) -> None:
+    turn = session.get("inflight_turn")
+    if not isinstance(turn, dict):
+        return
+    turn["assistant_parts"] = list(envelope.get("parts") or [])
 
 
 def _coerce_seed_history(value: Any) -> list[dict]:
@@ -8249,14 +8333,23 @@ def _inflight_text(value: Any) -> str:
     return _content_display_text(value).strip()
 
 
-def _start_inflight_turn(session: dict, text: Any) -> None:
+def _start_inflight_turn(
+    session: dict, text: Any, image_paths: list[str] | None = None
+) -> None:
     now = time.time()
+    content: Any = text
+    if image_paths:
+        content = [{"type": "text", "text": text}]
+        content.extend({"type": "image", "ref": f"@image:{path}"} for path in image_paths)
+    user_parts = _message_parts({"role": "user", "content": content})
     session["inflight_turn"] = {
         "assistant": "",
+        "assistant_parts": [],
         "started_at": now,
         "streaming": True,
         "updated_at": now,
         "user": _inflight_text(text),
+        "user_parts": user_parts,
     }
 
 
@@ -8266,8 +8359,19 @@ def _append_inflight_delta(session: dict, delta: Any) -> None:
         return
     turn = session.get("inflight_turn")
     if not isinstance(turn, dict):
-        turn = {"assistant": "", "streaming": True, "user": ""}
+        turn = {"assistant": "", "assistant_parts": [], "streaming": True, "user": ""}
     turn["assistant"] = f"{turn.get('assistant') or ''}{text}"
+    current_parts = list(turn.get("assistant_parts") or [])
+    if current_parts and current_parts[-1].get("kind") == "text" \
+            and current_parts[-1].get("id") == "assistant-stream":
+        current_parts[-1] = _stream_text_part(
+            f"{current_parts[-1].get('text') or ''}{text}",
+            part_id="assistant-stream",
+            timestamp=current_parts[-1].get("timestamp"),
+        )
+    else:
+        current_parts.append(_stream_text_part(text, timestamp=time.time()))
+    turn["assistant_parts"] = _message_parts({"parts": current_parts})["parts"]
     turn["streaming"] = True
     turn["updated_at"] = time.time()
     session["inflight_turn"] = turn
@@ -8875,6 +8979,22 @@ def _inflight_snapshot(session: dict) -> dict | None:
         "streaming": streaming,
         "user": user,
     }
+    assistant_envelope = _message_parts({
+        "role": "assistant",
+        "parts": turn.get("assistant_parts") or ([{"type": "text", "text": assistant}] if assistant else []),
+    })
+    if assistant_envelope["parts"]:
+        snapshot.update(_wire_part_fields(assistant_envelope))
+    user_envelope = turn.get("user_parts")
+    if not isinstance(user_envelope, dict) and user:
+        # In-memory turns created by an older process predate user_parts.
+        # Synthesize the same bounded text fallback used for legacy durable
+        # rows so a reconnect never changes the additive contract shape.
+        user_envelope = _message_parts({"role": "user", "content": user})
+    if isinstance(user_envelope, dict) and isinstance(user_envelope.get("parts"), list):
+        user_fields = _wire_part_fields(user_envelope)
+        snapshot["user_parts"] = user_fields["parts"]
+        snapshot["user_parts_clipped"] = user_fields["parts_clipped"]
     raw_corrections = turn.get("corrections") or []
     raw_offsets = turn.get("correction_offsets") or []
     correction_pairs = [
@@ -8949,6 +9069,11 @@ def _emit_terminal_turn_error(
         "error": message,
         "recoverable": True,
     }
+    payload.update(_wire_part_fields(_message_parts({
+        "role": "assistant",
+        "parts": turn.get("assistant_parts") or ([{"type": "text", "text": partial}] if partial else []),
+    })))
+    payload["parts_mode"] = "replace"
     if error_surface:
         payload["error_surface"] = error_surface
     if partial:
@@ -9422,7 +9547,9 @@ def _live_visible_history(session: dict, db, in_memory_fallback: list[dict]) -> 
     key = session.get("session_key")
     if db is not None and key:
         try:
-            display = db.get_messages_as_conversation(key, include_ancestors=True, include_row_ids=True)
+            display = db.get_messages_as_conversation(
+                key, include_ancestors=True, include_row_ids=True, include_parts=True
+            )
             return _reconcile_display_with_live(display, in_memory_fallback)
         except Exception:
             logger.debug("live display projection read failed", exc_info=True)
@@ -11218,7 +11345,7 @@ def _run_prompt_submit(
         # A retained failed turn (see _fail_inflight_turn) is a stale leftover
         # by the time a new turn starts — replace it, never append onto it.
         if not isinstance(inflight, dict) or inflight.get("status") == "error":
-            _start_inflight_turn(session, text)
+            _start_inflight_turn(session, text, images)
         agent = session["agent"]
         if hasattr(agent, "clear_interrupt"):
             try:
@@ -11244,7 +11371,20 @@ def _run_prompt_submit(
         len(text) if isinstance(text, str) else "-",
         len(images),
     )
-    _emit("message.start", sid)
+    _start_parts_content: Any = text
+    if images:
+        _start_parts_content = [{"type": "text", "text": text}]
+        _start_parts_content.extend(
+            {"type": "image", "ref": f"@image:{path}"} for path in images
+        )
+    _emit(
+        "message.start",
+        sid,
+        _wire_part_fields(_message_parts({
+            "role": "user",
+            "content": _start_parts_content,
+        })),
+    )
 
     def run():
         # The conversation runs on a fresh thread, so ContextVars from the RPC
@@ -11486,6 +11626,11 @@ def _run_prompt_submit(
                 with session["history_lock"]:
                     _append_inflight_delta(session, delta)
                 payload = {"text": delta}
+                payload.update(_wire_part_fields(_message_parts({
+                    "role": "assistant",
+                    "parts": [_stream_text_part(delta, timestamp=time.time())],
+                })))
+                payload["parts_mode"] = "append"
                 if streamer and (r := streamer.feed(delta)) is not None:
                     payload["rendered"] = r
                 if tts_queue is not None and isinstance(delta, str):
@@ -11499,10 +11644,16 @@ def _run_prompt_submit(
             # Gated on display.interim_assistant_messages (default true).
             if _load_interim_assistant_messages():
                 def _interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:
-                    _emit("message.interim", sid, {
+                    payload = {
                         "text": text,
                         "already_streamed": already_streamed,
-                    })
+                    }
+                    payload.update(_wire_part_fields(_message_parts({
+                        "role": "assistant",
+                        "parts": [_stream_text_part(text, timestamp=time.time())],
+                    })))
+                    payload["parts_mode"] = "seal" if already_streamed else "append"
+                    _emit("message.interim", sid, payload)
 
                 agent.interim_assistant_callback = _interim_assistant_cb
             else:
@@ -11730,6 +11881,13 @@ def _run_prompt_submit(
                 status = "complete"
 
             payload = {"text": raw, "usage": _get_usage(agent), "status": status}
+            _assistant_envelope = _assistant_turn_parts(
+                result.get("messages") if isinstance(result, dict) else None,
+                fallback_text=raw,
+                reasoning=last_reasoning,
+            )
+            payload.update(_wire_part_fields(_assistant_envelope))
+            payload["parts_mode"] = "replace"
             if last_reasoning:
                 payload["reasoning"] = last_reasoning
             if status_note:
@@ -11766,6 +11924,7 @@ def _run_prompt_submit(
                 except Exception:
                     _error_surface = None
             with session["history_lock"]:
+                _set_inflight_assistant_parts(session, _assistant_envelope)
                 if status == "error":
                     # Returned-error result (provider 4xx, budget, etc.): retain
                     # the failed turn for resume replay instead of clearing it.
@@ -14493,7 +14652,7 @@ def _format_live_history_output(session: dict) -> str:
         if db is not None and session.get("session_key"):
             try:
                 history = db.get_messages_as_conversation(
-                    session["session_key"], include_ancestors=True, include_row_ids=True
+                    session["session_key"], include_ancestors=True, include_row_ids=True, include_parts=True
                 )
             except Exception:
                 pass
@@ -14536,7 +14695,7 @@ def _format_live_context_output(session: dict) -> str:
             try:
                 messages = _history_to_messages(
                     db.get_messages_as_conversation(
-                        session["session_key"], include_ancestors=True, include_row_ids=True
+                        session["session_key"], include_ancestors=True, include_row_ids=True, include_parts=True
                     )
                 )
             except Exception:

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -1,5 +1,6 @@
 import type { BillingBlock, UsageModelData } from '@hermes/shared/billing'
 import type { HermesSkin } from '@hermes/shared/skin'
+import type { GatewayTranscriptPart, GatewayTranscriptPartsFields } from '@hermes/shared/transcript-parts'
 
 import type { SessionInfo, SlashCategory, SubagentStatus, Usage } from './types.js'
 
@@ -16,7 +17,7 @@ export interface GatewayCompletionItem {
   text: string
 }
 
-export interface GatewayTranscriptMessage {
+export interface GatewayTranscriptMessage extends GatewayTranscriptPartsFields {
   context?: string
   display_kind?: string
   display_metadata?: Record<string, unknown>
@@ -212,10 +213,12 @@ export interface SessionActiveListResponse {
   sessions?: SessionActiveItem[]
 }
 
-export interface SessionInflightTurn {
+export interface SessionInflightTurn extends GatewayTranscriptPartsFields {
   assistant?: string
   streaming?: boolean
   user?: string
+  user_parts?: GatewayTranscriptPart[]
+  user_parts_clipped?: boolean
 }
 
 export interface SessionActivateResponse {
@@ -616,7 +619,7 @@ export type GatewayEvent =
   | { payload: SessionInfo; session_id?: string; type: 'session.info' }
   | { payload?: { text?: string }; session_id?: string; type: 'thinking.delta' }
   | { payload?: { kind?: string }; session_id?: string; type: 'reaction' }
-  | { payload?: undefined; session_id?: string; type: 'message.start' }
+  | { payload?: GatewayTranscriptPartsFields; session_id?: string; type: 'message.start' }
   | { payload?: { kind?: string; text?: string }; session_id?: string; type: 'status.update' }
   | {
       payload?: {
@@ -684,12 +687,18 @@ export type GatewayEvent =
   | { payload: { name?: string; preview?: string }; session_id?: string; type: 'tool.progress' }
   | { payload: { name?: string }; session_id?: string; type: 'tool.generating' }
   | {
-      payload: { args_text?: string; context?: string; name?: string; tool_id: string; todos?: unknown[] }
+      payload: GatewayTranscriptPartsFields & {
+        args_text?: string
+        context?: string
+        name?: string
+        tool_id: string
+        todos?: unknown[]
+      }
       session_id?: string
       type: 'tool.start'
     }
   | {
-      payload: {
+      payload: GatewayTranscriptPartsFields & {
         duration_s?: number
         error?: string
         inline_diff?: string
@@ -735,14 +744,18 @@ export type GatewayEvent =
   | { payload: SubagentEventPayload; session_id?: string; type: 'subagent.tool' }
   | { payload: SubagentEventPayload; session_id?: string; type: 'subagent.progress' }
   | { payload: SubagentEventPayload; session_id?: string; type: 'subagent.complete' }
-  | { payload: { rendered?: string; text?: string }; session_id?: string; type: 'message.delta' }
   | {
-      payload: { already_streamed?: boolean; text: string }
+      payload: GatewayTranscriptPartsFields & { rendered?: string; text?: string }
+      session_id?: string
+      type: 'message.delta'
+    }
+  | {
+      payload: GatewayTranscriptPartsFields & { already_streamed?: boolean; text: string }
       session_id?: string
       type: 'message.interim'
     }
   | {
-      payload?: {
+      payload?: GatewayTranscriptPartsFields & {
         billing?: BillingBlock
         failure_reason?: string
         reasoning?: string


### PR DESCRIPTION
## Summary

- add a versioned, bounded ordered `parts` envelope beside the existing legacy text projection
- persist text, reasoning, media references, tool calls, and tool results through SQLite, compression clones, resume hydration, mirror/session writes, and live gateway events
- preserve provider/model history, role alternation, prompt-cache bytes, and unbounded legacy inflight text exactly as before
- redact signed URL authority, inline media bytes, and local paths while retaining inert modality evidence
- expose the additive contract through shared TypeScript and TUI gateway types
- retain the complete logical assistant/tool run when internal continuation nudges add synthetic user-role rows

## Contract

- legacy `content` / `text` remains authoritative and unchanged for existing clients
- `parts_version: 1`, `parts`, and `parts_clipped` are additive
- streaming uses `parts_mode: append`; terminal reconciliation uses `replace`; already-streamed interim boundaries use `seal`
- admission is bounded by part, node, depth, scalar, and encoded-byte limits with explicit clipping evidence
- legacy database rows and older in-memory inflight turns synthesize a bounded display-only fallback; model history never receives `parts`

## Verification

- rebased onto current upstream main `dc50f020905d5bdca5d5f683a5898f85b9c07dbd`
- focused logical-turn/ordered-parts contract: 10 passed
- TUI/session + Hermes-state regression: 848 passed
- the same broader suite on untouched current main: 838 passed with the same three failures (Desktop toolset order dependency, subprocess live-system guard cleanup, SQLite trace-callback assertion)
- shared TypeScript typecheck passed
- Ruff, compileall, and diff check passed

Exact implementation head: `d0f7ca737637c0ddd2b155d97c7c5dfd95e398f3`.

No live gateway deployment or physical-device claim is included in this PR. Independent QA is intentionally not self-posted.
