### PR TITLE
fix(agent): resolve profile identity for symlink-overlay HERMES_HOME dirs

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -486,23 +486,23 @@ def classify_cross_profile_target(path: str) -> Optional[dict]:
 
     # For a symlink-overlay home the env-derived root is the overlay itself,
     # while write targets resolve through the symlinks into the BACKING root
-    # (#93862). Classify against the backing root when one is known so
-    # profile-scoped writes are not silently unclassifiable.
-    active_profile = "default"
-    try:
-        from hermes_constants import profile_identity_for_home
+    # (#93862). The identity probe walks the overlay's symlinks, so it is
+    # computed lazily — only when classification actually needs it (target
+    # outside the env-derived root, or a scoped-area hit) — keeping the
+    # common bail-out paths free of the walk.
+    _identity: list = []
 
-        active_profile, backing_root = profile_identity_for_home(_hermes_home_path())
-        if backing_root is not None:
-            backing_real = backing_root.resolve()
+    def _profile_identity() -> tuple:
+        if not _identity:
+            resolved = ("default", None)
             try:
-                target.relative_to(root_real)
-            except ValueError:
-                # Target not under the env-derived root — fall back to the
-                # backing root the active profile actually lives under.
-                root_real = backing_real
-    except Exception:
-        pass
+                from hermes_constants import profile_identity_for_home
+
+                resolved = profile_identity_for_home(_hermes_home_path())
+            except Exception:
+                pass
+            _identity.append(resolved)
+        return _identity[0]
 
     target_profile: Optional[str] = None
     area: Optional[str] = None
@@ -510,7 +510,15 @@ def classify_cross_profile_target(path: str) -> Optional[dict]:
     try:
         rel = target.relative_to(root_real)
     except ValueError:
-        return None
+        # Target not under the env-derived root — fall back to the backing
+        # root the active profile actually lives under, when one is known.
+        _, backing_root = _profile_identity()
+        if backing_root is None:
+            return None
+        try:
+            rel = target.relative_to(backing_root.resolve())
+        except (OSError, RuntimeError, ValueError):
+            return None
 
     parts = rel.parts
     if not parts:
@@ -531,6 +539,7 @@ def classify_cross_profile_target(path: str) -> Optional[dict]:
     else:
         return None
 
+    active_profile = _profile_identity()[0]
     if target_profile == active_profile:
         # In-profile write — not a cross-profile event.
         return None

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -447,24 +447,18 @@ def _resolve_active_profile_name() -> str:
 
     ``~/.hermes``              -> ``"default"``
     ``~/.hermes/profiles/X``  -> ``"X"``
