### PR TITLE
fix(desktop): preserve macOS locale markers after pack

### DIFF
--- a/apps/desktop/scripts/after-pack.mjs
+++ b/apps/desktop/scripts/after-pack.mjs
@@ -8,10 +8,8 @@
  * to the stock "Electron" icon/name (the bug when the stamp lived only in
  * install.ps1, which the update path doesn't use).
  *
- * Windows-only: rcedit edits PE resources, irrelevant on macOS/Linux where the
- * app identity comes from the bundle Info.plist / desktop entry. Best-effort:
- * a stamp failure must never fail an otherwise-good build (worst case is the
- * stock icon, not a broken app), so we log and resolve rather than throw.
+ * On macOS, restore the empty app-level locale directories that electron-builder
+ * drops while copying Electron. Chromium uses them to select the renderer locale.
  *
  * electron-builder passes a context with:
  *   - electronPlatformName: 'win32' | 'darwin' | 'linux'
@@ -19,16 +17,43 @@
  *   - packager.appInfo.productFilename: the exe basename (e.g. 'Hermes')
  */
 
+import { mkdir, readdir } from 'node:fs/promises'
 import path from 'node:path'
 
 import { stampExeIdentity } from './set-exe-identity.mjs'
 
+async function restoreMacLocaleMarkers(appOutDir, productName) {
+  const appContents = path.join(appOutDir, `${productName}.app`, 'Contents')
+  const frameworkResources = path.join(
+    appContents,
+    'Frameworks',
+    'Electron Framework.framework',
+    'Versions',
+    'A',
+    'Resources'
+  )
+  const appResources = path.join(appContents, 'Resources')
+  const entries = await readdir(frameworkResources, { withFileTypes: true })
+  const localeMarkers = entries.filter(entry => entry.isDirectory() && entry.name.endsWith('.lproj'))
+
+  await Promise.all(localeMarkers.map(entry => mkdir(path.join(appResources, entry.name), { recursive: true })))
+
+  return localeMarkers.length
+}
+
 export default async function afterPack(context) {
+  const productName = context.packager?.appInfo?.productFilename || 'Hermes'
+
+  if (context.electronPlatformName === 'darwin') {
+    const restored = await restoreMacLocaleMarkers(context.appOutDir, productName)
+    console.log(`[after-pack] restored ${restored} macOS locale markers`)
+    return
+  }
+
   if (context.electronPlatformName !== 'win32') {
     return
   }
 
-  const productName = context.packager?.appInfo?.productFilename || 'Hermes'
   const exe = path.join(context.appOutDir, `${productName}.exe`)
   const desktopRoot = path.resolve(import.meta.dirname, '..')
 
@@ -39,3 +64,5 @@ export default async function afterPack(context) {
     console.warn(`[after-pack] exe identity stamp failed (${err.message}); Hermes.exe keeps the stock Electron icon`)
   }
 }
+
+export { restoreMacLocaleMarkers }

--- a/apps/desktop/scripts/after-pack.mjs
+++ b/apps/desktop/scripts/after-pack.mjs
@@ -10,6 +10,7 @@
  *
  * On macOS, restore the empty app-level locale directories that electron-builder
  * drops while copying Electron. Chromium uses them to select the renderer locale.
+ * Windows identity stamping stays best-effort so a cosmetic failure cannot fail a package.
  *
  * electron-builder passes a context with:
  *   - electronPlatformName: 'win32' | 'darwin' | 'linux'
@@ -23,22 +24,28 @@ import path from 'node:path'
 import { stampExeIdentity } from './set-exe-identity.mjs'
 
 async function restoreMacLocaleMarkers(appOutDir, productName) {
-  const appContents = path.join(appOutDir, `${productName}.app`, 'Contents')
-  const frameworkResources = path.join(
-    appContents,
-    'Frameworks',
-    'Electron Framework.framework',
-    'Versions',
-    'A',
-    'Resources'
-  )
-  const appResources = path.join(appContents, 'Resources')
-  const entries = await readdir(frameworkResources, { withFileTypes: true })
-  const localeMarkers = entries.filter(entry => entry.isDirectory() && entry.name.endsWith('.lproj'))
+  try {
+    const appContents = path.join(appOutDir, `${productName}.app`, 'Contents')
+    const frameworkResources = path.join(
+      appContents,
+      'Frameworks',
+      'Electron Framework.framework',
+      'Versions',
+      'A',
+      'Resources'
+    )
+    const appResources = path.join(appContents, 'Resources')
+    const entries = await readdir(frameworkResources, { withFileTypes: true })
+    const localeMarkers = entries.filter(entry => entry.isDirectory() && entry.name.endsWith('.lproj'))
 
-  await Promise.all(localeMarkers.map(entry => mkdir(path.join(appResources, entry.name), { recursive: true })))
+    await Promise.all(localeMarkers.map(entry => mkdir(path.join(appResources, entry.name), { recursive: true })))
 
-  return localeMarkers.length
+    return localeMarkers.length
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err)
+    console.warn(`[after-pack] macOS locale markers were not restored: ${detail}`)
+    return 0
+  }
 }
 
 export default async function afterPack(context) {

--- a/apps/desktop/scripts/after-pack.test.mjs
+++ b/apps/desktop/scripts/after-pack.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { test } from 'vitest'
+import { test, vi } from 'vitest'
 
 import afterPack, { restoreMacLocaleMarkers } from './after-pack.mjs'
 
@@ -36,6 +36,19 @@ test('restoreMacLocaleMarkers recreates only framework locale directories', asyn
     assert.equal(fs.statSync(path.join(contents, 'Resources', 'en_GB.lproj')).isDirectory(), true)
     assert.equal(fs.existsSync(path.join(contents, 'Resources', 'locale.pak')), false)
   } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('restoreMacLocaleMarkers leaves packing intact when framework resources are unavailable', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-after-pack-'))
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  try {
+    assert.equal(await restoreMacLocaleMarkers(root, 'Hermes'), 0)
+    assert.equal(warn.mock.calls.length, 1)
+    assert.match(warn.mock.calls[0][0], /macOS locale markers were not restored/)
+  } finally {
+    warn.mockRestore()
     fs.rmSync(root, { recursive: true, force: true })
   }
 })

