### PR TITLE
feat(desktop): show full file name on hover when truncated

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/tree.tsx
@@ -5,6 +5,7 @@ import { type NodeApi, type NodeRendererProps, type RowRendererProps, Tree, type
 
 import { TreeSkeleton } from '@/components/chat/skeletons'
 import { Codicon } from '@/components/ui/codicon'
+import { OverflowTip } from '@/components/ui/tooltip'
 import { markRightPanePerf } from '@/debug/right-pane-events'
 import { useResizeObserver } from '@/hooks/use-resize-observer'
 import { cn } from '@/lib/utils'
@@ -347,7 +348,6 @@ function ProjectTreeRow({
         ...style,
         paddingLeft: withTreeInset(style.paddingLeft)
       }}
-      title={node.data.id}
     >
       {/* No chevron column — the folder icon (open/closed) already carries the
           expand state, so the extra glyph was pure noise. */}
@@ -367,7 +367,12 @@ function ProjectTreeRow({
       ) : (
         // Git decoration (VS Code-style): tint changed files; the explicit color
         // wins over the row's hover/selected text color, so it persists.
-        <span className={cn('min-w-0 flex-1 truncate', changeKind && CHANGE_TINT[changeKind])}>{node.data.name}</span>
+        // OverflowTip shows the full name on hover only when it actually
+        // overflows — the row's native `title` is removed so the two tooltips
+        // don't compete (#93781).
+        <OverflowTip label={node.data.name}>
+          <span className={cn('min-w-0 flex-1 truncate', changeKind && CHANGE_TINT[changeKind])}>{node.data.name}</span>
+        </OverflowTip>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

Fixes #93781: in the Desktop Files pane, long file/folder names are ellipsized with no way to see the full name. The row-level native `title={node.data.id}` exposed the full path on every row rather than the omitted name only when it overflows.

## Approach

- Wrap the truncated name (`<span class=...truncate>`) in `OverflowTip` (#85161's primitive) with `label={node.data.name}` — it measures `scrollWidth` vs `clientWidth` and opens only on actual overflow.
- Remove the row-level `title={node.data.id}` so the two hover tooltips don't compete.
- Keeps the compact single-line layout and the existing Git-change tint.

## Test Plan

- `tsc --noEmit`: clean for tree.tsx (2 pre-existing sdk/index.ts errors unrelated).
- `eslint src/app/right-sidebar/files/tree.tsx`: clean.
- No logic change — pure presentational; reuses the well-tested OverflowTip.

## Risk / Exclusions

- Presentational only; no tree behavior, rename, or selection changes.
- Keyboard focus keeps the existing a11y affordances (full name is in the accessible name via the text itself).

References #93781