### PR TITLE
fix(kanban): run wake turns under the target profile's runtime scope

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -15,6 +15,7 @@ import logging
 import os
 import sqlite3
 import time
+from contextlib import nullcontext
 from contextvars import Context
 from pathlib import Path
 from typing import Any, Callable, Optional
@@ -934,12 +935,36 @@ class GatewayKanbanWatchersMixin:
                             # push-capable adapters (the non-push /
                             # self-post branch is handled BEFORE the
                             # cursor advance above).
-                            await deliver_wake(
-                                adapter,
-                                text=_synth,
-                                session_id=_session_key,
-                                source=_source,
-                            )
+                            # Run the wake turn under the target profile's
+                            # runtime scope (#93851): handle_message() here
+                            # bypasses the inbound dispatch layer that
+                            # installs the per-turn secret scope, so under
+                            # multiplexing the woken agent's credential
+                            # reads and in-turn adapter/client resolution
+                            # fell back to the default profile — its Slack
+                            # bot is not a member of the target DM and
+                            # every in-turn send failed channel_not_found,
+                            # silently losing the completion report. Same
+                            # _profile_runtime_scope wrapper slash commands
+                            # use for the identical bypass; a resolution
+                            # failure falls back to the unscoped wake
+                            # (exactly the old behavior) rather than
+                            # skipping the turn.
+                            try:
+                                from gateway.run import _profile_runtime_scope
+
+                                _wake_ctx = _profile_runtime_scope(
+                                    self._resolve_profile_home_for_source(_source)
+                                )
+                            except Exception:
+                                _wake_ctx = nullcontext()
+                            with _wake_ctx:
+                                await deliver_wake(
+                                    adapter,
+                                    text=_synth,
+                                    session_id=_session_key,
+                                    source=_source,
+                                )
                             logger.info(
                                 "kanban notifier: woke agent for %s on %s/%s profile=%s events=%s",
                                 sub["task_id"], platform_str, sub["chat_id"], sub_profile or "default", _wake_kinds,

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -951,12 +951,23 @@ class GatewayKanbanWatchersMixin:
                             # (exactly the old behavior) rather than
                             # skipping the turn.
                             try:
+                                # Local import: gateway.run imports this
+                                # module — hoisting it would be a cycle.
                                 from gateway.run import _profile_runtime_scope
 
                                 _wake_ctx = _profile_runtime_scope(
                                     self._resolve_profile_home_for_source(_source)
                                 )
-                            except Exception:
+                            except Exception as exc:
+                                # Fail-open to the unscoped wake (the old
+                                # behavior) rather than skipping the turn —
+                                # but leave a trace so operators can tell
+                                # scoped from unscoped wakes in retrospect.
+                                logger.warning(
+                                    "kanban notifier: profile scope unavailable"
+                                    " for %s/%s (%s); delivering unscoped",
+                                    platform_str, sub["chat_id"], exc,
+                                )
                                 _wake_ctx = nullcontext()
                             with _wake_ctx:
                                 await deliver_wake(

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -1130,3 +1130,74 @@ def test_gc_archived_rows_already_removed_by_unsub(kanban_home):
         assert kb.list_notify_subs(conn, tid) == []
     finally:
         conn.close()
+
+
+@pytest.mark.asyncio
+async def test_notifier_wake_runs_under_profile_secret_scope(kanban_home, tmp_path):
+    """The wake turn must run inside the target profile's secret scope (#93851).
+
+    handle_message() in the wake path bypasses the inbound dispatch layer
+    that installs the per-turn profile scope, so under multiplexing the
+    woken agent's credential reads and in-turn adapter resolution fell
+    back to the default profile — its Slack bot was not a member of the
+    target DM and every in-turn send failed channel_not_found, silently
+    losing the completion report.
+    """
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform
+
+    profile_home = tmp_path / "profiles" / "jini"
+    profile_home.mkdir(parents=True)
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="scoped task", assignee="worker1")
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="telegram", chat_id="chat1",
+            delivery_mode="notify+wake", notifier_profile="jini",
+        )
+        kb.block_task(conn, tid, reason="scoped block")
+    finally:
+        conn.close()
+
+    runner = object.__new__(GatewayRunner)
+    runner._owns_kanban_dispatcher_lock = lambda: True
+    runner._running = True
+    runner._kanban_sub_fail_counts = {}
+
+    fake_adapter = MagicMock()
+    fake_adapter.send = AsyncMock()
+    runner.adapters = {Platform.TELEGRAM: fake_adapter}
+    # notifier_profile="jini" routes adapter resolution through the
+    # multiplex per-profile registry, not the default map.
+    runner._profile_adapters = {"jini": {Platform.TELEGRAM: fake_adapter}}
+    runner._resolve_profile_home_for_source = lambda source: profile_home
+
+    scope_at_wake: list = [None]
+
+    async def _capture_wake(*args, **kwargs):
+        from agent.secret_scope import current_secret_scope
+        scope_at_wake[0] = current_secret_scope()
+
+    _orig_sleep = asyncio.sleep
+    tick_count = 0
+
+    async def _fast_sleep(_):
+        nonlocal tick_count
+        await _orig_sleep(0)
+        tick_count += 1
+        if tick_count >= 3:
+            runner._running = False
+
+    wake_mock = AsyncMock(side_effect=_capture_wake)
+    with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep), \
+         patch("gateway.wake.deliver_wake", new=wake_mock):
+        await asyncio.wait_for(
+            runner._kanban_notifier_watcher(interval=1),
+            timeout=10.0,
+        )
+
+    wake_mock.assert_awaited_once()
+    assert scope_at_wake[0] is not None, (
+        "wake turn ran without any profile secret scope active"
+    )

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -1174,10 +1174,13 @@ async def test_notifier_wake_runs_under_profile_secret_scope(kanban_home, tmp_pa
     runner._resolve_profile_home_for_source = lambda source: profile_home
 
     scope_at_wake: list = [None]
+    home_override_at_wake: list = [None]
 
     async def _capture_wake(*args, **kwargs):
         from agent.secret_scope import current_secret_scope
+        from hermes_constants import get_hermes_home_override
         scope_at_wake[0] = current_secret_scope()
+        home_override_at_wake[0] = get_hermes_home_override()
 
     _orig_sleep = asyncio.sleep
     tick_count = 0
@@ -1201,3 +1204,81 @@ async def test_notifier_wake_runs_under_profile_secret_scope(kanban_home, tmp_pa
     assert scope_at_wake[0] is not None, (
         "wake turn ran without any profile secret scope active"
     )
+    # Identity, not just presence: a regression that wrapped the wake in the
+    # DEFAULT profile's scope would still pass the check above.
+    assert home_override_at_wake[0] == str(profile_home), (
+        "wake turn ran under the wrong profile's scope"
+    )
+
+
+@pytest.mark.asyncio
+async def test_notifier_wake_fails_open_unscoped_on_resolution_error(
+    kanban_home, tmp_path, caplog
+):
+    """Resolution failure must degrade to the unscoped wake (the old
+    behavior), not skip the turn — and leave a warning trace so operators
+    can tell scoped from unscoped wakes apart (#93851 review)."""
+    import logging
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="fail-open task", assignee="worker1")
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="telegram", chat_id="chat1",
+            delivery_mode="notify+wake", notifier_profile="jini",
+        )
+        kb.block_task(conn, tid, reason="fail-open block")
+    finally:
+        conn.close()
+
+    runner = object.__new__(GatewayRunner)
+    runner._owns_kanban_dispatcher_lock = lambda: True
+    runner._running = True
+    runner._kanban_sub_fail_counts = {}
+
+    fake_adapter = MagicMock()
+    fake_adapter.send = AsyncMock()
+    runner.adapters = {Platform.TELEGRAM: fake_adapter}
+    runner._profile_adapters = {"jini": {Platform.TELEGRAM: fake_adapter}}
+
+    def _boom(source):
+        raise RuntimeError("profile home lookup exploded")
+
+    runner._resolve_profile_home_for_source = _boom
+
+    scope_at_wake: list = ["unset"]
+
+    async def _capture_wake(*args, **kwargs):
+        from agent.secret_scope import current_secret_scope
+        scope_at_wake[0] = current_secret_scope()
+
+    _orig_sleep = asyncio.sleep
+    tick_count = 0
+
+    async def _fast_sleep(_):
+        nonlocal tick_count
+        await _orig_sleep(0)
+        tick_count += 1
+        if tick_count >= 3:
+            runner._running = False
+
+    wake_mock = AsyncMock(side_effect=_capture_wake)
+    with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep), \
+         patch("gateway.wake.deliver_wake", new=wake_mock), \
+         caplog.at_level(logging.WARNING, logger="gateway.kanban_watchers"):
+        await asyncio.wait_for(
+            runner._kanban_notifier_watcher(interval=1),
+            timeout=10.0,
+        )
+
+    wake_mock.assert_awaited_once(), (
+        "resolution failure must not skip the wake turn"
+    )
+    assert scope_at_wake[0] is None, (
+        "failed scope resolution should deliver the wake unscoped"
+    )
+    assert any(
+        "profile scope unavailable" in r.message for r in caplog.records
+    ), "fail-open fallback should leave a warning trace"


