### PR TITLE
fix(computer-use): allow pidless isolated browser launch

### DIFF
--- a/tests/tools/test_computer_use_browser_authorization.py
+++ b/tests/tools/test_computer_use_browser_authorization.py
@@ -70,6 +70,20 @@ def test_existing_profile_prepare_delegates_authorization_to_driver():
     ]
 
 
+def test_existing_profile_prepare_requires_positive_pid():
+    driver = _PrepareDriver()
+    result = _route(driver).prepare(
+        pid=None,
+        window_id=202,
+        profile_mode="existing_profile",
+        grant_existing_profile=True,
+    )
+
+    assert result["status"] == "refused"
+    assert result["code"] == "browser_pid_required"
+    assert driver.calls == []
+
+
 def test_existing_profile_prepare_refused_without_config_grant():
     driver = _PrepareDriver()
     result = _route(driver).prepare(
@@ -133,6 +147,44 @@ def test_isolated_prepare_unaffected_by_the_grant():
 
     assert result["status"] == "ok"
     assert [name for name, _ in driver.calls] == ["browser_prepare"]
+    assert driver.calls[0][1]["pid"] == 101
+
+
+@pytest.mark.parametrize(
+    ("profile_mode", "profile_name", "expected_profile"),
+    [
+        ("isolated_new", None, {"mode": "isolated_new"}),
+        (
+            "isolated_named",
+            "research",
+            {"mode": "isolated_named", "name": "research"},
+        ),
+    ],
+)
+def test_driver_owned_isolated_prepare_does_not_require_pid(
+    profile_mode, profile_name, expected_profile
+):
+    """The driver launches isolated profiles, so no existing pid is required."""
+    driver = _PrepareDriver()
+    result = _route(driver).prepare(
+        pid=None,
+        profile_mode=profile_mode,
+        profile_name=profile_name,
+        allow_launch=True,
+        grant_existing_profile=False,
+    )
+
+    assert result["status"] == "ok"
+    assert driver.calls == [
+        (
+            "browser_prepare",
+            {
+                "allow_launch": True,
+                "profile": expected_profile,
+                "session": "hermes-a",
+            },
+        )
+    ]
 
 
 def test_backend_resolves_authorization_and_ignores_model_supplied_values(monkeypatch):

--- a/tools/computer_use/browser_route.py
+++ b/tools/computer_use/browser_route.py
@@ -402,11 +402,12 @@ class CuaTypedBrowserRoute:
         if missing is not None:
             return missing
         exact_pid = _positive_int(pid)
-        if exact_pid is None:
-            return _refusal(
-                "browser_pid_required", "browser_prepare requires a positive pid."
-            )
         if profile_mode == "existing_profile":
+            if exact_pid is None:
+                return _refusal(
+                    "browser_pid_required",
+                    "browser_prepare requires a positive pid.",
+                )
             exact_window = _positive_int(window_id)
             if exact_window is None:
                 return _refusal(
@@ -458,10 +459,11 @@ class CuaTypedBrowserRoute:
                 )
             profile["name"] = profile_name
         args: Dict[str, Any] = {
-            "pid": exact_pid,
             "allow_launch": True,
             "profile": profile,
         }
+        if exact_pid is not None:
+            args["pid"] = exact_pid
         exact_window = _positive_int(window_id)
         if exact_window is not None:
             args["window_id"] = exact_window


### PR DESCRIPTION
## What does this PR do?

Aligns Hermes' typed browser preparation with Cua Driver's driver-owned isolated profile contract.

`isolated_new` and `isolated_named` now reach `browser_prepare` without an existing PID when `allow_launch=true`. The positive PID requirement remains scoped to `existing_profile`, where Hermes still requires the exact PID and window ID before attachment.

When callers provide an optional PID or window ID for an isolated preparation, Hermes continues to forward valid values.

## Related Issue

Fixes #93763

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/computer_use/browser_route.py`: require a positive PID only for `existing_profile`, and omit absent PID values from driver-owned isolated requests.
- `tests/tools/test_computer_use_browser_authorization.py`: cover PID-less `isolated_new` and `isolated_named`, preserve optional PID forwarding, and pin the existing-profile PID guard.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_computer_use_browser_authorization.py tests/tools/test_computer_use_browser_contract_020.py tests/tools/test_computer_use_cua_0_9.py tests/tools/test_computer_use_cua_0_10_permissions.py`.
2. Confirm all 106 tests pass.
3. Run `uv run ruff check tools/computer_use/browser_route.py tests/tools/test_computer_use_browser_authorization.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04.2 LTS, x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — this request-shaping change is platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A; the existing public schema already makes PID optional and documents driver-owned launch

## Screenshots / Logs

Focused computer-use suites: **106 passed**.

Ruff on both changed files: **passed**.

A full `scripts/run_tests.sh` run was attempted. It reached about 60% before the 60-minute local command limit. Unrelated environment failures appeared first, including missing optional `acp` dependencies and update tests blocked by the live-system process guard. This PR does not claim a full-suite pass.

The live pre-fix refusal against Cua Driver 0.21.0 is recorded in #93763. A patched desktop/Cua E2E was not run from this checkout because it has no isolated desktop driver session.