### PR TITLE
fix(matrix): split E2EE deps out of platform.matrix so Matrix installs on macOS

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6315,13 +6315,15 @@ def _all_platforms() -> list[dict]:
     shape with ``_registry_entry`` holding the source.
 
     Platform-specific gating: some platforms can't be configured on
-    every host. Currently:
-      - Matrix is hidden on Windows. The [matrix] extra pulls
-        ``mautrix[encryption]`` -> ``python-olm``, which has no Windows
-        wheel and needs ``make`` + libolm to build from sdist. There's
-        no native Windows path that works, so we don't offer it in the
-        picker. Users who want Matrix on Windows can run hermes under
-        WSL.
+    every host. Currently: none.
+
+    Matrix used to be hidden on Windows because the [matrix] extra pulled
+    ``mautrix[encryption]`` -> ``python-olm``, which has no Windows wheel.
+    Since #62401 the crypto packages live in their own lazy feature
+    (``platform.matrix.e2ee``) and plain ``mautrix`` is a pure-python
+    wheel, so the plaintext adapter installs on every host and Matrix is
+    back in the picker (#76092). Only E2EE stays gated, in
+    ``tools/lazy_deps.py::_unsupported_feature_reason``.
     """
     # Populate the registry so plugin platforms are visible. Idempotent.
     # Bundled platform plugins (``kind: platform``) auto-load unconditionally,
@@ -6337,10 +6339,6 @@ def _all_platforms() -> list[dict]:
 
     platforms = [dict(p) for p in _PLATFORMS]
 
-    # Drop platforms that can't function on this host. See docstring.
-    if sys.platform == "win32":
-        platforms = [p for p in platforms if p.get("key") != "matrix"]
-
     by_key = {p["key"]: p for p in platforms}
 
     try:
@@ -6351,11 +6349,6 @@ def _all_platforms() -> list[dict]:
     for entry in platform_registry.all_entries():
         if entry.name in by_key:
             continue  # built-in already covers it
-        # Drop platforms that can't function on this host. Matrix is hidden on
-        # Windows (python-olm has no Windows wheel) — applies whether matrix is
-        # a built-in or, post-#41112, a registry-discovered plugin.
-        if sys.platform == "win32" and entry.name == "matrix":
-            continue
         platforms.append(
             {
                 "key": entry.name,

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2,7 +2,9 @@
 
 Connects to any Matrix homeserver (self-hosted or matrix.org) via the
 mautrix Python SDK.  Supports optional end-to-end encryption (E2EE)
-when installed with ``pip install "mautrix[encryption]"``.
+when additionally installed with ``pip install "mautrix[encryption]"`` —
+that extra pulls python-olm, which builds on Linux only, so E2EE is opt-in
+and the plaintext adapter never depends on it (#62401).
 
 Environment variables:
     MATRIX_HOMESERVER           Homeserver URL (e.g. https://matrix.example.org)
@@ -609,7 +611,8 @@ _OUTBOUND_MENTION_RE = re.compile(
 
 _E2EE_INSTALL_HINT = (
     "Install with: pip install 'mautrix[encryption]' asyncpg aiosqlite  "
-    "(requires libolm C library)"
+    "(needs the libolm C library, which builds on Linux only — see "
+    "hermes-agent[matrix-e2ee])"
 )
 
 _MATRIX_IMAGE_FILENAME_EXTS = frozenset({
@@ -804,6 +807,43 @@ def _check_e2ee_deps() -> bool:
         return True
     except (ImportError, AttributeError):
         return False
+
+
+def _e2ee_unsupported_reason() -> str:
+    """Why E2EE cannot be installed on this host, or ``""`` if it can.
+
+    Thin wrapper over the lazy-dep platform gate so callers (setup wizard,
+    dep installer) don't each re-derive "is python-olm buildable here".
+    """
+    try:
+        from tools.lazy_deps import unsupported_reason
+
+        return unsupported_reason("platform.matrix.e2ee") or ""
+    except Exception:  # pragma: no cover — defensive
+        return ""
+
+
+def _ensure_matrix_e2ee_deps() -> bool:
+    """Best-effort lazy install of the E2EE crypto group.
+
+    Split out of ``platform.matrix`` in #62401: enabling Matrix must never
+    pull python-olm, so the crypto packages install here instead — only once
+    the resolved E2EE mode says they're wanted. Returns False (with a logged
+    reason) rather than raising; the caller's ``required``/``optional`` policy
+    decides whether that is fatal.
+    """
+    blocked = _e2ee_unsupported_reason()
+    if blocked:
+        logger.warning("Matrix: cannot install E2EE dependencies — %s", blocked)
+        return False
+    try:
+        from tools.lazy_deps import ensure as _lazy_ensure
+
+        _lazy_ensure("platform.matrix.e2ee", prompt=False)
+    except Exception as exc:
+        logger.warning("Matrix: E2EE dependency install failed: %s", exc)
+        return False
+    return _check_e2ee_deps()
 
 
 def _normalize_e2ee_mode(value: Any) -> str:
@@ -1043,8 +1083,9 @@ def ensure_matrix_deps() -> bool:
     """
     # Check whether any package in the platform.matrix feature group is
     # missing.  ``feature_missing`` is cheap (per-spec importlib.metadata
-    # lookups) and correctly handles ``mautrix[encryption]`` by stripping
-    # the extras marker before checking the bare package.
+    # lookups).  This group is plaintext-only since #62401 — the crypto
+    # packages live in platform.matrix.e2ee and install further down, once
+    # the resolved E2EE mode says they're wanted.
     try:
         from tools.lazy_deps import feature_missing, ensure_and_bind
         missing = feature_missing("platform.matrix")
@@ -1078,13 +1119,18 @@ def ensure_matrix_deps() -> bool:
         if not ensure_and_bind("platform.matrix", _import, globals(), prompt=False):
             logger.warning(
                 "Matrix: required packages not installed (%s). "
-                "Run: pip install 'mautrix[encryption]' asyncpg aiosqlite "
+                "Run: pip install mautrix asyncpg aiosqlite "
                 "Markdown aiohttp-socks",
                 ", ".join(missing) if missing else "platform.matrix",
             )
             return False
 
     e2ee_mode = _resolve_e2ee_mode()
