### PR TITLE
fix(approval): compose tirith descriptions from the structured remediation field

### DIFF
--- a/tests/tools/test_tirith_approval_description.py
+++ b/tests/tools/test_tirith_approval_description.py
@@ -1,0 +1,94 @@
+"""Tirith approval descriptions compose from the structured remediation field (#93839).
+
+tirith (upstream, since v0.2.5) appends third-party promotional hints to the
+free-text ``description`` of findings — e.g. the getvet.sh cross-promotion on
+the "safer alternative" line — and ``_format_tirith_description`` rendered
+that text verbatim into terminal approval prompts and platform approval
+cards (Slack), where it reads as the agent recommending an unrelated
+product. The clean structured guidance lives in ``remediation``; the
+formatter now prefers it, falling back to ``description`` only for findings
+that carry no remediation (no hardcoded promo-string filters, which upstream
+wording changes would silently defeat).
+"""
+
+from tools.approval import _format_tirith_description
+
+
+def test_promo_in_description_is_not_rendered_when_remediation_exists():
+    """The reporter's exact finding shape: description carries the
+    getvet.sh promo, remediation is the clean structured guidance."""
+    result = {
+        "action": "warn",
+        "summary": "1 warning",
+        "findings": [
+            {
+                "rule_id": "curl_pipe_shell",
+                "severity": "HIGH",
+                "title": "Pipe to interpreter: curl | python3",
+                "description": (
+                    "Command pipes output from 'curl' directly to interpreter "
+                    "'python3'. Downloaded content will be executed without "
+                    "inspection.\n  Safer: tirith run https://api.example.com/data "
+                    "— or: vet https://api.example.com/data  (https://getvet.sh)"
+                ),
+                "remediation": (
+                    "Download first with curl -o, review the script, then "
+                    "execute. Or use tirith run <url>."
+                ),
+            }
+        ],
+    }
+
+    out = _format_tirith_description(result)
+
+    assert "getvet.sh" not in out
+    assert "vet https://" not in out
+    assert "Download first with curl -o" in out
+    assert "Pipe to interpreter" in out
+    assert "[HIGH]" in out
+
+
+def test_description_fallback_when_no_remediation():
+    """Findings without a remediation field keep the historical
+    description-based rendering."""
+    result = {
+        "action": "warn",
+        "summary": "1 warning",
+        "findings": [
+            {
+                "severity": "LOW",
+                "title": "Plain finding",
+                "description": "Some plain detail text",
+            }
+        ],
+    }
+
+    out = _format_tirith_description(result)
+
+    assert "Plain finding: Some plain detail text" in out
+
+
+def test_mixed_findings_use_remediation_where_available():
+    result = {
+        "action": "block",
+        "summary": "2 findings",
+        "findings": [
+            {
+                "severity": "HIGH",
+                "title": "With remediation",
+                "description": "promo-laden description",
+                "remediation": "clean guidance A",
+            },
+            {
+                "severity": "LOW",
+                "title": "Without remediation",
+                "description": "plain description B",
+            },
+        ],
+    }
+
+    out = _format_tirith_description(result)
+
+    assert "clean guidance A" in out
+    assert "promo-laden description" not in out
+    assert "plain description B" in out

--- a/tests/tools/test_tirith_approval_description.py
+++ b/tests/tools/test_tirith_approval_description.py
@@ -92,3 +92,47 @@ def test_mixed_findings_use_remediation_where_available():
     assert "clean guidance A" in out
     assert "promo-laden description" not in out
     assert "plain description B" in out
+
+
+def test_empty_string_remediation_falls_back_to_description():
+    """``remediation: ""`` is falsy — the finding must keep the
+    description-based rendering, not render an empty detail."""
+    result = {
+        "action": "warn",
+        "summary": "1 warning",
+        "findings": [
+            {
+                "severity": "MEDIUM",
+                "title": "Empty remediation",
+                "description": "plain fallback text",
+                "remediation": "",
+            }
+        ],
+    }
+
+    out = _format_tirith_description(result)
+
+    assert "Empty remediation: plain fallback text" in out
+
+
+def test_non_string_remediation_falls_back_to_description():
+    """A structured (list) remediation from a future tirith version must
+    not render a Python repr into approval prompts."""
+    result = {
+        "action": "warn",
+        "summary": "1 warning",
+        "findings": [
+            {
+                "severity": "MEDIUM",
+                "title": "Structured remediation",
+                "description": "plain fallback text",
+                "remediation": ["step one", "step two"],
+            }
+        ],
+    }
+
+    out = _format_tirith_description(result)
+
+    assert "Structured remediation: plain fallback text" in out
+    assert "step one" not in out
+    assert "[" not in out.split("Structured remediation", 1)[-1]

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -4109,6 +4109,15 @@ def _format_tirith_description(tirith_result: dict) -> str:
     it keeps approvals to security content without hardcoding filters
     against specific promo strings (which upstream wording changes would
     silently defeat).
