### PR TITLE
feat(gateway): inject event context into compatible plugin handlers

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18009,7 +18009,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 plugin_handler = get_plugin_command_handler(command.replace("_", "-"))
                 if plugin_handler:
                     user_args = event.get_command_args().strip()
-                    result = plugin_handler(user_args)
+                    # Preserve the historical handler(raw_args) contract, while
+                    # allowing plugins that explicitly accept ``event`` to make
+                    # chat-scoped gateway changes (for example Telegram menus).
+                    import inspect
+                    try:
+                        params = inspect.signature(plugin_handler).parameters.values()
+                        accepts_event = any(
+                            (
+                                p.name == "event"
+                                and p.kind
+                                in (
+                                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                                    inspect.Parameter.KEYWORD_ONLY,
+                                )
+                            )
+                            or p.kind is inspect.Parameter.VAR_KEYWORD
+                            for p in params
+                        )
+                    except (TypeError, ValueError):
+                        # Some valid callables do not expose a Python signature.
+                        # Preserve the established one-argument plugin contract.
+                        accepts_event = False
+                    result = plugin_handler(user_args, event=event) if accepts_event else plugin_handler(user_args)
                     if asyncio.iscoroutine(result):
                         result = await result
                     return str(result) if result else None

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -225,3 +225,49 @@ async def test_command_hook_rewrite_routes_to_plugin(monkeypatch):
     # First emit_collect fires on the original command; after rewrite the
     # dispatcher does NOT re-fire for the new command (one decision per turn).
     assert call_log == ["command:status"]
+
+
+@pytest.mark.asyncio
+async def test_plugin_command_receives_event_only_when_keyword_compatible(monkeypatch):
+    """New event context is opt-in and cannot break legacy plugin handlers."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+    from hermes_cli import plugins as _plugins_mod
+
+    def accepts_event(args, *, event):
+        return f"event:{args}:{event.get_command_args()}"
+
+    monkeypatch.setattr(
+        _plugins_mod,
+        "get_plugin_command_handler",
+        lambda name: accepts_event if name == "metricas" else None,
+    )
+
+    assert await runner._handle_message(_make_event("/metricas seven")) == "event:seven:seven"
+
+
+@pytest.mark.asyncio
+async def test_plugin_command_positional_only_event_keeps_legacy_invocation(monkeypatch):
+    """A positional-only optional event cannot receive the keyword injection."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+    from hermes_cli import plugins as _plugins_mod
+
+    def legacy(args, event=None, /):
+        return f"legacy:{args}:{event}"
+
+    monkeypatch.setattr(
+        _plugins_mod,
+        "get_plugin_command_handler",
+        lambda name: legacy if name == "metricas" else None,
+    )
+
+    assert await runner._handle_message(_make_event("/metricas seven")) == "legacy:seven:None"


### PR DESCRIPTION
## What
Passes the incoming `MessageEvent` as an optional `event=` keyword to plugin command handlers that explicitly accept it or accept `**kwargs`.

## Compatibility
Existing one-argument handlers and positional-only `event` signatures retain the legacy call shape. Uninspectable callables also fall back safely.

## Validation
- `tests/gateway/test_unknown_command.py` — 7 passed
- `git diff --check` clean