### PR TITLE
feat(gateway): carry command metadata through reset

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -56,6 +56,9 @@ import yaml
 from hermes_cli.config import get_hermes_home
 
 
+COMMAND_REWRITE_METADATA_SUPPORTED = True
+
+
 HOOKS_DIR = get_hermes_home() / "hooks"
 
 

--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -18,6 +18,14 @@ Events:
 
 Errors in hooks are caught and logged but never block the main pipeline.
 
+Recognized gateway ``command:<name>`` hooks run after user authorization and
+slash-command access control. They may return a decision dict. A ``rewrite``
+decision accepts ``command_name`` and ``raw_args`` plus an optional ``metadata``
+dict. Metadata is merged onto the in-flight message event, survives native
+destructive-command confirmation, and is exposed as ``command_metadata`` on
+``session:end``, ``session:reset``, and plugin ``on_session_reset`` only when the
+rewritten reset actually executes.
+
 Context dict passed to ``agent:start`` / ``agent:end`` handlers:
   platform     -- source platform name (e.g. "telegram", "matrix", "slack")
   user_id      -- platform user id of the sender

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17539,6 +17539,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             hook_ctx = {
                 "platform": source.platform.value if source.platform else "",
                 "user_id": source.user_id,
+                "session_key": _quick_key,
                 "command": canonical,
                 "raw_command": command,
                 "args": raw_args,
@@ -17576,6 +17577,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if not new_command:
                         continue
                     new_args = str(hook_result.get("raw_args", "")).strip()
+                    new_metadata = hook_result.get("metadata")
+                    if isinstance(new_metadata, dict):
+                        event.metadata = {
+                            **(event.metadata or {}),
+                            **new_metadata,
+                        }
                     event.text = f"/{new_command} {new_args}".strip()
                     command = event.get_command()
                     _cmd_def = _resolve_cmd(command) if command else None

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -266,6 +266,7 @@ class GatewaySlashCommandsMixin:
             "platform": source.platform.value if source.platform else "",
             "user_id": source.user_id,
             "session_key": session_key,
+            "command_metadata": dict(event.metadata or {}),
         })
 
         # Emit session:reset hook
@@ -273,6 +274,7 @@ class GatewaySlashCommandsMixin:
             "platform": source.platform.value if source.platform else "",
             "user_id": source.user_id,
             "session_key": session_key,
+            "command_metadata": dict(event.metadata or {}),
         })
 
         # Resolve session config info to surface to the user, scoped to the
@@ -337,6 +339,7 @@ class GatewaySlashCommandsMixin:
                 reason="new_session",
                 old_session_id=_old_sid,
                 new_session_id=_new_sid,
+                command_metadata=dict(event.metadata or {}),
             )
         except Exception:
             pass

--- a/tests/gateway/test_35994_reset_button_deadlock.py
+++ b/tests/gateway/test_35994_reset_button_deadlock.py
@@ -17,6 +17,7 @@ import threading
 import time
 from datetime import datetime
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -198,3 +199,46 @@ async def test_reset_completes_when_cleanup_times_out(caplog):
     ), "expected the timeout warning to be logged"
     runner.session_store.reset_session.assert_called_once()
     assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_reset_propagates_confirmed_command_metadata(monkeypatch):
+    """Only the event that actually reaches native reset emits its attached intent."""
+    runner = _make_runner_with_cached_agent(lambda: None)
+    event = _make_event("/new")
+    event.metadata = {
+        "session_commands": {"action": "newall", "nonce": "confirmed-nonce"}
+    }
+    lifecycle_calls = []
+    hook_emit = cast(AsyncMock, runner.hooks.emit)
+
+    monkeypatch.setattr(
+        "hermes_cli.lifecycle.invoke_hook",
+        lambda event_type, **context: lifecycle_calls.append((event_type, context)),
+    )
+
+    await runner._handle_reset_command(event)
+
+    reset_emits = [
+        call for call in hook_emit.await_args_list if call.args[0] == "session:reset"
+    ]
+    end_emits = [
+        call for call in hook_emit.await_args_list if call.args[0] == "session:end"
+    ]
+    assert len(end_emits) == 1
+    assert end_emits[0].args[1]["command_metadata"] == event.metadata
+    assert len(reset_emits) == 1
+    assert reset_emits[0].args[1]["command_metadata"] == event.metadata
+    assert lifecycle_calls == [
+        (
+            "on_session_reset",
+            {
+                "session_id": "sess-new",
+                "platform": "telegram",
+                "reason": "new_session",
+                "old_session_id": "sess-old",
+                "new_session_id": "sess-new",
+                "command_metadata": event.metadata,
+            },
+        )
+    ]

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -225,3 +225,77 @@ async def test_command_hook_rewrite_routes_to_plugin(monkeypatch):
     # First emit_collect fires on the original command; after rewrite the
     # dispatcher does NOT re-fire for the new command (one decision per turn).
     assert call_log == ["command:status"]
