### PR TITLE
fix(agent): preserve Bedrock redacted reasoning for replay

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -27,6 +27,7 @@ the same Converse API integration in TypeScript via ``@aws-sdk/client-bedrock``.
 Requires: ``boto3`` (optional dependency — only needed when using the Bedrock provider).
 """
 
+import base64
 import json
 import logging
 import os
@@ -1007,28 +1008,84 @@ def convert_messages_to_converse(
 
         if role == "assistant":
             content_blocks = []
-            # Convert text content
-            if isinstance(content, str) and content.strip():
-                content_blocks.append({"text": content})
-            elif isinstance(content, list):
-                content_blocks.extend(_convert_content_to_converse(content))
+            ordered_blocks = msg.get("bedrock_content_blocks")
+            if isinstance(ordered_blocks, list) and ordered_blocks:
+                # Rebuild the exact Bedrock block sequence captured at
+                # normalization time. Redacted bytes are stored as base64 so
+                # the sidecar remains JSON-safe in assistant history.
+                for block in ordered_blocks:
+                    if not isinstance(block, dict):
+                        continue
+                    if "text" in block and isinstance(block["text"], str):
+                        content_blocks.append({"text": block["text"]})
+                    elif "reasoningContent" in block:
+                        reasoning = block["reasoningContent"]
+                        if not isinstance(reasoning, dict):
+                            continue
+                        replay = {}
+                        if isinstance(reasoning.get("text"), str):
+                            replay["text"] = reasoning["text"]
+                        encoded = reasoning.get("redactedContentBase64")
+                        if isinstance(encoded, str) and encoded:
+                            try:
+                                replay["redactedContent"] = base64.b64decode(encoded, validate=True)
+                            except (ValueError, TypeError):
+                                continue
+                        if replay:
+                            content_blocks.append({"reasoningContent": replay})
+                    elif "toolUse" in block and isinstance(block["toolUse"], dict):
+                        tu = block["toolUse"]
+                        content_blocks.append({"toolUse": {
+                            "toolUseId": tu.get("toolUseId", ""),
+                            "name": tu.get("name", ""),
+                            "input": tu.get("input", {}),
+                        }})
 
-            # Convert tool calls
-            tool_calls = msg.get("tool_calls", [])
-            for tc in (tool_calls or []):
-                fn = tc.get("function", {})
-                args_str = fn.get("arguments", "{}")
-                try:
-                    args_dict = json.loads(args_str) if isinstance(args_str, str) else args_str
-                except (json.JSONDecodeError, TypeError):
-                    args_dict = {}
-                content_blocks.append({
-                    "toolUse": {
-                        "toolUseId": tc.get("id", ""),
-                        "name": fn.get("name", ""),
-                        "input": args_dict,
-                    }
-                })
+                if not content_blocks:
+                    ordered_blocks = None
+
+            if content_blocks:
+                # Ordered replay is authoritative; do not append parallel
+                # reasoning/text/tool lists a second time.
+                pass
+            else:
+                # Bedrock may return opaque encrypted reasoning instead of text.
+                # Preserve the payload in the provider-neutral reasoning_details
+                # envelope so the next tool turn can replay it byte-for-byte.
+                for detail in (msg.get("reasoning_details") or []):
+                    if not isinstance(detail, dict) or detail.get("type") != "redacted_thinking":
+                        continue
+                    encoded = detail.get("data") or detail.get("redactedContentBase64")
+                    if not isinstance(encoded, str) or not encoded:
+                        continue
+                    try:
+                        redacted = base64.b64decode(encoded, validate=True)
+                    except (ValueError, TypeError):
+                        continue
+                    content_blocks.append({"reasoningContent": {"redactedContent": redacted}})
+
+                # Convert text content
+                if isinstance(content, str) and content.strip():
+                    content_blocks.append({"text": content})
+                elif isinstance(content, list):
+                    content_blocks.extend(_convert_content_to_converse(content))
+
+                # Convert tool calls
+                tool_calls = msg.get("tool_calls", [])
+                for tc in (tool_calls or []):
+                    fn = tc.get("function", {})
+                    args_str = fn.get("arguments", "{}")
+                    try:
+                        args_dict = json.loads(args_str) if isinstance(args_str, str) else args_str
+                    except (json.JSONDecodeError, TypeError):
+                        args_dict = {}
+                    content_blocks.append({
+                        "toolUse": {
+                            "toolUseId": tc.get("id", ""),
+                            "name": fn.get("name", ""),
+                            "input": args_dict,
+                        }
+                    })
 
             if not content_blocks:
                 content_blocks = [{"text": _EMPTY_TEXT_PLACEHOLDER}]
@@ -1102,19 +1159,48 @@ def normalize_converse_response(response: Dict) -> SimpleNamespace:
 
     text_parts = []
     reasoning_parts = []
+    reasoning_details = []
+    ordered_blocks = []
     tool_calls = []
 
     for block in content_blocks:
         if "text" in block:
             text_parts.append(block["text"])
+            ordered_blocks.append({"text": block["text"]})
         elif "reasoningContent" in block:
             reasoning = block["reasoningContent"]
             if isinstance(reasoning, dict):
                 thinking_text = reasoning.get("text", "")
+                encoded = None
                 if thinking_text:
                     reasoning_parts.append(str(thinking_text))
+                redacted = reasoning.get("redactedContent")
+                if redacted is not None:
+                    if isinstance(redacted, (bytes, bytearray)):
+                        encoded = base64.b64encode(bytes(redacted)).decode("ascii")
+                    elif isinstance(redacted, str):
+                        encoded = redacted
+                    else:
+                        encoded = None
+                    if encoded:
+                        reasoning_details.append({
+                            "type": "redacted_thinking",
+                            "data": encoded,
+                        })
+                if thinking_text or encoded:
+                    ordered_reasoning = {}
+                    if thinking_text:
+                        ordered_reasoning["text"] = str(thinking_text)
+                    if encoded:
+                        ordered_reasoning["redactedContentBase64"] = encoded
+                    ordered_blocks.append({"reasoningContent": ordered_reasoning})
         elif "toolUse" in block:
             tu = block["toolUse"]
+            ordered_blocks.append({"toolUse": {
+                "toolUseId": tu.get("toolUseId", ""),
+                "name": tu.get("name", ""),
+                "input": tu.get("input", {}),
+            }})
             tool_calls.append(SimpleNamespace(
                 id=tu.get("toolUseId", ""),
                 type="function",
@@ -1130,6 +1216,8 @@ def normalize_converse_response(response: Dict) -> SimpleNamespace:
         content="\n".join(text_parts) if text_parts else None,
         tool_calls=tool_calls if tool_calls else None,
         reasoning_content="\n\n".join(reasoning_parts) if reasoning_parts else None,
+        reasoning_details=reasoning_details or None,
+        bedrock_content_blocks=ordered_blocks or None,
     )
 
     # Build usage stats. Converse's inputTokens excludes cache read/write
@@ -1226,7 +1314,10 @@ def stream_converse_with_callbacks(
     """
     text_parts: List[str] = []
     reasoning_parts: List[str] = []
