### PR TITLE
feat(desktop): update installed AppImages in place

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -4565,7 +4565,13 @@ async function applyUpdatesPosixHandoff(opts: any) {
   // only a binary the rebuild replaced with a launchable sandbox helper —
   // replaying the original launch context (filtered args, cwd, sandbox
   // opt-out) so a deep-link or --no-sandbox launch survives the update.
-  const targetApp = IS_MAC ? runningAppBundle() : process.execPath
+  // AppImages are replaced at their stable APPIMAGE path. process.execPath
+  // points into the temporary mount and cannot be atomically replaced.
+  const targetApp = IS_MAC
+    ? runningAppBundle()
+    : process.platform === 'linux' && process.env.APPIMAGE
+      ? process.env.APPIMAGE
+      : process.execPath
 
   if (targetApp) {
     args.push('--relaunch-target', targetApp)

--- a/hermes_cli/update_cmd_deps.py
+++ b/hermes_cli/update_cmd_deps.py
@@ -818,6 +818,13 @@ def _rebuild_desktop_after_update(
     See #88251.
     """
     from hermes_cli.update_cmd import _m
+    if (
+        sys.platform == "linux"
+        and os.environ.get("APPIMAGE")
+        and os.environ.get("HERMES_APPIMAGE_UPDATE") == "1"
+    ):
+        print("→ Desktop AppImage update is handled separately")
+        return True
     # The release tree is git-ignored and can vanish mid-update; pre-update presence suffices.
     # Never make people who never used Desktop pay for an Electron build.
     has_desktop_app = had_desktop_app_before_update or _desktop_app_present(desktop_dir)

--- a/scripts/desktop-update/appimage_update.py
+++ b/scripts/desktop-update/appimage_update.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Download and atomically replace the latest Hermes AppImage."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import re
+import stat
+import sys
+import tempfile
+from pathlib import Path
+from typing import Callable
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+DEFAULT_RELEASE_API = "https://api.github.com/repos/NousResearch/hermes-agent/releases/latest"
+USER_AGENT = "Hermes-AppImage-Updater"
+CHUNK_SIZE = 1024 * 1024
+SHA256_RE = re.compile(r"\b[a-fA-F0-9]{64}\b")
+
+
+class AppImageUpdateError(RuntimeError):
+    """Raised when an AppImage update cannot be completed safely."""
+
+
+def appimage_arch(machine: str | None = None) -> str:
+    """Map the host architecture to electron-builder's artifact suffix."""
+    value = (machine or platform.machine()).lower()
+    if value in {"x86_64", "amd64"}:
+        return "x64"
+    if value in {"aarch64", "arm64"}:
+        return "arm64"
+    if value in {"armv7l", "armv7", "armhf"}:
+        return "armv7l"
+    raise AppImageUpdateError(f"Unsupported Linux architecture: {value or 'unknown'}")
+
+
+def _request(url: str) -> Request:
+    return Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": USER_AGENT,
+        },
+    )
+
+
+def _read_json(url: str, opener: Callable[..., object] = urlopen) -> dict:
+    try:
+        with opener(_request(url), timeout=30) as response:  # type: ignore[union-attr]
+            payload = json.load(response)  # type: ignore[arg-type]
+    except (HTTPError, URLError, TimeoutError, OSError, ValueError) as exc:
+        raise AppImageUpdateError(f"Could not check for the latest AppImage: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise AppImageUpdateError("The release service returned an invalid response")
+    return payload
+
+
+def _asset_for_release(release: dict, arch: str) -> dict:
+    assets = release.get("assets")
+    if not isinstance(assets, list):
+        raise AppImageUpdateError("The latest release has no downloadable assets")
+
+    candidates = []
+    arch_token = f"linux-{arch}".lower()
+    for asset in assets:
+        if not isinstance(asset, dict):
+            continue
+        name = str(asset.get("name") or "")
+        if name.lower().endswith(".appimage") and arch_token in name.lower():
+            candidates.append(asset)
+    if len(candidates) != 1:
+        names = ", ".join(str(a.get("name") or "") for a in candidates)
+        detail = f" ({names})" if names else ""
+        raise AppImageUpdateError(f"Could not uniquely identify the {arch} AppImage{detail}")
+    asset = candidates[0]
+    if not asset.get("browser_download_url"):
+        raise AppImageUpdateError("The latest AppImage has no download URL")
+    return asset
+
+
+def _checksum_from_release(release: dict, asset: dict, opener: Callable[..., object]) -> str:
+    digest = str(asset.get("digest") or "")
+    if digest.lower().startswith("sha256:"):
+        expected = digest.split(":", 1)[1].strip().lower()
+        if SHA256_RE.fullmatch(expected):
+            return expected
+
+    # Older releases may omit `digest`; only accept a checksum from this release.
+    assets = release.get("assets") or []
+    asset_name = str(asset.get("name") or "")
+    sidecars = [
+        candidate
+        for candidate in assets
+        if isinstance(candidate, dict)
+        and str(candidate.get("name") or "").lower()
+        in {f"{asset_name}.sha256".lower(), "sha256sums.txt", "checksums.txt"}
+    ]
+    for sidecar in sidecars:
+        url = sidecar.get("browser_download_url")
+        if not url:
+            continue
+        try:
+            with opener(_request(str(url)), timeout=30) as response:  # type: ignore[union-attr]
+                text = response.read().decode("utf-8", "replace")  # type: ignore[union-attr]
+        except (HTTPError, URLError, TimeoutError, OSError) as exc:
+            raise AppImageUpdateError(f"Could not download the AppImage checksum: {exc}") from exc
+        if str(sidecar.get("name") or "").lower() == f"{asset_name}.sha256".lower():
+            matches = SHA256_RE.findall(text)
+            if len(matches) == 1:
+                return matches[0].lower()
+            continue
+
+        matches = []
+        for line in text.splitlines():
+            match = re.fullmatch(r"\s*([a-fA-F0-9]{64})\s+\*?(.+?)\s*", line)
+            if match and Path(match.group(2)).name == asset_name:
+                matches.append(match.group(1).lower())
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            raise AppImageUpdateError(f"The checksum file has multiple entries for {asset_name}")
+    raise AppImageUpdateError("The latest AppImage has no verifiable SHA-256 digest")
+
+
+def _download_and_install(
+    target: Path,
+    asset: dict,
+    expected_sha256: str,
+    opener: Callable[..., object] = urlopen,
+) -> None:
+    target = target.expanduser()
+    if target.is_symlink():
+        try:
+            target = target.resolve(strict=True)
+        except OSError as exc:
+            raise AppImageUpdateError(f"AppImage symlink target is unavailable: {target}") from exc
+    if not target.is_file():
+        raise AppImageUpdateError(f"AppImage path is not a regular file: {target}")
+    parent = target.parent
+    mode = stat.S_IMODE(target.stat().st_mode) | stat.S_IXUSR
+    temp_path: Path | None = None
+    actual = hashlib.sha256()
+    try:
+        with opener(_request(str(asset["browser_download_url"])), timeout=120) as response:  # type: ignore[union-attr]
+            with tempfile.NamedTemporaryFile(
+                dir=parent, prefix=f".{target.name}.", suffix=".download", delete=False
+            ) as temp:
+                temp_path = Path(temp.name)
+                source = response  # type: ignore[assignment]
+                while True:
+                    chunk = source.read(CHUNK_SIZE)  # type: ignore[union-attr]
+                    if not chunk:
+                        break
+                    actual.update(chunk)
+                    temp.write(chunk)
+                temp.flush()
+                os.fsync(temp.fileno())
+        actual_hex = actual.hexdigest()
+        if actual_hex != expected_sha256:
+            raise AppImageUpdateError(
+                f"AppImage checksum mismatch (expected {expected_sha256}, got {actual_hex})"
+            )
+        os.chmod(temp_path, mode)
+        os.replace(temp_path, target)
+        temp_path = None
+        try:
+            dir_fd = os.open(parent, os.O_DIRECTORY)
+        except (AttributeError, OSError):
+            return
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except (HTTPError, URLError, TimeoutError, OSError) as exc:
+        raise AppImageUpdateError(f"Could not download the latest AppImage: {exc}") from exc
+    finally:
+        if temp_path is not None:
+            try:
+                temp_path.unlink()
+            except OSError:
+                pass
+
+
+def update_appimage(
+    target: str | Path,
+    *,
+    arch: str,
+    release_api: str = DEFAULT_RELEASE_API,
+    opener: Callable[..., object] = urlopen,
+) -> str:
+    """Install the verified latest AppImage and return its release tag."""
+    release = _read_json(release_api, opener)
+    if release.get("draft") or release.get("prerelease"):
+        raise AppImageUpdateError("The latest release is not stable")
+    asset = _asset_for_release(release, arch)
+    expected = _checksum_from_release(release, asset, opener)
+    _download_and_install(Path(target), asset, expected, opener)
+    return str(release.get("tag_name") or "latest")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", required=True, type=Path)
+    parser.add_argument("--arch", required=True)
+    parser.add_argument("--release-api", default=DEFAULT_RELEASE_API)
+    args = parser.parse_args(argv)
+    try:
+        tag = update_appimage(args.target, arch=args.arch, release_api=args.release_api)
+    except AppImageUpdateError as exc:
+        print(f"AppImage update failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"AppImage updated to {tag}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -120,6 +120,15 @@ json_escape() { # minimal JSON string escape: \ " and control whitespace
   printf '%s' "$s"
 }
 
+appimage_arch() {
+  case "$(uname -m)" in
+    x86_64|amd64) echo x64 ;;
+    aarch64|arm64) echo arm64 ;;
+    armv7l|armv7|armhf) echo armv7l ;;
+    *) return 1 ;;
+  esac
+}
+
 notify_fallback() { # status message — renderer-free recovery surface.
   # Fires only when there is no shim window. BEST-EFFORT immediate channel:
   # each rung requires EXECUTION acceptance, not existence — notify-send's
@@ -319,6 +328,11 @@ stop_ui() { # error/manual outcomes keep the window up briefly so a watching
 GATE="" GATE_MSG=""
 linux_gate() {
   local unpacked="$INSTALL_ROOT/apps/desktop/release/linux-unpacked" sb arg
+  if [ "$(uname)" = "Linux" ] && [ -n "${APPIMAGE:-}" ] \
+      && [ "$RELAUNCH_TARGET" = "$APPIMAGE" ] && [ -x "$RELAUNCH_TARGET" ]; then
+    GATE=relaunch
+    return
+  fi
   case "$RELAUNCH_TARGET" in
     "$unpacked"/*) ;;
     *) GATE=skew GATE_MSG="Backend updated, but the desktop app package (AppImage/deb/rpm) was not changed. Update or reinstall it to match."; return ;;
@@ -723,6 +737,11 @@ start_ui
 HERMES_BIN="$INSTALL_ROOT/venv/bin/hermes"
 [ -x "$HERMES_BIN" ] || { FINAL_CODE=3 FINAL_MSG="Update aborted: $HERMES_BIN is missing. The install needs repair (run the Hermes installer or hermes doctor)."; log "$FINAL_MSG"; exit 3; }
 
+APPIMAGE_MODE=0
+if [ "$(uname)" = "Linux" ] && [ -n "${APPIMAGE:-}" ] && [ -x "$APPIMAGE" ]; then
+  APPIMAGE_MODE=1
+fi
+
 # Heal a venv the reverted TCC anchor left bricked BEFORE invoking the CLI:
 # venv/bin/hermes execs venv/bin/python3, so a dead alias kills every attempt
 # and its retry identically (#95759). macOS-only artifact; probe is cheap.
@@ -760,6 +779,9 @@ if "${UPDATE_INVOKE[@]}" update --help 2>/dev/null | grep -q -- '--keep-stash'; 
   KEEP_STASH="--keep-stash"
 else
   log "installed hermes predates --keep-stash; running without it"
+fi
+if [ "$APPIMAGE_MODE" -eq 1 ]; then
+  export HERMES_APPIMAGE_UPDATE=1
 fi
 log "running: ${UPDATE_INVOKE[*]} update --yes --gateway $KEEP_STASH --branch $BRANCH"
 publish_stage "Updating code and dependencies"
@@ -801,6 +823,39 @@ if [ "$CODE" -eq 0 ] && printf '%s' "$OUT" | grep -q "Desktop build failed"; the
     FINAL_CODE=6 FINAL_MSG="Code and dependencies updated, but the Desktop app rebuild failed - you are running the previous build. Run hermes desktop --force-build from a terminal to retry."
     exit 6
   }
+fi
+
+if [ "$CODE" -eq 0 ] && [ "$APPIMAGE_MODE" -eq 1 ]; then
+  APPIMAGE_PYTHON="$INSTALL_ROOT/venv/bin/python3"
+  # Reuse the same bootability check as UPDATE_INVOKE: an executable python3
+  # can still be the macOS TCC-broken alias that caused the main update to
+  # fall back to venv/bin/python.
+  if ! tcc_probe_python "$APPIMAGE_PYTHON"; then
+    APPIMAGE_PYTHON="$INSTALL_ROOT/venv/bin/python"
+  fi
+  if ! tcc_probe_python "$APPIMAGE_PYTHON"; then
+    APPIMAGE_PYTHON="$(command -v python3 2>/dev/null || true)"
+  fi
+  if ! tcc_probe_python "${APPIMAGE_PYTHON:-/nonexistent}" || [ ! -f "$SCRIPT_DIR/appimage_update.py" ]; then
+    FINAL_CODE=7 FINAL_MSG="Code updated, but the AppImage updater is unavailable. The existing desktop app was kept."
+    log "$FINAL_MSG"
+    exit 7
+  fi
+  publish_stage "Installing the latest desktop AppImage"
+  APPIMAGE_ARGS=("--target" "$APPIMAGE" "--arch" "$(appimage_arch 2>/dev/null || true)")
+  if [ -n "${HERMES_APPIMAGE_RELEASE_API:-}" ]; then
+    APPIMAGE_ARGS+=("--release-api" "$HERMES_APPIMAGE_RELEASE_API")
+  fi
+  if [ -z "${APPIMAGE_ARGS[3]:-}" ]; then
+    FINAL_CODE=7 FINAL_MSG="Code updated, but this Linux architecture has no AppImage release. The existing desktop app was kept."
+    log "$FINAL_MSG"
+    exit 7
+  fi
+  if ! "$APPIMAGE_PYTHON" "$SCRIPT_DIR/appimage_update.py" "${APPIMAGE_ARGS[@]}" >> "$LOG" 2>&1; then
+    FINAL_CODE=7 FINAL_MSG="Code updated, but the latest AppImage could not be downloaded or verified. The existing desktop app was kept."
+    log "$FINAL_MSG"
+    exit 7
+  fi
 fi
 
 if [ "$CODE" -eq 0 ]; then FINAL_CODE=0 FINAL_MSG="Update complete."

--- a/scripts/desktop-update/repro.sh
+++ b/scripts/desktop-update/repro.sh
@@ -108,6 +108,9 @@ case "$MODE" in
     decide() { bash "$SCRIPT_DIR/posix.sh" --self-test-gate --install-root "$G/hermes-agent" "$@" | cut -d: -f1; }
 
     expect "appimage (not under unpacked)"      skew     "$(decide --relaunch-target /opt/Hermes/hermes)"
+    APPIMAGE_PATH="$G/Hermes.AppImage"
+    touch "$APPIMAGE_PATH" && chmod +x "$APPIMAGE_PATH"
+    expect "installed AppImage is relaunchable" relaunch "$(APPIMAGE="$APPIMAGE_PATH" decide --relaunch-target "$APPIMAGE_PATH")"
     expect "sibling-prefix dir not fooled"      skew     "$(decide --relaunch-target "$UNPACKED-evil/hermes")"
     expect "no chrome-sandbox (namespace)"      relaunch "$(decide --relaunch-target "$UNPACKED/hermes")"
 

--- a/tests/hermes_cli/test_update_desktop_stale_warning.py
+++ b/tests/hermes_cli/test_update_desktop_stale_warning.py
@@ -98,6 +98,17 @@ def test_up_to_date_desktop_returns_true_without_spawning(desktop_env):
     assert calls["builds"] == 0
 
 
+def test_appimage_update_skips_source_desktop_rebuild(desktop_env, monkeypatch, capsys):
+    desktop_dir, calls = desktop_env
+    monkeypatch.setenv("APPIMAGE", "/tmp/Hermes.AppImage")
+    monkeypatch.setenv("HERMES_APPIMAGE_UPDATE", "1")
+    monkeypatch.setattr(update_cmd.sys, "platform", "linux")
+
+    assert _run(desktop_dir) is True
+    assert calls["builds"] == 0
+    assert "handled separately" in capsys.readouterr().out
+
+
 def test_desktop_never_installed_returns_true(tmp_path, monkeypatch):
     spawned = []
     monkeypatch.setattr(

--- a/tests/scripts/test_appimage_update.py
+++ b/tests/scripts/test_appimage_update.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).parents[2] / "scripts" / "desktop-update" / "appimage_update.py"
+SPEC = importlib.util.spec_from_file_location("appimage_update", MODULE_PATH)
+assert SPEC and SPEC.loader
+appimage_update = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(appimage_update)
+
+
+class Response:
+    def __init__(self, body: bytes):
+        self.body = io.BytesIO(body)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self, size: int = -1):
+        return self.body.read(size)
+
+
+def release_payload(binary: bytes, *, digest: str | None = None) -> tuple[dict, dict]:
+    asset = {
+        "name": "Hermes-0.20.6-linux-x64.AppImage",
+        "browser_download_url": "https://downloads.example/hermes.AppImage",
+    }
+    if digest is not None:
+        asset["digest"] = digest
+    release = {"tag_name": "v2026.8.24", "draft": False, "prerelease": False, "assets": [asset]}
+    return release, asset
+
+
+def test_appimage_arch_maps_supported_machines():
+    assert appimage_update.appimage_arch("x86_64") == "x64"
+    assert appimage_update.appimage_arch("aarch64") == "arm64"
+    assert appimage_update.appimage_arch("armv7l") == "armv7l"
+
+
+def test_appimage_arch_rejects_unknown_machine():
+    with pytest.raises(appimage_update.AppImageUpdateError, match="Unsupported"):
+        appimage_update.appimage_arch("mips64")
+
+
+def test_update_appimage_verifies_digest_and_replaces_atomically(tmp_path: Path):
+    old = b"old appimage"
+    new = b"new appimage"
+    target = tmp_path / "Hermes.AppImage"
+    target.write_bytes(old)
+    target.chmod(0o755)
+    digest = hashlib.sha256(new).hexdigest()
+    release, _ = release_payload(new, digest=f"sha256:{digest}")
+    responses = {
+        "https://api.example/releases/latest": Response(json.dumps(release).encode()),
+        "https://downloads.example/hermes.AppImage": Response(new),
+    }
+
+    def opener(request, timeout):
+        assert timeout in (30, 120)
+        return responses[request.full_url]
+
+    assert (
+        appimage_update.update_appimage(
+            target, arch="x64", release_api="https://api.example/releases/latest", opener=opener
+        )
+        == "v2026.8.24"
+    )
+    assert target.read_bytes() == new
+    assert target.stat().st_mode & 0o111
+    assert list(tmp_path.glob("*.download")) == []
+
+
+def test_update_appimage_does_not_need_sidecar_when_release_has_digest(tmp_path: Path):
+    new = b"new appimage"
+    digest = hashlib.sha256(new).hexdigest()
+    release, _ = release_payload(new, digest=f"sha256:{digest}")
+    release["assets"].append(
+        {
+            "name": "SHA256SUMS.txt",
+            "browser_download_url": "https://downloads.example/SHA256SUMS.txt",
+        }
+    )
+    target = tmp_path / "Hermes.AppImage"
+    target.write_bytes(b"old")
+
+    def opener(request, timeout):
+        if request.full_url.endswith("latest"):
+            return Response(json.dumps(release).encode())
+        if request.full_url.endswith("hermes.AppImage"):
+            return Response(new)
+        raise AssertionError("release digest should avoid the checksum sidecar")
+
+    appimage_update.update_appimage(
+        target, arch="x64", release_api="https://api.example/releases/latest", opener=opener
+    )
+    assert target.read_bytes() == new
+
+
+def test_update_appimage_checksum_mismatch_keeps_existing_file(tmp_path: Path):
+    target = tmp_path / "Hermes.AppImage"
+    target.write_bytes(b"known-good")
+    release, _ = release_payload(b"bad", digest=f"sha256:{hashlib.sha256(b'expected').hexdigest()}")
+    responses = {
+        "https://api.example/releases/latest": Response(json.dumps(release).encode()),
+        "https://downloads.example/hermes.AppImage": Response(b"bad"),
+    }
+
+    def opener(request, timeout):
+        return responses[request.full_url]
+
+    with pytest.raises(appimage_update.AppImageUpdateError, match="checksum mismatch"):
+        appimage_update.update_appimage(
+            target, arch="x64", release_api="https://api.example/releases/latest", opener=opener
+        )
+    assert target.read_bytes() == b"known-good"
+    assert list(tmp_path.glob("*.download")) == []
+
+
+def test_update_appimage_accepts_checksum_sidecar_for_older_release(tmp_path: Path):
+    new = b"new appimage"
+    digest = hashlib.sha256(new).hexdigest()
+    release, asset = release_payload(new)
+    release["assets"].append(
+        {
+            "name": "SHA256SUMS.txt",
+            "browser_download_url": "https://downloads.example/SHA256SUMS.txt",
+        }
+    )
+    target = tmp_path / "Hermes.AppImage"
+    target.write_bytes(b"old")
+    responses = {
+        "https://api.example/releases/latest": Response(json.dumps(release).encode()),
+        "https://downloads.example/SHA256SUMS.txt": Response(f"{digest}  {asset['name']}\n".encode()),
+        "https://downloads.example/hermes.AppImage": Response(new),
+    }
+
+    def opener(request, timeout):
+        return responses[request.full_url]
+
+    appimage_update.update_appimage(
+        target, arch="x64", release_api="https://api.example/releases/latest", opener=opener
+    )
+    assert target.read_bytes() == new
+
+
+def test_update_appimage_rejects_ambiguous_checksum_sidecar(tmp_path: Path):
+    new = b"new appimage"
+    digest = hashlib.sha256(new).hexdigest()
+    release, asset = release_payload(new)
+    release["assets"].append(
+        {
+            "name": "SHA256SUMS.txt",
+            "browser_download_url": "https://downloads.example/SHA256SUMS.txt",
+        }
+    )
+    target = tmp_path / "Hermes.AppImage"
+    target.write_bytes(b"old")
+    responses = {
+        "https://api.example/releases/latest": Response(json.dumps(release).encode()),
+        "https://downloads.example/SHA256SUMS.txt": Response(
+            f"{digest}  {asset['name']}\n{digest}  {asset['name']}\n".encode()
+        ),
+    }
+
+    def opener(request, timeout):
+        return responses[request.full_url]
+
+    with pytest.raises(appimage_update.AppImageUpdateError, match="multiple entries"):
+        appimage_update.update_appimage(
+            target, arch="x64", release_api="https://api.example/releases/latest", opener=opener
+        )
+    assert target.read_bytes() == b"old"
+
+
+def test_update_appimage_updates_symlink_target_without_replacing_link(tmp_path: Path):
+    real = tmp_path / "real.AppImage"
+    real.write_bytes(b"old")
+    link = tmp_path / "Hermes.AppImage"
+    link.symlink_to(real)
+    release, _ = release_payload(b"new", digest=f"sha256:{hashlib.sha256(b'new').hexdigest()}")
+
+    def opener(request, timeout):
+        if request.full_url.endswith("latest"):
+            return Response(json.dumps(release).encode())
+        return Response(b"new")
+
+    appimage_update.update_appimage(
+        link, arch="x64", release_api="https://api.example/releases/latest", opener=opener
+    )
+    assert link.is_symlink()
+    assert real.read_bytes() == b"new"


### PR DESCRIPTION
## Summary

#93302 tracks a gap in the Linux desktop update path: an AppImage can be installed and launched, but the update flow only refreshes the backend source tree. It cannot replace the AppImage that the user is running.

This change adds the AppImage path to the existing POSIX updater:

- keep the normal backend and dependency update
- skip rebuilding an unpacked desktop app when the current process came from an AppImage
- find the matching Linux AppImage in the latest stable release
- verify its SHA-256 digest before installing it
- download beside the current file and replace it atomically
- leave the current file untouched if download or verification fails
- relaunch from the stable `APPIMAGE` path instead of the temporary mount path

The existing update paths for macOS, Windows, source installs, deb, and rpm are unchanged.

Closes #93302.

## Tests

- `pytest -q tests/scripts/test_appimage_update.py tests/hermes_cli/test_update_desktop_stale_warning.py tests/hermes_cli/test_update_shim_fail_closed.py tests/hermes_cli/test_update_handoff_backend_reap.py tests/hermes_cli/test_update_lock.py tests/hermes_cli/test_update_post_pull_syntax_guard.py`: 58 passed
- `npm run typecheck`: passed
- `npm run lint`: 0 errors; existing warnings only
- `npm test`: 7,290 passed, 3 skipped
- Python lint, shell syntax checks, and `git diff --check`: passed

The latest public release did not contain an AppImage asset when this was tested, so a live download could not be run. The updater tests use a local release/API fixture and cover a successful install, checksum mismatch, checksum sidecar fallback, symlink targets, and cleanup of failed downloads.
