### PR TITLE
fix(gateway): scope run-scoped API routes to the calling profile

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1564,6 +1564,15 @@ class APIServerAdapter(BasePlatformAdapter):
         # resolves requests by session key, while API clients address the
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
+        # Which profile created each run. Run state is keyed by run_id alone,
+        # which is unique per host but records nothing about ownership. Under
+        # gateway.multiplex_profiles every served profile holds a valid API
+        # key, so _check_auth proving "a valid key" was enough to read and
+        # control another profile's runs (#93689). Kept out of the run record
+        # itself so the GET /v1/runs/{id} body does not grow a field — and does
+        # not disclose the owning profile's name to a caller who has no other
+        # way to learn it.
+        self._run_owner_profiles: Dict[str, str] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
         self._session_dbs: Dict[str, Any] = {}
         self._session_db_cache_lock = threading.Lock()
@@ -4788,6 +4797,10 @@ class APIServerAdapter(BasePlatformAdapter):
         queue: "asyncio.Queue[Optional[tuple[str, Dict[str, Any]]]]" = asyncio.Queue()
         message_id = f"msg_{uuid.uuid4().hex}"
         run_id = f"run_{uuid.uuid4().hex}"
+        # Stamped the moment the id exists, while still inside the
+        # middleware's profile scope: the work below hops to an executor
+        # thread the ContextVar does not follow.
+        self._claim_run_owner(run_id, _api_request_profile.get())
         self._set_run_status(
             run_id,
             "queued",
@@ -7460,10 +7473,97 @@ class APIServerAdapter(BasePlatformAdapter):
     _RUN_STREAM_TTL = 300  # seconds before orphaned runs are swept
     _RUN_STATUS_TTL = 3600  # seconds to retain terminal run status for polling
 
+    @staticmethod
+    def _normalized_profile(value: Optional[str]) -> str:
+        """Collapse the unnamed listener and an explicit 'default' to one name."""
+        return (value or "default").strip() or "default"
+
+    def _caller_profile(self) -> str:
+        """Profile of the in-flight request, per the middleware ContextVar."""
+        return self._normalized_profile(_api_request_profile.get())
+
+    def _claim_run_owner(self, run_id: str, profile: Optional[str]) -> None:
+        """Record the creating profile for *run_id*, write-once.
+
+        Taken from an explicit value captured in the request handler rather
+        than read ambiently: ContextVars do not follow run_in_executor
+        threads, and runs finish their lives there.
+        """
+        self._run_owner_profiles.setdefault(
+            run_id, self._normalized_profile(profile)
+        )
+
+    def _run_visible_to_caller(self, run_id: str) -> bool:
+        """Whether the in-flight request may see or control *run_id*.
+
+        Unowned runs stay visible: ownership is stamped at creation, so a
+        record without one predates this state (or came from a path that
+        never registered), and refusing it would break runs that are nobody's
+        to steal. Anything with a recorded owner must match exactly.
+        """
+        owner = self._run_owner_profiles.get(run_id)
+        if owner is None:
+            return True
+        return owner == self._caller_profile()
+
+    def _release_run_owner_if_forgotten(self, run_id: str) -> None:
+        """Drop ownership only once nothing keyed by *run_id* survives.
+
+        Ownership has to outlive every surface it protects, and the sweeps
+        retire those surfaces on different clocks: statuses on
+        ``_RUN_STATUS_TTL``, transports on ``_RUN_STREAM_TTL``, and the
+        agent/task refs not until the task is actually done. Reclaiming the
+        owner with the status alone would leave a live agent ref reachable
+        through ``/stop`` by anyone — ``_run_visible_to_caller`` fails open
+        with no owner — and the "stopping" status write that follows would
+        re-stamp the run to whoever asked, write-once, locking the real owner
+        out for good.
+        """
+        if (
+            run_id in self._run_statuses
+            or run_id in self._active_run_agents
+            or run_id in self._active_run_tasks
+            or run_id in self._run_streams
+            or run_id in self._run_approval_sessions
+        ):
+            return
+        self._run_owner_profiles.pop(run_id, None)
+
+    def _foreign_run_response(
+        self, request: "web.Request", run_id: str
+    ) -> "web.Response":
+        """404 — never 403.
+
+        A distinct status would confirm the run exists to a caller who is not
+        allowed to know that, and run ids are the only thing keeping runs
+        unenumerable. Logged rather than refused silently, so a cross-profile
+        attempt leaves the same operator-visible trace an auth failure does.
+        """
+        logger.warning(
+            "API server refused run %r for profile %r: owned by another "
+            "profile; %s",
+            run_id,
+            self._caller_profile(),
+            self._request_audit_log_suffix(request),
+        )
+        return web.json_response(
+            _openai_error(f"Run not found: {run_id}", code="run_not_found"),
+            status=404,
+        )
+
     def _set_run_status(self, run_id: str, status: str, **fields: Any) -> Dict[str, Any]:
         """Update pollable run status without exposing private agent objects."""
         now = time.time()
         current = self._run_statuses.get(run_id, {})
+        if not current:
+            # Belt-and-braces: the two creation sites claim ownership
+            # explicitly from the request context, which is the authoritative
+            # value. Claiming again here means a record can never exist
+            # without an owner even if a new creation path appears. Write-once
+            # inside _claim_run_owner, so a later transition — including one a
+            # foreign caller triggers, or one running on an executor thread
+            # where the ContextVar is unset — cannot re-stamp it.
+            self._claim_run_owner(run_id, _api_request_profile.get())
         current.update({
             "object": "hermes.run",
             "run_id": run_id,
@@ -7656,6 +7756,11 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response(_openai_error(selection_error), status=400)
 
         run_id = f"run_{uuid.uuid4().hex}"
+        # As at the other creation site: stamped the moment the id exists,
+        # while still inside the middleware's profile scope — and before any
+        # run-keyed state is registered under it, so no future await inserted
+        # below can open a window where the id resolves but the owner does not.
+        self._claim_run_owner(run_id, _api_request_profile.get())
         session_id = session_id or run_id
         # Approval queues gate host-side tool execution and must be isolated
         # per API run.  Client-provided session IDs and memory session keys are
@@ -7977,6 +8082,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
                 self._stopping_run_ids.discard(run_id)
+                # Normally the terminal status record outlives this and the
+                # sweeper reclaims the owner along with it. If the sweeper
+                # already took that status while this run was still live,
+                # these pops drop the last surface — and nothing would ever
+                # revisit the id, stranding the owner entry for the life of
+                # the process.
+                self._release_run_owner_if_forgotten(run_id)
 
         self._activate_admitted_request()
         task = asyncio.create_task(_run_and_close())
@@ -8004,6 +8116,8 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         run_id = request.match_info["run_id"]
+        if not self._run_visible_to_caller(run_id):
+            return self._foreign_run_response(request, run_id)
         status = self._run_statuses.get(run_id)
         if status is None:
             return web.json_response(
@@ -8020,9 +8134,17 @@ class APIServerAdapter(BasePlatformAdapter):
 
         run_id = request.match_info["run_id"]
 
+        # Ownership is part of the wait condition rather than a gate before it.
+        # This is the only route that admits a caller before the run is
+        # registered, so a check up front would pass on an id that is claimed —
+        # by someone else — inside the window. Folding it in also keeps a
+        # foreign run indistinguishable from one that never existed: same 404,
+        # same body, same elapsed wait. Refusing up front instead returned in
+        # ~0.1ms against ~1s for an unknown id, which answers "does this run
+        # exist?" as plainly as the 403 this route deliberately avoids.
         # Allow subscribing slightly before the run is registered (race condition window)
         for _ in range(20):
-            if run_id in self._run_streams:
+            if run_id in self._run_streams and self._run_visible_to_caller(run_id):
                 break
             await asyncio.sleep(0.05)
         else:
@@ -8071,6 +8193,8 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         run_id = request.match_info["run_id"]
+        if not self._run_visible_to_caller(run_id):
+            return self._foreign_run_response(request, run_id)
         status = self._run_statuses.get(run_id)
         if status is None:
             return web.json_response(
@@ -8159,6 +8283,8 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         run_id = request.match_info["run_id"]
+        if not self._run_visible_to_caller(run_id):
+            return self._foreign_run_response(request, run_id)
         status = self._run_statuses.get(run_id)
         if status is None:
             return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
@@ -8219,6 +8345,8 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         run_id = request.match_info["run_id"]
+        if not self._run_visible_to_caller(run_id):
+            return self._foreign_run_response(request, run_id)
         agent = self._active_run_agents.get(run_id)
         task = self._active_run_tasks.get(run_id)
 
@@ -8282,6 +8410,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
                 self._stopping_run_ids.discard(run_id)
+            # This loop retires the agent/task refs, so it is also a
+            # point where a run can become fully forgotten — and only
+            # then may its owner be reclaimed.
+            self._release_run_owner_if_forgotten(run_id)
 
         stale_statuses = [
             run_id
@@ -8291,6 +8423,7 @@ class APIServerAdapter(BasePlatformAdapter):
         ]
         for run_id in stale_statuses:
             self._run_statuses.pop(run_id, None)
+            self._release_run_owner_if_forgotten(run_id)
 
     # ------------------------------------------------------------------
     # BasePlatformAdapter interface

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7493,18 +7493,44 @@ class APIServerAdapter(BasePlatformAdapter):
             run_id, self._normalized_profile(profile)
         )
 
+    def _run_state_exists(self, run_id: str) -> bool:
+        """Whether any run-keyed state survives under *run_id*.
+
+        The single definition of "this run is a thing", shared by the
+        visibility rule and the ownership-release rule so the two cannot
+        drift: an owner is released exactly when this returns False, and an
+        id that has state but no owner is exactly the case that must fail
+        closed.
+        """
+        return (
+            run_id in self._run_statuses
+            or run_id in self._active_run_agents
+            or run_id in self._active_run_tasks
+            or run_id in self._run_streams
+            or run_id in self._run_approval_sessions
+        )
+
     def _run_visible_to_caller(self, run_id: str) -> bool:
         """Whether the in-flight request may see or control *run_id*.
 
-        Unowned runs stay visible: ownership is stamped at creation, so a
-        record without one predates this state (or came from a path that
-        never registered), and refusing it would break runs that are nobody's
-        to steal. Anything with a recorded owner must match exactly.
+        A recorded owner must match exactly. With no owner recorded, the
+        answer turns on whether the run exists at all:
+
+        - No run-keyed state — an id that names nothing. Admitted, because
+          ``/events`` deliberately lets a client subscribe in the moment
+          before its run is registered. Nothing is disclosed by proceeding:
+          the caller waits on state that does not exist, and the wait
+          condition re-tests ownership once it does.
+        - Run state present but unstamped. Refused. Missing provenance on a
+          real run is not "nobody's to steal" — it is an unanswered
+          authorization question, and answering it "yes" would make the
+          boundary allow-all for every served profile precisely when the
+          metadata that decides it is absent.
         """
         owner = self._run_owner_profiles.get(run_id)
-        if owner is None:
-            return True
-        return owner == self._caller_profile()
+        if owner is not None:
+            return owner == self._caller_profile()
+        return not self._run_state_exists(run_id)
 
     def _release_run_owner_if_forgotten(self, run_id: str) -> None:
         """Drop ownership only once nothing keyed by *run_id* survives.
@@ -7512,20 +7538,16 @@ class APIServerAdapter(BasePlatformAdapter):
         Ownership has to outlive every surface it protects, and the sweeps
         retire those surfaces on different clocks: statuses on
         ``_RUN_STATUS_TTL``, transports on ``_RUN_STREAM_TTL``, and the
-        agent/task refs not until the task is actually done. Reclaiming the
-        owner with the status alone would leave a live agent ref reachable
-        through ``/stop`` by anyone — ``_run_visible_to_caller`` fails open
-        with no owner — and the "stopping" status write that follows would
-        re-stamp the run to whoever asked, write-once, locking the real owner
-        out for good.
+        agent/task refs not until the task is actually done. Releasing on the
+        status alone would leave a live agent ref reachable through ``/stop``
+        and the "stopping" status write that follows would re-stamp the run
+        to whoever asked, write-once, locking the real owner out for good.
+
+        Releasing only when no state remains also keeps
+        ``_run_visible_to_caller`` from ever seeing a stateful id with no
+        owner, which it treats as fail-closed rather than as a run to serve.
         """
-        if (
-            run_id in self._run_statuses
-            or run_id in self._active_run_agents
-            or run_id in self._active_run_tasks
-            or run_id in self._run_streams
-            or run_id in self._run_approval_sessions
-        ):
+        if self._run_state_exists(run_id):
             return
         self._run_owner_profiles.pop(run_id, None)
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -609,6 +609,11 @@ class TestDisconnectedAgentReap:
         agent = MagicMock()
         _publish_turn_process_ownership(agent, "run-stop-sess")
         adapter._active_run_agents["run_x"] = agent
+        # Run-scoped routes are gated on the creating profile, and a run whose
+        # ownership is unstamped fails closed. Both creation sites claim before
+        # registering any run-keyed state, so a real run always carries this;
+        # the hand-built state above has to say so too.
+        adapter._claim_run_owner("run_x", None)
 
         request = MagicMock()
         request.match_info = {"run_id": "run_x"}

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -10,6 +10,8 @@ Covers:
 """
 
 import asyncio
+import json
+import logging
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -806,3 +808,430 @@ class TestRunsProviderAuthFailure:
                 assert status["status"] == "failed"
                 assert status["error"] == "⚠️ Provider authentication failed: No credentials found for provider 'nous'"
                 assert status["last_event"] == "run.failed"
+
+
+# ---------------------------------------------------------------------------
+# Cross-profile run isolation (#93689)
+# ---------------------------------------------------------------------------
+
+class TestRunProfileScoping:
+    """Run-scoped routes authenticate the caller but must also scope to it.
+
+    Run state is keyed by run_id alone. Under ``gateway.multiplex_profiles``
+    every served profile holds a valid API key, so ``_check_auth`` returning
+    None proved only "some valid key" — any profile could then read another
+    profile's run output and, worse, stop/steer/approve it, executing under
+    the target's tool permissions rather than the caller's.
+    """
+
+    @staticmethod
+    def _seed_run(adapter, run_id: str, owner: str, *, status: str = "running"):
+        """Register a run as if *owner* had created it through the API."""
+        from gateway.platforms.api_server import _api_request_profile
+
+        token = _api_request_profile.set(owner)
+        try:
+            adapter._claim_run_owner(run_id, _api_request_profile.get())
+            adapter._set_run_status(run_id, status, session_id="sess")
+        finally:
+            _api_request_profile.reset(token)
+
+    @staticmethod
+    async def _as_profile(adapter, profile, handler, run_id, **kwargs):
+        """Invoke *handler* with the request-profile ContextVar set."""
+        from gateway.platforms.api_server import _api_request_profile
+
+        request = MagicMock()
+        request.match_info = {"run_id": run_id}
+        for key, value in kwargs.items():
+            setattr(request, key, value)
+        token = _api_request_profile.set(profile)
+        try:
+            return await handler(request)
+        finally:
+            _api_request_profile.reset(token)
+
+    @pytest.fixture
+    def adapter(self):
+        adapter = _make_adapter()
+        # Authentication is not the gap — every profile legitimately holds a
+        # valid key. Pin it open so the test measures scoping alone.
+        adapter._check_auth = lambda request: None
+        return adapter
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("caller", ["beta", "default", None])
+    async def test_foreign_profile_cannot_read_a_run(self, adapter, caller):
+        self._seed_run(adapter, "run_alpha", "alpha")
+        response = await self._as_profile(
+            adapter, caller, adapter._handle_get_run, "run_alpha"
+        )
+        assert response.status == 404
+
+    @pytest.mark.asyncio
+    async def test_owning_profile_can_read_its_own_run(self, adapter):
+        self._seed_run(adapter, "run_alpha", "alpha")
+        response = await self._as_profile(
+            adapter, "alpha", adapter._handle_get_run, "run_alpha"
+        )
+        assert response.status == 200
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("caller", ["beta", "default"])
+    async def test_foreign_profile_cannot_stop_a_run(self, adapter, caller):
+        """The critical case: stopping executes against the target's agent."""
+        self._seed_run(adapter, "run_alpha", "alpha")
+        agent = MagicMock()
+        adapter._active_run_agents["run_alpha"] = agent
+
+        response = await self._as_profile(
+            adapter, caller, adapter._handle_stop_run, "run_alpha"
+        )
+        assert response.status == 404
+        # Not merely refused — the run must be untouched.
+        assert "run_alpha" not in adapter._stopping_run_ids
+        assert adapter._run_statuses["run_alpha"]["status"] == "running"
+
+    @pytest.mark.asyncio
+    async def test_owning_profile_can_stop_its_own_run(self, adapter):
+        self._seed_run(adapter, "run_alpha", "alpha")
+        adapter._active_run_agents["run_alpha"] = MagicMock()
+
+        response = await self._as_profile(
+            adapter, "alpha", adapter._handle_stop_run, "run_alpha"
+        )
+        assert response.status == 200
+        assert "run_alpha" in adapter._stopping_run_ids
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("handler_name", [
+        "_handle_get_run", "_handle_run_events",
+        "_handle_run_approval", "_handle_steer_run", "_handle_stop_run",
+    ])
+    async def test_every_run_scoped_route_is_scoped(self, adapter, handler_name):
+        """All five routes, not just the ones with an obvious blast radius."""
+        self._seed_run(adapter, "run_alpha", "alpha")
+        adapter._active_run_agents["run_alpha"] = MagicMock()
+        adapter._run_streams["run_alpha"] = []
+
+        response = await self._as_profile(
+            adapter, "beta", getattr(adapter, handler_name), "run_alpha"
+        )
+        assert response.status == 404
+
+    @pytest.mark.asyncio
+    async def test_refusal_is_404_not_403(self, adapter):
+        """403 would confirm the run exists. Run ids are the only thing
+        keeping runs unenumerable — there is no collection route."""
+        self._seed_run(adapter, "run_alpha", "alpha")
+
+        foreign = await self._as_profile(
+            adapter, "beta", adapter._handle_get_run, "run_alpha"
+        )
+        absent = await self._as_profile(
+            adapter, "beta", adapter._handle_get_run, "run_does_not_exist"
+        )
+        assert foreign.status == absent.status == 404
+        # Same error code too — only the echoed run id differs, which the
+        # caller already supplied.
+        assert (
+            json.loads(foreign.body)["error"]["code"]
+            == json.loads(absent.body)["error"]["code"]
+            == "run_not_found"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unnamed_listener_and_explicit_default_are_one_profile(
+        self, adapter
+    ):
+        """The default listener reaches handlers with the ContextVar unset;
+        /p/default/ sets it to "default". They are the same owner."""
+        self._seed_run(adapter, "run_d", None)
+        assert adapter._run_owner_profiles["run_d"] == "default"
+
+        for caller in (None, "default"):
+            response = await self._as_profile(
+                adapter, caller, adapter._handle_get_run, "run_d"
+            )
+            assert response.status == 200
+
+    @pytest.mark.asyncio
+    async def test_ownership_is_write_once(self, adapter):
+        """A later status update — including one a foreign caller triggers —
+        must not be able to re-stamp the owner."""
+        self._seed_run(adapter, "run_alpha", "alpha")
+        self._seed_run(adapter, "run_alpha", "beta", status="running")
+        assert adapter._run_owner_profiles["run_alpha"] == "alpha"
+
+    @pytest.mark.asyncio
+    async def test_a_bare_status_write_still_gets_an_owner(self, adapter):
+        """A run record cannot exist without an owner.
+
+        This is the shape the vulnerability took: registering a run through
+        the ordinary status write and then reading it from another profile.
+        On the unfixed code the foreign read returns 200.
+        """
+        from gateway.platforms.api_server import _api_request_profile
+
+        token = _api_request_profile.set("alpha")
+        try:
+            adapter._set_run_status("run_bare", "running", session_id="s")
+        finally:
+            _api_request_profile.reset(token)
+
+        assert adapter._run_owner_profiles.get("run_bare") == "alpha"
+
+        foreign = await self._as_profile(
+            adapter, "beta", adapter._handle_get_run, "run_bare"
+        )
+        assert foreign.status == 404
+
+        owner = await self._as_profile(
+            adapter, "alpha", adapter._handle_get_run, "run_bare"
+        )
+        assert owner.status == 200
+
+    @pytest.mark.asyncio
+    async def test_a_transition_cannot_re_stamp_the_owner(self, adapter):
+        """Executor threads run transitions with the ContextVar unset, and a
+        foreign caller can trigger one. Neither may take ownership."""
+        from gateway.platforms.api_server import _api_request_profile
+
+        token = _api_request_profile.set("alpha")
+        try:
+            adapter._set_run_status("run_t", "queued", session_id="s")
+        finally:
+            _api_request_profile.reset(token)
+
+        adapter._set_run_status("run_t", "running")          # no profile in scope
+        token = _api_request_profile.set("beta")
+        try:
+            adapter._set_run_status("run_t", "completed")    # foreign profile
+        finally:
+            _api_request_profile.reset(token)
+
+        assert adapter._run_owner_profiles["run_t"] == "alpha"
+
+    def test_owner_is_reclaimed_with_the_rest_of_the_run_state(self, adapter):
+        """The owner map must not outlive the run it describes."""
+        # Status records are only reclaimed once terminal and past their TTL.
+        self._seed_run(adapter, "run_alpha", "alpha", status="completed")
+        adapter._run_streams_created["run_alpha"] = 0.0
+        adapter._run_streams["run_alpha"] = []
+
+        adapter._sweep_orphaned_runs_once(
+            now=time.time() + adapter._RUN_STATUS_TTL + 1
+        )
+
+        assert "run_alpha" not in adapter._run_statuses
+        assert "run_alpha" not in adapter._run_owner_profiles
+
+    def test_owner_survives_a_sweep_while_the_run_is_still_controllable(
+        self, adapter
+    ):
+        """Ownership must outlive every surface it protects.
+
+        The status record and the agent ref retire on different clocks, so a
+        terminal-but-stale status can be reclaimed while a live agent ref
+        remains. /stop gates on the agent ref, not on the status — so dropping
+        the owner here would hand a still-live run to any caller.
+        """
+        self._seed_run(adapter, "run_alpha", "alpha", status="cancelled")
+        adapter._active_run_agents["run_alpha"] = MagicMock()
+
+        adapter._sweep_orphaned_runs_once(
+            now=time.time() + adapter._RUN_STATUS_TTL + 1
+        )
+
+        assert "run_alpha" not in adapter._run_statuses
+        assert adapter._run_owner_profiles.get("run_alpha") == "alpha"
+
+    def test_the_owner_goes_when_the_last_surface_does(self, adapter):
+        """The other end of that rule: ownership must not be immortal either.
+
+        If the sweeper already took the status while the run was live, the
+        run-completion teardown drops the last surface — and nothing would
+        revisit the id afterwards, so the entry has to be released there.
+        """
+        self._seed_run(adapter, "run_alpha", "alpha", status="cancelled")
+        adapter._active_run_agents["run_alpha"] = MagicMock()
+        adapter._sweep_orphaned_runs_once(
+            now=time.time() + adapter._RUN_STATUS_TTL + 1
+        )
+        assert adapter._run_owner_profiles.get("run_alpha") == "alpha"
+
+        adapter._active_run_agents.pop("run_alpha", None)   # teardown
+        adapter._release_run_owner_if_forgotten("run_alpha")
+
+        assert "run_alpha" not in adapter._run_owner_profiles
+
+    def test_the_creation_site_claim_is_what_names_the_right_profile(
+        self, adapter
+    ):
+        """Pins why the creation sites claim at all, rather than leaving it to
+        _set_run_status.
+
+        Ownership would exist either way — but a run hops to an executor
+        thread the ContextVar does not follow, and its first status write can
+        land there. Claimed only at that point, the run would be stamped
+        "default" instead of its creator.
+        """
+        from gateway.platforms.api_server import _api_request_profile
+
+        token = _api_request_profile.set("alpha")
+        try:                                            # creation site, in scope
+            adapter._claim_run_owner("run_x", _api_request_profile.get())
+        finally:
+            _api_request_profile.reset(token)
+
+        adapter._set_run_status("run_x", "queued", session_id="s")   # executor
+
+        assert adapter._run_owner_profiles["run_x"] == "alpha"
+
+    def test_an_unowned_run_stays_visible(self, adapter):
+        """The deliberate fail-open branch. A run nobody claimed is nobody's
+        to steal, and refusing it would break any path that never registered."""
+        adapter._run_statuses["run_orphan"] = {"status": "running"}
+
+        assert adapter._run_visible_to_caller("run_orphan") is True
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [(None, "default"), ("", "default"), ("   ", "default"),
+         ("  coder  ", "coder"), ("default", "default")],
+    )
+    def test_profile_names_are_normalized(self, adapter, raw, expected):
+        assert adapter._normalized_profile(raw) == expected
+
+    @pytest.mark.asyncio
+    async def test_the_run_body_never_names_the_owning_profile(self, adapter):
+        """Ownership lives in a side table precisely so the response body does
+        not disclose it to a caller with no other way to learn it."""
+        # A profile name that is not a substring of the run id, so the
+        # assertion cannot pass on an echoed id alone.
+        self._seed_run(adapter, "run_1", "zephyr")
+
+        response = await self._as_profile(
+            adapter, "zephyr", adapter._handle_get_run, "run_1"
+        )
+
+        assert response.status == 200
+        assert "zephyr" not in response.body.decode()
+
+    @pytest.mark.asyncio
+    async def test_events_cannot_be_timed_to_learn_that_a_run_exists(
+        self, adapter, monkeypatch
+    ):
+        """A foreign run must be indistinguishable from one that never existed.
+
+        Refusing before the subscribe-early wait returned in ~0.1ms against
+        ~1s for an unknown id — an existence oracle as plain as the 403 this
+        route deliberately avoids.
+        """
+        slept = []
+
+        async def _fake_sleep(delay):
+            slept.append(delay)
+
+        monkeypatch.setattr(asyncio, "sleep", _fake_sleep)
+
+        self._seed_run(adapter, "run_alpha", "alpha")
+        adapter._run_streams["run_alpha"] = asyncio.Queue()
+
+        foreign = await self._as_profile(
+            adapter, "beta", adapter._handle_run_events, "run_alpha"
+        )
+        foreign_waits = len(slept)
+        slept.clear()
+        absent = await self._as_profile(
+            adapter, "beta", adapter._handle_run_events, "run_absent"
+        )
+        absent_waits = len(slept)
+
+        assert foreign.status == absent.status == 404
+        assert foreign_waits == absent_waits > 0
+        assert (
+            json.loads(foreign.body)["error"]["code"]
+            == json.loads(absent.body)["error"]["code"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_cross_profile_attempt_is_logged(self, adapter, caplog):
+        """Refusals leave the same operator-visible trace an auth failure does
+        — a silent 404 gives an operator nothing to investigate."""
+        self._seed_run(adapter, "run_alpha", "alpha")
+
+        with caplog.at_level(logging.WARNING):
+            await self._as_profile(
+                adapter, "beta", adapter._handle_get_run, "run_alpha"
+            )
+
+        assert any(
+            "run_alpha" in r.getMessage() and "another" in r.getMessage()
+            for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("handler_name", ["_handle_steer_run", "_handle_run_approval"])
+    async def test_the_worst_case_routes_leave_the_run_untouched(
+        self, adapter, handler_name
+    ):
+        """Refusing the response is not enough for the routes that execute
+        against the target's agent — nothing may reach it."""
+        self._seed_run(adapter, "run_alpha", "alpha")
+        agent = MagicMock()
+        adapter._active_run_agents["run_alpha"] = agent
+
+        response = await self._as_profile(
+            adapter, "beta", getattr(adapter, handler_name), "run_alpha"
+        )
+
+        assert response.status == 404
+        agent.steer.assert_not_called()
+        assert adapter._run_statuses["run_alpha"]["status"] == "running"
+        assert "run_alpha" not in adapter._stopping_run_ids
+
+    @pytest.mark.asyncio
+    async def test_a_swept_status_does_not_expose_a_live_run_to_stop(
+        self, adapter
+    ):
+        """The end the previous test guards: without an owner, /stop would
+        reach the agent and the "stopping" write would re-stamp the run to
+        the caller — write-once, so permanently."""
+        self._seed_run(adapter, "run_alpha", "alpha", status="cancelled")
+        adapter._active_run_agents["run_alpha"] = MagicMock()
+        adapter._sweep_orphaned_runs_once(
+            now=time.time() + adapter._RUN_STATUS_TTL + 1
+        )
+
+        response = await self._as_profile(
+            adapter, "beta", adapter._handle_stop_run, "run_alpha"
+        )
+
+        assert response.status == 404
+        assert "run_alpha" not in adapter._stopping_run_ids
+        assert adapter._run_owner_profiles["run_alpha"] == "alpha"
+
+    @pytest.mark.asyncio
+    async def test_subscribing_before_a_run_exists_cannot_capture_it(
+        self, adapter
+    ):
+        """/events is the one route that admits a caller before the run is
+        registered. An unowned run is visible by design, so the entry check
+        passes — the run must be re-checked once it appears."""
+
+        async def _create_run_mid_wait():
+            await asyncio.sleep(0.1)
+            self._seed_run(adapter, "run_late", "alpha")
+            adapter._run_streams["run_late"] = asyncio.Queue()
+
+        creator = asyncio.create_task(_create_run_mid_wait())
+        try:
+            response = await self._as_profile(
+                adapter, "beta", adapter._handle_run_events, "run_late"
+            )
+        finally:
+            await creator
+
+        assert response.status == 404
+        assert "run_late" not in adapter._run_stream_subscribers

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -1088,12 +1088,76 @@ class TestRunProfileScoping:
 
         assert adapter._run_owner_profiles["run_x"] == "alpha"
 
-    def test_an_unowned_run_stays_visible(self, adapter):
-        """The deliberate fail-open branch. A run nobody claimed is nobody's
-        to steal, and refusing it would break any path that never registered."""
-        adapter._run_statuses["run_orphan"] = {"status": "running"}
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("handler_name", [
+        "_handle_get_run", "_handle_run_events",
+        "_handle_run_approval", "_handle_steer_run", "_handle_stop_run",
+    ])
+    @pytest.mark.parametrize("caller", ["beta", "alpha", "default", None])
+    async def test_an_existing_run_without_an_owner_stamp_is_refused(
+        self, adapter, handler_name, caller
+    ):
+        """Missing provenance on a real run is an unanswered authorization
+        question, not permission.
 
-        assert adapter._run_visible_to_caller("run_orphan") is True
+        Serving it would turn the boundary allow-all for every served profile
+        exactly when the metadata that decides it is absent — so it is refused
+        for *every* caller, not merely a foreign one. Nothing on the ordinary
+        creation paths loses the stamp today; this pins the invariant rather
+        than a reachable path.
+        """
+        adapter._run_statuses["run_ghost"] = {"status": "running", "session_id": "s"}
+        adapter._active_run_agents["run_ghost"] = MagicMock()
+        adapter._run_streams["run_ghost"] = asyncio.Queue()
+        assert "run_ghost" not in adapter._run_owner_profiles
+
+        response = await self._as_profile(
+            adapter, caller, getattr(adapter, handler_name), "run_ghost"
+        )
+
+        assert response.status == 404
+        assert "run_ghost" not in adapter._stopping_run_ids
+        assert adapter._run_statuses["run_ghost"]["status"] == "running"
+
+    @pytest.mark.parametrize("surface", [
+        "_run_statuses", "_active_run_agents", "_active_run_tasks",
+        "_run_streams", "_run_approval_sessions",
+    ])
+    def test_any_surviving_surface_closes_an_unstamped_run(
+        self, adapter, surface
+    ):
+        """Each surface independently, so the rule cannot be satisfied by the
+        status dict alone while a live agent ref stays reachable."""
+        getattr(adapter, surface)["run_ghost"] = MagicMock()
+
+        assert adapter._run_visible_to_caller("run_ghost") is False
+
+    def test_an_id_that_names_nothing_is_not_refused(self, adapter):
+        """The complement, and the reason the rule is about state rather than
+        about ownership alone: /events deliberately admits a caller in the
+        moment before its run is registered."""
+        assert adapter._run_state_exists("run_unknown") is False
+        assert adapter._run_visible_to_caller("run_unknown") is True
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_id_still_enters_the_events_wait(
+        self, adapter, monkeypatch
+    ):
+        """Fail-closed must not collapse the subscribe-early window: an id
+        with no state waits, it is not refused up front."""
+        slept = []
+
+        async def _fake_sleep(delay):
+            slept.append(delay)
+
+        monkeypatch.setattr(asyncio, "sleep", _fake_sleep)
+
+        response = await self._as_profile(
+            adapter, "beta", adapter._handle_run_events, "run_unknown"
+        )
+
+        assert response.status == 404
+        assert len(slept) > 0
 
     @pytest.mark.parametrize(
         "raw,expected",

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -621,12 +621,25 @@ to the routed profile**:
 - Unprefixed routes and `/p/default/...` keep using the default profile's key.
 - A named profile with no `API_SERVER_KEY` of its own fails closed — its
   prefix is unreachable until you set one.
+- Run-scoped routes — `/v1/runs/{run_id}` and its `/events`, `/approval`,
+  `/steer` and `/stop` children — are bound to the profile that created the
+  run. Authentication proves *a* valid key; it does not prove the run is
+  yours. A profile asking for someone else's run gets `404`, the same answer
+  it would get for a run id that never existed.
 
 :::warning Breaking change (July 2026)
 Before this fix, a valid default-profile key was accepted on any
 `/p/<profile>/` prefix. If you relied on one shared key across profile
 prefixes, set a distinct `API_SERVER_KEY` in each profile's `.env` — reused
 default keys on named prefixes now return `401`.
+:::
+
+:::warning Breaking change (August 2026)
+Run-scoped routes used to accept any served profile's key, because run state
+is keyed by `run_id` alone and records nothing about ownership. If you polled,
+steered or stopped a run from a profile other than the one that created it,
+that now returns `404` — send the request under the creating profile's prefix
+and key.
 :::
 
 :::warning Security

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -208,6 +208,16 @@ home). `hermes status` reports the multiplexer and the profiles it serves;
 own `runtime_status.json` under its own home, so existing per-profile readers
 keep working.
 
+#### 6. API runs belong to the profile that started them
+
+The [API server](/user-guide/features/api-server)'s run-scoped routes
+(`/v1/runs/{run_id}` and its `/events`, `/approval`, `/steer`, `/stop`
+children) are keyed by run id, which is unique per host but says nothing about
+ownership. Multiplexed, every served profile holds a valid key, so a bearer
+token proves only that the caller is *some* served profile. Those routes now
+also require the caller to be the profile that created the run; anyone else
+gets `404`, indistinguishable from a run id that never existed.
+
 #### What does **not** change
 
 Per-profile `.env` credential isolation is preserved and, if anything,


### PR DESCRIPTION
## What does this PR do?

Five run-scoped API routes authenticated the caller but never scoped to it. Run state is keyed by `run_id` alone, and under `gateway.multiplex_profiles` every served profile holds a valid `API_SERVER_KEY` — so `_check_auth` returning `None` proved *"some valid key"*, not *"this run's key"*. Any served profile could read, steer, approve or stop another profile's run.

Reading is a confidentiality problem (output plus token usage). `/stop`, `/steer` and `/approval` are an integrity one: they act on the **target's** agent, under the target's tool permissions and secrets, not the caller's.

The fix records the creating profile in a side table, requires it to match, and fails closed when a real run's ownership is missing.

**Why this is in scope, given SECURITY.md §2.6.4.** That rule — "within the authorized set, all callers are equally trusted" — is about callers inside one profile's allowlist, not across profiles. The project already models per-profile separation inside this single adapter, deliberately:

- `website/docs/user-guide/features/api-server.md` documents that "**authentication is bound to the routed profile**", shipped as a breaking change in July 2026 — a default-profile key on a named prefix returns `401`.
- `AGENTS.md` §7 requires profile-level config, "credentials **AND** authorization", to be read scope-aware under multiplexing, and calls falling back to the default profile's value a leak (#72348, #86905).
- `website/docs/user-guide/multi-profile-gateways.md` promises session keys are namespaced per profile and `.env` isolation is "if anything, stricter".

Run state was the one surface that did not keep that promise, which puts this under §3.1's "trust-model documentation violations" rather than §2.6.4.

## Related Issue

Fixes #93689

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**`gateway/platforms/api_server.py`** — the fix.

- `_run_owner_profiles: Dict[str, str]` maps run id to owning profile. Deliberately a side table rather than a field on the run record, so the `GET /v1/runs/{run_id}` body neither grows a key nor discloses the owning profile's name to a caller with no other way to learn it. This is also why the implementation departs from the issue's suggested "stamp `request_profile` into run records": a record-resident stamp has to be stripped from every response builder, forever.
- Both creation sites claim ownership the moment the id exists, while still inside the middleware's profile scope and before any run-keyed state is published under it. The value is captured explicitly rather than read later: ContextVars do not follow `run_in_executor` threads and runs live out their lives there — the same reason the surrounding code already captures `request_profile` before hopping to the executor. Claimed only on the far side, a run would be stamped `default` instead of its creator.
- `_set_run_status` claims it again whenever it *creates* a record, so a record cannot exist without an owner even if a new creation path appears. `_claim_run_owner` is write-once, so it is a backstop rather than an authority rewrite: a later transition — including one a foreign caller triggers via `/stop`, or one running on an executor thread with the ContextVar unset — cannot re-stamp it.
- Guards in `_handle_get_run`, `_handle_run_approval`, `_handle_steer_run` and `_handle_stop_run`, each immediately after `_check_auth`, before any state is read or written.
- Refusal is **404, never 403**. A distinct status would confirm the run exists to a caller not allowed to know that, and run ids are the only thing keeping runs unenumerable — there is no collection route on `/v1/runs`. The refusal is logged with the same audit suffix `_check_auth` uses, so a cross-profile attempt leaves the operator-visible trace an auth failure does rather than being silently denied.
- **Missing ownership fails closed when the run is real.** `_run_visible_to_caller` distinguishes two cases that had been collapsed into one permissive answer: an id with **no run-keyed state at all** is admitted, because `/events` deliberately lets a client subscribe in the moment before its run is registered and nothing is disclosed by waiting on state that does not exist; an id with **run state present but no owner stamp** is refused, for every caller rather than only a foreign one. Missing provenance on a real run is an unanswered authorization question, not permission — answering it "yes" would make the boundary allow-all for every served profile precisely when the metadata that decides it is absent.
- `_run_state_exists` is the single definition of "this run is a thing", shared by the visibility rule and the ownership-release rule so the two cannot drift: an owner is released exactly when no state remains, which is exactly the case the visibility rule admits. It spans `_run_statuses`, `_active_run_agents`, `_active_run_tasks`, `_run_streams` and `_run_approval_sessions`, so the rule cannot be satisfied by the status dict alone while a live agent ref stays reachable through `/stop`.
- On `/events`, ownership is part of the subscribe-early wait *condition* rather than a gate before it, re-evaluated on every iteration. That window is the one place a caller is admitted before the run is registered, so a check up front would pass on an id claimed — by someone else — inside it. Folding it in also keeps a foreign run indistinguishable from one that never existed: both exhaust the same bounded wait and return the same 404 body, while a run claimed by the caller proceeds immediately.
- Ownership is released only once nothing keyed by the run survives. Statuses, transports and the agent/task refs retire on different clocks (`_RUN_STATUS_TTL` 3600s vs `_RUN_STREAM_TTL` 300s vs task completion); releasing on the status alone left a live agent ref reachable through `/stop` by anyone, and the `"stopping"` write that follows would have re-stamped the run to the caller — write-once, so the real owner would have been locked out permanently. The run-completion teardown releases too: if the sweeper already took the status while the run was live, those pops drop the last surface and nothing would revisit the id, stranding the entry for the life of the process.
- The unnamed listener and an explicit `/p/default/` normalise to one profile, matching the middleware's own `profile or "default"`, so the default listener keeps reaching its own runs.

**Docs** — `api-server.md` and `multi-profile-gateways.md` state that run-scoped routes belong to the creating profile, next to the auth-binding rules and the other isolation guarantees. Includes a dated breaking-change admonition matching the July 2026 one above it.

**`tests/gateway/test_api_server_runs.py`** — 60 cases in `TestRunProfileScoping` (file total 25 → 85).

## How to Test

1. **Reproduce.** Auth is pinned open on purpose — under multiplexing both callers legitimately hold valid keys, so what is measured is scoping:

   ```python
   adapter._check_auth = lambda request: None
   adapter._run_visible_to_caller = lambda run_id: True   # pre-fix behaviour
   ```

   With that line, `alpha` creates a run and `beta` gets:

   ```
   beta  GET  /v1/runs/run_alpha        -> 200
   beta  POST /v1/runs/run_alpha/stop   -> 200
   alpha's run status afterwards        -> 'stopping'
   ```

   Without it (this PR), both are `404` and alpha's run stays `'running'`.

2. **Run the tests.**

   ```
   ./scripts/run_tests.sh tests/gateway/test_api_server_runs.py
   ```

3. **Confirm each test earns its place.** Reverting any single rule — a handler guard, the fail-closed treatment of a stateful unstamped run, the `/events` wait condition, the release-on-last-surface rule, the teardown release, or the refusal log — turns the matching cases red and nothing else. The fail-closed rule alone accounts for 25 of them.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04.4 LTS, Python 3.11.15

One box left unticked rather than ticked loosely. This environment has a broken `cryptography` install (`ModuleNotFoundError: No module named '_cffi_backend'`), so a whole-suite pass is not achievable here and an absolute count would say nothing. Instead I ran the 15 test files covering `api_server`, run state and `multiplex_profiles` on this branch **and on its base**, and diffed the failure sets: **250 passed / 43 failed unpatched → 310 passed / 43 failed patched**, identical failure sets, zero new failures and zero lost detections. Both sides were re-measured on the current base after the rebase rather than carried over from the previous one. All three commits are independently green (59 / 59 / 85), so the series stays bisectable.

**One disclosure:** this changes an existing test's *fixture*, not its expectation. `TestDisconnectedAgentReap::test_stop_run_reaps_owned_processes` builds run state by hand (`_active_run_agents["run_x"] = agent`, with no creation path) and so produced exactly the unstamped-but-real run this now refuses. It claims ownership the way both creation sites do; the assertion is untouched.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — **N/A**: no config keys added or changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — **N/A**: no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — **N/A**: in-process dict and ContextVar logic only; no paths, processes, signals or filesystem semantics
- [x] I've updated tool descriptions/schemas if I changed tool behavior — **N/A**: no tool behavior change

## Screenshots / Logs

`alpha` creates a run; `beta` is a different served profile. Auth passes for both throughout — only scoping differs.

```
BEFORE (guard removed):
  beta  GET  /v1/runs/run_alpha        -> 200
  beta  POST /v1/runs/run_alpha/stop   -> 200
  alpha's run status afterwards        -> 'stopping'
  alpha GET  /v1/runs/run_alpha        -> 200  (owner)

AFTER  (this PR):
  beta  GET  /v1/runs/run_alpha        -> 404
  beta  POST /v1/runs/run_alpha/stop   -> 404
  alpha's run status afterwards        -> 'running'
  alpha GET  /v1/runs/run_alpha        -> 200  (owner)
```

The foreign `/stop` is refused *and* the run is verifiably untouched — the tests assert on `_stopping_run_ids`, the run status, and that the agent was never called, not just the response code.

`/events` existence oracle, measured on this head. Ownership now lives in the wait condition, so a foreign run and an unknown id exhaust the same bounded wait:

```
foreign existing run : 404 in  1005.3 ms
nonexistent run      : 404 in  1005.6 ms
```

Before that change those were ~0.1 ms and ~1009 ms respectively — an existence answer as plain as the 403 this route deliberately avoids.

```
$ ./scripts/run_tests.sh tests/gateway/test_api_server_runs.py
85 passed
```