### PR TITLE
fix: make gateway Telegram connect success visible in foreground

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13439,6 +13439,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # engages drain on the first tick.
         self._spawn_supervised(self._drain_control_watcher, "drain_control_watcher")
 
+        # Positive readiness confirmation on stdout. The startup banner is
+        # print()ed, but every readiness record after it ("Connected to
+        # Telegram", "✓ telegram connected", "Gateway running with N
+        # platform(s)", this line) is INFO — and the stderr log handler is
+        # WARNING-only unless -v is passed. A healthy foreground gateway was
+        # therefore indistinguishable from a wedged one: banner, then silence
+        # for the life of the process. That is how a fully-connected adapter
+        # gets diagnosed as "hung" and SIGKILLed. print()ed rather than logged
+        # at WARNING because a successful start is not a warning, and printed
+        # unconditionally to match the banner above it.
+        try:
+            print("  ⚕ Gateway ready — press Ctrl+C to stop", flush=True)
+        except Exception:  # noqa: BLE001 - console output must never block start
+            pass
         logger.info("Press Ctrl+C to stop")
         
         return True

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4660,6 +4660,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 + _init_timeout * _max_connect
                 + 120.0  # extra margin for between-attempt sleeps + overhead
             )
+            # Tracks whether any attempt after the first logged a visible
+            # WARNING. If so, the success message below is promoted to WARNING
+            # too, so an operator who saw "attempt 2/8" also sees it resolve
+            # instead of being left staring at the last warning forever.
+            _connect_retry_warned = False
             for _attempt in range(_max_connect):
                 rebuild_app = False
                 try:
@@ -4675,7 +4680,21 @@ class TelegramAdapter(BasePlatformAdapter):
                             f"or set HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT / "
                             f"HERMES_TELEGRAM_INIT_TIMEOUT to a lower value."
                         )
-                    logger.warning(
+                    # Attempt 1 is the routine path, so it logs at INFO like
+                    # the rest of the startup flow. Logging it at WARNING made a
+                    # *successful* connect indistinguishable from a permanent
+                    # hang at default verbosity: the stderr handler is
+                    # WARNING-only unless -v is passed, so the console printed
+                    # "Connecting to Telegram (attempt 1/8)…" and then went
+                    # silent for the life of the process — the matching
+                    # "Connected to Telegram" below is INFO. Operators read that
+                    # silence as "wedged on attempt 1, never retries, never
+                    # times out" and SIGKILL a healthy gateway. Only a retry is
+                    # abnormal enough to earn WARNING.
+                    if _attempt > 0:
+                        _connect_retry_warned = True
+                    logger.log(
+                        logging.INFO if _attempt == 0 else logging.WARNING,
                         "[%s] Connecting to Telegram (attempt %d/%d)…",
                         self.name, _attempt + 1, _max_connect,
                     )
@@ -4905,7 +4924,12 @@ class TelegramAdapter(BasePlatformAdapter):
             
             self._mark_connected()
             mode = "webhook" if self._webhook_mode else "polling"
-            logger.info("[%s] Connected to Telegram (%s mode)", self.name, mode)
+            # Match the visibility of the loudest connect message: if a retry
+            # warning reached the console, its resolution must too.
+            logger.log(
+                logging.WARNING if _connect_retry_warned else logging.INFO,
+                "[%s] Connected to Telegram (%s mode)", self.name, mode,
+            )
 
             # Start the persistent heartbeat loop in polling mode. Webhook mode
             # receives updates via incoming pushes — there is no long-poll


### PR DESCRIPTION
## Problem

The Telegram adapter logged "Connecting to Telegram (attempt 1/8)..." at
WARNING level, but the matching "Connected to Telegram" was only INFO. The
default stderr handler is WARNING-only, so operators saw the connect attempt
line and then silence — making a healthy gateway indistinguishable from a
wedged one.

## Fix

Two changes:

1. **`plugins/platforms/telegram/adapter.py`** — Downgrade attempt 1 to INFO
   (it is the routine path, not a warning). Retries (attempt 2+) stay WARNING.
   Track whether a retry warning was emitted so the final success message is
   promoted to match.

2. **`gateway/run.py`** — Add a print()ed "Gateway ready" confirmation after
   all platforms start, so a foreground gateway always shows a visible
   readiness line regardless of log level.

## Result

A foreground gateway now always shows:

Gateway ready — press Ctrl+C to stop


No more operators diagnosing a healthy gateway as 'hung' and SIGKILLing it.

## Related

Fixes a real operator pain point encountered when running a second profile
gateway (`hermes --profile threads gateway run`). The gateway was healthy
and connected — the only issue was that the operator couldn't see it.
