### PR TITLE
fix(mcp): resolve tool-call timeouts via the unified deadline layer (#85125 2g)

### DIFF
--- a/tests/tools/test_mcp_timeout_resolution.py
+++ b/tests/tools/test_mcp_timeout_resolution.py
@@ -1,0 +1,52 @@
+"""Contract tests for MCP tool-timeout resolution (#85125 Phase 2g).
+
+Default-behavior invariance (tracker regression policy rule 1): with no
+``timeouts:`` section and no per-server key, every resolved value must equal
+today's — the resolver only unifies WHERE the value is read, never what it is.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.mcp_tool import _DEFAULT_TOOL_TIMEOUT, _resolve_tool_timeout
+
+
+class TestMcpToolTimeoutResolution:
+    def test_default_unchanged_with_nothing_configured(self, monkeypatch):
+        monkeypatch.setattr("agent.deadline._timeouts_section", lambda: {})
+        assert _resolve_tool_timeout({}) == _DEFAULT_TOOL_TIMEOUT == 300
+
+    def test_per_server_timeout_always_wins(self, monkeypatch):
+        # Per-server config beats the global timeouts section (documented
+        # precedence: most specific wins).
+        monkeypatch.setattr(
+            "agent.deadline._timeouts_section",
+            lambda: {"mcp": {"tool_call": 120}},
+        )
+        assert _resolve_tool_timeout({"timeout": 45}) == 45
+
+    def test_timeouts_section_beats_default(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.deadline._timeouts_section",
+            lambda: {"mcp": {"tool_call": 120}},
+        )
+        assert _resolve_tool_timeout({}) == 120.0
+
+    def test_invalid_timeouts_value_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.deadline._timeouts_section",
+            lambda: {"mcp": {"tool_call": "soon"}},
+        )
+        assert _resolve_tool_timeout({}) == _DEFAULT_TOOL_TIMEOUT
+
+    def test_resolution_failure_fails_back_to_default(self, monkeypatch):
+        def _boom():
+            raise RuntimeError("config unreadable")
+
+        monkeypatch.setattr("agent.deadline._timeouts_section", _boom)
+        assert _resolve_tool_timeout({}) == _DEFAULT_TOOL_TIMEOUT
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -552,6 +552,31 @@ _MCP_LOG_LEVEL_MAP = {
 # ---------------------------------------------------------------------------
 
 _DEFAULT_TOOL_TIMEOUT = 300      # seconds for tool calls
+
+
+def _resolve_tool_timeout(config: dict) -> float:
+    """Per-server tool-call timeout with unified-layer resolution (#85125 2g).
+
+    Precedence: per-server ``mcp_servers.<name>.timeout`` (most specific,
+    always wins) > ``timeouts.mcp.tool_call`` in config.yaml > the historical
+    default. Values are platform-clamped by ``resolve_timeout`` either way.
+    Defaults are unchanged: with neither key set this returns 300, exactly
+    as before.
+    """
+    per_server = config.get("timeout")
+    if per_server is not None:
+        return per_server
+    try:
+        from agent.deadline import resolve_timeout
+
+        resolved = resolve_timeout("mcp.tool_call", default=_DEFAULT_TOOL_TIMEOUT)
+        if resolved is not None:
+            return resolved
+    except Exception:
+        logger.debug("mcp.tool_call timeout resolution failed", exc_info=True)
+    return _DEFAULT_TOOL_TIMEOUT
+
+
 _DEFAULT_CONNECT_TIMEOUT = 60    # seconds for initial connection per server
 _MAX_RECONNECT_RETRIES = 5
 _MAX_INITIAL_CONNECT_RETRIES = 3 # retries for the very first connection attempt
@@ -3725,7 +3750,7 @@ class MCPServerTask:
         connection drops unexpectedly (unless shutdown was requested).
         """
         self._config = config
-        self.tool_timeout = config.get("timeout", _DEFAULT_TOOL_TIMEOUT)
+        self.tool_timeout = _resolve_tool_timeout(config)
         self._auth_type = (config.get("auth") or "").lower().strip()
         self._idle_timeout_seconds = _get_lifecycle_seconds(config, "idle_timeout_seconds")
         self._max_lifetime_seconds = _get_lifecycle_seconds(config, "max_lifetime_seconds")
@@ -7038,7 +7063,7 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
     registered_names: List[str] = []
     toolset_name = f"mcp-{name}"
     fingerprint = config_fingerprint(config)
-    tool_timeout = config.get("timeout", _DEFAULT_TOOL_TIMEOUT)
+    tool_timeout = _resolve_tool_timeout(config)
     tools_filter = config.get("tools") or {}
     include_set = _normalize_name_filter(
         tools_filter.get("include"), f"mcp_servers.{name}.tools.include"


### PR DESCRIPTION
#85125 Phase 2g. Both readers of the per-server MCP tool-call timeout — the connection's `run()` (`self.tool_timeout`) and the cache-path tool registration — each did their own private `config.get("timeout", 300)`. They now route through one `_resolve_tool_timeout` helper wired to the unified deadline layer.

Documented precedence (most specific wins):
1. `mcp_servers.<name>.timeout` — per-server config, always wins (unchanged)
2. `timeouts.mcp.tool_call` — the unified `timeouts:` section (#85147)
3. the historical 300s default (unchanged)

Values resolved through the section pass `resolve_timeout`'s platform clamp; a failed resolution falls back to the historical default. **No default changes** — with nothing configured every resolved value equals today's, pinned by contract tests per the tracker's regression policy (rule 1).

## Verification

- New `tests/tools/test_mcp_timeout_resolution.py`: 5 contract tests (default invariance, per-server-beats-section, section-beats-default, invalid-value fallback, resolution-failure fallback)
- Full MCP test sweep (`tests/tools/ -k mcp`): 639 passed
- ruff clean; no new env vars; no cache impact

Part of #85125 (Phase 2g).
