### PR TITLE
fix(desktop): make HUD interactions reliable on Linux/X11

### DIFF
--- a/apps/desktop/electron/hud-geometry.test.ts
+++ b/apps/desktop/electron/hud-geometry.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { applyHudResetBounds, defaultHudBounds } from './hud-geometry'
+
+test('defaultHudBounds restores the standard centered bottom layout', () => {
+  assert.deepEqual(defaultHudBounds({ x: 0, y: 25, width: 1440, height: 875 }), {
+    x: 410,
+    y: 508,
+    width: 620,
+    height: 320
+  })
+})
+
+test('defaultHudBounds fits the default layout to a small work area', () => {
+  assert.deepEqual(defaultHudBounds({ x: -800, y: 0, width: 480, height: 240 }), {
+    x: -800,
+    y: 0,
+    width: 480,
+    height: 240
+  })
+})
+
+test('defaultHudBounds keeps the spawn fallback when no display is available', () => {
+  assert.deepEqual(defaultHudBounds(), { x: undefined, y: undefined, width: 620, height: 320 })
+})
+
+test('applyHudResetBounds restores the resize lock and reports native failure', () => {
+  let resizable = false
+  const win = {
+    isDestroyed: () => false,
+    isResizable: () => resizable,
+    setResizable: (value: boolean) => {
+      resizable = value
+    },
+    setBounds: () => {
+      throw new Error('window disappeared')
+    }
+  }
+
+  assert.equal(applyHudResetBounds(win, { x: 0, y: 0, width: 620, height: 320 }), false)
+  assert.equal(resizable, false)
+})
+
+test('applyHudResetBounds flips resizable on while the size changes', () => {
+  let resizable = false
+  const applied: Array<{ height: number; width: number }> = []
+  const win = {
+    isDestroyed: () => false,
+    isResizable: () => resizable,
+    setResizable: (value: boolean) => {
+      resizable = value
+    },
+    setBounds: (bounds: { height: number; width: number }) => {
+      assert.equal(resizable, true)
+      applied.push({ width: bounds.width, height: bounds.height })
+    }
+  }
+
+  assert.equal(applyHudResetBounds(win, { x: 10, y: 20, width: 620, height: 320 }), true)
+  assert.equal(resizable, false)
+  assert.deepEqual(applied, [{ width: 620, height: 320 }])
+})

