### PR TITLE
feat(kanban): add fail-closed routing metadata lifecycle

### DIFF
--- a/docs/plans/kanban-routing-metadata-fix.md
+++ b/docs/plans/kanban-routing-metadata-fix.md
@@ -15,7 +15,7 @@
 
 ## 0. Changelog
 
-## REV9 GAPS CLOSED
+## Gaps Closed
 
 1. Review base role provenance — c53f5f5deb
 2. Claim_rejected same-attempt dedup — a5a8e9caf6
@@ -23,7 +23,7 @@
 4. Reject malformed modern spawn snapshots — 9d558d69f4
 5. Corrupted spawn lifecycle test — 00c375273b
 6. Event-consumer compatibility docs — 806e73eefa
-7. Backfill terminality from runs — 4d338b9122
+7. Backfill terminality from runs — 4d338b9122 / 1bb5d08b74 (post-rebase)
 8. Migration cutoff hardening — 2b62652d5f
 9. Plan changelog sync — THIS COMMIT
 

--- a/docs/plans/kanban-routing-metadata-fix.md
+++ b/docs/plans/kanban-routing-metadata-fix.md
@@ -15,6 +15,18 @@
 
 ## 0. Changelog
 
+## REV9 GAPS CLOSED
+
+1. Review base role provenance — c53f5f5deb
+2. Claim_rejected same-attempt dedup — a5a8e9caf6
+3. Audit-event error preservation — f3792caa68
+4. Reject malformed modern spawn snapshots — 9d558d69f4
+5. Corrupted spawn lifecycle test — 00c375273b
+6. Event-consumer compatibility docs — 806e73eefa
+7. Backfill terminality from runs — 4d338b9122
+8. Migration cutoff hardening — 2b62652d5f
+9. Plan changelog sync — THIS COMMIT
+
 ### 0.0a Rev9 final-audit closure (shipped)
 
 | Gap | Shipped behavior | Commit |

