### PR TITLE
fix(tui): dispatch /refine against the live session agent on TUI/desktop

### DIFF
--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -300,11 +300,16 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
   },
   {
     name: '/refine',
-    description: 'Review this conversation now, save lessons to memory/skills',
+    description: 'Review this conversation now and save lessons to memory/skills',
     surface: exec(),
     argumentMode: 'text'
   },
   { name: '/retry', description: 'Retry the last user message', surface: exec() },
+  {
+    name: '/review',
+    description: 'Spawn an independent subagent to review the work just discussed (PR, code, docs)',
+    surface: exec()
+  },
   { name: '/rollback', description: 'List or restore filesystem checkpoints', surface: exec() },
   {
     name: '/save',

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -298,6 +298,12 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     surface: exec(),
     argumentMode: 'text'
   },
+  {
+    name: '/refine',
+    description: 'Review this conversation now, save lessons to memory/skills',
+    surface: exec(),
+    argumentMode: 'text'
+  },
   { name: '/retry', description: 'Retry the last user message', surface: exec() },
   { name: '/rollback', description: 'List or restore filesystem checkpoints', surface: exec() },
   {

--- a/run_agent.py
+++ b/run_agent.py
@@ -1902,7 +1902,7 @@ class AIAgent:
         # inflating token cost (#85859). An explicit ``/refine`` (``focus`` set)
         # is a deliberate user request and still runs.
         if focus is None and getattr(self, "_delegate_depth", 0) > 0:
-            return
+            return False
         # Explicit off-switch for automatic post-turn forks
         # (``auxiliary.background_review.enabled: false``). Manual ``/refine``
         # still works — same contract as zeroing the nudge intervals (#87250).
@@ -1913,7 +1913,7 @@ class AIAgent:
             from agent.background_review import load_background_review_settings
             enabled, task_cfg = load_background_review_settings()
             if not enabled:
-                return
+                return False
         from agent.background_review import (
             finish_background_review_run,
             prepare_background_review_run,
@@ -1923,7 +1923,7 @@ class AIAgent:
 
         review_run = prepare_background_review_run(self)
         if review_run is None:
-            return
+            return False
         try:
             target, _prompt = spawn_background_review_thread(
                 self,
@@ -1945,6 +1945,7 @@ class AIAgent:
         except Exception:
             finish_background_review_run(self, review_run)
             raise
+        return True
 
     def _build_memory_write_metadata(
         self,

--- a/tests/tui_gateway/test_desktop_slash_parity.py
+++ b/tests/tui_gateway/test_desktop_slash_parity.py
@@ -1,0 +1,76 @@
+"""Desktop/TUI slash-command parity for the live-dispatch family.
+
+Three registration layers must agree for commands that run against the live
+session agent: ``_LIVE_SESSION_DIRECT_COMMANDS`` (server routing), the
+``slash.exec`` if-ladder (per-command handler), and the desktop TS registry
+(``DESKTOP_COMMAND_SPECS``). The first two are pinned by
+``test_refine_command.py``; this file pins the cross-language half — every
+live-dispatch command that exists server-side must also exist in the desktop
+palette, or it silently never shows up there.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+@pytest.fixture()
+def server(hermes_home, monkeypatch):
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+        },
+    ):
+        mod = importlib.import_module("tui_gateway.server")
+    yield mod
+    mod._sessions.clear()
+    mod._pending.clear()
+    mod._answers.clear()
+
+
+def _desktop_spec_names():
+    """Parse the desktop registry's command names without executing TS."""
+    repo_root = Path(__file__).resolve().parents[2]
+    ts_path = (
+        repo_root
+        / "apps"
+        / "desktop"
+        / "src"
+        / "lib"
+        / "desktop-slash-commands.ts"
+    )
+    text = ts_path.read_text(encoding="utf-8")
+    return set(re.findall(r"name:\s*'(/[a-z0-9-]+)'", text))
+
+
+def test_live_dispatch_commands_exist_in_desktop_registry(server):
+    """Commands that dispatch to the live session agent must be listed in the
+    desktop palette. A missing row means the desktop classifies the command
+    as an unknown extension — exactly how /refine's bug stayed invisible.
+
+    Pinned family: /review + /refine (the two live-agent fork commands).
+    Other _LIVE_SESSION_DIRECT_COMMANDS members are deliberately excluded:
+    several map to different desktop affordances by design (/clear is a
+    client action, /history a client surface, /effort//models//prompt//
+    /rename route through other controls), so set-equality would be false.
+    """
+    live_agent_family = {"/review", "/refine"}
+    desktop = _desktop_spec_names()
+    missing = sorted(live_agent_family - desktop)
+    assert not missing, f"live-agent commands missing from desktop registry: {missing}"

--- a/tests/tui_gateway/test_refine_command.py
+++ b/tests/tui_gateway/test_refine_command.py
@@ -144,3 +144,74 @@ def test_refine_rejects_while_turn_is_running(server, session):
     r = _call(server, "slash.exec", command="/refine", session_id=sid)
     assert "wait for the current turn" in r["result"]["output"]
     assert not s["agent"]._spawn_background_review.called
+
+
+def test_review_shares_the_refusal_guards(server, session):
+    """The extracted preflight must keep /review's contract byte-compatible."""
+    sid, s = session
+    r = _call(server, "slash.exec", command="/review check the diff", session_id=sid)
+    # Live dispatch reached start_review (MagicMock agent -> dispatch note path
+    # raises nothing); what matters here is the guard parity below.
+    s["running"] = True
+    r = _call(server, "slash.exec", command="/review", session_id=sid)
+    assert "wait for the current turn" in r["result"]["output"]
+    del s["agent"]
+    r = _call(server, "slash.exec", command="/review", session_id=sid)
+    assert "Nothing to review yet" in r["result"]["output"]
+
+
+def test_refine_on_compute_host_session_is_refused(server, session, monkeypatch):
+    # turn_isolation defaults off; enable it the way production config would
+    # so the compute-host classification in the preflight actually engages.
+    monkeypatch.setattr(
+        server,
+        "_load_dashboard_process_isolation_config",
+        lambda cfg=None: {"turn_isolation": True},
+    )
+    sid, s = session
+    s["_compute_host_active"] = True
+    r = _call(server, "slash.exec", command="/refine", session_id=sid)
+    assert "local agent only" in r["result"]["output"]
+    assert not s["agent"]._spawn_background_review.called
+    # And the same guard governs /review.
+    r = _call(server, "slash.exec", command="/review", session_id=sid)
+    assert "local agent only" in r["result"]["output"]
+
+
+def test_refine_with_empty_conversation_reports_honestly(server, session):
+    sid, s = session
+    agent = s["agent"]
+    agent._session_messages = []
+    del s["history"]
+    s.pop("history_lock", None)
+    r = _call(server, "slash.exec", command="/refine", session_id=sid)
+    assert "conversation is empty" in r["result"]["output"]
+    assert not agent._spawn_background_review.called
+
+
+def test_refine_without_skill_manage_degrades_gracefully(server, session):
+    sid, s = session
+    s["agent"].valid_tool_names = set()
+    r = _call(
+        server,
+        "slash.exec",
+        command="/refine remember the deploy order",
+        session_id=sid,
+    )
+    out = r["result"]["output"]
+    assert out.startswith("⚗")
+    kwargs = s["agent"]._spawn_background_review.call_args.kwargs
+    assert kwargs.get("review_skills") is False
+    assert kwargs.get("review_memory") is True
+
+
+def test_refine_reports_when_no_review_was_started(server, session):
+    """Admission honesty: _spawn_background_review returning falsy (declined:
+    review already active / auto-reviews disabled) must NOT produce a fake
+    '⚗ Reviewing…' success message."""
+    sid, s = session
+    s["agent"]._spawn_background_review.return_value = False
+    r = _call(server, "slash.exec", command="/refine", session_id=sid)
+    out = r["result"]["output"]
+    assert not out.startswith("⚗")
+    assert "No review was started" in out

--- a/tests/tui_gateway/test_refine_command.py
+++ b/tests/tui_gateway/test_refine_command.py
@@ -1,0 +1,146 @@
+"""Desktop/TUI /refine must dispatch against the LIVE session's agent.
+
+``slash.exec`` routes commands in ``_LIVE_SESSION_DIRECT_COMMANDS`` to the
+live TUI/desktop session's agent (see ``_live_slash_command_output``);
+everything else falls through to the per-session slash-worker subprocess.
+The slash worker builds a bare ``HermesCLI`` that never constructs an
+AIAgent for pure slash commands, so ``/refine`` routed there always answers
+"Nothing to refine yet — send a message first." even mid-conversation.
+
+``/review`` already lives in the direct set; these tests pin ``/refine``
+to the same treatment: snapshot the live history, hand it to the live
+agent's ``_spawn_background_review``, report the background dispatch.
+"""
+
+from __future__ import annotations
+
+import importlib
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+@pytest.fixture()
+def server(hermes_home, monkeypatch):
+    # Mocks are scoped to the initial import only (see
+    # tests/tui_gateway/test_protocol.py for the rationale).
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+        },
+    ):
+        mod = importlib.import_module("tui_gateway.server")
+
+    monkeypatch.setattr(mod, "_hermes_home", hermes_home)
+    monkeypatch.setattr(mod, "_cfg_cache", None)
+    monkeypatch.setattr(mod, "_cfg_mtime", None)
+    monkeypatch.setattr(mod, "_cfg_path", None)
+    yield mod
+    mod._sessions.clear()
+    mod._pending.clear()
+    mod._answers.clear()
+
+
+@pytest.fixture()
+def session(server):
+    sid = "sid-refine"
+    agent = MagicMock()
+    agent.valid_tool_names = {"skill_manage"}
+    agent._session_messages = [
+        {"role": "user", "content": "we deployed via docker compose"},
+        {"role": "assistant", "content": "Deployed. Staging is up."},
+    ]
+    s = {
+        "session_key": "tui-refine-session-1",
+        "history": list(agent._session_messages),
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "cols": 120,
+        "agent": agent,
+    }
+    server._sessions[sid] = s
+    return sid, s
+
+
+def _call(server, method, **params):
+    handler = server._methods[method]
+    return handler(1, params)
+
+
+class _StubWorker:
+    """Stands in for the slash-worker subprocess so the test never spawns one.
+
+    If the bug regresses (refine falls back to the worker route), the stub
+    records the use instead of silently launching a child HermesCLI.
+    """
+
+    used = False
+
+    def __init__(self, *a, **kw):
+        _StubWorker.used = True
+
+    def run(self, cmd):
+        return f"(stub worker executed: {cmd})"
+
+    def close(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _no_real_worker(monkeypatch, server):
+    _StubWorker.used = False
+    monkeypatch.setattr(server, "_SlashWorker", _StubWorker)
+
+
+def test_refine_dispatches_live_background_review(server, session):
+    sid, s = session
+    r = _call(
+        server, "slash.exec", command="/refine focus on the deploy steps", session_id=sid
+    )
+
+    assert r["result"]["output"].startswith("⚗"), r
+    assert "background" in r["result"]["output"]
+    assert "focus on the deploy steps" in r["result"]["output"]
+    # The review fork must receive the LIVE conversation snapshot.
+    agent = s["agent"]
+    assert agent._spawn_background_review.called
+    kwargs = agent._spawn_background_review.call_args.kwargs
+    snapshot = kwargs.get("messages_snapshot")
+    assert any(m.get("content") == "we deployed via docker compose" for m in snapshot)
+    assert kwargs.get("review_memory") is True
+    assert kwargs.get("review_skills") is True
+    assert kwargs.get("focus") == "focus on the deploy steps"
+    # And it must NOT have been delegated to the slash-worker subprocess.
+    assert _StubWorker.used is False
+
+
+def test_refine_without_agent_reports_honestly(server, session):
+    sid, s = session
+    del s["agent"]
+    s["history"] = []
+    r = _call(server, "slash.exec", command="/refine", session_id=sid)
+    assert "Nothing to refine yet" in r["result"]["output"]
+    assert _StubWorker.used is False
+
+
+def test_refine_rejects_while_turn_is_running(server, session):
+    sid, s = session
+    s["running"] = True
+    r = _call(server, "slash.exec", command="/refine", session_id=sid)
+    assert "wait for the current turn" in r["result"]["output"]
+    assert not s["agent"]._spawn_background_review.called

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -16,7 +16,7 @@ import time
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, NamedTuple, Optional
+from typing import Any, Callable, Dict, List, NamedTuple, Optional
 
 from agent.secret_scope import (
     build_profile_secret_scope,
@@ -14549,6 +14549,45 @@ _LIVE_SESSION_DIRECT_COMMANDS = frozenset(
 _ISOLATED_SESSION_READ_COMMANDS = frozenset({"context", "tools", "help"})
 
 
+def _live_session_dispatch_preflight(cmd: str, session: Optional[dict]) -> Optional[str]:
+    """Shared /review + /refine guards; returns the refusal text or None.
+
+    Order matters: the agent check needs a non-None session, so session-None
+    must resolve first.
+    """
+    if session is None:
+        return f"Nothing to {cmd} yet — send a message first."
+    if _session_uses_compute_host(session):
+        return (
+            f"/{cmd} runs on the local agent only for now — this session's "
+            "agent lives on a remote compute host."
+        )
+    if session.get("agent") is None:
+        return f"Nothing to {cmd} yet — send a message first."
+    if session.get("running"):
+        return f"session busy — wait for the current turn to finish, then /{cmd}"
+    return None
+
+
+def _snapshot_live_history(session: dict) -> List[Dict[str, Any]]:
+    """Snapshot the live conversation for a background fork.
+
+    Prefers the session's own history under its lock; falls back to the
+    agent's message list when the session record hasn't been populated yet
+    (the two alias each other once a turn completes).
+    """
+    history_lock = session.get("history_lock")
+    if history_lock is not None:
+        with history_lock:
+            snapshot = list(session.get("history", []))
+    else:
+        snapshot = list(session.get("history", []))
+    if not snapshot:
+        agent = session.get("agent")
+        snapshot = list(getattr(agent, "_session_messages", None) or [])
+    return snapshot
+
+
 def _format_live_review_output(session: Optional[dict], arg: str) -> str:
     """Dispatch /review against the live TUI/desktop session's agent.
 
@@ -14560,27 +14599,13 @@ def _format_live_review_output(session: Optional[dict], arg: str) -> str:
     fallback), which is exactly what ``_session_owns_notification_event``
     matches against.
     """
-    if session is None:
-        return "Nothing to review yet — send a message first."
-    if _session_uses_compute_host(session):
-        return (
-            "/review runs on the local agent only for now — this session's "
-            "agent lives on a remote compute host."
-        )
-    agent = session.get("agent")
-    if agent is None:
-        return "Nothing to review yet — send a message first."
-    if session.get("running"):
-        return "session busy — wait for the current turn to finish, then /review"
+    refusal = _live_session_dispatch_preflight("review", session)
+    if refusal:
+        return refusal
 
-    history_lock = session.get("history_lock")
-    if history_lock is not None:
-        with history_lock:
-            snapshot = list(session.get("history", []))
-    else:
-        snapshot = list(session.get("history", []))
-    if not snapshot:
-        snapshot = list(getattr(agent, "_session_messages", None) or [])
+    assert session is not None  # preflight guarantees non-None from here on
+    agent = session["agent"]
+    snapshot = _snapshot_live_history(session)
 
     try:
         from agent.review_engine import format_dispatch_note, start_review
@@ -14600,41 +14625,24 @@ def _format_live_refine_output(session: Optional[dict], arg: str) -> str:
     on a snapshot of the live conversation — the same machinery as the
     automatic post-turn review, but user-triggered with optional focus
     instructions. Writes go to the memory + skill stores in a background
-    thread; the live conversation and prompt cache are untouched.
-
-    Without this branch, ``/refine`` falls through to the slash-worker
-    subprocess, whose bare ``HermesCLI`` never constructs an AIAgent for
-    pure slash commands — so it always answered "Nothing to refine yet"
-    even mid-conversation. ``/review`` needed the identical treatment.
+    thread; the live conversation and prompt cache are untouched. Must run
+    on the live agent: the slash-worker subprocess never constructs one for
+    pure slash commands.
     """
-    if session is None:
-        return "Nothing to refine yet — send a message first."
-    if _session_uses_compute_host(session):
-        return (
-            "/refine runs on the local agent only for now — this session's "
-            "agent lives on a remote compute host."
-        )
-    agent = session.get("agent")
-    if agent is None:
-        return "Nothing to refine yet — send a message first."
-    if session.get("running"):
-        return "session busy — wait for the current turn to finish, then /refine"
+    refusal = _live_session_dispatch_preflight("refine", session)
+    if refusal:
+        return refusal
 
-    history_lock = session.get("history_lock")
-    if history_lock is not None:
-        with history_lock:
-            snapshot = list(session.get("history", []))
-    else:
-        snapshot = list(session.get("history", []))
-    if not snapshot:
-        snapshot = list(getattr(agent, "_session_messages", None) or [])
+    assert session is not None  # preflight guarantees non-None from here on
+    agent = session["agent"]
+    snapshot = _snapshot_live_history(session)
     if not snapshot:
         return "Nothing to refine yet — the conversation is empty."
 
     review_skills = "skill_manage" in getattr(agent, "valid_tool_names", set())
     focus = (arg or "").strip() or None
     try:
-        agent._spawn_background_review(
+        started = agent._spawn_background_review(
             messages_snapshot=snapshot,
             review_memory=True,
             review_skills=review_skills,
@@ -14642,6 +14650,16 @@ def _format_live_refine_output(session: Optional[dict], arg: str) -> str:
         )
     except Exception as exc:
         return f"/refine failed to start: {exc}"
+    # _spawn_background_review returns False (pre-fix callers may return
+    # None) when it silently declined: a review run is already active, or
+    # automatic reviews are disabled and no focus was given. Never claim a
+    # start that didn't happen.
+    if not started:
+        return (
+            "No review was started — a background review is already running "
+            "(or automatic reviews are disabled). Try again shortly, or add "
+            "focus instructions to force a manual pass."
+        )
     tail = f" (focus: {focus})" if focus else ""
     return (
         f"⚗ Reviewing this conversation in the background{tail} — "

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -14538,6 +14538,7 @@ _LIVE_SESSION_DIRECT_COMMANDS = frozenset(
         "history",
         "models",
         "prompt",
+        "refine",
         "rename",
         "review",
         "status",
@@ -14590,6 +14591,62 @@ def _format_live_review_output(session: Optional[dict], arg: str) -> str:
     except Exception as exc:
         return f"/review failed to start: {exc}"
     return format_dispatch_note(result, arg or "")
+
+
+def _format_live_refine_output(session: Optional[dict], arg: str) -> str:
+    """Dispatch /refine against the live TUI/desktop session's agent.
+
+    Runs the memory/skill review fork (``AIAgent._spawn_background_review``)
+    on a snapshot of the live conversation — the same machinery as the
+    automatic post-turn review, but user-triggered with optional focus
+    instructions. Writes go to the memory + skill stores in a background
+    thread; the live conversation and prompt cache are untouched.
+
+    Without this branch, ``/refine`` falls through to the slash-worker
+    subprocess, whose bare ``HermesCLI`` never constructs an AIAgent for
+    pure slash commands — so it always answered "Nothing to refine yet"
+    even mid-conversation. ``/review`` needed the identical treatment.
+    """
+    if session is None:
+        return "Nothing to refine yet — send a message first."
+    if _session_uses_compute_host(session):
+        return (
+            "/refine runs on the local agent only for now — this session's "
+            "agent lives on a remote compute host."
+        )
+    agent = session.get("agent")
+    if agent is None:
+        return "Nothing to refine yet — send a message first."
+    if session.get("running"):
+        return "session busy — wait for the current turn to finish, then /refine"
+
+    history_lock = session.get("history_lock")
+    if history_lock is not None:
+        with history_lock:
+            snapshot = list(session.get("history", []))
+    else:
+        snapshot = list(session.get("history", []))
+    if not snapshot:
+        snapshot = list(getattr(agent, "_session_messages", None) or [])
+    if not snapshot:
+        return "Nothing to refine yet — the conversation is empty."
+
+    review_skills = "skill_manage" in getattr(agent, "valid_tool_names", set())
+    focus = (arg or "").strip() or None
+    try:
+        agent._spawn_background_review(
+            messages_snapshot=snapshot,
+            review_memory=True,
+            review_skills=review_skills,
+            focus=focus,
+        )
+    except Exception as exc:
+        return f"/refine failed to start: {exc}"
+    tail = f" (focus: {focus})" if focus else ""
+    return (
+        f"⚗ Reviewing this conversation in the background{tail} — "
+        f"any memory/skill updates will be reported when done."
+    )
 
 
 def _format_live_usage_output(session: dict) -> str:
@@ -14799,6 +14856,8 @@ def _live_slash_command_output(sid: str, session: Optional[dict], name: str, arg
         return _format_live_usage_output(session)
     if name == "review":
         return _format_live_review_output(session, arg)
+    if name == "refine":
+        return _format_live_refine_output(session, arg)
     if name == "history":
         if session is None:
             return "No conversation history yet."


### PR DESCRIPTION
## What

On the desktop app and TUI, `/refine` always answered **"Nothing to refine yet —
send a message first."** even mid-conversation. The command was missing from
`_LIVE_SESSION_DIRECT_COMMANDS`, so `slash.exec` routed it to the slash-worker
subprocess, whose bare `HermesCLI` never constructs an `AIAgent` for pure slash commands. The live conversation was never consulted.

## Why

Commit `12395e57b` gave sibling command `/review` the live-dispatch treatment
(set membership + a dedicated `_format_live_review_output` branch), but `/refine` got neither.

Details and reproduction in #93918. Closes #93918

## How

- Add `"refine"` to `_LIVE_SESSION_DIRECT_COMMANDS`.
- New `_format_live_refine_output(session, arg)`, mirroring `/review`:
  - compute-host guard ("runs on the local agent only for now")
  - busy-session guard ("wait for the current turn to finish")
  - snapshot `session["history"]` under `history_lock`, falling back to
    `agent._session_messages`, then an honest "the conversation is empty"
  - dispatch `agent._spawn_background_review(messages_snapshot=…,
    review_memory=True, review_skills="skill_manage" in agent.valid_tool_names,
    focus=<args or None>)` and report the background dispatch
- Register `/refine` in the desktop slash-command registry
  (`apps/desktop/src/lib/desktop-slash-commands.ts`) so it is no longer treated
  as an unknown extension command by the desktop palette/classifier.

The review fork runs in the existing background thread against a frozen snapshot;
live conversation and prompt cache are untouched (same contract as CLI/gateway).

## Tests

New `tests/tui_gateway/test_refine_command.py` drives the real `slash.exec`
handler on a bare server:

- live dispatch: output reports the background review with focus text; the stub
  slash worker asserts the subprocess route is **not** taken; the fork receives
  the real conversation snapshot and correct flags
- no agent / empty history → honest "Nothing to refine yet" without spawning
  the worker
- busy session → rejected before any dispatch

Full `tests/tui_gateway/` run: failure sets identical to clean `HEAD`
(6 pre-existing Windows-only failures; one flaky timing pair flips on both
trees). Desktop `tsc -p tsconfig.json --noEmit`: clean.

---

*Disclosure: this issue diagnosis and patch were prepared with AI assistance
(Claude/Hermes agent session).*
