### PR TITLE
fix(dashboard-auth): styled HTML error page for /auth/callback instead of raw JSON

### DIFF
--- a/hermes_cli/dashboard_auth/login_page.py
+++ b/hermes_cli/dashboard_auth/login_page.py
@@ -455,6 +455,195 @@ _PASSWORD_FORM_SCRIPT = """\
 """
 
 
+_AUTH_ERROR_HTML_TEMPLATE = """\
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Sign-in failed — Hermes Agent</title>
+<style>
+  @font-face {{
+    font-family: 'Collapse';
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url('/fonts/Collapse-Regular.woff2') format('woff2');
+  }}
+  @font-face {{
+    font-family: 'Collapse';
+    font-style: normal;
+    font-weight: 700;
+    font-display: swap;
+    src: url('/fonts/Collapse-Bold.woff2') format('woff2');
+  }}
+  @font-face {{
+    font-family: 'Rules Compressed';
+    font-style: normal;
+    font-weight: 600;
+    font-display: swap;
+    src: url('/fonts/RulesCompressed-Medium.woff2') format('woff2');
+  }}
+  :root {{
+    --background-base: #170d02;
+    --midground: #ffac02;
+    --foreground: #ffffff;
+    --hairline: color-mix(in srgb, #ffac02 18%, transparent);
+    --error: #ff6b6b;
+  }}
+  *, *::before, *::after {{ box-sizing: border-box; }}
+  html, body {{
+    margin: 0;
+    padding: 0;
+    min-height: 100%;
+    background: var(--background-base);
+    color: var(--foreground);
+    font-family: 'Collapse', system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-size: 16px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }}
+  body {{
+    display: grid;
+    place-items: center;
+    padding: clamp(1.5rem, 6vh, 6rem) 1.25rem;
+  }}
+  main {{
+    width: 100%;
+    max-width: 26rem;
+    animation: slide-up 0.6s ease-out both;
+  }}
+  @keyframes slide-up {{
+    from {{ opacity: 0; transform: translateY(6px); }}
+    to   {{ opacity: 1; transform: translateY(0); }}
+  }}
+  @media (prefers-reduced-motion: reduce) {{
+    main {{ animation: none; }}
+  }}
+  .brand {{
+    text-align: center;
+    margin-bottom: 1.75rem;
+    font-family: 'Rules Compressed', 'Collapse', sans-serif;
+    font-weight: 600;
+    font-size: 1.05rem;
+    letter-spacing: 0.32em;
+    text-transform: uppercase;
+    color: var(--midground);
+  }}
+  .brand .dot {{
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    background: var(--midground);
+    margin: 0 0.55em 0.18em;
+    vertical-align: middle;
+    border-radius: 1px;
+  }}
+  .card {{
+    padding: 2.25rem 2rem 2rem;
+    background: color-mix(in srgb, #ffffff 2%, var(--background-base));
+    border: 1px solid var(--hairline);
+    box-shadow:
+      inset 1px 1px 0 0 color-mix(in srgb, #ffffff 5%, transparent),
+      inset -1px -1px 0 0 rgba(0, 0, 0, 0.4),
+      0 24px 60px -20px rgba(0, 0, 0, 0.6);
+  }}
+  .icon {{
+    width: 2.5rem;
+    height: 2.5rem;
+    margin: 0 0 1.25rem;
+    border: 1px solid var(--error);
+    color: var(--error);
+    display: grid;
+    place-items: center;
+    font-family: 'Rules Compressed', sans-serif;
+    font-weight: 600;
+    font-size: 1.3rem;
+  }}
+  h1 {{
+    margin: 0 0 0.75rem;
+    font-family: 'Rules Compressed', 'Collapse', sans-serif;
+    font-weight: 600;
+    font-size: 1.6rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--foreground);
+  }}
+  .message {{
+    margin: 0 0 1.75rem;
+    color: color-mix(in srgb, var(--foreground) 75%, transparent);
+    font-size: 0.92rem;
+    word-break: break-word;
+  }}
+  .retry-btn {{
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0.95rem 1rem;
+    text-align: center;
+    background: var(--midground);
+    color: var(--background-base);
+    font-family: 'Collapse', sans-serif;
+    font-weight: 700;
+    font-size: 0.78rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    text-decoration: none;
+    border: 0;
+    border-radius: 0;
+    box-shadow:
+      inset 1px 1px 0 0 rgba(255, 255, 255, 0.5),
+      inset -1px -1px 0 0 rgba(0, 0, 0, 0.5);
+    transition: filter 0.12s ease-out;
+  }}
+  .retry-btn:hover {{ filter: brightness(1.08); }}
+  .retry-btn:active {{ filter: invert(1); }}
+  .retry-btn:focus-visible {{
+    outline: 2px solid var(--midground);
+    outline-offset: 3px;
+  }}
+</style>
+</head>
+<body>
+<main>
+  <div class="brand">Nous<span class="dot"></span>Research</div>
+  <div class="card">
+    <div class="icon">!</div>
+    <h1>Sign-in failed</h1>
+    <p class="message">{message}</p>
+    <a class="retry-btn" href="/login">Back to sign in</a>
+  </div>
+</main>
+</body>
+</html>
+"""
+
+
+def render_auth_error_html(*, message: str) -> str:
+    """Render the HTML page shown for a failed ``/auth/callback`` request.
+
+    ``/auth/callback`` is the OAuth 2.0 / OpenID Connect redirection
+    endpoint (RFC 6749 §3.1.2, RFC 6749 §4.1.2) that the identity
+    provider (IDP) navigates the *top-level browser window* to — it is
+    never called via ``fetch``/XHR. Returning a FastAPI ``HTTPException``
+    on that endpoint therefore renders its JSON body directly as page
+    content instead of a document, which is what this function replaces.
+    It reuses :func:`render_login_html`'s visual language (same design
+    tokens, fonts, and card layout) so a failed callback still looks like
+    part of the app, with a link back to ``/login`` to retry.
+
+    Security note: ``message`` may echo back caller-controlled text (an
+    IDP-supplied ``error_description``, or a provider exception message)
+    and is HTML-escaped via :func:`html.escape` before interpolation into
+    the template — the standard mitigation for reflected XSS when
+    untrusted text is embedded in an HTML response (OWASP XSS Prevention
+    Cheat Sheet, rule #1: HTML-entity-encode untrusted data before
+    inserting it into HTML element content).
+    """
+    return _AUTH_ERROR_HTML_TEMPLATE.format(message=html.escape(message))
+
+
 def render_login_html(*, next_path: str = "") -> str:
     """Return the full HTML for ``GET /login``.
 

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -46,7 +46,10 @@ from hermes_cli.dashboard_auth.cookies import (
     set_pkce_cookie,
     set_session_cookies,
 )
-from hermes_cli.dashboard_auth.login_page import render_login_html
+from hermes_cli.dashboard_auth.login_page import (
+    render_auth_error_html,
+    render_login_html,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -431,6 +434,38 @@ async def auth_callback(
     error: str = "",
     error_description: str = "",
 ):
+    """OAuth 2.0 / OIDC redirection endpoint (RFC 6749 §4.1.2).
+
+    The identity provider (IDP) navigates the browser here after the
+    user authenticates, with ``code`` + ``state`` (success) or ``error``
+    (+ ``error_description``, per RFC 6749 §4.1.2.1) on failure. This
+    completes the Authorization Code Grant:
+
+      1. **CSRF protection** (RFC 6749 §10.12 / OAuth 2.0 Security BCP
+         §4.7.1): the ``state`` value returned by the IDP is compared
+         against the one this app generated and stored server-side in
+         the PKCE cookie at ``/auth/login`` — a mismatch means the
+         request did not originate from a login flow we started.
+      2. **PKCE** (RFC 7636): the ``code_verifier`` stashed in that same
+         cookie is handed to ``complete_login`` for the token exchange,
+         proving this callback is being redeemed by the same client
+         that initiated the authorization request (mitigates
+         authorization-code interception).
+      3. **RFC 8252** (OAuth 2.0 for Native Apps): if the PKCE cookie
+         carries a ``broker=`` marker, this call originated from
+         ``/auth/native/authorize`` and completes via a loopback
+         redirect instead of setting browser session cookies — see the
+         ``broker_state`` branch below.
+
+    Because this route is only ever reached via a full top-level
+    browser navigation (never fetch/XHR), every failure branch returns
+    an :class:`~fastapi.responses.HTMLResponse` rendered by
+    :func:`~hermes_cli.dashboard_auth.login_page.render_auth_error_html`
+    rather than raising :class:`~fastapi.HTTPException` — an
+    ``HTTPException`` would otherwise dump raw JSON as the page body.
+    Each failure is also recorded via :func:`audit_log` before the
+    response is built.
+    """
     pkce_raw = read_pkce_cookie(request)
     if not pkce_raw:
         audit_log(
@@ -438,9 +473,12 @@ async def auth_callback(
             reason="missing_pkce_cookie",
             ip=_client_ip(request),
         )
-        raise HTTPException(
+        return HTMLResponse(
+            render_auth_error_html(
+                message="Missing sign-in state cookie. Your browser may be "
+                "blocking cookies, or the link expired — please try again."
+            ),
             status_code=400,
-            detail="Missing PKCE state cookie",
         )
 
     # Parse ``provider=...;state=...;verifier=...;next=...`` — the
@@ -466,9 +504,12 @@ async def auth_callback(
 
     p = get_provider(provider_name)
     if p is None:
-        raise HTTPException(
+        return HTMLResponse(
+            render_auth_error_html(
+                message=f"Unknown sign-in provider: {provider_name!r}. "
+                "Please start over."
+            ),
             status_code=400,
-            detail=f"Unknown provider in cookie: {provider_name!r}",
         )
 
     if error:
@@ -479,9 +520,12 @@ async def auth_callback(
             error=error,
             ip=_client_ip(request),
         )
-        raise HTTPException(
+        detail = f"{error} ({error_description})" if error_description else error
+        return HTMLResponse(
+            render_auth_error_html(
+                message=f"Sign-in was cancelled or failed: {detail}"
+            ),
             status_code=400,
-            detail=f"OAuth error from provider: {error} ({error_description})",
         )
 
     if not state or state != expected_state:
@@ -491,9 +535,12 @@ async def auth_callback(
             reason="state_mismatch",
             ip=_client_ip(request),
         )
-        raise HTTPException(
+        return HTMLResponse(
+            render_auth_error_html(
+                message="Sign-in state check failed (possible expired or "
+                "replayed link). Please try signing in again."
+            ),
             status_code=400,
-            detail="OAuth state mismatch (CSRF check failed)",
         )
 
     try:
@@ -510,7 +557,10 @@ async def auth_callback(
             reason="invalid_code",
             ip=_client_ip(request),
         )
-        raise HTTPException(status_code=400, detail=f"Invalid code: {e}")
+        return HTMLResponse(
+            render_auth_error_html(message=str(e)),
+            status_code=400,
+        )
     except ProviderError as e:
         audit_log(
             AuditEvent.LOGIN_FAILURE,
@@ -518,9 +568,11 @@ async def auth_callback(
             reason="provider_unreachable",
             ip=_client_ip(request),
         )
-        raise HTTPException(
+        return HTMLResponse(
+            render_auth_error_html(
+                message=f"Sign-in provider is temporarily unavailable: {e}"
+            ),
             status_code=503,
-            detail=f"Provider unreachable: {e}",
         )
 
     audit_log(
@@ -556,9 +608,12 @@ async def auth_callback(
                 reason="pending_not_found",
                 ip=_client_ip(request),
             )
-            raise HTTPException(
+            return HTMLResponse(
+                render_auth_error_html(
+                    message="Native login expired or unknown; please "
+                    "restart sign-in from the app."
+                ),
                 status_code=400,
-                detail="Native login expired or unknown; restart sign-in.",
             )
         from urllib.parse import urlencode
 


### PR DESCRIPTION
## Summary

`/auth/callback` is the OAuth 2.0 / OIDC redirection endpoint (RFC 6749 §4.1.2) that the identity provider navigates the top-level browser window to on completion — it is never called via `fetch`/XHR. Because of that, raising `HTTPException` on any failure branch rendered raw `{"detail": "..."}` JSON directly as the page content instead of a proper document, which is a poor experience for anyone hitting a real-world failure (expired link, blocked cookies, IDP error, CSRF/state mismatch, or an auth provider rejecting the code — e.g. an allowlist denial).

This PR:

- Adds `render_auth_error_html()` to `login_page.py`, reusing the existing `/login` page's design system (fonts, color tokens, card/button styling) so a failed callback still looks like part of the app, with a link back to `/login` to retry.
- Switches every browser-facing failure branch in `auth_callback` (missing PKCE cookie, unknown provider, IDP `error`, state mismatch, `InvalidCodeError`, `ProviderError`, and the RFC 8252 native-app "pending expired" case) from `raise HTTPException(...)` to `return HTMLResponse(render_auth_error_html(...), status_code=...)`.
- HTML-escapes any caller-controlled text (IDP `error_description`, provider exception messages) before rendering, per the OWASP XSS Prevention Cheat Sheet, since that text is now embedded in an HTML response rather than a JSON payload.
- Documents the OAuth 2.0 Authorization Code Grant, PKCE, CSRF `state` check, and RFC 8252 native-app flow directly on `auth_callback`'s docstring, and the XSS-mitigation rationale on `render_auth_error_html`'s docstring.

Audit logging (`audit_log(...)`) is untouched — only the response type changes for these branches, from JSON to HTML. `/auth/native/token` (the desktop app's own JSON API endpoint, not a browser navigation target) is deliberately left returning `HTTPException`/JSON, since that path is consumed programmatically.

## Test plan

- [x] `python -m py_compile` on both changed files
- [x] Manually exercised `/auth/callback` with a state-mismatch request against a running dashboard instance behind a reverse proxy with a real OAuth provider configured — confirmed `HTTP 400` with `content-type: text/html` and the styled error page rendering correctly, including the fonts referenced by the page loading via the existing pre-auth `/fonts/*` allowlist
- [ ] CI