### PR TITLE
fix(agent): scope auxiliary semaphores to event loops

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -57,6 +57,7 @@ import re
 import threading
 import time
 import uuid
+import weakref
 from pathlib import Path  # noqa: F401 — used by test mocks
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, TYPE_CHECKING
@@ -8384,7 +8385,7 @@ def _get_task_extra_body(task: str) -> Dict[str, Any]:
 # semaphore caps in-flight calls so retry amplification stays bounded.
 
 _aux_sync_semaphores: Dict[str, Tuple[int, threading.BoundedSemaphore]] = {}
-_aux_async_semaphores: Dict[Tuple[str, int], Tuple[int, Any]] = {}
+_aux_async_semaphores: Dict[str, weakref.WeakKeyDictionary] = {}
 _aux_sem_lock = threading.Lock()
 
 
@@ -8428,12 +8429,24 @@ def _acquire_async_aux_semaphore(task: Optional[str]):
         loop = asyncio.get_running_loop()
     except RuntimeError:
         return None
-    key = (task, id(loop))
     with _aux_sem_lock:
-        entry = _aux_async_semaphores.get(key)
+        # Cache by the loop object, not id(loop): CPython may recycle an
+        # address after a closed loop is collected, which would otherwise
+        # hand a dead loop's semaphore (including its exhausted permits) to a
+        # new loop. Weak keys keep the process-global cache from retaining
+        # every loop forever; closed loops are pruned eagerly because a
+        # semaphore can temporarily retain its loop through pending waiters.
+        task_cache = _aux_async_semaphores.get(task)
+        if task_cache is None:
+            task_cache = weakref.WeakKeyDictionary()
+            _aux_async_semaphores[task] = task_cache
+        for cached_loop in list(task_cache):
+            if cached_loop.is_closed():
+                del task_cache[cached_loop]
+        entry = task_cache.get(loop)
         if entry is None or entry[0] != limit:
             semaphore = asyncio.Semaphore(limit)
-            _aux_async_semaphores[key] = (limit, semaphore)
+            task_cache[loop] = (limit, semaphore)
             return semaphore
         return entry[1]
 

--- a/tests/agent/test_auxiliary_concurrency.py
+++ b/tests/agent/test_auxiliary_concurrency.py
@@ -106,6 +106,33 @@ class TestSemaphoreCache:
             sem2 = _acquire_async_aux_semaphore("compression")
             assert sem1 is sem2
 
+    def test_async_cache_does_not_alias_distinct_loops_with_same_address(self):
+        """A recycled loop address must not reuse a semaphore from a dead loop."""
+        import agent.auxiliary_client as auxiliary_client
+
+        async def acquire_for_current_loop():
+            return _acquire_async_aux_semaphore("compression")
+
+        def run_once(loop):
+            asyncio.set_event_loop(loop)
+            try:
+                return loop.run_until_complete(acquire_for_current_loop())
+            finally:
+                loop.close()
+                asyncio.set_event_loop(None)
+
+        with (
+            patch(
+                "agent.auxiliary_client._get_auxiliary_task_config",
+                return_value={"max_concurrency": 2},
+            ),
+            patch.object(auxiliary_client, "id", return_value=123, create=True),
+        ):
+            sem1 = run_once(asyncio.new_event_loop())
+            sem2 = run_once(asyncio.new_event_loop())
+
+        assert sem1 is not sem2
+
     def test_async_returns_none_with_no_running_loop(self):
         with patch(
             "agent.auxiliary_client._get_auxiliary_task_config",


### PR DESCRIPTION
## Summary
- Scopes auxiliary async semaphores by event-loop object identity instead of `id(loop)`.
- Uses weak loop keys and prunes closed loops.
- Preserves same-loop reuse and configured concurrency limits.
- Adds deterministic collision regression coverage.

## Problem and impact
The process-global auxiliary semaphore cache could reuse a semaphore from a closed event loop after address recycling. An exhausted semaphore could then block a new auxiliary call indefinitely; a contended semaphore could also produce cross-loop failures.

## Root cause
The cache key was `(task, id(loop))`. The integer address is not a lifecycle-safe identity after the loop is collected, and the module-level dictionary had no loop ownership or pruning.

## Implementation decision
The fix stores a per-task `weakref.WeakKeyDictionary` keyed by the actual event-loop object. Closed loops are pruned eagerly because a semaphore with pending waiters can temporarily retain its loop. Existing same-loop reuse and limit-change rebuilding remain intact.

## Scope and compatibility
- Applies only to auxiliary async concurrency limiting.
- Synchronous semaphore behavior is unchanged.
- No provider calls or credentials are needed to exercise the regression.
- The rare natural allocator collision is made deterministic in the test by forcing two distinct loops to present the same address key to the unfixed implementation.

## Files
- `agent/auxiliary_client.py`
- `tests/agent/test_auxiliary_concurrency.py`

## Verification
- Local: `scripts/run_tests.sh tests/agent/test_auxiliary_concurrency.py -q` → `19 passed`.
- Local `ruff check`: passed.
- Local `git diff --check`: passed.
- Remote required checks: passed at last verification.
- The supplied report recorded natural address reuse in 5/6 trials; an independent 500-loop probe collected the old loop but did not naturally recycle that exact address on this runtime.

Fixes #93772