+    reasoning_details: List[Dict[str, Any]] = []
     tool_calls: List[SimpleNamespace] = []
+    stream_blocks: Dict[int, Dict[str, Any]] = {}
+    current_block_index: Optional[int] = None
     current_tool: Optional[Dict] = None
     current_text_buffer: List[str] = []
     has_tool_use = False
@@ -1248,7 +1339,9 @@ def stream_converse_with_callbacks(
             break
 
         if "contentBlockStart" in event:
-            start = event["contentBlockStart"].get("start", {})
+            start_event = event["contentBlockStart"]
+            current_block_index = start_event.get("contentBlockIndex", len(stream_blocks))
+            start = start_event.get("start", {})
             if "toolUse" in start:
                 has_tool_use = True
                 # Flush any accumulated text
@@ -1260,6 +1353,11 @@ def stream_converse_with_callbacks(
                     "name": start["toolUse"].get("name", ""),
                     "input_json": "",
                 }
+                stream_blocks[current_block_index] = {"toolUse": {
+                    "toolUseId": current_tool["toolUseId"],
+                    "name": current_tool["name"],
+                    "input": {},
+                }}
                 if on_tool_start:
                     on_tool_start(current_tool["name"])
 
@@ -1267,6 +1365,8 @@ def stream_converse_with_callbacks(
             delta = event["contentBlockDelta"].get("delta", {})
             if "text" in delta:
                 text = delta["text"]
+                block = stream_blocks.setdefault(current_block_index if current_block_index is not None else len(stream_blocks), {"text": ""})
+                block["text"] = block.get("text", "") + text
                 current_text_buffer.append(text)
                 # Fire text delta callback only when no tool calls are present
                 # (same semantics as Anthropic/chat_completions streaming)
@@ -1284,6 +1384,23 @@ def stream_converse_with_callbacks(
                         reasoning_parts.append(str(thinking_text))
                         if on_reasoning_delta:
                             on_reasoning_delta(thinking_text)
+                        block = stream_blocks.setdefault(current_block_index if current_block_index is not None else len(stream_blocks), {"reasoningContent": {}})
+                        block.setdefault("reasoningContent", {})["text"] = block["reasoningContent"].get("text", "") + str(thinking_text)
+                    redacted = reasoning.get("redactedContent")
+                    if redacted is not None:
+                        if isinstance(redacted, (bytes, bytearray)):
+                            encoded = base64.b64encode(bytes(redacted)).decode("ascii")
+                        elif isinstance(redacted, str):
+                            encoded = redacted
+                        else:
+                            encoded = None
+                        if encoded:
+                            reasoning_details.append({
+                                "type": "redacted_thinking",
+                                "data": encoded,
+                            })
+                            block = stream_blocks.setdefault(current_block_index if current_block_index is not None else len(stream_blocks), {"reasoningContent": {}})
+                            block.setdefault("reasoningContent", {})["redactedContentBase64"] = encoded
 
         elif "contentBlockStop" in event:
             if current_tool is not None:
@@ -1299,6 +1416,8 @@ def stream_converse_with_callbacks(
                         arguments=json.dumps(input_dict),
                     ),
                 ))
+                if current_block_index is not None and current_block_index in stream_blocks:
+                    stream_blocks[current_block_index]["toolUse"]["input"] = input_dict
                 current_tool = None
             elif current_text_buffer:
                 text_parts.append("".join(current_text_buffer))
@@ -1325,6 +1444,8 @@ def stream_converse_with_callbacks(
         content="\n".join(text_parts) if text_parts else None,
         tool_calls=tool_calls if tool_calls else None,
         reasoning_content="\n\n".join(reasoning_parts) if reasoning_parts else None,
+        reasoning_details=reasoning_details or None,
+        bedrock_content_blocks=[stream_blocks[i] for i in sorted(stream_blocks)] or None,
     )
 
     input_tokens = usage_data.get("inputTokens", 0)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2277,6 +2277,10 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     if ordered_blocks:
         msg["anthropic_content_blocks"] = ordered_blocks
 
+    bedrock_blocks = getattr(assistant_message, "bedrock_content_blocks", None)
+    if bedrock_blocks:
+        msg["bedrock_content_blocks"] = bedrock_blocks
+
     # Codex Responses API: preserve encrypted reasoning items for
     # multi-turn continuity. These get replayed as input on the next turn.
     codex_items = getattr(assistant_message, "codex_reasoning_items", None)

--- a/agent/transports/bedrock.py
+++ b/agent/transports/bedrock.py
@@ -107,12 +107,19 @@ class BedrockTransport(ProviderTransport):
 
         reasoning = getattr(msg, "reasoning", None) or getattr(msg, "reasoning_content", None)
 
+        provider_data = {}
+        if getattr(msg, "reasoning_details", None):
+            provider_data["reasoning_details"] = msg.reasoning_details
+        if getattr(msg, "bedrock_content_blocks", None):
+            provider_data["bedrock_content_blocks"] = msg.bedrock_content_blocks
+
         return NormalizedResponse(
             content=msg.content,
             tool_calls=tool_calls,
             finish_reason=finish_reason,
             reasoning=reasoning,
             usage=usage,
+            provider_data=provider_data or None,
         )
 
     def validate_response(self, response: Any) -> bool:

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -316,6 +316,10 @@ class ChatCompletionsTransport(ProviderTransport):
           gateways (e.g. opencode-go, codex.nekos.me) reject with
           ``Extra inputs are not permitted, field: 'messages[N]._empty_recovery_synthetic'``,
           which then poisons every subsequent request in the session.
+        - Provider-specific ordered replay sidecars --
+          ``anthropic_content_blocks`` and ``bedrock_content_blocks`` are
+          durable-history data for their native transports, not part of the
+          Chat Completions schema. They must not cross a provider boundary.
         """
         strip_extra_content = not _model_consumes_thought_signature(
             kwargs.get("model")
@@ -331,6 +335,8 @@ class ChatCompletionsTransport(ProviderTransport):
                 or "effect_disposition" in msg
                 or "timestamp" in msg  # #47868 — strict providers reject this
                 or "api_content" in msg  # persist-what-you-send sidecar
+                or "anthropic_content_blocks" in msg
+                or "bedrock_content_blocks" in msg
             ):
                 needs_sanitize = True
                 break
@@ -402,6 +408,8 @@ class ChatCompletionsTransport(ProviderTransport):
                 or "effect_disposition" in msg
                 or "timestamp" in msg  # #47868 — leak into strict providers
                 or "api_content" in msg  # persist-what-you-send sidecar
+                or "anthropic_content_blocks" in msg
+                or "bedrock_content_blocks" in msg
             ):
                 out_msg = mutable_msg()
                 out_msg.pop("codex_reasoning_items", None)
@@ -410,6 +418,8 @@ class ChatCompletionsTransport(ProviderTransport):
                 out_msg.pop("effect_disposition", None)
                 out_msg.pop("timestamp", None)  # #47868 — leak into strict providers
                 out_msg.pop("api_content", None)  # persist-what-you-send sidecar
+                out_msg.pop("anthropic_content_blocks", None)
+                out_msg.pop("bedrock_content_blocks", None)
 
 
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).

--- a/agent/transports/types.py
+++ b/agent/transports/types.py
@@ -134,6 +134,12 @@ class NormalizedResponse:
         return pd.get("anthropic_content_blocks")
 
     @property
+    def bedrock_content_blocks(self):
+        """Verbatim, order-preserving Bedrock Converse content blocks."""
+        pd = self.provider_data or {}
+        return pd.get("bedrock_content_blocks")
+
+    @property
     def codex_reasoning_items(self):
         pd = self.provider_data or {}
         return pd.get("codex_reasoning_items")

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -348,6 +348,85 @@ class TestNormalizeConverseResponse:
         assert tool_calls[0].function.name == "read_file"
         assert json.loads(tool_calls[0].function.arguments) == {"path": "/tmp/test.txt"}
 
+    def test_redacted_reasoning_is_preserved_for_replay(self):
+        from agent.bedrock_adapter import normalize_converse_response
+
+        response = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"reasoningContent": {"redactedContent": b"opaque-bedrock-bytes"}},
+                        {"toolUse": {"toolUseId": "call_1", "name": "read_file", "input": {}}},
+                    ],
+                },
+            },
+            "stopReason": "tool_use",
+            "usage": {"inputTokens": 1, "outputTokens": 2},
+        }
+
+        result = normalize_converse_response(response)
+        details = result.choices[0].message.reasoning_details
+        assert details == [{
+            "type": "redacted_thinking",
+            "data": "b3BhcXVlLWJlZHJvY2stYnl0ZXM=",
+        }]
+
+
+    def test_redacted_reasoning_replays_as_bedrock_content_block(self):
+        from agent.bedrock_adapter import convert_messages_to_converse
+
+        _system, messages = convert_messages_to_converse([
+            {
+                "role": "assistant",
+                "content": None,
+                "reasoning_details": [{
+                    "type": "redacted_thinking",
+                    "data": "b3BhcXVlLWJlZHJvY2stYnl0ZXM=",
+                }],
+                "tool_calls": [{
+                    "id": "call_1",
+                    "function": {"name": "read_file", "arguments": "{}"},
+                }],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ])
+        assistant = next(m for m in messages if m["role"] == "assistant")
+        assert assistant["content"][0] == {
+            "reasoningContent": {"redactedContent": b"opaque-bedrock-bytes"}
+        }
+
+    def test_interleaved_reasoning_and_tools_keep_exact_order(self):
+        from agent.bedrock_adapter import convert_messages_to_converse, normalize_converse_response
+
+        normalized = normalize_converse_response({
+            "output": {"message": {"role": "assistant", "content": [
+                {"reasoningContent": {"redactedContent": b"r1"}},
+                {"toolUse": {"toolUseId": "t1", "name": "one", "input": {"n": 1}}},
+                {"reasoningContent": {"redactedContent": b"r2"}},
+                {"toolUse": {"toolUseId": "t2", "name": "two", "input": {"n": 2}}},
+            ]}},
+            "stopReason": "tool_use",
+        })
+        msg = normalized.choices[0].message
+        _system, replay = convert_messages_to_converse([{
+            "role": "user", "content": "go",
+        }, {
+            "role": "assistant", "content": msg.content,
+            "tool_calls": [{
+                "id": tc.id, "type": "function",
+                "function": {"name": tc.function.name, "arguments": tc.function.arguments},
+            } for tc in msg.tool_calls],
+            "reasoning_details": msg.reasoning_details,
+            "bedrock_content_blocks": msg.bedrock_content_blocks,
+        }])
+        blocks = replay[1]["content"]
+        assert [next(iter(block)) for block in blocks] == [
+            "reasoningContent", "toolUse", "reasoningContent", "toolUse"
+        ]
+        assert blocks[0]["reasoningContent"]["redactedContent"] == b"r1"
+        assert blocks[2]["reasoningContent"]["redactedContent"] == b"r2"
+
 
 
 
@@ -376,6 +455,27 @@ class TestNormalizeConverseStreamEvents:
         assert result.choices[0].finish_reason == "stop"
         assert result.usage.prompt_tokens == 5
         assert result.usage.completion_tokens == 3
+
+    def test_redacted_reasoning_stream_is_preserved(self):
+        from agent.bedrock_adapter import normalize_converse_stream_events
+
+        events = {"stream": [
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockStart": {"contentBlockIndex": 0, "start": {}}},
+            {"contentBlockDelta": {
+                "contentBlockIndex": 0,
+                "delta": {"reasoningContent": {"redactedContent": b"stream-secret"}},
+            }},
+            {"contentBlockStop": {"contentBlockIndex": 0}},
+            {"messageStop": {"stopReason": "end_turn"}},
+            {"metadata": {"usage": {"inputTokens": 2, "outputTokens": 3}}},
+        ]}
+
+        result = normalize_converse_stream_events(events)
+        assert result.choices[0].message.reasoning_details == [{
+            "type": "redacted_thinking",
+            "data": "c3RyZWFtLXNlY3JldA==",
+        }]
 
     def test_tool_use_stream(self):
         from agent.bedrock_adapter import normalize_converse_stream_events

--- a/tests/agent/test_bedrock_transport_replay.py
+++ b/tests/agent/test_bedrock_transport_replay.py
@@ -1,0 +1,113 @@
+"""Production Bedrock transport/history replay regressions."""
+
+import sys
+from types import ModuleType
+
+import pytest
+
+
+class _FakeAgent:
+    verbose_logging = False
+    reasoning_callback = None
+    stream_delta_callback = None
+    _stream_callback = None
+
+    @staticmethod
+    def _extract_reasoning(message):
+        return getattr(message, "reasoning_content", None)
+
+    @staticmethod
+    def _strip_think_blocks(text):
+        return text
+
+    @staticmethod
+    def _needs_thinking_reasoning_pad():
+        return False
+
+    @staticmethod
+    def _split_responses_tool_id(value):
+        return value, None
+
+    @staticmethod
+    def _deterministic_call_id(name, args, index):
+        return f"call-{index}"
+
+    @staticmethod
+    def _derive_responses_function_call_id(value, response_item_id=None):
+        return value
+
+
+def _raw_response():
+    return {
+        "output": {"message": {"role": "assistant", "content": [
+            {"reasoningContent": {"redactedContent": b"r1"}},
+            {"toolUse": {"toolUseId": "t1", "name": "one", "input": {"n": 1}}},
+            {"reasoningContent": {"redactedContent": b"r2"}},
+            {"toolUse": {"toolUseId": "t2", "name": "two", "input": {"n": 2}}},
+        ]}},
+        "stopReason": "tool_use",
+    }
+
+
+def _stream_response():
+    return {"stream": [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockStart": {"contentBlockIndex": 0, "start": {}}},
+        {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {
+            "reasoningContent": {"redactedContent": b"r1"},
+        }}},
+        {"contentBlockStop": {"contentBlockIndex": 0}},
+        {"contentBlockStart": {"contentBlockIndex": 1, "start": {
+            "toolUse": {"toolUseId": "t1", "name": "one"},
+        }}},
+        {"contentBlockDelta": {"contentBlockIndex": 1, "delta": {
+            "toolUse": {"input": '{"n":1}'},
+        }}},
+        {"contentBlockStop": {"contentBlockIndex": 1}},
+        {"contentBlockStart": {"contentBlockIndex": 2, "start": {}}},
+        {"contentBlockDelta": {"contentBlockIndex": 2, "delta": {
+            "reasoningContent": {"redactedContent": b"r2"},
+        }}},
+        {"contentBlockStop": {"contentBlockIndex": 2}},
+        {"contentBlockStart": {"contentBlockIndex": 3, "start": {
+            "toolUse": {"toolUseId": "t2", "name": "two"},
+        }}},
+        {"contentBlockDelta": {"contentBlockIndex": 3, "delta": {
+            "toolUse": {"input": '{"n":2}'},
+        }}},
+        {"contentBlockStop": {"contentBlockIndex": 3}},
+        {"messageStop": {"stopReason": "tool_use"}},
+    ]}
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+def test_bedrock_transport_preserves_reasoning_and_order(streaming):
+    from agent.bedrock_adapter import normalize_converse_response, normalize_converse_stream_events, convert_messages_to_converse
+    from agent.transports.bedrock import BedrockTransport
+
+    raw = _stream_response() if streaming else _raw_response()
+    adapter_response = (
+        normalize_converse_stream_events(raw)
+        if streaming else normalize_converse_response(raw)
+    )
+    normalized = BedrockTransport().normalize_response(adapter_response)
+    assert normalized.provider_data["reasoning_details"] == [
+        {"type": "redacted_thinking", "data": "cjE="},
+        {"type": "redacted_thinking", "data": "cjI="},
+    ]
+
+    # Exercise the real history builder against the transport's canonical
+    # NormalizedResponse, rather than the adapter-only SimpleNamespace.
+    sys.modules.setdefault("requests", ModuleType("requests"))
+    from agent.chat_completion_helpers import build_assistant_message
+    history = build_assistant_message(_FakeAgent(), normalized, "tool_calls")
+    assert history["reasoning_details"] == normalized.provider_data["reasoning_details"]
+    assert history["bedrock_content_blocks"] == normalized.provider_data["bedrock_content_blocks"]
+    _system, messages = convert_messages_to_converse([
+        {"role": "user", "content": "go"}, history,
+    ])
+    blocks = messages[1]["content"]
+    assert [next(iter(block)) for block in blocks] == [
+        "reasoningContent", "toolUse", "reasoningContent", "toolUse"
+    ]
+    assert [block["reasoningContent"]["redactedContent"] for block in blocks if "reasoningContent" in block] == [b"r1", b"r2"]

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -140,6 +140,49 @@ class TestChatCompletionsBasic:
         # Original list untouched (deepcopy-on-demand)
         assert msgs[0]["timestamp"] == 1781976577.0
 
+    def test_convert_messages_strips_provider_replay_sidecars(self, transport):
+        """Native-provider replay channels must not cross a provider boundary.
+
+        ``bedrock_content_blocks`` intentionally remains in durable history so
+        Bedrock can restore signed/reasoning blocks in their original order.
+        Chat Completions providers do not recognize it, though, and strict
+        endpoints reject unknown keys in ``messages`` with HTTP 400/422.
+        """
+        msgs = [
+            {"role": "user", "content": "use a tool"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": "{}"},
+                    }
+                ],
+                "anthropic_content_blocks": [{"thinking": "signed"}],
+                "bedrock_content_blocks": [
+                    {"reasoningContent": {"redactedContentBase64": "cmVhc29uaW5n"}},
+                    {
+                        "toolUse": {
+                            "toolUseId": "call_1",
+                            "name": "lookup",
+                            "input": {},
+                        }
+                    },
+                ],
+            },
+        ]
+
+        result = transport.convert_messages(msgs, model="gpt-4o")
+
+        assert "anthropic_content_blocks" not in result[1]
+        assert "bedrock_content_blocks" not in result[1]
+        assert result[1]["tool_calls"] == msgs[1]["tool_calls"]
+        # Durable history remains available if this conversation returns to Bedrock.
+        assert "anthropic_content_blocks" in msgs[1]
+        assert "bedrock_content_blocks" in msgs[1]
+
     def test_convert_messages_no_copy_without_timestamp(self, transport):
         """A timestamp-free message list needs no sanitize pass and is
         returned by identity (preserves the deepcopy-on-demand contract)."""


### PR DESCRIPTION
## What does this PR do?

Preserves Amazon Bedrock Converse `reasoningContent.redactedContent` across response normalization and assistant replay. The opaque payload is retained byte-for-byte for both non-streaming and streaming responses, so follow-up tool turns remain valid.

## Related Issue

Fixes #93811

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/bedrock_adapter.py`
  - Encode redacted Bedrock reasoning bytes into `reasoning_details`.
  - Restore them as `reasoningContent.redactedContent` bytes during assistant replay.
  - Apply the same preservation in streaming normalization.
- `tests/agent/test_bedrock_adapter.py`
  - Add non-streaming normalization/replay regression coverage.
  - Add streaming redacted-reasoning regression coverage.

## How to Test

1. On the unmodified base commit `dff84f18901c3b3c082e7783ea03b7bb7b9ef6c7`, run:
   `python -m pytest tests/agent/test_bedrock_adapter.py -k redacted_reasoning -q`
   and observe `2 failed, 66 deselected`.
2. On this branch, run the same command: `3 passed, 66 deselected`.
3. Run the full adapter module: `64 passed, 5 skipped`.
4. Neighbor control `tests/agent/test_bedrock_empty_text_blocks.py`: `3 passed` on both base and fix.

The complete local evidence is recorded in `radar/reports/2026-08-24-hermes-43909-evidence/`.

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Windows 11

### Notes for Reviewer

This preserves the opaque payload without decoding or interpreting it. Ordinary text reasoning remains unchanged. The base red test and fixed green test are available in the linked evidence directory.