+    # The crypto packages are no longer part of platform.matrix (#62401), so
+    # install them on first use when E2EE is actually switched on. No-ops when
+    # they're already present; the checks below still decide the policy.
+    if e2ee_mode != "off" and not _check_e2ee_deps():
+        _ensure_matrix_e2ee_deps()
     if e2ee_mode == "required" and not _check_e2ee_deps():
         logger.error(
             "Matrix: E2EE is required but dependencies are missing. %s. "
@@ -5314,30 +5360,52 @@ def interactive_setup() -> None:
             print_success("Matrix credentials saved")
 
     if token or get_env_value("MATRIX_PASSWORD"):
-        want_e2ee = prompt_yes_no("Enable end-to-end encryption (E2EE)?", False)
+        # Only offer E2EE where its dependency can actually be installed.
+        # python-olm builds from sdist on macOS/Windows and fails; asking the
+        # question there just walks the user into a compiler traceback (#62401).
+        e2ee_blocked = _e2ee_unsupported_reason()
+        if e2ee_blocked:
+            want_e2ee = False
+            print_info(f"End-to-end encryption is unavailable here — {e2ee_blocked}")
+            print_info("   Continuing with plaintext Matrix (unencrypted rooms).")
+        else:
+            want_e2ee = prompt_yes_no("Enable end-to-end encryption (E2EE)?", False)
         if want_e2ee:
             save_env_value("MATRIX_ENCRYPTION", "true")
             print_success("E2EE enabled")
 
-        matrix_pkg = "mautrix[encryption]" if want_e2ee else "mautrix"
+        # Always install the plaintext runtime; add the crypto group only when
+        # E2EE was requested, so answering "no" never pulls python-olm.
+        _features = ["platform.matrix"] + (["platform.matrix.e2ee"] if want_e2ee else [])
         try:
-            from tools.lazy_deps import ensure as _lazy_ensure, feature_missing
-            _missing_before = feature_missing("platform.matrix")
-            if _missing_before:
-                print_info(f"Installing {matrix_pkg} (+ {len(_missing_before)} runtime deps)...")
+            from tools.lazy_deps import (
+                ensure as _lazy_ensure,
+                feature_missing,
+                feature_specs,
+            )
+            for _feature in _features:
+                _missing_before = feature_missing(_feature)
+                if not _missing_before:
+                    continue
+                _label = "Matrix E2EE" if _feature.endswith(".e2ee") else "mautrix"
+                print_info(f"Installing {_label} ({len(_missing_before)} packages)...")
                 try:
-                    _lazy_ensure("platform.matrix", prompt=False)
-                    print_success(f"{matrix_pkg} installed")
+                    _lazy_ensure(_feature, prompt=False)
+                    print_success(f"{_label} installed")
                 except Exception as exc:
-                    print_warning(
-                        "Install failed — run manually: pip install "
-                        "'mautrix[encryption]' asyncpg aiosqlite Markdown aiohttp-socks"
-                    )
+                    _manual = " ".join(f"'{s}'" for s in feature_specs(_feature))
+                    print_warning(f"Install failed — run manually: pip install {_manual}")
                     print_info(f"  Error: {exc}")
+                    if _feature.endswith(".e2ee"):
+                        print_info(
+                            "  Matrix still works without E2EE — set "
+                            "MATRIX_E2EE_MODE=off to silence the startup warning."
+                        )
         except ImportError:
             try:
                 __import__("mautrix")
             except ImportError:
+                matrix_pkg = "mautrix[encryption]" if want_e2ee else "mautrix"
                 print_info(f"Installing {matrix_pkg}...")
                 from hermes_cli.tools_config import _pip_install
 
@@ -5449,7 +5517,7 @@ def register(ctx) -> None:
         ensure_deps_fn=ensure_matrix_deps,
         is_connected=_is_connected,
         required_env=["MATRIX_HOMESERVER", "MATRIX_ACCESS_TOKEN"],
-        install_hint="pip install 'mautrix[encryption]'",
+        install_hint="pip install mautrix",
         setup_fn=interactive_setup,
         apply_yaml_config_fn=_apply_yaml_config,
         allowed_users_env="MATRIX_ALLOWED_USERS",

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -819,7 +819,19 @@ def _e2ee_unsupported_reason() -> str:
         from tools.lazy_deps import unsupported_reason
 
         return unsupported_reason("platform.matrix.e2ee") or ""
-    except Exception:  # pragma: no cover — defensive
+    except Exception:
+        # Fail CLOSED on the hosts we know cannot build olm. Returning "" here
+        # would mean "E2EE is installable", so a broken/partial install (where
+        # importing tools.lazy_deps fails) would make the wizard offer E2EE and
+        # walk the user straight into the doomed build this split exists to
+        # prevent. The platform test needs no imports, so it still holds.
+        if sys.platform in ("win32", "darwin"):
+            where = "Windows" if sys.platform == "win32" else "macOS"
+            return (
+                f"unsupported on {where}: Matrix E2EE depends on python-olm "
+                f"(libolm), which has no {where} wheel and cannot be built "
+                "from sdist here."
+            )
         return ""
 
 
@@ -836,6 +848,14 @@ def _ensure_matrix_e2ee_deps() -> bool:
     if blocked:
         logger.warning("Matrix: cannot install E2EE dependencies — %s", blocked)
         return False
+    # This can run mid-connect, and on a host with a toolchain python-olm
+    # builds libolm from sdist — tens of seconds with no output of its own.
+    # Announce it so an otherwise unexplained pause in adapter startup is
+    # attributable.
+    logger.info(
+        "Matrix: installing E2EE dependencies (python-olm + crypto stack) — "
+        "this may take a while if python-olm builds from source..."
+    )
     try:
         from tools.lazy_deps import ensure as _lazy_ensure
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,14 @@ dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==2.0.0"
 messaging = ["python-telegram-bot[webhooks]==22.8", "discord.py[voice]==2.7.1", "aiohttp==3.14.3", "brotlicffi==1.2.0.1", "slack-bolt==1.30.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.30.0", "slack-sdk==3.43.0", "aiohttp==3.14.3"]
-matrix = ["mautrix[encryption]==0.21.1", "aiosqlite==0.22.1", "asyncpg==0.31.0", "aiohttp-socks==0.11.0", "aiohttp==3.14.3"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7 (mautrix/aiohttp-socks only cap aiohttp<4 / >=3.10, so pin the patched floor directly)
+matrix = ["mautrix==0.21.1", "aiosqlite==0.22.1", "asyncpg==0.31.0", "aiohttp-socks==0.11.0", "aiohttp==3.14.3"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7 (mautrix/aiohttp-socks only cap aiohttp<4 / >=3.10, so pin the patched floor directly)
+# Matrix E2EE, split out of [matrix] in #62401. The [encryption] extra pulls
+# python-olm, whose bundled libolm builds only on Linux — it has no macOS or
+# Windows wheel, libolm is archived upstream (gone from Homebrew), and its
+# list.hh does not compile under Apple Clang 21. Keeping it in [matrix] made
+# `uv sync --extra matrix` fail on macOS for users who never wanted E2EE.
+# Plaintext Matrix is the default; opt in here when the host can build olm.
+matrix-e2ee = ["hermes-agent[matrix]", "mautrix[encryption]==0.21.1", "python-olm==3.2.16"]
 # WeCom callback-mode adapter — parses untrusted XML POST bodies from
 # WeCom-controlled callback endpoints, so we use defusedxml (drop-in
 # replacement for stdlib xml.etree.ElementTree) to block billion-laughs

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -907,6 +907,62 @@ class TestMatrixRequirements:
             "missing (#31116)"
         )
 
+    def test_e2ee_group_is_lazily_installed_when_encryption_on(self, monkeypatch):
+        """E2EE deps moved out of platform.matrix (#62401), so switching
+        encryption on must pull them in on first use — otherwise enabling E2EE
+        would silently never install olm."""
+        monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "syt_test")
+        monkeypatch.setenv("MATRIX_HOMESERVER", "https://matrix.example.org")
+        monkeypatch.setenv("MATRIX_E2EE_MODE", "required")
+
+        import plugins.platforms.matrix.adapter as matrix_mod
+
+        ensured = []
+        with patch.object(matrix_mod, "_check_e2ee_deps", return_value=False), \
+             patch.object(matrix_mod, "_e2ee_unsupported_reason", return_value=""), \
+             patch("tools.lazy_deps.feature_missing", return_value=()), \
+             patch("tools.lazy_deps.ensure", side_effect=lambda f, **k: ensured.append(f)):
+            matrix_mod.check_matrix_requirements()
+
+        assert ensured == ["platform.matrix.e2ee"]
+
+    def test_e2ee_group_is_not_installed_when_encryption_off(self, monkeypatch):
+        """The whole point of the split: the default (E2EE off) path must not
+        touch python-olm, which cannot build on macOS or Windows."""
+        monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "syt_test")
+        monkeypatch.setenv("MATRIX_HOMESERVER", "https://matrix.example.org")
+        monkeypatch.setenv("MATRIX_E2EE_MODE", "off")
+
+        import plugins.platforms.matrix.adapter as matrix_mod
+
+        ensured = []
+        with patch.object(matrix_mod, "_check_e2ee_deps", return_value=False), \
+             patch("tools.lazy_deps.feature_missing", return_value=()), \
+             patch("tools.lazy_deps.ensure", side_effect=lambda f, **k: ensured.append(f)):
+            assert matrix_mod.check_matrix_requirements() is True
+
+        assert ensured == []
+
+    def test_e2ee_install_is_skipped_on_hosts_where_olm_cannot_build(self, monkeypatch):
+        """Don't spend a doomed compile on macOS/Windows — the platform gate
+        answers before pip is invoked."""
+        monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "syt_test")
+        monkeypatch.setenv("MATRIX_HOMESERVER", "https://matrix.example.org")
+        monkeypatch.setenv("MATRIX_E2EE_MODE", "optional")
+
+        import plugins.platforms.matrix.adapter as matrix_mod
+
+        with patch.object(matrix_mod, "_check_e2ee_deps", return_value=False), \
+             patch.object(
+                 matrix_mod, "_e2ee_unsupported_reason",
+                 return_value="unsupported on macOS: ...",
+             ), \
+             patch("tools.lazy_deps.feature_missing", return_value=()), \
+             patch("tools.lazy_deps.ensure",
+                   side_effect=AssertionError("pip must not run on a gated host")):
+            # optional mode degrades to plaintext rather than failing.
+            assert matrix_mod.check_matrix_requirements() is True
+
 
 # ---------------------------------------------------------------------------
 # Access-token auth / E2EE bootstrap

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -943,6 +943,39 @@ class TestMatrixRequirements:
 
         assert ensured == []
 
