### PR TITLE
fix(a11y): raise desktop text token contrast to WCAG AA

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -324,10 +324,18 @@
       var(--ui-accent) var(--theme-control-active-accent-mix),
       color-mix(in srgb, var(--ui-base) 5%, transparent)
     );
+    /* Text ramp: each rung is `--ui-base` at an alpha against the surface
+       beneath. The lowest rungs fell below WCAG AA (4.5:1) on light themes:
+       tertiary at 54% (3.47:1) and quaternary at 36% (2.16:1). Raising them
+       to 68% clears AA on every first-party theme (worst case nous-alt dark
+       at 4.91:1). Tertiary and quaternary end up equivalent - at these
+       alphas no gap can both keep a visual step and clear AA, so we trade
+       the finer hierarchy for readable text. Decorative text that wants a
+       genuinely faint rung should use its own token, not quaternary. */
     --ui-text-primary: color-mix(in srgb, var(--ui-base) 94%, transparent);
     --ui-text-secondary: color-mix(in srgb, var(--ui-base) 74%, transparent);
-    --ui-text-tertiary: color-mix(in srgb, var(--ui-base) 54%, transparent);
-    --ui-text-quaternary: color-mix(in srgb, var(--ui-base) 36%, transparent);
+    --ui-text-tertiary: color-mix(in srgb, var(--ui-base) 68%, transparent);
+    --ui-text-quaternary: color-mix(in srgb, var(--ui-base) 68%, transparent);
     /* Transcript scaffolding — thinking headers, settled tool runs, the live
        activity ticker. One colour for all of them (see `ScaffoldRow`), pitched
        between the secondary and tertiary greys those lines used to pick

--- a/apps/desktop/src/themes/text-contrast.test.ts
+++ b/apps/desktop/src/themes/text-contrast.test.ts
@@ -1,7 +1,10 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 import { contrastRatio, mix } from './color'
 import { BUILTIN_THEME_LIST } from './presets'
+import { TEXT_RAMP, TEXT_RAMP_CSS_VARS } from './text-ramp'
 import type { DesktopTheme, DesktopThemeColors } from './types'
 
 /**
@@ -12,7 +15,7 @@ import type { DesktopTheme, DesktopThemeColors } from './types'
  * (tertiary 54%, quaternary 36%) fell below WCAG AA (4.5:1) on light themes and
  * were raised to 68%. This test re-derives the composited color and asserts the
  * informative text levels clear AA on the surfaces where secondary/status text
- * actually renders (app background, sidebar, and card).
+ * actually renders (app background, sidebar, card, and popover).
  *
  * Scope: first-party themes only. catppuccin, everforest and solarized are
  * marketplace forks whose foregrounds come from upstream (see the comment atop
@@ -21,16 +24,27 @@ import type { DesktopTheme, DesktopThemeColors } from './types'
  * drifting from upstream. They remain known debt, tracked against #38072.
  */
 
