### PR TITLE
fix(cli): add .bun and .npm to backup exclusion list (#93760)

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -94,6 +94,11 @@ _EXCLUDED_DIRS = {
     ".pytest_cache",
     ".mypy_cache",
     ".ruff_cache",
+    # JS runtime caches — populated when terminal.home_mode places a
+    # profile-local HOME under HERMES_HOME; each npm/npx/bun invocation
+    # writes hundreds of MB here.  Regenerable via reinstall.
+    ".bun",
+    ".npm",
 }
 
 # File-name suffixes to skip


### PR DESCRIPTION
## Summary

Fixes #93760.

`_EXCLUDED_DIRS` in `hermes_cli/backup.py` was missing `.bun` and `.npm` — JS runtime caches that accumulate hundreds of MB when `terminal.home_mode` places a profile-local HOME under HERMES_HOME. Every `npm`/`npx`/`bun` invocation writes cache data there, causing backups to balloon (82% of archive size on affected hosts per the issue report).

## Changes

- `hermes_cli/backup.py`: Added `.bun` and `.npm` to `_EXCLUDED_DIRS` with a comment explaining they are JS runtime caches, regenerable via reinstall.

## Testing

- Verified syntax: `python3 -m py_compile hermes_cli/backup.py`
- The change is additive (new entries in an existing exclusion set) — no behavioral change for directories already excluded.