--- a/apps/desktop/electron/hud-geometry.test.ts
+++ b/apps/desktop/electron/hud-geometry.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { applyHudResetBounds, defaultHudBounds } from './hud-geometry'
+import { applyHudResetBounds, defaultHudBounds, normalizeHudResizeBounds } from './hud-geometry'
 
 test('defaultHudBounds restores the standard centered bottom layout', () => {
   assert.deepEqual(defaultHudBounds({ x: 0, y: 25, width: 1440, height: 875 }), {
@@ -28,6 +28,7 @@ test('defaultHudBounds keeps the spawn fallback when no display is available', (
 
 test('applyHudResetBounds restores the resize lock and reports native failure', () => {
   let resizable = false
+
   const win = {
     isDestroyed: () => false,
     isResizable: () => resizable,
@@ -46,6 +47,7 @@ test('applyHudResetBounds restores the resize lock and reports native failure', 
 test('applyHudResetBounds flips resizable on while the size changes', () => {
   let resizable = false
   const applied: Array<{ height: number; width: number }> = []
+
   const win = {
     isDestroyed: () => false,
     isResizable: () => resizable,
@@ -61,4 +63,19 @@ test('applyHudResetBounds flips resizable on while the size changes', () => {
   assert.equal(applyHudResetBounds(win, { x: 10, y: 20, width: 620, height: 320 }), true)
   assert.equal(resizable, false)
   assert.deepEqual(applied, [{ width: 620, height: 320 }])
+})
+
+test('normalizeHudResizeBounds rounds finite geometry and clamps the HUD minimums', () => {
+  assert.deepEqual(normalizeHudResizeBounds({ x: 10.4, y: -20.6, width: 100, height: 80 }), {
+    x: 10,
+    y: -21,
+    width: 380,
+    height: 160
+  })
+})
+
+test('normalizeHudResizeBounds rejects incomplete or non-finite native geometry', () => {
+  assert.equal(normalizeHudResizeBounds(null), null)
+  assert.equal(normalizeHudResizeBounds({ x: 0, y: 0, width: Number.NaN, height: 320 }), null)
+  assert.equal(normalizeHudResizeBounds({ x: 0, y: 0, width: 620 }), null)
 })

--- a/apps/desktop/electron/hud-geometry.ts
+++ b/apps/desktop/electron/hud-geometry.ts
@@ -1,0 +1,74 @@
+export const HUD_WIDTH = 620
+export const HUD_HEIGHT = 320
+export const HUD_BOTTOM_MARGIN = 72
+
+export interface HudWorkArea {
+  height: number
+  width: number
+  x: number
+  y: number
+}
+
+/** Display-aware default bounds used to spawn and recover the HUD layout. */
+export function defaultHudBounds(area?: HudWorkArea): {
+  height: number
+  width: number
+  x?: number
+  y?: number
+} {
+  if (!area) {
+    return { width: HUD_WIDTH, height: HUD_HEIGHT, x: undefined, y: undefined }
+  }
+
+  const width = Math.min(HUD_WIDTH, area.width)
+  const height = Math.min(HUD_HEIGHT, area.height)
+
+  return {
+    width,
+    height,
+    x: Math.round(area.x + (area.width - width) / 2),
+    y: Math.round(Math.max(area.y, area.y + area.height - height - HUD_BOTTOM_MARGIN))
+  }
+}
+
+export interface HudBoundsWindow {
+  isDestroyed(): boolean
+  isResizable(): boolean
+  setBounds(bounds: { height: number; width: number; x?: number; y?: number }): void
+  setResizable(resizable: boolean): void
+}
+
+/**
+ * Apply recovery bounds. The HUD is created non-resizable (a transparent
+ * frameless window must not expose a system resize hot-zone), which on
+ * Windows/Linux also blocks programmatic setBounds sizing — flip it on
+ * briefly, same as the corner-resize IPC.
+ *
+ * On native Wayland the compositor ignores the position half of setBounds
+ * (clients cannot place themselves). Size still applies, which is what
+ * unsticks the tall/narrow persisted geometry from #87055.
+ */
+export function applyHudResetBounds(
+  win: HudBoundsWindow,
+  bounds: { height: number; width: number; x?: number; y?: number }
+): boolean {
+  try {
+    const wasResizable = win.isResizable()
+
+    if (!wasResizable) {
+      win.setResizable(true)
+    }
+
+    try {
+      win.setBounds(bounds)
+    } finally {
+      if (!wasResizable && !win.isDestroyed()) {
+        win.setResizable(false)
+      }
+    }
+
+    return true
+  } catch {
+    return false
+  }
+}

--- a/apps/desktop/electron/hud-geometry.ts
+++ b/apps/desktop/electron/hud-geometry.ts
@@ -38,6 +38,37 @@ export interface HudBoundsWindow {
   setResizable(resizable: boolean): void
 }
 
+export interface HudResizeBounds {
+  height: number
+  width: number
+  x: number
+  y: number
+}
+
+/** Validate renderer-provided resize geometry before it reaches native APIs. */
+export function normalizeHudResizeBounds(value: unknown): HudResizeBounds | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+
+  const candidate = value as Partial<Record<keyof HudResizeBounds, unknown>>
+  const x = Number(candidate.x)
+  const y = Number(candidate.y)
+  const width = Number(candidate.width)
+  const height = Number(candidate.height)
+
+  if (![x, y, width, height].every(Number.isFinite)) {
+    return null
+  }
+
+  return {
+    x: Math.round(x),
+    y: Math.round(y),
+    width: Math.max(380, Math.round(width)),
+    height: Math.max(160, Math.round(height))
+  }
+}
+
 /**
  * Apply recovery bounds. The HUD is created non-resizable (a transparent
  * frameless window must not expose a system resize hot-zone), which on

--- a/apps/desktop/electron/hud-input-policy.test.ts
+++ b/apps/desktop/electron/hud-input-policy.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for the HUD input policy. The split is the point: the solid
+ * fallback has to reach the X11 windows where the input region never comes
+ * back, and has to leave native Wayland (and macOS/Windows) on click-through.
+ */
+
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { hudInputPolicy } from './hud-input-policy'
+
+const X11_SESSION = { DISPLAY: ':0', XDG_SESSION_TYPE: 'x11' }
+const WAYLAND_SESSION = { WAYLAND_DISPLAY: 'wayland-0', XDG_SESSION_TYPE: 'wayland' }
+const XWAYLAND_SESSION = { DISPLAY: ':0', WAYLAND_DISPLAY: 'wayland-0', XDG_SESSION_TYPE: 'wayland' }
+
+test('the click-through design is kept everywhere it works', () => {
+  for (const platform of ['darwin', 'win32']) {
+    assert.equal(hudInputPolicy(platform, {}, []), 'click-through')
+    assert.equal(hudInputPolicy(platform, X11_SESSION, []), 'click-through')
+  }
+})
+
+test('an X11 session gets the solid HUD', () => {
+  assert.equal(hudInputPolicy('linux', X11_SESSION, []), 'solid')
+})
+
+test('a Wayland session keeps click-through — Electron 20+ is a native Wayland client there', () => {
+  assert.equal(hudInputPolicy('linux', WAYLAND_SESSION, []), 'click-through')
+  assert.equal(hudInputPolicy('linux', XWAYLAND_SESSION, []), 'click-through')
+})
+
+test('asking for a native Wayland surface keeps the click-through path', () => {
+  for (const argv of [['--ozone-platform=wayland'], ['--ozone-platform-hint=wayland']]) {
+    assert.equal(hudInputPolicy('linux', WAYLAND_SESSION, argv), 'click-through')
+  }
+
+  assert.equal(
+    hudInputPolicy('linux', { ...WAYLAND_SESSION, ELECTRON_OZONE_PLATFORM_HINT: 'wayland' }, []),
+    'click-through'
+  )
+})
+
+test('an auto hint follows the session', () => {
+  assert.equal(hudInputPolicy('linux', WAYLAND_SESSION, ['--ozone-platform-hint=auto']), 'click-through')
+  assert.equal(hudInputPolicy('linux', X11_SESSION, ['--ozone-platform-hint=auto']), 'solid')
+  assert.equal(hudInputPolicy('linux', XWAYLAND_SESSION, ['--ozone-platform-hint=auto']), 'click-through')
+})
+
+test('asking for X11 on a Wayland session gets the solid HUD', () => {
+  assert.equal(hudInputPolicy('linux', WAYLAND_SESSION, ['--ozone-platform=x11']), 'solid')
+  assert.equal(
+    hudInputPolicy('linux', { ...WAYLAND_SESSION, ELECTRON_OZONE_PLATFORM_HINT: 'x11' }, []),
+    'solid'
+  )
+})
+
+test('the explicit switch beats the hint, and the last switch wins', () => {
+  assert.equal(
+    hudInputPolicy('linux', WAYLAND_SESSION, ['--ozone-platform-hint=auto', '--ozone-platform=x11']),
+    'solid'
+  )
+  assert.equal(
+    hudInputPolicy('linux', X11_SESSION, ['--ozone-platform=x11', '--ozone-platform=wayland']),
+    'click-through'
+  )
+})
+
+test('a backend nobody recognises follows the session, not a silent X11 default', () => {
+  assert.equal(hudInputPolicy('linux', X11_SESSION, ['--ozone-platform=headless']), 'solid')
+  assert.equal(hudInputPolicy('linux', WAYLAND_SESSION, ['--ozone-platform=headless']), 'click-through')
+  assert.equal(hudInputPolicy('linux', {}, []), 'solid')
+})

--- a/apps/desktop/electron/hud-input-policy.test.ts
+++ b/apps/desktop/electron/hud-input-policy.test.ts
@@ -8,7 +8,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { hudInputPolicy } from './hud-input-policy'
+import { hudInputPolicy, hudUsesNativeDrag, hudUsesWorkspaceTransfer } from './hud-input-policy'
 
 const X11_SESSION = { DISPLAY: ':0', XDG_SESSION_TYPE: 'x11' }
 const WAYLAND_SESSION = { WAYLAND_DISPLAY: 'wayland-0', XDG_SESSION_TYPE: 'wayland' }
@@ -70,4 +70,22 @@ test('a backend nobody recognises follows the session, not a silent X11 default'
   assert.equal(hudInputPolicy('linux', X11_SESSION, ['--ozone-platform=headless']), 'solid')
   assert.equal(hudInputPolicy('linux', WAYLAND_SESSION, ['--ozone-platform=headless']), 'click-through')
   assert.equal(hudInputPolicy('linux', {}, []), 'solid')
+})
+
+test('only a native Wayland HUD gets a compositor drag region', () => {
+  assert.equal(hudUsesNativeDrag('darwin', WAYLAND_SESSION, []), false)
+  assert.equal(hudUsesNativeDrag('win32', WAYLAND_SESSION, []), false)
+  assert.equal(hudUsesNativeDrag('linux', X11_SESSION, []), false)
+  assert.equal(hudUsesNativeDrag('linux', WAYLAND_SESSION, []), true)
+  assert.equal(hudUsesNativeDrag('linux', WAYLAND_SESSION, ['--ozone-platform=x11']), false)
+  assert.equal(hudUsesNativeDrag('linux', X11_SESSION, ['--ozone-platform=wayland']), true)
+})
+
+test('only a renderer-driven Linux HUD needs temporary all-workspace visibility', () => {
+  assert.equal(hudUsesWorkspaceTransfer('darwin', X11_SESSION, []), false)
+  assert.equal(hudUsesWorkspaceTransfer('win32', X11_SESSION, []), false)
+  assert.equal(hudUsesWorkspaceTransfer('linux', X11_SESSION, []), true)
+  assert.equal(hudUsesWorkspaceTransfer('linux', WAYLAND_SESSION, []), false)
+  assert.equal(hudUsesWorkspaceTransfer('linux', WAYLAND_SESSION, ['--ozone-platform=x11']), true)
+  assert.equal(hudUsesWorkspaceTransfer('linux', X11_SESSION, ['--ozone-platform=wayland']), false)
 })

--- a/apps/desktop/electron/hud-input-policy.ts
+++ b/apps/desktop/electron/hud-input-policy.ts
@@ -1,0 +1,98 @@
+/**
+ * Which input model the HUD can safely use on this system.
+ *
+ * The HUD's default is per-element click-through: the window ignores the mouse
+ * and turns solid only where the renderer's hit test finds a control under the
+ * cursor. That design rests on `setIgnoreMouseEvents(false)` actually handing
+ * the input region back. On X11 it does not — once a window has ignored the
+ * mouse the X server keeps hit-testing straight through it, and no later call
+ * restores it. Ignore is a one-way door there, so the only policy that works
+ * is never to walk through it: keep the HUD a normal solid window.
+ *
+ * That trade is a real loss — a solid HUD swallows clicks in the faded band
+ * above the composer — so it is scoped to the Ozone backend where restore is
+ * known to be broken, not to every Linux desktop.
+ *
+ * The windowing backend, not the login session type, is what decides this.
+ * Electron 20+ defaults `ozone-platform-hint` to `auto`, which prefers a
+ * native Wayland surface on a Wayland session. That is why HUD drag via
+ * `setBounds` is a no-op for those users (#82851): they are already a Wayland
+ * client. Native Wayland keeps click-through (main's cursor poll re-arms it).
+ * X11 and explicit XWayland (`--ozone-platform=x11` / `ozone_platform_hint:
+ * x11`) take the solid path.
+ */
+
+export type HudInputPolicy = 'click-through' | 'solid'
+
+type Backend = 'wayland' | 'x11'
+
+/**
+ * The Ozone platform this process was asked for, or null when nothing asked.
+ *
+ * `--ozone-platform` names a backend outright and `--ozone-platform-hint`
+ * (equivalently `ELECTRON_OZONE_PLATFORM_HINT`) asks for one, with `auto`
+ * meaning "Wayland if the session is Wayland". The explicit switch wins over
+ * the hint, and a repeated switch resolves last-one-wins, matching Chromium.
+ */
+function requestedOzonePlatform(env: NodeJS.ProcessEnv, argv: readonly string[]): null | string {
+  let explicit: null | string = null
+  let hint: null | string = null
+
+  for (const arg of argv) {
+    const match = /^--ozone-platform(-hint)?=(.+)$/.exec(arg)
+
+    if (!match) {
+      continue
+    }
+
+    if (match[1]) {
+      hint = match[2].toLowerCase()
+    } else {
+      explicit = match[2].toLowerCase()
+    }
+  }
+
+  return explicit ?? hint ?? env.ELECTRON_OZONE_PLATFORM_HINT?.toLowerCase() ?? null
+}
+
+function sessionIsWayland(env: NodeJS.ProcessEnv): boolean {
+  return env.XDG_SESSION_TYPE === 'wayland' || (Boolean(env.WAYLAND_DISPLAY) && !env.DISPLAY)
+}
+
+/**
+ * The backend Electron will actually use on Linux.
+ *
+ * Unset / `auto` follows the session: Wayland sessions get a native Wayland
+ * surface (Electron 20+ default), X11 sessions stay on X11. An explicit
+ * `--ozone-platform=x11` (or `desktop.ozone_platform_hint: x11`) is the
+ * COSMIC always-on-top escape hatch and lands on the solid HUD path.
+ */
+function linuxBackend(env: NodeJS.ProcessEnv, argv: readonly string[]): Backend {
+  const requested = requestedOzonePlatform(env, argv)
+
+  if (requested === 'x11') {
+    return 'x11'
+  }
+
+  if (requested === 'wayland') {
+    return 'wayland'
+  }
+
+  return sessionIsWayland(env) ? 'wayland' : 'x11'
+}
+
+/**
+ * The input model the HUD should use.
+ *
+ * macOS and Windows keep the click-through design: `setIgnoreMouseEvents(true,
+ * { forward: true })` is `@platform darwin,win32`, so the renderer goes on
+ * seeing the cursor while the window ignores it and can re-arm whenever the
+ * pointer comes back to the bar.
+ */
+export function hudInputPolicy(platform: string, env: NodeJS.ProcessEnv, argv: readonly string[]): HudInputPolicy {
+  if (platform !== 'linux') {
+    return 'click-through'
+  }
+
+  return linuxBackend(env, argv) === 'x11' ? 'solid' : 'click-through'
+}

--- a/apps/desktop/electron/hud-input-policy.ts
+++ b/apps/desktop/electron/hud-input-policy.ts
@@ -96,3 +96,33 @@ export function hudInputPolicy(platform: string, env: NodeJS.ProcessEnv, argv: r
 
   return linuxBackend(env, argv) === 'x11' ? 'solid' : 'click-through'
 }
+
+/**
+ * Whether the renderer needs a native compositor drag region for the HUD.
+ *
+ * Native Wayland cannot honour app-driven window positions, so it needs
+ * `-webkit-app-region: drag`. X11 can use the renderer's `moveBy` path and
+ * must not install that region: it consumes the pointer stream needed by the
+ * renderer's immediate Ctrl+primary-button drag.
+ */
+export function hudUsesNativeDrag(platform: string, env: NodeJS.ProcessEnv, argv: readonly string[]): boolean {
+  return platform === 'linux' && hudInputPolicy(platform, env, argv) === 'click-through'
+}
+
+/**
+ * Whether a renderer-driven HUD move needs the X11 workspace-transfer bridge.
+ *
+ * While the pointer is grabbed the window is made temporarily visible on all
+ * desktops. Releasing the grab clears that flag; Chromium's X11 backend then
+ * reads `_NET_CURRENT_DESKTOP` and sends `_NET_WM_DESKTOP` for that desktop,
+ * which gives KWin the same "hold window + switch desktop" behaviour as a
+ * native titlebar drag. Native Wayland already delegates movement to the
+ * compositor and must stay out of this path.
+ */
+export function hudUsesWorkspaceTransfer(
+  platform: string,
+  env: NodeJS.ProcessEnv,
+  argv: readonly string[]
+): boolean {
+  return platform === 'linux' && hudInputPolicy(platform, env, argv) === 'solid'
+}

--- a/apps/desktop/electron/hud-ipc.ts
+++ b/apps/desktop/electron/hud-ipc.ts
@@ -4,7 +4,8 @@
 // latch when handing the session back to the app window.
 import { type BrowserWindow, ipcMain } from 'electron'
 
-import { hudInputPolicy } from './hud-input-policy'
+import { normalizeHudResizeBounds } from './hud-geometry'
+import { hudInputPolicy, hudUsesNativeDrag, hudUsesWorkspaceTransfer } from './hud-input-policy'
 import { hudFrostFor, type TranslucencyState } from './translucency'
 
 export interface HudIpcDeps {
@@ -27,6 +28,38 @@ export function registerHudIpc({
   resetHudLayout,
   setHudSessionId
 }: HudIpcDeps) {
+  // The renderer needs this before first paint so X11 never installs the
+  // Chromium drag region that steals modifier-drag gestures from the WM.
+  // Main answers because it owns the actual Ozone backend selection.
+  ipcMain.on('hermes:hud:native-drag', event => {
+    event.returnValue = hudUsesNativeDrag(process.platform, process.env, process.argv)
+  })
+
+  // X11/KWin window transfer: a renderer-driven grab is temporarily sticky so
+  // the user can keep Ctrl+primary-button held while invoking KDE's desktop
+  // switch shortcut. Clearing sticky on release makes Chromium assign the
+  // window to `_NET_CURRENT_DESKTOP`, exactly like releasing a native titlebar
+  // drag on the destination desktop. Native Wayland owns its move loop and
+  // Windows/macOS stay out of this Linux-specific bridge.
+  ipcMain.on('hermes:hud:workspace-transfer', (event, transferring) => {
+    const hudWindow = getHudWindow()
+
+    if (
+      !hudWindow ||
+      hudWindow.isDestroyed() ||
+      event.sender !== hudWindow.webContents ||
+      !hudUsesWorkspaceTransfer(process.platform, process.env, process.argv)
+    ) {
+      return
+    }
+
+    try {
+      hudWindow.setVisibleOnAllWorkspaces(Boolean(transferring))
+    } catch {
+      // Workspace APIs are window-manager capabilities — best effort.
+    }
+  })
+
   // Whether the band currently covers the window below the bar. The renderer
   // is the only party that can know this (it measures the transcript), and it
   // is half of the frost decision — the other half is the user's setting,
@@ -159,7 +192,7 @@ export function registerHudIpc({
     })
   })
 
-  // Resize from the HUD's corner handle. The window is created non-resizable
+  // Resize from the HUD's edge/corner handles. The window is created non-resizable
   // (see spawnHudWindow — a transparent frameless window must not expose a
   // system resize hot-zone, or dragging grows it), which on Windows/Linux also
   // blocks programmatic setBounds sizing — so briefly flip resizable on while
@@ -171,20 +204,30 @@ export function registerHudIpc({
       return
     }
 
-    const win = hudWindow
-    const width = Math.max(380, Math.round(Number(bounds.width)))
-    const height = Math.max(160, Math.round(Number(bounds.height)))
-    const [curW, curH] = win.getSize()
-    const resizing = width !== curW || height !== curH
+    const nextBounds = normalizeHudResizeBounds(bounds)
 
-    if (resizing && !win.isResizable()) {
-      win.setResizable(true)
+    if (!nextBounds) {
+      return
     }
 
-    win.setBounds({ x: Math.round(Number(bounds.x)), y: Math.round(Number(bounds.y)), width, height })
+    const win = hudWindow
+    const { width, height } = nextBounds
+    const [curW, curH] = win.getSize()
+    const resizing = width !== curW || height !== curH
+    const restoreResizeLock = resizing && !win.isResizable()
 
-    if (resizing) {
-      win.setResizable(false)
+    try {
+      if (restoreResizeLock) {
+        win.setResizable(true)
+      }
+
+      win.setBounds(nextBounds)
+    } catch {
+      // The window may disappear between validation and the native call.
+    } finally {
+      if (restoreResizeLock && !win.isDestroyed()) {
+        win.setResizable(false)
+      }
     }
   })
 

--- a/apps/desktop/electron/hud-ipc.ts
+++ b/apps/desktop/electron/hud-ipc.ts
@@ -4,6 +4,7 @@
 // latch when handing the session back to the app window.
 import { type BrowserWindow, ipcMain } from 'electron'
 
+import { hudInputPolicy } from './hud-input-policy'
 import { hudFrostFor, type TranslucencyState } from './translucency'
 
 export interface HudIpcDeps {
@@ -13,6 +14,7 @@ export interface HudIpcDeps {
   getHudWindow: () => BrowserWindow | null
   openHudWindow: (sessionId: null | string, profile: null | string) => void
   closeHudWindow: () => void
+  resetHudLayout: () => boolean
   setHudSessionId: (sessionId: null | string) => void
 }
 
@@ -22,6 +24,7 @@ export function registerHudIpc({
   getHudWindow,
   openHudWindow,
   closeHudWindow,
+  resetHudLayout,
   setHudSessionId
 }: HudIpcDeps) {
   // Whether the band currently covers the window below the bar. The renderer
@@ -111,9 +114,19 @@ export function registerHudIpc({
   ipcMain.on('hermes:hud:ignore-mouse', (_event, ignore) => {
     const hudWindow = getHudWindow()
 
-    if (hudWindow && !hudWindow.isDestroyed()) {
-      hudWindow.setIgnoreMouseEvents(Boolean(ignore), { forward: true })
+    if (!hudWindow || hudWindow.isDestroyed()) {
+      return
     }
+
+    // On X11 ignore-mouse is a one-way door: setIgnoreMouseEvents(false)
+    // cannot restore the input region afterwards. Veto the request there so
+    // the HUD stays a normal solid window. Native Wayland and macOS/Windows
+    // keep the per-element path.
+    if (Boolean(ignore) && hudInputPolicy(process.platform, process.env, process.argv) === 'solid') {
+      return
+    }
+
+    hudWindow.setIgnoreMouseEvents(Boolean(ignore), { forward: true })
   })
 
   ipcMain.on('hermes:hud:move-by', (event, delta) => {
@@ -173,6 +186,16 @@ export function registerHudIpc({
     if (resizing) {
       win.setResizable(false)
     }
+  })
+
+  ipcMain.handle('hermes:hud:reset-layout', event => {
+    const hudWindow = getHudWindow()
+
+    if (!hudWindow || hudWindow.isDestroyed() || event.sender !== hudWindow.webContents) {
+      return { ok: false }
+    }
+
+    return { ok: resetHudLayout() }
   })
 
   // The HUD renderer reporting which session it is on, so the close broadcast

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -192,6 +192,8 @@ import {
 } from './hardening'
 import { cursorPointInWindow } from './hud-cursor'
 import { startHudGameOverlayWatch } from './hud-game-overlay'
+import { applyHudResetBounds, defaultHudBounds } from './hud-geometry'
+import { hudInputPolicy } from './hud-input-policy'
 import { registerHudIpc } from './hud-ipc'
 import { snapHudBounds } from './hud-snap'
 import { createHudSnapShortcut } from './hud-snap-shortcut'
@@ -6580,6 +6582,19 @@ function restorePersistedZoomLevel(window) {
   const saved = readZoomState()
 
   if (saved != null) {
+    // Drift-guard: skip when this window already shows the persisted level.
+    // Blindly re-applying on every resize/move would race the compositor's
+    // surface reconfigure during a Wayland resize storm (Cosmic tiled mode
+    // fires one whenever a new session window opens — #84818) and keep the
+    // renderer notification stream churning for no gain. The settle-verify
+    // chain in installZoomReassertOnWindowEvents re-applies only when the
+    // window actually drifted from the persisted level.
+    const current = window.webContents?.getZoomLevel?.()
+
+    if (current != null && Math.abs(current - saved) < 1e-9) {
+      return
+    }
+
     applyZoomLevel(window.webContents, saved)
 
     return
@@ -11557,9 +11572,6 @@ let hudProfile = null
 // of a game chat frame, and where one belongs. Defaults only: once the user
 // moves or resizes the HUD, hud-state.json wins (same pattern as the main
 // window's window-state.json).
-const HUD_WIDTH = 620
-const HUD_HEIGHT = 320
-const HUD_BOTTOM_MARGIN = 72
 const HUD_STATE_PATH = path.join(app.getPath('userData'), 'hud-state.json')
 
 function readHudState() {
@@ -11594,6 +11606,26 @@ function persistHudState() {
   }
 }
 
+function resetHudWindowLayout(): boolean {
+  if (!hudWindow || hudWindow.isDestroyed()) {
+    return false
+  }
+
+  const win = hudWindow
+  const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint())
+  const bounds = defaultHudBounds(display?.workArea)
+
+  if (!applyHudResetBounds(win, bounds)) {
+    rememberLog('[hud-state] reset layout failed while applying native bounds')
+
+    return false
+  }
+
+  persistHudState()
+
+  return true
+}
+
 const schedulePersistHudState = debounce(persistHudState, 250)
 
 // How often Linux gets told where the cursor is. Fast enough that the bar is
@@ -11626,6 +11658,8 @@ function applyHudSnapToPointer() {
 
   // setBounds — NOT setPosition alone: on Windows, a transparent frameless
   // window silently grows ~1px per setPosition call (see move-by handler).
+  // On native Wayland the compositor ignores the position half; the snap
+  // shortcut is therefore a documented no-op there.
   hudWindow.setBounds({
     x: origin.x,
     y: origin.y,
@@ -11659,6 +11693,21 @@ function registerHudSnapShortcut() {
  */
 function startHudCursorFeed(win: BrowserWindow) {
   if (process.platform !== 'linux') {
+    return
+  }
+
+  // On an X11 window `setIgnoreMouseEvents(false)` does not restore the input
+  // region once the window has ignored the mouse. Ignore is a one-way door
+  // there, so the HUD is held solid for its whole life (the companion veto
+  // is in the hermes:hud:ignore-mouse handler). Native Wayland keeps the
+  // poll — that is what re-arms click-through when the pointer returns.
+  if (hudInputPolicy(process.platform, process.env, process.argv) === 'solid') {
+    try {
+      win.setIgnoreMouseEvents(false)
+    } catch {
+      // best effort
+    }
+
     return
   }
 
@@ -11752,19 +11801,7 @@ function hudBounds() {
   const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint())
   const area = display?.workArea
 
-  if (!area) {
-    return { width: HUD_WIDTH, height: HUD_HEIGHT, x: undefined, y: undefined }
-  }
-
-  const width = Math.min(HUD_WIDTH, area.width)
-  const height = Math.min(HUD_HEIGHT, area.height)
-
-  return {
-    width,
-    height,
-    x: Math.round(area.x + (area.width - width) / 2),
-    y: Math.round(Math.max(area.y, area.y + area.height - height - HUD_BOTTOM_MARGIN))
-  }
+  return defaultHudBounds(area)
 }
 
 function hudUrl(sessionId, profile) {
@@ -12611,6 +12648,7 @@ const hudIpc = registerHudIpc({
   getHudWindow: () => hudWindow,
   openHudWindow,
   closeHudWindow,
+  resetHudLayout: resetHudWindowLayout,
   setHudSessionId: value => {
     hudSessionId = value
   }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -11844,7 +11844,7 @@ function spawnHudWindow(sessionId, profile) {
     // interprets pointer capture near the edge as a resize gesture, so the
     // window grows a few px every drag (worse at >100% DPI scaling). The
     // composer drag calls setPosition, which must move the window, not resize
-    // it. Resizing is done by the renderer's corner handle through
+    // it. Resizing is done by the renderer's edge/corner handles through
     // `hermes:hud:set-bounds`, which flips resizable on for the call — the
     // same pattern the pet overlay uses for its wheel-scale.
     resizable: false,
@@ -11878,14 +11878,17 @@ function spawnHudWindow(sessionId, profile) {
   win.setAlwaysOnTop(true, IS_MAC ? 'floating' : 'screen-saver')
   win.setHiddenInMissionControl?.(true)
 
-  try {
-    win.setVisibleOnAllWorkspaces(
-      true,
-      IS_MAC ? { visibleOnFullScreen: true, skipTransformProcessType: true } : undefined
-    )
-  } catch {
-    // Not supported everywhere — best effort.
+  if (IS_MAC) {
+    try {
+      win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true, skipTransformProcessType: true })
+    } catch {
+      // Not supported everywhere — best effort.
+    }
   }
+
+  // Linux intentionally starts on ONE virtual desktop. During a renderer
+  // grab, hermes:hud:workspace-transfer temporarily makes the X11 window
+  // sticky; releasing it assigns the HUD to KDE's then-current desktop.
 
   // Streaming into a window that is ALWAYS blurred (the user is in another
   // app) is the entire feature, so it gets the same stream-aware unthrottling

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -75,6 +75,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     setIgnoreMouse: ignore => ipcRenderer.send('hermes:hud:ignore-mouse', ignore),
     moveBy: delta => ipcRenderer.send('hermes:hud:move-by', delta),
     setBounds: bounds => ipcRenderer.send('hermes:hud:set-bounds', bounds),
+    resetLayout: () => ipcRenderer.invoke('hermes:hud:reset-layout'),
     // Whether the band covers the window below the bar. Main pairs it with the
     // user's translucency setting to decide the native frost (macOS vibrancy /
     // Windows 11 DWM backdrop) — see hudFrostFor.

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -8,6 +8,7 @@ import { contextBridge, ipcRenderer, webFrame, webUtils } from 'electron'
 // "Desktop IPC bridge is unavailable"). No reply means no glass, which degrades
 // to an ordinary opaque window rather than a page thinned over nothing.
 const translucencySupport = ipcRenderer.sendSync('hermes:translucency:support')
+const hudNativeDrag = ipcRenderer.sendSync('hermes:hud:native-drag') === true
 
 contextBridge.exposeInMainWorld('hermesDesktop', {
   glassSupported: translucencySupport?.glass === true,
@@ -70,10 +71,12 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   // sized as a floating bar, so it mounts the real composer. Main owns the
   // window; `onChanged` keeps every window's toggle truthful.
   hud: {
+    nativeDrag: hudNativeDrag,
     open: request => ipcRenderer.invoke('hermes:hud:open', request),
     close: () => ipcRenderer.invoke('hermes:hud:close'),
     setIgnoreMouse: ignore => ipcRenderer.send('hermes:hud:ignore-mouse', ignore),
     moveBy: delta => ipcRenderer.send('hermes:hud:move-by', delta),
+    setWorkspaceTransfer: transferring => ipcRenderer.send('hermes:hud:workspace-transfer', transferring),
     setBounds: bounds => ipcRenderer.send('hermes:hud:set-bounds', bounds),
     resetLayout: () => ipcRenderer.invoke('hermes:hud:reset-layout'),
     // Whether the band covers the window below the bar. Main pairs it with the

--- a/apps/desktop/electron/zoom.test.ts
+++ b/apps/desktop/electron/zoom.test.ts
@@ -13,7 +13,10 @@ import {
   clampZoomLevel,
   DEFAULT_ZOOM_LEVEL,
   installZoomReassertOnWindowEvents,
+  isDebouncedReassertEvent,
   percentToZoomLevel,
+  ZOOM_REASSERT_MAX_SETTLE_CHECKS,
+  ZOOM_REASSERT_SETTLE_DELAY_MS,
   ZOOM_RESIZE_REASSERT_DELAY_MS,
   ZOOM_STEP,
   ZOOM_STORAGE_KEY,
@@ -101,7 +104,7 @@ test('installZoomReassertOnWindowEvents wires show, restore, focus, resize, and 
   assert.equal(calls, 5)
 })
 
-test('focus event reasserts zoom immediately without debounce (Windows high-DPI alt-tab, #50837)', () => {
+test('focus event reasserts zoom immediately without debounce on Windows (high-DPI alt-tab, #50837)', () => {
   const handlers = new Map()
 
   const win = {
@@ -120,12 +123,22 @@ test('focus event reasserts zoom immediately without debounce (Windows high-DPI 
     'win32'
   )
 
-  // focus should trigger immediate reassert — no timer involved
+  // focus on Windows triggers immediate reassert — no timer involved
   handlers.get('focus')()
   assert.equal(calls, 1)
 })
 
-test('installZoomReassertOnWindowEvents debounces Linux resize and move events at the trailing edge', () => {
+test('isDebouncedReassertEvent debounces focus only on Linux, not Windows/macOS', () => {
+  assert.equal(isDebouncedReassertEvent('focus', 'linux'), true)
+  assert.equal(isDebouncedReassertEvent('focus', 'win32'), false)
+  assert.equal(isDebouncedReassertEvent('focus', 'darwin'), false)
+  assert.equal(isDebouncedReassertEvent('resize', 'linux'), true)
+  assert.equal(isDebouncedReassertEvent('resize', 'win32'), true)
+  assert.equal(isDebouncedReassertEvent('show', 'linux'), false)
+  assert.equal(isDebouncedReassertEvent('restore', 'linux'), false)
+})
+
+test('installZoomReassertOnWindowEvents debounces Linux resize, move, and focus events at the trailing edge', () => {
   vi.useFakeTimers()
 
   try {
@@ -158,10 +171,102 @@ test('installZoomReassertOnWindowEvents debounces Linux resize and move events a
     vi.advanceTimersByTime(ZOOM_RESIZE_REASSERT_DELAY_MS / 2)
     assert.equal(calls, 1)
 
+    // focus on Linux is also debounced — a session switch fires focus but
+    // the reassert must not jump the zoom mid-interaction.
+    handlers.get('focus')()
+    vi.advanceTimersByTime(ZOOM_RESIZE_REASSERT_DELAY_MS / 2)
+    assert.equal(calls, 1)
+    vi.advanceTimersByTime(ZOOM_RESIZE_REASSERT_DELAY_MS / 2)
+    assert.equal(calls, 2)
+
     handlers.get('resize')()
     destroyed = true
     vi.advanceTimersByTime(ZOOM_RESIZE_REASSERT_DELAY_MS)
-    assert.equal(calls, 1)
+    assert.equal(calls, 2)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+test('installZoomReassertOnWindowEvents re-verifies Linux zoom after the debounced re-assert so a dropped re-apply is retried', () => {
+  vi.useFakeTimers()
+
+  try {
+    const handlers = new Map()
+
+    const win = {
+      isDestroyed: () => false,
+      on(event, listener) {
+        handlers.set(event, listener)
+      }
+    }
+
+    let calls = 0
+    installZoomReassertOnWindowEvents(
+      win,
+      () => {
+        calls += 1
+      },
+      'linux'
+    )
+
+    handlers.get('resize')()
+    vi.advanceTimersByTime(ZOOM_RESIZE_REASSERT_DELAY_MS)
+    assert.equal(calls, 1, 'debounced re-assert fires once')
+
+    // Cosmic tiling can drop the just-applied zoom mid-reconfigure; the
+    // settle-verify chain re-asserts on a bounded schedule until it converges:
+    // one initial re-assert plus ZOOM_REASSERT_MAX_SETTLE_CHECKS follow-ups.
+    for (let i = 1; i <= ZOOM_REASSERT_MAX_SETTLE_CHECKS; i++) {
+      vi.advanceTimersByTime(ZOOM_REASSERT_SETTLE_DELAY_MS)
+      assert.equal(calls, 1 + i, `settle check ${i} re-asserts`)
+    }
+
+    vi.advanceTimersByTime(ZOOM_REASSERT_SETTLE_DELAY_MS * 2)
+    assert.equal(calls, 1 + ZOOM_REASSERT_MAX_SETTLE_CHECKS, 'settle chain is bounded and stops')
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+test('installZoomReassertOnWindowEvents resets the settle chain on a fresh re-assert', () => {
+  vi.useFakeTimers()
+
+  try {
+    const handlers = new Map()
+
+    const win = {
+      isDestroyed: () => false,
+      on(event, listener) {
+        handlers.set(event, listener)
+      }
+    }
+
+    let calls = 0
+    installZoomReassertOnWindowEvents(
+      win,
+      () => {
+        calls += 1
+      },
+      'linux'
+    )
+
+    handlers.get('show')()
+    vi.advanceTimersByTime(ZOOM_REASSERT_SETTLE_DELAY_MS)
+    assert.equal(calls, 2, 'initial re-assert plus one settle check')
+
+    // A second transition while the first settle chain is still pending must
+    // restart the chain from zero instead of exhausting the budget.
+    handlers.get('restore')()
+    assert.equal(calls, 3, 'fresh transition re-asserts immediately')
+
+    for (let i = 1; i <= ZOOM_REASSERT_MAX_SETTLE_CHECKS; i++) {
+      vi.advanceTimersByTime(ZOOM_REASSERT_SETTLE_DELAY_MS)
+      assert.equal(calls, 3 + i, `restarted chain settle check ${i} re-asserts`)
+    }
+
+    vi.advanceTimersByTime(ZOOM_REASSERT_SETTLE_DELAY_MS * 2)
+    assert.equal(calls, 3 + ZOOM_REASSERT_MAX_SETTLE_CHECKS, 'restarted chain is bounded too')
   } finally {
     vi.useRealTimers()
   }

--- a/apps/desktop/electron/zoom.ts
+++ b/apps/desktop/electron/zoom.ts
@@ -65,10 +65,35 @@ export function applyZoomLevel(webContents, level) {
 // fallbacks before re-applying the persisted level.
 export const ZOOM_RESIZE_REASSERT_DELAY_MS = 100
 
+// Linux settle-verify: a re-assert can land while the compositor is still
+// reconfiguring the window's surface (Cosmic tiled mode fires a resize storm
+// the moment a new session window opens, and the final event can arrive before
+// the new scale is committed), in which case Chromium drops the just-applied
+// zoom and the window stays stuck at the wrong scale until the next
+// transition. After the debounced re-assert we therefore re-check a few times
+// at a settle delay; each re-assert is drift-guarded (see
+// restorePersistedZoomLevel), so a window that already matches the persisted
+// level costs nothing and the chain is bounded.
+export const ZOOM_REASSERT_SETTLE_DELAY_MS = 300
+export const ZOOM_REASSERT_MAX_SETTLE_CHECKS = 3
+
 export function zoomReassertWindowEvents(platform = process.platform) {
   return platform === 'linux'
     ? ['show', 'restore', 'focus', 'resize', 'move']
     : ['show', 'restore', 'focus', 'resized', 'moved']
+}
+
+// Linux/Wayland fires `focus` on intra-app focus shifts (sidebar clicks,
+// Ctrl+Tab session switching, tile activation) — not just the cross-app
+// alt-tab the Windows high-DPI immediate-reassert guard (#50837) targets.
+// An undebounced reassert on every such focus event re-applies the persisted
+// zoom level mid-interaction, producing a visible zoom/DPI jump. Debounce
+// `focus` alongside `resize`/`move` on Linux; Windows alt-tab keeps its
+// immediate path because `platform` is `win32` there.
+const DEBOUNCED_REASSERT_EVENTS = new Set(['resize', 'move'])
+
+export function isDebouncedReassertEvent(event, platform = process.platform) {
+  return DEBOUNCED_REASSERT_EVENTS.has(event) || (platform === 'linux' && event === 'focus')
 }
 
 export function installZoomReassertOnWindowEvents(win, reassert, platform = process.platform) {
@@ -77,6 +102,33 @@ export function installZoomReassertOnWindowEvents(win, reassert, platform = proc
   }
 
   let resizeTimer
+  let settleTimer
+  let settleChecks = 0
+
+  const scheduleSettleCheck = () => {
+    if (platform !== 'linux') {
+      return
+    }
+
+    settleChecks += 1
+
+    if (settleChecks > ZOOM_REASSERT_MAX_SETTLE_CHECKS) {
+      return
+    }
+
+    settleTimer = setTimeout(() => {
+      if (!win.isDestroyed?.()) {
+        reassert()
+        scheduleSettleCheck()
+      }
+    }, ZOOM_REASSERT_SETTLE_DELAY_MS)
+  }
+
+  const reassertWithSettleCheck = () => {
+    settleChecks = 0
+    reassert()
+    scheduleSettleCheck()
+  }
 
   for (const event of zoomReassertWindowEvents(platform)) {
     win.on(event, () => {
@@ -84,8 +136,9 @@ export function installZoomReassertOnWindowEvents(win, reassert, platform = proc
         return
       }
 
-      if (event !== 'resize' && event !== 'move') {
-        reassert()
+      if (!isDebouncedReassertEvent(event, platform)) {
+        clearTimeout(settleTimer)
+        reassertWithSettleCheck()
 
         return
       }
@@ -93,7 +146,8 @@ export function installZoomReassertOnWindowEvents(win, reassert, platform = proc
       clearTimeout(resizeTimer)
       resizeTimer = setTimeout(() => {
         if (!win.isDestroyed?.()) {
-          reassert()
+          clearTimeout(settleTimer)
+          reassertWithSettleCheck()
         }
       }, ZOOM_RESIZE_REASSERT_DELAY_MS)
     })

--- a/apps/desktop/src/app/chat/composer/controls.test.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.test.tsx
@@ -72,6 +72,7 @@ describe('HUD mode', () => {
     expect(screen.getByLabelText('Voice dictation')).toBeTruthy()
     expect(screen.getByLabelText('Read replies aloud')).toBeTruthy()
     expect(screen.queryByLabelText('Exit HUD mode')).toBeNull()
+    expect(screen.queryByLabelText('Reset HUD size and position')).toBeNull()
     expect(screen.queryByLabelText('Voice')).toBeNull()
   })
 
@@ -80,6 +81,7 @@ describe('HUD mode', () => {
     renderControls()
 
     expect(screen.getByLabelText('Voice')).toBeTruthy()
+    expect(screen.getByLabelText('Reset HUD size and position')).toBeTruthy()
     expect(screen.getByLabelText('Exit HUD mode')).toBeTruthy()
 
     // Folded away, not duplicated — the whole point is the row's width back.

--- a/apps/desktop/src/app/chat/composer/controls.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.tsx
@@ -7,7 +7,7 @@ import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { AudioLines, Ear, EarOff, iconSize, Layers3, Loader2, Square, Volume2, VolumeX } from '@/lib/icons'
 import { cn } from '@/lib/utils'
-import { $hudMode, closeHud } from '@/store/hud'
+import { $hudMode, closeHud, resetHudLayout } from '@/store/hud'
 import { $wakeWord, toggleWakeWord } from '@/store/wake-word'
 
 import { ACTIVE_ICON_BTN, GHOST_ICON_BTN, PRIMARY_ICON_BTN } from './control-classes'
@@ -173,27 +173,41 @@ export function ComposerControls({
           the surface, paid for in every state, for a control that is invisible
           until hovered. Here it costs no reserved space and sits with the other
           things you can press. */}
-      {hudMode ? <ExitHudButton /> : null}
+      {hudMode ? <HudWindowButtons /> : null}
     </div>
   )
 }
 
-function ExitHudButton() {
+function HudWindowButtons() {
   const { t } = useI18n()
 
   return (
-    <Tip label={t.titlebar.exitHud}>
-      <Button
-        aria-label={t.titlebar.exitHud}
-        className={cn(GHOST_ICON_BTN, 'p-0')}
-        onClick={closeHud}
-        size="icon"
-        type="button"
-        variant="ghost"
-      >
-        <Codicon name="screen-normal" size="0.875rem" />
-      </Button>
-    </Tip>
+    <>
+      <Tip label={t.titlebar.resetHudLayout}>
+        <Button
+          aria-label={t.titlebar.resetHudLayout}
+          className={cn(GHOST_ICON_BTN, 'p-0')}
+          onClick={resetHudLayout}
+          size="icon"
+          type="button"
+          variant="ghost"
+        >
+          <Codicon name="discard" size="0.875rem" />
+        </Button>
+      </Tip>
+      <Tip label={t.titlebar.exitHud}>
+        <Button
+          aria-label={t.titlebar.exitHud}
+          className={cn(GHOST_ICON_BTN, 'p-0')}
+          onClick={closeHud}
+          size="icon"
+          type="button"
+          variant="ghost"
+        >
+          <Codicon name="screen-normal" size="0.875rem" />
+        </Button>
+      </Tip>
+    </>
   )
 }
 

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -12,6 +12,7 @@ import { PR_COMMENT_URL_RE } from '@/lib/chat-runtime'
 import { sanitizeComposerInput } from '@/lib/composer-input-sanitize'
 import { DATA_IMAGE_URL_RE } from '@/lib/embedded-images'
 import { triggerHaptic } from '@/lib/haptics'
+import { isLinuxPlatform } from '@/lib/platform'
 import { cn } from '@/lib/utils'
 import { interceptsTypedVoiceStop } from '@/lib/voice-stop-word'
 import { sessionCompacting } from '@/store/compaction'
@@ -1006,7 +1007,11 @@ export function ChatBar({
           'min-h-[1.625rem] min-h-(--composer-input-min-height) max-h-(--composer-input-max-height) cursor-text overflow-y-auto whitespace-pre-wrap break-words [overflow-wrap:anywhere] bg-transparent pb-1 pr-1 pt-1 leading-normal text-foreground outline-none disabled:cursor-not-allowed',
           '**:data-ref-text:cursor-default',
           stacked && 'pl-3',
-          stacked ? 'w-full' : 'min-w-(--composer-input-inline-min-width) flex-1'
+          stacked ? 'w-full' : 'min-w-(--composer-input-inline-min-width) flex-1',
+          // Inside the Linux HUD drag region: a drag region swallows the page's
+          // mouse input whole, so the input must opt back out or it becomes
+          // unclickable. Buttons are covered by the global no-drag rule.
+          hudMode && isLinuxPlatform() && '[-webkit-app-region:no-drag]'
         )}
         contentEditable={!inputDisabled}
         data-placeholder={placeholder}
@@ -1184,7 +1189,12 @@ export function ChatBar({
             className={cn(
               'group/composer relative w-full overflow-visible rounded-2xl',
               poppedOut && 'bg-transparent',
-              dragging && 'cursor-grabbing select-none touch-none'
+              dragging && 'cursor-grabbing select-none touch-none',
+              // Linux HUD: the bar is a native compositor drag handle
+              // (xdg_toplevel.move / _NET_WM_MOVERESIZE). setBounds position
+              // is a no-op on Wayland, so this is the only way to move it
+              // there. pt-4 is the grab band once the input/buttons opt out.
+              hudMode && isLinuxPlatform() && 'hud-native-drag pt-4 [-webkit-app-region:drag]'
             )}
             data-drag-active={dragActive ? '' : undefined}
             data-hud-grabbing={hudGrabbing ? '' : undefined}

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -108,7 +108,13 @@ export function ChatBar({
   onTranscribeAudio
 }: ChatBarProps) {
   const hudMode = useStore($hudMode)
-  const { grabbing: hudGrabbing, onPointerDown: onHudDragPointerDown } = useHudComposerDrag(hudMode)
+  const hudNativeDrag = hudMode && window.hermesDesktop?.hud?.nativeDrag === true
+  const hudX11Drag = hudMode && isLinuxPlatform() && !hudNativeDrag
+
+  const { grabbing: hudGrabbing, onPointerDown: onHudDragPointerDown } = useHudComposerDrag(hudMode && !hudNativeDrag, {
+    controlDrag: hudX11Drag,
+    workspaceTransfer: hudX11Drag
+  })
 
   // Typed stop phrase during an active voice conversation ends it — same
   // semantics as SAYING "stop" (voice-stop-word.ts) or clicking the pill's
@@ -1008,10 +1014,10 @@ export function ChatBar({
           '**:data-ref-text:cursor-default',
           stacked && 'pl-3',
           stacked ? 'w-full' : 'min-w-(--composer-input-inline-min-width) flex-1',
-          // Inside the Linux HUD drag region: a drag region swallows the page's
-          // mouse input whole, so the input must opt back out or it becomes
-          // unclickable. Buttons are covered by the global no-drag rule.
-          hudMode && isLinuxPlatform() && '[-webkit-app-region:no-drag]'
+          // Inside the native Wayland HUD drag region: a drag region swallows
+          // the page's mouse input whole, so the input must opt back out or it
+          // becomes unclickable. Buttons use the global no-drag rule.
+          hudNativeDrag && '[-webkit-app-region:no-drag]'
         )}
         contentEditable={!inputDisabled}
         data-placeholder={placeholder}
@@ -1190,11 +1196,11 @@ export function ChatBar({
               'group/composer relative w-full overflow-visible rounded-2xl',
               poppedOut && 'bg-transparent',
               dragging && 'cursor-grabbing select-none touch-none',
-              // Linux HUD: the bar is a native compositor drag handle
-              // (xdg_toplevel.move / _NET_WM_MOVERESIZE). setBounds position
-              // is a no-op on Wayland, so this is the only way to move it
-              // there. pt-4 is the grab band once the input/buttons opt out.
-              hudMode && isLinuxPlatform() && 'hud-native-drag pt-4 [-webkit-app-region:drag]'
+              // Native Wayland HUD: setBounds cannot position a top-level
+              // surface, so the bar must ask the compositor to move it. X11
+              // stays out of app-region mode so the renderer receives its
+              // Ctrl+primary-button drag. pt-4 is the carved-out grab band.
+              hudNativeDrag && 'hud-native-drag pt-4 [-webkit-app-region:drag]'
             )}
             data-drag-active={dragActive ? '' : undefined}
             data-hud-grabbing={hudGrabbing ? '' : undefined}
@@ -1206,7 +1212,8 @@ export function ChatBar({
             onDragLeave={handleDragLeave}
             onDragOver={handleDragOver}
             onDrop={handleDrop}
-            onPointerDown={hudMode ? onHudDragPointerDown : popoutAllowed ? onComposerGesturePointerDown : undefined}
+            onPointerDown={!hudMode && popoutAllowed ? onComposerGesturePointerDown : undefined}
+            onPointerDownCapture={hudMode ? onHudDragPointerDown : undefined}
             onSubmit={e => {
               e.preventDefault()
 

--- a/apps/desktop/src/app/hud/click-through.ts
+++ b/apps/desktop/src/app/hud/click-through.ts
@@ -68,10 +68,16 @@ export function hudIgnoresMouse(
  * decision, a different courier.
  *
  * It follows that nothing in HUD mode may declare `-webkit-app-region: drag`
- * at all: a draggable region swallows the page's mouse events, so the moves
- * never arrive and the window is stranded on whatever it last decided —
- * usually transparent, which is also why pressing the handle fell through to
- * the app behind. Dragging is `useHudComposerDrag` instead.
+ * on macOS/Windows: a draggable region swallows the page's mouse events, so
+ * the moves never arrive and the window is stranded on whatever it last
+ * decided — usually transparent, which is also why pressing the handle fell
+ * through to the app behind. Dragging there is `useHudComposerDrag` instead.
+ *
+ * Linux is the exception: the solidity decision is fed from MAIN's cursor
+ * poll (`startHudCursorFeed`), which a drag region cannot starve — so the
+ * HUD composer root declares `-webkit-app-region: drag` (input carved out
+ * as no-drag) and the compositor moves the window natively. That is also
+ * the only move that works on Wayland, where `setBounds` position is a no-op.
  */
 export function useHudClickThrough(rootRef: RefObject<HTMLElement | null>): void {
   useEffect(() => {

--- a/apps/desktop/src/app/hud/composer-drag.test.ts
+++ b/apps/desktop/src/app/hud/composer-drag.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react'
+import { act, render, renderHook } from '@testing-library/react'
+import { createElement } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useHudComposerDrag } from './composer-drag'
@@ -10,6 +11,7 @@ const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDeskt
 const initialHermesDesktop = desktopWindow.hermesDesktop
 
 const moveBy = vi.fn()
+const setWorkspaceTransfer = vi.fn()
 
 function setWindowSize(width: number, height: number) {
   Object.defineProperty(window, 'outerWidth', { configurable: true, value: width })
@@ -30,8 +32,9 @@ function pressTarget() {
 beforeEach(() => {
   vi.useFakeTimers()
   moveBy.mockClear()
+  setWorkspaceTransfer.mockClear()
   setWindowSize(620, 320)
-  desktopWindow.hermesDesktop = { hud: { moveBy } } as unknown as Window['hermesDesktop']
+  desktopWindow.hermesDesktop = { hud: { moveBy, setWorkspaceTransfer } } as unknown as Window['hermesDesktop']
 })
 
 afterEach(() => {
@@ -63,6 +66,7 @@ describe('useHudComposerDrag', () => {
     act(() => void window.dispatchEvent(new PointerEvent('pointermove', { pointerId: 1, screenX: 110, screenY: 210 })))
 
     expect(moveBy).toHaveBeenCalledWith({ x: 10, y: 10, width: 620, height: 320 })
+    expect(setWorkspaceTransfer).not.toHaveBeenCalled()
 
     // A window that drifted wider mid-drag must not feed its new size back in —
     // that is exactly how the Windows growth compounded.
@@ -88,5 +92,95 @@ describe('useHudComposerDrag', () => {
     act(() => void window.dispatchEvent(new PointerEvent('pointermove', { pointerId: 1, screenX: 102, screenY: 201 })))
 
     expect(moveBy).not.toHaveBeenCalled()
+    expect(setWorkspaceTransfer).not.toHaveBeenCalled()
+  })
+
+  it('spans X11 workspaces only for an armed grab, then pins to the current desktop on release', () => {
+    const target = pressTarget()
+
+    const { result } = renderHook(() =>
+      useHudComposerDrag(true, { controlDrag: true, workspaceTransfer: true })
+    )
+
+    act(() =>
+      result.current.onPointerDown({
+        button: 0,
+        ctrlKey: true,
+        currentTarget: target,
+        pointerId: 9,
+        preventDefault: vi.fn(),
+        screenX: 100,
+        screenY: 200
+      } as never)
+    )
+
+    expect(setWorkspaceTransfer).toHaveBeenLastCalledWith(true)
+
+    act(() => void window.dispatchEvent(new PointerEvent('pointerup', { pointerId: 9 })))
+
+    expect(setWorkspaceTransfer).toHaveBeenLastCalledWith(false)
+  })
+
+  it('moves immediately with Ctrl over selected text without destroying the selection', () => {
+    function Harness() {
+      const { onPointerDown } = useHudComposerDrag(true, { controlDrag: true })
+
+      return createElement(
+        'form',
+        { 'data-testid': 'composer', onPointerDownCapture: onPointerDown },
+        createElement(
+          'div',
+          { contentEditable: true, 'data-testid': 'editor', suppressContentEditableWarning: true, tabIndex: 0 },
+          'selected text stays selected'
+        )
+      )
+    }
+
+    const { getByTestId } = render(createElement(Harness))
+    const editor = getByTestId('editor')
+    const text = editor.firstChild!
+    editor.focus()
+    const range = document.createRange()
+    range.setStart(text, 0)
+    range.setEnd(text, 13)
+    const selection = window.getSelection()!
+    selection.removeAllRanges()
+    selection.addRange(range)
+
+    const down = new PointerEvent('pointerdown', {
+      bubbles: true,
+      button: 0,
+      buttons: 1,
+      cancelable: true,
+      ctrlKey: true,
+      pointerId: 7,
+      screenX: 300,
+      screenY: 180
+    })
+
+    act(() => void editor.dispatchEvent(down))
+
+    expect(down.defaultPrevented).toBe(true)
+    expect(document.activeElement).toBe(editor)
+    expect(selection.toString()).toBe('selected text')
+
+    const dragStart = new Event('dragstart', { bubbles: true, cancelable: true })
+    const selectStart = new Event('selectstart', { bubbles: true, cancelable: true })
+    act(() => void editor.dispatchEvent(dragStart))
+    act(() => void editor.dispatchEvent(selectStart))
+
+    expect(dragStart.defaultPrevented).toBe(true)
+    expect(selectStart.defaultPrevented).toBe(true)
+
+    act(
+      () =>
+        void window.dispatchEvent(
+          new PointerEvent('pointermove', { buttons: 1, cancelable: true, pointerId: 7, screenX: 301, screenY: 182 })
+        )
+    )
+
+    expect(moveBy).toHaveBeenCalledWith({ x: 1, y: 2, width: 620, height: 320 })
+    expect(document.activeElement).toBe(editor)
+    expect(selection.toString()).toBe('selected text')
   })
 })

--- a/apps/desktop/src/app/hud/composer-drag.ts
+++ b/apps/desktop/src/app/hud/composer-drag.ts
@@ -12,26 +12,61 @@ interface PressState {
   armed: boolean
   lastX: number
   lastY: number
+  mode: 'control' | 'hold'
   originH: number
   originW: number
   pointerId: number
   startX: number
   startY: number
   target: HTMLElement
+  workspaceTransfer: boolean
+}
+
+interface HudComposerDragOptions {
+  /** X11 escape hatch: Ctrl+primary-button grabs immediately instead of
+   *  competing with Chromium's text-selection drag until the hold timer. */
+  controlDrag?: boolean
+  /** X11/KWin only: keep the grabbed window visible while the user changes
+   *  virtual desktops, then pin it to the destination desktop on release. */
+  workspaceTransfer?: boolean
+}
+
+function capturePointer(state: PressState): void {
+  try {
+    state.target.setPointerCapture?.(state.pointerId)
+  } catch {
+    // A renderer can reject capture after selection/native-drag bookkeeping.
+    // Window capture-phase listeners below still keep the in-window gesture
+    // alive, so a failed capture must not abort the drag altogether.
+  }
+}
+
+function releasePointer(state: PressState): void {
+  try {
+    if (state.target.hasPointerCapture?.(state.pointerId)) {
+      state.target.releasePointerCapture?.(state.pointerId)
+    }
+  } catch {
+    // Pointer cancellation may invalidate the id before React cleans up.
+  }
+}
+
+function setWorkspaceTransfer(transferring: boolean): void {
+  window.hermesDesktop?.hud?.setWorkspaceTransfer?.(transferring)
 }
 
 /**
- * HUD-only: press and hold the composer, then drag to move the window.
+ * HUD-only: press and hold the composer, then drag to move the window. On X11,
+ * Ctrl+primary-button is an immediate grab that also works over selected text.
  *
  * The way to move the HUD on macOS/Windows. An `-webkit-app-region: drag`
  * handle is the obvious alternative and cannot work THERE: the window manager
  * takes a drag region's mouse input whole, which starves `useHudClickThrough`
  * of the moves it decides solidity from, so the window is already transparent
  * by the time the press lands and it falls through to the app behind. See
- * click-through.ts. On Linux the composer bar itself is a native drag region
- * instead (root drag + input no-drag), so this gesture is only the fallback
- * for presses that land on the interactive surface — and a no-op for position
- * on native Wayland, where the compositor owns placement.
+ * click-through.ts. Native Wayland uses a compositor drag region instead,
+ * because apps cannot place their own top-level surfaces there. X11 stays on
+ * this renderer path and additionally supports an immediate Ctrl-drag.
  *
  * Deltas are read in SCREEN coordinates. Client coordinates are relative to the
  * window we are moving, so a window that keeps up with the cursor reports the
@@ -41,7 +76,10 @@ interface PressState {
  * (see hermes:hud:move-by — a transparent frameless window drifts wider on
  * Windows otherwise). Same shape as the pet overlay's drag.
  */
-export function useHudComposerDrag(enabled: boolean) {
+export function useHudComposerDrag(
+  enabled: boolean,
+  { controlDrag = false, workspaceTransfer = false }: HudComposerDragOptions = {}
+) {
   const [grabbing, setGrabbing] = useState(false)
   const stateRef = useRef<PressState | null>(null)
   const timerRef = useRef<number | null>(null)
@@ -54,8 +92,12 @@ export function useHudComposerDrag(enabled: boolean) {
 
     const state = stateRef.current
 
-    if (state?.target.hasPointerCapture(state.pointerId)) {
-      state.target.releasePointerCapture(state.pointerId)
+    if (state) {
+      if (state.workspaceTransfer) {
+        setWorkspaceTransfer(false)
+      }
+
+      releasePointer(state)
     }
 
     stateRef.current = null
@@ -69,21 +111,48 @@ export function useHudComposerDrag(enabled: boolean) {
       }
 
       const target = event.currentTarget
+      const immediate = controlDrag && event.ctrlKey
 
-      stateRef.current = {
-        armed: false,
+      // A press over an existing contentEditable selection otherwise starts
+      // Chromium's native text drag, which cancels our pointer stream. Cancel
+      // that default action before it is chosen; do not blur or rewrite the
+      // Selection, so the user's selected text survives moving the window.
+      if (immediate) {
+        event.preventDefault()
+      }
+
+      const state: PressState = {
+        armed: immediate,
         lastX: event.screenX,
         lastY: event.screenY,
+        mode: immediate ? 'control' : 'hold',
         originH: window.outerHeight,
         originW: window.outerWidth,
         pointerId: event.pointerId,
         startX: event.screenX,
         startY: event.screenY,
-        target
+        target,
+        workspaceTransfer: false
       }
+
+      stateRef.current = state
 
       if (timerRef.current !== null) {
         window.clearTimeout(timerRef.current)
+      }
+
+      if (immediate) {
+        state.workspaceTransfer = workspaceTransfer
+
+        if (workspaceTransfer) {
+          setWorkspaceTransfer(true)
+        }
+
+        setGrabbing(true)
+        triggerHaptic('selection')
+        capturePointer(state)
+
+        return
       }
 
       timerRef.current = window.setTimeout(() => {
@@ -94,19 +163,25 @@ export function useHudComposerDrag(enabled: boolean) {
         }
 
         state.armed = true
+        state.workspaceTransfer = workspaceTransfer
+
+        if (workspaceTransfer) {
+          setWorkspaceTransfer(true)
+        }
+
         setGrabbing(true)
         triggerHaptic('selection')
 
         // Capture so the moves keep arriving once the cursor outruns the bar,
         // and drop the caret so the drag isn't also extending a selection.
-        state.target.setPointerCapture(state.pointerId)
+        capturePointer(state)
 
         if (document.activeElement instanceof HTMLElement) {
           document.activeElement.blur()
         }
       }, LONG_PRESS_MS)
     },
-    [enabled]
+    [controlDrag, enabled, workspaceTransfer]
   )
 
   useEffect(() => {
@@ -163,14 +238,27 @@ export function useHudComposerDrag(enabled: boolean) {
       reset()
     }
 
-    window.addEventListener('pointermove', onMove)
-    window.addEventListener('pointerup', onUp)
-    window.addEventListener('pointercancel', onUp)
+    const preventEditorGesture = (event: Event) => {
+      if (stateRef.current?.mode === 'control') {
+        event.preventDefault()
+      }
+    }
+
+    // Capture phase wins the race against contentEditable selection/drag
+    // handlers. `dragstart` is a second guard for an already-selected range;
+    // `selectstart` stops the same press from replacing that range.
+    window.addEventListener('pointermove', onMove, true)
+    window.addEventListener('pointerup', onUp, true)
+    window.addEventListener('pointercancel', onUp, true)
+    window.addEventListener('dragstart', preventEditorGesture, true)
+    window.addEventListener('selectstart', preventEditorGesture, true)
 
     return () => {
-      window.removeEventListener('pointermove', onMove)
-      window.removeEventListener('pointerup', onUp)
-      window.removeEventListener('pointercancel', onUp)
+      window.removeEventListener('pointermove', onMove, true)
+      window.removeEventListener('pointerup', onUp, true)
+      window.removeEventListener('pointercancel', onUp, true)
+      window.removeEventListener('dragstart', preventEditorGesture, true)
+      window.removeEventListener('selectstart', preventEditorGesture, true)
     }
   }, [enabled, reset])
 

--- a/apps/desktop/src/app/hud/composer-drag.ts
+++ b/apps/desktop/src/app/hud/composer-drag.ts
@@ -23,11 +23,15 @@ interface PressState {
 /**
  * HUD-only: press and hold the composer, then drag to move the window.
  *
- * The only way to move the HUD. An `-webkit-app-region: drag` handle is the
- * obvious alternative and cannot work here: the window manager takes a drag
- * region's mouse input whole, which starves `useHudClickThrough` of the moves
- * it decides solidity from, so the window is already transparent by the time
- * the press lands and it falls through to the app behind. See click-through.ts.
+ * The way to move the HUD on macOS/Windows. An `-webkit-app-region: drag`
+ * handle is the obvious alternative and cannot work THERE: the window manager
+ * takes a drag region's mouse input whole, which starves `useHudClickThrough`
+ * of the moves it decides solidity from, so the window is already transparent
+ * by the time the press lands and it falls through to the app behind. See
+ * click-through.ts. On Linux the composer bar itself is a native drag region
+ * instead (root drag + input no-drag), so this gesture is only the fallback
+ * for presses that land on the interactive surface — and a no-op for position
+ * on native Wayland, where the compositor owns placement.
  *
  * Deltas are read in SCREEN coordinates. Client coordinates are relative to the
  * window we are moving, so a window that keeps up with the cursor reports the

--- a/apps/desktop/src/app/hud/hud-shell.tsx
+++ b/apps/desktop/src/app/hud/hud-shell.tsx
@@ -14,7 +14,7 @@ import { useHudGameOverlay } from './game-overlay'
 import { useHudGlass } from './glass'
 import { useHudGoto, useReportHudSession } from './handoff'
 import { hudTranscriptHeight } from './layout'
-import { useHudResizeHandle } from './resize-handle'
+import { hudResizeDirections, useHudResizeHandle } from './resize-handle'
 import { useHudThreadFocus } from './thread-focus'
 
 /** How long the transcript lingers at its glanceable opacity — after a turn
@@ -372,11 +372,12 @@ export function HudShell() {
   useHudClickThrough(rootRef)
   useHudThreadFocus(rootRef)
 
-  // Corner resize handle. The window is created non-resizable so dragging can
+  // Edge/corner resize frame. The window is created non-resizable so dragging can
   // never be misread as a resize gesture (the Windows transparent-frameless
   // growth bug); the handle is the one sanctioned way to change size, driving
   // the same flip-resizable-for-the-call pattern the pet overlay uses.
   const { resizing: hudResizing, onPointerDown: onHudResizePointerDown } = useHudResizeHandle()
+  const resizeDirections = hudResizeDirections(window.hermesDesktop?.hud?.nativeDrag === true)
 
   // Force the HOST layers transparent. index.html's pre-paint script writes an
   // opaque themed background onto <html> as an INLINE style (the anti-white-
@@ -421,19 +422,20 @@ export function HudShell() {
 
       <WiredPane part="chatRoutes" />
 
-      {/* The resize handle: bottom-right corner, the one sanctioned way to
-          change the HUD's size. Invisible chrome — a hot corner, not a
-          button — so it never reads as part of the surface. `data-hud-grabbing`
-          is the same flag the composer drag raises: a gesture in progress owns
-          the window, so click-through can't hand the mouse away mid-resize
-          when the growing edge outruns the cursor. */}
-      <div
-        aria-hidden
-        className="absolute bottom-0 right-0 z-20"
-        data-hud-grabbing={hudResizing ? '' : undefined}
-        data-hud-resize=""
-        onPointerDown={onHudResizePointerDown}
-      />
+      {/* CanvasTTY-style resize frame. Windows/macOS/X11 get every edge and
+          corner; native Wayland gets the right/bottom handles it can honour
+          without forbidden global positioning. The handles are invisible
+          chrome with native cursors. `data-hud-grabbing` keeps click-through
+          from handing the pointer away while the window changes under it. */}
+      {resizeDirections.map(direction => (
+        <div
+          aria-hidden
+          data-hud-grabbing={hudResizing ? '' : undefined}
+          data-hud-resize={direction}
+          key={direction}
+          onPointerDown={event => onHudResizePointerDown(event, direction)}
+        />
+      ))}
     </div>
   )
 }

--- a/apps/desktop/src/app/hud/resize-handle.test.ts
+++ b/apps/desktop/src/app/hud/resize-handle.test.ts
@@ -1,0 +1,98 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { HUD_RESIZE_DIRECTIONS, hudResizeBounds, hudResizeDirections, useHudResizeHandle } from './resize-handle'
+
+const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
+const initialHermesDesktop = desktopWindow.hermesDesktop
+const setBounds = vi.fn()
+
+function setWindowBounds(x: number, y: number, width: number, height: number): void {
+  Object.defineProperty(window, 'screenX', { configurable: true, value: x })
+  Object.defineProperty(window, 'screenY', { configurable: true, value: y })
+  Object.defineProperty(window, 'outerWidth', { configurable: true, value: width })
+  Object.defineProperty(window, 'outerHeight', { configurable: true, value: height })
+}
+
+function resizeTarget(): HTMLElement {
+  const target = document.createElement('div')
+  target.setPointerCapture = vi.fn()
+  target.hasPointerCapture = vi.fn(() => false)
+  target.releasePointerCapture = vi.fn()
+  document.body.append(target)
+
+  return target
+}
+
+beforeEach(() => {
+  setBounds.mockClear()
+  setWindowBounds(100, 200, 620, 320)
+  desktopWindow.hermesDesktop = { hud: { setBounds } } as unknown as Window['hermesDesktop']
+})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+
+  if (initialHermesDesktop) {
+    desktopWindow.hermesDesktop = initialHermesDesktop
+  } else {
+    delete desktopWindow.hermesDesktop
+  }
+})
+
+describe('hudResizeBounds', () => {
+  const origin = { x: 100, y: 200, width: 620, height: 320 }
+
+  it('resizes from every CanvasTTY edge and corner while preserving the opposite edges', () => {
+    expect(hudResizeBounds(origin, 'n', 40, 30)).toEqual({ x: 100, y: 230, width: 620, height: 290 })
+    expect(hudResizeBounds(origin, 'ne', 40, 30)).toEqual({ x: 100, y: 230, width: 660, height: 290 })
+    expect(hudResizeBounds(origin, 'e', 40, 30)).toEqual({ x: 100, y: 200, width: 660, height: 320 })
+    expect(hudResizeBounds(origin, 'se', 40, 30)).toEqual({ x: 100, y: 200, width: 660, height: 350 })
+    expect(hudResizeBounds(origin, 's', 40, 30)).toEqual({ x: 100, y: 200, width: 620, height: 350 })
+    expect(hudResizeBounds(origin, 'sw', 40, 30)).toEqual({ x: 140, y: 200, width: 580, height: 350 })
+    expect(hudResizeBounds(origin, 'w', 40, 30)).toEqual({ x: 140, y: 200, width: 580, height: 320 })
+    expect(hudResizeBounds(origin, 'nw', 40, 30)).toEqual({ x: 140, y: 230, width: 580, height: 290 })
+  })
+
+  it('clamps at the minimum without moving the opposite edge', () => {
+    expect(hudResizeBounds(origin, 'nw', 1000, 1000)).toEqual({ x: 340, y: 360, width: 380, height: 160 })
+    expect(hudResizeBounds(origin, 'se', -1000, -1000)).toEqual({ x: 100, y: 200, width: 380, height: 160 })
+  })
+})
+
+describe('hudResizeDirections', () => {
+  it('keeps every edge and corner on platforms with global window positioning', () => {
+    expect(hudResizeDirections(false)).toBe(HUD_RESIZE_DIRECTIONS)
+  })
+
+  it('exposes only position-preserving handles on native Wayland', () => {
+    expect(hudResizeDirections(true)).toEqual(['e', 'se', 's'])
+  })
+})
+
+describe('useHudResizeHandle', () => {
+  it('sends the selected edge geometry through the HUD bridge', () => {
+    const target = resizeTarget()
+    const { result } = renderHook(() => useHudResizeHandle())
+
+    act(() =>
+      result.current.onPointerDown(
+        {
+          button: 0,
+          currentTarget: target,
+          pointerId: 4,
+          preventDefault: vi.fn(),
+          screenX: 300,
+          screenY: 300,
+          stopPropagation: vi.fn()
+        } as never,
+        'nw'
+      )
+    )
+    act(() =>
+      void window.dispatchEvent(new PointerEvent('pointermove', { pointerId: 4, screenX: 250, screenY: 275 }))
+    )
+
+    expect(setBounds).toHaveBeenCalledWith({ x: 50, y: 175, width: 670, height: 345 })
+  })
+})

--- a/apps/desktop/src/app/hud/resize-handle.ts
+++ b/apps/desktop/src/app/hud/resize-handle.ts
@@ -4,7 +4,27 @@ import { type PointerEvent as ReactPointerEvent, useCallback, useEffect, useRef,
 const HUD_MIN_WIDTH = 380
 const HUD_MIN_HEIGHT = 160
 
+export const HUD_RESIZE_DIRECTIONS = ['n', 'ne', 'e', 'se', 's', 'sw', 'w', 'nw'] as const
+
+export type HudResizeDirection = (typeof HUD_RESIZE_DIRECTIONS)[number]
+
+const HUD_WAYLAND_RESIZE_DIRECTIONS = ['e', 'se', 's'] as const satisfies readonly HudResizeDirection[]
+
+/** Native Wayland cannot read or change a top-level window's global x/y, so
+ *  only edges that preserve the existing top-left position are truthful. */
+export function hudResizeDirections(nativeDrag: boolean): readonly HudResizeDirection[] {
+  return nativeDrag ? HUD_WAYLAND_RESIZE_DIRECTIONS : HUD_RESIZE_DIRECTIONS
+}
+
+export interface HudResizeBounds {
+  height: number
+  width: number
+  x: number
+  y: number
+}
+
 interface ResizeState {
+  direction: HudResizeDirection
   startX: number
   startY: number
   originX: number
@@ -12,10 +32,63 @@ interface ResizeState {
   originW: number
   originH: number
   pointerId: number
+  target: HTMLElement
+}
+
+/** Resize one or two anchored edges while preserving every opposite edge. */
+export function hudResizeBounds(
+  origin: HudResizeBounds,
+  direction: HudResizeDirection,
+  dx: number,
+  dy: number
+): HudResizeBounds {
+  const right = origin.x + origin.width
+  const bottom = origin.y + origin.height
+  const west = direction.includes('w')
+  const east = direction.includes('e')
+  const north = direction.includes('n')
+  const south = direction.includes('s')
+
+  const width = west
+    ? Math.max(HUD_MIN_WIDTH, origin.width - dx)
+    : east
+      ? Math.max(HUD_MIN_WIDTH, origin.width + dx)
+      : origin.width
+
+  const height = north
+    ? Math.max(HUD_MIN_HEIGHT, origin.height - dy)
+    : south
+      ? Math.max(HUD_MIN_HEIGHT, origin.height + dy)
+      : origin.height
+
+  return {
+    x: west ? right - width : origin.x,
+    y: north ? bottom - height : origin.y,
+    width,
+    height
+  }
+}
+
+function capturePointer(state: ResizeState): void {
+  try {
+    state.target.setPointerCapture?.(state.pointerId)
+  } catch {
+    // Window capture-phase listeners below keep the in-window gesture alive.
+  }
+}
+
+function releasePointer(state: ResizeState): void {
+  try {
+    if (state.target.hasPointerCapture?.(state.pointerId)) {
+      state.target.releasePointerCapture?.(state.pointerId)
+    }
+  } catch {
+    // Pointer cancellation may invalidate the id before cleanup.
+  }
 }
 
 /**
- * HUD-only: drag the corner handle to resize the window.
+ * HUD-only: drag any edge or corner handle to resize the window.
  *
  * The window is created `resizable: false` (see spawnHudWindow — a transparent
  * frameless window must not expose a system resize hot-zone, or every drag
@@ -23,41 +96,50 @@ interface ResizeState {
  * screen bounds and main flips resizable on for the setBounds call. Same
  * pattern as the pet overlay's wheel-scale (`hermes:pet-overlay:set-bounds`).
  *
- * The top-left corner is anchored; only the bottom-right follows the pointer.
- * Deltas are read in SCREEN coordinates, like the composer drag: client
- * coordinates are relative to a window that is changing size, so they cannot
- * be trusted mid-resize.
+ * Each handle preserves its opposite edge, matching ordinary desktop windows
+ * and CanvasTTY cards. Deltas are read in SCREEN coordinates, like the composer
+ * drag: client coordinates are relative to a window that is changing position
+ * and size, so they cannot be trusted mid-resize.
  */
 export function useHudResizeHandle(): {
   resizing: boolean
-  onPointerDown: (event: ReactPointerEvent<HTMLElement>) => void
+  onPointerDown: (event: ReactPointerEvent<HTMLElement>, direction: HudResizeDirection) => void
 } {
   const [resizing, setResizing] = useState(false)
   const stateRef = useRef<ResizeState | null>(null)
 
   const reset = useCallback(() => {
+    const state = stateRef.current
+
+    if (state) {
+      releasePointer(state)
+    }
+
     stateRef.current = null
     setResizing(false)
   }, [])
 
-  const onPointerDown = useCallback((event: ReactPointerEvent<HTMLElement>) => {
+  const onPointerDown = useCallback((event: ReactPointerEvent<HTMLElement>, direction: HudResizeDirection) => {
     if (event.button !== 0) {
       return
     }
 
     stateRef.current = {
+      direction,
       startX: event.screenX,
       startY: event.screenY,
       originX: window.screenX,
       originY: window.screenY,
       originW: window.outerWidth,
       originH: window.outerHeight,
-      pointerId: event.pointerId
+      pointerId: event.pointerId,
+      target: event.currentTarget
     }
 
     setResizing(true)
-    event.currentTarget.setPointerCapture(event.pointerId)
+    capturePointer(stateRef.current)
     event.preventDefault()
+    event.stopPropagation()
   }, [])
 
   useEffect(() => {
@@ -73,12 +155,14 @@ export function useHudResizeHandle(): {
       const dx = event.screenX - state.startX
       const dy = event.screenY - state.startY
 
-      window.hermesDesktop?.hud?.setBounds?.({
-        x: state.originX,
-        y: state.originY,
-        width: Math.max(HUD_MIN_WIDTH, state.originW + dx),
-        height: Math.max(HUD_MIN_HEIGHT, state.originH + dy)
-      })
+      window.hermesDesktop?.hud?.setBounds?.(
+        hudResizeBounds(
+          { x: state.originX, y: state.originY, width: state.originW, height: state.originH },
+          state.direction,
+          dx,
+          dy
+        )
+      )
     }
 
     const onUp = (event: PointerEvent) => {
@@ -91,14 +175,14 @@ export function useHudResizeHandle(): {
       reset()
     }
 
-    window.addEventListener('pointermove', onMove)
-    window.addEventListener('pointerup', onUp)
-    window.addEventListener('pointercancel', onUp)
+    window.addEventListener('pointermove', onMove, true)
+    window.addEventListener('pointerup', onUp, true)
+    window.addEventListener('pointercancel', onUp, true)
 
     return () => {
-      window.removeEventListener('pointermove', onMove)
-      window.removeEventListener('pointerup', onUp)
-      window.removeEventListener('pointercancel', onUp)
+      window.removeEventListener('pointermove', onMove, true)
+      window.removeEventListener('pointerup', onUp, true)
+      window.removeEventListener('pointercancel', onUp, true)
     }
   }, [reset])
 

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -96,6 +96,7 @@ declare global {
         setIgnoreMouse: (ignore: boolean) => void
         moveBy: (delta: { x: number; y: number; width: number; height: number }) => void
         setBounds: (bounds: { x: number; y: number; width: number; height: number }) => void
+        resetLayout: () => Promise<{ ok: boolean }>
         setFrost: (showing: boolean) => Promise<{ ok: boolean }>
         setSession: (sessionId: null | string) => void
         onGoto: (callback: (sessionId: string) => void) => () => void

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -91,10 +91,12 @@ declare global {
       // bar — so it mounts the real composer rather than a lookalike. Main
       // owns the window; `onChanged` keeps every window's toggle truthful.
       hud?: {
+        nativeDrag: boolean
         open: (request?: { sessionId?: null | string; profile?: null | string }) => Promise<{ ok: boolean }>
         close: () => Promise<{ ok: boolean }>
         setIgnoreMouse: (ignore: boolean) => void
         moveBy: (delta: { x: number; y: number; width: number; height: number }) => void
+        setWorkspaceTransfer?: (transferring: boolean) => void
         setBounds: (bounds: { x: number; y: number; width: number; height: number }) => void
         resetLayout: () => Promise<{ ok: boolean }>
         setFrost: (showing: boolean) => Promise<{ ok: boolean }>

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -218,6 +218,7 @@ export const ar = defineLocale({
     openStarmap: 'فتح خريطة الذاكرة',
     enterHud: 'وضع HUD',
     exitHud: 'إنهاء وضع HUD',
+    resetHudLayout: 'إعادة تعيين حجم HUD وموضعه',
     layoutEditor: 'محرر التخطيط',
     layoutEditorTitle: modifier => `محرر التخطيط — انقر مع ${modifier} لإعادة ضبط التخطيط`
   },

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -251,6 +251,7 @@ export const en: Translations = {
     openStarmap: 'Open memory graph',
     enterHud: 'HUD mode',
     exitHud: 'Exit HUD mode',
+    resetHudLayout: 'Reset HUD size and position',
     layoutEditor: 'Layout editor',
     layoutEditorTitle: mod => `Layout editor — ${mod}-click resets the layout`
   },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -249,7 +249,8 @@ export const ja = defineLocale({
     muteHaptics: '触覚フィードバックをオフ',
     unmuteHaptics: '触覚フィードバックをオン',
     openSettings: '設定を開く',
-    openStarmap: 'メモリグラフを開く'
+    openStarmap: 'メモリグラフを開く',
+    resetHudLayout: 'HUD のサイズと位置をリセット'
   },
 
   language: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -287,6 +287,7 @@ export interface Translations {
     openStarmap: string
     enterHud: string
     exitHud: string
+    resetHudLayout: string
     layoutEditor: string
     layoutEditorTitle: (modifier: string) => string
   }

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -241,7 +241,8 @@ export const zhHant = defineLocale({
     muteHaptics: '靜音觸感回饋',
     unmuteHaptics: '開啟觸感回饋',
     openSettings: '開啟設定',
-    openStarmap: '開啟記憶圖譜'
+    openStarmap: '開啟記憶圖譜',
+    resetHudLayout: '重設 HUD 大小和位置'
   },
 
   language: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -244,6 +244,7 @@ export const zh: Translations = {
     openStarmap: '打开记忆图谱',
     enterHud: 'HUD 模式',
     exitHud: '退出 HUD 模式',
+    resetHudLayout: '重置 HUD 大小和位置',
     layoutEditor: '布局编辑器',
     layoutEditorTitle: mod => `布局编辑器 — ${mod} 点击重置布局`
   },

--- a/apps/desktop/src/lib/platform.ts
+++ b/apps/desktop/src/lib/platform.ts
@@ -17,3 +17,6 @@ export const isMacPlatform = (): boolean =>
 // default userAgent. Win32 / Windows NT are the real tokens.
 export const isWindowsPlatform = (): boolean =>
   typeof navigator !== 'undefined' && /win32|windows/i.test(navigator.platform || navigator.userAgent || '')
+
+export const isLinuxPlatform = (): boolean =>
+  typeof navigator !== 'undefined' && /linux/i.test(navigator.platform || navigator.userAgent || '')

--- a/apps/desktop/src/store/hud.test.ts
+++ b/apps/desktop/src/store/hud.test.ts
@@ -4,16 +4,17 @@ import { $activeGatewayProfile } from '@/store/profile'
 import { $sessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
-import { $hudActive, $hudSession, openHud } from './hud'
+import { $hudActive, $hudSession, openHud, resetHudLayout } from './hud'
 
 const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
 const initialHermesDesktop = desktopWindow.hermesDesktop
 
 const open = vi.fn().mockResolvedValue({ ok: true })
+const resetLayout = vi.fn().mockResolvedValue({ ok: true })
 
 function installBridge() {
   desktopWindow.hermesDesktop = {
-    hud: { open }
+    hud: { open, resetLayout }
   } as unknown as Window['hermesDesktop']
 }
 
@@ -23,6 +24,7 @@ function session(overrides: Partial<SessionInfo>): SessionInfo {
 
 beforeEach(() => {
   open.mockClear()
+  resetLayout.mockClear()
   installBridge()
   $hudActive.set(false)
   $hudSession.set(null)
@@ -36,6 +38,14 @@ afterEach(() => {
   } else {
     delete desktopWindow.hermesDesktop
   }
+})
+
+describe('resetHudLayout', () => {
+  it('uses the native HUD recovery capability', () => {
+    resetHudLayout()
+
+    expect(resetLayout).toHaveBeenCalledOnce()
+  })
 })
 
 describe('openHud profile targeting (#82285)', () => {

--- a/apps/desktop/src/store/hud.ts
+++ b/apps/desktop/src/store/hud.ts
@@ -87,6 +87,11 @@ export function closeHud(): void {
 
 export const toggleHud = (sessionId?: null | string) => ($hudActive.get() ? closeHud() : openHud(sessionId))
 
+/** Restore the HUD's persisted geometry to its display-aware default. */
+export function resetHudLayout(): void {
+  void window.hermesDesktop?.hud?.resetLayout?.()
+}
+
 /** Tell main which session this HUD is on. Main holds it (the HUD's renderer
  *  doesn't outlive the window) and hands it back in the close broadcast so the
  *  app window knows what to re-home onto. */

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -3136,22 +3136,22 @@ button[data-slot='aui_msg-reactions'] svg {
   --thread-viewport-height: 100%;
 }
 
-/* `-webkit-app-region: drag` in HUD mode is LINUX ONLY. The window manager
-   takes a draggable region's mouse input whole, so the page never sees the
+/* `-webkit-app-region: drag` in HUD mode is NATIVE WAYLAND ONLY. The window
+   manager takes a draggable region's mouse input whole, so the page never sees the
    cursor arrive there — on macOS/Windows that starves `useHudClickThrough`,
    which decides solidity from exactly those moves, so the press falls through
    to the app behind (every app-region attempt there was therefore unusable,
-   and left the HUD solid over dead space once you left it). On Linux the
+   and left the HUD solid over dead space once you left it). Native Wayland's
    click-through decision is fed by MAIN's cursor poll (`startHudCursorFeed`),
-   not by page events, so a drag region cannot starve it: the bar stays solid,
-   the compositor takes the press, and the window moves natively
-   (xdg_toplevel.move on Wayland, _NET_WM_MOVERESIZE on X11). The composer's
-   interactive surface opts back out with `-webkit-app-region: no-drag` (input
-   element + the global button rule); the rest of the bar is the handle.
-   macOS/Windows keep dragging on `useHudComposerDrag` — press and hold the
-   bar, then move. */
+   not page events, and apps cannot position their own top-level surfaces, so
+   the compositor takes the press and moves the window with xdg_toplevel.move.
+   X11 deliberately keeps the renderer drag path: a Chromium drag region
+   intercepts the pointer stream needed by Ctrl+primary-button drag. The
+   composer's interactive surface opts out with `-webkit-app-region: no-drag`
+   (input element + global button rule); the rest of the bar is the handle.
+   macOS/Windows/X11 use `useHudComposerDrag` — press and hold, then move. */
 
-/* Grip affordance for the Linux drag band: the composer's top padding (pt-4)
+/* Grip affordance for the native Wayland drag band: the top padding (pt-4)
    is the only surface the region owns once the input/buttons are carved out,
    so make it look like a handle — a centered pill, like a mobile grip. */
 .hud-native-drag::before {
@@ -3335,21 +3335,83 @@ button[data-slot='aui_msg-reactions'] svg {
    Both problems were the placement, not the button: on the bar it is already
    on our surface. */
 
-/* The corner resize handle — a hot corner, not a button. The window is created
+/* The resize frame — hot edges/corners, not buttons. The window is created
    non-resizable (the transparent-frameless Windows drag-growth bug), so this
    is the one sanctioned way to change the HUD's size; it drives
    `hermes:hud:set-bounds`, which flips resizable on for the call.
 
-   Deliberately invisible chrome: no glyph, no border — the corner of the bar
-   reads as the affordance, and painting a handle on a surface that lives over
-   other apps would be a stray UI fragment. It opts in to pointer events the
-   same way every other HUD control does (the shell defaults to none). */
+   CanvasTTY grammar: four edge strips + four larger corner targets, each with
+   its native resize cursor and each preserving the opposite edge. Deliberately
+   invisible chrome: no glyph or border over whatever app is below the HUD. */
 [data-hud-shell] [data-hud-resize] {
-  width: 1.25rem;
-  height: 1.25rem;
-  cursor: nwse-resize;
+  position: absolute;
+  z-index: 20;
   pointer-events: auto;
   touch-action: none;
+}
+
+[data-hud-shell] [data-hud-resize='n'] {
+  top: 0;
+  right: 1.25rem;
+  left: 1.25rem;
+  height: 0.625rem;
+  cursor: ns-resize;
+}
+
+[data-hud-shell] [data-hud-resize='e'] {
+  top: 1.25rem;
+  right: 0;
+  bottom: 1.25rem;
+  width: 0.625rem;
+  cursor: ew-resize;
+}
+
+[data-hud-shell] [data-hud-resize='s'] {
+  right: 1.25rem;
+  bottom: 0;
+  left: 1.25rem;
+  height: 0.625rem;
+  cursor: ns-resize;
+}
+
+[data-hud-shell] [data-hud-resize='w'] {
+  top: 1.25rem;
+  bottom: 1.25rem;
+  left: 0;
+  width: 0.625rem;
+  cursor: ew-resize;
+}
+
+[data-hud-shell] [data-hud-resize='ne'],
+[data-hud-shell] [data-hud-resize='se'],
+[data-hud-shell] [data-hud-resize='sw'],
+[data-hud-shell] [data-hud-resize='nw'] {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+[data-hud-shell] [data-hud-resize='ne'] {
+  top: 0;
+  right: 0;
+  cursor: nesw-resize;
+}
+
+[data-hud-shell] [data-hud-resize='se'] {
+  right: 0;
+  bottom: 0;
+  cursor: nwse-resize;
+}
+
+[data-hud-shell] [data-hud-resize='sw'] {
+  bottom: 0;
+  left: 0;
+  cursor: nesw-resize;
+}
+
+[data-hud-shell] [data-hud-resize='nw'] {
+  top: 0;
+  left: 0;
+  cursor: nwse-resize;
 }
 
 /* The composer's drop target is a full-window dashed sheet sized for the app's

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -3136,15 +3136,37 @@ button[data-slot='aui_msg-reactions'] svg {
   --thread-viewport-height: 100%;
 }
 
-/* NOTHING in HUD mode declares `-webkit-app-region: drag`. The window manager
+/* `-webkit-app-region: drag` in HUD mode is LINUX ONLY. The window manager
    takes a draggable region's mouse input whole, so the page never sees the
-   cursor arrive there — and `useHudClickThrough`, which decides whether the
-   window is solid from exactly those moves, has already handed the window away
-   by the time you press. Every version of the app-region handle was therefore
-   both unusable (the press fell through to the app behind) and the reason the
-   HUD stayed solid over dead space once you left it. The two mechanisms cannot
-   share a window; click-through wins, and dragging is `useHudComposerDrag` —
-   press and hold the bar, then move. */
+   cursor arrive there — on macOS/Windows that starves `useHudClickThrough`,
+   which decides solidity from exactly those moves, so the press falls through
+   to the app behind (every app-region attempt there was therefore unusable,
+   and left the HUD solid over dead space once you left it). On Linux the
+   click-through decision is fed by MAIN's cursor poll (`startHudCursorFeed`),
+   not by page events, so a drag region cannot starve it: the bar stays solid,
+   the compositor takes the press, and the window moves natively
+   (xdg_toplevel.move on Wayland, _NET_WM_MOVERESIZE on X11). The composer's
+   interactive surface opts back out with `-webkit-app-region: no-drag` (input
+   element + the global button rule); the rest of the bar is the handle.
+   macOS/Windows keep dragging on `useHudComposerDrag` — press and hold the
+   bar, then move. */
+
+/* Grip affordance for the Linux drag band: the composer's top padding (pt-4)
+   is the only surface the region owns once the input/buttons are carved out,
+   so make it look like a handle — a centered pill, like a mobile grip. */
+.hud-native-drag::before {
+  content: '';
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 40px;
+  height: 4px;
+  border-radius: 9999px;
+  background: color-mix(in srgb, var(--ui-text-tertiary) 55%, transparent);
+  pointer-events: none;
+}
+
 [data-hud-shell] [data-slot='composer-dock'] {
   /* The one surface that is always there, so the one that always takes the
      mouse — everything else in the shell earns it by being on screen. */

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3695,6 +3695,15 @@ DEFAULT_CONFIG = {
         # explicit ozone backend, or GPU workaround flags. A list of strings;
         # a single string is also accepted and shell-split.
         "electron_flags": [],
+        # Linux Ozone backend hint, bridged to ELECTRON_OZONE_PLATFORM_HINT
+        # at launch (an explicit env var still wins). "auto" is Chromium's
+        # default — Wayland on a Wayland session, X11 otherwise.
+        # Set "x11" to run under XWayland when a compositor ignores
+        # always-on-top for native Wayland clients (COSMIC, issue #84011).
+        # That also lands the HUD on the solid-window input path, because
+        # setIgnoreMouseEvents is a one-way door on X11.
+        # "wayland" forces a native Wayland surface.
+        "ozone_platform_hint": "auto",
         # GPU hardware acceleration policy for the desktop app:
         #   "auto"  - let the app detect remote displays (SSH/VNC/RDP) and
         #             disable GPU only then (default; current behavior).

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7769,26 +7769,29 @@ def _detect_linux_password_store() -> str | None:
     return None
 
 
-def _desktop_launch_options() -> tuple[list[str], str, str]:
+def _desktop_launch_options() -> tuple[list[str], str, str, str]:
     """Read `desktop.*` launch options from config.yaml.
 
-    Returns ``(electron_flags, disable_gpu, password_store)`` where
+    Returns ``(electron_flags, disable_gpu, password_store, ozone_hint)`` where
     ``electron_flags`` is a list of extra Electron CLI flags, ``disable_gpu``
     is one of "auto"/"1"/"0" (normalized for the HERMES_DESKTOP_DISABLE_GPU
-    env var the Electron app reads), and ``password_store`` is "auto" or one
+    env var the Electron app reads), ``password_store`` is "auto" or one
     of the Chromium password-store backends (unknown values normalize to
-    "auto"). Best-effort: any config error yields the safe defaults
-    ``([], "auto", "auto")`` so a malformed config never blocks the launch.
+    "auto"), and ``ozone_hint`` is one of "auto"/"x11"/"wayland" (normalized
+    for ``ELECTRON_OZONE_PLATFORM_HINT``). Best-effort: any config error
+    yields the safe defaults ``([], "auto", "auto", "auto")`` so a malformed
+    config never blocks the launch.
     """
     flags: list[str] = []
     disable_gpu = "auto"
     password_store = "auto"
+    ozone_hint = "auto"
     try:
         from hermes_cli.config import load_config
 
         desktop_cfg = (load_config() or {}).get("desktop") or {}
     except Exception:
-        return flags, disable_gpu, password_store
+        return flags, disable_gpu, password_store, ozone_hint
 
     raw_flags = desktop_cfg.get("electron_flags")
     if isinstance(raw_flags, str):
@@ -7813,7 +7816,13 @@ def _desktop_launch_options() -> tuple[list[str], str, str]:
         low_store = raw_store.strip().lower()
         if low_store in _LINUX_PASSWORD_STORES:
             password_store = low_store
-    return flags, disable_gpu, password_store
+
+    raw_ozone = desktop_cfg.get("ozone_platform_hint", "auto")
+    if isinstance(raw_ozone, str):
+        low_ozone = raw_ozone.strip().lower()
+        if low_ozone in ("auto", "x11", "wayland"):
+            ozone_hint = low_ozone
+    return flags, disable_gpu, password_store, ozone_hint
 
 
 def _register_linux_desktop_entry() -> None:
@@ -7864,12 +7873,18 @@ def cmd_gui(args: argparse.Namespace):
         env["HERMES_DESKTOP_CWD"] = os.getcwd()
 
     # Desktop launch options from config.yaml (`desktop.electron_flags`,
-    # `desktop.disable_gpu`). The GPU policy is bridged to the env var the
-    # Electron app already reads; an explicit env var still wins over config so
-    # `HERMES_DESKTOP_DISABLE_GPU=... hermes desktop` keeps working.
-    config_electron_flags, config_disable_gpu, config_password_store = _desktop_launch_options()
+    # `desktop.disable_gpu`, `desktop.ozone_platform_hint`). The GPU policy
+    # and ozone hint are bridged to env vars the Electron/Chromium process
+    # already reads; an explicit env var still wins over config so
+    # `HERMES_DESKTOP_DISABLE_GPU=... hermes desktop` and
+    # `ELECTRON_OZONE_PLATFORM_HINT=... hermes desktop` keep working.
+    config_electron_flags, config_disable_gpu, config_password_store, config_ozone_hint = (
+        _desktop_launch_options()
+    )
     if config_disable_gpu != "auto" and "HERMES_DESKTOP_DISABLE_GPU" not in os.environ:
         env["HERMES_DESKTOP_DISABLE_GPU"] = config_disable_gpu
+    if config_ozone_hint != "auto" and "ELECTRON_OZONE_PLATFORM_HINT" not in os.environ:
+        env["ELECTRON_OZONE_PLATFORM_HINT"] = config_ozone_hint
 
     # Linux keychain backend for safeStorage (`desktop.password_store`).
     # Chromium needs the --password-store switch to pick the right keychain;

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -588,8 +588,73 @@ def test_gui_skips_desktop_entry_off_linux(tmp_path, monkeypatch):
 def test_desktop_launch_options_normalizes_password_store(raw, expected):
     cfg = {"desktop": {"password_store": raw}}
     with patch("hermes_cli.config.load_config", return_value=cfg):
-        _, _, store = cli_main._desktop_launch_options()
+        _, _, store, _ = cli_main._desktop_launch_options()
     assert store == expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("x11", "x11"),
+        ("WAYLAND", "wayland"),
+        ("auto", "auto"),
+        ("bogus", "auto"),
+        (True, "auto"),
+    ],
+)
+def test_desktop_launch_options_normalizes_ozone_hint(raw, expected):
+    """``desktop.ozone_platform_hint`` normalizes to x11/wayland/auto."""
+    cfg = {"desktop": {"ozone_platform_hint": raw}}
+    with patch("hermes_cli.config.load_config", return_value=cfg):
+        _, _, _, hint = cli_main._desktop_launch_options()
+    assert hint == expected
+
+
+def test_desktop_launch_options_ozone_hint_defaults_auto():
+    with patch("hermes_cli.config.load_config", return_value={}):
+        assert cli_main._desktop_launch_options()[3] == "auto"
+
+
+def test_gui_bridges_ozone_hint_to_launch_env(tmp_path, monkeypatch):
+    """COSMIC HUD: ``desktop.ozone_platform_hint: x11`` sets
+    ``ELECTRON_OZONE_PLATFORM_HINT`` on the launched Electron process."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    _make_packaged_executable(root, monkeypatch)
+
+    ok = subprocess.CompletedProcess([], 0)
+    cfg = {"desktop": {"ozone_platform_hint": "x11"}}
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=ok), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._write_desktop_build_stamp"), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
+         patch("hermes_cli.config.load_config", return_value=cfg), \
+         patch("hermes_cli.linux_desktop_entry.install_desktop_entry", return_value=None), \
+         patch("hermes_cli.main.subprocess.run", side_effect=[ok, ok]) as mock_run, \
+         pytest.raises(SystemExit):
+        cli_main.cmd_gui(_ns())
+
+    launch_env = mock_run.call_args_list[1].kwargs["env"]
+    assert launch_env.get("ELECTRON_OZONE_PLATFORM_HINT") == "x11"
+
+    monkeypatch.setenv("ELECTRON_OZONE_PLATFORM_HINT", "wayland")
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=ok), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._write_desktop_build_stamp"), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
+         patch("hermes_cli.config.load_config", return_value=cfg), \
+         patch("hermes_cli.linux_desktop_entry.install_desktop_entry", return_value=None), \
+         patch("hermes_cli.main.subprocess.run", side_effect=[ok, ok]) as mock_run2, \
+         pytest.raises(SystemExit):
+        cli_main.cmd_gui(_ns())
+
+    launch_env = mock_run2.call_args_list[1].kwargs["env"]
+    assert launch_env.get("ELECTRON_OZONE_PLATFORM_HINT") == "wayland"
 
 
 # --- desktop.password_store detection & bridging (linux) ------------------

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -131,10 +131,22 @@ Talk to Hermes and hear it back, the same [voice mode](./features/voice-mode.md)
 
 **⌘/Ctrl+Shift+H** (or the titlebar button) detaches the chat into a chrome-free, always-on-top floating bar that sits over whatever you are working in. The app window steps aside; the HUD keeps your live conversation and a composer. Where you park it is context — the bar's position tells Hermes which app and screen you're asking about, so "this", "here", and "that page" resolve to what's underneath it.
 
-- **Moving the bar** — **press and hold** anywhere on the composer for a beat, then drag. A quick press still types; a held press grabs the window. This is the only way to move the HUD — there is no titlebar to drag.
+- **Moving the bar** — on macOS and Windows, **press and hold** anywhere on the composer for a beat, then drag. A quick press still types; a held press grabs the window. On Linux the composer bar is a native window-manager drag handle (the compositor moves it — the only way that works on Wayland, where an app cannot place its own window).
 - **Resizing** — drag the bottom-right corner of the bar.
-- **Snap to pointer** — **⌘/Ctrl+Shift+G** (a global hotkey, works from any app) jumps the HUD to wherever your cursor is.
+- **Reset layout** — the discard control on the bar restores the default size and (on X11 / macOS / Windows) position. Use this if a persisted size leaves the HUD unusable.
+- **Snap to pointer** — **⌘/Ctrl+Shift+G** (a global hotkey, works from any app) jumps the HUD to wherever your cursor is. On native Wayland this is a no-op — the compositor owns placement.
 - **Exiting** — click the exit button on the bar, or press **⌘/Ctrl+Shift+H** again. The app window comes back with your session intact.
+
+#### Linux / Wayland
+
+Electron 20+ already runs as a native Wayland client on a Wayland session. Drag, click-through, and resize work on that path. A few compositors (notably COSMIC) ignore `always-on-top` for native Wayland windows. To restore pinning, run the app under XWayland:
+
+```yaml
+desktop:
+  ozone_platform_hint: x11
+```
+
+That bridges to `ELECTRON_OZONE_PLATFORM_HINT` at launch (an explicit env var still wins). The trade: X11 cannot restore a window that has ignored the mouse, so the HUD stays a solid window instead of click-through. Some KDE setups also report keyboard breakage with the X11 ozone backend — leave the hint on `auto` unless you need always-on-top.
 
 ### Settings & onboarding
 

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -131,8 +131,8 @@ Talk to Hermes and hear it back, the same [voice mode](./features/voice-mode.md)
 
 **⌘/Ctrl+Shift+H** (or the titlebar button) detaches the chat into a chrome-free, always-on-top floating bar that sits over whatever you are working in. The app window steps aside; the HUD keeps your live conversation and a composer. Where you park it is context — the bar's position tells Hermes which app and screen you're asking about, so "this", "here", and "that page" resolve to what's underneath it.
 
-- **Moving the bar** — on macOS and Windows, **press and hold** anywhere on the composer for a beat, then drag. A quick press still types; a held press grabs the window. On Linux the composer bar is a native window-manager drag handle (the compositor moves it — the only way that works on Wayland, where an app cannot place its own window).
-- **Resizing** — drag the bottom-right corner of the bar.
+- **Moving the bar** — on macOS and Windows, **press and hold** anywhere on the composer for a beat, then drag. On Linux/X11, hold **Ctrl** and drag with the primary mouse button for an immediate grab (including over selected text); press-and-hold remains available too. Keep the grab held while invoking your desktop switch shortcut to carry the HUD onto another virtual desktop. On native Wayland the composer bar is a compositor drag handle (the only way to move it, because an app cannot place its own window).
+- **Resizing** — drag any edge or corner of the bar; the opposite edge stays anchored. Native Wayland exposes the right and bottom edges because the compositor does not allow apps to position top-level windows themselves.
 - **Reset layout** — the discard control on the bar restores the default size and (on X11 / macOS / Windows) position. Use this if a persisted size leaves the HUD unusable.
 - **Snap to pointer** — **⌘/Ctrl+Shift+G** (a global hotkey, works from any app) jumps the HUD to wherever your cursor is. On native Wayland this is a no-op — the compositor owns placement.
 - **Exiting** — click the exit button on the bar, or press **⌘/Ctrl+Shift+H** again. The app window comes back with your session intact.


### PR DESCRIPTION
## Dependency and attribution

This is a **draft follow-up built directly on #93553** (`bb/wayland-hud` at `06a553c`). It is not intended to compete with or obscure that work.

Related issue: #83473.

- #93553 and its Wayland/input-policy foundation remain authored by @OutThisLife.
- This branch preserves those commits unchanged and adds one isolated commit: `29c1d22d7f`.
- After #93553 lands, this branch will be rebased onto `main` so this PR shows only the X11/KDE interaction delta before it is marked ready.

## What this adds

### Reliable X11 grabbing

- Keeps native Wayland on the compositor drag-region path introduced by #93553.
- Keeps X11 out of Chromium app-region dragging so the renderer retains the pointer stream.
- Adds immediate **Ctrl + primary-button** HUD movement on X11 while retaining the existing press-and-hold fallback.
- Handles pointer movement in capture phase and suppresses Chromium's native `selectstart`/`dragstart` only for the Ctrl grab.
- Preserves an existing `contentEditable` text selection instead of blurring or rewriting it.
- Uses screen-coordinate deltas and the snapshotted window size, preserving the existing Windows transparent-window growth guard.

### KDE virtual-desktop transfer

- Linux HUD windows now start on one virtual desktop instead of being permanently sticky.
- During an armed X11 grab only, the renderer asks main to temporarily call `setVisibleOnAllWorkspaces(true)`.
- On release/cancel/unmount, main clears that state. Chromium's X11 backend assigns the window to the then-current desktop, matching KWin's "hold window, switch desktop, release" interaction.
- The IPC is accepted only from the active HUD `webContents` and is gated to the X11/XWayland policy. Windows, macOS, and native Wayland never enter this path.
- macOS keeps its existing permanent all-workspaces behavior.

### Resize from supported edges and corners

- Adds CanvasTTY-style invisible handles with native cursors.
- Windows, macOS, and X11 expose all eight directions (`N/NE/E/SE/S/SW/W/NW`) and preserve the opposite edge.
- Native Wayland exposes `E/S/SE` only. Electron/Wayland prohibits reading or changing global top-level `x/y`, so top/left handles could not honestly preserve their opposite edge.
- Renderer-provided bounds are finite-validated, rounded, and minimum-clamped before reaching Electron.
- The temporary `resizable` unlock is restored in `finally`, including native-call failure paths.

## Platform behavior

| Platform/backend | Move path | Workspace behavior | Resize handles |
| --- | --- | --- | --- |
| Linux X11 / explicit XWayland | Ctrl+primary-button or hold; renderer screen deltas | Temporarily sticky during grab, pinned to destination on release | All 8 |
| Native Wayland | Native compositor drag region | Compositor-owned | `E/S/SE` |
| macOS | Existing press-and-hold renderer path | Existing all-spaces behavior preserved | All 8 |
| Windows | Existing press-and-hold renderer path | No workspace API calls | All 8 |

## Verification

### Manual runtime verification

Packaged Electron 40.10.2 build on **Manjaro Linux, KDE Plasma, X11**:

- HUD remains clickable/focusable after focus loss.
- Ctrl+primary-button moves immediately and repeatedly.
- Moving works over an existing text selection without clearing or extending it.
- Every X11 edge and corner resizes with the opposite edge anchored.
- While keeping Ctrl+primary-button held, invoking the KDE desktop-switch shortcut carries the HUD to the destination desktop; releasing leaves it only on that desktop.

The reporter confirmed the combined X11 interaction flow as working end-to-end. Windows, macOS, and native Wayland were not manually runtime-tested here; their behavior is guarded by explicit policy branches and covered by unit/type/build checks.

### Automated checks

```text
npm run typecheck
  PASS

npx eslint <changed desktop TypeScript files>
  PASS (0 warnings)

npm test -- --project electron \
  electron/hud-input-policy.test.ts \
  electron/hud-geometry.test.ts
  PASS: 17 tests

npm test -- --project ui \
  src/app/hud/composer-drag.test.ts \
  src/app/hud/resize-handle.test.ts \
  src/app/hud/layout.test.ts \
  src/app/hud/click-through.test.ts
  PASS: 19 tests

npm run build
  PASS: renderer, Electron main/preload bundles, native dependency staging

git diff --check
  PASS
```

## Notes for review

- `hudUsesNativeDrag` and `hudUsesWorkspaceTransfer` are pure policy functions with macOS, Windows, X11, native Wayland, and explicit Ozone override coverage.
- [Electron documents](https://www.electronjs.org/docs/latest/api/browser-window) that `setVisibleOnAllWorkspaces` is a no-op on Windows; the implementation additionally prevents Windows from sending or handling this IPC at all.
- The same API reference documents that global position introspection/mutation is prohibited on Wayland; the resize-direction policy avoids presenting handles that require it.
- Some Wayland compositors may still restrict programmatic sizing itself; `E/S/SE` retain the existing best-effort resize path without adding position-dependent behavior.
- The resize chrome is invisible and does not add new visible UI.