+    def test_e2ee_gate_fails_closed_when_lazy_deps_is_unimportable(self, monkeypatch):
+        """A broken install must not be read as "E2EE is fine here".
+
+        ``_e2ee_unsupported_reason`` swallows exceptions so callers stay simple.
+        If that swallow returned "" on macOS/Windows it would mean "installable",
+        and the wizard would offer E2EE and trigger the python-olm build this
+        split exists to avoid. The platform check needs no imports, so it must
+        survive ``tools.lazy_deps`` failing to import at all.
+        """
+        import builtins
+
+        import plugins.platforms.matrix.adapter as matrix_mod
+
+        real_import = builtins.__import__
+
+        def _blocked(name, *a, **kw):
+            if name == "tools.lazy_deps" or name.startswith("tools.lazy_deps."):
+                raise ImportError("simulated broken install")
+            return real_import(name, *a, **kw)
+
+        for plat, label in (("darwin", "macOS"), ("win32", "Windows")):
+            monkeypatch.setattr(matrix_mod.sys, "platform", plat)
+            with patch.object(builtins, "__import__", _blocked):
+                reason = matrix_mod._e2ee_unsupported_reason()
+            assert reason, f"gate must stay closed on {label} when lazy_deps is broken"
+            assert label in reason
+
+        # ...but a host that *can* build olm is still not blocked by a
+        # transient import failure.
+        monkeypatch.setattr(matrix_mod.sys, "platform", "linux")
+        with patch.object(builtins, "__import__", _blocked):
+            assert matrix_mod._e2ee_unsupported_reason() == ""
+
     def test_e2ee_install_is_skipped_on_hosts_where_olm_cannot_build(self, monkeypatch):
         """Don't spend a doomed compile on macOS/Windows — the platform gate
         answers before pip is invoked."""

--- a/tests/gateway/test_matrix_plugin_setup.py
+++ b/tests/gateway/test_matrix_plugin_setup.py
@@ -81,3 +81,55 @@ class TestMatrixHomeChannelClear:
         assert "MATRIX_HOME_ROOM" not in saved
 
 
+
+class TestMatrixE2EEInstallRouting:
+    """The E2EE answer must decide what gets installed (#62401).
+
+    ``matrix_pkg = "mautrix[encryption]" if want_e2ee else "mautrix"`` used to
+    be cosmetic — it fed print strings while the install call hardcoded
+    ``platform.matrix``, whose spec carried the ``[encryption]`` extra. So
+    answering "no" still triggered a python-olm build, which is fatal on macOS.
+    """
+
+    def _run(self, monkeypatch, *, want_e2ee, blocked_reason=""):
+        import plugins.platforms.matrix.adapter as matrix_mod
+
+        ensured, saved, removed = [], {}, []
+        _patch_setup_io(
+            monkeypatch, _PROMPTS_BLANK, [want_e2ee], saved, removed, existing={}
+        )
+        # Every feature reports work to do, so a skipped install can only mean
+        # the wizard never asked for that feature.
+        monkeypatch.setattr(lazy_deps_mod, "feature_missing", lambda f: ("pkg==1",))
+        monkeypatch.setattr(
+            lazy_deps_mod, "ensure",
+            lambda feature, **kw: ensured.append(feature),
+        )
+        monkeypatch.setattr(
+            matrix_mod, "_e2ee_unsupported_reason", lambda: blocked_reason
+        )
+        interactive_setup()
+        return ensured, saved
+
+    def test_declining_e2ee_never_installs_the_crypto_group(self, monkeypatch):
+        ensured, saved = self._run(monkeypatch, want_e2ee=False)
+        assert ensured == ["platform.matrix"], (
+            "answering 'no' to E2EE must install the plaintext group only — "
+            f"got {ensured}"
+        )
+        assert "MATRIX_ENCRYPTION" not in saved
+
+    def test_accepting_e2ee_installs_both_groups(self, monkeypatch):
+        ensured, saved = self._run(monkeypatch, want_e2ee=True)
+        assert ensured == ["platform.matrix", "platform.matrix.e2ee"]
+        assert saved.get("MATRIX_ENCRYPTION") == "true"
+
+    def test_e2ee_not_offered_where_olm_cannot_build(self, monkeypatch):
+        """On macOS/Windows the wizard must not walk the user into a doomed
+        build. The queued answer is "yes", so if the E2EE question were still
+        asked the wizard would take it and both assertions below would fail."""
+        ensured, saved = self._run(
+            monkeypatch, want_e2ee=True, blocked_reason="unsupported on macOS: ..."
+        )
+        assert ensured == ["platform.matrix"]
+        assert "MATRIX_ENCRYPTION" not in saved

--- a/tests/hermes_cli/test_gateway_platform_gating.py
+++ b/tests/hermes_cli/test_gateway_platform_gating.py
@@ -5,55 +5,52 @@ in one place — ``_all_platforms()`` — so the setup wizard, the curses
 gateway-config menu, and any future picker all see the same filtered
 list.
 
