### PR TITLE
fix(telegram): tag voice notes with MessageType.VOICE so auto-TTS replies fire

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9970,6 +9970,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=".ogg")
                 event.media_urls = [cached_path]
                 event.media_types = ["audio/ogg"]
+                # Tag the event as a voice note (#92165): the outgoing
+                # auto-TTS reply gate (_should_send_voice_reply) matches on
+                # message_type == VOICE; without this the gate is silently
+                # false and a spoken reply is never synthesized.
+                event.message_type = MessageType.VOICE
                 logger.info("[Telegram] Cached user voice at %s", cached_path)
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache voice: %s", _redact_telegram_error_text(e), exc_info=True)

--- a/tests/gateway/test_telegram_voice_message_type.py
+++ b/tests/gateway/test_telegram_voice_message_type.py
@@ -1,0 +1,82 @@
+"""Telegram voice notes must tag MessageEvent.message_type = VOICE (#92165).
+
+The inbound ``if msg.voice:`` branch cached the audio but never set
+``event.message_type``, unlike its sibling photo/video/audio branches.
+The outgoing auto-TTS reply gate (``_should_send_voice_reply``, checked
+in ``gateway/platforms/base.py`` and ``gateway/run.py``) matches on
+``message_type == MessageType.VOICE`` — so a Telegram voice note never
+triggered a spoken reply, silently.
+
+Harness mirrors ``test_telegram_documents.py`` (real adapter instance,
+caches redirected to tmp_path, events captured via a mocked
+``handle_message``).
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageType
+
+
+@pytest.fixture()
+def adapter(tmp_path, monkeypatch):
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    monkeypatch.setattr(
+        "gateway.platforms.base.AUDIO_CACHE_DIR", tmp_path / "audio_cache"
+    )
+    config = PlatformConfig(enabled=True, token="fake-token")
+    a = TelegramAdapter(config)
+    a.handle_message = AsyncMock()
+    a._is_callback_user_authorized = lambda user_id, **_kw: True
+    return a
+
+
+def _voice_message(file_size=1024):
+    voice = MagicMock()
+    voice.file_size = file_size
+    file_obj = AsyncMock()
+    file_obj.download_as_bytearray = AsyncMock(return_value=bytearray(b"ogg"))
+    file_obj.file_path = "voice/file.ogg"
+    voice.get_file = AsyncMock(return_value=file_obj)
+
+    msg = MagicMock()
+    msg.message_id = 7
+    msg.text = ""
+    msg.caption = None
+    msg.date = None
+    msg.photo = None
+    msg.video = None
+    msg.audio = None
+    msg.voice = voice
+    msg.sticker = None
+    msg.document = None
+    msg.media_group_id = None
+    msg.chat = MagicMock()
+    msg.chat.id = 100
+    msg.chat.type = "private"
+    msg.chat.title = None
+    msg.chat.full_name = "Tester"
+    msg.from_user = MagicMock()
+    msg.from_user.id = 1
+    msg.from_user.full_name = "Tester"
+    msg.message_thread_id = None
+    msg.reply_text = AsyncMock()
+    return msg
+
+
+@pytest.mark.asyncio
+async def test_voice_note_sets_message_type_voice(adapter):
+    update = MagicMock()
+    update.message = _voice_message()
+
+    await adapter._handle_media_message(update, MagicMock())
+
+    assert adapter.handle_message.await_count >= 1
+    event = adapter.handle_message.call_args[0][0]
+    assert event.media_types == ["audio/ogg"]
+    assert event.message_type == MessageType.VOICE, (
+        "auto-TTS reply gate matches message_type == VOICE (#92165)"
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes the silently-never-firing **outgoing auto-TTS reply for Telegram voice notes** (#92165). With `/voice tts` + `/voice on` active, replying to a real Telegram voice note never produced a synthesized audio reply — no audio, no error anywhere in `gateway.log`.

Root cause (traced, and matching the reporter's own verified fix): in `plugins/platforms/telegram/adapter.py`, the inbound ``if msg.voice:`` branch caches the audio and sets `event.media_urls` / `event.media_types` but **never sets `event.message_type`** — unlike its sibling photo/video/audio branches. The outgoing auto-TTS gate (`_should_send_voice_reply`, checked in `gateway/platforms/base.py` ~L5960 and `gateway/run.py`) matches on `event.message_type == MessageType.VOICE`, so the condition was always false for voice notes. Incoming STT kept working because that path was decoupled from `message_type` when #16185 was fixed — exactly the asymmetry the reporter suspected.

The fix is the reporter's one-liner plus a regression test:

```python
event.message_type = MessageType.VOICE
```

## Related Issue

Fixes #92165

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Tests

## Changes Made

- `plugins/platforms/telegram/adapter.py`: set `event.message_type = MessageType.VOICE` in the `msg.voice` branch of `_handle_media_message`, with a comment citing #92165.
- `tests/gateway/test_telegram_voice_message_type.py`: drives the **real** `TelegramAdapter._handle_media_message` with a voice-note message (caches redirected to tmp), captures the event passed to `handle_message`, and asserts `media_types == ["audio/ogg"]` **and** `message_type == MessageType.VOICE`. Harness mirrors `test_telegram_documents.py`.

## How to Test

1. `uv run python -m pytest tests/gateway/test_telegram_voice_message_type.py tests/gateway/test_telegram_audio_vs_voice.py tests/gateway/test_telegram_voice_v0_regressions.py -q` → 6 passed.
2. `ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_voice_message_type.py` → clean.
3. Manual: with TTS enabled, send a Telegram voice note → the bot's reply arrives as a synthesized voice bubble (previously text-only, silent no-op).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls?q=is%3Apr) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run targeted test suites locally and they pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Docs N/A · cli-config.yaml.example N/A · CONTRIBUTING/AGENTS N/A
- [x] Cross-platform impact: none (Telegram adapter logic) → N/A
- [x] No tool schema change → N/A

## Screenshots / Logs

N/A
