### PR TITLE
fix(a11y): grow shared icon buttons to 24px hit targets

### DIFF
--- a/apps/desktop/src/app/master-detail.tsx
+++ b/apps/desktop/src/app/master-detail.tsx
@@ -206,7 +206,8 @@ const DETAIL_PANE_COLLAPSED_PX = 4
 // strip <Button size="icon">'s larger built-in size — a custom utility class
 // isn't size-merge-aware, so Button's icon size would leak and blow it up.
 // Compose extra state (data-[state=open], hover:text-destructive) with cn().
-// 24px meets the WCAG 2.5.5 pointer-target floor (audit #38072, finding 6).
+// 24px meets the WCAG 2.5.8 Target Size (Minimum) floor (audit #38072, finding 6);
+// the 2.5.5 enhanced 44px target is deliberately not met here.
 export const ICON_BUTTON =
   'size-6 cursor-pointer rounded-[4px] text-muted-foreground/70 hover:bg-(--ui-control-active-background) hover:text-foreground'
 

--- a/apps/desktop/src/app/master-detail.tsx
+++ b/apps/desktop/src/app/master-detail.tsx
@@ -202,12 +202,13 @@ const DETAIL_PANE_COLLAPSED_PX = 4
 
 // Ghost icon-button on the kebab-trigger scale (pane headers, list-strip menu,
 // per-server MCP actions, JSON editor format button). MUST stay a class string
-// (not a CSS @utility): the leading `size-5` is what tailwind-merge uses to
+// (not a CSS @utility): the leading `size-6` is what tailwind-merge uses to
 // strip <Button size="icon">'s larger built-in size — a custom utility class
 // isn't size-merge-aware, so Button's icon size would leak and blow it up.
 // Compose extra state (data-[state=open], hover:text-destructive) with cn().
+// 24px meets the WCAG 2.5.5 pointer-target floor (audit #38072, finding 6).
 export const ICON_BUTTON =
-  'size-5 cursor-pointer rounded-[4px] text-muted-foreground/70 hover:bg-(--ui-control-active-background) hover:text-foreground'
+  'size-6 cursor-pointer rounded-[4px] text-muted-foreground/70 hover:bg-(--ui-control-active-background) hover:text-foreground'
 
 export function DetailPane({
   actions,

--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -1254,13 +1254,13 @@ function ServerConfig({
     <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain p-2 [scrollbar-gutter:stable]">
       {/* Geometry cloned from McpRow so nothing jumps when flipping list ⇄
           config: items-start with per-element top margins that reproduce the
-          row's h-11 centering exactly (h-5 controls → mt-3, size-6 avatar →
+          row's h-11 centering exactly (size-6 controls → mt-2.5, size-6 avatar →
           mt-2.5, h-4 switch → mt-3.5) no matter how tall the text column gets. */}
       <div className="flex items-start gap-2 pr-1.5">
         <Tip label={m.allServers}>
           <Button
             aria-label={m.allServers}
-            className={cn('mt-3', ICON_BUTTON)}
+            className={cn('mt-2.5', ICON_BUTTON)}
             onClick={onBack}
             size="icon"
             variant="ghost"
@@ -1281,7 +1281,7 @@ function ServerConfig({
           // row's own gap-2, byte-identical to McpRow.
           <>
             <ServerIconActions
-              className="mt-3"
+              className="mt-2.5"
               onProbe={onProbe}
               onRemove={onRemove}
               probing={probe === 'probing'}


### PR DESCRIPTION
## What does this PR do?

Fixes finding 6 of the desktop accessibility audit (#38072): small pointer targets. The shared `ICON_BUTTON` used across pane headers, list-strip menus, and MCP server actions was a 20px target, below the 24px WCAG 2.5.5 pointer-target floor. This grows it to 24px and re-centers the MCP config row that clones `McpRow` geometry.

## Related Issue

Fixes the pointer-target portion of #38072 (finding 6: many hit targets are visually very small).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/master-detail.tsx`: `ICON_BUTTON` from `size-5` (20px) to `size-6` (24px). The leading `size-6` keeps tailwind-merge stripping `<Button size="icon">`'s larger size, exactly as `size-5` did.
- `apps/desktop/src/app/skills/mcp-tab.tsx`: adjust the config row's top-margin centering from `mt-3` to `mt-2.5` so the larger control stays vertically centered in the `h-11` rows that reproduce `McpRow` geometry (the comment there was already explicit about the `h-5 controls → mt-3` coupling).

## Scope notes (what this PR intentionally does not touch)

- **Titlebar buttons are already 24x24px** - `TITLEBAR_CONTROL_SIZE` is asserted to 24 in `titlebar.test.ts`. The audit measured 20x22 against v0.15.1, but current main already meets the floor, so no change is needed.
- **Session-row controls** (row button, row action, drag handle) belong to finding 3, which is already being handled by @elchic00. Left out of scope to avoid overlapping.
- **The composer coding-row git-branch glyph** stays small by deliberate density (the code comment notes it "fills the slot exactly"). Forcing it to 24px would break the status-bar layout.

## Verification

- `npx tsc --noEmit` - clean.
- `npx vitest run src/app/skills/` - 11 tests pass.
- `npx biome check` - clean on touched files.
