### PR TITLE
fix(desktop): refresh open transcripts after reconnect

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -159,20 +159,22 @@ describe('active transcript refresh', () => {
     )
   })
 
-  it('does not add a periodic transcript poll to local/Desktop sessions', async () => {
+  it('keeps a periodic visibility backstop for local/Desktop sessions', async () => {
     vi.useFakeTimers()
     $changeEventsAvailable.set(true)
     const refresh = vi.fn(async () => undefined)
 
     renderSync(refresh)
-    expect(refresh).not.toHaveBeenCalled()
+    expect(refresh).toHaveBeenCalledTimes(1)
+    await act(async () => Promise.resolve())
+    refresh.mockClear()
 
     await act(async () => {
-      vi.advanceTimersByTime(60_000)
+      vi.advanceTimersByTime(30_000)
       await Promise.resolve()
     })
 
-    expect(refresh).not.toHaveBeenCalled()
+    expect(refresh).toHaveBeenCalledTimes(1)
   })
 
   it('retains the existing periodic backstop for messaging sessions', async () => {
@@ -220,6 +222,7 @@ describe('active transcript refresh', () => {
     const refresh = vi.fn(async () => undefined)
 
     renderSync(refresh)
+    refresh.mockClear()
 
     act(() => {
       for (let index = 0; index < 20; index += 1) {

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -128,8 +128,8 @@ export async function reconcileActiveTranscript({
 const CRON_POLL_INTERVAL_MS = 30_000
 const CRON_BACKSTOP_INTERVAL_MS = 5 * 60_000
 const MESSAGING_POLL_INTERVAL_MS = 10_000
-const ACTIVE_MESSAGING_SESSION_POLL_INTERVAL_MS = 5_000
-const ACTIVE_MESSAGING_SESSION_BACKSTOP_INTERVAL_MS = 30_000
+const ACTIVE_TRANSCRIPT_POLL_INTERVAL_MS = 5_000
+const ACTIVE_TRANSCRIPT_BACKSTOP_INTERVAL_MS = 30_000
 // Match the TUI's live-session refresh cadence. Auto-compression can rotate a
 // stored session id while its turn keeps running; until the next snapshot the
 // sidebar row points at the new id while the renderer still knows the old one.
@@ -354,7 +354,6 @@ function visiblePoll(intervalMs: number, tick: () => void): () => void {
 export function useBackgroundSync({
   activeConnectionId,
   activeGatewayProfile,
-  activeIsMessaging,
   activeSessionId,
   activeStoredSessionId,
   freshDraftReady,
@@ -571,11 +570,12 @@ export function useBackgroundSync({
     requestActiveTranscriptRefresh(true)
   }, [activeSessionId, activeStoredSessionId, activeTranscriptBusy, gatewayState, requestActiveTranscriptRefresh])
 
-  // Preserve the pre-existing messaging behavior: refresh once when a
-  // messaging transcript opens, then keep its visibility backstop. Desktop
-  // sessions never enter this effect and therefore gain no periodic timer.
+  // Refresh once when any transcript opens, then keep a visibility-gated
+  // backstop. Change events remain the live path; the timer covers a renderer
+  // that stayed open while its runtime socket was interrupted or reaped and
+  // can therefore no longer rely on another sessions.changed broadcast.
   useEffect(() => {
-    if (gatewayState !== 'open' || !activeIsMessaging || !activeSessionId || !activeStoredSessionId) {
+    if (gatewayState !== 'open' || !activeSessionId || !activeStoredSessionId) {
       return
     }
 
@@ -584,11 +584,10 @@ export function useBackgroundSync({
     runScheduledRefresh()
 
     return visiblePoll(
-      changeEventsAvailable ? ACTIVE_MESSAGING_SESSION_BACKSTOP_INTERVAL_MS : ACTIVE_MESSAGING_SESSION_POLL_INTERVAL_MS,
+      changeEventsAvailable ? ACTIVE_TRANSCRIPT_BACKSTOP_INTERVAL_MS : ACTIVE_TRANSCRIPT_POLL_INTERVAL_MS,
       runScheduledRefresh
     )
   }, [
-    activeIsMessaging,
     activeSessionId,
     activeStoredSessionId,
     changeEventsAvailable,


### PR DESCRIPTION
## What does this PR do?

Keeps the active Desktop transcript hydrated after its runtime socket is interrupted or reaped. Change events remain the live path; an initial refresh and visibility-gated poll provide the backstop when the open renderer can no longer rely on a fresh `sessions.changed` broadcast.

This completes the visibility side of the session-recovery work already merged on `main`: resume-and-replay can recover the request, and the still-open transcript can now show the recovered result without requiring the user to switch away and back.

## Related Issue

Related to #91276. The failure was reproduced in Echo5 Engineering issue #258.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/contrib/hooks/use-background-sync.ts`: hydrate every open transcript immediately and keep the existing visibility-aware 5s/30s backstop, rather than limiting it to sessions already marked `MESSAGING`.
- `apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts`: prove a local/Desktop transcript refreshes on open and over time while preserving change-event coalescing.

## How to Test

1. Open a local/Desktop transcript whose runtime has been interrupted or reaped.
2. Allow the resumed turn or persisted reply to land without switching sessions.
3. Confirm the open transcript refreshes immediately and then through the visibility-gated backstop.

Automated evidence:

- `npm run test:ui -- --run src/app/contrib/hooks/use-background-sync.test.ts src/app/contrib/hooks/use-background-sync.test.tsx` — 16 passed.
- `npm run check` — passed: 5,616 UI tests, 1,674 platform tests with 3 skipped, and the desktop/plugin suites including 532 Bot Mode tests; lint reported 0 errors and 115 pre-existing warnings.
- `git diff --check` — passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — not run; this is a Desktop TypeScript-only change and the complete Desktop check passed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing contract or config changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer-only timer and visibility primitives already used by this hook
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable; the regression is covered at the hook boundary and by the complete Desktop test suite.
