### PR TITLE
fix(desktop): don't resolve() a symlinked venv python in Linux Exec=

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -66,6 +66,21 @@ def resolve_exec_command() -> str:
     """
     from hermes_cli.relaunch import resolve_hermes_bin
 
+    # ``sys.executable`` is already an absolute path (CPython guarantees this)
+    # and MUST be used as-is, never through ``Path(...).resolve()``. A venv
+    # created with ``python -m venv --symlinks`` (or by ``uv``, which shares
+    # one managed CPython across every venv it creates) has ``venv/bin/python``
+    # as a symlink to that shared interpreter. CPython's venv/site-packages
+    # detection keys off the *invoked* executable path — it walks up from
+    # ``sys.executable``'s own directory looking for ``pyvenv.cfg`` — and only
+    # finds it when the venv path itself is what's exec'd. ``.resolve()``
+    # dereferences the symlink to the shared interpreter's real path outside
+    # the venv, silently losing venv/site-packages resolution: the process
+    # boots with the venv's own dependencies invisible (e.g.
+    # ``ModuleNotFoundError: No module named 'yaml'``), invisible to the user
+    # because desktop entries run with ``Terminal=false`` (#90292).
+    venv_python = sys.executable
+
     bin_path = resolve_hermes_bin()
     if bin_path:
         resolved = Path(bin_path).resolve()
@@ -78,11 +93,11 @@ def resolve_exec_command() -> str:
             # third-party import (#90292) — silently, since Terminal=false.
             # sys.executable is the interpreter actually running Hermes (the
             # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            argv = [venv_python, str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        argv = [venv_python, "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
 
 

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -93,6 +93,12 @@ def test_exec_falls_back_to_interpreter_module(tmp_path, xdg_home, monkeypatch):
 # interpreter when the DE spawns the .desktop entry → ModuleNotFoundError,
 # silent (Terminal=false). The Exec line must prefix sys.executable for any
 # resolved bin that is a python script escaping the running venv.
+#
+# The prefix must be sys.executable AS-IS, never resolved: a venv created
+# with symlinks (or by uv, which shares one managed CPython across every venv
+# it creates) has venv/bin/python as a symlink, and CPython's venv detection
+# keys off the invoked path — resolving it away loses site-packages
+# resolution and reproduces the exact bug this prefix exists to fix.
 def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_home, monkeypatch):
     import sys
 
@@ -107,8 +113,7 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    interpreter = str(Path(sys.executable).resolve())
-    assert exec_line.split(" ")[0].strip('"') == interpreter
+    assert exec_line.split(" ")[0].strip('"') == sys.executable
     assert str(hermes_bin) in exec_line
     assert exec_line.endswith("desktop")
 
@@ -147,6 +152,36 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
     # Console-script with the venv's own interpreter in the shebang: correct
     # as-is, prefixing would only add noise.
     assert exec_line == f"{hermes_bin} desktop"
+
+
+# Regression test: a venv whose ``bin/python`` is a SYMLINK to a shared
+# managed CPython (e.g. `uv`-created venvs, or `python -m venv --symlinks`)
+# must keep the symlink path in Exec=, never the dereferenced target. Writing
+# the resolved target loses venv/site-packages resolution and the launched
+# process dies with ModuleNotFoundError on the first third-party import,
+# invisible to the user because Terminal=false. This asserts the module-level
+# fallback branch (no resolvable hermes bin) uses sys.executable verbatim.
+def test_exec_module_fallback_keeps_symlinked_venv_python_unresolved(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+
+    real_interpreter = tmp_path / "real-cpython" / "bin" / "python3.11"
+    real_interpreter.parent.mkdir(parents=True)
+    real_interpreter.write_text("", encoding="utf-8")
+
+    venv_python = tmp_path / "venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.symlink_to(real_interpreter)
+
+    monkeypatch.setattr(lde.sys, "executable", str(venv_python))
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: None)
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    # Must be the venv symlink path, NOT real_interpreter (the resolved target).
+    assert exec_line.split(" ")[0].strip('"') == str(venv_python)
+    assert str(real_interpreter) not in exec_line
 
 
 def test_install_is_idempotent_and_skips_cache_refresh(tmp_path, xdg_home, monkeypatch):


### PR DESCRIPTION
## Summary

`resolve_exec_command()` in `hermes_cli/linux_desktop_entry.py` builds the `Exec=` line for the Linux `hermes.desktop` menu entry. It called `Path(sys.executable).resolve()` to get an absolute interpreter path — but `sys.executable` is already absolute (CPython guarantees this), so the only effect of `.resolve()` was dereferencing a symlink.

A venv whose `bin/python` is a **symlink** to a shared managed CPython — e.g. any venv created by `uv` (which shares one managed CPython across every venv it creates), or `python -m venv --symlinks` — has `venv/bin/python` pointing at a CPython binary living *outside* the venv. CPython's venv/site-packages detection keys off the path that was actually invoked (it walks up from `sys.executable`'s own directory looking for `pyvenv.cfg`), so resolving the symlink away silently loses that resolution.

Concretely: the process launched from the `.desktop` entry boots against the bare shared interpreter with none of Hermes' dependencies installed, and dies instantly with `ModuleNotFoundError` (e.g. `No module named 'yaml'`) on the first third-party import. This is invisible to the user because desktop entries run with `Terminal=false` — clicking the menu icon appears to silently do nothing, which is exactly the symptom #90292 describes (this is a recurrence specific to symlink-based venvs).

## Fix

Use `sys.executable` as-is (no `.resolve()`) in both branches of `resolve_exec_command()` that prefix it onto the `Exec=` line.

## Test plan

- Added `test_exec_module_fallback_keeps_symlinked_venv_python_unresolved`: builds a fake venv with `bin/python` as a real symlink to a separate fake interpreter and asserts the written `Exec=` line keeps the symlink path, not the resolved target.
- Updated `test_exec_prefixes_interpreter_for_env_shebang_python_script` to assert against unresolved `sys.executable` instead of the resolved path.
- Full suite: `tests/hermes_cli/test_linux_desktop_entry.py` — 16 passed, 2 skipped (macOS/Windows-only tests, expected on this Linux runner).

## Repro (before the fix)

On a system where Hermes' venv is uv-managed (`venv/bin/python` → symlink to `~/.local/share/uv/python/cpython-.../bin/python3.11`), `hermes desktop` writes `Exec=<resolved system python path> .../hermes desktop` into `~/.local/share/applications/hermes.desktop`. Every click on the Hermes menu icon after that silently spawns a doomed process (system Python without Hermes deps) and exits — no window, no error dialog, because `Terminal=false`. Confirmed live and fixed identically on a CachyOS/Arch + uv-managed-venv install.