### PR TITLE
fix(gateway): silent socket drops heal themselves on every surface (salvage #89958, #90012, #89984)

### DIFF
--- a/apps/desktop/src/lib/json-rpc-gateway-heartbeat.test.ts
+++ b/apps/desktop/src/lib/json-rpc-gateway-heartbeat.test.ts
@@ -1,0 +1,131 @@
+import { JsonRpcGatewayClient } from '@hermes/shared'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+interface ListenerEntry {
+  callback: (event: any) => void
+  once: boolean
+}
+
+class FakeSocket {
+  static readonly CLOSED = 3
+  static readonly OPEN = 1
+
+  readonly sent: string[] = []
+  readyState = FakeSocket.OPEN
+  private listeners = new Map<string, ListenerEntry[]>()
+
+  addEventListener(type: string, callback: (event: any) => void, options?: AddEventListenerOptions): void {
+    const entries = this.listeners.get(type) ?? []
+
+    entries.push({ callback, once: Boolean(options?.once) })
+    this.listeners.set(type, entries)
+  }
+
+  close(): void {
+    if (this.readyState === FakeSocket.CLOSED) {
+      return
+    }
+
+    this.readyState = FakeSocket.CLOSED
+    this.emit('close', { code: 1000 })
+  }
+
+  emit(type: string, event: any = {}): void {
+    const entries = [...(this.listeners.get(type) ?? [])]
+
+    for (const entry of entries) {
+      entry.callback(event)
+
+      if (entry.once) {
+        this.removeEventListener(type, entry.callback)
+      }
+    }
+  }
+
+  message(frame: unknown): void {
+    this.emit('message', { data: JSON.stringify(frame) })
+  }
+
+  removeEventListener(type: string, callback: (event: any) => void): void {
+    this.listeners.set(
+      type,
+      (this.listeners.get(type) ?? []).filter(entry => entry.callback !== callback)
+    )
+  }
+
+  send(payload: string): void {
+    this.sent.push(payload)
+  }
+}
+
+describe('JsonRpcGatewayClient heartbeat recovery', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('invalidates a silently dead advertised socket and ignores its late frames', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('WebSocket', { OPEN: FakeSocket.OPEN })
+    const socket = new FakeSocket()
+    const states: string[] = []
+    const events: string[] = []
+
+    const client = new JsonRpcGatewayClient({
+      heartbeatDeadlineMs: 45,
+      heartbeatIntervalMs: 15,
+      socketFactory: () => socket as unknown as WebSocket
+    })
+
+    client.onState(state => states.push(state))
+    client.onAny(event => events.push(event.type))
+
+    const connected = client.connect('ws://gateway.test/api/ws')
+    socket.emit('open')
+    await connected
+    socket.message({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'gateway.ready', payload: { heartbeat: true } }
+    })
+
+    await vi.advanceTimersByTimeAsync(61)
+
+    expect(client.connectionState).toBe('closed')
+    expect(socket.readyState).toBe(FakeSocket.CLOSED)
+    expect(states.at(-1)).toBe('closed')
+
+    socket.message({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'message.complete', payload: { text: 'late duplicate' } }
+    })
+    expect(events).toEqual(['gateway.ready'])
+  })
+
+  it('keeps older backends open when gateway.ready does not advertise heartbeat', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('WebSocket', { OPEN: FakeSocket.OPEN })
+    const socket = new FakeSocket()
+
+    const client = new JsonRpcGatewayClient({
+      heartbeatDeadlineMs: 45,
+      heartbeatIntervalMs: 15,
+      socketFactory: () => socket as unknown as WebSocket
+    })
+
+    const connected = client.connect('ws://gateway.test/api/ws')
+    socket.emit('open')
+    await connected
+    socket.message({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'gateway.ready', payload: {} }
+    })
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(client.connectionState).toBe('open')
+    expect(socket.readyState).toBe(FakeSocket.OPEN)
+    expect(socket.sent).toEqual([])
+  })
+})

