### PR TITLE
fix(docker): keep persistent container state shared across sessions

### DIFF
--- a/tests/tools/test_shared_container_task_id.py
+++ b/tests/tools/test_shared_container_task_id.py
@@ -117,6 +117,42 @@ def test_no_session_key_still_defaults(monkeypatch):
     assert terminal_tool._resolve_container_task_id(None) == "default"
 
 
+def test_persistent_docker_ignores_gateway_session_key(monkeypatch):
+    """Persistent Docker keeps one sandbox across gateway sessions."""
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "true")
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+
+    for session_key in ("gateway-A", "gateway-B"):
+        tokens = set_session_vars(session_key=session_key)
+        try:
+            assert terminal_tool._resolve_container_task_id(None) == "default"
+            assert terminal_tool._resolve_container_task_id("subagent-A") == "default"
+        finally:
+            clear_session_vars(tokens)
+
+
+def test_nonpersistent_docker_keeps_gateway_sessions_isolated(monkeypatch):
+    """Non-persistent Docker still assigns a distinct key per session."""
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "false")
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+
+    resolved = []
+    for session_key in ("gateway-A", "gateway-B"):
+        tokens = set_session_vars(session_key=session_key)
+        try:
+            resolved.append(terminal_tool._resolve_container_task_id(None))
+        finally:
+            clear_session_vars(tokens)
+
+    assert resolved == ["session:gateway-A", "session:gateway-B"]
+
+
 # --- Production gateway path: session key bound via ContextVars ---------------
 #
 # The tests above set HERMES_SESSION_KEY through os.environ, which only

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1429,8 +1429,16 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
     """
     if task_id and _has_isolation_overrides(task_id):
         return task_id
-    if task_id and _docker_session_isolation_enabled():
-        return _resolve_container_alias(task_id)
+    docker_session_isolation = _docker_session_isolation_enabled()
+    if docker_session_isolation:
+        if task_id:
+            return _resolve_container_alias(task_id)
+    elif os.getenv("TERMINAL_ENV", "local") == "docker":
+        # Persistent Docker deliberately shares one long-lived container across
+        # CLI, gateway, dashboard, and subagent sessions. Session-key scoping
+        # below is for backends such as SSH; applying it here fragments the
+        # documented shared Docker sandbox into one container per chat.
+        return "default"
     # Per-session isolation: when a session key is present (the WebUI streaming
     # layer sets it per-session, the gateway per-message via contextvars), scope
     # the container to it so switching profiles can't reuse a previous profile's
@@ -1439,10 +1447,9 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
     # container (the #16177 shared-container intent). CLI mode has no session key
     # and falls through to "default", behaviour unchanged. See commit e00f940a9.
     #
-    # This runs *after* the isolation-override and docker/container_persistent
-    # branches above: those paths already key containers per task_id, so they
-    # stay authoritative where they apply and this only covers the cases that
-    # would otherwise collapse to the shared "default" key (notably SSH).
+    # This runs *after* the isolation-override and Docker persistence branches:
+    # those paths stay authoritative, while non-persistent Docker calls without
+    # a task_id and non-Docker backends still get session-scoped keys.
     session_key = _current_session_key()
     if session_key:
         return f"session:{session_key}"


### PR DESCRIPTION
## What does this PR do?

With persistent Docker enabled, gateway and desktop sessions now reuse the documented shared `default` container instead of silently creating one container per chat. This keeps installed packages, files, and authentication state visible across Hermes surfaces while preserving per-session isolation for non-persistent Docker and session-scoped environment caches for SSH and other backends.

### Symptom

A file or package created from one gateway session is missing in a later session even though `terminal.backend: docker` and `container_persistent: true` promise one long-lived shared container. Host sandbox paths are keyed by the gateway session instead of `docker/default`.

### Impact

Users relying on persistent Docker lose cross-session access to container state and repeatedly rebuild or reauthenticate environments that should be shared.

### Bug Cause

**Trigger:** `tools/terminal_tool.py` / `_resolve_container_task_id()` / a gateway session key is present while persistent Docker is selected.

**Causal chain:**
1. The gateway binds `HERMES_SESSION_KEY` for each conversation.
2. `_resolve_container_task_id()` applied session-key scoping after the Docker persistence branch without excluding shared persistent Docker.
3. Each conversation resolved to a different `session:<key>` environment slot, so it created or reused a different container instead of `default`.

**Why it is wrong:** `container_persistent: true` is the explicit shared-container mode. Session-key scoping was added to prevent SSH environment reuse across profiles, but its unconditional fallback overrode Docker's persistence contract.

**Working sibling / contrast:** Non-persistent Docker already uses `_docker_session_isolation_enabled()` and continues to resolve distinct session keys; SSH and other non-Docker backends still use the session-key fallback.

**Ruled out:** Container cleanup is not the cause. The wrong environment key is selected before container creation or reuse, and a resolver regression test reproduces the mismatch without invoking lifecycle cleanup.

### Fix

Make Docker persistence authoritative in the environment-key resolver: isolated Docker continues through task/session resolution, while persistent Docker returns `default` before the non-Docker session-key fallback. Add gateway-ContextVar regression coverage for both persistence modes.

## Related Issue

Closes #93764

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/terminal_tool.py` - preserve the shared `default` key for persistent Docker while retaining isolated and non-Docker keying.
- `tests/tools/test_shared_container_task_id.py` - cover persistent sharing and non-persistent isolation across gateway session ContextVars.

## How to Test

1. Configure `terminal.backend: docker` with `container_persistent: true` and bind two gateway session keys; both must resolve to `default`.
2. Set `container_persistent: false`; the same sessions must resolve to distinct `session:<key>` values.
3. Run:

```bash
scripts/run_tests.sh tests/tools/test_shared_container_task_id.py -q
```

Result: 13 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [x] I've run the repository test entry on the relevant tests and all tests pass.
- [x] I've added regression tests for the bug.
- [x] I've tested the resolver behavior on Windows 11 using the repository's hermetic test runner.

### Documentation & Housekeeping

- [x] Relevant documentation updates are not needed; this restores the existing documented contract.
- [x] `cli-config.yaml.example` changes are not needed; no config keys changed.
- [x] `CONTRIBUTING.md` and `AGENTS.md` changes are not needed; no architecture or workflow changed.
- [x] Cross-platform impact was considered; the change is backend-key resolution using platform-independent Python logic.
- [x] Tool descriptions and schemas do not need changes; the existing persistent-container behavior is restored.

## Screenshots / Logs

N/A - automated resolver coverage records the before/after behavior.
