### PR TITLE
fix(telegram): preserve scoped menus and prioritize /insights

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -736,6 +736,7 @@ _TELEGRAM_MENU_PRIORITY = (
     # Lower-priority but still useful operational built-ins.
     "reasoning",
     "usage",
+    "insights",
     "platforms",
     "platform",
     "profile",

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9572,9 +9572,18 @@ class TelegramAdapter(BasePlatformAdapter):
                     return
                 from telegram import BotCommand, BotCommandScopeChat
                 from hermes_cli.commands import telegram_menu_commands, telegram_menu_max_commands
+                scope = BotCommandScopeChat(chat_id=chat_id)
+                # A chat-specific menu may have been deliberately chosen via
+                # the Bot API.  Preserve it across gateway restarts instead of
+                # replacing it with the broad auto-generated list.
+                existing = await self._bot.get_my_commands(scope=scope)
+                if existing:
+                    self._forum_command_registered.add(chat_id)
+                    logger.info("[%s] Preserved existing chat-specific command menu for forum chat %s", self.name, chat_id)
+                    return
                 menu_commands, _ = telegram_menu_commands(max_commands=telegram_menu_max_commands())
                 bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
-                await self._bot.set_my_commands(bot_commands, scope=BotCommandScopeChat(chat_id=chat_id))
+                await self._bot.set_my_commands(bot_commands, scope=scope)
                 self._forum_command_registered.add(chat_id)
                 logger.info("[%s] Lazy-registered %d commands for forum chat %s", self.name, len(bot_commands), chat_id)
             except Exception as e:

--- a/tests/gateway/test_telegram_forum_commands.py
+++ b/tests/gateway/test_telegram_forum_commands.py
@@ -18,6 +18,7 @@ def _make_test_adapter():
     adapter.config = PlatformConfig(enabled=True, token="***", extra={})
     # ``name`` is a property derived from platform.value.title()
     adapter._bot = MagicMock()
+    adapter._bot.get_my_commands = AsyncMock(return_value=[])
     adapter._bot.set_my_commands = AsyncMock()
     adapter._forum_command_registered = set()
     adapter._forum_lock = asyncio.Lock()
@@ -83,3 +84,17 @@ async def test_ensure_forum_commands_race_safety():
 
     # The lock should make this exactly 1 call, not 2.
     assert adapter._bot.set_my_commands.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_forum_commands_preserves_existing_chat_menu():
+    """A deliberate chat-scoped menu must survive a gateway restart."""
+    adapter = _make_test_adapter()
+    adapter._bot.get_my_commands = AsyncMock(return_value=[MagicMock()])
+    msg = _forum_message(chat_id=-456, is_forum=True)
+
+    await adapter._ensure_forum_commands(msg)
+
+    assert -456 in adapter._forum_command_registered
+    adapter._bot.get_my_commands.assert_awaited_once()
+    adapter._bot.set_my_commands.assert_not_awaited()

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -637,6 +637,18 @@ class TestDiscordSkillCmdKeyDispatch:
 class TestTelegramMenuCommands:
     """Integration: telegram_menu_commands enforces the 32-char limit."""
 
+    def test_default_menu_keeps_insights_visible(self, tmp_path, monkeypatch):
+        """A capped Telegram menu must keep aggregate usage discoverable."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        menu, hidden = telegram_menu_commands(max_commands=60)
+        names = [name for name, _description in menu]
+
+        assert len(menu) == 60
+        assert hidden > 0
+        assert "insights" in names
+
+
 
 
 


### PR DESCRIPTION
## What
Avoids overwriting a Telegram chat's existing scoped command menu when a new adapter instance initializes. Also keeps `/insights` in the capped Telegram command list.

## Validation
- `tests/hermes_cli/test_commands.py tests/gateway/test_telegram_forum_commands.py` — 57 passed
- `git diff --check` clean