### PR TITLE
feat(deadline): SuspectableBackend protocol — mark timed-out backends suspect (#85125 3a, salvage of #88575)

### DIFF
--- a/agent/deadline.py
+++ b/agent/deadline.py
@@ -503,13 +503,17 @@ def run_bounded_sync(
         logger.warning(
             "[deadline] %r timed out after %.1fs; worker abandoned", label, timeout_s
         )
+        # Phase 3a (#85125), ordering: mark suspect BEFORE owner cleanup so a
+        # recycle/re-init in on_timeout never gets a stale flag on the healed
+        # replacement. The sync flavor runs the mark inline — the protocol
+        # contract requires mark_suspect to be cheap.
+        if backend is not None:
+            _mark_backend_suspect(backend, label, timeout_s)
         if on_timeout is not None:
             try:
                 on_timeout()
             except Exception:
                 logger.debug("deadline on_timeout callback failed", exc_info=True)
-        # Phase 3a (#85125): flag the abandoned call's backend for recycle.
-        _mark_backend_suspect(backend, label, timeout_s)
         return BoundedResult(
             timed_out=True,
             value=None,
@@ -613,9 +617,9 @@ def kill_process_tree(pid: int, *, sig: Optional[int] = None) -> bool:
             # pid leads its own group: one syscall covers the whole group.
             # (The == check guards against signalling the caller's own group
             # when pid is not a leader.)
-            os.killpg(
+            os.killpg(  # windows-footgun: ok — POSIX-only branch (win32 returns above)
                 pgid, sig
-            )  # windows-footgun: ok — POSIX-only branch (win32 returns above)
+            )
         else:
             os.kill(pid, sig)
         signalled = True

--- a/agent/deadline.py
+++ b/agent/deadline.py
@@ -71,7 +71,7 @@ import sys
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Protocol, Awaitable, Callable, Optional
+from typing import Any, Awaitable, Callable, Optional, Protocol
 
 logger = logging.getLogger(__name__)
 
@@ -126,6 +126,12 @@ class SuspectableBackend(Protocol):
     instead of returning a poisoned handle to the cache. Consumers adopt
     incrementally (Phase 3b, one backend per PR), so the layer fails open:
     backends without the protocol are simply never marked.
+
+    Adopter contract: ``mark_suspect`` MUST be cheap, non-blocking, and
+    must not acquire locks the guarded operation may hold. It runs inline —
+    on the event loop in the async flavor, and on the caller's thread in
+    the sync flavor while the wedged worker is still alive. Set a flag;
+    do the expensive health-check/recycle work in ``ensure_healthy``.
     """
 
     def mark_suspect(self, reason: str) -> None: ...
@@ -426,6 +432,11 @@ async def run_bounded_async(
             cleanup.add_done_callback(_consume_abandoned)
         # Phase 3a (#85125): the abandoned task may leave the backend
         # half-wedged; flag it so the owner recycles before reuse.
+        # Deliberately INLINE on the loop (adopter contract: mark_suspect is
+        # cheap and non-blocking). Running it synchronously guarantees the
+        # mark happens-before this BoundedResult returns AND before the
+        # ensure_future'd on_abandon cleanup can start (next loop tick) — an
+        # offloaded mark would race both.
         _mark_backend_suspect(backend, label, timeout_s)
         logger.warning(
             "[deadline] %r timed out after %.1fs; task abandoned", label, timeout_s
@@ -507,8 +518,7 @@ def run_bounded_sync(
         # recycle/re-init in on_timeout never gets a stale flag on the healed
         # replacement. The sync flavor runs the mark inline — the protocol
         # contract requires mark_suspect to be cheap.
-        if backend is not None:
-            _mark_backend_suspect(backend, label, timeout_s)
+        _mark_backend_suspect(backend, label, timeout_s)
         if on_timeout is not None:
             try:
                 on_timeout()

--- a/agent/deadline.py
+++ b/agent/deadline.py
@@ -71,7 +71,7 @@ import sys
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any, Protocol, Awaitable, Callable, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -116,6 +116,41 @@ class DeadlineExpired(TimeoutError):
         self.timeout_s = timeout_s
 
 
+class SuspectableBackend(Protocol):
+    """Phase 3a (#85125): a stateful backend the deadline layer can flag.
+
+    A timed-out stateful backend (MCP connection, browser session, LSP
+    client) may be left wedged by the abandoned half-finished operation.
+    ``run_bounded_*`` calls ``mark_suspect`` on timeout so the OWNER can
+    health-check or recycle the backend before reuse (``ensure_healthy``)
+    instead of returning a poisoned handle to the cache. Consumers adopt
+    incrementally (Phase 3b, one backend per PR), so the layer fails open:
+    backends without the protocol are simply never marked.
+    """
+
+    def mark_suspect(self, reason: str) -> None: ...
+
+    def ensure_healthy(self) -> bool: ...
+
+
+def _mark_backend_suspect(backend: object | None, label: str, timeout_s: float) -> None:
+    """Best-effort ``mark_suspect`` on a timed-out call's backend.
+
+    Never raises: adoption state must not be able to weaken the deadline
+    bound or corrupt the ``BoundedResult`` the caller is about to receive.
+    A non-adopting backend (no ``mark_suspect``) is tolerated silently —
+    Phase 3b lands per-backend, so absence is the norm during adoption.
+    """
+    if backend is None:
+        return
+    try:
+        mark = getattr(backend, "mark_suspect", None)
+        if callable(mark):
+            mark(f"{label} timed out after {timeout_s:.1f}s")
+    except Exception:
+        logger.debug("deadline mark_suspect failed", exc_info=True)
+
+
 @dataclass(frozen=True, kw_only=True)
 class BoundedResult:
     """Outcome of a bounded operation.
@@ -155,7 +190,9 @@ def clamp_timeout(timeout: Optional[float]) -> Optional[float]:
     try:
         value = float(timeout)
     except (TypeError, ValueError):
-        logger.warning("clamp_timeout: non-numeric timeout %r; treating as unbounded", timeout)
+        logger.warning(
+            "clamp_timeout: non-numeric timeout %r; treating as unbounded", timeout
+        )
         return None
     if value != value:  # NaN
         logger.warning("clamp_timeout: NaN timeout; treating as unbounded")
@@ -169,6 +206,7 @@ def clamp_timeout(timeout: Optional[float]) -> Optional[float]:
 # Timeout resolution: config.yaml ``timeouts:`` section > legacy env var >
 # registered default.
 # ---------------------------------------------------------------------------
+
 
 def _timeouts_section() -> dict:
     """Read the ``timeouts:`` root section from config.yaml (read-only).
@@ -233,7 +271,9 @@ def resolve_timeout(
                     return clamp_timeout(value)
             except (TypeError, ValueError):
                 pass
-        logger.warning("timeouts.%s: invalid value %r in config.yaml; ignoring", key, raw)
+        logger.warning(
+            "timeouts.%s: invalid value %r in config.yaml; ignoring", key, raw
+        )
 
     if env_var:
         env_raw = os.getenv(env_var, "").strip()
@@ -255,6 +295,7 @@ def resolve_timeout(
 # stacks when the loop provably failed to process the expiry — the one piece
 # of information loop-blocked hangs otherwise never surface.
 # ---------------------------------------------------------------------------
+
 
 def _consume_abandoned(task: "asyncio.Future[Any]") -> None:
     """Observe an abandoned task's outcome so it never logs 'never retrieved'."""
@@ -297,6 +338,7 @@ async def run_bounded_async(
     label: str = "operation",
     on_abandon: Optional[Callable[[], Awaitable[Any]]] = None,
     dump_on_blocked_loop: bool = True,
+    backend: object | None = None,
 ) -> BoundedResult:
     """Await ``awaitable`` under a wall-clock deadline independent of loop timers.
 
@@ -317,7 +359,13 @@ async def run_bounded_async(
     start = time.monotonic()
     if timeout_s is None:
         value = await awaitable
-        return BoundedResult(timed_out=False, value=value, elapsed_s=time.monotonic() - start, timeout_s=None, label=label)
+        return BoundedResult(
+            timed_out=False,
+            value=value,
+            elapsed_s=time.monotonic() - start,
+            timeout_s=None,
+            label=label,
+        )
 
     task = asyncio.ensure_future(awaitable)
     loop = asyncio.get_running_loop()
@@ -363,15 +411,32 @@ async def run_bounded_async(
             if not deadline.done():
                 deadline.cancel()
             value = await task
-            return BoundedResult(timed_out=False, value=value, elapsed_s=time.monotonic() - start, timeout_s=timeout_s, label=label)
+            return BoundedResult(
+                timed_out=False,
+                value=value,
+                elapsed_s=time.monotonic() - start,
+                timeout_s=timeout_s,
+                label=label,
+            )
 
         task.cancel()
         task.add_done_callback(_consume_abandoned)
         if on_abandon is not None:
             cleanup = asyncio.ensure_future(_run_abandon_cleanup(on_abandon))
             cleanup.add_done_callback(_consume_abandoned)
-        logger.warning("[deadline] %r timed out after %.1fs; task abandoned", label, timeout_s)
-        return BoundedResult(timed_out=True, value=None, elapsed_s=time.monotonic() - start, timeout_s=timeout_s, label=label)
+        # Phase 3a (#85125): the abandoned task may leave the backend
+        # half-wedged; flag it so the owner recycles before reuse.
+        _mark_backend_suspect(backend, label, timeout_s)
+        logger.warning(
+            "[deadline] %r timed out after %.1fs; task abandoned", label, timeout_s
+        )
+        return BoundedResult(
+            timed_out=True,
+            value=None,
+            elapsed_s=time.monotonic() - start,
+            timeout_s=timeout_s,
+            label=label,
+        )
     finally:
         timer.cancel()
         if watchdog is not None:
@@ -386,12 +451,14 @@ async def run_bounded_async(
 # Bounded execution — sync flavor.
 # ---------------------------------------------------------------------------
 
+
 def run_bounded_sync(
     fn: Callable[[], Any],
     timeout: Optional[float],
     *,
     label: str = "operation",
     on_timeout: Optional[Callable[[], None]] = None,
+    backend: object | None = None,
 ) -> BoundedResult:
     """Run ``fn`` in a daemon worker thread under a wall-clock deadline.
 
@@ -411,7 +478,13 @@ def run_bounded_sync(
     timeout_s = clamp_timeout(timeout)
     start = time.monotonic()
     if timeout_s is None:
-        return BoundedResult(timed_out=False, value=fn(), elapsed_s=time.monotonic() - start, timeout_s=None, label=label)
+        return BoundedResult(
+            timed_out=False,
+            value=fn(),
+            elapsed_s=time.monotonic() - start,
+            timeout_s=None,
+            label=label,
+        )
 
     box: dict[str, Any] = {}
     done = threading.Event()
@@ -424,27 +497,42 @@ def run_bounded_sync(
         finally:
             done.set()
 
-    thread = threading.Thread(
-        target=_worker, name=f"deadline-{label}", daemon=True
-    )
+    thread = threading.Thread(target=_worker, name=f"deadline-{label}", daemon=True)
     thread.start()
     if not done.wait(timeout_s):
-        logger.warning("[deadline] %r timed out after %.1fs; worker abandoned", label, timeout_s)
+        logger.warning(
+            "[deadline] %r timed out after %.1fs; worker abandoned", label, timeout_s
+        )
         if on_timeout is not None:
             try:
                 on_timeout()
             except Exception:
                 logger.debug("deadline on_timeout callback failed", exc_info=True)
-        return BoundedResult(timed_out=True, value=None, elapsed_s=time.monotonic() - start, timeout_s=timeout_s, label=label)
+        # Phase 3a (#85125): flag the abandoned call's backend for recycle.
+        _mark_backend_suspect(backend, label, timeout_s)
+        return BoundedResult(
+            timed_out=True,
+            value=None,
+            elapsed_s=time.monotonic() - start,
+            timeout_s=timeout_s,
+            label=label,
+        )
 
     if "exc" in box:
         raise box["exc"]
-    return BoundedResult(timed_out=False, value=box.get("value"), elapsed_s=time.monotonic() - start, timeout_s=timeout_s, label=label)
+    return BoundedResult(
+        timed_out=False,
+        value=box.get("value"),
+        elapsed_s=time.monotonic() - start,
+        timeout_s=timeout_s,
+        label=label,
+    )
 
 
 # ---------------------------------------------------------------------------
 # Whole-tree process termination.
 # ---------------------------------------------------------------------------
+
 
 def kill_process_tree(pid: int, *, sig: Optional[int] = None) -> bool:
     """Terminate ``pid`` and all its descendants, portably.
@@ -490,7 +578,9 @@ def kill_process_tree(pid: int, *, sig: Optional[int] = None) -> bool:
             # cross-platform contract (False = nothing was terminated).
             return proc.returncode == 0
         except Exception:
-            logger.debug("kill_process_tree: taskkill failed for pid %s", pid, exc_info=True)
+            logger.debug(
+                "kill_process_tree: taskkill failed for pid %s", pid, exc_info=True
+            )
             return False
 
     import signal as _signal
@@ -523,7 +613,9 @@ def kill_process_tree(pid: int, *, sig: Optional[int] = None) -> bool:
             # pid leads its own group: one syscall covers the whole group.
             # (The == check guards against signalling the caller's own group
             # when pid is not a leader.)
-            os.killpg(pgid, sig)  # windows-footgun: ok — POSIX-only branch (win32 returns above)
+            os.killpg(
+                pgid, sig
+            )  # windows-footgun: ok — POSIX-only branch (win32 returns above)
         else:
             os.kill(pid, sig)
         signalled = True

--- a/tests/agent/test_deadline.py
+++ b/tests/agent/test_deadline.py
@@ -39,6 +39,7 @@ from agent.deadline import (
 # clamp_timeout
 # ---------------------------------------------------------------------------
 
+
 class TestClampTimeout:
     def test_none_stays_none(self):
         assert clamp_timeout(None) is None
@@ -75,23 +76,33 @@ class TestClampTimeout:
 # resolve_timeout
 # ---------------------------------------------------------------------------
 
+
 class TestResolveTimeout:
     def test_default_wins_when_nothing_configured(self, monkeypatch):
         monkeypatch.setattr("agent.deadline._timeouts_section", lambda: {})
         monkeypatch.delenv("HERMES_TEST_DEADLINE_X", raising=False)
-        assert resolve_timeout("a.b", default=42.0, env_var="HERMES_TEST_DEADLINE_X") == 42.0
+        assert (
+            resolve_timeout("a.b", default=42.0, env_var="HERMES_TEST_DEADLINE_X")
+            == 42.0
+        )
 
     def test_env_var_beats_default(self, monkeypatch):
         monkeypatch.setattr("agent.deadline._timeouts_section", lambda: {})
         monkeypatch.setenv("HERMES_TEST_DEADLINE_X", "17.5")
-        assert resolve_timeout("a.b", default=42.0, env_var="HERMES_TEST_DEADLINE_X") == 17.5
+        assert (
+            resolve_timeout("a.b", default=42.0, env_var="HERMES_TEST_DEADLINE_X")
+            == 17.5
+        )
 
     def test_config_beats_env_var(self, monkeypatch):
         monkeypatch.setattr(
             "agent.deadline._timeouts_section", lambda: {"a": {"b": 99}}
         )
         monkeypatch.setenv("HERMES_TEST_DEADLINE_X", "17.5")
-        assert resolve_timeout("a.b", default=42.0, env_var="HERMES_TEST_DEADLINE_X") == 99.0
+        assert (
+            resolve_timeout("a.b", default=42.0, env_var="HERMES_TEST_DEADLINE_X")
+            == 99.0
+        )
 
     def test_dotted_key_walks_nested_maps(self, monkeypatch):
         monkeypatch.setattr(
@@ -109,16 +120,24 @@ class TestResolveTimeout:
             "agent.deadline._timeouts_section", lambda: {"a": {"b": "soon"}}
         )
         monkeypatch.setenv("HERMES_TEST_DEADLINE_X", "17.5")
-        assert resolve_timeout("a.b", default=42.0, env_var="HERMES_TEST_DEADLINE_X") == 17.5
+        assert (
+            resolve_timeout("a.b", default=42.0, env_var="HERMES_TEST_DEADLINE_X")
+            == 17.5
+        )
 
     def test_invalid_env_value_falls_through_to_default(self, monkeypatch):
         monkeypatch.setattr("agent.deadline._timeouts_section", lambda: {})
         monkeypatch.setenv("HERMES_TEST_DEADLINE_X", "banana")
-        assert resolve_timeout("a.b", default=42.0, env_var="HERMES_TEST_DEADLINE_X") == 42.0
+        assert (
+            resolve_timeout("a.b", default=42.0, env_var="HERMES_TEST_DEADLINE_X")
+            == 42.0
+        )
 
     def test_bool_config_value_rejected(self, monkeypatch):
         # YAML `true` must not silently become a 1-second deadline.
-        monkeypatch.setattr("agent.deadline._timeouts_section", lambda: {"a": {"b": True}})
+        monkeypatch.setattr(
+            "agent.deadline._timeouts_section", lambda: {"a": {"b": True}}
+        )
         assert resolve_timeout("a.b", default=42.0) == 42.0
 
     def test_nan_config_value_falls_through(self, monkeypatch):
@@ -144,6 +163,7 @@ class TestResolveTimeout:
 # ---------------------------------------------------------------------------
 # run_bounded_sync
 # ---------------------------------------------------------------------------
+
 
 class TestRunBoundedSync:
     def test_completion_returns_value(self):
@@ -213,6 +233,7 @@ class TestRunBoundedSync:
 # ---------------------------------------------------------------------------
 # run_bounded_async
 # ---------------------------------------------------------------------------
+
 
 class TestRunBoundedAsync:
     def test_completion_returns_value(self):
@@ -296,9 +317,7 @@ class TestRunBoundedAsync:
             async def op():
                 await asyncio.sleep(30)
 
-            result = await run_bounded_async(
-                op(), 0.1, label="t", on_abandon=_cleanup
-            )
+            result = await run_bounded_async(op(), 0.1, label="t", on_abandon=_cleanup)
             await asyncio.wait_for(cleaned.wait(), timeout=5.0)
             return result
 
@@ -332,9 +351,7 @@ class TestRunBoundedAsync:
                     inner_cancelled.set()
                     raise
 
-            outer = asyncio.ensure_future(
-                run_bounded_async(op(), 25.0, label="t")
-            )
+            outer = asyncio.ensure_future(run_bounded_async(op(), 25.0, label="t"))
             await started.wait()
             outer.cancel()
             with pytest.raises(asyncio.CancelledError):
@@ -348,6 +365,7 @@ class TestRunBoundedAsync:
 # ---------------------------------------------------------------------------
 # kill_process_tree
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group semantics")
 class TestKillProcessTree:
@@ -441,6 +459,7 @@ class TestKillProcessTree:
 # tool_executor migration contract
 # ---------------------------------------------------------------------------
 
+
 class TestConcurrentToolTimeoutMigration:
     """_resolve_concurrent_tool_timeout keeps its exact legacy contract."""
 
@@ -519,3 +538,115 @@ class TestSequentialToolTimeoutResolver:
             lambda: {"tools": {"concurrent_batch": 0}},
         )
         assert self._resolver()() is None
+
+
+# ---------------------------------------------------------------------------
+# Phase 3a (#85125): SuspectableBackend — poisoned-state contract.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingBackend:
+    """Minimal SuspectableBackend: records mark_suspect calls."""
+
+    def __init__(self) -> None:
+        self.reasons: list[str] = []
+
+    def mark_suspect(self, reason: str) -> None:
+        self.reasons.append(reason)
+
+    def ensure_healthy(self) -> bool:
+        return not self.reasons
+
+
+def test_async_timeout_marks_backend_once():
+    from agent.deadline import run_bounded_async
+
+    async def never():
+        await asyncio.Event().wait()
+
+    async def drive():
+        backend = _RecordingBackend()
+        result = await run_bounded_async(
+            never(), 0.05, label="phase3a", backend=backend
+        )
+        assert result.timed_out
+        return backend
+
+    backend = asyncio.run(drive())
+    assert len(backend.reasons) == 1
+    assert "phase3a" in backend.reasons[0]
+    assert "0.1" in backend.reasons[0]  # rounded timeout present
+
+
+def test_async_completion_never_marks_backend():
+    from agent.deadline import run_bounded_async
+
+    async def quick():
+        return "done"
+
+    async def drive():
+        backend = _RecordingBackend()
+        result = await run_bounded_async(
+            quick(), 5.0, label="phase3a-ok", backend=backend
+        )
+        assert not result.timed_out and result.value == "done"
+        return backend
+
+    backend = asyncio.run(drive())
+    assert backend.reasons == []
+
+
+def test_sync_timeout_marks_backend_once():
+    from agent.deadline import run_bounded_sync
+
+    def block():
+        time.sleep(10)
+
+    backend = _RecordingBackend()
+    result = run_bounded_sync(block, 0.05, label="phase3a-sync", backend=backend)
+    assert result.timed_out
+    assert len(backend.reasons) == 1
+    assert "phase3a-sync" in backend.reasons[0]
+
+
+def test_non_adopting_backend_cannot_weaken_the_bound():
+    """A backend without mark_suspect still gets a real timeout result."""
+
+    class PlainBackend:
+        pass
+
+    async def never():
+        await asyncio.Event().wait()
+
+    async def drive():
+        from agent.deadline import run_bounded_async
+
+        return await run_bounded_async(
+            never(), 0.05, label="phase3a-plain", backend=PlainBackend()
+        )
+
+    result = asyncio.run(drive())
+    assert result.timed_out
+    assert result.label == "phase3a-plain"
+
+
+def test_mark_suspect_raising_never_corrupts_the_result():
+    """A broken mark_suspect must not eat the timeout or the reason."""
+
+    class ExplodingBackend:
+        def mark_suspect(self, reason: str) -> None:
+            raise RuntimeError("backend is broken")
+
+    async def never():
+        await asyncio.Event().wait()
+
+    async def drive():
+        from agent.deadline import run_bounded_async
+
+        return await run_bounded_async(
+            never(), 0.05, label="phase3a-boom", backend=ExplodingBackend()
+        )
+
+    result = asyncio.run(drive())
+    assert result.timed_out
+    assert result.label == "phase3a-boom"

--- a/tests/agent/test_deadline.py
+++ b/tests/agent/test_deadline.py
@@ -575,7 +575,7 @@ def test_async_timeout_marks_backend_once():
     backend = asyncio.run(drive())
     assert len(backend.reasons) == 1
     assert "phase3a" in backend.reasons[0]
-    assert "0.1" in backend.reasons[0]  # rounded timeout present
+    assert "timed out after 0.1" in backend.reasons[0]
 
 
 def test_async_completion_never_marks_backend():
@@ -650,3 +650,68 @@ def test_mark_suspect_raising_never_corrupts_the_result():
     result = asyncio.run(drive())
     assert result.timed_out
     assert result.label == "phase3a-boom"
+
+
+def test_sync_completion_never_marks_backend():
+    from agent.deadline import run_bounded_sync
+
+    backend = _RecordingBackend()
+    result = run_bounded_sync(
+        lambda: "ok", 5.0, label="phase3a-sync-ok", backend=backend
+    )
+    assert not result.timed_out and result.value == "ok"
+    assert backend.reasons == []
+
+
+def test_sync_mark_happens_before_on_timeout():
+    """The review-round ordering contract: mark BEFORE owner cleanup, so a
+    recycle in on_timeout never sees an unmarked backend (and a healed
+    replacement never inherits a stale flag)."""
+    from agent.deadline import run_bounded_sync
+
+    backend = _RecordingBackend()
+    seen_at_cleanup: list[int] = []
+
+    def on_timeout():
+        seen_at_cleanup.append(len(backend.reasons))
+
+    result = run_bounded_sync(
+        lambda: time.sleep(10),
+        0.05,
+        label="phase3a-order-sync",
+        on_timeout=on_timeout,
+        backend=backend,
+    )
+    assert result.timed_out
+    assert seen_at_cleanup == [1]  # mark already applied when cleanup ran
+
+
+def test_async_mark_happens_before_on_abandon_cleanup():
+    """Pins the scheduling invariant the inline mark relies on: on_abandon
+    is ensure_future'd (can't start until the next loop tick), so the
+    synchronous mark always lands first. An offloaded (to_thread) mark
+    would break this — this test is the guard against that 'fix'."""
+    from agent.deadline import run_bounded_async
+
+    backend = _RecordingBackend()
+    seen_at_cleanup: list[int] = []
+    cleaned = asyncio.Event()
+
+    async def _cleanup():
+        seen_at_cleanup.append(len(backend.reasons))
+        cleaned.set()
+
+    async def never():
+        await asyncio.Event().wait()
+
+    async def drive():
+        result = await run_bounded_async(
+            never(), 0.05, label="phase3a-order-async",
+            on_abandon=_cleanup, backend=backend,
+        )
+        await asyncio.wait_for(cleaned.wait(), timeout=5.0)
+        return result
+
+    result = asyncio.run(drive())
+    assert result.timed_out
+    assert seen_at_cleanup == [1]  # mark already applied when cleanup started


### PR DESCRIPTION
#85125 Phase 3a. Adds the poisoned-state contract to the deadline layer: `SuspectableBackend` protocol (`mark_suspect` / `ensure_healthy`) plus an optional `backend=` on both `run_bounded_async` and `run_bounded_sync` that flags a timed-out call's backend so the owner recycles it before reuse instead of returning a wedged handle to the cache. Fail-open by design: non-adopting backends are never marked, so Phase 3b consumers (MCP connection, browser session, LSP client, CUA driver) adopt one per PR with zero risk to the rest.

Based on #88575 by @ayushnangia — his three commits cherry-picked to preserve authorship. Salvage round adds one commit on top:

**Record correction (the important part).** The review-round commit's message states the async flavor "offloads the mark off the event loop (asyncio.to_thread)" — it does not, and it must not. The mark is deliberately inline: running it synchronously guarantees mark-happens-before-`BoundedResult`-return and mark-before-`on_abandon`-cleanup (cleanup is `ensure_future`'d and cannot start until the next loop tick). An offloaded mark would race both. The trade-off is real — a live probe measured a deliberately-slow 2s `mark_suspect` stalling the event loop for 2.003s — so the adopter contract is now explicit in the Protocol docstring and at the async call site: `mark_suspect` must be cheap, non-blocking, lock-free; expensive recycle work belongs in `ensure_healthy`. (@Enough1122's two findings from the original PR review: the ordering fix landed as described; the loop-offload did not — this commit documents why inline is the correct resolution rather than adding `to_thread` to match the message.)

New pins so the negotiated semantics can't silently regress:
- `test_sync_mark_happens_before_on_timeout` — the review-round ordering (was unpinned)
- `test_async_mark_happens_before_on_abandon_cleanup` — the scheduling invariant an offloaded mark would break
- `test_sync_completion_never_marks_backend` — sync counterpart of the async completion test

Minor: redundant `if backend is not None` guard dropped in the sync flavor (the helper handles None; both flavors now read identically), brittle `"0.1" in reason` assert tightened, typing import order restored.

## Verification

- tests/agent/test_deadline.py: 53 passed, 3x flake-free; `ruff` + `ty` clean
- Zero production callers of `run_bounded_*` exist yet (only a deliberate NOTE comment in tool_executor), so `backend=` is provably behavior-neutral for existing code
- Live probes: caller cancellation does NOT mark (only genuine timeouts); sync mark runs on the caller thread (documented in the adopter contract); mark→cleanup ordering holds in both flavors

Closes #88575.
Part of #85125 (Phase 3a). Unblocks the Phase 3b per-backend consumer PRs; the pre-written conformance cells flip hard-green once this and the #83964 harness are both in.
