### PR TITLE
fix(gateway): skip fenced code blocks in extract_images (#93724)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4503,48 +4503,70 @@ class BasePlatformAdapter(ABC):
     def extract_images(content: str) -> Tuple[List[Tuple[str, str]], str]:
         """
         Extract image URLs from markdown and HTML image tags in a response.
-        
+
         Finds patterns like:
         - ![alt text](https://example.com/image.png)
         - <img src="https://example.com/image.png">
         - <img src="https://example.com/image.png"></img>
-        
+
+        Image tags inside fenced code blocks (```...```) and inline code
+        (`` `...` ``) are skipped — those are prose examples, not real
+        attachments.  Matches the guard used by ``_mask_protected_spans``
+        and ``_clean_media_tags``.
+
         Args:
             content: The response text to scan.
-        
+
         Returns:
             Tuple of (list of (url, alt_text) pairs, cleaned content with image tags removed).
         """
         images = []
         cleaned = content
-        
+
+        # Build protected spans: fenced code blocks and inline code.
+        # Character offsets are used to skip matches that land inside them.
+        protected: list = []
+        for m in re.finditer(r'```[^\n]*\n.*?```', content, re.DOTALL):
+            protected.append((m.start(), m.end()))
+        for m in re.finditer(r'`[^`\n]+`', content):
+            protected.append((m.start(), m.end()))
+
+        def _in_protected(pos: int) -> bool:
+            return any(s <= pos < e for s, e in protected)
+
         # Match markdown images: ![alt](url)
         md_pattern = r'!\[([^\]]*)\]\((https?://[^\s\)]+)\)'
         for match in re.finditer(md_pattern, content):
+            if _in_protected(match.start()):
+                continue
             alt_text = match.group(1)
             url = match.group(2)
             # Only extract URLs that look like actual images
             if any(url.lower().endswith(ext) or ext in url.lower() for ext in
                    ['.png', '.jpg', '.jpeg', '.gif', '.webp', 'fal.media', 'fal-cdn', 'replicate.delivery']):
                 images.append((url, alt_text))
-        
+
         # Match HTML img tags: <img src="url"> or <img src="url"></img> or <img src="url"/>
         html_pattern = r'<img\s+src=["\']?(https?://[^\s"\'<>]+)["\']?\s*/?>\s*(?:</img>)?'
         for match in re.finditer(html_pattern, content):
+            if _in_protected(match.start()):
+                continue
             url = match.group(1)
             images.append((url, ""))
-        
+
         # Remove only the matched image tags from content (not all markdown images)
         if images:
             extracted_urls = {url for url, _ in images}
             def _remove_if_extracted(match):
+                if _in_protected(match.start()):
+                    return match.group(0)
                 url = match.group(2) if match.lastindex >= 2 else match.group(1)
                 return '' if url in extracted_urls else match.group(0)
             cleaned = re.sub(md_pattern, _remove_if_extracted, cleaned)
             cleaned = re.sub(html_pattern, _remove_if_extracted, cleaned)
             # Clean up leftover blank lines
             cleaned = re.sub(r'\n{3,}', '\n\n', cleaned).strip()
-        
+
         return images, cleaned
     
     async def send_voice(


### PR DESCRIPTION
## Summary

Fixes #93724.

`extract_images()` scanned the entire response body for markdown and HTML image tags without excluding fenced code blocks or inline code. When an agent explains markdown image syntax (e.g. `![Alt text](https://example.com/image.png)` inside a ```markdown block), the example was treated as a real attachment: the URL was queued for delivery and removed from the code block, leaving the user with an empty fence.

## Changes

- `gateway/platforms/base.py`: Added protected-span guards to `extract_images()` that skip matches inside fenced code blocks (` ```...``` `) and inline code (`` `...` ``). This matches the guard pattern already used by `_mask_protected_spans` and `_clean_media_tags` in the same class.

## Testing

- Verified syntax: `python3 -m py_compile gateway/platforms/base.py`
- The fix is scoped to `extract_images()` only — no changes to sibling extractors.
- Protected-span detection uses the same regex patterns as `_mask_protected_spans` for consistency.