-const TEXT_LEVELS = {
-  // `--ui-text-secondary` (74%) drives `--dt-secondary-foreground`.
-  secondary: 0.74,
-  // `--ui-text-tertiary` (68%) drives the status bar and command-center captions.
-  tertiary: 0.68,
-  // `--ui-text-quaternary` (68%) drives timestamps and empty-state counts.
-  // Intentionally equal to tertiary: at these alphas no gap both keeps a
-  // visual step and clears AA, so we trade the finer hierarchy for readable text.
-  quaternary: 0.68
-} as const
+const STYLES_CSS = resolve(__dirname, '../styles.css')
+
+// The test lives in src/themes/, styles.css lives in src/. The context.tsx
+// seed mapping we also pin (--theme-foreground from colors.foreground) is in
+// src/themes/context.tsx.
+const CONTEXT_TSX = resolve(__dirname, 'context.tsx')
+
+/** The `--ui-text-*` declarations parsed out of styles.css, e.g. 0.74. */
+function cssTextAlphas(): Record<string, number> {
+  const css = readFileSync(STYLES_CSS, 'utf8')
+  const alphas: Record<string, number> = {}
+
+  for (const [level, cssVar] of Object.entries(TEXT_RAMP_CSS_VARS)) {
+    const re = new RegExp(`${cssVar}\\s*:\\s*color-mix\\(in srgb, var\\(--ui-base\\)\\s*([\\d.]+)%,\\s*transparent\\)`)
+    const match = css.match(re)
+    expect(match, `styles.css is missing the ${cssVar} declaration`).toBeTruthy()
+    alphas[level] = Number(match![1]) / 100
+  }
+
+  return alphas
+}
 
 const FIRST_PARTY_NAMES = new Set([
   'nous',
@@ -47,7 +61,8 @@ const FIRST_PARTY_NAMES = new Set([
 const surfacesFor = (c: DesktopThemeColors): string[] => [
   c.background,
   c.sidebarBackground ?? c.background,
-  c.card
+  c.card,
+  c.popover
 ]
 
 /** A theme's renderable palettes; first-party single-mode themes share one. */
@@ -59,6 +74,31 @@ const palettesFor = (theme: DesktopTheme): Array<[string, DesktopThemeColors]> =
 ]
 
 describe('ui-text token contrast', () => {
+  // The CSS ramp and the source-of-truth constant must never drift: if someone
+  // tweaks an alpha in styles.css, this fails instead of the guard measuring
+  // stale numbers (review: constants-drift risk).
+  it('matches the ramp declared in styles.css', () => {
+    const cssAlphas = cssTextAlphas()
+    for (const [level, expected] of Object.entries(TEXT_RAMP)) {
+      expect(cssAlphas[level], `--ui-text-* alpha for ${level} drifted from text-ramp.ts`).toBeCloseTo(expected, 2)
+    }
+  })
+
+  // The test composites `mix(colors.foreground, pct)` while the CSS mixes
+  // `var(--ui-base)`. That is only equivalent while --ui-base resolves to the
+  // theme's foreground, so pin the chain here: styles.css must derive --ui-base
+  // from --theme-foreground (the seed the theme context sets from colors.foreground).
+  it('--ui-base derives from the theme foreground (not a repurposed surface)', () => {
+    const css = readFileSync(STYLES_CSS, 'utf8')
+    expect(css).toMatch(/--ui-base\s*:\s*var\(--theme-foreground\)/)
+
+    // And the theme context publishes --theme-foreground from the theme's
+    // foreground seed, closing the --ui-base -> --theme-foreground ->
+    // colors.foreground chain that the contrast composition assumes.
+    const context = readFileSync(CONTEXT_TSX, 'utf8')
+    expect(context).toMatch(/'--theme-foreground'\s*:\s*c\.foreground/)
+  })
+
   for (const theme of BUILTIN_THEME_LIST) {
     if (!FIRST_PARTY_NAMES.has(theme.name)) {
       continue
@@ -66,10 +106,14 @@ describe('ui-text token contrast', () => {
 
     for (const [mode, colors] of palettesFor(theme)) {
       describe(`${theme.name} (${mode})`, () => {
-        for (const [level, pct] of Object.entries(TEXT_LEVELS)) {
+        for (const [level, pct] of Object.entries(TEXT_RAMP)) {
+          if (level === 'primary') {
+            continue
+          }
+
           it(`${level} clears 4.5:1 on every status surface`, () => {
             for (const surface of surfacesFor(colors)) {
-              // Re-derive the composited token: base at P% over the surface.
+              // Re-derive the composited token: --ui-base at P% over the surface.
               const token = mix(surface, colors.foreground, pct)
               expect(contrastRatio(token, surface), `${level} on ${surface}`).toBeGreaterThanOrEqual(4.5)
             }

--- a/apps/desktop/src/themes/text-contrast.test.ts
+++ b/apps/desktop/src/themes/text-contrast.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import { contrastRatio, mix } from './color'
+import { BUILTIN_THEME_LIST } from './presets'
+import type { DesktopTheme, DesktopThemeColors } from './types'
+
+/**
+ * Guard the `--ui-text-*` token ramp in styles.css against contrast regressions.
+ *
+ * Those tokens are derived as `color-mix(in srgb, var(--ui-base) P%, transparent)`,
+ * which paints as `base at P% alpha` over the surface beneath. The lowest rungs
+ * (tertiary 54%, quaternary 36%) fell below WCAG AA (4.5:1) on light themes and
+ * were raised to 68%. This test re-derives the composited color and asserts the
+ * informative text levels clear AA on the surfaces where secondary/status text
+ * actually renders (app background, sidebar, and card).
+ *
+ * Scope: first-party themes only. catppuccin, everforest and solarized are
+ * marketplace forks whose foregrounds come from upstream (see the comment atop
+ * presets.ts - "re-convert marketplace forks from the upstream extension rather
+ * than hand-editing hexes"), so we can't fix their contrast here without
+ * drifting from upstream. They remain known debt, tracked against #38072.
+ */
+
+const TEXT_LEVELS = {
+  // `--ui-text-secondary` (74%) drives `--dt-secondary-foreground`.
+  secondary: 0.74,
+  // `--ui-text-tertiary` (68%) drives the status bar and command-center captions.
+  tertiary: 0.68,
+  // `--ui-text-quaternary` (68%) drives timestamps and empty-state counts.
+  // Intentionally equal to tertiary: at these alphas no gap both keeps a
+  // visual step and clears AA, so we trade the finer hierarchy for readable text.
+  quaternary: 0.68
+} as const
+
+const FIRST_PARTY_NAMES = new Set([
+  'nous',
+  'github',
+  'nous-alt',
+  'midnight',
+  'ember',
+  'mono',
+  'slate',
+  'cyberpunk'
+])
+
+/** The surfaces secondary/status text renders on, per theme mode. */
+const surfacesFor = (c: DesktopThemeColors): string[] => [
+  c.background,
+  c.sidebarBackground ?? c.background,
+  c.card
+]
+
+/** A theme's renderable palettes; first-party single-mode themes share one. */
+const palettesFor = (theme: DesktopTheme): Array<[string, DesktopThemeColors]> => [
+  ['light', theme.colors],
+  ...(theme.darkColors && theme.darkColors !== theme.colors
+    ? ([['dark', theme.darkColors]] as Array<[string, DesktopThemeColors]>)
+    : [])
+]
+
+describe('ui-text token contrast', () => {
+  for (const theme of BUILTIN_THEME_LIST) {
+    if (!FIRST_PARTY_NAMES.has(theme.name)) {
+      continue
+    }
+
+    for (const [mode, colors] of palettesFor(theme)) {
+      describe(`${theme.name} (${mode})`, () => {
+        for (const [level, pct] of Object.entries(TEXT_LEVELS)) {
+          it(`${level} clears 4.5:1 on every status surface`, () => {
+            for (const surface of surfacesFor(colors)) {
+              // Re-derive the composited token: base at P% over the surface.
+              const token = mix(surface, colors.foreground, pct)
+              expect(contrastRatio(token, surface), `${level} on ${surface}`).toBeGreaterThanOrEqual(4.5)
+            }
+          })
+        }
+      })
+    }
+  }
+})

--- a/apps/desktop/src/themes/text-ramp.ts
+++ b/apps/desktop/src/themes/text-ramp.ts
@@ -1,0 +1,34 @@
+/**
+ * Source of truth for the `--ui-text-*` ramp in styles.css.
+ *
+ * Each rung paints `--ui-base` at an alpha over the surface beneath (see the
+ * `color-mix(in srgb, var(--ui-base) P%, transparent)` definitions in
+ * styles.css). Keeping the percentages here - and having text-contrast.test.ts
+ * parse styles.css to confirm they match - means the ramp cannot drift between
+ * the CSS and the contrast guard: a change to either side fails the test
+ * instead of silently shipping stale numbers.
+ */
+export const TEXT_RAMP = {
+  primary: 0.94,
+  // `--ui-text-secondary` drives `--dt-secondary-foreground`.
+  secondary: 0.74,
+  // `--ui-text-tertiary` drives the status bar and command-center captions.
+  tertiary: 0.68,
+  // `--ui-text-quaternary` drives timestamps and empty-state counts.
+  // Intentionally equal to tertiary: at these alphas no gap both keeps a
+  // visual step and clears AA, so the finer hierarchy is traded for readable
+  // text.
+  quaternary: 0.68
+} as const
+
+/**
+ * The CSS custom property each ramp rung maps to, keyed to match `TEXT_RAMP`.
+ * The test parses these exact declarations out of styles.css to prove the
+ * source-of-truth values and production are the same thing.
+ */
+export const TEXT_RAMP_CSS_VARS = {
+  primary: '--ui-text-primary',
+  secondary: '--ui-text-secondary',
+  tertiary: '--ui-text-tertiary',
+  quaternary: '--ui-text-quaternary'
+} as const


### PR DESCRIPTION
## What does this PR do?

Raises the Desktop UI's secondary text tokens to WCAG AA contrast (4.5:1). The `--ui-text-tertiary` and `--ui-text-quaternary` tokens in `src/styles.css` were derived as `color-mix(in srgb, var(--ui-base) 54% / 36%, transparent)`, which fell to 3.47:1 and 2.16:1 respectively on light themes - below the AA threshold for normal text. The audit (#38072, finding 4) flagged this against status-bar labels ("Gateway / ready / Agents"), a reorder hint, and empty-state counts.

This raises both tokens to 68%, which clears AA on every first-party theme (worst case is nous-alt dark over its mission-blue card at 4.91:1). Adds a token-level contrast regression test covering the first-party themes and the surfaces where secondary/status text renders.

## Related Issue

Fixes the contrast portion of #38072 (finding 4: secondary/status text insufficient contrast).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/styles.css`: raise `--ui-text-tertiary` from 54% to 68% and `--ui-text-quaternary` from 36% to 68%, with a comment explaining the trade-off.
- `apps/desktop/src/themes/text-contrast.test.ts` (new): re-derives the composited token color for every first-party theme and asserts secondary/tertiary/quaternary clear 4.5:1 on the background, sidebar, and card surfaces.

## Trade-off and scope

- **Tertiary and quaternary end up equivalent.** The four-rung alpha ramp cannot keep a visual step between tertiary and quaternary *and* clear AA on the light themes - any gap drops the lower rung below 4.5:1. This PR prioritizes readable text over the finer hierarchy. Decorative text that genuinely needs a fainter rung should use its own token rather than quaternary.
- **catppuccin, everforest and solarized remain known debt.** Their foregrounds come from upstream marketplace forks (see the comment atop `presets.ts`: "re-convert marketplace forks from the upstream extension rather than hand-editing hexes"), so their contrast can't be fixed here without drifting from upstream. The test excludes them and notes this.

## Verification

- `npx vitest run src/themes/text-contrast.test.ts` - 33 tests pass.
- `npx vitest run src/themes/` - 138 tests pass (11 files), no regressions.
- `npx biome check` - clean on touched files.
