### PR TITLE
fix: secure_parent_dir() skips entire install tree, not just /opt/hermes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -298,7 +298,7 @@ RUN uv pip install --no-cache-dir --no-deps -e "."
 USER root
 RUN mkdir -p /opt/hermes/bin && \
     cp /opt/hermes/docker/hermes-exec-shim.sh /opt/hermes/bin/hermes && \
-    chmod 0755 /opt/hermes/bin/hermes && \
+    chmod 0755 /opt/hermes /opt/hermes/bin/hermes && \
     printf 'docker\n' > /opt/hermes/.install_method
 # The ``.install_method`` stamp is baked next to the running code (the install
 # tree), NOT into $HERMES_HOME. $HERMES_HOME (/opt/data) is a shared data

--- a/contributors/emails/bradmarshall987@users.noreply.github.com
+++ b/contributors/emails/bradmarshall987@users.noreply.github.com
@@ -1,0 +1,1 @@
+bradmarshall987

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1023,6 +1023,15 @@ def secure_parent_dir(path: Path) -> None:
     # Refuse root and its direct children (/usr, /home, /var, /tmp, …).
     if parent == Path("/") or len(parent.parts) < 3:
         return
+    # Refuse /opt/hermes. The install dir lives on the image layer;
+    # chmodding it to 0700 breaks hermes-user traversal and produces
+    # spurious "Permission denied" on every new exec until manual
+    # `chmod 0755 /opt/hermes`. Reproducer: any auth write to a file
+    # directly under /opt/hermes (e.g. /opt/hermes/auth.json when
+    # HERMES_HOME resolves there) triggers the 0700 chmod and locks
+    # out UID 10000. See issue #25821 follow-up.
+    if str(parent) == "/opt/hermes":
+        return
     try:
         os.chmod(parent, 0o700)
     except OSError:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -350,6 +350,11 @@ _HERMES_NODE_TARGET_MAJOR = int(os.environ.get("HERMES_NODE_TARGET_MAJOR", "22")
 _managed_node_heal_attempted = False
 _NODE_BOOTSTRAP_SCRIPT = Path(__file__).resolve().parent / "scripts" / "lib" / "node-bootstrap.sh"
 
+# Install tree root (this file lives at <install_root>/hermes_constants.py).
+# Used by secure_parent_dir() to skip chmod on the install dir — chmodding it
+# 0700 breaks hermes-user traversal in Docker (UID 10000). See #25821, #93050.
+_INSTALL_ROOT = Path(__file__).resolve().parent
+
 
 def node_tool_runnable(path: str | None) -> bool:
     """Return True only when *path* is a Node/npm/npx binary that actually runs.
@@ -1023,14 +1028,10 @@ def secure_parent_dir(path: Path) -> None:
     # Refuse root and its direct children (/usr, /home, /var, /tmp, …).
     if parent == Path("/") or len(parent.parts) < 3:
         return
-    # Refuse /opt/hermes. The install dir lives on the image layer;
-    # chmodding it to 0700 breaks hermes-user traversal and produces
-    # spurious "Permission denied" on every new exec until manual
-    # `chmod 0755 /opt/hermes`. Reproducer: any auth write to a file
-    # directly under /opt/hermes (e.g. /opt/hermes/auth.json when
-    # HERMES_HOME resolves there) triggers the 0700 chmod and locks
-    # out UID 10000. See issue #25821 follow-up.
-    if str(parent) == "/opt/hermes":
+    # Refuse the install tree root. chmodding it 0700 breaks hermes-user
+    # traversal in Docker (UID 10000) and any other install where the
+    # runtime user doesn't own the install dir. See #25821, #93050.
+    if parent == _INSTALL_ROOT or _INSTALL_ROOT in parent.parents:
         return
     try:
         os.chmod(parent, 0o700)

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -560,8 +560,29 @@ class TestSecureParentDir:
         secure_parent_dir(Path("/foo"))
         assert called_with == []
 
+    def test_install_tree_skipped(self, monkeypatch):
+        """Parent dir equal to (or inside) the install tree must NOT be chmod'd.
 
+        Regression test for #93050: secure_parent_dir() chmod'd /opt/hermes to
+        0700 because it has 3 path parts and passed the ``< 3`` guard, locking
+        out UID 10000 (hermes user) from traversing the install dir.
+        """
+        install_root = Path(hermes_constants.__file__).resolve().parent
 
+        # Directly under the install root (e.g. /opt/hermes/auth.json)
+        target = install_root / "auth.json"
+        called_with = []
+        monkeypatch.setattr(os, "chmod", lambda p, m: called_with.append((str(p), m)))
+        secure_parent_dir(target)
+        assert called_with == [], "must not chmod the install root"
+
+        # Inside a subdirectory of the install root
+        sub = install_root / "subdir"
+        target2 = sub / "auth.json"
+        called_with2 = []
+        monkeypatch.setattr(os, "chmod", lambda p, m: called_with2.append((str(p), m)))
+        secure_parent_dir(target2)
+        assert called_with2 == [], "must not chmod dirs inside the install tree"
 
     @pytest.mark.require_symlinks
     def test_symlink_resolved(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
Salvage of #93050 by @bradmarshall987 — prevents `secure_parent_dir()` from chmod'ing the install tree to 0700, which locks out the hermes user (UID 10000) from traversing it.

## Problem
`secure_parent_dir()` guards against chmod'ing `/` or top-level dirs (`len(parent.parts) < 3`), but `/opt/hermes` (the Docker install dir) has exactly 3 path parts and passes the guard. When any auth file is written directly under `/opt/hermes`, the dir gets chmod'd to 0700 and every new exec fails with "Permission denied" until manual `chmod 0755 /opt/hermes`. Observed in production twice (2026-07-06 and 2026-08-22).

## Changes
- **hermes_constants.py**: Replaced the contributor's hardcoded `str(parent) == "/opt/hermes"` with dynamic install-tree detection: `parent == Path(__file__).resolve().parent or _install_root in parent.parents`. This catches ALL install paths (Docker `/opt/hermes`, apt `/usr/local/lib/hermes-agent`, git clone, `/opt/hermes-custom`) and their subdirectories, not just the Docker top-level.
- **Dockerfile**: `chmod 0755 /opt/hermes /opt/hermes/bin/hermes` (from contributor's commit) — ensures fresh builds start with the install dir traversable.
- **tests/test_hermes_constants.py**: Added `test_install_tree_skipped` — verifies both the install root and subdirectories are excluded from chmod.
- **contributors/emails/**: Added mapping for `bradmarshall987@users.noreply.github.com`.

## Attribution
- Commit 1 (cherry-picked, original author preserved): @bradmarshall987's fix from #93050
- Commit 2 (follow-up): widened to dynamic install-tree detection + test + contributor mapping

## Validation
| | Before | After |
|---|---|---|
| Bug | `/opt/hermes` chmod'd to 0700 | Install tree + subdirs skipped |
| Install paths covered | Only `/opt/hermes` | All (dynamic via `__file__`) |
| Tests | 3 in TestSecureParentDir | 4 (added install-tree skip) |
| Full suite | — | 62 passed, 5 skipped, 0 failed |
| Lint | — | ruff clean, ty clean |

Closes #93050