+
+    Information trade-off, accepted deliberately: when ``remediation``
+    exists the free-text ``description`` is dropped entirely — including
+    the finding's explanation of *why* it is risky — because that is where
+    the promotional hints live, so appending description would reintroduce
+    them. Title plus remediation advice is kept as the decision-relevant
+    minimum. Only string remediations are honored; a structured (list/dict)
+    value from a future tirith version would otherwise render as a Python
+    repr into approval prompts, so non-strings fall back to description.
     """
     findings = tirith_result.get("findings") or []
     if not findings:
@@ -4119,7 +4128,12 @@ def _format_tirith_description(tirith_result: dict) -> str:
     for f in findings:
         severity = f.get("severity", "")
         title = f.get("title", "")
-        detail = f.get("remediation") or f.get("description") or ""
+        remediation = f.get("remediation")
+        detail = (
+            remediation
+            if isinstance(remediation, str) and remediation
+            else (f.get("description") or "")
+        )
         if title and detail:
             parts.append(f"[{severity}] {title}: {detail}" if severity else f"{title}: {detail}")
         elif title:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -4097,8 +4097,18 @@ def request_tool_approval(
 def _format_tirith_description(tirith_result: dict) -> str:
     """Build a human-readable description from tirith findings.
 
-    Includes severity, title, and description for each finding so users
-    can make an informed approval decision.
+    Composes from the structured ``remediation`` field when present,
+    falling back to the free-text ``description`` only for findings that
+    carry no remediation. tirith (upstream, by design since v0.2.5)
+    stuffs third-party promotional hints into ``description`` — e.g. the
+    getvet.sh cross-promotion appended to the "safer alternative" line —
+    and Hermes renders this text verbatim into approval prompts and
+    platform approval cards (Slack), where it reads as the agent
+    recommending an unrelated product (#93839). ``remediation`` is the
+    clean structured guidance field for exactly this purpose; preferring
+    it keeps approvals to security content without hardcoding filters
+    against specific promo strings (which upstream wording changes would
+    silently defeat).
     """
     findings = tirith_result.get("findings") or []
     if not findings:
@@ -4109,9 +4119,9 @@ def _format_tirith_description(tirith_result: dict) -> str:
     for f in findings:
         severity = f.get("severity", "")
         title = f.get("title", "")
-        desc = f.get("description", "")
-        if title and desc:
-            parts.append(f"[{severity}] {title}: {desc}" if severity else f"{title}: {desc}")
+        detail = f.get("remediation") or f.get("description") or ""
+        if title and detail:
+            parts.append(f"[{severity}] {title}: {detail}" if severity else f"{title}: {detail}")
         elif title:
             parts.append(f"[{severity}] {title}" if severity else title)
     if not parts:


### PR DESCRIPTION
## What does this PR do?

tirith (the bundled security scanner, upstream since v0.2.5) appends third-party promotional hints to the free-text `description` of its findings — the getvet.sh cross-promotion on the "safer alternative" line — and `_format_tirith_description` rendered that text verbatim into terminal approval prompts and platform approval cards (Slack), where it reads as the agent itself recommending an unrelated product (#93839; the reporter's user literally asked "Are you recommending https://getvet.sh/?"). The clean structured guidance lives in the `remediation` field, which upstream keeps promo-free. This PR makes the formatter prefer `remediation`, falling back to `description` only for findings that carry no remediation.

## Related Issue

Fixes #93839

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/approval.py` — `_format_tirith_description`: per-finding detail is now `f.get("remediation") or f.get("description") or ""`, with the docstring documenting the upstream promo mechanism (#93839) and why a structured-field preference beats hardcoded promo-string filters (upstream wording changes would silently defeat them). Severity/title composition and all fallback paths are unchanged.
- `tests/tools/test_tirith_approval_description.py` — new (3 tests): the reporter's exact finding shape renders the clean remediation with no `getvet.sh` / `vet https://` text; a finding without remediation keeps the historical description-based rendering; mixed findings use remediation where available and description otherwise.

## How to Test

- New: `.venv/bin/python -m pytest tests/tools/test_tirith_approval_description.py -q` — should pass (3 tests). On unpatched `main`, the promo test fails (getvet.sh renders into the approval description), pinning the regression.
- Regression: `.venv/bin/python -m pytest tests/tools/test_command_guards.py tests/tools/test_approval_deny_rules.py tests/tools/test_approval_mode_parity.py tests/tools/test_tirith_approval_description.py -q` — should pass (52 tests), including the existing guard that asserts the "Security scan" description shape.

Observed result: locally, the reporter's exact tirith finding (description carrying the promo line, remediation carrying "Download first with curl -o…") now renders as `[HIGH] Pipe to interpreter: curl | python3: Download first with curl -o, review the script, then execute. Or use tirith run <url>.` — no third-party text on any surface.

## Checklist

- [x] Code follows project style (no unrelated changes)
- [x] Self-reviewed the diff
- [x] Added/updated tests covering the fix
- [x] All new and existing tests pass locally (3 new + 49 existing around the change)
- [x] PR targets `upstream/main` from a fork branch
