### PR TITLE
fix(desktop): clear edit latch timer on unmount

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -108,6 +108,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   const [triggerPlacement, setTriggerPlacement] = useState<'bottom' | 'top'>('top')
   const [focusRequestId, setFocusRequestId] = useState(0)
   const [submitting, setSubmitting] = useState(false)
+  const submitLatchTimerRef = useRef<number | null>(null)
   // True while OS-drop files are being staged/uploaded into the session. Blocks
   // submit and shows a spinner so confirming the edit can't race the async
   // upload and drop the gateway-side ref before it lands in the draft.
@@ -117,6 +118,16 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   const at = useAtCompletions({ cwd, gateway, sessionId })
   const slash = useSlashCompletions({ gateway })
   const emoji = useEmojiCompletions()
+
+  useEffect(
+    () => () => {
+      if (submitLatchTimerRef.current !== null) {
+        window.clearTimeout(submitLatchTimerRef.current)
+        submitLatchTimerRef.current = null
+      }
+    },
+    []
+  )
 
   // This is the one composer that routinely unmounts, so it is where the focus
   // bus leaks: confirming or cancelling an edit tears the composer down while
@@ -602,7 +613,10 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
       // Clear latch after cooldown to allow re-submission. This prevents rapid
       // double-Enter but doesn't require tracking when onEdit settles (which may
       // be synchronous or async, and whose promise we don't have access to).
-      window.setTimeout(() => {
+      // `submitting` blocks re-entry until this handle fires, so only one latch
+      // timer can exist at a time.
+      submitLatchTimerRef.current = window.setTimeout(() => {
+        submitLatchTimerRef.current = null
         setSubmitting(false)
       }, 200)
     } catch {

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
@@ -233,6 +233,34 @@ describe('Enter submission and latch behavior', () => {
     })
   })
 
+  it('cancels the submitting latch timer when the edit composer unmounts', async () => {
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout')
+    const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout')
+
+    try {
+      const onEdit = vi.fn(async () => {})
+      const view = render(<IncrementalHarness onEdit={onEdit} />)
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Edit message' }))
+
+      const editor = await screen.findByRole('textbox', { name: 'Edit message' })
+      editor.textContent = 'submit before unmount'
+      fireEvent.input(editor)
+      fireEvent.keyDown(editor, { key: 'Enter' })
+
+      await waitFor(() => expect(onEdit).toHaveBeenCalledTimes(1))
+      const timerIndex = setTimeoutSpy.mock.calls.map(([, delay]) => delay).lastIndexOf(200)
+      const timerId = setTimeoutSpy.mock.results[timerIndex]?.value
+
+      expect(timerIndex).toBeGreaterThanOrEqual(0)
+      view.unmount()
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(timerId)
+    } finally {
+      setTimeoutSpy.mockRestore()
+      clearTimeoutSpy.mockRestore()
+    }
+  })
+
   it('inserts a newline on Shift+Enter without submitting', async () => {
     const onEdit = vi.fn(async () => {})
     render(<IncrementalHarness onEdit={onEdit} />)


### PR DESCRIPTION
## Summary

Clear the inline edit composer's 200 ms submission-latch timer when the composer unmounts. Without cleanup, the callback can call React after jsdom has torn down `window`, making the otherwise-passing Desktop UI suite fail nondeterministically.

Add a regression test that captures the latch timer and verifies unmount clears that exact handle.

## Related issue

Fixes #92462.

## Validation

Validation on rebased head `ce25b637e3f` over frozen `main` `28b758d5caa`:

- Focused UserEditComposer suite: **10 passed**
- Desktop typecheck: passed
- ESLint on changed files: 0 errors
- `git diff --check` and contributor-attribution audit: passed
- The history-only rebase produces the exact same tree as merging the prior head onto that frozen main.

## Related

Observed in the required-check run for #93007 after all 5,695 UI assertions passed: https://github.com/NousResearch/hermes-agent/actions/runs/32720835162/job/97411776638