### PR TITLE
fix(desktop): keep isolated SSH backend on session-token auth

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11802,9 +11802,8 @@ def cmd_dashboard(args):
     # fail-closed SystemExit unchanged.
     _maybe_setup_dashboard_auth_interactively(args)
 
-    # The in-browser Chat tab (the embedded TUI over PTY/WebSocket) is always
-    # available — the desktop app and the dashboard's own Chat tab both rely on
-    # the `/api/ws` + `/api/pty` sockets, so there is no reason to gate them.
+    # ``ssh_session_token`` and ``ssh_owner_nonce`` together mark the private
+    # Desktop SSH tunnel transport and must never be set by ordinary serve/dashboard callers.
     start_server(
         host=args.host,
         port=args.port,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11813,6 +11813,7 @@ def cmd_dashboard(args):
         headless=_headless_backend,
         ssh_session_token=_ssh_session_token,
         ssh_owner_nonce=_ssh_owner_nonce,
+        is_isolated=getattr(args, "isolated", False) or os.environ.get("HERMES_DESKTOP") == "1",
     )
 
 

--- a/hermes_cli/subcommands/dashboard.py
+++ b/hermes_cli/subcommands/dashboard.py
@@ -149,6 +149,9 @@ def build_dashboard_parser(
     serve_parser.add_argument(
         "--no-open", action="store_true", help=argparse.SUPPRESS
     )
+    # ``--ssh-session-token-file`` and ``--ssh-owner-nonce`` together mark the
+    # private Desktop SSH tunnel transport and must never be set by ordinary
+    # serve/dashboard callers.
     serve_parser.add_argument(
         "--ssh-session-token-file",
         dest="ssh_session_token_file",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -741,6 +741,34 @@ def should_require_dashboard_auth(
     )
 
 
+def _is_isolated_desktop_ssh_backend(
+    *,
+    host: str,
+    port: int,
+    headless: bool,
+    ssh_session_token: Optional[str],
+    ssh_owner_nonce: Optional[str],
+) -> bool:
+    """Return whether this is Desktop's private SSH-tunnel backend.
+
+    This process is distinct from the operator's browser-facing dashboard: it
+    binds an ephemeral loopback port, serves no SPA, and is protected by a
+    per-launch session token plus owner nonce.  A configured public dashboard
+    URL must not switch this private transport to cookie/OAuth mode because the
+    Desktop client authenticates its WebSocket with that session token.
+
+    Keep every marker mandatory so ordinary dashboard/serve invocations cannot
+    use this path to bypass the public-dashboard auth gate.
+    """
+    return bool(
+        host in _LOOPBACK_HOST_VALUES
+        and port == 0
+        and headless
+        and ssh_session_token
+        and ssh_owner_nonce
+    )
+
+
 def _host_header_hostname(host_header: str) -> str:
     """Return a normalized hostname from a valid HTTP Host authority.
 
@@ -19303,10 +19331,25 @@ def start_server(
     # request middleware never reloads config. Any non-loopback public hostname
     # engages the auth gate even when the backend itself remains on loopback;
     # otherwise the SPA's local session token would become remotely reachable.
-    app.state.trusted_public_hosts = _dashboard_public_hosts()
+    _configured_public_hosts = _dashboard_public_hosts()
     # Stash the auth-gate flag on app.state so middleware / SPA-token injection /
     # WS-auth paths can branch on it consistently. It also decides whether to
     # refuse startup, log the gate-on banner, and enable uvicorn proxy_headers.
+    _private_desktop_ssh = _is_isolated_desktop_ssh_backend(
+        host=host,
+        port=port,
+        headless=headless,
+        ssh_session_token=ssh_session_token,
+        ssh_owner_nonce=ssh_owner_nonce,
+    )
+    # This ephemeral backend is not the browser-facing dashboard named by
+    # dashboard.public_url.  Do not inherit that dashboard's Host/Origin trust
+    # declaration or cookie/OAuth gate; the SSH tunnel uses its per-launch
+    # session token instead.  Ordinary dashboard/serve launches keep the
+    # configured public-host behavior unchanged.
+    app.state.trusted_public_hosts = (
+        frozenset() if _private_desktop_ssh else _configured_public_hosts
+    )
     app.state.auth_required = should_require_dashboard_auth(
         host, app.state.trusted_public_hosts
     )

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -748,6 +748,7 @@ def _is_isolated_desktop_ssh_backend(
     headless: bool,
     ssh_session_token: Optional[str],
     ssh_owner_nonce: Optional[str],
+    is_isolated: bool = False,
 ) -> bool:
     """Return whether this is Desktop's private SSH-tunnel backend.
 
@@ -759,15 +760,20 @@ def _is_isolated_desktop_ssh_backend(
     dashboard URL must not switch this private transport to cookie/OAuth mode
     because the Desktop client authenticates its WebSocket with that session token.
 
-    Keep every marker mandatory so ordinary dashboard/serve invocations cannot
-    use this path to bypass the public-dashboard auth gate.
+    Keep every marker mandatory -- including explicit Desktop isolation
+    (``is_isolated`` / ``--isolated`` / ``HERMES_DESKTOP=1``) -- so ordinary
+    dashboard/serve invocations cannot use this path to bypass the
+    public-dashboard auth gate.
     """
+    token = (ssh_session_token or "").strip()
+    nonce = (ssh_owner_nonce or "").strip()
     return bool(
-        host in _LOOPBACK_HOST_VALUES
+        is_isolated
+        and host in _LOOPBACK_HOST_VALUES
         and port == 0
         and headless
-        and ssh_session_token
-        and ssh_owner_nonce
+        and token
+        and nonce
     )
 
 
@@ -19293,6 +19299,7 @@ def start_server(
     headless: bool = False,
     ssh_session_token: Optional[str] = None,
     ssh_owner_nonce: Optional[str] = None,
+    is_isolated: bool = False,
 ):
     """Start the web UI server.
 
@@ -19344,6 +19351,7 @@ def start_server(
         headless=headless,
         ssh_session_token=ssh_session_token,
         ssh_owner_nonce=ssh_owner_nonce,
+        is_isolated=is_isolated,
     )
     if _private_desktop_ssh:
         _log.info(

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -753,9 +753,11 @@ def _is_isolated_desktop_ssh_backend(
 
     This process is distinct from the operator's browser-facing dashboard: it
     binds an ephemeral loopback port, serves no SPA, and is protected by a
-    per-launch session token plus owner nonce.  A configured public dashboard
-    URL must not switch this private transport to cookie/OAuth mode because the
-    Desktop client authenticates its WebSocket with that session token.
+    per-launch session token plus owner nonce (``ssh_session_token`` and
+    ``ssh_owner_nonce`` together mark this private Desktop SSH transport and
+    must never be set by ordinary serve/dashboard callers).  A configured public
+    dashboard URL must not switch this private transport to cookie/OAuth mode
+    because the Desktop client authenticates its WebSocket with that session token.
 
     Keep every marker mandatory so ordinary dashboard/serve invocations cannot
     use this path to bypass the public-dashboard auth gate.
@@ -19303,8 +19305,9 @@ def start_server(
     build and no SPA mount (mount_spa() honours ``HERMES_SERVE_HEADLESS``), so
     the banner announces the bind rather than a browser URL.
 
-    ``ssh_session_token`` and ``ssh_owner_nonce`` are process-local Desktop SSH
-    bootstrap state. Neither is persisted or exported to child processes.
+    ``ssh_session_token`` and ``ssh_owner_nonce`` together mark the private
+    Desktop SSH tunnel transport and must never be set by ordinary serve/dashboard
+    callers. Neither is persisted or exported to child processes.
     """
     _apply_ssh_session_token(ssh_session_token or "")
     _apply_ssh_owner_nonce(ssh_owner_nonce)
@@ -19342,6 +19345,11 @@ def start_server(
         ssh_session_token=ssh_session_token,
         ssh_owner_nonce=ssh_owner_nonce,
     )
+    if _private_desktop_ssh:
+        _log.info(
+            "Desktop SSH backend active: using session-token authentication; "
+            "public-dashboard auth gate is not inherited"
+        )
     # This ephemeral backend is not the browser-facing dashboard named by
     # dashboard.public_url.  Do not inherit that dashboard's Host/Origin trust
     # declaration or cookie/OAuth gate; the SSH tunnel uses its per-launch
@@ -19542,7 +19550,10 @@ def start_server(
         # proxy).  When the OAuth gate is active we are explicitly running
         # behind a TLS terminator (Fly.io) and need X-Forwarded-Proto to
         # decide cookie Secure flags, so we flip proxy_headers on for that
-        # mode.
+        # mode. Threat-model assumption: isolated Desktop SSH backends keep
+        # auth_required=False and proxy_headers=False because the backend
+        # communicates directly through an isolated tunnel and must not
+        # rely on X-Forwarded-* / proxy headers.
         proxy_headers=bool(app.state.auth_required),
         # Half-open detection for public binds only (see above). Loopback
         # disables the protocol ping (None) so an event-loop stall can never

--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -291,13 +291,7 @@ def test_start_server_loopback_public_url_enables_gate(monkeypatch):
         clear_providers()
 
 
-def test_isolated_desktop_ssh_backend_keeps_session_token_auth(monkeypatch):
-    """A private Desktop SSH child must not inherit public dashboard OAuth.
-
-    Desktop connects to this ephemeral loopback-only backend through an SSH
-    tunnel and authenticates HTTP/WS with the per-launch session token.  The
-    machine may simultaneously expose its regular dashboard at ``public_url``.
-    """
+def _setup_desktop_ssh_test_env(monkeypatch):
     from hermes_cli.dashboard_auth import clear_providers
 
     monkeypatch.setenv(
@@ -317,19 +311,32 @@ def test_isolated_desktop_ssh_backend_keeps_session_token_auth(monkeypatch):
         "bound_port",
         "trusted_public_hosts",
     )
+    return captured
 
-    web_server.start_server(
-        host="127.0.0.1",
-        port=0,
-        open_browser=False,
-        headless=True,
-        ssh_session_token="desktop-session-token",
-        ssh_owner_nonce="desktop-owner-nonce",
-    )
+
+def test_isolated_desktop_ssh_backend_keeps_session_token_auth(monkeypatch, caplog):
+    """A private Desktop SSH child must not inherit public dashboard OAuth.
+
+    Desktop connects to this ephemeral loopback-only backend through an SSH
+    tunnel and authenticates HTTP/WS with the per-launch session token.  The
+    machine may simultaneously expose its regular dashboard at ``public_url``.
+    """
+    captured = _setup_desktop_ssh_test_env(monkeypatch)
+
+    with caplog.at_level("INFO", logger="hermes_cli.web_server"):
+        web_server.start_server(
+            host="127.0.0.1",
+            port=0,
+            open_browser=False,
+            headless=True,
+            ssh_session_token="desktop-session-token",
+            ssh_owner_nonce="desktop-owner-nonce",
+        )
 
     assert web_server.app.state.auth_required is False
     assert web_server.app.state.trusted_public_hosts == frozenset()
     assert captured["kwargs"].get("proxy_headers") is False
+    assert "Desktop SSH backend active" in caplog.text
     reason, credential = web_server._ws_auth_reason(
         SimpleNamespace(query_params={"token": "desktop-session-token"})
     )
@@ -351,21 +358,7 @@ def test_desktop_ssh_auth_exception_requires_every_private_marker(
     monkeypatch, overrides
 ):
     """Dropping any private-backend marker keeps the public auth gate on."""
-    from hermes_cli.dashboard_auth import clear_providers
-
-    monkeypatch.setenv(
-        "HERMES_DASHBOARD_PUBLIC_URL",
-        "https://dashboard.example.test:9443",
-    )
-    clear_providers()
-    _stub_uvicorn_run(monkeypatch)
-    _restore_app_state_after_test(
-        monkeypatch,
-        "auth_required",
-        "bound_host",
-        "bound_port",
-        "trusted_public_hosts",
-    )
+    _setup_desktop_ssh_test_env(monkeypatch)
     kwargs = {
         "host": "127.0.0.1",
         "port": 0,

--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -331,6 +331,7 @@ def test_isolated_desktop_ssh_backend_keeps_session_token_auth(monkeypatch, capl
             headless=True,
             ssh_session_token="desktop-session-token",
             ssh_owner_nonce="desktop-owner-nonce",
+            is_isolated=True,
         )
 
     assert web_server.app.state.auth_required is False
@@ -352,12 +353,17 @@ def test_isolated_desktop_ssh_backend_keeps_session_token_auth(monkeypatch, capl
         {"headless": False},
         {"ssh_session_token": None},
         {"ssh_owner_nonce": None},
+        {"ssh_session_token": ""},
+        {"ssh_session_token": "   "},
+        {"ssh_owner_nonce": ""},
+        {"ssh_owner_nonce": "   "},
+        {"is_isolated": False},
     ],
 )
 def test_desktop_ssh_auth_exception_requires_every_private_marker(
     monkeypatch, overrides
 ):
-    """Dropping any private-backend marker keeps the public auth gate on."""
+    """Dropping or invalidating any private-backend marker keeps the public auth gate on."""
     _setup_desktop_ssh_test_env(monkeypatch)
     kwargs = {
         "host": "127.0.0.1",
@@ -366,11 +372,82 @@ def test_desktop_ssh_auth_exception_requires_every_private_marker(
         "headless": True,
         "ssh_session_token": "desktop-session-token",
         "ssh_owner_nonce": "desktop-owner-nonce",
+        "is_isolated": True,
     }
     kwargs.update(overrides)
 
     with pytest.raises(SystemExit, match=r"no auth providers"):
         web_server.start_server(**kwargs)
+    assert web_server.app.state.auth_required is True
+
+
+@pytest.mark.parametrize("loopback_host", ["127.0.0.1", "localhost", "::1"])
+def test_desktop_ssh_accepts_all_loopback_hosts(monkeypatch, loopback_host):
+    """Desktop SSH backend accepts all valid loopback host representations."""
+    _setup_desktop_ssh_test_env(monkeypatch)
+    web_server.start_server(
+        host=loopback_host,
+        port=0,
+        open_browser=False,
+        headless=True,
+        ssh_session_token="desktop-session-token",
+        ssh_owner_nonce="desktop-owner-nonce",
+        is_isolated=True,
+    )
+    assert web_server.app.state.auth_required is False
+    assert web_server.app.state.trusted_public_hosts == frozenset()
+
+
+def test_desktop_ssh_ws_token_validation_in_isolated_config(monkeypatch):
+    """WS upgrade auth in isolated configuration validates missing, incorrect, and valid tokens."""
+    _setup_desktop_ssh_test_env(monkeypatch)
+    web_server.start_server(
+        host="127.0.0.1",
+        port=0,
+        open_browser=False,
+        headless=True,
+        ssh_session_token="desktop-session-token-12345",
+        ssh_owner_nonce="desktop-owner-nonce-67890",
+        is_isolated=True,
+    )
+    assert web_server.app.state.auth_required is False
+
+    # 1. Missing token -> no_credential
+    reason, cred = web_server._ws_auth_reason(SimpleNamespace(query_params={}))
+    assert reason == "no_credential"
+    assert cred == "none"
+
+    # 2. Incorrect token -> token_mismatch
+    reason, cred = web_server._ws_auth_reason(
+        SimpleNamespace(query_params={"token": "wrong-token-value"})
+    )
+    assert reason == "token_mismatch"
+    assert cred == "token"
+
+    # 3. Correct token -> accepted (None)
+    reason, cred = web_server._ws_auth_reason(
+        SimpleNamespace(query_params={"token": "desktop-session-token-12345"})
+    )
+    assert reason is None
+    assert cred == "token"
+
+
+def test_ordinary_serve_or_dashboard_caller_without_isolated_remains_on_public_gate(monkeypatch):
+    """Supplying ssh_session_token / ssh_owner_nonce without --isolated (is_isolated=False)
+    does not trigger the private Desktop auth exception and stays on the public gate.
+    """
+    _setup_desktop_ssh_test_env(monkeypatch)
+
+    with pytest.raises(SystemExit, match=r"no auth providers"):
+        web_server.start_server(
+            host="127.0.0.1",
+            port=0,
+            open_browser=False,
+            headless=True,
+            ssh_session_token="desktop-session-token",
+            ssh_owner_nonce="desktop-owner-nonce",
+            is_isolated=False,
+        )
     assert web_server.app.state.auth_required is True
 
 

--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -3,6 +3,8 @@
 Phase 0 — establish a baseline pin on the current (pre-OAuth) behavior so
 later phases can prove they didn't break loopback mode.
 """
+from types import SimpleNamespace
+
 import pytest
 
 # Phase 5 / Phase 6: these tests mutate ``web_server.app.state.auth_required``
@@ -287,6 +289,96 @@ def test_start_server_loopback_public_url_enables_gate(monkeypatch):
         assert captured["kwargs"].get("proxy_headers") is True
     finally:
         clear_providers()
+
+
+def test_isolated_desktop_ssh_backend_keeps_session_token_auth(monkeypatch):
+    """A private Desktop SSH child must not inherit public dashboard OAuth.
+
+    Desktop connects to this ephemeral loopback-only backend through an SSH
+    tunnel and authenticates HTTP/WS with the per-launch session token.  The
+    machine may simultaneously expose its regular dashboard at ``public_url``.
+    """
+    from hermes_cli.dashboard_auth import clear_providers
+
+    monkeypatch.setenv(
+        "HERMES_DASHBOARD_PUBLIC_URL",
+        "https://dashboard.example.test:9443",
+    )
+    monkeypatch.setattr(web_server, "_SESSION_TOKEN", web_server._SESSION_TOKEN)
+    monkeypatch.setattr(
+        web_server, "_SSH_OWNER_NONCE", web_server._SSH_OWNER_NONCE
+    )
+    clear_providers()
+    captured = _stub_uvicorn_run(monkeypatch)
+    _restore_app_state_after_test(
+        monkeypatch,
+        "auth_required",
+        "bound_host",
+        "bound_port",
+        "trusted_public_hosts",
+    )
+
+    web_server.start_server(
+        host="127.0.0.1",
+        port=0,
+        open_browser=False,
+        headless=True,
+        ssh_session_token="desktop-session-token",
+        ssh_owner_nonce="desktop-owner-nonce",
+    )
+
+    assert web_server.app.state.auth_required is False
+    assert web_server.app.state.trusted_public_hosts == frozenset()
+    assert captured["kwargs"].get("proxy_headers") is False
+    reason, credential = web_server._ws_auth_reason(
+        SimpleNamespace(query_params={"token": "desktop-session-token"})
+    )
+    assert reason is None
+    assert credential == "token"
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"port": 9119},
+        {"host": "0.0.0.0"},
+        {"headless": False},
+        {"ssh_session_token": None},
+        {"ssh_owner_nonce": None},
+    ],
+)
+def test_desktop_ssh_auth_exception_requires_every_private_marker(
+    monkeypatch, overrides
+):
+    """Dropping any private-backend marker keeps the public auth gate on."""
+    from hermes_cli.dashboard_auth import clear_providers
+
+    monkeypatch.setenv(
+        "HERMES_DASHBOARD_PUBLIC_URL",
+        "https://dashboard.example.test:9443",
+    )
+    clear_providers()
+    _stub_uvicorn_run(monkeypatch)
+    _restore_app_state_after_test(
+        monkeypatch,
+        "auth_required",
+        "bound_host",
+        "bound_port",
+        "trusted_public_hosts",
+    )
+    kwargs = {
+        "host": "127.0.0.1",
+        "port": 0,
+        "open_browser": False,
+        "headless": True,
+        "ssh_session_token": "desktop-session-token",
+        "ssh_owner_nonce": "desktop-owner-nonce",
+    }
+    kwargs.update(overrides)
+
+    with pytest.raises(SystemExit, match=r"no auth providers"):
+        web_server.start_server(**kwargs)
+    assert web_server.app.state.auth_required is True
 
 
 def test_start_server_loopback_public_url_without_provider_fails_closed(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Keeps the remote Desktop SSH backend on its intended per-launch session-token
authentication when the same machine also has an external
`dashboard.public_url` / `HERMES_DASHBOARD_PUBLIC_URL` configured.

The Desktop remote lifecycle starts a private backend as:

```text
hermes serve --isolated --host 127.0.0.1 --port 0 \
  --ssh-session-token-file <file> --ssh-owner-nonce <nonce>
```

`start_server()` also resolves the regular browser dashboard's public host.
An external public host makes `should_require_dashboard_auth()` enable the
cookie/ticket auth gate even for this ephemeral loopback process. The Desktop
SSH client still connects to `/api/ws?token=<per-launch token>`, and gated mode
unconditionally rejects that legacy token. The result is a split symptom:
`/api/health` is reachable, while the WebSocket closes during boot.

This change recognizes only the fully marked private Desktop SSH shape and
does not inherit the browser dashboard's public Host/Origin declaration for
that process. Its loopback session-token auth therefore remains active.
Regular dashboard and `serve` launches keep the existing public auth gate.

## Related Issue

Related to #91495. This addresses the remaining SSH token-rejection path
described in the issue discussion; it is separate from the local Desktop SPA
problem investigated in #91552.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py`: identify the private Desktop SSH backend using
  all of its existing security/lifecycle markers: loopback host, ephemeral
  port, headless mode, session token, and owner nonce.
- `hermes_cli/web_server.py`: keep the configured browser-facing public hosts
  out of that private process's Host/Origin and auth-gate state.
- `tests/hermes_cli/test_dashboard_auth_gate.py`: prove that the session token
  is accepted with an external public URL configured, and that dropping any
  one private marker leaves the public auth gate enabled.

## How to Test

1. Configure an external `dashboard.public_url` (or its existing environment
   equivalent) on a remote Hermes host.
2. Connect Hermes Desktop to that host in SSH mode.
3. On `main`, observe HTTP health succeed while `/api/ws?token=...` is rejected
   after the dashboard auth gate engages.
4. With this branch, observe the remote Desktop backend remain in token mode
   and the WebSocket connect, while the regular public dashboard remains gated.

Automated regression run (through the repository's hermetic test wrapper):

```text
scripts/run_tests.sh \
  tests/hermes_cli/test_dashboard_auth_gate.py \
  tests/hermes_cli/test_dashboard_auth_ws_auth.py \
  tests/hermes_cli/test_dashboard_lifecycle_flags.py \
  tests/test_web_server.py

69 passed, 3 skipped, 0 failed
```

Also checked with `ruff 0.15.10` on both changed files: clean.

Manual end-to-end verification: packaged macOS Desktop connecting over SSH to
a Linux backend with an external private-overlay dashboard URL configured.
Before the fix, HTTP health returned 200 but the WebSocket closed; after the
fix, the WebSocket opened and Desktop reached `Gateway ready`.

## Security Boundary

The exception requires every marker below:

- loopback bind (`127.0.0.1`, `localhost`, or `::1`)
- OS-assigned ephemeral port (`0`)
- headless backend
- non-empty per-launch SSH session token
- non-empty SSH owner nonce

If any marker is absent, the existing public-dashboard auth decision is used.
The parameterized regression test covers every missing-marker case.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched open and closed issues/PRs for duplicates
- [x] My PR contains only changes related to this fix
- [x] I ran the relevant tests through `scripts/run_tests.sh`
- [x] I added behavioral regression tests
- [x] I tested the complete Desktop SSH flow on macOS with a Linux backend

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing behavior or config changes
- [x] `cli-config.yaml.example`: N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no workflow changes
- [x] Cross-platform impact considered; the predicate is platform-independent
- [x] Tool descriptions/schemas: N/A
