### PR TITLE
chore: add cycorld to AUTHOR_MAP

### DIFF
--- a/contributors/emails/cycorld.com@gmail.com
+++ b/contributors/emails/cycorld.com@gmail.com
@@ -1,0 +1,1 @@
+cycorld


### PR DESCRIPTION
## Summary
Adds contributor email mapping for @cycorld (cycorld.com@gmail.com) ahead of salvaging PR #92189.

Must merge BEFORE #93762 — the contributor attribution check runs against main.