### PR TITLE
fix(gateway): preserve detached turns and compacted message order

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -12027,6 +12027,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 )
                 all_rows = cursor.fetchall()
             seen: dict = {}
+            first_id: dict = {}
             for row in all_rows:
                 dedupe_content = row["content"]
                 if row["role"] == "user":
@@ -12057,10 +12058,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     row["tool_calls"],
                     row["tool_name"],
                 )
+                first_id[key] = min(first_id.get(key, row["id"]), row["id"])
                 cur = seen.get(key)
                 if cur is None or (row["active"], row["id"]) > (cur["active"], cur["id"]):
                     seen[key] = row
-            rows = sorted(seen.values(), key=lambda r: r["id"])
+            # Keep the preferred representative, but order logical messages by
+            # their first-ever row. A protected-tail copy can have a newer id
+            # than messages emitted after the original row.
+            rows = [
+                row
+                for key, row in sorted(seen.items(), key=lambda item: first_id[item[0]])
+            ]
             if latest:
                 rows = rows[::-1]
             rows = rows[offset:]

--- a/tests/hermes_state/test_get_messages_include_compacted.py
+++ b/tests/hermes_state/test_get_messages_include_compacted.py
@@ -158,6 +158,32 @@ class TestDisplayDedupe:
         assert len(msgs) == 2
         assert [m["content"] for m in msgs] == ["turn 1", "answer 1"]
 
+    def test_new_generation_copy_keeps_original_chronological_position(self, db):
+        """A protected-tail copy inserted after a newer message stays in its
+        original position in the display read (C, A, B regression)."""
+        sid = "s1"
+        db.create_session(sid, source="cli")
+        db.append_messages_batch(
+            sid,
+            [
+                {"role": "assistant", "content": "A", "timestamp": 100.0},
+                {"role": "assistant", "content": "B", "timestamp": 200.0},
+            ],
+        )
+        original = _row_ids(db, sid)
+        db._execute_write(
+            lambda conn: conn.execute(
+                "UPDATE messages SET active = 0, compacted = 1 WHERE session_id = ?",
+                [sid],
+            )
+        )
+        db.append_message(sid, role="user", content="C", timestamp=300.0)
+        self._copy_tail_as_new_generation(db, sid, original)
+
+        msgs = db.get_messages(sid, include_compacted=True)
+
+        assert [m["content"] for m in msgs] == ["A", "B", "C"]
+
     def test_dedupe_prefers_live_row_then_newest_generation(self, db):
         """When generations conflict, the live row wins; otherwise the newest
         generation (highest id) wins."""

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4790,10 +4790,10 @@ def test_session_resume_does_not_rebind_after_client_gone_interrupt_claim(monkey
         server._sessions.pop("live-sid", None)
 
 
-def test_ws_orphan_reap_defers_running_turn_for_active_delegation(monkeypatch):
+def test_ws_orphan_reap_interrupts_running_turn_with_active_delegation(monkeypatch):
     callbacks = []
     interrupted = []
-    delegation_active = iter((True, False, False))
+    delegation_active = iter((True, True, False))
 
     class _Timer:
         def __init__(self, _delay, callback):
@@ -4808,7 +4808,6 @@ def test_ws_orphan_reap_defers_running_turn_for_active_delegation(monkeypatch):
 
     def _interrupt():
         interrupted.append("interrupted")
-        session["running"] = False
 
     session = _session(
         agent=types.SimpleNamespace(interrupt=_interrupt),
@@ -4831,7 +4830,8 @@ def test_ws_orphan_reap_defers_running_turn_for_active_delegation(monkeypatch):
         server._schedule_ws_orphan_reap("delegating-turn")
         callbacks.pop(0)()
 
-        assert interrupted == []
+        assert interrupted == ["interrupted"]
+        assert session["_client_gone_interrupt_requested"] is True
         assert len(callbacks) == 1
 
         callbacks.pop(0)()
@@ -4839,10 +4839,13 @@ def test_ws_orphan_reap_defers_running_turn_for_active_delegation(monkeypatch):
         assert interrupted == ["interrupted"]
         assert len(callbacks) == 1
 
+        session["running"] = False
         callbacks.pop(0)()
         assert "delegating-turn" not in server._sessions
     finally:
         server._sessions.pop("delegating-turn", None)
+        server._pending_ws_reaps.pop("delegating-turn", None)
+        server._ws_orphan_reap_polls.pop("delegating-turn", None)
 
 
 def test_ws_orphan_reap_interrupts_in_process_turn(monkeypatch):
@@ -4884,6 +4887,61 @@ def test_ws_orphan_reap_interrupts_in_process_turn(monkeypatch):
         assert len(callbacks) == 1
     finally:
         server._sessions.pop("inline-sid", None)
+
+
+def test_ws_orphan_reap_interrupts_before_zero_poll_bound(monkeypatch):
+    callbacks = []
+    interrupted = []
+    torn_down = []
+
+    class _Timer:
+        def __init__(self, _delay, callback):
+            callbacks.append(callback)
+
+        def start(self):
+            return None
+
+    class _Supervisor:
+        def interrupt(self, sid, *, request_id=None):
+            interrupted.append((sid, request_id))
+
+    session = _session(
+        agent=None,
+        transport=server._detached_ws_transport,
+        running=True,
+        _compute_host_active=True,
+    )
+    sid = "zero-bound-sid"
+    server._sessions[sid] = session
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.01)
+    monkeypatch.setattr(server, "_WS_ORPHAN_INTERRUPT_REAP_MAX_POLLS", 0)
+    monkeypatch.setattr(server.threading, "Timer", _Timer)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
+    monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: _Supervisor())
+    monkeypatch.setattr(server, "_session_has_active_delegations", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        server,
+        "_teardown_popped_session",
+        lambda claimed, *, end_reason: torn_down.append((claimed, end_reason)) or True,
+    )
+
+    try:
+        server._schedule_ws_orphan_reap(sid)
+        callbacks.pop(0)()
+
+        assert interrupted == [(sid, f"client-gone-{sid}")]
+        assert sid in server._sessions
+        assert sid not in server._ws_orphan_reap_polls
+        assert len(callbacks) == 1
+
+        callbacks.pop(0)()
+
+        assert sid not in server._sessions
+        assert torn_down == [(session, "ws_orphan_reap")]
+    finally:
+        server._sessions.pop(sid, None)
+        server._pending_ws_reaps.pop(sid, None)
+        server._ws_orphan_reap_polls.pop(sid, None)
 
 
 def test_ws_disconnect_running_sidecar_still_closes_without_orphan_timer(monkeypatch):

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -454,6 +454,14 @@ def _(rid, params: dict) -> dict:
                 live_sid = _find_live_unpersisted(target, profile_home)
                 live = _sessions.get(live_sid) if live_sid else None
                 if live is not None:
+                    if (
+                        live.get("_client_gone_interrupt_requested")
+                        and live.get("running")
+                    ):
+                        if owns_db:
+                            with contextlib.suppress(Exception):
+                                db.close()
+                        return _err(rid, 4009, "session disconnect interrupt settling")
                     if owns_db:
                         with contextlib.suppress(Exception):
                             db.close()
@@ -469,6 +477,9 @@ def _(rid, params: dict) -> dict:
                         with live.setdefault("history_lock", threading.Lock()):
                             live["transport"] = transport
                             live.setdefault("viewers", {})[transport] = time.time()
+                            if not live.get("running"):
+                                live.pop("_client_gone_interrupt_requested", None)
+                                live.pop("_client_gone_interrupt_polls", None)
                     _cancel_ws_orphan_reap(live_sid)
                     history = live.get("history") or []
                     return _ok(
@@ -629,8 +640,13 @@ def _(rid, params: dict) -> dict:
             with _session_resume_lock:
                 if _sessions.get(sid) is not session:
                     return _err(rid, 4007, "session no longer live; retry resume")
-                if session.get("_client_gone_interrupt_requested"):
+                if session.get("_client_gone_interrupt_requested") and session.get(
+                    "running"
+                ):
                     return _err(rid, 4009, "session disconnect interrupt settling")
+                if not session.get("running"):
+                    session.pop("_client_gone_interrupt_requested", None)
+                    session.pop("_client_gone_interrupt_polls", None)
                 # This resume reattaches the live record: cancel any pending
                 # ws-orphan reap timer armed while the client was detached
                 # (storm killer — _live_session_payload's rebind also cancels,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1362,6 +1362,7 @@ def _session_has_active_delegations(sid: str, session: dict | None = None) -> bo
 # broadcast session.reclaimed, and trigger the client's auto-re-resume — a
 # reap->broadcast->resume feedback storm. Guarded by _sessions_lock.
 _pending_ws_reaps: dict[str, threading.Timer] = {}
+_ws_orphan_reap_polls: dict[str, int] = {}
 
 
 def _cancel_ws_orphan_reap(sid: str) -> None:
@@ -1376,6 +1377,7 @@ def _cancel_ws_orphan_reap(sid: str) -> None:
     """
     with _sessions_lock:
         timer = _pending_ws_reaps.pop(sid, None)
+        _ws_orphan_reap_polls.pop(sid, None)
     if timer is not None:
         try:
             timer.cancel()
@@ -1392,6 +1394,9 @@ def _schedule_ws_orphan_reap(sid: str, *, delay_s: float | None = None) -> None:
     """
     if _WS_ORPHAN_REAP_GRACE_S <= 0:
         return
+    if delay_s is None:
+        with _sessions_lock:
+            _ws_orphan_reap_polls.pop(sid, None)
 
     def _reap() -> None:
         # Serialize the orphan re-check against session.resume (which re-binds a
@@ -1407,44 +1412,61 @@ def _schedule_ws_orphan_reap(sid: str, *, delay_s: float | None = None) -> None:
         reschedule_delay = None
         interrupt_session = None
         session = None
+        try:
+            max_polls = max(0, int(_WS_ORPHAN_INTERRUPT_REAP_MAX_POLLS))
+        except (TypeError, ValueError, OverflowError):
+            max_polls = 0
         with _session_resume_lock:
-            # This Timer is running: drop its registration so a concurrent
-            # _cancel_ws_orphan_reap doesn't cancel a dead Timer object while
-            # a rescheduled one (registered below) is the live owner.
             with _sessions_lock:
+                # This Timer is running: drop its registration so a concurrent
+                # _cancel_ws_orphan_reap doesn't cancel a dead Timer object while
+                # a rescheduled one (registered below) is the live owner.
                 _pending_ws_reaps.pop(sid, None)
-            current = _sessions.get(sid)
-            if current is None or not _ws_session_is_detached(current):
-                return
-            if _session_has_active_delegations(sid, current):
-                reschedule_delay = _WS_ORPHAN_REAP_GRACE_S
-            elif current.get("running"):
-                # Mid-turn detached sessions must never drop the single
-                # Timer (#85578): after the reconnect grace the turn is
-                # interrupted once, then the reap keeps polling until the
-                # normal turn-finalization path settles.
-                polls = int(current.get("_client_gone_interrupt_polls") or 0) + 1
-                current["_client_gone_interrupt_polls"] = polls
-                if polls > _WS_ORPHAN_INTERRUPT_REAP_MAX_POLLS:
-                    # The interrupted turn never settled inside the budget —
-                    # force-reap rather than parking the session + a timer
-                    # chain forever. Loud by design: this only fires when a
-                    # turn is genuinely stuck past interrupt.
-                    logger.error(
-                        "client_gone sid=%s: turn did not settle after %d "
-                        "interrupt polls (%.0fs) — force-reaping detached "
-                        "session",
-                        sid, polls - 1,
-                        (polls - 1) * _WS_ORPHAN_INTERRUPT_REAP_POLL_S,
-                    )
-                    session = _pop_session_by_id(sid)
-                else:
+                current = _sessions.get(sid)
+                if current is None or not _ws_session_is_detached(current):
+                    _ws_orphan_reap_polls.pop(sid, None)
+                    return
+
+                has_active_delegations = _session_has_active_delegations(sid, current)
+                if current.get("running"):
+                    # The first expiry is a state transition, not a settlement
+                    # poll. A zero/invalid bound must still issue the one
+                    # client-gone interrupt first.
                     if not current.get("_client_gone_interrupt_requested"):
                         current["_client_gone_interrupt_requested"] = True
                         interrupt_session = current
-                    reschedule_delay = _WS_ORPHAN_INTERRUPT_REAP_POLL_S
-            else:
-                session = _pop_session_by_id(sid)
+                        reschedule_delay = _WS_ORPHAN_INTERRUPT_REAP_POLL_S
+                    else:
+                        try:
+                            polls = int(_ws_orphan_reap_polls.get(sid, 0)) + 1
+                        except (TypeError, ValueError, OverflowError):
+                            polls = 1
+                        if polls > max_polls:
+                            _ws_orphan_reap_polls.pop(sid, None)
+                            # The interrupted turn never settled inside the
+                            # budget — force-reap rather than parking the
+                            # session and timer chain forever.
+                            logger.error(
+                                "client_gone sid=%s: turn did not settle after %d "
+                                "interrupt polls (%.0fs) — force-reaping detached "
+                                "session",
+                                sid,
+                                polls - 1,
+                                (polls - 1) * _WS_ORPHAN_INTERRUPT_REAP_POLL_S,
+                            )
+                            session = _pop_session_by_id(sid)
+                        else:
+                            _ws_orphan_reap_polls[sid] = polls
+                            reschedule_delay = _WS_ORPHAN_INTERRUPT_REAP_POLL_S
+                elif has_active_delegations:
+                    # Delegation owns the return address independently of the
+                    # client. It may keep the session parked indefinitely, but
+                    # must never consume the running-turn settlement budget.
+                    _ws_orphan_reap_polls.pop(sid, None)
+                    reschedule_delay = _WS_ORPHAN_REAP_GRACE_S
+                else:
+                    _ws_orphan_reap_polls.pop(sid, None)
+                    session = _pop_session_by_id(sid)
 
         if interrupt_session is not None:
             try:
@@ -1460,11 +1482,8 @@ def _schedule_ws_orphan_reap(sid: str, *, delay_s: float | None = None) -> None:
                 )
             except Exception:
                 logger.exception("client_gone interrupt failed sid=%s", sid)
