### PR TITLE
fix(send_message): honor markdown_support for QQ in standalone send

### DIFF
--- a/tests/tools/test_send_message_qqbot_markdown.py
+++ b/tests/tools/test_send_message_qqbot_markdown.py
@@ -1,0 +1,155 @@
+"""Regression test for #26697 — ``send_message`` honors ``markdown_support``
+for the QQ platform.
+
+The QQ gateway adapter (``gateway/platforms/qqbot/adapter.py``) reads
+``markdown_support`` from ``pconfig.extra`` (default ``True``) and sends
+C2C/group messages with ``msg_type: 2`` and a ``markdown.content`` body,
+plus a ``msg_seq``. Before this fix the ``send_message`` tool's
+``_send_qqbot`` helper hardcoded ``msg_type: 0`` and a plain ``content``
+field, so markdown tables / formatted output were delivered as raw text.
+
+This local edition also asserts the ``msg_seq`` field that the upstream
+review required (C2C/group payloads must carry it), and that the guild
+channel endpoint keeps the plain ``{"content": ...}`` shape.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from gateway.config import PlatformConfig
+from tools.send_message_tool import _send_qqbot
+
+
+def _make_resp(status_code, json_data=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json = MagicMock(return_value=json_data or {})
+    return resp
+
+
+def _httpx_client_with_responses(responses):
+    """Return a ``patch`` context for ``httpx.AsyncClient`` that replies
+    with the supplied responses in order.
+    """
+    client = AsyncMock()
+    client.post = AsyncMock(side_effect=responses)
+    client_ctx = MagicMock()
+    client_ctx.__aenter__ = AsyncMock(return_value=client)
+    client_ctx.__aexit__ = AsyncMock(return_value=False)
+    return client_ctx, client
+
+
+def _make_pconfig(markdown_support=True):
+    extra = {"app_id": "1234567"}
+    if markdown_support is not None:
+        extra["markdown_support"] = markdown_support
+    return PlatformConfig(enabled=True, token="secret", extra=extra)
+
+
+def _call(pconfig, content="| col1 | col2 |\n|---|---|\n| a | b |"):
+    return asyncio.run(_send_qqbot(pconfig, "openid-1", content))
+
+
+def test_c2c_uses_markdown_payload_when_markdown_support_true():
+    token_resp = _make_resp(200, {"access_token": "***"})
+    channel_resp = _make_resp(404, {"code": 11403, "message": "频道不存在"})
+    c2c_resp = _make_resp(200, {"id": "msg-1"})
+
+    client_ctx, client = _httpx_client_with_responses(
+        [token_resp, channel_resp, c2c_resp]
+    )
+    with patch("httpx.AsyncClient", return_value=client_ctx):
+        result = _call(_make_pconfig(markdown_support=True))
+
+    assert result == {
+        "success": True, "platform": "qqbot", "chat_id": "openid-1",
+        "message_id": "msg-1",
+    }
+    c2c_call = client.post.await_args_list[2]
+    assert c2c_call.args[0] == "https://api.sgroup.qq.com/v2/users/openid-1/messages"
+    sent = c2c_call.kwargs["json"]
+    assert sent["msg_type"] == 2
+    assert sent["markdown"]["content"].startswith("| col1 | col2 |")
+    assert "msg_seq" in sent and 0 <= sent["msg_seq"] < 65536
+    assert "content" not in sent  # the top-level `content` field is NOT used for markdown
+
+
+def test_group_uses_markdown_payload_when_markdown_support_true():
+    token_resp = _make_resp(200, {"access_token": "***"})
+    channel_resp = _make_resp(404, {})
+    c2c_resp = _make_resp(404, {})
+    group_resp = _make_resp(200, {"id": "msg-2"})
+
+    client_ctx, client = _httpx_client_with_responses(
+        [token_resp, channel_resp, c2c_resp, group_resp]
+    )
+    with patch("httpx.AsyncClient", return_value=client_ctx):
+        result = _call(_make_pconfig(markdown_support=True))
+
+    assert result["success"] is True
+    group_call = client.post.await_args_list[3]
+    assert group_call.args[0] == "https://api.sgroup.qq.com/v2/groups/openid-1/messages"
+    sent = group_call.kwargs["json"]
+    assert sent["msg_type"] == 2
+    assert sent["markdown"]["content"].startswith("| col1 | col2 |")
+    assert "msg_seq" in sent and 0 <= sent["msg_seq"] < 65536
+
+
+def test_c2c_uses_plain_text_when_markdown_support_false():
+    token_resp = _make_resp(200, {"access_token": "***"})
+    channel_resp = _make_resp(404, {})
+    c2c_resp = _make_resp(200, {"id": "msg-3"})
+
+    client_ctx, client = _httpx_client_with_responses(
+        [token_resp, channel_resp, c2c_resp]
+    )
+    with patch("httpx.AsyncClient", return_value=client_ctx):
+        result = _call(_make_pconfig(markdown_support=False), content="hello")
+
+    assert result["success"] is True
+    c2c_call = client.post.await_args_list[2]
+    sent = c2c_call.kwargs["json"]
+    assert sent["msg_type"] == 0
+    assert sent["content"] == "hello"
+    assert "markdown" not in sent
+    assert "msg_seq" in sent and 0 <= sent["msg_seq"] < 65536
+
+
+def test_markdown_support_defaults_to_true_when_unset():
+    """Default behavior must match the gateway adapter (also defaults True)."""
+    token_resp = _make_resp(200, {"access_token": "***"})
+    channel_resp = _make_resp(404, {})
+    c2c_resp = _make_resp(200, {"id": "msg-4"})
+
+    client_ctx, client = _httpx_client_with_responses(
+        [token_resp, channel_resp, c2c_resp]
+    )
+    with patch("httpx.AsyncClient", return_value=client_ctx):
+        result = _call(_make_pconfig(markdown_support=None), content="hi")
+
+    assert result["success"] is True
+    c2c_call = client.post.await_args_list[2]
+    sent = c2c_call.kwargs["json"]
+    assert sent["msg_type"] == 2
+    assert sent["markdown"]["content"] == "hi"
+    assert "msg_seq" in sent
+
+
+def test_channel_endpoint_payload_unchanged():
+    """The guild channel endpoint never used markdown; ensure the fix does
+    not start sending an unsupported payload shape to it.
+    """
+    token_resp = _make_resp(200, {"access_token": "***"})
+    channel_resp = _make_resp(200, {"id": "chan-1"})
+
+    client_ctx, client = _httpx_client_with_responses([token_resp, channel_resp])
+    with patch("httpx.AsyncClient", return_value=client_ctx):
+        result = _call(_make_pconfig(markdown_support=True))
+
+    assert result["success"] is True
+    channel_call = client.post.await_args_list[1]
+    assert channel_call.args[0] == "https://api.sgroup.qq.com/channels/openid-1/messages"
+    sent = channel_call.kwargs["json"]
+    assert "markdown" not in sent
+    assert "msg_seq" not in sent
+    assert sent["content"].startswith("| col1 | col2 |")

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -11,6 +11,7 @@ import logging
 import os
 import re
 import time
+import uuid
 
 
 from agent.redact import redact_sensitive_text
@@ -2152,6 +2153,18 @@ def _check_send_message():
         return False
 
 
+def _next_msg_seq(msg_id: str) -> int:
+    """Generate a message sequence number in 0..65535 range.
+
+    Same algorithm as ``gateway/platforms/qqbot/adapter.py::_next_msg_seq``
+    so the standalone send path stays payload-compatible with the gateway
+    adapter (QQ requires ``msg_seq`` on C2C/group markdown messages).
+    """
+    time_part = int(time.time()) % 100000000
+    rand = int(uuid.uuid4().hex[:4], 16)
+    return (time_part ^ rand) % 65536
+
+
 async def _send_qqbot(pconfig, chat_id, message):
     """Send via QQBot using the REST API directly (no WebSocket needed).
 
