### PR TITLE
fix(desktop): keep remote chats sendable after session reap

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -3271,6 +3271,61 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID, text: 'message after wake' })
   })
 
+  it('publishes the recovered runtime binding before retrying through the remote owner router', async () => {
+    // The window-level request router translates runtime ids back to stored ids
+    // before choosing an owning remote gateway. session.resume returns a brand
+    // new runtime id, so the retry must publish that binding first; otherwise
+    // the router treats the short runtime id as a stored id, misses its owner,
+    // and falls back to the ambient (wrong) gateway with another 4001.
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    let bindingPublished = false
+    let submitAttempts = 0
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'prompt.submit') {
+        submitAttempts += 1
+
+        if (submitAttempts === 1) {
+          throw new JsonRpcGatewayError('session not found', { code: 4001 })
+        }
+
+        if (!bindingPublished) {
+          throw new JsonRpcGatewayError('session not found on ambient gateway', { code: 4001 })
+        }
+
+        return {} as never
+      }
+
+      if (method === 'session.resume') {
+        return { session_id: RECOVERED_SESSION_ID } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onUpdateState={(runtimeId, storedId) => {
+          if (runtimeId === RECOVERED_SESSION_ID && storedId === STORED_SESSION_ID) {
+            bindingPublished = true
+          }
+        }}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        storedSessionId={STORED_SESSION_ID}
+      />
+    )
+
+    expect(await handle!.submitText('remote follow-up after reap')).toBe(true)
+    expect(bindingPublished).toBe(true)
+    expect(calls.map(call => call.method)).toEqual(['prompt.submit', 'session.resume', 'prompt.submit'])
+    expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID, text: 'remote follow-up after reap' })
+  })
+
   it('resumes the stored session and retries once when reloadFromMessage (regenerate) reports "session not found"', async () => {
     // reloadFromMessage builds its own prompt.submit call inline instead of
     // going through the shared send() path submitText/redirectPrompt use, so

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -775,9 +775,20 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
               onRecovered: recoveredId => {
                 if (onRuntimeRecovered) {
                   onRuntimeRecovered(recoveredId)
-                } else if (targetIsCurrentView()) {
-                  activeSessionIdRef.current = recoveredId
-                  setActiveSessionId(recoveredId)
+                } else {
+                  // Publish stored→runtime ownership before the helper retries
+                  // prompt.submit. The window router needs this binding to keep
+                  // the fresh runtime on its owning remote gateway; without it,
+                  // the retry treats the short id as a stored id and falls back
+                  // to the ambient backend with another 4001 (#93744).
+                  if (recoverStoredSessionId) {
+                    updateSessionState(recoveredId, state => state, recoverStoredSessionId)
+                  }
+
+                  if (targetIsCurrentView()) {
+                    activeSessionIdRef.current = recoveredId
+                    setActiveSessionId(recoveredId)
+                  }
                 }
               }
             },


### PR DESCRIPTION
## What does this PR do?

Remote Desktop chats can accept the first turn, lose their in-memory runtime after a WebSocket orphan reap, and then reject every follow-up with `4001 session not found` even though the durable conversation still exists. This change publishes the fresh runtime-to-stored-session binding before retrying `prompt.submit`, so the window request router sends that retry back to the remote gateway that owns the chat instead of falling through to the ambient backend.

### Symptom

A Desktop client connected to a remote gateway completes the first message. After the runtime is detached and reaped, the next message reports `session not found` and is not appended to the existing conversation.

### Impact

Users cannot continue an affected remote conversation until its runtime binding is restored by another path. The stored transcript remains intact, but follow-up messages are dropped.

### Bug Cause

**Trigger:** `apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts` / the `withSessionNotFoundResume` recovery callback.

**Causal chain:**
1. `prompt.submit` targets a stale runtime id after the remote gateway has reaped that runtime.
2. `session.resume` correctly returns a fresh runtime id, but the main chat path updates only the active runtime ref and atom before retrying.
3. The window request router cannot translate the fresh runtime id back to its stored session, treats it as a stored id, misses the remote owner, and falls back to the ambient gateway. The retry receives another `4001`.

**Why it is wrong:** The recovered runtime becomes usable before its ownership mapping becomes visible to the routing boundary that dispatches the immediate retry.

**Working sibling / contrast:** Session tiles provide `onRuntimeRecovered`, which publishes their recovered runtime binding before retrying. The main chat fallback did not publish the equivalent binding.

**Ruled out:** The JSON-RPC error classifier already recognizes `session not found`, and the resume helper already performs a bounded resume-then-retry. The failing regression test confirms the missing step is ownership publication between those two RPCs.

### Fix

Publish the recovered stored-session/runtime relationship through `updateSessionState` before the retry. Preserve the existing foreground-only active-session update, while also making background recovery routable without retargeting the visible chat. Add a regression that rejects the retry unless the binding is published first, matching the remote owner router's contract.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts` - publish recovered runtime ownership before retrying a session-scoped request.
- `apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx` - cover remote owner routing across stale-runtime recovery.

## How to Test

1. Connect Desktop to a remote gateway and open a persisted conversation.
2. Let its WebSocket-owned runtime detach and pass the configured orphan-reap grace period.
3. Send a follow-up and verify it resumes the same stored conversation without a `4001`.
4. Run the automated regression and Desktop typecheck:

```bash
cd apps/desktop
npx vitest run src/app/session/hooks/use-prompt-actions/index.test.tsx
npm run typecheck
```

Local result: 125 tests passed; TypeScript typecheck passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant test entry and all tests pass
- [x] I've added tests for my changes
- [x] I've tested the automated recovery contract on Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; the user-facing contract is unchanged
- [x] Config example update is N/A; no config keys changed
- [x] Architecture guide update is N/A; the existing session identity contract is preserved
- [x] I've considered cross-platform impact; the renderer state/routing change is platform-independent
- [x] Tool description/schema updates are N/A

## Screenshots / Logs

The focused regression fails before the production change because the retry occurs without an owner binding, then passes after the binding is published. No UI screenshots are needed for this state-routing fix.
