### PR TITLE
fix(slack): brand task cards by profile

### DIFF
--- a/docs/relay-connector-contract.md
+++ b/docs/relay-connector-contract.md
@@ -1,4 +1,4 @@
-# Relay ↔ Connector Contract (v1, EXPERIMENTAL)
+# Relay ↔ Connector Contract (v2, EXPERIMENTAL)
 
 > **Status:** EXPERIMENTAL. This contract MAY CHANGE without a deprecation
 > cycle until at least two real Class-1 platforms (Discord + Telegram) have
@@ -27,7 +27,7 @@ connector owns all platform-specific socket/identity logic.
    draft/edit/thread/markdown capabilities) and registers an inbound handler.
 4. Connector then streams inbound events and accepts outbound actions.
 
-`contract_version` (currently `1`) is carried in the descriptor. The gateway
+`contract_version` (currently `2`) is carried in the descriptor. The gateway
 ignores unknown descriptor fields (forward-compat) and fills missing optional
 fields from defaults.
 
@@ -401,6 +401,12 @@ The gateway calls the transport with action dicts. Source of truth:
 | `react` | `chat_id`, `message_id`, `emoji`, `remove?`, `metadata?` | `{success: bool, error?}` |
 | `thread_create` | `chat_id` (parent), `thread_name`, `message_id?` (anchor), `metadata?` | `{success: bool, thread_id?, error?}` |
 | `thread_rename` | `chat_id` (parent), `message_id` (the THREAD id), `thread_name`, `only_if_current_name?`, `metadata?` | `{success: bool, error?}` |
+| `task_card` | `chat_id`, `card_id`, `chunks`, `metadata`, `title?`, `fallback_text?` | `{success: bool, error?}` |
+| `task_card_stop` | `chat_id`, `card_id`, `metadata?` | `{success: bool, error?}` |
+
+`task_card` identity fields are contract v2. A gateway sends `title` and
+`fallback_text` only when the descriptor selected for that chat advertises
+`contract_version >= 2`; v1 connectors receive the original task-card payload.
 
 `get_chat_info(chat_id)` is a separate proxied call returning at least
 `{name, type}`.

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -708,9 +708,9 @@ class RelayAdapter(BasePlatformAdapter):
         reply_to/metadata/fallback_text) — not a card_id. The card stream
         key is derived per (chat, reply_to-thread): one card per turn
         thread, matching the connector's (channel, card_id) keying.
-        ``fallback_text``/``title`` are accepted for contract parity; the
-        connector's plan-mode stream renders task chunks, so they are not
-        forwarded.
+        Contract v2 forwards ``title`` and ``fallback_text`` so connector-side
+        task cards use the same profile-scoped identity as native Slack cards.
+        Contract v1 keeps its original payload byte-for-byte.
 
         ``tasks`` are the TurnRunner's normalized task dicts (id/title/
         status/details/output); the connector maps them onto its
@@ -735,15 +735,25 @@ class RelayAdapter(BasePlatformAdapter):
             # Slack card streams are thread replies (same rule as draft):
             # anchor on the triggering message when the runner gave us one.
             merged_meta["thread_ts"] = str(reply_to)
+        frame = {
+            "op": "task_card",
+            "chat_id": chat_id,
+            "card_id": card_id,
+            "chunks": [dict(t) for t in tasks],
+            "metadata": self._with_scope(chat_id, merged_meta),
+        }
+        descriptor = self._descriptor_for_chat(str(chat_id))
+        raw_contract_version = getattr(descriptor, "contract_version", 1)
+        contract_version = (
+            raw_contract_version if type(raw_contract_version) is int else 1
+        )
+        if contract_version >= 2:
+            frame["title"] = title
+            if fallback_text is not None:
+                frame["fallback_text"] = fallback_text
         try:
             result = await self._transport.send_outbound(
-                {
-                    "op": "task_card",
-                    "chat_id": chat_id,
-                    "card_id": card_id,
-                    "chunks": [dict(t) for t in tasks],
-                    "metadata": self._with_scope(chat_id, merged_meta),
-                },
+                frame,
                 platform=self._platform_by_chat.get(str(chat_id)),
             )
         except Exception as e:

