### PR TITLE
feat(cron): make execution-ledger retention cap configurable (#93616)

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -7,24 +7,36 @@ proved gone. Terminal states are immutable.
 
 from __future__ import annotations
 
+import logging
 import os
 import sqlite3
 import threading
 import uuid
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
 
+logger = logging.getLogger(__name__)
+
 # Optional test override. Production resolves the path at transaction time so
 # dashboard operations that temporarily enter another profile cannot leak that
 # profile's execution records into the import-time home.
 EXECUTIONS_FILE: Optional[Path] = None
-MAX_TERMINAL_EXECUTIONS = 1000
+# Shipped default for the terminal-history retention cap, plus the optional
+# module override tests inject through. ``None`` means production should resolve
+# the live cap from ``cron.max_terminal_executions`` in config.yaml;
+# ``monkeypatch.setattr`` of MAX_TERMINAL_EXECUTIONS to any valid value wins over
+# config (#93616), including an explicit override equal to the shipped default.
+DEFAULT_MAX_TERMINAL_EXECUTIONS = 1000
+MAX_TERMINAL_EXECUTIONS: Optional[int] = None
+_SQLITE_MAX_INTEGER = (1 << 63) - 1
 _TERMINAL_STATES = ("completed", "failed", "unknown")
 _lock = threading.RLock()
 _PROCESS_ID = uuid.uuid4().hex
+_last_retention_error_by_ledger: Dict[str, str] = {}
 
 
 def _connect() -> sqlite3.Connection:
@@ -126,9 +138,119 @@ def _owner_is_live(pid: int, started_at: Optional[int]) -> bool:
     return current is not None and current == started_at
 
 
-def _prune_unlocked(conn: sqlite3.Connection) -> None:
-    limit = max(0, int(MAX_TERMINAL_EXECUTIONS))
-    conn.execute(
+def _retention_error(value: Any) -> ValueError:
+    return ValueError(
+        "cron.max_terminal_executions must be a whole number between 1 and "
+        f"{_SQLITE_MAX_INTEGER}, got {value!r}"
+    )
+
+
+def resolve_max_terminal_executions(
+    value: Any, *, default: int = DEFAULT_MAX_TERMINAL_EXECUTIONS
+) -> int:
+    """Validate one configured terminal-history retention cap.
+
+    Accepts integers in SQLite's signed 64-bit range, whole-number floats, and
+    digit-only strings. ``None`` means "unset" and validates *default* through
+    the same path. Everything else — booleans, zero, negatives, oversized or
+    fractional values, empty or non-numeric strings — raises ``ValueError``.
+    Pruning callers must treat that as fail-closed (skip the DELETE); silently
+    coercing e.g. ``-1`` to ``0`` would wipe the entire terminal ledger, while
+    binding a value above SQLite's range would roll back the terminal update.
+    """
+    candidate = default if value is None else value
+    if isinstance(candidate, bool):
+        raise _retention_error(candidate)
+    if isinstance(candidate, int):
+        if not 1 <= candidate <= _SQLITE_MAX_INTEGER:
+            raise _retention_error(candidate)
+        return candidate
+    if isinstance(candidate, float):
+        if not candidate.is_integer():
+            raise _retention_error(candidate)
+        parsed = int(candidate)
+        if not 1 <= parsed <= _SQLITE_MAX_INTEGER:
+            raise _retention_error(candidate)
+        return parsed
+    if isinstance(candidate, str):
+        stripped = candidate.strip()
+        # isdigit() rejects signs, decimals, underscores, and empty strings;
+        # int() can still fail on exotic unicode digits isdigit() accepts.
+        if not stripped.isdigit():
+            raise _retention_error(candidate)
+        try:
+            parsed = int(stripped)
+        except ValueError:
+            raise _retention_error(candidate) from None
+        if not 1 <= parsed <= _SQLITE_MAX_INTEGER:
+            raise _retention_error(candidate)
+        return parsed
+    raise _retention_error(candidate)
+
+
+def current_max_terminal_executions() -> int:
+    """Resolve the live terminal-history cap for this process.
+
+    Precedence:
+
+    1. ``MAX_TERMINAL_EXECUTIONS``, when a test (or caller) set the optional
+       override — preserves the existing
+       ``monkeypatch.setattr(executions, "MAX_TERMINAL_EXECUTIONS", N)``
+       injection point.
+    2. ``cron.max_terminal_executions`` from the active profile's
+       config.yaml, via the read-only config fast path.
+    3. :data:`DEFAULT_MAX_TERMINAL_EXECUTIONS`.
+
+    There is deliberately no environment-variable override — behavioral
+    settings live in config.yaml. Raises ``ValueError`` when the resolved
+    value is invalid or the config loader raises, so pruning callers can fail
+    closed instead of deleting with a wrong cap.
+    """
+    if MAX_TERMINAL_EXECUTIONS is not None:
+        return resolve_max_terminal_executions(MAX_TERMINAL_EXECUTIONS)
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        config = load_config_readonly()
+    except Exception as exc:
+        raise ValueError(
+            f"could not read cron.max_terminal_executions from config.yaml: {exc}"
+        ) from exc
+    cron_config = config.get("cron") if isinstance(config, dict) else None
+    if cron_config is None:
+        return resolve_max_terminal_executions(None)
+    if not isinstance(cron_config, dict):
+        raise ValueError(
+            "cron section in config.yaml must be a mapping, got "
+            f"{type(cron_config).__name__}"
+        )
+    return resolve_max_terminal_executions(cron_config.get("max_terminal_executions"))
+
+
+def _prune_unlocked(conn: sqlite3.Connection) -> int:
+    """Prune the oldest terminal rows beyond the retention cap.
+
+    In-flight (``claimed``/``running``) rows are never touched. On an
+    invalid cap or resolution error this fails closed: it logs and deletes
+    nothing rather than pruning with a wrong limit. Returns the number of rows
+    deleted.
+    """
+    database_row = conn.execute("PRAGMA database_list").fetchone()
+    ledger_key = str(database_row[2]) if database_row is not None else "<unknown>"
+    try:
+        limit = current_max_terminal_executions()
+    except ValueError as exc:
+        detail = str(exc)
+        if _last_retention_error_by_ledger.get(ledger_key) != detail:
+            logger.error(
+                "Skipping cron execution-history prune — %s. Fix "
+                "cron.max_terminal_executions in config.yaml to resume pruning.",
+                exc,
+            )
+            _last_retention_error_by_ledger[ledger_key] = detail
+        return 0
+    _last_retention_error_by_ledger.pop(ledger_key, None)
+    cur = conn.execute(
         """DELETE FROM executions WHERE id IN (
              SELECT id FROM executions
              WHERE status IN ('completed','failed','unknown')
@@ -136,6 +258,7 @@ def _prune_unlocked(conn: sqlite3.Connection) -> None:
            )""",
         (limit,),
     )
+    return cur.rowcount
 
 
 def create_execution(job_id: str, *, source: str) -> Dict[str, Any]:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2818,6 +2818,14 @@ DEFAULT_CONFIG = {
         # recent .md files and prunes older ones. 0 or negative disables
         # pruning (for operators who manage cleanup externally). Default 50.
         "output_retention": 50,
+        # Maximum number of terminal execution-ledger rows (completed /
+        # failed / unknown) kept in cron/executions.db; the oldest rows
+        # beyond the cap are pruned on write. In-flight (claimed/running)
+        # attempts are never pruned. Must be a whole number from 1 through
+        # SQLite's signed 64-bit maximum — an invalid value skips pruning
+        # entirely (fail closed) instead of deleting history with a wrong cap.
+        # Default 1000.
+        "max_terminal_executions": 1000,
         # Timeout (seconds) for a no-agent cron script. Also overridable via
         # HERMES_CRON_SCRIPT_TIMEOUT. Keep this in sync with
         # cron.scheduler._DEFAULT_SCRIPT_TIMEOUT so config set recognizes the

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -14,6 +14,7 @@ def _point_ledger(monkeypatch, tmp_path):
     import cron.executions as executions
 
     monkeypatch.setattr(executions, "EXECUTIONS_FILE", tmp_path / "cron" / "executions.db")
+    monkeypatch.setattr(executions, "_last_retention_error_by_ledger", {})
     return executions
 
 
@@ -81,6 +82,306 @@ def test_retention_bounds_terminal_history_but_preserves_inflight(monkeypatch, t
     records = executions.list_executions(limit=100)
     assert len([row for row in records if row["status"] == "completed"]) == 3
     assert executions.latest_execution("live")["status"] == "running"
+
+
+def _write_retention_config(raw_value):
+    """Write a real config.yaml into the isolated HERMES_HOME."""
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        f"cron:\n  max_terminal_executions: {raw_value}\n", encoding="utf-8"
+    )
+
+
+def test_resolve_max_terminal_executions_accepts_valid_values():
+    from cron.executions import (
+        DEFAULT_MAX_TERMINAL_EXECUTIONS,
+        resolve_max_terminal_executions,
+    )
+
+    cases = [
+        (None, DEFAULT_MAX_TERMINAL_EXECUTIONS),  # unset → shipped default
+        (1, 1),
+        (5000, 5000),
+        ((1 << 63) - 1, (1 << 63) - 1),
+        (str((1 << 63) - 1), (1 << 63) - 1),
+        ("25", 25),
+        ("  10  ", 10),
+        (250.0, 250),
+    ]
+    for raw, expected in cases:
+        assert resolve_max_terminal_executions(raw) == expected, raw
+
+
+def test_resolve_max_terminal_executions_rejects_invalid_values():
+    import pytest
+
+    from cron.executions import resolve_max_terminal_executions
+
+    invalid = [
+        True, False,           # booleans are not caps
+        0, -1, -1000,          # zero/negative would wipe or corrupt history
+        0.0, -3.0, 1.5,        # fractional / non-positive floats
+        float("inf"), float("nan"),
+        "", "   ",             # empty strings
+        "0", "-1", "+5",       # non-positive / signed strings
+        "1.5", "abc", "1000x", "1_000",
+        1 << 63, str(1 << 63),
+        [1000], {"cap": 1000},
+    ]
+    for raw in invalid:
+        with pytest.raises(ValueError):
+            resolve_max_terminal_executions(raw)
+
+    with pytest.raises(ValueError):
+        resolve_max_terminal_executions(None, default=1 << 63)
+
+
+def test_default_config_ships_module_default_cap():
+    """The shipped config default and the module default must agree, and the
+    shipped value must pass its own validation."""
+    from cron.executions import (
+        DEFAULT_MAX_TERMINAL_EXECUTIONS,
+        resolve_max_terminal_executions,
+    )
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    cron_config = DEFAULT_CONFIG["cron"]
+    assert isinstance(cron_config, dict)
+    configured = cron_config["max_terminal_executions"]
+    assert configured == DEFAULT_MAX_TERMINAL_EXECUTIONS
+    assert resolve_max_terminal_executions(configured) == DEFAULT_MAX_TERMINAL_EXECUTIONS
+
+
+def test_default_cap_applies_without_user_config(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+
+    assert (
+        executions.current_max_terminal_executions()
+        == executions.DEFAULT_MAX_TERMINAL_EXECUTIONS
+    )
+
+
+def test_config_cap_applies_end_to_end(monkeypatch, tmp_path):
+    """Real config.yaml in an isolated HERMES_HOME drives the prune cap."""
+    executions = _point_ledger(monkeypatch, tmp_path)
+    _write_retention_config(2)
+
+    assert executions.current_max_terminal_executions() == 2
+
+    inflight = executions.create_execution("live", source="builtin")
+    executions.mark_execution_running(inflight["id"])
+    for index in range(6):
+        row = executions.create_execution(f"done-{index}", source="builtin")
+        executions.finish_execution(row["id"], success=True)
+
+    records = executions.list_executions(limit=100)
+    assert len([row for row in records if row["status"] == "completed"]) == 2
+    assert executions.latest_execution("live")["status"] == "running"
+
+
+def test_configured_cap_and_ledger_follow_context_local_profile(
+    monkeypatch, tmp_path
+):
+    """Each in-process profile keeps its own cap and execution history."""
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    executions = _point_ledger(monkeypatch, tmp_path)
+    monkeypatch.setattr(executions, "EXECUTIONS_FILE", None)
+    profiles = [(tmp_path / "profile-two", 2), (tmp_path / "profile-four", 4)]
+
+    for profile_home, cap in profiles:
+        token = set_hermes_home_override(profile_home)
+        try:
+            _write_retention_config(cap)
+            for index in range(6):
+                row = executions.create_execution(
+                    f"{profile_home.name}-{index}", source="builtin"
+                )
+                executions.finish_execution(row["id"], success=True)
+        finally:
+            reset_hermes_home_override(token)
+
+    for profile_home, cap in profiles:
+        token = set_hermes_home_override(profile_home)
+        try:
+            records = executions.list_executions(limit=100)
+            assert len(records) == cap
+            assert all(row["job_id"].startswith(profile_home.name) for row in records)
+        finally:
+            reset_hermes_home_override(token)
+
+
+def test_monkeypatched_module_constant_wins_over_config(monkeypatch, tmp_path):
+    """The existing test injection point must beat a configured value."""
+    executions = _point_ledger(monkeypatch, tmp_path)
+    _write_retention_config(500)
+    monkeypatch.setattr(executions, "MAX_TERMINAL_EXECUTIONS", 3)
+
+    assert executions.current_max_terminal_executions() == 3
+
+    for index in range(8):
+        row = executions.create_execution(f"done-{index}", source="builtin")
+        executions.finish_execution(row["id"], success=True)
+    records = executions.list_executions(limit=100)
+    assert len([row for row in records if row["status"] == "completed"]) == 3
+
+
+def test_explicit_default_sized_module_override_wins_over_config(monkeypatch, tmp_path):
+    """An explicit override equal to the shipped default is still an override."""
+    executions = _point_ledger(monkeypatch, tmp_path)
+    _write_retention_config(7)
+    monkeypatch.setattr(
+        executions,
+        "MAX_TERMINAL_EXECUTIONS",
+        executions.DEFAULT_MAX_TERMINAL_EXECUTIONS,
+    )
+
+    assert (
+        executions.current_max_terminal_executions()
+        == executions.DEFAULT_MAX_TERMINAL_EXECUTIONS
+    )
+
+
+def test_env_var_does_not_override_configured_cap(monkeypatch, tmp_path):
+    """No HERMES_* env override exists for this setting — config.yaml wins."""
+    executions = _point_ledger(monkeypatch, tmp_path)
+    _write_retention_config(7)
+    monkeypatch.setenv("HERMES_CRON_MAX_EXECUTIONS", "99999")
+    monkeypatch.setenv("HERMES_CRON_MAX_TERMINAL_EXECUTIONS", "99999")
+
+    assert executions.current_max_terminal_executions() == 7
+
+
+def test_env_var_does_not_override_default_cap(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    monkeypatch.setenv("HERMES_CRON_MAX_EXECUTIONS", "5")
+    monkeypatch.setenv("HERMES_CRON_MAX_TERMINAL_EXECUTIONS", "5")
+
+    assert (
+        executions.current_max_terminal_executions()
+        == executions.DEFAULT_MAX_TERMINAL_EXECUTIONS
+    )
+
+
+def test_invalid_configured_cap_fails_closed_without_deleting(
+    monkeypatch, tmp_path, caplog
+):
+    """An invalid cap must skip pruning entirely — never coerce and delete."""
+    import logging
+
+    import pytest
+
+    executions = _point_ledger(monkeypatch, tmp_path)
+    _write_retention_config(0)
+
+    with pytest.raises(ValueError):
+        executions.current_max_terminal_executions()
+
+    inflight = executions.create_execution("live", source="builtin")
+    executions.mark_execution_running(inflight["id"])
+    with caplog.at_level(logging.ERROR, logger="cron.executions"):
+        for index in range(5):
+            row = executions.create_execution(f"done-{index}", source="builtin")
+            executions.finish_execution(row["id"], success=True)
+
+    records = executions.list_executions(limit=100)
+    assert len([row for row in records if row["status"] == "completed"]) == 5
+    assert executions.latest_execution("live")["status"] == "running"
+    errors = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.ERROR
+        and "max_terminal_executions" in record.message
+    ]
+    assert len(errors) == 1
+
+
+def test_oversized_configured_cap_fails_closed_without_rolling_back_terminal_state(
+    monkeypatch, tmp_path, caplog
+):
+    """A non-bindable SQLite offset must not roll back a completed execution."""
+    import logging
+
+    import pytest
+
+    executions = _point_ledger(monkeypatch, tmp_path)
+    _write_retention_config(1 << 63)
+
+    with pytest.raises(ValueError):
+        executions.current_max_terminal_executions()
+
+    claimed = executions.create_execution("oversized-cap", source="builtin")
+    with caplog.at_level(logging.ERROR, logger="cron.executions"):
+        completed = executions.finish_execution(claimed["id"], success=True)
+
+    assert completed is not None
+    assert completed["status"] == "completed"
+    assert executions.latest_execution("oversized-cap")["status"] == "completed"
+    assert sum(
+        record.levelno == logging.ERROR
+        and "max_terminal_executions" in record.message
+        for record in caplog.records
+    ) == 1
+
+
+def test_retention_error_is_reported_again_after_a_valid_resolution(
+    monkeypatch, tmp_path, caplog
+):
+    """A repaired setting ends the suppressed-error streak for its ledger."""
+    import logging
+
+    executions = _point_ledger(monkeypatch, tmp_path)
+    resolved = iter([ValueError("invalid cap"), 3, ValueError("invalid cap")])
+
+    def _resolve_next():
+        result = next(resolved)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(executions, "current_max_terminal_executions", _resolve_next)
+
+    with caplog.at_level(logging.ERROR, logger="cron.executions"):
+        for index in range(3):
+            row = executions.create_execution(f"streak-{index}", source="builtin")
+            executions.finish_execution(row["id"], success=True)
+
+    assert sum(record.levelno == logging.ERROR for record in caplog.records) == 2
+
+
+def test_non_numeric_configured_cap_fails_closed_without_deleting(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    _write_retention_config("not-a-number")
+
+    for index in range(4):
+        row = executions.create_execution(f"done-{index}", source="builtin")
+        executions.finish_execution(row["id"], success=True)
+
+    records = executions.list_executions(limit=100)
+    assert len([row for row in records if row["status"] == "completed"]) == 4
+
+
+def test_recover_prune_honors_configured_cap(monkeypatch, tmp_path):
+    """The restart-recovery prune path resolves the same configured cap."""
+    executions = _point_ledger(monkeypatch, tmp_path)
+    _write_retention_config(2)
+
+    for index in range(5):
+        executions.create_execution(f"dead-{index}", source="builtin")
+    monkeypatch.setattr(executions, "_PROCESS_ID", "another-process")
+    monkeypatch.setattr(executions, "_owner_is_live", lambda pid, started_at: False)
+
+    assert executions.recover_interrupted_executions() == 5
+
+    records = executions.list_executions(limit=100)
+    assert len(records) == 2
+    assert all(row["status"] == "unknown" for row in records)
 
 
 def test_corrupt_store_fails_closed_without_overwrite(monkeypatch, tmp_path):

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -334,6 +334,22 @@ Inspect recent attempts with `hermes cron runs [job-id] --limit 20` (alias:
 `history`). Terminal history is bounded; active attempts are never pruned. The
 ledger is included in quick backups.
 
+By default the ledger keeps the 1000 most recent terminal rows (`completed`,
+`failed`, `unknown`) and prunes older ones on write. High-volume deployments
+running many short-interval jobs can raise the cap so the ledger covers a
+longer audit window:
+
+```yaml
+cron:
+  max_terminal_executions: 20000   # default 1000; whole number from 1 to 2^63-1
+```
+
+In-flight (`claimed`/`running`) attempts are never pruned regardless of the
+cap. An invalid value (zero, negative, non-numeric, or above SQLite's signed
+64-bit integer limit) does not prune with a wrong limit — Hermes skips pruning
+entirely and logs one error per distinct invalid setting until the value is
+fixed.
+
 ### Repeated-failure review nudge
 
 Each job tracks a `failure_streak` — consecutive failed runs (delivery


### PR DESCRIPTION
High-volume profiles can exhaust the 1,000-row terminal execution ledger quickly, removing useful audit history for slower jobs. Independent production validation reported that one `*/5` job occupied 979 of 1,000 retained rows, leaving only 4 AM-report and 3 PM-report executions.

## What does this PR do?

This PR makes the terminal execution-ledger cap configurable per profile while preserving the existing default and pruning behavior:

- Reads `cron.max_terminal_executions` from the active profile's `config.yaml`.
- Keeps the backward-compatible default of 1,000 terminal rows.
- Validates values as positive whole numbers within SQLite's signed 64-bit integer range.
- Fails closed when the cap is invalid or cap resolution raises: the terminal execution state is committed, but destructive pruning is skipped.
- Logs the first error for each distinct invalid setting and ledger, suppressing repeated high-volume error spam until a valid resolution resets the streak.
- Preserves the module-level test/caller override, including an explicit override equal to the default.
- Never prunes `claimed` or `running` executions.

This does not change cron cadence, scheduling, job execution, or per-job retention priority.

## Related Issue

Fixes #93616

Related implementations: #97818 uses a different configuration name and fallback policy; #98511 additionally introduces per-job fairness. This PR intentionally keeps the scope to the configurable, strictly validated global cap requested in #93616.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/executions.py`
  - Resolves and strictly validates the profile-local terminal-row cap before binding it to SQLite.
  - Skips pruning on invalid values without rolling back the terminal execution update.
  - Keeps override precedence, profile isolation, in-flight preservation, and deduplicated error reporting.
- `hermes_cli/config_defaults.py`
  - Registers `cron.max_terminal_executions` with a default of 1,000.
- `tests/cron/test_execution_ledger.py`
  - Covers valid, invalid, and oversized values; config and override precedence; profile isolation; fail-closed terminal writes; log deduplication/reset; and recovery pruning.
- `website/docs/user-guide/features/cron.md`
  - Documents the setting, bounds, and fail-closed behavior.

## How to Test

1. Set `cron.max_terminal_executions: 7` in a profile's `config.yaml`.
2. Complete more than seven executions and confirm only seven terminal rows remain while `claimed`/`running` rows are preserved.
3. Set the value to `0`, a non-number, or `9223372036854775808`; confirm completed executions remain `completed` and historical rows are not deleted.
4. Run the canonical cron suite:
   ```text
   HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh -j 8 tests/cron/ -q --tb=short
   ```

## Validation

Current PR head: `2c316305c337539b1abdf60b4ea54aa4608190bf`

Locally validated head: `91ed3aeac9ecc35ed4cbaf8b39f1a18f64ea0180`

The current head is a patch-equivalent rebase of the locally validated head onto `18a76be1`; both commits have stable patch-id `e8dccd475d7a955a6f25658affcfe849cc86b5a5`. The local results below validate the unchanged patch, but do not substitute for current-head CI on the rebased base.

- Cron suite: 81 files, 1,072 passed, 0 failed, 1 Windows-only test skipped on macOS.
- Docs generator: 9 passed, 0 failed.
- `ruff check .`: passed.
- `ty check` on the three changed Python files: passed.
- Windows footgun scan (`--all`): passed, 1,035 files scanned.
- Documentation ASCII guard: passed, 436 files checked.
- `git diff --check` and merge-tree check against the then-current `main` (`4f225435`): passed.
- Platform: macOS 26.5.2 arm64, Python 3.11.15.

The earlier independent validation of `f3b9a218` reported 30 focused tests passing. Current-head GitHub CI status is recorded in the latest PR follow-up; no current-head CI result is claimed until those workflows actually run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs and documented the overlapping implementations above
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass (the canonical 1,072-test cron suite is green; the repository-wide suite is left to CI)
- [x] I've added tests for my changes
- [x] I've tested on macOS 26.5.2 arm64

### Documentation & Housekeeping

- [x] I've updated the relevant cron documentation
- [x] `cli-config.yaml.example` is N/A; the new key is registered in the canonical `DEFAULT_CONFIG`
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A
- [x] I've considered cross-platform impact and run the repository's Windows footgun scan
- [x] Tool descriptions/schemas are N/A
