### PR TITLE
fix(desktop): route ambient SSH profile deletion to remote

### DIFF
--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -615,6 +615,17 @@ export const host = {
     }
 
     const targetProfile = route?.targetProfile || name
+    // A name-only call is ambient, not local: Bot Mode's active SSH roster
+    // rows deliberately use the ambient gateway door and therefore carry no
+    // explicit owner route. Preserve the active registry connection so the
+    // profile teardown and DELETE both land on the VPS instead of retiring the
+    // unrelated local pool and leaving the warmed remote backend to recreate
+    // the deleted profile.
+    const ambientConnectionId = route ? null : String(activeGatewayConnectionId() || '').trim()
+
+    const ambientRemoteConnectionId = ambientConnectionId && ambientConnectionId !== 'local'
+      ? ambientConnectionId
+      : null
 
     if (!name) {
       throw new Error('deleteProfile: profile name required')
@@ -635,11 +646,18 @@ export const host = {
     // A hover-warmed Bot Mode row owns a retained renderer socket. Retire it
     // before Electron stops the profile backend so the socket closure cannot
     // schedule a reconnect that resurrects the deleted profile.
-    if (!route || route.mode === 'local') {
+    if (route?.mode === 'local' || (!route && !ambientRemoteConnectionId)) {
       retireLocalProfileGateways(targetProfile)
     }
 
-    await deleteProfile(targetProfile, route ? { connectionId: route.connectionId, profile: route.profile } : undefined)
+    await deleteProfile(
+      targetProfile,
+      route
+        ? { connectionId: route.connectionId, profile: route.profile }
+        : ambientRemoteConnectionId
+          ? { connectionId: ambientRemoteConnectionId, profile: name }
+          : undefined
+    )
 
     // The profile rail paints from the shared $profiles cache; without a
     // refresh the deleted profile's badge survives and clicking it starts a

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -108,6 +108,7 @@ const { openSession: openSessionCore } = await import('@/app/open-session')
 const { deleteProfile } = await import('@/hermes')
 
 const {
+  activeGatewayConnectionId,
   openGatewayForAgent,
   openGatewayForProfile,
   requestGatewayForAgent,
@@ -152,6 +153,7 @@ const profile = (name: string): ProfileInfo => ({
 
 afterEach(() => {
   vi.clearAllMocks()
+  vi.mocked(activeGatewayConnectionId).mockReturnValue('local')
   $activeGatewayProfile.set('remote-worker')
   $gatewaySwapTarget.set(null)
   setMockAtom($focusedRuntimeId, null)
@@ -187,6 +189,18 @@ describe('connection-aware plugin host APIs', () => {
     // The rail paints from $profiles; skipping the refresh leaves a stale
     // badge whose click hot-loops against the deletion guard (#88769).
     expect(refreshProfiles).toHaveBeenCalled()
+  })
+
+  it('pins an ambient SSH profile delete to the active connection and target profile', async () => {
+    vi.mocked(activeGatewayConnectionId).mockReturnValue('ssh-vps')
+
+    await host.deleteProfile('worker')
+
+    expect(retireLocalProfileGateways).not.toHaveBeenCalled()
+    expect(deleteProfile).toHaveBeenCalledWith('worker', {
+      connectionId: 'ssh-vps',
+      profile: 'worker'
+    })
   })
 
   it('refreshes the profile inventory before asking Electron for routes', async () => {


### PR DESCRIPTION
## What does this PR do?

Routes name-only Bot Mode profile deletion through the active non-local gateway connection. An ambient delete initiated from an SSH roster no longer retires unrelated local profile gateways or sends an unscoped delete to the local backend.

This is intentionally narrower than #89806. That PR coordinates teardown after deletion reaches a shared remote backend; this change fixes the preceding Desktop routing step.

## Related Issue

Fixes #93734

Related: #89806, #89729, #89756, #90006

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/sdk/index.ts` - preserve `activeGatewayConnectionId()` for a name-only delete when the active connection is non-local, skip local gateway retirement, and pass the connection and profile to `deleteProfile`.
- `apps/desktop/src/sdk/profile-routing.test.ts` - add a regression test proving an ambient SSH delete stays pinned to the active VPS connection and does not retire local gateways.

## How to Test

1. Connect Desktop to an SSH gateway and invoke `host.deleteProfile(name)` without an explicit route from the active Bot Mode roster.
2. Verify the request passes `{ connectionId: <active SSH connection>, profile: name }` to `deleteProfile`.
3. Verify `retireLocalProfileGateways` is not called for that remote delete and local behavior remains unchanged when the active connection is `local`.

Automated verification on Linux:

- `npm test -- --run src/sdk` - 65 passed
- `npm run typecheck` - passed
- `npx eslint src/sdk/index.ts src/sdk/profile-routing.test.ts` - clean
- `git diff --check origin/main...HEAD` - clean

Repository-wide `npm run lint` currently reports unrelated pre-existing failures outside these two changed files. Focused lint for the changed files is clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing issues and PRs for duplicates
- [x] My PR contains only this routing fix and its regression test
- [ ] I've run `pytest tests/ -q` - N/A, this is a Desktop TypeScript-only change; the scoped Vitest suite above passed
- [x] I've added a regression test
- [x] I've tested the scoped automated checks on Linux

### Documentation & Housekeeping

- [x] Documentation update - N/A, no user-facing API or configuration changed
- [x] `cli-config.yaml.example` update - N/A, no config key changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update - N/A, no architecture or workflow changed
- [x] Cross-platform impact considered - the change is renderer routing logic with no platform-specific API
- [x] Tool descriptions or schemas update - N/A, no model tool changed

## Screenshots / Logs

Focused test result: 4 test files passed, 65 tests passed. The regression asserts that an ambient `ssh-vps` delete does not retire local gateways and calls `deleteProfile('worker', { connectionId: 'ssh-vps', profile: 'worker' })`.
