### PR TITLE
fix(agent): drop unpairable tool calls before API send

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3790,6 +3790,42 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             elif isinstance(tc, dict):
                 tc["function"] = {"name": _EMPTY_NAME_SENTINEL, "arguments": "{}"}
 
+    # --- Drop assistant tool_calls that cannot be paired on the wire ---
+    # A tool call with no usable id cannot receive a role=tool response. Keep
+    # it in the assistant payload and the final request contains an
+    # unbalanced tool batch (N calls, N-1 results), which strict providers
+    # reject. Remove only the unpairable call on this per-call copy; never
+    # mutate the stored trajectory or invent an identifier for a call whose
+    # result cannot be correlated safely.
+    unpairable_tool_calls = 0
+    normalized_unpairable: List[Dict[str, Any]] = []
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            normalized_unpairable.append(msg)
+            continue
+        tool_calls = msg.get("tool_calls")
+        if not isinstance(tool_calls, list) or not tool_calls:
+            normalized_unpairable.append(msg)
+            continue
+        kept_tool_calls = [tc for tc in tool_calls if tool_call_id_variants(tc)]
+        if len(kept_tool_calls) == len(tool_calls):
+            normalized_unpairable.append(msg)
+            continue
+        unpairable_tool_calls += len(tool_calls) - len(kept_tool_calls)
+        if kept_tool_calls:
+            normalized_unpairable.append({**msg, "tool_calls": kept_tool_calls})
+        else:
+            normalized_unpairable.append(
+                {key: value for key, value in msg.items() if key != "tool_calls"}
+            )
+    if unpairable_tool_calls:
+        messages = normalized_unpairable
+        _ra().logger.warning(
+            "Pre-call sanitizer: dropped %d assistant tool_call(s) without "
+            "a usable pairing id",
+            unpairable_tool_calls,
+        )
+
     assistant_call_variants: List[tuple[Any, frozenset[str]]] = []
     surviving_call_ids: set[str] = set()
     for msg in messages:

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -636,6 +636,40 @@ def test_sanitize_drops_empty_tool_calls_array():
     assert assistant["content"] == "answer"
 
 
+def test_sanitize_drops_tool_call_without_pairing_id():
+    """An unpairable tool call must not reach the API without a result."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "run both tools"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_ok",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                },
+                {
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_ok", "content": "ok"},
+    ]
+
+    out = sanitize_api_messages(messages)
+    assistant = next(msg for msg in out if msg.get("role") == "assistant")
+    tool_results = [msg for msg in out if msg.get("role") == "tool"]
+
+    assert [tc["id"] for tc in assistant["tool_calls"]] == ["call_ok"]
+    assert [msg["tool_call_id"] for msg in tool_results] == ["call_ok"]
+    assert len(assistant["tool_calls"]) == len(tool_results)
+    assert len(messages[1]["tool_calls"]) == 2
+
+
 def test_repair_drops_stale_empty_tool_calls_on_merged_assistant():
     """repair_message_sequence must drop a stale ``tool_calls: []`` on the
     surviving message of a consecutive-assistant merge (#77921).


### PR DESCRIPTION
## Summary
- Removes assistant tool calls with no usable pairing identifier from the final per-call API copy.
- Preserves valid tool calls and results.
- Leaves persisted conversation history unchanged.
- Adds a mixed valid/unpairable batch regression test.

## Problem and impact
An assistant message could contain two tool calls while only one had a correlatable `role: tool` result. The malformed payload reached the final API boundary as N calls and N-1 results, allowing strict provider validation to reject the request and leaving the model with an unpairable call.

## Root cause
`sanitize_api_messages()` indexed only calls returned by `_tool_call_id_variants()`. A call with no usable ID was excluded from the missing-result stub pass, but the later reconstruction loop copied the original call into the assistant message anyway.

## Implementation decision
The fix drops only unpairable assistant calls from the per-call copy. It deliberately does not invent an ID because there is no safe way to correlate a future result with a fabricated identifier. The stored transcript remains unchanged for prompt-cache and history stability.

## Scope and compatibility
- Valid `id`, `call_id`, and alias variants remain unchanged.
- Empty/null `tool_calls` arrays remain covered by the existing empty-array fixes, including PR #86654.
- No credentials, provider data, or network fixtures are used.

## Files
- `agent/agent_runtime_helpers.py`
- `tests/run_agent/test_message_sequence_repair.py`

## Verification
- Local: `scripts/run_tests.sh tests/run_agent/test_message_sequence_repair.py -q` → `36 passed`.
- Local `ruff check`: passed.
- Local `git diff --check`: passed.
- Remote required checks: passed at last verification.
- The real pre-fix reproduction observed 2 assistant calls, 1 result, and 1 unpaired call remaining.

Fixes #93769