### PR TITLE
feat(mcp): add Machine Library by Space Frontiers search tools

### DIFF
--- a/optional-mcps/machine_library/manifest.yaml
+++ b/optional-mcps/machine_library/manifest.yaml
@@ -2,19 +2,19 @@
 # Presence in this directory = approval. Merged via PR review.
 manifest_version: 1
 
-name: space_frontiers
+name: machine_library
 description: >-
   Search scholarly and public sources; fetch citable content.
-source: https://spacefrontiers.org/mcp
+source: https://machinelibrary.ai/mcp
 
-# Space Frontiers ships a hosted Streamable HTTP MCP server with native
+# Machine Library, the search product of Space Frontiers, provides native
 # OAuth 2.1, PKCE, and Dynamic Client Registration. Hermes's MCP client and
 # mcp_oauth_manager handle discovery, browser authorization, token exchange,
 # and refresh; nothing runs locally. The subdomain root is the Streamable HTTP
 # endpoint (POST /), rather than a landing page with a separate /mcp path.
 transport:
   type: http
-  url: https://mcp.spacefrontiers.org
+  url: https://mcp.machinelibrary.ai
 
 auth:
   type: oauth
@@ -24,7 +24,7 @@ auth:
 
 # Enable the four composable retrieval tools so Hermes can search, fetch, and
 # inspect source material directly. The higher-level spacefrontiers_research
-# agent remains available through `hermes mcp configure space_frontiers`, but
+# agent remains available through `hermes mcp configure machine_library`, but
 # is intentionally not enabled by default.
 tools:
   default_enabled:
@@ -35,25 +35,32 @@ tools:
 
 # Composer-suggestion triggers (desktop brand pills). Deliberately avoid the
 # generic phrase "deep research" so ordinary research prompts do not advertise
-# a third-party service unless the user mentions Space Frontiers or its URL.
+# a third-party service unless the user mentions Machine Library, Space
+# Frontiers, or either URL.
 suggest:
   keywords:
+    - machine library
+    - machinelibrary
     - space frontiers
     - spacefrontiers
   hosts:
+    - machinelibrary.ai
     - spacefrontiers.org
 
 post_install: |
-  On first connection Hermes opens a browser to authorize with Space Frontiers
-  (or run `hermes mcp login space_frontiers`). Approve access, then restart the
+  Machine Library is the search and AI product of Space Frontiers. Existing
+  Space Frontiers accounts and prepaid credits work here.
+
+  On first connection Hermes opens a browser to authorize with Machine Library
+  (or run `hermes mcp login machine_library`). Approve access, then restart the
   session so the selected tools load.
 
   The four retrieval tools are enabled by default: scholarly document search,
   social search, bounded full-text fetch, and in-document passage search. They
   return compact results and canonical source URIs so Hermes can inspect and
   cite the underlying material directly. Usage consumes prepaid API credits;
-  create or fund an account at https://spacefrontiers.org.
+  create or fund an account at https://machinelibrary.ai.
 
   The higher-level `spacefrontiers_research` agent is not enabled by default.
   Enable it or otherwise customize the tool selection any time with:
-    hermes mcp configure space_frontiers
+    hermes mcp configure machine_library

--- a/optional-mcps/space_frontiers/manifest.yaml
+++ b/optional-mcps/space_frontiers/manifest.yaml
@@ -1,0 +1,59 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: space_frontiers
+description: >-
+  Search scholarly and public sources; fetch citable content.
+source: https://spacefrontiers.org/mcp
+
+# Space Frontiers ships a hosted Streamable HTTP MCP server with native
+# OAuth 2.1, PKCE, and Dynamic Client Registration. Hermes's MCP client and
+# mcp_oauth_manager handle discovery, browser authorization, token exchange,
+# and refresh; nothing runs locally. The subdomain root is the Streamable HTTP
+# endpoint (POST /), rather than a landing page with a separate /mcp path.
+transport:
+  type: http
+  url: https://mcp.spacefrontiers.org
+
+auth:
+  type: oauth
+  # Both RFC 9728 protected-resource metadata and authorization-server
+  # metadata advertise the single `search` scope. The MCP SDK selects that
+  # discovered scope automatically, so no provider-specific override is needed.
+
+# Enable the four composable retrieval tools so Hermes can search, fetch, and
+# inspect source material directly. The higher-level spacefrontiers_research
+# agent remains available through `hermes mcp configure space_frontiers`, but
+# is intentionally not enabled by default.
+tools:
+  default_enabled:
+    - spacefrontiers_search_documents
+    - spacefrontiers_search_social
+    - spacefrontiers_fetch_document
+    - spacefrontiers_search_in_document
+
+# Composer-suggestion triggers (desktop brand pills). Deliberately avoid the
+# generic phrase "deep research" so ordinary research prompts do not advertise
+# a third-party service unless the user mentions Space Frontiers or its URL.
+suggest:
+  keywords:
+    - space frontiers
+    - spacefrontiers
+  hosts:
+    - spacefrontiers.org
+
+post_install: |
+  On first connection Hermes opens a browser to authorize with Space Frontiers
+  (or run `hermes mcp login space_frontiers`). Approve access, then restart the
+  session so the selected tools load.
+
+  The four retrieval tools are enabled by default: scholarly document search,
+  social search, bounded full-text fetch, and in-document passage search. They
+  return compact results and canonical source URIs so Hermes can inspect and
+  cite the underlying material directly. Usage consumes prepaid API credits;
+  create or fund an account at https://spacefrontiers.org.
+
+  The higher-level `spacefrontiers_research` agent is not enabled by default.
+  Enable it or otherwise customize the tool selection any time with:
+    hermes mcp configure space_frontiers


