### PR TITLE
fix(coding): require code evidence for instruction markers

### DIFF
--- a/agent/coding_context.py
+++ b/agent/coding_context.py
@@ -71,30 +71,50 @@ CODING_TOOLSET = "coding"
 # in a group is not pair-programming.
 INTERACTIVE_CODING_PLATFORMS = {"cli", "tui", "acp", "desktop", ""}
 
-# Project-root signals that mark a directory as a code workspace even when it
-# isn't (yet) a git repo. Cheap filename checks — no parsing.
-_PROJECT_MARKERS = (
+# Project manifests that mark a directory as a code workspace even when it
+# isn't (yet) a git repo. Cheap filename checks — no parsing. A manifest is
+# dispositive on its own.
+_MANIFEST_MARKERS = (
     "pyproject.toml", "setup.py", "setup.cfg", "requirements.txt",
     "package.json", "tsconfig.json", "deno.json",
     "Cargo.toml", "go.mod", "pom.xml", "build.gradle", "build.gradle.kts",
     "Gemfile", "composer.json", "mix.exs", "pubspec.yaml",
     "CMakeLists.txt", "Makefile", "Dockerfile",
-    "AGENTS.md", "CLAUDE.md", ".cursorrules",
 )
 
-# Agent-instruction files surfaced separately from manifests in the snapshot.
-_CONTEXT_FILES = ("AGENTS.md", "CLAUDE.md", ".cursorrules")
+# Agent-instruction files. Unlike manifests these are NOT sufficient project
+# evidence on their own — they appear in prose/notes/research vaults too, so
+# they require bounded source-code corroboration (see _marker_root).
+_INSTRUCTION_MARKERS = ("AGENTS.md", "CLAUDE.md", ".cursorrules")
 
-# Source-file extensions that make a git repo a *code* workspace even with no
+# Complete project-root marker union, surfaced in project-fact snapshots.
+_PROJECT_MARKERS = _MANIFEST_MARKERS + _INSTRUCTION_MARKERS
+
+# Agent-instruction files surfaced separately from manifests in the snapshot.
+_CONTEXT_FILES = _INSTRUCTION_MARKERS
+
+# Source-file extensions that corroborate a code workspace even with no
 # manifest. Without this, `git init` on a notes/writing/research folder (a huge
 # non-coding use case) would flip the whole session into the coding posture just
-# for having a `.git`. A manifest still wins on its own (see `_PROJECT_MARKERS`).
+# for having a `.git`. A manifest still wins on its own; an instruction marker
+# requires this corroboration. Includes application, static-web, infrastructure,
+# schema, and smart-contract source types.
 _CODE_EXTENSIONS = frozenset({
     ".py", ".pyi", ".ipynb", ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs",
     ".go", ".rs", ".java", ".kt", ".kts", ".scala", ".rb", ".php", ".c", ".h",
     ".cc", ".cpp", ".hpp", ".cs", ".swift", ".m", ".mm", ".dart", ".ex", ".exs",
     ".lua", ".sh", ".bash", ".zsh", ".sql", ".vue", ".svelte", ".r", ".jl",
     ".hs", ".clj", ".erl", ".pl",
+    # application / static-web
+    ".html", ".htm", ".css", ".scss", ".sass", ".less",
+    # infrastructure / IaC
+    ".tf", ".tfvars", ".hcl",
+    # schema / IPC
+    ".proto",
+    # smart contracts
+    ".sol",
+    # systems / functional / other
+    ".zig", ".fs", ".fsx", ".vb", ".groovy",
 })
 
 # Dirs never worth scanning for the code check (deps/build/vcs/venv noise).
@@ -103,22 +123,29 @@ _CODE_SCAN_SKIP_DIRS = frozenset({
     "target", ".next", ".turbo", "vendor",
 })
 
+# Conventional code roots may contain another package directory before source
+# files appear (for example ``src/pkg/main.py``). Descend those roots one extra
+# level without treating arbitrary nested vault/project folders as code signals.
+_CODE_SCAN_DEEP_DIRS = frozenset({"src", "app", "lib", "tests", "test"})
+
 # Bounded sweep: a code workspace reveals itself in the first handful of entries.
 _CODE_SCAN_MAX_ENTRIES = 500
 
 
 def _has_code_files(root: Path) -> bool:
-    """Cheap, bounded check for source files in a repo's top two levels.
+    """Cheap, bounded check for source files in a repo's top few levels.
 
     Lets a git repo of loose scripts (no manifest) still read as a code
-    workspace while a bare notes/writing repo does not. Scans the root and its
-    immediate subdirectories only, capped at ``_CODE_SCAN_MAX_ENTRIES`` stats —
-    a handful of readdirs at session start, not a full walk.
+    workspace while a bare notes/writing repo does not. Scans the root, its
+    immediate subdirectories, plus one package level beneath conventional
+    ``src``/``app``/``lib``/``tests``/``test`` roots, capped at
+    ``_CODE_SCAN_MAX_ENTRIES`` stats — a handful of readdirs at session start,
+    not a full walk.
     """
     seen = 0
-    stack = [(root, True)]
+    stack = [(root, 0)]
     while stack:
-        directory, is_root = stack.pop()
+        directory, depth = stack.pop()
         try:
             with os.scandir(directory) as entries:
                 for entry in entries:
@@ -130,8 +157,9 @@ def _has_code_files(root: Path) -> bool:
                         if entry.is_file():
                             if os.path.splitext(name)[1].lower() in _CODE_EXTENSIONS:
                                 return True
-                        elif is_root and entry.is_dir() and name not in _CODE_SCAN_SKIP_DIRS and not name.startswith("."):
-                            stack.append((Path(entry.path), False))
+                        elif entry.is_dir() and name not in _CODE_SCAN_SKIP_DIRS and not name.startswith("."):
+                            if depth == 0 or (depth == 1 and directory.name in _CODE_SCAN_DEEP_DIRS):
+                                stack.append((Path(entry.path), depth + 1))
                     except OSError:
                         continue
         except OSError:
@@ -409,6 +437,11 @@ def _marker_root(cwd: Path) -> Optional[Path]:
     even when the user is in a subdirectory. ``$HOME`` itself is skipped — a
     Makefile or AGENTS.md sitting in the home directory is global user config,
     not a project-root signal.
+
+    A project manifest is dispositive on its own. An instruction marker
+    (``AGENTS.md`` / ``CLAUDE.md`` / ``.cursorrules``) is NOT — prose and notes
+    vaults carry them too, so they only count when the directory actually holds
+    corroborating source code.
     """
     current = cwd.resolve()
     home = _home()
@@ -425,9 +458,37 @@ def _marker_root(cwd: Path) -> Optional[Path]:
             break
         if parent == home or (temp_root is not None and parent == temp_root):
             continue
-        for marker in _PROJECT_MARKERS:
-            if (parent / marker).exists():
+        if any((parent / marker).exists() for marker in _MANIFEST_MARKERS):
+            return parent
+        if any((parent / marker).exists() for marker in _INSTRUCTION_MARKERS):
+            if _has_code_files(parent):
                 return parent
+    return None
+
+
+def _code_workspace_root(cwd: Path) -> Optional[Path]:
+    """Nearest ancestor that is a genuine code workspace, or ``None``.
+
+    The single source of truth for \"is this a code workspace?\", shared by
+    posture detection and project-fact / verify-on-stop consumers so they never
+    drift. Returns the nearest ancestor that is:
+
+    * a manifest root (dispositive), or
+    * an instruction-marker root corroborated by source code, or
+    * a bare git repo that actually holds source code.
+
+    A prose/notes Git vault (instruction markers only, no source) returns
+    ``None``, so it is never independently reclassified as code. The ``$HOME``
+    dotfiles repo is excluded.
+    """
+    marker = _marker_root(cwd)
+    if marker is not None:
+        return marker
+    git_root = _git_root(cwd)
+    if git_root is not None and git_root == _home():
+        return None  # dotfiles repo at $HOME — not a code workspace
+    if git_root is not None and _has_code_files(git_root):
+        return git_root
     return None
 
 
@@ -454,16 +515,7 @@ def _detect_profile_name(mode: str, platform: str, cwd_str: str) -> str:
     if platform and platform.strip().lower() not in INTERACTIVE_CODING_PLATFORMS:
         return GENERAL_PROFILE.name
     cwd = Path(cwd_str)
-    # A recognized project root (manifest / AGENTS.md / .cursorrules) is a code
-    # workspace on its own — cheap stat checks, no scan.
-    if _marker_root(cwd) is not None:
-        return CODING_PROFILE.name
-    git_root = _git_root(cwd)
-    if git_root is not None and git_root == _home():
-        git_root = None  # dotfiles repo at $HOME — not a code workspace
-    # A bare git repo only counts when it actually holds code, so `git init` on a
-    # notes/writing/research folder stays in the general posture.
-    if git_root is not None and _has_code_files(git_root):
+    if _code_workspace_root(cwd) is not None:
         return CODING_PROFILE.name
     return GENERAL_PROFILE.name
 
@@ -784,7 +836,7 @@ def detect_project_facts(root: Path) -> ProjectFacts:
     of truth for both the prompt snapshot (:func:`_project_facts`) and the
     gateway's ``project.facts`` — so the UI never re-sniffs verify commands.
     """
-    manifests = [m for m in _PROJECT_MARKERS if m not in _CONTEXT_FILES and (root / m).is_file()]
+    manifests = [m for m in _MANIFEST_MARKERS if (root / m).is_file()]
     package_managers = list(
         dict.fromkeys(pm for lock, pm in (*_PY_LOCKFILES, *_JS_LOCKFILES) if (root / lock).is_file())
     )
@@ -846,9 +898,11 @@ def project_facts_for(cwd: Optional[str | Path] = None) -> Optional[dict[str, An
     Same detection the system-prompt snapshot uses (git root, else marker root),
     exposed for non-prompt consumers (the desktop verify UI) so they never
     re-derive "are we coding?" or duplicate the verify-command sniffing.
+    Aligned with :func:`_code_workspace_root`: an instruction-only prose Git
+    vault returns ``None`` rather than being reclassified as code.
     """
     resolved = _resolve_cwd(cwd)
-    root = _git_root(resolved) or _marker_root(resolved)
+    root = _code_workspace_root(resolved)
     if root is None:
         return None
 

--- a/tests/agent/test_coding_context.py
+++ b/tests/agent/test_coding_context.py
@@ -172,6 +172,54 @@ class TestProjectFacts:
             assert cmd in verify_line
 
 
+# ── instruction-only prose Git vault (never reclassified as code) ──────────
+
+def _prose_git_vault(path: Path) -> Path:
+    """Create a git repo containing only an instruction marker + prose notes."""
+    env = {
+        "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+        "HOME": str(path),
+    }
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "AGENTS.md").write_text("# workspace instructions\n")
+    (path / "notes.md").write_text("# prose only\n")
+    for args in (
+        ["init", "-q", "-b", "main"],
+        ["add", "-A"],
+        ["commit", "-q", "-m", "init commit"],
+    ):
+        subprocess.run([shutil.which("git"), "-C", str(path), *args], check=True, env=env)
+    return path
+
+
+class TestProseGitVaultStaysGeneral:
+    def test_instruction_only_git_vault_is_not_coding(self, tmp_path):
+        vault = _prose_git_vault(tmp_path / "vault")
+        cfg = {"agent": {"coding_context": "auto"}}
+        assert cc.is_coding_context(platform="cli", cwd=vault, config=cfg) is False
+
+    def test_project_facts_none_for_instruction_only_git_vault(self, tmp_path):
+        vault = _prose_git_vault(tmp_path / "vault")
+        assert cc.project_facts_for(vault) is None
+
+    def test_project_facts_present_for_instruction_marker_plus_source(self, tmp_path):
+        vault = _prose_git_vault(tmp_path / "vault")
+        (vault / "main.py").write_text("print('hi')\n")
+        assert cc.project_facts_for(vault) is not None
+
+    def test_verification_snapshot_no_project_for_prose_vault(self, tmp_path):
+        """verify-on-stop receives no project for an instruction-only Git
+        workspace editing a non-document path — it stays general, so no verify
+        recipe is implied."""
+        from agent.verification_stop import _verification_snapshot
+        vault = _prose_git_vault(tmp_path / "vault")
+        snapshot = _verification_snapshot(
+            session_id="sess", changed_paths=[str(vault / "notes.md")]
+        )
+        assert snapshot is None
+
+
 
 # ── $HOME dotfiles guard ────────────────────────────────────────────────────
 
