### PR TITLE
[Phase G] Bind child processes to typed authority

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -28,7 +28,12 @@ from openai.types.chat.chat_completion_message_tool_call import (
 
 from agent.file_safety import get_read_block_error, get_write_denied_error, is_write_approval_required
 from agent.redact import redact_sensitive_text
-from tools.environments.local import hermes_subprocess_env
+from tools.child_process_authority import (
+    build_child_process_env,
+    model_driver_spec,
+    probe_spec,
+    stdin_for_spec,
+)
 
 ACP_MARKER_BASE_URL = "acp://copilot"
 _DEFAULT_TIMEOUT_SECONDS = 900.0
@@ -112,9 +117,14 @@ def _acp_supported(command: str, args: list[str]) -> bool | None:
     if cached is not None:
         return cached
     try:
+        spec = probe_spec(source="agent.copilot_acp_client.acp_probe")
         probe = subprocess.run(
             [command, "--help"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env=build_child_process_env(spec),
+            stdin=stdin_for_spec(spec),
         )
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return None
@@ -157,7 +167,9 @@ def _build_subprocess_env() -> dict[str, str]:
     # Copilot ACP is a model-driving CLI executor: it legitimately needs LLM
     # provider credentials. Route through the central helper so Tier-1 secrets
     # (gateway bot tokens, GitHub auth, infra) are still stripped (#29157).
-    env = hermes_subprocess_env(inherit_credentials=True)
+    env = build_child_process_env(
+        model_driver_spec(source="agent.copilot_acp_client")
+    )
     home = _resolve_home_dir()
     env["HOME"] = home
     from hermes_constants import apply_subprocess_home_env

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -194,12 +194,22 @@ def _platform_asset_name() -> str:
         # don't need bullet-proof detection — getting it wrong falls
         # back to a clear error from the binary loader, which we catch.
         try:
+            from tools.child_process_authority import (
+                build_child_process_env,
+                probe_spec,
+                stdin_for_spec,
+            )
+
+            spec = probe_spec(source="agent.secret_sources.bitwarden.libc")
             res = subprocess.run(
                 ["ldd", "--version"],
                 capture_output=True,
-                text=True, encoding='utf-8', errors='replace',
+                text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=2,
-                stdin=subprocess.DEVNULL,
+                env=build_child_process_env(spec),
+                stdin=stdin_for_spec(spec),
             )
             if "musl" in (res.stdout + res.stderr).lower():
                 libc = "musl"
@@ -678,22 +688,22 @@ def _run_bws_list(
     # bws child intentionally receives the access token.  Under a profile-local
     # fetch it must not inherit sibling credentials from process-global env.
     source_env = get_source_environment()
-    if source_env is os.environ:
-        from tools.environments.local import build_subprocess_env
+    from tools.child_process_authority import (
+        build_child_process_env,
+        bws_vault_spec,
+    )
 
-        env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
-    else:
-        env = dict(source_env)
-    env["BWS_ACCESS_TOKEN"] = access_token
-    # Make sure we're not echoing telemetry / colour codes into json.
-    env.setdefault("NO_COLOR", "1")
-    # Region / self-hosted support.  bws defaults to https://vault.bitwarden.com
-    # (US Cloud); EU Cloud users need https://vault.bitwarden.eu, and
-    # self-hosted users need their own URL.  When unset, fall back to whatever
-    # BWS_SERVER_URL the caller already had in their shell env (preserved by
-    # the copy above) so manual overrides keep working too.
+    overrides = {
+        "BWS_ACCESS_TOKEN": access_token,
+        "NO_COLOR": "1",
+    }
     if server_url:
-        env["BWS_SERVER_URL"] = server_url
+        overrides["BWS_SERVER_URL"] = server_url
+    env = build_child_process_env(
+        bws_vault_spec(source="agent.secret_sources.bitwarden"),
+        source_env=source_env,
+        overrides=overrides,
+    )
 
     try:
         proc = subprocess.run(  # noqa: S603 — bws path is trusted

--- a/agent/secret_sources/command.py
+++ b/agent/secret_sources/command.py
@@ -180,20 +180,17 @@ def _run_helper(
         )
         return None
 
-    # User-configured secret-helper command: runs with the user's full shell
-    # env by design (it may need any credential to resolve the secret).
     source_env = get_source_environment()
-    if source_env is os.environ:
-        # Legacy single-profile startup intentionally preserves the existing
-        # helper contract, which may rely on the user's full environment.
-        from tools.environments.local import build_subprocess_env
-        env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
-    else:
-        # A multiplex profile must never inherit sibling secrets from the
-        # process-global environment.  hydrate_profile_secret_sources seeds
-        # only global-safe values plus this profile's own .env.
-        env = dict(source_env)
-    env["HERMES_SECRET_KEY"] = secret_key
+    from tools.child_process_authority import (
+        build_child_process_env,
+        secret_helper_spec,
+    )
+
+    env = build_child_process_env(
+        secret_helper_spec(source="agent.secret_sources.command"),
+        source_env=source_env,
+        overrides={"HERMES_SECRET_KEY": secret_key},
+    )
 
     try:
         proc = subprocess.Popen(  # noqa: S602 — command is the user's own config

--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -239,23 +239,20 @@ def _scrub(text: str) -> str:
 
 
 def _op_child_env(token_value: str) -> Dict[str, str]:
-    """Build a minimal allowlisted environment for the ``op`` child process."""
-    source_env = get_source_environment()
-    env: Dict[str, str] = {}
-    for key in _OP_ENV_ALLOWLIST:
-        val = source_env.get(key)
-        if val is not None:
-            env[key] = val
-    # Desktop / interactive session credentials.
-    for key, val in source_env.items():
-        if key.startswith("OP_SESSION_"):
-            env[key] = val
-    # `op` reads OP_SERVICE_ACCOUNT_TOKEN regardless of which env var the user
-    # configured Hermes to source it from, so normalize to that name here.
+    """Build the typed minimal environment for the ``op`` child process."""
+    from tools.child_process_authority import (
+        build_child_process_env,
+        op_vault_spec,
+    )
+
+    overrides = {"NO_COLOR": "1"}
     if token_value:
-        env["OP_SERVICE_ACCOUNT_TOKEN"] = token_value
-    env["NO_COLOR"] = "1"
-    return env
+        overrides["OP_SERVICE_ACCOUNT_TOKEN"] = token_value
+    return build_child_process_env(
+        op_vault_spec(source="agent.secret_sources.onepassword"),
+        source_env=get_source_environment(),
+        overrides=overrides,
+    )
 
 
 def _run_op_read(
@@ -287,6 +284,7 @@ def _run_op_read(
             encoding="utf-8",
             errors="replace",
             timeout=_OP_RUN_TIMEOUT,
+            stdin=subprocess.DEVNULL,
         )
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError(

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -25,7 +25,14 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
-from tools.environments.local import hermes_subprocess_env
+from tools.child_process_authority import (
+    KANBAN_WORKER_GRANT_PREFIXES,
+    KANBAN_WORKER_GRANTS,
+    build_child_process_env,
+    model_driver_spec,
+    probe_spec,
+    stdin_for_spec,
+)
 
 # Default minimum codex version we test against. The PR sets this from the
 # `codex --version` parsed at install time; bumping is a one-line change here.
@@ -87,9 +94,14 @@ class CodexAppServerClient:
         # centralized helper so Tier-1 + dynamic-internal secrets are always
         # stripped while provider creds still flow, matching copilot_acp_client
         # (#29157 sibling spawn-site gap).
-        spawn_env = hermes_subprocess_env(inherit_credentials=True)
-        if env:
-            spawn_env.update(env)
+        spawn_env = build_child_process_env(
+            model_driver_spec(
+                source="agent.transports.codex_app_server",
+                grants=KANBAN_WORKER_GRANTS,
+                grant_prefixes=KANBAN_WORKER_GRANT_PREFIXES,
+            ),
+            overrides=env,
+        )
         if codex_home:
             spawn_env["CODEX_HOME"] = codex_home
 
@@ -391,12 +403,16 @@ def check_codex_binary(
 
     Returns (ok, message). Used by setup wizard and runtime startup."""
     try:
+        spec = probe_spec(source="agent.transports.codex_app_server.version")
         proc = subprocess.run(
             [codex_bin, "--version"],
             capture_output=True,
-            text=True, encoding='utf-8', errors='replace',
+            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=10,
-            stdin=subprocess.DEVNULL,
+            env=build_child_process_env(spec),
+            stdin=stdin_for_spec(spec),
         )
     except FileNotFoundError:
         return False, (

--- a/apps/shared/package.json
+++ b/apps/shared/package.json
@@ -8,7 +8,8 @@
     "./billing": "./src/billing-types.ts",
     "./billing-policy": "./src/billing-policy.ts",
     "./charge-settlement": "./src/charge-settlement.ts",
-    "./skin": "./src/skin.ts"
+    "./skin": "./src/skin.ts",
+    "./authority-manifest": "./src/authority/manifest.ts"
   },
   "types": "./src/index.ts",
   "scripts": {

--- a/apps/shared/src/authority/manifest.ts
+++ b/apps/shared/src/authority/manifest.ts
@@ -1,0 +1,616 @@
+type JsonRecord = Record<string, unknown>;
+
+const KNOWN_DOMAINS = deepFreeze([
+  "github.operation",
+  "sandbox.execution",
+  "child_process.operation",
+  "gateway.mutation",
+] as const);
+
+const KNOWN_ACTOR_CLASSES = deepFreeze([
+  "human",
+  "github_app",
+  "workflow",
+  "automation",
+  "external_bot",
+] as const);
+
+const TOP_LEVEL_KEYS = deepFreeze(["schema_version", "policy_version", "domains"] as const);
+const DOMAIN_KEYS = deepFreeze(["sinks", "operation_classes"] as const);
+const SINK_KEYS = deepFreeze(["broker", "direct_symbols"] as const);
+const OPERATION_KEYS = deepFreeze([
+  "sink_class",
+  "required_capabilities",
+  "allowed_actor_classes",
+  "allowed_resource_states",
+] as const);
+const REQUEST_KEYS = deepFreeze([
+  "domain",
+  "operation_class",
+  "actor_class",
+  "resource_state",
+  "capabilities",
+] as const);
+const CAPABILITY_GRANT_KEYS = deepFreeze([
+  "capability",
+  "granted",
+  "source",
+  "generation",
+] as const);
+
+const CANONICAL_MANIFEST_JSON = `{
+  "schema_version": 1,
+  "policy_version": "2026.08.25-v2",
+  "domains": {
+    "github.operation": {
+      "sinks": {
+        "github.issue.metadata.write": {
+          "broker": "githubMutationBroker",
+          "direct_symbols": [
+            "issues.addLabels",
+            "issues.removeLabel",
+            "issues.update"
+          ]
+        },
+        "github.comment.write": {
+          "broker": "githubMutationBroker",
+          "direct_symbols": [
+            "issues.createComment",
+            "pulls.createReview",
+            "pulls.createReviewComment"
+          ]
+        },
+        "github.contents.write": {
+          "broker": "githubMutationBroker",
+          "direct_symbols": [
+            "repos.createOrUpdateFileContents",
+            "repos.deleteFile"
+          ]
+        },
+        "github.gitdata.write": {
+          "broker": "githubMutationBroker",
+          "direct_symbols": [
+            "git.createBlob",
+            "git.createCommit",
+            "git.createRef",
+            "git.createTree",
+            "git.updateRef"
+          ]
+        },
+        "github.pull_request.create": {
+          "broker": "githubMutationBroker",
+          "direct_symbols": [
+            "pulls.create"
+          ]
+        },
+        "github.actions.dispatch": {
+          "broker": "githubMutationBroker",
+          "direct_symbols": [
+            "actions.createWorkflowDispatch"
+          ]
+        }
+      },
+      "operation_classes": {
+        "github.issue.metadata.write": {
+          "sink_class": "github.issue.metadata.write",
+          "required_capabilities": [
+            "issues:metadata:write"
+          ],
+          "allowed_actor_classes": [
+            "human",
+            "github_app",
+            "workflow",
+            "automation"
+          ],
+          "allowed_resource_states": [
+            "open",
+            "closed"
+          ]
+        },
+        "github.comment.write": {
+          "sink_class": "github.comment.write",
+          "required_capabilities": [
+            "comments:write"
+          ],
+          "allowed_actor_classes": [
+            "human",
+            "github_app",
+            "workflow",
+            "automation"
+          ],
+          "allowed_resource_states": [
+            "open",
+            "closed"
+          ]
+        },
+        "github.contents.write": {
+          "sink_class": "github.contents.write",
+          "required_capabilities": [
+            "contents:write"
+          ],
+          "allowed_actor_classes": [
+            "human",
+            "github_app",
+            "workflow",
+            "automation"
+          ],
+          "allowed_resource_states": [
+            "current"
+          ]
+        },
+        "github.gitdata.write": {
+          "sink_class": "github.gitdata.write",
+          "required_capabilities": [
+            "git_objects:write",
+            "refs:write"
+          ],
+          "allowed_actor_classes": [
+            "human",
+            "github_app",
+            "workflow",
+            "automation"
+          ],
+          "allowed_resource_states": [
+            "current"
+          ]
+        },
+        "github.pull_request.create": {
+          "sink_class": "github.pull_request.create",
+          "required_capabilities": [
+            "pull_requests:create"
+          ],
+          "allowed_actor_classes": [
+            "human",
+            "github_app",
+            "workflow",
+            "automation"
+          ],
+          "allowed_resource_states": [
+            "current"
+          ]
+        },
+        "github.actions.dispatch": {
+          "sink_class": "github.actions.dispatch",
+          "required_capabilities": [
+            "actions:dispatch"
+          ],
+          "allowed_actor_classes": [
+            "human",
+            "github_app",
+            "workflow",
+            "automation"
+          ],
+          "allowed_resource_states": [
+            "current"
+          ]
+        }
+      }
+    }
+  }
+}
+`;
+
+const CANONICAL_MANIFEST_SHA256 =
+  "d427e3cd580f97a18103cbb73c04dc0baf2565f8509bcd298ee7aff049588d8e";
+
+export class ManifestValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+
+    this.name = "ManifestValidationError";
+  }
+}
+
+export class AdmissionRequestValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+
+    this.name = "AdmissionRequestValidationError";
+  }
+}
+
+export type CapabilityGrant = Readonly<{
+  capability: string;
+  granted: boolean;
+  source: string;
+  generation: string;
+}>;
+
+export type CapabilityProof = Readonly<{
+  capability: string;
+  source: string;
+  generation: string;
+}>;
+
+export type AdmissionRequest = Readonly<{
+  domain: string;
+  operation_class: string;
+  actor_class: string;
+  resource_state: string;
+  capabilities: readonly CapabilityGrant[];
+}>;
+
+export type AuthorityDecision = Readonly<{
+  allowed: boolean;
+  operation_class: string;
+  reason_code: string;
+  matched_rule: string | null;
+  capability_proofs: readonly CapabilityProof[];
+  policy_version: string;
+}>;
+
+export type CompiledSink = Readonly<{
+  broker: string;
+  direct_symbols: readonly string[];
+}>;
+
+export type CompiledOperation = Readonly<{
+  sink_class: string;
+  required_capabilities: readonly string[];
+  allowed_actor_classes: readonly string[];
+  allowed_resource_states: readonly string[];
+}>;
+
+export type CompiledDomain = Readonly<{
+  sinks: Readonly<Record<string, CompiledSink>>;
+  operations: Readonly<Record<string, CompiledOperation>>;
+}>;
+
+export type CompiledManifest = Readonly<{
+  schemaVersion: 1;
+  policyVersion: string;
+  domains: Readonly<Record<string, CompiledDomain>>;
+}>;
+
+export type AuthorityManifestArtifact = Readonly<{
+  manifest_bytes: readonly number[];
+  manifest_sha256: string;
+  manifest: CompiledManifest;
+}>;
+
+function deepFreeze<T>(value: T): T {
+  if (typeof value !== "object" || value === null || Object.isFrozen(value)) {
+    return value;
+  }
+
+  for (const child of Object.values(value as JsonRecord)) {
+    deepFreeze(child);
+  }
+  return Object.freeze(value);
+}
+
+function hasOwn(value: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function asRecord(value: unknown, where: string): JsonRecord {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new ManifestValidationError(`${where} must be an object`);
+  }
+  return value as JsonRecord;
+}
+
+function requireExactKeys(
+  value: JsonRecord,
+  expected: readonly string[],
+  where: string,
+  ErrorType: typeof ManifestValidationError = ManifestValidationError,
+): void {
+  const actual = Object.keys(value);
+  const unknown = actual.filter((key) => !expected.includes(key)).sort();
+  const missing = expected.filter((key) => !hasOwn(value, key)).sort();
+  if (unknown.length > 0 || missing.length > 0) {
+    const details = [
+      unknown.length > 0 ? `unknown=${JSON.stringify(unknown)}` : null,
+      missing.length > 0 ? `missing=${JSON.stringify(missing)}` : null,
+    ]
+      .filter(Boolean)
+      .join(", ");
+    throw new ErrorType(`${where} must be closed (${details})`);
+  }
+}
+
+function requireNonemptyString(value: unknown, where: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new ManifestValidationError(`${where} must be a non-empty string`);
+  }
+  return value;
+}
+
+function requireUniqueStrings(
+  value: unknown,
+  where: string,
+  options: { nonempty?: boolean } = {},
+): string[] {
+  const nonempty = options.nonempty ?? true;
+  if (!Array.isArray(value)) {
+    throw new ManifestValidationError(`${where} must be an array`);
+  }
+  if (nonempty && value.length === 0) {
+    throw new ManifestValidationError(`${where} must not be empty`);
+  }
+  if (value.some((item) => typeof item !== "string" || item.trim().length === 0)) {
+    throw new ManifestValidationError(`${where} must contain only non-empty strings`);
+  }
+  const strings = value as string[];
+  if (new Set(strings).size !== strings.length) {
+    throw new ManifestValidationError(`${where} must not contain duplicates`);
+  }
+  return [...strings];
+}
+
+export function compileAuthorityManifest(rawValue: unknown): CompiledManifest {
+  const raw = asRecord(rawValue, "manifest");
+  requireExactKeys(raw, TOP_LEVEL_KEYS, "manifest");
+  if (raw.schema_version !== 1) {
+    throw new ManifestValidationError("schema_version must equal 1");
+  }
+  const policyVersion = requireNonemptyString(raw.policy_version, "policy_version");
+  const rawDomains = asRecord(raw.domains, "domains");
+  if (Object.keys(rawDomains).length === 0) {
+    throw new ManifestValidationError("domains must be a non-empty object");
+  }
+
+  const unknownDomains = Object.keys(rawDomains)
+    .filter((domain) => !KNOWN_DOMAINS.includes(domain as (typeof KNOWN_DOMAINS)[number]))
+    .sort();
+  if (unknownDomains.length > 0) {
+    throw new ManifestValidationError(`unknown domains: ${JSON.stringify(unknownDomains)}`);
+  }
+
+  const domains = Object.create(null) as Record<string, CompiledDomain>;
+  for (const domainName of Object.keys(rawDomains).sort()) {
+    const rawDomain = asRecord(rawDomains[domainName], `domains.${domainName}`);
+    requireExactKeys(rawDomain, DOMAIN_KEYS, `domains.${domainName}`);
+    const rawSinks = asRecord(rawDomain.sinks, `domains.${domainName}.sinks`);
+    const rawOperations = asRecord(
+      rawDomain.operation_classes,
+      `domains.${domainName}.operation_classes`,
+    );
+    if (Object.keys(rawSinks).length === 0) {
+      throw new ManifestValidationError(`domains.${domainName}.sinks must be non-empty`);
+    }
+    if (Object.keys(rawOperations).length === 0) {
+      throw new ManifestValidationError(
+        `domains.${domainName}.operation_classes must be non-empty`,
+      );
+    }
+
+    const sinks = Object.create(null) as Record<string, CompiledSink>;
+    for (const [sinkName, sinkValue] of Object.entries(rawSinks)) {
+      requireNonemptyString(sinkName, `domains.${domainName}.sink name`);
+      const sinkSpec = asRecord(sinkValue, `sink ${sinkName}`);
+      requireExactKeys(sinkSpec, SINK_KEYS, `sink ${sinkName}`);
+      const broker = requireNonemptyString(sinkSpec.broker, `sink ${sinkName}.broker`);
+      const directSymbols = requireUniqueStrings(
+        sinkSpec.direct_symbols,
+        `sink ${sinkName}.direct_symbols`,
+        { nonempty: false },
+      ).sort();
+      sinks[sinkName] = deepFreeze({ broker, direct_symbols: directSymbols });
+    }
+
+    const operations = Object.create(null) as Record<string, CompiledOperation>;
+    for (const [operationName, operationValue] of Object.entries(rawOperations)) {
+      requireNonemptyString(operationName, `domains.${domainName}.operation class name`);
+      const operationSpec = asRecord(operationValue, `operation ${operationName}`);
+      requireExactKeys(operationSpec, OPERATION_KEYS, `operation ${operationName}`);
+
+      const sinkClass = requireNonemptyString(
+        operationSpec.sink_class,
+        `operation ${operationName}.sink_class`,
+      );
+      if (!hasOwn(sinks, sinkClass)) {
+        throw new ManifestValidationError(
+          `operation ${operationName} references unregistered sink ${sinkClass}`,
+        );
+      }
+
+      const requiredCapabilities = requireUniqueStrings(
+        operationSpec.required_capabilities,
+        `operation ${operationName}.required_capabilities`,
+      );
+      if (requiredCapabilities.some((capability) => capability.includes("*"))) {
+        throw new ManifestValidationError(
+          `operation ${operationName} contains an ambient wildcard capability`,
+        );
+      }
+
+      const actorClasses = requireUniqueStrings(
+        operationSpec.allowed_actor_classes,
+        `operation ${operationName}.allowed_actor_classes`,
+      );
+      const unknownActors = actorClasses.filter(
+        (actor) =>
+          !KNOWN_ACTOR_CLASSES.includes(actor as (typeof KNOWN_ACTOR_CLASSES)[number]),
+      );
+      if (unknownActors.length > 0) {
+        throw new ManifestValidationError(
+          `operation ${operationName} has unknown actor classes ${JSON.stringify(unknownActors)}`,
+        );
+      }
+
+      const resourceStates = requireUniqueStrings(
+        operationSpec.allowed_resource_states,
+        `operation ${operationName}.allowed_resource_states`,
+      );
+      operations[operationName] = deepFreeze({
+        sink_class: sinkClass,
+        required_capabilities: requiredCapabilities,
+        allowed_actor_classes: actorClasses.sort(),
+        allowed_resource_states: resourceStates.sort(),
+      });
+    }
+
+    domains[domainName] = deepFreeze({ sinks, operations });
+  }
+
+  return deepFreeze({ schemaVersion: 1, policyVersion, domains });
+}
+
+export function parseAdmissionRequest(rawValue: unknown): AdmissionRequest {
+  let raw: JsonRecord;
+  try {
+    raw = asRecord(rawValue, "admission request");
+  } catch (error) {
+    throw new AdmissionRequestValidationError((error as Error).message);
+  }
+  requireExactKeys(
+    raw,
+    REQUEST_KEYS,
+    "admission request",
+    AdmissionRequestValidationError,
+  );
+
+  const fields = Object.create(null) as Record<string, string>;
+  for (const field of ["domain", "operation_class", "actor_class", "resource_state"] as const) {
+    const value = raw[field];
+    if (typeof value !== "string") {
+      throw new AdmissionRequestValidationError(`${field} must be a string`);
+    }
+    fields[field] = value;
+  }
+
+  if (!Array.isArray(raw.capabilities)) {
+    throw new AdmissionRequestValidationError("capabilities must be an array");
+  }
+  const capabilities = raw.capabilities.map((value, index): CapabilityGrant => {
+    let grant: JsonRecord;
+    try {
+      grant = asRecord(value, `capabilities[${index}]`);
+    } catch (error) {
+      throw new AdmissionRequestValidationError((error as Error).message);
+    }
+    requireExactKeys(
+      grant,
+      CAPABILITY_GRANT_KEYS,
+      `capabilities[${index}]`,
+      AdmissionRequestValidationError,
+    );
+    if (typeof grant.capability !== "string") {
+      throw new AdmissionRequestValidationError(
+        `capabilities[${index}].capability must be a string`,
+      );
+    }
+    if (typeof grant.granted !== "boolean") {
+      throw new AdmissionRequestValidationError(
+        `capabilities[${index}].granted must be a boolean`,
+      );
+    }
+    if (typeof grant.source !== "string") {
+      throw new AdmissionRequestValidationError(
+        `capabilities[${index}].source must be a string`,
+      );
+    }
+    if (typeof grant.generation !== "string") {
+      throw new AdmissionRequestValidationError(
+        `capabilities[${index}].generation must be a string`,
+      );
+    }
+    return deepFreeze({
+      capability: grant.capability,
+      granted: grant.granted,
+      source: grant.source,
+      generation: grant.generation,
+    });
+  });
+
+  return deepFreeze({
+    domain: fields.domain,
+    operation_class: fields.operation_class,
+    actor_class: fields.actor_class,
+    resource_state: fields.resource_state,
+    capabilities,
+  });
+}
+
+function decision(
+  manifest: CompiledManifest,
+  request: AdmissionRequest,
+  reasonCode: string,
+  matchedRule: string | null,
+  options: {
+    allowed?: boolean;
+    capabilityProofs?: readonly CapabilityProof[];
+  } = {},
+): AuthorityDecision {
+  return deepFreeze({
+    allowed: options.allowed ?? false,
+    operation_class: request.operation_class,
+    reason_code: reasonCode,
+    matched_rule: matchedRule,
+    capability_proofs: [...(options.capabilityProofs ?? [])],
+    policy_version: manifest.policyVersion,
+  });
+}
+
+export function evaluateAuthorityOperation(
+  manifest: CompiledManifest,
+  requestValue: AdmissionRequest,
+): AuthorityDecision {
+  const request = parseAdmissionRequest(requestValue);
+  const domain = manifest.domains[request.domain];
+  const operation = domain?.operations[request.operation_class];
+  const matchedRule = operation
+    ? `${request.domain}.${request.operation_class}`
+    : null;
+
+  if (!operation) {
+    return decision(manifest, request, "unsupported_operation", null);
+  }
+
+  if (!operation.allowed_actor_classes.includes(request.actor_class)) {
+    return decision(manifest, request, "actor_forbidden", matchedRule);
+  }
+
+  if (!operation.allowed_resource_states.includes(request.resource_state)) {
+    return decision(manifest, request, "resource_state_denied", matchedRule);
+  }
+
+  const grants = Object.create(null) as Record<string, CapabilityGrant>;
+  for (const grant of request.capabilities) {
+    if (
+      grant.capability.trim().length === 0 ||
+      grant.source.trim().length === 0 ||
+      grant.generation.trim().length === 0 ||
+      hasOwn(grants, grant.capability)
+    ) {
+      return decision(manifest, request, "invalid_capability_proof", matchedRule);
+    }
+    grants[grant.capability] = grant;
+  }
+
+  if (
+    operation.required_capabilities.some(
+      (capability) => !hasOwn(grants, capability) || !grants[capability].granted,
+    )
+  ) {
+    return decision(manifest, request, "missing_capability", matchedRule);
+  }
+
+  const capabilityProofs = operation.required_capabilities.map((capability) =>
+    deepFreeze({
+      capability,
+      source: grants[capability].source,
+      generation: grants[capability].generation,
+    }),
+  );
+  return decision(manifest, request, "allowed", matchedRule, {
+    allowed: true,
+    capabilityProofs,
+  });
+}
+
+function buildCanonicalManifestArtifact(): AuthorityManifestArtifact {
+  const manifestBytes = deepFreeze(
+    Array.from(new TextEncoder().encode(CANONICAL_MANIFEST_JSON)),
+  );
+  const raw: unknown = JSON.parse(CANONICAL_MANIFEST_JSON);
+  return deepFreeze({
+    manifest_bytes: manifestBytes,
+    manifest_sha256: CANONICAL_MANIFEST_SHA256,
+    manifest: compileAuthorityManifest(raw),
+  });
+}
+
+export const CANONICAL_AUTHORITY_MANIFEST = buildCanonicalManifestArtifact();

--- a/authority/conformance.v1.json
+++ b/authority/conformance.v1.json
@@ -1,0 +1,476 @@
+{
+  "schema_version": 1,
+  "vectors": [
+    {
+      "name": "issue_metadata_write_allowed_with_exact_grant",
+      "request": {
+        "domain": "github.operation",
+        "operation_class": "github.issue.metadata.write",
+        "actor_class": "github_app",
+        "resource_state": "open",
+        "capabilities": [
+          {
+            "capability": "issues:metadata:write",
+            "granted": true,
+            "source": "app_installation_token",
+            "generation": "cred-1"
+          }
+        ]
+      },
+      "expected": {
+        "allowed": true,
+        "operation_class": "github.issue.metadata.write",
+        "reason_code": "allowed",
+        "matched_rule": "github.operation.github.issue.metadata.write",
+        "capability_proofs": [
+          {
+            "capability": "issues:metadata:write",
+            "source": "app_installation_token",
+            "generation": "cred-1"
+          }
+        ],
+        "policy_version": "2026.08.25-v2"
+      }
+    },
+    {
+      "name": "comment_write_allowed_with_exact_grant",
+      "request": {
+        "domain": "github.operation",
+        "operation_class": "github.comment.write",
+        "actor_class": "github_app",
+        "resource_state": "open",
+        "capabilities": [
+          {
+            "capability": "comments:write",
+            "granted": true,
+            "source": "app_installation_token",
+            "generation": "cred-2"
+          }
+        ]
+      },
+      "expected": {
+        "allowed": true,
+        "operation_class": "github.comment.write",
+        "reason_code": "allowed",
+        "matched_rule": "github.operation.github.comment.write",
+        "capability_proofs": [
+          {
+            "capability": "comments:write",
+            "source": "app_installation_token",
+            "generation": "cred-2"
+          }
+        ],
+        "policy_version": "2026.08.25-v2"
+      }
+    },
+    {
+      "name": "contents_write_allowed_with_exact_grant",
+      "request": {
+        "domain": "github.operation",
+        "operation_class": "github.contents.write",
+        "actor_class": "automation",
+        "resource_state": "current",
+        "capabilities": [
+          {
+            "capability": "contents:write",
+            "granted": true,
+            "source": "contents_token",
+            "generation": "cred-3"
+          }
+        ]
+      },
+      "expected": {
+        "allowed": true,
+        "operation_class": "github.contents.write",
+        "reason_code": "allowed",
+        "matched_rule": "github.operation.github.contents.write",
+        "capability_proofs": [
+          {
+            "capability": "contents:write",
+            "source": "contents_token",
+            "generation": "cred-3"
+          }
+        ],
+        "policy_version": "2026.08.25-v2"
+      }
+    },
+    {
+      "name": "gitdata_write_preserves_object_and_ref_proof_pairing",
+      "request": {
+        "domain": "github.operation",
+        "operation_class": "github.gitdata.write",
+        "actor_class": "automation",
+        "resource_state": "current",
+        "capabilities": [
+          {
+            "capability": "refs:write",
+            "granted": true,
+            "source": "ref_token",
+            "generation": "cred-4b"
+          },
+          {
+            "capability": "git_objects:write",
+            "granted": true,
+            "source": "git_object_token",
+            "generation": "cred-4a"
+          }
+        ]
+      },
+      "expected": {
+        "allowed": true,
+        "operation_class": "github.gitdata.write",
+        "reason_code": "allowed",
+        "matched_rule": "github.operation.github.gitdata.write",
+        "capability_proofs": [
+          {
+            "capability": "git_objects:write",
+            "source": "git_object_token",
+            "generation": "cred-4a"
+          },
+          {
+            "capability": "refs:write",
+            "source": "ref_token",
+            "generation": "cred-4b"
+          }
+        ],
+        "policy_version": "2026.08.25-v2"
+      }
+    },
+    {
+      "name": "pull_request_create_allowed_with_exact_grant",
+      "request": {
+        "domain": "github.operation",
+        "operation_class": "github.pull_request.create",
+        "actor_class": "automation",
+        "resource_state": "current",
+        "capabilities": [
+          {
+            "capability": "pull_requests:create",
+            "granted": true,
+            "source": "pull_request_token",
+            "generation": "cred-5"
+          }
+        ]
+      },
+      "expected": {
+        "allowed": true,
+        "operation_class": "github.pull_request.create",
+        "reason_code": "allowed",
+        "matched_rule": "github.operation.github.pull_request.create",
+        "capability_proofs": [
+          {
+            "capability": "pull_requests:create",
+            "source": "pull_request_token",
+            "generation": "cred-5"
+          }
+        ],
+        "policy_version": "2026.08.25-v2"
+      }
+    },
+    {
+      "name": "actions_dispatch_allowed_with_exact_grant",
+      "request": {
+        "domain": "github.operation",
+        "operation_class": "github.actions.dispatch",
+        "actor_class": "workflow",
+        "resource_state": "current",
+        "capabilities": [
+          {
+            "capability": "actions:dispatch",
+            "granted": true,
+            "source": "workflow_dispatch_token",
+            "generation": "cred-6"
+          }
+        ]
+      },
+      "expected": {
+        "allowed": true,
+        "operation_class": "github.actions.dispatch",
+        "reason_code": "allowed",
+        "matched_rule": "github.operation.github.actions.dispatch",
+        "capability_proofs": [
+          {
+            "capability": "actions:dispatch",
+            "source": "workflow_dispatch_token",
+            "generation": "cred-6"
+          }
+        ],
+        "policy_version": "2026.08.25-v2"
+      }
+    },
+    {
+      "name": "unknown_operation_precedes_other_refusals",
+      "request": {
+        "domain": "github.operation",
+        "operation_class": "github.admin_everything",
+        "actor_class": "external_bot",
+        "resource_state": "deleted",
+        "capabilities": [
+          {
+            "capability": "*",
+            "granted": true,
+            "source": "",
+            "generation": ""
+          }
+        ]
+      },
+      "expected": {
+        "allowed": false,
+        "operation_class": "github.admin_everything",
+        "reason_code": "unsupported_operation",
+        "matched_rule": null,
+        "capability_proofs": [],
+        "policy_version": "2026.08.25-v2"
+      }
+    },
+    {
+      "name": "actor_forbidden_precedes_resource_and_proof",
+      "request": {
+        "domain": "github.operation",
+        "operation_class": "github.gitdata.write",
+        "actor_class": "external_bot",
+        "resource_state": "deleted",
+        "capabilities": [
+          {
+            "capability": "git_objects:write",
+            "granted": true,
+            "source": "",
+            "generation": ""
+          },
+          {
+            "capability": "refs:write",
+            "granted": true,
+            "source": "",
+            "generation": ""
+          }
+        ]
+      },
+      "expected": {
+        "allowed": false,
+        "operation_class": "github.gitdata.write",
+        "reason_code": "actor_forbidden",
+        "matched_rule": "github.operation.github.gitdata.write",
+        "capability_proofs": [],
+        "policy_version": "2026.08.25-v2"
+      }
+    },
+    {
+      "name": "resource_state_precedes_invalid_proof",
+      "request": {
+        "domain": "github.operation",
+        "operation_class": "github.comment.write",
+        "actor_class": "human",
+        "resource_state": "merged",
+        "capabilities": [
+          {
+            "capability": "comments:write",
+            "granted": true,
+            "source": "",
+            "generation": ""
+          }
+        ]
+      },
+      "expected": {
+        "allowed": false,
+        "operation_class": "github.comment.write",
+        "reason_code": "resource_state_denied",
+        "matched_rule": "github.operation.github.comment.write",
+        "capability_proofs": [],
+        "policy_version": "2026.08.25-v2"
+      }
+    },
+    {
+      "name": "blank_provenance_fails_closed",
+      "request": {
+        "domain": "github.operation",
+        "operation_class": "github.comment.write",
+        "actor_class": "human",
+        "resource_state": "open",
+        "capabilities": [
+          {
+            "capability": "comments:write",
+            "granted": true,
+            "source": "",
+            "generation": "cred-7"
+          }
+        ]
+      },
+      "expected": {
+        "allowed": false,
+        "operation_class": "github.comment.write",
+        "reason_code": "invalid_capability_proof",
+        "matched_rule": "github.operation.github.comment.write",
+        "capability_proofs": [],
+        "policy_version": "2026.08.25-v2"
+      }
+    },
+    {
+      "name": "duplicate_conflicting_grants_fail_closed",
+      "request": {
+        "domain": "github.operation",
+        "operation_class": "github.comment.write",
+        "actor_class": "human",
+        "resource_state": "open",
+        "capabilities": [
+          {
+            "capability": "comments:write",
+            "granted": true,
+            "source": "user_api_token",
+            "generation": "cred-8"
+          },
+          {
+            "capability": "comments:write",
+            "granted": false,
+            "source": "user_api_token",
+            "generation": "cred-8"
+          }
+        ]
+      },
+      "expected": {
+        "allowed": false,
+        "operation_class": "github.comment.write",
+        "reason_code": "invalid_capability_proof",
+        "matched_rule": "github.operation.github.comment.write",
+        "capability_proofs": [],
+        "policy_version": "2026.08.25-v2"
+      }
+    },
+    {
+      "name": "duplicate_proof_precedes_missing_capability",
+      "request": {
+        "domain": "github.operation",
+        "operation_class": "github.gitdata.write",
+        "actor_class": "workflow",
+        "resource_state": "current",
+        "capabilities": [
+          {
+            "capability": "git_objects:write",
+            "granted": true,
+            "source": "object_token",
+            "generation": "cred-9"
+          },
+          {
+            "capability": "git_objects:write",
+            "granted": false,
+            "source": "object_token",
+            "generation": "cred-9"
+          }
+        ]
+      },
+      "expected": {
+        "allowed": false,
+        "operation_class": "github.gitdata.write",
+        "reason_code": "invalid_capability_proof",
+        "matched_rule": "github.operation.github.gitdata.write",
+        "capability_proofs": [],
+        "policy_version": "2026.08.25-v2"
+      }
+    },
+    {
+      "name": "all_required_gitdata_capabilities_must_be_present",
+      "request": {
+        "domain": "github.operation",
+        "operation_class": "github.gitdata.write",
+        "actor_class": "workflow",
+        "resource_state": "current",
+        "capabilities": [
+          {
+            "capability": "git_objects:write",
+            "granted": true,
+            "source": "object_token",
+            "generation": "cred-10"
+          }
+        ]
+      },
+      "expected": {
+        "allowed": false,
+        "operation_class": "github.gitdata.write",
+        "reason_code": "missing_capability",
+        "matched_rule": "github.operation.github.gitdata.write",
+        "capability_proofs": [],
+        "policy_version": "2026.08.25-v2"
+      }
+    },
+    {
+      "name": "contents_authority_does_not_admit_gitdata_write",
+      "request": {
+        "domain": "github.operation",
+        "operation_class": "github.gitdata.write",
+        "actor_class": "automation",
+        "resource_state": "current",
+        "capabilities": [
+          {
+            "capability": "contents:write",
+            "granted": true,
+            "source": "contents_token",
+            "generation": "cred-11"
+          }
+        ]
+      },
+      "expected": {
+        "allowed": false,
+        "operation_class": "github.gitdata.write",
+        "reason_code": "missing_capability",
+        "matched_rule": "github.operation.github.gitdata.write",
+        "capability_proofs": [],
+        "policy_version": "2026.08.25-v2"
+      }
+    },
+    {
+      "name": "gitdata_authority_does_not_admit_pull_request_create",
+      "request": {
+        "domain": "github.operation",
+        "operation_class": "github.pull_request.create",
+        "actor_class": "automation",
+        "resource_state": "current",
+        "capabilities": [
+          {
+            "capability": "git_objects:write",
+            "granted": true,
+            "source": "object_token",
+            "generation": "cred-12a"
+          },
+          {
+            "capability": "refs:write",
+            "granted": true,
+            "source": "ref_token",
+            "generation": "cred-12b"
+          }
+        ]
+      },
+      "expected": {
+        "allowed": false,
+        "operation_class": "github.pull_request.create",
+        "reason_code": "missing_capability",
+        "matched_rule": "github.operation.github.pull_request.create",
+        "capability_proofs": [],
+        "policy_version": "2026.08.25-v2"
+      }
+    },
+    {
+      "name": "adjacent_workflow_authority_does_not_admit_actions_dispatch",
+      "request": {
+        "domain": "github.operation",
+        "operation_class": "github.actions.dispatch",
+        "actor_class": "workflow",
+        "resource_state": "current",
+        "capabilities": [
+          {
+            "capability": "workflows:write",
+            "granted": true,
+            "source": "workflow_token",
+            "generation": "cred-13"
+          }
+        ]
+      },
+      "expected": {
+        "allowed": false,
+        "operation_class": "github.actions.dispatch",
+        "reason_code": "missing_capability",
+        "matched_rule": "github.operation.github.actions.dispatch",
+        "capability_proofs": [],
+        "policy_version": "2026.08.25-v2"
+      }
+    }
+  ]
+}

--- a/authority/manifest-mutations.v1.json
+++ b/authority/manifest-mutations.v1.json
@@ -1,0 +1,245 @@
+{
+  "schema_version": 1,
+  "cases": [
+    {
+      "name": "canonical_manifest",
+      "mutations": [],
+      "expected": {
+        "schema_valid": true,
+        "compiler_valid": true
+      }
+    },
+    {
+      "name": "boolean_schema_version",
+      "mutations": [
+        {
+          "op": "set",
+          "path": [
+            "schema_version"
+          ],
+          "value": true
+        }
+      ],
+      "expected": {
+        "schema_valid": false,
+        "compiler_valid": false
+      }
+    },
+    {
+      "name": "valid_direct_symbol_extension",
+      "mutations": [
+        {
+          "op": "append",
+          "path": [
+            "domains",
+            "github.operation",
+            "sinks",
+            "github.comment.write",
+            "direct_symbols"
+          ],
+          "value": "issues.createDiscussionComment"
+        }
+      ],
+      "expected": {
+        "schema_valid": true,
+        "compiler_valid": true
+      }
+    },
+    {
+      "name": "unknown_top_level_field",
+      "mutations": [
+        {
+          "op": "set",
+          "path": [
+            "ambient_fallback"
+          ],
+          "value": true
+        }
+      ],
+      "expected": {
+        "schema_valid": false,
+        "compiler_valid": false
+      }
+    },
+    {
+      "name": "unknown_domain",
+      "mutations": [
+        {
+          "op": "set",
+          "path": [
+            "domains",
+            "unknown.operation"
+          ],
+          "value": {
+            "sinks": {
+              "unknown.sink": {
+                "broker": "unknownBroker",
+                "direct_symbols": []
+              }
+            },
+            "operation_classes": {
+              "unknown.write": {
+                "sink_class": "unknown.sink",
+                "required_capabilities": [
+                  "unknown:write"
+                ],
+                "allowed_actor_classes": [
+                  "human"
+                ],
+                "allowed_resource_states": [
+                  "current"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "expected": {
+        "schema_valid": false,
+        "compiler_valid": false
+      }
+    },
+    {
+      "name": "missing_policy_version",
+      "mutations": [
+        {
+          "op": "delete",
+          "path": [
+            "policy_version"
+          ]
+        }
+      ],
+      "expected": {
+        "schema_valid": false,
+        "compiler_valid": false
+      }
+    },
+    {
+      "name": "blank_sink_broker",
+      "mutations": [
+        {
+          "op": "set",
+          "path": [
+            "domains",
+            "github.operation",
+            "sinks",
+            "github.comment.write",
+            "broker"
+          ],
+          "value": ""
+        }
+      ],
+      "expected": {
+        "schema_valid": false,
+        "compiler_valid": false
+      }
+    },
+    {
+      "name": "duplicate_direct_symbol",
+      "mutations": [
+        {
+          "op": "append",
+          "path": [
+            "domains",
+            "github.operation",
+            "sinks",
+            "github.comment.write",
+            "direct_symbols"
+          ],
+          "value": "issues.createComment"
+        }
+      ],
+      "expected": {
+        "schema_valid": false,
+        "compiler_valid": false
+      }
+    },
+    {
+      "name": "unregistered_sink_reference",
+      "mutations": [
+        {
+          "op": "set",
+          "path": [
+            "domains",
+            "github.operation",
+            "operation_classes",
+            "github.comment.write",
+            "sink_class"
+          ],
+          "value": "github.api.unregistered"
+        }
+      ],
+      "expected": {
+        "schema_valid": true,
+        "compiler_valid": false
+      }
+    },
+    {
+      "name": "wildcard_capability",
+      "mutations": [
+        {
+          "op": "set",
+          "path": [
+            "domains",
+            "github.operation",
+            "operation_classes",
+            "github.comment.write",
+            "required_capabilities"
+          ],
+          "value": [
+            "comments:*"
+          ]
+        }
+      ],
+      "expected": {
+        "schema_valid": false,
+        "compiler_valid": false
+      }
+    },
+    {
+      "name": "duplicate_required_capability",
+      "mutations": [
+        {
+          "op": "set",
+          "path": [
+            "domains",
+            "github.operation",
+            "operation_classes",
+            "github.comment.write",
+            "required_capabilities"
+          ],
+          "value": [
+            "comments:write",
+            "comments:write"
+          ]
+        }
+      ],
+      "expected": {
+        "schema_valid": false,
+        "compiler_valid": false
+      }
+    },
+    {
+      "name": "unknown_actor_class",
+      "mutations": [
+        {
+          "op": "set",
+          "path": [
+            "domains",
+            "github.operation",
+            "operation_classes",
+            "github.comment.write",
+            "allowed_actor_classes"
+          ],
+          "value": [
+            "root"
+          ]
+        }
+      ],
+      "expected": {
+        "schema_valid": false,
+        "compiler_valid": false
+      }
+    }
+  ]
+}

--- a/authority/manifest.schema.json
+++ b/authority/manifest.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://hermes-agent.nousresearch.com/schemas/authority-manifest-v1.json",
+  "title":"Hermes Authority Policy Manifest v1",
+  "type":"object",
+  "additionalProperties":false,
+  "required":["schema_version","policy_version","domains"],
+  "properties":{"schema_version":{"const":1},"policy_version":{"type":"string","minLength":1},"domains":{"type":"object","additionalProperties":false,"minProperties":1,"properties":{"github.operation":{"$ref":"#/$defs/domain"},"sandbox.execution":{"$ref":"#/$defs/domain"},"child_process.operation":{"$ref":"#/$defs/domain"},"gateway.mutation":{"$ref":"#/$defs/domain"}}}},
+  "$defs":{"domain":{"type":"object","additionalProperties":false,"required":["sinks","operation_classes"],"properties":{"sinks":{"type":"object","minProperties":1,"additionalProperties":{"$ref":"#/$defs/sink"}},"operation_classes":{"type":"object","minProperties":1,"additionalProperties":{"$ref":"#/$defs/operation"}}}},"sink":{"type":"object","additionalProperties":false,"required":["broker","direct_symbols"],"properties":{"broker":{"type":"string","minLength":1},"direct_symbols":{"type":"array","items":{"type":"string","minLength":1},"uniqueItems":true}}},"operation":{"type":"object","additionalProperties":false,"required":["sink_class","required_capabilities","allowed_actor_classes","allowed_resource_states"],"properties":{"sink_class":{"type":"string","minLength":1},"required_capabilities":{"type":"array","minItems":1,"items":{"type":"string","minLength":1,"not":{"pattern":"\\*"}},"uniqueItems":true},"allowed_actor_classes":{"type":"array","minItems":1,"items":{"enum":["human","github_app","workflow","automation","external_bot"]},"uniqueItems":true},"allowed_resource_states":{"type":"array","minItems":1,"items":{"type":"string","minLength":1},"uniqueItems":true}}}}
+}

--- a/authority/manifest.v1.json
+++ b/authority/manifest.v1.json
@@ -1,0 +1,150 @@
+{
+  "schema_version": 1,
+  "policy_version": "2026.08.25-v2",
+  "domains": {
+    "github.operation": {
+      "sinks": {
+        "github.issue.metadata.write": {
+          "broker": "githubMutationBroker",
+          "direct_symbols": [
+            "issues.addLabels",
+            "issues.removeLabel",
+            "issues.update"
+          ]
+        },
+        "github.comment.write": {
+          "broker": "githubMutationBroker",
+          "direct_symbols": [
+            "issues.createComment",
+            "pulls.createReview",
+            "pulls.createReviewComment"
+          ]
+        },
+        "github.contents.write": {
+          "broker": "githubMutationBroker",
+          "direct_symbols": [
+            "repos.createOrUpdateFileContents",
+            "repos.deleteFile"
+          ]
+        },
+        "github.gitdata.write": {
+          "broker": "githubMutationBroker",
+          "direct_symbols": [
+            "git.createBlob",
+            "git.createCommit",
+            "git.createRef",
+            "git.createTree",
+            "git.updateRef"
+          ]
+        },
+        "github.pull_request.create": {
+          "broker": "githubMutationBroker",
+          "direct_symbols": [
+            "pulls.create"
+          ]
+        },
+        "github.actions.dispatch": {
+          "broker": "githubMutationBroker",
+          "direct_symbols": [
+            "actions.createWorkflowDispatch"
+          ]
+        }
+      },
+      "operation_classes": {
+        "github.issue.metadata.write": {
+          "sink_class": "github.issue.metadata.write",
+          "required_capabilities": [
+            "issues:metadata:write"
+          ],
+          "allowed_actor_classes": [
+            "human",
+            "github_app",
+            "workflow",
+            "automation"
+          ],
+          "allowed_resource_states": [
+            "open",
+            "closed"
+          ]
+        },
+        "github.comment.write": {
+          "sink_class": "github.comment.write",
+          "required_capabilities": [
+            "comments:write"
+          ],
+          "allowed_actor_classes": [
+            "human",
+            "github_app",
+            "workflow",
+            "automation"
+          ],
+          "allowed_resource_states": [
+            "open",
+            "closed"
+          ]
+        },
+        "github.contents.write": {
+          "sink_class": "github.contents.write",
+          "required_capabilities": [
+            "contents:write"
+          ],
+          "allowed_actor_classes": [
+            "human",
+            "github_app",
+            "workflow",
+            "automation"
+          ],
+          "allowed_resource_states": [
+            "current"
+          ]
+        },
+        "github.gitdata.write": {
+          "sink_class": "github.gitdata.write",
+          "required_capabilities": [
+            "git_objects:write",
+            "refs:write"
+          ],
+          "allowed_actor_classes": [
+            "human",
+            "github_app",
+            "workflow",
+            "automation"
+          ],
+          "allowed_resource_states": [
+            "current"
+          ]
+        },
+        "github.pull_request.create": {
+          "sink_class": "github.pull_request.create",
+          "required_capabilities": [
+            "pull_requests:create"
+          ],
+          "allowed_actor_classes": [
+            "human",
+            "github_app",
+            "workflow",
+            "automation"
+          ],
+          "allowed_resource_states": [
+            "current"
+          ]
+        },
+        "github.actions.dispatch": {
+          "sink_class": "github.actions.dispatch",
+          "required_capabilities": [
+            "actions:dispatch"
+          ],
+          "allowed_actor_classes": [
+            "human",
+            "github_app",
+            "workflow",
+            "automation"
+          ],
+          "allowed_resource_states": [
+            "current"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/docs/design/process-edge-authority.md
+++ b/docs/design/process-edge-authority.md
@@ -1,0 +1,153 @@
+# Process-Edge Authority Architecture
+
+Status: Phase G implementation contract
+Architecture owner: #91911
+Class tracker: #83565
+
+## Decision
+
+The closed class is not merely “credentials inherited by subprocesses.” It is:
+
+> Ambient process authority crossing a principal, profile, role, or trust boundary.
+
+An environment variable can encode a provider credential, gateway ownership,
+Kanban lifecycle authority, session identity, profile provenance, loader
+control, or routing state. The same name can be required on one edge and an
+authority leak on another. Therefore a global denylist or `inherit_credentials`
+boolean cannot represent the security decision.
+
+The control-plane rule from #91911 applies directly:
+
+> Coordinates select. Current proof objects authorize.
+
+For process creation, the executable and environment are coordinates. A typed,
+current process-edge contract authorizes what crosses.
+
+## Invariants
+
+1. Every non-terminal credential-bearing or full-profile child declares an
+   immutable process intent and expected principal.
+2. The live parent environment is never copied by an ordinary call site.
+3. Gateway, session, Kanban, delegation, and other control-plane authority is
+   denied unless the exact edge declares a grant.
+4. Model-driving CLIs receive model authentication, not every tool or messaging
+   credential owned by the active profile.
+5. Trusted Hermes execution children may receive profile tool capabilities, but
+   not gateway transport or parent lifecycle authority.
+6. Vault CLIs receive a positive operational allowlist plus their own exact auth
+   family and closed stdin.
+7. Profile-scoped execution fails closed when multiplexing is active without an
+   installed profile scope.
+8. Caller overrides pass through the same policy and cannot reintroduce stripped
+   authority after construction.
+9. Spawn receipts contain policy identity and environment key names, never
+   values.
+10. The model-authored terminal path remains sanitize-by-default at the shared
+    `_popen_bash` boundary.
+
+## Typed intents
+
+| Intent | Principal | Environment contract |
+|---|---|---|
+| `MODEL_DRIVER` | model-driving external CLI | safe OS baseline, exact provider auth, explicit edge grants |
+| `TRUSTED_HERMES_CHILD` | Hermes runtime | active profile view, explicit tool grants, no parent role authority |
+| `INTERACTIVE_HERMES_PTY` | Hermes runtime | trusted-child contract with PTY stdin |
+| `VAULT_CLI` | external credential tool | safe/network baseline plus BWS or OP auth family only |
+| `SECRET_HELPER` | operator-configured helper | active profile view with transport/lifecycle authority removed |
+| `CHECKPOINT_GIT` | local infrastructure | local OS baseline plus exact internal Git variables |
+| `CONTAINER_CONTROL` | local infrastructure | sanitized non-provider control environment |
+| `CONTAINER_IMAGE_BUILD` | local infrastructure | sanitized control environment plus six registry-auth variables |
+| `PROBE` | local infrastructure | minimal baseline, closed stdin, no credentials |
+
+## Explicit authority continuation
+
+Kanban authority demonstrates why an edge contract is necessary:
+
+- dispatcher → real worker: allowed;
+- worker → Codex → `hermes-tools`: allowed by an explicit Kanban grant;
+- worker → arbitrary nested `hermes chat`: denied;
+- gateway → ordinary descendant: gateway ownership denied.
+
+The grant is attached to the edge, not inferred from the presence of
+`HERMES_KANBAN_*` in the parent environment.
+
+## Current implementation boundary
+
+`tools.child_process_authority` is the Phase G narrow waist. During migration it
+uses the existing terminal sanitizer as an internal implementation primitive,
+but production callers may no longer select
+`inherit_credentials=True`, `scrub_secrets=False`, or remerge
+`os.environ` themselves.
+
+The first implementation slice migrates:
+
+- compute-host, CLI-exec, Codex, Copilot ACP, and dashboard PTY children;
+- CLI TUI, dashboard machine reroute, gateway restart watcher, dashboard setup,
+  and slash-worker Hermes runtime children;
+- Codex, repository-build, PID, and libc probes;
+- TUI `shell.exec` and quick-command terminal children through the established
+  sanitized terminal boundary;
+- Bitwarden and 1Password fetch/probe children;
+- operator command-secret helpers;
+- checkpoint Git;
+- Apptainer/Singularity lifecycle and image-build children; and
+- the shared Docker/SSH/Singularity terminal `_popen_bash` boundary, including
+  explicit stripping of Bitwarden and 1Password bootstrap authority.
+
+An AST gate rejects recurrence of the retired ambient-authority escape hatches.
+Every production module that imports the typed broker must also pass explicit
+`env` and `stdin` arguments at each direct subprocess boundary; omission is a
+CI failure rather than an implicit request for ambient inheritance.
+
+## Interlocks
+
+- #77027: shared model-authored terminal boundary; its unique current semantics
+  are folded into `_popen_bash`.
+- #91293: profile provenance, persistent runtime, and arbitrary-name
+  cross-profile isolation; this remains the profile-boundary implementation
+  owner and should compose with this broker rather than duplicate it.
+- #92633: inherited gateway marker is not gateway ownership.
+- #92416: nested children must not inherit Kanban lifecycle ownership.
+- #92309: the exact worker → `hermes-tools` edge requires bounded authority
+  continuation.
+- #70372: Desktop/TypeScript process policy must consume the same intent/grant
+  model in its own survivor.
+- #91362: fixed-command workers are the reference for literal argv, executable
+  validation, and credential-free command children.
+- #77467: vault CLI full-environment sink; the `VAULT_CLI` intent is its
+  canonical implementation.
+
+## Remaining class-wide phases
+
+The Python Phase G seam is necessary but not the final repository-wide closure.
+The following are required before #83565 itself closes:
+
+1. generate Python and TypeScript policy artifacts from one reviewed manifest;
+2. route Desktop, Node bridges, plugin sidecars, installers, and descendants
+   through typed intents;
+3. structurally ban direct production spawn APIs outside approved broker
+   modules in Python and JS/TS;
+4. replace original provider secrets with audience-bound broker grants wherever
+   lower-trust children do not require the raw credential;
+5. add randomized child/grandchild canaries and mutation tests across every
+   registered intent;
+6. emit value-free runtime receipts at production spawn boundaries; and
+7. execute the final independent sweep against one post-merge upstream `main`
+   SHA with the boundary check enforced as required CI.
+
+## Closure predicate
+
+Close #83565 only when one immutable upstream `main` SHA proves:
+
+- no production child environment is derived from live ambient state outside
+  the broker;
+- no production API exposes an untyped full-inheritance switch;
+- every child edge declares principal, intent, profile, executable identity,
+  grants, stdin policy, and descendant policy;
+- each authority has provenance and an explicit permitted-edge set;
+- Python and TypeScript policy hashes agree;
+- canary and mutation witnesses fail when the boundary is weakened;
+- no relevant regression remains expected-failure;
+- all superseded work identifies the upstream commit that absorbed its unique
+  behavior and attribution; and
+- the boundary status is actually required on `main`.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11516,8 +11516,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 """
             ).strip()
-            from tools.environments.local import build_subprocess_env
-            watcher_env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=True)
+            from tools.child_process_authority import (
+                ChildStdinPolicy,
+                build_child_process_env,
+                stdin_for_spec,
+                trusted_hermes_child_spec,
+            )
+
+            watcher_spec = trusted_hermes_child_spec(
+                source="gateway.run.restart_watcher.windows",
+                stdin=ChildStdinPolicy.CLOSED,
+            )
+            watcher_env = build_child_process_env(watcher_spec)
             # This watcher is intentionally outside the running gateway. If it
             # inherits the gateway marker, `hermes gateway restart` refuses to
             # run as a self-restart loop guard and the gateway stays stopped.
@@ -11561,6 +11571,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     watcher_argv,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
+                    stdin=stdin_for_spec(watcher_spec),
                     env=watcher_env,
                     **windows_detach_popen_kwargs(),
                 )
@@ -11570,6 +11581,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         watcher_argv,
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL,
+                        stdin=stdin_for_spec(watcher_spec),
                         env=watcher_env,
                         creationflags=windows_detach_flags_without_breakaway(),
                     )
@@ -11606,8 +11618,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # _HERMES_GATEWAY=1 from us, and the CLI's self-restart loop guard
         # refuses to run when that marker is set — silently (DEVNULL), so the
         # gateway stops and never comes back.
-        from tools.environments.local import build_subprocess_env
-        watcher_env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=True)
+        from tools.child_process_authority import (
+            ChildStdinPolicy,
+            build_child_process_env,
+            stdin_for_spec,
+            trusted_hermes_child_spec,
+        )
+
+        watcher_spec = trusted_hermes_child_spec(
+            source="gateway.run.restart_watcher.posix",
+            stdin=ChildStdinPolicy.CLOSED,
+        )
+        watcher_env = build_child_process_env(watcher_spec)
         watcher_env.pop("_HERMES_GATEWAY", None)
         setsid_bin = shutil.which("setsid")
         if setsid_bin:
@@ -11615,6 +11637,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 [setsid_bin, "bash", "-lc", shell_cmd],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
+                stdin=stdin_for_spec(watcher_spec),
                 env=watcher_env,
                 start_new_session=True,
             )
@@ -11623,6 +11646,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 ["bash", "-lc", shell_cmd],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
+                stdin=stdin_for_spec(watcher_spec),
                 env=watcher_env,
                 start_new_session=True,
             )

--- a/hermes_cli/authority/__init__.py
+++ b/hermes_cli/authority/__init__.py
@@ -1,0 +1,37 @@
+"""Authority Execution Layer primitives."""
+
+from .manifest import (
+    CANONICAL_AUTHORITY_MANIFEST,
+    AdmissionRequest,
+    AdmissionRequestValidationError,
+    AuthorityDecision,
+    AuthorityManifestArtifact,
+    CapabilityGrant,
+    CapabilityProof,
+    CompiledDomain,
+    CompiledManifest,
+    CompiledOperation,
+    CompiledSink,
+    ManifestValidationError,
+    admission_request_from_mapping,
+    compile_authority_manifest,
+    evaluate_authority_operation,
+)
+
+__all__ = [
+    "CANONICAL_AUTHORITY_MANIFEST",
+    "AdmissionRequest",
+    "AdmissionRequestValidationError",
+    "AuthorityDecision",
+    "AuthorityManifestArtifact",
+    "CapabilityGrant",
+    "CapabilityProof",
+    "CompiledDomain",
+    "CompiledManifest",
+    "CompiledOperation",
+    "CompiledSink",
+    "ManifestValidationError",
+    "admission_request_from_mapping",
+    "compile_authority_manifest",
+    "evaluate_authority_operation",
+]

--- a/hermes_cli/authority/manifest.py
+++ b/hermes_cli/authority/manifest.py
@@ -1,0 +1,640 @@
+"""Authority policy manifest compiler and admission evaluator.
+
+This module is deliberately transport-free. It compiles a closed policy
+manifest into a normalized representation and evaluates whether an operation
+is policy-admitted. It does not execute effects, mint carriers, or settle
+operations; those belong to later Authority Execution Layer shards.
+
+The canonical S1 policy is embedded below as one immutable runtime artifact.
+Consumers import that artifact instead of locating and reparsing a repository
+file, so packaged Python installations retain the exact bytes, digest, sink
+ownership, and compiled policy that later shards bind into proof objects.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping, Sequence
+
+KNOWN_DOMAINS = frozenset(
+    {
+        "github.operation",
+        "sandbox.execution",
+        "child_process.operation",
+        "gateway.mutation",
+    }
+)
+KNOWN_ACTOR_CLASSES = frozenset(
+    {"human", "github_app", "workflow", "automation", "external_bot"}
+)
+_TOP_LEVEL_KEYS = frozenset({"schema_version", "policy_version", "domains"})
+_DOMAIN_KEYS = frozenset({"sinks", "operation_classes"})
+_SINK_KEYS = frozenset({"broker", "direct_symbols"})
+_OPERATION_KEYS = frozenset(
+    {
+        "sink_class",
+        "required_capabilities",
+        "allowed_actor_classes",
+        "allowed_resource_states",
+    }
+)
+_REQUEST_KEYS = frozenset(
+    {"domain", "operation_class", "actor_class", "resource_state", "capabilities"}
+)
+_CAPABILITY_GRANT_KEYS = frozenset(
+    {"capability", "granted", "source", "generation"}
+)
+
+_CANONICAL_MANIFEST_BYTES = b'''{
+  "schema_version": 1,
+  "policy_version": "2026.08.25-v2",
+  "domains": {
+    "github.operation": {
+      "sinks": {
+        "github.issue.metadata.write": {
+          "broker": "githubMutationBroker",
+          "direct_symbols": [
+            "issues.addLabels",
+            "issues.removeLabel",
+            "issues.update"
+          ]
+        },
+        "github.comment.write": {
+          "broker": "githubMutationBroker",
+          "direct_symbols": [
+            "issues.createComment",
+            "pulls.createReview",
+            "pulls.createReviewComment"
+          ]
+        },
+        "github.contents.write": {
+          "broker": "githubMutationBroker",
+          "direct_symbols": [
+            "repos.createOrUpdateFileContents",
+            "repos.deleteFile"
+          ]
+        },
+        "github.gitdata.write": {
+          "broker": "githubMutationBroker",
+          "direct_symbols": [
+            "git.createBlob",
+            "git.createCommit",
+            "git.createRef",
+            "git.createTree",
+            "git.updateRef"
+          ]
+        },
+        "github.pull_request.create": {
+          "broker": "githubMutationBroker",
+          "direct_symbols": [
+            "pulls.create"
+          ]
+        },
+        "github.actions.dispatch": {
+          "broker": "githubMutationBroker",
+          "direct_symbols": [
+            "actions.createWorkflowDispatch"
+          ]
+        }
+      },
+      "operation_classes": {
+        "github.issue.metadata.write": {
+          "sink_class": "github.issue.metadata.write",
+          "required_capabilities": [
+            "issues:metadata:write"
+          ],
+          "allowed_actor_classes": [
+            "human",
+            "github_app",
+            "workflow",
+            "automation"
+          ],
+          "allowed_resource_states": [
+            "open",
+            "closed"
+          ]
+        },
+        "github.comment.write": {
+          "sink_class": "github.comment.write",
+          "required_capabilities": [
+            "comments:write"
+          ],
+          "allowed_actor_classes": [
+            "human",
+            "github_app",
+            "workflow",
+            "automation"
+          ],
+          "allowed_resource_states": [
+            "open",
+            "closed"
+          ]
+        },
+        "github.contents.write": {
+          "sink_class": "github.contents.write",
+          "required_capabilities": [
+            "contents:write"
+          ],
+          "allowed_actor_classes": [
+            "human",
+            "github_app",
+            "workflow",
+            "automation"
+          ],
+          "allowed_resource_states": [
+            "current"
+          ]
+        },
+        "github.gitdata.write": {
+          "sink_class": "github.gitdata.write",
+          "required_capabilities": [
+            "git_objects:write",
+            "refs:write"
+          ],
+          "allowed_actor_classes": [
+            "human",
+            "github_app",
+            "workflow",
+            "automation"
+          ],
+          "allowed_resource_states": [
+            "current"
+          ]
+        },
+        "github.pull_request.create": {
+          "sink_class": "github.pull_request.create",
+          "required_capabilities": [
+            "pull_requests:create"
+          ],
+          "allowed_actor_classes": [
+            "human",
+            "github_app",
+            "workflow",
+            "automation"
+          ],
+          "allowed_resource_states": [
+            "current"
+          ]
+        },
+        "github.actions.dispatch": {
+          "sink_class": "github.actions.dispatch",
+          "required_capabilities": [
+            "actions:dispatch"
+          ],
+          "allowed_actor_classes": [
+            "human",
+            "github_app",
+            "workflow",
+            "automation"
+          ],
+          "allowed_resource_states": [
+            "current"
+          ]
+        }
+      }
+    }
+  }
+}
+'''
+_CANONICAL_MANIFEST_SHA256 = (
+    "d427e3cd580f97a18103cbb73c04dc0baf2565f8509bcd298ee7aff049588d8e"
+)
+
+
+class ManifestValidationError(ValueError):
+    """Raised when a manifest is not closed, explicit, and internally valid."""
+
+
+class AdmissionRequestValidationError(ValueError):
+    """Raised when an admission request is structurally malformed."""
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityGrant:
+    capability: str
+    granted: bool
+    source: str
+    generation: str
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityProof:
+    capability: str
+    source: str
+    generation: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "capability": self.capability,
+            "source": self.source,
+            "generation": self.generation,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AdmissionRequest:
+    domain: str
+    operation_class: str
+    actor_class: str
+    resource_state: str
+    capabilities: tuple[CapabilityGrant, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorityDecision:
+    allowed: bool
+    operation_class: str
+    reason_code: str
+    matched_rule: str | None
+    capability_proofs: tuple[CapabilityProof, ...]
+    policy_version: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "allowed": self.allowed,
+            "operation_class": self.operation_class,
+            "reason_code": self.reason_code,
+            "matched_rule": self.matched_rule,
+            "capability_proofs": [proof.as_dict() for proof in self.capability_proofs],
+            "policy_version": self.policy_version,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CompiledSink:
+    broker: str
+    direct_symbols: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class CompiledOperation:
+    sink_class: str
+    required_capabilities: tuple[str, ...]
+    allowed_actor_classes: frozenset[str]
+    allowed_resource_states: frozenset[str]
+
+
+@dataclass(frozen=True, slots=True)
+class CompiledDomain:
+    sinks: Mapping[str, CompiledSink]
+    operations: Mapping[str, CompiledOperation]
+
+
+@dataclass(frozen=True, slots=True)
+class CompiledManifest:
+    schema_version: int
+    policy_version: str
+    domains: Mapping[str, CompiledDomain]
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorityManifestArtifact:
+    """Exact packaged bytes, digest, and the sole canonical compiled policy."""
+
+    manifest_bytes: bytes
+    manifest_sha256: str
+    manifest: CompiledManifest
+
+
+def _closed_key_error(
+    value: Mapping[str, Any], expected: frozenset[str], where: str
+) -> str | None:
+    actual = frozenset(value)
+    if actual == expected:
+        return None
+    unknown = sorted(actual - expected)
+    missing = sorted(expected - actual)
+    details: list[str] = []
+    if unknown:
+        details.append(f"unknown={unknown}")
+    if missing:
+        details.append(f"missing={missing}")
+    return f"{where} must be closed ({', '.join(details)})"
+
+
+def _require_exact_keys(
+    value: Mapping[str, Any], expected: frozenset[str], where: str
+) -> None:
+    if error := _closed_key_error(value, expected, where):
+        raise ManifestValidationError(error)
+
+
+def _require_nonempty_string(value: Any, where: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ManifestValidationError(f"{where} must be a non-empty string")
+    return value
+
+
+def _require_unique_strings(
+    value: Any, where: str, *, nonempty: bool = True
+) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise ManifestValidationError(f"{where} must be an array")
+    if nonempty and not value:
+        raise ManifestValidationError(f"{where} must not be empty")
+    if any(not isinstance(item, str) or not item.strip() for item in value):
+        raise ManifestValidationError(f"{where} must contain only non-empty strings")
+    if len(set(value)) != len(value):
+        raise ManifestValidationError(f"{where} must not contain duplicates")
+    return tuple(value)
+
+
+def compile_authority_manifest(raw: Mapping[str, Any]) -> CompiledManifest:
+    """Validate and compile a closed Authority Policy Manifest v1.
+
+    Closed means no unknown top-level/domain/operation/sink fields, no unknown
+    domains, no implicit capabilities, no wildcard grants, and no operation
+    that points at an unregistered sink. Sink ownership metadata survives
+    compilation so later shards never need a second raw-JSON parser.
+    """
+
+    if not isinstance(raw, Mapping):
+        raise ManifestValidationError("manifest must be an object")
+    _require_exact_keys(raw, _TOP_LEVEL_KEYS, "manifest")
+
+    schema_version = raw["schema_version"]
+    if (
+        isinstance(schema_version, bool)
+        or not isinstance(schema_version, (int, float))
+        or schema_version != 1
+    ):
+        raise ManifestValidationError("schema_version must equal 1")
+    policy_version = _require_nonempty_string(raw["policy_version"], "policy_version")
+
+    raw_domains = raw["domains"]
+    if not isinstance(raw_domains, Mapping) or not raw_domains:
+        raise ManifestValidationError("domains must be a non-empty object")
+    unknown_domains = sorted(set(raw_domains) - KNOWN_DOMAINS)
+    if unknown_domains:
+        raise ManifestValidationError(f"unknown domains: {unknown_domains}")
+
+    domains: dict[str, CompiledDomain] = {}
+    for domain_name in sorted(raw_domains):
+        raw_domain = raw_domains[domain_name]
+        if not isinstance(raw_domain, Mapping):
+            raise ManifestValidationError(f"domains.{domain_name} must be an object")
+        _require_exact_keys(raw_domain, _DOMAIN_KEYS, f"domains.{domain_name}")
+
+        raw_sinks = raw_domain["sinks"]
+        raw_operations = raw_domain["operation_classes"]
+        if not isinstance(raw_sinks, Mapping) or not raw_sinks:
+            raise ManifestValidationError(f"domains.{domain_name}.sinks must be non-empty")
+        if not isinstance(raw_operations, Mapping) or not raw_operations:
+            raise ManifestValidationError(
+                f"domains.{domain_name}.operation_classes must be non-empty"
+            )
+
+        sinks: dict[str, CompiledSink] = {}
+        for sink_name, sink_spec in raw_sinks.items():
+            _require_nonempty_string(sink_name, f"domains.{domain_name}.sink name")
+            if not isinstance(sink_spec, Mapping):
+                raise ManifestValidationError(f"sink {sink_name} must be an object")
+            _require_exact_keys(sink_spec, _SINK_KEYS, f"sink {sink_name}")
+            broker = _require_nonempty_string(
+                sink_spec["broker"], f"sink {sink_name}.broker"
+            )
+            direct_symbols = _require_unique_strings(
+                sink_spec["direct_symbols"],
+                f"sink {sink_name}.direct_symbols",
+                nonempty=False,
+            )
+            sinks[sink_name] = CompiledSink(
+                broker=broker,
+                direct_symbols=tuple(sorted(direct_symbols)),
+            )
+
+        operations: dict[str, CompiledOperation] = {}
+        for operation_name, operation_spec in raw_operations.items():
+            _require_nonempty_string(
+                operation_name, f"domains.{domain_name}.operation class name"
+            )
+            if not isinstance(operation_spec, Mapping):
+                raise ManifestValidationError(f"operation {operation_name} must be an object")
+            _require_exact_keys(
+                operation_spec, _OPERATION_KEYS, f"operation {operation_name}"
+            )
+
+            sink_class = _require_nonempty_string(
+                operation_spec["sink_class"],
+                f"operation {operation_name}.sink_class",
+            )
+            if sink_class not in sinks:
+                raise ManifestValidationError(
+                    f"operation {operation_name} references unregistered sink {sink_class}"
+                )
+
+            required_capabilities = _require_unique_strings(
+                operation_spec["required_capabilities"],
+                f"operation {operation_name}.required_capabilities",
+            )
+            if any("*" in capability for capability in required_capabilities):
+                raise ManifestValidationError(
+                    f"operation {operation_name} contains an ambient wildcard capability"
+                )
+
+            actor_classes = _require_unique_strings(
+                operation_spec["allowed_actor_classes"],
+                f"operation {operation_name}.allowed_actor_classes",
+            )
+            unknown_actors = sorted(set(actor_classes) - KNOWN_ACTOR_CLASSES)
+            if unknown_actors:
+                raise ManifestValidationError(
+                    f"operation {operation_name} has unknown actor classes {unknown_actors}"
+                )
+
+            resource_states = _require_unique_strings(
+                operation_spec["allowed_resource_states"],
+                f"operation {operation_name}.allowed_resource_states",
+            )
+
+            operations[operation_name] = CompiledOperation(
+                sink_class=sink_class,
+                required_capabilities=required_capabilities,
+                allowed_actor_classes=frozenset(actor_classes),
+                allowed_resource_states=frozenset(resource_states),
+            )
+
+        domains[domain_name] = CompiledDomain(
+            sinks=MappingProxyType(sinks),
+            operations=MappingProxyType(operations),
+        )
+
+    return CompiledManifest(
+        schema_version=1,
+        policy_version=policy_version,
+        domains=MappingProxyType(domains),
+    )
+
+
+def admission_request_from_mapping(raw: Mapping[str, Any]) -> AdmissionRequest:
+    """Parse a closed request shape without weakening proof semantics."""
+
+    if not isinstance(raw, Mapping):
+        raise AdmissionRequestValidationError("admission request must be an object")
+    if error := _closed_key_error(raw, _REQUEST_KEYS, "admission request"):
+        raise AdmissionRequestValidationError(error)
+
+    string_fields: dict[str, str] = {}
+    for field in ("domain", "operation_class", "actor_class", "resource_state"):
+        value = raw[field]
+        if not isinstance(value, str):
+            raise AdmissionRequestValidationError(f"{field} must be a string")
+        string_fields[field] = value
+
+    capabilities_raw = raw["capabilities"]
+    if not isinstance(capabilities_raw, Sequence) or isinstance(
+        capabilities_raw, (str, bytes)
+    ):
+        raise AdmissionRequestValidationError("capabilities must be an array")
+
+    capabilities: list[CapabilityGrant] = []
+    for index, item in enumerate(capabilities_raw):
+        if not isinstance(item, Mapping):
+            raise AdmissionRequestValidationError(
+                f"capabilities[{index}] must be an object"
+            )
+        if error := _closed_key_error(
+            item, _CAPABILITY_GRANT_KEYS, f"capabilities[{index}]"
+        ):
+            raise AdmissionRequestValidationError(error)
+        capability = item["capability"]
+        source = item["source"]
+        generation = item["generation"]
+        granted = item["granted"]
+        if not isinstance(capability, str):
+            raise AdmissionRequestValidationError(
+                f"capabilities[{index}].capability must be a string"
+            )
+        if not isinstance(source, str):
+            raise AdmissionRequestValidationError(
+                f"capabilities[{index}].source must be a string"
+            )
+        if not isinstance(generation, str):
+            raise AdmissionRequestValidationError(
+                f"capabilities[{index}].generation must be a string"
+            )
+        if not isinstance(granted, bool):
+            raise AdmissionRequestValidationError(
+                f"capabilities[{index}].granted must be a boolean"
+            )
+        capabilities.append(
+            CapabilityGrant(
+                capability=capability,
+                granted=granted,
+                source=source,
+                generation=generation,
+            )
+        )
+
+    return AdmissionRequest(
+        domain=string_fields["domain"],
+        operation_class=string_fields["operation_class"],
+        actor_class=string_fields["actor_class"],
+        resource_state=string_fields["resource_state"],
+        capabilities=tuple(capabilities),
+    )
+
+
+def _decision(
+    manifest: CompiledManifest,
+    request: AdmissionRequest,
+    reason_code: str,
+    matched_rule: str | None,
+    *,
+    allowed: bool = False,
+    capability_proofs: tuple[CapabilityProof, ...] = (),
+) -> AuthorityDecision:
+    return AuthorityDecision(
+        allowed=allowed,
+        operation_class=request.operation_class,
+        reason_code=reason_code,
+        matched_rule=matched_rule,
+        capability_proofs=capability_proofs,
+        policy_version=manifest.policy_version,
+    )
+
+
+def evaluate_authority_operation(
+    manifest: CompiledManifest, request: AdmissionRequest
+) -> AuthorityDecision:
+    """Evaluate policy admission without performing any external effect.
+
+    Refusal precedence is unsupported operation, forbidden actor, denied
+    resource state, invalid capability proof, then missing capability.
+    """
+
+    domain = manifest.domains.get(request.domain)
+    operation = domain.operations.get(request.operation_class) if domain else None
+    matched_rule = (
+        f"{request.domain}.{request.operation_class}" if operation is not None else None
+    )
+
+    if operation is None:
+        return _decision(manifest, request, "unsupported_operation", None)
+
+    if request.actor_class not in operation.allowed_actor_classes:
+        return _decision(manifest, request, "actor_forbidden", matched_rule)
+
+    if request.resource_state not in operation.allowed_resource_states:
+        return _decision(manifest, request, "resource_state_denied", matched_rule)
+
+    grants: dict[str, CapabilityGrant] = {}
+    for grant in request.capabilities:
+        if (
+            not grant.capability.strip()
+            or not grant.source.strip()
+            or not grant.generation.strip()
+            or grant.capability in grants
+        ):
+            return _decision(
+                manifest,
+                request,
+                "invalid_capability_proof",
+                matched_rule,
+            )
+        grants[grant.capability] = grant
+
+    if any(
+        capability not in grants or not grants[capability].granted
+        for capability in operation.required_capabilities
+    ):
+        return _decision(manifest, request, "missing_capability", matched_rule)
+
+    proofs = tuple(
+        CapabilityProof(
+            capability=capability,
+            source=grants[capability].source,
+            generation=grants[capability].generation,
+        )
+        for capability in operation.required_capabilities
+    )
+    return _decision(
+        manifest,
+        request,
+        "allowed",
+        matched_rule,
+        allowed=True,
+        capability_proofs=proofs,
+    )
+
+
+def _build_canonical_manifest_artifact() -> AuthorityManifestArtifact:
+    digest = hashlib.sha256(_CANONICAL_MANIFEST_BYTES).hexdigest()
+    if digest != _CANONICAL_MANIFEST_SHA256:
+        raise RuntimeError("embedded authority manifest bytes do not match their digest")
+
+    raw = json.loads(_CANONICAL_MANIFEST_BYTES)
+    if not isinstance(raw, Mapping):  # pragma: no cover - guarded by literal + tests
+        raise RuntimeError("embedded authority manifest must decode to an object")
+
+    return AuthorityManifestArtifact(
+        manifest_bytes=_CANONICAL_MANIFEST_BYTES,
+        manifest_sha256=digest,
+        manifest=compile_authority_manifest(raw),
+    )
+
+
+CANONICAL_AUTHORITY_MANIFEST = _build_canonical_manifest_artifact()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2880,10 +2880,17 @@ def _launch_tui(
 
     import tempfile
 
-    # TUI child is a hermes process: propagate the profile-home contract via
-    # the single factory; keep secrets (the TUI/agent needs provider creds).
-    from tools.environments.local import build_subprocess_env
-    env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=True)
+    # TUI child is a Hermes process: declare an interactive typed edge that
+    # retains profile-scoped agent/tool authority while stripping parent
+    # gateway and orchestration authority.
+    from tools.child_process_authority import (
+        build_child_process_env,
+        interactive_hermes_pty_spec,
+        stdin_for_spec,
+    )
+
+    tui_spec = interactive_hermes_pty_spec(source="hermes_cli.main.launch_tui")
+    env = build_child_process_env(tui_spec)
     try:
         from hermes_cli.config import apply_terminal_config_to_env
         apply_terminal_config_to_env(env=env)
@@ -3006,7 +3013,12 @@ def _launch_tui(
     code: Optional[int] = None
     try:
         try:
-            code = subprocess.call(argv, cwd=str(cwd), env=env)
+            code = subprocess.call(
+                argv,
+                cwd=str(cwd),
+                env=env,
+                stdin=stdin_for_spec(tui_spec),
+            )
         except KeyboardInterrupt:
             code = 130
 
@@ -11884,6 +11896,34 @@ def _is_electron_packaged_web_dist(path: str) -> bool:
     return "app.asar" in path.replace("\\", "/")
 
 
+def _machine_dashboard_reexec_env() -> dict[str, str]:
+    """Build the trusted child env for a named-profile dashboard reroute."""
+
+    from tools.child_process_authority import (
+        ChildStdinPolicy,
+        build_child_process_env,
+        trusted_hermes_child_spec,
+    )
+
+    try:
+        from hermes_constants import get_default_hermes_root
+
+        machine_root = str(get_default_hermes_root())
+    except Exception:
+        machine_root = ""
+
+    env = build_child_process_env(
+        trusted_hermes_child_spec(
+            source="hermes_cli.main.machine_dashboard_reexec",
+            stdin=ChildStdinPolicy.CLOSED,
+        ),
+        overrides={"HERMES_HOME": machine_root} if machine_root else None,
+    )
+    if not machine_root:
+        env.pop("HERMES_HOME", None)
+    return env
+
+
 def cmd_dashboard(args):
     """Start the web UI server, or (with --stop/--status) manage running ones."""
     _token_file = getattr(args, "ssh_session_token_file", None)
@@ -12002,10 +12042,7 @@ def cmd_dashboard(args):
             reexec_argv.append("--insecure")
         if getattr(args, "skip_build", False):
             reexec_argv.append("--skip-build")
-        from tools.environments.local import build_subprocess_env
-        # Exact env preservation: HERMES_HOME is explicitly pinned to the
-        # machine root below — the factory must not re-inject a profile home.
-        env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
+        env = _machine_dashboard_reexec_env()
         # Pin the child to the machine ROOT, not the launching profile's
         # HERMES_HOME.  We must resolve the root explicitly instead of just
         # dropping HERMES_HOME: in the Docker layout the machine root is
@@ -12017,13 +12054,6 @@ def cmd_dashboard(args):
         # returns the root for both layouts: ~/.hermes for a standard install
         # and /opt/data for Docker (it strips a trailing profiles/<name>).
         # See the support report for the double-mount workaround this avoids.
-        try:
-            from hermes_constants import get_default_hermes_root
-            env["HERMES_HOME"] = str(get_default_hermes_root())
-        except Exception:
-            # Best-effort: if root resolution fails, fall back to the prior
-            # behaviour (drop HERMES_HOME) rather than block the reroute.
-            env.pop("HERMES_HOME", None)
         # On Windows, os.execvpe() does not truly replace the process — it
         # spawns via CreateProcess then the parent exits.  Under Python 3.14+
         # this can crash with STATUS_ACCESS_VIOLATION (0xC0000005) when

--- a/hermes_cli/onepassword_secrets_cli.py
+++ b/hermes_cli/onepassword_secrets_cli.py
@@ -483,6 +483,13 @@ def _yn(b: bool) -> str:
 
 def _op_version(binary: Path) -> str:
     try:
+        from tools.child_process_authority import (
+            build_child_process_env,
+            probe_spec,
+            stdin_for_spec,
+        )
+
+        spec = probe_spec(source="hermes_cli.onepassword_secrets_cli.op_version")
         res = subprocess.run(
             [str(binary), "--version"],
             capture_output=True,
@@ -490,6 +497,8 @@ def _op_version(binary: Path) -> str:
             encoding="utf-8",
             errors="replace",
             timeout=5,
+            env=build_child_process_env(spec),
+            stdin=stdin_for_spec(spec),
         )
         if res.returncode == 0:
             return (res.stdout or res.stderr).strip().splitlines()[0]
@@ -510,17 +519,23 @@ def _op_whoami(
     cmd = [str(binary), "whoami"]
     if account:
         cmd += ["--account", account]
-    # 1Password CLI child: intentionally receives the service-account token —
-    # no scrub, no HOME rewrite (op stores auth state under the real home).
-    from tools.environments.local import build_subprocess_env
-    env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
-    env.setdefault("NO_COLOR", "1")
+    from tools.child_process_authority import (
+        build_child_process_env,
+        op_vault_spec,
+    )
+
+    overrides = {"NO_COLOR": "1"}
     if token_value:
-        env["OP_SERVICE_ACCOUNT_TOKEN"] = token_value
+        overrides["OP_SERVICE_ACCOUNT_TOKEN"] = token_value
+    env = build_child_process_env(
+        op_vault_spec(source="hermes_cli.onepassword_secrets_cli.whoami"),
+        overrides=overrides,
+    )
     try:
         res = subprocess.run(
             cmd, env=env, capture_output=True, text=True,
-            encoding="utf-8", errors="replace", timeout=10
+            encoding="utf-8", errors="replace", timeout=10,
+            stdin=subprocess.DEVNULL,
         )
     except (OSError, subprocess.TimeoutExpired):
         return None

--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -143,13 +143,14 @@ class PtyBridge:
         # simple terminal probes like `tput cols` fail before winsize reads.
         # Preserve explicit caller overrides, but backfill a sensible default
         # when TERM is missing or blank.
-        # env=None fallback: callers own env policy (process_registry already
-        # sanitizes). Build via the factory with exact preservation so the
-        # site stays findable without changing inherited content.
-        from tools.environments.local import build_subprocess_env
-        spawn_env = (
-            build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
-            if env is None else env.copy()
+        from tools.child_process_authority import (
+            build_child_process_env,
+            interactive_hermes_pty_spec,
+        )
+
+        spawn_env = build_child_process_env(
+            interactive_hermes_pty_spec(source="hermes_cli.pty_bridge"),
+            source_env=env,
         )
         if not spawn_env.get("TERM"):
             spawn_env["TERM"] = "xterm-256color"

--- a/hermes_cli/secrets_cli.py
+++ b/hermes_cli/secrets_cli.py
@@ -599,11 +599,20 @@ def _yn(b: bool) -> str:
 
 def _bws_version(binary: Path) -> str:
     try:
+        from tools.child_process_authority import (
+            build_child_process_env,
+            probe_spec,
+            stdin_for_spec,
+        )
+
+        spec = probe_spec(source="hermes_cli.secrets_cli.bws_version")
         res = subprocess.run(
             [str(binary), "--version"],
             capture_output=True,
             text=True, encoding='utf-8', errors='replace',
             timeout=5,
+            env=build_child_process_env(spec),
+            stdin=stdin_for_spec(spec),
         )
         if res.returncode == 0:
             return (res.stdout or res.stderr).strip().splitlines()[0]
@@ -648,14 +657,21 @@ def _list_projects(
     binary: Path, token: str, console: Console, *, server_url: str = ""
 ) -> Optional[List[dict]]:
     """Call ``bws project list`` and return the parsed list, or None on failure."""
-    # Secret-manager CLI child: intentionally receives tokens — no scrub,
-    # no HOME rewrite (bws stores state under the real user home).
-    from tools.environments.local import build_subprocess_env
-    env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
-    env["BWS_ACCESS_TOKEN"] = token
-    env.setdefault("NO_COLOR", "1")
+    from tools.child_process_authority import (
+        build_child_process_env,
+        bws_vault_spec,
+    )
+
+    overrides = {
+        "BWS_ACCESS_TOKEN": token,
+        "NO_COLOR": "1",
+    }
     if server_url:
-        env["BWS_SERVER_URL"] = server_url
+        overrides["BWS_SERVER_URL"] = server_url
+    env = build_child_process_env(
+        bws_vault_spec(source="hermes_cli.secrets_cli.list_projects"),
+        overrides=overrides,
+    )
     try:
         res = subprocess.run(
             [str(binary), "project", "list", "--output", "json"],
@@ -663,6 +679,7 @@ def _list_projects(
             capture_output=True,
             text=True, encoding='utf-8', errors='replace',
             timeout=15,
+            stdin=subprocess.DEVNULL,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         console.print(f"  [red]Couldn't list projects: {exc}[/red]")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6328,10 +6328,20 @@ def _trim_setup_output(value: Optional[str], limit: int = 4000) -> str:
 
 
 def _memory_provider_setup_env() -> Dict[str, str]:
-    # External package-manager child (npm/uv/pip): exact env preservation —
-    # scrubbing or HOME rewriting could break user tool auth/config.
-    from tools.environments.local import build_subprocess_env
-    env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
+    # External package-manager child (npm/uv/pip): retain profile-scoped tool
+    # authority while stripping parent gateway and orchestration authority.
+    from tools.child_process_authority import (
+        ChildStdinPolicy,
+        build_child_process_env,
+        trusted_hermes_child_spec,
+    )
+
+    env = build_child_process_env(
+        trusted_hermes_child_spec(
+            source="hermes_cli.web_server.memory_provider_setup",
+            stdin=ChildStdinPolicy.CLOSED,
+        )
+    )
     home = Path.home()
     extra_bins = [
         home / ".brv-cli" / "bin",
@@ -6378,6 +6388,7 @@ def _run_setup_command(
         shell=shell,
         executable="/bin/bash" if shell else None,
         env=_memory_provider_setup_env(),
+        stdin=subprocess.DEVNULL,
         capture_output=True,
         text=True,
         # Lossy UTF-8 decode — setup tools emit UTF-8; never let a
@@ -16543,14 +16554,25 @@ def _resolve_chat_argv(
         profile_dir = _resolve_profile_dir(requested)
 
     argv, cwd = _make_tui_argv(PROJECT_ROOT / "ui-tui", tui_dev=False)
-    # Hermes TUI child: build via the single spawn-env factory (profile-home
-    # contract applied; secrets kept — the spawned agent needs provider creds).
-    # An explicit profile scope still overrides HERMES_HOME before config is
-    # bridged into the child environment.
-    from tools.environments.local import build_subprocess_env
-    env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=True)
-    if profile_dir is not None:
-        env["HERMES_HOME"] = str(profile_dir)
+    # Hermes TUI child: declare an interactive typed edge that retains
+    # profile-scoped agent/tool authority while stripping parent gateway and
+    # orchestration authority. An explicit profile scope overrides HERMES_HOME
+    # before config is bridged into the child environment.
+    from tools.child_process_authority import (
+        build_child_process_env,
+        interactive_hermes_pty_spec,
+    )
+
+    env = build_child_process_env(
+        interactive_hermes_pty_spec(
+            source="hermes_cli.web_server.dashboard_chat_pty"
+        ),
+        overrides=(
+            {"HERMES_HOME": str(profile_dir)}
+            if profile_dir is not None
+            else None
+        ),
+    )
     try:
         from hermes_cli.config import (
             apply_terminal_config_to_env,

--- a/hermes_cli/win_pty_bridge.py
+++ b/hermes_cli/win_pty_bridge.py
@@ -88,11 +88,14 @@ class WinPtyBridge:
                     "pywinpty is not installed. Install with: pip install pywinpty"
                 )
             raise PtyUnavailableError("ConPTY is unavailable on this platform.")
-        # See pty_bridge.py: exact-preservation factory for the env=None fallback.
-        from tools.environments.local import build_subprocess_env
-        spawn_env = (
-            build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
-            if env is None else dict(env)
+        from tools.child_process_authority import (
+            build_child_process_env,
+            interactive_hermes_pty_spec,
+        )
+
+        spawn_env = build_child_process_env(
+            interactive_hermes_pty_spec(source="hermes_cli.win_pty_bridge"),
+            source_env=env,
         )
         if not spawn_env.get("TERM"):
             spawn_env["TERM"] = "xterm-256color"

--- a/scripts/check-windows-footguns.py
+++ b/scripts/check-windows-footguns.py
@@ -804,6 +804,28 @@ def main(argv: list[str]) -> int:
         )
         return 1
 
+    if args.all:
+        # This established blocking static-check job also owns the Phase G
+        # process-edge AST admission. Keep structural policy in CI rather than
+        # introducing a source-reading behavior test.
+        from check_process_edge_authority import scan_repository
+
+        authority_findings = scan_repository()
+        if authority_findings:
+            print(
+                "\n✗ Production child-process authority bypasses remain:",
+                file=sys.stderr,
+            )
+            for finding in authority_findings:
+                print(f"  {finding}", file=sys.stderr)
+            print(
+                "  Use tools.child_process_authority with a typed "
+                "ChildProcessSpec.",
+                file=sys.stderr,
+            )
+            return 1
+        print("✓ Process-edge authority check passed.")
+
     print(
         f"✓ No Windows footguns found ({files_scanned} file(s) scanned)."
     )

--- a/scripts/check_process_edge_authority.py
+++ b/scripts/check_process_edge_authority.py
@@ -1,0 +1,340 @@
+"""Blocking structural check for retired ambient process-authority paths.
+
+This is an AST-based CI checker, not a source-reading behavior test. The typed
+broker is the only production module allowed to translate a process intent into
+legacy environment helpers during migration. Once a production function opts
+in to that broker, every direct subprocess boundary in that function must make
+both its environment and stdin policy explicit.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCAN_DIRS = (
+    "agent",
+    "cron",
+    "gateway",
+    "hermes_cli",
+    "tools",
+    "tui_gateway",
+)
+OWNER_FILES = {
+    "tools/environments/local.py",
+    "tools/child_process_authority.py",
+}
+_SUBPROCESS_METHODS = {
+    "Popen",
+    "call",
+    "check_call",
+    "check_output",
+    "run",
+}
+_NO_POLICY_SUBPROCESS_METHODS = {
+    "getoutput",
+    "getstatusoutput",
+}
+_ASYNCIO_SUBPROCESS_METHODS = {
+    "create_subprocess_exec",
+    "create_subprocess_shell",
+}
+
+
+def _iter_python_files():
+    for directory in SCAN_DIRS:
+        root = REPO_ROOT / directory
+        if root.is_dir():
+            yield from root.rglob("*.py")
+    for name in ("cli.py", "hermes_constants.py"):
+        path = REPO_ROOT / name
+        if path.is_file():
+            yield path
+
+
+def _call_name(node: ast.Call) -> str:
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return ""
+
+
+def _is_os_environ(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "os"
+        and node.attr == "environ"
+    )
+
+
+def _is_ambient_env_expression(node: ast.AST) -> bool:
+    if isinstance(node, ast.Constant) and node.value is None:
+        return True
+    if _is_os_environ(node):
+        return True
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "copy"
+        and _is_os_environ(node.func.value)
+    ):
+        return True
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "dict"
+        and node.args
+        and _is_os_environ(node.args[0])
+    ):
+        return True
+    if isinstance(node, ast.Dict):
+        return any(
+            key is None and _is_os_environ(value)
+            for key, value in zip(node.keys, node.values)
+        )
+    return False
+
+
+def _is_true(node: ast.AST) -> bool:
+    return isinstance(node, ast.Constant) and node.value is True
+
+
+def _is_false(node: ast.AST) -> bool:
+    return isinstance(node, ast.Constant) and node.value is False
+
+
+def _is_ambient_environment_access(node: ast.AST) -> bool:
+    if isinstance(node, ast.Attribute):
+        return (
+            isinstance(node.value, ast.Name)
+            and node.value.id == "os"
+            and node.attr in {"environ", "environb"}
+        )
+    if isinstance(node, ast.Call):
+        func = node.func
+        return (
+            isinstance(func, ast.Attribute)
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "os"
+            and func.attr in {"getenv", "getenvb", "putenv", "unsetenv"}
+        )
+    return False
+
+
+def _function_calls_child_env_broker(node: ast.AST) -> bool:
+    return any(
+        isinstance(child, ast.Call) and _call_name(child) == "build_child_process_env"
+        for child in ast.walk(node)
+    )
+
+
+def _imports_process_authority(tree: ast.AST) -> bool:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module == "tools.child_process_authority":
+                return True
+        elif isinstance(node, ast.Import):
+            if any(
+                alias.name == "tools.child_process_authority" for alias in node.names
+            ):
+                return True
+    return False
+
+
+def _module_aliases(tree: ast.AST, module: str) -> set[str]:
+    aliases = {module}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == module:
+                    aliases.add(alias.asname or module)
+    return aliases
+
+
+def _direct_import_aliases(
+    tree: ast.AST,
+    module: str,
+    names: set[str],
+) -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or node.module != module:
+            continue
+        for alias in node.names:
+            if alias.name in names:
+                aliases[alias.asname or alias.name] = alias.name
+    return aliases
+
+
+def _spawn_call_name(
+    node: ast.Call,
+    *,
+    subprocess_modules: set[str],
+    subprocess_functions: dict[str, str],
+    asyncio_modules: set[str],
+    asyncio_functions: dict[str, str],
+) -> str | None:
+    func = node.func
+    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+        if func.value.id in subprocess_modules and func.attr in (
+            _SUBPROCESS_METHODS | _NO_POLICY_SUBPROCESS_METHODS
+        ):
+            return f"subprocess.{func.attr}"
+        if (
+            func.value.id in asyncio_modules
+            and func.attr in _ASYNCIO_SUBPROCESS_METHODS
+        ):
+            return f"asyncio.{func.attr}"
+    if isinstance(func, ast.Name):
+        if func.id in subprocess_functions:
+            return f"subprocess.{subprocess_functions[func.id]}"
+        if func.id in asyncio_functions:
+            return f"asyncio.{asyncio_functions[func.id]}"
+    return None
+
+
+def _find_escape_hatches_in_source(source: str, rel: str) -> list[str]:
+    if rel in OWNER_FILES:
+        return []
+
+    try:
+        tree = ast.parse(source, filename=rel)
+    except SyntaxError:
+        return []
+
+    subprocess_modules = _module_aliases(tree, "subprocess")
+    subprocess_functions = _direct_import_aliases(
+        tree,
+        "subprocess",
+        _SUBPROCESS_METHODS | _NO_POLICY_SUBPROCESS_METHODS,
+    )
+    asyncio_modules = _module_aliases(tree, "asyncio")
+    asyncio_functions = _direct_import_aliases(
+        tree,
+        "asyncio",
+        _ASYNCIO_SUBPROCESS_METHODS,
+    )
+
+    findings: list[str] = []
+    for function in ast.walk(tree):
+        if not isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not _function_calls_child_env_broker(function):
+            continue
+        for node in ast.walk(function):
+            if _is_ambient_environment_access(node):
+                findings.append(
+                    f"{rel}:{getattr(node, 'lineno', '?')}: "
+                    "direct ambient environment access beside child-env broker"
+                )
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _call_name(node)
+        keywords = {kw.arg: kw.value for kw in node.keywords if kw.arg}
+
+        if (
+            name == "hermes_subprocess_env"
+            and "inherit_credentials" in keywords
+            and _is_true(keywords["inherit_credentials"])
+        ):
+            findings.append(f"{rel}:{node.lineno}: untyped inherit_credentials=True")
+
+        if (
+            name == "build_subprocess_env"
+            and "scrub_secrets" in keywords
+            and _is_false(keywords["scrub_secrets"])
+        ):
+            findings.append(f"{rel}:{node.lineno}: untyped scrub_secrets=False")
+
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "update"
+            and node.args
+            and _is_os_environ(node.args[0])
+        ):
+            findings.append(f"{rel}:{node.lineno}: ambient env.update(os.environ)")
+
+    # God-files contain unrelated process surfaces. Once one function adopts
+    # the broker, require explicit env/stdin on every spawn in that function,
+    # without accidentally declaring every other function migrated too.
+    for function in ast.walk(tree):
+        if not isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not _function_calls_child_env_broker(function):
+            continue
+        for node in ast.walk(function):
+            if not isinstance(node, ast.Call):
+                continue
+            keywords = {kw.arg: kw.value for kw in node.keywords if kw.arg}
+            spawn_name = _spawn_call_name(
+                node,
+                subprocess_modules=subprocess_modules,
+                subprocess_functions=subprocess_functions,
+                asyncio_modules=asyncio_modules,
+                asyncio_functions=asyncio_functions,
+            )
+            if spawn_name is None:
+                continue
+            if spawn_name.rsplit(".", 1)[-1] in _NO_POLICY_SUBPROCESS_METHODS:
+                findings.append(
+                    f"{rel}:{node.lineno}: {spawn_name} cannot carry typed env/stdin policy"
+                )
+                continue
+            if "env" not in keywords:
+                findings.append(
+                    f"{rel}:{node.lineno}: {spawn_name} missing explicit env policy"
+                )
+            elif _is_ambient_env_expression(keywords["env"]):
+                findings.append(
+                    f"{rel}:{node.lineno}: {spawn_name} explicitly requests ambient env"
+                )
+            if "stdin" not in keywords:
+                findings.append(
+                    f"{rel}:{node.lineno}: {spawn_name} missing explicit stdin policy"
+                )
+
+    return findings
+
+
+def _find_escape_hatches(path: Path) -> list[str]:
+    rel = path.relative_to(REPO_ROOT).as_posix()
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    return _find_escape_hatches_in_source(source, rel)
+
+
+def scan_repository() -> list[str]:
+    return [
+        finding
+        for path in _iter_python_files()
+        for finding in _find_escape_hatches(path)
+    ]
+
+
+def main() -> int:
+    import sys
+
+    findings = scan_repository()
+    if not findings:
+        print("Process-edge authority check passed.")
+        return 0
+    print("Production child-process authority bypasses remain:", file=sys.stderr)
+    for finding in findings:
+        print(f"  {finding}", file=sys.stderr)
+    print(
+        "Use tools.child_process_authority with a typed ChildProcessSpec.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests-js/authority-manifest-conformance.test.ts
+++ b/tests-js/authority-manifest-conformance.test.ts
@@ -1,0 +1,216 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  type AdmissionRequest,
+  CANONICAL_AUTHORITY_MANIFEST,
+  compileAuthorityManifest,
+  evaluateAuthorityOperation,
+  ManifestValidationError,
+} from "../apps/shared/src/authority/manifest";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+
+const CANONICAL_GITHUB_OPERATIONS = [
+  "github.issue.metadata.write",
+  "github.comment.write",
+  "github.contents.write",
+  "github.gitdata.write",
+  "github.pull_request.create",
+  "github.actions.dispatch",
+] as const;
+
+type Mutation = {
+  op: "set" | "delete" | "append";
+  path: string[];
+  value?: unknown;
+};
+
+type MutationCase = {
+  name: string;
+  mutations: Mutation[];
+  expected: {
+    compiler_valid: boolean;
+    schema_valid: boolean;
+  };
+};
+
+async function readJson(path: string): Promise<unknown> {
+  return JSON.parse(await readFile(new URL(path, `file://${root}/`), "utf8"));
+}
+
+function asMutableRecord(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new TypeError("mutation path must traverse objects");
+  }
+  return value as Record<string, unknown>;
+}
+
+function applyMutations(base: unknown, mutations: Mutation[]): unknown {
+  const result = structuredClone(base);
+  for (const mutation of mutations) {
+    let parent: unknown = result;
+    for (const part of mutation.path.slice(0, -1)) {
+      parent = asMutableRecord(parent)[part];
+    }
+    const key = mutation.path.at(-1);
+    if (key === undefined) {
+      throw new TypeError("mutation path must not be empty");
+    }
+    const record = asMutableRecord(parent);
+    if (mutation.op === "set") {
+      record[key] = structuredClone(mutation.value);
+    } else if (mutation.op === "delete") {
+      delete record[key];
+    } else {
+      const target = record[key];
+      if (!Array.isArray(target)) {
+        throw new TypeError("append mutation target must be an array");
+      }
+      target.push(structuredClone(mutation.value));
+    }
+  }
+  return result;
+}
+
+describe("authority manifest cross-language conformance", () => {
+  it("packages the exact canonical bytes, hash, and immutable compiler output", async () => {
+    const sourceBytes = await readFile(new URL("authority/manifest.v1.json", `file://${root}/`));
+    const artifact = CANONICAL_AUTHORITY_MANIFEST;
+    const runtimeBytes = Buffer.from(artifact.manifest_bytes);
+
+    expect(runtimeBytes).toEqual(sourceBytes);
+    expect(createHash("sha256").update(runtimeBytes).digest("hex")).toBe(
+      artifact.manifest_sha256,
+    );
+    expect(artifact.manifest.policyVersion).toBe("2026.08.25-v2");
+    expect(Object.isFrozen(artifact)).toBe(true);
+    expect(Object.isFrozen(artifact.manifest_bytes)).toBe(true);
+    expect(Object.isFrozen(artifact.manifest)).toBe(true);
+    expect(() => {
+      (artifact.manifest_bytes as number[]).push(0);
+    }).toThrow(TypeError);
+  });
+
+  it("pins the six canonical GitHub operation classes and one-to-one sinks", () => {
+    const manifest = CANONICAL_AUTHORITY_MANIFEST.manifest;
+    const domain = manifest.domains["github.operation"];
+
+    expect(Object.keys(domain.operations).sort()).toEqual(
+      [...CANONICAL_GITHUB_OPERATIONS].sort(),
+    );
+    expect(Object.keys(domain.sinks).sort()).toEqual([...CANONICAL_GITHUB_OPERATIONS].sort());
+
+    for (const [operationName, operation] of Object.entries(domain.operations)) {
+      expect(operation.sink_class).toBe(operationName);
+    }
+
+    expect(domain.operations["github.contents.write"].required_capabilities).toEqual([
+      "contents:write",
+    ]);
+    expect(domain.operations["github.gitdata.write"].required_capabilities).toEqual([
+      "git_objects:write",
+      "refs:write",
+    ]);
+    expect(domain.operations["github.pull_request.create"].required_capabilities).toEqual([
+      "pull_requests:create",
+    ]);
+    expect(domain.operations["github.actions.dispatch"].required_capabilities).toEqual([
+      "actions:dispatch",
+    ]);
+  });
+
+  it("runs the canonical vectors through the TypeScript evaluator", async () => {
+    const manifest = CANONICAL_AUTHORITY_MANIFEST.manifest;
+
+    const vectors = (await readJson("authority/conformance.v1.json")) as {
+      schema_version: number;
+      vectors: Array<{
+        name: string;
+        request: AdmissionRequest;
+        expected: unknown;
+      }>;
+    };
+
+    expect(vectors.schema_version).toBe(1);
+
+    for (const vector of vectors.vectors) {
+      expect(evaluateAuthorityOperation(manifest, vector.request), vector.name).toEqual(
+        vector.expected,
+      );
+    }
+  });
+
+  it("runs the shared accepted/rejected mutation corpus through the compiler", async () => {
+    const canonical = await readJson("authority/manifest.v1.json");
+    const corpus = (await readJson("authority/manifest-mutations.v1.json")) as {
+      schema_version: number;
+      cases: MutationCase[];
+    };
+
+    expect(corpus.schema_version).toBe(1);
+    for (const testCase of corpus.cases) {
+      const candidate = applyMutations(canonical, testCase.mutations);
+      if (testCase.expected.compiler_valid) {
+        expect(() => compileAuthorityManifest(candidate), testCase.name).not.toThrow();
+      } else {
+        expect(() => compileAuthorityManifest(candidate), testCase.name).toThrow(
+          ManifestValidationError,
+        );
+      }
+    }
+  });
+
+  it("retains immutable sink broker and direct-symbol ownership", () => {
+    const manifest = CANONICAL_AUTHORITY_MANIFEST.manifest;
+    const domain = manifest.domains["github.operation"];
+    const sink = domain.sinks["github.comment.write"];
+
+    expect(sink).toEqual({
+      broker: "githubMutationBroker",
+      direct_symbols: ["issues.createComment", "pulls.createReview", "pulls.createReviewComment"],
+    });
+    for (const operation of Object.values(domain.operations)) {
+      expect(domain.sinks[operation.sink_class]).toBeDefined();
+    }
+  });
+
+  it("does not expose runtime-mutable compiled policy", () => {
+    const manifest = CANONICAL_AUTHORITY_MANIFEST.manifest;
+    const request: AdmissionRequest = {
+      domain: "github.operation",
+      operation_class: "github.comment.write",
+      actor_class: "human",
+      resource_state: "open",
+      capabilities: [
+        {
+          capability: "comments:write",
+          granted: true,
+          source: "user_api_token",
+          generation: "cred-immutability",
+        },
+      ],
+    };
+    const before = evaluateAuthorityOperation(manifest, request);
+
+    expect(() => {
+      (manifest.domains as Record<string, unknown>)["ambient.operation"] = {};
+    }).toThrow(TypeError);
+    expect(() => {
+      const required = manifest.domains["github.operation"].operations["github.comment.write"]
+        .required_capabilities as string[];
+      required.push("admin:*");
+    }).toThrow(TypeError);
+    expect(() => {
+      const sink = manifest.domains["github.operation"].sinks[
+        "github.comment.write"
+      ] as { broker: string };
+      sink.broker = "ambientBroker";
+    }).toThrow(TypeError);
+
+    expect(evaluateAuthorityOperation(manifest, request)).toEqual(before);
+  });
+});

