### PR TITLE
fix(update): back off to installable daily snapshots

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6152,6 +6152,29 @@ def _nixos_build_env() -> dict[str, str] | None:
         pass  # nix-shell not available — caller will get None
 
     return None
+
+
+def _npm_ci_failure_allows_install_fallback(output: str) -> bool:
+    """Whether a failed ``npm ci`` can plausibly be repaired by ``npm install``.
+
+    Registry/network/package-availability failures are identical for both
+    commands, so retrying them only doubles update latency.  The fallback is
+    useful for its original cases: a drifted lockfile or npm too old to know
+    the ``ci`` command.
+    """
+    lowered = (output or "").lower()
+    return any(
+        marker in lowered
+        for marker in (
+            "code eusage",
+            "package.json and package-lock.json are in sync",
+            "package-lock.json or npm-shrinkwrap.json with lockfileversion",
+            "unknown command: ci",
+            'unknown command "ci"',
+        )
+    )
+
+
 def _run_npm_install_deterministic(
     npm: str,
     cwd: Path,
@@ -6207,8 +6230,14 @@ def _run_npm_install_deterministic(
             ci_result = _run([npm_exe, "ci", "--include=dev", *extra_args])
             if ci_result.returncode == 0:
                 return ci_result
-            # Fall through to `npm install` — lockfile may be out of sync on a
-            # WIP fork/branch, or `npm ci` may not be available on very old npm.
+            combined = f"{ci_result.stdout or ''}\n{ci_result.stderr or ''}"
+            if not _npm_ci_failure_allows_install_fallback(combined):
+                # A registry/network/package-availability failure will fail
+                # identically under `npm install`; return immediately so the
+                # updater can try an older source snapshot instead.
+                return ci_result
+            # Lockfile drift (or an npm too old for `ci`) is the narrow case
+            # where `npm install --no-save` can genuinely recover.
         return _run([npm_exe, "install", "--no-save", "--include=dev", *extra_args])
 
     result = _attempt(npm)
@@ -9632,6 +9661,7 @@ def _install_python_dependencies_with_optional_fallback(
     *,
     env: dict[str, str] | None = None,
     group: str = "all",
+    require_all_extras: bool = False,
 ) -> None:
     """Install base deps plus as many optional extras as the environment supports.
 
@@ -9694,11 +9724,22 @@ def _install_python_dependencies_with_optional_fallback(
             strict_quarantine=True,
         )
 
+    initial_args = ["install"]
+    if require_all_extras and _is_uv_command(install_cmd_prefix):
+        # A selected fallback must be reproducible, not a venv carrying
+        # packages left behind by a failed newer candidate.
+        initial_args.append("--exact")
+    initial_args.extend(["-e", f".[{group}]"])
     try:
-        _install(["install", "-e", f".[{group}]"])
+        _install(initial_args)
         _verify_console_scripts_installed(install_cmd_prefix, env=env)
         return
     except subprocess.CalledProcessError:
+        if require_all_extras:
+            # Candidate validation is intentionally one-shot. Falling back to
+            # base + N individual extras multiplies a mirror outage into many
+            # slow failures and can leave a mixed environment.
+            raise
         print(
             "  ⚠ Optional extras failed, reinstalling base dependencies and retrying extras individually..."
         )

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1351,6 +1351,394 @@ def _print_called_process_error_tail(
         print(f"    {line}")
 
 
+class UpdateDependencyInstallError(RuntimeError):
+    """A candidate checkout could not install all required dependencies."""
+
+
+def _fast_update_dependency_env(
+    base: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Package-manager environment for fast, multi-candidate update probes.
+
+    ``hermes update`` can try up to eight daily source snapshots.  Leaving uv,
+    pip, and npm's normal retry/backoff policies enabled turns one blocked
+    package into many minutes per candidate before Hermes can try an older
+    known-good snapshot.  Keep a short per-request timeout and no in-command
+    retries; the day-by-day source fallback is the retry policy at this layer.
+    """
+    env = dict(os.environ if base is None else base)
+    env.update(
+        {
+            "UV_HTTP_RETRIES": "0",
+            "UV_HTTP_TIMEOUT": "15",
+            "PIP_RETRIES": "0",
+            "PIP_DEFAULT_TIMEOUT": "15",
+            "npm_config_fetch_retries": "0",
+            "npm_config_fetch_timeout": "15000",
+            "npm_config_fetch_retry_mintimeout": "1000",
+            "npm_config_fetch_retry_maxtimeout": "15000",
+        }
+    )
+    return env
+
+
+def _daily_dependency_backoff_candidates(
+    git_cmd: list[str],
+    cwd: Path,
+    *,
+    tip_sha: str,
+    lower_bound_sha: str,
+    max_days: int = 8,
+) -> list[str]:
+    """Return one first-parent upstream commit per prior 24-hour boundary.
+
+    Candidates must still contain the pre-update HEAD, so an update never
+    becomes a downgrade.  Empty days naturally repeat the previous commit and
+    are deduplicated.  Best effort: unavailable/shallow history yields fewer
+    candidates rather than making the primary update fail.
+    """
+    tip_time = subprocess.run(
+        git_cmd + ["show", "-s", "--format=%ct", tip_sha],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if tip_time.returncode != 0:
+        return []
+    try:
+        tip_epoch = int((tip_time.stdout or "").strip())
+    except ValueError:
+        return []
+
+    candidates: list[str] = []
+    seen = {tip_sha, lower_bound_sha}
+    for days in range(1, max_days + 1):
+        cutoff = tip_epoch - days * 86400
+        result = subprocess.run(
+            git_cmd
+            + [
+                "rev-list",
+                "-1",
+                "--first-parent",
+                f"--before=@{cutoff}",
+                tip_sha,
+            ],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        candidate = (result.stdout or "").strip() if result.returncode == 0 else ""
+        if not candidate or candidate in seen:
+            continue
+        contains_current = subprocess.run(
+            git_cmd + ["merge-base", "--is-ancestor", lower_bound_sha, candidate],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        if contains_current.returncode != 0:
+            break
+        seen.add(candidate)
+        candidates.append(candidate)
+    return candidates
+
+
+def _working_tree_clean_for_dependency_backoff(
+    git_cmd: list[str], cwd: Path
+) -> bool:
+    """Fail-closed cleanliness probe immediately before a destructive reset."""
+    status = subprocess.run(
+        git_cmd + ["status", "--porcelain", "--untracked-files=all"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    return status.returncode == 0 and not (status.stdout or "").strip()
+
+
+def _run_dependency_attempts_with_daily_backoff(
+    git_cmd: list[str],
+    cwd: Path,
+    *,
+    tip_sha: str,
+    lower_bound_sha: str,
+    install_attempt,
+    max_days: int = 8,
+    on_all_failed=None,
+    target_branch: str = "main",
+):
+    """Try dependency installation at tip, then one older commit per day.
+
+    ``install_attempt`` receives the candidate SHA and must either return its
+    result or raise ``CalledProcessError``/``UpdateDependencyInstallError``.
+    Older candidates are selected with transactional ``checkout -B``. Git
+    therefore refuses rather than overwrites a concurrent local edit, and only
+    moves the target branch after the checkout itself succeeds. The next normal
+    update sees that branch behind its remote and retries newer commits. If
+    every candidate fails, source is restored to the pre-update SHA before the
+    original failure is re-raised.
+    """
+    tip_contains_current = subprocess.run(
+        git_cmd + ["merge-base", "--is-ancestor", lower_bound_sha, tip_sha],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if tip_contains_current.returncode != 0:
+        if _working_tree_clean_for_dependency_backoff(git_cmd, cwd):
+            restore = subprocess.run(
+                git_cmd + ["checkout", "-B", target_branch, lower_bound_sha],
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+            if restore.returncode != 0:
+                if on_all_failed is not None:
+                    on_all_failed()
+                raise UpdateDependencyInstallError(
+                    "fetched tip does not contain the pre-update HEAD and "
+                    "failed to restore pre-update source"
+                )
+        if on_all_failed is not None:
+            on_all_failed()
+        raise UpdateDependencyInstallError(
+            "fetched tip does not contain the pre-update HEAD"
+        )
+
+    candidates = [tip_sha] + _daily_dependency_backoff_candidates(
+        git_cmd,
+        cwd,
+        tip_sha=tip_sha,
+        lower_bound_sha=lower_bound_sha,
+        max_days=max_days,
+    )
+    last_error: BaseException | None = None
+    for index, candidate in enumerate(candidates):
+        if index:
+            if not _working_tree_clean_for_dependency_backoff(git_cmd, cwd):
+                if on_all_failed is not None:
+                    on_all_failed()
+                raise UpdateDependencyInstallError(
+                    "working tree became dirty during dependency validation; "
+                    "refusing to reset it"
+                ) from last_error
+            print(
+                f"  → Dependency install failed; trying the update from "
+                f"{index} day(s) earlier ({candidate[:10]})..."
+            )
+            checkout = subprocess.run(
+                git_cmd + ["checkout", "-B", target_branch, candidate],
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+            if checkout.returncode != 0:
+                if not _working_tree_clean_for_dependency_backoff(git_cmd, cwd):
+                    if on_all_failed is not None:
+                        on_all_failed()
+                    raise UpdateDependencyInstallError(
+                        "working tree changed while selecting a dependency "
+                        "candidate; checkout refused without overwriting it"
+                    ) from last_error
+                continue
+            if not _working_tree_clean_for_dependency_backoff(git_cmd, cwd):
+                if on_all_failed is not None:
+                    on_all_failed()
+                raise UpdateDependencyInstallError(
+                    "working tree changed while selecting a dependency "
+                    "candidate; changes were preserved"
+                ) from last_error
+            syntax_ok, failing_path, syntax_error = _validate_critical_files_syntax(
+                cwd
+            )
+            if not syntax_ok:
+                print(
+                    f"  ⚠ Skipping {candidate[:10]}: critical source does not "
+                    f"parse ({failing_path}: {syntax_error})"
+                )
+                continue
+            _m()._clear_bytecode_cache(cwd)
+        try:
+            return candidate, install_attempt(candidate)
+        except (subprocess.CalledProcessError, UpdateDependencyInstallError) as exc:
+            last_error = exc
+            if isinstance(exc, subprocess.CalledProcessError):
+                _print_called_process_error_tail(exc)
+            else:
+                print(f"  ⚠ {exc}")
+
+    if _working_tree_clean_for_dependency_backoff(git_cmd, cwd):
+        restore = subprocess.run(
+            git_cmd + ["checkout", "-B", target_branch, lower_bound_sha],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        if restore.returncode != 0:
+            if on_all_failed is not None:
+                on_all_failed()
+            detail = (restore.stderr or restore.stdout or "").strip()
+            suffix = f": {detail.splitlines()[0]}" if detail else ""
+            raise UpdateDependencyInstallError(
+                "all update targets failed and failed to restore pre-update "
+                f"source{suffix}"
+            ) from last_error
+    else:
+        if on_all_failed is not None:
+            on_all_failed()
+        raise UpdateDependencyInstallError(
+            "working tree became dirty during dependency validation; "
+            "source was left untouched"
+        ) from last_error
+    if on_all_failed is not None:
+        on_all_failed()
+    if last_error is not None:
+        raise UpdateDependencyInstallError(
+            f"all update targets failed ({last_error})"
+        ) from last_error
+    raise UpdateDependencyInstallError("no eligible update target could be tested")
+
+
+def _install_update_candidate_dependencies(
+    git_cmd: list[str], *, pre_pull_sha: str | None, force_reinstall: bool = False
+) -> dict:
+    """Install Python + Node dependencies for the checkout currently on disk.
+
+    This is deliberately one candidate-sized transaction so the caller can
+    reset to an older upstream commit and repeat the exact same validation.
+    Returns the Python install context needed by the later lazy-dependency
+    refresh after a candidate has been accepted.
+    """
+    deps_current = not force_reinstall and _editable_install_is_current(
+        git_cmd, _m().PROJECT_ROOT, pre_pull_sha
+    )
+    if deps_current:
+        print("→ Python dependencies unchanged — skipping reinstall")
+    else:
+        print("→ Updating Python dependencies...")
+
+    from hermes_cli.managed_uv import (
+        ensure_uv,
+        managed_python_env,
+        update_managed_uv,
+    )
+
+    update_managed_uv()
+    uv_bin = ensure_uv()
+    pip_cmd = [_m().sys.executable, "-m", "pip"]
+    if not uv_bin:
+        uv_bin = _ensure_uv_for_termux(pip_cmd)
+    if force_reinstall and not uv_bin:
+        raise UpdateDependencyInstallError(
+            "validating an older update candidate requires uv exact-sync; "
+            "pip cannot prove the environment is uncontaminated"
+        )
+    install_group = "all"
+    install_env: dict[str, str] | None = None
+
+    if uv_bin:
+        install_env = _fast_update_dependency_env(managed_python_env())
+        install_env["VIRTUAL_ENV"] = str(_m().PROJECT_ROOT / "venv")
+        if _m()._is_termux_env(install_env):
+            install_env.pop("PYTHONPATH", None)
+            install_env.pop("PYTHONHOME", None)
+            install_group = "termux-all"
+            print(
+                "  → Termux detected: using uv + curated termux-all optional profile..."
+            )
+        install_prefix = [uv_bin, "pip"]
+        if not deps_current:
+            if _m()._is_termux_env(install_env) and _is_android_python():
+                print(
+                    "  → Termux/Android detected: prebuilding psutil with "
+                    "Linux source path compatibility..."
+                )
+                _install_psutil_android_compat(install_prefix, env=install_env)
+            _m()._install_python_dependencies_with_optional_fallback(
+                install_prefix,
+                env=install_env,
+                group=install_group,
+                require_all_extras=True,
+            )
+    else:
+        install_env = _fast_update_dependency_env()
+        try:
+            subprocess.run(
+                pip_cmd + ["--version"],
+                cwd=_m().PROJECT_ROOT,
+                check=True,
+                capture_output=True,
+                env=install_env,
+            )
+        except subprocess.CalledProcessError:
+            subprocess.run(
+                [
+                    _m().sys.executable,
+                    "-m",
+                    "ensurepip",
+                    "--upgrade",
+                    "--default-pip",
+                ],
+                cwd=_m().PROJECT_ROOT,
+                check=True,
+                env=install_env,
+            )
+        if _m()._is_termux_env(install_env):
+            install_group = "termux-all"
+            print("  → Termux detected: using curated termux-all optional profile...")
+        install_prefix = pip_cmd
+        if not deps_current:
+            if _m()._is_termux_env(install_env) and _is_android_python():
+                print(
+                    "  → Termux/Android detected: prebuilding psutil with "
+                    "Linux source path compatibility..."
+                )
+                _install_psutil_android_compat(pip_cmd, env=install_env)
+            _m()._install_python_dependencies_with_optional_fallback(
+                pip_cmd,
+                env=install_env,
+                group=install_group,
+                require_all_extras=True,
+            )
+
+    if deps_current:
+        _m()._verify_core_dependencies_installed(
+            install_prefix, env=install_env, group=install_group
+        )
+        _m()._verify_console_scripts_installed(install_prefix, env=install_env)
+
+    _m()._clear_update_incomplete_marker()
+
+    node_failures = _update_node_dependencies(force=force_reinstall)
+    if node_failures:
+        raise UpdateDependencyInstallError(
+            "Node.js dependency install failed for: " + ", ".join(node_failures)
+        )
+
+    return {
+        "install_prefix": install_prefix,
+        "lazy_env": install_env,
+        "install_group": install_group,
+        "node_failures": node_failures,
+    }
+
+
 def _zip_overlay_block_reason(
     root: Path, *, ignore_staging_artifacts: bool = False
 ) -> Optional[str]:
@@ -3050,7 +3438,7 @@ def _repair_node_deps_on_current_checkout(print_completion) -> None:
     print_completion("✓ Already up to date!")
 
 
-def _update_node_dependencies() -> list[str]:
+def _update_node_dependencies(*, force: bool = False) -> list[str]:
     """Refresh Node deps for the ui-tui and web workspaces.
 
     Returns the list of labels whose npm install failed (empty on success),
@@ -3100,7 +3488,7 @@ def _update_node_dependencies() -> list[str]:
     except Exception:
         pass
 
-    if not _m()._npm_lockfile_changed(shared_hermes_root):
+    if not force and not _m()._npm_lockfile_changed(shared_hermes_root):
         logger.info("npm lockfile unchanged, skipping npm install")
         return []
 
@@ -3137,7 +3525,9 @@ def _update_node_dependencies() -> list[str]:
 
     from hermes_constants import with_hermes_node_path
 
-    nixos_env = with_hermes_node_path(_m()._nixos_build_env())
+    nixos_env = _fast_update_dependency_env(
+        with_hermes_node_path(_m()._nixos_build_env())
+    )
 
     # NOTE: capture_output=False here is deliberate (#18840) — optional
     # postinstall scripts print download progress, and capturing it makes a
@@ -6737,91 +7127,52 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # via ``_recover_from_interrupted_install``. Cleared after the core
         # ``.[all]`` install completes — lazy refresh uses a separate marker.
         _write_update_incomplete_marker()
-        deps_current = _editable_install_is_current(
-            git_cmd, _m().PROJECT_ROOT, pre_pull_sha
-        )
-        if deps_current:
-            print("→ Python dependencies unchanged — skipping reinstall")
-        else:
-            print("→ Updating Python dependencies...")
-        from hermes_cli.managed_uv import ensure_uv, update_managed_uv
+        dependency_tip_sha = post_pull_sha
 
-        # Keep managed uv current — runs `uv self update` if we already have one.
-        update_managed_uv()
-
-        uv_bin = ensure_uv()
-
-        pip_cmd = [sys.executable, "-m", "pip"]
-        if not uv_bin:
-            uv_bin = _ensure_uv_for_termux(pip_cmd)
-        install_group = "all"
-
-        if uv_bin:
-            # Use official managed_python_env() isolation so third-party
-            # UV_PYTHON_INSTALL_DIR (e.g. WorkBuddy) cannot hijack uv; then
-            # point VIRTUAL_ENV at this install's venv.
-            from hermes_cli.managed_uv import managed_python_env
-
-            uv_env = managed_python_env()
-            uv_env["VIRTUAL_ENV"] = str(_m().PROJECT_ROOT / "venv")
-            if _m()._is_termux_env(uv_env):
-                uv_env.pop("PYTHONPATH", None)
-                uv_env.pop("PYTHONHOME", None)
-                install_group = "termux-all"
-                print("  → Termux detected: using uv + curated termux-all optional profile...")
-            if not deps_current:
-                if _m()._is_termux_env(uv_env) and _is_android_python():
-                    print("  → Termux/Android detected: prebuilding psutil with Linux source path compatibility...")
-                    _install_psutil_android_compat([uv_bin, "pip"], env=uv_env)
-                _m()._install_python_dependencies_with_optional_fallback(
-                    [uv_bin, "pip"], env=uv_env, group=install_group
-                )
-        else:
-            # Use sys.executable to explicitly call the venv's pip module,
-            # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu.
-            # Some environments lose pip inside the venv; bootstrap it back with
-            # ensurepip before trying the editable install.
-            pip_cmd = [sys.executable, "-m", "pip"]
-            try:
-                subprocess.run(
-                    pip_cmd + ["--version"],
-                    cwd=_m().PROJECT_ROOT,
-                    check=True,
-                    capture_output=True,
-                )
-            except subprocess.CalledProcessError:
-                subprocess.run(
-                    [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
-                    cwd=_m().PROJECT_ROOT,
-                    check=True,
-                )
-            if _m()._is_termux_env():
-                install_group = "termux-all"
-                print("  → Termux detected: using curated termux-all optional profile...")
-            if not deps_current:
-                if _m()._is_termux_env() and _is_android_python():
-                    print("  → Termux/Android detected: prebuilding psutil with Linux source path compatibility...")
-                    _install_psutil_android_compat(pip_cmd)
-                _m()._install_python_dependencies_with_optional_fallback(pip_cmd, group=install_group)
-
-        install_prefix = [uv_bin, "pip"] if uv_bin else pip_cmd
-        lazy_env = uv_env if uv_bin else None
-
-        if deps_current:
-            # The verification normally runs inside the install we just
-            # skipped. Run it here so a wrong skip self-heals into a real
-            # install (both verifiers reinstall what they find missing)
-            # instead of leaving a venv nobody checked.
-            _m()._verify_core_dependencies_installed(
-                install_prefix, env=lazy_env, group=install_group
+        def _install_candidate(_candidate_sha: str):
+            # Each retry can mutate the venv, so renew the crash-recovery
+            # breadcrumb before every candidate attempt.
+            _write_update_incomplete_marker()
+            return _install_update_candidate_dependencies(
+                git_cmd,
+                pre_pull_sha=pre_pull_sha,
+                force_reinstall=_candidate_sha != dependency_tip_sha,
             )
-            _m()._verify_console_scripts_installed(install_prefix, env=lazy_env)
 
-        # Core ``.[all]`` install finished. Clear the generic core breadcrumb
-        # before the lazy-refresh phase — that phase uses its own marker so a
-        # later lazy failure cannot be "healed" by clearing the core marker
-        # based on a narrow 7-package import probe (#58004 review).
-        _m()._clear_update_incomplete_marker()
+        # Moving to a historical upstream commit is only attempted while the
+        # tree is clean. A normal interactive autostash may already
+        # have been restored above; in that case preserve the user's files and
+        # surface the install failure without attempting source backoff.
+        can_backoff = bool(pre_pull_sha and post_pull_sha) and (
+            auto_stash_ref is None or keep_stash or discard_local_changes
+        )
+        if can_backoff:
+            selected_sha, dependency_state = (
+                _run_dependency_attempts_with_daily_backoff(
+                    git_cmd,
+                    _m().PROJECT_ROOT,
+                    tip_sha=post_pull_sha,
+                    lower_bound_sha=pre_pull_sha,
+                    install_attempt=_install_candidate,
+                    max_days=8,
+                    on_all_failed=_write_update_incomplete_marker,
+                    target_branch=branch,
+                )
+            )
+            if selected_sha != post_pull_sha:
+                print(
+                    f"  ✓ Selected upstream commit {selected_sha[:10]} after "
+                    "dependency validation; newer commits remain available "
+                    "for the next update."
+                )
+                post_pull_sha = selected_sha
+        else:
+            dependency_state = _install_candidate(post_pull_sha or "HEAD")
+
+        install_prefix = dependency_state["install_prefix"]
+        lazy_env = dependency_state["lazy_env"]
+        install_group = dependency_state["install_group"]
+        node_failures = dependency_state["node_failures"]
 
         # The update process is still the old Python interpreter process. Run
         # one final cache/module refresh immediately before lazy backend
@@ -6887,7 +7238,6 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print("    Run `hermes update` again — if it persists, reinstall:")
             print("    https://hermes-agent.nousresearch.com")
 
-        node_failures = _update_node_dependencies()
         _m()._build_web_ui(_m().PROJECT_ROOT / "web")
 
         desktop_build_ok = _rebuild_desktop_after_update(
@@ -8376,6 +8726,21 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # Fail-closed shim contention (#87331): strict quarantine refused
         # BEFORE any installer ran — defer via marker, exit 2, no ZIP.
         _refuse_update_for_contended_shims(e)
+    except UpdateDependencyInstallError as e:
+        print(f"✗ Dependency validation failed for every eligible update target: {e}")
+        print(
+            "  The updater refused candidate checkouts if files appeared. When "
+            "the tree stayed clean it attempted to restore the pre-update "
+            "commit; inspect `git status` if a rollback failure is reported. "
+            "The recovery marker remains for the next launch."
+        )
+        try:
+            from hermes_cli.update_receipt import finalize_update_receipt
+
+            finalize_update_receipt("failed")
+        except Exception:
+            pass
+        sys.exit(1)
     except subprocess.CalledProcessError as e:
         stage = _format_update_failure_stage(e)
         if _should_zip_fallback_on_update_error(e):

--- a/tests/hermes_cli/test_update_dependency_backoff.py
+++ b/tests/hermes_cli/test_update_dependency_backoff.py
@@ -1,0 +1,573 @@
+"""Dependency-install fallback tests for ``hermes update``."""
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import update_cmd
+
+
+def _completed(cmd, returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(cmd, returncode, stdout, stderr)
+
+
+def test_daily_backoff_candidates_select_one_upstream_commit_per_day(monkeypatch, tmp_path):
+    responses = {
+        "@1727913600": "day1\n",
+        "@1727827200": "day2\n",
+        "@1727740800": "day2\n",  # no commit that day: deduplicated
+        "@1727654400": "too-old\n",
+    }
+
+    def fake_run(cmd, **_kwargs):
+        joined = " ".join(cmd)
+        if "show -s --format=%ct tip" in joined:
+            return _completed(cmd, stdout="1728000000\n")
+        if "rev-list -1 --first-parent --before=" in joined:
+            stamp = next(key for key in responses if key in joined)
+            return _completed(cmd, stdout=responses[stamp])
+        if "merge-base --is-ancestor base" in joined:
+            return _completed(cmd, returncode=1 if cmd[-1] == "too-old" else 0)
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+
+    assert update_cmd._daily_dependency_backoff_candidates(
+        ["git"], tmp_path, tip_sha="tip", lower_bound_sha="base", max_days=4
+    ) == ["day1", "day2"]
+
+
+def test_dependency_attempt_backs_off_and_keeps_successful_upstream_target(
+    monkeypatch, tmp_path, capsys
+):
+    monkeypatch.setattr(
+        update_cmd,
+        "_daily_dependency_backoff_candidates",
+        lambda *_args, **_kwargs: ["older-1", "older-2"],
+    )
+    checkouts = []
+
+    def fake_run(cmd, **_kwargs):
+        if "checkout" in cmd:
+            checkouts.append(cmd[-1])
+        return _completed(cmd)
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+    attempts = []
+
+    def install(candidate):
+        attempts.append(candidate)
+        if candidate in {"tip", "older-1"}:
+            raise subprocess.CalledProcessError(1, ["uv", "pip", "install"])
+        return {"candidate": candidate}
+
+    selected, result = update_cmd._run_dependency_attempts_with_daily_backoff(
+        ["git"],
+        tmp_path,
+        tip_sha="tip",
+        lower_bound_sha="base",
+        install_attempt=install,
+        max_days=8,
+    )
+
+    assert selected == "older-2"
+    assert result == {"candidate": "older-2"}
+    assert attempts == ["tip", "older-1", "older-2"]
+    assert checkouts == ["older-1", "older-2"]
+    assert "trying the update from 2 day(s) earlier" in capsys.readouterr().out
+
+
+def test_dependency_attempt_treats_node_failure_as_candidate_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        update_cmd,
+        "_daily_dependency_backoff_candidates",
+        lambda *_args, **_kwargs: ["older"],
+    )
+    monkeypatch.setattr(
+        update_cmd.subprocess,
+        "run",
+        lambda cmd, **_kwargs: _completed(cmd),
+    )
+
+    def install(candidate):
+        if candidate == "tip":
+            raise update_cmd.UpdateDependencyInstallError(
+                "Node.js dependency install failed"
+            )
+        return "ok"
+
+    assert update_cmd._run_dependency_attempts_with_daily_backoff(
+        ["git"],
+        tmp_path,
+        tip_sha="tip",
+        lower_bound_sha="base",
+        install_attempt=install,
+    ) == ("older", "ok")
+
+
+def test_dependency_attempt_restores_original_source_when_every_candidate_fails(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        update_cmd,
+        "_daily_dependency_backoff_candidates",
+        lambda *_args, **_kwargs: ["older"],
+    )
+    checkouts = []
+
+    def fake_run(cmd, **_kwargs):
+        if "checkout" in cmd:
+            checkouts.append(cmd[-1])
+        return _completed(cmd)
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+
+    def install(_candidate):
+        raise subprocess.CalledProcessError(1, ["uv", "pip", "install"])
+
+    failed_callbacks = []
+    with pytest.raises(update_cmd.UpdateDependencyInstallError, match="all update targets"):
+        update_cmd._run_dependency_attempts_with_daily_backoff(
+            ["git"],
+            tmp_path,
+            tip_sha="tip",
+            lower_bound_sha="base",
+            install_attempt=install,
+            on_all_failed=lambda: failed_callbacks.append(True),
+        )
+
+    assert checkouts == ["older", "base"]
+    assert failed_callbacks == [True]
+
+
+def test_dependency_backoff_refuses_checkout_when_files_appear_mid_update(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        update_cmd,
+        "_daily_dependency_backoff_candidates",
+        lambda *_args, **_kwargs: ["older"],
+    )
+    monkeypatch.setattr(
+        update_cmd,
+        "_working_tree_clean_for_dependency_backoff",
+        lambda *_args, **_kwargs: False,
+    )
+    checkouts = []
+
+    def fake_run(cmd, **_kwargs):
+        if "merge-base" in cmd:
+            return _completed(cmd)
+        if "checkout" in cmd:
+            checkouts.append(cmd[-1])
+        return _completed(cmd)
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+
+    with pytest.raises(
+        update_cmd.UpdateDependencyInstallError, match="working tree became dirty"
+    ):
+        update_cmd._run_dependency_attempts_with_daily_backoff(
+            ["git"],
+            tmp_path,
+            tip_sha="tip",
+            lower_bound_sha="base",
+            install_attempt=lambda _candidate: (_ for _ in ()).throw(
+                subprocess.CalledProcessError(1, ["uv", "pip", "install"])
+            ),
+        )
+
+    assert checkouts == []
+
+
+def test_checkout_toctou_preserves_edit_created_after_clean_probe(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        update_cmd,
+        "_daily_dependency_backoff_candidates",
+        lambda *_args, **_kwargs: ["older"],
+    )
+    cleanliness = iter([True, False])
+    monkeypatch.setattr(
+        update_cmd,
+        "_working_tree_clean_for_dependency_backoff",
+        lambda *_args, **_kwargs: next(cleanliness),
+    )
+    checkouts = []
+
+    def fake_run(cmd, **_kwargs):
+        if "merge-base" in cmd:
+            return _completed(cmd)
+        if "checkout" in cmd:
+            checkouts.append(cmd[-1])
+            # Real non-forced checkout refuses when the racing edit conflicts.
+            return _completed(cmd, returncode=1, stderr="local changes would be overwritten")
+        return _completed(cmd)
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+
+    with pytest.raises(
+        update_cmd.UpdateDependencyInstallError,
+        match="checkout refused without overwriting",
+    ):
+        update_cmd._run_dependency_attempts_with_daily_backoff(
+            ["git"],
+            tmp_path,
+            tip_sha="tip",
+            lower_bound_sha="base",
+            install_attempt=lambda _candidate: (_ for _ in ()).throw(
+                subprocess.CalledProcessError(1, ["uv", "pip", "install"])
+            ),
+        )
+
+    assert checkouts == ["older"]
+
+
+def test_git_checkout_B_is_transactional_when_local_edit_would_be_lost(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args):
+        return subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+
+    assert git("init", "-b", "main").returncode == 0
+    git("config", "user.email", "test@example.invalid")
+    git("config", "user.name", "Hermes Test")
+    tracked = repo / "tracked.txt"
+    tracked.write_text("base\n", encoding="utf-8")
+    git("add", "tracked.txt")
+    assert git("commit", "-m", "base").returncode == 0
+    base = git("rev-parse", "HEAD").stdout.strip()
+
+    tracked.write_text("tip\n", encoding="utf-8")
+    git("add", "tracked.txt")
+    assert git("commit", "-m", "tip").returncode == 0
+    tip = git("rev-parse", "HEAD").stdout.strip()
+    tracked.write_text("user edit\n", encoding="utf-8")
+
+    checkout = git("checkout", "-B", "main", base)
+
+    assert checkout.returncode != 0
+    assert git("rev-parse", "HEAD").stdout.strip() == tip
+    assert tracked.read_text(encoding="utf-8") == "user edit\n"
+
+
+def test_dependency_backoff_never_attempts_tip_below_pre_update_head(
+    monkeypatch, tmp_path
+):
+    installs = []
+    checkouts = []
+
+    def fake_run(cmd, **_kwargs):
+        if "merge-base" in cmd:
+            return _completed(cmd, returncode=1)
+        if "checkout" in cmd:
+            checkouts.append(cmd[-1])
+        return _completed(cmd)
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        update_cmd, "_working_tree_clean_for_dependency_backoff", lambda *_args: True
+    )
+
+    with pytest.raises(
+        update_cmd.UpdateDependencyInstallError, match="does not contain the pre-update HEAD"
+    ):
+        update_cmd._run_dependency_attempts_with_daily_backoff(
+            ["git"],
+            tmp_path,
+            tip_sha="tip",
+            lower_bound_sha="base",
+            install_attempt=lambda candidate: installs.append(candidate),
+        )
+
+    assert installs == []
+    assert checkouts == ["base"]
+
+
+def test_fast_dependency_network_env_disables_package_manager_retries():
+    env = update_cmd._fast_update_dependency_env({"KEEP": "yes"})
+
+    assert env["KEEP"] == "yes"
+    assert env["UV_HTTP_RETRIES"] == "0"
+    assert env["UV_HTTP_TIMEOUT"] == "15"
+    assert env["PIP_RETRIES"] == "0"
+    assert env["PIP_DEFAULT_TIMEOUT"] == "15"
+    assert env["npm_config_fetch_retries"] == "0"
+    assert env["npm_config_fetch_timeout"] == "15000"
+
+
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [
+        ("npm ERR! code EUSAGE\nnpm ci can only install packages when package.json and package-lock.json are in sync", True),
+        ("Unknown command: ci", True),
+        ("npm ERR! 404 Not Found - GET https://registry/pkg", False),
+        ("npm ERR! network request timed out", False),
+    ],
+)
+def test_npm_ci_only_falls_back_to_install_for_lockfile_or_old_npm_errors(
+    output, expected
+):
+    from hermes_cli import main as hm
+
+    assert hm._npm_ci_failure_allows_install_fallback(output) is expected
+
+
+def test_install_update_candidate_uses_fast_env_and_requires_node_success(
+    monkeypatch, tmp_path
+):
+    installs = []
+    fake_main = SimpleNamespace(
+        PROJECT_ROOT=tmp_path,
+        sys=SimpleNamespace(executable="python"),
+        _is_windows=lambda: False,
+        _is_termux_env=lambda _env=None: False,
+        _install_python_dependencies_with_optional_fallback=lambda prefix, **kwargs: installs.append(
+            (prefix, kwargs)
+        ),
+        _verify_core_dependencies_installed=lambda *_args, **_kwargs: None,
+        _verify_console_scripts_installed=lambda *_args, **_kwargs: None,
+        _clear_update_incomplete_marker=lambda: None,
+    )
+    monkeypatch.setattr(update_cmd, "_m", lambda: fake_main)
+    monkeypatch.setattr(update_cmd, "_editable_install_is_current", lambda *_args: False)
+    node_forces = []
+    monkeypatch.setattr(
+        update_cmd,
+        "_update_node_dependencies",
+        lambda *, force=False: node_forces.append(force) or [],
+    )
+    monkeypatch.setattr("hermes_cli.managed_uv.update_managed_uv", lambda: None)
+    monkeypatch.setattr("hermes_cli.managed_uv.ensure_uv", lambda: "uv")
+    monkeypatch.setattr(
+        "hermes_cli.managed_uv.managed_python_env", lambda: {"KEEP": "yes"}
+    )
+
+    state = update_cmd._install_update_candidate_dependencies(
+        ["git"], pre_pull_sha="base"
+    )
+
+    assert installs[0][0] == ["uv", "pip"]
+    install_env = installs[0][1]["env"]
+    assert install_env["KEEP"] == "yes"
+    assert install_env["UV_HTTP_RETRIES"] == "0"
+    assert install_env["npm_config_fetch_retries"] == "0"
+    assert installs[0][1]["require_all_extras"] is True
+    assert state["install_prefix"] == ["uv", "pip"]
+    assert state["node_failures"] == []
+    assert node_forces == [False]
+
+
+def test_install_update_candidate_raises_when_node_dependencies_fail(
+    monkeypatch, tmp_path
+):
+    fake_main = SimpleNamespace(
+        PROJECT_ROOT=tmp_path,
+        sys=SimpleNamespace(executable="python"),
+        _is_windows=lambda: False,
+        _is_termux_env=lambda _env=None: False,
+        _install_python_dependencies_with_optional_fallback=lambda *_args, **_kwargs: None,
+        _verify_core_dependencies_installed=lambda *_args, **_kwargs: None,
+        _verify_console_scripts_installed=lambda *_args, **_kwargs: None,
+        _clear_update_incomplete_marker=lambda: None,
+    )
+    monkeypatch.setattr(update_cmd, "_m", lambda: fake_main)
+    monkeypatch.setattr(update_cmd, "_editable_install_is_current", lambda *_args: False)
+    monkeypatch.setattr(
+        update_cmd,
+        "_update_node_dependencies",
+        lambda *, force=False: ["ui-tui, web workspaces"],
+    )
+    monkeypatch.setattr("hermes_cli.managed_uv.update_managed_uv", lambda: None)
+    monkeypatch.setattr("hermes_cli.managed_uv.ensure_uv", lambda: "uv")
+    monkeypatch.setattr("hermes_cli.managed_uv.managed_python_env", lambda: {})
+
+    with pytest.raises(
+        update_cmd.UpdateDependencyInstallError, match="Node.js dependency install failed"
+    ):
+        update_cmd._install_update_candidate_dependencies(
+            ["git"], pre_pull_sha="base"
+        )
+
+
+def test_older_candidate_forces_clean_python_and_node_reinstall(monkeypatch, tmp_path):
+    installs = []
+    node_forces = []
+    fake_main = SimpleNamespace(
+        PROJECT_ROOT=tmp_path,
+        sys=SimpleNamespace(executable="python"),
+        _is_windows=lambda: False,
+        _is_termux_env=lambda _env=None: False,
+        _install_python_dependencies_with_optional_fallback=lambda prefix, **kwargs: installs.append(
+            (prefix, kwargs)
+        ),
+        _verify_core_dependencies_installed=lambda *_args, **_kwargs: None,
+        _verify_console_scripts_installed=lambda *_args, **_kwargs: None,
+        _clear_update_incomplete_marker=lambda: None,
+    )
+    monkeypatch.setattr(update_cmd, "_m", lambda: fake_main)
+    monkeypatch.setattr(update_cmd, "_editable_install_is_current", lambda *_args: True)
+    monkeypatch.setattr(
+        update_cmd,
+        "_update_node_dependencies",
+        lambda *, force=False: node_forces.append(force) or [],
+    )
+    monkeypatch.setattr("hermes_cli.managed_uv.update_managed_uv", lambda: None)
+    monkeypatch.setattr("hermes_cli.managed_uv.ensure_uv", lambda: "uv")
+    monkeypatch.setattr("hermes_cli.managed_uv.managed_python_env", lambda: {})
+
+    update_cmd._install_update_candidate_dependencies(
+        ["git"], pre_pull_sha="base", force_reinstall=True
+    )
+
+    assert len(installs) == 1
+    assert installs[0][1]["require_all_extras"] is True
+    assert node_forces == [True]
+
+
+def test_older_candidate_requires_uv_for_exact_environment(monkeypatch, tmp_path):
+    fake_main = SimpleNamespace(
+        PROJECT_ROOT=tmp_path,
+        sys=SimpleNamespace(executable="python"),
+        _is_windows=lambda: False,
+        _is_termux_env=lambda _env=None: False,
+    )
+    monkeypatch.setattr(update_cmd, "_m", lambda: fake_main)
+    monkeypatch.setattr(update_cmd, "_editable_install_is_current", lambda *_args: True)
+    monkeypatch.setattr(update_cmd, "_ensure_uv_for_termux", lambda _cmd: None)
+    monkeypatch.setattr("hermes_cli.managed_uv.update_managed_uv", lambda: None)
+    monkeypatch.setattr("hermes_cli.managed_uv.ensure_uv", lambda: None)
+
+    with pytest.raises(
+        update_cmd.UpdateDependencyInstallError, match="requires uv exact-sync"
+    ):
+        update_cmd._install_update_candidate_dependencies(
+            ["git"], pre_pull_sha="base", force_reinstall=True
+        )
+
+
+def test_all_fail_raises_when_source_rollback_fails(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        update_cmd, "_daily_dependency_backoff_candidates", lambda *_a, **_k: []
+    )
+    monkeypatch.setattr(
+        update_cmd, "_working_tree_clean_for_dependency_backoff", lambda *_a: True
+    )
+
+    def fake_run(cmd, **_kwargs):
+        if "merge-base" in cmd:
+            return _completed(cmd)
+        if "checkout" in cmd:
+            return _completed(cmd, returncode=1, stderr="cannot checkout")
+        return _completed(cmd)
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+
+    with pytest.raises(
+        update_cmd.UpdateDependencyInstallError, match="failed to restore pre-update source"
+    ):
+        update_cmd._run_dependency_attempts_with_daily_backoff(
+            ["git"],
+            tmp_path,
+            tip_sha="tip",
+            lower_bound_sha="base",
+            install_attempt=lambda _candidate: (_ for _ in ()).throw(
+                subprocess.CalledProcessError(1, ["uv", "pip", "install"])
+            ),
+        )
+
+
+def test_deterministic_npm_does_not_retry_registry_failure_as_install(
+    monkeypatch, tmp_path
+):
+    from hermes_cli import main as hm
+
+    (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
+    calls = []
+
+    def fail_registry(cmd, **_kwargs):
+        calls.append(cmd)
+        return _completed(cmd, 1, stderr="npm ERR! 404 Not Found")
+
+    monkeypatch.setattr(hm, "_run_npm_watching_for_engine_failure", fail_registry)
+    monkeypatch.setattr("hermes_cli.npm_engine.maybe_repair_npm_engine", lambda *_args: None)
+
+    result = hm._run_npm_install_deterministic("npm", tmp_path)
+
+    assert result.returncode == 1
+    assert [cmd[1] for cmd in calls] == ["ci"]
+
+
+def test_deterministic_npm_retries_lockfile_drift_as_install(monkeypatch, tmp_path):
+    from hermes_cli import main as hm
+
+    (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
+    calls = []
+
+    def run(cmd, **_kwargs):
+        calls.append(cmd)
+        if cmd[1] == "ci":
+            return _completed(cmd, 1, stderr="npm ERR! code EUSAGE")
+        return _completed(cmd)
+
+    monkeypatch.setattr(hm, "_run_npm_watching_for_engine_failure", run)
+
+    result = hm._run_npm_install_deterministic("npm", tmp_path)
+
+    assert result.returncode == 0
+    assert [cmd[1] for cmd in calls] == ["ci", "install"]
+
+
+def test_strict_python_candidate_fails_after_one_exact_uv_attempt(monkeypatch):
+    from hermes_cli import main as hm
+
+    calls = []
+
+    def fail(cmd, **_kwargs):
+        calls.append(cmd)
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(hm, "_is_windows", lambda: False)
+    monkeypatch.setattr(hm, "_run_quarantined_install", fail)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        hm._install_python_dependencies_with_optional_fallback(
+            ["uv", "pip"], require_all_extras=True
+        )
+
+    assert len(calls) == 1
+    assert calls[0] == ["uv", "pip", "install", "--exact", "-e", ".[all]"]
+
+
+def test_forced_node_candidate_bypasses_success_hash_cache(monkeypatch, tmp_path):
+    from hermes_cli import main as hm
+
+    (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
+    npm_calls = []
+
+    monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(hm, "_resolve_node_runtime_npm", lambda: "npm")
+    monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda _root: False)
+    monkeypatch.setattr(
+        hm,
+        "_run_npm_install_deterministic",
+        lambda *args, **kwargs: npm_calls.append((args, kwargs))
+        or _completed(["npm", "ci"]),
+    )
+    monkeypatch.setattr(
+        "tools.browser_tool.warm_agent_browser_npx_cache", lambda: True
+    )
+
+    assert update_cmd._update_node_dependencies(force=True) == []
+    assert len(npm_calls) == 1


### PR DESCRIPTION
## Summary
- fail fast on mirror/network failures instead of multiplying uv, pip, and npm retry delays
- validate the fetched tip, then up to eight daily first-parent upstream snapshots until both Python and Node dependencies install cleanly
- keep fallback environments reproducible with uv exact-sync and forced npm ci; preserve local edits with transactional `checkout -B` transitions
- restore the pre-update source and retain the recovery marker when every candidate fails

## Safety
- never selects a candidate older than the pre-update HEAD
- rejects force-pushed tips that do not contain the installed commit
- refuses candidate movement when the tree is dirty and uses Git's transactional checkout behavior for TOCTOU safety
- checks rollback results and finalizes failed update receipts

## Tests
- 56 related update/venv/backoff tests passed
- 11 Node dependency update tests passed
- `py_compile` and `git diff --check` passed
- dedicated suite includes real-Git proof that `checkout -B` preserves a racing local edit

The full legacy `test_cmd_update.py` has a pre-existing Windows-host failure caused by its global subprocess mock interacting with managed Node discovery; the same test fails on unmodified main.
