### PR TITLE
fix(approval): enforce explicit timeout on the smart-approval guardian call (#85125 2c, salvage of #84125)

### DIFF
--- a/tests/tools/test_smart_approval_policy.py
+++ b/tests/tools/test_smart_approval_policy.py
@@ -110,5 +110,45 @@ class TestSmartApprovePolicyInjection(unittest.TestCase):
         assert _smart_approve("echo hi", "flagged") == "escalate"
 
 
+    @patch("agent.auxiliary_client._get_task_timeout")
+    @patch("tools.approval._get_approval_config")
+    @patch("agent.auxiliary_client.call_llm")
+    def test_smart_approve_passes_explicit_timeout(
+        self, mock_call_llm, mock_cfg, mock_task_timeout
+    ):
+        """Regression for #82846: the guardian call must pass an explicit
+        timeout instead of relying on the default resolution inside call_llm
+        (a defeated internal timeout silently froze agent turns in
+        production). The explicit value must equal what
+        auxiliary.approval.timeout resolves to."""
+        mock_call_llm.return_value = _make_response("APPROVE")
+        mock_cfg.return_value = {"mode": "smart"}
+        mock_task_timeout.return_value = 42.0
+
+        assert _smart_approve("echo hi", "flagged") == "approve"
+        _, kwargs = mock_call_llm.call_args
+        assert kwargs.get("timeout") == 42.0
+
+
+    @patch("tools.approval._get_approval_config")
+    @patch("agent.auxiliary_client.call_llm")
+    def test_smart_approve_failure_logs_warning_and_escalates(
+        self, mock_call_llm, mock_cfg
+    ):
+        """A failed/blocked guardian call must surface as a WARNING with the
+        elapsed time (not a silent DEBUG) — #82846's hang was invisible
+        precisely because nothing logged at the failure point."""
+        mock_call_llm.side_effect = TimeoutError("stalled provider")
+        mock_cfg.return_value = {"mode": "smart"}
+
+        with patch("tools.approval.logger") as mock_logger:
+            assert _smart_approve("echo hi", "flagged") == "escalate"
+
+        assert mock_logger.warning.called
+        args, _ = mock_logger.warning.call_args
+        assert "Smart approvals: LLM call failed" in args[0]
+        assert "TimeoutError" in str(args)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3543,8 +3543,22 @@ def _smart_approve(command: str, description: str) -> str:
     Inspired by OpenAI Codex's Smart Approvals guardian subagent
     (openai/codex#13860).
     """
+    _smart_t0 = time.monotonic()
     try:
-        from agent.auxiliary_client import call_llm
+        from agent.auxiliary_client import _get_task_timeout, call_llm
+
+        # Explicit timeout for the guardian call. This synchronous call gates
+        # EVERY flagged terminal command — relying on the timeout being
+        # resolved correctly inside call_llm has burned users in production:
+        # a stalled provider response silently froze the agent turn for tens
+        # of minutes with zero log output (#82846, #72500). Pass the same
+        # configured value explicitly (belt) and log the call + duration
+        # (suspenders) so a hang is visible in the logs instead of silent.
+        smart_timeout = _get_task_timeout("approval")
+        logger.debug(
+            "Smart approvals: assessing risk for command (timeout=%ss)",
+            smart_timeout,
+        )
 
         # Strip shell comments to remove the easiest injection vector.
         sanitized_command = _strip_shell_comments(command)
@@ -3601,6 +3615,11 @@ def _smart_approve(command: str, description: str) -> str:
             ],
             temperature=0,
             max_tokens=16,
+            timeout=smart_timeout,
+        )
+        logger.debug(
+            "Smart approvals: LLM call completed in %.1fs",
+            time.monotonic() - _smart_t0,
         )
 
         answer = (response.choices[0].message.content or "").strip().upper()
@@ -3613,7 +3632,15 @@ def _smart_approve(command: str, description: str) -> str:
             return "escalate"
 
     except Exception as e:
-        logger.debug("Smart approvals: LLM call failed (%s), escalating", e)
+        # WARNING (was DEBUG): a failed/blocked guardian call is a real event
+        # the operator needs to see — the whole point of #82846 is that the
+        # hang was invisible. Log the elapsed time and error class too.
+        logger.warning(
+            "Smart approvals: LLM call failed after %.1fs (%s: %s), escalating",
+            time.monotonic() - _smart_t0,
+            type(e).__name__,
+            e,
+        )
         return "escalate"
 
 


### PR DESCRIPTION
#85125 Phase 2c. The smart-approval guardian LLM call gates every flagged terminal command, synchronously, on the turn hot path — and it relied on the timeout being resolved somewhere inside `call_llm`. A stalled provider froze agent turns for tens of minutes with zero log output (#82846). The call now passes an explicit `timeout=` resolved from `auxiliary.approval.timeout` (belt), logs the call + duration at DEBUG, and a failed/blocked guardian call escalates with a WARNING carrying elapsed time and error class instead of an invisible DEBUG (suspenders — the hang was invisible precisely because nothing logged at the failure point).

Based on #84125 by @yflmq001 — cherry-picked to preserve authorship (one dead local re-import removed in the amend).

Resolution-key note (tracker alignment): the phase item sketched `resolve_timeout("approval.guardian_llm")`, but the tracker's own disposition table rules that auxiliary-LLM timeouts stay owned by `auxiliary_client`'s resolution (`auxiliary.{task}.timeout`) with any `resolve_timeout` migration deliberately out of scope for now (#66635/#62458 cluster). `_get_task_timeout("approval")` is that resolution — explicit per-call values are always honored by `_effective_aux_timeout`, so the enforced bound and the config key stay in lockstep with every other auxiliary task.

## Verification

- tests/tools/test_smart_approval_policy.py + test_smart_approval_injection.py: 20 passed (includes the two new regression tests: explicit-timeout-equals-resolved-value, failure-logs-WARNING-and-escalates)
- Fail-safe unchanged: any guardian failure still returns "escalate" (fail closed to human review)
- ruff clean; no new config keys, no cache impact

Closes #84125. Fixes #82846.
Part of #85125 (Phase 2c).