--- a/tests/authority/test_manifest_conformance.py
+++ b/tests/authority/test_manifest_conformance.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from copy import deepcopy
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from typing import Any, Mapping
+
+import pytest
+
+from hermes_cli.authority.manifest import (
+    CANONICAL_AUTHORITY_MANIFEST,
+    AdmissionRequestValidationError,
+    ManifestValidationError,
+    admission_request_from_mapping,
+    compile_authority_manifest,
+    evaluate_authority_operation,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = ROOT / "authority" / "manifest.v1.json"
+SCHEMA_PATH = ROOT / "authority" / "manifest.schema.json"
+MUTATIONS_PATH = ROOT / "authority" / "manifest-mutations.v1.json"
+VECTORS_PATH = ROOT / "authority" / "conformance.v1.json"
+
+CANONICAL_GITHUB_OPERATIONS = frozenset(
+    {
+        "github.issue.metadata.write",
+        "github.comment.write",
+        "github.contents.write",
+        "github.gitdata.write",
+        "github.pull_request.create",
+        "github.actions.dispatch",
+    }
+)
+CANONICAL_GITHUB_SINKS = frozenset(CANONICAL_GITHUB_OPERATIONS)
+
+_SCHEMA_KEYWORDS = frozenset(
+    {
+        "$schema",
+        "$id",
+        "$defs",
+        "$ref",
+        "title",
+        "description",
+        "type",
+        "additionalProperties",
+        "required",
+        "properties",
+        "const",
+        "minLength",
+        "minProperties",
+        "minItems",
+        "items",
+        "uniqueItems",
+        "enum",
+        "not",
+        "pattern",
+    }
+)
+
+
+def _read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _resolve_ref(root: Mapping[str, Any], ref: str) -> Mapping[str, Any]:
+    if not ref.startswith("#/"):
+        raise AssertionError(f"unsupported external schema reference: {ref}")
+    value: Any = root
+    for raw_part in ref[2:].split("/"):
+        part = raw_part.replace("~1", "/").replace("~0", "~")
+        value = value[part]
+    if not isinstance(value, Mapping):
+        raise AssertionError(f"schema reference does not resolve to an object: {ref}")
+    return value
+
+
+def _schema_errors(
+    instance: Any,
+    schema: Mapping[str, Any],
+    root: Mapping[str, Any],
+    path: str = "$",
+) -> list[str]:
+    unsupported = set(schema) - _SCHEMA_KEYWORDS
+    if unsupported:
+        raise AssertionError(
+            f"schema gate does not implement keywords: {sorted(unsupported)}"
+        )
+    if "$ref" in schema:
+        return _schema_errors(instance, _resolve_ref(root, schema["$ref"]), root, path)
+
+    errors: list[str] = []
+    if "const" in schema:
+        expected = schema["const"]
+        if instance != expected or type(instance) is not type(expected):
+            errors.append(f"{path}: expected const {expected!r}")
+    if "enum" in schema and instance not in schema["enum"]:
+        errors.append(f"{path}: value is not in enum")
+
+    expected_type = schema.get("type")
+    type_matches = (
+        expected_type is None
+        or (expected_type == "object" and isinstance(instance, Mapping))
+        or (expected_type == "array" and isinstance(instance, list))
+        or (expected_type == "string" and isinstance(instance, str))
+    )
+    if not type_matches:
+        errors.append(f"{path}: expected {expected_type}")
+        return errors
+
+    if isinstance(instance, Mapping):
+        if len(instance) < schema.get("minProperties", 0):
+            errors.append(f"{path}: too few properties")
+        required = schema.get("required", [])
+        for key in required:
+            if key not in instance:
+                errors.append(f"{path}: missing required property {key}")
+        properties = schema.get("properties", {})
+        additional = schema.get("additionalProperties", True)
+        for key, value in instance.items():
+            child_path = f"{path}.{key}"
+            if key in properties:
+                errors.extend(_schema_errors(value, properties[key], root, child_path))
+            elif additional is False:
+                errors.append(f"{child_path}: additional property is forbidden")
+            elif isinstance(additional, Mapping):
+                errors.extend(_schema_errors(value, additional, root, child_path))
+
+    if isinstance(instance, list):
+        if len(instance) < schema.get("minItems", 0):
+            errors.append(f"{path}: too few items")
+        if schema.get("uniqueItems"):
+            encoded = [json.dumps(item, sort_keys=True) for item in instance]
+            if len(set(encoded)) != len(encoded):
+                errors.append(f"{path}: items are not unique")
+        item_schema = schema.get("items")
+        if isinstance(item_schema, Mapping):
+            for index, value in enumerate(instance):
+                errors.extend(
+                    _schema_errors(value, item_schema, root, f"{path}[{index}]")
+                )
+
+    if isinstance(instance, str):
+        if len(instance) < schema.get("minLength", 0):
+            errors.append(f"{path}: string is too short")
+        pattern = schema.get("pattern")
+        if pattern is not None and re.search(pattern, instance):
+            pass
+
+    negated = schema.get("not")
+    if isinstance(negated, Mapping) and not _schema_errors(instance, negated, root, path):
+        errors.append(f"{path}: matched forbidden schema")
+
+    if isinstance(instance, str) and "pattern" in schema:
+        if re.search(schema["pattern"], instance) is None:
+            errors.append(f"{path}: pattern did not match")
+
+    return errors
+
+
+def _apply_mutations(raw: Any, mutations: list[Mapping[str, Any]]) -> Any:
+    result = deepcopy(raw)
+    for mutation in mutations:
+        path = mutation["path"]
+        parent = result
+        for part in path[:-1]:
+            parent = parent[part]
+        key = path[-1]
+        operation = mutation["op"]
+        if operation == "set":
+            parent[key] = deepcopy(mutation["value"])
+        elif operation == "delete":
+            del parent[key]
+        elif operation == "append":
+            parent[key].append(deepcopy(mutation["value"]))
+        else:
+            raise AssertionError(f"unknown mutation operation: {operation}")
+    return result
+
+
+def test_canonical_runtime_artifact_matches_exact_source_bytes_and_hash() -> None:
+    source_bytes = MANIFEST_PATH.read_bytes()
+    artifact = CANONICAL_AUTHORITY_MANIFEST
+
+    assert artifact.manifest_bytes == source_bytes
+    assert artifact.manifest_sha256 == hashlib.sha256(source_bytes).hexdigest()
+    assert artifact.manifest.policy_version == "2026.08.25-v2"
+
+    with pytest.raises(FrozenInstanceError):
+        artifact.manifest_sha256 = "mutable"  # type: ignore[misc]
+
+
+def test_shared_conformance_vectors_match_python_evaluator() -> None:
+    manifest = CANONICAL_AUTHORITY_MANIFEST.manifest
+    vectors = _read_json(VECTORS_PATH)
+    assert vectors["schema_version"] == 1
+
+    for vector in vectors["vectors"]:
+        request = admission_request_from_mapping(vector["request"])
+        decision = evaluate_authority_operation(manifest, request)
+        assert decision.as_dict() == vector["expected"], vector["name"]
+
+
+def test_manifest_uses_the_canonical_github_vertical_slice() -> None:
+    manifest = CANONICAL_AUTHORITY_MANIFEST.manifest
+    domain = manifest.domains["github.operation"]
+
+    assert frozenset(domain.operations) == CANONICAL_GITHUB_OPERATIONS
+    assert frozenset(domain.sinks) == CANONICAL_GITHUB_SINKS
+
+    for operation_name, operation in domain.operations.items():
+        assert operation.sink_class == operation_name
+
+    assert domain.operations["github.contents.write"].required_capabilities == (
+        "contents:write",
+    )
+    assert domain.operations["github.gitdata.write"].required_capabilities == (
+        "git_objects:write",
+        "refs:write",
+    )
+    assert domain.operations["github.pull_request.create"].required_capabilities == (
+        "pull_requests:create",
+    )
+    assert domain.operations["github.actions.dispatch"].required_capabilities == (
+        "actions:dispatch",
+    )
+
+
+def test_schema_and_compiler_share_the_mutation_corpus() -> None:
+    canonical = _read_json(MANIFEST_PATH)
+    schema = _read_json(SCHEMA_PATH)
+    corpus = _read_json(MUTATIONS_PATH)
+    assert corpus["schema_version"] == 1
+
+    for case in corpus["cases"]:
+        candidate = _apply_mutations(canonical, case["mutations"])
+        schema_valid = not _schema_errors(candidate, schema, schema)
+        assert schema_valid is case["expected"]["schema_valid"], case["name"]
+
+        try:
+            compile_authority_manifest(candidate)
+        except ManifestValidationError:
+            compiler_valid = False
+        else:
+            compiler_valid = True
+        assert compiler_valid is case["expected"]["compiler_valid"], case["name"]
+
+
+def test_compiler_preserves_immutable_sink_ownership_metadata() -> None:
+    manifest = CANONICAL_AUTHORITY_MANIFEST.manifest
+    domain = manifest.domains["github.operation"]
+    sink = domain.sinks["github.comment.write"]
+
+    assert sink.broker == "githubMutationBroker"
+    assert sink.direct_symbols == (
+        "issues.createComment",
+        "pulls.createReview",
+        "pulls.createReviewComment",
+    )
+    for operation in domain.operations.values():
+        assert operation.sink_class in domain.sinks
+
+    with pytest.raises(TypeError):
+        manifest.domains["github.operation"] = domain  # type: ignore[index]
+    with pytest.raises(TypeError):
+        domain.sinks["github.comment.write"] = sink  # type: ignore[index]
+    with pytest.raises(FrozenInstanceError):
+        sink.broker = "ambientBroker"  # type: ignore[misc]
+
+
+def test_admission_request_parser_rejects_open_or_coerced_shapes() -> None:
+    raw = {
+        "domain": "github.operation",
+        "operation_class": "github.comment.write",
+        "actor_class": "human",
+        "resource_state": "open",
+        "capabilities": [
+            {
+                "capability": "comments:write",
+                "granted": True,
+                "source": "user_api_token",
+                "generation": "cred-1",
+            }
+        ],
+    }
+
+    with pytest.raises(AdmissionRequestValidationError, match="unknown"):
+        admission_request_from_mapping({**raw, "ambient_fallback": True})
+
+    invalid_grant = deepcopy(raw)
+    invalid_grant["capabilities"][0]["granted"] = "yes"
+    with pytest.raises(AdmissionRequestValidationError, match="boolean"):
+        admission_request_from_mapping(invalid_grant)

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -226,9 +226,9 @@ def test_launch_tui_exports_model_provider_and_toolsets(monkeypatch, main_mod):
         lambda tui_dir, tui_dev: (["node", "dist/entry.js"], Path(".")),
     )
 