--- a/apps/desktop/src/lib/json-rpc-gateway-recovery.test.ts
+++ b/apps/desktop/src/lib/json-rpc-gateway-recovery.test.ts
@@ -1,0 +1,196 @@
+import { JsonRpcGatewayClient } from '@hermes/shared'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+interface ListenerEntry {
+  callback: (event: any) => void
+  once: boolean
+}
+
+class LoopbackSocket {
+  static readonly CLOSED = 3
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+
+  readyState = LoopbackSocket.CONNECTING
+  private listeners = new Map<string, ListenerEntry[]>()
+
+  constructor(
+    readonly generation: number,
+    private readonly backend: RecoveryBackend
+  ) {}
+
+  addEventListener(type: string, callback: (event: any) => void, options?: AddEventListenerOptions): void {
+    const entries = this.listeners.get(type) ?? []
+
+    entries.push({ callback, once: Boolean(options?.once) })
+    this.listeners.set(type, entries)
+  }
+
+  close(): void {
+    if (this.readyState === LoopbackSocket.CLOSED) {
+      return
+    }
+
+    this.readyState = LoopbackSocket.CLOSED
+    this.emit('close', { code: 1000 })
+  }
+
+  message(frame: unknown): void {
+    this.emit('message', { data: JSON.stringify(frame) })
+  }
+
+  open(): void {
+    this.readyState = LoopbackSocket.OPEN
+    this.emit('open', {})
+    this.message({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'gateway.ready', payload: { heartbeat: true } }
+    })
+  }
+
+  removeEventListener(type: string, callback: (event: any) => void): void {
+    this.listeners.set(
+      type,
+      (this.listeners.get(type) ?? []).filter(entry => entry.callback !== callback)
+    )
+  }
+
+  send(payload: string): void {
+    this.backend.receive(this, JSON.parse(payload) as Record<string, any>)
+  }
+
+  private emit(type: string, event: any): void {
+    const entries = [...(this.listeners.get(type) ?? [])]
+
+    for (const entry of entries) {
+      entry.callback(event)
+
+      if (entry.once) {
+        this.removeEventListener(type, entry.callback)
+      }
+    }
+  }
+}
+
+class RecoveryBackend {
+  readonly sockets: LoopbackSocket[] = []
+  readonly messages: Array<{ role: 'assistant' | 'user'; content: string }> = []
+  promptSubmits = 0
+
+  createSocket(): LoopbackSocket {
+    const socket = new LoopbackSocket(this.sockets.length + 1, this)
+
+    this.sockets.push(socket)
+    queueMicrotask(() => socket.open())
+
+    return socket
+  }
+
+  receive(socket: LoopbackSocket, frame: Record<string, any>): void {
+    if (socket.generation === 1 && frame.method === 'prompt.submit') {
+      this.promptSubmits += 1
+      this.messages.push(
+        { role: 'user', content: String(frame.params?.text ?? '') },
+        { role: 'assistant', content: 'persisted while transport was blackholed' }
+      )
+
+      // Accepted and persisted, but every outbound packet (including the RPC
+      // response, heartbeat acknowledgement, and message.complete) is dropped.
+      return
+    }
+
+    if (socket.generation === 1) {
+      return
+    }
+
+    if (frame.method === 'gateway.ping') {
+      socket.message({ jsonrpc: '2.0', id: frame.id, result: { ok: true } })
+
+      return
+    }
+
+    if (frame.method === 'session.activate') {
+      socket.message({
+        jsonrpc: '2.0',
+        id: frame.id,
+        result: {
+          session_id: 'runtime-1',
+          session_key: 'stored-1',
+          messages: this.messages,
+          running: false,
+          status: 'idle'
+        }
+      })
+    }
+  }
+}
+
+describe('hermes-ws-recovery-v1 silent blackhole', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('recovers the persisted final on a replacement socket without duplicating the prompt', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('WebSocket', { OPEN: LoopbackSocket.OPEN })
+    const backend = new RecoveryBackend()
+
+    const client = new JsonRpcGatewayClient({
+      heartbeatDeadlineMs: 45,
+      heartbeatIntervalMs: 15,
+      socketFactory: () => backend.createSocket() as unknown as WebSocket
+    })
+
+    let epoch = 0
+    let intentionalShutdown = false
+    let recovered: Promise<any> | null = null
+
+    client.onState(state => {
+      if (state === 'open') {
+        epoch += 1
+
+        if (epoch > 1) {
+          recovered = client.request('session.activate', { session_id: 'runtime-1' })
+        }
+      }
+
+      if (state === 'closed' && !intentionalShutdown) {
+        void client.connect('ws://gateway.test/api/ws')
+      }
+    })
+
+    await client.connect('ws://gateway.test/api/ws')
+    await Promise.resolve()
+
+    const ambiguousSubmit = client
+      .request('prompt.submit', { session_id: 'runtime-1', text: 'one prompt' })
+      .then(
+        () => null,
+        error => error as Error
+      )
+
+    await vi.advanceTimersByTimeAsync(61)
+    await vi.waitFor(() => expect(backend.sockets).toHaveLength(2))
+    await vi.waitFor(() => expect(recovered).not.toBeNull())
+
+    await expect(ambiguousSubmit).resolves.toMatchObject({
+      message: 'WebSocket heartbeat acknowledgement timed out'
+    })
+    await expect(recovered).resolves.toMatchObject({
+      messages: [
+        { role: 'user', content: 'one prompt' },
+        { role: 'assistant', content: 'persisted while transport was blackholed' }
+      ],
+      running: false,
+      status: 'idle'
+    })
+    expect(backend.promptSubmits).toBe(1)
+
+    intentionalShutdown = true
+    client.close()
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(backend.sockets).toHaveLength(2)
+  })
+})

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -77,6 +77,8 @@ export interface GatewayClientOptions {
   connectErrorMessage?: string
   connectTimeoutMs?: number
   createRequestId?: (nextId: number) => GatewayRequestId
+  heartbeatDeadlineMs?: number
+  heartbeatIntervalMs?: number
   /** Return true to intercept the default closed-state transition. */
   onSocketClose?: (event: CloseEvent) => boolean | void
   requestIdPrefix?: string
@@ -87,6 +89,8 @@ export interface GatewayClientOptions {
 
 const ANY = '*'
 const DEFAULT_REQUEST_TIMEOUT_MS = 120_000
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 15_000
+const DEFAULT_HEARTBEAT_DEADLINE_MS = 45_000
 // A reconnect after sleep/wake must not hang forever in 'connecting' (which
 // keeps the composer disabled and stuck on "Starting Hermes..."). If the open
 // handshake doesn't land in this window, fail to 'error' so callers can retry.
@@ -97,6 +101,9 @@ export class JsonRpcGatewayClient {
   private pending = new Map<GatewayRequestId, PendingCall>()
   private socket: WebSocketLike | null = null
   private state: ConnectionState = 'idle'
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null
+  private heartbeatSequence = 0
+  private lastInboundAt = 0
   private readonly eventHandlers = new Map<string, Set<(event: GatewayEvent) => void>>()
   private readonly stateHandlers = new Set<(state: ConnectionState) => void>()
   private readonly options: Required<Omit<GatewayClientOptions, 'socketFactory'>> &
@@ -108,6 +115,8 @@ export class JsonRpcGatewayClient {
       connectErrorMessage: options.connectErrorMessage ?? 'WebSocket connection failed',
       connectTimeoutMs: options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS,
       createRequestId: options.createRequestId ?? ((nextId: number) => `${options.requestIdPrefix ?? 'r'}${nextId}`),
+      heartbeatDeadlineMs: options.heartbeatDeadlineMs ?? DEFAULT_HEARTBEAT_DEADLINE_MS,
+      heartbeatIntervalMs: options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS,
       notConnectedErrorMessage: options.notConnectedErrorMessage ?? 'gateway not connected',
       onSocketClose: options.onSocketClose ?? (() => false),
       requestIdPrefix: options.requestIdPrefix ?? 'r',
@@ -153,12 +162,14 @@ export class JsonRpcGatewayClient {
 
     const socket = this.options.socketFactory?.(wsUrl) ?? new WebSocket(wsUrl)
     this.socket = socket
+    this.stopHeartbeat()
 
     socket.addEventListener('message', message => {
       if (this.socket !== socket) {
         return
       }
 
+      this.lastInboundAt = Date.now()
       this.handleMessage(message.data)
     })
 
@@ -172,6 +183,7 @@ export class JsonRpcGatewayClient {
       }
 
       this.socket = null
+      this.stopHeartbeat()
       this.setState('closed')
       this.rejectAllPending(new Error(this.options.closedErrorMessage))
     })
@@ -253,9 +265,24 @@ export class JsonRpcGatewayClient {
       socket.close()
     } finally {
       this.socket = null
+      this.stopHeartbeat()
       this.setState('closed')
       this.rejectAllPending(new Error(this.options.closedErrorMessage))
     }
+  }
+
+  /**
+   * Invalidate the current socket generation after an ambiguous transport
+   * outcome. The outer connection owner decides whether/when to reconnect.
+   */
+  invalidate(message = this.options.closedErrorMessage): void {
+    const socket = this.socket
+
+    if (!socket) {
+      return
+    }
+
+    this.invalidateSocket(socket, new Error(message))
   }
 
   on<P = unknown>(type: GatewayEventName, handler: (event: GatewayEvent<P>) => void): () => void {
@@ -408,8 +435,79 @@ export class JsonRpcGatewayClient {
     }
 
     if (frame.method === 'event' && frame.params?.type) {
+      if (frame.params.type === 'gateway.ready' && this.gatewayReadyAdvertisesHeartbeat(frame.params.payload)) {
+        const socket = this.socket
+
+        if (socket) {
+          this.startHeartbeat(socket)
+        }
+      }
+
       this.dispatchEvent(frame.params)
     }
+  }
+
+  private gatewayReadyAdvertisesHeartbeat(payload: unknown): boolean {
+    return Boolean(payload && typeof payload === 'object' && (payload as { heartbeat?: unknown }).heartbeat === true)
+  }
+
+  private startHeartbeat(socket: WebSocketLike): void {
+    this.stopHeartbeat()
+    this.lastInboundAt = Date.now()
+
+    if (this.options.heartbeatIntervalMs <= 0 || this.options.heartbeatDeadlineMs <= 0) {
+      return
+    }
+
+    this.heartbeatTimer = setInterval(() => {
+      if (this.socket !== socket || socket.readyState !== WebSocket.OPEN) {
+        return
+      }
+
+      if (Date.now() - this.lastInboundAt >= this.options.heartbeatDeadlineMs) {
+        this.invalidateSocket(socket, new Error('WebSocket heartbeat acknowledgement timed out'))
+
+        return
+      }
+
+      try {
+        socket.send(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: `heartbeat-${++this.heartbeatSequence}`,
+            method: 'gateway.ping',
+            params: {}
+          })
+        )
+      } catch (error) {
+        this.invalidateSocket(socket, error instanceof Error ? error : new Error(String(error)))
+      }
+    }, this.options.heartbeatIntervalMs)
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer !== null) {
+      clearInterval(this.heartbeatTimer)
+      this.heartbeatTimer = null
+    }
+  }
+
+  private invalidateSocket(socket: WebSocketLike, error: Error): void {
+    if (this.socket !== socket) {
+      return
+    }
+
+    this.socket = null
+    this.stopHeartbeat()
+
+    try {
+      socket.close()
+    } catch {
+      // The generation was already invalidated; the reconnect owner can redial.
+    }
+
+    this.setState('closed')
+    this.rejectAllPending(error)
   }
 
   private clearPending(id: GatewayRequestId): void {

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -153,6 +153,50 @@ def test_ws_starts_mcp_discovery_before_ready(monkeypatch):
     assert events == ["accept", "ready_after_0"]
 
 
+def test_ws_ready_advertises_heartbeat_and_ping_is_inline(monkeypatch):
+    sent = []
+    inbound = iter(
+        [
+            json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": "heartbeat-1",
+                    "method": "gateway.ping",
+                    "params": {},
+                }
+            )
+        ]
+    )
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0)
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+        async def receive_text(self):
+            try:
+                return next(inbound)
+            except StopIteration:
+                raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    asyncio.run(ws_mod.handle_ws(FakeWS()))
+
+    ready = sent[0]["params"]
+    assert ready["type"] == "gateway.ready"
+    assert ready["payload"]["heartbeat"] is True
+    assert sent[1] == {
+        "jsonrpc": "2.0",
+        "result": {"ok": True},
+        "id": "heartbeat-1",
+    }
+
+
 def test_ws_transport_serializes_concurrent_sends():
     active_sends = 0
     max_active_sends = 0

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -29,6 +29,7 @@ import json
 import logging
 import socket
 import threading
