### PR TITLE
fix(desktop): scope stream throttling per window

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -14506,27 +14506,31 @@ ipcMain.handle('hermes:stopPreviewFileWatch', (_event, id) => stopPreviewFileWat
 // merged picture. Keyed by webContents id so a closed window stops counting.
 const activeWorkByWebContents = new Map<number, ActiveWork>()
 
-// The same merged picture drives background throttling: chat windows run
-// unthrottled while any turn is in flight (streaming must paint while hidden)
-// and fall back to Chromium's default throttling at idle. See stream-throttle.ts.
+// Background throttling is renderer-scoped: the window that reports live work
+// keeps painting while hidden, without waking every sibling profile/window.
+// The quit guard below still uses the globally merged picture.
 const streamThrottle = createStreamThrottle()
-
-function updateStreamThrottleFromActiveWork() {
-  streamThrottle.update(mergeActiveWork(activeWorkByWebContents.values()).count > 0)
-}
 
 ipcMain.on('hermes:active-work', (event, payload) => {
   const id = event.sender.id
+  const win = BrowserWindow.fromWebContents(event.sender)
 
   if (!activeWorkByWebContents.has(id)) {
     event.sender.once('destroyed', () => {
       activeWorkByWebContents.delete(id)
-      updateStreamThrottleFromActiveWork()
+
+      if (win) {
+        streamThrottle.update(win, false)
+      }
     })
   }
 
-  activeWorkByWebContents.set(id, normalizeActiveWork(payload))
-  updateStreamThrottleFromActiveWork()
+  const activeWork = normalizeActiveWork(payload)
+  activeWorkByWebContents.set(id, activeWork)
+
+  if (win) {
+    streamThrottle.update(win, activeWork.count > 0)
+  }
 })
 
 ipcMain.on('hermes:titlebar-theme', (_event, payload) => {

--- a/apps/desktop/electron/session-windows.ts
+++ b/apps/desktop/electron/session-windows.ts
@@ -18,11 +18,10 @@ const SESSION_WINDOW_MIN_HEIGHT = 620
 // throttling opt-out).
 //
 // Background throttling is deliberately NOT set here. It is managed at runtime
-// by main.ts (`setBackgroundThrottling` driven by the merged `hermes:active-work`
-// reports): while any turn is in flight every chat window is unthrottled so the
-// transcript's bounded timer flush keeps painting while blurred, occluded, or
-// minimized — and once all turns finish, Chromium's default throttling returns
-// so an idle hidden window costs ~nothing. A static `backgroundThrottling:
+// by main.ts (`setBackgroundThrottling` driven by each renderer's
+// `hermes:active-work` report): only a window with a turn in flight is
+// unthrottled so its bounded timer flush keeps painting while blurred,
+// occluded, or minimized — sibling windows stay quiet. A static `backgroundThrottling:
 // false` here would pin `document.visibilityState` to 'visible' forever,
 // turning every visibility-gated poll in the renderer into an always-on timer
 // (the "Hermes idles at 20% CPU while minimized" bug). The preload path is

--- a/apps/desktop/electron/stream-throttle.test.ts
+++ b/apps/desktop/electron/stream-throttle.test.ts
@@ -67,27 +67,29 @@ test('registering a window applies the current throttle state immediately', () =
   // Idle default: throttling allowed.
   assert.deepEqual(idle.calls, [true])
 
-  throttle.update(true)
+  throttle.update(idle, true)
   const late = makeWindow()
   throttle.register(late)
 
-  // A window created mid-stream starts unthrottled.
-  assert.deepEqual(late.calls, [false])
+  // Another renderer's stream does not wake a newly created sibling window.
+  assert.deepEqual(late.calls, [true])
+  assert.equal(throttle.isUnthrottled(idle), true)
+  assert.equal(throttle.isUnthrottled(late), false)
 })
 
-test('a turn in flight unthrottles every chat window; settling re-throttles after the trailing delay', () => {
+test('a turn in flight unthrottles its own window; settling re-throttles after the trailing delay', () => {
   const timers = makeTimers()
   const throttle = createStreamThrottle(timers)
   const win = makeWindow()
   throttle.register(win)
 
-  throttle.update(true)
+  throttle.update(win, true)
   assert.deepEqual(win.calls, [true, false])
   assert.equal(throttle.isUnthrottled(), true)
 
   // Turn ends: not re-throttled synchronously — the tail flush needs full
   // cadence — only after the trailing timer fires.
-  throttle.update(false)
+  throttle.update(win, false)
   assert.deepEqual(win.calls, [true, false])
   assert.equal(throttle.isUnthrottled(), true)
 
@@ -102,12 +104,12 @@ test('a new turn during the trailing window cancels the pending re-throttle', ()
   const win = makeWindow()
   throttle.register(win)
 
-  throttle.update(true)
-  throttle.update(false)
+  throttle.update(win, true)
+  throttle.update(win, false)
   assert.equal(timers.pendingCount, 1)
 
   // Busy again before the delay elapses: stay unthrottled, timer cancelled.
-  throttle.update(true)
+  throttle.update(win, true)
   assert.equal(timers.pendingCount, 0)
   assert.equal(throttle.isUnthrottled(), true)
 
@@ -122,14 +124,39 @@ test('repeated busy reports do not re-apply or stack timers', () => {
   const win = makeWindow()
   throttle.register(win)
 
-  throttle.update(true)
-  throttle.update(true)
-  throttle.update(true)
+  throttle.update(win, true)
+  throttle.update(win, true)
+  throttle.update(win, true)
   assert.deepEqual(win.calls, [true, false])
 
-  throttle.update(false)
-  throttle.update(false)
+  throttle.update(win, false)
+  throttle.update(win, false)
   assert.equal(timers.pendingCount, 1)
+})
+
+test('concurrent windows throttle independently', () => {
+  const timers = makeTimers()
+  const throttle = createStreamThrottle(timers)
+  const first = makeWindow()
+  const second = makeWindow()
+  throttle.register(first)
+  throttle.register(second)
+
+  throttle.update(first, true)
+  assert.deepEqual(first.calls, [true, false])
+  assert.deepEqual(second.calls, [true])
+
+  throttle.update(second, true)
+  throttle.update(first, false)
+  assert.equal(timers.pendingCount, 1)
+  assert.equal(throttle.isUnthrottled(first), true)
+  assert.equal(throttle.isUnthrottled(second), true)
+
+  timers.fire()
+  assert.deepEqual(first.calls, [true, false, true])
+  assert.deepEqual(second.calls, [true, false])
+  assert.equal(throttle.isUnthrottled(first), false)
+  assert.equal(throttle.isUnthrottled(second), true)
 })
 
 test('closed and destroyed windows drop out without throwing', () => {
@@ -146,7 +173,7 @@ test('closed and destroyed windows drop out without throwing', () => {
 
   throttle.register(gone)
 
-  throttle.update(true)
+  throttle.update(closedWin, true)
   // Only the registration-time call landed; nothing after close.
   assert.deepEqual(closedWin.calls, [true])
 })

--- a/apps/desktop/electron/stream-throttle.ts
+++ b/apps/desktop/electron/stream-throttle.ts
@@ -7,13 +7,12 @@
 // turns every visibility-gated poll and clock tick in the renderer into an
 // always-on timer. An idle, hidden Hermes burned ~20% CPU forever.
 //
-// So throttling is a runtime dial instead: the renderers already report
-// "which chats are mid-turn" for the quit guard (`hermes:active-work`), and
-// this controller rides the merged edge of those reports. Any turn in flight →
-// every registered chat window gets `setBackgroundThrottling(false)`, exactly
-// the streaming behavior the static flag used to provide. All turns done →
-// after a short trailing delay (so tail flushes land at full cadence) Chromium's
-// default throttling returns and hidden windows go quiet.
+// So throttling is a runtime dial instead: each renderer already reports
+// "which chats are mid-turn" for the quit guard (`hermes:active-work`). Only
+// the reporting window gets `setBackgroundThrottling(false)` while it streams;
+// sibling profiles and secondary windows remain eligible for Chromium's normal
+// background throttling. When that window's turns finish, a short trailing
+// delay lets its final coalesced flush land before throttling returns.
 //
 // Pure and Electron-free (timers + the WebContents surface are injected) so it
 // can be unit-tested, mirroring session-windows.ts.
@@ -37,26 +36,39 @@ interface TimersLike {
 }
 
 export interface StreamThrottle {
-  /** True while windows are currently unthrottled (streaming or trailing). */
-  isUnthrottled(): boolean
+  /** True while this window (or any window when omitted) is unthrottled. */
+  isUnthrottled(win?: ThrottleWindowLike): boolean
   /** Track a chat window; applies the current state immediately and stops
    * tracking on close. */
   register(win: ThrottleWindowLike & { on?: (event: string, fn: () => void) => void }): void
-  /** Report whether any turn is in flight across all renderers. */
-  update(busy: boolean): void
+  /** Report whether this window has a turn in flight. */
+  update(win: ThrottleWindowLike, busy: boolean): void
+}
+
+interface WindowThrottleState {
+  trailing: unknown | null
+  unthrottled: boolean
 }
 
 export function createStreamThrottle(
   timers: TimersLike = { clearTimeout: handle => clearTimeout(handle as never), setTimeout },
   delayMs: number = RETHROTTLE_DELAY_MS
 ): StreamThrottle {
-  const windows = new Set<ThrottleWindowLike>()
-  let unthrottled = false
-  let trailing: unknown = null
+  const windows = new Map<ThrottleWindowLike, WindowThrottleState>()
 
-  function apply(win: ThrottleWindowLike) {
+  function remove(win: ThrottleWindowLike) {
+    const state = windows.get(win)
+
+    if (state && state.trailing !== null) {
+      timers.clearTimeout(state.trailing)
+    }
+
+    windows.delete(win)
+  }
+
+  function apply(win: ThrottleWindowLike, state: WindowThrottleState) {
     if (win.isDestroyed()) {
-      windows.delete(win)
+      remove(win)
 
       return
     }
@@ -64,55 +76,63 @@ export function createStreamThrottle(
     const contents = win.webContents
 
     if (!contents || contents.isDestroyed()) {
+      remove(win)
+
       return
     }
 
     try {
-      contents.setBackgroundThrottling(!unthrottled)
+      contents.setBackgroundThrottling(!state.unthrottled)
     } catch {
       // A window mid-teardown can throw; it's about to leave the set anyway.
     }
   }
 
-  function applyAll() {
-    for (const win of windows) {
-      apply(win)
-    }
-  }
-
   return {
-    isUnthrottled: () => unthrottled,
+    isUnthrottled: win =>
+      win ? (windows.get(win)?.unthrottled ?? false) : [...windows.values()].some(state => state.unthrottled),
 
     register(win) {
-      windows.add(win)
-      win.on?.('closed', () => windows.delete(win))
-      apply(win)
+      if (windows.has(win)) {
+        return
+      }
+
+      const state: WindowThrottleState = { trailing: null, unthrottled: false }
+      windows.set(win, state)
+      win.on?.('closed', () => remove(win))
+      apply(win, state)
     },
 
-    update(busy) {
+    update(win, busy) {
+      const state = windows.get(win)
+
+      if (!state) {
+        return
+      }
+
       if (busy) {
-        if (trailing !== null) {
-          timers.clearTimeout(trailing)
-          trailing = null
+        if (state.trailing !== null) {
+          timers.clearTimeout(state.trailing)
+          state.trailing = null
         }
 
-        if (!unthrottled) {
-          unthrottled = true
-          applyAll()
+        if (!state.unthrottled) {
+          state.unthrottled = true
+          apply(win, state)
         }
 
         return
       }
 
-      if (!unthrottled || trailing !== null) {
+      if (!state.unthrottled || state.trailing !== null) {
         return
       }
 
       // Trailing edge: keep full cadence briefly so the final flush paints.
-      trailing = timers.setTimeout(() => {
-        trailing = null
-        unthrottled = false
-        applyAll()
+      state.trailing = timers.setTimeout(() => {
+        state.trailing = null
+        state.unthrottled = false
+        apply(win, state)
       }, delayMs)
     }
   }


### PR DESCRIPTION
## What does this PR do?

Scopes Electron background-throttling state to each chat window instead of treating all registered windows as one global throttle domain.

Previously, one window reporting active work caused `setBackgroundThrottling(false)` on every registered chat window. With multiple primary/secondary windows, an idle or hidden renderer therefore stayed unthrottled solely because another window was streaming. The global grace timer also kept all windows awake together after the active window finished.

The controller now tracks busy state and grace timers per window. The main-process IPC handler resolves the sending `webContents` to its owning `BrowserWindow` and updates only that window. Quit-guard accounting remains global and unchanged.

This is related to the desktop CPU reports in #88288, but deliberately does **not** claim to fix every cause reported there (including backend CPU and platform GPU/compositor behavior).

## Related Issue

Related to #88288.

Coordination note: #92463 also changes `electron/stream-throttle.ts`, but on a different axis (visibility semantics). This PR is limited to per-window state ownership and should be reconciled with that work rather than treated as a competing visibility-policy change.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/stream-throttle.ts`
  - replace the global active/grace state with per-window state;
  - apply throttling and grace timers only to the window whose renderer reported work;
  - clean up a window's timer/state on removal.
- `apps/desktop/electron/main.ts`
  - resolve the IPC sender to its owning `BrowserWindow`;
  - update that window's throttle state while preserving globally merged quit guards.
- `apps/desktop/electron/session-windows.ts`
  - update comments to document per-window behavior.
- `apps/desktop/electron/stream-throttle.test.ts`
  - cover independent concurrent-window transitions and cleanup.

## How to Test

1. Open two chat windows.
2. Start a turn in one window while leaving the other idle or hidden.
3. Verify only the active window disables Chromium background throttling.
4. Finish the turn and verify that window returns to throttled mode after its grace period without changing the other window.

Automated gates run after rebasing onto current `origin/main`:

- `npm run test:desktop:platforms` — 118 files passed, 1 skipped; 1,701 tests passed, 3 skipped.
- Focused `electron/stream-throttle.test.ts` — 6/6 passed.
- `npm run typecheck` — passed.
- ESLint on all four changed files — passed.
- `git diff --check origin/main...HEAD` — passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing open and merged issues/PRs.
- [x] My PR contains only changes related to this fix.
- [x] Desktop platform tests pass.
- [x] I've added tests for the bug.
- [x] Tested on Windows 11 with WSL2/WSLg.

### Documentation & Housekeeping

- [x] Documentation update — N/A; no public configuration or API changed.
- [x] `cli-config.yaml.example` update — N/A; no config key changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A.
- [x] Cross-platform impact considered; the controller remains platform-neutral.
- [x] Tool descriptions/schemas update — N/A.