-    def fake_call(argv, cwd=None, env=None):
+    def fake_call(argv, cwd=None, env=None, stdin=None):
         nonlocal active_path_during_call
-        captured.update({"argv": argv, "cwd": cwd, "env": env})
+        captured.update({"argv": argv, "cwd": cwd, "env": env, "stdin": stdin})
         active_path_during_call = Path(env["HERMES_TUI_ACTIVE_SESSION_FILE"])
         assert active_path_during_call.exists()
         return 1
@@ -252,6 +252,7 @@ def test_launch_tui_exports_model_provider_and_toolsets(monkeypatch, main_mod):
     assert active_path_during_call == active_path
     assert not active_path.exists()
     assert env["NODE_ENV"] == "production"
+    assert captured["stdin"] is None
 
 
 
@@ -282,7 +283,6 @@ def test_make_tui_argv_dev_prebuilds_hermes_ink(monkeypatch, main_mod, tmp_path)
     assert argv == [str(tsx), "src/entry.tsx"]
     assert cwd == tui_dir
     assert calls == [(["/usr/bin/npm", "run", "build"], str(ink_dir))]
-
 
 
 

--- a/tests/security/test_child_process_authority_guard.py
+++ b/tests/security/test_child_process_authority_guard.py
@@ -1,0 +1,54 @@
+"""Behavior tests for the process-edge authority CI checker."""
+
+from scripts.check_process_edge_authority import _find_escape_hatches_in_source
+
+
+def test_guard_detects_missing_env_and_stdin_on_typed_consumer():
+    findings = _find_escape_hatches_in_source(
+        """
+import subprocess
+from tools.child_process_authority import build_child_process_env, probe_spec
+
+def run_probe():
+    spec = probe_spec(source="example")
+    build_child_process_env(spec)
+    subprocess.run(["probe"])
+""",
+        "agent/example.py",
+    )
+
+    assert any("missing explicit env policy" in finding for finding in findings)
+    assert any("missing explicit stdin policy" in finding for finding in findings)
+
+
+def test_guard_detects_explicit_ambient_env_on_typed_consumer():
+    findings = _find_escape_hatches_in_source(
+        """
+import os
+import subprocess as sp
+from tools.child_process_authority import build_child_process_env, probe_spec
+
+def run_probe():
+    spec = probe_spec(source="example")
+    build_child_process_env(spec)
+    sp.run(["probe"], env=os.environ.copy(), stdin=sp.DEVNULL)
+""",
+        "agent/example.py",
+    )
+
+    assert any("explicitly requests ambient env" in finding for finding in findings)
+
+
+def test_guard_accepts_explicit_brokered_spawn_policy():
+    findings = _find_escape_hatches_in_source(
+        """
+from subprocess import DEVNULL, run
+from tools.child_process_authority import build_child_process_env, probe_spec
+
+spec = probe_spec(source="example")
+run(["probe"], env=build_child_process_env(spec), stdin=DEVNULL)
+""",
+        "agent/example.py",
+    )
+
+    assert findings == []

