### PR TITLE
fix(gateway): honor explicit Home Assistant disable

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2233,13 +2233,11 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # Home Assistant
     hass_token = getenv("HASS_TOKEN")
     if hass_token:
-        if Platform.HOMEASSISTANT not in config.platforms:
-            config.platforms[Platform.HOMEASSISTANT] = PlatformConfig()
-        config.platforms[Platform.HOMEASSISTANT].enabled = True
-        config.platforms[Platform.HOMEASSISTANT].token = hass_token
+        hass_config = _enable_from_env(Platform.HOMEASSISTANT)
+        hass_config.token = hass_token
         hass_url = getenv("HASS_URL")
         if hass_url:
-            config.platforms[Platform.HOMEASSISTANT].extra["url"] = hass_url
+            hass_config.extra["url"] = hass_url
 
     # Email
     email_addr = getenv("EMAIL_ADDRESS")

--- a/tests/gateway/test_homeassistant.py
+++ b/tests/gateway/test_homeassistant.py
@@ -250,6 +250,29 @@ class TestConfigIntegration:
         assert ha.token == "env-token"
         assert ha.extra["url"] == "http://10.0.0.5:8123"
 
+    def test_explicit_disabled_survives_hass_env(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  homeassistant:\n"
+            "    enabled: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HASS_TOKEN", "tool-only-token")
+        monkeypatch.setenv("HASS_URL", "http://10.0.0.5:8123")
+        for var in ["TELEGRAM_BOT_TOKEN", "DISCORD_BOT_TOKEN", "SLACK_BOT_TOKEN"]:
+            monkeypatch.delenv(var, raising=False)
+
+        from gateway.config import load_gateway_config
+
+        config = load_gateway_config()
+        ha = config.platforms[Platform.HOMEASSISTANT]
+        assert ha.enabled is False
+        assert ha.token == "tool-only-token"
+        assert ha.extra["url"] == "http://10.0.0.5:8123"
+
 
 # ---------------------------------------------------------------------------
 # send() via REST API


### PR DESCRIPTION
## Summary

- route Home Assistant environment enablement through the shared `_enable_from_env()` helper
- preserve an explicit `platforms.homeassistant.enabled: false` while still loading `HASS_TOKEN` and `HASS_URL`
- add a regression test for the explicit-disable case

## Problem

The Home Assistant environment override unconditionally set `enabled = True` whenever `HASS_TOKEN` was present. This bypassed the existing `_enabled_explicit` precedence marker used by other platform integrations.

A profile may intentionally keep Home Assistant credentials available to tools while disabling the gateway adapter. In that configuration, loading gateway config unexpectedly re-enabled the adapter. In multiplexed deployments this can also create duplicate adapter ownership for the same credential.

## Why this change

An explicit user setting should take precedence over credential-based auto-enablement. At the same time, disabling the adapter should not remove the token or URL from the loaded platform configuration, because non-adapter tools may still need them.

Using the existing `_enable_from_env()` helper gives Home Assistant the same precedence behavior as other environment-enabled platforms.

## Reproduction

1. Set `platforms.homeassistant.enabled: false` in `config.yaml`.
2. Provide `HASS_TOKEN` and `HASS_URL` through the environment.
3. Load gateway configuration.
4. Observe that Home Assistant is unexpectedly enabled.

## Testing

- `ruff check gateway/config.py tests/gateway/test_homeassistant.py`
- `scripts/run_tests.sh tests/gateway/test_homeassistant.py tests/gateway/test_config.py tests/gateway/test_slack_mention.py` — 106 passed

## Platform tested

- macOS
- Python 3.11
