### PR TITLE
fix(desktop): keep Home new sessions detached from the last project

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -4,6 +4,7 @@ import type { MutableRefObject } from 'react'
 import { useEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { NO_PROJECT_ID } from '@/app/chat/sidebar/projects/workspace-groups'
 import { $terminalTakeover, setTerminalTakeover } from '@/app/right-sidebar/store'
 import { noteActiveTreeGroup, revealTreePane } from '@/components/pane-shell/tree/store'
 import {
@@ -91,7 +92,7 @@ const RUNTIME_SESSION_ID = 'rt-new-001'
 
 type HarnessHandle = Pick<
   ReturnType<typeof useSessionActions>,
-  'createBackendSessionForSend' | 'removeSession' | 'selectSidebarItem' | 'startFreshSessionDraft'
+  'createBackendSessionForSend' | 'openNewSessionTile' | 'removeSession' | 'selectSidebarItem' | 'startFreshSessionDraft'
 >
 
 function storedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
@@ -2754,6 +2755,7 @@ describe('createBackendSessionForSend workspace target', () => {
     cleanup()
     $newChatProfile.set(null)
     $activeGatewayProfile.set('default')
+    $projectScope.set(ALL_PROJECTS)
     setCurrentCwd('')
     setNewChatWorkspaceTarget(undefined)
     vi.restoreAllMocks()
@@ -2786,6 +2788,68 @@ describe('createBackendSessionForSend workspace target', () => {
     )
 
     expect(params).toMatchObject({ cwd: '/clicked-workspace' })
+  })
+
+  it('does not inherit a stale cwd when Home is the active project scope', async () => {
+    const params = await createWith(
+      () => {
+        $projectScope.set(NO_PROJECT_ID)
+      },
+      () => {
+        // Simulate the stale live path left by the previously selected project
+        // before the new draft is submitted.
+        $currentCwd.set('/previous-project')
+      }
+    )
+
+    expect(params).not.toHaveProperty('cwd')
+  })
+})
+
+describe('openNewSessionTile workspace target', () => {
+  afterEach(() => {
+    cleanup()
+    $projectScope.set(ALL_PROJECTS)
+    $projectTree.set([])
+    vi.restoreAllMocks()
+  })
+
+  it('omits cwd for a Home tile even when project scope resolves to a repo', async () => {
+    $projectScope.set('p_voice')
+    $projectTree.set([
+      {
+        id: 'p_voice',
+        label: 'Voice Assistant',
+        path: '/Users/oschmidt/Checkouts/voice-assistant',
+        repos: [],
+        sessionCount: 0
+      } as never
+    ])
+
+    let createParams: Record<string, unknown> | undefined
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        createParams = params
+
+        return {
+          info: { cwd: '', model: 'test-model', tools: {}, skills: {} },
+          session_id: RUNTIME_SESSION_ID,
+          stored_session_id: 'stored-home-tile'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={value => (handle = value)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.openNewSessionTile('center', { cwd: null, listed: false })
+    })
+
+    expect(createParams).not.toHaveProperty('cwd')
   })
 })
 describe('selectSidebarItem', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 import type { NavigateFunction } from 'react-router'
 
+import { NO_PROJECT_ID } from '@/app/chat/sidebar/projects/workspace-groups'
 import { graftRefreshedTailOntoBackfill } from '@/app/chat/transcript-backfill'
 import { revealTreePane } from '@/components/pane-shell/tree/store'
 import { setWorkspaceScope } from '@/components/pane-shell/workspace-scope'
@@ -30,6 +31,7 @@ import {
   normalizeProfileKey
 } from '@/store/profile'
 import {
+  $projectScope,
   beginSessionMutation,
   endSessionMutation,
   resolveNewSessionCwd,
@@ -470,10 +472,13 @@ export function useSessionActions({
         // An explicit one-shot workspace target (null → detached, string → that
         // folder) wins; otherwise the live cwd, then the project-aware default
         // (resolveNewSessionCwd — a project's new session keeps its repo cwd).
+        // Home is an explicit detached scope: do not let a stale live cwd from
+        // the previously selected project leak into this new session (#84220).
         const workspaceTarget = $newChatWorkspaceTarget.get()
+        const homeScope = $projectScope.get() === NO_PROJECT_ID
 
         const cwd =
-          workspaceTarget === null
+          workspaceTarget === null || (workspaceTarget === undefined && homeScope)
             ? ''
             : typeof workspaceTarget === 'string'
               ? workspaceTarget.trim()
@@ -612,16 +617,24 @@ export function useSessionActions({
 
       try {
         // Fresh tile → the caller's workspace when one was named (the sidebar
-        // "+" on a project/worktree lane), else the resolved new-session cwd
-        // (project scope → configured default).
+        // "+" on a project/worktree lane), explicit null means Home/detached,
+        // else the resolved new-session cwd (project scope → configured default).
+        // `options?.cwd || resolve…` is wrong for Home: null is falsy and used
+        // to fall through into the last project folder while main chat was
+        // occupied (openTab path for "New session in Home").
         const capturedRoute = options?.route === undefined ? $newChatRoute.get() : options.route
         const workspaceScope = options?.workspaceScope ?? { workspaceMode: 'sessions' }
+        const cwd =
+          options?.cwd === null
+            ? ''
+            : typeof options?.cwd === 'string'
+              ? options.cwd.trim()
+              : resolveNewSessionCwd()
 
         const params = {
-          ...(await desktopSessionCreateParams((options?.cwd || resolveNewSessionCwd()).trim(), capturedRoute)),
+          ...(await desktopSessionCreateParams(cwd, capturedRoute)),
           ...(workspaceScope.workspaceMode === 'bots' ? { hidden: true } : {})
         }
-
         const created = capturedRoute
           ? await requestGatewayForAgent<SessionCreateResponse>(
               capturedRoute.connectionId,

--- a/apps/desktop/src/app/session/workspace-session-target.test.ts
+++ b/apps/desktop/src/app/session/workspace-session-target.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
 import {
   $currentBranch,
   $currentCwd,
   $newChatWorkspaceTarget,
+  type NewChatWorkspaceTarget,
   setCurrentBranch,
   setCurrentCwd,
   setNewChatWorkspaceTarget
@@ -18,6 +20,8 @@ describe('startWorkspaceSession', () => {
     setCurrentBranch('')
     setCurrentCwd('')
     setNewChatWorkspaceTarget(undefined)
+    $projectScope.set(ALL_PROJECTS)
+    $projectTree.set([])
     vi.restoreAllMocks()
   })
 
@@ -32,7 +36,7 @@ describe('startWorkspaceSession', () => {
 
     const activeSessionIdRef = { current: null }
 
-    const startFreshSessionDraft = vi.fn((options?: { workspaceTarget: string }) => {
+    const startFreshSessionDraft = vi.fn((options?: { workspaceTarget: NewChatWorkspaceTarget }) => {
       setNewChatWorkspaceTarget(options?.workspaceTarget)
       setCurrentCwd(options?.workspaceTarget || '')
     })
@@ -69,5 +73,37 @@ describe('startWorkspaceSession', () => {
     expect($newChatWorkspaceTarget.get()).toBe('/normalized-b')
     expect($currentCwd.get()).toBe('/normalized-b')
     expect($currentBranch.get()).toBe('main')
+  })
+
+  it('keeps a Home new-session request detached even when another project scope is active', () => {
+    $projectScope.set('p_voice')
+    $projectTree.set([
+      {
+        id: 'p_voice',
+        label: 'Voice Assistant',
+        path: '/Users/oschmidt/Checkouts/voice-assistant',
+        repos: [],
+        sessionCount: 0
+      }
+    ])
+
+    const requestGateway = vi.fn()
+    const activeSessionIdRef = { current: null }
+    const startFreshSessionDraft = vi.fn((options?: { workspaceTarget: NewChatWorkspaceTarget }) => {
+      setNewChatWorkspaceTarget(options?.workspaceTarget)
+      setCurrentCwd(options?.workspaceTarget || '')
+    })
+
+    startWorkspaceSession({
+      activeSessionIdRef,
+      path: null,
+      requestGateway,
+      startFreshSessionDraft
+    })
+
+    expect(startFreshSessionDraft).toHaveBeenCalledWith({ workspaceTarget: null })
+    expect(requestGateway).not.toHaveBeenCalled()
+    expect($newChatWorkspaceTarget.get()).toBeNull()
+    expect($currentCwd.get()).toBe('')
   })
 })

--- a/apps/desktop/src/app/session/workspace-session-target.ts
+++ b/apps/desktop/src/app/session/workspace-session-target.ts
@@ -3,6 +3,7 @@ import type { MutableRefObject } from 'react'
 import { followActiveSessionCwd, resolveNewSessionCwd } from '@/store/projects'
 import {
   $newChatWorkspaceTargetGeneration,
+  type NewChatWorkspaceTarget,
   setCurrentBranch,
   setCurrentCwd,
   setNewChatWorkspaceTarget
@@ -14,7 +15,7 @@ interface WorkspaceSessionOptions {
   onExplicitWorkspace?: (cwd: string) => void
   path: null | string
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
-  startFreshSessionDraft: (options?: { workspaceTarget: string }) => void
+  startFreshSessionDraft: (options?: { workspaceTarget: NewChatWorkspaceTarget }) => void
 }
 
 export function startWorkspaceSession({
@@ -25,13 +26,22 @@ export function startWorkspaceSession({
   requestGateway,
   startFreshSessionDraft
 }: WorkspaceSessionOptions): void {
-  // A worktree lane carries its own path; a project trunk can be path-less, so
-  // fall back to the active project's root for that existing controller path.
-  const explicitTarget = path?.trim()
+  // Home's "+" passes path=null on purpose ("no folder"). That must stay
+  // detached — do NOT fall through to resolveNewSessionCwd(), which can still
+  // return a default/remembered project folder and re-attach the last repo
+  // (digitwo: New session in Home still shows `main`).
+  if (path === null) {
+    startFreshSessionDraft({ workspaceTarget: null })
+
+    return
+  }
+
+  // A worktree lane carries its own path. Empty string (legacy/path-less trunk)
+  // can fall back to the active project's root, but null was handled above.
+  const explicitTarget = path.trim()
   const target = explicitTarget || resolveNewSessionCwd()
 
   startFreshSessionDraft(target ? { workspaceTarget: target } : undefined)
-
   if (!target) {
     return
   }


### PR DESCRIPTION
## Summary
- Home's **New session in Home** (`path` / `cwd` = `null`) was treated as falsy and fell through to `resolveNewSessionCwd()`, so a new Home chat could still land in the previous project folder and show its git branch (especially the tab `openTab` path while main chat is occupied).
- Treat explicit `null` as detached on the draft path, the tile-create path, and Home-scope `session.create`, so stale `$currentCwd` cannot leak back in.

Fixes the residual class tracked by #84220 (related open attempts: #84814, #88370).

## Test plan
- [x] `npx vitest run --project ui src/app/session/workspace-session-target.test.ts src/app/session/hooks/use-session-actions.test.tsx`
- [ ] Desktop: open a project chat → Projects overview → **New session in Home** (`+`) while main is occupied → new tab should have **no** branch / project path
- [ ] Desktop: Home scope → New session / Ctrl+N → composer stays detached even if Files pane still showed the old project path
- [ ] Desktop: project row `+` still anchors the new session at that project root