### PR TITLE
feat(openrouter): add response_cache_exclude_models config knob

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -952,7 +952,7 @@ def init_agent(
             effective_base = base_url
             if base_url_host_matches(effective_base, "openrouter.ai"):
                 from agent.auxiliary_client import build_or_headers
-                client_kwargs["default_headers"] = build_or_headers()
+                client_kwargs["default_headers"] = build_or_headers(model=getattr(agent, "model", None))
             elif base_url_host_matches(effective_base, "integrate.api.nvidia.com"):
                 from agent.auxiliary_client import build_nvidia_nim_headers
                 client_kwargs["default_headers"] = build_nvidia_nim_headers(effective_base)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -614,7 +614,7 @@ def _apply_user_default_headers(headers: dict | None) -> dict | None:
     return merged or headers
 
 
-def build_or_headers(or_config: dict | None = None) -> dict:
+def build_or_headers(or_config: dict | None = None, model: str | None = None) -> dict:
     """Build OpenRouter headers, optionally including response-cache headers.
 
     Precedence for response cache: env var > config.yaml > default (enabled).
@@ -628,6 +628,13 @@ def build_or_headers(or_config: dict | None = None) -> dict:
 
     *or_config* is the ``openrouter`` section from config.yaml.  When *None*,
     falls back to reading config from disk via ``load_config()``.
+
+    *model* optionally scopes the cache decision to a single model.  When
+    given and it matches an entry in ``openrouter.response_cache_exclude_models``
+    (prefix match when the entry ends in ``/`` or ``*``, else exact id), the
+    cache header is omitted — e.g. stealth/* proxy models can return empty
+    responses that get cached and then replay to defeat the empty-response
+    retry loop.
     """
     headers = dict(_OR_HEADERS_BASE)
 
@@ -645,6 +652,37 @@ def build_or_headers(or_config: dict | None = None) -> dict:
         cache_enabled = env_cache in _TRUTHY_ENV_VALUES
     else:
         cache_enabled = or_config.get("response_cache", False)
+
+    # Per-model cache exclusion (config knob).  Prefix match on trailing
+    # "/" or "*", exact match otherwise.  Normalizes a list, a comma-separated
+    # string, or a JSON-encoded list (e.g. from `hermes config set`) to entries.
+    if model:
+        m = str(model).lower()
+        raw_excludes = or_config.get("response_cache_exclude_models", []) or []
+        if isinstance(raw_excludes, str):
+            s = raw_excludes.strip()
+            if s.startswith("["):
+                try:
+                    import json as _json
+                    parsed = _json.loads(s)
+                    raw_excludes = parsed if isinstance(parsed, list) else [s]
+                except Exception:
+                    raw_excludes = [s]
+            elif "," in s:
+                raw_excludes = [p.strip() for p in s.split(",") if p.strip()]
+            else:
+                raw_excludes = [s]
+        for entry in raw_excludes:
+            e = str(entry).lower().strip()
+            if not e:
+                continue
+            if e.endswith(("/", "*")):
+                if m.startswith(e.rstrip("/*") + "/") or m.startswith(e.rstrip("*")):
+                    cache_enabled = False
+                    break
+            elif m == e:
+                cache_enabled = False
+                break
 
     if not cache_enabled:
         return headers

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -176,6 +176,9 @@ model:
 # openrouter:
 #   response_cache: true         # Enable response caching (default: true)
 #   response_cache_ttl: 300      # Cache TTL in seconds, 1-86400 (default: 300)
+#   response_cache_exclude_models: []   # Model ids/prefixes that bypass the cache.
+#                                #   Trailing "/" or "*" = prefix match; otherwise exact id.
+#                                #   e.g. ["stealth/"] disables caching for every stealth/* model.
 
 # =============================================================================
 # Git Worktree Isolation

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1523,10 +1523,16 @@ DEFAULT_CONFIG = {
     #   pick the strongest available coder (router's documented default
     #   when the plugins block is omitted).
     #   See: https://openrouter.ai/docs/guides/routing/routers/pareto-router
+    # response_cache_exclude_models: list of model ids/prefixes that bypass
+    #   the response cache even when response_cache is enabled.  A trailing
+    #   "/" or "*" is a prefix match; otherwise exact model id.  Useful for
+    #   stealth/* proxy models that can return empty responses which, if
+    #   cached, replay into the empty-response retry loop.
     "openrouter": {
         "response_cache": True,
         "response_cache_ttl": 300,
         "min_coding_score": 0.65,
+        "response_cache_exclude_models": [],
     },
 
     # AWS Bedrock provider configuration.

--- a/run_agent.py
+++ b/run_agent.py
@@ -4509,7 +4509,7 @@ class AIAgent:
         )
 
         if base_url_host_matches(base_url, "openrouter.ai"):
-            self._client_kwargs["default_headers"] = build_or_headers()
+            self._client_kwargs["default_headers"] = build_or_headers(model=getattr(self, "model", None))
         elif base_url_host_matches(base_url, "integrate.api.nvidia.com"):
             self._client_kwargs["default_headers"] = build_nvidia_nim_headers(base_url)
         elif base_url_host_matches(base_url, "api.routermint.com"):

--- a/tests/agent/test_openrouter_response_cache.py
+++ b/tests/agent/test_openrouter_response_cache.py
@@ -220,6 +220,94 @@ class TestEnvVarOverrides:
         assert headers["X-OpenRouter-Cache"] == "true"
         assert headers["X-OpenRouter-Cache-TTL"] == "600"
 
+class TestModelCacheExclusion:
+    """Test model-scoped cache exclusion via response_cache_exclude_models."""
+
+    def test_prefix_match_excludes_stealth(self):
+        from agent.auxiliary_client import build_or_headers
+
+        cfg = {"response_cache": True, "response_cache_exclude_models": ["stealth/"]}
+        headers = build_or_headers(or_config=cfg, model="stealth/ox-alpha")
+        assert "X-OpenRouter-Cache" not in headers
+
+    def test_prefix_match_other_stealth_model(self):
+        from agent.auxiliary_client import build_or_headers
+
+        cfg = {"response_cache": True, "response_cache_exclude_models": ["stealth/"]}
+        headers = build_or_headers(or_config=cfg, model="stealth/some-other")
+        assert "X-OpenRouter-Cache" not in headers
+
+    def test_unlisted_model_still_cached(self):
+        from agent.auxiliary_client import build_or_headers
+
+        cfg = {"response_cache": True, "response_cache_exclude_models": ["stealth/"]}
+        headers = build_or_headers(or_config=cfg, model="anthropic/claude-sonnet-4")
+        assert headers["X-OpenRouter-Cache"] == "true"
+
+    def test_exact_match_excluded(self):
+        from agent.auxiliary_client import build_or_headers
+
+        cfg = {"response_cache": True, "response_cache_exclude_models": ["foo/bar"]}
+        headers = build_or_headers(or_config=cfg, model="foo/bar")
+        assert "X-OpenRouter-Cache" not in headers
+
+    def test_exact_match_no_substring_bleed(self):
+        from agent.auxiliary_client import build_or_headers
+
+        cfg = {"response_cache": True, "response_cache_exclude_models": ["foo/bar"]}
+        headers = build_or_headers(or_config=cfg, model="foo/bar-baz")
+        assert headers["X-OpenRouter-Cache"] == "true"
+
+    def test_wildcard_suffix_prefix_match(self):
+        from agent.auxiliary_client import build_or_headers
+
+        cfg = {"response_cache": True, "response_cache_exclude_models": ["stealth*"]}
+        headers = build_or_headers(or_config=cfg, model="stealth/ox-alpha")
+        assert "X-OpenRouter-Cache" not in headers
+
+    def test_case_insensitive(self):
+        from agent.auxiliary_client import build_or_headers
+
+        cfg = {"response_cache": True, "response_cache_exclude_models": ["STEALTH/"]}
+        headers = build_or_headers(or_config=cfg, model="Stealth/Ox-Alpha")
+        assert "X-OpenRouter-Cache" not in headers
+
+    def test_empty_exclude_list_caches_stealth(self):
+        from agent.auxiliary_client import build_or_headers
+
+        cfg = {"response_cache": True, "response_cache_exclude_models": []}
+        headers = build_or_headers(or_config=cfg, model="stealth/ox-alpha")
+        assert headers["X-OpenRouter-Cache"] == "true"
+
+    def test_json_string_form(self):
+        from agent.auxiliary_client import build_or_headers
+
+        cfg = {"response_cache": True, "response_cache_exclude_models": '["stealth/"]'}
+        headers = build_or_headers(or_config=cfg, model="stealth/ox-alpha")
+        assert "X-OpenRouter-Cache" not in headers
+
+    def test_comma_separated_string_form(self):
+        from agent.auxiliary_client import build_or_headers
+
+        cfg = {"response_cache": True, "response_cache_exclude_models": "stealth/, foo/bar"}
+        assert "X-OpenRouter-Cache" not in build_or_headers(or_config=cfg, model="stealth/x")
+        assert "X-OpenRouter-Cache" not in build_or_headers(or_config=cfg, model="foo/bar")
+
+    def test_single_bare_string_form(self):
+        from agent.auxiliary_client import build_or_headers
+
+        cfg = {"response_cache": True, "response_cache_exclude_models": "stealth/"}
+        headers = build_or_headers(or_config=cfg, model="stealth/ox-alpha")
+        assert "X-OpenRouter-Cache" not in headers
+
+    def test_no_model_arg_ignores_exclude_list(self):
+        from agent.auxiliary_client import build_or_headers
+
+        cfg = {"response_cache": True, "response_cache_exclude_models": ["stealth/"]}
+        headers = build_or_headers(or_config=cfg)
+        assert headers["X-OpenRouter-Cache"] == "true"
+
+
 class TestDefaultConfig:
     """Verify the openrouter config section is in DEFAULT_CONFIG."""
 
@@ -230,6 +318,12 @@ class TestDefaultConfig:
         or_cfg = DEFAULT_CONFIG["openrouter"]
         assert or_cfg["response_cache"] is True
         assert or_cfg["response_cache_ttl"] == 300
+
+    def test_response_cache_exclude_models_default(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        or_cfg = DEFAULT_CONFIG["openrouter"]
+        assert or_cfg.get("response_cache_exclude_models") == []
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1446,6 +1446,24 @@ provider_routing:
 
 **Shortcuts:** Append `:nitro` to any model name for throughput sorting (e.g., `anthropic/claude-sonnet-4:nitro`), or `:floor` for price sorting.
 
+## OpenRouter Response Caching
+
+OpenRouter can serve identical requests from its response cache (zero billing). Enable it under the `openrouter` section of `~/.hermes/config.yaml`:
+
+```yaml
+openrouter:
+  response_cache: true        # Enable OpenRouter response caching (X-OpenRouter-Cache header). Default true.
+  response_cache_ttl: 300     # Seconds a cached response stays valid (1-86400). Default 300.
+  response_cache_exclude_models: []   # Models/prefixes that bypass the cache.
+```
+
+Notes:
+
+- A trailing `/` or `*` in `response_cache_exclude_models` is a **prefix** match; otherwise the entry must equal the full model id. For example, `"stealth/"` excludes every `stealth/*` model while leaving all other OpenRouter models cached.
+- This is useful for proxy models (like `stealth/*`) that can return empty responses — if an empty response gets cached, OpenRouter replays it on retry and defeats Hermes's empty-response retry loop.
+- `response_cache_exclude_models` accepts a YAML list, a comma-separated string, or a JSON-encoded list (what `hermes config set` writes).
+- The `HERMES_OPENROUTER_CACHE` environment variable overrides `response_cache` globally (see [Environment Variables](/reference/environment-variables)).
+
 ## OpenRouter Pareto Code Router
 
 OpenRouter ships an experimental coding-model router at `openrouter/pareto-code` that auto-routes requests to the cheapest model meeting a coding-quality bar (ranked by [Artificial Analysis](https://artificialanalysis.ai/)). Pick this model and tune the `min_coding_score` knob in `~/.hermes/config.yaml`:


### PR DESCRIPTION
## What does this PR do?

Adds an `openrouter.response_cache_exclude_models` config knob so specific OpenRouter models (or model prefixes) can bypass OpenRouter's response cache even while caching is enabled globally.

**Problem it solves:** the cache could only be toggled globally. When a model returns an empty response, OpenRouter caches it and replays it on retry — defeating Hermes's empty-response retry loop. This is observed with `stealth/*` proxy models (e.g. `stealth/ox-alpha` returns empty content + reasoning, gets cached, and all 3 retries hit the cache as `X-OpenRouter-Cache-Status: HIT`).

**Approach:** a per-model exclusion list, matching the existing config style (`min_coding_score` lives beside it in the same `openrouter` section). `build_or_headers()` already controls the `X-OpenRouter-Cache` header; it now takes the active model and skips the header when the model matches an exclude entry.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/config.py` — add `openrouter.response_cache_exclude_models` to `DEFAULT_CONFIG` (default `[]`), with a doc comment.
- `agent/auxiliary_client.py` — `build_or_headers()` accepts a `model` arg; drops `X-OpenRouter-Cache` for excluded models. Prefix match on trailing `/` or `*`, exact match otherwise. Normalizes list / comma-separated string / JSON-encoded string (what `hermes config set` writes).
- `run_agent.py` + `agent/agent_init.py` — pass the active model into `build_or_headers()`.
- `tests/agent/test_openrouter_response_cache.py` — 13 new cases: prefix/exact/wildcard matching, case-insensitivity, value-shape normalization, empty-list fallthrough, and no-model fallthrough.
- `cli-config.yaml.example` + `website/docs/integrations/providers.md` — document the knob.

## How to Test

1. Set in config:
   ```yaml
   openrouter:
     response_cache: true
     response_cache_exclude_models:
       - stealth/
   ```
2. Verify headers: a request for `stealth/ox-alpha` omits `X-OpenRouter-Cache`; `anthropic/claude-sonnet-4` still sends it.
3. `pytest tests/agent/test_openrouter_response_cache.py -q` — all pass (59 tests).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(openrouter): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] I've updated relevant documentation (providers.md, docstrings)
- [x] I've updated `cli-config.yaml.example` (added config key)
- [x] Cross-platform impact considered (N/A — pure header/config logic)
- [x] Tool descriptions/schemas unchanged (N/A)
