### PR TITLE
fix: recover live replies from deleted Telegram DM topics

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5610,23 +5610,49 @@ class BasePlatformAdapter(ABC):
                 return result
 
         # A private Telegram DM topic can disappear while an agent turn is
-        # running. The normal plain-text fallback below would preserve both
-        # its reply anchor and topic metadata, sending the retry to the same
-        # deleted topic. Route this one recovery attempt to the parent DM.
+        # running. Telegram may report this as a missing thread, closed topic,
+        # or deleted topic. The normal plain-text fallback below would preserve
+        # both its reply anchor and topic metadata, sending the retry to the
+        # same deleted topic. Route this one recovery attempt to the parent DM.
+        normalized_error = " ".join(error_str.lower().split())
+        missing_dm_topic_markers = (
+            "thread not found",
+            "topic deleted",
+            "topic closed",
+            "topic not found",
+            "direct messages topic",
+        )
         if (
-            "thread not found" in error_str.lower()
-            and isinstance(metadata, dict)
+            isinstance(metadata, dict)
             and metadata.get("telegram_dm_topic_reply_fallback")
+            and any(marker in normalized_error for marker in missing_dm_topic_markers)
         ):
+            stale_thread_id = (
+                metadata.get("thread_id")
+                or metadata.get("message_thread_id")
+                or metadata.get("direct_messages_topic_id")
+            )
+            fallback_metadata = {
+                key: value
+                for key, value in metadata.items()
+                if key not in {
+                    "thread_id",
+                    "message_thread_id",
+                    "direct_messages_topic_id",
+                    "telegram_dm_topic_reply_fallback",
+                    "telegram_reply_to_message_id",
+                }
+            }
             logger.warning(
-                "[%s] Telegram DM topic vanished; retrying without reply/topic routing",
-                self.name,
+                "[%s] Telegram DM topic vanished (chat=%s thread=%s); "
+                "retrying without reply/topic routing",
+                self.name, chat_id, stale_thread_id,
             )
             return await self.send(
                 chat_id=chat_id,
                 content=content,
                 reply_to=None,
-                metadata=None,
+                metadata=fallback_metadata or None,
             )
 
         # Non-network / post-retry formatting failure: try plain text as fallback

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5609,6 +5609,26 @@ class BasePlatformAdapter(ABC):
                     logger.debug("[%s] Could not send delivery-failure notice: %s", self.name, notify_err)
                 return result
 
+        # A private Telegram DM topic can disappear while an agent turn is
+        # running. The normal plain-text fallback below would preserve both
+        # its reply anchor and topic metadata, sending the retry to the same
+        # deleted topic. Route this one recovery attempt to the parent DM.
+        if (
+            "thread not found" in error_str.lower()
+            and isinstance(metadata, dict)
+            and metadata.get("telegram_dm_topic_reply_fallback")
+        ):
+            logger.warning(
+                "[%s] Telegram DM topic vanished; retrying without reply/topic routing",
+                self.name,
+            )
+            return await self.send(
+                chat_id=chat_id,
+                content=content,
+                reply_to=None,
+                metadata=None,
+            )
+
         # Non-network / post-retry formatting failure: try plain text as fallback
         logger.warning("[%s] Send failed: %s — trying plain-text fallback", self.name, error_str)
         fallback_result = await self.send(

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -179,9 +179,10 @@ class TestSendWithRetryFallback:
             "thread_id": "10802",
             "telegram_dm_topic_reply_fallback": True,
             "direct_messages_topic_id": "10802",
+            "notify": True,
         }
         adapter._send_results = [
-            SendResult(success=False, error="Message thread not found"),
+            SendResult(success=False, error="Bad Request: topic deleted"),
             SendResult(success=True, message_id="parent_dm_ok"),
         ]
 
@@ -191,7 +192,32 @@ class TestSendWithRetryFallback:
 
         assert result.success
         assert len(adapter._send_calls) == 2
