### PR TITLE
fix(fmv): preserve partial patch mutation accounting

### DIFF
--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -454,33 +454,92 @@ def _extract_file_mutation_targets(tool_name: str, args: Dict[str, Any]) -> List
     return []
 
 
-def _extract_landed_file_mutation_paths(
-    tool_name: str,
-    args: Dict[str, Any],
-    result: Any,
-) -> List[str]:
-    """Return the concrete file paths a successful mutation reports."""
-    targets = _extract_file_mutation_targets(tool_name, args)
-    if tool_name not in _FILE_MUTATING_TOOLS or not isinstance(result, str):
-        return targets
+def _extract_reported_landed_paths(result: Any) -> List[str]:
+    """Return ONLY the explicit landed subset a tool result reports.
+
+    Pulls ``files_modified``, ``files_created``, and ``files_deleted`` from a
+    parsed JSON tool result (including both endpoints of an ``old -> new``
+    move), or ``resolved_path``. Returns ``[]`` when the result carries no
+    explicit landed list — so a complete no-write failure is never treated as
+    landed (the caller distinguishes "no reported landed paths" from the
+    requested-targets fallback).
+    """
+    if not isinstance(result, str):
+        return []
     try:
         data = json.loads(result.strip())
     except Exception:
-        return targets
+        return []
     if not isinstance(data, dict):
-        return targets
+        return []
 
-    files = data.get("files_modified")
-    if isinstance(files, list):
-        landed = [str(p) for p in files if p]
-        if landed:
-            return landed
+    landed: List[str] = []
+    for field in ("files_modified", "files_created", "files_deleted"):
+        files = data.get(field)
+        if not isinstance(files, list):
+            continue
+        for item in files:
+            if not item:
+                continue
+            value = str(item)
+            if field == "files_modified" and " -> " in value:
+                # A move is reported as ``old -> new``; both endpoints changed.
+                landed.extend(part for part in value.split(" -> ") if part)
+            else:
+                landed.append(value)
+    if landed:
+        return list(dict.fromkeys(landed))
 
     resolved = data.get("resolved_path")
     if resolved:
         return [str(resolved)]
 
+    return []
+
+
+def _extract_landed_file_mutation_paths(
+    tool_name: str,
+    args: Dict[str, Any],
+    result: Any,
+) -> List[str]:
+    """Return the concrete file paths a mutation reports as landed.
+
+    Aggregates the explicit landed subset from a tool result — ``files_modified``,
+    ``files_created``, and ``files_deleted`` (including both endpoints of a
+    ``old -> new`` move) — so a partial multi-file patch that reports some
+    files as landed can reconcile exactly which targets changed. Falls back to
+    the requested targets when the result carries no explicit landed list.
+    """
+    targets = _extract_file_mutation_targets(tool_name, args)
+    if tool_name not in _FILE_MUTATING_TOOLS or not isinstance(result, str):
+        return targets
+    reported = _extract_reported_landed_paths(result)
+    if reported:
+        return reported
     return targets
+
+
+def _paths_equal_reconciled(requested: str, landed: str) -> bool:
+    """Return True when a requested path and a reported landed path are the same file.
+
+    Handles the absolute/relative mismatch between the requested target (often
+    relative to the execution cwd, e.g. ``src/app.py``) and the tool-reported
+    landed path (often absolute, e.g. ``/tmp/project/src/app.py``). Also handles
+    duplicate requested paths. Reconciles by comparing each spelling against the
+    other as a suffix, so the most-specific match wins; an ambiguous shorter
+    suffix (e.g. a bare ``app.py`` that is a suffix of several landed paths) is
+    not cleared.
+    """
+    if not requested or not landed:
+        return False
+    a = os.path.normcase(os.path.normpath(str(requested)))
+    b = os.path.normcase(os.path.normpath(str(landed)))
+    if a == b:
+        return True
+    # One is a suffix of the other at a path-component boundary.
+    if a.endswith(os.sep + b) or b.endswith(os.sep + a):
+        return True
+    return False
 
 
 def _extract_error_preview(result: Any, max_len: int = 180) -> str:

--- a/agent/tool_result_classification.py
+++ b/agent/tool_result_classification.py
@@ -34,7 +34,16 @@ def file_mutation_result_landed(tool_name: str, result: Any) -> bool:
     if not isinstance(data, dict) or data.get("error"):
         return False
     if tool_name == "write_file":
-        return "bytes_written" in data
+        bytes_written = data.get("bytes_written")
+        # A failed write_file that reports ``bytes_written: 0`` is not landed —
+        # zero bytes written means nothing changed on disk.
+        return isinstance(bytes_written, (int, float)) and bytes_written > 0
     if tool_name == "patch":
+        # A patch is only a complete success when ``success`` is True AND there
+        # is no top-level error (the error guard above already handles the
+        # latter). A partial patch failure that reports non-empty
+        # files_modified/created/deleted stays error-shaped for CLI display and
+        # tool-call guardrails; FMV reconciles the explicit landed subset
+        # separately via ``_extract_landed_file_mutation_paths``.
         return data.get("success") is True
     return False

--- a/run_agent.py
+++ b/run_agent.py
@@ -217,6 +217,8 @@ from agent.tool_dispatch_helpers import (
     _append_subdir_hint_to_multimodal,  # noqa: F401  # re-exported for tests that `from run_agent import _append_subdir_hint_to_multimodal`
     _extract_file_mutation_targets,
     _extract_landed_file_mutation_paths,
+    _extract_reported_landed_paths,
+    _paths_equal_reconciled,
     _extract_error_preview,
     _trajectory_normalize_msg,  # noqa: F401  # re-exported for tests that `from run_agent import _trajectory_normalize_msg`
 )
@@ -3642,6 +3644,15 @@ class AIAgent:
         model recovered within the turn).  Silently no-ops if the per-turn
         state dict hasn't been initialised yet (e.g. a tool dispatched
         outside ``run_conversation``).