@@ -337,11 +385,61 @@ class TestProfiles:
 # ── detection signals ───────────────────────────────────────────────────────
 
 class TestDetection:
-    @pytest.mark.parametrize("marker", ["pyproject.toml", "package.json", "go.mod", "AGENTS.md"])
+    @pytest.mark.parametrize("marker", ["pyproject.toml", "package.json", "go.mod"])
     def test_project_manifest_triggers_without_git(self, tmp_path, marker):
         (tmp_path / marker).write_text("x")
         cfg = {"agent": {"coding_context": "auto"}}
         assert cc.is_coding_context(platform="cli", cwd=tmp_path, config=cfg) is True
+
+    @pytest.mark.parametrize("marker", cc._INSTRUCTION_MARKERS)
+    def test_instruction_marker_alone_stays_general(self, tmp_path, marker):
+        """An instruction marker in a prose-only workspace is NOT coding."""
+        (tmp_path / marker).write_text("# workspace instructions\n")
+        (tmp_path / "notes.md").write_text("# prose only\n")
+        cfg = {"agent": {"coding_context": "auto"}}
+        assert cc.is_coding_context(platform="cli", cwd=tmp_path, config=cfg) is False
+
+    @pytest.mark.parametrize("marker", cc._INSTRUCTION_MARKERS)
+    def test_instruction_marker_with_source_file_triggers(self, tmp_path, marker):
+        (tmp_path / marker).write_text("# workspace instructions\n")
+        (tmp_path / "main.py").write_text("print('hello')\n")
+        cfg = {"agent": {"coding_context": "auto"}}
+        assert cc.is_coding_context(platform="cli", cwd=tmp_path, config=cfg) is True
+
+    @pytest.mark.parametrize(
+        "filename", ["index.html", "style.css", "style.scss", "style.less", "main.tf", "variables.tfvars", "config.hcl", "message.proto", "contract.sol", "main.zig", "main.fsx", "Main.vb", "build.groovy"]
+    )
+    def test_instruction_marker_with_static_web_and_iac_source_triggers(self, tmp_path, filename):
+        (tmp_path / "AGENTS.md").write_text("# workspace instructions\n")
+        (tmp_path / filename).write_text("x")
+        cfg = {"agent": {"coding_context": "auto"}}
+        assert cc.is_coding_context(platform="cli", cwd=tmp_path, config=cfg) is True
+
+    def test_instruction_marker_with_src_layout_triggers(self, tmp_path):
+        (tmp_path / "AGENTS.md").write_text("# workspace instructions\n")
+        package = tmp_path / "src" / "pkg"
+        package.mkdir(parents=True)
+        (package / "main.py").write_text("print('hello')\n")
+        cfg = {"agent": {"coding_context": "auto"}}
+        assert cc.is_coding_context(platform="cli", cwd=tmp_path, config=cfg) is True
+
+    def test_instruction_marker_ignores_code_in_arbitrary_nested_project(self, tmp_path):
+        (tmp_path / "AGENTS.md").write_text("# vault instructions\n")
+        nested = tmp_path / "projects" / "utility"
+        nested.mkdir(parents=True)
+        (nested / "main.py").write_text("print('nested project')\n")
+        cfg = {"agent": {"coding_context": "auto"}}
+        assert cc.is_coding_context(platform="cli", cwd=tmp_path, config=cfg) is False
+
+    def test_instruction_marker_with_manifest_triggers(self, tmp_path):
+        (tmp_path / "AGENTS.md").write_text("# workspace instructions\n")
+        (tmp_path / "package.json").write_text("{}\n")
+        cfg = {"agent": {"coding_context": "auto"}}
+        assert cc.is_coding_context(platform="cli", cwd=tmp_path, config=cfg) is True
+
+    def test_project_marker_union_remains_complete(self):
+        assert cc._PROJECT_MARKERS == cc._MANIFEST_MARKERS + cc._INSTRUCTION_MARKERS
+        assert cc._CONTEXT_FILES == cc._INSTRUCTION_MARKERS
 
     def test_marker_in_parent_counts_from_subdir(self, tmp_path):
         (tmp_path / "pyproject.toml").write_text("x")