-        assert adapter._send_calls[1] == ("chat1", "completed response", None, None)
+        assert adapter._send_calls[1] == (
+            "chat1", "completed response", None, {"notify": True},
+        )
+
+    @pytest.mark.asyncio
+    async def test_thread_failure_without_private_dm_fallback_keeps_routing(self):
+        """Forum and group sends retain their normal plain-text fallback."""
+        adapter = _StubAdapter()
+        metadata = {"thread_id": "42", "notify": True}
+        adapter._send_results = [
+            SendResult(success=False, error="Message thread not found"),
+            SendResult(success=True, message_id="generic_fallback_ok"),
+        ]
+
+        result = await adapter._send_with_retry(
+            "chat1", "completed response", reply_to="10782", metadata=metadata,
+        )
+
+        assert result.success
+        assert len(adapter._send_calls) == 2
+        assert adapter._send_calls[1] == (
+            "chat1",
+            "(Response formatting failed, plain text:)\n\ncompleted response",
+            "10782",
+            metadata,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -24,7 +24,7 @@ class _StubAdapter(BasePlatformAdapter):
         cfg = PlatformConfig()
         super().__init__(cfg, Platform.TELEGRAM)
         self._send_results = []   # queue of SendResult to return per call
-        self._send_calls = []     # record of (chat_id, content) sent
+        self._send_calls = []     # record of (chat_id, content, reply_to, metadata) sent
 
     def _next_result(self) -> SendResult:
         if self._send_results:
@@ -32,7 +32,7 @@ class _StubAdapter(BasePlatformAdapter):
         return SendResult(success=True, message_id="ok")
 
     async def send(self, chat_id, content, reply_to=None, metadata=None, **kwargs) -> SendResult:
-        self._send_calls.append((chat_id, content))
+        self._send_calls.append((chat_id, content, reply_to, metadata))
         return self._next_result()
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
@@ -166,6 +166,32 @@ class TestSendWithRetryFallback:
         assert len(adapter._send_calls) == 2
         # Fallback content should be plain-text notice
         assert "plain text" in adapter._send_calls[1][1].lower()
+
+    @pytest.mark.asyncio
+    async def test_missing_private_dm_topic_retries_without_stale_routing(self):
+        """A deleted Telegram DM topic must fall back to the parent DM.
+
+        Retaining the reply anchor or private-topic metadata sends the fallback
+        to the same deleted topic and drops an otherwise completed response.
+        """
+        adapter = _StubAdapter()
+        metadata = {
+            "thread_id": "10802",
+            "telegram_dm_topic_reply_fallback": True,
+            "direct_messages_topic_id": "10802",
+        }
+        adapter._send_results = [
+            SendResult(success=False, error="Message thread not found"),
+            SendResult(success=True, message_id="parent_dm_ok"),
+        ]
+
+        result = await adapter._send_with_retry(
+            "chat1", "completed response", reply_to="10782", metadata=metadata,
+        )
+
+        assert result.success
+        assert len(adapter._send_calls) == 2
+        assert adapter._send_calls[1] == ("chat1", "completed response", None, None)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Recover a live Telegram private-DM-topic reply when its topic is deleted during an agent turn.
- Retry the completed response once in the parent DM without the stale reply anchor or topic metadata.
- Add regression coverage for the deleted-topic final-response path.

## Reproduction
1. Start an agent turn in a Telegram private DM topic.
2. Delete the topic while the turn is executing.
3. The original final response fails with `Message thread not found`; the existing generic plain-text fallback preserves the deleted topic's routing and fails again.

## Validation
- Added a test that asserts the recovery retry clears both `reply_to` and private-DM-topic metadata.
- `uv run --locked --extra dev pytest tests/gateway/test_send_retry.py tests/gateway/test_telegram_thread_fallback.py tests/gateway/test_telegram_prune_stale_topic_binding_31501.py -o 'addopts=' -q`
- Result: `41 passed in 2.07s`.

## Live evidence
A disposable topic was deleted during an in-flight `sleep 90` turn. The gateway then logged both `Send failed: Message thread not found` and `Fallback send also failed: Message thread not found`, reproducing the defect.