### PR TITLE
feat: scheduled_round_robin credential pool strategy

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -110,12 +110,23 @@ STRATEGY_FILL_FIRST = "fill_first"
 STRATEGY_ROUND_ROBIN = "round_robin"
 STRATEGY_RANDOM = "random"
 STRATEGY_LEAST_USED = "least_used"
+# Timer-based rotation: stay on one credential until a configured interval has
+# elapsed, instead of rotating on every selection like ``round_robin``.
+STRATEGY_SCHEDULED_ROUND_ROBIN = "scheduled_round_robin"
 SUPPORTED_POOL_STRATEGIES = {
     STRATEGY_FILL_FIRST,
     STRATEGY_ROUND_ROBIN,
     STRATEGY_RANDOM,
     STRATEGY_LEAST_USED,
+    STRATEGY_SCHEDULED_ROUND_ROBIN,
 }
+
+# Defaults for ``credential_pool_scheduling`` (scheduled_round_robin only).
+SCHEDULED_ROTATION_DEFAULT_INTERVAL_MINUTES = 60
+# Entry field holding the epoch time of the last timed rotation. Written to the
+# entry the pool rotated *to*, so a restart recovers both the cursor and the
+# rotation deadline instead of dropping back to the first credential.
+SCHEDULED_ROTATION_STATE_KEY = "last_rotation_at"
 
 # Cooldown before retrying an exhausted credential.
 # Transient 401 auth failures cool down briefly so single-key setups can recover.
@@ -176,6 +187,9 @@ _EXTRA_KEYS = frozenset({
     # with the entry so a restart doesn't downgrade a billing bench back to a
     # 60s transient cooldown.
     "failure_reason",
+    # Epoch time of the last scheduled_round_robin rotation, written by
+    # ``CredentialPool._persist`` (SCHEDULED_ROTATION_STATE_KEY).
+    "last_rotation_at",
 })
 
 
@@ -548,6 +562,50 @@ def get_pool_strategy(provider: str) -> str:
     return STRATEGY_FILL_FIRST
 
 
