### PR TITLE
fix(telegram): preserve cross-chat external reply context

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2343,6 +2343,10 @@ class MessageEvent:
     reply_to_author_id: Optional[str] = None
     reply_to_author_name: Optional[str] = None
     reply_to_is_own_message: bool = False  # True when the user replied to this bot/assistant's message
+    # True when the quoted context came from a cross-chat external reference
+    # (Telegram ``external_reply``): there is no in-chat message id, but the
+    # quote must still be injected as a disambiguation pointer.
+    reply_from_external: bool = False
 
     # Structured interactive-prompt reply (relay Phase 3). Present when this
     # event is the user answering a native interactive prompt rendered by the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18600,13 +18600,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"{message_text}"
                 )
 
-        if getattr(event, "reply_to_text", None) and event.reply_to_message_id:
+        if getattr(event, "reply_to_text", None) and (
+            event.reply_to_message_id or getattr(event, "reply_from_external", False)
+        ):
             # Always inject the reply-to pointer — even when the quoted text
             # already appears in history. The prefix isn't deduplication, it's
             # disambiguation: it tells the agent *which* prior message the user
             # is referencing. History can contain the same or similar text
             # multiple times, and without an explicit pointer the agent has to
             # guess (or answer for both subjects). Token overhead is minimal.
+            # Cross-chat external quotes (Telegram ``external_reply``) carry no
+            # in-chat message id, so they are gated on the explicit
+            # ``reply_from_external`` marker instead of an id.
             reply_snippet = event.reply_to_text[:500]
             if getattr(event, "reply_to_is_own_message", False):
                 message_text = (

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -10675,6 +10675,38 @@ class TelegramAdapter(BasePlatformAdapter):
         # / caption when no native quote is present.
         reply_to_id = None
         reply_to_text = None
+        # External replies (cross-chat quotes, ExternalReplyInfo): when the
+        # user quotes a message from a *different* chat or channel, Telegram
+        # sends ``external_reply`` and leaves ``reply_to_message`` empty.
+        # Without handling, the reference is dropped entirely and the agent
+        # receives a bare question with no idea what it refers to. Extract
+        # the quoted text/caption (preferring the user's manual selection)
+        # so the standard reply-context pipeline can inject it. There is no
+        # in-chat message id for an external reference, so ``reply_to_id``
+        # stays None; downstream injection must not require an id for this
+        # shape (see the matching change in gateway/run.py).
+        external_reply = getattr(message, "external_reply", None)
+        if external_reply is not None:
+            external_quote = getattr(message, "quote", None)
+            external_quote_text = (
+                getattr(external_quote, "text", None)
+                if external_quote is not None
+                else None
+            )
+            if not external_quote_text:
+                external_quote_text = (
+                    getattr(external_reply, "text", None)
+                    or getattr(external_reply, "caption", None)
+                )
+            if external_quote_text:
+                origin = getattr(external_reply, "origin", None)
+                origin_chat = getattr(origin, "chat", None) if origin is not None else None
+                origin_title = getattr(origin_chat, "title", None) if origin_chat is not None else None
+                if origin_title:
+                    reply_to_text = f"{origin_title}: {external_quote_text}"
+                else:
+                    reply_to_text = external_quote_text
+
         if message.reply_to_message:
             reply_to_id = str(message.reply_to_message.message_id)
             quote = getattr(message, "quote", None)
@@ -10719,6 +10751,9 @@ class TelegramAdapter(BasePlatformAdapter):
             platform_update_id=update_id,
             reply_to_message_id=reply_to_id,
             reply_to_text=reply_to_text,
+            reply_from_external=bool(
+                getattr(message, "external_reply", None) is not None and reply_to_text
+            ),
             auto_skill=topic_skill,
             channel_prompt=_channel_prompt,
             timestamp=message.date,

--- a/tests/gateway/test_telegram_external_reply.py
+++ b/tests/gateway/test_telegram_external_reply.py
@@ -1,0 +1,166 @@
+"""Tests for Telegram external-reply (cross-chat quote) handling.
+
+Telegram delivers two distinct reply shapes:
+
+* ``message.reply_to_message`` — a reply inside the same chat. The adapter
+  already extracts its text via the quote → full-text → rich-echo chain.
+* ``message.external_reply`` — a reply/quote pointing at a message in a
+  *different* chat or channel (``ExternalReplyInfo``). No
+  ``reply_to_message`` is populated in that case, so without explicit
+  support the adapter previously dropped the reference entirely: the agent
+  received a bare "what does this mean?" with zero context about what was
+  being asked about.
+
+These tests pin the external-reply contract: extract the quoted text (or a
+caption for media origins), attribute it to the originating chat, and feed
+it through the normal ``reply_to_*`` pipeline so ``_prepare_inbound_message_text``
+injects the standard disambiguation prefix.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def _make_adapter():
+    return TelegramAdapter(PlatformConfig(enabled=True, token="***", extra={}))
+
+
+def _make_message(
+    text="what does this mean?",
+    external_reply=None,
+    quote=None,
+):
+    chat = SimpleNamespace(id=111, type="private", title=None, full_name="Alice")
+    user = SimpleNamespace(id=42, full_name="Alice")
+    return SimpleNamespace(
+        chat=chat,
+        from_user=user,
+        text=text,
+        message_thread_id=None,
+        message_id=1001,
+        reply_to_message=None,
+        external_reply=external_reply,
+        quote=quote,
+        date=None,
+        forum_topic_created=None,
+    )
+
+
+def _external_reply(text=None, caption=None, origin_chat_title="News Channel", **origin_extra):
+    origin = SimpleNamespace(chat=SimpleNamespace(title=origin_chat_title), **origin_extra)
+    return SimpleNamespace(
+        origin=origin,
+        message_id=None,
+        text=text,
+        caption=caption,
+    )
+
+
+def test_external_reply_text_used_as_reply_to_text():
+    """Quoted text from an external message becomes reply_to_text, prefixed
+    with the origin chat title so the agent knows the context is external."""
+    adapter = _make_adapter()
+    msg = _make_message(
+        external_reply=_external_reply(text="Breaking: new model released today"),
+    )
+
+    from gateway.platforms.base import MessageType
+
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.reply_to_text == (
+        "News Channel: Breaking: new model released today"
+    )
+    assert event.reply_from_external is True
+    # No real in-chat message id exists for an external reference.
+    assert event.reply_to_message_id is None
+
+
+def test_external_reply_caption_used_when_no_text():
+    """Media-originating external replies expose their caption instead."""
+    adapter = _make_adapter()
+    msg = _make_message(
+        external_reply=_external_reply(caption="Look at this chart"),
+    )
+
+    from gateway.platforms.base import MessageType
+
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.reply_to_text == "News Channel: Look at this chart"
+    assert event.reply_from_external is True
+
+
+def test_external_reply_quote_preferred_over_full_text():
+    """A manual selection inside the external message wins over full text."""
+    adapter = _make_adapter()
+    msg = _make_message(
+        external_reply=_external_reply(text="Full article body ..."),
+        quote=SimpleNamespace(text="the one key sentence"),
+    )
+
+    from gateway.platforms.base import MessageType
+
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.reply_to_text == "News Channel: the one key sentence"
+    assert event.reply_from_external is True
+
+
+def test_external_reply_without_text_yields_none():
+    """No text/caption/quote → no fabricated context."""
+    adapter = _make_adapter()
+    msg = _make_message(external_reply=_external_reply())
+
+    from gateway.platforms.base import MessageType
+
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.reply_to_text is None
+    assert event.reply_from_external is False
+
+
+@pytest.mark.asyncio
+async def test_external_reply_injected_with_source_attribution():
+    """End-to-end: cross-chat quote gets the standard reply prefix, and when
+    the origin is a different chat/channel the pointer says where it came
+    from so the agent knows the context is external."""
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+    )
+    runner.adapters = {}
+    runner._model = "openai/gpt-4.1-mini"
+    runner._base_url = None
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_name="DM",
+        chat_type="private",
+        user_name="Alice",
+    )
+    event = MessageEvent(
+        text="这是什么意思",
+        source=source,
+        reply_to_message_id=None,
+        reply_to_text="Some quoted content from another channel",
+        reply_from_external=True,
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[{"role": "user", "content": "unrelated"}],
+    )
+
+    assert result is not None
+    assert '[Replying to: "Some quoted content from another channel"]' in result
+    assert result.endswith("这是什么意思")


### PR DESCRIPTION
## What does this PR do?

Telegram delivers two distinct reply shapes: quoting a message **inside the same chat** populates `reply_to_message` (already handled by the gateway), but quoting a message from **a different chat or channel** populates `external_reply` instead — and the adapter ignored that field entirely. The agent received a bare follow-up question ("what does this mean?") with zero context about what was being referenced.

This PR preserves cross-chat external reply context by reusing the existing `[Replying to: "..."]` injection pipeline, with source attribution when the origin chat title is known:

```
[Replying to: "Venture Capital: “One of my favorite tricks is the inversion process.”"]
看得到这条引用吗
```

## Related Issue

No existing issue; searched open/closed issues and PRs for `external_reply` / quoted-message variants — closest hit is #43397 (forwarded-message metadata), which is a different mechanism and does not conflict.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/telegram/adapter.py` — extract `ExternalReplyInfo` text/caption into the existing `reply_to_text` field (preferring the user's manual `TextQuote` selection over the full message text); prefix the origin chat title (`f"{origin_title}: {text}"`) when available via the four `MessageOrigin*` variants
- `gateway/platforms/base.py` — add `MessageEvent.reply_from_external: bool = False`. External replies have no same-chat `message_id`, and the downstream injection previously required both text **and** an ID, so external replies could never trigger it
- `gateway/run.py` — relax the injection condition to also fire when `reply_from_external` is set (same `[Replying to: "..."]` format, 500-char snippet cap unchanged)
- `tests/gateway/test_telegram_external_reply.py` — new regression tests: text extraction, caption fallback, manual-quote preference, empty payload → None, and end-to-end injection through `_prepare_inbound_message_text`

## How to Test

1. Automated: `venv/bin/python -m pytest tests/gateway/test_telegram_external_reply.py tests/gateway/test_telegram_reply_quote.py tests/gateway/test_reply_to_injection.py -q` → 8 passed; sabotage check confirmed the new tests fail without the fix; `ruff check` clean; full `pytest tests/ -q` green (see checklist)
2. Manual reproduction (verified live on Telegram):
   - Quote any message from a *different* chat/channel, send "看得到这条引用吗" ("can you see this quote?")
   - Before this PR: gateway log shows `reply_to_id=None reply_to_text=None` — the agent has no idea what's being asked about
   - After this PR: log shows `reply_to_id=None reply_to_text='Venture Capital: “One of my favorite tricks...”'` and the agent answers about the quoted content

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 22.04 (VPS)

### Documentation & Housekeeping

- [x] N/A — behavior addition reuses the existing injection format; no config keys, architecture or tool-schema changes

## Screenshots / Logs

Live gateway log from production verification (2026-08-24):

```
INFO gateway.run: inbound message: platform=telegram user=… chat=… msg='看得到这条引用吗' reply_to_id=None reply_to_text='Venture Capital: “One of my favorite tricks is the inversion process.”'
```