+import time
 from typing import Any
 
 from tui_gateway import server
@@ -103,6 +104,7 @@ class WSTransport:
         #: browser-controller registration.
         self.auth_identity = auth_identity
         self._closed = False
+        self._last_inbound_at = time.monotonic()
         # Token-coalescing buffer (CF-2). Streamed token frames land here and a
         # short timer flushes the batch. The lock guards the buffer + the
         # "armed" flag against the worker threads that call write(); the timer
@@ -115,6 +117,17 @@ class WSTransport:
         # writes need an async boundary because several batches can be queued on
         # the owning loop while it recovers from a stall.
         self._send_lock = asyncio.Lock()
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def last_inbound_at(self) -> float:
+        return self._last_inbound_at
+
+    def mark_inbound(self) -> None:
+        self._last_inbound_at = time.monotonic()
 
     @staticmethod
     def _is_streaming_frame(obj: dict) -> bool:
@@ -361,7 +374,11 @@ async def handle_ws(
                     # change_events: this backend broadcasts pet.changed /
                     # cron.changed / sessions.changed, so clients can demote
                     # their legacy polls to slow backstops.
-                    "payload": {"skin": skin_payload, "change_events": True},
+                    "payload": {
+                        "skin": skin_payload,
+                        "change_events": True,
+                        "heartbeat": True,
+                    },
                 },
             }
         )
