### PR TITLE
fix(compressor): bound single-file sampling by population like directory mode

### DIFF
--- a/tests/test_trajectory_compressor_sample.py
+++ b/tests/test_trajectory_compressor_sample.py
@@ -1,0 +1,62 @@
+"""Sampling bounds in trajectory_compressor single-file mode (#93737).
+
+The single-file branch sampled `max(1, ...)` entries without bounding by
+the population, so an empty input (or one holding only invalid JSON
+lines) crashed `random.sample` with "Sample larger than population",
+aborting unattended batch runs. The directory branch already bounded with
+`min(sample_size, len(entries))` — these tests pin the mirrored guard and
+the unchanged non-empty behavior by driving main() directly in dry-run
+mode (which exercises the sampling block and returns before any
+model/tokenizer dependency).
+"""
+
+import json
+
+import trajectory_compressor
+
+
+def test_empty_input_with_sample_percent_exits_cleanly(tmp_path, capsys):
+    empty = tmp_path / "empty.jsonl"
+    empty.write_text("", encoding="utf-8")
+
+    trajectory_compressor.main(input=str(empty), sample_percent=50, dry_run=True)
+    out = capsys.readouterr().out
+
+    assert "Loaded 0 trajectories" in out
+    assert "Sampled 0 trajectories (50% of 0)" in out
+
+
+def test_invalid_lines_only_input_exits_cleanly(tmp_path, capsys):
+    bad = tmp_path / "bad.jsonl"
+    bad.write_text("not json\nalso not json\n", encoding="utf-8")
+
+    trajectory_compressor.main(input=str(bad), sample_percent=25, dry_run=True)
+    out = capsys.readouterr().out
+
+    assert "Sampled 0 trajectories" in out
+
+
+def test_nonempty_input_still_samples_requested_percent(tmp_path, capsys):
+    good = tmp_path / "good.jsonl"
+    good.write_text(
+        "\n".join(json.dumps({"id": i}) for i in range(4)) + "\n",
+        encoding="utf-8",
+    )
+
+    trajectory_compressor.main(input=str(good), sample_percent=50, dry_run=True)
+    out = capsys.readouterr().out
+
+    assert "Sampled 2 trajectories (50% of 4)" in out
+
+
+def test_directory_mode_empty_files_remain_clean(tmp_path, capsys):
+    """The already-guarded directory branch keeps its behavior when the
+    directory holds only empty JSONL files."""
+    data = tmp_path / "runs"
+    data.mkdir()
+    (data / "a.jsonl").write_text("", encoding="utf-8")
+
+    trajectory_compressor.main(input=str(data), sample_percent=50, dry_run=True)
+    out = capsys.readouterr().out
+
+    assert "Sampled 0 from 0 total trajectories" in out

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -1481,7 +1481,10 @@ def main(
         if sample_percent is not None:
             random.seed(seed)
             sample_size = max(1, int(total_entries * sample_percent / 100))
-            entries = random.sample(entries, sample_size)
+            # Bound by population like the directory branch below: an empty
+            # input (or one holding only invalid lines) must not crash
+            # random.sample with "Sample larger than population" (#93737).
+            entries = random.sample(entries, min(sample_size, len(entries)))
             print(f"   Sampled {len(entries):,} trajectories ({sample_percent}% of {total_entries:,})")
         
         if dry_run:


### PR DESCRIPTION
## What does this PR do?

`trajectory_compressor.py` in single-file mode crashed with `ValueError: Sample larger than population or is negative` when the input JSONL was empty (or contained only invalid JSON lines) and `--sample_percent` was used — `sample_size = max(1, int(0 * pct / 100))` forced the floor to 1 and `random.sample([], 1)` raised, aborting unattended batch runs mid-way. The directory branch of the same `main()` already guards with `min(sample_size, len(entries))`; the single-file branch was missing the same bound — an asymmetric oversight, as the reporter put it. This PR mirrors the guard.

## Related Issue

Fixes #93737

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `trajectory_compressor.py` — single-file sampling branch: `random.sample(entries, min(sample_size, len(entries)))` with a comment naming the directory-branch parity and #93737. No behavior change for non-empty inputs.
- `tests/test_trajectory_compressor_sample.py` — new (4 tests): empty input + `--sample_percent` reports `Sampled 0 trajectories (50% of 0)` and completes the dry run; invalid-lines-only input likewise; a non-empty 4-entry input still samples exactly `50% → 2` (unchanged behavior pinned); the directory branch with an empty JSONL keeps its existing `Sampled 0 from 0 total trajectories` output.

## How to Test

- New: `.venv/bin/python -m pytest tests/test_trajectory_compressor_sample.py -q` — should pass (4 tests; needs `fire` and `rich` installed for the module import). On unpatched `main`, the two empty/invalid-input tests fail with the reported `ValueError`, pinning the regression.
- Regression: `.venv/bin/python -m pytest tests/test_trajectory_compressor.py -q` — should pass (21 tests).
- Reporter's exact repro: `echo -n "" > empty.jsonl && python trajectory_compressor.py --input empty.jsonl --sample_percent 50 --dry_run` — should pass.

Observed result: locally, the reporter's repro now prints `Loaded 0 trajectories` → `Sampled 0 trajectories (50% of 0)` → dry-run summary and exits 0 (previously the traceback at `random.sample`); the non-empty control still samples the requested percent and all 21 existing compressor tests pass.

## Checklist

- [x] Code follows project style (no unrelated changes)
- [x] Self-reviewed the diff
- [x] Added/updated tests covering the fix
- [x] All new and existing tests pass locally (4 new + 21 existing)
- [x] PR targets `upstream/main` from a fork branch
