### PR TITLE
fix(acp): classify browser console as execute

### DIFF
--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -43,6 +43,7 @@ TOOL_KIND_MAP: Dict[str, ToolKind] = {
     "browser_navigate": "fetch",
     "browser_click": "execute",
     "browser_type": "execute",
+    "browser_console": "execute",
     "browser_snapshot": "read",
     "browser_vision": "read",
     "browser_scroll": "execute",

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -1,5 +1,6 @@
 """Tests for acp_adapter.tools — tool kind mapping and ACP content building."""
 
+import pytest
 
 from acp_adapter.edit_approval import EditProposal
 from acp_adapter.tools import (
@@ -40,12 +41,9 @@ class TestToolKindMap:
     def test_tool_kind_terminal(self):
         assert get_tool_kind("terminal") == "execute"
 
-
-
-
-
-
-
+    @pytest.mark.parametrize("tool_name", ["browser_click", "browser_console"])
+    def test_browser_actions_have_execute_kind(self, tool_name):
+        assert get_tool_kind(tool_name) == "execute"
 
     def test_unknown_tool_returns_other_kind(self):
         assert get_tool_kind("nonexistent_tool_xyz") == "other"


### PR DESCRIPTION
## What does this PR do?

Classifies `browser_console` ACP tool calls as `execute` instead of the generic `other` kind. Console evaluation executes JavaScript through the browser/CDP path, so this keeps ACP routing and safety/UI treatment consistent with other browser actions such as `browser_click` and `browser_type`.

## Related Issue

No related issue; this is a self-contained mapping omission.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `browser_console: execute` to `acp_adapter/tools.py`.
- Add parameterized browser-action kind coverage in `tests/acp/test_tools.py`.

## How to Test

1. Run `scripts/run_tests.sh tests/acp`.
2. Confirm all ACP tests pass.
3. Call `get_tool_kind("browser_console")` and confirm it returns `execute`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure ACP mapping, platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

`tests/acp/test_tools.py` was observed RED before the mapping change (`browser_console`: `other` vs expected `execute`) and GREEN afterward. `scripts/run_tests.sh tests/acp` passes 128 tests across 14 files.
