### PR TITLE
test(daemon_pool): add cross-version regression test for _worker args contract

### DIFF
--- a/tests/tools/test_daemon_pool.py
+++ b/tests/tools/test_daemon_pool.py
@@ -7,14 +7,23 @@ concurrent.futures.thread._threads_queues, whose atexit hook joins every
 worker unconditionally — even after shutdown(wait=False).
 """
 
+import inspect
 import subprocess
 import sys
 import threading
 import time
+from unittest.mock import patch
 
-from concurrent.futures.thread import _threads_queues
+from concurrent.futures.thread import _threads_queues, _worker
 
 from tools.daemon_pool import DaemonThreadPoolExecutor
+
+# Python 3.14 refactored concurrent.futures.thread._worker: the
+# initializer/initargs params were replaced by a single ``ctx`` argument
+# produced by ThreadPoolExecutor._create_worker_context().  This flag drives
+# version-contract assertions so the test suite fails loudly if the daemon
+# pool ever ships the wrong args shape for the running interpreter.
+_WORKER_USES_CTX = "ctx" in inspect.signature(_worker).parameters
 
 
 def test_workers_are_daemon_threads():
@@ -81,6 +90,60 @@ def test_wedged_worker_does_not_block_interpreter_exit():
     )
     assert proc.returncode == 0
     assert "main-done" in proc.stdout
+
+
+def test_worker_args_match_running_interpreter_contract():
+    """Lock the _worker args shape to the active Python interpreter.
+
+    CPython 3.14 collapsed ``_worker(executor_ref, work_queue, initializer,
+    initargs)`` into ``_worker(executor_ref, ctx, work_queue)`` where ``ctx``
+    comes from ``_create_worker_context()``.  The daemon pool must build the
+    args tuple that the *running* interpreter's ``_worker`` expects — passing
+    the legacy 4-tuple to a 3-param ``_worker`` (or vice-versa) kills the worker
+    and silently drops every submitted future.
+
+    We intercept ``threading.Thread`` so we can inspect the args the pool hands
+    to ``_worker`` without spawning a real worker thread.  Only on 3.14+ do
+    we stub ``_create_worker_context`` (the legacy path never calls it).
+    """
+    captured: dict = {}
+
+    class CaptureThread(threading.Thread):
+        def start(self):
+            captured["args"] = self._args
+            captured["daemon"] = self.daemon
+            captured["target"] = self._target
+
+    thread_patcher = patch("tools.daemon_pool.threading.Thread", CaptureThread)
+
+    # Only stub _create_worker_context on interpreters that actually have it
+    # (Python >= 3.14).  On older runtimes the legacy branch never calls it, so
+    # injecting it with create=True would trick the pool into taking the 3.14
+    # path and produce a false-positive failure.  On 3.14+ the method is an
+    # instance attribute (set by ThreadPoolExecutor.__init__, not a class
+    # method), so we set it directly on the pool instance after construction.
+    thread_patcher.start()
+    try:
+        pool = DaemonThreadPoolExecutor(max_workers=1)
+        if _WORKER_USES_CTX:
+            pool._create_worker_context = lambda *_a: "FAKE_CTX"  # type: ignore[attr-defined]
+        pool._adjust_thread_count()
+        pool.shutdown(wait=False)
+    finally:
+        thread_patcher.stop()
+
+    assert "args" in captured, "Thread target wasn't created (patch missed?)"
+    assert captured["target"] is _worker, "pool must still use stdlib _worker"
+    assert captured["daemon"] is True, "worker must be daemon=True"
+
+    worker_args = captured["args"]
+    if _WORKER_USES_CTX:
+        # Python >= 3.14: (executor_ref, ctx, work_queue) — 3 positional args.
+        assert len(worker_args) == 3
+        assert worker_args[1] == "FAKE_CTX"
+    else:
+        # Python 3.8–3.13: (executor_ref, work_queue, initializer, initargs).
+        assert len(worker_args) == 4
 
 
 def _repo_root():

--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -38,8 +38,14 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
     """ThreadPoolExecutor variant whose workers do not block process exit."""
 
     def _adjust_thread_count(self) -> None:
-        # Mirrors CPython's implementation (3.8–3.13) with two changes:
-        # daemon=True and no _threads_queues registration.
+        # Mirrors CPython's implementation with two changes: daemon=True and no
+        # _threads_queues registration.  CPython refactored the worker-args
+        # contract in 3.14: the ``_worker`` target went from
+        # ``(executor_ref, work_queue, initializer, initargs)`` (3.8–3.13) to
+        # ``(executor_ref, ctx, work_queue)`` where ``ctx`` comes from
+        # ``self._create_worker_context()`` and ``_initializer``/``_initargs``
+        # no longer exist as attributes.  Detect which contract is in effect at
+        # runtime so a single class works across versions.
         if self._idle_semaphore.acquire(timeout=0):
             return
 
@@ -49,15 +55,22 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
         num_threads = len(self._threads)
         if num_threads < self._max_workers:
             thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
+            executor_ref = weakref.ref(self, weakref_cb)
+            if hasattr(self, "_create_worker_context"):
+                # CPython >= 3.14
+                args = (executor_ref, self._create_worker_context(), self._work_queue)
+            else:
+                # CPython 3.8–3.13
+                args = (
+                    executor_ref,
+                    self._work_queue,
+                    getattr(self, "_initializer", None),
+                    getattr(self, "_initargs", ()),
+                )
             t = threading.Thread(
                 name=thread_name,
                 target=_worker,
-                args=(
-                    weakref.ref(self, weakref_cb),
-                    self._work_queue,
-                    self._initializer,
-                    self._initargs,
-                ),
+                args=args,
                 daemon=True,
             )
             t.start()


### PR DESCRIPTION
Follow-up to #65182: adds a regression test that locks the worker-args tuple shape to the running interpreter (3-arg on 3.14+, 4-arg on 3.8-3.13), verifies daemon=True, and confirms the target is still stdlib concurrent.futures.thread._worker.

This addresses the review feedback requesting a regression test pinning the Python 3.14 _worker signature contract.

Verified green on both Python 3.12.3 and 3.14.4.