@@ -404,6 +421,7 @@ async def handle_ws(
             line = raw.strip()
             if not line:
                 continue
+            transport.mark_inbound()
             messages += 1
 
             try:
@@ -438,6 +456,22 @@ async def handle_ws(
             # response dict, which we write here from the loop.
             req_id = req.get("id") if isinstance(req, dict) else None
             req_method = req.get("method") if isinstance(req, dict) else None
+
+            if req_method == "gateway.ping":
+                ok = await transport.write_async(
+                    {
+                        "jsonrpc": "2.0",
+                        "result": {"ok": True},
+                        "id": req_id,
+                    }
+                )
+                if not ok:
+                    disconnect_reason = "send_failed_after_heartbeat"
+                    send_failures += 1
+                    _log.warning("ws heartbeat reply send failed peer=%s id=%s", peer, req_id)
+                    break
+                continue
+
             try:
                 resp = await asyncio.to_thread(server.dispatch, req, transport)
             except Exception:

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -97,7 +97,7 @@ const { FakeWebSocket } = vi.hoisted(() => {
 
 vi.mock('undici', () => ({ WebSocket: FakeWebSocket }))
 
-import { GatewayClient } from '../gatewayClient.js'
+import { GatewayClient, RECONNECT_BASE_MS, RECONNECT_MAX_MS, WS_HEARTBEAT_DEAD_MS, WS_HEARTBEAT_INTERVAL_MS } from '../gatewayClient.js'
 
 describe('GatewayClient websocket attach mode', () => {
   const originalWebSocket = globalThis.WebSocket
@@ -492,5 +492,129 @@ describe('GatewayClient websocket attach mode', () => {
     expect(tail).not.toContain('token=secret')
 
     gw.kill()
+  })
+
+  it('keeps a healthy idle websocket open when heartbeat acknowledgements arrive (issue #32997)', async () => {
+    vi.useFakeTimers()
+    process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'
+    const gw = new GatewayClient()
+
+    try {
+      gw.start()
+      const socket = FakeWebSocket.instances[0]!
+
+      socket.open()
+      socket.message(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'event',
+          params: { type: 'gateway.ready', payload: { heartbeat: true } }
+        })
+      )
+      await vi.advanceTimersByTimeAsync(WS_HEARTBEAT_INTERVAL_MS)
+
+      const heartbeat = JSON.parse(socket.sent.at(-1) ?? '{}') as { id: string; method: string }
+
+      expect(heartbeat.method).toBe('gateway.ping')
+      socket.message(JSON.stringify({ id: heartbeat.id, jsonrpc: '2.0', result: { ok: true } }))
+
+      await vi.advanceTimersByTimeAsync(WS_HEARTBEAT_DEAD_MS + WS_HEARTBEAT_INTERVAL_MS)
+      expect(socket.readyState).toBe(FakeWebSocket.OPEN)
+      expect(FakeWebSocket.instances).toHaveLength(1)
+    } finally {
+      gw.kill()
+      vi.useRealTimers()
+    }
+  })
+
+  it('auto-reconnects after a missing heartbeat acknowledgement (issue #32997)', async () => {
+    vi.useFakeTimers()
+    process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'
+    const gw = new GatewayClient()
+
+    try {
+      gw.start()
+      const first = FakeWebSocket.instances[0]!
+
+      first.open()
+      first.message(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'event',
+          params: { type: 'gateway.ready', payload: { heartbeat: true } }
+        })
+      )
+      await vi.advanceTimersByTimeAsync(WS_HEARTBEAT_INTERVAL_MS)
+      expect(JSON.parse(first.sent.at(-1) ?? '{}')).toMatchObject({ method: 'gateway.ping' })
+      await vi.advanceTimersByTimeAsync(WS_HEARTBEAT_DEAD_MS + WS_HEARTBEAT_INTERVAL_MS)
+      await vi.advanceTimersByTimeAsync(RECONNECT_BASE_MS)
+      expect(FakeWebSocket.instances.length).toBeGreaterThanOrEqual(2)
+    } finally {
+      gw.kill()
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not heartbeat an older backend that omits the capability', async () => {
+    vi.useFakeTimers()
+    process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'
+    const gw = new GatewayClient()
+
+    try {
+      gw.start()
+      const socket = FakeWebSocket.instances[0]!
+
+      socket.open()
+      socket.message(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'event',
+          params: { type: 'gateway.ready', payload: {} }
+        })
+      )
+      await vi.advanceTimersByTimeAsync(WS_HEARTBEAT_DEAD_MS + WS_HEARTBEAT_INTERVAL_MS)
+      expect(socket.readyState).toBe(FakeWebSocket.OPEN)
+      expect(socket.sent).toEqual([])
+      expect(FakeWebSocket.instances).toHaveLength(1)
+    } finally {
+      gw.kill()
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not double-reconnect when the exit subscriber restarts immediately', async () => {
+    vi.useFakeTimers()
+    process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'
+    const gw = new GatewayClient()
+
+    try {
+      gw.on('exit', () => gw.start())
+      gw.start()
+      const first = FakeWebSocket.instances[0]!
+
+      first.open()
+      gw.drain()
+      await Promise.resolve()
+      first.close(1011)
+
+      expect(FakeWebSocket.instances).toHaveLength(2)
+      await vi.advanceTimersByTimeAsync(RECONNECT_BASE_MS)
+      expect(FakeWebSocket.instances).toHaveLength(2)
+    } finally {
+      gw.kill()
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not auto-reconnect after an intentional kill() (issue #32997)', async () => {
+    vi.useFakeTimers()
+    process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'
+    const gw = new GatewayClient()
+    gw.start()
+    FakeWebSocket.instances[0]!.open()
+    gw.kill() // sets disposed
+    await vi.advanceTimersByTimeAsync(WS_HEARTBEAT_DEAD_MS + RECONNECT_MAX_MS + 1000)
+    expect(FakeWebSocket.instances.length).toBe(1) // no reconnect attempted
+    vi.useRealTimers()
   })
 })

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -21,6 +21,18 @@ const WS_OPEN = 1
 const WS_CLOSING = 2
 const WS_CLOSED = 3
 
+// Keepalive + dead-connection detection. A silent drop (macOS sleep, proxy
+// idle timeout, VPN reconnect) kills the TCP socket without a `close` event,
+// so the client hangs forever (issue #32997). Browser/undici WebSocket does
+// not expose an acknowledged ping/pong API, so this uses a small JSON-RPC
+// heartbeat that the TUI gateway explicitly answers. Healthy idle sockets stay
+// open; only a missing heartbeat ack forces close -> reconnect.
+export const WS_HEARTBEAT_INTERVAL_MS = 15_000
+export const WS_HEARTBEAT_DEAD_MS = 45_000
+// Exponential backoff for reconnect attempts after a transport drop.
+export const RECONNECT_BASE_MS = 1_000
+export const RECONNECT_MAX_MS = 30_000
+
 const getWebSocketCtor = (): typeof WebSocket =>
   typeof WebSocket === 'undefined' ? (UndiciWebSocket as unknown as typeof WebSocket) : WebSocket
 
@@ -149,6 +161,15 @@ export class GatewayClient extends EventEmitter {
   private drainGeneration = 0
   private stdoutRl: ReturnType<typeof createInterface> | null = null
   private stderrRl: ReturnType<typeof createInterface> | null = null
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private reconnectAttempts = 0
+  private lastActivityAt = 0
+  private heartbeatSeq = 0
+  private heartbeatPendingId: string | null = null
+  private heartbeatSentAt = 0
+  // Set on kill() so we never auto-reconnect after an intentional shutdown.
+  private disposed = false
 
   constructor() {
     super()
@@ -164,6 +185,10 @@ export class GatewayClient extends EventEmitter {
       if (this.readyTimer) {
         clearTimeout(this.readyTimer)
         this.readyTimer = null
+      }
+
+      if (ev.payload?.heartbeat && this.ws?.readyState === WS_OPEN) {
+        this.startHeartbeat(this.ws)
       }
     }
 
@@ -208,6 +233,96 @@ export class GatewayClient extends EventEmitter {
     } catch {
       // best effort
     }
+  }
+
+  private startHeartbeat(ws: WebSocket) {
+    this.stopHeartbeat()
+    this.lastActivityAt = Date.now()
+    this.heartbeatPendingId = null
+    this.heartbeatSentAt = 0
+    this.heartbeatTimer = setInterval(() => {
+      if (this.ws !== ws || ws.readyState !== WS_OPEN) {
+        return
+      }
+
+      const now = Date.now()
+
+      if (this.heartbeatPendingId && now - this.heartbeatSentAt > WS_HEARTBEAT_DEAD_MS) {
+        this.lifecycle('[lifecycle] websocket silent drop detected (heartbeat ack timeout); forcing reconnect')
+        this.stopHeartbeat()
+
+        try {
+          ws.close()
+        } catch {
+          // ignore
+        }
+
+        return
+      }
+
+      if (this.heartbeatPendingId) {
+        return
+      }
+
+      const id = `h${++this.heartbeatSeq}`
+
+      this.heartbeatPendingId = id
+      this.heartbeatSentAt = now
+
+      try {
+        ws.send(JSON.stringify({ id, jsonrpc: '2.0', method: 'gateway.ping', params: { last_activity_ms: this.lastActivityAt } }))
+      } catch {
+        this.lifecycle('[lifecycle] websocket heartbeat send failed; forcing reconnect')
+        this.stopHeartbeat()
+
+        try {
+          ws.close()
+        } catch {
+          // ignore
+        }
+      }
+    }, WS_HEARTBEAT_INTERVAL_MS)
+    this.heartbeatTimer.unref?.()
+  }
+
+  private stopHeartbeat() {
+    if (this.heartbeatTimer !== null) {
+      clearInterval(this.heartbeatTimer)
+      this.heartbeatTimer = null
+    }
+
+    this.heartbeatPendingId = null
+    this.heartbeatSentAt = 0
+  }
+
+  private scheduleReconnect() {
+    if (this.disposed || this.reconnectTimer !== null) {
+      return
+    }
+
+    const delay = Math.min(RECONNECT_BASE_MS * 2 ** this.reconnectAttempts, RECONNECT_MAX_MS)
+    this.reconnectAttempts += 1
+    this.lifecycle(`[lifecycle] scheduling gateway reconnect in ${delay}ms (attempt ${this.reconnectAttempts})`)
+    this.publish({ type: 'gateway.reconnecting', payload: { attempt: this.reconnectAttempts, delay_ms: delay } })
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+
+      if (this.disposed) {
+        return
+      }
+
+      this.start()
+    }, delay)
+    this.reconnectTimer.unref?.()
+  }
+
+  private clearReconnect() {
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+
+    this.reconnectAttempts = 0
   }
 
   private resetStartupState() {
@@ -257,6 +372,14 @@ export class GatewayClient extends EventEmitter {
     this.closeSidecarSocket()
     this.lifecycle(`[lifecycle] transport exit code=${code ?? 'null'} reason=${reason ?? 'none'}`)
     this.rejectPending(new Error(reason || `gateway exited${code === null ? '' : ` (${code})`}`))
+
+    // Self-heal: a dropped transport (real close OR silent drop caught by the
+    // heartbeat) should reconnect instead of stranding the UI on a dead socket
+    // (issue #32997). Intentional shutdown sets `disposed` and skips this.
+    // Schedule before the synchronous 'exit' emission: useMainApp's existing
+    // recovery subscriber may call start() immediately, and start() cancels this
+    // timer so there is only one recovery owner.
+    this.scheduleReconnect()
 
     if (this.subscribed) {
       this.emit('exit', code)
@@ -320,6 +443,7 @@ export class GatewayClient extends EventEmitter {
   }
 
   private handleWebSocketFrame(raw: unknown) {
+    this.lastActivityAt = Date.now()
     const text = asWireText(raw)
 
     if (!text) {
@@ -453,6 +577,8 @@ export class GatewayClient extends EventEmitter {
               resolve()
             }
 
+            this.lastActivityAt = Date.now()
+            this.clearReconnect()
             this.connectSidecarMirror()
           },
           { once: true }
@@ -504,6 +630,7 @@ export class GatewayClient extends EventEmitter {
         }
 
         this.pushLog(`[lifecycle] websocket close code=${ev.code}`)
+        this.stopHeartbeat()
         this.ws = null
         this.wsConnectPromise = null
         this.handleTransportExit(ev.code, `gateway websocket closed${ev.code ? ` (${ev.code})` : ''}`)
@@ -521,6 +648,9 @@ export class GatewayClient extends EventEmitter {
   }
 
   start() {
+    this.disposed = false
+    this.clearReconnect()
+
     const root = process.env.HERMES_PYTHON_SRC_ROOT ?? resolve(import.meta.dirname, '../../')
     const attachUrl = resolveGatewayAttachUrl()
     const sidecarUrl = resolveSidecarUrl()
@@ -528,6 +658,8 @@ export class GatewayClient extends EventEmitter {
     this.attachUrl = attachUrl
     this.sidecarUrl = sidecarUrl
     this.resetStartupState()
+    this.clearReconnect()
+    this.stopHeartbeat()
 
     if (this.proc && !this.proc.killed && this.proc.exitCode === null) {
       this.lifecycle(`[lifecycle] replacing live gateway child ${describeChild(this.proc)}`)
@@ -549,6 +681,14 @@ export class GatewayClient extends EventEmitter {
 
   private dispatch(msg: Record<string, unknown>) {
     const id = msg.id as string | undefined
+
+    if (id && id === this.heartbeatPendingId) {
+      this.heartbeatPendingId = null
+      this.heartbeatSentAt = 0
+
+      return
+    }
+
     const p = id ? this.pending.get(id) : undefined
 
     if (p) {
@@ -776,6 +916,9 @@ export class GatewayClient extends EventEmitter {
   }
 
   kill(reason = 'requested') {
+    this.disposed = true
+    this.clearReconnect()
+    this.stopHeartbeat()
     const proc = this.proc
     const killed = proc?.kill()
 

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -611,7 +611,7 @@ export interface SpawnTreeLoadResponse {
 }
 
 export type GatewayEvent =
-  | { payload?: { skin?: GatewaySkin }; session_id?: string; type: 'gateway.ready' }
+  | { payload?: { heartbeat?: boolean; skin?: GatewaySkin }; session_id?: string; type: 'gateway.ready' }
   | { payload?: GatewaySkin; session_id?: string; type: 'skin.changed' }
   | { payload: SessionInfo; session_id?: string; type: 'session.info' }
   | { payload?: { text?: string }; session_id?: string; type: 'thinking.delta' }
@@ -649,6 +649,7 @@ export type GatewayEvent =
     }
   | { payload?: { reason?: string }; session_id?: string; type: 'dashboard.new_session_requested' }
   | { payload: { line: string }; session_id?: string; type: 'gateway.stderr' }
+  | { payload?: { attempt?: number; delay_ms?: number }; session_id?: string; type: 'gateway.reconnecting' }
   | {
       payload?: { level?: 'info' | 'warn' | 'error'; message?: string }
       session_id?: string


### PR DESCRIPTION
## Summary

Silent WebSocket drops (macOS sleep/wake, network switches) no longer permanently strand the desktop or TUI — every client surface now heartbeats the gateway and rebuilds a socket that stops answering. Salvages @100yenadmin's three-part heartbeat series in dependency order: #89958 (wire contract) → #90012 (shared desktop client) → #89984 (ink TUI client).

Completes the cluster that #93694 (merged earlier today) started for the desktop wake path: that was a one-shot probe on wake signals; this adds the continuous heartbeat plus TUI coverage.

## Changes

- `tui_gateway/ws.py` (#89958): `gateway.ping` answered inline on the WS read loop; `gateway.ready` advertises `heartbeat: true`; transport stamps `last_inbound_at`.
- `apps/shared/src/json-rpc-gateway.ts` (#90012): `JsonRpcGatewayClient` sends `gateway.ping` on an interval, tracks last-heard time, and invalidates the socket GENERATION when silent past deadline — late frames from a dead socket are dropped, replacement connections never replay work.
- `ui-tui/src/gatewayClient.ts` (#89984): heartbeat + bounded exponential reconnect (1s/2s/4s/8s, 30s cap). Covers #32997's fixes 1+2.

All three are capability-gated on the server's `heartbeat` advert — against an older backend nothing changes.

## Validation

| suite | result |
|---|---|
| tests/test_tui_gateway_ws.py | 7/7 (incl. new heartbeat advert + inline ping tests) |
| desktop json-rpc-gateway heartbeat/recovery vitest | 3/3 |
| ui-tui gatewayClient vitest | 18/18 |
| Coexistence | `ping` (session-RPC probe, #93694) and `gateway.ping` (WS-inline heartbeat) are distinct paths, both live |

Addresses the liveness half of #89083 and #32997 fixes 1+2; part of the #83166 recovery series.

Credit: @100yenadmin (#89958, #90012, #89984) — all three commits preserved with full authorship.

## Infographic

![Heartbeat of the gateway](https://v3b.fal.media/files/b/0aa79c75/yEIKlMndWxQW6feUYQlS6_dc3SuP1e.png)