### PR DESCRIPTION
## What does this PR do?

Adds **Machine Library**, the search and AI product of **Space Frontiers**, to the curated MCP catalog as an official vendor-hosted Streamable HTTP server. Users install it with `hermes mcp install machine_library`; Hermes's native OAuth flow handles discovery, Dynamic Client Registration, PKCE, token exchange, and refresh.

The endpoint is `https://mcp.machinelibrary.ai`. Existing Space Frontiers accounts and prepaid credits work on the new domain. The four composable retrieval tools are enabled by default:

- `spacefrontiers_search_documents` — scholarly document search
- `spacefrontiers_search_social` — public social sources and transcripts
- `spacefrontiers_fetch_document` — bounded full text and references by canonical URI
- `spacefrontiers_search_in_document` — relevant passages inside a document

The wire tool names remain unchanged. The higher-level `spacefrontiers_research` agent is available as an unchecked opt-in through `hermes mcp configure machine_library`.

## Related Issue

None. This is the existing first-party catalog contribution, updated for the product's new name and domain.

## Type of Change

- [x] New feature: optional MCP catalog entry

## Changes Made

- Added `optional-mcps/machine_library/manifest.yaml` with native OAuth and the hosted root endpoint.
- Added composer suggestions for Machine Library and Space Frontiers, including both domains. Generic research phrases do not trigger service suggestions.
- Documented account continuity, credit usage, four default retrieval tools, and opt-in research configuration.

## Trust and Data Handling

This is a first-party submission from the Space Frontiers maintainer. Product and setup documentation: https://machinelibrary.ai/mcp.

Nothing executes locally. Hermes stores tokens through its existing MCP OAuth manager. The manifest contains no secrets. Queries and requested source identifiers are sent to Machine Library, operated by Space Frontiers, and retrieval consumes prepaid API credits. The OAuth issuer stays stable for existing credentials; the new MCP host advertises its own resource URL.

## How to Test

1. Run `hermes mcp catalog` and find `machine_library`.
2. Run `hermes mcp install machine_library` and complete browser authorization.
3. Start a new session and confirm the four retrieval tools load.
4. Run `hermes mcp configure machine_library` and confirm the research agent remains opt-in.

## Validation Performed

- `scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py -q`: **25 passed**.
- Loaded the shipped entry through Hermes's real catalog parser with an isolated temporary `HERMES_HOME`; it builds `{"url":"https://mcp.machinelibrary.ai","auth":"oauth"}` and selects the four existing retrieval tool names.
- Verified live protected-resource discovery for `https://mcp.machinelibrary.ai`, the existing authorization-server issuer, Dynamic Client Registration, and S256 PKCE.
- Production gateway checks verified MCP initialize, tools/list, and a real authenticated search on the new host.
- Tested on macOS arm64 with Python 3.13.7. A complete interactive Hermes browser login was not repeated during this naming update.

## Checklist

- [x] Read `CONTRIBUTING.md` and `AGENTS.md`.
- [x] Conventional Commit messages; focused catalog-only change.
- [x] Updated the existing PR rather than creating a duplicate.
- [x] Existing shipped-manifest tests cover this data-only addition.
- [x] No core configuration keys, architecture, tool schemas, or local process behavior changed.