--- a/gateway/relay/descriptor.py
+++ b/gateway/relay/descriptor.py
@@ -35,7 +35,7 @@ from dataclasses import asdict, dataclass
 
 # Bump additively (never reinterpret an existing field) during the experimental
 # phase; a breaking change requires updating both repos in lockstep.
-CONTRACT_VERSION = 1
+CONTRACT_VERSION = 2
 
 
 @dataclass(frozen=True)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4588,6 +4588,9 @@ class TurnRunner:
         message so progress stays live for the rest of the turn.
         """
         ctx = self._ctx
+        from gateway.task_card_identity import GENERIC_TASK_CARD_TITLE
+
+        task_card_title = ctx.native_task_card_title or GENERIC_TASK_CARD_TITLE
         tasks: Dict[str, Dict[str, str]] = {}
         task_order: List[str] = []
         fallback_msg_id: Optional[str] = None
@@ -4613,7 +4616,7 @@ class TurnRunner:
                 f"- {task['title']} - {labels.get(task['status'], task['status'])}"
                 for task in _visible_tasks()
             ]
-            return "Hermes is working\n" + "\n".join(lines)
+            return task_card_title + "\n" + "\n".join(lines)
 
         def _apply_native_event(raw: Any) -> bool:
             nonlocal anonymous_seq
@@ -4690,7 +4693,7 @@ class TurnRunner:
                 result = await adapter.send_native_task_card_progress(
                     chat_id=ctx.source.chat_id,
                     tasks=_visible_tasks(),
-                    title="Hermes is working",
+                    title=task_card_title,
                     reply_to=ctx._progress_reply_to,
                     metadata=ctx._progress_metadata,
                     fallback_text=_fallback_text(),
@@ -28482,6 +28485,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # flags would silently leave the native feature inactive).
         _progress_adapter_for_native = self._adapter_for_source(source)
         _native_slack_task_cards = False
+        _native_task_card_title = None
         if (
             source.platform == Platform.SLACK
             and _progress_adapter_for_native is not None
@@ -28493,6 +28497,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             except Exception:
                 logger.debug("Slack native task-card config check failed", exc_info=True)
+        if _native_slack_task_cards:
+            from gateway.task_card_identity import resolve_task_card_title
+            from hermes_constants import get_hermes_home
+
+            _native_task_card_title = resolve_task_card_title(get_hermes_home())
         needs_progress_queue = (
             tool_progress_enabled or _thinking_enabled or _native_slack_task_cards
         )
@@ -28588,6 +28597,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             interim_assistant_messages_enabled=interim_assistant_messages_enabled,
             needs_progress_queue=needs_progress_queue,
             _native_slack_task_cards=_native_slack_task_cards,
+            native_task_card_title=_native_task_card_title,
             _voice_ack_fired=_voice_ack_fired,
             _voice_ack_guild=_voice_ack_guild,
             _voice_ack_loop=_voice_ack_loop,

--- a/gateway/task_card_identity.py
+++ b/gateway/task_card_identity.py
@@ -1,0 +1,70 @@
+"""Profile-scoped identity for public gateway task-card progress."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from pathlib import Path
+
+from hermes_cli.profiles import read_profile_meta
+
+GENERIC_TASK_CARD_TITLE = "Hermes is working"
+_MAX_DISPLAY_NAME_CHARS = 64
+_MAX_SOURCE_CHARS = 4096
+_ZERO_WIDTH_JOINER = "\u200d"
+_UNSAFE_BIDI = frozenset(
+    {
+        "\u061c",
+        "\u200e",
+        "\u200f",
+        "\u202a",
+        "\u202b",
+        "\u202c",
+        "\u202d",
+        "\u202e",
+        "\u2066",
+        "\u2067",
+        "\u2068",
+        "\u2069",
+    }
+)
+
+
+def _clean_display_name(value: object) -> str:
+    """Return a bounded, single-line display name safe for a public title."""
+    if not isinstance(value, str):
+        return ""
+
+    source = unicodedata.normalize("NFC", value[:_MAX_SOURCE_CHARS])
+    cleaned: list[str] = []
+    for char in source:
+        if char.isspace():
+            cleaned.append(" ")
+            continue
+        if char in _UNSAFE_BIDI:
+            continue
+        if unicodedata.category(char).startswith("C") and char != _ZERO_WIDTH_JOINER:
+            continue
+        cleaned.append(char)
+
+    result = re.sub(r" +", " ", "".join(cleaned)).strip()
+    result = result[:_MAX_DISPLAY_NAME_CHARS].rstrip()
+    while result and (
+        result.endswith(_ZERO_WIDTH_JOINER)
+        or unicodedata.category(result[-1]).startswith("M")
+    ):
+        result = result[:-1].rstrip()
+    return result
+
+
+def resolve_task_card_title(profile_home: str | Path) -> str:
+    """Resolve one profile's public working title, with the legacy fallback."""
+    try:
+        display_name = _clean_display_name(
+            read_profile_meta(Path(profile_home)).get("display_name")
+        )
+    except Exception:
+        display_name = ""
+    return (
+        f"{display_name} is working" if display_name else GENERIC_TASK_CARD_TITLE
+    )

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -141,5 +141,6 @@ class TurnContext:
     # published by TurnRunner (like voice_ack_callback above) so tool starts
     # and completions correlate by real tool-call ID instead of tool name.
     _native_slack_task_cards: bool = False
