### PR TITLE
fix(desktop): hide stale workspace on new chat

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/coding-row.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/coding-row.test.tsx
@@ -1,36 +1,79 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { atom } from 'nanostores'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $notifications, clearNotifications } from '@/store/notifications'
+import {
+  releaseWorkspaceCwdOwner,
+  setActiveSessionId,
+  setFreshDraftReady,
+  setSelectedStoredSessionId,
+  setWorkspaceCwdOwner
+} from '@/store/session'
 
 vi.mock('@/store/coding-status', () => ({
   registerRepoStatusCwd: () => undefined,
-  repoStatusForCwd: () =>
-    atom({
-      added: 12,
-      ahead: 0,
-      behind: 0,
-      branch: 'bb/hitbox',
-      defaultBranch: 'main',
-      detached: false,
-      removed: 3,
-      untracked: 0
-    }),
+  repoStatusForCwd: (cwd?: string) =>
+    atom(
+      cwd
+        ? {
+            added: 12,
+            ahead: 0,
+            behind: 0,
+            branch: 'bb/hitbox',
+            defaultBranch: 'main',
+            detached: false,
+            removed: 3,
+            untracked: 0
+          }
+        : null
+    ),
   repoWorktreesForCwd: () => atom([])
 }))
 
 const { CodingStatusRow } = await import('./coding-row')
 
