### PR TITLE
fix(desktop): refresh hidden Bot Chats after background writes

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -3,7 +3,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $changeEventsAvailable, notifySessionsChanged, resetLiveSync } from '@/store/live-sync'
-import { $activeSessionId, $selectedStoredSessionId, setBusy, setMessagingSessions, setSessions } from '@/store/session'
+import {
+  $activeSessionId,
+  $selectedStoredSessionId,
+  setBusy,
+  setMessagingSessions,
+  setSessionOwnerHint,
+  setSessions
+} from '@/store/session'
 import {
   $attentionSessionIds,
   $stalledSessionIds,
@@ -31,13 +38,13 @@ const { getLatestSessionMessages } = await import('@/hermes')
 const ACTIVE_RUNTIME_ID = 'runtime-active'
 const ACTIVE_STORED_ID = 'stored-active'
 
-function transcript(answer: string) {
+function transcript(answer: string, sessionId = ACTIVE_STORED_ID) {
   return {
     messages: [
       { content: 'question', role: 'user', timestamp: 1 },
       { content: answer, role: 'assistant', timestamp: 2 }
     ],
-    session_id: ACTIVE_STORED_ID
+    session_id: sessionId
   }
 }
 
@@ -140,11 +147,58 @@ describe('active transcript refresh', () => {
     vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('answer') as never)
   })
 
+  it('refreshes a hidden session through its unique complete owner route', async () => {
+    const hiddenStoredSessionId = 'hidden-bot-chat'
+    const ownerRoute = {
+      connectionId: 'ssh-bot-owner',
+      mode: 'remote' as const,
+      profile: 'bot-route',
+      targetProfile: 'bot-profile'
+    }
+    $changeEventsAvailable.set(true)
+    $activeSessionId.set(ACTIVE_RUNTIME_ID)
+    $selectedStoredSessionId.set(hiddenStoredSessionId)
+    setSessionOwnerHint(hiddenStoredSessionId, ownerRoute)
+    const fixture = makeRefresh(resolveActiveTranscriptSession)
+    fixture.selectedStoredSessionIdRef.current = hiddenStoredSessionId
+    vi.mocked(getLatestSessionMessages).mockResolvedValue(
+      transcript('hidden external answer', hiddenStoredSessionId) as never
+    )
+
+    renderSync(fixture.refresh, { activeStoredSessionId: hiddenStoredSessionId })
+
+    act(() => notifySessionsChanged())
+
+    await waitFor(() =>
+      expect(getLatestSessionMessages).toHaveBeenCalledWith(hiddenStoredSessionId, {
+        connectionId: ownerRoute.connectionId,
+        profile: ownerRoute.targetProfile
+      })
+    )
+    expect(fixture.states.get(ACTIVE_RUNTIME_ID)?.messages.at(-1)?.parts[0]).toMatchObject({
+      text: 'hidden external answer'
+    })
+  })
+
   it('refreshes a local/Desktop session when sessions.changed ticks', async () => {
     $changeEventsAvailable.set(true)
     $activeSessionId.set(ACTIVE_RUNTIME_ID)
     $selectedStoredSessionId.set(ACTIVE_STORED_ID)
-    setSessions([{ id: ACTIVE_STORED_ID, profile: 'desktop-profile', source: 'desktop' } as never])
+    setSessionOwnerHint(ACTIVE_STORED_ID, {
+      connectionId: 'stale-owner',
+      mode: 'remote',
+      profile: 'wrong-profile',
+      targetProfile: 'wrong-target'
+    })
+    setSessions([
+      {
+        connectionId: 'future-visible-owner',
+        id: ACTIVE_STORED_ID,
+        profile: 'desktop-profile',
+        source: 'desktop',
+        targetProfile: 'must-not-rewrite-visible-row'
+      } as never
+    ])
     const fixture = makeRefresh(resolveActiveTranscriptSession)
     vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('external answer') as never)
 
@@ -157,6 +211,7 @@ describe('active transcript refresh', () => {
         text: 'external answer'
       })
     )
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(ACTIVE_STORED_ID, 'desktop-profile')
   })
 
   it('does not add a periodic transcript poll to local/Desktop sessions', async () => {
@@ -239,6 +294,12 @@ describe('active transcript refresh', () => {
 
 describe('reconcileActiveTranscript', () => {
   it('resolves and hydrates a messaging session from the messaging sessions store', async () => {
+    setSessionOwnerHint(ACTIVE_STORED_ID, {
+      connectionId: 'stale-messaging-owner',
+      mode: 'remote',
+      profile: 'wrong-profile',
+      targetProfile: 'wrong-target'
+    })
     setMessagingSessions([{ id: ACTIVE_STORED_ID, profile: 'messaging-profile', source: 'telegram' } as never])
     const fixture = makeRefresh(resolveActiveTranscriptSession)
     vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('telegram answer') as never)
@@ -248,6 +309,85 @@ describe('reconcileActiveTranscript', () => {
     expect(getLatestSessionMessages).toHaveBeenCalledWith(ACTIVE_STORED_ID, 'messaging-profile')
     expect(fixture.states.get(ACTIVE_RUNTIME_ID)?.messages.at(-1)?.parts[0]).toMatchObject({
       text: 'telegram answer'
+    })
+  })
+
+  it('fails closed when a hidden session id has multiple owner hints', async () => {
+    const ambiguousStoredSessionId = 'ambiguous-hidden-chat'
+    setSessionOwnerHint(ambiguousStoredSessionId, {
+      connectionId: 'owner-a',
+      mode: 'remote',
+      profile: 'bot'
+    })
+    setSessionOwnerHint(ambiguousStoredSessionId, {
+      connectionId: 'owner-b',
+      mode: 'remote',
+      profile: 'bot'
+    })
+    const fixture = makeRefresh(resolveActiveTranscriptSession)
+    fixture.selectedStoredSessionIdRef.current = ambiguousStoredSessionId
+
+    await fixture.refresh()
+
+    expect(getLatestSessionMessages).not.toHaveBeenCalled()
+    expect(fixture.updateSessionState).not.toHaveBeenCalled()
+  })
+
+  it('uses the presentation profile when a hidden owner has no target profile', async () => {
+    const hiddenStoredSessionId = 'hidden-no-target'
+    setSessionOwnerHint(hiddenStoredSessionId, {
+      connectionId: 'owner-no-target',
+      mode: 'remote',
+      profile: 'presentation-profile'
+    })
+    const fixture = makeRefresh(resolveActiveTranscriptSession)
+    fixture.selectedStoredSessionIdRef.current = hiddenStoredSessionId
+
+    await fixture.refresh()
+
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(hiddenStoredSessionId, {
+      connectionId: 'owner-no-target',
+      profile: 'presentation-profile'
+    })
+  })
+
+  it('reads and publishes only the active hidden owner when another owner coexists', async () => {
+    const ownerAStoredSessionId = 'owner-a-chat'
+    const ownerBStoredSessionId = 'owner-b-hidden-chat'
+    const ownerBRoute = {
+      connectionId: 'owner-b',
+      mode: 'remote' as const,
+      profile: 'bot-route',
+      targetProfile: 'bot-b'
+    }
+    setSessions([{ id: ownerAStoredSessionId, profile: 'bot-a', source: 'desktop' } as never])
+    setSessionOwnerHint(ownerAStoredSessionId, {
+      connectionId: 'owner-a',
+      mode: 'remote',
+      profile: 'bot-route',
+      targetProfile: 'bot-a'
+    })
+    setSessionOwnerHint(ownerBStoredSessionId, ownerBRoute)
+    const fixture = makeRefresh(resolveActiveTranscriptSession)
+    fixture.selectedStoredSessionIdRef.current = ownerBStoredSessionId
+    vi.mocked(getLatestSessionMessages).mockResolvedValue(
+      transcript('owner B answer', ownerBStoredSessionId) as never
+    )
+
+    await fixture.refresh()
+
+    expect(getLatestSessionMessages).toHaveBeenCalledTimes(1)
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(ownerBStoredSessionId, {
+      connectionId: ownerBRoute.connectionId,
+      profile: ownerBRoute.targetProfile
+    })
+    expect(fixture.updateSessionState).toHaveBeenCalledWith(
+      ACTIVE_RUNTIME_ID,
+      expect.any(Function),
+      ownerBStoredSessionId
+    )
+    expect(fixture.states.get(ACTIVE_RUNTIME_ID)?.messages.at(-1)?.parts[0]).toMatchObject({
+      text: 'owner B answer'
     })
   })
 

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -2,7 +2,7 @@ import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
 import { graftRefreshedTailOntoBackfill } from '@/app/chat/transcript-backfill'
-import { getLatestSessionMessages } from '@/hermes'
+import { getLatestSessionMessages, type ProfileScope } from '@/hermes'
 import { preserveLocalAssistantErrors, sealOpenToolParts, toChatMessages } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { sessionMessagesSignature } from '@/lib/session-signatures'
@@ -16,9 +16,11 @@ import {
   $messagingSessions,
   $selectedStoredSessionId,
   $sessions,
+  getSessionOwnerHint,
   sessionMatchesStoredId,
   setCurrentCwd
 } from '@/store/session'
+import type { SessionProfileRoute } from '@/store/session-request-router'
 import {
   $sessionStates,
   publishSessionState,
@@ -30,15 +32,23 @@ import type { ClientSessionState } from '../../types'
 import type { GatewayRequester } from '../types'
 
 interface ActiveTranscriptSession {
+  ownerRoute?: SessionProfileRoute
   profile?: string | null
 }
 
-/** Resolve an active transcript from either local recents or messaging slices. */
+/** Resolve an active transcript from visible rows or its unique hidden owner. */
 export function resolveActiveTranscriptSession(storedSessionId: string): ActiveTranscriptSession | undefined {
-  return (
+  const visible =
     $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ??
     $messagingSessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
-  )
+
+  if (visible) {
+    return { profile: visible.profile }
+  }
+
+  const ownerRoute = getSessionOwnerHint(storedSessionId)
+
+  return ownerRoute ? { ownerRoute, profile: ownerRoute.profile } : undefined
 }
 
 export interface ActiveTranscriptRefreshDeps {
@@ -82,7 +92,13 @@ export async function reconcileActiveTranscript({
   requestSequenceRef.current = requestId
 
   try {
-    const latest = await getLatestSessionMessages(storedSessionId, stored.profile)
+    const profileScope: ProfileScope = stored.ownerRoute
+      ? {
+          connectionId: stored.ownerRoute.connectionId,
+          profile: stored.ownerRoute.targetProfile ?? stored.ownerRoute.profile
+        }
+      : stored.profile
+    const latest = await getLatestSessionMessages(storedSessionId, profileScope)
 
     if (
       requestId !== requestSequenceRef.current ||
@@ -93,7 +109,15 @@ export async function reconcileActiveTranscript({
       return
     }
 
-    const signatureKey = `${stored.profile ?? 'default'}:${storedSessionId}`
+    const signatureKey = stored.ownerRoute
+      ? JSON.stringify([
+          stored.ownerRoute.connectionId,
+          stored.ownerRoute.profile,
+          stored.ownerRoute.targetProfile ?? '',
+          stored.ownerRoute.mode ?? '',
+          storedSessionId
+        ])
+      : `${stored.profile ?? 'default'}:${storedSessionId}`
     const signature = sessionMessagesSignature(latest.messages)
 
     if (signatureRef.current.get(signatureKey) === signature) {


### PR DESCRIPTION
## What does this PR do?

A canonical Bot Mode `Bot Chat` can receive a reply outside the current renderer stream, persist it to the owning profile's `state.db`, and broadcast `sessions.changed`, while the visible main transcript stays stale until Desktop restarts.

The existing background-sync reconciliation already refreshes the active transcript on `sessions.changed`, but `resolveActiveTranscriptSession()` only resolves rows from `$sessions` and `$messagingSessions`. Canonical Bot Chats are intentionally `hidden=1`, so they are absent from both lists. Reconciliation therefore returns early without reading the persisted reply.

This change extends that existing resolution chain with the existing unique session-owner hint:

1. ordinary `$sessions` rows keep first priority;
2. `$messagingSessions` rows keep second priority;
3. only an otherwise-hidden session falls back to `getSessionOwnerHint()`;
4. ambiguous same-ID owner hints continue to fail closed.

For a hidden owner, the full `SessionProfileRoute` remains the identity/signature source while the REST transcript read receives the API's existing `ProfileScope` projection: `{ connectionId, profile: targetProfile ?? profile }`.

### Compatibility / why this is non-breaking

- Visible ordinary and messaging rows still call `getLatestSessionMessages(id, profileString)`.
- Their legacy signature key remains byte-identical.
- A visible row carrying future `connectionId` / `targetProfile` metadata is not reclassified as a hidden owner.
- No new polling, owner registry, API, persisted field, config key, dependency, or migration is introduced.
- Existing busy, request-sequence, active-session, stale-response, deduplication, and local-error guards are unchanged.

## Related Issue

Fixes #93604

### Related work (not a duplicate)

#93687 forces `session.resume` when the user explicitly switches bots, preventing a stale cached surface from satisfying the open-time hydration heuristic. This PR covers the separate path where the Bot Chat is already active and a background/external write emits `sessions.changed`; no new `openSession()` call occurs, so #93687's `forceResume` path does not run.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/contrib/hooks/use-background-sync.ts`
  - resolve hidden active transcripts through the existing unique owner hint after visible-session precedence;
  - project routed owners into the existing REST `ProfileScope`;
  - isolate hidden-owner transcript signatures without changing visible-session keys.
- `apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts`
  - cover hidden unique-owner refresh and `targetProfile` projection;
  - cover no-target fallback, ambiguous owner fail-closed behavior, visible/messaging precedence, and cross-owner isolation;
  - prove visible rows retain the legacy string scope even if connection metadata is present.

## How to Test

Automated focused regression:

```bash
cd apps/desktop
npm run test:ui -- src/app/contrib/hooks/use-background-sync.test.ts
# 20 passed

npm run typecheck
npm run build
```

Real Windows 11 Electron E2E, using an isolated `HERMES_HOME` and the repository Playwright fixture:

1. Create `default` and `bot-b` through the real Desktop UI.
2. Open both through the real Bot Mode roster, creating canonical `Bot Chat` sessions.
3. Verify both persisted rows are `hidden=1`, `title=Bot Chat` in separate profile databases.
4. Externally persist an owner-A reply and verify the active owner-B transcript does not display it.
5. Externally persist an owner-B reply; the real file watcher emits `sessions.changed` and the visible B transcript refreshes without switching bots or restarting Desktop.

Observed results on exact SHA `233bfee8ebc4dfa8d5f85486bf06356eb83ea926`:

- focused background-sync regression: **20/20 passed**;
- Desktop TypeScript typecheck (renderer, Electron, E2E): **passed**;
- production build + dist assertion: **passed**;
- shipped Electron boot baseline: **5/5 passed**;
- real dual-owner hidden Bot Chat E2E: **1/1 passed**;
- independent Claude Code exact-SHA review: **PASS**;
- independent Codex exact-SHA review: **PASS**;
- `git diff --check`: **passed**.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: Desktop TypeScript-only change; relevant Desktop gates are listed above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; this restores the existing refresh contract
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A; no architecture or workflow changed
- [x] Cross-platform impact considered: the production change is renderer TypeScript with no OS-specific behavior
- [x] Tool description/schema update is N/A

## Screenshots / Logs

No user-facing layout change. The real Electron E2E validates the persisted hidden-session state and visible transcript transition described above.
