### PR TITLE
fix(telegram): cache SVG attachments as documents, not bitmaps

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1788,6 +1788,7 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".log": "text/plain",
     ".json": "application/json",
     ".xml": "application/xml",
+    ".svg": "image/svg+xml",
     ".yaml": "application/yaml",
     ".yml": "application/yaml",
     ".toml": "application/toml",
@@ -1819,7 +1820,7 @@ SUPPORTED_DOCUMENT_TYPES = {
 
 _TEXT_INJECT_EXTENSIONS = {
     ".txt", ".md", ".markdown", ".csv", ".tsv", ".log",
-    ".json", ".jsonl", ".ndjson", ".xml", ".yaml", ".yml", ".toml",
+    ".json", ".jsonl", ".ndjson", ".xml", ".svg", ".yaml", ".yml", ".toml",
     ".ini", ".cfg", ".conf", ".env", ".properties",
     ".html", ".htm", ".css", ".scss", ".sass", ".less",
     ".py", ".pyi", ".js", ".mjs", ".cjs", ".ts", ".tsx", ".jsx",
@@ -2232,7 +2233,7 @@ def cache_media_bytes(
     display = re.sub(r"[^\w.\- ]", "_", filename) if filename else (ext.lstrip(".") or "file")
 
     is_image = (
-        mime.startswith("image/")
+        (mime.startswith("image/") and mime != "image/svg+xml")
         or ext in SUPPORTED_IMAGE_DOCUMENT_TYPES
         or default_kind == "image"
     )

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -10053,7 +10053,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 # Telegram may deliver screenshots/photos as documents. If the
                 # payload is actually an image, route it through the image cache
                 # and batching path instead of rejecting it as a document.
-                if ext in _TELEGRAM_IMAGE_EXTENSIONS or doc_mime.startswith("image/"):
+                if (ext in _TELEGRAM_IMAGE_EXTENSIONS or doc_mime.startswith("image/")) and doc_mime != "image/svg+xml":
                     file_obj = await doc.get_file()
                     image_bytes = await file_obj.download_as_bytearray()
                     image_ext = ext if ext in _TELEGRAM_IMAGE_EXTENSIONS else _TELEGRAM_IMAGE_MIME_TO_EXT.get(doc_mime, ".jpg")


### PR DESCRIPTION
## Problem

SVG files arrive from Telegram with MIME `image/svg+xml`. In `cache_media_bytes` (and the Telegram adapter's document branch), the classification uses:

```python
is_image = mime.startswith("image/")
```

`image/svg+xml` matches `image/`, so SVGs get routed through `cache_image_from_bytes()`. That function validates via magic bytes (`_looks_like_image`: PNG/JPEG/GIF/BMP/WEBP only). SVG bytes start with `<?xml` or `<svg`, so they fail validation, raise `ValueError`, and the file is **silently dropped** — no log line, no agent-visible context. The user's attachment never reaches the agent.

## Root cause

`image/svg+xml` is an `image/*` MIME but is **not a bitmap** — it's an XML text vector format. The `mime.startswith("image/")` shortcut incorrectly conflates the two.

## Fix

Three coordinated changes, all scoped to SVG classification:

1. `cache_media_bytes`: exclude `image/svg+xml` from the `is_image` bitmap path so SVGs fall through to the generic document cache (which correctly handles arbitrary/unknown types).
2. Add `.svg` → `image/svg+xml` to `SUPPORTED_DOCUMENT_TYPES`.
3. Add `.svg` to `_TEXT_INJECT_EXTENSIONS` so small SVGs inline into the prompt (SVG is text; the agent can read it directly).
4. Mirror the exclusion in the Telegram adapter's document-handling branch so SVG documents don't get forced down the image path there either.

## Verification

Ran against the patched code (both the local 0.20.5 tree and a branch rebased on latest `main`):

- SVG with `.svg` filename → cached as `document`, MIME `image/svg+xml` ✅
- SVG with MIME only → cached as `document` ✅
- PNG (regression check) → still cached as `image` ✅

## Notes

- The send-direction (`.svg` in `MEDIA_DELIVERY_EXTS`) already existed upstream; this PR fixes the **receive** direction only.
- This is a general bug affecting any user who sends an SVG to the bot, not a single-platform edge case.