--- a/tests/tools/test_child_process_authority.py
+++ b/tests/tools/test_child_process_authority.py
@@ -1,0 +1,736 @@
+"""Tests for typed child-process authority contracts."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from tools.child_process_authority import (
+    BWS_VAULT_GRANTS,
+    CONTAINER_REGISTRY_AUTH_KEYS,
+    KANBAN_WORKER_GRANT_PREFIXES,
+    KANBAN_WORKER_GRANTS,
+    ChildStdinPolicy,
+    build_child_process_env,
+    build_spawn_receipt,
+    bws_vault_spec,
+    checkpoint_git_spec,
+    container_image_build_spec,
+    interactive_hermes_pty_spec,
+    model_driver_spec,
+    op_vault_spec,
+    probe_spec,
+    secret_helper_spec,
+    stdin_for_spec,
+    trusted_hermes_child_spec,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_multiplex_state():
+    from agent.secret_scope import (
+        reset_secret_scope,
+        set_multiplex_active,
+        set_secret_scope,
+    )
+
+    set_multiplex_active(False)
+    token = set_secret_scope(None)
+    try:
+        yield
+    finally:
+        reset_secret_scope(token)
+        set_multiplex_active(False)
+
+
+def _plant(monkeypatch):
+    values = {
+        "PATH": os.environ.get("PATH", "/usr/bin"),
+        "HOME": os.environ.get("HOME", "/tmp"),
+        "HTTPS_PROXY": "http://proxy.invalid:8080",
+        "OPENAI_API_KEY": "provider-secret",
+        "ACME_LOGIN": "arbitrary-profile-secret",
+        "GH_TOKEN": "github-tool-secret",
+        "DISCORD_BOT_TOKEN": "gateway-transport-secret",
+        "BWS_ACCESS_TOKEN": "vault-bootstrap-secret",
+        "BWS_SERVER_URL": "https://vault.example.invalid",
+        "GATEWAY_RELAY_SECRET": "relay-secret",
+        "AUXILIARY_VISION_API_KEY": "aux-secret",
+        "_HERMES_GATEWAY": "1",
+        "HERMES_KANBAN_TASK": "task-a",
+        "HERMES_KANBAN_RUN_ID": "run-a",
+        "HERMES_SESSION_ID": "session-a",
+        "HERMES_PROFILE": "profile-a",
+    }
+    for key, value in values.items():
+        monkeypatch.setenv(key, value)
+    return values
+
+
+def test_model_driver_gets_model_auth_not_ambient_tool_or_role_authority(monkeypatch):
+    _plant(monkeypatch)
+
+    env = build_child_process_env(model_driver_spec(source="test:model-driver"))
+
+    assert env["OPENAI_API_KEY"] == "provider-secret"
+    assert env["PATH"]
+    assert "ACME_LOGIN" not in env
+    assert "GH_TOKEN" not in env
+    assert "DISCORD_BOT_TOKEN" not in env
+    assert "BWS_ACCESS_TOKEN" not in env
+    assert "GATEWAY_RELAY_SECRET" not in env
+    assert "_HERMES_GATEWAY" not in env
+    assert "HERMES_KANBAN_TASK" not in env
+    assert "HERMES_SESSION_ID" not in env
+
+
+def test_kanban_authority_crosses_only_the_declared_model_driver_edge(monkeypatch):
+    _plant(monkeypatch)
+    spec = model_driver_spec(
+        source="test:kanban-model-driver",
+        grants=KANBAN_WORKER_GRANTS,
+        grant_prefixes=KANBAN_WORKER_GRANT_PREFIXES,
+    )
+
+    env = build_child_process_env(spec)
+
+    assert env["HERMES_KANBAN_TASK"] == "task-a"
+    assert env["HERMES_KANBAN_RUN_ID"] == "run-a"
+    assert env["HERMES_SESSION_ID"] == "session-a"
+    assert env["HERMES_PROFILE"] == "profile-a"
+    assert "_HERMES_GATEWAY" not in env
+    assert "DISCORD_BOT_TOKEN" not in env
+
+
+def test_trusted_hermes_child_gets_profile_tools_not_gateway_transport(monkeypatch):
+    _plant(monkeypatch)
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "op-token")
+    monkeypatch.setenv("OP_SESSION_acme", "session-token")
+
+    env = build_child_process_env(
+        trusted_hermes_child_spec(source="test:trusted-runtime")
+    )
+
+    assert env["OPENAI_API_KEY"] == "provider-secret"
+    assert env["ACME_LOGIN"] == "arbitrary-profile-secret"
+    assert env["GH_TOKEN"] == "github-tool-secret"
+    assert env["AUXILIARY_VISION_API_KEY"] == "aux-secret"
+    assert env["BWS_ACCESS_TOKEN"] == "vault-bootstrap-secret"
+    assert env["OP_SERVICE_ACCOUNT_TOKEN"] == "op-token"
+    assert env["OP_SESSION_acme"] == "session-token"
+    assert "DISCORD_BOT_TOKEN" not in env
+    assert "GATEWAY_RELAY_SECRET" not in env
+    assert "_HERMES_GATEWAY" not in env
+    assert "HERMES_KANBAN_TASK" not in env
+
+
+def test_explicit_profile_home_override_wins_context_home(monkeypatch):
+    from tools.environments import local
+
+    _plant(monkeypatch)
+    monkeypatch.setattr(
+        local,
+        "_inject_context_hermes_home",
+        lambda env: env.__setitem__("HERMES_HOME", "/ambient-profile"),
+    )
+
+    env = build_child_process_env(
+        trusted_hermes_child_spec(source="test:target-profile"),
+        overrides={"HERMES_HOME": "/target-profile"},
+    )
+
+    assert env["HERMES_HOME"] == "/target-profile"
+
+
+def test_overrides_require_positive_policy_and_block_execution_authority(monkeypatch):
+    _plant(monkeypatch)
+    spec = trusted_hermes_child_spec(source="test:override")
+
+    env = build_child_process_env(
+        spec,
+        overrides={
+            "SAFE_OVERRIDE": "no-longer-ambiently-safe",
+            "LD_PRELOAD": "/tmp/evil.so",
+            "DYLD_INSERT_LIBRARIES": "/tmp/evil.dylib",
+            "PYTHONPATH": "/tmp/evil-python",
+            "PYTHONHOME": "/tmp/evil-home",
+            "NODE_OPTIONS": "--require=/tmp/evil.js",
+            "BASH_ENV": "/tmp/evil-bashrc",
+            "ENV": "/tmp/evil-shrc",
+            "APPTAINERENV_LD_PRELOAD": "/tmp/wrapped-evil.so",
+            "SINGULARITYENV_NODE_OPTIONS": "--require=/tmp/wrapped-evil.js",
+            "DISCORD_BOT_TOKEN": "smuggled",
+            "APPTAINERENV_GATEWAY_RELAY_SECRET": "wrapped-smuggle",
+            "_HERMES_GATEWAY": "1",
+            "HERMES_HOME": "/target-profile",
+        },
+    )
+
+    assert env["HERMES_HOME"] == "/target-profile"
+    for denied in (
+        "SAFE_OVERRIDE",
+        "LD_PRELOAD",
+        "DYLD_INSERT_LIBRARIES",
+        "PYTHONPATH",
+        "PYTHONHOME",
+        "NODE_OPTIONS",
+        "BASH_ENV",
+        "ENV",
+        "APPTAINERENV_LD_PRELOAD",
+        "SINGULARITYENV_NODE_OPTIONS",
+        "DISCORD_BOT_TOKEN",
+        "APPTAINERENV_GATEWAY_RELAY_SECRET",
+        "_HERMES_GATEWAY",
+    ):
+        assert denied not in env
+
+
+def test_safe_baseline_is_inherited_but_not_override_authority(monkeypatch):
+    import hermes_constants
+    from tools.environments import local
+
+    monkeypatch.setattr(local, "_inject_context_hermes_home", lambda _env: None)
+    monkeypatch.setattr(hermes_constants, "apply_subprocess_home_env", lambda _env: None)
+    source = {
+        "PATH": "/ambient/bin",
+        "HOME": "/ambient/home",
+        "TMP": "/ambient/tmp",
+        "XDG_CONFIG_HOME": "/ambient/xdg",
+    }
+    overrides = {
+        "PATH": "/attacker/bin",
+        "HOME": "/attacker/home",
+        "TMP": "/attacker/tmp",
+        "XDG_CONFIG_HOME": "/attacker/xdg",
+    }
+
+    for spec in (
+        probe_spec(source="test:probe-baseline"),
+        checkpoint_git_spec(source="test:checkpoint-baseline"),
+    ):
+        env = build_child_process_env(spec, source_env=source, overrides=overrides)
+        assert env["PATH"] == "/ambient/bin"
+        assert env["HOME"] == "/ambient/home"
+        assert env["TMP"] == "/ambient/tmp"
+        assert env["XDG_CONFIG_HOME"] == "/ambient/xdg"
+
+
+def test_bws_vault_edge_is_minimal_and_keeps_network_controls(monkeypatch):
+    _plant(monkeypatch)
+    spec = bws_vault_spec(source="test:bws")
+
+    env = build_child_process_env(
+        spec,
+        overrides={
+            "BWS_ACCESS_TOKEN": "edge-token",
+            "NO_COLOR": "1",
+        },
+    )
+
+    assert set(BWS_VAULT_GRANTS) <= set(env)
+    assert env["BWS_ACCESS_TOKEN"] == "edge-token"
+    assert env["BWS_SERVER_URL"] == "https://vault.example.invalid"
+    assert env["HTTPS_PROXY"] == "http://proxy.invalid:8080"
+    assert env["NO_COLOR"] == "1"
+    assert "OPENAI_API_KEY" not in env
+    assert "ACME_LOGIN" not in env
+    assert "GH_TOKEN" not in env
+    assert "HERMES_KANBAN_TASK" not in env
+
+
+def test_op_vault_edge_admits_only_op_auth_family(monkeypatch):
+    _plant(monkeypatch)
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "op-token")
+    monkeypatch.setenv("OP_SESSION_acme", "session-token")
+    monkeypatch.setenv("OP_LOAD_DESKTOP_APP_SETTINGS", "false")
+    monkeypatch.setenv("OP_CACHE", "false")
+
+    env = build_child_process_env(op_vault_spec(source="test:op"))
+
+    assert env["OP_SERVICE_ACCOUNT_TOKEN"] == "op-token"
+    assert env["OP_SESSION_acme"] == "session-token"
+    assert env["OP_LOAD_DESKTOP_APP_SETTINGS"] == "false"
+    assert env["OP_CACHE"] == "false"
+    assert "OPENAI_API_KEY" not in env
+    assert "ACME_LOGIN" not in env
+    assert "GH_TOKEN" not in env
+
+
+def test_secret_helper_keeps_profile_data_but_not_parent_role(monkeypatch):
+    _plant(monkeypatch)
+
+    env = build_child_process_env(
+        secret_helper_spec(source="test:helper"),
+        overrides={"HERMES_SECRET_KEY": "WANTED"},
+    )
+
+    assert env["ACME_LOGIN"] == "arbitrary-profile-secret"
+    assert env["OPENAI_API_KEY"] == "provider-secret"
+    assert env["GH_TOKEN"] == "github-tool-secret"
+    assert env["HERMES_SECRET_KEY"] == "WANTED"
+    assert "DISCORD_BOT_TOKEN" not in env
+    assert "_HERMES_GATEWAY" not in env
+    assert "HERMES_KANBAN_TASK" not in env
+
+
+def test_checkpoint_git_does_not_inherit_or_override_git_injection(monkeypatch):
+    _plant(monkeypatch)
+    monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+    monkeypatch.setenv("GIT_CONFIG_KEY_0", "credential.helper")
+    monkeypatch.setenv("GIT_CONFIG_VALUE_0", "!evil")
+    monkeypatch.setenv("GIT_ASKPASS", "/tmp/askpass")
+    spec = checkpoint_git_spec(source="test:checkpoint")
+
+    env = build_child_process_env(
+        spec,
+        overrides={
+            "GIT_DIR": "/tmp/store",
+            "GIT_WORK_TREE": "/tmp/work",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_SYSTEM": os.devnull,
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_COUNT": "2",
+            "GIT_SSH_COMMAND": "ssh -oProxyCommand=evil",
+            "APPTAINERENV_GIT_SSH_COMMAND": "wrapped-evil",
+            "NODE_OPTIONS": "--require=/tmp/evil.js",
+        },
+    )
+
+    assert env["GIT_DIR"] == "/tmp/store"
+    assert env["GIT_WORK_TREE"] == "/tmp/work"
+    assert "GIT_CONFIG_COUNT" not in env
+    assert "GIT_CONFIG_KEY_0" not in env
+    assert "GIT_CONFIG_VALUE_0" not in env
+    assert "GIT_ASKPASS" not in env
+    assert "GIT_SSH_COMMAND" not in env
+    assert "APPTAINERENV_GIT_SSH_COMMAND" not in env
+    assert "NODE_OPTIONS" not in env
+    assert "HTTPS_PROXY" not in env
+    assert "OPENAI_API_KEY" not in env
+
+
+def test_container_image_build_gets_only_registry_auth(monkeypatch):
+    _plant(monkeypatch)
+    for index, key in enumerate(CONTAINER_REGISTRY_AUTH_KEYS):
+        monkeypatch.setenv(key, f"registry-{index}")
+
+    env = build_child_process_env(
+        container_image_build_spec(source="test:image-build"),
+        overrides={
+            "APPTAINER_TMPDIR": "/tmp/apptainer",
+            "APPTAINER_CACHEDIR": "/tmp/cache",
+        },
+    )
+
+    for index, key in enumerate(CONTAINER_REGISTRY_AUTH_KEYS):
+        assert env[key] == f"registry-{index}"
+    assert env["APPTAINER_TMPDIR"] == "/tmp/apptainer"
+    assert env["APPTAINER_CACHEDIR"] == "/tmp/cache"
+    assert "OPENAI_API_KEY" not in env
+    assert "BWS_ACCESS_TOKEN" not in env
+    assert "DISCORD_BOT_TOKEN" not in env
+
+
+def test_interactive_pty_is_typed_and_stdin_is_not_synthesized(monkeypatch):
+    _plant(monkeypatch)
+    spec = interactive_hermes_pty_spec(source="test:pty")
+    env = build_child_process_env(spec)
+
+    assert spec.stdin is ChildStdinPolicy.PTY
+    assert stdin_for_spec(spec) is None
+    assert env["OPENAI_API_KEY"] == "provider-secret"
+    assert "DISCORD_BOT_TOKEN" not in env
+
+
+def test_closed_probe_stdin_and_environment(monkeypatch):
+    _plant(monkeypatch)
+    monkeypatch.setenv("TMP", "/tmp/ambient")
+    spec = probe_spec(source="test:probe")
+    env = build_child_process_env(
+        spec,
+        overrides={
+            "TMP": "/tmp/probe",
+            "LD_PRELOAD": "/tmp/evil.so",
+            "PYTHONPATH": "/tmp/evil-python",
+            "NODE_OPTIONS": "--require=/tmp/evil.js",
+            "GIT_CONFIG_COUNT": "1",
+            "SINGULARITYENV_LD_PRELOAD": "/tmp/wrapped-evil.so",
+        },
+    )
+
+    assert stdin_for_spec(spec) is subprocess.DEVNULL
+    assert env["TMP"] == "/tmp/ambient"
+    assert "OPENAI_API_KEY" not in env
+    assert "ACME_LOGIN" not in env
+    assert "BWS_ACCESS_TOKEN" not in env
+    assert "LD_PRELOAD" not in env
+    assert "PYTHONPATH" not in env
+    assert "NODE_OPTIONS" not in env
+    assert "GIT_CONFIG_COUNT" not in env
+    assert "SINGULARITYENV_LD_PRELOAD" not in env
+
+
+def test_active_multiplex_scope_is_authoritative(monkeypatch):
+    from agent.secret_scope import (
+        reset_secret_scope,
+        set_multiplex_active,
+        set_secret_scope,
+    )
+
+    _plant(monkeypatch)
+    set_multiplex_active(True)
+    token = set_secret_scope({
+        "OPENAI_API_KEY": "profile-b-provider",
+        "ACME_LOGIN": "profile-b-arbitrary",
+    })
+    try:
+        env = build_child_process_env(
+            trusted_hermes_child_spec(source="test:profile-b")
+        )
+    finally:
+        reset_secret_scope(token)
+        set_multiplex_active(False)
+
+    assert env["OPENAI_API_KEY"] == "profile-b-provider"
+    assert env["ACME_LOGIN"] == "profile-b-arbitrary"
+    assert env.get("HERMES_PROFILE") == "profile-a"
+    assert "DISCORD_BOT_TOKEN" not in env
+
+
+def test_multiplex_without_scope_fails_closed(monkeypatch):
+    from agent.secret_scope import set_multiplex_active
+
+    _plant(monkeypatch)
+    set_multiplex_active(True)
+    with pytest.raises(RuntimeError, match="no active profile secret scope"):
+        build_child_process_env(trusted_hermes_child_spec(source="test:unscoped"))
+
+
+def test_spawn_receipt_contains_keys_not_values(monkeypatch):
+    _plant(monkeypatch)
+    spec = bws_vault_spec(source="test:receipt")
+    env = build_child_process_env(
+        spec,
+        overrides={"BWS_ACCESS_TOKEN": "receipt-canary-secret"},
+    )
+
+    receipt = build_spawn_receipt(
+        spec,
+        argv=["/usr/bin/bws", "secret", "list"],
+        env=env,
+    )
+    encoded = json.dumps(receipt, sort_keys=True)
+
+    assert "BWS_ACCESS_TOKEN" in encoded
+    assert "receipt-canary-secret" not in encoded
+    assert "provider-secret" not in encoded
+    assert receipt["intent"] == "vault_cli"
+    assert len(receipt["policy_sha256"]) == 64
+
+
+def test_policy_hash_covers_authority_manifest(monkeypatch):
+    from tools import child_process_authority as authority
+
+    baseline = authority._policy_hash()
+    monkeypatch.setattr(
+        authority,
+        "_CONTROL_PLANE_EXACT",
+        authority._CONTROL_PLANE_EXACT | {"HERMES_NEW_CONTROL_AUTHORITY"},
+    )
+
+    assert authority._policy_hash() != baseline
+
+
+def test_policy_hash_covers_provider_registry_authority(monkeypatch):
+    from hermes_cli import auth
+    from tools import child_process_authority as authority
+
+    baseline = authority._policy_hash()
+    registry = dict(auth.PROVIDER_REGISTRY)
+    registry["policy-hash-canary"] = SimpleNamespace(
+        api_key_env_vars=("POLICY_HASH_CANARY_API_KEY",),
+        base_url_env_var="POLICY_HASH_CANARY_BASE_URL",
+    )
+    monkeypatch.setattr(auth, "PROVIDER_REGISTRY", registry)
+
+    assert "POLICY_HASH_CANARY_API_KEY" in authority._provider_env_names()
+    assert authority._policy_hash() != baseline
+
+
+def test_spawn_receipt_hash_uses_current_provider_registry(monkeypatch):
+    from hermes_cli import auth
+    from tools import child_process_authority as authority
+
+    spec = probe_spec(source="test:receipt-policy")
+    baseline = authority.build_spawn_receipt(spec, argv=["probe"], env={})[
+        "policy_sha256"
+    ]
+    registry = dict(auth.PROVIDER_REGISTRY)
+    registry["receipt-policy-canary"] = SimpleNamespace(
+        api_key_env_vars=("RECEIPT_POLICY_CANARY_API_KEY",),
+        base_url_env_var="RECEIPT_POLICY_CANARY_BASE_URL",
+    )
+    monkeypatch.setattr(auth, "PROVIDER_REGISTRY", registry)
+
+    current = authority.build_spawn_receipt(spec, argv=["probe"], env={})[
+        "policy_sha256"
+    ]
+    assert current == authority._policy_hash()
+    assert current != baseline
+
+
+class _DummyProcess:
+    def __init__(self):
+        self.stdin = None
+        self.stdout = None
+        self.stderr = None
+        self.returncode = 0
+        self.pid = 1234
+
+
+def test_shared_remote_terminal_popen_sanitizes_omitted_env(monkeypatch):
+    from tools.environments import base as base_env
+
+    _plant(monkeypatch)
+    monkeypatch.setenv("bws_access_token", "lowercase-vault-bootstrap")
+    monkeypatch.setenv("OP_SESSION_acme", "op-session-secret")
+    calls = []
+
+    def fake_popen(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return _DummyProcess()
+
+    monkeypatch.setattr(base_env.subprocess, "Popen", fake_popen)
+    base_env._popen_bash(["bash", "-c", "true"])
+
+    child_env = calls[0][1]["env"]
+    assert child_env["PATH"]
+    assert "OPENAI_API_KEY" not in child_env
+    assert "BWS_ACCESS_TOKEN" not in child_env
+    assert "bws_access_token" not in child_env
+    assert "OP_SESSION_acme" not in child_env
+    assert "DISCORD_BOT_TOKEN" not in child_env
+    assert "APPTAINERENV_GATEWAY_RELAY_SECRET" not in child_env
+
+
+def test_bitwarden_source_uses_minimal_vault_edge(monkeypatch):
+    from pathlib import Path
+
+    from agent.secret_sources import bitwarden
+
+    _plant(monkeypatch)
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0, stdout="[]", stderr="")
+
+    monkeypatch.setattr(bitwarden.subprocess, "run", fake_run)
+    secrets, warnings = bitwarden._run_bws_list(
+        Path("/usr/bin/bws"),
+        "edge-token",
+        "project-id",
+        server_url="https://vault.example.invalid",
+    )
+
+    assert secrets == {}
+    assert warnings == []
+    child_env = calls[0][1]["env"]
+    assert child_env["BWS_ACCESS_TOKEN"] == "edge-token"
+    assert child_env["BWS_SERVER_URL"] == "https://vault.example.invalid"
+    assert "OPENAI_API_KEY" not in child_env
+    assert "ACME_LOGIN" not in child_env
+    assert calls[0][1]["stdin"] is subprocess.DEVNULL
+
+
+def test_onepassword_source_uses_minimal_vault_edge(monkeypatch):
+    from agent.secret_sources import onepassword
+
+    _plant(monkeypatch)
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "op-token")
+    monkeypatch.setenv("OP_SESSION_acme", "session-token")
+
+    env = onepassword._op_child_env("override-token")
+
+    assert env["OP_SERVICE_ACCOUNT_TOKEN"] == "override-token"
+    assert env["OP_SESSION_acme"] == "session-token"
+    assert "OPENAI_API_KEY" not in env
+    assert "ACME_LOGIN" not in env
+
+
+def test_checkpoint_git_env_isolated_at_real_callsite(monkeypatch, tmp_path):
+    from tools import checkpoint_manager
+
+    _plant(monkeypatch)
+    monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+    monkeypatch.setenv("GIT_ASKPASS", "/tmp/askpass")
+    store = tmp_path / "store"
+    work = tmp_path / "work"
+    store.mkdir()
+    work.mkdir()
+
+    env = checkpoint_manager._git_env(store, str(work))
+
+    assert env["GIT_DIR"] == str(store)
+    assert env["GIT_WORK_TREE"] == str(work.resolve())
+    assert env["GIT_CONFIG_GLOBAL"] == os.devnull
+    assert "GIT_CONFIG_COUNT" not in env
+    assert "GIT_ASKPASS" not in env
+    assert "OPENAI_API_KEY" not in env
+
+
+def test_singularity_image_build_uses_explicit_registry_grants(monkeypatch, tmp_path):
+    from tools.environments import singularity
+
+    _plant(monkeypatch)
+    for index, key in enumerate(CONTAINER_REGISTRY_AUTH_KEYS):
+        monkeypatch.setenv(key, f"registry-{index}")
+    monkeypatch.setattr(singularity, "_get_apptainer_cache_dir", lambda: tmp_path)
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(singularity.subprocess, "run", fake_run)
+    result = singularity._get_or_build_sif(
+        "docker://example.invalid/private:latest",
+        "apptainer",
+    )
+
+    assert result.endswith("example.invalid-private-latest.sif")
+    child_env = calls[0][1]["env"]
+    for index, key in enumerate(CONTAINER_REGISTRY_AUTH_KEYS):
+        assert child_env[key] == f"registry-{index}"
+    assert "OPENAI_API_KEY" not in child_env
+    assert "BWS_ACCESS_TOKEN" not in child_env
+
+
+def test_codex_version_probe_uses_minimal_closed_edge(monkeypatch):
+    from agent.transports import codex_app_server
+
+    _plant(monkeypatch)
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout="codex-cli 0.125.0\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(codex_app_server.subprocess, "run", fake_run)
+
+    ok, version = codex_app_server.check_codex_binary()
+
+    assert ok is True
+    assert version == "0.125.0"
+    child_env = calls[0][1]["env"]
+    assert child_env["PATH"]
+    assert "OPENAI_API_KEY" not in child_env
+    assert "ACME_LOGIN" not in child_env
+    assert "HERMES_KANBAN_TASK" not in child_env
+    assert calls[0][1]["stdin"] is subprocess.DEVNULL
+
+
+def test_bitwarden_libc_probe_uses_minimal_closed_edge(monkeypatch):
+    from agent.secret_sources import bitwarden
+
+    _plant(monkeypatch)
+    calls = []
+
+    monkeypatch.setattr(bitwarden.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(bitwarden.platform, "machine", lambda: "x86_64")
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout="ldd (GNU libc) 2.39\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(bitwarden.subprocess, "run", fake_run)
+
+    asset = bitwarden._platform_asset_name()
+
+    assert asset.startswith("bws-x86_64-unknown-linux-gnu-")
+    child_env = calls[0][1]["env"]
+    assert child_env["PATH"]
+    assert "OPENAI_API_KEY" not in child_env
+    assert "BWS_ACCESS_TOKEN" not in child_env
+    assert "ACME_LOGIN" not in child_env
+    assert calls[0][1]["stdin"] is subprocess.DEVNULL
+
+
+def test_host_supervisor_probes_use_minimal_closed_edges(monkeypatch):
+    from tui_gateway import host_supervisor
+
+    _plant(monkeypatch)
+    calls = []
+
+    def fake_check_output(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[0] == "git":
+            return "abc123\n"
+        return "python -m tui_gateway.compute_host\n"
+
+    def fail_read_bytes(_path):
+        raise OSError("force ps fallback")
+
+    monkeypatch.setattr(host_supervisor.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(host_supervisor.Path, "read_bytes", fail_read_bytes)
+
+    assert host_supervisor._build_sha() == "abc123"
+    assert "tui_gateway.compute_host" in host_supervisor._pid_command(1234)
+
+    assert len(calls) == 2
+    for _cmd, kwargs in calls:
+        child_env = kwargs["env"]
+        assert child_env["PATH"]
+        assert "OPENAI_API_KEY" not in child_env
+        assert "ACME_LOGIN" not in child_env
+        assert "HERMES_KANBAN_TASK" not in child_env
+        assert kwargs["stdin"] is subprocess.DEVNULL
+
+
+def test_checkpoint_store_init_uses_minimal_typed_edge(monkeypatch, tmp_path):
+    from tools import checkpoint_manager
+
+    _plant(monkeypatch)
+    monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+    monkeypatch.setenv("GIT_ASKPASS", "/tmp/askpass")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(checkpoint_manager.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        checkpoint_manager,
+        "_run_git",
+        lambda *_args, **_kwargs: (True, "", ""),
+    )
+
+    store = tmp_path / "checkpoints" / "store"
+    error = checkpoint_manager._init_store(store, str(tmp_path))
+
+    assert error is None
+    assert len(calls) == 1
+    child_env = calls[0][1]["env"]
+    assert child_env["GIT_CONFIG_GLOBAL"] == os.devnull
+    assert child_env["GIT_CONFIG_SYSTEM"] == os.devnull
+    assert child_env["GIT_CONFIG_NOSYSTEM"] == "1"
+    assert "GIT_CONFIG_COUNT" not in child_env
+    assert "GIT_ASKPASS" not in child_env
+    assert "OPENAI_API_KEY" not in child_env
+    assert "ACME_LOGIN" not in child_env
+    assert calls[0][1]["stdin"] is subprocess.DEVNULL

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -312,22 +312,24 @@ def _git_env(
     ``store/indexes/<hash>`` so projects don't race on a shared index.
     """
     normalized_working_dir = _normalize_path(working_dir)
