### PR TITLE
feat(mcp): bind tool arguments to authenticated sessions

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -367,6 +367,50 @@ class TestSchemaConversion:
         assert schema["description"] == "Read a file"
         assert "properties" in schema["parameters"]
 
+    def test_hides_session_bound_arguments_from_model_schema(self):
+        from tools.mcp_tool import _convert_mcp_schema
+
+        mcp_tool = _make_mcp_tool(
+            name="list_mail",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "client_domain": {"type": "string"},
+                    "operator_slack_id": {
+                        "type": "string",
+                        "x-hermes-session-env": "HERMES_SESSION_USER_ID",
+                        "x-hermes-required-platform": "slack",
+                    },
+                },
+                "required": ["client_domain", "operator_slack_id"],
+            },
+        )
+
+        schema = _convert_mcp_schema("workspace", mcp_tool)
+
+        assert schema["parameters"]["properties"] == {
+            "client_domain": {"type": "string"}
+        }
+        assert schema["parameters"]["required"] == ["client_domain"]
+
+    def test_rejects_session_binding_to_arbitrary_environment_variable(self):
+        from tools.mcp_tool import _convert_mcp_schema
+
+        mcp_tool = _make_mcp_tool(
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "secret": {
+                        "type": "string",
+                        "x-hermes-session-env": "AWS_SECRET_ACCESS_KEY",
+                    }
+                },
+            },
+        )
+
+        with pytest.raises(ValueError, match="unsupported Hermes session value"):
+            _convert_mcp_schema("unsafe", mcp_tool)
+
     def test_definitions_as_property_name_is_preserved(self):
         """A tool parameter literally named ``definitions`` must not be renamed.
 
@@ -575,6 +619,80 @@ class TestToolHandler:
             mock_session.call_tool.assert_called_once_with("greet", arguments={"name": "world"})
         finally:
             _servers.pop("test_srv", None)
+
+    def test_session_binding_overwrites_model_supplied_identity(self):
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(
+            return_value=_make_call_result("ok", is_error=False)
+        )
+        server = _make_mock_server("test_srv", session=mock_session)
+        _servers["test_srv"] = server
+        session_values = {
+            "HERMES_SESSION_PLATFORM": "slack",
+            "HERMES_SESSION_USER_ID": "U_TRUSTED",
+        }
+
+        try:
+            handler = _make_tool_handler(
+                "test_srv",
+                "list_mail",
+                120,
+                session_bindings={
+                    "operator_slack_id": {
+                        "env": "HERMES_SESSION_USER_ID",
+                        "required_platform": "slack",
+                    }
+                },
+            )
+            with patch(
+                "gateway.session_context.get_session_env",
+                side_effect=lambda name, default="": session_values.get(name, default),
+            ), self._patch_mcp_loop():
+                result = json.loads(handler({
+                    "client_domain": "example.com",
+                    "operator_slack_id": "U_ATTACKER_CHOICE",
+                }))
+
+            assert result["result"] == "ok"
+            mock_session.call_tool.assert_called_once_with(
+                "list_mail",
+                arguments={
+                    "client_domain": "example.com",
+                    "operator_slack_id": "U_TRUSTED",
+                },
+            )
+        finally:
+            _servers.pop("test_srv", None)
+
+    def test_session_binding_fails_closed_outside_required_platform(self):
+        from tools.mcp_tool import _make_tool_handler
+
+        handler = _make_tool_handler(
+            "test_srv",
+            "list_mail",
+            120,
+            session_bindings={
+                "operator_slack_id": {
+                    "env": "HERMES_SESSION_USER_ID",
+                    "required_platform": "slack",
+                }
+            },
+        )
+        session_values = {
+            "HERMES_SESSION_PLATFORM": "cli",
+            "HERMES_SESSION_USER_ID": "U_TRUSTED",
+        }
+
+        with patch(
+            "gateway.session_context.get_session_env",
+            side_effect=lambda name, default="": session_values.get(name, default),
+        ):
+            result = json.loads(handler({}))
+
+        assert "error" in result
+        assert "authenticated slack session" in result["error"]
 
 
     def test_recycled_stdio_server_reconnects_lazily_on_tool_call(self):

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -138,6 +138,29 @@ logger = logging.getLogger(__name__)
 _MCP_HARD_RESULT_CAP_CHARS = 2_000_000
 
 
+# MCP servers may declare that selected top-level arguments must come from
+# Hermes' authenticated session context instead of the model. Only these
+# gateway-owned values are eligible for binding; rejecting unknown names
+# prevents a server (or a tampered lazy-schema cache) from reading arbitrary
+# process environment variables.
+_MCP_SESSION_ENV_ALLOWLIST = frozenset({
+    "HERMES_SESSION_PLATFORM",
+    "HERMES_SESSION_SOURCE",
+    "HERMES_SESSION_CHAT_ID",
+    "HERMES_SESSION_CHAT_TYPE",
+    "HERMES_SESSION_CHAT_NAME",
+    "HERMES_SESSION_THREAD_ID",
+    "HERMES_SESSION_USER_ID",
+    "HERMES_SESSION_USER_ID_ALT",
+    "HERMES_SESSION_USER_NAME",
+    "HERMES_SESSION_SCOPE_ID",
+    "HERMES_SESSION_KEY",
+    "HERMES_SESSION_ID",
+    "HERMES_SESSION_MESSAGE_ID",
+    "HERMES_SESSION_PROFILE",
+})
+
+
 def _truncate_mcp_text_result(text: str, max_chars: int = _MCP_HARD_RESULT_CAP_CHARS) -> str:
     """Bound pathological MCP text before it propagates (#56059).
 
@@ -5768,7 +5791,98 @@ def _mark_server_call_started(server: Any) -> None:
         mark_tool_call()
 
 
-def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
+def _extract_mcp_session_bindings(input_schema: Any) -> Dict[str, Dict[str, str]]:
+    """Return validated host-bound argument declarations from an MCP schema."""
+    if not isinstance(input_schema, dict):
+        return {}
+    properties = input_schema.get("properties")
+    if not isinstance(properties, dict):
+        return {}
+
+    bindings: Dict[str, Dict[str, str]] = {}
+    for argument_name, property_schema in properties.items():
+        if not isinstance(property_schema, dict):
+            continue
+        env_name = property_schema.get("x-hermes-session-env")
+        if env_name is None:
+            continue
+        if not isinstance(argument_name, str) or not argument_name:
+            raise ValueError("MCP session-bound argument names must be non-empty strings")
+        if env_name not in _MCP_SESSION_ENV_ALLOWLIST:
+            raise ValueError(
+                f"MCP argument '{argument_name}' requests unsupported Hermes session value"
+            )
+
+        binding = {"env": env_name}
+        required_platform = property_schema.get("x-hermes-required-platform")
+        if required_platform is not None:
+            if not isinstance(required_platform, str) or not required_platform.strip():
+                raise ValueError(
+                    f"MCP argument '{argument_name}' has an invalid required platform"
+                )
+            binding["required_platform"] = required_platform.strip().lower()
+        bindings[argument_name] = binding
+    return bindings
+
+
+def _strip_mcp_session_bound_arguments(
+    input_schema: dict,
+    bindings: Dict[str, Dict[str, str]],
+) -> dict:
+    """Hide host-bound arguments from the schema presented to the model."""
+    if not bindings:
+        return input_schema
+
+    stripped = dict(input_schema)
+    properties = dict(stripped.get("properties") or {})
+    for argument_name in bindings:
+        properties.pop(argument_name, None)
+    stripped["properties"] = properties
+
+    required = stripped.get("required")
+    if isinstance(required, list):
+        remaining = [name for name in required if name not in bindings]
+        if remaining:
+            stripped["required"] = remaining
+        else:
+            stripped.pop("required", None)
+    return stripped
+
+
+def _bind_mcp_session_arguments(
+    args: Any,
+    bindings: Dict[str, Dict[str, str]],
+) -> dict:
+    """Overwrite declared arguments with trusted values from this session."""
+    effective_args = dict(args) if isinstance(args, dict) else {}
+    if not bindings:
+        return effective_args
+
+    from gateway.session_context import get_session_env
+
+    platform = get_session_env("HERMES_SESSION_PLATFORM", "").strip().lower()
+    for argument_name, binding in bindings.items():
+        required_platform = binding.get("required_platform")
+        if required_platform and platform != required_platform:
+            raise ValueError(
+                f"MCP tool requires an authenticated {required_platform} session"
+            )
+        value = get_session_env(binding["env"], "")
+        if not value:
+            raise ValueError(
+                f"MCP tool is missing required authenticated session context for "
+                f"'{argument_name}'"
+            )
+        effective_args[argument_name] = value
+    return effective_args
+
+
+def _make_tool_handler(
+    server_name: str,
+    tool_name: str,
+    tool_timeout: float,
+    session_bindings: Optional[Dict[str, Dict[str, str]]] = None,
+):
     """Return a sync handler that calls an MCP tool via the background loop.
 
     The handler conforms to the registry's dispatch interface:
@@ -5776,6 +5890,13 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
     """
 
     def _handler(args: dict, **kwargs) -> str:
+        try:
+            effective_args = _bind_mcp_session_arguments(
+                args, session_bindings or {}
+            )
+        except ValueError as exc:
+            return tool_error(str(exc))
+
         # Trust-tier gate (security boundary): write-capable tools on
         # servers configured ``trust: untrusted`` must be approved by the
         # user before ANY transport work happens — including the lazy
@@ -5852,7 +5973,9 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # it and detect the gateway platform / session for routing.
                 server._pending_call_context = contextvars.copy_context()
                 try:
-                    result = await server.session.call_tool(tool_name, arguments=args)
+                    result = await server.session.call_tool(
+                        tool_name, arguments=effective_args
+                    )
                 finally:
                     server._pending_call_context = None
             # The RPC round-trip completed — the session is demonstrably
@@ -6500,13 +6623,16 @@ def _convert_mcp_schema(server_name: str, mcp_tool) -> dict:
         A dict suitable for ``registry.register(schema=...)``.
     """
     prefixed_name = mcp_prefixed_tool_name(server_name, mcp_tool.name)
+    raw_input_schema = mcp_field(mcp_tool, "input_schema", "inputSchema")
+    session_bindings = _extract_mcp_session_bindings(raw_input_schema)
+    normalized_input_schema = _normalize_mcp_input_schema(raw_input_schema)
     return {
         "name": prefixed_name,
         "description": strip_unicode_tags(
             mcp_tool.description or f"MCP tool {mcp_tool.name} from {server_name}"
         ),
-        "parameters": _normalize_mcp_input_schema(
-            mcp_field(mcp_tool, "input_schema", "inputSchema")
+        "parameters": _strip_mcp_session_bound_arguments(
+            normalized_input_schema, session_bindings
         ),
     }
 
@@ -6836,6 +6962,8 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             continue
 
         _scan_mcp_description(name, mcp_tool.name, mcp_tool.description or "")
+        raw_input_schema = mcp_field(mcp_tool, "input_schema", "inputSchema")
+        session_bindings = _extract_mcp_session_bindings(raw_input_schema)
         schema = _convert_mcp_schema(name, mcp_tool)
         candidates.append(
             {
@@ -6843,7 +6971,10 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
                 "origin": f"tool {mcp_tool.name!r}",
                 "schema": schema,
                 "handler": _make_tool_handler(
-                    name, mcp_tool.name, server.tool_timeout
+                    name,
+                    mcp_tool.name,
+                    server.tool_timeout,
+                    session_bindings=session_bindings,
                 ),
                 "check_fn": check_fn,
             }
@@ -7111,6 +7242,7 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
         # Defense-in-depth: the cache file is user-writable JSON, so run the
         # same injection scan the eager discovery path applies.
         _scan_mcp_description(name, mcp_tool.name, mcp_tool.description or "")
+        session_bindings = _extract_mcp_session_bindings(raw_schema)
         schema = _convert_mcp_schema(name, mcp_tool)
         registry_name = schema["name"]
         existing_toolset = registry.get_toolset_for_tool(registry_name)
@@ -7125,7 +7257,12 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
             name=registry_name,
             toolset=toolset_name,
             schema=schema,
-            handler=_make_tool_handler(name, raw_name, tool_timeout),
+            handler=_make_tool_handler(
+                name,
+                raw_name,
+                tool_timeout,
+                session_bindings=session_bindings,
+            ),
             check_fn=check_fn,
             is_async=False,
             description=schema["description"],


### PR DESCRIPTION
## What does this PR do?

MCP servers can now bind selected tool arguments to Hermes' authenticated session context. This closes a trust gap for shared agents: the model can request an action, but it cannot choose the user, chat, thread, or other host-owned identity passed to the MCP server.

The server declares a top-level argument with `x-hermes-session-env` and may constrain it with `x-hermes-required-platform`. Hermes removes that argument from the model-facing schema, reads the value from `gateway.session_context` at call time, and overwrites any model-supplied value before transport. Unknown environment names, missing context, and platform mismatches fail closed. The same behavior applies to eager and cached MCP registration.

This is security-sensitive. The environment allowlist prevents an MCP schema or a modified cache from exposing arbitrary process secrets.

## Related Issue

N/A. This is a generic host capability needed by shared multi-user MCP deployments.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_tool.py`
  - validates session-binding schema extensions against a fixed allowlist
  - hides host-bound arguments from model-visible tool schemas
  - injects trusted session values immediately before `tools/call`
  - applies the contract to live and lazy cached registration
- `tests/tools/test_mcp_tool.py`
  - covers schema hiding, arbitrary-environment rejection, spoof overwrite, and platform failure

## How to Test

1. Run `uv run --frozen --extra mcp --with pytest python -m pytest tests/tools/test_mcp_tool.py -q`.
2. Confirm all 101 tests pass.
3. Run `uvx ruff check tools/mcp_tool.py tests/tools/test_mcp_tool.py` and `git diff --check`.

## New concepts

### Host-bound MCP arguments

A host-bound argument is declared by the MCP server but supplied by the trusted agent host, not by the language model. It is useful for authenticated identity and routing values that must match the current session.

Here, `x-hermes-session-env: HERMES_SESSION_USER_ID` removes the corresponding argument from the model schema and binds it from Hermes' context immediately before the RPC. This is safer than putting the user ID in the prompt or trusting a model-provided argument. It should not be used for ordinary business inputs that the model or user is expected to choose.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the extension is documented in code and this PR
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-independent schema and context handling
- [x] I've updated tool descriptions/schemas if I changed tool behavior — the MCP schema extension is covered by conversion tests

## Screenshots / Logs

Focused MCP test suite: `101 passed`. Ruff and `git diff --check`: passed.