### PR DESCRIPTION
## What does this PR do?

Fixes coding-context detection misclassifying instruction-only workspaces as code projects. `AGENTS.md`, `CLAUDE.md`, and `.cursorrules` appear in prose/notes/research vaults as well as real code projects, so an instruction marker alone is not reliable project evidence. This split makes a true project manifest dispositive on its own, while an instruction marker now requires bounded source-code corroboration before a directory is treated as a code workspace.

Previously, an instruction-only knowledge vault would flip the whole session into the coding posture (with its operating brief and verify-on-stop expectations) solely because it had an agent context file.

## Related Issue

None (no issue opened; bug-fix contribution).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/coding_context.py`
  - Split `_PROJECT_MARKERS` into `_MANIFEST_MARKERS` (dispositive) and `_INSTRUCTION_MARKERS` (`AGENTS.md` / `CLAUDE.md` / `.cursorrules`, requiring code corroboration). `_PROJECT_MARKERS` remains the complete union surfaced in project-fact snapshots.
  - `_has_code_files` now scans one package level beneath conventional `src`/`app`/`lib`/`tests`/`test` roots; `_CODE_EXTENSIONS` expanded with static-web (HTML/CSS/SCSS/Sass/Less), infrastructure (Terraform/HCL/proto), smart-contract (Solidity), and systems/functional (Zig/F#/VB/Groovy) source types.
  - New `_code_workspace_root()` is the single source of truth shared by posture detection, `project_facts_for()`, and verify-on-stop, so an instruction-only prose Git vault is never independently reclassified as code.
- `tests/agent/test_coding_context.py` — instruction marker alone stays general; marker plus source becomes coding; static-web/IaC/contract/functional source corroborates; `src/pkg/main.py` layout corroborates; arbitrary nested `projects/utility/main.py` does not classify the vault root; manifests remain dispositive; project facts return `None` for an instruction-only prose Git workspace; verify-on-stop receives no project for such a workspace.

## How to Test

1. `python -m pytest tests/agent/test_coding_context.py tests/agent/test_verification_stop.py tests/agent/test_verification_evidence.py -q` → `85 passed, 1 skipped`.
2. Ruff: `ruff check agent/coding_context.py tests/agent/test_coding_context.py` → clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not fully run**: the canonical full-suite run on this Windows host is non-diagnostic (untouched tests fail from missing async-test support, Pyright init timeouts, and Windows symlink privilege limits). The focused coding-context + verification suites pass green; ruff is clean.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Updated docstrings/comments for the marker split, bounded extra scan level, and instruction-marker corroboration
- [ ] Updated `cli-config.yaml.example` if config keys changed — N/A (no new config)
- [x] Considered cross-platform impact per the compatibility guide

## Screenshots / Logs

N/A (no visual change).
