### PR TITLE
fix(cli): fall back to input() when prompt_toolkit can't attach stdin

### DIFF
--- a/hermes_cli/cli_output.py
+++ b/hermes_cli/cli_output.py
@@ -61,12 +61,16 @@ def line_input(prompt_text: str) -> str:
 
     try:
         return prompt_toolkit_prompt(ANSI(prompt_text))
-    except OSError:
+    except (KeyboardInterrupt, EOFError):
+        raise
+    except Exception:
         # Some terminals report isatty() == True yet reject registering stdin
         # with the asyncio event-loop selector (observed on macOS, where kqueue
         # raises EINVAL / "Invalid argument" for fd 0). prompt_toolkit cannot
         # attach its input there, so fall back to the built-in line reader,
-        # which needs no selector and works in cooked mode.
+        # which needs no selector and works in cooked mode.  Any prompt_toolkit
+        # runtime failure (OSError, ValueError, RuntimeError) degrades the same
+        # way — the wizard proceeds instead of crashing.
         return input(prompt_text)
 
 

--- a/hermes_cli/cli_output.py
+++ b/hermes_cli/cli_output.py
@@ -59,7 +59,15 @@ def line_input(prompt_text: str) -> str:
     except ImportError:
         return input(prompt_text)
 
-    return prompt_toolkit_prompt(ANSI(prompt_text))
+    try:
+        return prompt_toolkit_prompt(ANSI(prompt_text))
+    except OSError:
+        # Some terminals report isatty() == True yet reject registering stdin
+        # with the asyncio event-loop selector (observed on macOS, where kqueue
+        # raises EINVAL / "Invalid argument" for fd 0). prompt_toolkit cannot
+        # attach its input there, so fall back to the built-in line reader,
+        # which needs no selector and works in cooked mode.
+        return input(prompt_text)
 
 
 def prompt(

--- a/tests/hermes_cli/test_cli_output.py
+++ b/tests/hermes_cli/test_cli_output.py
@@ -70,6 +70,30 @@ def test_line_input_falls_back_to_input_when_prompt_toolkit_raises_oserror(monke
     assert seen["prompt"] == "Choice [1/2]: "
 
 
+def test_line_input_falls_back_to_input_on_any_prompt_toolkit_failure(monkeypatch):
+    """Any prompt_toolkit runtime failure — not just OSError — degrades to
+    input() so the wizard keeps running.  ValueError and RuntimeError can
+    arise from exotic stream wrappers or event-loop issues that share the
+    same root cause: prompt_toolkit cannot attach stdin on this terminal.
+    """
+    seen = {}
+
+    def raising_prompt(*_args, **_kwargs):
+        raise ValueError("Invalid file descriptor")
+
+    def fake_input(prompt_text):
+        seen["prompt"] = prompt_text
+        return "fallback-value"
+
+    monkeypatch.setattr(cli_output.sys, "stdin", _TTY())
+    monkeypatch.setattr(cli_output.sys, "stdout", _TTY())
+    monkeypatch.setattr("prompt_toolkit.prompt", raising_prompt)
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    assert cli_output.line_input("Enter token: ") == "fallback-value"
+    assert seen["prompt"] == "Enter token: "
+
+
 def test_password_prompt_uses_masked_secret_prompt(monkeypatch):
     seen = {}
 

--- a/tests/hermes_cli/test_cli_output.py
+++ b/tests/hermes_cli/test_cli_output.py
@@ -42,6 +42,34 @@ def test_line_input_preserves_builtin_input_for_redirected_stdin(monkeypatch):
     assert seen["prompt"] == "Enter model name: "
 
 
+def test_line_input_falls_back_to_input_when_prompt_toolkit_raises_oserror(monkeypatch):
+    """isatty() can report True while the asyncio selector still rejects stdin.
+
+    Under a `curl ... | bash` install the setup wizard reattaches stdin from
+    /dev/tty, so isatty() is True and the guard above passes. prompt_toolkit
+    then fails to register fd 0 with the event-loop selector (observed on
+    macOS, where kqueue raises OSError EINVAL / "Invalid argument"). line_input
+    must degrade to the built-in reader instead of letting the OSError abort
+    the whole wizard.
+    """
+    seen = {}
+
+    def raising_prompt(*_args, **_kwargs):
+        raise OSError(22, "Invalid argument")
+
+    def fake_input(prompt_text):
+        seen["prompt"] = prompt_text
+        return "fallback-value"
+
+    monkeypatch.setattr(cli_output.sys, "stdin", _TTY())
+    monkeypatch.setattr(cli_output.sys, "stdout", _TTY())
+    monkeypatch.setattr("prompt_toolkit.prompt", raising_prompt)
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    assert cli_output.line_input("Choice [1/2]: ") == "fallback-value"
+    assert seen["prompt"] == "Choice [1/2]: "
+
+
 def test_password_prompt_uses_masked_secret_prompt(monkeypatch):
     seen = {}
 


### PR DESCRIPTION
## Summary

`hermes setup` no longer crashes when prompt_toolkit cannot attach stdin — it falls back to the built-in `input()` reader. On some terminals (macOS under `curl | bash`), `isatty()` returns True yet the asyncio kqueue selector rejects fd 0 with `EINVAL`, aborting the wizard.

## Changes

- `hermes_cli/cli_output.py`: Wrap `prompt_toolkit_prompt()` in `try/except Exception` (re-raising `KeyboardInterrupt`/`EOFError` first) so ANY prompt_toolkit runtime failure degrades to `input()` — matching the established pattern in `masked_secret_prompt`.
- `tests/hermes_cli/test_cli_output.py`: Two regression tests — OSError fallback (original) and ValueError fallback (wider catch).

## Validation

| | Before | After |
|---|---|---|
| OSError from prompt_toolkit | Wizard crashes | Falls back to `input()` |
| ValueError/RuntimeError | Wizard crashes | Falls back to `input()` |
| KeyboardInterrupt/EOFError | Propagated | Propagated (not swallowed) |
| Tests | 4 passed | 6 passed |

Salvage of #92782 by @wo-o — cherry-picked with authorship preserved, widened exception catch added as follow-up.

Closes #92782
