### PR TITLE
fix(models): resolve user-declared providers in parse_model_input

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2803,30 +2803,67 @@ def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
     if colon > 0:
         provider_part = stripped[:colon].strip().lower()
         model_part = stripped[colon + 1:].strip()
-        if provider_part and model_part and provider_part in _KNOWN_PROVIDER_NAMES:
-            if provider_part == "custom":
-                lowered = stripped.lower()
-                for custom_id in sorted(
-                    _configured_custom_provider_ids() - {"custom"},
-                    key=len,
-                    reverse=True,
-                ):
-                    prefix = f"{custom_id.lower()}:"
-                    if lowered.startswith(prefix):
-                        return custom_id, stripped[len(custom_id) + 1 :].strip()
-            # Support custom:name:model triple syntax for named custom
-            # providers.  ``custom:local:qwen`` → ("custom:local", "qwen").
-            # Single colon ``custom:qwen`` → ("custom", "qwen") as before.
-            if provider_part == "custom" and ":" in model_part:
-                second_colon = model_part.find(":")
-                custom_name = model_part[:second_colon].strip()
-                actual_model = model_part[second_colon + 1:].strip()
-                if custom_name and actual_model:
-                    custom_id = f"custom:{custom_name.lower()}"
-                    if custom_id in _configured_custom_provider_ids():
-                        return (custom_id, actual_model)
-                    return ("custom", model_part)
-            return (normalize_provider(provider_part), model_part)
+        if provider_part and model_part:
+            # User-declared providers (``providers:`` and named
+            # ``custom_providers:`` entries in config.yaml) are real routing
+            # targets, but they are not in _KNOWN_PROVIDER_NAMES — only the
+            # bare "custom" bucket is. Without this check, ``myrouter:gpt``
+            # from a client (e.g. an ACP model selector that renders choices
+            # as ``provider:model``) fails the known-name branch below and
+            # the FULL string ``myrouter:gpt`` is returned as the model id,
+            # which the endpoint rejects ("modelCode does not exist").
+            if provider_part not in _KNOWN_PROVIDER_NAMES:
+                try:
+                    from hermes_cli.config import (
+                        get_compatible_custom_providers,
+                        load_config,
+                    )
+                    from hermes_cli.providers import (
+                        resolve_custom_provider,
+                        resolve_user_provider,
+                    )
+
+                    cfg = load_config()
+                    user_providers = (
+                        cfg.get("providers") if isinstance(cfg, dict) else None
+                    )
+                    resolved = resolve_user_provider(
+                        provider_part,
+                        user_providers if isinstance(user_providers, dict) else {},
+                    ) or resolve_custom_provider(
+                        provider_part,
+                        get_compatible_custom_providers(cfg)
+                        if isinstance(cfg, dict)
+                        else [],
+                    )
+                    if resolved is not None:
+                        return (resolved.id, model_part)
+                except Exception:
+                    pass
+            if provider_part in _KNOWN_PROVIDER_NAMES:
+                if provider_part == "custom":
+                    lowered = stripped.lower()
+                    for custom_id in sorted(
+                        _configured_custom_provider_ids() - {"custom"},
+                        key=len,
+                        reverse=True,
+                    ):
+                        prefix = f"{custom_id.lower()}:"
+                        if lowered.startswith(prefix):
+                            return custom_id, stripped[len(custom_id) + 1 :].strip()
+                # Support custom:name:model triple syntax for named custom
+                # providers.  ``custom:local:qwen`` → ("custom:local", "qwen").
+                # Single colon ``custom:qwen`` → ("custom", "qwen") as before.
+                if provider_part == "custom" and ":" in model_part:
+                    second_colon = model_part.find(":")
+                    custom_name = model_part[:second_colon].strip()
+                    actual_model = model_part[second_colon + 1:].strip()
+                    if custom_name and actual_model:
+                        custom_id = f"custom:{custom_name.lower()}"
+                        if custom_id in _configured_custom_provider_ids():
+                            return (custom_id, actual_model)
+                        return ("custom", model_part)
+                return (normalize_provider(provider_part), model_part)
     return (current_provider, stripped)
 
 

