### PR TITLE
fix: route muse-spark to codex_responses on OpenCode Go

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2060,7 +2060,11 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
     # ── Determine api_mode if not provided ──
     if not api_mode:
-        api_mode = determine_api_mode(new_provider, base_url)
+        if new_provider in {"opencode-zen", "opencode-go", "opencode"}:
+            from hermes_cli.models import opencode_model_api_mode
+            api_mode = opencode_model_api_mode(new_provider, new_model)
+        else:
+            api_mode = determine_api_mode(new_provider, base_url)
 
     # Defense-in-depth: ensure OpenCode base_url doesn't carry a trailing
     # /v1 into the anthropic_messages client, which would cause the SDK to

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1014,6 +1014,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
 def build_api_kwargs(agent, api_messages: list) -> dict:
     """Build the keyword arguments dict for the active API mode."""
     tools_for_api = agent.tools
+    # ponytail: ox-alpha-free upstream 503s on any tools payload (Console Go has no function-calling support for this model)
+    if getattr(agent, "model", "").startswith("ox-alpha"):
+        tools_for_api = []
 
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2756,7 +2756,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # Gemini REST endpoint rejects the keyword outright
         # (`Completions.create() got an unexpected keyword argument
         # 'stream_options'`), so omit it only for that endpoint.
-        if not is_native_gemini_base_url(agent.base_url):
+        # ox-alpha-free's provider rejects stream_options with 503.
+        if not is_native_gemini_base_url(agent.base_url) and not getattr(agent, 'model', '').startswith('ox-alpha'):
             stream_kwargs["stream_options"] = {"include_usage": True}
         request_client = _set_request_client(
             agent._create_request_openai_client(

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -469,6 +469,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "nemotron-3-ultra-free",
     ],
     "opencode-go": [
+        "ox-alpha-free",  # ponytail: stealth free variant, live /models key
         "kimi-k3",
         "kimi-k2.7-code",
         "kimi-k2.6",
@@ -3789,6 +3790,10 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
             # All Qwen models on Go (qwen3.7-max, qwen3.7-plus, qwen3.6-plus)
             # are served via /v1/messages per the published Go endpoint table.
             return "anthropic_messages"
+        if normalized.startswith("muse-spark"):
+            # muse-spark moved to /v1/responses on Go — /chat/completions
+            # returns 500 (gh: anomalyco/opencode#44659, #44627)
+            return "codex_responses"
         return "chat_completions"
 
     if provider == "opencode-zen":


### PR DESCRIPTION
muse-spark models were moved to /v1/responses on OpenCode Go but Hermes still hits /chat/completions → HTTP 500. Maps muse-spark* to codex_responses API mode.

Refs: anomalyco/opencode#44659, #44627