### PR TITLE
fix(bot-mode): keep active group chat rename on one group

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/bot-row.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row.test.tsx
@@ -19,7 +19,7 @@ import type * as HermesSdk from '@hermes/plugin-sdk'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { BotRow } from './bot-row'
+import { BotRow, GroupRow } from './bot-row'
 import { translateBots } from './i18n-test-helper'
 import type { RosterRow } from './types'
 
@@ -140,6 +140,29 @@ describe('the menu opens the same forever-chat a row click does', () => {
     fireEvent.click(await screen.findByText('Open Bot Chat'))
 
     expect(openRosterBot.mock.calls).toEqual([[bot]])
+  })
+})
+
+describe('the group row exposes its existing settings', () => {
+  it('opens Group settings from the context menu', async () => {
+    const onSettings = vi.fn()
+
+    render(
+      <GroupRow
+        active={false}
+        group="Planning"
+        members={[]}
+        needsYou={false}
+        onDisband={noop}
+        onOpen={noop}
+        onSettings={onSettings}
+      />
+    )
+
+    fireEvent.contextMenu(screen.getByRole('button'))
+    fireEvent.click(await screen.findByText('Group settings'))
+
+    expect(onSettings).toHaveBeenCalledWith({ members: [], name: 'Planning' })
   })
 })
 

--- a/apps/desktop/src/plugins/hermes-bots/bot-row.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row.tsx
@@ -456,9 +456,10 @@ interface GroupRowProps {
   needsYou: boolean
   onDisband: (room: { members: GroupMember[]; name: string }) => void
   onOpen: (group: string) => void
+  onSettings: (room: { members: GroupMember[]; name: string }) => void
 }
 