+    symlink-overlay home whose members point into ``profiles/X`` -> ``"X"``
+    (#93862)
 
     Falls back to ``"default"`` on any resolution failure so the guard
     never raises into the tool path.
     """
     try:
-        home_real = _hermes_home_path().resolve()
-        root_real = _hermes_root_path().resolve()
-    except (OSError, RuntimeError):
+        from hermes_constants import profile_name_for_home
+
+        return profile_name_for_home(_hermes_home_path())
+    except Exception:
         return "default"
-    profiles_dir = root_real / "profiles"
-    try:
-        rel = home_real.relative_to(profiles_dir)
-        parts = rel.parts
-        if len(parts) >= 1:
-            return parts[0]
-    except ValueError:
-        pass
-    return "default"
 
 
 def classify_cross_profile_target(path: str) -> Optional[dict]:
@@ -489,6 +483,26 @@ def classify_cross_profile_target(path: str) -> Optional[dict]:
         root_real = _hermes_root_path().resolve()
     except (OSError, RuntimeError):
         return None
+
+    # For a symlink-overlay home the env-derived root is the overlay itself,
+    # while write targets resolve through the symlinks into the BACKING root
+    # (#93862). Classify against the backing root when one is known so
+    # profile-scoped writes are not silently unclassifiable.
+    active_profile = "default"
+    try:
+        from hermes_constants import profile_identity_for_home
+
+        active_profile, backing_root = profile_identity_for_home(_hermes_home_path())
+        if backing_root is not None:
+            backing_real = backing_root.resolve()
+            try:
+                target.relative_to(root_real)
+            except ValueError:
+                # Target not under the env-derived root — fall back to the
+                # backing root the active profile actually lives under.
+                root_real = backing_real
+    except Exception:
+        pass
 
     target_profile: Optional[str] = None
     area: Optional[str] = None
@@ -517,7 +531,6 @@ def classify_cross_profile_target(path: str) -> Optional[dict]:
     else:
         return None
 
-    active_profile = _resolve_active_profile_name()
     if target_profile == active_profile:
         # In-profile write — not a cross-profile event.
         return None

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -319,21 +319,21 @@ def _agent_skills_dir(agent: Any) -> Optional[Path]:
 def _profile_name_for_home(home: Path) -> str:
     """Derive the profile name for an explicit agent home.
 
-    ``<root>/profiles/X`` -> ``"X"``; anything else -> ``"default"``.
+    ``<root>/profiles/X`` -> ``"X"``; a symlink-overlay home whose members
+    point into ``profiles/X`` -> ``"X"`` (#93862); anything else ->
+    ``"default"``.
 
-    Uses :func:`get_default_hermes_root` (NOT ``get_hermes_home()``): on a
+    Uses :func:`hermes_constants.profile_name_for_home`, which resolves
+    against ``get_default_hermes_root()`` (NOT ``get_hermes_home()``): on a
     correctly bound profile session the ambient home IS the profile dir, so
     ``get_hermes_home()/profiles`` would never contain ``home`` and every
     profile would misreport as "default".
     """
     try:
-        from hermes_constants import get_default_hermes_root
+        from hermes_constants import profile_name_for_home
 
-        root = get_default_hermes_root()
-        rel = home.resolve().relative_to((root / "profiles").resolve())
-        return rel.parts[0] if rel.parts else "default"
-    except (ValueError, OSError):
-        # Home IS the root (default profile) or unrelatable -> default.
+        return profile_name_for_home(home)
+    except Exception:
         return "default"
 
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -5,6 +5,7 @@ without risk of circular imports.
 """
 
 import os
+import re
 import shutil
 import stat
 import sys
@@ -240,6 +241,13 @@ _PROFILE_OVERLAY_MEMBERS = (
     "sessions",
 )
 
+# The on-disk profile id shape enforced at profile-creation time
+# (hermes_cli.profiles._PROFILE_ID_RE). Kept as a literal here because this
+# module must stay stdlib-only and import-safe; a name that could not have
+# been created as a profile must not be *recovered* as one either — every
+# recovery path below is anchored on it.
+_PROFILE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
 
 def profile_identity_for_home(
     home: Path | str | None = None,
@@ -266,6 +274,13 @@ def profile_identity_for_home(
        symlinks into a shared named profile (#93862).
     3. Anything else -> ``(\"default\", None)``.
 
+    Windows note: overlay recovery (step 2) keys off ``Path.is_symlink()``,
+    which is False for NTFS junctions — junction-based overlays are
+    currently unsupported and resolve to ``default`` (steps 1/1b, which use
+    full path resolution, are unaffected). Widening the check to any
+    reparse-point divergence is possible but needs validation on a real
+    win32 host before it can gate the write guard's active side.
+
     Import-safe, never raises; falls back to ``(\"default\", None)``.
     """
     try:
@@ -288,8 +303,16 @@ def profile_identity_for_home(
         # 1b. The resolved home IS a profile dir under some OTHER root
         # (e.g. HERMES_HOME is a symlink to <custom-root>/profiles/<name>,
         # where root derivation from the unresolved env path picked the
-        # wrong root). The layout convention is unambiguous either way.
-        if home_real.parent.name == "profiles" and home_real.name:
+        # wrong root). Unlike step 1 this is not anchored to the configured
+        # root, so any directory literally named "profiles" would qualify —
+        # require the child to also pass the profile-id shape enforced at
+        # creation time (e.g. ``/srv/app/profiles/Cache.d`` is not a
+        # profile, but ``/srv/app/profiles/cache`` we accept: bounded risk,
+        # it misnames as a *named* profile rather than crossing a boundary).
+        if (
+            home_real.parent.name == "profiles"
+            and _PROFILE_NAME_RE.match(home_real.name)
+        ):
             return home_real.name, home_real.parent.parent
 
         # 2. Symlink-overlay recovery. Only inspect members that are
@@ -313,11 +336,13 @@ def profile_identity_for_home(
                 target = candidate.resolve(strict=True)
             except OSError:
                 continue
-            # Exact tail: target == <root>/profiles/<name>/<member>
+            # Exact tail: target == <root>/profiles/<name>/<member>, with
+            # <name> passing the creation-time profile-id shape (same
+            # reasoning as step 1b — this path is not root-anchored).
             if (
                 target.name == member
                 and target.parent.parent.name == "profiles"
-                and target.parent.name
+                and _PROFILE_NAME_RE.match(target.parent.name)
             ):
                 recovered.add((target.parent.name, target.parent.parent.parent))
         if len(recovered) == 1:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -227,6 +227,115 @@ def get_default_hermes_root() -> Path:
     return result
 
 
+# Overlay members whose symlink targets can identify the backing profile.
+# Ordered: SOUL.md is the most distinctive single file, then the
+# profile-scoped areas. Keep this list short — it is walked on prompt build.
+_PROFILE_OVERLAY_MEMBERS = (
+    "SOUL.md",
+    "plugins",
+    "cron",
+    "skills",
+    "hooks",
+    "memories",
+    "sessions",
+)
+
+
+def profile_identity_for_home(
+    home: Path | str | None = None,
+) -> tuple[str, "Path | None"]:
+    """Derive ``(profile_name, backing_root)`` for a Hermes home directory.
+
+    ``backing_root`` is the Hermes root that owns the resolved profile (the
+    parent of its ``profiles`` dir) — for symlink-overlay homes this is the
+    root the symlink TARGETS live under, which is what profile-scoped path
+    classification must use. ``(\"default\", None)`` when no named profile can
+    be derived.
+
+    Resolution order:
+
+    1. ``<root>/profiles/<name>`` (after resolving symlinks) -> ``<name>``.
+    1b. Resolved home IS ``<other-root>/profiles/<name>`` (a HERMES_HOME
+       symlinked to a profile under a different root).
+    2. Symlink-overlay recovery: when *home* is neither the root nor a
+       profile dir, but contains well-known members (``SOUL.md``,
+       ``plugins/``, ``cron/``, ...) that are symlinks whose targets match
+       the exact layout ``<root>/profiles/<name>/<member>``, the identity is
+       recovered from those targets. Multi-agent orchestration platforms
+       produce this layout: a per-task ``HERMES_HOME`` whose contents are
+       symlinks into a shared named profile (#93862).
+    3. Anything else -> ``(\"default\", None)``.
+
+    Import-safe, never raises; falls back to ``(\"default\", None)``.
+    """
+    try:
+        if home is None:
+            home_path = get_hermes_home()
+        else:
+            home_path = Path(home)
+        home_real = home_path.resolve()
+        profiles_dir = (get_default_hermes_root() / "profiles").resolve()
+
+        # 1. Direct profile dir (symlinked HERMES_HOME to a profile also
+        # lands here, because home_real is fully resolved).
+        try:
+            rel = home_real.relative_to(profiles_dir)
+            if rel.parts:
+                return rel.parts[0], profiles_dir.parent
+        except ValueError:
+            pass
+
+        # 1b. The resolved home IS a profile dir under some OTHER root
+        # (e.g. HERMES_HOME is a symlink to <custom-root>/profiles/<name>,
+        # where root derivation from the unresolved env path picked the
+        # wrong root). The layout convention is unambiguous either way.
+        if home_real.parent.name == "profiles" and home_real.name:
+            return home_real.name, home_real.parent.parent
+
+        # 2. Symlink-overlay recovery. Only inspect members that are
+        # actually symlinks — a real (copied) file identifies nothing — and
+        # only trust targets that (a) exist, (b) match the exact layout
+        # ``<root>/profiles/<name>/<member>`` at the tail (a "profiles" dir
+        # elsewhere in the path identifies nothing), and (c) agree: if two
+        # members VALIDLY identify DIFFERENT profiles the overlay is
+        # ambiguous or crafted, and the conservative answer is "default" —
+        # this identity feeds the cross-profile write guard's active side,
+        # so a conflicting link must not be able to reassign it. Dangling
+        # or malformed links identify nothing and are ignored (overlay
+        # decay — e.g. a pruned profile area — is legitimate and must not
+        # nuke an otherwise-unanimous identity).
+        recovered: set[tuple[str, Path]] = set()
+        for member in _PROFILE_OVERLAY_MEMBERS:
+            candidate = home_path / member
+            try:
+                if not candidate.is_symlink() or not candidate.exists():
+                    continue
+                target = candidate.resolve(strict=True)
+            except OSError:
+                continue
+            # Exact tail: target == <root>/profiles/<name>/<member>
+            if (
+                target.name == member
+                and target.parent.parent.name == "profiles"
+                and target.parent.name
+            ):
+                recovered.add((target.parent.name, target.parent.parent.parent))
+        if len(recovered) == 1:
+            return next(iter(recovered))
+    except (OSError, RuntimeError, ValueError):
+        pass
+    return "default", None
+
+
+def profile_name_for_home(home: Path | str | None = None) -> str:
+    """Derive the profile name for a Hermes home directory.
+
+    Thin wrapper over :func:`profile_identity_for_home` for callers that
+    only need the name. Import-safe, never raises.
+    """
+    return profile_identity_for_home(home)[0]
+
+
 def get_optional_skills_dir(default: Path | None = None) -> Path:
     """Return the optional-skills directory, honoring package-manager wrappers.
 

--- a/tests/agent/test_overlay_profile_resolution.py
+++ b/tests/agent/test_overlay_profile_resolution.py
@@ -1,0 +1,272 @@
+"""Regression tests for #93862: profile resolution for symlink-overlay homes.
+
+Multi-agent orchestration platforms isolate each task's sessions/logs/cache in
+a per-task HERMES_HOME while sharing a named profile's skills/plugins/cron/
+SOUL via symlinks::
+
+    HERMES_HOME=/workspaces/<task>/hermes-home
+      ├── SOUL.md   -> <root>/profiles/workflow_evaluator/SOUL.md
+      ├── plugins/  -> <root>/profiles/workflow_evaluator/plugins
+      └── cron/     -> <root>/profiles/workflow_evaluator/cron
+
+The profile name is baked into every symlink target, but resolution only
+pattern-matched the home path itself, so overlay homes reported "default".
+
+Contract under test:
+- direct profile dir still resolves (``<root>/profiles/X`` -> X)
+- overlay home with symlinked members resolves to the backing profile
+- overlay with plain COPIED files (no symlinks) stays "default"
+- root home stays "default"
+- both consumers (system prompt hint, cross-profile write guard) agree
+"""
+
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="symlink creation requires elevated privileges on Windows",
+)
+
+
+@pytest.fixture()
+def profile_farm(tmp_path, monkeypatch):
+    """A fake hermes root with a named profile and an overlay home."""
+    root = tmp_path / "hermes-root"
+    profile = root / "profiles" / "workflow_evaluator"
+    (profile / "plugins").mkdir(parents=True)
+    (profile / "cron").mkdir()
+    (profile / "SOUL.md").write_text("# soul\n")
+
+    overlay = tmp_path / "workspaces" / "task-1" / "hermes-home"
+    overlay.mkdir(parents=True)
+    (overlay / "SOUL.md").symlink_to(profile / "SOUL.md")
+    (overlay / "plugins").symlink_to(profile / "plugins")
+    (overlay / "cron").symlink_to(profile / "cron")
+    # Non-shared, task-local state alongside the symlinks:
+    (overlay / "sessions").mkdir()
+
+    # Make the fake root authoritative for get_default_hermes_root():
+    # HERMES_HOME outside the native home, parent not named "profiles",
+    # so the env path itself is treated as the root... except we want the
+    # overlay as HOME. get_default_hermes_root() derives the root from
+    # HERMES_HOME, so for overlay layouts the recovered name comes from
+    # the symlink targets, not the root relation — which is the point.
+    monkeypatch.setenv("HERMES_HOME", str(overlay))
+    # Reset memos that cache root/home resolution.
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "_default_hermes_root_memo", None, raising=False)
+    return root, profile, overlay
+
+
+def test_direct_profile_dir_resolves(tmp_path, monkeypatch):
+    import hermes_constants
+    from hermes_constants import profile_name_for_home
+
+    root = tmp_path / "hermes-root"
+    profile = root / "profiles" / "milo"
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+    monkeypatch.setattr(hermes_constants, "_default_hermes_root_memo", None, raising=False)
+
+    assert profile_name_for_home(profile) == "milo"
+
+
+def test_overlay_home_recovers_profile_from_symlinks(profile_farm):
+    from hermes_constants import profile_name_for_home
+
+    _root, _profile, overlay = profile_farm
+    assert profile_name_for_home(overlay) == "workflow_evaluator"
+
+
+def test_overlay_with_copied_files_stays_default(tmp_path, monkeypatch):
+    """Plain copies identify nothing — no symlink, no recovery."""
+    import hermes_constants
+    from hermes_constants import profile_name_for_home
+
+    overlay = tmp_path / "copied-home"
+    (overlay / "plugins").mkdir(parents=True)
+    (overlay / "SOUL.md").write_text("# soul\n")
+    monkeypatch.setenv("HERMES_HOME", str(overlay))
+    monkeypatch.setattr(hermes_constants, "_default_hermes_root_memo", None, raising=False)
+
+    assert profile_name_for_home(overlay) == "default"
+
+
+def test_root_home_stays_default(tmp_path, monkeypatch):
+    import hermes_constants
+    from hermes_constants import profile_name_for_home
+
+    root = tmp_path / "hermes-root"
+    (root / "profiles").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setattr(hermes_constants, "_default_hermes_root_memo", None, raising=False)
+
+    assert profile_name_for_home(root) == "default"
+
+
+def test_symlinked_home_itself_still_resolves(tmp_path, monkeypatch):
+    """A HERMES_HOME that is itself a symlink TO a profile dir resolves via
+    path resolution (pre-existing behavior, must not regress)."""
+    import hermes_constants
+    from hermes_constants import profile_name_for_home
+
+    root = tmp_path / "hermes-root"
+    profile = root / "profiles" / "milo"
+    profile.mkdir(parents=True)
+    link = tmp_path / "home-link"
+    link.symlink_to(profile)
+    monkeypatch.setenv("HERMES_HOME", str(link))
+    monkeypatch.setattr(hermes_constants, "_default_hermes_root_memo", None, raising=False)
+
+    assert profile_name_for_home(link) == "milo"
+
+
+def test_system_prompt_and_file_safety_agree_on_overlay(profile_farm, monkeypatch):
+    """Both consumers of profile resolution must report the same name for an
+    overlay home: the prompt hint (#93862's symptom) and the cross-profile
+    write guard (same bug class — a mismatch would misclassify the session's
+    own profile writes)."""
+    _root, _profile, overlay = profile_farm
+
+    from agent.system_prompt import _profile_name_for_home as prompt_name
+    import agent.file_safety as fs
+
+    monkeypatch.setattr(fs, "_hermes_home_path", lambda: overlay)
+
+    assert prompt_name(overlay) == "workflow_evaluator"
+    assert fs._resolve_active_profile_name() == "workflow_evaluator"
+
+
+def test_disagreeing_symlinks_stay_default(profile_farm, tmp_path):
+    """If overlay members point into DIFFERENT profiles, the overlay is
+    ambiguous (or crafted) and the conservative answer is default — a single
+    stale or malicious link must not reassign the guard's active side."""
+    from hermes_constants import profile_name_for_home
+
+    root, _profile, overlay = profile_farm
+    other = root / "profiles" / "victim"
+    (other / "skills").mkdir(parents=True)
+    (overlay / "skills").symlink_to(other / "skills")
+
+    assert profile_name_for_home(overlay) == "default"
+
+
+def test_broken_symlink_identifies_nothing(tmp_path, monkeypatch):
+    """A dangling symlink must not supply a profile name (resolve must be
+    strict)."""
+    import hermes_constants
+    from hermes_constants import profile_name_for_home
+
+    overlay = tmp_path / "broken-home"
+    overlay.mkdir()
+    (overlay / "SOUL.md").symlink_to(
+        tmp_path / "hermes-root" / "profiles" / "ghost" / "SOUL.md"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(overlay))
+    monkeypatch.setattr(hermes_constants, "_default_hermes_root_memo", None, raising=False)
+
+    assert profile_name_for_home(overlay) == "default"
+
+
+def test_nested_profiles_dir_in_path_identifies_nothing(tmp_path, monkeypatch):
+    """Only the exact tail ``profiles/<name>/<member>`` identifies a profile.
+    A ``profiles`` directory elsewhere in the target path must not — e.g.
+    ``.../profiles/archive/root/plugins`` is not profile "archive"."""
+    import hermes_constants
+    from hermes_constants import profile_name_for_home
+
+    deep = tmp_path / "profiles" / "archive" / "root" / "plugins"
+    deep.mkdir(parents=True)
+    overlay = tmp_path / "nested-home"
+    overlay.mkdir()
+    (overlay / "plugins").symlink_to(deep)
+    monkeypatch.setenv("HERMES_HOME", str(overlay))
+    monkeypatch.setattr(hermes_constants, "_default_hermes_root_memo", None, raising=False)
+
+    # Target tail is root/plugins under .../profiles/archive/..., NOT
+    # profiles/<name>/plugins — identifies nothing.
+    assert profile_name_for_home(overlay) == "default"
+
+
+class TestOverlayCrossProfileGuardEndToEnd:
+    """The guard itself, not just name agreement: an overlay session must be
+    able to write its OWN backing profile unwarned, while writes into other
+    profiles' scoped areas are still classified — even though the env-derived
+    root is the overlay dir, not the backing root (#93862)."""
+
+    @pytest.fixture()
+    def guard(self, profile_farm, monkeypatch):
+        import agent.file_safety as fs
+
+        _root, _profile, overlay = profile_farm
+        monkeypatch.setattr(fs, "_hermes_home_path", lambda: overlay)
+        return fs
+
+    def test_own_backing_profile_write_is_in_profile(self, guard, profile_farm):
+        _root, profile, _overlay = profile_farm
+        target = profile / "skills" / "new-skill" / "SKILL.md"
+        assert guard.classify_cross_profile_target(str(target)) is None
+
+    def test_other_profile_write_is_flagged(self, guard, profile_farm):
+        root, _profile, _overlay = profile_farm
+        other = root / "profiles" / "victim" / "skills" / "x.md"
+        result = guard.classify_cross_profile_target(str(other))
+        assert result is not None
+        assert result["active_profile"] == "workflow_evaluator"
+        assert result["target_profile"] == "victim"
+        assert result["area"] == "skills"
+
+    def test_default_profile_area_write_is_flagged(self, guard, profile_farm):
+        root, _profile, _overlay = profile_farm
+        default_area = root / "skills" / "x.md"
+        result = guard.classify_cross_profile_target(str(default_area))
+        assert result is not None
+        assert result["active_profile"] == "workflow_evaluator"
+        assert result["target_profile"] == "default"
+
+    def test_unrelated_path_is_not_classified(self, guard, tmp_path):
+        assert guard.classify_cross_profile_target(str(tmp_path / "code" / "a.py")) is None
+
+
+class TestMixedOverlayPinnedBehavior:
+    """Pin the intended semantics for imperfect overlays: NOISE (dangling or
+    malformed links) is ignored when the valid links are unanimous — overlay
+    decay is legitimate — while a valid CONFLICT always resolves to default.
+    """
+
+    def test_valid_links_plus_dangling_still_resolve(self, profile_farm):
+        """A dangling extra link (e.g. a pruned profile area) must not nuke
+        an otherwise-unanimous identity."""
+        from hermes_constants import profile_name_for_home
+
+        root, _profile, overlay = profile_farm
+        (overlay / "memories").symlink_to(
+            root / "profiles" / "workflow_evaluator" / "memories"  # does not exist
+        )
+        assert profile_name_for_home(overlay) == "workflow_evaluator"
+
+    def test_valid_links_plus_malformed_target_still_resolve(self, profile_farm, tmp_path):
+        """A link whose target exists but has no profiles/<name>/<member>
+        tail identifies nothing and is ignored."""
+        from hermes_constants import profile_name_for_home
+
+        _root, _profile, overlay = profile_farm
+        elsewhere = tmp_path / "shared-scratch"
+        elsewhere.mkdir()
+        (overlay / "hooks").symlink_to(elsewhere)
+        assert profile_name_for_home(overlay) == "workflow_evaluator"
+
+    def test_valid_conflict_beats_noise_and_resolves_default(self, profile_farm, tmp_path):
+        """Conflicting VALID identities resolve to default even alongside
+        additional noise links."""
+        from hermes_constants import profile_name_for_home
+
+        root, _profile, overlay = profile_farm
+        other = root / "profiles" / "victim"
+        (other / "skills").mkdir(parents=True)
+        (overlay / "skills").symlink_to(other / "skills")
+        (overlay / "memories").symlink_to(root / "nowhere")  # dangling noise
+        assert profile_name_for_home(overlay) == "default"

--- a/tests/agent/test_overlay_profile_resolution.py
+++ b/tests/agent/test_overlay_profile_resolution.py
@@ -24,7 +24,12 @@ import sys
 
 import pytest
 
-pytestmark = pytest.mark.skipif(
+# Symlink creation requires elevated privileges on Windows, so tests that
+# build symlink fixtures skip there. Tests that exercise the non-symlink
+# resolution paths (direct profile dir, copied files, root home, slug
+# validation) run on every platform, keeping the import path and the
+# non-overlay contract exercised on win32 CI.
+requires_symlinks = pytest.mark.skipif(
     sys.platform == "win32",
     reason="symlink creation requires elevated privileges on Windows",
 )
@@ -74,6 +79,7 @@ def test_direct_profile_dir_resolves(tmp_path, monkeypatch):
     assert profile_name_for_home(profile) == "milo"
 
 
+@requires_symlinks
 def test_overlay_home_recovers_profile_from_symlinks(profile_farm):
     from hermes_constants import profile_name_for_home
 
@@ -107,6 +113,7 @@ def test_root_home_stays_default(tmp_path, monkeypatch):
     assert profile_name_for_home(root) == "default"
 
 
+@requires_symlinks
 def test_symlinked_home_itself_still_resolves(tmp_path, monkeypatch):
     """A HERMES_HOME that is itself a symlink TO a profile dir resolves via
     path resolution (pre-existing behavior, must not regress)."""
@@ -124,6 +131,7 @@ def test_symlinked_home_itself_still_resolves(tmp_path, monkeypatch):
     assert profile_name_for_home(link) == "milo"
 
 
+@requires_symlinks
 def test_system_prompt_and_file_safety_agree_on_overlay(profile_farm, monkeypatch):
     """Both consumers of profile resolution must report the same name for an
     overlay home: the prompt hint (#93862's symptom) and the cross-profile
@@ -140,6 +148,7 @@ def test_system_prompt_and_file_safety_agree_on_overlay(profile_farm, monkeypatc
     assert fs._resolve_active_profile_name() == "workflow_evaluator"
 
 
+@requires_symlinks
 def test_disagreeing_symlinks_stay_default(profile_farm, tmp_path):
     """If overlay members point into DIFFERENT profiles, the overlay is
     ambiguous (or crafted) and the conservative answer is default — a single
@@ -154,6 +163,7 @@ def test_disagreeing_symlinks_stay_default(profile_farm, tmp_path):
     assert profile_name_for_home(overlay) == "default"
 
 
+@requires_symlinks
 def test_broken_symlink_identifies_nothing(tmp_path, monkeypatch):
     """A dangling symlink must not supply a profile name (resolve must be
     strict)."""
@@ -171,6 +181,7 @@ def test_broken_symlink_identifies_nothing(tmp_path, monkeypatch):
     assert profile_name_for_home(overlay) == "default"
 
 
+@requires_symlinks
 def test_nested_profiles_dir_in_path_identifies_nothing(tmp_path, monkeypatch):
     """Only the exact tail ``profiles/<name>/<member>`` identifies a profile.
     A ``profiles`` directory elsewhere in the target path must not — e.g.
@@ -191,6 +202,7 @@ def test_nested_profiles_dir_in_path_identifies_nothing(tmp_path, monkeypatch):
     assert profile_name_for_home(overlay) == "default"
 
 
+@requires_symlinks
 class TestOverlayCrossProfileGuardEndToEnd:
     """The guard itself, not just name agreement: an overlay session must be
     able to write its OWN backing profile unwarned, while writes into other
@@ -231,6 +243,7 @@ class TestOverlayCrossProfileGuardEndToEnd:
         assert guard.classify_cross_profile_target(str(tmp_path / "code" / "a.py")) is None
 
 
+@requires_symlinks
 class TestMixedOverlayPinnedBehavior:
     """Pin the intended semantics for imperfect overlays: NOISE (dangling or
     malformed links) is ignored when the valid links are unanimous — overlay
@@ -270,3 +283,85 @@ class TestMixedOverlayPinnedBehavior:
         (overlay / "skills").symlink_to(other / "skills")
         (overlay / "memories").symlink_to(root / "nowhere")  # dangling noise
         assert profile_name_for_home(overlay) == "default"
+
+
+class TestProfileNameShapeValidation:
+    """Names that could not have been created as profiles (per the
+    creation-time id shape ``[a-z0-9][a-z0-9_-]{0,63}``) must not be
+    *recovered* as profiles either — neither by the parent-name check (1b)
+    nor by overlay recovery (2), both of which are not anchored to the
+    configured root and would otherwise accept any directory literally
+    named ``profiles``."""
+
+    @requires_symlinks
+    def test_symlinked_home_to_invalid_slug_dir_stays_default(
+        self, tmp_path, monkeypatch
+    ):
+        """``/srv/app/profiles/Cache.d`` is not a profile — a HERMES_HOME
+        symlinked to it must not resolve to profile \"Cache.d\"."""
+        import hermes_constants
+        from hermes_constants import profile_name_for_home
+
+        not_a_profile = tmp_path / "srv" / "app" / "profiles" / "Cache.d"
+        not_a_profile.mkdir(parents=True)
+        link = tmp_path / "home-link"
+        link.symlink_to(not_a_profile)
+        monkeypatch.setenv("HERMES_HOME", str(link))
+        monkeypatch.setattr(
+            hermes_constants, "_default_hermes_root_memo", None, raising=False
+        )
+
+        assert profile_name_for_home(link) == "default"
+
+    @requires_symlinks
+    def test_overlay_link_into_invalid_slug_name_identifies_nothing(
+        self, tmp_path, monkeypatch
+    ):
+        """An overlay member whose target tail is ``profiles/<bad>/<member>``
+        with an invalid profile id identifies nothing."""
+        import hermes_constants
+        from hermes_constants import profile_name_for_home
+
+        bad = tmp_path / "root" / "profiles" / "Not A Profile" / "plugins"
+        bad.mkdir(parents=True)
+        overlay = tmp_path / "overlay-home"
+        overlay.mkdir()
+        (overlay / "plugins").symlink_to(bad)
+        monkeypatch.setenv("HERMES_HOME", str(overlay))
+        monkeypatch.setattr(
+            hermes_constants, "_default_hermes_root_memo", None, raising=False
+        )
+
+        assert profile_name_for_home(overlay) == "default"
+
+    @requires_symlinks
+    def test_invalid_slug_link_is_noise_beside_unanimous_valid_links(
+        self, profile_farm, tmp_path
+    ):
+        """A link into an invalid-id \"profile\" is noise, not a conflict —
+        unanimous valid links still resolve."""
+        from hermes_constants import profile_name_for_home
+
+        root, _profile, overlay = profile_farm
+        bad = root / "profiles" / "UPPER" / "skills"
+        bad.mkdir(parents=True)
+        (overlay / "skills").symlink_to(bad)
+
+        assert profile_name_for_home(overlay) == "workflow_evaluator"
+
+
+def test_profile_name_for_home_smoke_no_symlinks(tmp_path, monkeypatch):
+    """Cross-platform (incl. win32) smoke: the helper imports and resolves a
+    plain directory without touching any symlink machinery."""
+    import hermes_constants
+    from hermes_constants import profile_identity_for_home, profile_name_for_home
+
+    plain = tmp_path / "plain-home"
+    plain.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(plain))
+    monkeypatch.setattr(
+        hermes_constants, "_default_hermes_root_memo", None, raising=False
+    )
+
+    assert profile_name_for_home(plain) == "default"
+    assert profile_identity_for_home(plain) == ("default", None)


### PR DESCRIPTION
## What does this PR do?

Fixes profile-identity resolution when `HERMES_HOME` is a symlink-overlay directory — the layout multi-agent orchestration platforms produce to isolate per-task sessions/logs while sharing a named profile's skills/plugins/cron/SOUL via symlinks. Resolution only pattern-matched the home path itself, so overlay homes reported `default` in the system prompt's "Active Hermes profile" hint even though every symlink target carries the profile name. The cross-profile write guard had the same blind spot, plus a second one: the env-derived root for an overlay home is the overlay itself, so profile-scoped writes into the *backing* root were silently unclassifiable.

The fix adds `hermes_constants.profile_identity_for_home()` as the single owner of the derivation, returning `(name, backing_root)`:

1. Direct `<root>/profiles/<name>` (unchanged, after symlink resolution).
2. Resolved home IS `<other-root>/profiles/<name>` — covers a `HERMES_HOME` symlinked to a profile under a different root.
3. Symlink-overlay recovery — deliberately strict, because the name feeds the write guard's active side:
   - only members that are actual symlinks count (a copied file identifies nothing),
   - targets must exist (`resolve(strict=True)`) and match the exact `<root>/profiles/<name>/<member>` tail (a `profiles` dir elsewhere in the path identifies nothing),
   - all validly-identifying members must **agree** — a conflict resolves conservatively to `default`,
   - dangling/malformed links are ignored as noise (overlay decay is legitimate and must not nuke a unanimous identity).

Both prior consumers (prompt hint, guard) now route through it so they can never disagree, and `classify_cross_profile_target()` falls back to the backing root when the write target is outside the env-derived root — an overlay session writes its own backing profile unwarned while writes into other profiles' scoped areas are still flagged.

**Independent review note:** this went through two rounds of fail-closed model review before submission. Adopted from review: the strict target-shape validation, the all-members-must-agree rule, and the end-to-end guard tests. Two reviewer suggestions were **not** adopted, flagged here for maintainer judgment: (a) warning on writes under *any* candidate root when an overlay is ambiguous — the ambiguous case retains main's current behavior (unclassifiable), since on main *every* overlay write is already unclassifiable and the guard is a soft rail, not a security boundary; (b) letting a dangling link invalidate an otherwise-unanimous identity — rejected because routine overlay decay would silently regress the fix, and a dangling link identifies nothing by construction.

## Related Issue

Fixes #93862

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_constants.py`: add `profile_identity_for_home()` / `profile_name_for_home()` (import-safe, stdlib-only, never raises)
- `agent/system_prompt.py`: `_profile_name_for_home()` routes through the shared helper
- `agent/file_safety.py`: `_resolve_active_profile_name()` routes through the shared helper; `classify_cross_profile_target()` classifies against the backing root when the target is outside the env-derived root
- `tests/agent/test_overlay_profile_resolution.py`: 16 regression tests — direct/overlay/copied/root/symlinked-home resolution, disagreement, dangling, nested-`profiles` path, mixed noise+conflict semantics, consumer agreement, and 4 end-to-end guard tests (own-backing-profile write unwarned; other-profile and default-area writes flagged; unrelated paths untouched)

## How to Test

1. `bash scripts/run_tests.sh tests/agent/test_overlay_profile_resolution.py` — 16/16 (all red on unpatched main; the module-level tests fail at import there since the helper doesn't exist)
2. Reproduce the issue's layout: create a named profile, `mkdir` an overlay dir, symlink `SOUL.md`/`plugins`/`cron` into the profile, run with `HERMES_HOME=<overlay>` — the system prompt hint now names the backing profile
3. Adjacent surface: `bash scripts/run_tests.sh tests/tools/test_cross_profile_guard.py tests/agent/test_profile_home_override_precedence.py tests/agent/test_system_prompt.py` — 47/47

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the test suite on the touched surface via `scripts/run_tests.sh` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2, Python 3.11 — including live validation against a real named profile and a real overlay farm symlinking into it

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — tests carry a Windows skip marker (symlink creation needs elevation); the helper itself is pure `pathlib` and degrades to `default` where symlinks are absent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Live validation on a real machine (macOS, named profile `milo`):

```
real profile dir      -> ('milo', ~/.hermes)
overlay farm into it  -> ('milo', ~/.hermes)
bare ~/.hermes        -> default
```
