### PR TITLE
test(skills): cover symlinked-home install lock recording (#86971)

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1664,6 +1664,95 @@ class TestInstallPathSafety:
 # ---------------------------------------------------------------------------
 
 
+    def test_install_through_symlinked_home_records_lock_entry(self, tmp_path):
+        """A HERMES_HOME reached through a symlink must still install cleanly.
+
+        _resolve_lock_install_path() returns a RESOLVED path, so comparing it
+        against an unresolved skills root raised ValueError *after* the bundle
+        had already been moved into place — the caller reported "Installation
+        blocked" while the files sat on disk with no lock entry (unlistable,
+        uninstallable). macOS /tmp -> /private/tmp and mounted skills dirs hit
+        this routinely.
+        """
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        real_root = tmp_path / "real"
+        real_root.mkdir()
+        link_root = tmp_path / "link"
+        try:
+            link_root.symlink_to(real_root, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation unsupported on this platform")
+
+        # Reach the skills tree through the symlink, as a symlinked
+        # HERMES_HOME / mounted skills dir does.
+        skills_dir = link_root / "skills"
+        quarantine_root = skills_dir / ".hub" / "quarantine"
+        quarantine_root.mkdir(parents=True)
+
+        q_dir = quarantine_root / "shop"
+        q_dir.mkdir()
+        (q_dir / "SKILL.md").write_text("---\nname: shop\n---\n")
+
+        bundle = hub.SkillBundle(
+            name="shop",
+            files={"SKILL.md": "---\nname: shop\n---\n"},
+            source="official",
+            identifier="official/productivity/shop",
+            trust_level="builtin",
+        )
+        scan_result = ScanResult(
+            skill_name="shop",
+            source="official",
+            trust_level="builtin",
+            verdict="safe",
+        )
+
+        lock_path = real_root / "lock.json"
+        with patch.object(hub, "SKILLS_DIR", skills_dir), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_root), \
+             patch.object(hub.HubLockFile.__init__, "__defaults__", (lock_path,)):
+            install_dir = hub.install_from_quarantine(
+                q_dir, "shop", "productivity", bundle, scan_result,
+            )
+
+        # Content actually landed...
+        assert (install_dir / "SKILL.md").exists()
+        # ...and the lock entry was recorded with a root-relative path, so the
+        # skill is listable / uninstallable rather than an orphan on disk.
+        recorded = json.loads(lock_path.read_text())["installed"]["shop"]
+        assert recorded["install_path"] == "productivity/shop"
+
+    def test_symlinked_home_install_still_rejects_escaping_category(self, tmp_path):
+        """Resolving the root must not weaken the escape check."""
+        import tools.skills_hub as hub
+
+        real_root = tmp_path / "real"
+        real_root.mkdir()
+        link_root = tmp_path / "link"
+        try:
+            link_root.symlink_to(real_root, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation unsupported on this platform")
+
+        skills_dir = link_root / "skills"
+        skills_dir.mkdir(parents=True)
+
+        with patch.object(hub, "SKILLS_DIR", skills_dir):
+            with pytest.raises(ValueError, match="Unsafe install path"):
+                hub._resolve_lock_install_path("../../escape", "escape")
+
+
+# ---------------------------------------------------------------------------
+# parallel_search_sources — overall_timeout must be honoured even when a
+# source blocks for far longer than the budget (regression: the executor used
+# `with ... as pool`, whose __exit__ calls shutdown(wait=True) and blocked the
+# caller on the slow worker, making overall_timeout a no-op).
+# ---------------------------------------------------------------------------
+
+
+
 class _FakeSource(SkillSource):
     def __init__(self, sid: str, sleep: float = 0.0, results=None):
         self._sid = sid


### PR DESCRIPTION
## What does this PR do?

The #86971 fix (`ed0a8a480e` — resolve the skills dir before `relative_to` so junction / symlink installs work) landed without a regression test that pins the end-to-end outcome. This adds that coverage.

Before #86971, `install_from_quarantine` moved the bundle into place and *then* computed the lock entry with `install_dir.relative_to(_skills_dir())` against an **unresolved** root. Whenever HERMES_HOME was reached through a symlink (macOS `/tmp` → `/private/tmp`, a mounted skills dir, a Windows junction), that raised `ValueError` after the move — the files sat on disk with no lock entry, unlistable and uninstallable.

The source is already fixed on `main`. This PR only adds two tests to `TestInstallPathSafety`:

- `test_install_through_symlinked_home_records_lock_entry` — a skills root reached through a symlink installs cleanly and records `install_path` as a **root-relative posix path**, so the skill stays listable / uninstallable.
- `test_symlinked_home_install_still_rejects_escaping_category` — resolving the root must not weaken the existing `Unsafe install path` escape check.

Both fail against the pre-#86971 source (ValueError after the move) and pass on current `main`.

## Related Issue

Refs #86971

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## How to Test

1. `uv run python -m pytest tests/tools/test_skills_hub.py -k "symlinked or InstallPathSafety" -q` → 14 pass.

## Checklist

- [x] My commit messages follow Conventional Commits (`test(skills):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this coverage
- [x] I've tested on my platform: macOS 14