--- a/apps/desktop/scripts/after-pack.test.mjs
+++ b/apps/desktop/scripts/after-pack.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { test } from 'vitest'
+
+import afterPack, { restoreMacLocaleMarkers } from './after-pack.mjs'
+
+function makeMacApp(root, productName = 'Hermes') {
+  const contents = path.join(root, `${productName}.app`, 'Contents')
+  const frameworkResources = path.join(
+    contents,
+    'Frameworks',
+    'Electron Framework.framework',
+    'Versions',
+    'A',
+    'Resources'
+  )
+
+  fs.mkdirSync(frameworkResources, { recursive: true })
+  fs.mkdirSync(path.join(contents, 'Resources'), { recursive: true })
+
+  return { contents, frameworkResources }
+}
+
+test('restoreMacLocaleMarkers recreates only framework locale directories', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-after-pack-'))
+  try {
+    const { contents, frameworkResources } = makeMacApp(root)
+    fs.mkdirSync(path.join(frameworkResources, 'nb.lproj'))
+    fs.mkdirSync(path.join(frameworkResources, 'en_GB.lproj'))
+    fs.writeFileSync(path.join(frameworkResources, 'locale.pak'), 'locale data')
+
+    assert.equal(await restoreMacLocaleMarkers(root, 'Hermes'), 2)
+    assert.equal(fs.statSync(path.join(contents, 'Resources', 'nb.lproj')).isDirectory(), true)
+    assert.equal(fs.statSync(path.join(contents, 'Resources', 'en_GB.lproj')).isDirectory(), true)
+    assert.equal(fs.existsSync(path.join(contents, 'Resources', 'locale.pak')), false)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('afterPack restores markers in the configured macOS app bundle', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-after-pack-'))
+  try {
+    const { contents, frameworkResources } = makeMacApp(root, 'Hermes Preview')
+    fs.mkdirSync(path.join(frameworkResources, 'nb.lproj'))
+
+    await afterPack({
+      appOutDir: root,
+      electronPlatformName: 'darwin',
+      packager: { appInfo: { productFilename: 'Hermes Preview' } }
+    })
+
+    assert.equal(fs.statSync(path.join(contents, 'Resources', 'nb.lproj')).isDirectory(), true)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('afterPack leaves non-macOS builds unchanged', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-after-pack-'))
+  try {
+    await afterPack({ appOutDir: root, electronPlatformName: 'linux' })
+    assert.deepEqual(fs.readdirSync(root), [])
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
Fixes #93912.

## Summary

- Restore the app-level `.lproj` directories from the packaged Electron Framework after macOS packing.
- If the framework resources are unavailable, log a warning and leave the package usable.
- Leave locale data and non-macOS packaging paths untouched.
- Add fixture coverage for locale filtering, missing framework resources, custom app names, and non-macOS builds.

## Testing

- `npm run typecheck --workspace apps/desktop`
- `npm test --workspace apps/desktop` (7,468 passed, 3 skipped)
- `npm test --workspace apps/desktop -- --project electron electron/remote-lifecycle.test.ts` (71 passed)
- `npx eslint apps/desktop/scripts/after-pack.mjs apps/desktop/scripts/after-pack.test.mjs`
- `npx prettier --check apps/desktop/scripts/after-pack.mjs apps/desktop/scripts/after-pack.test.mjs`