-                with _sessions_lock:
-                    if _sessions.get(sid) is interrupt_session:
-                        interrupt_session.pop(
-                            "_client_gone_interrupt_requested", None
-                        )
+                # Keep the transition guard set: the interrupt was attempted
+                # once, so subsequent callbacks belong to settlement.
 
         if reschedule_delay is not None:
             _schedule_ws_orphan_reap(sid, delay_s=reschedule_delay)
@@ -1513,6 +1532,7 @@ def _close_sessions_for_transport(
     for sid, session in owned:
         claimed_for_teardown = None
         should_schedule_reap = False
+        should_cancel_reap = False
         # A session.resume fast-path rebinds its live session while holding
         # _session_resume_lock. Take that lock before re-checking the snapshot
         # so a reconnect cannot move the transport between this check and the
@@ -1554,13 +1574,18 @@ def _close_sessions_for_transport(
                     if remaining:
                         remaining.sort(key=lambda item: item[0])
                         current["transport"] = remaining[-1][1]
+                        should_cancel_reap = True
                     else:
                         current["transport"] = _detached_ws_transport
+                        _ws_orphan_reap_polls.pop(sid, None)
+                        current.pop("_client_gone_interrupt_polls", None)
                         current.pop("_client_gone_interrupt_requested", None)
                         should_schedule_reap = True
         if claimed_for_teardown is not None:
             if _teardown_popped_session(claimed_for_teardown, end_reason=end_reason):
                 reaped += 1
+        elif should_cancel_reap:
+            _cancel_ws_orphan_reap(sid)
         elif should_schedule_reap:
             detached += 1
             try:
@@ -10297,8 +10322,14 @@ def _claim_or_reuse_live(
                 lease.release()
             # The winner is being reattached by this resume: any pending
             # ws-orphan reap for it must not fire against the reclaimed
-            # client (storm killer — see _cancel_ws_orphan_reap).
-            _cancel_ws_orphan_reap(live[0])
+            # client (storm killer — see _cancel_ws_orphan_reap). Keep the
+            # timer while a client-gone interrupt is still settling so the
+            # caller receives the retryable 4009 response from _reuse_live_response.
+            if not (
+                live[1].get("_client_gone_interrupt_requested")
+                and live[1].get("running")
+            ):
+                _cancel_ws_orphan_reap(live[0])
             return live
         with _sessions_lock:
             _sessions[sid] = record
@@ -10662,6 +10693,9 @@ def _live_session_payload(
                 # A live transport rebind means the client is back — any
                 # pending ws-orphan reap must not fire (storm killer).
                 _cancel_ws_orphan_reap(sid)
+                if not session.get("running"):
+                    session.pop("_client_gone_interrupt_requested", None)
+                    session.pop("_client_gone_interrupt_polls", None)
         if touch:
             session["last_active"] = time.time()
         in_memory_history = list(session.get("display_history_prefix") or []) + list(


### PR DESCRIPTION
## Summary

- Preserve detached, still-running WebSocket sessions through transient transport loss.
- Bound orphan-reap polling so a genuinely hung detached turn is eventually reclaimed.
- Keep compacted-message display chronology independent of SQLite row order.

## Why

A WebSocket detach during ordinary navigation or reconnect must not be treated as a user interruption. Separately, compaction can copy protected-tail messages into a newer generation; display deduplication must retain the preferred row while ordering by the logical message's earliest row.

## Fix

- Detached running sessions are polled for a bounded number of grace intervals, with debug progress logging and an error-level force-reap fallback for a turn that never settles.
- Resume always rebinds a still-live detached session and clears orphan-reap bookkeeping.
- Deduplicated logical messages use the minimum row ID as their chronological anchor instead of relying on SQL result order.

## Tests

- `python -m pytest -q tests/hermes_state/test_get_messages_include_compacted.py` — 12 passed
- `python -m pytest -q tests/test_tui_gateway_server.py -k 'ws_orphan_reap or resume'` — 33 passed
- Local pre-submit helper with audit, Ruff, focused tests, and clean-baseline comparison — ready for human review

## Scope and safety

- The bound preserves normal reconnect behavior while preventing an unbounded timer chain for a hung session.
- The force-reap path is logged and uses the existing session teardown path.
- No credentials, machine-specific paths, or private incident details.

## Review note

The orphan-reap behavior and compacted-message ordering are independently testable concerns; they remain in one update here because they share the detached-session/message-recovery regression surface.