@@ -2197,11 +2210,31 @@ async def _send_qqbot(pconfig, chat_id, message):
                 "Authorization": f"QQBot {access_token}",
                 "Content-Type": "application/json",
             }
-            payload = {"content": message[:4000], "msg_type": 0}
+            # Mirror the gateway adapter: when `markdown_support: true` is
+            # configured (the default), C2C and group endpoints expect a
+            # `markdown.content` body with `msg_type: 2`. Plain text uses
+            # `content` with `msg_type: 0`. The guild channel endpoint uses
+            # the simpler `{"content": ...}` shape regardless, matching
+            # `gateway/platforms/qqbot/adapter.py::_send_guild_text`.
+            markdown_support = bool(extra.get("markdown_support", True))
+            content = message[:4000]
+            if markdown_support:
+                v2_payload = {
+                    "markdown": {"content": content},
+                    "msg_type": 2,
+                    "msg_seq": _next_msg_seq(chat_id),
+                }
+            else:
+                v2_payload = {
+                    "content": content,
+                    "msg_type": 0,
+                    "msg_seq": _next_msg_seq(chat_id),
+                }
+            channel_payload = {"content": content}
 
             # Try channel endpoint first (works for guild channels)
             url = f"https://api.sgroup.qq.com/channels/{chat_id}/messages"
