### PR TITLE
fix(gateway): preserve queued messages at recursion cap

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9037,6 +9037,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         session_key: str,
         adapter: Any,
         pending_event: Optional["MessageEvent"],
+        *,
+        defer_if_recursion_limit: bool = False,
     ) -> Optional["MessageEvent"]:
         """Promote the next overflow item after the slot was drained.
 
@@ -9052,6 +9054,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _q_state = self._peek_session_state(session_key)
         overflow = _q_state.conversation.queued_events if _q_state else None
         if not overflow:
+            return pending_event
+        # The recursion guard below may refuse to process ``pending_event``.
+        # Do not pop the overflow head before that guard: if it is staged in
+        # the slot and the guard then requeues ``pending_event`` through the
+        # single-slot merge helper, the staged event is overwritten and lost.
+        # Leaving the overflow untouched lets the FIFO enqueue path restore
+        # the already-dequeued event ahead of the tail.
+        if defer_if_recursion_limit and pending_event is not None:
             return pending_event
         next_queued = overflow.pop(0)
         if pending_event is None:
@@ -29538,7 +29548,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # occupied for the full FIFO chain, which (a) preserves
                 # order, and (b) causes any mid-chain /queue to correctly
                 # route to overflow rather than jumping the queue.
-                pending_event = self._promote_queued_event(session_key, adapter, pending_event)
+                pending_event = self._promote_queued_event(
+                    session_key,
+                    adapter,
+                    pending_event,
+                    defer_if_recursion_limit=_interrupt_depth >= self._MAX_INTERRUPT_DEPTH,
+                )
                 if result.get("interrupted") and not pending_event and result.get("interrupt_message"):
                     interrupt_message = result.get("interrupt_message")
                     if _is_control_interrupt_message(interrupt_message):
@@ -29634,7 +29649,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                     adapter = self._adapter_for_source(source)
                     if adapter and pending_event:
-                        merge_pending_message_event(adapter._pending_messages, session_key, pending_event)
+                        self._enqueue_fifo(session_key, pending_event, adapter)
                     elif adapter and hasattr(adapter, 'queue_message'):
                         adapter.queue_message(session_key, pending)
                     return result_holder[0] or {"final_response": response, "messages": history}

--- a/tests/gateway/test_queue_consumption.py
+++ b/tests/gateway/test_queue_consumption.py
@@ -6,6 +6,7 @@ after the agent finishes its current task — not silently dropped.
 """
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 
@@ -168,6 +169,45 @@ class TestQueueConsumptionAfterCompletion:
         # pending_event (which is what `returned` is), and the slot
         # gets the next-in-line item.
         assert adapter._pending_messages[session_key].text == "Q2"
+
+    def test_recursion_cap_requeues_dequeued_event_before_overflow(self):
+        """The recursion guard must preserve the complete FIFO chain."""
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        state = SimpleNamespace(conversation=SimpleNamespace(queued_events=[]))
+        runner._peek_session_state = lambda _key: state
+        runner._session_state = lambda _key: state
+        adapter = _StubAdapter()
+        session_key = "telegram:user:recursion-cap"
+
+        for text in ("Q1", "Q2", "Q3", "Q4"):
+            runner._enqueue_fifo(
+                session_key,
+                MessageEvent(
+                    text=text,
+                    message_type=MessageType.TEXT,
+                    source=MagicMock(),
+                    message_id=f"q-{text}",
+                ),
+                adapter,
+            )
+
+        pending_event = _dequeue_pending_event(adapter, session_key)
+        pending_event = runner._promote_queued_event(
+            session_key,
+            adapter,
+            pending_event,
+            defer_if_recursion_limit=True,
+        )
+        runner._enqueue_fifo(session_key, pending_event, adapter)
+
+        assert adapter._pending_messages[session_key].text == "Q1"
+        assert [event.text for event in state.conversation.queued_events] == [
+            "Q2",
+            "Q3",
+            "Q4",
+        ]
 
 
 class TestBusyInputModeQueueFifo:


### PR DESCRIPTION
## Summary
- Prevents overflow promotion when the interrupt recursion cap will defer the current pending event.
- Requeues the pending event through the FIFO path instead of the single-slot overwrite helper.
- Preserves normal promotion when recursion is allowed.
- Adds a regression proving all queued events survive in order.

## Problem and impact
The gateway queue uses one adapter slot for the head and `SessionState.conversation.queued_events` for overflow. At the recursion ceiling, the drain path could lose the next queued message permanently while later messages still ran, creating both data loss and order inversion.

## Root cause
The drain popped the overflow head into the adapter slot before checking `_MAX_INTERRUPT_DEPTH`. The cap branch then called `merge_pending_message_event(..., merge_text=False)`, whose text-only fallback assigns into the slot and overwrites the promoted event.

## Implementation decision
When the recursion cap will defer the current event, promotion is deferred too. The current event is then placed back through `_enqueue_fifo`, leaving the overflow tail untouched. This preserves the existing normal path and avoids merging separate user turns.

## Scope and compatibility
- Normal queue promotion is unchanged when recursion is below the cap.
- The fix applies to the drain/re-entry boundary and complements the input-side FIFO fix for #28503.
- No sleeps or timing assumptions are used in the regression.

## Files
- `gateway/run.py`
- `tests/gateway/test_queue_consumption.py`

## Verification
- Local: `scripts/run_tests.sh tests/gateway/test_queue_consumption.py -q` → `6 passed`.
- Local `ruff check`: passed.
- Local `git diff --check`: passed.
- Remote required checks: passed at last verification.
- The real pre-fix reproduction lost `msg2` from `[msg1, msg2, msg3, msg4]`; the regression now preserves the full FIFO chain.

Fixes #93871