### PR TITLE
fix(gateway): skip not-found unit when checking systemd timeout alignment

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -362,18 +362,29 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
 
     # Query systemctl for TimeoutStopUSec.  Use --user OR system depending
     # on which manager actually owns the unit.  Try user first since
-    # that's the common case for hermes.
+    # that's the common case for hermes.  IMPORTANT: `systemctl --user show`
+    # returns exit 0 with the DEFAULT value even for a unit that is
+    # LoadState=not-found, so we must verify the unit is actually loaded in
+    # that manager before trusting the value — otherwise a system-service
+    # gateway misreports a stale unit based on the user manager's default.
     timeout_us: Optional[int] = None
     for flag in (["--user"], []):
         try:
             result = subprocess.run(
-                ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],
+                ["systemctl", *flag, "show", unit_name,
+                 "--property=LoadState", "--property=TimeoutStopUSec"],
                 capture_output=True, text=True, timeout=2.0,
             )
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
             continue
         if result.returncode != 0:
             continue
+        load_state = None
+        for line in result.stdout.splitlines():
+            if line.startswith("LoadState="):
+                load_state = line.split("=", 1)[1].strip()
+        if load_state == "not-found":
+            continue  # not owned by this manager — try the next one
         # Output: "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000"
         for line in result.stdout.splitlines():
             if line.startswith("TimeoutStopUSec="):


### PR DESCRIPTION
## What does this PR do?

Fixes a false-positive "stale systemd unit" warning emitted by `check_systemd_timing_alignment()` when the gateway runs as a **system** unit (VPS/LXC deployment).

**Bug:** the detector queries `systemctl --user show <unit>` first. systemd returns exit 0 with the *default* `TimeoutStopUSec` value even when the unit is `LoadState=not-found` in the user manager. So a gateway running under a system unit reads a phantom 90s from the user manager, logs a spurious "stale systemd unit detected" warning, and never checks the real system unit (which may already be correctly regenerated).

**Fix:** also read `LoadState` and skip `not-found` units before trusting their `TimeoutStopUSec`, so the check falls through to the manager that actually owns the unit.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/shutdown_forensics.py` — `check_systemd_timing_alignment()` now fetches `LoadState` alongside `TimeoutStopUSec` and skips `not-found` units.

## How to Test

1. Run the gateway as a system unit (`hermes gateway install --system --force`).
2. Confirm `systemctl --user show hermes-gateway.service` returns `LoadState=not-found` (no user unit).
3. Start the gateway and check the journal — no "stale systemd unit detected" warning when the system unit's `TimeoutStopSec` is correct.
4. Verify the detector still warns when the system unit is genuinely stale (e.g. `TimeoutStopSec=90` with `drain_timeout=180`).

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've tested on Linux (Ubuntu 24.04, system-service deployment)
- [x] Documentation: N/A (behavioral bug fix, no config/doc surface)