+
+        A partial multi-file patch that reports ``success: false`` plus a
+        top-level error AND a non-empty ``files_modified``/``files_created``/
+        ``files_deleted`` landed subset stays error-shaped for CLI display and
+        tool-call guardrails, but FMV reconciles the explicitly-reported landed
+        subset: those targets are treated as landed (moved to the changed set
+        and cleared from the failure state), so only the unresolved requested
+        targets remain failed. Relative and absolute spellings of the same path
+        reconcile to one another.
         """
         if tool_name not in _FILE_MUTATING_TOOLS:
             return
@@ -3652,8 +3663,20 @@ class AIAgent:
         if not targets:
             return
         landed = file_mutation_result_landed(tool_name, result)
-        if landed:
-            landed_paths = _extract_landed_file_mutation_paths(tool_name, args, result)
+        # Explicitly-reported landed subset (files_modified/created/deleted +
+        # resolved_path), empty for a complete no-write failure. Distinct from
+        # ``landed_paths`` below so an error-shaped partial patch can still
+        # reconcile the files it actually changed.
+        reported_landed = _extract_reported_landed_paths(result)
+        if landed or reported_landed:
+            # Track landed/changed paths and feed the checkpoint ledger whether
+            # the call is a clean success OR a partial patch failure that
+            # explicitly reported some files as landed.
+            landed_paths = (
+                _extract_landed_file_mutation_paths(tool_name, args, result)
+                if landed
+                else reported_landed
+            )
             changed = getattr(self, "_turn_file_mutation_paths", None)
             if changed is not None:
                 changed.update(landed_paths)
@@ -3668,7 +3691,20 @@ class AIAgent:
                         pass
         if is_error and not landed:
             preview = _extract_error_preview(result)
+            # A later partial retry may report a target as landed under a
+            # different spelling (relative vs absolute) than the key recorded by
+            # an earlier attempt — clear any equivalent prior failure key.
+            if reported_landed:
+                for existing in list(state.keys()):
+                    if any(_paths_equal_reconciled(existing, lp) for lp in reported_landed):
+                        state.pop(existing, None)
             for path in targets:
+                # A landed (reported or reconciled) target is not a failure —
+                # it changed on disk. Only unresolved requested targets stay
+                # in the failure state.
+                if any(_paths_equal_reconciled(path, lp) for lp in reported_landed):
+                    state.pop(path, None)
+                    continue
                 # Keep the FIRST error we saw for a given path unless we
                 # later see success.  A repeated failure with a different
                 # message shouldn't silently overwrite the original.

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -228,6 +228,115 @@ class TestRecordFileMutationResult:
         assert "first error" in agent._turn_failed_file_mutations["/tmp/a.md"]["error_preview"]
 
 
+class TestPartialPatchFailureAccounting:
+    """A V4A patch can modify some files and then fail on a later operation.
+
+    FMV must reconcile the explicitly-reported landed subset so only the
+    unresolved requested targets remain in the failure state — while the call
+    stays error-shaped for CLI display and tool-call guardrails.
+    """
+
+    def _bare(self):
+        return _bare_agent()
+
+    def test_partial_patch_only_clears_landed_targets(self):
+        agent = self._bare()
+        args = {
+            "mode": "patch",
+            "patch": (
+                "*** Begin Patch\n"
+                "*** Update File: /tmp/changed.md\n"
+                "@@ @@\n-old\n+new\n"
+                "*** Update File: /tmp/failed.md\n"
+                "@@ @@\n-old\n+new\n"
+                "*** End Patch\n"
+            ),
+        }
+        result = json.dumps({
+            "success": False,
+            "error": "Apply phase failed after one file changed",
+            "files_modified": ["/tmp/changed.md"],
+        })
+        agent._record_file_mutation_result("patch", args, result, is_error=True)
+
+        assert agent._turn_file_mutation_paths == {"/tmp/changed.md"}
+        assert "/tmp/changed.md" not in agent._turn_failed_file_mutations
+        assert set(agent._turn_failed_file_mutations) == {"/tmp/failed.md"}
+
+    def test_partial_patch_clears_equivalent_absolute_prior_key(self):
+        agent = self._bare()
+        # Earlier attempt failed, recorded under a RELATIVE spelling.
+        agent._record_file_mutation_result(
+            "patch", {"mode": "replace", "path": "src/app.py", "old_string": "x", "new_string": "y"},
+            json.dumps({"error": "not found"}), is_error=True,
+        )
+        assert "src/app.py" in agent._turn_failed_file_mutations
+        # Later partial retry reports the same file landed under an ABSOLUTE path.
+        args = {"mode": "patch", "patch": "*** Begin Patch\n*** Update File: /tmp/project/src/app.py\n*** End Patch\n"}
+        result = json.dumps({
+            "success": False,
+            "error": "later op failed",
+            "files_modified": ["/tmp/project/src/app.py"],
+        })
+        agent._record_file_mutation_result("patch", args, result, is_error=True)
+        assert "src/app.py" not in agent._turn_failed_file_mutations
+
+    def test_complete_no_write_failure_stays_failed(self):
+        agent = self._bare()
+        args = {"mode": "patch", "patch": "*** Begin Patch\n*** Update File: /tmp/a.md\n*** End Patch\n"}
+        result = json.dumps({
+            "success": False,
+            "error": "failed before any file changed",
+            "files_modified": [],
+            "files_created": [],
+            "files_deleted": [],
+        })
+        agent._record_file_mutation_result("patch", args, result, is_error=True)
+        assert "/tmp/a.md" in agent._turn_failed_file_mutations
+        assert agent._turn_file_mutation_paths == set()
+
+    def test_success_true_with_top_level_error_is_still_failure_for_fmv_state(self):
+        """success:true AND a top-level error is not a complete success; the
+        call stays error-shaped, but FMV reconciles only explicit landed paths."""
+        agent = self._bare()
+        args = {"mode": "patch", "patch": "*** Begin Patch\n*** Update File: /tmp/a.md\n*** End Patch\n"}
+        result = json.dumps({
+            "success": True,
+            "error": "partial apply",
+            "files_modified": ["/tmp/a.md"],
+        })
+        agent._record_file_mutation_result("patch", args, result, is_error=True)
+        # a.md was explicitly reported landed — cleared.
+        assert "/tmp/a.md" not in agent._turn_failed_file_mutations
+        assert "/tmp/a.md" in agent._turn_file_mutation_paths
+
+    def test_detect_tool_failure_stays_true_for_partial_patch(self):
+        from agent.display import _detect_tool_failure
+        result = json.dumps({
+            "success": False,
+            "error": "Apply phase failed after one file changed",
+            "files_modified": ["/tmp/changed.md"],
+        })
+        is_failure, _ = _detect_tool_failure("patch", result)
+        assert is_failure is True
+
+    def test_landed_paths_aggregate_update_add_delete_move(self):
+        result = json.dumps({
+            "success": False,
+            "error": "later operation failed",
+            "files_modified": ["/tmp/old.md -> /tmp/new.md"],
+            "files_created": ["/tmp/created.md"],
+            "files_deleted": ["/tmp/deleted.md"],
+        })
+        paths = _extract_landed_file_mutation_paths("patch", {"mode": "patch", "patch": "*** Begin Patch\n*** End Patch\n"}, result)
+        assert set(paths) == {"/tmp/old.md", "/tmp/new.md", "/tmp/created.md", "/tmp/deleted.md"}
+
+    def test_failed_write_file_zero_bytes_not_landed(self):
+        from agent.tool_result_classification import file_mutation_result_landed
+        result = json.dumps({"bytes_written": 0, "error": "write failed"})
+        assert file_mutation_result_landed("write_file", result) is False
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Preserves partial file-mutation accounting in the per-turn file-mutation verifier (FMV). A V4A multi-file patch can modify some files and then fail on a later operation, reporting `success: false` plus a top-level error plus non-empty `files_modified` / `files_created` / `files_deleted`. Previously FMV treated every requested file as unmodified on such a partial failure, silently dropping the edits that DID land from the changed-set and the agent-write (checkpoint/rollback) ledger.

The fix keeps the call error-shaped for CLI display and tool-call guardrails, but lets FMV reconcile the explicitly-reported landed subset: those targets move to the changed set and are cleared from the failure state (including clearing an equivalent prior key under a different relative/absolute spelling), leaving only the unresolved requested targets failed. A complete no-write failure still remains a failure.

## Related Issue

None (no issue opened; bug-fix contribution).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/tool_result_classification.py` — `file_mutation_result_landed()`: a `write_file` with `bytes_written: 0` is not landed; a patch is only a complete success when `success` is `True` AND there is no top-level error.
- `agent/tool_dispatch_helpers.py`
  - `_extract_landed_file_mutation_paths()` aggregates `files_modified`, `files_created`, and `files_deleted` (including both endpoints of an `old -> new` move) instead of only `files_modified`.
  - New `_extract_reported_landed_paths()` returns only the explicit landed subset (`[]` for a complete no-write failure).
  - New `_paths_equal_reconciled()` matches a requested target to a reported landed path across relative/absolute spellings (most-specific suffix wins).
- `run_agent.py` — `_record_file_mutation_result()` reconciles the reported landed subset on a partial failure: those targets move to the changed set and are cleared from the failure state, leaving only unresolved targets failed.
- Tests: focused regressions for update/add/delete/move landed extraction, exact and relative/absolute reconciliation, partial retry clearing an equivalent prior failure, complete no-write failure staying failed, `success: true` + top-level error remaining a failure, `_detect_tool_failure()` staying true for partial patches, and `write_file` with zero bytes not counted as landed.

## How to Test

1. `python -m pytest tests/agent/test_tool_result_classification.py tests/agent/test_tool_dispatch_helpers.py tests/agent/test_display.py tests/agent/test_tool_guardrails.py tests/run_agent/test_file_mutation_verifier.py tests/tools/test_patch_failure_tracking.py tests/tools/test_patch_parser.py -q` → `133 passed`.
2. Ruff: `ruff check agent/tool_result_classification.py agent/tool_dispatch_helpers.py run_agent.py` → clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not fully run**: the canonical full-suite run on this Windows host is non-diagnostic (untouched tests fail from missing async-test support, Pyright init timeouts, and Windows symlink privilege limits). The focused classification/display/guardrails/dispatch/FMV/patch suites pass green (133 passed); ruff is clean.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Updated docstrings/comments for the partial-write accounting
- [ ] Updated `cli-config.yaml.example` if config keys changed — N/A (no new config)
- [x] Considered cross-platform impact per the compatibility guide

## Screenshots / Logs

N/A (no visual change).
