### PR TITLE
fix: defer unstarted tools when steer arrives

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -126,6 +126,7 @@ _DEFAULT_IMAGE_PARALLEL_REQUESTS = 4
 # Keep this above the stock auxiliary.web_extract timeout (360s) so the batch
 # guard does not preempt a slow-but-valid summarization attempt.
 _DEFAULT_CONCURRENT_TOOL_TIMEOUT_S = 420.0
+_CONCURRENT_WAIT_POLL_INTERVAL_S = 0.25
 # Upper bound a concurrent worker will wait at the start-order gate for all
 # earlier-ordered tools to advance before proceeding out of order. Long enough
 # to cover slow-but-legitimate authorization (e.g. an approval round-trip),
@@ -334,6 +335,49 @@ def _cancelled_tool_result(reason: str = "user interrupt") -> str:
         },
         ensure_ascii=False,
     )
+
+
+def _has_pending_steer(agent) -> bool:
+    """Return whether user guidance is waiting for the next tool boundary.
+
+    ``AIAgent.steer()`` is called from gateway/UI threads while the executor
+    runs on the turn thread. Read the slot under the same lock used by
+    ``steer()`` and ``_drain_pending_steer()`` so a tool-batch breakout never
+    races a concurrent append.
+    """
+    lock = getattr(agent, "_pending_steer_lock", None)
+    if lock is None:
+        return bool(getattr(agent, "_pending_steer", None))
+    with lock:
+        return bool(getattr(agent, "_pending_steer", None))
+
+
+def _append_steer_deferred_tool_results(
+    agent,
+    messages: list,
+    tool_calls,
+) -> bool:
+    """Close unstarted tool calls so the model can process a pending steer."""
+    for tool_call in tool_calls:
+        name = getattr(getattr(tool_call, "function", None), "name", "") or "tool"
+        messages.append(
+            make_tool_result_message(
+                name,
+                (
+                    f"[Tool execution deferred — {name} was not started. "
+                    "User guidance arrived and must be processed first]"
+                ),
+                _pairing_tool_call_id(tool_call),
+                effect_disposition="none",
+            )
+        )
+        if not _flush_session_db_after_tool_progress(
+            agent,
+            messages,
+            stage=f"steer-deferred tool result {name}",
+        ):
+            return False
+    return True
 
 
 def _emit_cancelled_terminal_post_tool_call(
@@ -1502,6 +1546,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         futures = []
         future_to_index = {}
         timed_out_indices: set[int] = set()
+        steer_deferred_indices: set[int] = set()
         deadline = time.monotonic() + timeout_s if timeout_s is not None else None
         if runnable_calls:
             max_workers = _max_workers_for_tool_batch(runnable_calls)
@@ -1517,6 +1562,22 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 for submit_index, (i, tc, name, args, scope_block) in enumerate(
                     runnable_calls
                 ):
+                    # A steer may arrive after the model emitted this batch but
+                    # before its tools were submitted. Do not start work the
+                    # user has already redirected; synthesize paired tool
+                    # results below so message-role alternation stays valid.
+                    if _has_pending_steer(agent):
+                        steer_deferred_indices.update(
+                            pending_i
+                            for pending_i, *_rest in runnable_calls[submit_index:]
+                        )
+                        agent._vprint(
+                            f"{agent.log_prefix}🧭 Steer pending — deferring "
+                            f"{len(steer_deferred_indices)} unstarted concurrent "
+                            "tool call(s)",
+                            force=True,
+                        )
+                        break
                     # Propagate the agent turn's ContextVars (e.g.
                     # _approval_session_key) AND thread-local approval/sudo
                     # callbacks into the worker thread; clears callbacks on exit.
@@ -1574,7 +1635,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 _conc_start = time.time()
                 _interrupt_logged = False
                 while True:
-                    wait_timeout = 5.0
+                    wait_timeout = _CONCURRENT_WAIT_POLL_INTERVAL_S
                     if deadline is not None:
                         effective_deadline = (
                             deadline + authorization_gate.excluded_seconds()
@@ -1657,6 +1718,29 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         concurrent.futures.wait(not_done, timeout=3.0)
                         break
 
+                    # A conversational steer must not kill tools that already
+                    # started (their side-effect state may be unknown), but it
+                    # should cancel queued futures so the model can reconsider
+                    # them. Keep waiting for running tools; only successfully
+                    # cancelled, never-started calls are classified as deferred.
+                    newly_deferred = (
+                        {
+                            future_to_index[f]
+                            for f in not_done
+                            if future_to_index[f] not in steer_deferred_indices
+                            and f.cancel()
+                        }
+                        if _has_pending_steer(agent)
+                        else set()
+                    )
+                    if newly_deferred:
+                        steer_deferred_indices.update(newly_deferred)
+                        agent._vprint(
+                            f"{agent.log_prefix}🧭 Steer pending — deferring "
+                            f"{len(newly_deferred)} queued concurrent tool call(s)",
+                            force=True,
+                        )
+
                     _conc_elapsed = int(time.time() - _conc_start)
                     # Heartbeat every ~30s (6 × 5s poll intervals)
                     if _conc_elapsed > 0 and _conc_elapsed % 30 < 6:
@@ -1723,6 +1807,24 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 middleware_trace=list(middleware_trace),
             )
             tool_duration = float(timeout_s or 0.0)
+        elif i in steer_deferred_indices and r is None:
+            function_result = (
+                f"[Tool execution deferred — {name} was not started. "
+                "User guidance arrived and must be processed first]"
+            )
+            effect_disposition = "none"
+            is_error = False
+            _emit_terminal_post_tool_call(
+                agent,
+                function_name=name,
+                function_args=args,
+                result=function_result,
+                effective_task_id=effective_task_id,
+                tool_call_id=tool_call_id,
+                status="deferred",
+                middleware_trace=list(middleware_trace),
+            )
+            tool_duration = 0.0
         elif r is None:
             # Tool was cancelled (interrupt) or thread didn't return
             if agent._interrupt_requested:
@@ -2838,6 +2940,22 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     return
             break
 
+        if _has_pending_steer(agent) and i < len(assistant_message.tool_calls):
+            remaining_calls = assistant_message.tool_calls[i:]
+            agent._vprint(
+                f"{agent.log_prefix}🧭 Steer pending — deferring "
+                f"{len(remaining_calls)} remaining tool call(s) so the model "
+                "can process the guidance",
+                force=True,
+            )
+            if not _append_steer_deferred_tool_results(
+                agent,
+                messages,
+                remaining_calls,
+            ):
+                return
+            break
+
     # ── Per-turn aggregate budget enforcement ─────────────────────────
     # Keep /steer pending until the final post-budget drain below.  The model
     # only receives this batch after all calls finish, and an early drain can
@@ -2885,9 +3003,30 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
         _exec_cwd = Path(_active_env.cwd) if _active_env is not None and _active_env.cwd else None
         segments = _plan_tool_batch_segments(assistant_message.tool_calls, execution_cwd=_exec_cwd)
 
-    for kind, calls in segments:
+    for segment_index, (kind, calls) in enumerate(segments):
         if getattr(agent, "_incremental_persistence_failed", False):
             return
+
+        if _has_pending_steer(agent):
+            remaining_calls = [
+                tool_call
+                for _remaining_kind, segment_calls in segments[segment_index:]
+                for tool_call in segment_calls
+            ]
+            if remaining_calls:
+                agent._vprint(
+                    f"{agent.log_prefix}🧭 Steer pending — deferring "
+                    f"{len(remaining_calls)} segmented tool call(s) so the "
+                    "model can process the guidance",
+                    force=True,
+                )
+                if not _append_steer_deferred_tool_results(
+                    agent,
+                    messages,
+                    remaining_calls,
+                ):
+                    return
+            break
         segment_message = SimpleNamespace(tool_calls=list(calls))
         if kind == "parallel":
             execute_tool_calls_concurrent(

--- a/tests/agent/test_steer_tool_breakout.py
+++ b/tests/agent/test_steer_tool_breakout.py
@@ -1,0 +1,300 @@
+"""Behavior tests for mid-batch user steering (#28172)."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _tool_call(name: str, index: int):
+    return SimpleNamespace(
+        id=f"call-{index}",
+        function=SimpleNamespace(name=name, arguments="{}"),
+    )
+
+
+class _StubAgent:
+    """Narrow executor double with explicit, non-MagicMock state."""
+
+    def __init__(self) -> None:
+        self._pending_steer = None
+        self._pending_steer_lock = threading.Lock()
+        self._interrupt_requested = False
+        self._tool_interrupt_reason = None
+        self._incremental_persistence_failed = False
+        self._last_persistence_error_cause = None
+        self._current_tool = None
+        self._tool_worker_threads: set[int] = set()
+        self._tool_worker_threads_lock = threading.Lock()
+        self._subdirectory_hints = MagicMock()
+        self._subdirectory_hints.check_tool_call.return_value = None
+        self._tool_guardrails = MagicMock()
+        self._checkpoint_mgr = MagicMock(enabled=False)
+        self._memory_manager = None
+        self._context_engine_tool_names = None
+        self._print_fn = print
+        self._invoke_tool = lambda *_args, **_kwargs: json.dumps({"status": "ok"})
+        self.quiet_mode = True
+        self.verbose_logging = False
+        self.tool_progress_mode = "off"
+        self.tool_progress_callback = None
+        self.tool_start_callback = None
+        self.tool_complete_callback = None
+        self.log_prefix = ""
+        self.log_prefix_chars = 200
+        self.tool_delay = 0
+        self.valid_tool_names = None
+        self.session_id = "steer-breakout-test"
+
+    def steer(self, text: str) -> None:
+        with self._pending_steer_lock:
+            self._pending_steer = text
+
+    def _drain_pending_steer(self):
+        with self._pending_steer_lock:
+            text = self._pending_steer
+            self._pending_steer = None
+            return text
+
+    def _apply_pending_steer_to_tool_results(self, messages, _count) -> None:
+        text = self._drain_pending_steer()
+        if not text:
+            return
+        for message in reversed(messages):
+            if message.get("role") == "tool":
+                message["content"] += f"\n\n[OUT-OF-BAND USER MESSAGE]\n{text}"
+                return
+
+    def _flush_messages_to_session_db(self, _messages) -> bool:
+        return True
+
+    def _touch_activity(self, _description) -> None:
+        return None
+
+    def _vprint(self, _message, force=False) -> None:
+        return None
+
+    def _safe_print(self, _message) -> None:
+        return None
+
+    def _wrap_verbose(self, _prefix, value):
+        return value
+
+    def _should_emit_quiet_tool_messages(self) -> bool:
+        return False
+
+    def _should_start_quiet_spinner(self) -> bool:
+        return False
+
+    def _has_stream_consumers(self) -> bool:
+        return False
+
+    def _append_guardrail_observation(
+        self, _name, _args, result, failed=False, tool_call_id=None
+    ):
+        return result
+
+    def _record_file_mutation_result(self, *_args, **_kwargs) -> None:
+        return None
+
+    def _tool_result_content_for_active_model(self, _name, result):
+        return result
+
+
+@pytest.fixture
+def executor_module(monkeypatch):
+    from agent import tool_executor as executor
+
+    executor._test_invoke = lambda *_args, **_kwargs: json.dumps({"status": "ok"})
+
+    def test_runtime():
+        return SimpleNamespace(
+            handle_function_call=lambda name, args, *_a, **_k: executor._test_invoke(
+                name, args
+            )
+        )
+
+    def passthrough_middleware(
+        _agent,
+        *,
+        function_args,
+        execute,
+        middleware_trace=None,
+        **_kwargs,
+    ):
+        return executor._ManagedToolResult(
+            result=execute(function_args),
+            args=function_args,
+            middleware_trace=list(middleware_trace or []),
+            blocked=False,
+            dispatched=True,
+        )
+
+    monkeypatch.setattr(
+        executor, "_run_agent_tool_execution_middleware", passthrough_middleware
+    )
+    monkeypatch.setattr(executor, "_ra", test_runtime)
+    monkeypatch.setattr(
+        executor, "_emit_terminal_post_tool_call", lambda *_a, **_k: None
+    )
+    monkeypatch.setattr(executor, "enforce_turn_budget", lambda *_a, **_k: None)
+    monkeypatch.setattr(executor, "get_active_env", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        executor,
+        "maybe_persist_tool_result",
+        lambda *, content, **_kwargs: content,
+    )
+    return executor
+
+
+def _tool_messages(messages):
+    return [message for message in messages if message.get("role") == "tool"]
+
+
+def test_sequential_steer_defers_every_unstarted_call(executor_module):
+    agent = _StubAgent()
+    invoked: list[str] = []
+
+    def invoke(name, *_args, **_kwargs):
+        invoked.append(name)
+        if len(invoked) == 1:
+            agent.steer("change the implementation approach")
+        return json.dumps({"status": "ok", "tool": name})
+
+    agent._invoke_tool = invoke
+    executor_module._test_invoke = invoke
+    calls = [_tool_call(f"tool-{index}", index) for index in range(3)]
+    messages: list[dict] = []
+
+    executor_module.execute_tool_calls_sequential(
+        agent,
+        SimpleNamespace(tool_calls=calls),
+        messages,
+        "task",
+    )
+
+    tool_messages = _tool_messages(messages)
+    assert invoked == ["tool-0"]
+    assert len(tool_messages) == len(calls)
+    assert "deferred" in tool_messages[1]["content"].lower()
+    assert "deferred" in tool_messages[2]["content"].lower()
+    assert tool_messages[1]["effect_disposition"] == "none"
+    assert tool_messages[2]["effect_disposition"] == "none"
+    assert "change the implementation approach" in tool_messages[-1]["content"]
+
+
+def test_concurrent_steer_cancels_only_queued_calls(executor_module, monkeypatch):
+    agent = _StubAgent()
+    started = threading.Event()
+    release = threading.Event()
+    invoked: list[str] = []
+
+    def invoke(name, *_args, **_kwargs):
+        invoked.append(name)
+        started.set()
+        assert release.wait(2.0)
+        return json.dumps({"status": "ok", "tool": name})
+
+    agent._invoke_tool = invoke
+    monkeypatch.setattr(
+        executor_module, "_max_workers_for_tool_batch", lambda _calls: 1
+    )
+    monkeypatch.setattr(executor_module, "_CONCURRENT_WAIT_POLL_INTERVAL_S", 0.02)
+
+    def send_steer() -> None:
+        assert started.wait(1.0)
+        agent.steer("do not run the remaining tools")
+        time.sleep(0.1)
+        release.set()
+
+    sender = threading.Thread(target=send_steer)
+    sender.start()
+    calls = [_tool_call(f"tool-{index}", index) for index in range(3)]
+    messages: list[dict] = []
+
+    executor_module.execute_tool_calls_concurrent(
+        agent,
+        SimpleNamespace(tool_calls=calls),
+        messages,
+        "task",
+    )
+    sender.join(timeout=1.0)
+
+    tool_messages = _tool_messages(messages)
+    assert invoked == ["tool-0"]
+    assert len(tool_messages) == len(calls)
+    assert "ok" in tool_messages[0]["content"]
+    assert all(
+        "deferred" in message["content"].lower() for message in tool_messages[1:]
+    )
+    assert all(message["effect_disposition"] == "none" for message in tool_messages[1:])
+    assert "do not run the remaining tools" in tool_messages[-1]["content"]
+
+
+def test_concurrent_pending_steer_submits_no_tools(executor_module):
+    agent = _StubAgent()
+    invoked: list[str] = []
+    agent._invoke_tool = lambda name, *_a, **_k: invoked.append(name)
+    agent.steer("replace the whole batch")
+    calls = [_tool_call(f"tool-{index}", index) for index in range(3)]
+    messages: list[dict] = []
+
+    executor_module.execute_tool_calls_concurrent(
+        agent,
+        SimpleNamespace(tool_calls=calls),
+        messages,
+        "task",
+    )
+
+    tool_messages = _tool_messages(messages)
+    assert invoked == []
+    assert len(tool_messages) == len(calls)
+    assert all("deferred" in message["content"].lower() for message in tool_messages)
+    assert all(message["effect_disposition"] == "none" for message in tool_messages)
+    assert "replace the whole batch" in tool_messages[-1]["content"]
+
+
+def test_segmented_batch_defers_later_segments(executor_module, monkeypatch):
+    agent = _StubAgent()
+    first = _tool_call("first", 1)
+    second = _tool_call("second", 2)
+    executed_segments: list[list] = []
+
+    def execute_first_segment(_agent, segment_message, messages, *_args, **_kwargs):
+        executed_segments.append(segment_message.tool_calls)
+        call = segment_message.tool_calls[0]
+        messages.append(
+            executor_module.make_tool_result_message(
+                call.function.name,
+                "ok",
+                call.id,
+            )
+        )
+        agent.steer("stop before the next segment")
+
+    monkeypatch.setattr(
+        executor_module,
+        "execute_tool_calls_sequential",
+        execute_first_segment,
+    )
+    messages: list[dict] = []
+
+    executor_module.execute_tool_calls_segmented(
+        agent,
+        SimpleNamespace(tool_calls=[first, second]),
+        messages,
+        "task",
+        segments=[("sequential", [first]), ("sequential", [second])],
+    )
+
+    tool_messages = _tool_messages(messages)
+    assert executed_segments == [[first]]
+    assert len(tool_messages) == 2
+    assert "deferred" in tool_messages[1]["content"].lower()
+    assert tool_messages[1]["effect_disposition"] == "none"
+    assert "stop before the next segment" in tool_messages[1]["content"]


### PR DESCRIPTION
## Summary

- stop sequential and segmented tool batches at the next safe boundary when a steer arrives
- cancel only concurrent futures that have not started, while allowing already-running tools to finish safely
- emit paired `effect_disposition="none"` tool results for deferred calls so provider role alternation remains valid
- poll concurrent batches every 250 ms so queued work is redirected promptly

This builds on the approach in #28808 by @zccyman and completes its concurrent cancellation handling: cancelled indices are tracked explicitly and are not misclassified as `thread_missing_result`. The original author is retained via a `Co-authored-by` trailer.

Fixes #28172.

## Safety semantics

A steer is conversational guidance, not a hard cancellation lease. This patch never kills an already-running tool because its external side-effect state may be unknown. It only prevents unstarted work from beginning, then returns control to the model with the steer attached at the existing post-tool boundary.

## Tests

```text
scripts/run_tests.sh \
  tests/run_agent/test_steer.py \
  tests/gateway/test_steer_command.py \
  tests/agent/test_steer_tool_breakout.py \
  tests/agent/test_tool_executor_checkpoint_paths.py \
  tests/run_agent/test_tool_executor_contextvar_propagation.py -q

44 passed, 0 failed
```

Also passed:

```text
python -m ruff check agent/tool_executor.py tests/agent/test_steer_tool_breakout.py
python -m py_compile agent/tool_executor.py tests/agent/test_steer_tool_breakout.py
git diff --check
```