-export function GroupRow({ active, group, members, needsYou, onOpen, onDisband }: GroupRowProps) {
+export function GroupRow({ active, group, members, needsYou, onOpen, onSettings, onDisband }: GroupRowProps) {
   const { t } = useI18n()
   const b = useBots()
   const rooms = useValue($groupChats)
@@ -554,6 +555,7 @@ export function GroupRow({ active, group, members, needsYou, onOpen, onDisband }
       <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
       <ContextMenuContent>
         <ContextMenuItem onSelect={() => onOpen(group)}>Open Group Chat</ContextMenuItem>
+        <ContextMenuItem onSelect={() => onSettings({ members, name: group })}>{b.group.settingsTitle}</ContextMenuItem>
         <ContextMenuSeparator />
         <ContextMenuItem
           className="text-destructive focus:text-destructive"

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.test.ts
@@ -137,6 +137,53 @@ describe('opening a room', () => {
   })
 })
 
+describe('rename', () => {
+  it('keeps the active drive on one room name', async () => {
+    const room = await loadRoom()
+
+    room.chat.$groupChats.set({
+      Old: {
+        log: [{ at: 1, from: { kind: 'user', name: 'You' }, id: 'm1', text: 'keep working' }],
+        running: true,
+        watermarks: {}
+      }
+    })
+
+    expect(await room.view.renameGroupChat('Old', 'New', [])).toBeNull()
+    expect(room.chat.$groupChats.get().Old).toBeDefined()
+    expect(room.chat.$groupChats.get().New).toBeUndefined()
+    expect(host.notify).toHaveBeenCalledWith({
+      kind: 'info',
+      message: 'Wait for the current replies to finish before renaming this group chat.'
+    })
+  })
+
+  it('moves the complete idle room and its unresolved attention once', async () => {
+    const room = await loadRoom()
+
+    room.chat.$groupChats.set({
+      Old: {
+        log: [{ at: 1, from: { kind: 'user', name: 'You' }, id: 'm1', text: 'keep working' }],
+        roomId: 'room-1',
+        running: false,
+        sessions: { builder: 'sid-1' },
+        stranded: { builder: { before: 1, thread: 'm1' } },
+        watermarks: {}
+      }
+    })
+    room.chat.$groupNeedsYou.set({ Old: true })
+
+    expect(await room.view.renameGroupChat('Old', 'New', [])).toBe('New')
+    expect(room.chat.$groupChats.get().Old).toBeUndefined()
+    expect(room.chat.$groupChats.get().New).toMatchObject({
+      roomId: 'room-1',
+      sessions: { builder: 'sid-1' },
+      stranded: { builder: { before: 1, thread: 'm1' } }
+    })
+    expect(room.chat.$groupNeedsYou.get()).toEqual({ New: true })
+  })
+})
+
 describe('disband', () => {
   it('removes only this membership, room log, workspace and needs-you state', async () => {
     const room = await loadRoom()

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
@@ -238,7 +238,7 @@ export async function disbandGroupChat(group: string, members: RosterRow[]) {
  *  rename, so even a member whose sid is later lost falls back to the same
  *  "Group: <roomId>" title lookup instead of a fresh "Group: <new name>".
  *  Returns the new name, or null when the target name is taken. */
-async function renameGroupChat(oldName: string, newName: string, members: GroupMember[] | null | undefined) {
+export async function renameGroupChat(oldName: string, newName: string, members: GroupMember[] | null | undefined) {
   const next = String(newName || '')
     .trim()
     .slice(0, 64)

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
@@ -230,6 +230,13 @@ export async function disbandGroupChat(group: string, members: RosterRow[]) {
   }
 }
 
+/** A room name is still part of the active drive's in-process address. Keep
+ *  that address stable until the drive releases it; roomId gives the durable
+ *  room its identity, but it cannot rewrite closures already in flight. */
+export function groupChatRenameBlocked(room: GroupChatRoom | null | undefined): boolean {
+  return Boolean(room?.running)
+}
+
 /** Rename a group chat. The group's NAME is its identity everywhere — the
  *  room-map key, each local member's ui_meta membership list, and derived
  *  state — so a rename re-keys all of them. Member gateway sessions are kept
@@ -246,6 +253,18 @@ export async function renameGroupChat(oldName: string, newName: string, members:
   if (!next || next === oldName) {
     return oldName
   }
+
+  if (groupChatRenameBlocked($groupChats.get()[oldName])) {
+    host.notify({
+      kind: 'info',
+      message: botsText().group.renameWait
+    })
+
+    return null
+  }
+
+  // Keep the guard-to-rekey span await-free: one JavaScript turn owns this
+  // identity transition, so a drive cannot start under the old name midway.
 
   // Renames are explicit user intent: reject a collision honestly instead of
   // silently suffixing like creation does. Disband tombstones don't hold
@@ -363,13 +382,15 @@ interface GroupChatSettingsDialogProps {
 /** Edit an existing group chat's name and picture. Renames re-key the room
  *  and every local member's membership (renameGroupChat); the picture rides
  *  the room record. Both apply on Save so a cancelled dialog changes nothing. */
-function GroupChatSettingsDialog({ group, members, open, onClose, onRenamed }: GroupChatSettingsDialogProps) {
+export function GroupChatSettingsDialog({ group, members, open, onClose, onRenamed }: GroupChatSettingsDialogProps) {
   const { t } = useI18n()
   const b = useBots()
   const rooms: Record<string, GroupChatRoom> = useValue($groupChats)
-  const current = (rooms[group] || {}).image || null
+  const room = rooms[group] || {}
+  const current = room.image || null
   const [name, setName] = useState(group)
   const [image, setImage] = useState(current)
+  const renameBlocked = name.trim() !== group && groupChatRenameBlocked(room)
   useEffect(() => {
     if (open) {
       setName(group)
@@ -430,11 +451,12 @@ function GroupChatSettingsDialog({ group, members, open, onClose, onRenamed }: G
             value={name}
           />
         </form>
+        {renameBlocked ? <p className="text-xs text-(--ui-text-tertiary)">{b.group.renameWait}</p> : null}
         <DialogFooter>
           <Button onClick={onClose} variant="secondary">
             {t.common.cancel}
           </Button>
-          <Button disabled={!name.trim()} onClick={() => void save()}>
+          <Button disabled={!name.trim() || renameBlocked} onClick={() => void save()}>
             {t.common.save}
           </Button>
         </DialogFooter>

--- a/apps/desktop/src/plugins/hermes-bots/group-rename-inflight.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rename-inflight.test.ts
@@ -13,6 +13,7 @@ vi.mock('@hermes/plugin-sdk', async () => {
 beforeEach(() => {
   vi.resetModules()
   runTimersInline()
+
   for (const key of Object.keys(host)) {
     delete host[key]
   }
@@ -21,8 +22,15 @@ beforeEach(() => {
 it.each(['stable-room-id', undefined])('keeps an in-flight reply on one room with identity %s', async roomId => {
   let release: (value: string) => void = () => undefined
   let entered: () => void = () => undefined
-  const started = new Promise<void>(resolve => { entered = resolve })
-  const reply = new Promise<string>(resolve => { release = resolve })
+
+  const started = new Promise<void>(resolve => {
+    entered = resolve
+  })
+
+  const reply = new Promise<string>(resolve => {
+    release = resolve
+  })
+
   const gateway = createGroupGateway({
     turn: ({ n }) => {
       if (n === 1) {
@@ -34,6 +42,7 @@ it.each(['stable-room-id', undefined])('keeps an in-flight reply on one room wit
       return '(pass)'
     }
   })
+
   Object.assign(host, gateway.host)
   const chat = await import('./group-chat')
   const rounds = await import('./group-rounds')
@@ -50,19 +59,31 @@ it.each(['stable-room-id', undefined])('keeps an in-flight reply on one room wit
   const drive = rounds.runGroupChatRounds('Old', [{ name: 'research', title: 'Research' }], 'thread-1')
   await started
   let renamed: null | string = null
+
   try {
     renamed = await view.renameGroupChat('Old', 'New', [])
   } finally {
     release('Completed reply')
     await drive
   }
+
   const current = chat.$groupChats.get()
-  console.info('RENAME_RECEIPT', { roomId, renamed, names: Object.keys(current), replies: Object.fromEntries(
-    Object.entries(current).map(([name, room]) => [name, room.log.filter(entry => entry.from.kind === 'member').map(entry => entry.text)])
-  ) })
+  console.info('RENAME_RECEIPT', {
+    roomId,
+    renamed,
+    names: Object.keys(current),
+    replies: Object.fromEntries(
+      Object.entries(current).map(([name, room]) => [
+        name,
+        room.log.filter(entry => entry.from.kind === 'member').map(entry => entry.text)
+      ])
+    )
+  })
   expect(renamed).toBeNull()
   expect(Object.keys(current)).toEqual(['Old'])
-  expect(current.Old.log.filter(entry => entry.from.kind === 'member').map(entry => entry.text)).toEqual(['Completed reply'])
+  expect(current.Old.log.filter(entry => entry.from.kind === 'member').map(entry => entry.text)).toEqual([
+    'Completed reply'
+  ])
   expect(current.Old.running).toBe(false)
   expect(await view.renameGroupChat('Old', 'New', [])).toBe('New')
   expect(Object.keys(chat.$groupChats.get())).toEqual(['New'])

--- a/apps/desktop/src/plugins/hermes-bots/group-rename-inflight.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rename-inflight.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, expect, it, vi } from 'vitest'
+
+import { createGroupGateway, runTimersInline, scriptedStorage } from './group-test-utils'
+
+const { host } = vi.hoisted(() => ({ host: {} as Record<string, unknown> }))
+
+vi.mock('@hermes/plugin-sdk', async () => {
+  const { pluginSdkMock } = await import('./group-test-utils')
+
+  return pluginSdkMock(host)
+})
+
+beforeEach(() => {
+  vi.resetModules()
+  runTimersInline()
+  for (const key of Object.keys(host)) {
+    delete host[key]
+  }
+})
+
+it.each(['stable-room-id', undefined])('keeps an in-flight reply on one room with identity %s', async roomId => {
+  let release: (value: string) => void = () => undefined
+  let entered: () => void = () => undefined
+  const started = new Promise<void>(resolve => { entered = resolve })
+  const reply = new Promise<string>(resolve => { release = resolve })
+  const gateway = createGroupGateway({
+    turn: ({ n }) => {
+      if (n === 1) {
+        entered()
+
+        return reply
+      }
+
+      return '(pass)'
+    }
+  })
+  Object.assign(host, gateway.host)
+  const chat = await import('./group-chat')
+  const rounds = await import('./group-rounds')
+  const view = await import('./group-chat-view')
+  const shared = await import('./shared')
+  shared.setPluginCtx(scriptedStorage(gateway.storage))
+  chat.updateGroupChat('Old', room => ({
+    ...room,
+    roomId,
+    running: true,
+    epoch: 1,
+    log: [{ id: 'user-entry', at: 1, from: { kind: 'user', name: 'You' }, text: 'Continue', thread: 'thread-1' }]
+  }))
+  const drive = rounds.runGroupChatRounds('Old', [{ name: 'research', title: 'Research' }], 'thread-1')
+  await started
+  let renamed: null | string = null
+  try {
+    renamed = await view.renameGroupChat('Old', 'New', [])
+  } finally {
+    release('Completed reply')
+    await drive
+  }
+  const current = chat.$groupChats.get()
+  console.info('RENAME_RECEIPT', { roomId, renamed, names: Object.keys(current), replies: Object.fromEntries(
+    Object.entries(current).map(([name, room]) => [name, room.log.filter(entry => entry.from.kind === 'member').map(entry => entry.text)])
+  ) })
+  expect(renamed).toBeNull()
+  expect(Object.keys(current)).toEqual(['Old'])
+  expect(current.Old.log.filter(entry => entry.from.kind === 'member').map(entry => entry.text)).toEqual(['Completed reply'])
+  expect(current.Old.running).toBe(false)
+  expect(await view.renameGroupChat('Old', 'New', [])).toBe('New')
+  expect(Object.keys(chat.$groupChats.get())).toEqual(['New'])
+  expect(chat.$groupChats.get().New.roomId).toBe(roomId)
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-row-settings.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-row-settings.test.tsx
@@ -1,0 +1,24 @@
+import type * as HermesSdk from '@hermes/plugin-sdk'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { expect, it, vi } from 'vitest'
+
+import { GroupRow } from './bot-row'
+import { translateBots } from './i18n-test-helper'
+
+vi.mock('@hermes/plugin-sdk', async importOriginal => {
+  const sdk = await importOriginal<typeof HermesSdk>()
+
+  return { ...sdk, usePluginI18n: () => translateBots }
+})
+
+it('opens the existing Group settings from the roster context menu', async () => {
+  const onSettings = vi.fn()
+  const props = {
+    active: false, group: 'Planning', members: [], needsYou: false,
+    onDisband: vi.fn(), onOpen: vi.fn(), onSettings
+  }
+  render(<GroupRow {...props} />)
+  fireEvent.contextMenu(screen.getByRole('button'))
+  fireEvent.click(await screen.findByText('Group settings'))
+  expect(onSettings).toHaveBeenCalledWith({ members: [], name: 'Planning' })
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-row-settings.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-row-settings.test.tsx
@@ -3,6 +3,8 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { expect, it, vi } from 'vitest'
 
 import { GroupRow } from './bot-row'
+import { $groupChats } from './group-chat'
+import { GroupChatSettingsDialog } from './group-chat-view'
 import { translateBots } from './i18n-test-helper'
 
 vi.mock('@hermes/plugin-sdk', async importOriginal => {
@@ -13,12 +15,32 @@ vi.mock('@hermes/plugin-sdk', async importOriginal => {
 
 it('opens the existing Group settings from the roster context menu', async () => {
   const onSettings = vi.fn()
+
   const props = {
-    active: false, group: 'Planning', members: [], needsYou: false,
-    onDisband: vi.fn(), onOpen: vi.fn(), onSettings
+    active: false,
+    group: 'Planning',
+    members: [],
+    needsYou: false,
+    onDisband: vi.fn(),
+    onOpen: vi.fn(),
+    onSettings
   }
+
   render(<GroupRow {...props} />)
   fireEvent.contextMenu(screen.getByRole('button'))
   fireEvent.click(await screen.findByText('Group settings'))
   expect(onSettings).toHaveBeenCalledWith({ members: [], name: 'Planning' })
+})
+
+it('blocks only a changed name while a reply is active', () => {
+  $groupChats.set({ Old: { log: [], watermarks: {}, running: true } })
+  render(<GroupChatSettingsDialog group="Old" members={[]} onClose={vi.fn()} open />)
+  const save = screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement
+  const input = screen.getByRole('textbox', { name: 'Group name' })
+  expect(save.disabled).toBe(false)
+  fireEvent.change(input, { target: { value: 'New' } })
+  expect(save.disabled).toBe(true)
+  expect(screen.getByText('Wait for the current replies to finish before renaming this group chat.')).toBeTruthy()
+  fireEvent.change(input, { target: { value: 'Old' } })
+  expect(save.disabled).toBe(false)
 })

--- a/apps/desktop/src/plugins/hermes-bots/i18n.ts
+++ b/apps/desktop/src/plugins/hermes-bots/i18n.ts
@@ -156,6 +156,7 @@ type BotsMessages = {
     settingsTitle: string
     settingsDesc: string
     nameLabel: string
+    renameWait: string
     searchToAdd: string
     searchToAddPlaceholder: string
     removeFromSelection: string
@@ -380,6 +381,7 @@ const en: BotsMessages = {
     settingsTitle: 'Group settings',
     settingsDesc: 'Rename the group or set a room picture. Members and history are kept.',
     nameLabel: 'Group name',
+    renameWait: 'Wait for the current replies to finish before renaming this group chat.',
     searchToAdd: 'Search bots to add',
     searchToAddPlaceholder: 'Search bots to add…',
     removeFromSelection: 'Remove from selection',
@@ -597,6 +599,7 @@ const ja: BotsMessages = {
     settingsTitle: 'グループ設定',
     settingsDesc: 'グループ名の変更や部屋の画像の設定ができます。メンバーと履歴は保持されます。',
     nameLabel: 'グループ名',
+    renameWait: '返信が完了するまで待ってから、このグループチャットの名前を変更してください。',
     searchToAdd: '追加するボットを検索',
     searchToAddPlaceholder: '追加するボットを検索…',
     removeFromSelection: '選択から外す',
@@ -810,6 +813,7 @@ const zh: BotsMessages = {
     settingsTitle: '群组设置',
     settingsDesc: '重命名群组或设置房间图片。成员和历史都会保留。',
     nameLabel: '群组名称',
+    renameWait: '请等待当前回复完成后再重命名此群聊。',
     searchToAdd: '搜索要添加的机器人',
     searchToAddPlaceholder: '搜索要添加的机器人…',
     removeFromSelection: '从选择中移除',
@@ -1023,6 +1027,7 @@ const zhHant: BotsMessages = {
     settingsTitle: '群組設定',
     settingsDesc: '重新命名群組或設定房間圖片。成員和歷史都會保留。',
     nameLabel: '群組名稱',
+    renameWait: '請等待目前回覆完成後再重新命名此群組聊天。',
     searchToAdd: '搜尋要加入的機器人',
     searchToAddPlaceholder: '搜尋要加入的機器人…',
     removeFromSelection: '從選取中移除',

--- a/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
@@ -57,7 +57,7 @@ import {
 } from './data'
 import { EditProfileDialog } from './edit-profile-dialog'
 import { $groupChats, $groupChatWorkspace, $groupNeedsYou } from './group-chat'
-import { disbandGroupChat, GroupChatWorkspace, openGroupChat } from './group-chat-view'
+import { disbandGroupChat, GroupChatSettingsDialog, GroupChatWorkspace, openGroupChat } from './group-chat-view'
 import { groupChatMemberBots, groupChatNames, groupLastActivity } from './group-membership'
 import { $groupMainTabsRev, shouldRenderGroupChatInPane } from './group-panes'
 import { $showHiddenBots, isBotHidden, isBotPinned } from './hidden-bots'
@@ -264,6 +264,7 @@ export function BotsPane() {
   // it is not part of the shared RosterRow model, so it rides as an extra here.
   const [deleting, setDeleting] = useState<null | (RosterRow & { path?: string })>(null)
   const [deletingGroup, setDeletingGroup] = useState<null | { members: GroupMember[]; name: string }>(null)
+  const [editingGroup, setEditingGroup] = useState<null | { members: GroupMember[]; name: string }>(null)
   const userSections = useValue($botSections)
   const dragging = useValue($draggingBot)
   useEscapeCancelsBotDrag()
@@ -575,6 +576,7 @@ export function BotsPane() {
       needsYou={Boolean(groupNeedsYou[row.name])}
       onDisband={setDeletingGroup}
       onOpen={openGroupChat}
+      onSettings={setEditingGroup}
     />
   )
 
@@ -1023,6 +1025,14 @@ export function BotsPane() {
         }}
         open={Boolean(editing)}
       />
+      {editingGroup ? (
+        <GroupChatSettingsDialog
+          group={editingGroup.name}
+          members={editingGroup.members}
+          onClose={() => setEditingGroup(null)}
+          open
+        />
+      ) : null}
       {grouping ? <GroupDialog bot={grouping} onClose={() => setGrouping(null)} /> : null}
       <ConfirmDialog
         busyLabel="Deleting…"


### PR DESCRIPTION
## What does this PR do?

Renaming a Bot Mode Group Chat while a Bot reply was in flight could split one
conversation into two roster rows. The room map moved to the new display name,
while the active async drive still closed over the old name and appended its
reply there.

This keeps the display name stable only while replies own the drive. The
settings dialog disables a changed name during that window, and
`renameGroupChat()` enforces the same invariant at the mutation boundary. Once
the drive finishes, an idle rename still moves the complete room record,
including its durable identity, sessions, stranded replies, and attention
state.

The Group Chat row context menu also opens the existing settings dialog, so
rename and picture controls are available from the place users naturally look
for them.

> [!NOTE]
> This is now a standalone current-main recut. #93993 remains separate; no attention-marker behavior is added here.

## Related work

- #94726 is the Bot Mode umbrella tracker.
- #93993 separately owns the Group Chat attention marker; it is not a prerequisite.
- #92041 contains a broader unresolved queueing implementation. This PR keeps
  the active-rename invariant independently reviewable and does not change
  delivery or queueing.
- #90933 owns timed-out and late reply delivery; an idle rename here preserves
  its late-reply state.
- Merged #96726 replaced the old `plugin.js` surface. This head ports the same
  behavior to the typed Bot Mode modules and design-system menu.

## Changes Made

- Guard `renameGroupChat()` while replies are active.
- Disable only a changed name during that window; picture-only saves and idle
  renames remain available.
- Add **Group settings** to each Group Chat row context menu.
- Localize the active-reply explanation.
- Cover active rejection, idle re-keying, late state preservation, and menu
  discovery with direct typed tests.

## How to Test

1. Start a Group Chat turn whose Bot reply remains active.
2. Open Group settings and change the name: Save stays disabled, and the room
   remains under its original name.
3. Let the reply finish, then rename: the room moves once and preserves its
   identity, sessions, stranded replies, and attention state.
4. Right-click a Group Chat row and confirm **Group settings** opens the same
   dialog as the header settings button.

## Validation

Current head `f0fd3977b6` on `main@245e48008f`:

- Three current-main regressions failed before the fixes; **178 tests across 12 files pass** afterward, without retries.
- Renderer typecheck, scoped ESLint and `git diff --check` pass. Every changed source/test owner is below 2,000 lines.
- Original authorship, author dates and cherry-pick provenance are preserved. Active-rename and roster-settings fixes remain separately selectable.
- No new packaged-app or live-UAT claim is made for this recut.

The pre-recut history remains on `dokterdok:preserve/pr93903-before-main-refresh-20260906`. No Python source changed.
