### PR TITLE
fix(a11y): add route-aware h1 and group titlebar clusters

### DIFF
--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -817,6 +817,7 @@ export function ContribController() {
   if (isHudWindow()) {
     return (
       <ContribWiring>
+        <RouteHeading />
         <HudShell />
       </ContribWiring>
     )

--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -86,6 +86,7 @@ import {
 } from '../chat/session-tile'
 import { AppContextMenu } from '../context-menu/app-context-menu'
 import { HudShell } from '../hud/hud-shell'
+import { RouteHeading } from '../shell/route-heading'
 import { $terminalTakeover, setTerminalTakeover } from '../right-sidebar/store'
 import { $workspaceIsPage } from '../routes'
 
@@ -829,6 +830,7 @@ export function ContribController() {
       style={{ '--sidebar-width': '100%' } as CSSProperties}
     >
       <ContribWiring>
+        <RouteHeading />
         <AppContextMenu />
         <div
           className="flex h-screen min-h-0 w-screen flex-col bg-(--ui-bg-chrome) text-(--ui-text-primary)"

--- a/apps/desktop/src/app/shell/route-heading.test.tsx
+++ b/apps/desktop/src/app/shell/route-heading.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { describe, expect, it } from 'vitest'
+
+import { RouteHeading } from './route-heading'
+
+describe('RouteHeading', () => {
+  const renderAt = (path: string) =>
+    render(
+      <MemoryRouter initialEntries={[path]}>
+        <RouteHeading />
+      </MemoryRouter>
+    )
+
+  it('renders a single top-level h1', () => {
+    renderAt('/')
+    expect(screen.getByRole('heading', { level: 1 })).toBeTruthy()
+  })
+
+  it('names the current route from its AppView', () => {
+    renderAt('/settings')
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Settings')
+  })
+
+  it('falls back to Chat for a session route', () => {
+    renderAt('/some-session-id')
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Chat')
+  })
+
+  it('tracks non-chat routes (skills, stripping the query)', () => {
+    renderAt('/skills?tab=mcp')
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Capabilities')
+  })
+})

--- a/apps/desktop/src/app/shell/route-heading.tsx
+++ b/apps/desktop/src/app/shell/route-heading.tsx
@@ -1,0 +1,21 @@
+import { useLocation } from 'react-router'
+
+import { useI18n } from '@/i18n'
+import { appViewForPath } from '@/app/routes'
+
+/**
+ * Screen-reader-only top-level heading for the desktop shell.
+ *
+ * Electron windows don't map to document-style heading rules the way a web
+ * page does, but screen-reader users still benefit from a stable h1 naming
+ * the current route (audit #38072, finding 5). The heading is visually hidden
+ * so the visual shell is untouched; it tracks the routed `AppView` so the
+ * announced name stays in sync with the screen.
+ */
+export function RouteHeading() {
+  const { t } = useI18n()
+  const location = useLocation()
+  const view = appViewForPath(location.pathname)
+
+  return <h1 className="sr-only">{t.shell.routeTitles[view]}</h1>
+}

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -268,6 +268,7 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
     <>
       <div
         aria-label={t.shell.windowControls}
+        role="group"
         className={cn(
           titlebarToolClusterClass,
           'left-(--titlebar-controls-left) top-(--titlebar-controls-top) translate-y-(--titlebar-controls-y-nudge)'
@@ -291,6 +292,7 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
       {visiblePaneTools.length > 0 && (
         <div
           aria-label={t.shell.paneControls}
+          role="group"
           className={cn(
             titlebarToolClusterClass,
             'top-[calc(var(--titlebar-controls-top)+var(--right-rail-top-inset,0px))] right-[calc(var(--titlebar-tools-right)+var(--shell-preview-toolbar-gap,0))]'
@@ -304,6 +306,7 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
 
       <div
         aria-label={t.shell.appControls}
+        role="group"
         className={cn(titlebarToolClusterClass, 'right-(--titlebar-tools-right) top-(--titlebar-controls-top)')}
       >
         {visibleSystemTools.map(tool => (

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2200,6 +2200,20 @@ export const ar = defineLocale({
     windowControls: 'تحكم النافذة',
     paneControls: 'تحكم اللوحات',
     appControls: 'تحكم التطبيق',
+    routeTitles: {
+      chat: 'الدردشة',
+      settings: 'الإعدادات',
+      'command-center': 'مركز الأوامر',
+      skills: 'المهارات',
+      messaging: 'الرسائل',
+      webhooks: 'خطافات الويب',
+      artifacts: 'القطع الأثرية',
+      cron: 'الوظائف المجدولة',
+      profiles: 'الملفات الشخصية',
+      agents: 'الوكلاء',
+      starmap: 'خريطة النجوم',
+      extension: 'الامتداد'
+    },
     modelMenu: {
       search: 'البحث عن نموذج...',
       noModels: 'لا توجد نماذج',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2782,6 +2782,20 @@ export const en: Translations = {
     windowControls: 'Window controls',
     paneControls: 'Pane controls',
     appControls: 'App controls',
+    routeTitles: {
+      chat: 'Chat',
+      settings: 'Settings',
+      'command-center': 'Command center',
+      skills: 'Capabilities',
+      messaging: 'Messaging',
+      webhooks: 'Webhooks',
+      artifacts: 'Artifacts',
+      cron: 'Scheduled jobs',
+      profiles: 'Profiles',
+      agents: 'Agents',
+      starmap: 'Starmap',
+      extension: 'Extension'
+    },
     modelMenu: {
       search: 'Search models',
       noModels: 'No models found',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2450,6 +2450,20 @@ export const ja = defineLocale({
     windowControls: 'ウィンドウコントロール',
     paneControls: 'ペインコントロール',
     appControls: 'アプリコントロール',
+    routeTitles: {
+      chat: 'チャット',
+      settings: '設定',
+      'command-center': 'コマンドセンター',
+      skills: 'スキル',
+      messaging: 'メッセージング',
+      webhooks: 'ウェブフック',
+      artifacts: 'アーティファクト',
+      cron: 'スケジュールジョブ',
+      profiles: 'プロフィール',
+      agents: 'エージェント',
+      starmap: 'スターアトラス',
+      extension: '拡張機能'
+    },
     modelMenu: {
       search: 'モデルを検索',
       noModels: 'モデルが見つかりません',

--- a/apps/desktop/src/i18n/route-titles.test.ts
+++ b/apps/desktop/src/i18n/route-titles.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { APP_ROUTES } from '@/app/routes'
+import { TRANSLATIONS } from './catalog'
+
+// The sr-only <h1> (RouteHeading) announces t.shell.routeTitles[view] for the
+// routed AppView. That index assumes every locale covers every view, so this
+// makes the invariant executable: any locale that omits a route title (or
+// ships an empty string) fails here instead of announcing a blank heading.
+describe('i18n route titles', () => {
+  const views = APP_ROUTES.map(route => route.view)
+
+  it('every locale defines a non-empty route title for every routed view', () => {
+    for (const [locale, translations] of Object.entries(TRANSLATIONS) as Array<
+      [string, (typeof TRANSLATIONS)[keyof typeof TRANSLATIONS]]
+    >) {
+      for (const view of views) {
+        const title = translations.shell.routeTitles[view]
+        expect(title, `${locale} missing route title for ${view}`).toBeTruthy()
+        expect(title.trim(), `${locale} route title for ${view} is empty`).not.toHaveLength(0)
+      }
+    }
+  })
+})

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2348,6 +2348,20 @@ export interface Translations {
     windowControls: string
     paneControls: string
     appControls: string
+    routeTitles: {
+      chat: string
+      settings: string
+      'command-center': string
+      skills: string
+      messaging: string
+      webhooks: string
+      artifacts: string
+      cron: string
+      profiles: string
+      agents: string
+      starmap: string
+      extension: string
+    }
     modelMenu: {
       search: string
       noModels: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2362,6 +2362,20 @@ export const zhHant = defineLocale({
     windowControls: '視窗控制項',
     paneControls: '窗格控制項',
     appControls: '應用程式控制項',
+    routeTitles: {
+      chat: '聊天',
+      settings: '設定',
+      'command-center': '命令中心',
+      skills: '技能',
+      messaging: '訊息',
+      webhooks: '網路鉤子',
+      artifacts: '產物',
+      cron: '排程工作',
+      profiles: '設定檔',
+      agents: '代理程式',
+      starmap: '星圖',
+      extension: '擴充功能'
+    },
     modelMenu: {
       search: '搜尋模型',
       noModels: '找不到模型',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2947,6 +2947,20 @@ export const zh: Translations = {
     windowControls: '窗口控件',
     paneControls: '面板控件',
     appControls: '应用控件',
+    routeTitles: {
+      chat: '聊天',
+      settings: '设置',
+      'command-center': '命令中心',
+      skills: '技能',
+      messaging: '消息',
+      webhooks: '网络钩子',
+      artifacts: '工件',
+      cron: '计划任务',
+      profiles: '配置文件',
+      agents: '智能体',
+      starmap: '星图',
+      extension: '扩展'
+    },
     modelMenu: {
       search: '搜索模型',
       noModels: '未找到模型',

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -1328,7 +1328,7 @@ export function KanbanBoardPage() {
       </Contribute>
 
       <header className="flex shrink-0 flex-wrap items-center gap-2 px-4 py-2">
-        <h1 className="text-sm font-semibold text-foreground">{k.title}</h1>
+        <h2 className="text-sm font-semibold text-foreground">{k.title}</h2>
         <span className="rounded-full bg-(--ui-bg-quaternary) px-1.5 py-px text-[0.625rem] tabular-nums text-(--ui-text-tertiary)">
           {total}
         </span>


### PR DESCRIPTION
## What does this PR do?

Fixes finding 5 of the desktop accessibility audit (#38072): the shell had no top-level heading, and the fixed titlebar clusters sat outside any landmark/group structure.

- Adds a visually hidden `<h1>` (`RouteHeading`) that names the current route. It derives the `AppView` from the router location via `appViewForPath`, so the announced name tracks the screen (chat, settings, skills, ...) and stays correct for session routes and query-bearing paths. Mounted once in `ContribController`, inside the shell.
- Exposes the three fixed titlebar clusters (window / pane / app controls) as `role="group"`. They already carried `aria-label`s; the explicit group role lets screen readers announce them as named groups rather than anonymous fixed chrome.

## Related Issue

Fixes the heading/landmark portion of #38072 (finding 5: no top-level heading, fixed titlebar controls outside landmarks).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/app/shell/route-heading.tsx` (new): visually hidden, route-aware h1.
- `apps/desktop/src/app/shell/route-heading.test.tsx` (new): covers the default route, a session route, and a query-bearing non-chat route.
- `apps/desktop/src/app/contrib/controller.tsx`: mounts `RouteHeading` in the shell.
- `apps/desktop/src/app/shell/titlebar-controls.tsx`: `role="group"` on the three titlebar clusters.
- `apps/desktop/src/i18n/{en,ja,ar,zh,zh-hant}.ts` + `types.ts`: `shell.routeTitles` per-route labels for every locale.

## Verification

- `npx tsc --noEmit` - clean.
- `npx vitest run src/app/contrib/ src/app/shell/ src/app/routes.test.ts src/i18n/` - 192 tests pass, no regressions.
- `npx biome check` - clean on touched files.
