### PR TITLE
fix(restart-loop-guard): bound clock-rollback future-entry adjacency by gap

### DIFF
--- a/gateway/restart_loop_guard.py
+++ b/gateway/restart_loop_guard.py
@@ -63,11 +63,23 @@ def _chain_ending_at(boots: List[float], ts: float, gap: float) -> List[float]:
     """Unbroken chain of boots leading up to ``ts`` (oldest first): walks backwards
     while each gap stays within ``gap``; the first wider gap ends the chain (older
     boots are a resolved episode).  Empty when nothing is recent — how a healthy
-    gateway forgets a loop."""
+    gateway forgets a loop.
+
+    A future entry (``t > ts``, from a clock rollback or a restored state file) counts
+    as adjacent only while it lies within ``gap`` of ``ts``: without that bound one
+    large backward step chains in arbitrarily old history and trips the breaker,
+    turning the documented fail-open contract into a fail-closed one.
+    """
     chain: List[float] = []
     prev = ts
     for t in sorted(boots, reverse=True):
-        if t > ts:  # clock moved backwards (NTP step, restored file): future entry is adjacent, not a break
+        if t > ts:
+            # Clock moved backwards (NTP step, restored state file). Treat a *recent*
+            # future entry as adjacent rather than dropping the whole chain — but bound
+            # it by ``gap`` like any other link: one large backward step must not chain
+            # in arbitrarily old history and trip the breaker (fail-open → fail-closed).
+            if t - ts > gap:
+                continue
             chain.append(t)
             continue
         if prev - t > gap:

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -1837,6 +1837,41 @@ class TestRestartLoopGuard:
         for ts in (1000.0, 1150.0, 1300.0, 1450.0):
             assert rlg.check_and_record(0, 60, now=ts) is False
 
+    def test_clock_rollback_does_not_self_prune_valid_chain(self):
+        """A distant future entry must be skipped, not break the walk: breaking
+        exits before reaching valid earlier boots and silently loses the chain."""
+        import gateway.restart_loop_guard as rlg
+
+        # Sorted reverse iteration sees [2000, 1100, 1050]:
+        #   2000 is 940s past ts (gap 300) → skipped
+        #   1100 is a forward entry within gap → adjacent
+        #   1050 is within gap of ts → chained
+        assert rlg._chain_ending_at(
+            [2000.0, 1100.0, 1050.0], 1060.0, 300.0
+        ) == [1050.0, 1100.0]
+
+    def test_distant_future_entry_is_not_chained(self):
+        """A clock rollback can leave a far-future boot in the log. It is bounded by
+        ``gap`` like any other link: one such entry plus a healthy 2-boot chain would
+        otherwise reach the trip threshold on unrelated history, turning the fail-open
+        contract into a fail-closed trip."""
+        import gateway.restart_loop_guard as rlg
+
+        # 5000 is 3950s ahead of ts (gap 300) → dropped; 1040/1030 stay linked.
+        assert rlg._chain_ending_at(
+            [5000.0, 1040.0, 1030.0], 1050.0, 300.0
+        ) == [1030.0, 1040.0]
+
+    def test_future_entry_within_gap_stays_adjacent(self):
+        """A *recent* future entry keeps its adjacency — the bound only drops ones
+        too far ahead of the reference time."""
+        import gateway.restart_loop_guard as rlg
+
+        assert rlg._chain_ending_at(
+            [1100.0, 1040.0], 1050.0, 300.0
+        ) == [1040.0, 1100.0]
+
+
 class TestTerminalToolGatewayLifecycleGuardRemote:
     """Remote-backend and two-session cwd regression coverage."""
 


### PR DESCRIPTION
## Bug

`_chain_ending_at()` admits **any** boot timestamped after `ts` into the chain and skips the gap check entirely:

```python
if t > ts:  # clock moved backwards (NTP step, restored file): future entry is adjacent, not a break
    chain.append(t)
    continue
```

After one large backward clock step (NTP correction, restored RTC, manual time change) arbitrarily old restart-interrupted boots chain in. With two boots from an episode weeks ago in `restart_loop.json`, one backward step plus one new boot reaches `max_restarts(3)` -> the auto-resume breaker fires on unrelated history and sessions stay resume-pending until the user manually messages. That violates the module's own documented fail-open contract ("a broken breaker must never wedge a healthy gateway").

Repro (direct module call, pre-fix):

```python
_chain_ending_at([1000.0, 1010.0], ts=500.0, gap=300.0)
# -> [1000.0, 1010.0]  -- weeks-old boots chained into "now"
```

## Fix

Bound the future-entry adjacency by the same `gap` every other link uses, and **`continue`** rather than `break` when skipping it:

```python
if t > ts:
    if t - ts > gap:
        continue          # too far ahead -> skip it, keep walking the rest
    chain.append(t)
    continue
```

- `break` (the variant in #93427) exits the walk on the first distant entry -- and because the walk is sorted descending, a distant future entry is always visited *first*: `boots=[2000, 1100, 1050], ts=1060, gap=300` -> `chain=[]`, silently losing a valid chain.
- Small backward steps (seconds) keep the intended adjacency behaviour unchanged.

## Tests

`tests/hermes_cli/test_gateway_restart_loop.py` -- 3 new cases, each confirmed to fail against the corresponding mutation:

| Case | Pins | Fails when |
|---|---|---|
| `test_clock_rollback_does_not_self_prune_valid_chain` | distant entry skipped, valid chain preserved | bound removed, or `break` used |
| `test_distant_future_entry_is_not_chained` | bound enforced | bound removed, or `break` used |
| `test_future_entry_within_gap_stays_adjacent` | bound does not over-reach | (guard: passes both ways by design) |

Full file: **300 passed**. `ruff check` clean.

Consolidates #93427 (same fix, `break` variant) into this PR.