+    native_task_card_title: Optional[str] = None
     native_tool_start_callback: Optional[Callable] = None
     native_tool_complete_callback: Optional[Callable] = None

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -894,10 +894,13 @@ def read_profile_meta(profile_dir: Path) -> dict:
         return empty
     if not isinstance(data, dict):
         return empty
+    raw_display_name = data.get("display_name")
     return {
         "description": str(data.get("description") or "").strip(),
         "description_auto": bool(data.get("description_auto", False)),
-        "display_name": str(data.get("display_name") or "").strip(),
+        "display_name": (
+            raw_display_name.strip() if isinstance(raw_display_name, str) else ""
+        ),
     }
 
 

--- a/tests/gateway/relay/test_descriptor.py
+++ b/tests/gateway/relay/test_descriptor.py
@@ -3,6 +3,10 @@
 from gateway.relay.descriptor import CONTRACT_VERSION, CapabilityDescriptor
 
 
+def test_contract_version_includes_task_card_identity_fields():
+    assert CONTRACT_VERSION >= 2
+
+
 def _telegram_descriptor(**overrides) -> CapabilityDescriptor:
     base = dict(
         contract_version=CONTRACT_VERSION,

--- a/tests/gateway/relay/test_relay_live_cards.py
+++ b/tests/gateway/relay/test_relay_live_cards.py
@@ -227,6 +227,84 @@ def _tasks():
 
 
 class TestTaskCardOps:
+    def test_v1_task_card_frame_remains_byte_compatible(self, loop):
+        adapter, stub = _connected_adapter(contract_version=1)
+        result = loop.run_until_complete(
+            adapter.send_native_task_card_progress(
+                chat_id="C1",
+                tasks=_tasks(),
+                title="Marko is working",
+                fallback_text="Marko is working\n- terminal - running",
+                reply_to="1700.100",
+            )
+        )
+
+        assert result.success
+        frame = next(s for s in stub.sent if s.get("op") == "task_card")
+        assert set(frame) == {"op", "chat_id", "card_id", "chunks", "metadata"}
+        assert "title" not in frame
+        assert "fallback_text" not in frame
+
+    def test_v2_task_card_frame_forwards_title_and_fallback(self, loop):
+        adapter, stub = _connected_adapter(contract_version=2)
+        result = loop.run_until_complete(
+            adapter.send_native_task_card_progress(
+                chat_id="C1",
+                tasks=_tasks(),
+                title="小助手 is working",
+                fallback_text="小助手 is working\n- terminal - running",
+                reply_to="1700.100",
+            )
+        )
+
+        assert result.success
+        frame = next(s for s in stub.sent if s.get("op") == "task_card")
+        assert frame["title"] == "小助手 is working"
+        assert frame["fallback_text"].startswith("小助手 is working\n")
+
+    def test_task_card_contract_version_is_resolved_per_chat(self, loop):
+        adapter, stub = _connected_adapter(contract_version=1)
+        v2 = make_desc(contract_version=2)
+        stub.descriptor_for_platform = lambda platform: v2  # type: ignore[attr-defined]
+        adapter._platform_by_chat["C-V2"] = "slack"
+
+        result = loop.run_until_complete(
+            adapter.send_native_task_card_progress(
+                chat_id="C-V2",
+                tasks=_tasks(),
+                title="Profile Two is working",
+                fallback_text="Profile Two is working\n- terminal - running",
+                reply_to="1700.200",
+            )
+        )
+
+        assert result.success
+        frame = next(s for s in stub.sent if s.get("op") == "task_card")
+        assert frame["title"] == "Profile Two is working"
+        assert frame["fallback_text"].startswith("Profile Two is working\n")
+
+    @pytest.mark.parametrize(
+        "malformed_version", [None, "not-a-number", "2", 2.0, 2.9, True, False, [], {}]
+    )
+    def test_malformed_contract_version_safely_uses_v1_frame(
+        self, loop, malformed_version
+    ):
+        adapter, stub = _connected_adapter(contract_version=malformed_version)
+
+        result = loop.run_until_complete(
+            adapter.send_native_task_card_progress(
+                chat_id="C1",
+                tasks=_tasks(),
+                title="Marko is working",
+                fallback_text="Marko is working\n- terminal - running",
+                reply_to="1700.100",
+            )
+        )
+
+        assert result.success
+        frame = next(s for s in stub.sent if s.get("op") == "task_card")
+        assert set(frame) == {"op", "chat_id", "card_id", "chunks", "metadata"}
+
     def test_progress_emits_task_card_op(self, loop):
         adapter, stub = _connected_adapter()
         result = loop.run_until_complete(

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -252,6 +252,7 @@ class NativeTaskCardAdapter(ProgressCaptureAdapter):
             {
                 "chat_id": chat_id,
                 "tasks": [dict(task) for task in tasks],
+                "title": title,
                 "metadata": dict(metadata or {}),
                 "fallback_text": fallback_text,
             }
@@ -1120,15 +1121,180 @@ async def test_slack_native_failure_keeps_editing_one_live_text_fallback(
         scope_id="T1",
     )
 
+    assert isinstance(adapter, FailingNativeTaskCardAdapter)
     assert result["final_response"] == "done"
     assert len(adapter.native_updates) == 1
+    assert adapter.native_updates[0]["title"] == "Hermes is working"
+    assert adapter.native_updates[0]["fallback_text"].startswith(
+        "Hermes is working\n"
+    )
     assert len(adapter.sent) == 1
+    assert adapter.sent[0]["content"].startswith("Hermes is working\n")
     assert adapter.sent[0]["content"].endswith("web_search - alpha - running")
     assert len(adapter.edits) >= 2
     assert {edit["message_id"] for edit in adapter.edits} == {"progress-1"}
     assert adapter.edits[-1]["content"].endswith("web_search - beta - error")
     assert "web_search - alpha - complete" in adapter.edits[-1]["content"]
     assert adapter.native_stops == 1
+
+
+@pytest.mark.asyncio
+async def test_slack_native_card_uses_profile_title_for_card_and_fallback(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "profile.yaml").write_text(
+        "display_name: Marko\n", encoding="utf-8"
+    )
+
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        DuplicateNativeToolsAgent,
+        session_id="sess-native-profile-title",
+        platform=Platform.SLACK,
+        chat_id="C1",
+        thread_id="thread-1",
+        adapter_cls=NativeTaskCardAdapter,
+        user_id="U1",
+        scope_id="T1",
+    )
+
+    assert isinstance(adapter, NativeTaskCardAdapter)
+    assert result["final_response"] == "done"
+    assert {update["title"] for update in adapter.native_updates} == {
+        "Marko is working"
+    }
+    assert all(
+        update["fallback_text"].startswith("Marko is working\n")
+        for update in adapter.native_updates
+    )
+
+
+@pytest.mark.asyncio
+async def test_slack_native_card_does_not_derive_title_from_typing_status(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "profile.yaml").write_text(
+        "display_name: Marko\n", encoding="utf-8"
+    )
+
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        DuplicateNativeToolsAgent,
+        session_id="sess-native-typing-independent",
+        config_data={
+            "platforms": {"slack": {"typing_status_text": "Definitely not Marko"}}
+        },
+        platform=Platform.SLACK,
+        chat_id="C1",
+        thread_id="thread-1",
+        adapter_cls=NativeTaskCardAdapter,
+        user_id="U1",
+        scope_id="T1",
+    )
+
+    assert isinstance(adapter, NativeTaskCardAdapter)
+    assert result["final_response"] == "done"
+    assert {update["title"] for update in adapter.native_updates} == {
+        "Marko is working"
+    }
+
+
+@pytest.mark.asyncio
+async def test_non_slack_platform_does_not_use_native_task_card_lane(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "profile.yaml").write_text(
+        "display_name: Marko\n", encoding="utf-8"
+    )
+
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        FakeAgent,
+        session_id="sess-native-non-slack",
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        adapter_cls=NativeTaskCardAdapter,
+    )
+
+    assert isinstance(adapter, NativeTaskCardAdapter)
+    assert result["final_response"] == "done"
+    assert adapter.native_updates == []
+
+
+@pytest.mark.asyncio
+async def test_concurrent_multiplex_task_card_titles_are_profile_isolated(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    for profile, display_name in (("marko", "Marko"), ("other", "Other Agent")):
+        profile_home = tmp_path / "profiles" / profile
+        profile_home.mkdir(parents=True)
+        (profile_home / "profile.yaml").write_text(
+            f"display_name: {display_name}\n", encoding="utf-8"
+        )
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+    fake_module = types.ModuleType("run_agent")
+    fake_module.AIAgent = DuplicateNativeToolsAgent  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "run_agent", fake_module)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    marko_adapter = NativeTaskCardAdapter()
+    other_adapter = NativeTaskCardAdapter()
+    runner = _make_runner(marko_adapter)
+    runner.config.multiplex_profiles = True
+    runner._profile_adapters = {
+        "marko": {Platform.SLACK: marko_adapter},
+        "other": {Platform.SLACK: other_adapter},
+    }
+
+    async def run_turn(profile, chat_id, adapter):
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id=chat_id,
+            chat_type="group",
+            thread_id=f"thread-{chat_id}",
+            user_id=f"user-{chat_id}",
+            scope_id=f"team-{chat_id}",
+            profile=profile,
+        )
+        source._transport_adapter_ref = lambda: adapter  # type: ignore[attr-defined]
+        return await runner._run_agent(
+            message="hello",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id=f"sess-{profile}",
+            session_key=f"agent:{profile}:slack:group:{chat_id}",
+        )
+
+    results = await asyncio.gather(
+        run_turn("marko", "C-MARKO", marko_adapter),
+        run_turn("other", "C-OTHER", other_adapter),
+    )
+
+    assert [result["final_response"] for result in results] == ["done", "done"]
+    assert {update["title"] for update in marko_adapter.native_updates} == {
+        "Marko is working"
+    }
+    assert {update["title"] for update in other_adapter.native_updates} == {
+        "Other Agent is working"
+    }
+    assert all(
+        "Marko" not in update["fallback_text"]
+        for update in other_adapter.native_updates
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -4580,6 +4580,30 @@ class TestNativeTaskCardProgress:
         ).native_task_cards_enabled() is False
 
     @pytest.mark.asyncio
