### PR TITLE
fix(backup): exclude .npm/.bun caches from the backup walk

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -99,6 +99,13 @@ _EXCLUDED_DIRS = {
     # invocation the agent runs populates ``.npm/`` and ``.bun/`` inside the
     # walked tree (#93760) — regenerable caches that otherwise ship in every
     # backup (measured at 82% of one install's payload).
+    #
+    # Intent: caches, not configuration. Matching below is by path
+    # component (same semantics as every name in this set): any directory
+    # named ``.npm``/``.bun`` at any depth is skipped — a stray *file* with
+    # that name is skipped too, since component matching cannot tell them
+    # apart. Don't extend this set with user-data dirs (e.g. ``.vscode``)
+    # without measuring payload share like #93760 did.
     ".npm",
     ".bun",
 }

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -94,6 +94,13 @@ _EXCLUDED_DIRS = {
     ".pytest_cache",
     ".mypy_cache",
     ".ruff_cache",
+    # JS package-manager caches. With ``terminal.home_mode`` pointing a
+    # profile's subprocess HOME at ``{HERMES_HOME}/home``, every npm/npx/bun
+    # invocation the agent runs populates ``.npm/`` and ``.bun/`` inside the
+    # walked tree (#93760) — regenerable caches that otherwise ship in every
+    # backup (measured at 82% of one install's payload).
+    ".npm",
+    ".bun",
 }
 
 # File-name suffixes to skip

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -158,6 +158,17 @@ class TestShouldExclude:
         # The .db itself is still included (and safe-copied separately)
         assert not _should_exclude(Path("state.db"))
 
+    def test_excludes_js_package_manager_caches(self):
+        """npm/bun caches must not ship: with terminal.home_mode pointing a
+        profile subprocess HOME at {HERMES_HOME}/home, every npm/npx/bun
+        invocation populates .npm/ and .bun/ inside the walked tree (#93760)
+        — regenerable caches, not state."""
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path(".npm/_cacache/content-v2/ab/cd/entry"))
+        assert _should_exclude(Path("home/.npm/_logs/2026-08-24.log"))
+        assert _should_exclude(Path(".bun/install/cache/zstd"))
+        assert _should_exclude(Path("profiles/coder/.bun/install/cache/x"))
+
 
 # ---------------------------------------------------------------------------
 # Backup tests

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -168,6 +168,11 @@ class TestShouldExclude:
         assert _should_exclude(Path("home/.npm/_logs/2026-08-24.log"))
         assert _should_exclude(Path(".bun/install/cache/zstd"))
         assert _should_exclude(Path("profiles/coder/.bun/install/cache/x"))
+        # Matching is by path component, so a stray file *named* like the
+        # cache dir is skipped as well — component checks can't tell a
+        # dotfile from a dot-directory. A near-miss component stays included.
+        assert _should_exclude(Path("docs/.npm"))
+        assert not _should_exclude(Path("npm/notes.txt"))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`_EXCLUDED_DIRS` in `hermes_cli/backup.py` pruned regenerable dependency and cache directories from the backup walk but was missing `.npm` and `.bun`. On installs where a profile's subprocess `HOME` resolves to `{HERMES_HOME}/home` (per `terminal.home_mode`), every `npm`/`npx`/`bun` invocation the agent makes populates those caches inside the walked tree — regenerable data that then ships in every backup (the reporter measured it at 82% of their install's payload). This adds both directories to the exclusion set, with the mechanism documented in a comment, matching the set's existing style.

## Related Issue

Fixes #93760

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `hermes_cli/backup.py` — `.npm` and `.bun` added to `_EXCLUDED_DIRS` with a comment naming the `terminal.home_mode` population path and #93760. The set is a single definition consumed by all four walk sites in the file, so every backup path is covered.
- `tests/hermes_cli/test_backup.py` — new `test_excludes_js_package_manager_caches` in `TestShouldExclude`: `.npm`/`.bun` contents at the tree root, under `home/`, and under a named profile are all excluded.

## How to Test

- New: `.venv/bin/python -m pytest tests/hermes_cli/test_backup.py::TestShouldExclude -q` — should pass (5 tests). On unpatched `main`, the new test fails (`.npm`/`.bun` paths are not excluded), pinning the regression.
- Regression: `.venv/bin/python -m pytest tests/hermes_cli/test_backup.py -q` — should pass except one pre-existing unrelated failure (`TestSafeCopyDb::test_locked_source_fails_fast_not_hang` fails identically on clean `main` in this environment; SQLite lock-behavior test, no overlap with the exclusion set).

Observed result: locally, all `TestShouldExclude` cases pass with the fix and the new test fails without it; the rest of the backup suite is unchanged apart from the pre-existing lock-test environment failure.

## Checklist

- [x] Code follows project style (no unrelated changes)
- [x] Self-reviewed the diff
- [x] Added/updated tests covering the fix
- [x] All new and existing tests pass locally (56 passed; 1 pre-existing environment failure identical on clean `main`)
- [x] PR targets `upstream/main` from a fork branch