+function renderAt(element: ReactElement, path = '/stored-session') {
+  return render(<MemoryRouter initialEntries={[path]}>{element}</MemoryRouter>)
+}
+
 describe('CodingStatusRow', () => {
+  beforeEach(() => {
+    setFreshDraftReady(false)
+    setActiveSessionId('runtime-current')
+    setSelectedStoredSessionId('stored-current')
+    setWorkspaceCwdOwner('stored-current')
+  })
+
   afterEach(() => {
     cleanup()
+    setActiveSessionId(null)
+    setFreshDraftReady(false)
+    setSelectedStoredSessionId(null)
+    setWorkspaceCwdOwner(null)
+  })
+
+  it('hides the previous branch while the main draft has no workspace owner', () => {
+    setActiveSessionId(null)
+    setSelectedStoredSessionId('stored-previous')
+    setWorkspaceCwdOwner('stored-previous')
+    setSelectedStoredSessionId(null)
+    releaseWorkspaceCwdOwner()
+    setWorkspaceCwdOwner(null)
+    setFreshDraftReady(true)
+
+    renderAt(<CodingStatusRow onOpen={() => undefined} repoPath="/repo/previous-worktree" />, '/')
+
+    expect(screen.queryByText('bb/hitbox')).toBeNull()
+    expect(screen.queryByText('~/repo/previous-worktree')).toBeNull()
   })
 
   it('opens the review pane from the branch and the diff counts, never the bar itself', () => {
     const onOpen = vi.fn()
 
-    const { container } = render(<CodingStatusRow onOpen={onOpen} repoPath="/repo" />)
+    const { container } = renderAt(<CodingStatusRow onOpen={onOpen} repoPath="/repo" />)
 
     const bar = container.querySelector<HTMLElement>('.coding-status-bar')
 
@@ -47,7 +90,7 @@ describe('CodingStatusRow', () => {
   })
 
   it('wraps the click targets without adding a layout box', () => {
-    const { container } = render(<CodingStatusRow onOpen={() => undefined} repoPath="/repo" />)
+    const { container } = renderAt(<CodingStatusRow onOpen={() => undefined} repoPath="/repo" />)
 
     // `display: contents` is what keeps the branch label and the counts direct
     // flex children of the row — the hit areas cost nothing visually.
@@ -58,7 +101,7 @@ describe('CodingStatusRow', () => {
   })
 
   it('parks the copy glyph against the end of the path, not the end of the row', () => {
-    render(<CodingStatusRow onOpen={() => undefined} repoPath="/Users/someone/www/repo" />)
+    renderAt(<CodingStatusRow onOpen={() => undefined} repoPath="/Users/someone/www/repo" />)
 
     const path = screen.getByText('~/www/repo')
 
@@ -76,7 +119,7 @@ describe('CodingStatusRow', () => {
     Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
     clearNotifications()
 
-    render(<CodingStatusRow onOpen={() => undefined} repoPath="/Users/someone/www/repo" />)
+    renderAt(<CodingStatusRow onOpen={() => undefined} repoPath="/Users/someone/www/repo" />)
 
     // Painted tildified, copied raw.
     expect(screen.getByText('~/www/repo')).toBeTruthy()

--- a/apps/desktop/src/app/chat/composer/status-stack/coding-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/coding-row.tsx
@@ -1,7 +1,9 @@
 import { useStore } from '@nanostores/react'
 import { memo, useEffect } from 'react'
+import { useLocation } from 'react-router'
 
 import { PrTag } from '@/app/chat/pr-tag'
+import { NEW_CHAT_ROUTE } from '@/app/routes'
 import { StatusRow } from '@/components/chat/status-row'
 import {
   type ActionItemSpec,
@@ -20,6 +22,9 @@ import { displayPath } from '@/lib/display-path'
 import { openWorktreeDialog, registerRepoStatusCwd, repoStatusForCwd, repoWorktreesForCwd } from '@/store/coding-status'
 import { notifyError } from '@/store/notifications'
 import { $pullRequestsByBranch, branchPrKey, refreshPullRequests } from '@/store/pull-requests'
+import { $freshDraftReady, $selectedStoredSessionId, $workspaceCwdOwner } from '@/store/session'
+
+import { useComposerScope } from '../scope'
 
 // Tiny uppercase section header, matching the composer "+" menu's labels.
 const MENU_SECTION = 'text-[0.625rem] font-semibold uppercase tracking-wider text-(--ui-text-tertiary)'
@@ -62,10 +67,22 @@ export const CodingStatusRow = memo(function CodingStatusRow({
   repoPath
 }: CodingStatusRowProps) {
   const { t } = useI18n()
+  const location = useLocation()
   const s = t.statusStack.coding
   const p = t.sidebar.projects
   const fileMenu = t.fileMenu
-  const resolvedRepoPath = repoPath?.trim() || undefined
+  const scope = useComposerScope()
+  const freshDraftReady = useStore($freshDraftReady)
+  const selectedStoredSessionId = useStore($selectedStoredSessionId)
+  const workspaceCwdOwner = useStore($workspaceCwdOwner)
+  const rawRepoPath = repoPath?.trim() || undefined
+
+  const primaryWorkspaceOwned =
+    location.pathname !== NEW_CHAT_ROUTE &&
+    !freshDraftReady &&
+    (workspaceCwdOwner ?? null) === (selectedStoredSessionId ?? null)
+
+  const resolvedRepoPath = scope.target !== 'main' || primaryWorkspaceOwned ? rawRepoPath : undefined
   // This surface's OWN worktree, always — never the primary's. The row used to
   // fall back to the global `$repoStatus` for a blank repoPath, which painted
   // the main pane's branch/± onto a tile whose cwd hadn't resolved yet. That

--- a/apps/desktop/src/app/right-sidebar/index.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.test.tsx
@@ -1,8 +1,17 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { HermesReadDirResult } from '@/global'
-import { $connection, $selectedStoredSessionId, $workspaceCwdOwner, setCurrentCwd } from '@/store/session'
+import {
+  $connection,
+  releaseWorkspaceCwdOwner,
+  setCurrentCwd,
+  setFreshDraftReady,
+  setSelectedStoredSessionId,
+  setWorkspaceCwdOwner
+} from '@/store/session'
 
 import { resetProjectTreeState } from './files/use-project-tree'
 
@@ -14,11 +23,16 @@ function installBridge() {
   ;(window as unknown as { hermesDesktop: { readDir: typeof readDir } }).hermesDesktop = { readDir }
 }
 
+function renderAt(element: ReactElement, path = '/stored-session') {
+  return render(<MemoryRouter initialEntries={[path]}>{element}</MemoryRouter>)
+}
+
 describe('RightSidebarPane', () => {
   beforeEach(() => {
     $connection.set(null)
-    $selectedStoredSessionId.set(null)
-    $workspaceCwdOwner.set(null)
+    setSelectedStoredSessionId(null)
+    setWorkspaceCwdOwner(null)
+    setFreshDraftReady(false)
     resetProjectTreeState()
     readDir.mockReset()
     readDir.mockResolvedValue({ entries: [{ isDirectory: false, name: 'README.md', path: '/repo/README.md' }] })
@@ -28,9 +42,10 @@ describe('RightSidebarPane', () => {
   afterEach(() => {
     cleanup()
     $connection.set(null)
-    $selectedStoredSessionId.set(null)
-    $workspaceCwdOwner.set(null)
     setCurrentCwd('')
+    setFreshDraftReady(false)
+    setSelectedStoredSessionId(null)
+    setWorkspaceCwdOwner(null)
     resetProjectTreeState()
     delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
   })
@@ -38,7 +53,7 @@ describe('RightSidebarPane', () => {
   it('renders the tree whenever the session has a working dir (repo or not) — no picker', async () => {
     setCurrentCwd('/repo')
 
-    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
+    renderAt(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
 
     const refresh = await screen.findByRole('button', { name: 'Refresh tree' })
 
@@ -51,11 +66,11 @@ describe('RightSidebarPane', () => {
   })
 
   it('does not read a retained cwd while it belongs to a previous session', async () => {
-    $selectedStoredSessionId.set('new-session')
-    $workspaceCwdOwner.set('previous-session')
+    setSelectedStoredSessionId('new-session')
+    setWorkspaceCwdOwner('previous-session')
     setCurrentCwd('/home/doug/default-profile-workspace')
 
-    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
+    renderAt(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
 
     await waitFor(() => expect(screen.queryByRole('button', { name: 'Refresh tree' })).toBeNull())
     expect(readDir).not.toHaveBeenCalled()
@@ -64,7 +79,24 @@ describe('RightSidebarPane', () => {
   it('shows no tree for a detached chat (no working dir)', async () => {
     setCurrentCwd('')
 
-    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
+    renderAt(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
+
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Refresh tree' })).toBeNull())
+    expect(readDir).not.toHaveBeenCalled()
+  })
+
+  it('hides the previous conversation tree while a fresh draft has no workspace owner', async () => {
+    setSelectedStoredSessionId('stored-previous')
+    setCurrentCwd('/repo/previous-worktree')
+    setWorkspaceCwdOwner('stored-previous')
+    setSelectedStoredSessionId(null)
+    releaseWorkspaceCwdOwner()
+    // A late runtime publication can still name the null-id draft as owner;
+    // an implicit draft target must remain hidden even through that race.
+    setWorkspaceCwdOwner(null)
+    setFreshDraftReady(true)
+
+    renderAt(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />, '/')
 
     await waitFor(() => expect(screen.queryByRole('button', { name: 'Refresh tree' })).toBeNull())
     expect(readDir).not.toHaveBeenCalled()

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -1,6 +1,8 @@
 import { useStore } from '@nanostores/react'
 import type { ComponentProps } from 'react'
+import { useLocation } from 'react-router'
 
+import { NEW_CHAT_ROUTE } from '@/app/routes'
 import { TreeSkeleton } from '@/components/chat/skeletons'
 import { ErrorBoundary } from '@/components/error-boundary'
 import { Button } from '@/components/ui/button'
@@ -13,7 +15,7 @@ import { cn } from '@/lib/utils'
 import { $panesFlipped } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { openPreview } from '@/store/preview'
-import { $currentCwd, $selectedStoredSessionId, $workspaceCwdOwner } from '@/store/session'
+import { $currentCwd, $freshDraftReady, $selectedStoredSessionId, $workspaceCwdOwner } from '@/store/session'
 
 import { SidebarPanelLabel } from '../shell/sidebar-label'
 
@@ -27,16 +29,26 @@ interface RightSidebarPaneProps {
 
 export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSidebarPaneProps) {
   const { t } = useI18n()
+  const location = useLocation()
   const r = t.rightSidebar
   const panesFlipped = useStore($panesFlipped)
-  const currentCwd = useStore($currentCwd).trim()
+  const rawCurrentCwd = useStore($currentCwd).trim()
+  const freshDraftReady = useStore($freshDraftReady)
   const selectedStoredSessionId = useStore($selectedStoredSessionId)
   const workspaceCwdOwner = useStore($workspaceCwdOwner)
 
-  // A transition intentionally retains the old CWD until the new session
-  // confirms its workspace. Do not issue a filesystem read against that path:
-  // under a gateway switch it may belong to a different remote machine.
-  const hasWorkspace = Boolean(currentCwd) && (workspaceCwdOwner ?? null) === (selectedStoredSessionId ?? null)
+  const workspaceCanPaint =
+    location.pathname !== NEW_CHAT_ROUTE &&
+    !freshDraftReady &&
+    (workspaceCwdOwner ?? null) === (selectedStoredSessionId ?? null)
+
+  const currentCwd = workspaceCanPaint ? rawCurrentCwd : ''
+
+  // Browse only a cwd known to belong to the selected conversation. During a
+  // fresh draft/session switch the raw atom can intentionally retain the old
+  // path to preserve pane state. A fresh draft has no conversation worktree yet,
+  // so it stays hidden until session.create applies the authoritative cwd.
+  const hasWorkspace = Boolean(currentCwd)
 
   const {
     collapseAll,

--- a/apps/desktop/src/app/right-sidebar/terminal/terminals.test.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/terminals.test.ts
@@ -5,12 +5,16 @@ const STORAGE_KEY = 'hermes.desktop.terminals.v1'
 
 async function loadTerminalStore() {
   const $currentCwd = atom('/workspace')
+  const $freshDraftReady = atom(false)
+  const workspaceCwdBelongsToSelectedSession = vi.fn(() => true)
 
   vi.doMock('@/store/session', () => ({
-    $currentCwd
+    $currentCwd,
+    $freshDraftReady,
+    workspaceCwdBelongsToSelectedSession
   }))
 
-  return { ...(await import('./terminals')), $currentCwd }
+  return { ...(await import('./terminals')), $currentCwd, $freshDraftReady, workspaceCwdBelongsToSelectedSession }
 }
 
 describe('terminal store persistence', () => {
@@ -56,6 +60,15 @@ describe('terminal store persistence', () => {
       activeTerminalId: userId,
       terminals: [{ auto: false, cwd: '/repo', id: userId, reviveBuffer: 'recent scrollback', title: 'server' }]
     })
+  })
+
+  it('does not launch a new terminal in the previous chat workspace while a fresh draft resolves', async () => {
+    const { $freshDraftReady, $terminals, createTerminal } = await loadTerminalStore()
+    $freshDraftReady.set(true)
+
+    const id = createTerminal()
+
+    expect($terminals.get().find(term => term.id === id)?.cwd).toBe('')
   })
 
   it('never attaches a revive buffer to an agent tab', async () => {

--- a/apps/desktop/src/app/right-sidebar/terminal/terminals.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/terminals.ts
@@ -1,7 +1,7 @@
 import { atom, computed } from 'nanostores'
 
 import { readKey, writeKey } from '@/lib/storage'
-import { $currentCwd } from '@/store/session'
+import { $currentCwd, $freshDraftReady, workspaceCwdBelongsToSelectedSession } from '@/store/session'
 
 import { setTerminalTakeover } from '../store'
 
@@ -159,7 +159,9 @@ const newId = () =>
 
 /** Append a fresh terminal and focus it. Captures the current cwd once (its only
  *  tie to session/project state); pass an explicit cwd to override. Returns the id. */
-export function createTerminal(cwd: string = $currentCwd.get()): string {
+export function createTerminal(
+  cwd: string = !$freshDraftReady.get() && workspaceCwdBelongsToSelectedSession() ? $currentCwd.get() : ''
+): string {
   const id = newId()
   $terminals.set([...$terminals.get(), { id, title: 'Terminal', auto: true, cwd, kind: 'user' }])
   $activeTerminalId.set(id)

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -27,6 +27,7 @@ import {
   $currentModel,
   $currentProvider,
   $currentReasoningEffort,
+  $freshDraftReady,
   $messages,
   $newChatWorkspaceTarget,
   $resumeFailedSessionId,
@@ -517,6 +518,32 @@ describe('startFreshSessionDraft', () => {
 
     expect($selectedStoredSessionId.get()).toBeNull()
     expect(workspaceCwdBelongsToSelectedSession()).toBe(false)
+  })
+
+  it('releases the fresh-draft paint gate when session creation fails', async () => {
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.create') {
+        throw new Error('create failed')
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+
+    render(<Harness onReady={value => (handle = value)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    act(() => handle!.startFreshSessionDraft({ preserveRoute: true }))
+    expect($freshDraftReady.get()).toBe(true)
+
+    await expect(
+      act(async () => {
+        await handle!.createBackendSessionForSend()
+      })
+    ).rejects.toThrow('create failed')
+
+    expect($freshDraftReady.get()).toBe(false)
   })
 
   it('fronts the workspace without closing a terminal that is merely behind a tab', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -46,7 +46,9 @@ import {
   setResumeFailedSessionId,
   setSelectedStoredSessionId,
   setSessions,
-  setTurnStartedAt
+  setTurnStartedAt,
+  setWorkspaceCwdOwner,
+  workspaceCwdBelongsToSelectedSession
 } from '@/store/session'
 import type { SessionProfileRoute } from '@/store/session-request-router'
 import { $sessionTiles } from '@/store/session-states'
@@ -498,6 +500,23 @@ describe('startFreshSessionDraft', () => {
     expect(navigate).not.toHaveBeenCalled()
     expect($currentCwd.get()).toBe('')
     expect($newChatWorkspaceTarget.get()).toBeNull()
+  })
+
+  it('does not let an implicit fresh draft claim the previous conversation workspace', async () => {
+    const requestGateway = vi.fn(async () => ({}) as never)
+    let handle: HarnessHandle | null = null
+
+    setSelectedStoredSessionId('stored-previous')
+    setCurrentCwd('/repo/previous-worktree')
+    setWorkspaceCwdOwner('stored-previous')
+
+    render(<Harness onReady={value => (handle = value)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    act(() => handle!.startFreshSessionDraft({ preserveRoute: true }))
+
+    expect($selectedStoredSessionId.get()).toBeNull()
+    expect(workspaceCwdBelongsToSelectedSession()).toBe(false)
   })
 
   it('fronts the workspace without closing a terminal that is merely behind a tab', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -50,6 +50,7 @@ import {
   $yoloActive,
   getSessionOwnerHint,
   type NewChatWorkspaceTarget,
+  releaseWorkspaceCwdOwner,
   resolveComposerSessionKey,
   sessionPinId,
   setActiveSessionId,
@@ -447,11 +448,17 @@ export function useSessionActions({
         setCurrentCwd(workspaceTarget)
       }
 
-      // A fresh draft resolves its own workspace right here, so it owns it. The
-      // selected stored id is null for a draft, and so is the owner — they match,
-      // which keeps workspace surfaces live on a new chat instead of treating the
-      // draft as an un-re-homed switch (#71254).
-      setWorkspaceCwdOwner(null)
+      // An implicit target is only the BASE used by session.create. The gateway
+      // may bind the conversation to a newly-created linked worktree, so claiming
+      // that base as the draft's own workspace leaks the previous/base branch and
+      // file tree until session.create returns the authoritative cwd. Explicit
+      // targets are already authoritative user choices and remain visible.
+      if (hasWorkspaceTarget) {
+        setWorkspaceCwdOwner(null)
+      } else {
+        releaseWorkspaceCwdOwner()
+      }
+
       setCurrentBranch('')
       // Never clear the composer here — ChatBar's per-thread draft swap owns it.
       setFreshDraftReady(true)
@@ -534,7 +541,6 @@ export function useSessionActions({
           broadcastSessionsChanged()
         }
 
-        setFreshDraftReady(false)
         setNewChatWorkspaceTarget(undefined)
         setActiveSessionId(created.session_id)
         setSelectedStoredSessionId(stored)
@@ -545,6 +551,10 @@ export function useSessionActions({
         if (runtimeInfo) {
           updateSessionState(created.session_id, state => ({ ...state, ...runtimeInfo }), stored)
         }
+
+        // Keep old workspace surfaces hidden until the newly-created session's
+        // authoritative cwd/worktree has been applied.
+        setFreshDraftReady(false)
 
         // User may have armed YOLO on the new-chat draft before the runtime
         // session existed — apply it to the freshly created session.

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -46,6 +46,7 @@ import {
   $currentReasoningEffort,
   $messages,
   $newChatWorkspaceTarget,
+  $newChatWorkspaceTargetGeneration,
   $sessions,
   $yoloActive,
   getSessionOwnerHint,
@@ -470,6 +471,7 @@ export function useSessionActions({
     async (preview: string | null = null): Promise<string | null> => {
       const startingStoredSessionId = selectedStoredSessionIdRef.current
       const startingRouteToken = getRouteToken()
+      const startingWorkspaceGeneration = $newChatWorkspaceTargetGeneration.get()
 
       creatingSessionRef.current = true
 
@@ -564,6 +566,13 @@ export function useSessionActions({
 
         return created.session_id
       } finally {
+        // A rejected/aborted create must not leave the draft-only paint gate
+        // latched forever. Do not clear it when the user started a newer draft
+        // while this request was in flight; that draft owns the next generation.
+        if ($newChatWorkspaceTargetGeneration.get() === startingWorkspaceGeneration) {
+          setFreshDraftReady(false)
+        }
+
         window.setTimeout(() => {
           creatingSessionRef.current = false
         }, 0)

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.test.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $currentCwd, setActiveSessionId, setSelectedStoredSessionId, setSessions } from '@/store/session'
+
+import { useStatusbarItems } from './use-statusbar-items'
+
+vi.mock('@/app/shell/approval-mode-menu', () => ({
+  useApprovalModeStatusbarItem: () => ({ id: 'approval-mode', label: 'Approvals', variant: 'menu' })
+}))
+vi.mock('@/app/shell/hooks/use-context-breakdown', () => ({
+  useContextBreakdown: () => ({ breakdown: null, loading: false })
+}))
+
+const wrapper = ({ children }: { children: ReactNode }) => <MemoryRouter>{children}</MemoryRouter>
+
+afterEach(() => {
+  cleanup()
+  $currentCwd.set('')
+  setActiveSessionId(null)
+  setSelectedStoredSessionId(null)
+  setSessions([])
+})
+
+describe('useStatusbarItems workspace ownership', () => {
+  it('does not paint the previous workspace path while a fresh draft is resolving', () => {
+    $currentCwd.set('/repo/previous-worktree')
+
+    const requestGateway = vi.fn(async () => ({})) as unknown as <T = unknown>(
+      method: string,
+      params?: Record<string, unknown>
+    ) => Promise<T>
+
+    const { result } = renderHook(
+      () =>
+        useStatusbarItems({
+          agentsOpen: false,
+          chatOpen: true,
+          commandCenterOpen: false,
+          extraLeftItems: [],
+          extraRightItems: [],
+          freshDraftReady: true,
+          gatewayState: 'open',
+          inferenceStatus: null,
+          openAgents: vi.fn(),
+          openCommandCenterSection: vi.fn(),
+          requestGateway,
+          statusSnapshot: null,
+          toggleCommandCenter: vi.fn()
+        }),
+      { wrapper }
+    )
+
+    expect(result.current.leftStatusbarItems.find(item => item.id === 'workspace-cwd')?.hidden).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -33,6 +33,7 @@ import {
   $sessions,
   $sessionStartedAt,
   $turnStartedAt,
+  $workspaceCwdOwner,
   idsShareLineage,
   sessionMatchesStoredId
 } from '@/store/session'
@@ -77,6 +78,7 @@ export function useStatusbarItems({
   commandCenterOpen,
   extraLeftItems,
   extraRightItems,
+  freshDraftReady,
   gatewayState,
   inferenceStatus,
   openAgents,
@@ -105,6 +107,7 @@ export function useStatusbarItems({
   const gatewayRestarting = useStore($gatewayRestarting)
   const primarySessionStartedAt = useStore($sessionStartedAt)
   const primaryTurnStartedAt = useStore($turnStartedAt)
+  const workspaceCwdOwner = useStore($workspaceCwdOwner)
 
   // The indicator must speak the same scope as the Spawn-tree panel it opens:
   // every session's subagents, never background system actions. Only two
@@ -153,6 +156,9 @@ export function useStatusbarItems({
 
   const selectedStoredSessionId = useStore($selectedStoredSessionId)
   const primaryFocused = !focusedStoredSessionId || focusedStoredSessionId === selectedStoredSessionId
+
+  const primaryWorkspaceOwned =
+    !freshDraftReady && (workspaceCwdOwner ?? null) === (selectedStoredSessionId ?? null)
 
   const activeSessionId = primaryFocused ? primaryActiveSessionId : (focusedRuntimeId ?? null)
   const busy = primaryFocused ? primaryBusy : focusedBusy
@@ -211,7 +217,7 @@ export function useStatusbarItems({
   const currentCwd = (
     (liveCwdBelongsToFocus ? focusedStateCwd : '') ||
     focusedRowCwd ||
-    (primaryFocused ? primaryCwd : '') ||
+    (primaryFocused && primaryWorkspaceOwned ? primaryCwd : '') ||
     ''
   ).trim()
 

--- a/apps/desktop/src/store/review.test.ts
+++ b/apps/desktop/src/store/review.test.ts
@@ -39,7 +39,14 @@ import {
   toggleReviewTreeMode,
   unstageReviewFile
 } from './review'
-import { $currentCwd } from './session'
+import {
+  $currentCwd,
+  $freshDraftReady,
+  releaseWorkspaceCwdOwner,
+  setFreshDraftReady,
+  setSelectedStoredSessionId,
+  setWorkspaceCwdOwner
+} from './session'
 
 // requestOneShot is the only cross-module dependency that must be faked (it
 // reaches the gateway); everything else routes through window.hermesDesktop.git,
@@ -101,6 +108,9 @@ beforeEach(() => {
   $reviewScopeCwd.set(null)
   $reviewScopeTarget.set('main')
   $currentCwd.set('/repo')
+  setFreshDraftReady(false)
+  setSelectedStoredSessionId(null)
+  setWorkspaceCwdOwner(null)
 })
 
 afterEach(() => {
@@ -129,6 +139,20 @@ describe('refreshReview', () => {
 
     expect($reviewIsRepo.get()).toBe(false)
     expect($reviewLoading.get()).toBe(false)
+  })
+
+  it('does not inspect a previous conversation cwd while a fresh draft is resolving', async () => {
+    const review = stubReview()
+    $reviewOpen.set(true)
+    setFreshDraftReady(true)
+    releaseWorkspaceCwdOwner()
+
+    await refreshReview()
+
+    expect(review.list).not.toHaveBeenCalled()
+    expect($reviewFiles.get()).toEqual([])
+    expect($reviewIsRepo.get()).toBe(false)
+    expect($freshDraftReady.get()).toBe(true)
   })
 
   it('populates the changed-file list from the bridge', async () => {

--- a/apps/desktop/src/store/review.ts
+++ b/apps/desktop/src/store/review.ts
@@ -12,7 +12,15 @@ import { Codecs, persistentAtom } from '@/lib/persisted'
 
 import { refreshRepoStatus, repoStatusForCwd } from './coding-status'
 import { stampSessionPrBranch } from './pull-requests'
-import { $busy, $currentCwd, $selectedStoredSessionId, $sessions } from './session'
+import {
+  $busy,
+  $currentCwd,
+  $freshDraftReady,
+  $selectedStoredSessionId,
+  $sessions,
+  $workspaceCwdOwner,
+  workspaceCwdBelongsToSelectedSession
+} from './session'
 import { $workspaceChangeTick } from './workspace-events'
 
 // State for the review pane: the working-tree changed-file list, the selected
@@ -97,7 +105,19 @@ export const $reviewScopeTarget = atom('main')
 
 /** The repo the pane is reading right now: its pinned scope, else the active
  *  session's cwd. Exported for pane helpers that join repo-relative paths. */
-export const reviewRepoCwd = (): null | string => $reviewScopeCwd.get()?.trim() || $currentCwd.get()?.trim() || null
+export const reviewRepoCwd = (): null | string => {
+  const scoped = $reviewScopeCwd.get()?.trim()
+
+  if (scoped) {
+    return scoped
+  }
+
+  if ($freshDraftReady.get() || !workspaceCwdBelongsToSelectedSession()) {
+    return null
+  }
+
+  return $currentCwd.get()?.trim() || null
+}
 
 const repoCwd = reviewRepoCwd
 
@@ -607,6 +627,14 @@ $currentCwd.subscribe(() => {
     onReviewRepoMoved()
   }
 })
+
+for (const gate of [$freshDraftReady, $selectedStoredSessionId, $workspaceCwdOwner]) {
+  gate.subscribe(() => {
+    if (!$reviewScopeCwd.get()) {
+      onReviewRepoMoved()
+    }
+  })
+}
 
 let prevScopeCwd = $reviewScopeCwd.get()
 


### PR DESCRIPTION
## Summary
- keep the previous cwd as non-authoritative draft state
- hide branch/path and Files tree on the new-chat route
- reveal the workspace only after session.create applies its authoritative cwd

## Verification
- 68 focused desktop UI tests passed after rebasing onto current main
- desktop TypeScript checks passed
- rebuilt macOS app verified with Computer Use: old branch/path/tree absent after New Session