### PR TITLE
fix(web): make keyless opt-out an authoritative egress gate

### DIFF
--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -19,12 +19,18 @@ provider configured as ``web.extract_backend`` falls through):
 from __future__ import annotations
 
 import logging
+import threading
+import time
 from typing import Optional
 
 from agent.provider_registry import ProviderRegistry, is_available_safe
 from agent.web_search_provider import WebSearchProvider
 
 logger = logging.getLogger(__name__)
+
+_KEYLESS_POLICY_WARNING_COOLDOWN_SECONDS = 300.0
+_keyless_policy_warning_at: dict[str, float] = {}
+_keyless_policy_warning_lock = threading.Lock()
 
 
 _registry: ProviderRegistry[WebSearchProvider] = ProviderRegistry(
@@ -139,6 +145,20 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
     return None
 
 
+def _warn_keyless_policy(reason: str, message: str, *args: object) -> None:
+    """Warn once per cooldown when malformed policy disables keyless web."""
+    now = time.monotonic()
+    with _keyless_policy_warning_lock:
+        last_warning = _keyless_policy_warning_at.get(reason)
+        if (
+            last_warning is not None
+            and now - last_warning < _KEYLESS_POLICY_WARNING_COOLDOWN_SECONDS
+        ):
+            return
+        _keyless_policy_warning_at[reason] = now
+    logger.warning(message, *args)
+
+
 def _keyless_tier_enabled() -> bool:
     """Read the authoritative anonymous-egress policy from config.yaml.
 
@@ -152,16 +172,37 @@ def _keyless_tier_enabled() -> bool:
 
         config = load_config()
         if not isinstance(config, dict):
+            _warn_keyless_policy(
+                "config-root",
+                "Keyless web fallback disabled: config root must be a mapping, got %s",
+                type(config).__name__,
+            )
             return False
         web_cfg = config.get("web")
         if web_cfg is None:
             return True
         if not isinstance(web_cfg, dict):
+            _warn_keyless_policy(
+                "web-section",
+                "Keyless web fallback disabled: web config must be a mapping, got %s",
+                type(web_cfg).__name__,
+            )
             return False
         value = web_cfg.get("keyless_fallback", True)
-        return value if isinstance(value, bool) else False
+        if isinstance(value, bool):
+            return value
+        _warn_keyless_policy(
+            "keyless-value",
+            "Keyless web fallback disabled: web.keyless_fallback must be boolean, got %s",
+            type(value).__name__,
+        )
+        return False
     except Exception as exc:  # noqa: BLE001 — config layer optional
-        logger.debug("keyless_fallback config read failed: %s", exc)
+        _warn_keyless_policy(
+            "config-read",
+            "Keyless web fallback disabled: could not read configuration (%s)",
+            type(exc).__name__,
+        )
         return False
 
 

--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -140,15 +140,29 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
 
 
 def _keyless_tier_enabled() -> bool:
-    """Read ``web.keyless_fallback`` from config.yaml (default: enabled)."""
+    """Read the authoritative anonymous-egress policy from config.yaml.
+
+    A valid config with no explicit setting retains the fresh-install default
+    (enabled).  Invalid/unavailable policy state fails closed: inability to
+    establish the user's opt-out state is not permission to send queries or
+    URLs to anonymous third-party endpoints.
+    """
     try:
         from hermes_cli.config import load_config
 
-        web_cfg = load_config().get("web") or {}
-        return bool(web_cfg.get("keyless_fallback", True))
+        config = load_config()
+        if not isinstance(config, dict):
+            return False
+        web_cfg = config.get("web")
+        if web_cfg is None:
+            return True
+        if not isinstance(web_cfg, dict):
+            return False
+        value = web_cfg.get("keyless_fallback", True)
+        return value if isinstance(value, bool) else False
     except Exception as exc:  # noqa: BLE001 — config layer optional
         logger.debug("keyless_fallback config read failed: %s", exc)
-        return True
+        return False
 
 
 def _disabled_web_plugin_for(configured: Optional[str] = None, *, capability: Optional[str] = None) -> Optional[str]:

--- a/plugins/web/keyless_mcp.py
+++ b/plugins/web/keyless_mcp.py
@@ -82,7 +82,10 @@ def keyless_enabled() -> bool:
         return _keyless_tier_enabled()
     except Exception as exc:  # noqa: BLE001 — resolver optional in stripped envs
         logger.debug("keyless_enabled(): registry helper unavailable: %s", exc)
-        return True
+        # Anonymous third-party egress needs positive policy evidence.  If the
+        # config authority cannot be reached, do not interpret that failure as
+        # permission to transmit the user's query or URLs.
+        return False
 
 
 _BACKEND_KEYS = ("backend", "search_backend", "extract_backend")
@@ -108,12 +111,31 @@ def provider_tier(name: str) -> str:
 
 
 def use_keyless(name: str, api_key: str) -> bool:
-    """Single chokepoint for search + extract: ``free`` → keyless even with a key; ``paid`` → keyed even
-    without one (the keyed path raises its usual missing-key error); ``auto`` → keyless only when no key + tier enabled."""
+    """Decide whether provider *name* should route via the keyless endpoint.
+
+    Single chokepoint shared by the Exa/Parallel search + extract paths so
+    tier semantics can't drift between capabilities:
+
+    - ``web.keyless_fallback: false`` → keyed, regardless of provider tier
+    - tier ``free``  → keyless, even when *api_key* is set, while the global
+      keyless policy is enabled
+    - tier ``paid``  → keyed, even when *api_key* is missing (the keyed
+      path then raises its usual missing-key error)
+    - tier ``auto``  → keyed when *api_key* is set; otherwise keyless when
+      ``web.keyless_fallback`` is enabled
+    """
+    # The global switch is an authoritative egress gate, not merely an
+    # auto-detection preference.  Check it before the explicit ``free`` tier
+    # so an operator/admin opt-out cannot be bypassed by a stale picker value.
+    if not keyless_enabled():
+        return False
+
     tier = provider_tier(name)
-    if tier in ("free", "paid"):
-        return tier == "free"
-    return not api_key and keyless_enabled()
+    if tier == "free":
+        return True
+    if tier == "paid":
+        return False
+    return not api_key
 
 
 # --- MCP transport ------------------------------------------------------------

--- a/tests/tools/test_web_keyless_fallback.py
+++ b/tests/tools/test_web_keyless_fallback.py
@@ -213,6 +213,31 @@ class TestProviderRouting:
         assert out["success"] is False
         assert "PARALLEL_API_KEY" in out["error"]
 
+    def test_keyless_disabled_overrides_explicit_free_tier(self, monkeypatch):
+        """The global switch is an egress gate, not an auto-mode preference."""
+        monkeypatch.setattr(registry, "_keyless_tier_enabled", lambda: False)
+        monkeypatch.setattr(keyless_mcp, "provider_tier", lambda _name: "free")
+        provider = ParallelWebSearchProvider()
+
+        with patch.object(keyless_mcp, "search_with_failover") as keyless:
+            out = provider.search("must stay local")
+
+        keyless.assert_not_called()
+        assert out["success"] is False
+        assert "PARALLEL_API_KEY" in out["error"]
+
+    @pytest.mark.parametrize(
+        "vendor", ["exa", "parallel", "tavily", "firecrawl", "keenable"]
+    )
+    def test_global_disable_blocks_every_explicit_free_vendor(
+        self, monkeypatch, vendor
+    ):
+        monkeypatch.setattr(keyless_mcp, "keyless_enabled", lambda: False)
+        monkeypatch.setattr(keyless_mcp, "provider_tier", lambda _name: "free")
+
+        assert keyless_mcp.use_keyless(vendor, "") is False
+        assert keyless_mcp.use_keyless(vendor, "configured-key") is False
+
     def test_is_available_stays_false_keyless(self):
         # Keyless tier must NOT leak into is_available() (legacy walk order).
         assert ParallelWebSearchProvider().is_available() is False
@@ -225,6 +250,7 @@ class TestProviderRouting:
             "agent.web_search_provider.get_provider_env",
             lambda name: "sk-real" if name == "PARALLEL_API_KEY" else "",
         )
+        monkeypatch.setattr(keyless_mcp, "keyless_enabled", lambda: True)
         monkeypatch.setattr(keyless_mcp, "provider_tier", lambda name: "free")
         provider = ParallelWebSearchProvider()
         with patch.object(
@@ -258,8 +284,16 @@ class TestProviderRouting:
         assert keyless_mcp.provider_tier("parallel") == "auto"  # invalid → auto
         assert keyless_mcp.provider_tier("keenable") == "auto"  # unset → auto
 
+    def test_keyless_enabled_fails_closed_when_policy_helper_raises(self, monkeypatch):
+        def _unavailable():
+            raise RuntimeError("config authority unavailable")
+
+        monkeypatch.setattr(registry, "_keyless_tier_enabled", _unavailable)
+        assert keyless_mcp.keyless_enabled() is False
+
     @pytest.mark.asyncio
     async def test_parallel_keyless_extract(self, monkeypatch):
+        monkeypatch.setattr(keyless_mcp, "keyless_enabled", lambda: True)
         monkeypatch.setattr(keyless_mcp, "_vendor_pinned", lambda n: n == "parallel")
         provider = ParallelWebSearchProvider()
         with patch.dict(
@@ -269,6 +303,40 @@ class TestProviderRouting:
             out = await provider.extract(["https://a"])
         assert out[0]["content"] == "c"
 
+
+class TestKeylessPolicyConfig:
+    @pytest.mark.parametrize("config", [{}, {"web": {}}, {"web": None}])
+    def test_valid_absent_setting_keeps_fresh_install_default(self, monkeypatch, config):
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+        assert registry._keyless_tier_enabled() is True
+
+    def test_explicit_false_disables(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"web": {"keyless_fallback": False}},
+        )
+        assert registry._keyless_tier_enabled() is False
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            None,
+            [],
+            {"web": "invalid"},
+            {"web": {"keyless_fallback": "false"}},
+            {"web": {"keyless_fallback": 1}},
+        ],
+    )
+    def test_malformed_policy_state_fails_closed(self, monkeypatch, config):
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+        assert registry._keyless_tier_enabled() is False
+
+    def test_config_read_failure_fails_closed(self, monkeypatch):
+        def _unreadable():
+            raise OSError("permission denied")
+
+        monkeypatch.setattr("hermes_cli.config.load_config", _unreadable)
+        assert registry._keyless_tier_enabled() is False
 
 # ---------------------------------------------------------------------------
 # Registry + _get_backend resolution order

--- a/tests/tools/test_web_keyless_fallback.py
+++ b/tests/tools/test_web_keyless_fallback.py
@@ -10,6 +10,7 @@ Covers:
 """
 
 import json
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -305,6 +306,14 @@ class TestProviderRouting:
 
 
 class TestKeylessPolicyConfig:
+    @pytest.fixture(autouse=True)
+    def _reset_policy_warning_throttle(self):
+        with registry._lock:
+            registry._keyless_policy_warning_at.clear()
+        yield
+        with registry._lock:
+            registry._keyless_policy_warning_at.clear()
+
     @pytest.mark.parametrize("config", [{}, {"web": {}}, {"web": None}])
     def test_valid_absent_setting_keeps_fresh_install_default(self, monkeypatch, config):
         monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
@@ -337,6 +346,49 @@ class TestKeylessPolicyConfig:
 
         monkeypatch.setattr("hermes_cli.config.load_config", _unreadable)
         assert registry._keyless_tier_enabled() is False
+
+    @pytest.mark.parametrize(
+        ("config", "message"),
+        [
+            (None, "config root must be a mapping"),
+            ({"web": "invalid"}, "web config must be a mapping"),
+            (
+                {"web": {"keyless_fallback": "false"}},
+                "web.keyless_fallback must be boolean",
+            ),
+        ],
+    )
+    def test_malformed_policy_warning_is_throttled(
+        self, monkeypatch, caplog, config, message
+    ):
+        monotonic_values = iter((10.0, 11.0, 311.0))
+        monkeypatch.setattr(registry.time, "monotonic", lambda: next(monotonic_values))
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+
+        with caplog.at_level(logging.WARNING, logger=registry.__name__):
+            assert registry._keyless_tier_enabled() is False
+            assert registry._keyless_tier_enabled() is False
+            assert registry._keyless_tier_enabled() is False
+
+        matching = [record for record in caplog.records if message in record.message]
+        assert len(matching) == 2
+        assert all(
+            "Keyless web fallback disabled" in record.message for record in matching
+        )
+
+    def test_config_read_failure_warns_without_exposing_error_text(
+        self, monkeypatch, caplog
+    ):
+        def _unreadable():
+            raise OSError("secret path")
+
+        monkeypatch.setattr("hermes_cli.config.load_config", _unreadable)
+        with caplog.at_level(logging.WARNING, logger=registry.__name__):
+            assert registry._keyless_tier_enabled() is False
+
+        assert "could not read configuration (OSError)" in caplog.text
+        assert "secret path" not in caplog.text
+
 
 # ---------------------------------------------------------------------------
 # Registry + _get_backend resolution order


### PR DESCRIPTION
## Summary

`web.keyless_fallback: false` is now an authoritative gate for anonymous web egress.

- The global opt-out is checked before an explicit `provider_tier: free`, so a stale or deliberate Free selection cannot bypass it.
- A valid config with no setting keeps the fresh-install default enabled.
- Unreadable or malformed policy state fails closed instead of being treated as permission to send queries or URLs to third-party endpoints.
- The shared `use_keyless()` chokepoint applies the policy to all five ring vendors and to both search and extract paths.

## Root cause

The docs describe `web.keyless_fallback: false` as disabling the whole keyless tier, but `use_keyless()` returned `True` for an explicit Free tier before consulting the global setting. Both policy helpers also returned `True` when config resolution raised.

This is a focused follow-up to the egress-policy finding on #90313: https://github.com/NousResearch/hermes-agent/pull/90313#pullrequestreview-4977946665

## Validation

- `scripts/run_tests.sh tests/tools/test_web_keyless_fallback.py tests/tools/test_web_keyless_rescue.py tests/tools/test_web_providers.py tests/tools/test_web_tools_tavily.py -q` — 102 passed
- `tests/plugins/web` + tools-config neighbors — 124 passed; 2 unrelated Parallel SDK tests fail identically on unmodified `origin/main` because the local test environment has lazy installs disabled and lacks `parallel-web`
- `ruff check` on all three changed files — passed
- `git diff --check` — passed

Regression coverage includes explicit-Free plus global-false through a real provider, all five vendor names through the shared routing decision, absent valid config, malformed policy shapes, and config read failure.
