### PR TITLE
fix(cron): share gateway-liveness helper with CLI and surface it on cronjob create+list

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -63,6 +63,27 @@ def _active_cron_provider_name() -> str:
         return "builtin"
 
 
+def _builtin_gateway_liveness() -> Optional[bool]:
+    """Tri-state liveness of the builtin cron scheduler's trigger.
+
+    Single source of truth shared by the CLI (``_warn_if_gateway_not_running``)
+    and the ``cronjob`` model tool (#87033): the builtin ticker only runs
+    inside the gateway process, so a scheduled job with no live gateway can
+    never fire. Non-builtin providers (e.g. Chronos) fire through their own
+    machinery and are deliberately exempt — a missing gateway process means
+    nothing for them, so they report active. ``None`` = probe failed; callers
+    must not claim either way.
+    """
+    try:
+        if _active_cron_provider_name() != "builtin":
+            return True  # external provider fires jobs without the gateway
+        from hermes_cli.gateway import find_gateway_pids
+
+        return bool(find_gateway_pids())
+    except Exception:
+        return None
+
+
 def _warn_if_gateway_not_running() -> None:
     """Warn that scheduled jobs won't fire unless the gateway is running.
 
@@ -79,15 +100,11 @@ def _warn_if_gateway_not_running() -> None:
     built-in ticker's trigger.
     """
     try:
-        if _active_cron_provider_name() != "builtin":
-            return
-
-        from hermes_cli.gateway import find_gateway_pids
-
-        if find_gateway_pids():
+        if _builtin_gateway_liveness() is not False:
+            # Active scheduler (gateway up, or an exempt non-builtin provider),
+            # or the probe failed — stay quiet rather than nag either way.
             return
     except Exception:
-        # If we can't determine gateway state, stay quiet rather than nag.
         return
 
     print(color("  ⚠  Gateway is not running — jobs won't fire automatically.", Colors.YELLOW))

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -99,12 +99,9 @@ def _warn_if_gateway_not_running() -> None:
     any non-builtin provider; the gateway-process heuristic only speaks to the
     built-in ticker's trigger.
     """
-    try:
-        if _builtin_gateway_liveness() is not False:
-            # Active scheduler (gateway up, or an exempt non-builtin provider),
-            # or the probe failed — stay quiet rather than nag either way.
-            return
-    except Exception:
+    # _builtin_gateway_liveness never raises (it maps probe failures to None),
+    # so no guard is needed here — False is the only warn-worthy state.
+    if _builtin_gateway_liveness() is not False:
         return
 
     print(color("  ⚠  Gateway is not running — jobs won't fire automatically.", Colors.YELLOW))

--- a/tests/cron/test_87033_cronjob_gateway_liveness.py
+++ b/tests/cron/test_87033_cronjob_gateway_liveness.py
@@ -103,6 +103,58 @@ class TestCreateSurfacesGatewayLiveness:
         assert "warning" not in result
 
 
+class TestListSurfacesGatewayLiveness:
+    """The `list` action has the same silent-inert-job failure mode as
+    create (#87033): an agent inspecting jobs with no gateway running must
+    learn they are not firing, not just see a clean list."""
+
+    def _list_jobs(self) -> dict:
+        from tools.cronjob_tools import cronjob
+
+        return json.loads(cronjob(action="list"))
+
+    def test_list_with_gateway_running_has_no_warning(self, hermes_env):
+        _create_job()  # ensure at least one job exists
+        with patch_liveness(provider="builtin", pids=[12345]):
+            result = self._list_jobs()
+
+        assert result["success"] is True
+        assert result["count"] >= 1
+        assert result["gateway_running"] is True
+        assert "warning" not in result
+
+    def test_list_without_gateway_warns_jobs_inert(self, hermes_env):
+        _create_job()
+        with patch_liveness(provider="builtin", pids=[]):
+            result = self._list_jobs()
+
+        assert result["success"] is True
+        assert result["gateway_running"] is False
+        warning = result.get("warning", "")
+        assert "will NOT fire" in warning, (
+            "the model must be told the listed jobs won't fire (#87033)"
+        )
+        assert "these jobs" in warning
+
+    def test_list_empty_without_gateway_stays_quiet(self, hermes_env):
+        """Nothing scheduled + no gateway → no alarm; there is nothing inert."""
+        with patch_liveness(provider="builtin", pids=[]):
+            result = self._list_jobs()
+
+        assert result["success"] is True
+        assert result["count"] == 0
+        assert "warning" not in result
+
+    def test_list_non_builtin_provider_is_exempt(self, hermes_env):
+        _create_job()
+        with patch_liveness(provider="chronos", pids=[]):
+            result = self._list_jobs()
+
+        assert result["success"] is True
+        assert result["gateway_running"] is True
+        assert "warning" not in result
+
+
 # ---------------------------------------------------------------------------
 
 

--- a/tests/cron/test_87033_cronjob_gateway_liveness.py
+++ b/tests/cron/test_87033_cronjob_gateway_liveness.py
@@ -1,0 +1,148 @@
+"""Tests for issue #87033 — the cronjob tool must surface gateway liveness.
+
+The builtin cron ticker only runs inside the gateway process. Before the
+fix, ``cronjob(action="create")`` returned a clean success even with no
+gateway running, so the agent confidently told the user a recurring task
+was scheduled while the job could never fire. The CLI already warned
+(``hermes cron list`` / ``hermes cron status``); the agent path did not.
+
+Contract pinned here:
+
+* create with a live gateway → ``gateway_running: true``, no warning;
+* create with no gateway → ``gateway_running: false`` + explicit warning
+  telling the model the job is saved but will not fire yet;
+* non-builtin scheduler providers are exempt (they fire without the gateway);
+* a failed liveness probe stays neutral (``gateway_running: null``) instead
+  of claiming either way.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+@pytest.fixture
+def hermes_env(tmp_path, monkeypatch):
+    """Isolate HERMES_HOME for each test so jobs don't leak."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "cron").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import importlib
+
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    import cron.jobs
+    importlib.reload(cron.jobs)
+    import cron.scheduler
+    importlib.reload(cron.scheduler)
+
+    return home
+
+
+def _create_job() -> dict:
+    from tools.cronjob_tools import cronjob
+
+    return json.loads(
+        cronjob(
+            action="create",
+            schedule="every 10m",
+            prompt="say hi",
+            name="liveness-probe-job",
+            deliver="local",
+        )
+    )
+
+
+class TestCreateSurfacesGatewayLiveness:
+    def test_create_with_gateway_running_has_no_warning(self, hermes_env):
+        with patch_liveness(provider="builtin", pids=[12345]) as patches:
+            result = _create_job()
+
+        assert result["success"] is True
+        assert result["gateway_running"] is True
+        assert "warning" not in result
+
+    def test_create_without_gateway_warns_not_scheduled(self, hermes_env):
+        with (
+            patch_liveness(provider="builtin", pids=[]),
+        ):
+            result = _create_job()
+
+        assert result["success"] is True, (
+            "the job itself is still created successfully"
+        )
+        assert result["gateway_running"] is False
+        warning = result.get("warning", "")
+        assert "not running" in warning.lower()
+        assert "will NOT fire" in warning, (
+            "the model must be told the job won't fire (#87033)"
+        )
+        assert "gateway" in warning.lower()
+
+    def test_non_builtin_provider_is_exempt(self, hermes_env):
+        """External schedulers (e.g. Chronos) fire without the gateway —
+        no false alarm may be raised for them."""
+        with patch_liveness(provider="chronos", pids=[]):
+            result = _create_job()
+
+        assert result["success"] is True
+        assert result["gateway_running"] is True
+        assert "warning" not in result
+
+    def test_failed_probe_stays_neutral(self, hermes_env):
+        """If liveness cannot be determined, say nothing either way."""
+        with patch_liveness(provider=None, pids=[]):  # probe raises → None
+            result = _create_job()
+
+        assert result["success"] is True
+        assert result["gateway_running"] is None
+        assert "warning" not in result
+
+
+# ---------------------------------------------------------------------------
+
+
+from contextlib import ExitStack
+
+
+class _LivenessPatches:
+    """Context manager patching the provider/gateway-pid probes."""
+
+    def __init__(self, *, provider, pids):
+        self._provider = provider
+        self._pids = pids
+
+    def __enter__(self):
+        from unittest.mock import patch
+
+        self._stack = ExitStack()
+
+        def _fake_provider_name():
+            if self._provider is None:
+                raise RuntimeError("probe failure")
+            return self._provider
+
+        self._stack.enter_context(
+            patch(
+                "hermes_cli.cron._active_cron_provider_name",
+                side_effect=_fake_provider_name,
+            )
+        )
+        self._stack.enter_context(
+            patch(
+                "hermes_cli.gateway.find_gateway_pids",
+                return_value=list(self._pids),
+            )
+        )
+        return self
+
+    def __exit__(self, *exc):
+        return self._stack.__exit__(*exc)
+
+
+def patch_liveness(*, provider, pids):
+    return _LivenessPatches(provider=provider, pids=pids)

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1223,6 +1223,28 @@ def _apply_continuity(
     return refs or None
 
 
+def _builtin_gateway_liveness() -> Optional[bool]:
+    """Gateway liveness for the builtin cron scheduler, or None when unknown.
+
+    Mirrors the CLI's ``_warn_if_gateway_not_running`` heuristic (#87033): the
+    builtin ticker only runs inside the gateway process, so a scheduled job
+    with no live gateway can never fire. Non-builtin providers (e.g. Chronos)
+    fire through their own machinery and are deliberately exempt — a missing
+    gateway process means nothing for them. ``None`` = probe failed; callers
+    must not claim either way.
+    """
+    try:
+        from hermes_cli.cron import _active_cron_provider_name
+
+        if _active_cron_provider_name() != "builtin":
+            return True  # external provider fires jobs without the gateway
+        from hermes_cli.gateway import find_gateway_pids
+
+        return bool(find_gateway_pids())
+    except Exception:
+        return None
+
+
 def cronjob(
     action: str,
     job_id: Optional[str] = None,
@@ -1368,22 +1390,38 @@ def cronjob(
             _local_notice = _local_delivery_notice(job, _normalize_deliver_param(deliver))
             if _local_notice:
                 _create_message = f"{_create_message} {_local_notice}"
-            return json.dumps(
-                {
-                    "success": True,
-                    "job_id": job["id"],
-                    "name": job["name"],
-                    "skill": job.get("skill"),
-                    "skills": job.get("skills", []),
-                    "schedule": job["schedule_display"],
-                    "repeat": _repeat_display(job),
-                    "deliver": job.get("deliver", "local"),
-                    "next_run_at": job["next_run_at"],
-                    "job": _format_job(job),
-                    "message": _create_message,
-                },
-                indent=2,
-            )
+            # Gateway liveness surfacing (#87033): the builtin scheduler's
+            # ticker lives in the gateway process, so a job created with no
+            # gateway running is stored but will never fire. Tell the model
+            # here — the CLI already warns, but the agent path saw only a
+            # clean success and confidently told the user it was scheduled.
+            _gw_running = _builtin_gateway_liveness()
+            _result = {
+                "success": True,
+                "job_id": job["id"],
+                "name": job["name"],
+                "skill": job.get("skill"),
+                "skills": job.get("skills", []),
+                "schedule": job["schedule_display"],
+                "repeat": _repeat_display(job),
+                "deliver": job.get("deliver", "local"),
+                "next_run_at": job["next_run_at"],
+                "job": _format_job(job),
+                "message": _create_message,
+            }
+            if _gw_running is False:
+                _result["gateway_running"] = False
+                _result["warning"] = (
+                    "The Hermes gateway is not running — this job is saved "
+                    "but will NOT fire until the gateway is started "
+                    "(hermes gateway install / hermes gateway start). "
+                    "Tell the user the task is scheduled but not active yet."
+                )
+            elif _gw_running is None:
+                _result["gateway_running"] = None
+            else:
+                _result["gateway_running"] = True
+            return json.dumps(_result, indent=2)
 
         if normalized == "list":
             jobs = [_format_job(job) for job in list_jobs(include_disabled=include_disabled)]

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1223,26 +1223,34 @@ def _apply_continuity(
     return refs or None
 
 
-def _builtin_gateway_liveness() -> Optional[bool]:
-    """Gateway liveness for the builtin cron scheduler, or None when unknown.
+def _gateway_liveness_notice() -> dict:
+    """Build the ``gateway_running``/``warning`` payload for tool results.
 
-    Mirrors the CLI's ``_warn_if_gateway_not_running`` heuristic (#87033): the
-    builtin ticker only runs inside the gateway process, so a scheduled job
-    with no live gateway can never fire. Non-builtin providers (e.g. Chronos)
-    fire through their own machinery and are deliberately exempt — a missing
-    gateway process means nothing for them. ``None`` = probe failed; callers
-    must not claim either way.
+    Thin adapter over the shared CLI helper ``hermes_cli.cron._builtin_gateway_liveness``
+    (#87033) so the CLI and this tool can never disagree about what "scheduler
+    active" means. Returns ``{}`` when the scheduler is active (nothing to say),
+    or carries ``gateway_running: false`` plus a model-facing ``warning`` when
+    the builtin ticker has no gateway process to run it.
     """
     try:
-        from hermes_cli.cron import _active_cron_provider_name
+        from hermes_cli.cron import _builtin_gateway_liveness
 
-        if _active_cron_provider_name() != "builtin":
-            return True  # external provider fires jobs without the gateway
-        from hermes_cli.gateway import find_gateway_pids
-
-        return bool(find_gateway_pids())
+        _gw = _builtin_gateway_liveness()
     except Exception:
-        return None
+        return {"gateway_running": None}
+    if _gw is False:
+        return {
+            "gateway_running": False,
+            "warning": (
+                "The Hermes gateway is not running — this job is saved "
+                "but will NOT fire until the gateway is started "
+                "(hermes gateway install / hermes gateway start). "
+                "Tell the user the task is scheduled but not active yet."
+            ),
+        }
+    if _gw is None:
+        return {"gateway_running": None}
+    return {"gateway_running": True}
 
 
 def cronjob(
@@ -1395,7 +1403,6 @@ def cronjob(
             # gateway running is stored but will never fire. Tell the model
             # here — the CLI already warns, but the agent path saw only a
             # clean success and confidently told the user it was scheduled.
-            _gw_running = _builtin_gateway_liveness()
             _result = {
                 "success": True,
                 "job_id": job["id"],
@@ -1408,24 +1415,29 @@ def cronjob(
                 "next_run_at": job["next_run_at"],
                 "job": _format_job(job),
                 "message": _create_message,
+                **_gateway_liveness_notice(),
             }
-            if _gw_running is False:
-                _result["gateway_running"] = False
-                _result["warning"] = (
-                    "The Hermes gateway is not running — this job is saved "
-                    "but will NOT fire until the gateway is started "
-                    "(hermes gateway install / hermes gateway start). "
-                    "Tell the user the task is scheduled but not active yet."
-                )
-            elif _gw_running is None:
-                _result["gateway_running"] = None
-            else:
-                _result["gateway_running"] = True
             return json.dumps(_result, indent=2)
 
         if normalized == "list":
             jobs = [_format_job(job) for job in list_jobs(include_disabled=include_disabled)]
-            return json.dumps({"success": True, "count": len(jobs), "jobs": jobs}, indent=2)
+            _result = {"success": True, "count": len(jobs), "jobs": jobs}
+            # Same silent-inert-job class as create (#87033): an agent
+            # inspecting existing jobs in a gateway-less environment must
+            # learn they are not firing, not just see a clean list.
+            _liveness = _gateway_liveness_notice()
+            if len(jobs) or "gateway_running" in _liveness and _liveness["gateway_running"] is None:
+                if len(jobs):
+                    _liveness_warning = _liveness.get("warning", "")
+                    if _liveness_warning:
+                        _liveness["warning"] = (
+                            "Note: " + _liveness_warning.replace(
+                                "this job is saved but will NOT fire",
+                                "these jobs are saved but will NOT fire",
+                            )
+                        )
+                _result.update(_liveness)
+            return json.dumps(_result, indent=2)
 
         if not job_id:
             return tool_error(f"job_id is required for action '{normalized}'", success=False)

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1223,14 +1223,16 @@ def _apply_continuity(
     return refs or None
 
 
-def _gateway_liveness_notice() -> dict:
+def _gateway_liveness_notice(plural: bool = False) -> dict:
     """Build the ``gateway_running``/``warning`` payload for tool results.
 
     Thin adapter over the shared CLI helper ``hermes_cli.cron._builtin_gateway_liveness``
     (#87033) so the CLI and this tool can never disagree about what "scheduler
-    active" means. Returns ``{}`` when the scheduler is active (nothing to say),
-    or carries ``gateway_running: false`` plus a model-facing ``warning`` when
-    the builtin ticker has no gateway process to run it.
+    active" means. Returns ``{"gateway_running": False, "warning": ...}`` when
+    the builtin ticker has no gateway process to run it, ``{"gateway_running":
+    None}`` when the probe failed, and ``{"gateway_running": True}`` when the
+    scheduler is active. ``plural`` rewords the warning for multi-job results
+    (the ``list`` action).
     """
     try:
         from hermes_cli.cron import _builtin_gateway_liveness
@@ -1238,11 +1240,12 @@ def _gateway_liveness_notice() -> dict:
         _gw = _builtin_gateway_liveness()
     except Exception:
         return {"gateway_running": None}
+    subject = "these jobs are saved" if plural else "this job is saved"
     if _gw is False:
         return {
             "gateway_running": False,
             "warning": (
-                "The Hermes gateway is not running — this job is saved "
+                f"The Hermes gateway is not running — {subject} "
                 "but will NOT fire until the gateway is started "
                 "(hermes gateway install / hermes gateway start). "
                 "Tell the user the task is scheduled but not active yet."
@@ -1424,19 +1427,10 @@ def cronjob(
             _result = {"success": True, "count": len(jobs), "jobs": jobs}
             # Same silent-inert-job class as create (#87033): an agent
             # inspecting existing jobs in a gateway-less environment must
-            # learn they are not firing, not just see a clean list.
-            _liveness = _gateway_liveness_notice()
-            if len(jobs) or "gateway_running" in _liveness and _liveness["gateway_running"] is None:
-                if len(jobs):
-                    _liveness_warning = _liveness.get("warning", "")
-                    if _liveness_warning:
-                        _liveness["warning"] = (
-                            "Note: " + _liveness_warning.replace(
-                                "this job is saved but will NOT fire",
-                                "these jobs are saved but will NOT fire",
-                            )
-                        )
-                _result.update(_liveness)
+            # learn they are not firing, not just see a clean list. An empty
+            # list has nothing inert — stay quiet (and skip the probe).
+            if jobs:
+                _result.update(_gateway_liveness_notice(plural=True))
             return json.dumps(_result, indent=2)
 
         if not job_id:


### PR DESCRIPTION
## Summary

`cronjob(action="create")` no longer reports unqualified success when the builtin scheduler has no gateway to fire jobs — the tool result now carries a tri-state `gateway_running` field plus an explicit warning the model can relay ("scheduled but not active yet"). Fixes #87033.

Salvage of @BrunoBza's #93098 (commit `b4d780556d`, authorship preserved via cherry-pick), with two follow-ups addressing review findings:

## Changes

- `tools/cronjob_tools.py` (from #93098): attach `gateway_running` (`true` / `false` + warning / `null` on probe failure) to create results.
- `hermes_cli/cron.py` (follow-up B): the tri-state heuristic now lives here as `_builtin_gateway_liveness()` — single source of truth; the CLI's `_warn_if_gateway_not_running()` consumes it, so CLI and tool can never disagree about what "scheduler active" means.
- `tools/cronjob_tools.py` (follow-up A): the `list` action surfaces the same liveness field/warning — an agent inspecting existing jobs in a gateway-less environment has the identical silent-inert-job failure mode. Empty lists stay quiet (nothing inert to warn about).
- Tests: 9 tests pin the contract across both actions (live / no-gateway / non-builtin-provider-exempt / failed-probe-neutral).

Note: the original PR branch carried two out-of-scope commits (#89315 replace-guard work that duplicates open PRs #93084/#89328, and a #92450 copy already merged on main) — deliberately not included.

## Validation

| Check | Result |
|---|---|
| New liveness tests | 9/9 pass |
| `tests/cron/` suite | 905 passed; only pre-existing env-contaminated `test_monitor_kind.py` failures (identical on pristine `origin/main`) |
| ruff | clean |
| ty diagnostics | identical set vs `origin/main` — zero new |
| E2E (real imports, isolated HERMES_HOME) | create+list tri-state verified through shared helper; CLI warn path intact |

Closes #87033
Supersedes #93098


## Simplify-pass follow-up (`bd8a90ec4b`)

/simplify-code on the full final diff converged on one finding cluster in the follow-up commit, all applied:
- `plural=` parameter authors both warning wordings at one site — removes the fragile exact-substring `.replace()`
- list-action conditional collapsed to `if jobs` (empty list = nothing inert, probe skipped)
- docstring/code mismatch fixed; dead try/except dropped from `_warn_if_gateway_not_running`

Re-validated: 9/9 liveness tests, full tests/cron/ (same pre-existing env-only failures), ruff clean, ty diagnostics unchanged, E2E re-run.