+
+
+@pytest.mark.asyncio
+async def test_command_hook_rewrite_carries_metadata_to_native_handler(monkeypatch):
+    """Authenticated command hooks can attach reset-time intent without disk markers."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    event = _make_event("/help")
+    event.metadata = {"existing": {"keep": True}}
+    expected_key = build_session_key(event.source)
+    seen_context = {}
+    seen_metadata = {}
+
+    async def _emit_collect(event_type, ctx):
+        if event_type == "command:help":
+            seen_context.update(ctx)
+            return [
+                {
+                    "decision": "rewrite",
+                    "command_name": "status",
+                    "raw_args": "",
+                    "metadata": {
+                        "session_commands": {"action": "newall", "nonce": "n1"}
+                    },
+                }
+            ]
+        return []
+
+    async def _status_handler(event):
+        seen_metadata.update(event.metadata)
+        return "status ok"
+
+    runner.hooks.emit_collect = AsyncMock(side_effect=_emit_collect)
+    runner._handle_status_command = _status_handler
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == "status ok"
+    assert seen_context["session_key"] == expected_key
+    assert seen_metadata == {
+        "existing": {"keep": True},
+        "session_commands": {"action": "newall", "nonce": "n1"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_command_cannot_attach_rewrite_metadata(monkeypatch):
+    """Command hooks are post-auth: rejected senders cannot mutate event state."""
+    runner = _make_runner()
+    runner._is_user_authorized = (
+        lambda source, *, allow_adapter_delegation=True: False
+    )
+    runner._get_unauthorized_dm_behavior = lambda *_args, **_kwargs: "ignore"
+    event = _make_event("/status")
+
+    runner.hooks.emit_collect = AsyncMock(
+        return_value=[
+            {
+                "decision": "rewrite",
+                "command_name": "new",
+                "metadata": {"untrusted": {"action": "reset"}},
+            }
+        ]
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result is None
+    assert event.metadata == {}
+    runner.hooks.emit_collect.assert_not_awaited()

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -77,19 +77,37 @@ async def handle(event_type: str, context: dict):
 |-------|---------------|--------------|
 | `gateway:startup` | Gateway process starts | `platforms` (list of active platform names) |
 | `session:start` | New messaging session created | `platform`, `user_id`, `session_id`, `session_key` |
-| `session:end` | Session ended (before reset) | `platform`, `user_id`, `session_key` |
-| `session:reset` | User ran `/new` or `/reset` | `platform`, `user_id`, `session_key` |
+| `session:end` | Session ended (before reset) | `platform`, `user_id`, `session_key`, `command_metadata` |
+| `session:reset` | User ran `/new` or `/reset` | `platform`, `user_id`, `session_key`, `command_metadata` |
 | `session:compress` | Context compression completed for a session | `platform`, `session_id`, `old_session_id` (empty when compacted in place), `in_place` (bool — `true` = transcript compacted on the same id, `false` = rotated from `old_session_id`), `compression_count` |
 | `agent:start` | Agent begins processing a message | `platform`, `user_id`, `chat_id`, `thread_id` (forum-topic / thread root id; empty when not in a thread), `chat_type` (`"dm"` \| `"group"` \| `"forum"`; empty if unknown), `session_id`, `message` (truncated to 500 chars) |
 | `agent:step` | Each iteration of the tool-calling loop | `platform`, `user_id`, `session_id`, `iteration`, `tool_names` |
 | `agent:end` | Agent finishes processing | same keys as `agent:start`, plus `response` (truncated to 500 chars) |
 | `reaction:added` | An emoji reaction was added to a message the bot can see (Slack adapter currently). Requires the `reactions:read` scope + the `reaction_added` bot event subscription; the bot must be a member of the channel. | `platform`, `reaction`, `user_id`, `item_user_id`, `item_type`, `channel_id`, `message_ts`, `team_id`, `event_ts`, `raw_event` |
 | `reaction:removed` | An emoji reaction was removed from a message the bot can see. Requires the `reaction_removed` bot event subscription. | same shape as `reaction:added` |
-| `command:*` | Any slash command executed | `platform`, `user_id`, `command`, `args` |
+| `command:*` | Any recognized slash command, after authorization and slash-command access control | `platform`, `user_id`, `session_key`, `command`, `raw_command`, `args`, `raw_args` |
 
 #### Wildcard Matching
 
 Handlers registered for `command:*` fire for any `command:` event (`command:model`, `command:reset`, etc.). Monitor all slash commands with a single subscription.
+
+#### Command Decisions and Reset Metadata
+
+Recognized gateway command hooks may return a decision dict. `deny` blocks the command, `handled` returns the hook's message without core dispatch, and `rewrite` re-resolves `command_name` with `raw_args`. A rewrite may also return a `metadata` dict. Hermes merges that dict onto the in-flight message event, carries it through native destructive-command confirmation, and exposes it as `command_metadata` on `session:end`, `session:reset`, and the plugin `on_session_reset` hook only if the reset executes. Cancellation and expiry emit no reset event, so they cannot leak rewrite intent into a later command.
+
+```python
+def handle(event_type: str, context: dict):
+    if event_type != "command:archive-and-new":
+        return None
+    return {
+        "decision": "rewrite",
+        "command_name": "new",
+        "raw_args": context.get("raw_args", ""),
+        "metadata": {"my_plugin": {"action": "archive"}},
+    }
+```
+
+Use a namespaced top-level key such as `my_plugin` so independent hooks do not overwrite each other's metadata.
 
 :::tip Threaded replies
 A handler posting a follow-up message into the same Telegram forum topic should include `message_thread_id=int(thread_id)` when `chat_type == "forum"` and `thread_id` is non-empty.


### PR DESCRIPTION
## What does this PR do?

Allow authenticated gateway `command:<name>` hooks to attach namespaced metadata when rewriting a recognized command, then carry that metadata through native destructive-command confirmation into `session:end`, `session:reset`, and plugin `on_session_reset` only when the reset actually executes.

This gives external commands a confirmation-safe way to perform post-reset work without pre-confirmation marker files or private source patches.

## Related Issue

No exact issue found. #82775 is adjacent: it fixes plugin-command name normalization and authorization, while this change preserves metadata after the already-authorized command hook rewrites into native reset handling. The changes do not overlap.

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` adds the stable session key to command-hook context and merges a rewrite decision's optional `metadata` dict onto the in-flight message event.
- `gateway/slash_commands.py` exposes a copy of that event metadata to `session:end`, `session:reset`, and plugin `on_session_reset` after the native reset executes.
- `gateway/hooks.py` exposes an explicit capability flag and documents the authenticated decision contract and reset-time metadata lifecycle.
- The hooks user guide documents the external command contract.
- Gateway regressions cover metadata merge, authorization ordering, and confirmed-reset propagation.

Security boundary: command hooks still run only after gateway authorization and slash-command access control. Unauthorized senders never reach the hook. Cancellation and expiry never execute `_handle_reset_command`, so no reset event or post-reset plugin side effect fires.

## How to Test

1. Run `uv run --extra dev python -m pytest tests/gateway/test_unknown_command.py tests/gateway/test_35994_reset_button_deadlock.py -o addopts= -q` (11 passed).
2. Run the external `/newhf`, `/newall`, handoff, and session-command integration files with `HERMES_AGENT_TEST_ROOT` pointed at this checkout (34 passed, 1 expected mixed-deployment skip).
3. Run Ruff, `py_compile`, and `git diff --check` on the six changed files (all passed).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] `cli-config.yaml.example` is N/A because no config key changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no contributor workflow changed
- [x] I've considered cross-platform impact: the change is platform-neutral Python and adds no OS-specific calls
- [x] Tool descriptions/schemas are N/A because no tool schema changed

## Screenshots / Logs

N/A — no UI change.
