### PR TITLE
fix(cli): exclude .bun and .npm caches from backup walk

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -89,6 +89,13 @@ _EXCLUDED_DIRS = {
     "site-packages",
     # Tool / build caches — all regeneratable.
     ".cache",
+    # Package-manager caches. These land under HERMES_HOME whenever a profile's
+    # subprocess HOME resolves to ``{HERMES_HOME}/home`` (see
+    # ``terminal.home_mode``) and the agent shells out to npm/npx/bun, so they
+    # are the same class as ``.cache`` above — and by far the largest: on the
+    # host that reported this they were 82% of the archive.
+    ".bun",             # bun's install cache — refetched on demand
+    ".npm",             # npm/npx cache (_cacache, _npx) — refetched on demand
     ".tox",
     ".nox",
     ".pytest_cache",

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -146,6 +146,22 @@ class TestShouldExclude:
         # The live DB is still backed up.
         assert not _should_exclude(Path("state.db"))
 
+    def test_excludes_package_manager_caches(self):
+        """npm/bun caches land under HERMES_HOME whenever a profile's subprocess
+        HOME resolves to ``{HERMES_HOME}/home`` and the agent shells out to
+        npm/npx/bun. They're regeneratable like ``.cache``, and dwarf everything
+        else in the archive if walked."""
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path("profiles/coder/home/.bun/install/cache/lodash@4.17.21"))
+        assert _should_exclude(Path("profiles/coder/home/.npm/_cacache/index-v5/00/ab/deadbeef"))
+        assert _should_exclude(Path("profiles/coder/home/.npm/_npx/1a2b3c/node_modules/x/index.js"))
+        # Also at the root profile, not just named ones.
+        assert _should_exclude(Path("home/.bun/install/cache/pkg"))
+        assert _should_exclude(Path("home/.npm/_cacache/tmp/x"))
+        # A skill or memory that merely mentions the tools is still backed up.
+        assert not _should_exclude(Path("skills/dev/npm-workflow/SKILL.md"))
+        assert not _should_exclude(Path("memories/bun-notes.md"))
+
     def test_excludes_sqlite_sidecars(self):
         """SQLite WAL/SHM/journal sidecars must not ship alongside the
         safe-copied .db — pairing a fresh snapshot with stale sidecar state


### PR DESCRIPTION
Fixes #93760.

## What and why

`_EXCLUDED_DIRS` in `hermes_cli/backup.py` prunes regeneratable dependency and
cache directories from the backup walk, but it is missing `.bun` and `.npm`.

Whenever a profile's subprocess `HOME` resolves to `{HERMES_HOME}/home` (per
`terminal.home_mode`) and the agent shells out to `npm`/`npx`/`bun`, those
caches are written **inside** the tree `hermes backup` walks, so they ship in
every archive.

On the host that hit this they were 82% of the whole backup — measured by
running the module's own exclusion logic over `HERMES_HOME`:

```
what currently enters the archive: 2.84 GB (116,190 files)
  2378.8 MB  profiles/<name>/home      <- 82%
   176.3 MB  node
    74.6 MB  bin
    50.3 MB  skills
    35.5 MB  state.db
```

Concretely: `.bun/install` 2.5 GB (1712 packages), `.npm/_npx` 793 MB,
`.npm/_cacache` 266 MB. The sibling `.cache/` (uv/pip/prisma, 353 MB) was
already excluded and correctly stayed out. The daily encrypted archive on that
host went from 157 MB to 991 MB the day a `home_mode` profile first ran
npm/bun, and stayed there — ~840 MB/day of storage, transfer and zip+GPG CPU
for cache that is refetched on demand.

This is the failure mode the set's own comment already describes ("a single
plugin venv, MCP-server install, or pip/uv cache living under HERMES_HOME gets
walked file-by-file, ballooning a backup to hundreds of thousands of
entries"). `.bun` and `.npm` are the same class of directory and were simply
missed.

## How to test

```bash
pytest tests/hermes_cli/test_backup.py -q
```

The new test `TestShouldExclude::test_excludes_package_manager_caches` covers
both named and root profiles, and asserts that files merely *named* after the
tools (a `npm-workflow/SKILL.md`, a `bun-notes.md` memory) are still backed up.
I verified it fails on `main` without the one-line set change and passes with
it.

To reproduce the original bug: point a profile's subprocess HOME at
`{HERMES_HOME}/home`, have the agent run anything using npm/npx/bun, then
`hermes backup -o /tmp/full.zip` and compare size and file count before/after.

## Platforms tested

Linux only — Ubuntu 24.04.4 LTS (kernel 6.8.0-138), x86_64, Python 3.11.15.
The change is two string entries in an existing set matched against path
components, so it carries no platform-specific behavior.

`tests/hermes_cli/test_backup.py` passes in full (57 tests). I did not run
`scripts/run_tests.sh` end to end — this host is a 1 vCPU box and the full
suite is impractical on it; CI will cover the rest.
