### PR TITLE
fix(browser): honor canonical managed Browser Use selection

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -4449,6 +4449,7 @@ def _write_provider_config(provider: dict, config: dict, *, managed_feature) -> 
             # switching providers keeps the driver choice intact.
             _set_selection("browser", "cloud_provider", bp)
         else:
+            browser_cfg.pop("cloud_provider", None)
             browser_cfg.pop("use_gateway", None)
 
     if provider.get("browser_backend"):

--- a/tests/tools/test_browser_use_cli_managed_selection.py
+++ b/tests/tools/test_browser_use_cli_managed_selection.py
@@ -63,3 +63,27 @@ def test_direct_browser_use_selection_stays_on_native_cli_path(monkeypatch):
     env = {}
     assert bu_cli._resolve_backend_cdp(env, "task-1") is None
     assert "BU_CDP_WS" not in env and "BU_CDP_URL" not in env
+
+
+def test_empty_browser_provider_clears_stale_managed_selection():
+    from hermes_cli.tools_config import _write_provider_config
+
+    config = {
+        "browser": {
+            "cloud_provider": "nous",
+            "use_gateway": True,
+            "backend": "browser-use",
+            "keep_me": "value",
+        }
+    }
+
+    _write_provider_config(
+        {"browser_provider": ""}, config, managed_feature=None
+    )
+
+    browser = config["browser"]
+    assert "cloud_provider" not in browser
+    assert "use_gateway" not in browser
+    assert browser["backend"] == "browser-use"
+    assert browser["keep_me"] == "value"
+