-    # git child with hand-isolated config env; exact preservation — a HOME
-    # rewrite would change which ~/.gitconfig the isolation vars are hiding.
-    from tools.environments.local import build_subprocess_env
-    env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
-    env["GIT_DIR"] = str(store)
-    env["GIT_WORK_TREE"] = str(normalized_working_dir)
-    env.pop("GIT_NAMESPACE", None)
-    env.pop("GIT_ALTERNATE_OBJECT_DIRECTORIES", None)
+    from tools.child_process_authority import (
+        build_child_process_env,
+        checkpoint_git_spec,
+    )
+
+    overrides = {
+        "GIT_DIR": str(store),
+        "GIT_WORK_TREE": str(normalized_working_dir),
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_SYSTEM": os.devnull,
+        "GIT_CONFIG_NOSYSTEM": "1",
+    }
     if index_file is not None:
-        env["GIT_INDEX_FILE"] = str(index_file)
-    else:
-        env.pop("GIT_INDEX_FILE", None)
-    env["GIT_CONFIG_GLOBAL"] = os.devnull
-    env["GIT_CONFIG_SYSTEM"] = os.devnull
-    env["GIT_CONFIG_NOSYSTEM"] = "1"
-    return env
+        overrides["GIT_INDEX_FILE"] = str(index_file)
+    return build_child_process_env(
+        checkpoint_git_spec(source="tools.checkpoint_manager"),
+        overrides=overrides,
+    )
 
 
 def _repair_bare_repo_dirs(store: Path) -> None:
@@ -497,17 +499,22 @@ def _init_store(store: Path, working_dir: str) -> Optional[str]:
     (store / _PROJECTS_DIRNAME).mkdir(exist_ok=True)
 
     # ``git init --bare`` rejects GIT_WORK_TREE, so we can't use _run_git
-    # here (which always sets GIT_DIR + GIT_WORK_TREE).  Use a raw
-    # subprocess with just the config-isolation env vars.
-    from tools.environments.local import build_subprocess_env
-    init_env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
-    init_env["GIT_CONFIG_GLOBAL"] = os.devnull
-    init_env["GIT_CONFIG_SYSTEM"] = os.devnull
-    init_env["GIT_CONFIG_NOSYSTEM"] = "1"
-    # Drop any inherited GIT_* that would interfere.
-    for k in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_NAMESPACE",
-              "GIT_ALTERNATE_OBJECT_DIRECTORIES"):
-        init_env.pop(k, None)
+    # here (which always sets GIT_DIR + GIT_WORK_TREE). Keep the same typed
+    # CHECKPOINT_GIT edge but grant only the config-isolation variables needed
+    # by the bare-repository initializer.
+    from tools.child_process_authority import (
+        build_child_process_env,
+        checkpoint_git_spec,
+    )
+
+    init_env = build_child_process_env(
+        checkpoint_git_spec(source="tools.checkpoint_manager.init_store"),
+        overrides={
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_SYSTEM": os.devnull,
+            "GIT_CONFIG_NOSYSTEM": "1",
+        },
+    )
     try:
         result = subprocess.run(
             ["git", "init", "--bare", str(store)],

--- a/tools/child_process_authority.py
+++ b/tools/child_process_authority.py
@@ -1,0 +1,816 @@
+"""Typed process-edge authority contracts for Hermes child processes.
+
+The trusted Hermes process can hold several kinds of ambient authority at once:
+profile credentials, gateway/controller markers, Kanban lifecycle ownership,
+session identity, and executable-loader state.  Copying ``os.environ`` and then
+subtracting names at each call site makes those authorities indistinguishable.
+
+This module is the narrow waist for child environments.  A caller selects a
+typed process intent; the policy decides which profile data, credential class,
+control-plane grant, stdin contract, and descendant semantics may cross that
+specific edge.  Environment values never appear in receipts.
+
+The first migration deliberately keeps the mature terminal sanitizer in
+``tools.environments.local`` as the implementation owner for model-authored
+terminal execution.  This module owns every non-terminal full-environment or
+credential-bearing child edge.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+POLICY_VERSION = 1
+
+
+class ChildProcessIntent(str, Enum):
+    """Security-relevant reason for creating a child process."""
+
+    MODEL_DRIVER = "model_driver"
+    TRUSTED_HERMES_CHILD = "trusted_hermes_child"
+    INTERACTIVE_HERMES_PTY = "interactive_hermes_pty"
+    VAULT_CLI = "vault_cli"
+    SECRET_HELPER = "secret_helper"
+    CHECKPOINT_GIT = "checkpoint_git"
+    CONTAINER_CONTROL = "container_control"
+    CONTAINER_IMAGE_BUILD = "container_image_build"
+    PROBE = "probe"
+
+
+class ChildPrincipal(str, Enum):
+    """Principal expected to execute inside the child."""
+
+    MODEL_DRIVING_CLI = "model_driving_cli"
+    HERMES_RUNTIME = "hermes_runtime"
+    USER_CONFIGURED_HELPER = "user_configured_helper"
+    EXTERNAL_CREDENTIAL_TOOL = "external_credential_tool"
+    LOCAL_INFRASTRUCTURE = "local_infrastructure"
+
+
+class ChildStdinPolicy(str, Enum):
+    CLOSED = "closed"
+    PIPE = "pipe"
+    PTY = "pty"
+
+
+class DescendantPolicy(str, Enum):
+    NO_AUTHORITY_DELEGATION = "no_authority_delegation"
+    SAME_PROFILE_RUNTIME = "same_profile_runtime"
+    TOOL_OWNED = "tool_owned"
+
+
+@dataclass(frozen=True)
+class ChildProcessSpec:
+    """Immutable authority contract for one parent -> child edge."""
+
+    intent: ChildProcessIntent
+    principal: ChildPrincipal
+    stdin: ChildStdinPolicy = ChildStdinPolicy.CLOSED
+    descendants: DescendantPolicy = DescendantPolicy.NO_AUTHORITY_DELEGATION
+    grants: tuple[str, ...] = ()
+    grant_prefixes: tuple[str, ...] = ()
+    target_profile: str = ""
+    source: str = ""
+
+    def __post_init__(self) -> None:
+        normalized = tuple(_normalize_name(name) for name in self.grants)
+        prefixes = tuple(_normalize_name(prefix) for prefix in self.grant_prefixes)
+        if any(not name for name in normalized):
+            raise ValueError("child-process grants must be non-empty environment names")
+        if any(not prefix for prefix in prefixes):
+            raise ValueError("child-process grant prefixes must be non-empty")
+        if len(set(normalized)) != len(normalized):
+            raise ValueError("duplicate child-process grant")
+        if len(set(prefixes)) != len(prefixes):
+            raise ValueError("duplicate child-process grant prefix")
+
+
+# Operational environment required to start ordinary local programs.  This is
+# deliberately a positive baseline, not a snapshot of the live Hermes process.
+_SAFE_BASE_KEYS = frozenset({
+    "PATH",
+    "HOME",
+    "USER",
+    "LOGNAME",
+    "SHELL",
+    "PWD",
+    "OLDPWD",
+    "USERPROFILE",
+    "APPDATA",
+    "LOCALAPPDATA",
+    "PROGRAMDATA",
+    "PROGRAMFILES",
+    "PROGRAMFILES(X86)",
+    "SYSTEMDRIVE",
+    "SYSTEMROOT",
+    "WINDIR",
+    "COMSPEC",
+    "PATHEXT",
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+    "XDG_CONFIG_HOME",
+    "XDG_CACHE_HOME",
+    "XDG_RUNTIME_DIR",
+    "LANG",
+    "LANGUAGE",
+    "LC_ALL",
+    "LC_CTYPE",
+    "TZ",
+    "TERM",
+    "COLORTERM",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+    "PYTHONUTF8",
+})
+
+# Network routing is a capability too.  Vault and container-image clients may
+# need enterprise proxies, while local checkpoint Git and version probes do not.
+_NETWORK_ROUTE_KEYS = frozenset({
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "no_proxy",
+})
+
+# Registry-auth exception inherited from the reviewed #77027 boundary.  No
+# other process-global credential is admitted to an image build.
+CONTAINER_REGISTRY_AUTH_KEYS = (
+    "APPTAINER_DOCKER_USERNAME",
+    "APPTAINER_DOCKER_PASSWORD",
+    "SINGULARITY_DOCKER_USERNAME",
+    "SINGULARITY_DOCKER_PASSWORD",
+    "DOCKER_USERNAME",
+    "DOCKER_PASSWORD",
+)
+
+BWS_VAULT_GRANTS = ("BWS_ACCESS_TOKEN", "BWS_SERVER_URL")
+OP_VAULT_GRANTS = (
+    "OP_SERVICE_ACCOUNT_TOKEN",
+    "OP_ACCOUNT",
+    "OP_CONNECT_HOST",
+    "OP_CONNECT_TOKEN",
+    "OP_LOAD_DESKTOP_APP_SETTINGS",
+    "OP_CACHE",
+)
+OP_VAULT_GRANT_PREFIXES = ("OP_SESSION_",)
+
+# Authority that may continue only across the dispatcher-worker -> Codex ->
+# hermes-tools edge.  Arbitrary nested chats and other model drivers do not get
+# this prefix.
+KANBAN_WORKER_GRANTS = ("HERMES_PROFILE", "HERMES_SESSION_ID")
+KANBAN_WORKER_GRANT_PREFIXES = ("HERMES_KANBAN_",)
+
+
+# Tool credentials that a trusted Hermes execution child may need to perform the
+# same tool calls as its parent.  Gateway transport/auth authority is
+# deliberately absent.
+TRUSTED_AGENT_TOOL_GRANTS = (
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+    "GITHUB_APP_ID",
+    "GITHUB_APP_PRIVATE_KEY_PATH",
+    "GITHUB_APP_INSTALLATION_ID",
+    "HASS_TOKEN",
+    "EMAIL_PASSWORD",
+    "MODAL_TOKEN_ID",
+    "MODAL_TOKEN_SECRET",
+    "DAYTONA_API_KEY",
+    *BWS_VAULT_GRANTS,
+    *OP_VAULT_GRANTS,
+)
+TRUSTED_AGENT_TOOL_GRANT_PREFIXES = (
+    "AUXILIARY_",
+    "_HERMES_FORCE_",
+    *OP_VAULT_GRANT_PREFIXES,
+)
+
+_CONTROL_PLANE_EXACT = frozenset({
+    "_HERMES_GATEWAY",
+    "HERMES_DELEGATED_CHILD_CONTEXT",
+    "HERMES_DASHBOARD_SESSION_TOKEN",
+})
+_CONTROL_PLANE_PREFIXES = (
+    "HERMES_KANBAN_",
+    "HERMES_SESSION_",
+)
+
+_FORWARDED_ENV_PREFIXES = ("APPTAINERENV_", "SINGULARITYENV_")
+_SECRET_SUFFIXES = (
+    "_API_KEY",
+    "_TOKEN",
+    "_SECRET",
+    "_PASSWORD",
+    "_PRIVATE_KEY",
+    "_CLIENT_SECRET",
+)
+
+# Mutable coordinates are explicit policy too.  These are values that reviewed
+# call sites need to select a child-owned home, lifecycle cadence, vault output
+# mode, or container cache location.  They are not a generic escape hatch for
+# arbitrary caller state.
+_OVERRIDE_COORDINATES: dict[ChildProcessIntent, frozenset[str]] = {
+    ChildProcessIntent.TRUSTED_HERMES_CHILD: frozenset({
+        "HERMES_HOME",
+        "HERMES_COMPUTE_HOST_HEARTBEAT_SECS",
+    }),
+    ChildProcessIntent.INTERACTIVE_HERMES_PTY: frozenset({"HERMES_HOME"}),
+    ChildProcessIntent.VAULT_CLI: frozenset({"NO_COLOR"}),
+    ChildProcessIntent.CONTAINER_IMAGE_BUILD: frozenset({
+        "APPTAINER_TMPDIR",
+        "APPTAINER_CACHEDIR",
+        "SINGULARITY_TMPDIR",
+        "SINGULARITY_CACHEDIR",
+    }),
+}
+_NETWORK_OVERRIDE_INTENTS = frozenset({
+    ChildProcessIntent.MODEL_DRIVER,
+    ChildProcessIntent.VAULT_CLI,
+    ChildProcessIntent.CONTAINER_IMAGE_BUILD,
+})
+
+
+def _normalize_name(name: str) -> str:
+    return str(name or "").strip().upper()
+
+
+def _effective_env_name(name: str) -> str:
+    normalized = _normalize_name(name)
+    changed = True
+    while changed:
+        changed = False
+        for prefix in _FORWARDED_ENV_PREFIXES:
+            if normalized.startswith(prefix):
+                normalized = normalized[len(prefix) :]
+                changed = True
+    return normalized
+
+
+def _casefold_lookup(source: Mapping[str, str], name: str) -> str | None:
+    wanted = _normalize_name(name)
+    for key, value in source.items():
+        if _normalize_name(key) == wanted:
+            return str(value)
+    return None
+
+
+def _grant_allows(spec: ChildProcessSpec, name: str) -> bool:
+    effective = _effective_env_name(name)
+    grants = {_normalize_name(item) for item in spec.grants}
+    if effective in grants:
+        return True
+    return any(
+        effective.startswith(_normalize_name(prefix)) for prefix in spec.grant_prefixes
+    )
+
+
+def _is_control_plane_authority(name: str) -> bool:
+    effective = _effective_env_name(name)
+    if effective in _CONTROL_PLANE_EXACT:
+        return True
+    return any(effective.startswith(prefix) for prefix in _CONTROL_PLANE_PREFIXES)
+
+
+def _is_tier1_or_internal(name: str) -> bool:
+    from tools.environments.local import (
+        _ALWAYS_STRIP_KEYS,
+        _HERMES_PROVIDER_ENV_FORCE_PREFIX,
+        _is_hermes_internal_secret,
+    )
+
+    effective = _effective_env_name(name)
+    if effective.startswith(_normalize_name(_HERMES_PROVIDER_ENV_FORCE_PREFIX)):
+        return True
+    if effective in {_normalize_name(key) for key in _ALWAYS_STRIP_KEYS}:
+        return True
+    return bool(_is_hermes_internal_secret(effective))
+
+
+def _provider_env_names() -> frozenset[str]:
+    """Return exact model-auth names from the provider registry.
+
+    This intentionally does not reuse the broad terminal blocklist: that set
+    also contains messaging and tool credentials.  A model-driving CLI receives
+    model authentication, not every integration secret in the active profile.
+    """
+
+    names: set[str] = {
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "COPILOT_GITHUB_TOKEN",
+        # General AWS chain used by Bedrock-backed model drivers.
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_PROFILE",
+        "AWS_DEFAULT_PROFILE",
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+        "AWS_CONFIG_FILE",
+        "AWS_SHARED_CREDENTIALS_FILE",
+        "AWS_ROLE_ARN",
+        "AWS_ROLE_SESSION_NAME",
+        "AWS_WEB_IDENTITY_TOKEN_FILE",
+        "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+        "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+        "AWS_EC2_METADATA_DISABLED",
+    }
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        for provider in PROVIDER_REGISTRY.values():
+            names.update(_normalize_name(item) for item in provider.api_key_env_vars)
+            if provider.base_url_env_var:
+                names.add(_normalize_name(provider.base_url_env_var))
+    except Exception:
+        # Fail closed: the caller may still declare an exact grant.
+        pass
+    return frozenset(name for name in names if name)
+
+
+def _profile_source(
+    explicit: Mapping[str, str] | None,
+) -> dict[str, str]:
+    """Return the current profile environment without cross-profile fallback."""
+
+    if explicit is not None:
+        return {str(key): str(value) for key, value in explicit.items()}
+
+    try:
+        from agent.secret_scope import (
+            _is_global_env,
+            current_secret_scope,
+            is_multiplex_active,
+        )
+
+        scope = current_secret_scope()
+        if scope is not None:
+            source = {
+                str(key): str(value)
+                for key, value in os.environ.items()
+                if _is_global_env(str(key))
+            }
+            source.update({str(key): str(value) for key, value in scope.items()})
+            return source
+        if is_multiplex_active():
+            raise RuntimeError(
+                "child-process authority requested with no active profile "
+                "secret scope while multiplexing is enabled"
+            )
+    except ImportError:
+        pass
+
+    return {str(key): str(value) for key, value in os.environ.items()}
+
+
+def _copy_named(
+    source: Mapping[str, str],
+    names: set[str] | frozenset[str] | tuple[str, ...],
+) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for name in names:
+        value = _casefold_lookup(source, str(name))
+        if value is not None:
+            out[str(name)] = value
+    return out
+
+
+def _copy_prefixes(
+    source: Mapping[str, str],
+    prefixes: tuple[str, ...],
+) -> dict[str, str]:
+    normalized = tuple(_normalize_name(prefix) for prefix in prefixes)
+    return {
+        str(key): str(value)
+        for key, value in source.items()
+        if any(_normalize_name(key).startswith(prefix) for prefix in normalized)
+    }
+
+
+def _safe_base(
+    source: Mapping[str, str],
+    *,
+    network: bool = False,
+) -> dict[str, str]:
+    names = set(_SAFE_BASE_KEYS)
+    if network:
+        names.update(_NETWORK_ROUTE_KEYS)
+    return _copy_named(source, names)
+
+
+def _strip_ungranted_authority(
+    env: dict[str, str],
+    spec: ChildProcessSpec,
+    *,
+    strip_provider_credentials: bool,
+) -> dict[str, str]:
+    provider_names = _provider_env_names()
+    for key in list(env):
+        effective = _effective_env_name(key)
+        granted = _grant_allows(spec, effective)
+        if _is_tier1_or_internal(effective) and not granted:
+            env.pop(key, None)
+            continue
+        if _is_control_plane_authority(effective) and not granted:
+            env.pop(key, None)
+            continue
+        if strip_provider_credentials and effective in provider_names and not granted:
+            env.pop(key, None)
+            continue
+        if strip_provider_credentials and _secret_like(effective) and not granted:
+            env.pop(key, None)
+    return env
+
+
+def _secret_like(name: str) -> bool:
+    effective = _effective_env_name(name)
+    if _is_tier1_or_internal(effective) or _is_control_plane_authority(effective):
+        return True
+    return effective.endswith(_SECRET_SUFFIXES)
+
+
+def _apply_overrides(
+    env: dict[str, str],
+    overrides: Mapping[str, str] | None,
+    spec: ChildProcessSpec,
+) -> None:
+    """Apply only names positively admitted by the typed edge policy.
+
+    Forwarding wrappers are separate authority channels and therefore require an
+    explicit spec grant.  Safe-baseline membership controls inheritance only;
+    caller writes require an intent-owned routing/network coordinate,
+    model-provider authority, or an exact/prefix grant.
+    """
+
+    if not overrides:
+        return
+
+    provider_names = _provider_env_names()
+    allowed_names: set[str] = set()
+    if spec.intent in _NETWORK_OVERRIDE_INTENTS:
+        allowed_names.update(_normalize_name(name) for name in _NETWORK_ROUTE_KEYS)
+    allowed_names.update(
+        _normalize_name(name) for name in _OVERRIDE_COORDINATES.get(spec.intent, ())
+    )
+    if spec.intent is ChildProcessIntent.MODEL_DRIVER:
+        allowed_names.update(provider_names)
+
+    for key, value in overrides.items():
+        name = str(key)
+        normalized = _normalize_name(name)
+        effective = _effective_env_name(name)
+        if _grant_allows(spec, effective):
+            env[name] = str(value)
+            continue
+        if normalized != effective:
+            # A container forwarding wrapper can only carry explicitly granted
+            # authority; baseline/coordinate admission is for this child only.
+            continue
+        if _is_tier1_or_internal(effective) or _is_control_plane_authority(effective):
+            continue
+        if effective in allowed_names:
+            env[name] = str(value)
+
+
+def build_child_process_env(
+    spec: ChildProcessSpec,
+    *,
+    source_env: Mapping[str, str] | None = None,
+    overrides: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Construct the environment authorized by ``spec``.
+
+    The returned mapping is new and detached from every source mapping.
+    Caller overrides are evaluated by the same policy; they cannot re-add a
+    stripped gateway token, lifecycle marker, wrapper tunnel, or dynamic Hermes
+    secret unless the edge declares an exact grant.
+    """
+
+    source = _profile_source(source_env)
+    trusted_profile_child = spec.intent in {
+        ChildProcessIntent.TRUSTED_HERMES_CHILD,
+        ChildProcessIntent.INTERACTIVE_HERMES_PTY,
+        ChildProcessIntent.SECRET_HELPER,
+    }
+    model_driver = spec.intent is ChildProcessIntent.MODEL_DRIVER
+
+    if trusted_profile_child:
+        env = dict(source)
+        env = _strip_ungranted_authority(
+            env,
+            spec,
+            strip_provider_credentials=False,
+        )
+    elif model_driver:
+        env = _safe_base(source, network=True)
+        env.update(_copy_named(source, _provider_env_names()))
+        env.update(_copy_named(source, spec.grants))
+        env.update(_copy_prefixes(source, spec.grant_prefixes))
+        env = _strip_ungranted_authority(
+            env,
+            spec,
+            strip_provider_credentials=False,
+        )
+    elif spec.intent is ChildProcessIntent.VAULT_CLI:
+        env = _safe_base(source, network=True)
+        env.update(_copy_named(source, spec.grants))
+        env.update(_copy_prefixes(source, spec.grant_prefixes))
+        env = _strip_ungranted_authority(
+            env,
+            spec,
+            strip_provider_credentials=True,
+        )
+    elif spec.intent is ChildProcessIntent.CHECKPOINT_GIT:
+        env = _safe_base(source, network=False)
+        env = _strip_ungranted_authority(
+            env,
+            spec,
+            strip_provider_credentials=True,
+        )
+    elif spec.intent is ChildProcessIntent.CONTAINER_IMAGE_BUILD:
+        from tools.environments.local import build_subprocess_env
+
+        env = build_subprocess_env(base=source)
+        env.update(_copy_named(source, CONTAINER_REGISTRY_AUTH_KEYS))
+        env = _strip_ungranted_authority(
+            env,
+            spec,
+            strip_provider_credentials=True,
+        )
+    elif spec.intent is ChildProcessIntent.CONTAINER_CONTROL:
+        from tools.environments.local import build_subprocess_env
+
+        env = build_subprocess_env(base=source)
+        env = _strip_ungranted_authority(
+            env,
+            spec,
+            strip_provider_credentials=True,
+        )
+    elif spec.intent is ChildProcessIntent.PROBE:
+        env = _safe_base(source, network=False)
+        env = _strip_ungranted_authority(
+            env,
+            spec,
+            strip_provider_credentials=True,
+        )
+    else:  # pragma: no cover - Enum exhaustiveness guard
+        raise ValueError(f"unsupported child-process intent: {spec.intent}")
+
+    # Preserve the existing context-local HERMES_HOME / subprocess HOME
+    # contract without re-snapshotting os.environ. Apply caller overrides only
+    # after this bridge so an explicit target-profile HERMES_HOME remains the
+    # authoritative child coordinate.
+    try:
+        from tools.environments.local import _inject_context_hermes_home
+
+        _inject_context_hermes_home(env)
+        from hermes_constants import apply_subprocess_home_env
+
+        apply_subprocess_home_env(env)
+    except Exception:
+        pass
+
+    _apply_overrides(env, overrides, spec)
+    env = _strip_ungranted_authority(
+        env,
+        spec,
+        strip_provider_credentials=not (trusted_profile_child or model_driver),
+    )
+
+    if spec.target_profile:
+        env["HERMES_PROFILE"] = spec.target_profile
+
+    env.setdefault("PYTHONUTF8", "1")
+    return env
+
+
+def stdin_for_spec(spec: ChildProcessSpec) -> Any:
+    """Translate the typed stdin policy to the subprocess API value."""
+
+    if spec.stdin is ChildStdinPolicy.CLOSED:
+        return subprocess.DEVNULL
+    if spec.stdin is ChildStdinPolicy.PIPE:
+        return subprocess.PIPE
+    return None
+
+
+def model_driver_spec(
+    *,
+    source: str,
+    grants: tuple[str, ...] = (),
+    grant_prefixes: tuple[str, ...] = (),
+) -> ChildProcessSpec:
+    return ChildProcessSpec(
+        intent=ChildProcessIntent.MODEL_DRIVER,
+        principal=ChildPrincipal.MODEL_DRIVING_CLI,
+        stdin=ChildStdinPolicy.PIPE,
+        descendants=DescendantPolicy.NO_AUTHORITY_DELEGATION,
+        grants=grants,
+        grant_prefixes=grant_prefixes,
+        source=source,
+    )
+
+
+def trusted_hermes_child_spec(
+    *,
+    source: str,
+    stdin: ChildStdinPolicy = ChildStdinPolicy.PIPE,
+    grants: tuple[str, ...] = TRUSTED_AGENT_TOOL_GRANTS,
+    grant_prefixes: tuple[str, ...] = TRUSTED_AGENT_TOOL_GRANT_PREFIXES,
+) -> ChildProcessSpec:
+    return ChildProcessSpec(
+        intent=ChildProcessIntent.TRUSTED_HERMES_CHILD,
+        principal=ChildPrincipal.HERMES_RUNTIME,
+        stdin=stdin,
+        descendants=DescendantPolicy.SAME_PROFILE_RUNTIME,
+        grants=grants,
+        grant_prefixes=grant_prefixes,
+        source=source,
+    )
+
+
+def interactive_hermes_pty_spec(*, source: str) -> ChildProcessSpec:
+    return ChildProcessSpec(
+        intent=ChildProcessIntent.INTERACTIVE_HERMES_PTY,
+        principal=ChildPrincipal.HERMES_RUNTIME,
+        stdin=ChildStdinPolicy.PTY,
+        descendants=DescendantPolicy.SAME_PROFILE_RUNTIME,
+        grants=TRUSTED_AGENT_TOOL_GRANTS,
+        grant_prefixes=TRUSTED_AGENT_TOOL_GRANT_PREFIXES,
+        source=source,
+    )
+
+
+def bws_vault_spec(*, source: str) -> ChildProcessSpec:
+    return ChildProcessSpec(
+        intent=ChildProcessIntent.VAULT_CLI,
+        principal=ChildPrincipal.EXTERNAL_CREDENTIAL_TOOL,
+        stdin=ChildStdinPolicy.CLOSED,
+        descendants=DescendantPolicy.TOOL_OWNED,
+        grants=BWS_VAULT_GRANTS,
+        source=source,
+    )
+
+
+def op_vault_spec(*, source: str) -> ChildProcessSpec:
+    return ChildProcessSpec(
+        intent=ChildProcessIntent.VAULT_CLI,
+        principal=ChildPrincipal.EXTERNAL_CREDENTIAL_TOOL,
+        stdin=ChildStdinPolicy.CLOSED,
+        descendants=DescendantPolicy.TOOL_OWNED,
+        grants=OP_VAULT_GRANTS,
+        grant_prefixes=OP_VAULT_GRANT_PREFIXES,
+        source=source,
+    )
+
+
+def secret_helper_spec(*, source: str) -> ChildProcessSpec:
+    return ChildProcessSpec(
+        intent=ChildProcessIntent.SECRET_HELPER,
+        principal=ChildPrincipal.USER_CONFIGURED_HELPER,
+        stdin=ChildStdinPolicy.CLOSED,
+        descendants=DescendantPolicy.TOOL_OWNED,
+        grants=("HERMES_SECRET_KEY", *TRUSTED_AGENT_TOOL_GRANTS),
+        grant_prefixes=TRUSTED_AGENT_TOOL_GRANT_PREFIXES,
+        source=source,
+    )
+
+
+def checkpoint_git_spec(*, source: str) -> ChildProcessSpec:
+    return ChildProcessSpec(
+        intent=ChildProcessIntent.CHECKPOINT_GIT,
+        principal=ChildPrincipal.LOCAL_INFRASTRUCTURE,
+        stdin=ChildStdinPolicy.CLOSED,
+        descendants=DescendantPolicy.NO_AUTHORITY_DELEGATION,
+        grants=(
+            "GIT_DIR",
+            "GIT_WORK_TREE",
+            "GIT_INDEX_FILE",
+            "GIT_CONFIG_GLOBAL",
+            "GIT_CONFIG_SYSTEM",
+            "GIT_CONFIG_NOSYSTEM",
+        ),
+        source=source,
+    )
+
+
+def container_control_spec(*, source: str) -> ChildProcessSpec:
+    return ChildProcessSpec(
+        intent=ChildProcessIntent.CONTAINER_CONTROL,
+        principal=ChildPrincipal.LOCAL_INFRASTRUCTURE,
+        stdin=ChildStdinPolicy.CLOSED,
+        descendants=DescendantPolicy.TOOL_OWNED,
+        source=source,
+    )
+
+
+def container_image_build_spec(*, source: str) -> ChildProcessSpec:
+    return ChildProcessSpec(
+        intent=ChildProcessIntent.CONTAINER_IMAGE_BUILD,
+        principal=ChildPrincipal.LOCAL_INFRASTRUCTURE,
+        stdin=ChildStdinPolicy.CLOSED,
+        descendants=DescendantPolicy.TOOL_OWNED,
+        grants=CONTAINER_REGISTRY_AUTH_KEYS,
+        source=source,
+    )
+
+
+def probe_spec(*, source: str) -> ChildProcessSpec:
+    return ChildProcessSpec(
+        intent=ChildProcessIntent.PROBE,
+        principal=ChildPrincipal.LOCAL_INFRASTRUCTURE,
+        stdin=ChildStdinPolicy.CLOSED,
+        descendants=DescendantPolicy.NO_AUTHORITY_DELEGATION,
+        source=source,
+    )
+
+
+def _policy_hash() -> str:
+    default_specs = (
+        model_driver_spec(source=""),
+        trusted_hermes_child_spec(source=""),
+        interactive_hermes_pty_spec(source=""),
+        bws_vault_spec(source=""),
+        op_vault_spec(source=""),
+        secret_helper_spec(source=""),
+        checkpoint_git_spec(source=""),
+        container_control_spec(source=""),
+        container_image_build_spec(source=""),
+        probe_spec(source=""),
+    )
+    payload = {
+        "version": POLICY_VERSION,
+        "contracts": [
+            {
+                "intent": spec.intent.value,
+                "principal": spec.principal.value,
+                "stdin": spec.stdin.value,
+                "descendants": spec.descendants.value,
+                "grants": sorted(_normalize_name(name) for name in spec.grants),
+                "grant_prefixes": sorted(
+                    _normalize_name(prefix) for prefix in spec.grant_prefixes
+                ),
+            }
+            for spec in default_specs
+        ],
+        "safe_base": sorted(_SAFE_BASE_KEYS),
+        "network": sorted(_NETWORK_ROUTE_KEYS),
+        "network_override_intents": sorted(
+            intent.value for intent in _NETWORK_OVERRIDE_INTENTS
+        ),
+        "override_coordinates": {
+            intent.value: sorted(_normalize_name(name) for name in names)
+            for intent, names in sorted(
+                _OVERRIDE_COORDINATES.items(), key=lambda item: item[0].value
+            )
+        },
+        "provider_env_names": sorted(_provider_env_names()),
+        "control_exact": sorted(_CONTROL_PLANE_EXACT),
+        "control_prefixes": sorted(_CONTROL_PLANE_PREFIXES),
+        "forwarded_prefixes": sorted(_FORWARDED_ENV_PREFIXES),
+        "secret_suffixes": sorted(_SECRET_SUFFIXES),
+        "registry_auth": sorted(CONTAINER_REGISTRY_AUTH_KEYS),
+        "kanban_grants": sorted(KANBAN_WORKER_GRANTS),
+        "kanban_grant_prefixes": sorted(KANBAN_WORKER_GRANT_PREFIXES),
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def build_spawn_receipt(
+    spec: ChildProcessSpec,
+    *,
+    argv: list[str] | tuple[str, ...],
+    env: Mapping[str, str],
+) -> dict[str, Any]:
+    """Return a value-free, serializable receipt for one spawn decision."""
+
+    return {
+        "policy_version": POLICY_VERSION,
+        "policy_sha256": _policy_hash(),
+        "intent": spec.intent.value,
+        "principal": spec.principal.value,
+        "stdin": spec.stdin.value,
+        "descendants": spec.descendants.value,
+        "target_profile": spec.target_profile or None,
+        "source": spec.source or None,
+        "executable": str(argv[0]) if argv else "",
+        "argv_count": len(argv),
+        "environment_keys": sorted(str(key) for key in env),
+        "grants": sorted(_normalize_name(name) for name in spec.grants),
+        "grant_prefixes": sorted(
+            _normalize_name(prefix) for prefix in spec.grant_prefixes
+        ),
+    }

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -424,6 +424,10 @@ def _popen_bash(
     this and call :func:`_pipe_stdin` directly.
     """
     kwargs.setdefault("creationflags", windows_hide_flags())
+    from tools.environments.local import build_subprocess_env
+
+    caller_env = kwargs.pop("env", None)
+    kwargs["env"] = build_subprocess_env(base=caller_env)
     proc = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -405,6 +405,8 @@ def _is_hermes_internal_secret(key: str) -> bool:
         upper.endswith("_SECRET") or upper.endswith("_KEY") or upper.endswith("_TOKEN")
     ):
         return True
+    if upper.startswith("OP_SESSION_"):
+        return True
     return False
 
 
@@ -498,6 +500,8 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     _plugin_strip = _plugin_terminal_env_strip_keys()
 
     for key, value in (base_env or {}).items():
+        if key.upper() in _ALWAYS_STRIP_KEYS:
+            continue
         if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             continue
         if _is_hermes_internal_secret(key):
@@ -512,6 +516,8 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
             sanitized[key] = resolved
 
     for key, value in (extra_env or {}).items():
+        if key.upper() in _ALWAYS_STRIP_KEYS:
+            continue
         if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             real_key = key[len(_HERMES_PROVIDER_ENV_FORCE_PREFIX):]
             if _is_hermes_internal_secret(real_key):
@@ -614,6 +620,12 @@ _ALWAYS_STRIP_KEYS: frozenset[str] = frozenset({
     "MODAL_TOKEN_ID",
     "MODAL_TOKEN_SECRET",
     "DAYTONA_API_KEY",
+    # Vault bootstrap authority is admitted only by the typed VAULT_CLI and
+    # trusted-Hermes-child edges. It must never ride a generic terminal or
+    # model-driving subprocess merely because the active profile owns it.
+    "BWS_ACCESS_TOKEN",
+    "OP_SERVICE_ACCOUNT_TOKEN",
+    "OP_CONNECT_TOKEN",
 })
 
 

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -45,9 +45,19 @@ def _ensure_singularity_available() -> str:
     """Preflight check: resolve the executable and verify it responds."""
     exe = _find_singularity_executable()
     try:
+        from tools.child_process_authority import (
+            build_child_process_env,
+            container_control_spec,
+            stdin_for_spec,
+        )
+
+        spec = container_control_spec(
+            source="tools.environments.singularity.preflight"
+        )
         result = subprocess.run(
             [exe, "version"], capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=10,
-            stdin=subprocess.DEVNULL,
+            env=build_child_process_env(spec),
+            stdin=stdin_for_spec(spec),
         )
     except FileNotFoundError:
         raise RuntimeError(
@@ -130,12 +140,20 @@ def _get_or_build_sif(image: str, executable: str = "apptainer") -> str:
         tmp_dir = cache_dir / "tmp"
         tmp_dir.mkdir(parents=True, exist_ok=True)
 
-        # apptainer/singularity build: external tool, may need registry
-        # credentials from the user env — exact preservation.
-        from tools.environments.local import build_subprocess_env
-        env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
-        env["APPTAINER_TMPDIR"] = str(tmp_dir)
-        env["APPTAINER_CACHEDIR"] = str(cache_dir)
+        from tools.child_process_authority import (
+            build_child_process_env,
+            container_image_build_spec,
+        )
+
+        env = build_child_process_env(
+            container_image_build_spec(
+                source="tools.environments.singularity.image_build"
+            ),
+            overrides={
+                "APPTAINER_TMPDIR": str(tmp_dir),
+                "APPTAINER_CACHEDIR": str(cache_dir),
+            },
+        )
 
         try:
             result = subprocess.run(
@@ -228,7 +246,25 @@ class SingularityEnvironment(BaseEnvironment):
         cmd.extend([str(self.image), self.instance_id])
 
         try:
-            result = subprocess.run(cmd, capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=120, stdin=subprocess.DEVNULL)
+            from tools.child_process_authority import (
+                build_child_process_env,
+                container_control_spec,
+                stdin_for_spec,
+            )
+
+            spec = container_control_spec(
+                source="tools.environments.singularity.instance_start"
+            )
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                encoding='utf-8',
+                errors='replace',
+                timeout=120,
+                env=build_child_process_env(spec),
+                stdin=stdin_for_spec(spec),
+            )
             if result.returncode != 0:
                 raise RuntimeError(f"Failed to start instance: {result.stderr}")
             self._instance_started = True
@@ -257,10 +293,20 @@ class SingularityEnvironment(BaseEnvironment):
         """Stop the instance. If persistent, the overlay dir survives."""
         if self._instance_started:
             try:
+                from tools.child_process_authority import (
+                    build_child_process_env,
+                    container_control_spec,
+                    stdin_for_spec,
+                )
+
+                spec = container_control_spec(
+                    source="tools.environments.singularity.instance_stop"
+                )
                 subprocess.run(
                     [self.executable, "instance", "stop", self.instance_id],
                     capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=30,
-                    stdin=subprocess.DEVNULL,
+                    env=build_child_process_env(spec),
+                    stdin=stdin_for_spec(spec),
                 )
                 logger.info("Singularity instance %s stopped", self.instance_id)
             except Exception as e:

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -23,7 +23,12 @@ from pathlib import Path
 from typing import Any
 
 from hermes_constants import get_hermes_home
-from tools.environments.local import hermes_subprocess_env
+from tools.child_process_authority import (
+    build_child_process_env,
+    probe_spec,
+    stdin_for_spec,
+    trusted_hermes_child_spec,
+)
 
 logger = logging.getLogger(__name__)
 _Thread = threading.Thread
@@ -68,6 +73,7 @@ def _repo_root() -> Path:
 
 def _build_sha() -> str:
     try:
+        spec = probe_spec(source="tui_gateway.host_supervisor.build_sha")
         return subprocess.check_output(
             ["git", "rev-parse", "HEAD"],
             cwd=str(_repo_root()),
@@ -76,6 +82,8 @@ def _build_sha() -> str:
             errors="replace",
             stderr=subprocess.DEVNULL,
             timeout=2,
+            env=build_child_process_env(spec),
+            stdin=stdin_for_spec(spec),
         ).strip()
     except Exception:
         return "unknown"
@@ -111,6 +119,7 @@ def _pid_command(pid: int) -> str:
     except Exception:
         pass
     try:
+        spec = probe_spec(source="tui_gateway.host_supervisor.pid_command")
         return subprocess.check_output(
             ["ps", "-p", str(pid), "-o", "command="],
             text=True,
@@ -118,6 +127,8 @@ def _pid_command(pid: int) -> str:
             errors="replace",
             stderr=subprocess.DEVNULL,
             timeout=2,
+            env=build_child_process_env(spec),
+            stdin=stdin_for_spec(spec),
         ).strip()
     except Exception:
         return ""
@@ -315,14 +326,20 @@ class HostSupervisor:
             raise RuntimeError("compute host respawn disabled after crash loop")
         self._hello_event.clear()
         self._hello = {}
-        env = hermes_subprocess_env(inherit_credentials=True)
-        env.update(os.environ)
-        if self.env:
-            env.update(self.env)
-        env["HERMES_COMPUTE_HOST_HEARTBEAT_SECS"] = str(self.heartbeat_secs)
-        env.setdefault("PYTHONPATH", str(_repo_root()))
-        if str(_repo_root()) not in env["PYTHONPATH"].split(os.pathsep):
-            env["PYTHONPATH"] = str(_repo_root()) + os.pathsep + env["PYTHONPATH"]
+        overrides = dict(self.env or {})
+        overrides["HERMES_COMPUTE_HOST_HEARTBEAT_SECS"] = str(self.heartbeat_secs)
+        env = build_child_process_env(
+            trusted_hermes_child_spec(source="tui_gateway.host_supervisor"),
+            overrides=overrides,
+        )
+        inherited_pythonpath = str(env.get("PYTHONPATH") or "")
+        repo_root = str(_repo_root())
+        pythonpath_parts = [
+            part for part in inherited_pythonpath.split(os.pathsep) if part
+        ]
+        if repo_root not in pythonpath_parts:
+            pythonpath_parts.insert(0, repo_root)
+        env["PYTHONPATH"] = os.pathsep.join(pythonpath_parts)
         proc = subprocess.Popen(
             self.argv,
             cwd=str(self.cwd),

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -381,6 +381,10 @@ def _(rid, params: dict) -> dict:
         # CREATE_NO_WINDOW on Windows — under the desktop GUI's windowless
         # parent, this spawn otherwise flashes a console (#56747).
         from hermes_cli._subprocess_compat import windows_hide_flags
+        from tools.child_process_authority import (
+            build_child_process_env,
+            trusted_hermes_child_spec,
+        )
 
         r = subprocess.run(
             [sys.executable, "-m", "hermes_cli.main", *argv],
@@ -394,7 +398,11 @@ def _(rid, params: dict) -> dict:
             cwd=os.getcwd(),
             # cli.exec runs `python -m hermes_cli.main` (can drive the agent) →
             # needs provider credentials. Tier-1 secrets still stripped (#29157).
-            env=hermes_subprocess_env(inherit_credentials=True),
+            env=build_child_process_env(
+                trusted_hermes_child_spec(
+                    source="tui_gateway.methods_tools.cli_exec"
+                )
+            ),
             stdin=subprocess.DEVNULL,
             creationflags=windows_hide_flags(),
         )
@@ -2548,13 +2556,21 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5001, "shell.exec unavailable: approval safety module not importable")
     try:
         from hermes_cli._subprocess_compat import windows_hide_flags
+        from tools.environments.local import build_subprocess_env
 
         r = subprocess.run(
-            cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd(),
+            cmd,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=os.getcwd(),
             # Force UTF-8 + lossy decode so non-UTF-8 child output can't crash
             # the gateway thread on locale-mismatched Windows (#53137).
-            encoding="utf-8", errors="replace",
+            encoding="utf-8",
+            errors="replace",
             stdin=subprocess.DEVNULL,
+            env=build_subprocess_env(),
             creationflags=windows_hide_flags(),
         )
         return _ok(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -458,19 +458,28 @@ class _SlashWorker:
         self._closed = False
         from hermes_cli._subprocess_compat import windows_hide_flags
 
-        # slash_worker runs the Hermes agent → needs provider credentials.
-        # Tier-1 secrets (gateway/GitHub/infra) are still stripped (#29157).
+        # slash_worker runs the Hermes agent → retain profile-scoped
+        # agent/tool authority while stripping parent gateway/orchestration
+        # authority (#29157).
         # Global-remote / multi-profile sessions: the worker must resolve
         # config/skills/state against the session's profile home, not the
         # gateway's launch HERMES_HOME (#40677). The override goes through the
-        # build_subprocess_env factory's `extra` (applied last, always wins)
-        # instead of a hand-rolled env["HERMES_HOME"] assignment.
-        from tools.environments.local import build_subprocess_env
-        env = build_subprocess_env(
-            hermes_subprocess_env(inherit_credentials=True),
-            scrub_secrets=False,
-            inherit_profile_home=False,  # base already carries the HOME contract
-            extra={"HERMES_HOME": str(profile_home)} if profile_home else None,
+        # typed broker's explicit override instead of a hand-rolled
+        # env["HERMES_HOME"] assignment.
+        from tools.child_process_authority import (
+            build_child_process_env,
+            stdin_for_spec,
+            trusted_hermes_child_spec,
+        )
+
+        worker_spec = trusted_hermes_child_spec(
+            source="tui_gateway.server.slash_worker"
+        )
+        env = build_child_process_env(
+            worker_spec,
+            overrides=(
+                {"HERMES_HOME": str(profile_home)} if profile_home else None
+            ),
         )
         # Prepend the Hermes venv bin dir and the user-local bin dir to PATH so
         # slash_worker child processes can resolve Hermes-managed CLIs
@@ -488,7 +497,7 @@ class _SlashWorker:
         # tools/mcp_tool.py _filter_mcp_children for defense-in-depth.
         self.proc = subprocess.Popen(
             argv,
-            stdin=subprocess.PIPE,
+            stdin=stdin_for_spec(worker_spec),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,


### PR DESCRIPTION
## What does this PR do?

Introduces a typed, fail-closed authority boundary for Python child-process creation.

> **Nothing ambient survives a boundary.** Executable path, profile name, parent PID, inherited environment, gateway role, or a prior successful launch may identify a candidate edge. None of them grants child authority.

The narrow waist is an immutable `ChildProcessSpec` evaluated by `tools/child_process_authority.py`. The broker—not each spawn site—owns environment construction, stdin behavior, descendant policy, target profile/source identity, positive grants, and a value-free receipt bound to the effective policy at spawn time.

This replaces ad hoc parent-environment inheritance and retired `inherit_credentials=True` / `scrub_secrets=False` patterns across the migrated process surfaces. Legitimate provider, vault, profile, registry, runtime, and tool coordinates cross the boundary only through reviewed intent-specific policy.

### Security contract

- Ordinary callers cannot request full credential inheritance or disable scrubbing.
- Safe baseline inheritance is not caller mutation authority; overrides require an intent-owned coordinate or an exact positive grant.
- Multiplex execution without an installed target-profile secret scope fails closed.
- Model drivers receive model-provider authority, not unrelated messaging, vault, Git, gateway, or infrastructure credentials.
- Vault CLIs receive only their reviewed auth families and run with closed stdin.
- Probes receive no credentials or interactive stdin; checkpoint Git receives no ambient askpass, config, provider, or network injection.
- Forwarded `APPTAINERENV_` / `SINGULARITYENV_` names are reduced to their effective authority and require the same authorization.
- Model-authored terminal execution remains sanitize-by-default.
- Spawn receipts remain value-free and bind the effective provider-authority policy at the boundary decision.

### Current publication object and merge order

- **Exact submitted head:** `eb532a36a2e85f69566ffeda5fb5d6157ce9d05a`
- **Submitted shape:** 2 commits, 36 changed files
- **Exact-head hosted state:** CI, Docker, and Nix are all successful; linked receipts are below.

The reviewed process-broker implementation has no unresolved runtime blocker at this head, but this two-commit stack is not yet the final merge object. It currently contains the S1 authority-ABI snapshot `5b97ff8351deeaa9100229135e8201ca7eba9abf` from the #95101 lineage plus the process-authority composition commit. #95101 must land through its own independent acceptance gate; this PR must then be restacked as the process-only delta over landed S1 and receive fresh exact-head CI, Docker, and Nix receipts.

This PR also does **not** close relay-to-process composition. #92931 remains the durable relay/lease/idempotency/settlement owner, while #93943 owns the remaining handoff at `tui_gateway/methods_bot_relay.py`. That file is not modified here, and this PR does not create a third relay owner.

## Related Issue

Part of #83565.

Depends on #95101.

Architecture and ownership interlocks: #95028, #92931, #93943, #77027, #70372.

This PR intentionally does not use `Fixes` or `Closes`: #83565 remains the repository-wide child-process authority tracker, and #93943 remains open until the durable relay event is composed into the admitted process edge with typed terminal settlement.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🧩 New skill

## Changes Made

- Added the central typed process broker in `tools/child_process_authority.py`, including immutable process intent, principal, grants, stdin/descendant policy, profile scoping, positive override admission, and value-free policy-bound receipts.
- Added the blocking structural guard in `scripts/check_process_edge_authority.py` and extended `scripts/check-windows-footguns.py` so migrated spawn sites cannot silently reintroduce ambient environment or stdin authority.
- Migrated model-driving and secret-source process boundaries in `agent/copilot_acp_client.py`, `agent/transports/codex_app_server.py`, and `agent/secret_sources/{bitwarden,command,onepassword}.py`.
- Migrated CLI and runtime process boundaries in `gateway/run.py`, `hermes_cli/{main,onepassword_secrets_cli,pty_bridge,secrets_cli,web_server,win_pty_bridge}.py`, `tools/checkpoint_manager.py`, `tools/environments/{base,local,singularity}.py`, and `tui_gateway/{host_supervisor,methods_tools,server}.py`.
- Documented the contract, ownership boundaries, migration order, and later manifest-generation phase in `docs/design/process-edge-authority.md`.
- Added focused Python and TypeScript conformance coverage in `tests/tools/test_child_process_authority.py`, `tests/security/test_child_process_authority_guard.py`, `tests/hermes_cli/test_tui_resume_flow.py`, `tests/authority/test_manifest_conformance.py`, and `tests-js/authority-manifest-conformance.test.ts`.
- The current stacked object also carries the ten-path S1 ABI snapshot under `authority/`, `hermes_cli/authority/`, and `apps/shared/src/authority/`. Those paths are dependency context from #95101, not the intended final process-only ownership of this PR.

## How to Test

1. Run the structural authority guard:
   ```bash
   python scripts/check_process_edge_authority.py
   ```
   Expected result: `Process-edge authority check passed.`

2. Run the focused behavioral and conformance suites:
   ```bash
   python -m pytest -q \
     tests/tools/test_child_process_authority.py \
     tests/security/test_child_process_authority_guard.py \
     tests/hermes_cli/test_tui_resume_flow.py \
     tests/authority/test_manifest_conformance.py
   ```

3. Run the repository-preferred full Python suite:
   ```bash
   scripts/run_tests.sh
   ```

4. Run the workspace JavaScript and TypeScript checks used by CI:
   ```bash
   npm ci
   node .github/scripts/run-workspace-checks.mjs
   ```

5. Confirm the adversarial cases remain pinned: loader/runtime/Git/config override smuggling, forwarded container-wrapper spellings, zero-grant probes, checkpoint-Git isolation, multiplex profile scoping, vault auth families, target-profile home, stdin policy, provider-registry policy-hash drift, and value-free receipts.

6. Confirm the exact final head—not an earlier or sibling object—has successful CI, Docker, and Nix runs. Any restack or new commit invalidates the receipts below and requires a fresh matrix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](../blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I've searched existing PRs to avoid duplicates
- [ ] This PR contains only related changes — the current stack still carries #95101's S1 snapshot and must be reduced to the process-only delta after #95101 lands
- [ ] I've run `pytest tests/ -q` and all tests pass — not claimed literally; the repository-preferred `scripts/run_tests.sh` completed successfully in exact-head CI
- [x] I've added tests for my changes
- [x] I've tested on my platform — exact-head hosted Linux, macOS, and Windows lanes completed successfully

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `docs/design/process-edge-authority.md`
- [x] I've updated `cli-config.yaml.example` if config changed — N/A; no configuration keys changed
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` if architecture or workflows changed — N/A; the product contract is documented in the dedicated design document and no contributor or agent workflow changed
- [x] I've considered cross-platform impact — Linux, macOS, Windows, Nix, Docker, PTY, and forwarded Singularity/Apptainer environment semantics are covered
- [x] I've updated tool descriptions / schemas if tool behavior changed — N/A; this changes internal process authority, not a user-facing tool schema

## Screenshots / Logs

No UI screenshots are applicable. Exact-object hosted receipts for `eb532a36a2e85f69566ffeda5fb5d6157ce9d05a`:

- [CI 32923053048](https://github.com/NousResearch/hermes-agent/actions/runs/32923053048) — **success**. Includes the full Python suite, Python e2e, JS/TS workspace checks, Ruff/ty, Windows-only and macOS-only tests, Windows footgun enforcement, attribution, supply-chain checks, and the final required-check gate.
- [Docker 32923052327](https://github.com/NousResearch/hermes-agent/actions/runs/32923052327) — **success**.
- [Nix 32923052430](https://github.com/NousResearch/hermes-agent/actions/runs/32923052430) — **success**.

No predecessor or sibling receipt transfers to this head. These receipts likewise do not transfer across the required post-#95101 restack.