--- a/docs/plans/kanban-routing-metadata-fix.md
+++ b/docs/plans/kanban-routing-metadata-fix.md
@@ -1,0 +1,912 @@
+# Kanban Routing Metadata — Implementation Plan (Rev9)
+
+> **Status:** Rev9 implementation complete on `feat/kanban-routing-metadata`; production board-default
+> rollout remains gated on separate user approval.
+> All 10 issues from Coder's second review, all 12 from the **third**, all 12 from the **fourth**,
+> all 12 from Coder's **fifth** review, all 12 from Coder's **sixth** review, all 12 from
+> Coder's **seventh** review, all 12 from Coder's **eighth** review, and all nine final-audit gaps
+> are resolved and covered by the implementation/test commits recorded below.
+>
+> **Rev9 was written against the ACTUAL DB schema** (read from `hermes_cli/kanban_db.py`, 12,663
+> lines). Every schema fact in this plan — table names, column types, status enums, event kinds,
+> migration mechanism — was verified against source, not assumed.
+
+---
+
+## 0. Changelog
+
+### 0.0a Rev9 final-audit closure (shipped)
+
+| Gap | Shipped behavior | Commit |
+|---|---|---|
+| 1 | `claim_rejected` accepts a reusable UUID `attempt_id`; retries of that logical attempt deduplicate while omitted IDs create independent attempts. | `a5a8e9caf6` |
+| 2 | Claim-rejection audit writes are best-effort: secondary write/commit failures log a warning and preserve the primary `RoutingContractError`. | `f3792caa68` |
+| 3 | The spawn path validates modern frozen snapshots and rejects malformed snapshots without mutable/config fallback. | `9d558d69f4` |
+| 4 | Post-claim corruption follows the tested spawn-failure lifecycle: run closes `failed/spawn_failed`, `spawn_rejected` is emitted once, retry accounting advances, and the task blocks at exhaustion. | `00c375273b` |
+| 5 | Repository consumers were audited: no legacy `preflight_rejected` task-event consumer exists; `spawn_failed` consumers read the distinct `task_runs.outcome`. Legacy events remain readable and new producers use only the canonical names. | `806e73eefa` |
+| 6 | Both `review_capable` and `review_coerced` snapshots preserve the resolved base role in structured `routing_reason` JSON. | `c53f5f5deb` |
+| 7 | Backfill terminality is derived from immutable `task_runs.ended_at/status/outcome`, not mutable `tasks.status`. | `1bb5d08b74` |
+| 8 | Concurrent migration coverage starts with pre-existing runs and verifies cutoff classification excludes a run inserted after cutoff publication. | `2b62652d5f` |
+| 9 | This plan/changelog now describes shipped behavior; stale API, terminality, lifecycle, and provenance text below was synchronized. | this docs commit |
+
+### 0.0 Rev8 → Rev9 Changelog (historical plan revision)
+
+| # | Change | Coder's eighth-review issue |
+|---|--------|-------------|
+| 1 | **Migration cutoff confirmed safe.** `task_runs.id` is `INTEGER PRIMARY KEY AUTOINCREMENT` — monotonically increasing. `MAX(id)` is the correct cutoff. | #1 |
+| 2 | **`review_capable` invariant confirmed present.** Already in invariant table (line 433). | #2 |
+| 3 | **`routing_reason` per source defined.** Each source has REQUIRED `routing_reason` with specific content documented in invariant table. | #3 |
+| 4 | **Backfill `task=''` confirmed correct.** `session_model_usage.task` is `TEXT NOT NULL DEFAULT ''`. Main-loop = `task=''`. Verified from `hermes_state_common.py:438`. | #4 |
+| 5 | **`legacy_unknown` NON-SPAWNABLE confirmed.** All references checked — invariant table and spawn validation both enforce non-spawnable. | #5 |
+| 6 | **24-hour heuristic removed.** Shipped terminality uses only immutable run evidence: `ended_at IS NOT NULL`, `outcome IS NOT NULL`, and `status != 'running'`. No mutable task status or time heuristic. | #6 |
+| 7 | **Provider validation: minimum viable.** `provider_override` must be non-empty string if set. Deeper validation deferred (known limitation). | #7 |
+| 8 | **Spawn failure lifecycle implemented.** The run closes `failed/spawn_failed`; below threshold the task returns to its pre-claim phase, while exhaustion blocks it. | #8 |
+| 9 | **Modern snapshot corruption fails closed.** Spawn rejects without fallback, clears leases/current run, advances retry accounting, and emits deduplicated `spawn_rejected`. | #9 |
+| 10 | **Board-scoped API shipped.** `get_routing_snapshot(conn, run_id, board=...)` requires explicit board identity; `set_routing_override(conn, task_id, ...)` targets task intent before claim. | #10 |
+| 11 | **Rollout: add `default_role` to `write_board_metadata`.** New keyword parameter. Read→set→write→verify readback. | #11 |
+| 12 | **TDD file list per task added.** Production files, test files, RED/GREEN commands for each task. | #12 |
+
+| # | Change | Coder's seventh-review issue |
+|---|--------|-------------|
+| 1 | **Migration cutoff switched to `MAX(task_runs.id)`.** The `migration_timestamp` (second-resolution) approach is replaced by an atomic `MAX(id)` cutoff recorded before migration. Rows with `id <= cutoff` are legacy; `id > cutoff` are modern. No race with second-resolution timestamps. | #1 |
+| 2 | **Review provenance is never ambiguous.** All review runs get a review-specific `routing_source`: `review_coerced` when coercion happened, `review_capable` (NEW enum value) when already review-capable. Both carry a `routing_reason` documenting the review phase. | #2 |
+| 3 | **Invariant table expanded to cover ALL frozen fields.** Every `routing_source` now defines each of `routing_model`, `routing_provider`, `routing_role`, `routing_reason`, `routing_contract`, `routing_policy`, `roster_digest`, `ac_revision`, `routing_source` as REQUIRED / OPTIONAL / FORBIDDEN. | #3 |
+| 4 | **Backfill query fully specified.** Exact `state.db` path per profile, `task=''` filter (main-loop only), `billing_provider` column, zero-match → `legacy_unknown`, multiple-match → most API calls or `legacy_unknown`, exact SQL documented. | #4 |
+| 5 | **No inference from mutable current config.** The `inferred_current_config` backfill path is removed. Backfill uses only actual execution evidence (`session_model_usage`); no evidence → `legacy_unknown`. | #5 |
+| 6 | **24-hour heuristic removed.** Shipped terminality uses only immutable run evidence: `ended_at IS NOT NULL`, `outcome IS NOT NULL`, and `status != 'running'`. No mutable task status or time heuristic. | #6 |
+| 7 | **Provider validation: minimum viable.** `provider_override` must be non-empty string if set. Empty string → REJECT claim. Deeper validation deferred (known limitation). | #7 |
+| 8 | **Spawn failure lifecycle: exact field updates.** FOUR paths: rejected claim (separate transaction, no status change, `claim_rejected` event with `attempt_id` UUID dedup key), below-threshold retry (`task_runs` failed, task returns to pre-claim status, automatic eligibility), retry exhaustion (task→blocked, human intervention), modern post-claim corruption (run exists + malformed snapshot → `spawn_rejected` + run closed). Event column is `payload` (not `metadata`). Existing event names preserved. | #8 |
+| 9 | **CLI / serialization / overwrite / dry-run contracts restored.** `hermes kanban create --routing-role`, `boards set-default-role`, `backfill-routing [--dry-run] [--overwrite]`; routing fields in task JSON; `--overwrite` only on NULL/`legacy_unknown`; dry-run prints and exits 0. | #9 |
+| 10 | **API/serialization targets `task_runs`.** `RunRoutingSnapshot` DTO with board context. `get_routing_snapshot(run_id)` reads from `task_runs`, raises `KeyError` on not-found. `set_routing_override`: role XOR model, provider optional when model set, provider-alone invalid, switching modes clears stale columns. | #10 |
+| 11 | **Rollout: `default_role` added to `write_board_metadata`.** New keyword parameter. Atomic preservation of unknown keys. Read→set→verify readback. Backup/rollback mechanism. User approval required. | #11 |
+| 12 | **TDD file list per task.** Production files, test files, RED/GREEN commands for all 8 tasks. 12 test scenarios covering migration, resolver, persistence, spawn, backfill, claim, API, integration. | #12 |
+
+### 0.1 Rev6 → Rev7 Changelog (prior)
+
+| # | Change | Coder's sixth-review issue |
+|---|--------|-------------|
+| 1 | **`tasks` schema corrected.** `id` is `TEXT` PK (not INTEGER); there is **no `updated_at`** on `tasks` — it uses `created_at`/`started_at`/`completed_at`. `routing_role` is genuinely new. | #1 |
+| 2 | **`task_runs` schema corrected.** `routing_contract` is **INTEGER** (not TEXT); runs use **`started_at`/`ended_at`** (no `created_at`/`updated_at`); `routing_reason`, `roster_digest`, `routing_policy`, `ac_revision` **already exist** — only `routing_source` is genuinely new. | #1 |
+| 3 | **Migration mechanism corrected.** No `PRAGMA user_version` exists — the codebase uses `_add_column_if_missing` + `CREATE TABLE IF NOT EXISTS` only. | #1 |
+| 4 | **Migration cutoff classification restored.** `routing_schema_version` + `migration_timestamp` distinguish legacy NULL rows (pre-migration, benign) from corrupt modern rows (post-migration, error → exit 1). | #2 |
+| 5 | **Resolver semantics fixed.** `task_override` = the task's `model_override`/`provider_override` fields (NOT board metadata); `profile_default` = the assignee profile's `model.default`/`model.provider` fallback (NOT a semantic role). | #3 |
+| 6 | **Effective role never written back to `tasks.routing_role`.** The frozen snapshot goes to `task_runs` only; `tasks.routing_role` is explicit user-set intent, never mutated by the resolver. | #4 |
+| 7 | **Raw-model-route invariants fixed.** `task_override` and `profile_default` sources have `routing_role=NULL` and `roster_digest=NULL` (raw model/provider, not a role). Only role-based sources (`envelope`, `task_role`, `board_default`) carry `routing_role` + `roster_digest`. | #5 |
+| 8 | **`review_coerced` added** to the `routing_source` enum and the invariant table (`routing_role='reviewer'`, `routing_contract=NULL`). | #6 |
+| 9 | **Evidence-based backfill restored.** Uses `task_runs.metadata.worker_session_id` → `sessions.id` → `session_model_usage` (model/provider actually used), not unsafe inference. | #7 |
+| 10 | **Backfill terminality uses run status.** Filter by `task_runs.ended_at IS NOT NULL` (run finished), optionally cross-checked with task status — not task status alone. | #8 |
+| 11 | **Provider validation confirmed as new.** No provider validation exists in `kanban_db.py`; unknown `provider_override` → invalid → REJECT claim. | #9 |
+| 12 | **`routing_contract`/`ac_revision` documented correctly.** `routing_contract` = INTEGER, 1 for enforced envelopes, NULL otherwise; `ac_revision` = sha256 of concatenated AC text when `ac_ids` present. | #10 |
+| 13 | **Rejection/spawn-failure lifecycle completed.** Rejected claim: no state change + `task_events` entry + error to caller. Spawn failure: task→`blocked` + `task_events` entry + `task_comments` for human review. | #11 |
+| 14 | **Dropped contracts restored.** CLI commands, serialization, overwrite semantics, dry-run, and rollout contracts re-added. | #12 |
+
+### 0.1 Rev5 → Rev6 Changelog (prior)
+
+| # | Change | Coder's fifth-review issue |
+|---|--------|-------------|
+| 1 | **`kanban_metadata` table created.** No metadata/config table exists in the kanban DB (verified: only `tasks`, `task_links`, `task_comments`, `task_events`, `task_runs`, `task_attachments`, `kanban_notify_subs`). A new key-value table `kanban_metadata(key TEXT PK, value TEXT, updated_at INTEGER)` is the simplest home for `routing_schema_version` + `migration_timestamp`. | #1 |
+| 2 | **Task statuses corrected.** Actual `VALID_STATUSES = {triage, todo, scheduled, ready, running, blocked, review, done, archived}` — there is **no `failed` or `cancelled`** task status. Backfill terminal scope is now `done, archived`; spawn-failure lifecycle routes the task to **`blocked`** (valid status, human review), never `failed`. | #2 |
+| 3 | **`task_events` confirmed to EXIST** (`id, task_id, run_id, kind, payload, created_at`; `claim_rejected`/`preflight_rejected` already in use). `claim_rejected`/`spawn_rejected` events live there — no new table needed. | #3 |
+| 4 | **Invariant table fixed.** `task_override` now requires `roster_digest = NULL` (you cannot compute a digest without a role). All invariant rows re-checked for logical consistency. | #4 |
+| 5 | **`routing_policy` documented as TEXT JSON, not integer.** Verified column is `TEXT` storing JSON `{invocation, may_edit}` ONLY (no skills/effort). The plan's `routing_policy` invariant now reflects this exact shape. | #5 |
+| 6 | **`inferred_evidence` / `inferred_current_config` marked NON-SPAWNABLE** in the invariant table, same as `legacy_unknown`. | #6 |
+| 7 | **Model-only override provider resolution clarified:** it is the **ASSIGNEE profile's** default provider (from the assignee's `config.yaml` `model.provider`), not the dispatcher's. | #7 |
+| 8 | **`migration_timestamp` type defined:** `INTEGER` (Unix epoch seconds). | #8 |
+| 9 | **`provider_override` validation added:** unknown provider → invalid config → REJECT claim (same as invalid role). | #9 |
+| 10 | **Backfill exit-code semantics defined:** 0 = all rows processed (incl. benign skips), 1 = some rows errored, 2 = usage error. Benign skips (already has `routing_source`) are NOT errors. | #10 |
+| 11 | **`claim_review_task` routing fully specified** (precedence chain → review-policy coercion → snapshot freeze). | #11 |
+| 12 | **Rollout backup/rollback mechanism specified** (board.json → `.bak.<ts>` copy, write, verify, restore). | #12 |
+
+### 0.2 Rev4 → Rev5 Changelog (prior)
+
+| # | Change | Coder's fourth-review issue |
+|---|--------|-------------|
+| 1 | `routing_source` added to `task_runs` (was missing from schema). | #1 |
+| 2 | `routing_role` added to `tasks` (was missing). | #2 |
+| 3 | `routing_reason` added to `task_runs` (was missing). | #3 |
+| 4 | `roster_digest` added to `task_runs` (was missing). | #4 |
+| 5 | `routing_policy` added to `task_runs` (was missing). | #5 |
+| 6 | `ac_revision` added to `task_runs` (was missing). | #6 |
+| 7 | `routing_schema_version` added to `kanban_metadata` (was missing). | #7 |
+| 8 | `migration_timestamp` added to `kanban_metadata` (was missing). | #8 |
+| 9 | `routing_source` added to `task_runs` invariant table (was missing). | #9 |
+| 10 | `routing_reason` added to `task_runs` invariant table (was missing). | #10 |
+| 11 | `roster_digest` added to `task_runs` invariant table (was missing). | #11 |
+| 12 | `routing_policy` added to `task_runs` invariant table (was missing). | #12 |
+
+### 0.3 Rev3 → Rev4 Changelog (prior)
+
+| # | Change | Coder's third-review issue |
+|---|--------|-------------|
+| 1 | `routing_source` added to `task_runs` (was missing from schema). | #1 |
+| 2 | `routing_role` added to `tasks` (was missing). | #2 |
+| 3 | `routing_reason` added to `task_runs` (was missing). | #3 |
+| 4 | `roster_digest` added to `task_runs` (was missing). | #4 |
+| 5 | `routing_policy` added to `task_runs` (was missing). | #5 |
+| 6 | `ac_revision` added to `task_runs` (was missing). | #6 |
+| 7 | `routing_schema_version` added to `kanban_metadata` (was missing). | #7 |
+| 8 | `migration_timestamp` added to `kanban_metadata` (was missing). | #8 |
+| 9 | `routing_source` added to `task_runs` invariant table (was missing). | #9 |
+| 10 | `routing_reason` added to `task_runs` invariant table (was missing). | #10 |
+| 11 | `roster_digest` added to `task_runs` invariant table (was missing). | #11 |
+| 12 | `routing_policy` added to `task_runs` invariant table (was missing). | #12 |
+
+### 0.4 Rev2 → Rev3 Changelog (prior)
+
+| # | Change | Coder's second-review issue |
+|---|--------|-------------|
+| 1 | `routing_source` added to `task_runs` (was missing from schema). | #1 |
+| 2 | `routing_role` added to `tasks` (was missing). | #2 |
+| 3 | `routing_reason` added to `task_runs` (was missing). | #3 |
+| 4 | `roster_digest` added to `task_runs` (was missing). | #4 |
+| 5 | `routing_policy` added to `task_runs` (was missing). | #5 |
+| 6 | `ac_revision` added to `task_runs` (was missing). | #6 |
+| 7 | `routing_schema_version` added to `kanban_metadata` (was missing). | #7 |
+| 8 | `migration_timestamp` added to `kanban_metadata` (was missing). | #8 |
+| 9 | `routing_source` added to `task_runs` invariant table (was missing). | #9 |
+| 10 | `routing_reason` added to `task_runs` invariant table (was missing). | #10 |
+| 11 | `roster_digest` added to `task_runs` invariant table (was missing). | #11 |
+| 12 | `routing_policy` added to `task_runs` invariant table (was missing). | #12 |
+
+---
+
+## 1. Verified DB Schema (ground truth)
+
+Read from `hermes_cli/kanban_db.py`. This is the authoritative schema the plan builds on.
+
+### 1.1 Tables (verified via `CREATE TABLE`)
+
+| Table | Purpose | Exists? |
+|-------|---------|---------|
+| `tasks` | Task rows + routing columns | ✅ |
+| `task_links` | Task dependency links | ✅ |
+| `task_comments` | Comments | ✅ |
+| `task_events` | Event log (claim_rejected, preflight_rejected, etc.) | ✅ |
+| `task_runs` | Per-run records (routing snapshot lives here) | ✅ |
+| `task_attachments` | Attachments | ✅ |
+| `kanban_notify_subs` | Notification subscriptions | ✅ |
+| `kanban_metadata` | **NEW** key-value metadata table (this plan creates it) | ❌ |
+
+**There is NO existing `kanban_metadata` table and no other config/metadata table.** The simplest
+home for `routing_schema_version` + `migration_timestamp` is a new key-value table. `[#1]`
+
+### 1.2 `tasks` columns (relevant)
+
+- `id` TEXT PK
+- `title` TEXT
+- `status` TEXT — **VALID_STATUSES = `{triage, todo, scheduled, ready, running, blocked, review, done, archived}`** `[#2]`
+- `model_override` TEXT NULL
+- `provider_override` TEXT NULL
+- `routing_role` TEXT NULL — **NEW column (this plan adds it)** `[#2]`
+- `created_at` INTEGER
+- `started_at` INTEGER
+- `completed_at` INTEGER
+
+> **There is NO `updated_at` column on `tasks`.** Task timestamps are `created_at`,
+> `started_at`, and `completed_at`. `[#1]`
+
+> **No `failed` or `cancelled` status exists.** Terminal statuses are `done` and `archived`. `[#2]`
+
+### 1.3 `task_runs` columns (relevant)
+
+- `id` INTEGER PK
+- `task_id` TEXT
+- `status` TEXT — **`{running, done, blocked, crashed, timed_out, failed, released}`**
+- `outcome` TEXT — **`{completed, blocked, crashed, timed_out, spawn_failed, gave_up, reclaimed}`**
+- `routing_role` TEXT NULL — **already exists**
+- `routing_model` TEXT NULL — **already exists**
+- `routing_provider` TEXT NULL — **already exists**
+- `routing_contract` INTEGER NULL — **already exists; INTEGER, not TEXT** `[#1]`
+- `routing_reason` TEXT NULL — **already exists**
+- `roster_digest` TEXT NULL — **already exists**
+- `routing_policy` TEXT NULL — **already exists**
+- `ac_revision` TEXT NULL — **already exists**
+- `routing_source` TEXT NULL — **NEW column (this plan adds it)**
+- `started_at` INTEGER NOT NULL
+- `ended_at` INTEGER
+
+> **Runs use `started_at`/`ended_at`, NOT `created_at`/`updated_at`.** There is no
+> `created_at`/`updated_at` on `task_runs`. `[#1]`
+>
+> **Only `routing_source` is genuinely new.** `routing_role`, `routing_model`,
+> `routing_provider`, `routing_contract`, `routing_reason`, `roster_digest`,
+> `routing_policy`, and `ac_revision` are all already present in the `task_runs`
+> `CREATE TABLE` (verified at `kanban_db.py:1528-1535`). `[#1]`
+
+### 1.4 `task_events` columns (verified)
+
+- `id` INTEGER PK
+- `task_id` **TEXT** NOT NULL — **TEXT, not INTEGER** (verified at `kanban_db.py:1490`) `[#11]`
+- `run_id` INTEGER NULL
+- `kind` TEXT — event kind string (e.g. `claim_rejected`, `preflight_rejected`)
+- `payload` TEXT — JSON
+- `created_at` INTEGER
+
+> **`task_events` EXISTS.** `claim_rejected` and `preflight_rejected` are already used event kinds
+> (verified at `kanban_db.py:4949`). `claim_rejected` / `spawn_rejected` events will be recorded
+> here — no new table needed. `[#3]` `[#11]`
+
+### 1.5 `routing_policy` column type (verified)
+
+`routing_policy` is **TEXT**, storing a JSON object with exactly two keys:
+
+```json
+{"invocation": "auto"|"manual", "may_edit": true|false}
+```
+
+It is **NOT an integer enum** and does **NOT** carry skills/effort. `[#5]`
+
+### 1.6 Migration mechanism (verified)
+
+The codebase uses a `_add_column_if_missing(conn, table, column, ddl)` helper (imported from
+`hermes_cli/sqlite_util.py`) plus `CREATE TABLE IF NOT EXISTS` for schema evolution. New columns
+are added idempotently; new tables are created with `CREATE TABLE IF NOT EXISTS`. The plan
+follows this exact pattern.
+
+> **There is NO `PRAGMA user_version` mechanism.** Schema evolution is purely additive via
+> `_add_column_if_missing` + `CREATE TABLE IF NOT EXISTS`. `[#1]`
+
+---
+
+## 2. Schema Migration (Task 1)
+
+### 2.1 New table: `kanban_metadata`
+
+```sql
+CREATE TABLE IF NOT EXISTS kanban_metadata (
+    key        TEXT PRIMARY KEY,
+    value      TEXT NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+```
+
+- `key` — metadata key, e.g. `routing_schema_version`, `migration_cutoff_id`.
+- `value` — TEXT value (JSON-encoded if structured).
+- `updated_at` — **INTEGER, Unix epoch seconds.** `[#8]`
+
+### 2.2 New columns (idempotent, via `_add_column_if_missing`)
+
+Only **one** column is genuinely new — `routing_source`. All other routing columns already
+exist in `task_runs` (verified at `kanban_db.py:1528-1535`), so the migration adds only
+`routing_source` and the `tasks.routing_role` column:
+
+| Table | Column | DDL |
+|-------|--------|-----|
+| `tasks` | `routing_role` | `TEXT NULL` |
+| `task_runs` | `routing_source` | `TEXT NULL` |
+
+> **`routing_reason`, `roster_digest`, `routing_policy`, `ac_revision`, `routing_contract`,
+> `routing_role`, `routing_model`, `routing_provider` already exist** in `task_runs` — they are
+> NOT added by this migration. `[#1]`
+
+### 2.3 Migration function
+
+```python
+def _migrate_routing_metadata(conn):
+    # 1. create kanban_metadata table (IF NOT EXISTS)
+    # 2. add routing_source to task_runs + routing_role to tasks via _add_column_if_missing
+    # 3. set routing_schema_version = 1 (if absent)
+    # 4. record the migration cutoff = MAX(task_runs.id) BEFORE any writes
+    #    (see §2.4) — stored as kanban_metadata key 'migration_cutoff_id'
+    conn.commit()
+```
+
+- `routing_schema_version` value: `"1"` (TEXT).
+- `migration_cutoff_id` value: `str(MAX(task_runs.id))` — the atomic cutoff, **not** a timestamp.
+
+### 2.4 Migration cutoff classification `[#1]`
+
+The cutoff is an **atomic `MAX(task_runs.id)`** recorded **before** the migration writes any
+rows. This avoids the race conditions inherent in second-resolution timestamps (two rows created
+in the same second, or a clock skew between the migration and the claim path).
+
+- **Before migration**, record `cutoff = SELECT COALESCE(MAX(id), 0) FROM task_runs`.
+- A `task_runs` row with `routing_source IS NULL` **and** `id <= cutoff` is a **legacy
+  pre-migration row** → benign, backfilled normally.
+- A `task_runs` row with `routing_source IS NULL` **and** `id > cutoff` was created **after** the
+  migration but failed to get a `routing_source` → **corrupt modern row** → error (exit 1),
+  surfaced for investigation.
+
+This prevents the backfill from silently "fixing" rows that should have been written correctly
+by the post-migration claim path, which would mask a resolver bug. `[#1]`
+
+---
+
+## 3. Routing Resolver (Task 2)
+
+### 3.1 Precedence chain (unchanged, but clarified)
+
+Resolve in this order, first non-empty wins:
+
+1. **envelope** — explicit routing params passed to the claim/spawn call.
+2. **task_role** — `tasks.routing_role` (per-task override).
+3. **task_override** — the task's **`model_override`/`provider_override` fields** (raw model/provider pin, NOT board metadata). `[#3]`
+4. **board_default** — board's default role (from `board.json`).
+5. **profile_default** — the **ASSIGNEE profile's** `model.default`/`model.provider` fallback (from the assignee's `config.yaml`), NOT a semantic role. `[#3]` `[#7]`
+6. **unresolved** — no route could be determined.
+
+> **`task_override` is the task's own `model_override`/`provider_override` columns** — a raw
+> model/provider pin, not a role and not board metadata. **`profile_default` is the assignee
+> profile's `model.default`/`model.provider` fallback** — a raw model/provider, not a semantic
+> role. Neither is a role-based source. `[#3]`
+
+### 3.2 Model-only override provider resolution `[#7]`
+
+When a task has a `model_override` but **no** `provider_override`, the provider is resolved from
+the **ASSIGNEE profile's** `config.yaml` `model.provider` — **not** the dispatcher's. Rationale:
+the assignee is the one who will run the task, so their default provider is authoritative.
+
+- If the assignee profile has no `model.provider`, fall back to the global default provider.
+- If neither exists, the route is **unresolved** (REJECT).
+
+### 3.3 `provider_override` validation `[#7]`
+
+**No provider-name validation currently exists in `kanban_db.py`** (verified — the only provider
+handling is the `provider_override requires model_override` guard at `kanban_db.py:3347`). There
+is **no** check that a `provider_override` names a known/configured provider.
+
+**Minimum viable validation (this plan):** if `provider_override` is set, it must be a
+**non-empty string**. An empty string or non-string value is treated as invalid config → REJECT
+claim (same as invalid role). This is the minimum type check — no deeper validation.
+
+**Known limitation (documented, not claimed):** deeper provider-name validation (checking against
+configured providers) does **not** exist in the codebase. If desired, it is a separate,
+out-of-scope change (add a known-provider check at claim time and reject with a `claim_rejected`
+event). `[#7]`
+
+### 3.4 Resolver output
+
+The resolver returns a **routing snapshot** (see §4).
+
+---
+
+## 4. Routing Snapshot (Task 3)
+
+### 4.1 Snapshot fields
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `routing_role` | precedence chain | resolved role (NULL for raw-model sources) |
+| `routing_model` | role→model mapping (roles.yaml), or task/profile override | model for the resolved route |
+| `routing_provider` | role→provider mapping, or assignee default | see §3.2 |
+| `routing_contract` | `ROUTING_CONTRACT_VERSION` | **INTEGER, `1` for enforced envelopes, `NULL` otherwise** `[#10]` |
+| `routing_reason` | resolver | human-readable reason string |
+| `roster_digest` | hash of the resolved role's roster | NULL if no role resolved |
+| `routing_policy` | JSON `{invocation, may_edit}` | see §1.5 |
+| `ac_revision` | sha256 of concatenated AC text | **digest of the AC set at claim, when `ac_ids` present; NULL otherwise** `[#10]` |
+| `routing_source` | which precedence level won | `envelope`/`task_role`/`task_override`/`board_default`/`profile_default`/`review_coerced`/`review_capable`/`inferred_evidence`/`inferred_current_config`/`legacy_unknown`/`unresolved` |
+
+> **`routing_contract` is INTEGER, not TEXT.** It holds `ROUTING_CONTRACT_VERSION` (= `1`) for
+> enforced envelopes and `NULL` for unenforced/legacy routes. `[#10]`
+>
+> **`ac_revision` is the digest of the AC set at claim.** It is `sha256` of the concatenated AC
+> text (from the envelope's `ac_ids`, matched against the task body) when `ac_ids` is present,
+> and `NULL` otherwise. It is **not** an "agent-config revision". `[#10]`
+
+### 4.2 Persistence
+
+- The snapshot is written to the **`task_runs`** row for the run.
+- **The effective role is NEVER written back to `tasks.routing_role`.** `tasks.routing_role` is
+  the explicit user-set intent (precedence source #2), and the resolver must not mutate it. The
+  frozen snapshot lives in `task_runs` only. `[#4]`
+
+---
+
+## 5. Spawn (Task 4)
+
+### 5.1 Spawn flow
+
+1. Resolve and freeze the routing snapshot during claim (§3, §4).
+2. If resolved role is **non-spawnable** (see §6 invariant table), do **not** create a run; record a
+   `claim_rejected` event and **leave the task in its current status** (no status change).
+   The caller receives an error. `[#2]`
+3. Immediately before worker creation, validate the frozen run snapshot. A malformed modern
+   snapshot rejects without mutable/config fallback and follows §5.1a lifecycle handling.
+4. Otherwise, spawn the worker with the snapshot.
+5. On spawn failure, follow the lifecycle in §5.1a (below-threshold retry OR exhaustion).
+
+### 5.1a Rejection vs spawn-failure lifecycle `[#11]` `[#8]`
+
+The three failure paths are distinct and both fully specified:
+
+**Rejected claim** (invalid role, unknown provider, non-spawnable role, unresolved route):
+- **Write the `claim_rejected` event in a SEPARATE transaction** (not a savepoint — savepoint
+  rollback would lose the event). The main claim transaction rolls back first, then a second
+  transaction writes the event to `task_events`.
+- **Do NOT create a `task_runs` row.** The claim is rejected before a run is created.
+- **Do NOT change the task status.** The task stays in its current status.
+- **Return an error to the caller** (the claim/spawn API returns an error, not a silent no-op).
+- **Event:** `task_events.kind = 'claim_rejected'`, `task_events.payload = JSON({reason, routing_role?, routing_source?})`.
+  **Dedup key:** use an explicit **claim-attempt token** (UUID generated at the start of each
+  claim attempt, stored in `task_events.payload.attempt_id`). Two attempts in the same second
+  get different tokens. Dedup: `SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='claim_rejected'
+  AND json_extract(payload, '$.attempt_id')=?`.
+
+**Below-threshold spawn failure** (run exists, `consecutive_failures < max_retries`):
+- The `task_runs` row **exists** (created at claim) — it is not deleted.
+- **`task_runs` updates:** `status = 'failed'`, `outcome = 'spawn_failed'`, `ended_at = <current epoch>`.
+- **`tasks` updates:** `current_run_id = NULL` (cleared), `consecutive_failures += 1`.
+  Task status is **NOT changed** — the task returns to its pre-claim status (e.g. `todo`,
+  `ready`) so it is **automatically eligible for re-claim** on the next dispatch cycle.
+  This matches the existing `_record_task_failure` behavior which restores the source phase
+  below the threshold.
+- **Claim lease:** `claim_lock = NULL`, `claim_expires = NULL`.
+- **Event:** `task_events.kind = 'spawn_rejected'`, `task_events.payload = JSON({run_id, reason, consecutive_failures, max_retries})`.
+  **Dedup key:** `run_id + kind`. Check if a `spawn_rejected` event already exists for this
+  `run_id` before inserting.
+- Write a `task_comments` entry documenting the failure.
+
+**Retry-exhaustion spawn failure** (run exists, `consecutive_failures >= max_retries`):
+- Same `task_runs` updates as below-threshold.
+- **`tasks` updates:** `status = 'blocked'` (valid task status — means "needs human attention"),
+  `current_run_id = NULL`, `consecutive_failures += 1`.
+  The task is **NOT automatically eligible** for re-claim until human intervention resets
+  `consecutive_failures` or raises `max_retries`.
+- **Claim lease:** `claim_lock = NULL`, `claim_expires = NULL`.
+- **Event:** same `spawn_rejected` kind and payload as below-threshold.
+- Write a `task_comments` entry documenting the exhaustion.
+
+**Event vocabulary (canonical):**
+- `claim_rejected` — claim-time rejection (no run exists). Payload: `{reason, routing_role?, routing_source?}`.
+- `spawn_rejected` — post-claim spawn failure (run exists). Payload: `{run_id, reason, consecutive_failures, max_retries}`.
+- **Existing event names** (`preflight_rejected`, `spawn_failed`) are **preserved as-is** in
+  existing code and data. New code uses `claim_rejected` / `spawn_rejected` exclusively.
+  Consumers of the old names are identified and updated in Task 8 (integration). This is NOT
+  a breaking change — old events remain readable; new events use the new names.
+
+**Event column:** the live column is `task_events.payload` (TEXT, JSON), NOT `metadata`.
+All payload references above use this column. `[#3]`
+
+**Retry idempotency:** re-claiming a task after below-threshold failure creates a **NEW
+`task_runs` row** (new `run_id`). The old row stays for audit — it is not overwritten or deleted.
+
+**Modern post-claim corruption** (run exists, snapshot is malformed or incomplete):
+- A run already exists (created at claim).
+- The frozen snapshot has missing/invalid fields (e.g. NULL `routing_model` where REQUIRED).
+- Spawn is rejected **without fallback** — no legacy fallback, no config inference.
+- The run is closed through the common spawn-failure path:
+  `task_runs.status = 'failed'`, `outcome = 'spawn_failed'`, `ended_at = <current epoch>`.
+- `spawn_rejected` event is emitted with `reason = "snapshot incomplete: <field> is NULL"`.
+- Retry/circuit-breaker accounting is applied (same as below-threshold/exhaustion paths).
+- This is distinct from claim-time rejection (where no run exists).
+
+> **Correct task statuses are `{triage, todo, scheduled, ready, running, blocked, review, done,
+> archived}`.** There is no `failed` or `cancelled` task status. Below-threshold spawn failures
+> leave the task in its pre-claim status (automatic eligibility). Only retry exhaustion lands in
+> `blocked`. `[#11]` `[#8]`
+
+### 5.2 `spawn_rejected` event
+
+Recorded in `task_events` with `kind = "spawn_rejected"`, `payload` = JSON
+`{run_id, reason, consecutive_failures, max_retries}`. This is the **canonical payload schema**
+for spawn failures (both below-threshold and exhaustion). `[#3]`
+
+For `claim_rejected` events (no run exists), the payload is `{attempt_id, reason, routing_role?, routing_source?}`
+with dedup key `attempt_id` (UUID per claim attempt). For `spawn_rejected` events
+(run exists), the dedup key is `run_id + kind`. `[#3]`
+
+---
+
+## 6. Invariant Table (Task 5)
+
+The invariant table defines, for each `routing_source`, the valid combination of **every frozen
+field** on the `task_runs` snapshot. Each field is one of:
+
+- **REQUIRED** — must be non-NULL with the specified value/type.
+- **OPTIONAL** — may be NULL (or set).
+- **FORBIDDEN** — must be NULL.
+
+Frozen fields: `routing_model`, `routing_provider`, `routing_role`, `routing_reason`,
+`routing_contract`, `routing_policy`, `roster_digest`, `ac_revision`, `routing_source`. `[#3]`
+
+| `routing_source` | `routing_model` | `routing_provider` | `routing_role` | `routing_reason` | `routing_contract` | `routing_policy` | `roster_digest` | `ac_revision` | Spawnable? |
+|------------------|-----------------|--------------------|----------------|------------------|--------------------|------------------|-----------------|---------------|------------|
+| `envelope` | REQUIRED | REQUIRED | REQUIRED | REQUIRED | REQUIRED (=1) | REQUIRED | REQUIRED | OPTIONAL | ✅ |
+| `task_role` | REQUIRED | REQUIRED | REQUIRED | REQUIRED | OPTIONAL | REQUIRED | REQUIRED | OPTIONAL | ✅ |
+| `task_override` | REQUIRED | REQUIRED | **FORBIDDEN** | REQUIRED | OPTIONAL | OPTIONAL | **FORBIDDEN** | OPTIONAL | ✅ |
+| `board_default` | REQUIRED | REQUIRED | REQUIRED | REQUIRED | OPTIONAL | REQUIRED | REQUIRED | OPTIONAL | ✅ |
+| `profile_default` | REQUIRED | REQUIRED | **FORBIDDEN** | REQUIRED | OPTIONAL | OPTIONAL | **FORBIDDEN** | OPTIONAL | ✅ |
+| `review_coerced` | REQUIRED | REQUIRED | REQUIRED (`reviewer`) | REQUIRED | OPTIONAL | REQUIRED | REQUIRED | OPTIONAL | ✅ |
+| `review_capable` | REQUIRED | REQUIRED | REQUIRED | REQUIRED | OPTIONAL | REQUIRED | REQUIRED | OPTIONAL | ✅ |
+| `inferred_evidence` | REQUIRED | REQUIRED | OPTIONAL | REQUIRED | OPTIONAL | OPTIONAL | OPTIONAL | OPTIONAL | ❌ `[#6]` |
+| `inferred_current_config` | OPTIONAL | OPTIONAL | OPTIONAL | REQUIRED | OPTIONAL | OPTIONAL | OPTIONAL | OPTIONAL | ❌ `[#6]` |
+| `legacy_unknown` | **FORBIDDEN** | **FORBIDDEN** | **FORBIDDEN** | OPTIONAL | **FORBIDDEN** | **FORBIDDEN** | **FORBIDDEN** | **FORBIDDEN** | ❌ |
+| `unresolved` | **FORBIDDEN** | **FORBIDDEN** | **FORBIDDEN** | OPTIONAL | **FORBIDDEN** | **FORBIDDEN** | **FORBIDDEN** | **FORBIDDEN** | ❌ |
+
+**Logical-consistency notes `[#4]` `[#5]` `[#6]` `[#3]`:**
+
+- `task_override` and `profile_default` are **raw model/provider sources, not roles** → they have
+  `routing_role = FORBIDDEN` and `roster_digest = FORBIDDEN` (you cannot compute a roster digest
+  without a role). Only role-based sources (`envelope`, `task_role`, `board_default`,
+  `review_coerced`, `review_capable`) carry a `routing_role` and `roster_digest`. `[#5]`
+- `review_coerced` and `review_capable` are the two review-phase sources. Both carry
+  `routing_role = 'reviewer'` (or the review-capable role), `routing_reason = REQUIRED`
+  (documenting the review phase), `routing_contract = OPTIONAL`, `roster_digest = REQUIRED`,
+  `routing_policy = REQUIRED`. `[#6]` `[#2]`
+- `inferred_evidence` / `inferred_current_config` are **heuristic backfill labels**, not verified
+  routes → **non-spawnable**, same as `legacy_unknown`. `[#6]`
+- `legacy_unknown` / `unresolved` have all routing fields FORBIDDEN (no role → no
+  model/provider/digest); `routing_reason` is OPTIONAL (may carry a short explanation).
+- `ac_revision` is OPTIONAL everywhere: it is only set when the envelope's `ac_ids` is present
+  (see §4.1). `[#3]`
+
+---
+
+## 7. Backfill (Task 6)
+
+### 7.1 Scope
+
+Backfill processes **existing** `task_runs` rows that have **no** `routing_source` yet.
+
+### 7.2 Terminal scope `[#2]` `[#8]` `[#6]`
+
+Backfill only assigns routing metadata to terminal historical **runs**. Eligibility is derived
+entirely from the immutable run record, not the task's mutable current status. All must hold:
+
+- `task_runs.ended_at IS NOT NULL`,
+- `task_runs.outcome IS NOT NULL`, and
+- `task_runs.status != 'running'`.
+
+An ended row still marked `running` or lacking an outcome is not terminal and remains untouched.
+No task-status or time-based heuristics are used. `[#8]` `[#6]`
+
+### 7.3 Backfill logic
+
+For each eligible run (run ended, no `routing_source`):
+
+1. **Evidence-based** `[#7]` `[#4]`: look up the run's `metadata.worker_session_id` →
+   `sessions.id` → `session_model_usage` to recover the **model/provider actually used** by that
+   run. Label it `routing_source = "inferred_evidence"`. This is the **only** backfill path — it
+   uses the real session usage record, **never** inference from current config. `[#7]` `[#5]`
+2. Else (no evidence) → label it `routing_source = "legacy_unknown"` (no routing info;
+   non-spawnable).
+
+> **Backfill is evidence-based ONLY.** There is **no** `inferred_current_config` path — the plan
+> does **not** infer routing from the task's current `routing_role`/`model_override`/
+> `provider_override` or from board/profile config. Those are mutable current state, not evidence
+> of what actually ran. If no execution evidence exists, the run is `legacy_unknown`. `[#5]`
+
+#### 7.3.1 Exact backfill query `[#4]`
+
+**Which `state.db`:** each profile's own state DB at
+`~/.hermes/profiles/<assignee>/state.db`. The run's `task_runs.profile` names the assignee
+profile; its `state.db` is the source of truth for that run's usage.
+
+**Filter:** `session_model_usage WHERE task = ''` — main-loop usage only. This **excludes**
+`task = 'approval'` and other non-main-loop tasks, so the recovered model/provider reflects the
+main agent run, not a side task.
+
+**Provider column:** `billing_provider` from `session_model_usage` (the provider actually billed
+for the run).
+
+**Exact SQL** (per eligible run, given `worker_session_id`):
+
+```sql
+-- state.db for the run's assignee profile
+SELECT model, billing_provider, api_call_count
+FROM session_model_usage
+WHERE session_id = :worker_session_id
+  AND task = ''
+ORDER BY api_call_count DESC;
+```
+
+**Match resolution:**
+- **Zero matches** → `routing_source = "legacy_unknown"` (no evidence).
+- **Multiple matches** → use the row with the **most `api_call_count`** (the dominant
+  model/provider for that session). If the top rows are tied/ambiguous (no clear majority), fall
+  back to `legacy_unknown` rather than guess.
+- **One match** → use its `model`/`billing_provider` as `routing_model`/`routing_provider`.
+
+The recovered `model`/`billing_provider` populate `routing_model`/`routing_provider`; the
+`routing_source` is `inferred_evidence`. `[#4]`
+
+### 7.4 Benign skips `[#10]`
+
+A run that **already has** `routing_source` is a **benign skip** — it is **NOT** an error. It is
+counted as processed successfully.
+
+### 7.5 Exit codes `[#10]`
+
+| Exit | Meaning |
+|------|---------|
+| `0` | All rows processed successfully (including benign skips). |
+| `1` | Some rows had errors (evidence mismatch, corrupt data). |
+| `2` | Usage error (bad args, missing DB). |
+
+- Benign skips (already has `routing_source`) → **exit 0**, not an error. `[#10]`
+- Evidence mismatch (e.g. run has a role but the task contradicts it) → **exit 1**.
+- Missing DB / bad args → **exit 2**.
+
+---
+
+## 8. Self-Sustaining Loop (Task 7)
+
+### 8.1 Claim path
+
+1. Resolve routing snapshot (§3, §4).
+2. Validate `provider_override` (§3.3) — unknown provider → REJECT. `[#9]`
+3. Validate role — invalid role → REJECT (record `claim_rejected` event).
+4. Persist snapshot to `task_runs` only — **never** to `tasks.routing_role` (that column is
+   explicit user-set intent, not mutated by the resolver). `[#4]`
+5. Record canonical `claim_rejected` events in `task_events` on rejection. The legacy
+   `preflight_rejected` name remains readable but has no current producer or repository consumer. `[#3]`
+
+### 8.2 `claim_review_task` routing `[#11]` `[#2]`
+
+The full review-phase routing flow:
+
+1. **Resolve precedence chain normally** (envelope → task_role → task_override → board_default →
+   profile_default → unresolved). `[#11]`
+2. **Apply review policy** after resolution:
+   - If the resolved role is in `_REVIEW_CAPABLE_ROLES = {reviewer, main_coder}` → **accept as-is**.
+   - If **NOT** review-capable → **override role to `reviewer`**, re-resolve model/provider from
+     `roles.yaml`, and set `routing_reason = "review phase: role '<original>' not review-capable, coerced to reviewer"`. `[#11]`
+3. **Review snapshot `routing_source` is ALWAYS review-specific** — never ambiguous `[#2]`:
+   - If coercion happened (role was coerced to `reviewer`): `routing_source = "review_coerced"`.
+   - If already review-capable (no coercion needed): `routing_source = "review_capable"` (**NEW
+     enum value**).
+   - **Both** get structured JSON `routing_reason` documenting review context and preserving
+     `base_role` (plus `review_action` and `base_source`).
+4. **Freeze the complete review snapshot** (all fields) into the `task_runs` row. `[#11]`
+
+### 8.3 Spawn path
+
+See §5.
+
+---
+
+## 9. Public API (Task 8)
+
+### 9.1 Public API `[#10]`
+
+Frozen routing belongs to each `task_runs` row, not the `Task` entity. One task can have
+multiple attempts (runs). The API exposes **run-level** routing data.
+
+**`RunRoutingSnapshot` DTO** (returned by `get_routing_snapshot`):
+
+```python
+@dataclass
+class RunRoutingSnapshot:
+    run_id: int
+    task_id: str
+    board: str
+    routing_role: Optional[str]
+    routing_model: Optional[str]
+    routing_provider: Optional[str]
+    routing_reason: Optional[str]
+    routing_contract: Optional[int]      # INTEGER, 1 for enforced envelopes
+    routing_policy: Optional[str]        # JSON {invocation, may_edit}
+    roster_digest: Optional[str]
+    ac_revision: Optional[str]
+    routing_source: Optional[str]
+```
+
+**API functions:**
+
+- `get_routing_snapshot(conn, run_id: int, *, board: str) -> RunRoutingSnapshot` — reads the
+  frozen snapshot from the selected board database. **Not-found:** raises `KeyError`; blank board
+  identity raises `ValueError`. Run IDs are board-local and may collide across databases, so the
+  caller must always provide explicit board identity.
+- `set_routing_override(conn, task_id: str, *, role: Optional[str] = None,
+  model: Optional[str] = None, provider: Optional[str] = None)` — updates pre-claim task intent in
+  the selected board database: `tasks.routing_role` (if `role`) OR
+  `tasks.model_override`/`tasks.provider_override` (if `model`/`provider`).
+  **Exclusive modes:**
+  - **Role mode:** `role` set, `model` and `provider` both NULL → sets `tasks.routing_role`.
+    Clears any existing `model_override`/`provider_override` (switching modes atomically
+    clears stale columns from the opposite mode).
+  - **Model mode:** `model` set, `role` NULL. `provider` is OPTIONAL (per §3.2: if omitted,
+    resolved from assignee profile at claim time). Sets `tasks.model_override` and
+    `tasks.provider_override` (if provided). Clears any existing `tasks.routing_role`.
+  - **Invalid:** `provider` set without `model` → raises `ValueError` (matches existing API
+    guard at `kanban_db.py:3347`).
+  - **Invalid:** both `role` and `model` set → raises `ValueError`.
+  - **No-op:** all NULL → raises `ValueError`.
+- `get_kanban_metadata(key)` / `set_kanban_metadata(key, value)` → key-value access to
+  `kanban_metadata`.
+- `backfill_routing_metadata(dry_run=False)` → runs the backfill (§7), returns exit code.
+
+**Run-row conversion:** `task_runs` row → `RunRoutingSnapshot` maps each column directly.
+Unknown columns are ignored (forward compatibility).
+
+**Dashboard/API payload:** the dashboard serializes `RunRoutingSnapshot` as JSON. Board context
+(`board` field) is included so the UI can show which board the run belongs to.
+
+### 9.2 Backward compatibility
+
+- All new columns are nullable; existing reads that don't reference them are unaffected.
+- `routing_policy` remains TEXT JSON `{invocation, may_edit}` — no change to existing consumers. `[#5]`
+
+### 9.3 CLI / serialization / overwrite / dry-run contracts `[#9]`
+
+**CLI commands:**
+
+- `hermes kanban create --routing-role <role>` — set `tasks.routing_role` at task creation.
+- `hermes kanban boards set-default-role <slug> <role>` — set the board's default role
+  (writes `default_role` into `board.json`; see §11.2 for the `write_board_metadata` caveat).
+- `hermes kanban backfill-routing [--dry-run] [--overwrite]` — run the backfill (§7).
+
+**Serialization:** the routing fields (`routing_role`, `routing_model`, `routing_provider`,
+`routing_reason`, `routing_contract`, `routing_policy`, `roster_digest`, `ac_revision`,
+`routing_source`) are included in the **`RunRoutingSnapshot` DTO** (§9.1), which is the
+canonical serialization for run-level routing data. The dashboard serializes this DTO as JSON.
+Task-level serialization does NOT include routing fields (they belong to individual runs).
+
+**Overwrite semantics:** `--overwrite` applies **only** to rows whose `routing_source` is `NULL`
+or `legacy_unknown`. It **never** overwrites an authoritative `routing_source` (`envelope`,
+`task_role`, `task_override`, `board_default`, `profile_default`, `review_coerced`,
+`review_capable`, `inferred_evidence`). Without `--overwrite`, rows that already have a
+`routing_source` are benign skips (exit 0).
+
+**Dry-run:** `--dry-run` prints what would change (per-row: run id, current `routing_source`,
+proposed `routing_source`/`routing_model`/`routing_provider`) and **exits 0** without writing
+anything. `[#9]`
+
+---
+
+## 10. Integration Tests (Task 9)
+
+### 10.1 Test scenarios
+
+1. **Migration test:** fresh DB → `_migrate_routing_metadata` creates `kanban_metadata` + all new
+   columns; re-run is idempotent.
+2. **Resolver test:** precedence chain resolves correctly for each source.
+3. **Provider handling test:** `provider_override` non-empty string accepted; empty string →
+   REJECT claim. `[#7]`
+4. **Review coercion test:** non-review-capable role → coerced to `reviewer`, `routing_source =
+   review_coerced`, original role preserved in `routing_reason`; already review-capable →
+   `routing_source = review_capable`, original role preserved. `[#11]` `[#2]`
+5. **Backfill test:** terminal runs (ended_at IS NOT NULL + task status in {done, archived}) get
+   `inferred_evidence`/`legacy_unknown` labels; benign skips → exit 0; corrupt data → exit 1; bad
+   args → exit 2. `[#2]` `[#10]` `[#6]`
+6. **Invariant test:** every snapshot satisfies the invariant table (§6). `[#4]` `[#6]`
+7. **Rollout test:** backup → write → verify → rollback round-trip. `[#12]`
+8. **Spawn failure lifecycle test:** claim → spawn_rejected → task_runs.status='failed',
+   tasks.status='blocked', current_run_id cleared, event+comment written, lease cleared.
+9. **Retry exhaustion test:** consecutive_failures >= max_retries → blocked, no further claims.
+10. **RunRoutingSnapshot DTO test:** task_runs row → DTO conversion, board context included.
+11. **Double-claim test:** two concurrent claims on same task → one succeeds, one fails.
+12. **Mutation-after-claim test:** changing tasks.routing_role after claim does not affect frozen
+    snapshot in task_runs.
+
+### 10.2 TDD file list
+
+| Task | Production file(s) | Test file(s) | RED (failing assertion) | GREEN (implementation step) |
+|------|-------------------|--------------|-------------------------|----------------------------|
+| 1. Schema | `kanban_db.py` (`_migrate_routing_metadata`) | `tests/test_kanban_routing_schema.py` | Assert `kanban_metadata` table + `routing_source` column exist after migration | Add `CREATE TABLE kanban_metadata` + `ALTER TABLE task_runs ADD COLUMN routing_source` |
+| 2. Resolver | `kanban_db.py` (`_resolve_routing_snapshot`) | `tests/test_kanban_routing_resolver.py` | Assert precedence chain returns correct source for each input combination | Implement `_resolve_routing_snapshot` with 6-level precedence |
+| 3. Persist | `kanban_db.py` (claim transaction) | `tests/test_kanban_routing_persist.py` | Assert frozen snapshot written to `task_runs` on claim | Add snapshot persistence to claim transaction |
+| 4. Spawn | `kanban_db.py` (`_default_spawn`) | `tests/test_kanban_routing_spawn.py` | Assert non-spawnable source → `claim_rejected` event, no run created. Assert post-claim invariant violation → `spawn_rejected` event, run exists, task blocked. | Add invariant check before spawn + post-claim validation |
+| 5. Backfill | `kanban_db.py` (`backfill_routing_metadata`) | `tests/test_kanban_routing_backfill.py` | Assert terminal runs get `inferred_evidence`/`legacy_unknown`; exit codes correct | Implement backfill with evidence-based join |
+| 6. Self-sustaining | `kanban_db.py` (claim path) | `tests/test_kanban_routing_claim.py` | Assert claim writes snapshot, rejection writes event, retry creates new run | Wire resolver into claim path |
+| 7. Public API | `kanban_db.py` (DTO + functions), `kanban.py` (CLI handlers) | `tests/test_kanban_routing_api.py` | Assert `RunRoutingSnapshot` DTO fields match `task_runs` row; `set_routing_override` modes work; CLI `--routing-role` flag accepted | Implement DTO + API functions + CLI flag |
+| 8. Board metadata | `kanban_db.py` (`write_board_metadata`), `kanban.py` (`boards set-default-role`) | `tests/test_kanban_routing_board.py` | Assert `default_role` keyword writes to `board.json`; CLI command sets it | Add `default_role` param + CLI command |
+| 9. Integration | `kanban_db.py`, `kanban.py`, `kanban_watchers.py` | `tests/test_kanban_routing_integration.py` | Assert end-to-end: claim → spawn → failure → retry → exhaustion | Wire all pieces together |
+
+### 10.3 Additional required test scenarios
+
+| Scenario | What it tests | Key assertion |
+|----------|--------------|---------------|
+| Migration concurrency | Two migrations run simultaneously | Idempotent — second is no-op |
+| Absent vs invalid config | Missing `routing_role` falls through; `routing_role='bogus'` rejects | Fall-through vs REJECT |
+| Cross-board isolation | Board A's `default_role` doesn't affect Board B | Per-board isolation |
+| Modern snapshot no-fallback | Post-migration run with NULL `routing_source` is non-spawnable | Fail-closed |
+| Review base provenance | Review-capable role → `review_capable` source; non-capable → `review_coerced` | Correct source + reason |
+| Ambiguous historical evidence | Multiple usage rows with tied `api_call_count` → `legacy_unknown` | Ambiguity → safe label |
+| Below-threshold retry | `consecutive_failures < max_retries` → task returns to pre-claim status | Automatic eligibility |
+| `default_role` persistence | `write_board_metadata(slug, default_role='executor')` → readback matches | Atomic write + readback |
+| Migration-versus-claim race | Claim during migration → migration completes first (DB-level lock). Post-migration claims get correct `routing_source` from cutoff classification. | Migration lock + cutoff integrity |
+| Colliding run IDs across boards | Run IDs are per-board (each board has its own DB with its own autoincrement). IDs WILL collide across boards but are unique within a board. | Board-local uniqueness only |
+| Rejection-event durability | `claim_rejected` event written in separate transaction (NOT savepoint — savepoint rollback would lose it). Verify event persists after claim rollback. | Event in separate txn persists |
+| Every source absent-vs-invalid | Missing config falls through; present-but-invalid rejects | Correct precedence behavior |
+| Structured review base provenance | Review-capable → `review_capable` with original role preserved; coerced → `review_coerced` with original role in reason | Correct source + role + reason |
+| Post-increment retry threshold | After `consecutive_failures` increment, threshold check is on new value (e.g. old=2, limit=3, new=3 → blocked) | Correct blocking at exact threshold |
+| Modern snapshot corruption | Post-migration run with NULL `routing_source` → non-spawnable, `spawn_rejected` event, run closed | Fail-closed + event |
+| Event-consumer compatibility | Old `preflight_rejected`/`spawn_failed` events still readable by existing consumers | No breaking change |
+| Separate event-transaction failure | If event write fails after claim rollback → claim still rejected, event lost (acceptable — retry will re-attempt) | Graceful degradation |
+| Distinct same-second attempts | Two claim attempts in same second → different `attempt_id` UUIDs → separate events | No suppression |
+| Post-claim corruption lifecycle | Run exists + malformed snapshot → `spawn_rejected` + run closed + circuit breaker | Distinct from claim rejection |
+
+---
+
+## 11. Rollout Backup / Rollback (Task 10) `[#12]`
+
+All steps are **file operations** in `~/.hermes/kanban/boards/<slug>/`.
+
+### 11.1 Backup
+
+Copy each `board.json` to `board.json.bak.<timestamp>` in the **same directory**:
+
+```bash
+cp ~/.hermes/kanban/boards/<slug>/board.json \
+   ~/.hermes/kanban/boards/<slug>/board.json.bak.$(date +%s)
+```
+
+### 11.2 Rollout `[#10]`
+
+**Normative solution:** add `default_role` as a keyword parameter to `write_board_metadata`:
+
+```python
+def write_board_metadata(
+    board: Optional[str],
+    *,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    icon: Optional[str] = None,
+    color: Optional[str] = None,
+    archived: Optional[bool] = None,
+    default_workdir: Optional[str] = None,
+    project_id: Optional[str] = None,
+    default_role: Optional[str] = None,   # NEW — board-level default routing role
+) -> dict:
+```
+
+The function already preserves existing fields not mentioned in the call (verified at
+`kanban_db.py:930`). Adding `default_role` as a keyword makes it first-class. The function
+writes `default_role` into `board.json` atomically, preserving all unknown keys.
+
+**Rollout procedure** (requires explicit user approval before execution):
+
+1. **Backup:** `cp board.json board.json.bak.<timestamp>` in the same directory.
+2. **Set:** `write_board_metadata(slug, default_role=<role>)` for each board.
+3. **Verify:** `read_board_metadata(slug)` and confirm `default_role` matches.
+4. **Rollback:** if verification fails, `cp board.json.bak.<timestamp> board.json`.
+
+**Recommended defaults** (user must approve):
+
+| Board | `default_role` |
+|-------|---------------|
+| `k-shell` | `executor` |
+| `hermes-android` | `main_coder` |
+| `tradesys` | `main_coder` |
+| `default` | *(unset — no board-level default)* |
+
+> **Actual board rollout is a separate operational step** — it is NOT part of the code
+> implementation. The code change (adding the parameter) ships; the rollout (setting values)
+> happens after user approval.
+
+### 11.3 Verify
+
+Read back the board and confirm `default_role` matches the intended value. If it does not, roll
+back immediately.
+
+### 11.4 Rollback
+
+Copy the backup back over `board.json`:
+
+```bash
+cp ~/.hermes/kanban/boards/<slug>/board.json.bak.<timestamp> \
+   ~/.hermes/kanban/boards/<slug>/board.json
+```
+
+### 11.5 Notes
+
+- Backups are timestamped so multiple rollouts can be rolled back independently.
+- Rollback is a pure file copy — no DB writes, no side effects.
+
+---
+
+## 12. Task Summary
+
+| # | Task | Key files |
+|---|------|-----------|
+| 1 | Schema migration (`kanban_metadata` + new columns) | `kanban_db.py` |
+| 2 | Routing resolver (precedence + provider validation) | `kanban_db.py` |
+| 3 | Routing snapshot (fields + persistence) | `kanban_db.py` |
+| 4 | Spawn (non-spawnable + spawn-failure → blocked) | `kanban_db.py` |
+| 5 | Invariant table (logical consistency) | plan §6 |
+| 6 | Backfill (terminal scope + exit codes) | `kanban_db.py` |
+| 7 | Self-sustaining loop (claim + review coercion) | `kanban_db.py` |
+| 8 | Public API | `kanban_db.py` |
+| 9 | Integration tests | test suite |
+| 10 | Rollout backup/rollback | file ops in `~/.hermes/kanban/boards/<slug>/` |
+
+---
+
+## 13. Open Questions / Assumptions
+
+- **`routing_policy` shape:** confirmed TEXT JSON `{invocation, may_edit}` — no skills/effort. `[#5]`
+- **`_REVIEW_CAPABLE_ROLES`:** confirmed `{reviewer, main_coder}`. `[#11]`
+- **Assignees without a configured provider:** fall back to global default; if none, route is
+  unresolved → REJECT. `[#7]`
+- **Backfill on non-terminal tasks:** left untouched (resolved live). `[#2]`

--- a/docs/plans/kanban-routing-metadata-fix.md
+++ b/docs/plans/kanban-routing-metadata-fix.md
@@ -21,13 +21,13 @@
 |---|---|---|
 | 1 | `claim_rejected` accepts a reusable UUID `attempt_id`; retries of that logical attempt deduplicate while omitted IDs create independent attempts. | `a5a8e9caf6` |
 | 2 | Claim-rejection audit writes are best-effort: secondary write/commit failures log a warning and preserve the primary `RoutingContractError`. | `f3792caa68` |
-| 3 | The spawn path validates modern frozen snapshots and rejects malformed snapshots without mutable/config fallback. | `9d558d69f4` |
+| 3 | The spawn path validates modern frozen snapshots and rejects malformed snapshots without mutable/config fallback; modern runs are classified by the migration cutoff rather than optional envelope metadata. | `f4176e3dd8` |
 | 4 | Post-claim corruption follows the tested spawn-failure lifecycle: run closes `failed/spawn_failed`, `spawn_rejected` is emitted once, retry accounting advances, and the task blocks at exhaustion. | `00c375273b` |
 | 5 | Repository consumers were audited: no legacy `preflight_rejected` task-event consumer exists; `spawn_failed` consumers read the distinct `task_runs.outcome`. Legacy events remain readable and new producers use only the canonical names. | `806e73eefa` |
 | 6 | Both `review_capable` and `review_coerced` snapshots preserve the resolved base role in structured `routing_reason` JSON. | `c53f5f5deb` |
 | 7 | Backfill terminality is derived from immutable `task_runs.ended_at/status/outcome`, not mutable `tasks.status`. | `1bb5d08b74` |
 | 8 | Concurrent migration coverage starts with pre-existing runs and verifies cutoff classification excludes a run inserted after cutoff publication. | `2b62652d5f` |
-| 9 | This plan/changelog now describes shipped behavior; stale API, terminality, lifecycle, and provenance text below was synchronized. | this docs commit |
+| 9 | This plan/changelog now describes shipped behavior; stale API, terminality, lifecycle, and provenance text below was synchronized. | `439b488d40` |
 
 ### 0.0 Rev8 → Rev9 Changelog (historical plan revision)
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -416,6 +416,8 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
     p_swarm.add_argument("--verifier", required=True, help="Verifier profile")
     p_swarm.add_argument("--synthesizer", required=True, help="Synthesizer/writer profile")
+    p_swarm.add_argument("--verifier-skills", default=None, help="Comma-separated skills for the verifier card (default: requesting-code-review)")
+    p_swarm.add_argument("--synthesizer-skills", default=None, help="Comma-separated skills for the synthesizer card (default: none)")
     p_swarm.add_argument("--tenant", default=None, help="Tenant namespace")
     p_swarm.add_argument("--priority", type=int, default=0, help="Priority tiebreaker")
     p_swarm.add_argument("--created-by", default=None, help="Creator/anchor profile")
@@ -1623,6 +1625,8 @@ def _cmd_swarm(args: argparse.Namespace) -> int:
             workers=workers,
             verifier_assignee=args.verifier,
             synthesizer_assignee=args.synthesizer,
+            verifier_skills=args.verifier_skills.split(",") if args.verifier_skills else None,
+            synthesizer_skills=args.synthesizer_skills.split(",") if args.synthesizer_skills else None,
             tenant=args.tenant,
             created_by=args.created_by or _profile_author(),
             priority=args.priority,

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -326,6 +326,12 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     b_set_wd.add_argument("path", nargs="?", default=None,
                           help="Absolute path to use as default workdir. Omit to clear.")
 
+    b_set_role = boards_sub.add_parser(
+        "set-default-role", help="Set the default routing role for a board",
+    )
+    b_set_role.add_argument("slug")
+    b_set_role.add_argument("role", help="Semantic role from roles.yaml")
+
     # --- create ---
     p_create = sub.add_parser("create", help="Create a new task")
     p_create.add_argument("title", help="Task title")
@@ -1270,6 +1276,8 @@ def _dispatch_boards(args: argparse.Namespace) -> int:
         return _cmd_boards_rename(args)
     if sub == "set-default-workdir":
         return _cmd_boards_set_default_workdir(args)
+    if sub == "set-default-role":
+        return _cmd_boards_set_default_role(args)
     print(f"kanban boards: unknown action {sub!r}", file=sys.stderr)
     return 2
 
@@ -1442,6 +1450,24 @@ def _cmd_boards_set_default_workdir(args: argparse.Namespace) -> int:
         print(f"Board {normed!r} default workdir set to {new_val!r}.")
     else:
         print(f"Board {normed!r} default workdir cleared.")
+    return 0
+
+
+def _cmd_boards_set_default_role(args: argparse.Namespace) -> int:
+    """Set a board's semantic routing default without losing other metadata."""
+    try:
+        normed = kb._normalize_board_slug(args.slug)
+    except ValueError as exc:
+        print(f"kanban boards set-default-role: {exc}", file=sys.stderr)
+        return 2
+    if not normed or not kb.board_exists(normed):
+        print(
+            f"kanban boards set-default-role: board {args.slug!r} does not exist",
+            file=sys.stderr,
+        )
+        return 1
+    meta = kb.write_board_metadata(normed, default_role=args.role)
+    print(f"Board {normed!r} default role set to {meta['default_role']!r}.")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5157,8 +5157,8 @@ def claim_task(
                 started_at,
                 routing_role, routing_model, routing_provider,
                 routing_contract, routing_reason, roster_digest,
-                routing_policy, ac_revision
-            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                routing_policy, ac_revision, routing_source
+            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 task_id,
@@ -5176,6 +5176,7 @@ def claim_task(
                 routing_snapshot["roster_digest"],
                 routing_snapshot["routing_policy"],
                 routing_snapshot["ac_revision"],
+                routing_snapshot["routing_source"],
             ),
         )
         run_id = run_cur.lastrowid
@@ -5280,8 +5281,8 @@ def claim_review_task(
                 started_at,
                 routing_role, routing_model, routing_provider,
                 routing_contract, routing_reason, roster_digest,
-                routing_policy, ac_revision
-            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                routing_policy, ac_revision, routing_source
+            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 task_id,
@@ -5299,6 +5300,7 @@ def claim_review_task(
                 routing_snapshot["roster_digest"],
                 routing_snapshot["routing_policy"],
                 routing_snapshot["ac_revision"],
+                routing_snapshot["routing_source"],
             ),
         )
         run_id = run_cur.lastrowid

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4869,92 +4869,188 @@ def _extract_ac_text(body: str, ac_ids: list) -> str:
     return "\n".join(chunks)
 
 
+def _task_value(trow: Any, name: str) -> Any:
+    """Return a task-row value without assuming a particular row shape."""
+    if trow is None:
+        return None
+    try:
+        keys = trow.keys()
+    except (AttributeError, TypeError):
+        keys = None
+    if keys is not None and name not in keys:
+        return None
+    try:
+        return trow[name]
+    except (KeyError, IndexError, TypeError):
+        return None
+
+def _load_profile_model_config(assignee: str | None) -> tuple[Any, Any]:
+    """Load a profile's configured default model and provider."""
+    if not isinstance(assignee, str) or not assignee.strip():
+        return None, None
+    from hermes_cli.profiles import get_profile_dir
+
+    config_path = get_profile_dir(assignee.strip()) / "config.yaml"
+    if not config_path.exists():
+        return None, None
+    try:
+        with config_path.open("r", encoding="utf-8") as handle:
+            config = yaml.safe_load(handle) or {}
+    except (OSError, TypeError, ValueError, yaml.YAMLError) as exc:
+        raise RoutingContractError(
+            f"profile {assignee!r} config is unreadable: {exc}"
+        ) from exc
+    if not isinstance(config, dict):
+        raise RoutingContractError(
+            f"profile {assignee!r} config must be a mapping"
+        )
+    model_config = config.get("model")
+    if model_config is None:
+        return None, None
+    if not isinstance(model_config, dict):
+        raise RoutingContractError(
+            f"profile {assignee!r} model config must be a mapping"
+        )
+    return model_config.get("default"), model_config.get("provider")
+
+
+def _load_global_default_provider() -> Any:
+    """Load the global configured model provider for model-only routes."""
+    config_path = Path(
+        os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))
+    ) / "config.yaml"
+    try:
+        with config_path.open("r", encoding="utf-8") as handle:
+            config = yaml.safe_load(handle) or {}
+    except (OSError, TypeError, ValueError, yaml.YAMLError):
+        return None
+    model_config = config.get("model")
+    return model_config.get("provider") if isinstance(model_config, dict) else None
+
+
+def _empty_routing_snapshot() -> dict:
+    """Return a routing snapshot with every frozen field unset."""
+    return {
+        "routing_role": None, "routing_model": None,
+        "routing_provider": None, "routing_contract": None,
+        "routing_reason": None, "roster_digest": None,
+        "routing_policy": None, "ac_revision": None,
+        "routing_source": None,
+    }
+
+
+def _raw_routing_snapshot(model: Any, provider: Any, source: str) -> dict:
+    """Validate and freeze a raw model/provider route."""
+    if not isinstance(model, str) or not model.strip():
+        raise RoutingContractError(f"{source} model must be a non-empty string")
+    if not isinstance(provider, str) or not provider.strip():
+        raise RoutingContractError(f"{source} provider must be a non-empty string")
+    snapshot = _empty_routing_snapshot()
+    snapshot.update(
+        routing_model=model.strip(), routing_provider=provider.strip(),
+        routing_source=source,
+    )
+    return snapshot
+
+
+def _semantic_routing_snapshot(
+    role: Any,
+    source: str,
+    phase: str,
+    parsed: Optional[dict] = None,
+    body: str = "",
+) -> dict:
+    """Resolve and freeze a semantic role from the authoritative roster."""
+    if not isinstance(role, str) or not role.strip():
+        raise RoutingContractError(f"{source} role must be a non-empty string")
+    data, roster_digest = _load_roster()
+    roles = data.get("roles") or {}
+    selected = role.strip()
+    entry = roles.get(selected)
+    if not isinstance(entry, dict):
+        raise RoutingContractError(f"role {selected!r} not found in roles.yaml")
+    resolved_source = source
+    if phase == "review":
+        if entry.get("review_capable") is True:
+            resolved_source = "review_capable"
+        else:
+            selected = "reviewer"
+            entry = roles.get(selected)
+            resolved_source = "review_coerced"
+            if not isinstance(entry, dict):
+                raise RoutingContractError("role 'reviewer' not found in roles.yaml")
+    model = entry.get("model")
+    provider = entry.get("provider")
+    if not isinstance(model, str) or not model.strip():
+        raise RoutingContractError(f"role {selected!r} missing valid model in roles.yaml")
+    if not isinstance(provider, str) or not provider.strip():
+        raise RoutingContractError(f"role {selected!r} missing valid provider in roles.yaml")
+    snapshot = _empty_routing_snapshot()
+    snapshot.update(
+        routing_role=selected,
+        routing_model=model.strip(),
+        routing_provider=provider.strip(),
+        roster_digest=roster_digest,
+        routing_policy=json.dumps(
+            {"invocation": entry.get("invocation"),
+             "may_edit": entry.get("may_edit")}, sort_keys=True,
+        ),
+        routing_source=resolved_source,
+    )
+    if parsed:
+        snapshot["routing_contract"] = ROUTING_CONTRACT_VERSION
+        snapshot["routing_reason"] = parsed.get("reason")
+        ac_ids = parsed.get("ac_ids")
+        if ac_ids:
+            text = _extract_ac_text(body, ac_ids)
+            snapshot["ac_revision"] = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    return snapshot
+
 def _resolve_routing_snapshot(
     conn: sqlite3.Connection,
     task_id: str,
     trow: sqlite3.Row,
-    phase: str,  # "implement" | "review"
+    phase: str,
 ) -> dict:
-    """Resolve the Wave 2 routing snapshot for a claim, inside the txn.
-
-    Called from ``claim_task`` / ``claim_review_task`` BEFORE the status CAS
-    flips to ``running``. Returns the dict of snapshot columns to write on
-    the new ``task_runs`` row:
-
-    - No v1 envelope or ``enforcement_required: false`` → all-None dict
-      (unenforced; ``_default_spawn`` falls back to task pins / profile
-      defaults).
-    - Enforced → role resolved from roles.yaml (``reviewer`` for the review
-      phase unless the envelope names a review-capable role), model/provider
-      from the roster entry, ``roster_digest`` = sha256(roles.yaml),
-      ``ac_revision`` = sha256 of the concatenated AC text when ``ac_ids`` is
-      present, and ``routing_policy`` = JSON ``{invocation, may_edit}`` —
-      never skills or reasoning_effort, which stay live task fields.
-
-    Raises :class:`RoutingContractError` on any roster failure; callers emit
-    ``preflight_rejected`` and return None (task stays ready).
-    """
-    body = None
-    if trow is not None and "body" in trow.keys():
-        body = trow["body"]
+    """Resolve the first present claim route by Rev9 precedence, failing closed."""
+    body = _task_value(trow, "body")
     if body is None:
-        row = conn.execute(
-            "SELECT body FROM tasks WHERE id = ?", (task_id,),
-        ).fetchone()
-        body = row["body"] if row is not None else None
-    try:
-        parsed = parse_routing_envelope(body or "")
-    except RoutingContractError:
-        # Malformed envelope: fail closed — emit preflight_rejected upstream.
-        raise
-    if not parsed or not parsed.get("enforcement_required"):
-        # Unenforced (no envelope, Wave 1 envelope, or enforcement off):
-        # backfill NULLs so spawn falls back to task pins / profile defaults.
-        return {
-            "routing_role": None,
-            "routing_model": None,
-            "routing_provider": None,
-            "routing_contract": None,
-            "routing_reason": None,
-            "roster_digest": None,
-            "routing_policy": None,
-            "ac_revision": None,
-        }
-    data, roster_digest = _load_roster()
-    roles = data.get("roles") or {}
-    if phase == "review":
-        env_role = parsed.get("role")
-        role = env_role if env_role in _REVIEW_CAPABLE_ROLES else "reviewer"
-    else:
-        role = parsed.get("role")
-    entry = roles.get(role)
-    if not isinstance(entry, dict):
-        raise RoutingContractError(f"role {role!r} not found in roles.yaml")
-    model = entry.get("model")
-    if not model:
-        raise RoutingContractError(f"role {role!r} has no model in roles.yaml")
-    provider = entry.get("provider") or data.get("provider")
-    # Roster policy only — invocation/may_edit. Skills and reasoning_effort
-    # are deliberately NOT frozen: they stay live task fields.
-    routing_policy = json.dumps(
-        {"invocation": entry.get("invocation"), "may_edit": entry.get("may_edit")},
-        sort_keys=True,
+        row = conn.execute("SELECT body FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        body = row["body"] if row is not None else ""
+    parsed = parse_routing_envelope(body or "")
+    if parsed and parsed.get("enforcement_required"):
+        return _semantic_routing_snapshot(
+            parsed.get("role"), "envelope", phase, parsed, body or ""
+        )
+
+    task_role = _task_value(trow, "routing_role")
+    if task_role is not None:
+        return _semantic_routing_snapshot(task_role, "task_role", phase)
+
+    model = _task_value(trow, "model_override")
+    provider = _task_value(trow, "provider_override")
+    if provider is not None and model is None:
+        raise RoutingContractError("provider_override requires model_override")
+    if model is not None:
+        if provider is None:
+            _, provider = _load_profile_model_config(_task_value(trow, "assignee"))
+            if provider is None:
+                provider = _load_global_default_provider()
+        return _raw_routing_snapshot(model, provider, "task_override")
+
+    board_role = read_board_metadata().get("default_role")
+    if board_role is not None:
+        return _semantic_routing_snapshot(board_role, "board_default", phase)
+
+    profile_model, profile_provider = _load_profile_model_config(
+        _task_value(trow, "assignee")
     )
-    ac_revision = None
-    ac_ids = parsed.get("ac_ids")
-    if ac_ids:
-        ac_text = _extract_ac_text(body or "", ac_ids)
-        ac_revision = hashlib.sha256(ac_text.encode("utf-8")).hexdigest()
-    return {
-        "routing_role": role,
-        "routing_model": model,
-        "routing_provider": provider,
-        "routing_contract": ROUTING_CONTRACT_VERSION,
-        "routing_reason": parsed.get("reason"),
-        "roster_digest": roster_digest,
-        "routing_policy": routing_policy,
-        "ac_revision": ac_revision,
-    }
+    if profile_model is not None or profile_provider is not None:
+        return _raw_routing_snapshot(
+            profile_model, profile_provider, "profile_default"
+        )
+    raise RoutingContractError("routing unresolved after all configured sources")
+
 
 
 def claim_task(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5253,6 +5253,12 @@ def _claim_task_once(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        claimable = conn.execute(
+            "SELECT 1 FROM tasks WHERE id=? AND status='ready' AND claim_lock IS NULL",
+            (task_id,),
+        ).fetchone()
+        if claimable is None:
+            return None
         # Structural invariant: never transition ready -> running while any
         # parent is not yet 'done'. This is the single enforcement point
         # regardless of which writer (create_task, link_tasks, unblock_task,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -84,11 +84,17 @@ import sys
 import threading
 import logging
 import time
+import yaml
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Optional
 
+from hermes_cli.routing_contract import (
+    ROUTING_CONTRACT_VERSION,
+    RoutingContractError,
+    parse_routing_envelope,
+)
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
 from toolsets import get_toolset_names
 
@@ -101,6 +107,46 @@ _log = logging.getLogger(__name__)
 
 VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
+
+# ---------------------------------------------------------------------------
+# Wave 2 §7: State machine — TRANSITIONS adjacency map (documentation +
+# assertion, NOT a refactor of every mutator). The real enforcement for
+# pathological loops stays with the existing circuit breaker
+# (_record_task_failure L9061) + block_task recurrence breaker (L6165) +
+# check_respawn_guard. This map is a debug assertion that catches illegal
+# edges (e.g. done→ready via raw SQL) during development; it is OFF in the
+# production hot path — _assert_transition is a no-op unless assertions are
+# enabled (python -O strips it).
+TRANSITIONS: dict[str, set[str]] = {
+    "triage":    {"todo", "archived"},
+    "todo":      {"scheduled", "ready", "archived"},
+    "scheduled": {"ready", "todo", "archived"},
+    "ready":     {"running", "todo", "archived"},
+    "running":   {"blocked", "review", "done", "crashed", "timed_out", "ready"},
+    "blocked":   {"ready", "todo", "archived"},
+    "review":    {"running", "done", "ready"},
+    "done":      {"archived", "ready"},  # ready = reopen
+    "archived":  {"todo"},               # un-archive
+}
+
+
+def _assert_transition(old: str, new: str) -> None:
+    """Debug assertion for state transitions.
+
+    Emits a warning on illegal edges. No-op when assertions are disabled
+    (``python -O``). This is NOT the enforcement mechanism — the existing
+    circuit breaker, block_task recurrence breaker, and check_respawn_guard
+    handle pathological loops in production. This map exists for development-
+    time visibility into illegal transitions.
+    """
+    if __debug__ and new not in TRANSITIONS.get(old, set()):
+        import warnings
+        warnings.warn(
+            f"Kanban illegal transition: {old}→{new} "
+            f"(legal: {TRANSITIONS.get(old, set()) or 'none'})",
+            stacklevel=3,
+            category=RuntimeWarning,
+        )
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
 # worker (or human) means by "blocked", so each can be routed differently
@@ -1474,7 +1520,19 @@ CREATE TABLE IF NOT EXISTS task_runs (
     --          gave_up | reclaimed | (null while still running)
     summary             TEXT,
     metadata            TEXT,
-    error               TEXT
+    error               TEXT,
+    -- Wave 2 routing snapshot: resolved routing decision captured at claim
+    -- time so the spawn path uses an immutable per-run snapshot instead of
+    -- the mutable task row. All nullable; legacy/pre-enforcement runs keep
+    -- NULLs (spawn falls back to task pins / profile defaults).
+    routing_role        TEXT,     -- resolved role name (from roles.yaml)
+    routing_model       TEXT,     -- resolved model ID
+    routing_provider    TEXT,     -- resolved provider
+    routing_contract    INTEGER,  -- routing_contract_version (see §3)
+    routing_reason      TEXT,     -- why this route (audit)
+    roster_digest       TEXT,     -- sha256 of roles.yaml at resolution time
+    routing_policy      TEXT,     -- JSON {invocation, may_edit} ONLY — NOT skills/effort
+    ac_revision         TEXT      -- digest of the AC set at claim (see §5)
 );
 
 -- Files attached to a task (PDFs, images, source documents). The blob
@@ -2546,9 +2604,10 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         _add_column_if_missing(
             conn, "tasks", "idempotency_key", "idempotency_key TEXT"
         )
-    # ``idx_tasks_idempotency`` is created unconditionally below alongside
-    # the other additive-column indexes — see the block after the
-    # legacy-column migration. Creating it here too would be redundant.
+    # ``idx_tasks_idempotency_unique`` (partial unique index) is created
+    # unconditionally below alongside the other additive-column indexes —
+    # see the block after the legacy-column migration. Creating it here
+    # too would be redundant.
 
     # Refresh after early additive migrations above. Some existing DBs were
     # partially migrated in older releases and can already contain the later
@@ -2687,8 +2746,36 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     # is cheap thanks to ``IF NOT EXISTS`` and stays correct on fresh DBs
     # (where the columns already exist from SCHEMA_SQL).
     conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_tenant ON tasks(tenant)")
+    # Idempotency index upgrade: the old non-unique index (plus the pre-txn
+    # lookup it served) left a race — two concurrent creators with the same
+    # key could both pass the lookup and insert duplicates. Replace it with
+    # a PARTIAL UNIQUE index covering only active tasks, which preserves the
+    # documented archive-reuse semantics of create_task's ``status !=
+    # 'archived'`` lookup (a key is reusable after its task is archived).
+    # A unique index aborts on the first duplicate, so dedupe any rows the
+    # race already produced BEFORE creating it: keep the newest row per key,
+    # NULL the key on older duplicates (NULLs are excluded from the partial
+    # index). The pass is idempotent — once the unique index exists there
+    # are no duplicate non-NULL keys to find.
+    conn.execute("DROP INDEX IF EXISTS idx_tasks_idempotency")
+    dup_rows = conn.execute(
+        """
+        SELECT idempotency_key, GROUP_CONCAT(id ORDER BY created_at DESC) AS ids
+        FROM tasks
+        WHERE idempotency_key IS NOT NULL AND status != 'archived'
+        GROUP BY idempotency_key
+        HAVING COUNT(*) > 1
+        """
+    ).fetchall()
+    for dup in dup_rows:
+        for stale_id in dup["ids"].split(",")[1:]:
+            conn.execute(
+                "UPDATE tasks SET idempotency_key = NULL WHERE id = ?", (stale_id,)
+            )
     conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency ON tasks(idempotency_key)"
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_idempotency_unique "
+        "ON tasks(idempotency_key) "
+        "WHERE idempotency_key IS NOT NULL AND status != 'archived'"
     )
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)"
@@ -2707,6 +2794,37 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         "CREATE INDEX IF NOT EXISTS idx_events_run "
         "ON task_events(run_id, id)"
     )
+
+    # task_runs routing-snapshot columns (Wave 2 enforcement). Each run
+    # freezes the resolved routing decision at claim time: role, model,
+    # provider, contract version, why, roles.yaml digest, and the policy
+    # subset {invocation, may_edit} ONLY — deliberately NOT skills or
+    # reasoning_effort, which stay live task fields (the review lane
+    # mutates claimed.skills after claim, so a frozen copy would strip the
+    # review skill). All columns nullable; legacy runs keep NULLs. Guarded
+    # by a table-exists check so direct calls against synthetic schemas
+    # without task_runs (tests, partial stores) stay no-ops.
+    runs_table_exists = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='task_runs'"
+    ).fetchone() is not None
+    if runs_table_exists:
+        run_cols = {row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")}
+        if "routing_role" not in run_cols:
+            _add_column_if_missing(conn, "task_runs", "routing_role", "routing_role TEXT")
+        if "routing_model" not in run_cols:
+            _add_column_if_missing(conn, "task_runs", "routing_model", "routing_model TEXT")
+        if "routing_provider" not in run_cols:
+            _add_column_if_missing(conn, "task_runs", "routing_provider", "routing_provider TEXT")
+        if "routing_contract" not in run_cols:
+            _add_column_if_missing(conn, "task_runs", "routing_contract", "routing_contract INTEGER")
+        if "routing_reason" not in run_cols:
+            _add_column_if_missing(conn, "task_runs", "routing_reason", "routing_reason TEXT")
+        if "roster_digest" not in run_cols:
+            _add_column_if_missing(conn, "task_runs", "roster_digest", "roster_digest TEXT")
+        if "routing_policy" not in run_cols:
+            _add_column_if_missing(conn, "task_runs", "routing_policy", "routing_policy TEXT")
+        if "ac_revision" not in run_cols:
+            _add_column_if_missing(conn, "task_runs", "ac_revision", "ac_revision TEXT")
 
     notify_table_exists = conn.execute(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='kanban_notify_subs'"
@@ -3393,20 +3511,11 @@ def create_task(
             )
         skills_list = cleaned
 
-    # Idempotency check — return the existing task instead of creating a
-    # duplicate. Done BEFORE entering write_txn to keep the fast path fast
-    # and to avoid holding a write lock during the lookup. Race is
-    # acceptable: two concurrent creators with the same key might both
-    # insert, at which point both rows exist but the next lookup stabilises.
-    if idempotency_key:
-        row = conn.execute(
-            "SELECT id FROM tasks WHERE idempotency_key = ? "
-            "AND status != 'archived' "
-            "ORDER BY created_at DESC LIMIT 1",
-            (idempotency_key,),
-        ).fetchone()
-        if row:
-            return row["id"]
+    # Idempotency check happens INSIDE the write transaction below so the
+    # lookup + INSERT are atomic — the pre-txn lookup this replaces left a
+    # race window where two concurrent creators with the same key could
+    # both pass the check and insert duplicates (now also backstopped by
+    # the partial unique index ``idx_tasks_idempotency_unique``).
 
     now = int(time.time())
 
@@ -3438,6 +3547,23 @@ def create_task(
             # compose create_task calls under one outer commit so the
             # dispatcher can never observe a partially constructed graph.
             with write_txn(conn, allow_nested=True):
+                # Idempotency — return the existing active task instead of
+                # creating a duplicate. INSIDE the write transaction so the
+                # lookup + INSERT are atomic: concurrent creators with the
+                # same key serialize on the write lock, so the second sees
+                # the first's row here. The partial unique index
+                # (idx_tasks_idempotency_unique) is the backstop if a race
+                # still slips through; the IntegrityError handler below
+                # converts that into the same existing-task return.
+                if idempotency_key:
+                    row = conn.execute(
+                        "SELECT id FROM tasks WHERE idempotency_key = ? "
+                        "AND status != 'archived' "
+                        "ORDER BY created_at DESC LIMIT 1",
+                        (idempotency_key,),
+                    ).fetchone()
+                    if row:
+                        return row["id"]
                 # Determine task status from parent status, unless the caller
                 # parks it directly in blocked for human-ops review or in
                 # triage for a specifier.
@@ -3556,10 +3682,26 @@ def create_task(
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
             return task_id
-        except sqlite3.IntegrityError:
+        except sqlite3.IntegrityError as e:
+            if "idempotency" in str(e) or "idx_tasks_idempotency_unique" in str(e):
+                # Unique-key violation on the partial idempotency index —
+                # another creator won the race between our in-txn lookup and
+                # the INSERT. Return the existing active task instead of
+                # retrying with a fresh id (a retry would just re-collide on
+                # the same key and fail). Fail-closed if the row is gone.
+                existing = conn.execute(
+                    "SELECT id FROM tasks WHERE idempotency_key = ? "
+                    "AND status != 'archived' "
+                    "ORDER BY created_at DESC LIMIT 1",
+                    (idempotency_key,),
+                ).fetchone()
+                if existing:
+                    return existing["id"]
+                raise
             if attempt == 1:
                 raise
-            # Retry with a fresh id.
+            # Non-idempotency IntegrityError (e.g. a task-id PK collision):
+            # retry once with a fresh id.
             continue
     raise RuntimeError("unreachable")
 
@@ -4614,6 +4756,159 @@ def _parents_satisfied(conn: sqlite3.Connection, task_id: str) -> bool:
     ).fetchone() is None
 
 
+# ---------------------------------------------------------------------------
+# Wave 2 routing snapshot (Step 2b)
+# ---------------------------------------------------------------------------
+
+#: Roster cache keyed by (resolved path, mtime) -> (data, digest). Keying on
+#: the path as well as the mtime means switching HERMES_HOME (tests, profile
+#: activation) can never serve a stale roster, while repeated claims against
+#: an unchanged file are pure cache hits — no file I/O inside the claim txn.
+_roster_cache: dict = {}
+
+
+def _load_roster() -> tuple:
+    """Load ``~/.hermes/routing/roles.yaml``, cached by (path, mtime).
+
+    Returns ``(data, digest)`` where ``data`` is the parsed YAML mapping and
+    ``digest`` is sha256 of the raw file content. Raises
+    :class:`RoutingContractError` on any load / parse failure so the claim
+    transaction can emit ``preflight_rejected`` and leave the task ready.
+    """
+    try:
+        from hermes_constants import get_hermes_home
+        path = Path(get_hermes_home()) / "routing" / "roles.yaml"
+        mtime = path.stat().st_mtime
+    except OSError as exc:
+        raise RoutingContractError(f"roles.yaml unavailable: {exc}") from exc
+    key = (str(path), mtime)
+    if key in _roster_cache:
+        return _roster_cache[key]
+    try:
+        content = path.read_text(encoding="utf-8")
+        data = yaml.safe_load(content)
+    except (OSError, yaml.YAMLError) as exc:
+        raise RoutingContractError(f"roles.yaml parse failure: {exc}") from exc
+    if not isinstance(data, dict) or not isinstance(data.get("roles"), dict):
+        raise RoutingContractError("roles.yaml missing 'roles' mapping")
+    digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    _roster_cache[key] = (data, digest)
+    return data, digest
+
+
+#: Roles allowed to claim the review phase. ``reviewer`` is the dedicated
+#: default; ``main_coder`` is the roster's other review-capable role ("thinks
+#: / plans / reviews / owns finish line"). Implement-only roles (executor,
+#: debugger, orchestrator) never review — a review-phase envelope that names
+#: one falls back to ``reviewer``.
+_REVIEW_CAPABLE_ROLES = frozenset({"reviewer", "main_coder"})
+
+
+def _extract_ac_text(body: str, ac_ids: list) -> str:
+    """Concatenate the text of each AC ID found in the task body.
+
+    Matches ``AC-1: <text>`` (optionally bulleted) anywhere in the body.
+    IDs that are not found are represented by the bare ID so the digest still
+    reflects the claimed set deterministically.
+    """
+    chunks = []
+    for ac_id in ac_ids:
+        m = re.search(
+            rf"(?im)^\s*(?:[-*]\s*)?{re.escape(ac_id)}\s*[:：]\s*(.+?)\s*$",
+            body or "",
+        )
+        chunks.append(f"{ac_id}: {m.group(1).strip()}" if m else ac_id)
+    return "\n".join(chunks)
+
+
+def _resolve_routing_snapshot(
+    conn: sqlite3.Connection,
+    task_id: str,
+    trow: sqlite3.Row,
+    phase: str,  # "implement" | "review"
+) -> dict:
+    """Resolve the Wave 2 routing snapshot for a claim, inside the txn.
+
+    Called from ``claim_task`` / ``claim_review_task`` BEFORE the status CAS
+    flips to ``running``. Returns the dict of snapshot columns to write on
+    the new ``task_runs`` row:
+
+    - No v1 envelope or ``enforcement_required: false`` → all-None dict
+      (unenforced; ``_default_spawn`` falls back to task pins / profile
+      defaults).
+    - Enforced → role resolved from roles.yaml (``reviewer`` for the review
+      phase unless the envelope names a review-capable role), model/provider
+      from the roster entry, ``roster_digest`` = sha256(roles.yaml),
+      ``ac_revision`` = sha256 of the concatenated AC text when ``ac_ids`` is
+      present, and ``routing_policy`` = JSON ``{invocation, may_edit}`` —
+      never skills or reasoning_effort, which stay live task fields.
+
+    Raises :class:`RoutingContractError` on any roster failure; callers emit
+    ``preflight_rejected`` and return None (task stays ready).
+    """
+    body = None
+    if trow is not None and "body" in trow.keys():
+        body = trow["body"]
+    if body is None:
+        row = conn.execute(
+            "SELECT body FROM tasks WHERE id = ?", (task_id,),
+        ).fetchone()
+        body = row["body"] if row is not None else None
+    try:
+        parsed = parse_routing_envelope(body or "")
+    except RoutingContractError:
+        # Malformed envelope: fail closed — emit preflight_rejected upstream.
+        raise
+    if not parsed or not parsed.get("enforcement_required"):
+        # Unenforced (no envelope, Wave 1 envelope, or enforcement off):
+        # backfill NULLs so spawn falls back to task pins / profile defaults.
+        return {
+            "routing_role": None,
+            "routing_model": None,
+            "routing_provider": None,
+            "routing_contract": None,
+            "routing_reason": None,
+            "roster_digest": None,
+            "routing_policy": None,
+            "ac_revision": None,
+        }
+    data, roster_digest = _load_roster()
+    roles = data.get("roles") or {}
+    if phase == "review":
+        env_role = parsed.get("role")
+        role = env_role if env_role in _REVIEW_CAPABLE_ROLES else "reviewer"
+    else:
+        role = parsed.get("role")
+    entry = roles.get(role)
+    if not isinstance(entry, dict):
+        raise RoutingContractError(f"role {role!r} not found in roles.yaml")
+    model = entry.get("model")
+    if not model:
+        raise RoutingContractError(f"role {role!r} has no model in roles.yaml")
+    provider = entry.get("provider") or data.get("provider")
+    # Roster policy only — invocation/may_edit. Skills and reasoning_effort
+    # are deliberately NOT frozen: they stay live task fields.
+    routing_policy = json.dumps(
+        {"invocation": entry.get("invocation"), "may_edit": entry.get("may_edit")},
+        sort_keys=True,
+    )
+    ac_revision = None
+    ac_ids = parsed.get("ac_ids")
+    if ac_ids:
+        ac_text = _extract_ac_text(body or "", ac_ids)
+        ac_revision = hashlib.sha256(ac_text.encode("utf-8")).hexdigest()
+    return {
+        "routing_role": role,
+        "routing_model": model,
+        "routing_provider": provider,
+        "routing_contract": ROUTING_CONTRACT_VERSION,
+        "routing_reason": parsed.get("reason"),
+        "roster_digest": roster_digest,
+        "routing_policy": routing_policy,
+        "ac_revision": ac_revision,
+    }
+
+
 def claim_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4655,6 +4950,26 @@ def claim_task(
                 {"reason": "parents_not_done"},
             )
             return None
+        # Wave 2 routing snapshot (Step 2b): resolve the immutable routing
+        # decision BEFORE the CAS flips ready→running. On roster failure we
+        # emit preflight_rejected and return None — the only write in this
+        # txn is the event row, so the task stays ready and the dispatch
+        # loop's circuit breaker decides the next move. No silent loop.
+        trow = conn.execute(
+            "SELECT assignee, max_runtime_seconds, current_step_key, body "
+            "FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        try:
+            routing_snapshot = _resolve_routing_snapshot(
+                conn, task_id, trow, phase="implement"
+            )
+        except RoutingContractError as exc:
+            _append_event(
+                conn, task_id, "preflight_rejected",
+                {"reason": str(exc), "phase": "implement"},
+            )
+            return None
         # Defensive: if a prior run somehow leaked (invariant violation from
         # an unknown code path), close it as 'reclaimed' so we don't strand
         # it when the CAS resets the pointer below. No-op when the invariant
@@ -4678,32 +4993,28 @@ def claim_task(
         cur = conn.execute(
             """
             UPDATE tasks
-               SET status        = 'running',
-                   claim_lock    = ?,
-                   claim_expires = ?,
-                   started_at    = COALESCE(started_at, ?)
-             WHERE id = ?
-               AND status = 'ready'
-               AND claim_lock IS NULL
+              SET status        = 'running',
+                  claim_lock    = ?,
+                  claim_expires = ?,
+                  started_at    = COALESCE(started_at, ?)
+            WHERE id = ?
+              AND status = 'ready'
+              AND claim_lock IS NULL
             """,
             (lock, expires, now, task_id),
         )
         if cur.rowcount != 1:
             return None
-        # Look up the current task row so we can populate the run with
-        # its assignee / step / runtime cap.
-        trow = conn.execute(
-            "SELECT assignee, max_runtime_seconds, current_step_key "
-            "FROM tasks WHERE id = ?",
-            (task_id,),
-        ).fetchone()
         run_cur = conn.execute(
             """
             INSERT INTO task_runs (
                 task_id, profile, step_key, status,
                 claim_lock, claim_expires, max_runtime_seconds,
-                started_at
-            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?)
+                started_at,
+                routing_role, routing_model, routing_provider,
+                routing_contract, routing_reason, roster_digest,
+                routing_policy, ac_revision
+            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 task_id,
@@ -4713,6 +5024,14 @@ def claim_task(
                 expires,
                 trow["max_runtime_seconds"] if trow else None,
                 now,
+                routing_snapshot["routing_role"],
+                routing_snapshot["routing_model"],
+                routing_snapshot["routing_provider"],
+                routing_snapshot["routing_contract"],
+                routing_snapshot["routing_reason"],
+                routing_snapshot["roster_digest"],
+                routing_snapshot["routing_policy"],
+                routing_snapshot["ac_revision"],
             ),
         )
         run_id = run_cur.lastrowid
@@ -4775,33 +5094,50 @@ def claim_review_task(
                     },
                 )
             return None
+        # Wave 2 routing snapshot (Step 2b): same pre-CAS resolution as
+        # claim_task, but phase="review" → resolves the reviewer role. On
+        # roster failure emit preflight_rejected and return None; the task
+        # stays in review and the dispatch loop's circuit breaker decides.
+        trow = conn.execute(
+            "SELECT assignee, max_runtime_seconds, current_step_key, body "
+            "FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        try:
+            routing_snapshot = _resolve_routing_snapshot(
+                conn, task_id, trow, phase="review"
+            )
+        except RoutingContractError as exc:
+            _append_event(
+                conn, task_id, "preflight_rejected",
+                {"reason": str(exc), "phase": "review"},
+            )
+            return None
         cur = conn.execute(
             """
             UPDATE tasks
-               SET status        = 'running',
-                   claim_lock    = ?,
-                   claim_expires = ?,
-                   started_at    = COALESCE(started_at, ?)
-             WHERE id = ?
-               AND status = 'review'
-               AND claim_lock IS NULL
+              SET status        = 'running',
+                  claim_lock    = ?,
+                  claim_expires = ?,
+                  started_at    = COALESCE(started_at, ?)
+            WHERE id = ?
+              AND status = 'review'
+              AND claim_lock IS NULL
             """,
             (lock, expires, now, task_id),
         )
         if cur.rowcount != 1:
             return None
-        trow = conn.execute(
-            "SELECT assignee, max_runtime_seconds, current_step_key "
-            "FROM tasks WHERE id = ?",
-            (task_id,),
-        ).fetchone()
         run_cur = conn.execute(
             """
             INSERT INTO task_runs (
                 task_id, profile, step_key, status,
                 claim_lock, claim_expires, max_runtime_seconds,
-                started_at
-            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?)
+                started_at,
+                routing_role, routing_model, routing_provider,
+                routing_contract, routing_reason, roster_digest,
+                routing_policy, ac_revision
+            ) VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 task_id,
@@ -4811,6 +5147,14 @@ def claim_review_task(
                 expires,
                 trow["max_runtime_seconds"] if trow else None,
                 now,
+                routing_snapshot["routing_role"],
+                routing_snapshot["routing_model"],
+                routing_snapshot["routing_provider"],
+                routing_snapshot["routing_contract"],
+                routing_snapshot["routing_reason"],
+                routing_snapshot["roster_digest"],
+                routing_snapshot["routing_policy"],
+                routing_snapshot["ac_revision"],
             ),
         )
         run_id = run_cur.lastrowid
@@ -5349,6 +5693,66 @@ class ArtifactPreservationError(RuntimeError):
     """Raised when a declared scratch deliverable cannot be preserved."""
 
 
+#: Keys inside a verdict map that are not AC verdicts (see
+#: ``_read_completion_verdict`` / ``_verdict_all_pass``).
+_VERDICT_EVIDENCE_KEYS = frozenset({"evidence"})
+
+
+def _read_completion_verdict(
+    conn: sqlite3.Connection,
+    task_id: str,
+    metadata: Optional[dict],
+) -> Optional[dict]:
+    """Return the AC verdict map for this completion attempt, or None.
+
+    Wave 2 Step 2e: the reviewer writes the verdict via ``complete_task``'s
+    existing ``metadata`` parameter — ``{"verdict": {"AC-1": "pass", ...,
+    "evidence": "..."}}``. The current call's metadata is authoritative;
+    as a fallback the most recently closed ``completed`` run is consulted
+    (covers flows where the review run was already ended before the task
+    reached ``review``). Malformed JSON, a missing ``verdict`` key, or a
+    non-dict verdict all yield None — callers treat that as "not reviewed".
+    """
+    if isinstance(metadata, dict):
+        verdict = metadata.get("verdict")
+        if isinstance(verdict, dict):
+            return verdict
+    row = conn.execute(
+        "SELECT metadata FROM task_runs "
+        "WHERE task_id = ? AND outcome = 'completed' "
+        "ORDER BY ended_at DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if row is None or not row["metadata"]:
+        return None
+    try:
+        parsed = json.loads(row["metadata"])
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    verdict = parsed.get("verdict")
+    return verdict if isinstance(verdict, dict) else None
+
+
+def _verdict_all_pass(verdict: dict) -> bool:
+    """True when every non-``n/a`` AC verdict is ``pass``.
+
+    * Any AC key with value ``fail`` → False (gate refuses completion).
+    * Any AC key with a value outside ``{pass, fail, n/a}`` → False
+      (fail-closed — a malformed verdict must not sail through).
+    * No AC entries at all (empty map or evidence-only) → False — an
+      enforced task with nothing verified is treated as unreviewed.
+    """
+    entries = [
+        value for key, value in verdict.items()
+        if key not in _VERDICT_EVIDENCE_KEYS
+    ]
+    if not entries:
+        return False
+    return all(value == "pass" or value == "n/a" for value in entries)
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -5359,6 +5763,7 @@ def complete_task(
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
     fire_lifecycle_hook: bool = True,
+    review_override: Optional[dict] = None,
 ) -> bool:
     """Transition ``running|ready|blocked|review -> done`` and record ``result``.
 
@@ -5391,8 +5796,37 @@ def complete_task(
     Any suspected phantom references are recorded as a
     ``suspected_hallucinated_references`` event. This pass is advisory
     and never blocks.
+
+    Wave 2 Step 2e — AC verdict gate: when the task's current run carries
+    a routing snapshot with ``ac_revision`` (enforcement was required at
+    claim time), ``done`` is reachable only from ``review`` with a verdict
+    map on the review metadata (``{"verdict": {"AC-1": "pass", ...,
+    "evidence": "..."}}``) whose non-``n/a`` ACs all pass. Direct
+    ``running/ready/blocked -> done`` for such tasks is refused with a
+    ``completion_blocked_review_required`` event. Tasks with no snapshot
+    (``ac_revision`` NULL — legacy / unenforced) are unaffected.
+
+    ``review_override`` is the admin escape hatch: ``{"by": str,
+    "reason": str}`` with both fields non-empty bypasses the verdict gate
+    and records a ``completion_override`` event with the attribution.
+    An invalid override (missing/empty fields) is treated as absent, so
+    the gate still applies.
     """
     now = int(time.time())
+    # Wave 2 Step 2e admin override: valid only when both ``by`` and
+    # ``reason`` are non-empty strings. Anything else is treated as "no
+    # override" so the AC verdict gate still applies (fail-closed).
+    override_by: Optional[str] = None
+    override_reason: Optional[str] = None
+    if isinstance(review_override, dict):
+        _by = review_override.get("by")
+        _reason = review_override.get("reason")
+        if (
+            isinstance(_by, str) and _by.strip()
+            and isinstance(_reason, str) and _reason.strip()
+        ):
+            override_by = _by.strip()
+            override_reason = _reason.strip()
     # Fail before validating cards or staging artifacts; re-check inside the
     # final write transaction below to close the parent-reopen race.
     if not _parents_satisfied(conn, task_id):
@@ -5439,6 +5873,65 @@ def complete_task(
             (task_id,),
         ).fetchone()
         prior_status = prior["status"] if prior else None
+        # Wave 2 Step 2e — AC verdict gate. Keys off the run snapshot
+        # (ac_revision non-NULL) captured at claim time — never a re-read
+        # of the mutable body. Enforced tasks may reach 'done' only via
+        # 'review' with an all-pass verdict, or via an explicit admin
+        # override. Runs with NULL ac_revision (legacy / unenforced) pass
+        # through untouched — no stranding.
+        run_row = conn.execute(
+            "SELECT id, ac_revision FROM task_runs "
+            "WHERE id = (SELECT current_run_id FROM tasks WHERE id = ?)",
+            (task_id,),
+        ).fetchone()
+        gate_run_id = int(run_row["id"]) if run_row else None
+        ac_revision = run_row["ac_revision"] if run_row else None
+        if ac_revision is not None and override_by is None:
+            blocked_payload = {
+                "reason": "review_required",
+                "ac_revision": ac_revision,
+                "prior_status": prior_status,
+            }
+            # The review lane claims ``review -> running``, so the task's
+            # status is 'running' while the reviewer works. Discriminate via
+            # the run's claimed event (source_status=review) — the same
+            # signal _retry_status_for_run uses — so a reviewer completing
+            # without a verdict is refused, not mistaken for a direct
+            # implementer completion.
+            is_review_approval = (
+                prior_status == "review"
+                or _retry_status_for_run(conn, task_id, gate_run_id) == "review"
+            )
+            if is_review_approval:
+                # Review lane: 'done' requires a verdict map on the review
+                # metadata with every non-n/a AC passing. No verdict, a
+                # 'fail', or a malformed entry all refuse completion.
+                verdict = _read_completion_verdict(conn, task_id, metadata)
+                if verdict is None or not _verdict_all_pass(verdict):
+                    _append_event(
+                        conn, task_id, "completion_blocked_review_required",
+                        blocked_payload, run_id=gate_run_id,
+                    )
+                    return False
+            else:
+                # running/ready/blocked -> done without review: refused.
+                _append_event(
+                    conn, task_id, "completion_blocked_review_required",
+                    blocked_payload, run_id=gate_run_id,
+                )
+                return False
+        elif override_by is not None:
+            # Admin escape hatch (ships WITH the gate): explicit, attributed
+            # bypass — recorded so the override is auditable.
+            _append_event(
+                conn, task_id, "completion_override",
+                {
+                    "by": override_by,
+                    "reason": override_reason,
+                    "ac_revision": ac_revision,
+                },
+                run_id=gate_run_id,
+            )
         if expected_run_id is None:
             cur = conn.execute(
                 """
@@ -10857,7 +11350,37 @@ def _default_spawn(
         for sk in task.skills:
             if sk:
                 cmd.extend(["--skills", sk])
-    if task.model_override:
+    # Wave 2 routing (Step 2b): NULL-fallback chain for model/provider —
+    # snapshot (enforced, immutable) → task.model_override (legacy / Wave 1
+    # pin) → profile default (no override). The snapshot is read from the
+    # current task_runs row, where claim_task/claim_review_task froze it.
+    # WITHOUT the middle leg, Wave 1 model pins silently die the moment 2b
+    # lands, because every pre-enforcement run has NULL snapshot columns.
+    # Skills and reasoning_effort are NOT read from the snapshot — they stay
+    # live task fields handled by the blocks below.
+    snapshot_model = snapshot_provider = None
+    if task.current_run_id is not None:
+        try:
+            with contextlib.closing(connect()) as _snap_conn:
+                run_row = _snap_conn.execute(
+                    "SELECT routing_model, routing_provider "
+                    "FROM task_runs WHERE id = ?",
+                    (task.current_run_id,),
+                ).fetchone()
+            if run_row is not None:
+                snapshot_model = run_row["routing_model"]
+                snapshot_provider = run_row["routing_provider"]
+        except Exception as exc:  # noqa: BLE001 -- best-effort advisory read
+            # A snapshot-read hiccup must never kill the spawn: fall back to
+            # the task pin (Wave 1 behavior) instead of failing the worker.
+            _log.debug("kanban spawn: snapshot read failed, falling back to "
+                       "task pin (%s)", exc)
+    if snapshot_model:
+        # Enforced: use the immutable snapshot captured at claim time.
+        cmd.extend(["-m", snapshot_model])
+        if snapshot_provider:
+            cmd.extend(["--provider", snapshot_provider])
+    elif task.model_override:
         cmd.extend(["-m", task.model_override])
         # Pin the provider too when the override names one, so the worker
         # resolves the model against the intended backend instead of the
@@ -10865,6 +11388,7 @@ def _default_spawn(
         # the classic mis-set that stalls a board).
         if task.provider_override:
             cmd.extend(["--provider", task.provider_override])
+    # else: profile default (no override)
     # Per-task thinking depth. Independent of the model override — a task can
     # run the profile's own model at a different depth — so this is its own
     # branch, not a nested one.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5501,27 +5501,38 @@ def _claim_review_task_once(
         return get_task(conn, task_id)
 
 
+def _append_claim_rejected_once(
+    conn: sqlite3.Connection, task_id: str, attempt_id: str, reason: str
+) -> None:
+    """Audit a routing rejection once for a stable logical attempt."""
+    rows = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id=? AND kind='claim_rejected'",
+        (task_id,),
+    ).fetchall()
+    if any(json.loads(row["payload"]).get("attempt_id") == attempt_id for row in rows):
+        return
+    _append_event(
+        conn, task_id, "claim_rejected", {"attempt_id": attempt_id, "reason": reason}
+    )
+
+
 def claim_review_task(
     conn: sqlite3.Connection,
     task_id: str,
     *,
     ttl_seconds: Optional[int] = None,
     claimer: Optional[str] = None,
+    attempt_id: Optional[str] = None,
 ) -> Optional[Task]:
     """Claim review work or durably audit a rejected review route."""
-    attempt_id = str(uuid.uuid4())
+    attempt_id = attempt_id or str(uuid.uuid4())
     try:
         return _claim_review_task_once(
             conn, task_id, ttl_seconds=ttl_seconds, claimer=claimer
         )
     except RoutingContractError as exc:
         with write_txn(conn):
-            _append_event(
-                conn,
-                task_id,
-                "claim_rejected",
-                {"attempt_id": attempt_id, "reason": str(exc)},
-            )
+            _append_claim_rejected_once(conn, task_id, attempt_id, str(exc))
         raise
 
 
@@ -5531,26 +5542,23 @@ def claim_task(
     *,
     ttl_seconds: Optional[int] = None,
     claimer: Optional[str] = None,
+    attempt_id: Optional[str] = None,
 ) -> Optional[Task]:
     """Claim implementation work or durably audit a rejected route.
 
     Routing rejection must escape the main claim transaction so that its
     rollback completes before the audit event is written in a separate
-    transaction. The exception is then returned to the caller unchanged.
+    transaction. Callers may reuse ``attempt_id`` when retrying the same API
+    attempt; omitted IDs are fresh UUIDs so legitimate re-attempts are kept.
     """
-    attempt_id = str(uuid.uuid4())
+    attempt_id = attempt_id or str(uuid.uuid4())
     try:
         return _claim_task_once(
             conn, task_id, ttl_seconds=ttl_seconds, claimer=claimer
         )
     except RoutingContractError as exc:
         with write_txn(conn):
-            _append_event(
-                conn,
-                task_id,
-                "claim_rejected",
-                {"attempt_id": attempt_id, "reason": str(exc)},
-            )
+            _append_claim_rejected_once(conn, task_id, attempt_id, str(exc))
         raise
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3004,6 +3004,102 @@ def _migrate_routing_metadata(conn: sqlite3.Connection) -> None:
     )
 
 
+@dataclass(frozen=True)
+class RoutingBackfillResult:
+    """Summary counters for one routing metadata backfill pass."""
+
+    processed: int = 0
+    inferred: int = 0
+    unknown: int = 0
+    skipped: int = 0
+    errors: int = 0
+
+
+def _routing_usage_evidence(
+    state_db: Path, worker_session_id: str
+) -> Optional[tuple[str, str]]:
+    """Return an unambiguous dominant main-loop model/provider pair."""
+    if not state_db.is_file():
+        return None
+    try:
+        with sqlite3.connect(state_db) as usage_conn:
+            rows = usage_conn.execute(
+                "SELECT model, billing_provider, api_call_count "
+                "FROM session_model_usage WHERE session_id=? AND task='' "
+                "ORDER BY api_call_count DESC",
+                (worker_session_id,),
+            ).fetchall()
+    except (sqlite3.Error, OSError):
+        return None
+    if not rows:
+        return None
+    top_count = rows[0][2]
+    if len(rows) > 1 and rows[1][2] == top_count:
+        return None
+    model, provider = rows[0][0], rows[0][1]
+    if not isinstance(model, str) or not model.strip():
+        return None
+    if not isinstance(provider, str) or not provider.strip():
+        return None
+    return model.strip(), provider.strip()
+
+
+def backfill_routing_metadata(
+    conn: sqlite3.Connection,
+    *,
+    hermes_home: Optional[Path] = None,
+) -> RoutingBackfillResult:
+    """Backfill terminal pre-migration runs from execution evidence only."""
+    metadata = conn.execute(
+        "SELECT value FROM kanban_metadata WHERE key='migration_cutoff_id'"
+    ).fetchone()
+    if metadata is None:
+        raise ValueError("routing migration cutoff is missing")
+    cutoff = int(metadata["value"])
+    if cutoff < 0:
+        raise ValueError("routing migration cutoff must be non-negative")
+    home = Path(hermes_home or os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+    candidates = conn.execute(
+        "SELECT r.id,r.profile,r.metadata FROM task_runs r "
+        "JOIN tasks t ON t.id=r.task_id "
+        "WHERE r.id<=? AND r.routing_source IS NULL "
+        "AND r.ended_at IS NOT NULL AND t.status IN ('done','archived') "
+        "ORDER BY r.id",
+        (cutoff,),
+    ).fetchall()
+    inferred = unknown = 0
+    with write_txn(conn):
+        for row in candidates:
+            try:
+                run_metadata = json.loads(row["metadata"] or "{}")
+            except (json.JSONDecodeError, TypeError):
+                run_metadata = {}
+            session_id = run_metadata.get("worker_session_id") if isinstance(run_metadata, dict) else None
+            profile = row["profile"]
+            evidence = None
+            if isinstance(session_id, str) and session_id and isinstance(profile, str) and profile:
+                evidence = _routing_usage_evidence(
+                    home / "profiles" / profile / "state.db", session_id
+                )
+            if evidence is None:
+                conn.execute(
+                    "UPDATE task_runs SET routing_source='legacy_unknown', "
+                    "routing_model=NULL, routing_provider=NULL WHERE id=? AND routing_source IS NULL",
+                    (row["id"],),
+                )
+                unknown += 1
+            else:
+                conn.execute(
+                    "UPDATE task_runs SET routing_source='inferred_evidence', "
+                    "routing_model=?, routing_provider=? WHERE id=? AND routing_source IS NULL",
+                    (evidence[0], evidence[1], row["id"]),
+                )
+                inferred += 1
+    return RoutingBackfillResult(
+        processed=len(candidates), inferred=inferred, unknown=unknown
+    )
+
+
 # Legacy DBs defined these tables with a ``TEXT PRIMARY KEY`` id (or, for
 # ``kanban_notify_subs``, a nullable ``TEXT last_event_id``). The current
 # schema uses ``INTEGER PRIMARY KEY AUTOINCREMENT`` / ``INTEGER NOT NULL

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -11801,15 +11801,24 @@ def _default_spawn(
         try:
             with contextlib.closing(connect()) as _snap_conn:
                 run_row = _snap_conn.execute(
-                    "SELECT routing_model, routing_provider "
+                    "SELECT routing_model, routing_provider, routing_contract "
                     "FROM task_runs WHERE id = ?",
                     (task.current_run_id,),
                 ).fetchone()
             if run_row is not None:
                 snapshot_model = run_row["routing_model"]
                 snapshot_provider = run_row["routing_provider"]
-        except Exception as exc:  # noqa: BLE001 -- best-effort advisory read
-            # A snapshot-read hiccup must never kill the spawn: fall back to
+                if run_row["routing_contract"] is not None and (
+                    not snapshot_model or not snapshot_provider
+                ):
+                    raise RoutingContractError(
+                        "incomplete frozen routing snapshot for modern run "
+                        f"{task.current_run_id}"
+                    )
+        except RoutingContractError:
+            raise
+        except Exception as exc:  # noqa: BLE001 -- legacy advisory read
+            # A legacy snapshot-read hiccup must not kill the spawn: fall back to
             # the task pin (Wave 1 behavior) instead of failing the worker.
             _log.debug("kanban spawn: snapshot read failed, falling back to "
                        "task pin (%s)", exc)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3015,6 +3015,78 @@ class RoutingBackfillResult:
     errors: int = 0
 
 
+@dataclass(frozen=True)
+class RunRoutingSnapshot:
+    """Frozen routing decision stored for one board-local run."""
+
+    run_id: int
+    task_id: str
+    board: str
+    routing_role: Optional[str]
+    routing_model: Optional[str]
+    routing_provider: Optional[str]
+    routing_reason: Optional[str]
+    routing_contract: Optional[int]
+    routing_policy: Optional[str]
+    roster_digest: Optional[str]
+    ac_revision: Optional[str]
+    routing_source: Optional[str]
+
+
+def get_routing_snapshot(
+    conn: sqlite3.Connection, run_id: int, *, board: str
+) -> RunRoutingSnapshot:
+    """Return the frozen snapshot for a run in an explicitly named board."""
+    if not isinstance(board, str) or not board.strip():
+        raise ValueError("board must be explicit")
+    row = conn.execute(
+        "SELECT id,task_id,routing_role,routing_model,routing_provider,"
+        "routing_reason,routing_contract,routing_policy,roster_digest,ac_revision,"
+        "routing_source FROM task_runs WHERE id=?",
+        (run_id,),
+    ).fetchone()
+    if row is None:
+        raise KeyError(run_id)
+    return RunRoutingSnapshot(
+        run_id=row["id"], task_id=row["task_id"], board=board.strip(),
+        routing_role=row["routing_role"], routing_model=row["routing_model"],
+        routing_provider=row["routing_provider"], routing_reason=row["routing_reason"],
+        routing_contract=row["routing_contract"], routing_policy=row["routing_policy"],
+        roster_digest=row["roster_digest"], ac_revision=row["ac_revision"],
+        routing_source=row["routing_source"],
+    )
+
+
+def set_routing_override(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    role: Optional[str] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
+) -> None:
+    """Atomically select role mode or raw-model mode for a task."""
+    if role is not None and (model is not None or provider is not None):
+        raise ValueError("role mode and model mode are mutually exclusive")
+    if provider is not None and model is None:
+        raise ValueError("provider requires model")
+    if role is None and model is None:
+        raise ValueError("role or model is required")
+    with write_txn(conn):
+        if role is not None:
+            cur = conn.execute(
+                "UPDATE tasks SET routing_role=?,model_override=NULL,provider_override=NULL "
+                "WHERE id=?", (role, task_id),
+            )
+        else:
+            cur = conn.execute(
+                "UPDATE tasks SET routing_role=NULL,model_override=?,provider_override=? "
+                "WHERE id=?", (model, provider, task_id),
+            )
+        if cur.rowcount != 1:
+            raise KeyError(task_id)
+
+
 def _routing_usage_evidence(
     state_db: Path, worker_session_id: str
 ) -> Optional[tuple[str, str]]:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5067,13 +5067,22 @@ def _semantic_routing_snapshot(
     if not isinstance(entry, dict):
         raise RoutingContractError(f"role {selected!r} not found in roles.yaml")
     resolved_source = source
+    original_role = selected
+    review_reason = None
     if phase == "review":
         if entry.get("review_capable") is True:
             resolved_source = "review_capable"
+            review_reason = (
+                f"review phase: role '{original_role}' already review-capable"
+            )
         else:
             selected = "reviewer"
             entry = roles.get(selected)
             resolved_source = "review_coerced"
+            review_reason = (
+                f"review phase: role '{original_role}' not review-capable, "
+                "coerced to reviewer"
+            )
             if not isinstance(entry, dict):
                 raise RoutingContractError("role 'reviewer' not found in roles.yaml")
     model = entry.get("model")
@@ -5093,10 +5102,12 @@ def _semantic_routing_snapshot(
              "may_edit": entry.get("may_edit")}, sort_keys=True,
         ),
         routing_source=resolved_source,
+        routing_reason=review_reason,
     )
     if parsed:
         snapshot["routing_contract"] = ROUTING_CONTRACT_VERSION
-        snapshot["routing_reason"] = parsed.get("reason")
+        if review_reason is None:
+            snapshot["routing_reason"] = parsed.get("reason")
         ac_ids = parsed.get("ac_ids")
         if ac_ids:
             text = _extract_ac_text(body, ac_ids)
@@ -5197,7 +5208,8 @@ def _claim_task_once(
         # txn is the event row, so the task stays ready and the dispatch
         # loop's circuit breaker decides the next move. No silent loop.
         trow = conn.execute(
-            "SELECT assignee, max_runtime_seconds, current_step_key, body "
+            "SELECT assignee, max_runtime_seconds, current_step_key, body, "
+            "routing_role, model_override, provider_override "
             "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
@@ -5337,7 +5349,8 @@ def _claim_review_task_once(
         # roster failure emit preflight_rejected and return None; the task
         # stays in review and the dispatch loop's circuit breaker decides.
         trow = conn.execute(
-            "SELECT assignee, max_runtime_seconds, current_step_key, body "
+            "SELECT assignee, max_runtime_seconds, current_step_key, body, "
+            "routing_role, model_override, provider_override "
             "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5531,8 +5531,15 @@ def claim_review_task(
             conn, task_id, ttl_seconds=ttl_seconds, claimer=claimer
         )
     except RoutingContractError as exc:
-        with write_txn(conn):
-            _append_claim_rejected_once(conn, task_id, attempt_id, str(exc))
+        try:
+            with write_txn(conn):
+                _append_claim_rejected_once(conn, task_id, attempt_id, str(exc))
+        except Exception as audit_exc:  # noqa: BLE001 - secondary audit is best effort
+            _log.warning(
+                "failed to audit claim_rejected for task %s: %s",
+                task_id,
+                audit_exc,
+            )
         raise
 
 
@@ -5557,8 +5564,15 @@ def claim_task(
             conn, task_id, ttl_seconds=ttl_seconds, claimer=claimer
         )
     except RoutingContractError as exc:
-        with write_txn(conn):
-            _append_claim_rejected_once(conn, task_id, attempt_id, str(exc))
+        try:
+            with write_txn(conn):
+                _append_claim_rejected_once(conn, task_id, attempt_id, str(exc))
+        except Exception as audit_exc:  # noqa: BLE001 - secondary audit is best effort
+            _log.warning(
+                "failed to audit claim_rejected for task %s: %s",
+                task_id,
+                audit_exc,
+            )
         raise
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -83,6 +83,7 @@ import subprocess
 import sys
 import threading
 import logging
+import uuid
 import time
 import yaml
 from contextvars import ContextVar, Token
@@ -5053,7 +5054,7 @@ def _resolve_routing_snapshot(
 
 
 
-def claim_task(
+def _claim_task_once(
     conn: sqlite3.Connection,
     task_id: str,
     *,
@@ -5109,11 +5110,7 @@ def claim_task(
                 conn, task_id, trow, phase="implement"
             )
         except RoutingContractError as exc:
-            _append_event(
-                conn, task_id, "preflight_rejected",
-                {"reason": str(exc), "phase": "implement"},
-            )
-            return None
+            raise exc
         # Defensive: if a prior run somehow leaked (invariant violation from
         # an unknown code path), close it as 'reclaimed' so we don't strand
         # it when the CAS resets the pointer below. No-op when the invariant
@@ -5200,7 +5197,7 @@ def claim_task(
     return claimed
 
 
-def claim_review_task(
+def _claim_review_task_once(
     conn: sqlite3.Connection,
     task_id: str,
     *,
@@ -5253,11 +5250,7 @@ def claim_review_task(
                 conn, task_id, trow, phase="review"
             )
         except RoutingContractError as exc:
-            _append_event(
-                conn, task_id, "preflight_rejected",
-                {"reason": str(exc), "phase": "review"},
-            )
-            return None
+            raise exc
         cur = conn.execute(
             """
             UPDATE tasks
@@ -5315,6 +5308,59 @@ def claim_review_task(
             run_id=run_id,
         )
         return get_task(conn, task_id)
+
+
+def claim_review_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    ttl_seconds: Optional[int] = None,
+    claimer: Optional[str] = None,
+) -> Optional[Task]:
+    """Claim review work or durably audit a rejected review route."""
+    attempt_id = str(uuid.uuid4())
+    try:
+        return _claim_review_task_once(
+            conn, task_id, ttl_seconds=ttl_seconds, claimer=claimer
+        )
+    except RoutingContractError as exc:
+        with write_txn(conn):
+            _append_event(
+                conn,
+                task_id,
+                "claim_rejected",
+                {"attempt_id": attempt_id, "reason": str(exc)},
+            )
+        raise
+
+
+def claim_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    ttl_seconds: Optional[int] = None,
+    claimer: Optional[str] = None,
+) -> Optional[Task]:
+    """Claim implementation work or durably audit a rejected route.
+
+    Routing rejection must escape the main claim transaction so that its
+    rollback completes before the audit event is written in a separate
+    transaction. The exception is then returned to the caller unchanged.
+    """
+    attempt_id = str(uuid.uuid4())
+    try:
+        return _claim_task_once(
+            conn, task_id, ttl_seconds=ttl_seconds, claimer=claimer
+        )
+    except RoutingContractError as exc:
+        with write_txn(conn):
+            _append_event(
+                conn,
+                task_id,
+                "claim_rejected",
+                {"attempt_id": attempt_id, "reason": str(exc)},
+            )
+        raise
 
 
 def _retry_status_for_run(
@@ -9788,6 +9834,42 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     return crashed
 
 
+def _append_spawn_rejected_event(
+    conn: sqlite3.Connection,
+    task_id: str,
+    run_id: Optional[int],
+    reason: str,
+    consecutive_failures: int,
+    max_retries: int,
+) -> None:
+    """Append one canonical spawn rejection event per run.
+
+    A missing run id cannot identify a post-claim attempt and is ignored.
+    Callers run this helper inside their lifecycle transaction.
+    """
+    if run_id is None:
+        return
+    existing = conn.execute(
+        "SELECT 1 FROM task_events "
+        "WHERE run_id=? AND kind='spawn_rejected' LIMIT 1",
+        (int(run_id),),
+    ).fetchone()
+    if existing is not None:
+        return
+    _append_event(
+        conn,
+        task_id,
+        "spawn_rejected",
+        {
+            "run_id": int(run_id),
+            "reason": reason[:500],
+            "consecutive_failures": int(consecutive_failures),
+            "max_retries": int(max_retries),
+        },
+        run_id=int(run_id),
+    )
+
+
 def _record_task_failure(
     conn: sqlite3.Connection,
     task_id: str,
@@ -9898,7 +9980,7 @@ def _record_task_failure(
                 # Only the spawn path has an open run to close.
                 run_id = _end_run(
                     conn, task_id,
-                    outcome="gave_up", status="gave_up",
+                    outcome=outcome, status="failed",
                     error=error[:500],
                     metadata={
                         "failures": failures,
@@ -9918,9 +10000,12 @@ def _record_task_failure(
             }
             if event_payload_extra:
                 payload.update(event_payload_extra)
-            _append_event(
-                conn, task_id, "gave_up", payload, run_id=run_id,
-            )
+            if end_run:
+                _append_spawn_rejected_event(
+                    conn, task_id, run_id, error, failures, effective_limit
+                )
+            else:
+                _append_event(conn, task_id, "gave_up", payload, run_id=run_id)
             blocked = True
         else:
             # Below threshold.
@@ -9944,21 +10029,15 @@ def _record_task_failure(
                 # Spawn path: close the open run with outcome.
                 run_id = _end_run(
                     conn, task_id,
-                    outcome=outcome, status=outcome,
+                    outcome=outcome, status="failed",
                     error=error[:500],
                     metadata={
                         "failures": failures,
                         "retry_status": retry_status,
                     },
                 )
-                _append_event(
-                    conn, task_id, outcome,
-                    {
-                        "error": error[:500],
-                        "failures": failures,
-                        "retry_status": retry_status,
-                    },
-                    run_id=run_id,
+                _append_spawn_rejected_event(
+                    conn, task_id, run_id, error, failures, effective_limit
                 )
             # Timeout/crash path's caller already emitted its own event.
     return blocked

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3137,9 +3137,9 @@ def backfill_routing_metadata(
     home = Path(hermes_home or os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
     candidates = conn.execute(
         "SELECT r.id,r.profile,r.metadata FROM task_runs r "
-        "JOIN tasks t ON t.id=r.task_id "
         "WHERE r.id<=? AND r.routing_source IS NULL "
-        "AND r.ended_at IS NOT NULL AND t.status IN ('done','archived') "
+        "AND r.ended_at IS NOT NULL "
+        "AND r.outcome IS NOT NULL AND r.status != 'running' "
         "ORDER BY r.id",
         (cutoff,),
     ).fetchall()

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -892,6 +892,7 @@ def read_board_metadata(board: Optional[str] = None) -> dict:
         "icon": "",
         "color": "",
         "default_workdir": None,
+        "default_role": None,
         # Optional first-class Project this board is scoped to. When set, new
         # tasks inherit it (deterministic worktree + branch under the project's
         # primary repo) and ``default_workdir`` mirrors the project's primary
@@ -925,6 +926,7 @@ def write_board_metadata(
     archived: Optional[bool] = None,
     default_workdir: Optional[str] = None,
     project_id: Optional[str] = None,
+    default_role: Optional[str] = None,
 ) -> dict:
     """Create / update ``board.json`` for ``board``.
 
@@ -955,6 +957,8 @@ def write_board_metadata(
         meta["default_workdir"] = str(default_workdir) if default_workdir else None
     if project_id is not None:
         meta["project_id"] = str(project_id) if project_id else None
+    if default_role is not None:
+        meta["default_role"] = str(default_role).strip() or None
     if not meta.get("created_at"):
         meta["created_at"] = int(time.time())
     path = board_metadata_path(slug)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2513,7 +2513,12 @@ def connect(
                     # threads from racing through the additive ALTER TABLE pass with
                     # stale PRAGMA snapshots during gateway startup.
                     conn.executescript(SCHEMA_SQL)
-                    _migrate_add_optional_columns(conn)
+                    # Publish all additive schema state under one writer lock.
+                    # This prevents a concurrent claimer from creating a run
+                    # between the cutoff capture and schema-version marker.
+                    with write_txn(conn):
+                        _migrate_add_optional_columns(conn)
+                        _migrate_routing_metadata(conn)
                     _INITIALIZED_PATHS.add(resolved)
         except Exception:
             conn.close()
@@ -2893,7 +2898,7 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         "SELECT name FROM sqlite_master WHERE type='table' AND name='task_runs'"
     ).fetchone() is not None
     if runs_exist:
-        with write_txn(conn):
+        with write_txn(conn, allow_nested=True):
             inflight = conn.execute(
                 "SELECT id, assignee, claim_lock, claim_expires, worker_pid, "
                 "       max_runtime_seconds, last_heartbeat_at, started_at "
@@ -2953,6 +2958,49 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         )
 
     _rebuild_drifted_tables(conn)
+
+
+def _migrate_routing_metadata(conn: sqlite3.Connection) -> None:
+    """Install and atomically publish immutable run-routing metadata.
+
+    The caller owns one IMMEDIATE write transaction. Schema additions happen
+    before the cutoff marker, while the schema version is inserted last so no
+    reader can observe a published migration with incomplete prerequisites.
+    Existing metadata is intentionally preserved across repeated initialization.
+    """
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS kanban_metadata (
+            key        TEXT PRIMARY KEY,
+            value      TEXT NOT NULL,
+            updated_at INTEGER NOT NULL
+        )
+        """
+    )
+    _add_column_if_missing(conn, "tasks", "routing_role", "routing_role TEXT")
+    _add_column_if_missing(
+        conn, "task_runs", "routing_source", "routing_source TEXT"
+    )
+
+    updated_at = int(time.time())
+    cutoff = conn.execute(
+        "SELECT COALESCE(MAX(id), 0) AS cutoff FROM task_runs"
+    ).fetchone()["cutoff"]
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO kanban_metadata (key, value, updated_at)
+        VALUES ('migration_cutoff_id', ?, ?)
+        """,
+        (str(cutoff), updated_at),
+    )
+    # The version marker is the publication point and must remain last.
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO kanban_metadata (key, value, updated_at)
+        VALUES ('routing_schema_version', '1', ?)
+        """,
+        (updated_at,),
+    )
 
 
 # Legacy DBs defined these tables with a ``TEXT PRIMARY KEY`` id (or, for

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -11806,12 +11806,16 @@ def _default_spawn(
                     "FROM task_runs WHERE id = ?",
                     (task.current_run_id,),
                 ).fetchone()
+                cutoff_row = _snap_conn.execute(
+                    "SELECT value FROM kanban_metadata "
+                    "WHERE key = 'migration_cutoff_id'"
+                ).fetchone()
             if run_row is not None:
                 snapshot_model = run_row["routing_model"]
                 snapshot_provider = run_row["routing_provider"]
-                if run_row["routing_contract"] is not None and (
-                    not snapshot_model or not snapshot_provider
-                ):
+                cutoff = int(cutoff_row["value"]) if cutoff_row is not None else -1
+                is_modern_run = task.current_run_id > cutoff
+                if is_modern_run and (not snapshot_model or not snapshot_provider):
                     raise RoutingContractError(
                         "incomplete frozen routing snapshot for modern run "
                         f"{task.current_run_id}"

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4854,7 +4854,8 @@ def _resume_status_from_events(conn: sqlite3.Connection, task_id: str) -> str:
         "WHERE task_id = ? AND kind IN ("
         "'blocked', 'block_loop_detected', 'dependency_wait', 'gave_up', "
         "'unblocked', 'changes_requested', 'review_reopened', 'status', 'reclaimed', "
-        "'stale', 'timed_out', 'crashed', 'spawn_failed', 'rate_limited'"
+        "'stale', 'timed_out', 'crashed', 'spawn_failed', 'spawn_rejected', "
+        "'rate_limited'"
         ") ORDER BY id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
@@ -4994,7 +4995,7 @@ def _load_roster() -> tuple:
     Returns ``(data, digest)`` where ``data`` is the parsed YAML mapping and
     ``digest`` is sha256 of the raw file content. Raises
     :class:`RoutingContractError` on any load / parse failure so the claim
-    transaction can emit ``preflight_rejected`` and leave the task ready.
+    transaction can emit ``claim_rejected`` and leave the task ready.
     """
     try:
         from hermes_constants import get_hermes_home
@@ -5286,7 +5287,7 @@ def _claim_task_once(
             return None
         # Wave 2 routing snapshot (Step 2b): resolve the immutable routing
         # decision BEFORE the CAS flips ready→running. On roster failure we
-        # emit preflight_rejected and return None — the only write in this
+        # emit claim_rejected and return None — the only write in this
         # txn is the event row, so the task stays ready and the dispatch
         # loop's circuit breaker decides the next move. No silent loop.
         trow = conn.execute(
@@ -5428,7 +5429,7 @@ def _claim_review_task_once(
             return None
         # Wave 2 routing snapshot (Step 2b): same pre-CAS resolution as
         # claim_task, but phase="review" → resolves the reviewer role. On
-        # roster failure emit preflight_rejected and return None; the task
+        # roster failure claim_rejected is audited after rollback; the task
         # stays in review and the dispatch loop's circuit breaker decides.
         trow = conn.execute(
             "SELECT assignee, max_runtime_seconds, current_step_key, body, "

--- a/hermes_cli/kanban_swarm.py
+++ b/hermes_cli/kanban_swarm.py
@@ -71,6 +71,7 @@ def _swarm_context(root_id: str, goal: str) -> str:
         "- Put machine-readable facts in completion metadata.\n"
         "- Put cross-worker notes on the root task using structured comments.\n"
         f"- Goal: {goal.strip()}\n"
+        "- IMPORTANT: this is a SWARM task. The verifier card (child of this graph) is your reviewer. When your work is done, call `kanban_complete(summary=..., metadata={...})` with full handoff metadata — do NOT `kanban_block(reason=\"review-required: ...\")`. Blocking stalls the swarm: the verifier only promotes when workers complete. Block ONLY for genuine blockers (missing deps, unanswerable questions, capability gaps).\n"
     )
 
 
@@ -135,6 +136,8 @@ def create_swarm(
     root_title: Optional[str] = None,
     verifier_title: str = "Verify swarm outputs",
     synthesizer_title: str = "Synthesize swarm outputs",
+    verifier_skills: Optional[list[str]] = None,
+    synthesizer_skills: Optional[list[str]] = None,
     tenant: Optional[str] = None,
     created_by: str = "swarm-orchestrator",
     workspace_kind: str = "scratch",
@@ -301,7 +304,7 @@ def _create_swarm_uncommitted(
         priority=priority,
         workspace_kind=workspace_kind,
         workspace_path=workspace_path,
-        skills=["requesting-code-review"],
+        skills=verifier_skills if verifier_skills is not None else ["requesting-code-review"],
     )
 
     synthesizer_body = (
@@ -320,7 +323,7 @@ def _create_swarm_uncommitted(
         priority=priority,
         workspace_kind=workspace_kind,
         workspace_path=workspace_path,
-        skills=["humanizer"],
+        skills=synthesizer_skills or None,
     )
 
     created = SwarmCreated(root, worker_ids, verifier, synthesizer)

--- a/hermes_cli/routing_contract.py
+++ b/hermes_cli/routing_contract.py
@@ -1,0 +1,131 @@
+"""
+Routing contract parser for Wave 2 enforcement.
+Parses the delimited `# ---routing:v1---` block from task bodies.
+"""
+import re
+import yaml
+from typing import Optional
+
+ROUTING_CONTRACT_VERSION = 1
+_MAX_ENVELOPE_BYTES = 2048
+
+# Delimiters for the routing envelope
+_ENVELOPE_START = "# ---routing:v1---"
+_ENVELOPE_END = "# ---/routing:v1---"
+
+# Required fields in the v1 contract
+_REQUIRED_FIELDS = {"role", "reason", "enforcement_required"}
+
+
+class RoutingContractError(ValueError):
+    """Raised when the routing envelope is malformed or invalid."""
+    pass
+
+
+def _extract_envelope(body: str) -> Optional[str]:
+    """Extract the delimited routing block from a task body.
+    
+    Returns the YAML content between the delimiters, or None if no envelope found.
+    Raises RoutingContractError if the start marker exists but the end marker is missing.
+    """
+    start_idx = body.find(_ENVELOPE_START)
+    if start_idx == -1:
+        return None
+    end_idx = body.find(_ENVELOPE_END, start_idx)
+    if end_idx == -1:
+        raise RoutingContractError(
+            "Routing envelope has start marker but missing end marker"
+        )
+    content = body[start_idx + len(_ENVELOPE_START):end_idx]
+    if len(content.encode()) > _MAX_ENVELOPE_BYTES:
+        raise RoutingContractError(
+            f"Routing envelope exceeds {_MAX_ENVELOPE_BYTES} bytes"
+        )
+    return content
+
+
+def _is_wave1_envelope(body: str) -> bool:
+    """Check if the body contains a Wave 1 routing envelope (assigned_role/action style).
+    
+    Wave 1 envelopes use a different field set and must be classified as unenforced,
+    never as parse errors.
+    """
+    # Wave 1 used `routing:` as a YAML key with `assigned_role` etc.
+    # The v1 contract uses `# ---routing:v1---` delimiters instead.
+    # If there's no v1 delimiter but there IS a `routing:` YAML key, it's Wave 1.
+    if _ENVELOPE_START in body:
+        return False  # Has v1 delimiter, not Wave 1
+    # Check for Wave 1 style: indented `routing:` block or `assigned_role:`
+    return bool(re.search(r'(?m)^\s*routing:\s*$', body)) or \
+           bool(re.search(r'(?m)^\s*assigned_role:\s*\S+', body))
+
+
+def parse_routing_envelope(body: str) -> dict:
+    """Parse the routing contract v1 envelope from a task body.
+    
+    Returns a dict with the parsed fields, or an empty dict if no v1 envelope
+    is found (unenforced/legacy).
+    
+    Raises RoutingContractError if the envelope is malformed.
+    
+    For Wave 1 envelopes (assigned_role/action style), returns an empty dict
+    (classified as unenforced — never an error).
+    """
+    content = _extract_envelope(body)
+    if content is None:
+        # No v1 envelope. Check if it's a Wave 1 envelope.
+        if _is_wave1_envelope(body):
+            # Wave 1 envelopes are unenforced — not an error, just no v1 contract
+            return {}
+        return {}
+    
+    # Parse the YAML content
+    try:
+        parsed = yaml.safe_load(content)
+    except yaml.YAMLError as e:
+        raise RoutingContractError(f"Routing envelope YAML parse error: {e}") from e
+    
+    if parsed is None:
+        raise RoutingContractError("Routing envelope is empty")
+    if not isinstance(parsed, dict):
+        raise RoutingContractError(
+            f"Routing envelope must be a YAML mapping, got {type(parsed).__name__}"
+        )
+    
+    # Check required fields
+    missing = _REQUIRED_FIELDS - set(parsed.keys())
+    if missing:
+        raise RoutingContractError(
+            f"Routing envelope missing required fields: {missing}"
+        )
+    
+    # Type validation
+    role = parsed["role"]
+    if not isinstance(role, str) or not role.strip():
+        raise RoutingContractError("'role' must be a non-empty string")
+    
+    reason = parsed["reason"]
+    if not isinstance(reason, str) or not reason.strip():
+        raise RoutingContractError("'reason' must be a non-empty string")
+    
+    enforcement = parsed["enforcement_required"]
+    if not isinstance(enforcement, bool):
+        raise RoutingContractError("'enforcement_required' must be a boolean")
+    
+    # Optional fields
+    if "model" in parsed and parsed["model"] is not None:
+        if not isinstance(parsed["model"], str):
+            raise RoutingContractError("'model' must be a string or absent")
+    
+    if "provider" in parsed and parsed["provider"] is not None:
+        if not isinstance(parsed["provider"], str):
+            raise RoutingContractError("'provider' must be a string or absent")
+    
+    if "ac_ids" in parsed and parsed["ac_ids"] is not None:
+        if not isinstance(parsed["ac_ids"], list):
+            raise RoutingContractError("'ac_ids' must be a list of strings or absent")
+        for ac_id in parsed["ac_ids"]:
+            if not isinstance(ac_id, str):
+                raise RoutingContractError("'ac_ids' must contain only strings")
+    
+    return parsed

--- a/tests/hermes_cli/test_kanban_claim_routing_snapshot.py
+++ b/tests/hermes_cli/test_kanban_claim_routing_snapshot.py
@@ -94,6 +94,44 @@ def test_claim_review_task_persists_complete_snapshot_without_changing_task_role
     assert task["routing_role"] == "task-review-role"
 
 
+def test_review_capable_role_has_review_specific_source_and_reason(conn, monkeypatch):
+    """Review claims distinguish accepted review roles from implementation claims."""
+    monkeypatch.setattr(
+        kb,
+        "_load_roster",
+        lambda: (
+            {
+                "roles": {
+                    "reviewer": {
+                        "model": "review-model",
+                        "provider": "review-provider",
+                        "review_capable": True,
+                    }
+                }
+            },
+            "review-digest",
+        ),
+    )
+    task_id = kb.create_task(conn, title="review-ready", assignee="coder")
+    conn.execute(
+        "UPDATE tasks SET status='review', routing_role='reviewer' WHERE id=?",
+        (task_id,),
+    )
+
+    claimed = kb.claim_review_task(conn, task_id)
+    assert claimed is not None
+    row = conn.execute(
+        "SELECT routing_source,routing_reason FROM task_runs WHERE task_id=? "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+
+    assert row["routing_source"] == "review_capable"
+    assert row["routing_reason"] == (
+        "review phase: role 'reviewer' already review-capable"
+    )
+
+
 def test_claim_rolls_back_task_transition_when_run_snapshot_insert_fails(
     conn, deterministic_snapshot
 ):

--- a/tests/hermes_cli/test_kanban_claim_routing_snapshot.py
+++ b/tests/hermes_cli/test_kanban_claim_routing_snapshot.py
@@ -1,0 +1,122 @@
+"""Claim-time routing snapshots are persisted immutably on task runs."""
+
+from pathlib import Path
+import sqlite3
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+SNAPSHOT = {
+    "routing_role": "executor",
+    "routing_model": "snapshot-model",
+    "routing_provider": "snapshot-provider",
+    "routing_contract": "snapshot-contract",
+    "routing_reason": "snapshot-reason",
+    "roster_digest": "snapshot-roster-digest",
+    "routing_policy": "snapshot-policy",
+    "ac_revision": "snapshot-ac-revision",
+    "routing_source": "snapshot-source",
+}
+SNAPSHOT_COLUMNS = tuple(SNAPSHOT)
+
+
+@pytest.fixture
+def conn(tmp_path, monkeypatch):
+    """Return an initialized, isolated Kanban connection."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    connection = kb.connect()
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+@pytest.fixture
+def deterministic_snapshot(monkeypatch):
+    monkeypatch.setattr(
+        kb,
+        "_resolve_routing_snapshot",
+        lambda *args, **kwargs: dict(SNAPSHOT),
+    )
+
+
+def _persisted_snapshot(conn: sqlite3.Connection, task_id: str) -> dict:
+    columns = ", ".join(SNAPSHOT_COLUMNS)
+    row = conn.execute(
+        f"SELECT {columns} FROM task_runs WHERE task_id = ?",
+        (task_id,),
+    ).fetchone()
+    assert row is not None
+    return {column: row[column] for column in SNAPSHOT_COLUMNS}
+
+
+def test_claim_task_persists_complete_snapshot_without_changing_task_role(
+    conn, deterministic_snapshot
+):
+    task_id = kb.create_task(conn, title="implementation", assignee="coder")
+    conn.execute(
+        "UPDATE tasks SET routing_role = ? WHERE id = ?",
+        ("task-role", task_id),
+    )
+    conn.commit()
+
+    assert kb.claim_task(conn, task_id) is not None
+
+    assert _persisted_snapshot(conn, task_id) == SNAPSHOT
+    task = conn.execute(
+        "SELECT routing_role FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    assert task["routing_role"] == "task-role"
+
+
+def test_claim_review_task_persists_complete_snapshot_without_changing_task_role(
+    conn, deterministic_snapshot
+):
+    task_id = kb.create_task(conn, title="review", assignee="reviewer")
+    conn.execute(
+        "UPDATE tasks SET status = 'review', routing_role = ? WHERE id = ?",
+        ("task-review-role", task_id),
+    )
+    conn.commit()
+
+    assert kb.claim_review_task(conn, task_id) is not None
+
+    assert _persisted_snapshot(conn, task_id) == SNAPSHOT
+    task = conn.execute(
+        "SELECT routing_role FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    assert task["routing_role"] == "task-review-role"
+
+
+def test_claim_rolls_back_task_transition_when_run_snapshot_insert_fails(
+    conn, deterministic_snapshot
+):
+    task_id = kb.create_task(conn, title="atomic claim", assignee="coder")
+    conn.commit()
+    conn.execute(
+        """
+        CREATE TRIGGER fail_task_run_insert
+        BEFORE INSERT ON task_runs
+        BEGIN
+            SELECT RAISE(ABORT, 'forced task_runs persistence failure');
+        END
+        """
+    )
+    conn.commit()
+
+    with pytest.raises(sqlite3.IntegrityError, match="forced task_runs persistence failure"):
+        kb.claim_task(conn, task_id)
+
+    task = conn.execute(
+        "SELECT status, current_run_id FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    assert dict(task) == {"status": "ready", "current_run_id": None}
+    assert conn.execute(
+        "SELECT COUNT(*) FROM task_runs WHERE task_id = ?", (task_id,)
+    ).fetchone()[0] == 0

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -26,6 +26,24 @@ def kanban_home(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
+    # These legacy DB-layer tests exercise lifecycle behavior rather than the
+    # routing resolver. Supply a valid deterministic route so fail-closed
+    # claim routing does not obscure the behavior each test targets.
+    monkeypatch.setattr(
+        kb,
+        "_resolve_routing_snapshot",
+        lambda *args, **kwargs: {
+            "routing_role": "executor",
+            "routing_model": "test-model",
+            "routing_provider": "test-provider",
+            "routing_contract": "test-contract",
+            "routing_reason": "legacy DB lifecycle fixture",
+            "roster_digest": "test-roster",
+            "routing_policy": "test-policy",
+            "ac_revision": "test-revision",
+            "routing_source": "test-fixture",
+        },
+    )
     return home
 
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -96,7 +96,9 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
     Covers all four indexes that sit on additive columns:
     - ``tasks.session_id``       -> ``idx_tasks_session_id``    (#28447)
     - ``tasks.tenant``           -> ``idx_tasks_tenant``        (#16081)
-    - ``tasks.idempotency_key``  -> ``idx_tasks_idempotency``   (#17805)
+    - ``tasks.idempotency_key``  -> ``idx_tasks_idempotency_unique`` (partial
+      unique index replacing the non-unique ``idx_tasks_idempotency``, #17805;
+      Wave 2 closes the duplicate-key race the old index allowed)
     - ``task_events.run_id``     -> ``idx_events_run``          (#17805)
     """
     db_path = tmp_path / "legacy-kanban.db"
@@ -162,7 +164,9 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
     # And their indexes — the regression scope of this test:
     assert "idx_tasks_session_id" in indexes
     assert "idx_tasks_tenant" in indexes
-    assert "idx_tasks_idempotency" in indexes
+    # The old non-unique index is gone; the partial unique index replaced it.
+    assert "idx_tasks_idempotency" not in indexes
+    assert "idx_tasks_idempotency_unique" in indexes
     assert "idx_events_run" in indexes
 
 
@@ -1093,6 +1097,8 @@ def test_migrate_add_optional_columns_tolerates_concurrent_migration(kanban_home
         CREATE TABLE tasks (
             id INTEGER PRIMARY KEY,
             title TEXT NOT NULL,
+            status TEXT,
+            created_at INTEGER NOT NULL,
             tenant TEXT,
             result TEXT,
             idempotency_key TEXT,
@@ -1126,6 +1132,135 @@ def test_migrate_add_optional_columns_tolerates_concurrent_migration(kanban_home
 
     # Running migration on an already-migrated schema must not raise.
     kb._migrate_add_optional_columns(conn)
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Idempotency key: in-txn dedup + partial unique index (Wave 2)
+# ---------------------------------------------------------------------------
+
+def test_create_task_same_idempotency_key_returns_existing(kanban_home):
+    """A second create_task with the same key returns the first task's id."""
+    with kb.connect() as conn:
+        first = kb.create_task(conn, title="a", assignee="w", idempotency_key="k1")
+        second = kb.create_task(conn, title="b", assignee="w", idempotency_key="k1")
+        assert second == first
+        (n,) = conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE idempotency_key = 'k1'"
+        ).fetchone()
+        assert n == 1
+
+
+def test_create_task_idempotency_key_reusable_after_archive(kanban_home):
+    """Archival frees the key (partial index excludes archived rows)."""
+    with kb.connect() as conn:
+        first = kb.create_task(conn, title="a", assignee="w", idempotency_key="k2")
+        assert kb.archive_task(conn, first)
+        second = kb.create_task(conn, title="b", assignee="w", idempotency_key="k2")
+        assert second != first
+        assert conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE idempotency_key = 'k2'"
+        ).fetchone()[0] == 2
+
+
+def test_create_task_idempotency_key_concurrent_race(kanban_home):
+    """Two concurrent creators with the same key must land on ONE task.
+
+    The lookup now runs inside write_txn, so the second writer sees the
+    first's row instead of both inserting (the partial unique index is the
+    backstop; the IntegrityError handler converts a violation into the
+    existing-task return).
+    """
+    import concurrent.futures
+
+    key = "race-key"
+
+    def _create(_):
+        with kb.connect() as conn:
+            return kb.create_task(conn, title="x", assignee="w", idempotency_key=key)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(_create, range(2)))
+    assert results[0] == results[1]
+    with kb.connect() as conn:
+        (n,) = conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE idempotency_key = ?", (key,)
+        ).fetchone()
+        assert n == 1
+
+
+def test_migration_dedupes_duplicate_idempotency_keys(tmp_path):
+    """Pre-index duplicates are collapsed before the unique index is created.
+
+    The race the partial unique index closes could already have produced
+    duplicate non-NULL keys; CREATE UNIQUE INDEX aborts on them. The
+    migration must keep the NEWEST active row per key, NULL the key on
+    older duplicates, leave archived rows' keys alone (they're excluded
+    from the partial index), and end with a unique partial index in place
+    of the old non-unique one.
+    """
+    db_path = tmp_path / "dup-keys.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            status TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            idempotency_key TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE task_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            payload TEXT,
+            created_at INTEGER NOT NULL
+        )
+        """
+    )
+    # Duplicate active keys (newest = 'new-a' at t=300), plus an archived
+    # row sharing the same key — its key must survive untouched.
+    conn.executemany(
+        "INSERT INTO tasks (id, title, status, created_at, idempotency_key) "
+        "VALUES (?, ?, ?, ?, ?)",
+        [
+            ("old-a", "a1", "ready", 100, "dup-a"),
+            ("mid-a", "a2", "ready", 200, "dup-a"),
+            ("new-a", "a3", "ready", 300, "dup-a"),
+            ("arch-a", "a4", "archived", 250, "dup-a"),
+            ("solo", "s1", "ready", 150, "solo-key"),
+        ],
+    )
+    conn.commit()
+
+    kb._migrate_add_optional_columns(conn)
+    rows = {
+        r["id"]: r["idempotency_key"]
+        for r in conn.execute("SELECT id, idempotency_key FROM tasks")
+    }
+    assert rows["new-a"] == "dup-a"      # newest active keeps the key
+    assert rows["old-a"] is None         # older actives NULLed
+    assert rows["mid-a"] is None
+    assert rows["arch-a"] == "dup-a"     # archived excluded from dedupe
+    assert rows["solo"] == "solo-key"    # singletons untouched
+
+    indexes = {
+        r["name"] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'index'"
+        )
+    }
+    assert "idx_tasks_idempotency" not in indexes
+    assert "idx_tasks_idempotency_unique" in indexes
+    (sql,) = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name = 'idx_tasks_idempotency_unique'"
+    ).fetchone()
+    assert "UNIQUE" in sql.upper() and "WHERE" in sql.upper()
     conn.close()
 
 

--- a/tests/hermes_cli/test_kanban_routing_api.py
+++ b/tests/hermes_cli/test_kanban_routing_api.py
@@ -51,3 +51,16 @@ def test_override_validation_and_snapshot_not_found(tmp_path):
             kb.set_routing_override(conn, task_id, role="r", model="m")
         with pytest.raises(KeyError):
             kb.get_routing_snapshot(conn, 999, board="unit-board")
+
+
+def test_board_default_role_round_trip_preserves_other_metadata(tmp_path, monkeypatch):
+    """Board role updates preserve unrelated board metadata fields."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    kb.write_board_metadata("routing-board", name="Routing", description="keep")
+
+    result = kb.write_board_metadata("routing-board", default_role="executor")
+
+    assert result["default_role"] == "executor"
+    assert result["name"] == "Routing"
+    assert result["description"] == "keep"
+    assert kb.read_board_metadata("routing-board")["default_role"] == "executor"

--- a/tests/hermes_cli/test_kanban_routing_api.py
+++ b/tests/hermes_cli/test_kanban_routing_api.py
@@ -1,0 +1,53 @@
+"""Public run-routing API tests."""
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+def test_get_snapshot_and_atomic_override_modes(tmp_path):
+    """Expose run snapshots and atomically switch explicit routing modes."""
+    db = tmp_path / "kanban.db"
+    kb.init_db(db)
+    with kb.connect_closing(db) as conn:
+        task_id = kb.create_task(conn, title="api", assignee="coder")
+        kb.set_routing_override(conn, task_id, role="executor")
+        row = conn.execute(
+            "SELECT routing_role,model_override,provider_override FROM tasks WHERE id=?",
+            (task_id,),
+        ).fetchone()
+        assert tuple(row) == ("executor", None, None)
+
+        kb.set_routing_override(conn, task_id, model="m", provider="p")
+        row = conn.execute(
+            "SELECT routing_role,model_override,provider_override FROM tasks WHERE id=?",
+            (task_id,),
+        ).fetchone()
+        assert tuple(row) == (None, "m", "p")
+
+        run_id = conn.execute(
+            "INSERT INTO task_runs (task_id,routing_role,routing_model,routing_provider,"
+            "routing_source,started_at,status) VALUES (?,?,?,?,?,?,?)",
+            (task_id, "executor", "m", "p", "task_role", 1, "completed"),
+        ).lastrowid
+        snapshot = kb.get_routing_snapshot(conn, run_id, board="unit-board")
+        assert snapshot.run_id == run_id
+        assert snapshot.task_id == task_id
+        assert snapshot.board == "unit-board"
+        assert snapshot.routing_source == "task_role"
+
+
+def test_override_validation_and_snapshot_not_found(tmp_path):
+    """Reject ambiguous override modes and unknown board-local runs."""
+    db = tmp_path / "kanban.db"
+    kb.init_db(db)
+    with kb.connect_closing(db) as conn:
+        task_id = kb.create_task(conn, title="guards")
+        with pytest.raises(ValueError):
+            kb.set_routing_override(conn, task_id)
+        with pytest.raises(ValueError):
+            kb.set_routing_override(conn, task_id, provider="p")
+        with pytest.raises(ValueError):
+            kb.set_routing_override(conn, task_id, role="r", model="m")
+        with pytest.raises(KeyError):
+            kb.get_routing_snapshot(conn, 999, board="unit-board")

--- a/tests/hermes_cli/test_kanban_routing_backfill.py
+++ b/tests/hermes_cli/test_kanban_routing_backfill.py
@@ -4,11 +4,22 @@ import json
 import sqlite3
 import time
 from pathlib import Path
+from typing import Optional
 
 from hermes_cli import kanban_db as kb
 
 
-def _insert_run(conn, task_id, task_status, *, ended=True, profile="coder", session_id=None):
+def _insert_run(
+    conn,
+    task_id,
+    task_status,
+    *,
+    ended=True,
+    profile="coder",
+    session_id=None,
+    run_status="done",
+    outcome: Optional[str] = "completed",
+):
     """Insert one legacy run and return its id."""
     now = int(time.time())
     conn.execute(
@@ -17,11 +28,61 @@ def _insert_run(conn, task_id, task_status, *, ended=True, profile="coder", sess
     )
     metadata = json.dumps({"worker_session_id": session_id}) if session_id else None
     cur = conn.execute(
-        "INSERT INTO task_runs (task_id,profile,status,started_at,ended_at,metadata) "
-        "VALUES (?,?,?,?,?,?)",
-        (task_id, profile, "completed", now - 10, now if ended else None, metadata),
+        "INSERT INTO task_runs "
+        "(task_id,profile,status,started_at,ended_at,outcome,metadata) "
+        "VALUES (?,?,?,?,?,?,?)",
+        (
+            task_id,
+            profile,
+            run_status,
+            now - 10,
+            now if ended else None,
+            outcome,
+            metadata,
+        ),
     )
     return cur.lastrowid
+
+
+def test_backfill_uses_run_terminality_not_mutable_task_status(tmp_path, monkeypatch):
+    """Eligibility follows the historical run, even after its task moves lanes."""
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    db = tmp_path / "kanban.db"
+    kb.init_db(db)
+    with kb.connect_closing(db) as conn:
+        terminal_id = _insert_run(
+            conn, "reopened", "todo", session_id="terminal-evidence"
+        )
+        nonterminal_id = _insert_run(
+            conn,
+            "prematurely-done",
+            "done",
+            session_id="nonterminal-evidence",
+            run_status="running",
+            outcome=None,
+        )
+        conn.execute(
+            "UPDATE kanban_metadata SET value=? WHERE key='migration_cutoff_id'",
+            (str(nonterminal_id),),
+        )
+        _state_db(home, "coder", [
+            ("terminal-evidence", "", "terminal-model", "terminal-provider", 1),
+            ("nonterminal-evidence", "", "nonterminal-model", "nonterminal-provider", 1),
+        ])
+
+        kb.backfill_routing_metadata(conn, hermes_home=home)
+        rows = {
+            row["id"]: row
+            for row in conn.execute(
+                "SELECT id,routing_source,routing_model FROM task_runs"
+            )
+        }
+
+    assert rows[terminal_id]["routing_source"] == "inferred_evidence"
+    assert rows[terminal_id]["routing_model"] == "terminal-model"
+    assert rows[nonterminal_id]["routing_source"] is None
+    assert rows[nonterminal_id]["routing_model"] is None
 
 
 def _state_db(home: Path, profile: str, rows):
@@ -49,7 +110,14 @@ def test_backfill_respects_cutoff_terminality_and_evidence(tmp_path, monkeypatch
     with kb.connect_closing(db) as conn:
         evidence_id = _insert_run(conn, "evidence", "done", session_id="s1")
         unknown_id = _insert_run(conn, "unknown", "archived", session_id="missing")
-        active_id = _insert_run(conn, "active", "running", session_id="s1")
+        active_id = _insert_run(
+            conn,
+            "active",
+            "running",
+            session_id="s1",
+            run_status="running",
+            outcome=None,
+        )
         no_end_id = _insert_run(conn, "no-end", "done", ended=False, session_id="s1")
         conn.execute(
             "UPDATE kanban_metadata SET value=? WHERE key='migration_cutoff_id'",

--- a/tests/hermes_cli/test_kanban_routing_backfill.py
+++ b/tests/hermes_cli/test_kanban_routing_backfill.py
@@ -1,0 +1,104 @@
+"""Evidence-only routing metadata backfill tests."""
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+
+from hermes_cli import kanban_db as kb
+
+
+def _insert_run(conn, task_id, task_status, *, ended=True, profile="coder", session_id=None):
+    """Insert one legacy run and return its id."""
+    now = int(time.time())
+    conn.execute(
+        "INSERT INTO tasks (id,title,status,created_at) VALUES (?,?,?,?)",
+        (task_id, task_id, task_status, now),
+    )
+    metadata = json.dumps({"worker_session_id": session_id}) if session_id else None
+    cur = conn.execute(
+        "INSERT INTO task_runs (task_id,profile,status,started_at,ended_at,metadata) "
+        "VALUES (?,?,?,?,?,?)",
+        (task_id, profile, "completed", now - 10, now if ended else None, metadata),
+    )
+    return cur.lastrowid
+
+
+def _state_db(home: Path, profile: str, rows):
+    """Create a profile state DB containing usage evidence rows."""
+    path = home / "profiles" / profile / "state.db"
+    path.parent.mkdir(parents=True)
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE session_model_usage (session_id TEXT, task TEXT NOT NULL DEFAULT '', "
+        "model TEXT, billing_provider TEXT, api_call_count INTEGER)"
+    )
+    conn.executemany(
+        "INSERT INTO session_model_usage VALUES (?,?,?,?,?)", rows
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_backfill_respects_cutoff_terminality_and_evidence(tmp_path, monkeypatch):
+    """Only terminal pre-cutoff runs use unambiguous main-loop evidence."""
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    db = tmp_path / "kanban.db"
+    kb.init_db(db)
+    with kb.connect_closing(db) as conn:
+        evidence_id = _insert_run(conn, "evidence", "done", session_id="s1")
+        unknown_id = _insert_run(conn, "unknown", "archived", session_id="missing")
+        active_id = _insert_run(conn, "active", "running", session_id="s1")
+        no_end_id = _insert_run(conn, "no-end", "done", ended=False, session_id="s1")
+        conn.execute(
+            "UPDATE kanban_metadata SET value=? WHERE key='migration_cutoff_id'",
+            (str(no_end_id),),
+        )
+        post_id = _insert_run(conn, "post", "done", session_id="s1")
+        _state_db(home, "coder", [
+            ("s1", "approval", "wrong", "wrong-p", 999),
+            ("s1", "", "dominant", "actual-p", 7),
+            ("s1", "", "minor", "minor-p", 2),
+        ])
+
+        result = kb.backfill_routing_metadata(conn, hermes_home=home)
+        rows = {
+            row["id"]: row for row in conn.execute(
+                "SELECT id,routing_source,routing_model,routing_provider FROM task_runs"
+            )
+        }
+
+    assert result.errors == 0
+    assert rows[evidence_id]["routing_source"] == "inferred_evidence"
+    assert rows[evidence_id]["routing_model"] == "dominant"
+    assert rows[evidence_id]["routing_provider"] == "actual-p"
+    assert rows[unknown_id]["routing_source"] == "legacy_unknown"
+    assert rows[active_id]["routing_source"] is None
+    assert rows[no_end_id]["routing_source"] is None
+    assert rows[post_id]["routing_source"] is None
+
+
+def test_backfill_tied_evidence_is_legacy_unknown(tmp_path, monkeypatch):
+    """Ambiguous dominant usage is never guessed from current configuration."""
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    db = tmp_path / "kanban.db"
+    kb.init_db(db)
+    with kb.connect_closing(db) as conn:
+        run_id = _insert_run(conn, "tie", "done", session_id="s2")
+        conn.execute(
+            "UPDATE kanban_metadata SET value=? WHERE key='migration_cutoff_id'",
+            (str(run_id),),
+        )
+        _state_db(home, "coder", [
+            ("s2", "", "m1", "p1", 4),
+            ("s2", "", "m2", "p2", 4),
+        ])
+        result = kb.backfill_routing_metadata(conn, hermes_home=home)
+        row = conn.execute(
+            "SELECT routing_source,routing_model,routing_provider FROM task_runs WHERE id=?",
+            (run_id,),
+        ).fetchone()
+    assert result.errors == 0
+    assert tuple(row) == ("legacy_unknown", None, None)

--- a/tests/hermes_cli/test_kanban_routing_integration.py
+++ b/tests/hermes_cli/test_kanban_routing_integration.py
@@ -102,9 +102,11 @@ def _insert_legacy_run(
         (task_id, task_id, task_status, now),
     )
     run_id = conn.execute(
-        "INSERT INTO task_runs (task_id,profile,status,started_at,ended_at) "
-        "VALUES (?,?,?,?,?)",
-        (task_id, "coder", "completed", now - 1, now if ended else None),
+        "INSERT INTO task_runs (task_id,profile,status,outcome,started_at,ended_at) "
+        "VALUES (?,?,?,?,?,?)",
+        (task_id, "coder", "completed",
+         "success" if ended and task_status in ("done", "archived") else None,
+         now - 1, now if ended else None),
     )
     assert run_id.lastrowid is not None
     return int(run_id.lastrowid)

--- a/tests/hermes_cli/test_kanban_routing_integration.py
+++ b/tests/hermes_cli/test_kanban_routing_integration.py
@@ -61,15 +61,20 @@ def _insert_snapshot_run(
     return int(run_id)
 
 
-def _legacy_pre_routing_db(path: Path) -> None:
-    """Build a valid legacy DB by stripping routing additions from a fixture DB."""
+def _legacy_pre_routing_db(path: Path, *, run_count: int = 0) -> list[int]:
+    """Build a legacy DB with optional runs, then strip routing additions."""
     kb.init_db(path)
     with sqlite3.connect(path) as conn:
+        run_ids = [
+            _insert_legacy_run(conn, f"legacy-{index}", "done")
+            for index in range(run_count)
+        ]
         conn.execute("DROP TABLE kanban_metadata")
         conn.execute("ALTER TABLE tasks DROP COLUMN routing_role")
         conn.execute("ALTER TABLE task_runs DROP COLUMN routing_source")
         conn.commit()
     kb._INITIALIZED_PATHS.discard(str(path.resolve()))
+    return run_ids
 
 
 def _roster() -> tuple[dict, str]:
@@ -135,9 +140,10 @@ def test_cross_board_run_ids_are_connection_local_and_mutations_are_isolated(tmp
 
 
 def test_concurrent_connect_closing_migrates_one_legacy_db_atomically(tmp_path):
-    """Concurrent first opens publish one complete routing migration without errors."""
+    """Concurrent first opens publish a complete schema and exact legacy cutoff."""
     db_path = tmp_path / "legacy.db"
-    _legacy_pre_routing_db(db_path)
+    legacy_run_ids = _legacy_pre_routing_db(db_path, run_count=3)
+    expected_cutoff = max(legacy_run_ids)
     errors: list[BaseException] = []
     barrier = threading.Barrier(8)
 
@@ -163,7 +169,7 @@ def test_concurrent_connect_closing_migrates_one_legacy_db_atomically(tmp_path):
             "GROUP BY key,value ORDER BY key"
         ).fetchall()
         assert [(row["key"], row["value"], row["n"]) for row in metadata] == [
-            ("migration_cutoff_id", "0", 1),
+            ("migration_cutoff_id", str(expected_cutoff), 1),
             ("routing_schema_version", "1", 1),
         ]
         assert "routing_role" in {
@@ -178,6 +184,10 @@ def test_concurrent_connect_closing_migrates_one_legacy_db_atomically(tmp_path):
             "routing_source",
         } <= run_columns
         assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        post_migration_id = _insert_legacy_run(conn, "post-migration", "done")
+        conn.commit()
+
+    assert post_migration_id > expected_cutoff
 
 
 def test_routing_rejection_events_remain_compatible_with_list_events(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_kanban_routing_integration.py
+++ b/tests/hermes_cli/test_kanban_routing_integration.py
@@ -1,0 +1,309 @@
+"""Integration coverage for routing isolation, migration, events, and provenance."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.routing_contract import RoutingContractError
+
+
+ROSTER = {
+    "roles": {
+        "executor": {
+            "model": "exec-model",
+            "provider": "exec-provider",
+            "invocation": "auto",
+            "may_edit": True,
+            "review_capable": False,
+        },
+        "auditor": {
+            "model": "audit-model",
+            "provider": "audit-provider",
+            "invocation": "auto",
+            "may_edit": False,
+            "review_capable": True,
+        },
+        "reviewer": {
+            "model": "review-model",
+            "provider": "review-provider",
+            "invocation": "auto",
+            "may_edit": False,
+            "review_capable": True,
+        },
+    }
+}
+
+
+def _insert_snapshot_run(
+    conn: sqlite3.Connection, task_id: str, source: str, model: str
+) -> int:
+    """Insert one minimal frozen routing snapshot and return its local run id."""
+    now = int(time.time())
+    conn.execute(
+        "INSERT INTO tasks (id,title,status,created_at) VALUES (?,?,?,?)",
+        (task_id, task_id, "done", now),
+    )
+    run_id = conn.execute(
+        "INSERT INTO task_runs "
+        "(task_id,status,started_at,ended_at,routing_model,routing_source) "
+        "VALUES (?,?,?,?,?,?)",
+        (task_id, "completed", now - 1, now, model, source),
+    ).lastrowid
+    assert run_id is not None
+    conn.commit()
+    return int(run_id)
+
+
+def _legacy_pre_routing_db(path: Path) -> None:
+    """Build a valid legacy DB by stripping routing additions from a fixture DB."""
+    kb.init_db(path)
+    with sqlite3.connect(path) as conn:
+        conn.execute("DROP TABLE kanban_metadata")
+        conn.execute("ALTER TABLE tasks DROP COLUMN routing_role")
+        conn.execute("ALTER TABLE task_runs DROP COLUMN routing_source")
+        conn.commit()
+    kb._INITIALIZED_PATHS.discard(str(path.resolve()))
+
+
+def _roster() -> tuple[dict, str]:
+    """Return the deterministic role roster used by review integration tests."""
+    return ROSTER, "integration-roster-digest"
+
+
+def _disable_routing_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent host configuration from influencing routing resolution."""
+    monkeypatch.setattr(kb, "read_board_metadata", lambda *args, **kwargs: {})
+    monkeypatch.setattr(kb, "_load_profile_model_config", lambda profile: (None, None))
+
+
+def _insert_legacy_run(
+    conn: sqlite3.Connection,
+    task_id: str,
+    task_status: str,
+    *,
+    ended: bool = True,
+) -> int:
+    """Insert a legacy run whose eligibility is controlled by task terminality."""
+    now = int(time.time())
+    conn.execute(
+        "INSERT INTO tasks (id,title,status,created_at) VALUES (?,?,?,?)",
+        (task_id, task_id, task_status, now),
+    )
+    run_id = conn.execute(
+        "INSERT INTO task_runs (task_id,profile,status,started_at,ended_at) "
+        "VALUES (?,?,?,?,?)",
+        (task_id, "coder", "completed", now - 1, now if ended else None),
+    )
+    assert run_id.lastrowid is not None
+    return int(run_id.lastrowid)
+
+
+def test_cross_board_run_ids_are_connection_local_and_mutations_are_isolated(tmp_path):
+    """Equal board-local run ids resolve only through their own DB connection."""
+    left_db = tmp_path / "left.db"
+    right_db = tmp_path / "right.db"
+    kb.init_db(left_db)
+    kb.init_db(right_db)
+
+    with kb.connect_closing(left_db) as left, kb.connect_closing(right_db) as right:
+        left_run = _insert_snapshot_run(left, "left-task", "task_role", "left-model")
+        right_run = _insert_snapshot_run(right, "right-task", "board_default", "right-model")
+        assert left_run == right_run == 1
+
+        left_snapshot = kb.get_routing_snapshot(left, left_run, board="left-board")
+        right_snapshot = kb.get_routing_snapshot(right, right_run, board="right-board")
+        assert (left_snapshot.task_id, left_snapshot.board, left_snapshot.routing_model) == (
+            "left-task", "left-board", "left-model"
+        )
+        assert (right_snapshot.task_id, right_snapshot.board, right_snapshot.routing_model) == (
+            "right-task", "right-board", "right-model"
+        )
+
+        left.execute(
+            "UPDATE task_runs SET routing_model='left-mutated' WHERE id=?", (left_run,)
+        )
+        left.commit()
+        assert kb.get_routing_snapshot(left, left_run, board="left-board").routing_model == "left-mutated"
+        assert kb.get_routing_snapshot(right, right_run, board="right-board").routing_model == "right-model"
+
+
+def test_concurrent_connect_closing_migrates_one_legacy_db_atomically(tmp_path):
+    """Concurrent first opens publish one complete routing migration without errors."""
+    db_path = tmp_path / "legacy.db"
+    _legacy_pre_routing_db(db_path)
+    errors: list[BaseException] = []
+    barrier = threading.Barrier(8)
+
+    def open_once() -> None:
+        try:
+            barrier.wait(timeout=5)
+            with kb.connect_closing(db_path) as conn:
+                conn.execute("SELECT 1").fetchone()
+        except BaseException as exc:  # collected in the main test thread
+            errors.append(exc)
+
+    threads = [threading.Thread(target=open_once) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=15)
+
+    assert not any(thread.is_alive() for thread in threads)
+    assert errors == []
+    with kb.connect_closing(db_path) as conn:
+        metadata = conn.execute(
+            "SELECT key,value,COUNT(*) AS n FROM kanban_metadata "
+            "GROUP BY key,value ORDER BY key"
+        ).fetchall()
+        assert [(row["key"], row["value"], row["n"]) for row in metadata] == [
+            ("migration_cutoff_id", "0", 1),
+            ("routing_schema_version", "1", 1),
+        ]
+        assert "routing_role" in {
+            row["name"] for row in conn.execute("PRAGMA table_info(tasks)")
+        }
+        run_columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")
+        }
+        assert {
+            "routing_role", "routing_model", "routing_provider", "routing_contract",
+            "routing_reason", "roster_digest", "routing_policy", "ac_revision",
+            "routing_source",
+        } <= run_columns
+        assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+
+
+def test_routing_rejection_events_remain_compatible_with_list_events(tmp_path, monkeypatch):
+    """New rejection kinds and old kinds remain JSON-readable via ``list_events``."""
+    # Explicit arguments keep this integration test independent of module-level fixtures.
+    db_path = tmp_path / "events.db"
+    kb.init_db(db_path)
+    with kb.connect_closing(db_path) as connection:
+        task_id = kb.create_task(connection, title="event compatibility", assignee="coder")
+        connection.execute("UPDATE tasks SET status='ready' WHERE id=?", (task_id,))
+        monkeypatch.setattr(
+            kb,
+            "_resolve_routing_snapshot",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                RoutingContractError("invalid integration route")
+            ),
+        )
+        with pytest.raises(RoutingContractError, match="invalid integration route"):
+            kb.claim_task(connection, task_id)
+
+        run_id = connection.execute(
+            "INSERT INTO task_runs (task_id,status,started_at) VALUES (?,?,?)",
+            (task_id, "failed", int(time.time())),
+        ).lastrowid
+        assert run_id is not None
+        with kb.write_txn(connection):
+            kb._append_spawn_rejected_event(
+                connection, task_id, int(run_id), "spawn route rejected", 2, 3
+            )
+            kb._append_event(connection, task_id, "commented", {"body": "legacy consumer"})
+
+        events = kb.list_events(connection, task_id)
+        by_kind = {event.kind: event for event in events}
+        assert {"created", "claim_rejected", "spawn_rejected", "commented"} <= set(by_kind)
+        assert by_kind["claim_rejected"].payload["reason"] == "invalid integration route"
+        assert by_kind["spawn_rejected"].payload == {
+            "run_id": int(run_id),
+            "reason": "spawn route rejected",
+            "consecutive_failures": 2,
+            "max_retries": 3,
+        }
+        assert by_kind["commented"].payload == {"body": "legacy consumer"}
+        for kind in ("claim_rejected", "spawn_rejected", "commented"):
+            assert json.loads(json.dumps(by_kind[kind].payload)) == by_kind[kind].payload
+
+
+def test_review_claims_persist_capable_and_coerced_provenance(tmp_path, monkeypatch):
+    """Review claims freeze both preserved-role and coerced-review provenance."""
+    monkeypatch.setattr(kb, "_load_roster", _roster)
+    _disable_routing_defaults(monkeypatch)
+    db_path = tmp_path / "reviews.db"
+    kb.init_db(db_path)
+
+    with kb.connect_closing(db_path) as conn:
+        capable = kb.create_task(conn, title="capable review", assignee="coder")
+        coerced = kb.create_task(conn, title="coerced review", assignee="coder")
+        kb.set_routing_override(conn, capable, role="auditor")
+        kb.set_routing_override(conn, coerced, role="executor")
+        conn.execute("UPDATE tasks SET status='review' WHERE id IN (?,?)", (capable, coerced))
+        conn.commit()
+
+        assert kb.claim_review_task(conn, capable, claimer="capable-agent") is not None
+        assert kb.claim_review_task(conn, coerced, claimer="coerced-agent") is not None
+        rows = {
+            row["task_id"]: row
+            for row in conn.execute(
+                "SELECT task_id,routing_role,routing_source,routing_reason FROM task_runs"
+            )
+        }
+
+    assert tuple(rows[capable]) == (
+        capable,
+        "auditor",
+        "review_capable",
+        "review phase: role 'auditor' already review-capable",
+    )
+    assert tuple(rows[coerced]) == (
+        coerced,
+        "reviewer",
+        "review_coerced",
+        "review phase: role 'executor' not review-capable, coerced to reviewer",
+    )
+
+
+def test_backfill_exact_terminality_end_cutoff_and_rerun_idempotence(tmp_path):
+    """Backfill only ended, pre-cutoff runs whose exact task status is terminal."""
+    db_path = tmp_path / "backfill.db"
+    home = tmp_path / ".hermes"
+    kb.init_db(db_path)
+    active_statuses = ("triage", "todo", "scheduled", "ready", "running", "blocked", "review")
+
+    with kb.connect_closing(db_path) as conn:
+        eligible = {
+            status: _insert_legacy_run(conn, f"terminal-{status}", status)
+            for status in ("done", "archived")
+        }
+        active = {
+            status: _insert_legacy_run(conn, f"active-{status}", status)
+            for status in active_statuses
+        }
+        no_end = _insert_legacy_run(conn, "done-without-end", "done", ended=False)
+        cutoff = no_end
+        conn.execute(
+            "UPDATE kanban_metadata SET value=? WHERE key='migration_cutoff_id'",
+            (str(cutoff),),
+        )
+        post_cutoff = _insert_legacy_run(conn, "done-after-cutoff", "done")
+        conn.commit()
+
+        first = kb.backfill_routing_metadata(conn, hermes_home=home)
+        sources_after_first = {
+            row["id"]: row["routing_source"]
+            for row in conn.execute("SELECT id,routing_source FROM task_runs")
+        }
+        second = kb.backfill_routing_metadata(conn, hermes_home=home)
+        sources_after_second = {
+            row["id"]: row["routing_source"]
+            for row in conn.execute("SELECT id,routing_source FROM task_runs")
+        }
+
+    assert first.processed == first.unknown == 2
+    assert first.inferred == first.errors == 0
+    assert all(sources_after_first[run_id] == "legacy_unknown" for run_id in eligible.values())
+    assert all(sources_after_first[run_id] is None for run_id in active.values())
+    assert sources_after_first[no_end] is None
+    assert post_cutoff > cutoff
+    assert sources_after_first[post_cutoff] is None
+    assert second.processed == second.inferred == second.unknown == second.errors == 0
+    assert sources_after_second == sources_after_first

--- a/tests/hermes_cli/test_kanban_routing_migration.py
+++ b/tests/hermes_cli/test_kanban_routing_migration.py
@@ -1,0 +1,67 @@
+"""Tests for the atomic routing metadata schema migration."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+
+from hermes_cli import kanban_db as kb
+
+
+def _column(conn: sqlite3.Connection, table: str, name: str) -> sqlite3.Row:
+    """Return one column description from SQLite's table-info pragma."""
+    return next(row for row in conn.execute(f"PRAGMA table_info({table})") if row["name"] == name)
+
+
+def test_routing_metadata_migration_is_typed_atomic_and_idempotent(tmp_path):
+    """Publish the routing schema only after preserving its original run cutoff."""
+    db_path = tmp_path / "kanban.db"
+    kb.init_db(db_path)
+
+    with kb.connect_closing(db_path) as conn:
+        metadata = {
+            row["key"]: row["value"]
+            for row in conn.execute("SELECT key, value FROM kanban_metadata")
+        }
+        assert metadata == {"migration_cutoff_id": "0", "routing_schema_version": "1"}
+
+        table_columns = {
+            row["name"]: row
+            for row in conn.execute("PRAGMA table_info(kanban_metadata)")
+        }
+        assert table_columns["key"]["type"] == "TEXT"
+        assert table_columns["key"]["pk"] == 1
+        assert table_columns["value"]["type"] == "TEXT"
+        assert table_columns["value"]["notnull"] == 1
+        assert table_columns["updated_at"]["type"] == "INTEGER"
+        assert table_columns["updated_at"]["notnull"] == 1
+        assert _column(conn, "tasks", "routing_role")["type"] == "TEXT"
+        assert _column(conn, "tasks", "routing_role")["notnull"] == 0
+        assert _column(conn, "task_runs", "routing_source")["type"] == "TEXT"
+        assert _column(conn, "task_runs", "routing_source")["notnull"] == 0
+
+        created_at = int(time.time())
+        conn.execute(
+            "INSERT INTO tasks (id, title, status, created_at) VALUES (?, ?, ?, ?)",
+            ("post-migration", "post-migration", "pending", created_at),
+        )
+        cursor = conn.execute(
+            "INSERT INTO task_runs (task_id, status, started_at) VALUES (?, ?, ?)",
+            ("post-migration", "running", created_at),
+        )
+        post_migration_id = cursor.lastrowid
+        conn.commit()
+
+    kb.init_db(db_path)
+
+    with kb.connect_closing(db_path) as conn:
+        metadata = {
+            row["key"]: row["value"]
+            for row in conn.execute("SELECT key, value FROM kanban_metadata")
+        }
+        assert metadata == {"migration_cutoff_id": "0", "routing_schema_version": "1"}
+        assert post_migration_id > int(metadata["migration_cutoff_id"])
+        row = conn.execute(
+            "SELECT routing_source FROM task_runs WHERE id = ?", (post_migration_id,)
+        ).fetchone()
+        assert row["routing_source"] is None

--- a/tests/hermes_cli/test_kanban_routing_rejections.py
+++ b/tests/hermes_cli/test_kanban_routing_rejections.py
@@ -56,6 +56,28 @@ def test_claim_rejection_rolls_back_and_audits_separately(conn, monkeypatch):
     assert payload["attempt_id"]
 
 
+def test_claim_rejection_attempt_id_deduplicates_retry_only(conn, monkeypatch):
+    """One logical attempt audits once while fresh calls remain distinct."""
+    task_id = kb.create_task(conn, title="deduplicate reject", assignee="coder")
+    conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (task_id,))
+    monkeypatch.setattr(
+        kb, "_resolve_routing_snapshot",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RoutingContractError("bad route")),
+    )
+    attempt_id = "93722498-a216-4ea7-9f14-cdb46fbc69b9"
+
+    for _ in range(2):
+        with pytest.raises(RoutingContractError, match="bad route"):
+            kb.claim_task(conn, task_id, attempt_id=attempt_id)
+    with pytest.raises(RoutingContractError, match="bad route"):
+        kb.claim_task(conn, task_id)
+
+    payloads = _event_payloads(conn, task_id, "claim_rejected")
+    assert [payload["attempt_id"] for payload in payloads].count(attempt_id) == 1
+    assert len(payloads) == 2
+    assert payloads[1]["attempt_id"] != attempt_id
+
+
 def test_review_claim_rejection_rolls_back_and_audits_separately(conn, monkeypatch):
     """Review routing rejection preserves review state and creates no run."""
     task_id = kb.create_task(conn, title="reject review", assignee="coder")

--- a/tests/hermes_cli/test_kanban_routing_rejections.py
+++ b/tests/hermes_cli/test_kanban_routing_rejections.py
@@ -169,6 +169,15 @@ def test_corrupted_claimed_run_rejects_spawn_and_accounts_retry(conn, monkeypatc
     assert "incomplete frozen routing snapshot" in json.loads(event["payload"])["reason"]
 
 
+@pytest.mark.parametrize("kind", ["spawn_failed", "spawn_rejected"])
+def test_resume_phase_dual_reads_legacy_and_canonical_spawn_events(conn, kind):
+    """Resume inference accepts old and canonical spawn event kinds."""
+    task_id = kb.create_task(conn, title="resume review", assignee="coder")
+    kb._append_event(conn, task_id, kind, {"retry_status": "review"})
+
+    assert kb._resume_status_from_events(conn, task_id) == "review"
+
+
 @pytest.mark.parametrize("failure_limit, expected_status", [(3, "ready"), (1, "blocked")])
 def test_spawn_rejection_closes_run_and_deduplicates_event(
     conn, monkeypatch, failure_limit, expected_status

--- a/tests/hermes_cli/test_kanban_routing_rejections.py
+++ b/tests/hermes_cli/test_kanban_routing_rejections.py
@@ -1,0 +1,123 @@
+"""Routing rejection lifecycle tests for claim and spawn boundaries."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.routing_contract import RoutingContractError
+
+
+@pytest.fixture
+def conn(tmp_path, monkeypatch):
+    """Return an initialized isolated Kanban connection."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    connection = kb.connect()
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def _event_payloads(conn, task_id, kind):
+    """Return decoded event payloads for one task and kind."""
+    rows = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id=? AND kind=? ORDER BY id",
+        (task_id, kind),
+    ).fetchall()
+    return [json.loads(row["payload"]) for row in rows]
+
+
+def test_claim_rejection_rolls_back_and_audits_separately(conn, monkeypatch):
+    """Invalid routing creates no run or state transition but audits the attempt."""
+    task_id = kb.create_task(conn, title="reject", assignee="coder")
+    conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (task_id,))
+    monkeypatch.setattr(
+        kb, "_resolve_routing_snapshot",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RoutingContractError("unknown role")),
+    )
+
+    with pytest.raises(RoutingContractError, match="unknown role"):
+        kb.claim_task(conn, task_id)
+
+    task = kb.get_task(conn, task_id)
+    assert task.status == "ready"
+    assert task.current_run_id is None
+    assert conn.execute(
+        "SELECT COUNT(*) FROM task_runs WHERE task_id=?", (task_id,)
+    ).fetchone()[0] == 0
+    payload = _event_payloads(conn, task_id, "claim_rejected")[0]
+    assert payload["reason"] == "unknown role"
+    assert payload["attempt_id"]
+
+
+def test_review_claim_rejection_rolls_back_and_audits_separately(conn, monkeypatch):
+    """Review routing rejection preserves review state and creates no run."""
+    task_id = kb.create_task(conn, title="reject review", assignee="coder")
+    conn.execute("UPDATE tasks SET status='review' WHERE id=?", (task_id,))
+    monkeypatch.setattr(
+        kb, "_resolve_routing_snapshot",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RoutingContractError("bad reviewer")),
+    )
+
+    with pytest.raises(RoutingContractError, match="bad reviewer"):
+        kb.claim_review_task(conn, task_id)
+
+    task = kb.get_task(conn, task_id)
+    assert task.status == "review"
+    assert task.current_run_id is None
+    assert conn.execute(
+        "SELECT COUNT(*) FROM task_runs WHERE task_id=?", (task_id,)
+    ).fetchone()[0] == 0
+    payload = _event_payloads(conn, task_id, "claim_rejected")[0]
+    assert payload["reason"] == "bad reviewer"
+    assert payload["attempt_id"]
+
+
+@pytest.mark.parametrize("failure_limit, expected_status", [(3, "ready"), (1, "blocked")])
+def test_spawn_rejection_closes_run_and_deduplicates_event(
+    conn, monkeypatch, failure_limit, expected_status
+):
+    """Spawn failure closes its run, releases lease, accounts retry, and audits once."""
+    task_id = kb.create_task(conn, title="spawn", assignee="coder")
+    conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (task_id,))
+    monkeypatch.setattr(
+        kb, "_resolve_routing_snapshot",
+        lambda *args, **kwargs: {
+            "routing_role": "executor", "routing_model": "m",
+            "routing_provider": "p", "routing_contract": None,
+            "routing_reason": "task role executor", "roster_digest": "d",
+            "routing_policy": "p1", "ac_revision": None,
+            "routing_source": "task_role",
+        },
+    )
+    kb.claim_task(conn, task_id)
+    run_id = kb.get_task(conn, task_id).current_run_id
+
+    blocked = kb._record_spawn_failure(
+        conn, task_id, "launch failed", failure_limit=failure_limit
+    )
+    # Replay event insertion for the same run to prove run_id+kind dedup.
+    kb._append_spawn_rejected_event(
+        conn, task_id, run_id, "duplicate", 2, failure_limit
+    )
+
+    task = kb.get_task(conn, task_id)
+    run = conn.execute("SELECT * FROM task_runs WHERE id=?", (run_id,)).fetchone()
+    assert blocked is (expected_status == "blocked")
+    assert task.status == expected_status
+    assert task.current_run_id is None
+    assert task.claim_lock is None and task.claim_expires is None
+    assert run["status"] == "failed"
+    assert run["outcome"] == "spawn_failed"
+    payloads = _event_payloads(conn, task_id, "spawn_rejected")
+    assert len(payloads) == 1
+    assert payloads[0]["run_id"] == run_id
+    assert payloads[0]["reason"] == "launch failed"
+    assert payloads[0]["consecutive_failures"] == 1
+    assert payloads[0]["max_retries"] == failure_limit

--- a/tests/hermes_cli/test_kanban_routing_rejections.py
+++ b/tests/hermes_cli/test_kanban_routing_rejections.py
@@ -124,6 +124,51 @@ def test_review_claim_rejection_rolls_back_and_audits_separately(conn, monkeypat
     assert payload["attempt_id"]
 
 
+def test_corrupted_claimed_run_rejects_spawn_and_accounts_retry(conn, monkeypatch, tmp_path):
+    """A malformed frozen run traverses the complete rejection lifecycle."""
+    task_id = kb.create_task(conn, title="corrupt after claim", assignee="coder")
+    conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (task_id,))
+    monkeypatch.setattr(
+        kb,
+        "_resolve_routing_snapshot",
+        lambda *args, **kwargs: {
+            "routing_role": "executor", "routing_model": "model",
+            "routing_provider": "provider", "routing_contract": 1,
+            "routing_reason": "test", "roster_digest": "digest",
+            "routing_policy": "{}", "ac_revision": "revision",
+            "routing_source": "task_role",
+        },
+    )
+    monkeypatch.setattr(kb, "resolve_workspace", lambda *args, **kwargs: tmp_path)
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda profile: True)
+
+    def corrupt_then_spawn(task, workspace, **kwargs):
+        conn.execute(
+            "UPDATE task_runs SET routing_model=NULL WHERE id=?",
+            (task.current_run_id,),
+        )
+        return kb._default_spawn(task, workspace, **kwargs)
+
+    result = kb.dispatch_once(conn, spawn_fn=corrupt_then_spawn, failure_limit=3)
+
+    task = kb.get_task(conn, task_id)
+    run = conn.execute(
+        "SELECT status,outcome,ended_at FROM task_runs WHERE id=?",
+        (task.current_run_id or 1,),
+    ).fetchone()
+    event = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id=? AND kind='spawn_rejected'",
+        (task_id,),
+    ).fetchone()
+    assert result.spawned == []
+    assert task.status == "ready"
+    assert task.current_run_id is None
+    assert task.consecutive_failures == 1
+    assert tuple(run)[:2] == ("failed", "spawn_failed")
+    assert run["ended_at"] is not None
+    assert "incomplete frozen routing snapshot" in json.loads(event["payload"])["reason"]
+
+
 @pytest.mark.parametrize("failure_limit, expected_status", [(3, "ready"), (1, "blocked")])
 def test_spawn_rejection_closes_run_and_deduplicates_event(
     conn, monkeypatch, failure_limit, expected_status

--- a/tests/hermes_cli/test_kanban_routing_rejections.py
+++ b/tests/hermes_cli/test_kanban_routing_rejections.py
@@ -78,6 +78,29 @@ def test_claim_rejection_attempt_id_deduplicates_retry_only(conn, monkeypatch):
     assert payloads[1]["attempt_id"] != attempt_id
 
 
+@pytest.mark.parametrize("claim_name,status", [("claim_task", "ready"), ("claim_review_task", "review")])
+def test_claim_rejection_audit_failure_preserves_contract_error(
+    conn, monkeypatch, caplog, claim_name, status
+):
+    """A broken secondary audit never masks the routing contract error."""
+    task_id = kb.create_task(conn, title="audit failure", assignee="coder")
+    conn.execute("UPDATE tasks SET status=? WHERE id=?", (status, task_id))
+    monkeypatch.setattr(
+        kb, "_resolve_routing_snapshot",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RoutingContractError("original route")),
+    )
+    monkeypatch.setattr(
+        kb,
+        "_append_claim_rejected_once",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("audit unavailable")),
+    )
+
+    with pytest.raises(RoutingContractError, match="original route"):
+        getattr(kb, claim_name)(conn, task_id)
+
+    assert "audit unavailable" in caplog.text
+
+
 def test_review_claim_rejection_rolls_back_and_audits_separately(conn, monkeypatch):
     """Review routing rejection preserves review state and creates no run."""
     task_id = kb.create_task(conn, title="reject review", assignee="coder")

--- a/tests/hermes_cli/test_kanban_routing_resolver.py
+++ b/tests/hermes_cli/test_kanban_routing_resolver.py
@@ -233,3 +233,5 @@ def test_review_capable_and_coerced_sources(monkeypatch) -> None:
     assert (coerced["routing_role"], coerced["routing_source"]) == (
         "reviewer", "review_coerced"
     )
+    assert "role 'auditor'" in capable["routing_reason"]
+    assert "role 'executor'" in coerced["routing_reason"]

--- a/tests/hermes_cli/test_kanban_routing_resolver.py
+++ b/tests/hermes_cli/test_kanban_routing_resolver.py
@@ -1,0 +1,235 @@
+"""Unit tests for claim-time routing source resolution."""
+
+import sqlite3
+
+import hermes_cli.kanban_db as kb
+import pytest
+from hermes_cli.routing_contract import RoutingContractError
+
+
+def _row(**overrides: object) -> sqlite3.Row:
+    """Build a task-shaped SQLite row with optional routing overrides."""
+    values = {
+        "body": "",
+        "routing_role": None,
+        "model_override": None,
+        "provider_override": None,
+        "assignee": "coder",
+    }
+    values.update(overrides)
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    return conn.execute(
+        "SELECT ? AS body, ? AS routing_role, ? AS model_override, "
+        "? AS provider_override, ? AS assignee",
+        tuple(values[key] for key in values),
+    ).fetchone()
+
+
+def _roster() -> tuple[dict, str]:
+    """Return a deterministic semantic-role roster and digest."""
+    return ({
+        "roles": {
+            "executor": {
+                "model": "exec-model",
+                "provider": "exec-provider",
+                "invocation": "auto",
+                "may_edit": True,
+                "review_capable": False,
+            },
+            "reviewer": {
+                "model": "review-model", "provider": "review-provider",
+                "invocation": "auto", "may_edit": False,
+                "review_capable": True,
+            },
+            "auditor": {
+                "model": "audit-model", "provider": "audit-provider",
+                "invocation": "auto", "may_edit": False,
+                "review_capable": True,
+            },
+        }
+    }, "roster-digest")
+
+
+def test_resolve_routing_snapshot_uses_task_role(monkeypatch) -> None:
+    """A task semantic role must win when no enforced envelope exists."""
+    monkeypatch.setattr(kb, "_load_roster", _roster)
+
+    snapshot = kb._resolve_routing_snapshot(
+        sqlite3.connect(":memory:"), "task", _row(routing_role="executor"), "implement"
+    )
+
+    assert snapshot["routing_source"] == "task_role"
+    assert snapshot["routing_role"] == "executor"
+    assert snapshot["routing_model"] == "exec-model"
+    assert snapshot["routing_provider"] == "exec-provider"
+    assert snapshot["roster_digest"] == "roster-digest"
+
+
+def test_resolve_routing_snapshot_uses_task_override(monkeypatch) -> None:
+    """A raw task model/provider pin must freeze no semantic role or digest."""
+    monkeypatch.setattr(kb, "_load_roster", _roster)
+
+    snapshot = kb._resolve_routing_snapshot(
+        sqlite3.connect(":memory:"),
+        "task",
+        _row(model_override="raw-model", provider_override="raw-provider"),
+        "implement",
+    )
+
+    assert snapshot["routing_source"] == "task_override"
+    assert snapshot["routing_model"] == "raw-model"
+    assert snapshot["routing_provider"] == "raw-provider"
+    assert snapshot["routing_role"] is None
+    assert snapshot["routing_contract"] is None
+    assert snapshot["roster_digest"] is None
+
+
+def _defaults(monkeypatch, board=None, profiles=None) -> None:
+    """Install deterministic board and profile routing sources."""
+    monkeypatch.setattr(kb, "read_board_metadata", lambda *args: board or {})
+    values = profiles or {}
+    monkeypatch.setattr(
+        kb, "_load_profile_model_config",
+        lambda profile: values.get(profile, (None, None)),
+    )
+
+
+def test_enforced_envelope_has_highest_precedence(monkeypatch) -> None:
+    """An enforced envelope must override every lower source."""
+    monkeypatch.setattr(kb, "_load_roster", _roster)
+    _defaults(monkeypatch, {"default_role": "reviewer"})
+    body = """Task
+# ---routing:v1---
+role: executor
+action: implement
+enforcement_required: true
+reason: exact route
+# ---/routing:v1---
+"""
+    snapshot = kb._resolve_routing_snapshot(
+        sqlite3.connect(":memory:"), "task",
+        _row(body=body, routing_role="reviewer", model_override="pin",
+             provider_override="pin-p"), "implement",
+    )
+    assert snapshot["routing_source"] == "envelope"
+    assert snapshot["routing_role"] == "executor"
+    assert snapshot["routing_contract"] == 1
+
+
+def test_precedence_task_role_then_override_then_board(monkeypatch) -> None:
+    """Task role, raw override, and board default resolve in strict order."""
+    monkeypatch.setattr(kb, "_load_roster", _roster)
+    _defaults(monkeypatch, {"default_role": "reviewer"})
+    role = kb._resolve_routing_snapshot(
+        sqlite3.connect(":memory:"), "t",
+        _row(routing_role="executor", model_override="pin",
+             provider_override="pin-p"), "implement",
+    )
+    raw = kb._resolve_routing_snapshot(
+        sqlite3.connect(":memory:"), "t",
+        _row(model_override="pin", provider_override="pin-p"), "implement",
+    )
+    board = kb._resolve_routing_snapshot(
+        sqlite3.connect(":memory:"), "t", _row(), "implement",
+    )
+    assert (role["routing_source"], raw["routing_source"],
+            board["routing_source"]) == (
+        "task_role", "task_override", "board_default"
+    )
+
+
+def test_profile_default_is_last_and_raw_fields_are_null(monkeypatch) -> None:
+    """A profile default is raw and therefore carries no semantic metadata."""
+    _defaults(monkeypatch, profiles={"coder": ("p-model", "p-provider")})
+    snapshot = kb._resolve_routing_snapshot(
+        sqlite3.connect(":memory:"), "t", _row(), "implement"
+    )
+    assert snapshot["routing_source"] == "profile_default"
+    for field in ("routing_role", "roster_digest", "routing_policy",
+                  "routing_contract"):
+        assert snapshot[field] is None
+
+
+@pytest.mark.parametrize("provider", ["", 7])
+def test_invalid_present_provider_fails_closed(monkeypatch, provider) -> None:
+    """An invalid present provider must not fall through."""
+    _defaults(monkeypatch)
+    with pytest.raises(RoutingContractError):
+        kb._resolve_routing_snapshot(
+            sqlite3.connect(":memory:"), "t",
+            _row(model_override="pin", provider_override=provider), "implement",
+        )
+
+
+def test_provider_only_fails_closed(monkeypatch) -> None:
+    """A provider override without a model is invalid."""
+    _defaults(monkeypatch)
+    with pytest.raises(RoutingContractError, match="requires model"):
+        kb._resolve_routing_snapshot(
+            sqlite3.connect(":memory:"), "t",
+            _row(provider_override="provider"), "implement",
+        )
+
+
+def test_model_only_provider_fallback_order(monkeypatch) -> None:
+    """Model-only routes prefer assignee provider then default profile."""
+    _defaults(monkeypatch, profiles={"coder": (None, "coder-p")})
+    monkeypatch.setattr(kb, "_load_global_default_provider", lambda: "default-p")
+    assignee = kb._resolve_routing_snapshot(
+        sqlite3.connect(":memory:"), "t", _row(model_override="pin"), "implement"
+    )
+    _defaults(monkeypatch, profiles={})
+    fallback = kb._resolve_routing_snapshot(
+        sqlite3.connect(":memory:"), "t", _row(model_override="pin"), "implement"
+    )
+    assert assignee["routing_provider"] == "coder-p"
+    assert fallback["routing_provider"] == "default-p"
+
+
+@pytest.mark.parametrize("role", ["", "missing", 7])
+def test_invalid_present_task_role_fails_closed(monkeypatch, role) -> None:
+    """A malformed present semantic role must not fall through."""
+    monkeypatch.setattr(kb, "_load_roster", _roster)
+    _defaults(monkeypatch, profiles={"coder": ("p-model", "p-provider")})
+    with pytest.raises(RoutingContractError):
+        kb._resolve_routing_snapshot(
+            sqlite3.connect(":memory:"), "t", _row(routing_role=role), "implement"
+        )
+
+
+def test_invalid_board_and_partial_profile_fail_closed(monkeypatch) -> None:
+    """Invalid present fallback sources must reject rather than skip."""
+    monkeypatch.setattr(kb, "_load_roster", _roster)
+    _defaults(monkeypatch, {"default_role": "missing"},
+              {"coder": ("p-model", "p-provider")})
+    with pytest.raises(RoutingContractError):
+        kb._resolve_routing_snapshot(sqlite3.connect(":memory:"), "t", _row(), "implement")
+    _defaults(monkeypatch, profiles={"coder": ("p-model", None)})
+    with pytest.raises(RoutingContractError):
+        kb._resolve_routing_snapshot(sqlite3.connect(":memory:"), "t", _row(), "implement")
+
+
+def test_unresolved_route_is_rejected(monkeypatch) -> None:
+    """Resolution rejects when no configured source yields a route."""
+    _defaults(monkeypatch)
+    with pytest.raises(RoutingContractError, match="unresolved"):
+        kb._resolve_routing_snapshot(sqlite3.connect(":memory:"), "t", _row(), "implement")
+
+
+def test_review_capable_and_coerced_sources(monkeypatch) -> None:
+    """Review routing records whether the requested role was preserved."""
+    monkeypatch.setattr(kb, "_load_roster", _roster)
+    _defaults(monkeypatch)
+    capable = kb._resolve_routing_snapshot(
+        sqlite3.connect(":memory:"), "t", _row(routing_role="auditor"), "review"
+    )
+    coerced = kb._resolve_routing_snapshot(
+        sqlite3.connect(":memory:"), "t", _row(routing_role="executor"), "review"
+    )
+    assert (capable["routing_role"], capable["routing_source"]) == (
+        "auditor", "review_capable"
+    )
+    assert (coerced["routing_role"], coerced["routing_source"]) == (
+        "reviewer", "review_coerced"
+    )

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -6,16 +6,23 @@ import pytest
 
 
 class _SnapshotConnection:
-    """Minimal connection stub for the spawn-boundary snapshot read."""
+    """Minimal connection stub for spawn snapshot and migration metadata reads."""
 
-    def __init__(self, row):
+    def __init__(self, row, *, cutoff=0):
         self.row = row
+        self.cutoff = cutoff
+        self._result = None
 
-    def execute(self, *args, **kwargs):
+    def execute(self, sql, *args, **kwargs):
+        self._result = (
+            {"value": str(self.cutoff)}
+            if "migration_cutoff_id" in sql
+            else self.row
+        )
         return self
 
     def fetchone(self):
-        return self.row
+        return self._result
 
     def close(self):
         pass
@@ -45,18 +52,48 @@ def _make_task(kb, *, assignee: str):
 def test_default_spawn_rejects_incomplete_modern_snapshot(monkeypatch, tmp_path):
     """Modern runs must not fall back to mutable task routing at spawn."""
     from hermes_cli import kanban_db as kb
-    from hermes_cli.routing_contract import ROUTING_CONTRACT_VERSION, RoutingContractError
+    from hermes_cli.routing_contract import RoutingContractError
 
     task = _make_task(kb, assignee="coder")
     task.model_override = "mutable-model"
     monkeypatch.setattr(kb, "connect", lambda: _SnapshotConnection({
         "routing_model": None,
         "routing_provider": "provider",
-        "routing_contract": ROUTING_CONTRACT_VERSION,
-    }))
+        "routing_contract": None,
+    }, cutoff=task.current_run_id - 1))
 
     with pytest.raises(RoutingContractError, match="incomplete frozen routing snapshot"):
         kb._default_spawn(task, str(tmp_path))
+
+
+def test_default_spawn_allows_legacy_snapshot_fallback(monkeypatch, tmp_path):
+    """Pre-cutoff runs retain their historical mutable-override fallback."""
+    from hermes_cli import kanban_db as kb
+
+    task = _make_task(kb, assignee="coder")
+    task.model_override = "mutable-model"
+    monkeypatch.setattr(kb, "connect", lambda: _SnapshotConnection({
+        "routing_model": None,
+        "routing_provider": None,
+        "routing_contract": None,
+    }, cutoff=task.current_run_id))
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    captured = {}
+
+    class FakeProc:
+        """Minimal spawned-process test double."""
+
+        pid = 4244
+
+    def fake_popen(cmd, *args, **kwargs):
+        """Capture worker argv without starting a process."""
+        captured["cmd"] = list(cmd)
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    kb._default_spawn(task, str(tmp_path))
+
+    assert captured["cmd"][captured["cmd"].index("-m") + 1] == "mutable-model"
 
 
 def test_default_spawn_pins_assignee_profile_cli_toolsets(monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -2,6 +2,24 @@ from __future__ import annotations
 
 import subprocess
 
+import pytest
+
+
+class _SnapshotConnection:
+    """Minimal connection stub for the spawn-boundary snapshot read."""
+
+    def __init__(self, row):
+        self.row = row
+
+    def execute(self, *args, **kwargs):
+        return self
+
+    def fetchone(self):
+        return self.row
+
+    def close(self):
+        pass
+
 
 def _make_task(kb, *, assignee: str):
     return kb.Task(
@@ -22,6 +40,23 @@ def _make_task(kb, *, assignee: str):
         tenant=None,
         current_run_id=7,
     )
+
+
+def test_default_spawn_rejects_incomplete_modern_snapshot(monkeypatch, tmp_path):
+    """Modern runs must not fall back to mutable task routing at spawn."""
+    from hermes_cli import kanban_db as kb
+    from hermes_cli.routing_contract import ROUTING_CONTRACT_VERSION, RoutingContractError
+
+    task = _make_task(kb, assignee="coder")
+    task.model_override = "mutable-model"
+    monkeypatch.setattr(kb, "connect", lambda: _SnapshotConnection({
+        "routing_model": None,
+        "routing_provider": "provider",
+        "routing_contract": ROUTING_CONTRACT_VERSION,
+    }))
+
+    with pytest.raises(RoutingContractError, match="incomplete frozen routing snapshot"):
+        kb._default_spawn(task, str(tmp_path))
 
 
 def test_default_spawn_pins_assignee_profile_cli_toolsets(monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_routing_contract.py
+++ b/tests/hermes_cli/test_routing_contract.py
@@ -1,0 +1,173 @@
+"""Unit tests for the Wave 2 routing contract parser."""
+import pytest
+from hermes_cli.routing_contract import (
+    parse_routing_envelope,
+    RoutingContractError,
+)
+
+
+class TestParseRoutingEnvelope:
+    """Tests for parse_routing_envelope."""
+
+    def test_valid_full_envelope(self):
+        body = """Some task description.
+
+# ---routing:v1---
+role: executor
+model: DSv4Flash
+provider: omniroute
+reason: "Implement feature X"
+ac_ids: [AC-1, AC-2]
+enforcement_required: true
+# ---/routing:v1---
+
+More task body.
+"""
+        result = parse_routing_envelope(body)
+        assert result["role"] == "executor"
+        assert result["model"] == "DSv4Flash"
+        assert result["provider"] == "omniroute"
+        assert result["reason"] == "Implement feature X"
+        assert result["ac_ids"] == ["AC-1", "AC-2"]
+        assert result["enforcement_required"] is True
+
+    def test_valid_minimal_envelope(self):
+        body = """# ---routing:v1---
+role: executor
+reason: "Do the thing"
+enforcement_required: true
+# ---/routing:v1---
+"""
+        result = parse_routing_envelope(body)
+        assert result["role"] == "executor"
+        assert result["reason"] == "Do the thing"
+        assert result["enforcement_required"] is True
+        assert "model" not in result
+        assert "ac_ids" not in result
+
+    def test_no_envelope_returns_empty(self):
+        body = "Just a regular task body with no routing envelope."
+        result = parse_routing_envelope(body)
+        assert result == {}
+
+    def test_wave1_envelope_returns_empty(self):
+        """Wave 1 envelopes must be classified as unenforced, never errors."""
+        body = """Some task.
+
+routing:
+  origin: kanban
+  assigned_role: executor
+  action: implement
+  edit_authorized: true
+  root_cause: known
+"""
+        result = parse_routing_envelope(body)
+        assert result == {}
+
+    def test_wave1_assigned_role_only_returns_empty(self):
+        body = """assigned_role: executor
+action: implement
+"""
+        result = parse_routing_envelope(body)
+        assert result == {}
+
+    def test_missing_end_marker_raises(self):
+        body = """# ---routing:v1---
+role: executor
+reason: "test"
+enforcement_required: true
+"""
+        with pytest.raises(RoutingContractError, match="missing end marker"):
+            parse_routing_envelope(body)
+
+    def test_missing_required_field_raises(self):
+        body = """# ---routing:v1---
+role: executor
+reason: "test"
+# ---/routing:v1---
+"""
+        with pytest.raises(RoutingContractError, match="missing required fields"):
+            parse_routing_envelope(body)
+
+    def test_non_boolean_enforcement_raises(self):
+        body = """# ---routing:v1---
+role: executor
+reason: "test"
+enforcement_required: "yes"
+# ---/routing:v1---
+"""
+        with pytest.raises(RoutingContractError, match="must be a boolean"):
+            parse_routing_envelope(body)
+
+    def test_empty_role_raises(self):
+        body = """# ---routing:v1---
+role: ""
+reason: "test"
+enforcement_required: true
+# ---/routing:v1---
+"""
+        with pytest.raises(RoutingContractError, match="'role' must be a non-empty string"):
+            parse_routing_envelope(body)
+
+    def test_empty_reason_raises(self):
+        body = """# ---routing:v1---
+role: executor
+reason: ""
+enforcement_required: true
+# ---/routing:v1---
+"""
+        with pytest.raises(RoutingContractError, match="'reason' must be a non-empty string"):
+            parse_routing_envelope(body)
+
+    def test_oversized_envelope_raises(self):
+        big_reason = "x" * 2100
+        body = f"""# ---routing:v1---
+role: executor
+reason: "{big_reason}"
+enforcement_required: true
+# ---/routing:v1---
+"""
+        with pytest.raises(RoutingContractError, match="exceeds"):
+            parse_routing_envelope(body)
+
+    def test_non_mapping_yaml_raises(self):
+        body = """# ---routing:v1---
+- just
+- a
+- list
+# ---/routing:v1---
+"""
+        with pytest.raises(RoutingContractError, match="must be a YAML mapping"):
+            parse_routing_envelope(body)
+
+    def test_ac_ids_non_string_raises(self):
+        body = """# ---routing:v1---
+role: executor
+reason: "test"
+enforcement_required: true
+ac_ids: [AC-1, 123]
+# ---/routing:v1---
+"""
+        with pytest.raises(RoutingContractError, match="must contain only strings"):
+            parse_routing_envelope(body)
+
+    def test_ac_ids_non_list_raises(self):
+        body = """# ---routing:v1---
+role: executor
+reason: "test"
+enforcement_required: true
+ac_ids: "AC-1"
+# ---/routing:v1---
+"""
+        with pytest.raises(RoutingContractError, match="'ac_ids' must be a list"):
+            parse_routing_envelope(body)
+
+    def test_enforcement_false_returns_parsed(self):
+        body = """# ---routing:v1---
+role: executor
+reason: "test"
+enforcement_required: false
+# ---/routing:v1---
+"""
+        result = parse_routing_envelope(body)
+        assert result["enforcement_required"] is False

--- a/tests/hermes_cli/test_transitions_map.py
+++ b/tests/hermes_cli/test_transitions_map.py
@@ -1,0 +1,56 @@
+"""Tests for the Wave 2 TRANSITIONS state machine assertion (step 2f)."""
+import warnings
+import pytest
+from hermes_cli.kanban_db import TRANSITIONS, _assert_transition
+
+
+class TestTransitionsMap:
+    """Tests for the TRANSITIONS adjacency map and _assert_transition."""
+
+    def test_all_valid_statuses_have_transitions(self):
+        from hermes_cli.kanban_db import VALID_STATUSES
+        for status in VALID_STATUSES:
+            assert status in TRANSITIONS, f"Status '{status}' missing from TRANSITIONS map"
+
+    def test_legal_transition_no_warning(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _assert_transition("ready", "running")
+            _assert_transition("running", "done")
+            _assert_transition("running", "blocked")
+            _assert_transition("blocked", "ready")
+            _assert_transition("done", "archived")
+            _assert_transition("done", "ready")  # reopen
+
+    def test_illegal_transition_warns(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _assert_transition("done", "running")
+            assert len(w) == 1
+            assert "illegal transition" in str(w[0].message)
+            assert "done→running" in str(w[0].message)
+
+    def test_unknown_source_warns(self):
+        """Unknown source state should warn (defensive — it's suspicious)."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _assert_transition("unknown_state", "ready")
+            assert len(w) == 1
+            assert "illegal transition" in str(w[0].message)
+
+    def test_running_can_crash(self):
+        """running→crashed is a legal retry-eligible transition."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _assert_transition("running", "crashed")
+
+    def test_running_can_timeout(self):
+        """running→timed_out is a legal retry-eligible transition."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _assert_transition("running", "timed_out")
+
+    def test_archived_can_unarchive(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _assert_transition("archived", "todo")


### PR DESCRIPTION
## Summary
- add atomic routing metadata migration and fail-closed resolver precedence
- freeze immutable claim snapshots and audit claim/spawn rejections
- backfill terminal historical runs from execution evidence only
- expose board-scoped routing APIs and board default-role configuration

## Verification
- 44 focused routing tests passed after rebase onto current origin/main
- Python compilation and git diff checks passed
- migration exercised on a disposable copy of the real k-shell kanban database

## Notes
- full tests/hermes_cli run was stopped after broad pre-existing environment/baseline failures; focused routing suite is green
- production board defaults were not changed