--- a/tests/tools/test_browser_use_cli_managed_selection.py
+++ b/tests/tools/test_browser_use_cli_managed_selection.py
@@ -1,0 +1,65 @@
+"""Regression coverage for canonical managed Browser Use selection (#93865)."""
+
+import tools.browser_use_cli as bu_cli
+
+
+def test_canonical_nous_selection_routes_browser_use_through_gateway(monkeypatch):
+    import tools.browser_tool as bt
+
+    class _BrowserUseProvider:
+        name = "browser-use"
+
+    monkeypatch.setattr(
+        "hermes_cli.config.read_raw_config_readonly",
+        lambda: {
+            "browser": {
+                "backend": "browser-use",
+                "cloud_provider": "nous",
+            }
+        },
+    )
+    monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
+    monkeypatch.setattr(bt, "_get_cloud_provider", lambda: _BrowserUseProvider())
+
+    seen = []
+
+    def session_info(cache_key):
+        seen.append(cache_key)
+        return {"cdp_url": "wss://managed.example/cdp/session"}
+
+    monkeypatch.setattr(bt, "_get_session_info", session_info)
+
+    env = {}
+    assert bu_cli._resolve_backend_cdp(env, "task-1") is None
+    assert seen == ["task-1"]
+    assert env["BU_CDP_WS"] == "wss://managed.example/cdp/session"
+
+
+def test_direct_browser_use_selection_stays_on_native_cli_path(monkeypatch):
+    import tools.browser_tool as bt
+
+    class _BrowserUseProvider:
+        name = "browser-use"
+
+    monkeypatch.setattr(
+        "hermes_cli.config.read_raw_config_readonly",
+        lambda: {
+            "browser": {
+                "backend": "browser-use",
+                "cloud_provider": "browser-use",
+            }
+        },
+    )
+    monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
+    monkeypatch.setattr(bt, "_get_cloud_provider", lambda: _BrowserUseProvider())
+    monkeypatch.setattr(
+        bt,
+        "_get_session_info",
+        lambda cache_key: (_ for _ in ()).throw(
+            AssertionError("direct Browser Use must not provision a gateway session")
+        ),
+    )
+
+    env = {}
+    assert bu_cli._resolve_backend_cdp(env, "task-1") is None
+    assert "BU_CDP_WS" not in env and "BU_CDP_URL" not in env

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -566,14 +566,9 @@ def _resolve_backend_cdp(
     # configs follow the same runtime contract.
     provider_key = str(getattr(provider, "name", "") or "").strip().lower()
     if provider_key == _BACKEND_KEY:
-        try:
-            from tools.tool_backend_helpers import NOUS_MANAGED_PROVIDER, read_selection
+        from tools.tool_backend_helpers import NOUS_MANAGED_PROVIDER, read_selection
 
-            managed_selection = read_selection("browser") == NOUS_MANAGED_PROVIDER
-        except Exception:
-            managed_selection = is_truthy_value(
-                _read_browser_cfg().get("use_gateway"), default=False
-            )
+        managed_selection = read_selection("browser") == NOUS_MANAGED_PROVIDER
         if not managed_selection:
             # Named BU cloud browsers are exclusive to their daemon — no shared
             # tab to isolate from.

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -559,17 +559,26 @@ def _resolve_backend_cdp(
     # Browser Use direct-API configs: the CLI talks to Browser Use cloud
     # natively (BU_AUTOSPAWN / auth login) — routing through the legacy
     # provider here would just create a second, redundant session. The
-    # Nous-gateway variant (use_gateway: true) DOES resolve through the
-    # provider: the gateway provisions the cloud browser server-side and
-    # returns its CDP URL, giving subscribers CLI mode with no raw key.
+    # managed Nous selection DOES resolve through the provider: the gateway
+    # provisions the cloud browser server-side and returns its CDP URL, giving
+    # subscribers CLI mode with no raw key. Use the shared persisted-selection
+    # reader so canonical cloud_provider: nous and legacy use_gateway: true
+    # configs follow the same runtime contract.
     provider_key = str(getattr(provider, "name", "") or "").strip().lower()
-    if provider_key == _BACKEND_KEY and not is_truthy_value(
-        _read_browser_cfg().get("use_gateway"), default=False
-    ):
-        # Named BU cloud browsers are exclusive to their daemon — no shared
-        # tab to isolate from.
-        env[_PRIVATE_BROWSER_SENTINEL] = "1"
-        return None
+    if provider_key == _BACKEND_KEY:
+        try:
+            from tools.tool_backend_helpers import NOUS_MANAGED_PROVIDER, read_selection
+
+            managed_selection = read_selection("browser") == NOUS_MANAGED_PROVIDER
+        except Exception:
+            managed_selection = is_truthy_value(
+                _read_browser_cfg().get("use_gateway"), default=False
+            )
+        if not managed_selection:
+            # Named BU cloud browsers are exclusive to their daemon — no shared
+            # tab to isolate from.
+            env[_PRIVATE_BROWSER_SENTINEL] = "1"
+            return None
 
     try:
         # Named sessions get their OWN provider browser, keyed by name so the


### PR DESCRIPTION
Fixes #93865.

`browser_exec` still decided whether Browser Use was managed by reading the legacy `browser.use_gateway` flag. The current `hermes tools` contract persists the managed choice as `browser.cloud_provider: nous` and removes that legacy flag, so managed Browser Use could be mistaken for direct Browser Use and skip gateway session provisioning.

This switches that decision to the existing `tools.tool_backend_helpers.read_selection("browser")` contract, which already maps both the canonical `cloud_provider: nous` form and legacy `use_gateway: true` configs to the managed selection. Direct `cloud_provider: browser-use` still stays on Browser Use CLI's native cloud path, avoiding duplicate sessions/billing.

The provider writer also now clears a stale canonical `browser.cloud_provider` when an empty browser-provider selection is written, alongside the legacy `use_gateway` cleanup. This prevents an old `nous` selection from becoming active again after the runtime starts honoring the canonical key, while preserving `browser.backend` and unrelated browser settings.

Regression coverage verifies canonical Nous routing, direct Browser Use routing, and stale managed-selection cleanup.

Validation: `uv run python -m pytest -q tests/tools/test_browser_use_cli_managed_selection.py` → 3 passed.