-            resp = await client.post(url, json=payload, headers=headers)
+            resp = await client.post(url, json=channel_payload, headers=headers)
             if resp.status_code in {200, 201}:
                 data = resp.json()
                 return {"success": True, "platform": "qqbot", "chat_id": chat_id,
@@ -2209,7 +2242,7 @@ async def _send_qqbot(pconfig, chat_id, message):
 
             # If channel endpoint failed (likely "频道不存在"), try C2C endpoint
             url_c2c = f"https://api.sgroup.qq.com/v2/users/{chat_id}/messages"
-            resp_c2c = await client.post(url_c2c, json=payload, headers=headers)
+            resp_c2c = await client.post(url_c2c, json=v2_payload, headers=headers)
             if resp_c2c.status_code in {200, 201}:
                 data = resp_c2c.json()
                 return {"success": True, "platform": "qqbot", "chat_id": chat_id,
@@ -2217,7 +2250,7 @@ async def _send_qqbot(pconfig, chat_id, message):
 
             # If C2C also failed, try group endpoint
             url_group = f"https://api.sgroup.qq.com/v2/groups/{chat_id}/messages"
-            resp_group = await client.post(url_group, json=payload, headers=headers)
+            resp_group = await client.post(url_group, json=v2_payload, headers=headers)
             if resp_group.status_code in {200, 201}:
                 data = resp_group.json()
                 return {"success": True, "platform": "qqbot", "chat_id": chat_id,


### PR DESCRIPTION
## Summary

Fixes the standalone `send_message` QQ path so it honors the `markdown_support` config, matching the gateway adapter.

`tools/send_message_tool.py::_send_qqbot` hardcoded `msg_type: 0` (plain text) and ignored `markdown_support`, so cron and other standalone deliveries to QQ rendered markdown (tables, bold, code) as raw text. This is the opposite of what `gateway/platforms/qqbot/adapter.py` does, which reads `markdown_support` (default `true`) and sends `msg_type: 2` with a `markdown.content` body.

## Changes

- **C2C & group endpoints** now send `msg_type: 2` + `markdown.content` + `msg_seq` when `markdown_support` is enabled (the default); plain-text mode keeps `msg_type: 0` + `content` and also carries `msg_seq`.
- **Guild channel endpoint** keeps the simpler `{"content": ...}` shape — it never supported markdown (mirrors `_send_guild_text`).
- Added module-level `_next_msg_seq()` reusing the gateway adapter's algorithm so standalone payloads stay API-compatible (QQ requires `msg_seq` on C2C/group markdown sends).
- **Regression tests** covering: markdown-enabled, plain-text, default-true, C2C, group, and channel-payload-unchanged. Sabotage-verified (4/5 fail on pre-fix code).

## Test plan

`tests/tools/test_send_message_qqbot_markdown.py` — 5 scenarios, all pass on the fix.

Fixes #26697