### PR TITLE
fix(macos): refuse root-run gateway install/start/restart under launchd (#67732)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5138,7 +5138,29 @@ def refresh_launchd_plist_if_needed() -> bool:
     return True
 
 
+def _refuse_root_macos_launchd(command: str) -> None:
+    """Exit with guidance when a launchd-managed gateway command runs as root on macOS.
+
+    launchd user agents require a GUI session, which root never has: bootstrapping
+    into ``gui/0``/``user/0`` fails outright (exit 125), and the detached fallback
+    that follows spawns the gateway as root, writing root-owned state into the real
+    user's ``HERMES_HOME`` that breaks every subsequent user-level launchd command
+    (#67732). Call this first, before any plist/state write or launchctl call, in
+    every command that can reach the launchd path on macOS.
+    """
+    if not is_macos() or os.geteuid() != 0:  # windows-footgun: ok — macOS-only guard, short-circuited by is_macos()
+        return
+    print_error(
+        f"Running `hermes gateway {command}` as root on macOS is not supported.\n"
+        "  launchd requires a GUI user session; root has none.\n"
+        "  Run the command without sudo instead:\n"
+        f"    hermes gateway {command}"
+    )
+    sys.exit(1)
+
+
 def launchd_install(force: bool = False):
+    _refuse_root_macos_launchd("install")
     plist_path = get_launchd_plist_path()
 
     if plist_path.exists() and not force:
@@ -5196,6 +5218,7 @@ def launchd_uninstall():
 
 
 def launchd_start():
+    _refuse_root_macos_launchd("start")
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
 
@@ -5374,6 +5397,7 @@ def _wait_for_launchd_service_pid(
 
 
 def launchd_restart():
+    _refuse_root_macos_launchd("restart")
     label = get_launchd_label()
     target = f"{_launchd_domain()}/{label}"
     drain_timeout = _get_restart_drain_timeout()

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2303,3 +2303,65 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
         )
         assert ok is False
         assert list_calls["n"] >= 1
+
+
+class TestRefuseRootMacosLaunchd:
+    """Tests for the shared root-on-macOS guard used by install/start/restart (#67732).
+
+    Regression guard: without this, `sudo hermes gateway install|start|restart`
+    on macOS writes a plist to /var/root, fails launchctl bootstrap (root has
+    no GUI session), and falls back to a root-run gateway that leaves
+    root-owned state in the real user's ~/.hermes, breaking every subsequent
+    user-level launchd command.
+    """
+
+    def test_noop_when_not_macos(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_cli.os, "geteuid", lambda: 0)
+
+        gateway_cli._refuse_root_macos_launchd("install")  # must not raise
+
+    def test_noop_when_macos_but_not_root(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli.os, "geteuid", lambda: 501)
+
+        gateway_cli._refuse_root_macos_launchd("install")  # must not raise
+
+    def test_exits_with_guidance_when_root_on_macos(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli.os, "geteuid", lambda: 0)
+
+        with pytest.raises(SystemExit) as exc_info:
+            gateway_cli._refuse_root_macos_launchd("start")
+
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "root" in out.lower()
+        assert "sudo" in out.lower()
+        assert "hermes gateway start" in out
+
+    @pytest.mark.parametrize("entry_point", ["launchd_install", "launchd_start", "launchd_restart"])
+    def test_root_on_macos_blocks_before_any_side_effect(self, monkeypatch, entry_point, tmp_path):
+        """Root on macOS must exit before touching the plist, launchctl, or the
+        detached-fallback / unsupported-marker path — for install, start, and
+        restart alike."""
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli.os, "geteuid", lambda: 0)
+
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        def _fail(*_a, **_k):
+            raise AssertionError(f"{entry_point} touched launchd/subprocess state before the root guard")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", _fail)
+        monkeypatch.setattr(gateway_cli, "_launchctl_bootstrap", _fail)
+        monkeypatch.setattr(gateway_cli, "_write_launchd_unsupported_marker", _fail)
+        monkeypatch.setattr(gateway_cli, "_spawn_detached_gateway", _fail)
+        monkeypatch.setattr(gateway_cli, "generate_launchd_plist", _fail)
+
+        with pytest.raises(SystemExit) as exc_info:
+            getattr(gateway_cli, entry_point)()
+
+        assert exc_info.value.code == 1
+        assert not plist_path.exists()


### PR DESCRIPTION
## Summary

`sudo hermes gateway install|start|restart` on macOS writes a plist to `/var/root`, fails `launchctl bootstrap` (root has no GUI session), and falls back to a root-run gateway that leaves root-owned state in `~/.hermes` — breaking every subsequent user-level launchd command. Reported in #67732.

## Fix

Adds one guard, `_refuse_root_macos_launchd(command)`, called at the top of `launchd_install()`, `launchd_start()`, and `launchd_restart()` — before any plist write, launchctl call, or the detached-fallback path. Exits with a clear message pointing at the non-sudo form of the command.

This covers all three launchd-managing entry points, not just `install`.

## Context

An earlier PR (#67741) added a guard in the same style, but only to `launchd_install()`. Both an automated review (`hermes-sweeper`) and a cross-PR triage bot (`hermes-graph`) independently flagged that `launchd_start()`/`launchd_restart()` remained unguarded and could still reach the same root-run cascade. #67741 also predates a restructuring of these three functions on `main` (self-healing plist regeneration in `start`, wedged-gateway handling in `restart`) and no longer applies cleanly, so this is written fresh against current `main` rather than built on that branch. Happy to have this squashed into #67741 or merged separately, whichever's easier to manage.

## Testing

- New test class `TestRefuseRootMacosLaunchd` (6 tests): no-op off-macOS, no-op macOS-non-root, correct exit code + message when root+macOS, and a parametrized check across all three entry points proving none touch the plist, `launchctl`, the detached fallback, or the unsupported-marker before exiting.
- - Full existing suite: 124 passed (`test_gateway.py` + `test_gateway_service.py`), 0 regressions.
- - `scripts/check-windows-footguns.py`: clean (this is exactly what failed CI on #67741).
- - `ruff check`: clean.
Closes #67732