--- a/tests/hermes_cli/test_parse_model_input_user_providers.py
+++ b/tests/hermes_cli/test_parse_model_input_user_providers.py
@@ -1,0 +1,60 @@
+"""parse_model_input resolves user-declared config providers (providers:/custom_providers:)."""
+
+import pytest
+
+from hermes_cli.models import parse_model_input
+
+
+def _write_provider_config(tmp_path, providers_yaml=""):
+    (tmp_path / "config.yaml").write_text(providers_yaml)
+
+
+def test_bare_user_declared_provider_prefix_is_split(tmp_path, monkeypatch):
+    """``myrouter:gpt`` with myrouter declared under providers: splits."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_provider_config(
+        tmp_path,
+        "model:\n  default: glm\n  provider: myrouter\n"
+        "providers:\n  myrouter:\n    base_url: http://127.0.0.1:20128/v1\n"
+        "    model: glm\n    api_key: sk-test\n",
+    )
+    provider, model = parse_model_input("myrouter:gpt", "myrouter")
+    assert provider == "myrouter"
+    assert model == "gpt"
+
+
+def test_named_custom_providers_entry_is_split(tmp_path, monkeypatch):
+    """``custom:myrouter:model`` resolves when myrouter is a custom_providers entry."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_provider_config(
+        tmp_path,
+        "custom_providers:\n  - name: myrouter\n"
+        "    base_url: http://127.0.0.1:20128/v1\n"
+        "    api_key: sk-test\n",
+    )
+    provider, model = parse_model_input("custom:myrouter:ocg/ox-alpha", "custom")
+    assert provider == "custom:myrouter"
+    assert model == "ocg/ox-alpha"
+
+
+def test_undeclared_prefix_stays_whole(tmp_path, monkeypatch):
+    """A colon-bearing model with an undeclared left side is not split."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_provider_config(tmp_path, "model:\n  default: gpt\n")
+    provider, model = parse_model_input(
+        "anthropic/claude-3.5-sonnet:beta", "openrouter"
+    )
+    assert provider == "openrouter"
+    assert model == "anthropic/claude-3.5-sonnet:beta"
+
+
+def test_builtin_provider_prefix_still_wins(tmp_path, monkeypatch):
+    """Builtin aliases keep working even when user config declares providers."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _write_provider_config(
+        tmp_path,
+        "providers:\n  myrouter:\n    base_url: http://127.0.0.1:20128/v1\n",
+    )
+    provider, model = parse_model_input("zai:glm-5.2", "myrouter")
+    assert provider == "zai"
+    assert model == "glm-5.2"


### PR DESCRIPTION
## Summary
- `parse_model_input` only recognized built-in provider names/aliases for the `provider:model` colon syntax. User-declared providers (`providers:` section or named `custom_providers:` entries in config.yaml) were invisible to it, so `myrouter:gpt` was returned as the **full string** model id with the provider unchanged.
- Downstream effect: the endpoint rejects the nonexistent model — e.g. an OpenAI-compatible gateway answering `HTTP 400 [1214][modelCode: does not exist]`. Every caller inherits the bug: the ACP model selector (clients like Paseo render choices as `provider:model`), `/model`, and the web UI.
- Fix at the shared choke point: when the colon prefix is not a built-in, resolve it against the user's config with the existing `resolve_user_provider` / `resolve_custom_provider` helpers (the same substrate `web_server.py`'s provider/model resolution already uses).
- Undeclared prefixes keep the previous keep-it-whole behavior, so colon-bearing model names (`anthropic/claude-3.5-sonnet:beta`, Ollama `model:tag` without a matching provider) are unaffected.

## Reproduction
config.yaml:
```yaml
providers:
  9router:
    base_url: http://127.0.0.1:20128/v1
    model: glm
    api_key: sk-...
```
Before: `parse_model_input("9router:gpt", "9router")` → `("9router", "9router:gpt")` — the gateway receives model `"9router:gpt"` → `400 [1214][modelCode: does not exist]`.
After: → `("9router", "gpt")`.

## Test plan
- [x] New `tests/hermes_cli/test_parse_model_input_user_providers.py`: bare `providers:` prefix splits; named `custom_providers:` (`custom:myrouter:model`) splits; undeclared prefix stays whole; built-in alias still wins over user config with the same shape.
- [x] Existing `tests/hermes_cli/test_model_validation.py` passes (34 tests).
- [x] Verified end-to-end against a live ACP session (`session/new` with `custom:9router:ocg/ox-alpha-free` → prompt completes).

## Relation to other PRs
#22430 patches a downstream symptom of this in `acp_adapter/server.py` (ACP only, `providers:` only, triggered on a residual colon in the model). This PR fixes the root cause in `parse_model_input` for all callers and both config sections.

*Written by Zephyr (AI Assistant)

