### PR TITLE
fix(kanban): guard ago() against non-finite backend timestamps

### DIFF
--- a/apps/desktop/src/plugins/kanban/ui.test.tsx
+++ b/apps/desktop/src/plugins/kanban/ui.test.tsx
@@ -1,0 +1,34 @@
+// Regression tests for the board-page crash of 2026-08-24: two task_comments
+// rows written by a raw-SQL bypass carried created_at as the STRING
+// '2026-08-24 06:39:32' instead of epoch seconds. ago() fed the string into
+// relativeTime() ('…' * 1000 -> NaN) and Intl.RelativeTimeFormat.format threw
+// "Value need to be finite number", taking the whole kanban page down
+// ("plugin:kanban:kanban:page failed to render"). The guard contract: ago()
+// returns null for anything that is not a finite number of seconds; every
+// call site already renders null as nothing.
+import { describe, expect, it } from 'vitest'
+
+import { ago } from './ui'
+
+describe('ago() guards against non-finite backend timestamps', () => {
+  it('formats normal epoch seconds', () => {
+    const out = ago(Math.floor(Date.now() / 1000) - 120)
+
+    expect(typeof out).toBe('string')
+    expect(out!.length).toBeGreaterThan(0)
+  })
+
+  it('returns null for the corrupt datetime-string shape seen in the wild', () => {
+    // Pre-fix this line THROWS: RangeError: Value need to be finite number
+    // for Intl.RelativeTimeFormat.prototype.format().
+    expect(ago('2026-08-24 06:39:32' as unknown as number)).toBeNull()
+  })
+
+  it('returns null for NaN, Infinity, 0, null, undefined', () => {
+    expect(ago(Number.NaN)).toBeNull()
+    expect(ago(Number.POSITIVE_INFINITY)).toBeNull()
+    expect(ago(0)).toBeNull()
+    expect(ago(null)).toBeNull()
+    expect(ago(undefined)).toBeNull()
+  })
+})

--- a/apps/desktop/src/plugins/kanban/ui.tsx
+++ b/apps/desktop/src/plugins/kanban/ui.tsx
@@ -71,8 +71,18 @@ export function errText(err: unknown): string {
   return raw
 }
 
-/** Backend timestamps are epoch SECONDS; the canonical formatter takes ms. */
-export const ago = (seconds?: null | number): null | string => (seconds ? relativeTime(seconds * 1000) : null)
+/** Backend timestamps are epoch SECONDS; the canonical formatter takes ms.
+ *  Anything that is not a finite number of seconds renders as nothing: a
+ *  raw-SQL bypass once wrote created_at as a 'YYYY-MM-DD HH:MM:SS' string,
+ *  and feeding it down the formatter chain made
+ *  Intl.RelativeTimeFormat.format throw a page-killing RangeError. */
+export const ago = (seconds?: null | number): null | string => {
+  if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds === 0) {
+    return null
+  }
+
+  return relativeTime(seconds * 1000)
+}
 
 const ELAPSED_SUFFIX = { day: 'd', hour: 'h', minute: 'm', second: 's' } as const
 


### PR DESCRIPTION
## What does this PR do?

Stops the kanban board page from crashing when `ago()` receives a timestamp that is not a whole number of seconds.

**The bug:** two card-comment rows in a kanban board stored `created_at` as the text `'2026-08-24 06:39:32'` instead of Unix time in seconds. The board page fed that text into `ago()`. `ago()` multiplied it by 1000 and produced `NaN`. The browser date-format function `Intl.RelativeTimeFormat.format()` threw `RangeError: Value need to be finite number for Intl.RelativeTimeFormat.prototype.format()`. The error killed the whole page (`plugin:kanban:kanban:page failed to render`). Agents working on the board were blocked.

**The fix:** `ago()` now returns `null` for anything that is not a finite number of seconds. Every place that shows the value already renders `null` as blank. So the guard changes nothing visible in normal use. It only stops one bad value from taking down the page.

**Why this approach:** the renderer must not crash because of one bad value anywhere in the data chain. Writers also need to keep timestamps clean; the `hermes kanban` CLI already normalizes them to `int(time.time())`, and these rows came from raw SQL that bypassed that path. Failing closed at the formatter boundary is the right defense layer.

## Related Issue

No issue exists for this crash yet. The commit message carries the exact reproduction and the root-cause record.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/kanban/ui.tsx` (the fix): `ago()` now checks `typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds === 0` and returns `null`. The old code was `seconds ? relativeTime(seconds * 1000) : null`.
- `apps/desktop/src/plugins/kanban/ui.test.tsx` (new regression test, 3 cases): (1) normal epoch seconds formats to a string; (2) the exact wild text shape `'2026-08-24 06:39:32'` returns `null`, pre-fix this line threw the RangeError above; (3) `NaN`, `Infinity`, `0`, `null`, and `undefined` all return `null`.

## How to Test

1. From `apps/desktop`, run `npx vitest run src/plugins/kanban/ui.test.tsx --project ui`. Pre-fix result: 2 failed, 1 passed, with the exact RangeError. Post-fix result: 3 passed.
2. Run `npx eslint apps/desktop/src/plugins/kanban/ui.tsx apps/desktop/src/plugins/kanban/ui.test.tsx` from the repo root. It reports no errors.
3. Open a kanban board that contains a timestamp that is not a whole number of seconds. The page renders. The relative time shows blank instead of crashing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(kanban): guard ago() against non-finite backend timestamps`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls); no duplicate for this crash
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass; N/A for this PR. The change is apps/desktop TypeScript only. The affected suite is vitest (see How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (native)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings); N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys; N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows; N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); N/A. No file I/O, no processes, no signals. The change is renderer logic only
- [x] I've updated tool descriptions/schemas if I changed tool behavior; N/A

## Screenshots / Logs

```
Pre-fix (branch base 057dcdf2, before the guard):
  Tests  2 failed (1 passed)
  RangeError: Value need to be finite number for Intl.RelativeTimeFormat.prototype.format()
      at ui.tsx:75:75 ago -> time.ts:55 relativeTime

Post-fix:
  Test Files  1 passed (1)
       Tests  3 passed (3)
   Duration  8.38s
```
