### PR TITLE
fix(mcp): watchdog tolerates non-fd std streams — stdio servers connect again headless

### DIFF
--- a/tests/tools/test_mcp_stdio_watchdog_nonfd.py
+++ b/tests/tools/test_mcp_stdio_watchdog_nonfd.py
@@ -1,0 +1,62 @@
+"""The stdio MCP watchdog must tolerate non-fd std streams (#93529).
+
+When Hermes runs headless / inside the asyncio gateway, ``sys.stdin`` and
+``sys.stdout`` can be ``None`` or wrapper objects with no OS-level file
+descriptor. The watchdog used to pass those objects straight into
+``subprocess.Popen``, so the supervised MCP server died before it ever
+spoke JSON-RPC ("Connection closed" on every stdio server). The fix
+resolves real fds with a raw 0/1/2 fallback — the supervisor process
+itself was spawned with the right inherited handles.
+"""
+
+import os
+
+import pytest
+
+from tools import mcp_stdio_watchdog
+
+
+def test_safe_fd_prefers_real_fileno():
+    assert mcp_stdio_watchdog._safe_fd(os.sys.__stdout__ or open(os.devnull), 1) >= 0
+
+
+def test_safe_fd_falls_back_when_fileno_raises():
+    class _NoFd:
+        def fileno(self):
+            raise OSError("not a real file")
+
+    assert mcp_stdio_watchdog._safe_fd(_NoFd(), 2) == 2
+
+
+def test_safe_fd_falls_back_on_none_stream():
+    # sys.stdin is None in some headless contexts; attribute access on None
+    # must not escape _safe_fd either way.
+    assert mcp_stdio_watchdog._safe_fd(None, 0) == 0
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX-only watchdog path")
+def test_main_runs_child_with_nonfd_streams(monkeypatch, capsys):
+    """End-to-end: even with fake non-fd streams bound to sys.std*, the
+    supervised child runs to completion (previously died pre-exec)."""
+
+    class _FakeStream:
+        def fileno(self):
+            raise OSError("wrapped stream has no fd")
+
+        def write(self, *_a, **_k):
+            return None
+
+        def flush(self):
+            return None
+
+        def read(self, *_a, **_k):
+            return ""
+
+    monkeypatch.setattr(mcp_stdio_watchdog.sys, "stdin", _FakeStream())
+    monkeypatch.setattr(mcp_stdio_watchdog.sys, "stdout", _FakeStream())
+    monkeypatch.setattr(mcp_stdio_watchdog.sys, "stderr", _FakeStream())
+
+    rc = mcp_stdio_watchdog.main(
+        ["--ppid", str(os.getppid()), "--", "/bin/sh", "-c", "exit 0"]
+    )
+    assert rc == 0

--- a/tools/mcp_stdio_watchdog.py
+++ b/tools/mcp_stdio_watchdog.py
@@ -100,6 +100,23 @@ def _watchdog_loop(proc: subprocess.Popen, original_ppid: int) -> None:
         time.sleep(_POLL_INTERVAL_S)
 
 
+def _safe_fd(stream, fallback_fd: int) -> int:
+    """Return a real file descriptor for a std stream, or the raw fallback.
+
+    When the Hermes gateway runs headless (or under asyncio stream
+    wrapping), ``sys.stdin``/``sys.stdout`` can be ``None`` or wrapper
+    objects with no OS-level fd (#93529). Passing such an object to
+    ``Popen`` kills the child before it ever speaks JSON-RPC. The
+    supervisor process itself was spawned with real inherited handles, so
+    its raw fd numbers (0/1/2) are exactly the right relay regardless of
+    what Python-level wrappers sit on top.
+    """
+    try:
+        return stream.fileno()
+    except Exception:
+        return fallback_fd
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Parent-death watchdog for a stdio MCP subprocess.",
@@ -120,9 +137,9 @@ def main(argv: list[str] | None = None) -> int:
     # touching our own group or the (already-gone) original parent's.
     proc = subprocess.Popen(
         real_argv,
-        stdin=sys.stdin,
-        stdout=sys.stdout,
-        stderr=sys.stderr,
+        stdin=_safe_fd(sys.stdin, 0),
+        stdout=_safe_fd(sys.stdout, 1),
+        stderr=_safe_fd(sys.stderr, 2),
         start_new_session=True,
     )
 


### PR DESCRIPTION
## What does this PR do?

Fixes **every stdio MCP server failing to connect when Hermes runs headless / inside the asyncio gateway** (#93529): `tools/mcp_stdio_watchdog.py` passed `sys.stdin`/`sys.stdout`/`sys.stderr` straight into `subprocess.Popen`. In gateway mode those can be `None` or asyncio stream wrappers with no OS-level file descriptor, so `Popen` failed and the supervised MCP server died before its first JSON-RPC initialize — surfacing as `✗ Connection failed (8-9s): Connection closed` for *all* stdio servers (`hermes mcp test`, real tool calls) while HTTP/SSE transports kept working.

The fix resolves real descriptors via `stream.fileno()` with a raw **0/1/2 fallback**: the supervisor process itself was spawned by Hermes with the correct inherited pipe handles, so its own fd numbers are exactly what the child must relay through, regardless of what Python-level wrappers sit on top of `sys.std*`. The watchdog stays a transparent no-op relay; nothing about its supervision logic changes.

## Related Issue

Fixes #93529

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Tests

## Changes Made

- `tools/mcp_stdio_watchdog.py`
  - new `_safe_fd(stream, fallback_fd)` helper: prefers `stream.fileno()`, falls back to the raw inherited fd number on `None` streams / any fileno error;
  - `main()` passes `_safe_fd(sys.stdin, 0) / _safe_fd(sys.stdout, 1) / _safe_fd(sys.stderr, 2)` to `Popen`.
- `tests/tools/test_mcp_stdio_watchdog_nonfd.py`:
  - unit: real stream → fd used; `fileno()` raising → fallback; `None` stream → fallback;
  - end-to-end (POSIX-gated): binds fake non-fd streams over `sys.std*`, runs `main(["--ppid", …, "--", "/bin/sh", "-c", "exit 0"])`, asserts the child executes and exits 0 — previously it died pre-exec.

## How to Test

1. `uv run python -m pytest tests/tools/test_mcp_stdio_watchdog_nonfd.py -q` → 3 passed, 1 skipped off-POSIX.
2. `ruff check tools/mcp_stdio_watchdog.py tests/tools/test_mcp_stdio_watchdog_nonfd.py` → clean.
3. Manual (Linux gateway): with a wrapped/absent `sys.stdin`, `hermes mcp test <stdio-server>` connects and discovers tools instead of `Connection closed`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls?q=is%3Apr) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run targeted test suites locally and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (POSIX path exercised by CI's Linux lane)

### Documentation & Housekeeping

- [x] Docs N/A · cli-config.yaml.example N/A · CONTRIBUTING/AGENTS N/A
- [x] Cross-platform impact: POSIX-only module guarded as before; Windows degrades identically
- [x] No tool schema change → N/A

## Screenshots / Logs

N/A
