### PR TITLE
fix(tools): preserve attach_to_session through cron handler

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -387,6 +387,31 @@ class TestUnifiedCronjobTool:
         stored = get_job(created["job_id"])
         assert stored["deliver"] == "telegram"
 
+    def test_update_attach_to_session_persists_and_is_visible(self):
+        """An attach-only update must persist and be observable via the tool."""
+        from cron.jobs import get_job
+
+        created = json.loads(
+            cronjob(action="create", prompt="x", schedule="every 1h")
+        )
+
+        updated = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                attach_to_session=True,
+            )
+        )
+
+        assert updated["success"] is True
+        assert updated["job"]["attach_to_session"] is True
+        stored = get_job(created["job_id"])
+        assert stored is not None
+        assert stored["attach_to_session"] is True
+
+        listing = json.loads(cronjob(action="list"))
+        assert listing["jobs"][0]["attach_to_session"] is True
+
 
 # =========================================================================
 # Agent-facing surface: per-job model pins are user-owned

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -435,6 +435,36 @@ class TestUnifiedCronjobTool:
         )
         assert listed["attach_to_session"] is False
 
+    @pytest.mark.parametrize("attach_to_session", [True, False])
+    def test_handler_forwards_attach_to_session(self, attach_to_session):
+        """The registered handler must forward both boolean override values."""
+        from tools.registry import registry
+
+        created_raw = registry.dispatch(
+            "cronjob",
+            {
+                "action": "create",
+                "prompt": "x",
+                "schedule": "every 1h",
+            },
+        )
+        assert isinstance(created_raw, str)
+        created = json.loads(created_raw)
+
+        updated_raw = registry.dispatch(
+            "cronjob",
+            {
+                "action": "update",
+                "job_id": created["job_id"],
+                "attach_to_session": attach_to_session,
+            },
+        )
+        assert isinstance(updated_raw, str)
+        updated = json.loads(updated_raw)
+
+        assert updated["success"] is True
+        assert updated["job"]["attach_to_session"] is attach_to_session
+
 
 # =========================================================================
 # Agent-facing surface: per-job model pins are user-owned

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -410,7 +410,30 @@ class TestUnifiedCronjobTool:
         assert stored["attach_to_session"] is True
 
         listing = json.loads(cronjob(action="list"))
-        assert listing["jobs"][0]["attach_to_session"] is True
+        listed = next(
+            job for job in listing["jobs"] if job["job_id"] == created["job_id"]
+        )
+        assert listed["attach_to_session"] is True
+
+        updated = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                attach_to_session=False,
+            )
+        )
+
+        assert updated["success"] is True
+        assert updated["job"]["attach_to_session"] is False
+        stored = get_job(created["job_id"])
+        assert stored is not None
+        assert stored["attach_to_session"] is False
+
+        listing = json.loads(cronjob(action="list"))
+        listed = next(
+            job for job in listing["jobs"] if job["job_id"] == created["job_id"]
+        )
+        assert listed["attach_to_session"] is False
 
 
 # =========================================================================

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1911,6 +1911,7 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        attach_to_session=args.get("attach_to_session"),
         monitor_script=args.get("monitor_script"),
         monitor_url=args.get("monitor_url"),
         task_id=kw.get("task_id"),

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -705,6 +705,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if isinstance(job.get("attach_to_session"), bool):
+        result["attach_to_session"] = job["attach_to_session"]
     stored_refs = job.get("context_from") or []
     if isinstance(stored_refs, str):
         stored_refs = [stored_refs]


### PR DESCRIPTION
## Summary

- forward `attach_to_session` from the registered tool handler into `cronjob()`
- include explicitly stored `true` and `false` values in agent-facing cron job output
- add regression coverage for handler propagation, persistence, update read-back, and list read-back

## Problem

The `cronjob` schema and implementation accept and persist `attach_to_session`, but the registered tool handler did not forward the argument. Agent-originated attach-only updates therefore reached `cronjob()` without any update value and returned `No updates provided.`

Separately, `_format_job()` omitted the field from tool responses. Even values written through direct callers were therefore invisible in update and list read-back.

## Why this change

The registered handler is the path used by agent tool calls, so accepting a field in the schema is not sufficient unless the handler forwards it. Agent-facing output must then faithfully expose both explicit boolean values: `false` is meaningful because it can override globally enabled delivery mirroring. The field remains omitted for legacy jobs where it was never set, preserving the distinction between "unset" and an explicit boolean value.

## Reproduction

1. Create a cron job without `attach_to_session`.
2. Through the registered tool handler, update only `attach_to_session`.
3. Observe `No updates provided.` because the handler drops the argument.
4. Through a direct caller, persist the value and observe that update and list responses omit it.

## Testing

- `ruff check tools/cronjob_tools.py tests/tools/test_cronjob_tools.py`
- `scripts/run_tests.sh tests/tools/test_cronjob_tools.py tests/cron/test_scheduler.py tests/cron/test_cronjob_schema.py` — 175 passed

## Related work

Related to #57556, which identified the missing handler forwarding. This focused change also preserves an explicit `false` value and covers both booleans through the registered handler.

## Platform tested

- macOS
- Python 3.11