### PR DESCRIPTION
## What does this PR do?

Under gateway multiplexing, a turn started by the **kanban notifier's wake** path ran without the target profile's secret scope (#93851). `deliver_wake` calls `adapter.handle_message` directly, bypassing the inbound dispatch layer that installs the per-turn profile scope — so the woken agent's credential reads (`get_secret('ANTHROPIC_TOKEN')` warning in the reporter's logs) and in-turn adapter/client resolution fell back to the default profile. On the reporter's 9-profile Slack deployment, the default bot is not a member of the target DM, so every in-turn progress send failed `channel_not_found` and the completion report was silently lost (only the final response, re-scoped elsewhere, still delivered). This wraps the push-wake `deliver_wake` call in the same `_profile_runtime_scope` the slash-command path uses for the identical dispatch bypass, resolving the profile home via `_resolve_profile_home_for_source` on the wake's `SessionSource`.

## Related Issue

Fixes #93851

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `gateway/kanban_watchers.py` — `_push_wake`: resolve the wake source's profile home and run `deliver_wake` inside `_profile_runtime_scope(home)` (the same wrapper `gateway/slash_commands.py` uses for its dispatch bypass), with a comment documenting the #93851 failure chain. A resolution failure falls back to `nullcontext()` — the unscoped wake, exactly the old behavior — rather than skipping the turn. The notifier's own text ping (already routed via `_authorization_adapter`) and the non-push self-post branch are untouched; single-profile gateways are unaffected (`_resolve_profile_home_for_source` resolves to the default home).
- `tests/hermes_cli/test_kanban_notify.py` — new `test_notifier_wake_runs_under_profile_secret_scope`: a `notify+wake` sub stamped with `notifier_profile="jini"` (routed through `_profile_adapters`, mirroring multiplex wiring) wakes the agent with `current_secret_scope()` active at the moment `deliver_wake` runs; on unpatched `main` the scope is `None` and the test fails.

## How to Test

- New: `.venv/bin/python -m pytest tests/hermes_cli/test_kanban_notify.py::test_notifier_wake_runs_under_profile_secret_scope -q` — should pass. On unpatched `main` it fails (the wake runs with no scope), pinning the regression.
- Regression: `.venv/bin/python -m pytest tests/hermes_cli/test_kanban_notify.py tests/gateway/test_wake_delivery.py tests/gateway/test_kanban_notifier_zero_sub_gate.py -q` — should pass (31 tests; needs `aiohttp` installed for the wake-delivery suites).

Observed result: locally, the wake for a stamped secondary profile now runs with that profile's secret scope active at `deliver_wake` time; all 24 pre-existing kanban-notify tests plus the wake-delivery suites stay green, and the scope-free default-path behavior (single profile, resolution failure) is unchanged by construction.

## Checklist

- [x] Code follows project style (no unrelated changes)
- [x] Self-reviewed the diff
- [x] Added/updated tests covering the fix
- [x] All new and existing tests pass locally (31 passed across the three suites)
- [x] PR targets `upstream/main` from a fork branch