+def _scheduled_interval_minutes(value: Any) -> float:
+    """Coerce a configured rotation interval, falling back to the default.
+
+    A non-numeric or non-positive interval would make every selection look
+    overdue and turn timed rotation back into per-request rotation, so it is
+    treated as unset.
+    """
+    try:
+        minutes = float(value)
+    except (TypeError, ValueError):
+        return float(SCHEDULED_ROTATION_DEFAULT_INTERVAL_MINUTES)
+    if minutes <= 0:
+        return float(SCHEDULED_ROTATION_DEFAULT_INTERVAL_MINUTES)
+    return minutes
+
+
+def get_pool_scheduling(provider: str) -> Dict[str, Any]:
+    """Return the ``scheduled_round_robin`` scheduling config for a provider.
+
+    An absent or malformed ``credential_pool_scheduling`` block yields ``{}``;
+    the pool then applies the same defaults documented here, so selecting the
+    strategy without configuring it still rotates hourly across healthy
+    credentials.
+    """
+    config = _load_config_safe()
+    if config is None:
+        return {}
+
+    scheduling = config.get("credential_pool_scheduling")
+    if not isinstance(scheduling, dict):
+        return {}
+
+    cfg = scheduling.get(provider)
+    if not isinstance(cfg, dict):
+        return {}
+
+    return {
+        "enabled": bool(cfg.get("enabled", True)),
+        "interval_minutes": _scheduled_interval_minutes(cfg.get("interval_minutes")),
+        "skip_unhealthy": bool(cfg.get("skip_unhealthy", True)),
+        "rotate_after_request": bool(cfg.get("rotate_after_request", True)),
+    }
+
+
 def credential_pool_matches_provider(
     pool_or_provider: Any,
     provider: Optional[str],
@@ -738,6 +796,52 @@ class CredentialPool:
         # loop runs unbounded and non-interruptible.  Reset whenever a real
         # entry is identified or an escape path returns None.
         self._unmatched_rotation_streak: int = 0
+        # scheduled_round_robin state; inert for every other strategy.
+        # ``_scheduled_interval`` stays None when the strategy is off or
+        # disabled via config, which makes the timed branch a sticky selection
+        # (no rotation deadline ever comes due).
+        self._scheduled_interval: Optional[float] = None
+        self._last_rotation_time: Optional[float] = None
+        self._rotate_after_request: bool = True
+        self._skip_unhealthy: bool = True
+        if self._strategy == STRATEGY_SCHEDULED_ROUND_ROBIN:
+            scheduling = get_pool_scheduling(provider)
+            if scheduling.get("enabled", True):
+                self._scheduled_interval = _scheduled_interval_minutes(
+                    scheduling.get(
+                        "interval_minutes",
+                        SCHEDULED_ROTATION_DEFAULT_INTERVAL_MINUTES,
+                    )
+                ) * 60.0
+            self._rotate_after_request = bool(
+                scheduling.get("rotate_after_request", True)
+            )
+            self._skip_unhealthy = bool(scheduling.get("skip_unhealthy", True))
+            self._restore_rotation_state()
+
+    def _restore_rotation_state(self) -> None:
+        """Recover the timed-rotation cursor and deadline from persistence.
+
+        Without this a restart resets the cursor to the first entry and starts
+        the interval over, so a frequently restarted process would pin
+        credential #1 forever.  The stamp is written by :meth:`_persist` onto
+        the entry that was rotated to, so the newest one identifies both.
+        """
+        newest_at: Optional[float] = None
+        newest_id: Optional[str] = None
+        for entry in self._entries:
+            stamped = _parse_absolute_timestamp(
+                entry.extra.get(SCHEDULED_ROTATION_STATE_KEY)
+            )
+            if stamped is None:
+                continue
+            if newest_at is None or stamped > newest_at:
+                newest_at = stamped
+                newest_id = entry.id
+        if newest_at is None:
+            return
+        self._last_rotation_time = newest_at
+        self._current_id = newest_id
 
     def has_credentials(self) -> bool:
         with self._lock:
@@ -841,11 +945,31 @@ class CredentialPool:
         # Self-locking (RLock): snapshotting self._entries must not race a
         # concurrent rotation when called from the deferred refresh path.
         with self._lock:
+            payload = [entry.to_dict() for entry in self._entries]
+            if self._strategy == STRATEGY_SCHEDULED_ROUND_ROBIN:
+                self._stamp_rotation_state(payload)
             write_credential_pool(
                 self.provider,
-                [entry.to_dict() for entry in self._entries],
+                payload,
                 removed_ids=removed_ids,
             )
+
+    def _stamp_rotation_state(self, payload: List[Dict[str, Any]]) -> None:
+        """Record the timed-rotation cursor on the entry it points at.
+
+        Exactly one entry carries ``last_rotation_at``, so a restart reads back
+        both which credential was in use and when it was picked (see
+        :meth:`_restore_rotation_state`).  The stamp is a plain epoch float —
+        no credential material is added to the persisted payload.
+        """
+        for entry in payload:
+            entry.pop(SCHEDULED_ROTATION_STATE_KEY, None)
+        if self._current_id is None or self._last_rotation_time is None:
+            return
+        for entry in payload:
+            if entry.get("id") == self._current_id:
+                entry[SCHEDULED_ROTATION_STATE_KEY] = self._last_rotation_time
+                return
 
     def _is_terminal_auth_failure(
         self,
@@ -2085,6 +2209,9 @@ class CredentialPool:
             self._current_id = entry.id
             return updated, pending_refresh
 
+        if self._strategy == STRATEGY_SCHEDULED_ROUND_ROBIN:
+            return self._select_scheduled(available), pending_refresh
+
         if self._strategy == STRATEGY_ROUND_ROBIN and len(available) > 1:
             entry = available[0]
             rotated = [candidate for candidate in self._entries if candidate.id != entry.id]
@@ -2097,6 +2224,85 @@ class CredentialPool:
         entry = available[0]
         self._current_id = entry.id
         return entry, pending_refresh
+
+    def _select_scheduled(
+        self, available: List[PooledCredential]
+    ) -> PooledCredential:
+        """Pick a credential for ``scheduled_round_robin``.
+
+        Stays on the current credential until the configured interval has
+        elapsed, then advances one step around the priority ring.  Error-driven
+        rotation is untouched: ``mark_exhausted_and_rotate`` benches the entry,
+        which drops it from *available* and forces a move here immediately,
+        without waiting for the timer.
+
+        Callers must hold ``self._lock`` (``_select_unlocked`` does).
+        """
+        now = time.time()
+        current = self._current_unlocked()
+        # A benched (or otherwise unselectable) current must not be handed out;
+        # treat it as "no current" so the ring advances to a healthy entry.
+        if current is not None and all(e.id != current.id for e in available):
+            current = None
+
+        if current is not None:
+            due = (
+                self._scheduled_interval is not None
+                and self._last_rotation_time is not None
+                and (now - self._last_rotation_time) >= self._scheduled_interval
+            )
+            if not due:
+                return current
+            # rotate_after_request: a lease on this credential means a request
+            # is in flight, so hold the rotation and re-check on the next
+            # selection — the deadline stays passed, nothing is lost.
+            if self._rotate_after_request and self._active_leases.get(current.id, 0) > 0:
+                return current
+
+        entry = self._next_scheduled_entry(current, available)
+        if current is not None and entry.id != current.id:
+            logger.info(
+                "credential pool: scheduled rotation %s -> %s (interval %.0fs)",
+                current.label or current.id[:8],
+                entry.label or entry.id[:8],
+                self._scheduled_interval or 0.0,
+            )
+        self._current_id = entry.id
+        self._last_rotation_time = now
+        self._persist()
+        return entry
+
+    def _next_scheduled_entry(
+        self,
+        current: Optional[PooledCredential],
+        available: List[PooledCredential],
+    ) -> PooledCredential:
+        """Return the entry following *current* in the priority ring.
+
+        With ``skip_unhealthy`` the ring is walked until a selectable entry is
+        found.  Without it, rotation only advances when the immediate successor
+        is selectable; an unhealthy successor holds the cursor in place instead
+        of reordering the ring around it.  Either way the result comes from
+        *available*, so a credential in cooldown is never handed out.
+        """
+        available_by_id = {entry.id: entry for entry in available}
+        if current is None:
+            return available[0]
+        start = next(
+            (idx for idx, e in enumerate(self._entries) if e.id == current.id),
+            None,
+        )
+        if start is None:  # pragma: no cover - current always comes from the ring
+            return available[0]
+        for step in range(1, len(self._entries) + 1):
+            candidate = self._entries[(start + step) % len(self._entries)]
+            selectable = available_by_id.get(candidate.id)
+            if selectable is not None:
+                return selectable
+            if not self._skip_unhealthy:
+                break
+        # Nothing else is selectable — stay on the current credential.
+        return available_by_id.get(current.id) or available[0]
 
     def peek(self) -> Optional[PooledCredential]:
         # Single lock acquisition for the whole read; call the unlocked

--- a/tests/agent/test_credential_pool_scheduled.py
+++ b/tests/agent/test_credential_pool_scheduled.py
@@ -1,0 +1,279 @@
+"""Tests for the scheduled_round_robin credential pool strategy."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from agent.credential_pool import (
+    STRATEGY_FILL_FIRST,
+    STRATEGY_SCHEDULED_ROUND_ROBIN,
+    SUPPORTED_POOL_STRATEGIES,
+    CredentialPool,
+    PooledCredential,
+    get_pool_scheduling,
+    get_pool_strategy,
+)
+
+INTERVAL_MINUTES = 60
+INTERVAL_SECONDS = INTERVAL_MINUTES * 60
+
+
+def _entry(entry_id: str, priority: int, **overrides) -> PooledCredential:
+    payload = {
+        "provider": "test",
+        "id": entry_id,
+        "label": entry_id,
+        "auth_type": "api_key",
+        "priority": priority,
+        "source": "manual",
+        "access_token": f"tok-{entry_id}",
+    }
+    payload.update(overrides)
+    return PooledCredential(**payload)
+
+
+def _exhausted(entry_id: str, priority: int) -> PooledCredential:
+    """An entry in a fresh 429 cooldown, i.e. unhealthy for the next hour."""
+    return _entry(
+        entry_id,
+        priority,
+        last_status="exhausted",
+        last_status_at=time.time(),
+        last_error_code=429,
+    )
+
+
+def _make_pool(
+    monkeypatch,
+    tmp_path,
+    entries,
+    *,
+    strategy: str = STRATEGY_SCHEDULED_ROUND_ROBIN,
+    **scheduling,
+) -> CredentialPool:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(
+        "agent.credential_pool.get_pool_strategy",
+        lambda _provider: strategy,
+    )
+    config = {
+        "enabled": True,
+        "interval_minutes": INTERVAL_MINUTES,
+        "skip_unhealthy": True,
+        "rotate_after_request": True,
+    }
+    config.update(scheduling)
+    monkeypatch.setattr(
+        "agent.credential_pool.get_pool_scheduling",
+        lambda _provider: config,
+    )
+    return CredentialPool("test", entries)
+
+
+def _expire_interval(pool: CredentialPool) -> None:
+    """Backdate the rotation stamp so the next selection is due."""
+    assert pool._last_rotation_time is not None
+    pool._last_rotation_time -= INTERVAL_SECONDS + 1
+
+
+def _persisted_entries(tmp_path):
+    auth_json = tmp_path / "hermes" / "auth.json"
+    store = json.loads(auth_json.read_text())
+    return store["credential_pool"]["test"]
+
+
+def test_rotates_only_after_the_interval_elapses(tmp_path, monkeypatch):
+    """Selection sticks to one credential per interval, then advances one step."""
+    pool = _make_pool(
+        monkeypatch, tmp_path, [_entry("a", 0), _entry("b", 1), _entry("c", 2)]
+    )
+
+    first = pool.select()
+    assert first is not None and first.id == "a"
+    # Repeated selections inside the window must not rotate (unlike round_robin).
+    assert pool.select().id == "a"
+    assert pool.select().id == "a"
+
+    _expire_interval(pool)
+    assert pool.select().id == "b"
+    assert pool.select().id == "b"
+
+    _expire_interval(pool)
+    assert pool.select().id == "c"
+
+    # Ring wraps back to the first credential.
+    _expire_interval(pool)
+    assert pool.select().id == "a"
+
+
+def test_rotation_skips_unhealthy_credential(tmp_path, monkeypatch):
+    """A credential in cooldown is stepped over, not handed out."""
+    pool = _make_pool(
+        monkeypatch, tmp_path, [_entry("a", 0), _exhausted("b", 1), _entry("c", 2)]
+    )
+
+    assert pool.select().id == "a"
+
+    _expire_interval(pool)
+    assert pool.select().id == "c"
+
+
+def test_skip_unhealthy_disabled_holds_cursor_on_unhealthy_successor(
+    tmp_path, monkeypatch
+):
+    """With skip_unhealthy off, rotation waits instead of reordering the ring."""
+    pool = _make_pool(
+        monkeypatch,
+        tmp_path,
+        [_entry("a", 0), _exhausted("b", 1), _entry("c", 2)],
+        skip_unhealthy=False,
+    )
+
+    assert pool.select().id == "a"
+
+    _expire_interval(pool)
+    # 'b' is next in the ring but benched, so 'a' keeps serving — 'c' is not
+    # pulled forward.
+    assert pool.select().id == "a"
+
+
+def test_active_lease_defers_rotation_until_request_finishes(tmp_path, monkeypatch):
+    """rotate_after_request: an in-flight request blocks the timed swap."""
+    pool = _make_pool(monkeypatch, tmp_path, [_entry("a", 0), _entry("b", 1)])
+
+    assert pool.select().id == "a"
+    assert pool.acquire_lease("a") == "a"
+
+    _expire_interval(pool)
+    assert pool.select().id == "a", "rotation must not interrupt an active lease"
+
+    pool.release_lease("a")
+    assert pool.select().id == "b", "rotation happens as soon as the lease drains"
+
+
+def test_rotate_after_request_disabled_rotates_despite_active_lease(
+    tmp_path, monkeypatch
+):
+    pool = _make_pool(
+        monkeypatch,
+        tmp_path,
+        [_entry("a", 0), _entry("b", 1)],
+        rotate_after_request=False,
+    )
+
+    assert pool.select().id == "a"
+    pool.acquire_lease("a")
+
+    _expire_interval(pool)
+    assert pool.select().id == "b"
+
+
+def test_exhaustion_rotates_immediately_without_waiting_for_the_timer(
+    tmp_path, monkeypatch
+):
+    """Error-driven rotation keeps its existing, immediate behaviour."""
+    pool = _make_pool(monkeypatch, tmp_path, [_entry("a", 0), _entry("b", 1)])
+
+    assert pool.select().id == "a"
+    rotated = pool.mark_exhausted_and_rotate(status_code=429, credential_id="a")
+    assert rotated is not None and rotated.id == "b"
+    assert pool.select().id == "b"
+
+
+def test_rotation_state_survives_restart(tmp_path, monkeypatch):
+    """A restart resumes on the same credential with the same deadline."""
+    pool = _make_pool(
+        monkeypatch, tmp_path, [_entry("a", 0), _entry("b", 1), _entry("c", 2)]
+    )
+    assert pool.select().id == "a"
+    _expire_interval(pool)
+    assert pool.select().id == "b"
+    rotated_at = pool._last_rotation_time
+
+    stored = _persisted_entries(tmp_path)
+    stamped = [e for e in stored if "last_rotation_at" in e]
+    assert [e["id"] for e in stamped] == ["b"], "only the current entry is stamped"
+    assert stamped[0]["last_rotation_at"] == pytest.approx(rotated_at)
+
+    restarted = _make_pool(
+        monkeypatch,
+        tmp_path,
+        [PooledCredential.from_dict("test", payload) for payload in stored],
+    )
+    assert restarted._last_rotation_time == pytest.approx(rotated_at)
+    # Resumes on 'b' rather than falling back to the first credential, and the
+    # restored deadline still governs the next rotation.
+    assert restarted.select().id == "b"
+    _expire_interval(restarted)
+    assert restarted.select().id == "c"
+
+
+def test_scheduled_strategy_is_recognized_by_get_pool_strategy(monkeypatch):
+    assert STRATEGY_SCHEDULED_ROUND_ROBIN in SUPPORTED_POOL_STRATEGIES
+    monkeypatch.setattr(
+        "agent.credential_pool._load_config_safe",
+        lambda: {
+            "credential_pool_strategies": {"anthropic": "scheduled_round_robin"},
+            "credential_pool_scheduling": {
+                "anthropic": {"interval_minutes": 30, "skip_unhealthy": False}
+            },
+        },
+    )
+    assert get_pool_strategy("anthropic") == STRATEGY_SCHEDULED_ROUND_ROBIN
+    assert get_pool_scheduling("anthropic") == {
+        "enabled": True,
+        "interval_minutes": 30.0,
+        "skip_unhealthy": False,
+        "rotate_after_request": True,
+    }
+    # Unconfigured providers fall back to the pool's own defaults.
+    assert get_pool_scheduling("openrouter") == {}
+
+
+@pytest.mark.parametrize("bad_interval", [0, -5, "sixty", None])
+def test_invalid_interval_falls_back_to_the_default(monkeypatch, bad_interval):
+    """A bad interval must not degrade into per-request rotation."""
+    monkeypatch.setattr(
+        "agent.credential_pool._load_config_safe",
+        lambda: {
+            "credential_pool_scheduling": {
+                "anthropic": {"interval_minutes": bad_interval}
+            }
+        },
+    )
+    assert get_pool_scheduling("anthropic")["interval_minutes"] == 60.0
+
+
+def test_fill_first_still_pins_the_first_credential(tmp_path, monkeypatch):
+    """Backwards compat: the default strategy is unaffected by the new branch."""
+    pool = _make_pool(
+        monkeypatch,
+        tmp_path,
+        [_entry("a", 0), _entry("b", 1), _entry("c", 2)],
+        strategy=STRATEGY_FILL_FIRST,
+    )
+
+    assert [pool.select().id for _ in range(3)] == ["a", "a", "a"]
+    assert pool._scheduled_interval is None
+    assert pool._last_rotation_time is None
+
+    # fill_first exhaustion still rotates to the next healthy credential.
+    assert pool.mark_exhausted_and_rotate(status_code=429, credential_id="a").id == "b"
+
+
+def test_round_robin_still_rotates_per_request(tmp_path, monkeypatch):
+    """Backwards compat: per-request rotation keeps its old behaviour."""
+    pool = _make_pool(
+        monkeypatch,
+        tmp_path,
+        [_entry("a", 0), _entry("b", 1), _entry("c", 2)],
+        strategy="round_robin",
+    )
+
+    assert [pool.select().id for _ in range(4)] == ["a", "b", "c", "a"]
+    assert not any(
+        "last_rotation_at" in entry for entry in _persisted_entries(tmp_path)
+    ), "non-scheduled strategies must not write rotation state"


### PR DESCRIPTION
## What

Adds a fifth credential-pool strategy: `scheduled_round_robin` — timer-based rotation. The pool stays on one credential until a configured interval elapses (default 60 min), instead of rotating on every selection like `round_robin`.

## Why

Multi-credential setups (e.g. several Claude Pro/Max OAuth subscriptions) benefit from spreading load over time rather than per request: each credential gets contiguous usage windows, which plays nicer with per-account rate-limit accounting, while error-driven rotation still fails over instantly.

## Behavior

- Stays on the current credential until the deadline; then advances one step around the priority ring
- `skip_unhealthy` (default true): walks the ring past benched/cooldown entries
- `rotate_after_request` (default true): an active lease defers rotation until the in-flight request finishes — the deadline stays due, nothing is lost
- Error rotation untouched: `mark_exhausted_and_rotate` benches immediately without waiting for the timer
- `last_rotation_at` is persisted on the active entry, so a restart recovers both cursor and deadline instead of resetting to credential #1
- Invalid/non-positive intervals fall back to the 60-minute default
- Fully backwards compatible: `fill_first`, `round_robin`, `random`, `least_used` unchanged; unknown strategies still fall back to `fill_first`

## Config

```yaml
credential_pool_strategies:
  anthropic: scheduled_round_robin

credential_pool_scheduling:
  anthropic:
    enabled: true
    interval_minutes: 60
    skip_unhealthy: true
    rotate_after_request: true
```

## Tests

14 new tests in `tests/agent/test_credential_pool_scheduled.py`: rotation timing, unhealthy skip (both modes), lease deferral (both modes), immediate exhaustion failover, restart persistence, config fallback (4 invalid-interval variants), strategy recognition, and `fill_first`/`round_robin` compatibility. All pass; the pre-existing failures in `test_restore_primary_pool_reselect.py` are unrelated (also fail on main).

Running live on our production install (3-credential Anthropic pool) since 2026-08-24.