### PR TITLE
fix(sessions): finalize abandoned session rows

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12153,6 +12153,57 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.warning("Legacy session recovery on startup failed: %s", exc)
         return exact, fallback
 
+    async def _sweep_abandoned_sessions(self) -> int:
+        """Finalize one bounded batch per served profile state store."""
+        if getattr(self.config, "multiplex_profiles", False):
+            try:
+                profile_homes = _multiplex_profile_homes(self.config)
+            except Exception as exc:
+                logger.debug("Abandoned session profile enumeration failed: %s", exc)
+                profile_homes = []
+
+            finalized = 0
+            for profile_name, profile_home in profile_homes:
+                try:
+                    with _profile_runtime_scope(profile_home):
+                        profile_config = load_gateway_config()
+                        finalized += await self._sweep_abandoned_sessions_for_active_profile(
+                            profile_config.default_reset_policy.idle_minutes,
+                            profile_name=profile_name,
+                        )
+                except Exception as exc:
+                    logger.debug(
+                        "Abandoned session sweep skipped for profile %s: %s",
+                        profile_name,
+                        exc,
+                    )
+            return finalized
+
+        return await self._sweep_abandoned_sessions_for_active_profile(
+            getattr(self.config.default_reset_policy, "idle_minutes", 1440)
+        )
+
+    async def _sweep_abandoned_sessions_for_active_profile(
+        self, idle_minutes: float, *, profile_name: str = ""
+    ) -> int:
+        """Sweep the state store resolved by the current profile scope."""
+        session_db = self._session_db
+        if session_db is None:
+            return 0
+        try:
+            finalized = await session_db.finalize_abandoned_sessions(
+                idle_minutes=idle_minutes
+            )
+        except Exception as exc:
+            logger.debug("Abandoned session sweep skipped: %s", exc)
+            return 0
+        if finalized:
+            suffix = f" for profile {profile_name}" if profile_name else ""
+            logger.info(
+                "Finalized %d abandoned session(s)%s", finalized, suffix
+            )
+        return finalized
+
     async def start(self) -> bool:
         """
         Start the gateway and all configured platform adapters.
@@ -12210,6 +12261,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if self._gateway_loop is not None:
             self._start_loop_liveness_guards(self._gateway_loop)
         logger.info("Session storage: %s", self.config.sessions_dir)
+        await self._sweep_abandoned_sessions()
 
         # Sanity-check that systemd's TimeoutStopSec covers our drain
         # window.  When the user upgraded hermes-agent without re-running
@@ -13527,6 +13579,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _MAX_FINALIZE_RETRIES = 3
         while self._running:
             try:
+                await self._sweep_abandoned_sessions()
                 await self.async_session_store._ensure_loaded()
                 # Collect expired sessions first, then log a single summary.
                 _expired_entries = []

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7888,6 +7888,52 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         return self._execute_write(_do) or 0
 
+    def finalize_abandoned_sessions(
+        self, *, idle_minutes: float = 1440, batch_size: int = 500
+    ) -> int:
+        """Finalize old live rows that never recorded an activity heartbeat.
+
+        These rows have a durable transcript, but no explicit lifecycle end
+        and no ``last_activity_at`` for the gateway expiry watcher to key off.
+        Select candidate ids through the existing ``started_at`` index and
+        update only a bounded batch so startup and watcher maintenance remain
+        cheap on large stores.
+
+        ``abandoned`` is intentionally terminal: unlike accidental cleanup
+        reasons such as ``agent_close`` and ``ws_orphan_reap``, stale-route
+        recovery must not reopen these sessions.
+        """
+        window_seconds = max(0.0, float(idle_minutes)) * 60.0
+        limit = max(1, int(batch_size))
+        cutoff = time.time() - window_seconds
+
+        def _do(conn):
+            now = time.time()
+            result = conn.execute(
+                """
+                UPDATE sessions
+                   SET ended_at = ?,
+                       end_reason = 'abandoned'
+                 WHERE id IN (
+                       SELECT id
+                         FROM sessions
+                        WHERE ended_at IS NULL
+                          AND end_reason IS NULL
+                          AND last_activity_at IS NULL
+                          AND COALESCE(message_count, 0) >= 1
+                          AND started_at < ?
+                        ORDER BY started_at
+                        LIMIT ?
+                 )
+                   AND ended_at IS NULL
+                   AND end_reason IS NULL
+                """,
+                (now, cutoff, limit),
+            )
+            return result.rowcount
+
+        return self._execute_write(_do) or 0
+
     def get_session(self, session_id: str) -> Optional[Dict[str, Any]]:
         """Get a session by ID."""
         # Cost/usage readers (/status, /usage, gateway endpoints) reach the

--- a/tests/gateway/test_abandoned_session_sweep.py
+++ b/tests/gateway/test_abandoned_session_sweep.py
@@ -1,0 +1,113 @@
+from types import SimpleNamespace
+import threading
+import time
+
+import pytest
+
+from gateway.config import GatewayConfig
+from gateway.run import GatewayRunner, _SESSION_DB_UNPINNED
+from hermes_state import SessionDB
+
+
+class _SessionDBStub:
+    def __init__(self, result=0, error=None):
+        self.result = result
+        self.error = error
+        self.calls = []
+
+    async def finalize_abandoned_sessions(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+def _runner(session_db, *, idle_minutes=90):
+    runner = object.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(
+        default_reset_policy=SimpleNamespace(idle_minutes=idle_minutes)
+    )
+    runner._session_db_pinned = session_db
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_sweep_uses_configured_idle_window():
+    session_db = _SessionDBStub(result=3)
+    runner = _runner(session_db, idle_minutes=37)
+
+    assert await runner._sweep_abandoned_sessions() == 3
+    assert session_db.calls == [{"idle_minutes": 37}]
+
+
+@pytest.mark.asyncio
+async def test_sweep_is_best_effort_when_database_is_unavailable():
+    runner = _runner(None)
+    assert await runner._sweep_abandoned_sessions() == 0
+
+    session_db = _SessionDBStub(error=RuntimeError("locked"))
+    runner = _runner(session_db)
+    assert await runner._sweep_abandoned_sessions() == 0
+
+
+@pytest.mark.asyncio
+async def test_multiplex_sweep_finalizes_each_profile_store(
+    tmp_path, monkeypatch
+):
+    import gateway.run as gateway_run
+    import hermes_state
+
+    root = tmp_path / "hermes"
+    secondary = root / "profiles" / "secondary"
+    root.mkdir(parents=True)
+    secondary.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setattr(
+        hermes_state, "DEFAULT_DB_PATH", hermes_state._IMPORT_DEFAULT_DB_PATH
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_multiplex_profile_homes",
+        lambda _config: [("default", root), ("secondary", secondary)],
+    )
+
+    old = time.time() - 2 * 86400
+    for home, session_id in (
+        (root, "root-abandoned"),
+        (secondary, "secondary-abandoned"),
+    ):
+        db = SessionDB(db_path=home / "state.db")
+        db.create_session(session_id, "telegram")
+        db.append_message(session_id, "user", "hello")
+        with db._lock:
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ?, last_activity_at = NULL "
+                "WHERE id = ?",
+                (old, session_id),
+            )
+            db._conn.commit()
+        db.close()
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner._session_db_pinned = _SESSION_DB_UNPINNED
+    runner._session_db_handles = {}
+    runner._session_db_handles_lock = threading.Lock()
+
+    try:
+        assert await runner._sweep_abandoned_sessions() == 2
+        root_db = SessionDB(db_path=root / "state.db")
+        secondary_db = SessionDB(db_path=secondary / "state.db")
+        try:
+            assert root_db.get_session("root-abandoned")["end_reason"] == "abandoned"
+            assert (
+                secondary_db.get_session("secondary-abandoned")["end_reason"]
+                == "abandoned"
+            )
+            assert root_db.get_session("secondary-abandoned") is None
+            assert secondary_db.get_session("root-abandoned") is None
+        finally:
+            root_db.close()
+            secondary_db.close()
+    finally:
+        runner.close_all_session_db_handles()

--- a/tests/hermes_state/test_orphan_gateway_session_repair.py
+++ b/tests/hermes_state/test_orphan_gateway_session_repair.py
@@ -308,3 +308,95 @@ class TestAdoption:
             db, "no_key_donor", keyed=False, started_at=time.time() - 100
         )
         assert db.adopt_orphaned_gateway_session(orphan, "no_key_donor") is False
+
+
+class TestAbandonedSessionFinalization:
+    def test_finalizes_old_heartbeatless_session_with_messages(self, db):
+        now = time.time()
+        _mk_session(
+            db,
+            "abandoned",
+            started_at=now - 1500 * 60,
+            last_activity_at=None,
+            messages=2,
+        )
+
+        assert db.finalize_abandoned_sessions(idle_minutes=1440) == 1
+
+        row = db.get_session("abandoned")
+        assert row["end_reason"] == "abandoned"
+        assert row["ended_at"] is not None
+
+    def test_preserves_rows_outside_the_zombie_signature(self, db):
+        now = time.time()
+        old = now - 1500 * 60
+        _mk_session(db, "empty", started_at=old, messages=0)
+        _mk_session(
+            db,
+            "active",
+            started_at=old,
+            last_activity_at=now - 60,
+            messages=2,
+        )
+        _mk_session(
+            db,
+            "recent",
+            started_at=now - 60,
+            last_activity_at=None,
+            messages=2,
+        )
+        _mk_session(
+            db,
+            "already-ended",
+            started_at=old,
+            ended_at=now - 30,
+            end_reason="new_command",
+            messages=2,
+        )
+
+        assert db.finalize_abandoned_sessions(idle_minutes=1440) == 0
+        assert db.get_session("empty")["ended_at"] is None
+        assert db.get_session("active")["ended_at"] is None
+        assert db.get_session("recent")["ended_at"] is None
+        assert db.get_session("already-ended")["end_reason"] == "new_command"
+
+    def test_is_idempotent_and_bounded(self, db):
+        old = time.time() - 1500 * 60
+        for index in range(3):
+            _mk_session(
+                db,
+                f"abandoned-{index}",
+                started_at=old + index,
+                last_activity_at=None,
+                messages=1,
+            )
+
+        assert db.finalize_abandoned_sessions(
+            idle_minutes=1440, batch_size=2
+        ) == 2
+        assert db.finalize_abandoned_sessions(
+            idle_minutes=1440, batch_size=2
+        ) == 1
+        assert db.finalize_abandoned_sessions(
+            idle_minutes=1440, batch_size=2
+        ) == 0
+
+    def test_abandoned_reason_is_not_recoverable(self, db):
+        now = time.time()
+        _mk_session(
+            db,
+            "older-live",
+            started_at=now - 1600 * 60,
+            last_activity_at=None,
+            messages=2,
+        )
+
+        assert db.finalize_abandoned_sessions(idle_minutes=1440) == 1
+        resolved = db.find_latest_gateway_session_for_peer(
+            source=PEER["source"],
+            user_id=PEER["user_id"],
+            session_key=PEER["session_key"],
+            chat_id=PEER["chat_id"],
+            chat_type=PEER["chat_type"],
+        )
+        assert resolved is None


### PR DESCRIPTION
## Summary
- finalize old message-bearing session rows that have no end marker or activity heartbeat as terminal `abandoned` sessions
- run the bounded sweep at gateway startup and expiry cadence, including every served multiplex profile under its own config and database scope
- add state-layer and gateway regressions for eligibility, exclusions, idempotence, recovery behavior, configured idle windows, and cross-profile isolation

## Validation
- `uv run --frozen --extra dev pytest -q tests/hermes_state/test_orphan_gateway_session_repair.py tests/gateway/test_abandoned_session_sweep.py` (20 passed)
- `uv run --frozen --extra dev ruff check hermes_state.py gateway/run.py tests/hermes_state/test_orphan_gateway_session_repair.py tests/gateway/test_abandoned_session_sweep.py`
- `git diff --check`

## Scope
This PR completes the bounded state-layer repair. Broader exit-path lifecycle changes for ACP/bridge ownership remain a separate follow-up.