-Currently:
-- Matrix is hidden on Windows. The ``[matrix]`` extra pulls
-  ``mautrix[encryption]`` -> ``python-olm``, which has no Windows wheel
-  and needs ``make`` + libolm to build from sdist. There's no native
-  Windows path that works.
+Currently nothing is gated here.
+
+Matrix used to be dropped on Windows: ``LAZY_DEPS["platform.matrix"]``
+pinned ``mautrix[encryption]``, which pulls ``python-olm``, which has no
+Windows wheel and needs ``make`` + libolm to build from sdist. #62401
+split the crypto packages into ``platform.matrix.e2ee``; plain
+``mautrix`` is a pure-python wheel, so the plaintext adapter installs on
+every host and the picker no longer hides it (#76092). The E2EE gate
+moved to ``tools/lazy_deps.py::_unsupported_feature_reason`` and is
+covered by ``tests/tools/test_lazy_deps_matrix_split.py``.
 """
 
 import pytest
 
 
-class TestMatrixHiddenOnWindows:
-    @pytest.mark.linux_only
-    def test_matrix_present_on_linux(self):
-        """Sanity: matrix is still in the picker on Linux.
-
-        Linux-gated because the assertion is the negative of the Windows
-        gate — it only means anything when the host really is not Windows.
-        """
+class TestMatrixAvailableEverywhere:
+    def test_matrix_present_in_picker(self):
+        """Matrix is offered on whatever host the suite runs on."""
         import hermes_cli.gateway as gateway_mod
 
         platforms = gateway_mod._all_platforms()
         keys = {p["key"] for p in platforms}
-        assert "matrix" in keys, "matrix must be available on Linux"
+        assert "matrix" in keys, "matrix must be available in the platform picker"
 
     @pytest.mark.windows_only
-    def test_matrix_absent_on_windows(self):
-        """The gate itself: matrix must be dropped on a real Windows host.
+    def test_matrix_present_on_windows(self):
+        """The regression that matters: a real Windows host must offer Matrix.
 
-        A patched ``sys.platform`` proved only that the ``if`` branch runs;
-        on native Windows this also proves the picker the user actually sees
-        omits the platform whose dependency cannot build here.
+        A patched ``sys.platform`` would only prove the branch was removed;
+        on native Windows this proves the picker the user actually sees now
+        includes the platform whose plaintext deps do install here (#76092).
         """
         import hermes_cli.gateway as gateway_mod
 
         platforms = gateway_mod._all_platforms()
         keys = {p["key"] for p in platforms}
-        assert "matrix" not in keys, "matrix must be hidden on Windows"
+        assert "matrix" in keys, "matrix must no longer be hidden on Windows"
 
     @pytest.mark.windows_only
     def test_other_platforms_unaffected_on_windows(self):
-        """Gating must only drop matrix, not collateral damage."""
+        """Removing the gate must not disturb the rest of the picker."""
         import hermes_cli.gateway as gateway_mod
 
         platforms = gateway_mod._all_platforms()
         keys = {p["key"] for p in platforms}
-        # A representative sample of platforms that have no Windows
-        # blockers — picker should still surface them.
         for must_have in ("telegram", "discord", "slack", "mattermost"):
             assert must_have in keys, (
-                f"{must_have} disappeared from Windows picker — gate is "
-                "over-filtering"
+                f"{must_have} disappeared from the Windows picker"
             )

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -18,7 +18,7 @@ def _load_package_data():
 
 
 def test_matrix_extra_not_in_all():
-    """The [matrix] extra pulls `mautrix[encryption]` -> `python-olm`,
+    """The [matrix] extra used to pull `mautrix[encryption]` -> `python-olm`,
     which has Linux-only wheels and no native build path on Windows or
     modern macOS (archived libolm, C++ errors with Clang 21+).
 
@@ -27,6 +27,11 @@ def test_matrix_extra_not_in_all():
     [matrix] extra is excluded from [all] entirely and routed through
     `tools/lazy_deps.py` (LAZY_DEPS["platform.matrix"]) — installs at
     first use, where the user is expected to have a toolchain.
+
+    #62401 then moved olm out of [matrix] into [matrix-e2ee], so the
+    exclusion is no longer what keeps olm out of a fresh install. Keep it
+    anyway: the lazy-install policy below applies to every backend, and
+    [matrix] still carries asyncpg, which builds from sdist without a wheel.
     """
     optional_dependencies = _load_optional_dependencies()
 
@@ -42,6 +47,29 @@ def test_matrix_extra_not_in_all():
         "tools/lazy_deps.py LAZY_DEPS['platform.matrix']. Found: "
         f"{matrix_in_all}"
     )
+
+
+def test_matrix_extra_does_not_pull_python_olm():
+    """`uv sync --extra matrix` must resolve on macOS and Windows (#62401).
+
+    The [encryption] extra pulls python-olm, which only builds on Linux. It
+    belongs to the opt-in [matrix-e2ee] extra, so the plaintext adapter — the
+    default, since MATRIX_E2EE_MODE resolves to `off` when unset — installs
+    without a compiler.
+    """
+    optional_dependencies = _load_optional_dependencies()
+
+    offending = [d for d in optional_dependencies["matrix"] if "[encryption]" in d]
+    assert not offending, (
+        "[matrix] must pin bare mautrix — the [encryption] extra pulls "
+        f"python-olm and breaks macOS/Windows installs. Found: {offending}"
+    )
+    assert "matrix-e2ee" in optional_dependencies, (
+        "[matrix-e2ee] must exist so operators on Linux can still opt into E2EE"
+    )
+    assert any(
+        "[encryption]" in d for d in optional_dependencies["matrix-e2ee"]
+    ), "[matrix-e2ee] must be the extra that actually carries the crypto deps"
 
 
 def test_lazy_installable_extras_excluded_from_all():
@@ -70,7 +98,7 @@ def test_lazy_installable_extras_excluded_from_all():
         "edge-tts", "tts-premium",
         "voice",  # faster-whisper / sounddevice / numpy
         "modal", "daytona", "vercel",
-        "messaging", "slack", "matrix", "dingtalk", "feishu",
+        "messaging", "slack", "matrix", "matrix-e2ee", "dingtalk", "feishu",
         "honcho", "hindsight",
         "supermemory", "mem0",
         "mistral",  # mistralai — Voxtral STT/TTS, lazy-installed (stt.mistral / tts.mistral)

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -320,9 +320,11 @@ class TestRefreshActiveFeatures:
         monkeypatch.setattr(ld, "active_features", lambda: [])
         assert ld.refresh_active_features() == {}
 
-    def test_windows_matrix_refresh_is_skipped_before_pip(self, monkeypatch):
+    def test_windows_matrix_e2ee_refresh_is_skipped_before_pip(self, monkeypatch):
         # Matrix E2EE pulls python-olm, which has no native Windows wheel/build
         # path. `hermes update` must not retry that doomed install every run.
+        # Post-#62401 the gate is on `platform.matrix.e2ee`; the plaintext
+        # `platform.matrix` group refreshes normally on every host.
         #
         # The subject here is the *consumer* — refresh_active_features honouring
         # the gate before pip — so we monkeypatch lazy_deps' own platform probe
@@ -332,11 +334,11 @@ class TestRefreshActiveFeatures:
             "_unsupported_feature_reason",
             lambda feature: (
                 "unsupported on Windows: Matrix E2EE depends on python-olm"
-                if feature == "platform.matrix"
+                if feature == "platform.matrix.e2ee"
                 else None
             ),
         )
-        monkeypatch.setattr(ld, "active_features", lambda: ["platform.matrix"])
+        monkeypatch.setattr(ld, "active_features", lambda: ["platform.matrix.e2ee"])
         monkeypatch.setattr(ld, "_is_satisfied", lambda spec: False)
         monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
         monkeypatch.setattr(
@@ -347,16 +349,19 @@ class TestRefreshActiveFeatures:
 
         result = ld.refresh_active_features()
 
-        assert result["platform.matrix"].startswith("skipped:")
-        assert "unsupported on Windows" in result["platform.matrix"]
+        assert result["platform.matrix.e2ee"].startswith("skipped:")
+        assert "unsupported on Windows" in result["platform.matrix.e2ee"]
 
     @pytest.mark.windows_only
     def test_matrix_probe_reports_unsupported_on_real_windows(self):
         # The probe itself keys off the real host: patching sys.platform only
         # proved the string, never that Windows actually hits this gate.
         assert "unsupported on Windows" in (
-            ld._unsupported_feature_reason("platform.matrix") or ""
+            ld._unsupported_feature_reason("platform.matrix.e2ee") or ""
         )
+        # ...and only E2EE is gated. Plain mautrix is a pure-python wheel, so
+        # the plaintext adapter must stay installable on Windows (#76092).
+        assert ld._unsupported_feature_reason("platform.matrix") is None
 
     def test_restore_snapshot_skips_telegram_with_lazy_installs_disabled(
         self, monkeypatch

--- a/tests/tools/test_lazy_deps_matrix_split.py
+++ b/tests/tools/test_lazy_deps_matrix_split.py
@@ -1,0 +1,160 @@
+"""``platform.matrix`` must install without pulling ``python-olm`` (#62401).
+
+The Matrix adapter treats E2EE as optional — ``_check_e2ee_deps()`` degrades
+to plaintext when olm is absent, and ``mautrix.crypto`` is only imported
+behind ``if self._encryption:``. But the lazy-dep group pinned
+``mautrix[encryption]``, so *every* Matrix user paid for a ``python-olm``
+build regardless of their E2EE answer.
+
+That build cannot succeed on macOS: python-olm ships manylinux wheels only,
+libolm was archived upstream and dropped from Homebrew, and its bundled
+``list.hh`` fails to compile under Apple Clang 21 (``++other_pos`` on a
+``T *const``) — a hard error, not something ``-Wno-*`` can silence.
+
+So the group is split: ``platform.matrix`` is the plaintext runtime and
+installs everywhere, ``platform.matrix.e2ee`` carries olm and is gated off
+the hosts where it cannot build.
+
+See also #64065 (``hermes update`` spurious refresh failure on macOS) and
+#85588 (the 0.21.1 pin bump taking the adapter down on macOS).
+"""
+import sys
+
+import pytest
+
+import tools.lazy_deps as ld
+
+BASE = "platform.matrix"
+E2EE = "platform.matrix.e2ee"
+
+
+def _names(feature):
+    return {ld._pkg_name_from_spec(s) for s in ld.LAZY_DEPS[feature]}
+
+
+class TestBaseFeatureIsOlmFree:
+    """The plaintext group must be installable on a host with no compiler."""
+
+    def test_base_feature_pins_plain_mautrix(self):
+        specs = ld.LAZY_DEPS[BASE]
+        assert any(s.startswith("mautrix==") for s in specs), (
+            f"{BASE} must pin bare mautrix (no extras marker); got {specs}"
+        )
+
+    def test_base_feature_has_no_encryption_extra(self):
+        offending = [s for s in ld.LAZY_DEPS[BASE] if "[encryption]" in s]
+        assert not offending, (
+            f"{BASE} must not request the [encryption] extra — it pulls "
+            f"python-olm, which cannot build on macOS. Found: {offending}"
+        )
+
+    def test_base_feature_does_not_name_python_olm(self):
+        assert "python-olm" not in _names(BASE)
+
+    def test_base_feature_keeps_the_plaintext_runtime_deps(self):
+        """Splitting olm out must not drop the deps connect() actually needs."""
+        required = {"mautrix", "aiosqlite", "asyncpg", "aiohttp-socks", "aiohttp"}
+        assert required <= _names(BASE), (
+            f"{BASE} lost runtime deps: {sorted(required - _names(BASE))}"
+        )
+
+
+class TestE2EEFeature:
+    def test_e2ee_feature_exists(self):
+        assert E2EE in ld.LAZY_DEPS
+
+    def test_e2ee_anchor_is_python_olm(self):
+        """``active_features()`` keys off ``specs[0]``.
+
+        If the anchor were mautrix, a plaintext Matrix install would mark the
+        E2EE group active and ``hermes update`` would retry the impossible olm
+        build on every run — exactly the #64065 symptom.
+        """
+        assert ld._pkg_name_from_spec(ld.LAZY_DEPS[E2EE][0]) == "python-olm"
+
+    def test_e2ee_requests_the_encryption_extra(self):
+        """Keep the extra so uv resolves anything upstream adds to it."""
+        assert any("[encryption]" in s for s in ld.LAZY_DEPS[E2EE])
+
+    def test_e2ee_lists_the_extra_contents_explicitly(self):
+        """``_is_satisfied`` strips ``[extras]``, so the extra alone is not a
+        detectable requirement — bare mautrix would satisfy it. The concrete
+        packages must be listed so a half-installed E2EE stack is spotted."""
+        assert {"python-olm", "pycryptodome", "unpaddedbase64", "base58"} <= _names(E2EE)
+
+    def test_plain_mautrix_does_not_satisfy_the_e2ee_group(self, monkeypatch):
+        """The #62401 'under-checking' defect: with only bare mautrix present,
+        the E2EE group must still report work to do."""
+        monkeypatch.setattr(
+            ld, "_is_satisfied",
+            lambda spec: ld._pkg_name_from_spec(spec) == "mautrix",
+        )
+        assert ld.feature_missing(E2EE) != ()
+
+    def test_e2ee_group_matches_mautrix_declared_extra(self):
+        """Drift guard: we mirror mautrix's ``[encryption]`` extra by hand, so
+        fail loudly if upstream adds a package we would silently skip."""
+        pytest.importorskip("mautrix")
+        from importlib.metadata import requires
+
+        from packaging.requirements import Requirement
+
+        declared = {
+            ld._pkg_name_from_spec(Requirement(raw).name)
+            for raw in (requires("mautrix") or ())
+            if (r := Requirement(raw)).marker
+            and r.marker.evaluate({"extra": "encryption"})
+        }
+        missing = {d.lower() for d in declared} - {n.lower() for n in _names(E2EE)}
+        assert not missing, (
+            f"mautrix[encryption] gained {sorted(missing)} — add them to "
+            f"LAZY_DEPS[{E2EE!r}] so _is_satisfied can see them"
+        )
+
+
+class TestActiveFeatureAnchoring:
+    def test_plaintext_install_does_not_activate_the_e2ee_group(self, monkeypatch):
+        installed = {"mautrix", "aiosqlite", "asyncpg", "aiohttp-socks", "aiohttp"}
+        monkeypatch.setattr(
+            ld, "_is_present",
+            lambda spec: ld._pkg_name_from_spec(spec) in installed,
+        )
+        active = ld.active_features()
+        assert BASE in active
+        assert E2EE not in active, (
+            "a plaintext Matrix install must not make hermes update retry the "
+            "olm build (#64065)"
+        )
+
+
+class TestPlatformGate:
+    @pytest.mark.parametrize("plat", ["win32", "darwin", "linux"])
+    def test_base_matrix_is_supported_on_every_host(self, monkeypatch, plat):
+        """Plain mautrix is a pure-python wheel — nothing to gate."""
+        monkeypatch.setattr(sys, "platform", plat)
+        assert ld._unsupported_feature_reason(BASE) is None
+
+    @pytest.mark.parametrize("plat,label", [("win32", "Windows"), ("darwin", "macOS")])
+    def test_e2ee_is_gated_where_olm_cannot_build(self, monkeypatch, plat, label):
+        monkeypatch.setattr(sys, "platform", plat)
+        reason = ld._unsupported_feature_reason(E2EE)
+        assert reason, f"E2EE must be gated on {label}"
+        # refresh_active_features classifies skips by this prefix.
+        assert reason.startswith("unsupported ")
+        assert label in reason
+        # The message has to leave the user somewhere to go.
+        assert "mautrix" in reason
+
+    def test_e2ee_is_allowed_on_linux(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        assert ld._unsupported_feature_reason(E2EE) is None
+
+    @pytest.mark.macos_only
+    def test_real_macos_host_gates_e2ee_but_not_base(self):
+        """Patching ``sys.platform`` only proves the branch string.
+
+        On a real Mac this is the assertion that matters: the gateway can
+        install Matrix, and only the impossible olm build is refused.
+        """
+        assert ld._unsupported_feature_reason(BASE) is None
+        assert "unsupported on macOS" in (ld._unsupported_feature_reason(E2EE) or "")

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -223,8 +223,13 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "slack-sdk==3.43.0",
         "aiohttp==3.14.3",  # prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
     ),
+    # Plaintext Matrix. Deliberately bare `mautrix` — the `[encryption]` extra
+    # pulls python-olm, and the adapter only imports mautrix.crypto behind
+    # `if self._encryption:`, so olm is dead weight for the default E2EE-off
+    # setup. Requiring it here made Matrix uninstallable on macOS for everyone
+    # (#62401, #85588); E2EE now lives in `platform.matrix.e2ee` below.
     "platform.matrix": (
-        "mautrix[encryption]==0.21.1",
+        "mautrix==0.21.1",
         "aiosqlite==0.22.1",
         "asyncpg==0.31.0",
         "aiohttp-socks==0.11.0",
@@ -232,6 +237,27 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         # aiohttp transitively, so a vulnerable already-installed aiohttp still
         # satisfies both — pin the patched floor here too, like platform.discord.
         "aiohttp==3.14.3",  # prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
+    ),
+    # Matrix E2EE. Installed only when the resolved E2EE mode is
+    # optional/required — never as a side effect of enabling Matrix.
+    #
+    # python-olm leads on purpose: `active_features()` anchors on specs[0], and
+    # it is the only package here that proves E2EE was actually installed. With
+    # mautrix as the anchor, a plaintext install would mark this group active
+    # and `hermes update` would retry the doomed olm build every run (#64065).
+    #
+    # The extra's contents are also listed one by one because `_is_satisfied`
+    # strips `[extras]` before checking, so `mautrix[encryption]` alone is
+    # satisfied by bare mautrix and a half-installed crypto stack would go
+    # unnoticed. `mautrix[encryption]` stays last so uv still resolves the
+    # extra proper — the explicit pins are the detectable half, not a
+    # replacement. test_lazy_deps_matrix_split.py guards against drift.
+    "platform.matrix.e2ee": (
+        "python-olm==3.2.16",
+        "pycryptodome==3.23.0",
+        "unpaddedbase64==2.1.0",
+        "base58==2.1.1",
+        "mautrix[encryption]==0.21.1",
     ),
     "platform.dingtalk": (
         "dingtalk-stream==0.24.3",
@@ -543,11 +569,22 @@ def _unsupported_feature_reason(feature: str) -> Optional[str]:
     known-impossible installs out of both first-use lazy installation and the
     ``hermes update`` lazy-refresh pass.
     """
-    if sys.platform == "win32" and feature == "platform.matrix":
+    if feature == "platform.matrix.e2ee" and sys.platform in ("win32", "darwin"):
+        # python-olm publishes manylinux wheels only, so both hosts fall back
+        # to building the bundled libolm from sdist — and neither can:
+        #   Windows: no `make`, and cmake 4.x rejects libolm's ancient
+        #            cmake_minimum_required (#58063).
+        #   macOS:   libolm was archived upstream and dropped from Homebrew,
+        #            and its list.hh does `++other_pos` on a `T *const`, which
+        #            Apple Clang 21 rejects outright — no flag silences it.
+        # Only E2EE is affected; plaintext Matrix installs fine on both.
+        where = "Windows" if sys.platform == "win32" else "macOS"
         return (
-            "unsupported on Windows: Matrix E2EE depends on python-olm, "
-            "which has no Windows wheel and requires make + libolm to build "
-            "from sdist. Run Hermes under WSL to use Matrix on Windows."
+            f"unsupported on {where}: Matrix E2EE depends on python-olm "
+            f"(libolm), which has no {where} wheel and cannot be built from "
+            "sdist here. Plaintext Matrix works — this only disables "
+            "encrypted rooms. For E2EE, run Hermes under Linux, WSL, or "
+            "Docker, where 'pip install mautrix[encryption]' resolves."
         )
     return None
 
@@ -840,6 +877,18 @@ def feature_specs(feature: str) -> tuple[str, ...]:
 def feature_missing(feature: str) -> tuple[str, ...]:
     """Return the subset of specs for ``feature`` not currently installed."""
     return tuple(s for s in feature_specs(feature) if not _is_satisfied(s))
+
+
+def unsupported_reason(feature: str) -> Optional[str]:
+    """Public read of the host capability gate — see
+    :func:`_unsupported_feature_reason`.
+
+    Lets callers ask "can this feature install here?" *before* offering it,
+    instead of discovering it by catching :class:`FeatureUnavailable` from a
+    half-finished install. Used by the Matrix setup wizard to skip the E2EE
+    prompt on hosts where python-olm cannot build.
+    """
+    return _unsupported_feature_reason(feature)
 
 
 def ensure(feature: str, *, prompt: bool = True) -> None:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -2019,7 +2019,7 @@ async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, 
     try:
         from plugins.platforms.matrix.adapter import MatrixAdapter
     except ImportError:
-        return {"error": "Matrix dependencies not installed. Run: pip install 'mautrix[encryption]'"}
+        return {"error": "Matrix dependencies not installed. Run: pip install mautrix"}
 
     adapter = MatrixAdapter(pconfig)
     try:

--- a/uv.lock
+++ b/uv.lock
@@ -1698,7 +1698,15 @@ matrix = [
     { name = "aiohttp-socks" },
     { name = "aiosqlite" },
     { name = "asyncpg" },
+    { name = "mautrix" },
+]
+matrix-e2ee = [
+    { name = "aiohttp" },
+    { name = "aiohttp-socks" },
+    { name = "aiosqlite" },
+    { name = "asyncpg" },
     { name = "mautrix", extra = ["encryption"] },
+    { name = "python-olm" },
 ]
 mcp = [
     { name = "httpx2" },
@@ -1858,6 +1866,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["homeassistant"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["homeassistant"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["honcho"], marker = "extra == 'termux'" },
+    { name = "hermes-agent", extras = ["matrix"], marker = "extra == 'matrix-e2ee'" },
     { name = "hermes-agent", extras = ["mcp"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["mcp"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["pty"], marker = "extra == 'all'" },
@@ -1878,7 +1887,8 @@ requires-dist = [
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.6.8" },
     { name = "markdown", specifier = "==3.10.2" },
-    { name = "mautrix", extras = ["encryption"], marker = "extra == 'matrix'", specifier = "==0.21.1" },
+    { name = "mautrix", marker = "extra == 'matrix'", specifier = "==0.21.1" },
+    { name = "mautrix", extras = ["encryption"], marker = "extra == 'matrix-e2ee'", specifier = "==0.21.1" },
     { name = "mcp", marker = "extra == 'computer-use'", specifier = "==2.0.0" },
     { name = "mcp", marker = "extra == 'dev'", specifier = "==2.0.0" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = "==2.0.0" },
@@ -1910,6 +1920,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "python-multipart", specifier = ">=0.0.9,<1" },
     { name = "python-multipart", marker = "extra == 'web'", specifier = "==0.0.32" },
+    { name = "python-olm", marker = "extra == 'matrix-e2ee'", specifier = "==3.2.16" },
     { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'messaging'", specifier = "==22.8" },
     { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'termux'", specifier = "==22.8" },
     { name = "pywin32", marker = "sys_platform == 'win32'", specifier = ">=306,<312" },
@@ -1946,7 +1957,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "matrix-e2ee", "wecom", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -356,14 +356,30 @@ Hermes supports Matrix end-to-end encryption, so you can chat with your bot in e
 
 ### Requirements
 
-E2EE requires the `mautrix` library with encryption extras and the `libolm` C library:
+:::warning Linux only
+E2EE depends on `python-olm`, which wraps the `libolm` C library. `libolm` has
+been archived upstream and only ships wheels for Linux, so **E2EE cannot be
+installed on macOS or Windows**:
+
+- **macOS** — `libolm` was removed from Homebrew, and building the bundled copy
+  fails under Apple Clang 21 (a const-correctness error in `list.hh`). No
+  compiler flag works around it.
+- **Windows** — there is no wheel, and the sdist build needs `make` plus a
+  toolchain that can build `libolm`.
+
+Plaintext Matrix works fine on both. To run an encrypted bot from a Mac or
+Windows box, host the gateway in Docker, WSL, or on a Linux server.
+:::
+
+On Linux, E2EE needs the `mautrix` encryption extras plus the `libolm` C library:
 
 ```bash
 # Install mautrix with E2EE support
 pip install 'mautrix[encryption]'
 
-# Or install with hermes extras
-cd ~/.hermes/hermes-agent && uv pip install -e ".[matrix]"
+# Or install with hermes extras (this is the E2EE extra —
+# ".[matrix]" installs the plaintext adapter only)
+cd ~/.hermes/hermes-agent && uv pip install -e ".[matrix-e2ee]"
 ```
 
 You also need `libolm` installed on your system:
@@ -372,12 +388,14 @@ You also need `libolm` installed on your system:
 # Debian/Ubuntu
 sudo apt install libolm-dev
 
-# macOS
-brew install libolm
-
 # Fedora
 sudo dnf install libolm-devel
 ```
+
+`hermes gateway setup` handles this for you: it installs the plaintext adapter
+first and only pulls the crypto packages after you answer **yes** to the E2EE
+prompt. On hosts where `libolm` cannot build, it skips the prompt entirely and
+tells you why rather than failing partway through a compile.
 
 ### Enable E2EE
 
@@ -617,7 +635,7 @@ If this returns your user info, the token is valid. If it returns an error, gene
 **Fix**: Install it:
 
 ```bash
-pip install 'mautrix[encryption]'
+pip install mautrix
 ```
 
 Or with Hermes extras:
@@ -625,6 +643,12 @@ Or with Hermes extras:
 ```bash
 cd ~/.hermes/hermes-agent && uv pip install -e ".[matrix]"
 ```
+
+:::tip
+Install plain `mautrix`, not `mautrix[encryption]`, unless you actually need
+encrypted rooms — the extra pulls `python-olm`, which only builds on Linux.
+See [Requirements](#requirements) above.
+:::
 
 ### Encryption errors / "could not decrypt event"
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/matrix.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/matrix.md
@@ -239,14 +239,28 @@ Hermes 支持 Matrix 端对端加密，你可以在加密房间中与机器人�
 
 ### 前提条件
 
-E2EE 需要带有加密扩展的 `mautrix` 库以及 `libolm` C 库：
+:::warning 仅支持 Linux
+E2EE 依赖 `python-olm`，它封装了 `libolm` C 库。`libolm` 已被上游归档，且只发布
+Linux wheel，因此 **macOS 和 Windows 上无法安装 E2EE**：
+
+- **macOS** —— Homebrew 已移除 `libolm`，而自带副本在 Apple Clang 21 下编译失败
+  （`list.hh` 中的 const 正确性错误）。没有编译选项可以绕过。
+- **Windows** —— 没有 wheel，且从 sdist 构建需要 `make` 以及能够构建 `libolm`
+  的工具链。
+
+明文 Matrix 在两者上都能正常工作。若要从 Mac 或 Windows 运行加密机器人，请将
+网关部署在 Docker、WSL 或 Linux 服务器上。
+:::
+
+在 Linux 上，E2EE 需要 `mautrix` 的加密扩展以及 `libolm` C 库：
 
 ```bash
 # 安装带 E2EE 支持的 mautrix
 pip install 'mautrix[encryption]'
 
-# 或通过 hermes extras 安装
-cd ~/.hermes/hermes-agent && uv pip install -e ".[matrix]"
+# 或通过 hermes extras 安装（这是 E2EE extra，
+# ".[matrix]" 只安装明文适配器）
+cd ~/.hermes/hermes-agent && uv pip install -e ".[matrix-e2ee]"
 ```
 
 你还需要在系统上安装 `libolm`：
@@ -255,12 +269,13 @@ cd ~/.hermes/hermes-agent && uv pip install -e ".[matrix]"
 # Debian/Ubuntu
 sudo apt install libolm-dev
 
-# macOS
-brew install libolm
-
 # Fedora
 sudo dnf install libolm-devel
 ```
+
+`hermes gateway setup` 会自动处理：它先安装明文适配器，只有在你对 E2EE 提示回答
+**是** 之后才拉取加密相关的包。在无法构建 `libolm` 的主机上，它会直接跳过该提示
+并说明原因，而不是在编译中途失败。
 
 ### 启用 E2EE
 
@@ -421,7 +436,7 @@ curl -H "Authorization: Bearer YOUR_TOKEN" \
 **解决方法**：安装它：
 
 ```bash
-pip install 'mautrix[encryption]'
+pip install mautrix
 ```
 
 或通过 Hermes extras：
@@ -429,6 +444,12 @@ pip install 'mautrix[encryption]'
 ```bash
 cd ~/.hermes/hermes-agent && uv pip install -e ".[matrix]"
 ```
+
+:::tip
+除非确实需要加密房间，否则请安装普通的 `mautrix` 而不是 `mautrix[encryption]`
+—— 该扩展会拉取 `python-olm`，而它只能在 Linux 上构建。参见上文的
+[前提条件](#前提条件)。
+:::
 
 ### 加密错误/"无法解密事件"
 


### PR DESCRIPTION
## What does this PR do?

Makes the Matrix gateway installable on macOS by moving the E2EE dependencies out of the base `platform.matrix` lazy-dep group.

`LAZY_DEPS["platform.matrix"]` pinned `mautrix[encryption]`, so **enabling Matrix always pulled `python-olm` — even with E2EE off, which is the default**. `python-olm` publishes manylinux wheels only, so macOS falls back to building the bundled libolm from sdist, and that build cannot succeed:

- libolm was archived upstream and **removed from Homebrew** (`brew install libolm` → "No available formula"), so there is no system-library escape hatch.
- The bundled `list.hh` does `++other_pos` on a `T *const`, which Apple Clang 21 rejects. It's a hard error, not a warning — I confirmed it survives dropping `-Werror`:

```
include/olm/list.hh:106:13: error: cannot assign to variable 'other_pos' with const-qualified type 'T *const'
  106 |             ++other_pos;
include/olm/list.hh:102:19: note: variable 'other_pos' declared const here
  102 |         T * const other_pos = other._data;
```

The setup wizard already computed `matrix_pkg = "mautrix[encryption]" if want_e2ee else "mautrix"` — but only used it for print strings, while the install call passed the hardcoded feature name. So answering **"no"** to the E2EE prompt still triggered the doomed build. That is the defect users actually hit.

The adapter never needed olm for this case: `mautrix.crypto` is imported behind `if self._encryption:`, and `_check_e2ee_deps()` already degrades to plaintext when it's absent.

## Related Issue

Fixes #62401
Fixes #85588
Fixes #64065
Fixes #76092

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

**`tools/lazy_deps.py`**
- `platform.matrix` → plain `mautrix==0.21.1` + the plaintext runtime deps.
- New `platform.matrix.e2ee` → `python-olm`, `pycryptodome`, `unpaddedbase64`, `base58`, `mautrix[encryption]`.
  - `python-olm` is **first on purpose**: `active_features()` anchors on `specs[0]`. With mautrix as the anchor, a plaintext install would mark E2EE active and `hermes update` would retry the impossible build every run (the #64065 symptom).
  - The extra's contents are listed explicitly because `_is_satisfied()` strips `[extras]` — bare mautrix would otherwise "satisfy" `mautrix[encryption]` and hide a half-installed crypto stack (#62401 defect 2). `mautrix[encryption]` stays last so uv still resolves the real extra.
- `_unsupported_feature_reason` gate moves from `platform.matrix` to `platform.matrix.e2ee`, and now covers **darwin as well as win32**, with a message that names the plaintext alternative.
- New public `unsupported_reason(feature)` so callers can ask "can this install here?" before offering it, rather than catching `FeatureUnavailable` mid-install.

**`plugins/platforms/matrix/adapter.py`**
- `interactive_setup` installs `platform.matrix.e2ee` **only** when E2EE is requested, and skips the E2EE prompt entirely on hosts where olm can't build (explaining why) instead of walking the user into a compiler traceback. Failure hints are now generated from the actual specs rather than a hardcoded string.
- `ensure_matrix_deps` lazy-installs the crypto group on first use when the resolved E2EE mode is `optional`/`required`.
- Install hints that named `mautrix[encryption]` for *base* deps now say `mautrix`.

**`hermes_cli/gateway.py`**
- Stops hiding Matrix in the Windows picker. It was hidden only because the base feature pulled olm; plain `mautrix` is a pure-python wheel, so plaintext Matrix works there now (#76092). Only E2EE stays gated.

**`pyproject.toml` / `uv.lock`**
- `[matrix]` drops the encryption extra; new `[matrix-e2ee]` keeps a supported opt-in path for Linux operators.

**Docs** (`website/docs/…/matrix.md` + zh-Hans mirror)
- The E2EE section told macOS users to `brew install libolm`, which no longer exists. Replaced with an accurate Linux-only warning and the `[matrix-e2ee]` extra.

## How to Test

On an Apple Silicon Mac (this reproduces the reported failure on `main`):

```bash
hermes gateway setup      # choose Matrix, answer "no" to E2EE
# main: "Install failed … subprocess.CalledProcessError: ['make','static']"
# this branch: installs cleanly, E2EE prompt is skipped with an explanation
```

Or directly against the lazy installer:

```python
from tools.lazy_deps import ensure, feature_missing, unsupported_reason
ensure("platform.matrix", prompt=False)
feature_missing("platform.matrix")            # -> ()
unsupported_reason("platform.matrix")         # -> None
unsupported_reason("platform.matrix.e2ee")    # -> "unsupported on macOS: …"
```

**Platform tested:** macOS 15 (Darwin 25.6.0), Apple Silicon (arm64), Python 3.11, Apple Clang 21.0.0.

### Verified end-to-end on a real deployment

Not just unit tests — this was run on the Mac that originally hit the bug, against a live Synapse homeserver, using an unmodified `hermes gateway`.

**Before** (that machine's own `gateway.log`, on stock `main`):

```
Matrix: required packages not installed (mautrix[encryption]==0.21.1, aiosqlite==0.22.1, …).
Platform 'Matrix' requirements not met (pip install 'mautrix[encryption]')
Platform 'matrix' is registered but adapter creation failed (check dependencies and config)
No adapter available for matrix
```

**After** (same machine, same config, this branch):

```
Connecting to matrix...
Matrix: logged in as @…:matrix.…
Matrix: initial sync complete, joined 0 rooms
✓ matrix connected
```

Then a full message round-trip — invite, auto-join, inbound, agent reply:

```
Matrix: invited to !…:matrix.… — joining (is_direct=True)
Matrix: joined !…:matrix.…
inbound message: platform=matrix user=… msg='hello'
response ready: platform=matrix time=4.1s api_calls=1 response=39 chars
Matrix: sent event $izMBYrll…
```

Installed set afterwards — note **no python-olm**, and no compiler was invoked at any point:

```
mautrix 0.21.1
  python-olm: NOT INSTALLED
  pycryptodome: NOT INSTALLED
  asyncpg: 0.31.0
  aiosqlite: 0.22.1
  aiohttp-socks: 0.11.0
```

The E2EE group refuses cleanly on the same host rather than dumping a build traceback:

```
Feature 'platform.matrix.e2ee' unavailable: unsupported on macOS: Matrix E2EE
depends on python-olm (libolm), which has no macOS wheel and cannot be built
from sdist here. Plaintext Matrix works — this only disables encrypted rooms.
For E2EE, run Hermes under Linux, WSL, or Docker…
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs — see **Relationship to existing PRs** below
- [x] My PR contains **only** changes related to this fix
- [x] I've run the full suite via `scripts/run_tests.sh` — no regressions; see **Test scope** below
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.6.0), arm64, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture/workflow change
- [x] I've considered cross-platform impact (this PR *is* a cross-platform fix; Windows behavior changes are called out above)
- [x] N/A — no tool schema changes

## Test scope

New tests:
- `tests/tools/test_lazy_deps_matrix_split.py` (18 tests) — group contents, anchor ordering, satisfaction checks, a drift guard against mautrix's declared `[encryption]` extra, and the platform gate on win32/darwin/linux plus a `macos_only` real-host assertion.
- `tests/gateway/test_matrix_plugin_setup.py` — the wizard's E2EE answer actually decides what installs (the defect in #62401).
- `tests/gateway/test_matrix.py` — runtime lazy-install of the crypto group, and that it is skipped when E2EE is off or the host is gated.

Updated `tests/tools/test_lazy_deps.py` and `tests/hermes_cli/test_gateway_platform_gating.py`, which encoded the old "Matrix is gated on Windows" contract.

**Full suite via the canonical runner** (`scripts/run_tests.sh`, per-file subprocess isolation, macOS 15 arm64, 16 workers). Rebased onto `main` @ `d736f5d` and run against that exact commit for comparison:

| | files | passed | failed | skipped |
|---|---|---|---|---|
| `main` @ `d736f5d` | 3263 | 36851 | 747 | 385 |
| this branch | 3264 | 36877 | 747 | 384 |

Both runs have **200 files with failures, and the two sets are identical** — diffing them yields no entries on either side. So: **no regressions.** Those 747 failures are pre-existing on `main` and reproduce identically here; they're local-environment issues (optional dependencies not installed on this machine, plus network-dependent tests), not something this PR touches.

The deltas are all accounted for: +1 file and +26 passed are this PR's new tests; −1 skipped is a gating test that was `linux_only`-skipped before and now runs on every host.

Targeted suites for this change, post-rebase:

```
tests/gateway/test_matrix.py, tests/gateway/test_matrix_plugin_setup.py,
tests/tools/test_lazy_deps.py, tests/tools/test_lazy_deps_matrix_split.py,
tests/test_packaging_metadata.py, tests/test_project_metadata.py,
tests/hermes_cli/test_gateway_platform_gating.py,
tests/hermes_cli/test_lazy_refresh_venv_repair.py
→ 220 passed, 0 failed, 3 skipped   (skips are windows_only)
```

`ruff check` is clean on every file touched. `uv lock --check` passes after the rebase.

## Note for reviewers: pin style on the new dependencies

The four new specs (`python-olm`, `pycryptodome`, `unpaddedbase64`, `base58`) use exact `==` pins.

That follows the convention actually in force in this repo — every entry in `LAZY_DEPS` and every extra in `pyproject.toml` is exact-pinned, per the rationale comment at the top of `[project.dependencies]` (tightened 2026-05-12 after Mini Shai-Hulud), and it is enforced by `tests/test_project_metadata.py::test_every_lazy_deps_exact_pin_matches_uv_lock`, which requires each LAZY_DEPS exact pin to match `uv.lock`.

Flagging it because **CONTRIBUTING.md's "Dependency pinning policy" table still says `==exact` is "Rejected — too tight"** and asks for `>=floor,<next_major`. That guidance looks like it predates the 2026-05-12 switch to exact pins and now contradicts both the manifests and the tests. I followed the code and the tests rather than the doc — happy to switch to ranges if you'd rather, though the pin-consistency test would need revisiting. Might be worth a separate docs fix either way.

## Relationship to existing PRs

Per CONTRIBUTING's duplicate check, two open PRs overlap:

- **#62433** *split lazy e2ee deps* — same core design, but stale (Jul 12) and doesn't cover the macOS gate, the Windows picker, pyproject/lock, or the docs.
- **#85596** *install mautrix without the encryption extra* — fixes the pyproject half only, and its author notes it was "not installed on a Mac in this session".

This PR does the full split and is verified end-to-end on the affected platform. Happy to fold it into either of those instead if a maintainer prefers — just say which.