+    async def test_native_payload_preserves_supplied_title_and_fallback(self, adapter):
+        client = adapter._app.client
+        client.api_call.side_effect = [{"ts": "stream-1"}, {"ok": True}]
+        title = "小助手 is working"
+        fallback = f"{title}\n- terminal - running"
+
+        result = await adapter.send_native_task_card_progress(
+            "C1",
+            [{"id": "call-1", "title": "terminal", "status": "in_progress"}],
+            title=title,
+            fallback_text=fallback,
+            metadata={"thread_id": "thread-1"},
+        )
+
+        assert result.success
+        append = client.api_call.await_args_list[1]
+        assert append.args[0] == "chat.appendStream"
+        assert append.kwargs["json"]["chunks"][0] == {
+            "type": "plan_update",
+            "title": title,
+        }
+        assert append.kwargs["json"]["markdown_text"] == fallback
+
+    @pytest.mark.asyncio
     async def test_native_updates_are_serialized_and_workspace_scoped(self, adapter):
         team_client = AsyncMock()
         start_count = 0

--- a/tests/gateway/test_task_card_identity.py
+++ b/tests/gateway/test_task_card_identity.py
@@ -1,0 +1,114 @@
+"""Public task-card titles derive safely from explicit profile metadata."""
+
+from __future__ import annotations
+
+import random
+import string
+import unicodedata
+
+import pytest
+import yaml
+
+from gateway.task_card_identity import (
+    GENERIC_TASK_CARD_TITLE,
+    resolve_task_card_title,
+)
+
+
+def _write_profile(home, display_name):
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "profile.yaml").write_text(
+        yaml.safe_dump({"display_name": display_name}, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    "display_name, expected",
+    [
+        ("Marko", "Marko is working"),
+        ("  Marko   Agent  ", "Marko Agent is working"),
+        ("小助手", "小助手 is working"),
+        ("Jose\u0301", "José is working"),
+        ("A\n\tB", "A B is working"),
+        ("A\x00B", "AB is working"),
+        ("A\u202eB", "AB is working"),
+        ("👩\u200d💻", "👩\u200d💻 is working"),
+    ],
+)
+def test_resolve_task_card_title_sanitizes_valid_string_metadata(
+    tmp_path, display_name, expected
+):
+    _write_profile(tmp_path, display_name)
+
+    assert resolve_task_card_title(tmp_path) == expected
+
+
+@pytest.mark.parametrize("display_name", [None, "", " \t\n ", [], {}, 0, False])
+def test_resolve_task_card_title_uses_exact_fallback_for_unusable_metadata(
+    tmp_path, display_name
+):
+    _write_profile(tmp_path, display_name)
+
+    assert resolve_task_card_title(tmp_path) == GENERIC_TASK_CARD_TITLE
+
+
+def test_resolve_task_card_title_uses_fallback_for_missing_profile(tmp_path):
+    assert resolve_task_card_title(tmp_path) == GENERIC_TASK_CARD_TITLE
+
+
+def test_resolve_task_card_title_uses_fallback_for_malformed_yaml(tmp_path):
+    (tmp_path / "profile.yaml").write_text("display_name: [", encoding="utf-8")
+
+    assert resolve_task_card_title(tmp_path) == GENERIC_TASK_CARD_TITLE
+
+
+def test_resolve_task_card_title_is_bounded_without_dangling_combining_or_joiner(
+    tmp_path,
+):
+    _write_profile(tmp_path, "a" * 200 + "e\u0301\u200d")
+
+    title = resolve_task_card_title(tmp_path)
+    name = title.removesuffix(" is working")
+    assert len(name) <= 64
+    assert name[-1] != "\u200d"
+    assert not unicodedata.category(name[-1]).startswith("M")
+
+
+def test_profile_paths_are_explicit_and_do_not_cross_contaminate(tmp_path):
+    marko_home = tmp_path / "marko"
+    other_home = tmp_path / "other"
+    _write_profile(marko_home, "Marko")
+    _write_profile(other_home, "Other Agent")
+
+    assert resolve_task_card_title(marko_home) == "Marko is working"
+    assert resolve_task_card_title(other_home) == "Other Agent is working"
+    assert "Marko" not in resolve_task_card_title(other_home)
+
+
+def test_randomized_titles_are_safe_and_deterministic(tmp_path):
+    rng = random.Random(94731)
+    alphabet = (
+        string.ascii_letters
+        + string.digits
+        + " \t\n\r"
+        + "小助手é👩\u200d💻"
+        + "\x00\x1f\u202a\u202e\u2066\u2069"
+    )
+
+    for index in range(250):
+        raw = "".join(rng.choice(alphabet) for _ in range(rng.randrange(0, 180)))
+        home = tmp_path / str(index)
+        _write_profile(home, raw)
+        first = resolve_task_card_title(home)
+        second = resolve_task_card_title(home)
+
+        assert first == second
+        assert first
+        assert first == GENERIC_TASK_CARD_TITLE or first.endswith(" is working")
+        assert "\n" not in first and "\r" not in first and "\t" not in first
+        assert not any(
+            char in "\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069"
+            for char in first
+        )
+        assert len(first) <= 64 + len(" is working")

--- a/tests/hermes_cli/test_profile_display_name.py
+++ b/tests/hermes_cli/test_profile_display_name.py
@@ -46,6 +46,17 @@ class TestMetaAndValidation:
     def test_missing_file_defaults_empty(self, profile_env):
         assert read_profile_meta(profile_env)["display_name"] == ""
 
+    @pytest.mark.parametrize(
+        "yaml_value",
+        ["[Marko]", "{name: Marko}", "42", "true"],
+    )
+    def test_non_string_display_name_defaults_empty(self, profile_env, yaml_value):
+        (profile_env / "profile.yaml").write_text(
+            f"display_name: {yaml_value}\n", encoding="utf-8"
+        )
+
+        assert read_profile_meta(profile_env)["display_name"] == ""
+
     def test_empty_clears_key_from_file(self, profile_env):
         write_profile_meta(profile_env, display_name="Harumesu")
         write_profile_meta(profile_env, display_name="")

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -568,6 +568,9 @@ platforms:
   is `tool_progress: off` (text bubbles spam channels; native cards don't).
 - Concurrent calls to the same tool are correlated by real tool-call ID, so
   parallel `web_search` calls each get their own row with the right status.
+- The card heading uses the active profile's presentation-only `display_name`
+  from `profile.yaml`. Profiles without one keep the backward-compatible
+  `Hermes is working` heading.
 - If the native stream can't start or update, Hermes falls back to a single
   continuously edited text message so progress stays live for the turn.
 - The card stream is stopped exactly once when the turn finalizes, including


### PR DESCRIPTION
## Summary

- derive Slack native task-card titles from the canonical profile `display_name`
- snapshot the resolved title once per turn so multiplexed profiles cannot leak identity across concurrent renders
- reuse the same title for native Slack cards and editable text fallback
- extend relay task-card contract v2 with `title` and `fallback_text` while preserving the exact v1 frame shape
- sanitize untrusted profile names and fall back exactly to `Hermes is working`

## Behavior

A profile with `display_name: Marko` now renders:

```text
Marko is working
```

Profiles without a usable display name continue to render:

```text
Hermes is working
```

This does not read or modify Slack `typing_status_text`, and non-Slack platforms do not enter the native task-card lane.

## Compatibility

Relay v1 frames retain their legacy key set. Relay v2 fields are emitted only when the per-chat descriptor advertises an actual integer contract version of 2 or newer. Malformed values, including booleans, numeric strings and floats, fail closed to v1.

The separate `gateway-gateway` connector repository was not available to this GitHub account, so connector-side v2 consumption is documented but not included here. Direct Slack native task cards do not depend on that connector.

## Verification

- 278 focused profile, gateway, Slack and relay tests passed
- 255 tests in `tests/gateway/relay` passed
- syntax and import checks passed
- `git diff --check` passed
- added-line security scan found no matches

Warnings were pre-existing `AsyncMock`/dependency deprecation warnings; there were no test failures.

## Live verification

Not performed as part of this PR. No gateway was restarted and no Slack message was posted from the development checkout.
