### PR TITLE
feat(feishu): add interactive slash-command confirmation buttons

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -282,6 +282,10 @@ _FEISHU_REACTION_FAILURE = "CrossMark"
 # delete-failures, not a capacity plan.
 _FEISHU_PROCESSING_REACTION_CACHE_SIZE = 1024
 _FEISHU_MESSAGE_TEXT_CACHE_SIZE = 512       # LRU cap for reply-context message text lookups
+# Un-clicked slash-confirm cards are dropped after this many seconds (matches
+# tools.slash_confirm.DEFAULT_TIMEOUT_SECONDS); otherwise ignored cards would
+# leak state forever and stale clicks would resolve long-dead prompts.
+_FEISHU_SLASH_CONFIRM_TTL_SECONDS = 300
 
 # QR onboarding constants
 _ONBOARD_ACCOUNTS_URLS = {
@@ -2209,7 +2213,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 "type": btn_type,
                 "value": {
                     "hermes_slash_confirm_action": action,
-                    "confirm_id": str(prompt_id),
+                    "prompt_id": str(prompt_id),
                 },
             }
 
@@ -2266,6 +2270,7 @@ class FeishuAdapter(BasePlatformAdapter):
                     "confirm_id": str(confirm_id),
                     "message_id": result.message_id or "",
                     "chat_id": chat_id,
+                    "created_at": time.time(),
                 }
             return result
         except Exception as exc:
@@ -3000,13 +3005,19 @@ class FeishuAdapter(BasePlatformAdapter):
 
     def _handle_slash_confirm_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
         """Schedule slash-confirm resolution and build the synchronous callback response."""
-        prompt_id = action_value.get("confirm_id")
+        prompt_id = action_value.get("prompt_id")
         if prompt_id is None:
-            logger.debug("[Feishu] Card action missing confirm_id, ignoring")
+            logger.debug("[Feishu] Card action missing prompt_id, ignoring")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
         state = self._slash_confirm_state.get(str(prompt_id))
         if not state:
             logger.debug("[Feishu] Slash confirm %s already resolved or unknown", prompt_id)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+        if time.time() - float(state.get("created_at", 0) or 0) > _FEISHU_SLASH_CONFIRM_TTL_SECONDS:
+            # The module-level pending confirm has already timed out; drop the
+            # stale card state so ignored cards can't leak or resolve late.
+            self._slash_confirm_state.pop(str(prompt_id), None)
+            logger.debug("[Feishu] Slash confirm %s expired, ignoring", prompt_id)
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
         choice = str(action_value.get("hermes_slash_confirm_action", "") or "").strip().lower()
@@ -3159,12 +3170,20 @@ class FeishuAdapter(BasePlatformAdapter):
         open_id: str = "",
         chat_id: str = "",
     ) -> None:
-        """Pop slash-confirm state and run the pending handler via tools.slash_confirm."""
-        state = self._slash_confirm_state.get(prompt_id)
+        """Atomically claim the pending confirm and run the handler via tools.slash_confirm."""
+        # Pop at coroutine entry: a double-click schedules two coroutines and
+        # only the first may claim the state, so the pending command's approve
+        # side can never run twice. The synchronous click handler's ``get``
+        # remains a cheap dedupe for the common single-click case.
+        state = self._slash_confirm_state.pop(prompt_id, None)
         if not state:
             logger.debug("[Feishu] Slash confirm %s already resolved or unknown", prompt_id)
             return
-        if not self._is_interactive_operator_authorized(open_id):
+        # Re-authorize with the same predicate the click handler used
+        # (_allow_group_message) so a card can never promise an approval the
+        # resolver would then refuse (phantom approval).
+        sender_id = SimpleNamespace(open_id=open_id, user_id="")
+        if not self._allow_group_message(sender_id, str(state.get("chat_id", "") or ""), is_bot=False):
             logger.warning(
                 "[Feishu] Unauthorized slash confirm click by %s for confirm %s",
                 open_id or "<unknown>", prompt_id,
@@ -3176,10 +3195,6 @@ class FeishuAdapter(BasePlatformAdapter):
                 "[Feishu] Slash confirm %s chat mismatch (expected=%s, got=%s)",
                 prompt_id, expected_chat_id, chat_id,
             )
-            return
-        state = self._slash_confirm_state.pop(prompt_id, None)
-        if not state:
-            logger.debug("[Feishu] Slash confirm %s already resolved while validating callback", prompt_id)
             return
         try:
             from tools.slash_confirm import resolve as resolve_slash_confirm
@@ -3197,6 +3212,20 @@ class FeishuAdapter(BasePlatformAdapter):
                         await self.send(_chat, result)
                     except Exception:
                         logger.debug("[Feishu] slash-confirm follow-up send failed", exc_info=True)
+            elif choice != "cancel":
+                # The callback card already showed a resolved state, but nothing
+                # was pending — the confirm timed out or was resolved elsewhere.
+                # Correct the record (mirrors _resolve_approval's expiry notice).
+                _chat = str(state.get("chat_id", "") or chat_id or "")
+                if _chat:
+                    try:
+                        await self.send(
+                            _chat,
+                            "⌛ That confirmation had already expired — the command "
+                            "was not run (it timed out or was resolved elsewhere).",
+                        )
+                    except Exception:
+                        logger.debug("[Feishu] expired slash-confirm notice failed", exc_info=True)
         except Exception as exc:
             logger.error("Failed to resolve Feishu slash confirm: %s", exc)
 

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1556,6 +1556,9 @@ class FeishuAdapter(BasePlatformAdapter):
         # Update prompt button state (prompt_id → {session_key, message_id, chat_id})
         self._update_prompt_state: Dict[int, Dict[str, str]] = {}
         self._update_prompt_counter = itertools.count(1)
+        # Slash-confirm button state (prompt_id → {session_key, confirm_id, message_id, chat_id})
+        self._slash_confirm_state: Dict[str, Dict[str, str]] = {}
+        self._slash_confirm_counter = itertools.count(1)
         # Feishu reaction deletion requires the opaque reaction_id returned
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
@@ -2196,6 +2199,80 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(exc))
 
     @staticmethod
+    def _build_slash_confirm_card(*, title: str, message: str, prompt_id: int) -> Dict[str, Any]:
+        """Build the interactive card for a slash-command confirmation."""
+
+        def _btn(label: str, action: str, btn_type: str) -> dict:
+            return {
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": label},
+                "type": btn_type,
+                "value": {
+                    "hermes_slash_confirm_action": action,
+                    "confirm_id": str(prompt_id),
+                },
+            }
+
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": title or "⚠️ Confirm Command", "tag": "plain_text"},
+                "template": "orange",
+            },
+            "elements": [
+                {"tag": "markdown", "content": message},
+                {
+                    "tag": "action",
+                    "actions": [
+                        _btn("✅ Approve Once", "once", "primary"),
+                        _btn("🔒 Always Approve", "always", "default"),
+                        _btn("❌ Cancel", "cancel", "danger"),
+                    ],
+                },
+            ],
+        }
+
+    async def send_slash_confirm(
+        self, chat_id: str, title: str, message: str, session_key: str,
+        confirm_id: str, metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an interactive card with Approve Once / Always / Cancel buttons.
+
+        The buttons carry ``hermes_slash_confirm_action`` so
+        ``_handle_slash_confirm_card_action`` can intercept them and call
+        ``tools.slash_confirm.resolve()`` to run the pending handler.
+        """
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            prompt_id = next(self._slash_confirm_counter)
+            payload = json.dumps(
+                self._build_slash_confirm_card(title=title, message=message, prompt_id=prompt_id),
+                ensure_ascii=False,
+            )
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=None,
+                metadata=metadata,
+            )
+
+            result = self._finalize_send_result(response, "send_slash_confirm failed")
+            if result.success:
+                self._slash_confirm_state[str(prompt_id)] = {
+                    "session_key": session_key,
+                    "confirm_id": str(confirm_id),
+                    "message_id": result.message_id or "",
+                    "chat_id": chat_id,
+                }
+            return result
+        except Exception as exc:
+            logger.warning("[Feishu] send_slash_confirm failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
+    @staticmethod
     def _build_resolved_approval_card(*, choice: str, user_name: str) -> Dict[str, Any]:
         """Build raw card JSON for a resolved approval action."""
         icon = "❌" if choice == "deny" else "✅"
@@ -2226,6 +2303,26 @@ class FeishuAdapter(BasePlatformAdapter):
             },
             "elements": [
                 {"tag": "markdown", "content": f"Answered by **{user_name}**"},
+            ],
+        }
+
+    @staticmethod
+    def _build_resolved_slash_confirm_card(*, choice: str, user_name: str) -> Dict[str, Any]:
+        """Build raw card JSON for a resolved slash-confirm action."""
+        if choice == "cancel":
+            icon, label, template = "❌", "Cancelled", "red"
+        elif choice == "always":
+            icon, label, template = "🔒", "Always approved", "green"
+        else:
+            icon, label, template = "✅", "Approved once", "green"
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": f"{icon} {label}", "tag": "plain_text"},
+                "template": template,
+            },
+            "elements": [
+                {"tag": "markdown", "content": f"{icon} **{label}** by {user_name}"},
             ],
         }
 
@@ -2734,11 +2831,21 @@ class FeishuAdapter(BasePlatformAdapter):
             action_value.get("hermes_update_prompt_action")
             if isinstance(action_value, dict) else None
         )
+        slash_confirm_action = (
+            action_value.get("hermes_slash_confirm_action")
+            if isinstance(action_value, dict) else None
+        )
 
         if hermes_action:
             return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
         if update_prompt_action:
             return self._handle_update_prompt_card_action(
+                event=event,
+                action_value=action_value,
+                loop=loop,
+            )
+        if slash_confirm_action:
+            return self._handle_slash_confirm_card_action(
                 event=event,
                 action_value=action_value,
                 loop=loop,
@@ -2891,6 +2998,63 @@ class FeishuAdapter(BasePlatformAdapter):
             response.card = card
         return response
 
+    def _handle_slash_confirm_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
+        """Schedule slash-confirm resolution and build the synchronous callback response."""
+        prompt_id = action_value.get("confirm_id")
+        if prompt_id is None:
+            logger.debug("[Feishu] Card action missing confirm_id, ignoring")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+        state = self._slash_confirm_state.get(str(prompt_id))
+        if not state:
+            logger.debug("[Feishu] Slash confirm %s already resolved or unknown", prompt_id)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        choice = str(action_value.get("hermes_slash_confirm_action", "") or "").strip().lower()
+        if choice not in {"once", "always", "cancel"}:
+            logger.debug("[Feishu] Card action has invalid slash confirm choice=%r", choice)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        operator = getattr(event, "operator", None)
+        open_id = str(getattr(operator, "open_id", "") or "")
+        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
+        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+            logger.warning("[Feishu] Unauthorized slash confirm click by %s", open_id or "<unknown>")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        callback_chat_id = str(getattr(getattr(event, "context", None), "open_chat_id", "") or "")
+        expected_chat_id = str(state.get("chat_id", "") or "")
+        if callback_chat_id and expected_chat_id and callback_chat_id != expected_chat_id:
+            logger.warning(
+                "[Feishu] Slash confirm callback chat mismatch for %s (expected=%s, got=%s)",
+                prompt_id,
+                expected_chat_id,
+                callback_chat_id,
+            )
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        user_name = self._get_cached_sender_name(open_id) or open_id
+        if not self._submit_on_loop(
+            loop,
+            self._resolve_slash_confirm(
+                prompt_id=str(prompt_id),
+                choice=choice,
+                user_name=user_name,
+                open_id=open_id,
+                chat_id=callback_chat_id,
+            ),
+        ):
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        if P2CardActionTriggerResponse is None:
+            return None
+        response = P2CardActionTriggerResponse()
+        if CallBackCard is not None:
+            card = CallBackCard()
+            card.type = "raw"
+            card.data = self._build_resolved_slash_confirm_card(choice=choice, user_name=user_name)
+            response.card = card
+        return response
+
     async def _resolve_approval(
         self,
         approval_id: Any,
@@ -2985,6 +3149,56 @@ class FeishuAdapter(BasePlatformAdapter):
             )
         except Exception as exc:
             logger.error("Failed to resolve Feishu update prompt: %s", exc)
+
+    async def _resolve_slash_confirm(
+        self,
+        prompt_id: str,
+        choice: str,
+        user_name: str,
+        *,
+        open_id: str = "",
+        chat_id: str = "",
+    ) -> None:
+        """Pop slash-confirm state and run the pending handler via tools.slash_confirm."""
+        state = self._slash_confirm_state.get(prompt_id)
+        if not state:
+            logger.debug("[Feishu] Slash confirm %s already resolved or unknown", prompt_id)
+            return
+        if not self._is_interactive_operator_authorized(open_id):
+            logger.warning(
+                "[Feishu] Unauthorized slash confirm click by %s for confirm %s",
+                open_id or "<unknown>", prompt_id,
+            )
+            return
+        expected_chat_id = str(state.get("chat_id", "") or "")
+        if expected_chat_id and chat_id and expected_chat_id != chat_id:
+            logger.warning(
+                "[Feishu] Slash confirm %s chat mismatch (expected=%s, got=%s)",
+                prompt_id, expected_chat_id, chat_id,
+            )
+            return
+        state = self._slash_confirm_state.pop(prompt_id, None)
+        if not state:
+            logger.debug("[Feishu] Slash confirm %s already resolved while validating callback", prompt_id)
+            return
+        try:
+            from tools.slash_confirm import resolve as resolve_slash_confirm
+            session_key = str(state.get("session_key", "") or "")
+            confirm_id = str(state.get("confirm_id", "") or "")
+            result = await resolve_slash_confirm(session_key, confirm_id, choice)
+            logger.info(
+                "Feishu slash confirm resolved for session %s (choice=%s, user=%s)",
+                session_key, choice, user_name,
+            )
+            if result:
+                _chat = str(state.get("chat_id", "") or chat_id or "")
+                if _chat:
+                    try:
+                        await self.send(_chat, result)
+                    except Exception:
+                        logger.debug("[Feishu] slash-confirm follow-up send failed", exc_info=True)
+        except Exception as exc:
+            logger.error("Failed to resolve Feishu slash confirm: %s", exc)
 
     async def _handle_reaction_event(self, event_type: str, data: Any) -> None:
         """Fetch the reacted-to message; if it was sent by this bot, emit a synthetic text event."""

--- a/tests/gateway/test_feishu_slash_confirm.py
+++ b/tests/gateway/test_feishu_slash_confirm.py
@@ -1,0 +1,316 @@
+"""Tests for Feishu interactive card slash-command confirmation buttons."""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the repo root is importable
+# ---------------------------------------------------------------------------
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+# ---------------------------------------------------------------------------
+# Minimal Feishu mock so FeishuAdapter can be imported without lark-oapi
+# ---------------------------------------------------------------------------
+def _ensure_feishu_mocks():
+    """Provide stubs for lark-oapi / aiohttp.web so the import succeeds."""
+    if importlib.util.find_spec("lark_oapi") is None and "lark_oapi" not in sys.modules:
+        mod = MagicMock()
+        for name in (
+            "lark_oapi", "lark_oapi.api.im.v1",
+            "lark_oapi.event", "lark_oapi.event.callback_type",
+        ):
+            sys.modules.setdefault(name, mod)
+    if importlib.util.find_spec("aiohttp") is None and "aiohttp" not in sys.modules:
+        aio = MagicMock()
+        sys.modules.setdefault("aiohttp", aio)
+        sys.modules.setdefault("aiohttp.web", aio.web)
+
+
+_ensure_feishu_mocks()
+
+from gateway.config import PlatformConfig
+import plugins.platforms.feishu.adapter as feishu_module
+from plugins.platforms.feishu.adapter import FeishuAdapter
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_adapter() -> FeishuAdapter:
+    """Create a FeishuAdapter with mocked internals."""
+    config = PlatformConfig(enabled=True)
+    adapter = FeishuAdapter(config)
+    adapter._client = MagicMock()
+    return adapter
+
+
+def _make_card_action_data(
+    action_value: dict,
+    chat_id: str = "oc_12345",
+    open_id: str = "ou_user1",
+) -> SimpleNamespace:
+    """Create a mock Feishu card action callback data object."""
+    return SimpleNamespace(
+        event=SimpleNamespace(
+            token="tok_abc",
+            context=SimpleNamespace(open_chat_id=chat_id),
+            operator=SimpleNamespace(open_id=open_id, user_id=open_id),
+            action=SimpleNamespace(
+                tag="button",
+                value=action_value,
+            ),
+        ),
+    )
+
+
+def _close_submitted_coro(coro, _loop):
+    """Close scheduled coroutines in sync-handler tests to avoid unawaited warnings."""
+    coro.close()
+    return SimpleNamespace(add_done_callback=lambda *_args, **_kwargs: None)
+
+
+class _FakeCallBackCard:
+    def __init__(self):
+        self.type = None
+        self.data = None
+
+
+class _FakeP2Response:
+    def __init__(self):
+        self.card = None
+
+
+@pytest.fixture(autouse=True)
+def _patch_callback_card_types(monkeypatch):
+    """Provide real-ish P2CardActionTriggerResponse / CallBackCard for tests."""
+    monkeypatch.setattr(feishu_module, "P2CardActionTriggerResponse", _FakeP2Response)
+    monkeypatch.setattr(feishu_module, "CallBackCard", _FakeCallBackCard)
+
+
+# ===========================================================================
+# send_slash_confirm — interactive card with three buttons
+# ===========================================================================
+
+class TestFeishuSendSlashConfirm:
+    """Test send_slash_confirm sends an interactive card."""
+
+    @pytest.mark.asyncio
+    async def test_sends_interactive_card(self):
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_sc_001"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_send:
+            result = await adapter.send_slash_confirm(
+                chat_id="oc_12345",
+                title="Confirm /reload-mcp",
+                message="This invalidates the provider prompt cache.",
+                session_key="agent:main:feishu:dm:oc_12345",
+                confirm_id="gw-42",
+            )
+
+        assert result.success is True
+        assert result.message_id == "msg_sc_001"
+
+        kwargs = mock_send.call_args[1]
+        assert kwargs["chat_id"] == "oc_12345"
+        assert kwargs["msg_type"] == "interactive"
+
+        card = json.loads(kwargs["payload"])
+        assert card["header"]["template"] == "orange"
+        assert "This invalidates the provider prompt cache." in card["elements"][0]["content"]
+
+        actions = card["elements"][1]["actions"]
+        assert len(actions) == 3
+        choices = [a["value"]["hermes_slash_confirm_action"] for a in actions]
+        assert choices == ["once", "always", "cancel"]
+
+    @pytest.mark.asyncio
+    async def test_stores_confirm_state(self):
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_sc_002"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            await adapter.send_slash_confirm(
+                chat_id="oc_12345",
+                title="t",
+                message="m",
+                session_key="my-session-key",
+                confirm_id="gw-7",
+            )
+
+        assert len(adapter._slash_confirm_state) == 1
+        prompt_id = list(adapter._slash_confirm_state.keys())[0]
+        state = adapter._slash_confirm_state[prompt_id]
+        assert state["session_key"] == "my-session-key"
+        assert state["confirm_id"] == "gw-7"
+        assert state["message_id"] == "msg_sc_002"
+        assert state["chat_id"] == "oc_12345"
+
+
+# ===========================================================================
+# _handle_slash_confirm_card_action — card callback routing
+# ===========================================================================
+
+class TestHandleSlashConfirmCardAction:
+    """Test card button clicks route to tools.slash_confirm.resolve."""
+
+    def test_returns_resolved_card_for_once(self):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_bob"}
+        adapter._slash_confirm_state["1"] = {
+            "session_key": "sess-1",
+            "confirm_id": "gw-1",
+            "message_id": "msg-1",
+            "chat_id": "oc_12345",
+        }
+        adapter._sender_name_cache["ou_bob"] = ("Bob", 9999999999)
+        data = _make_card_action_data(
+            {"hermes_slash_confirm_action": "once", "confirm_id": "1"},
+            open_id="ou_bob",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        assert response.card.type == "raw"
+        card = response.card.data
+        assert card["header"]["template"] == "green"
+        assert "Approved once" in card["header"]["title"]["content"]
+
+    def test_returns_resolved_card_for_cancel(self):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_bob"}
+        adapter._slash_confirm_state["2"] = {
+            "session_key": "sess-2",
+            "confirm_id": "gw-2",
+            "message_id": "msg-2",
+            "chat_id": "oc_12345",
+        }
+        adapter._sender_name_cache["ou_bob"] = ("Bob", 9999999999)
+        data = _make_card_action_data(
+            {"hermes_slash_confirm_action": "cancel", "confirm_id": "2"},
+            open_id="ou_bob",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        card = response.card.data
+        assert card["header"]["template"] == "red"
+        assert "Cancelled" in card["header"]["title"]["content"]
+
+    def test_rejects_click_from_unauthorized_user(self):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_allowed"}
+        adapter._slash_confirm_state["3"] = {
+            "session_key": "sess-3",
+            "confirm_id": "gw-3",
+            "message_id": "msg-3",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {"hermes_slash_confirm_action": "once", "confirm_id": "3"},
+            open_id="ou_attacker",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
+
+    def test_chat_mismatch_returns_no_card(self):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_bob"}
+        adapter._slash_confirm_state["4"] = {
+            "session_key": "sess-4",
+            "confirm_id": "gw-4",
+            "message_id": "msg-4",
+            "chat_id": "oc_expected",
+        }
+        data = _make_card_action_data(
+            {"hermes_slash_confirm_action": "once", "confirm_id": "4"},
+            chat_id="oc_mismatch",
+            open_id="ou_bob",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response.card is None
+        mock_submit.assert_not_called()
+        assert "4" in adapter._slash_confirm_state
+
+
+# ===========================================================================
+# _resolve_slash_confirm — async resolution via tools.slash_confirm
+# ===========================================================================
+
+class TestResolveSlashConfirm:
+    """Test _resolve_slash_confirm pops state and calls tools.slash_confirm.resolve."""
+
+    @pytest.mark.asyncio
+    async def test_resolves_once(self):
+        adapter = _make_adapter()
+        adapter._slash_confirm_state["1"] = {
+            "session_key": "sess-1",
+            "confirm_id": "gw-1",
+            "message_id": "msg-1",
+            "chat_id": "oc_12345",
+        }
+
+        with patch("tools.slash_confirm.resolve", new_callable=AsyncMock, return_value="ok") as mock_resolve:
+            await adapter._resolve_slash_confirm("1", "once", "Bob", open_id="ou_bob", chat_id="oc_12345")
+
+        mock_resolve.assert_called_once_with("sess-1", "gw-1", "once")
+        assert "1" not in adapter._slash_confirm_state
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_click_does_not_resolve(self):
+        adapter = _make_adapter()
+        adapter._admins = {"ou_admin"}
+        adapter._slash_confirm_state["5"] = {
+            "session_key": "sess-5",
+            "confirm_id": "gw-5",
+            "message_id": "msg-5",
+            "chat_id": "oc_12345",
+        }
+
+        with patch("tools.slash_confirm.resolve", new_callable=AsyncMock) as mock_resolve:
+            await adapter._resolve_slash_confirm("5", "once", "Mallory", open_id="ou_intruder", chat_id="oc_12345")
+
+        mock_resolve.assert_not_called()
+        assert "5" in adapter._slash_confirm_state

--- a/tests/gateway/test_feishu_slash_confirm.py
+++ b/tests/gateway/test_feishu_slash_confirm.py
@@ -3,6 +3,7 @@
 import importlib.util
 import json
 import sys
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -52,6 +53,19 @@ def _make_adapter() -> FeishuAdapter:
     adapter = FeishuAdapter(config)
     adapter._client = MagicMock()
     return adapter
+
+
+def _make_state(**overrides) -> dict:
+    """Build a fresh (non-expired) slash-confirm state entry."""
+    state = {
+        "session_key": "sess-1",
+        "confirm_id": "gw-1",
+        "message_id": "msg-1",
+        "chat_id": "oc_12345",
+        "created_at": time.time(),
+    }
+    state.update(overrides)
+    return state
 
 
 def _make_card_action_data(
@@ -139,6 +153,8 @@ class TestFeishuSendSlashConfirm:
         assert len(actions) == 3
         choices = [a["value"]["hermes_slash_confirm_action"] for a in actions]
         assert choices == ["once", "always", "cancel"]
+        # The button value carries the prompt id under an unambiguous key.
+        assert all(a["value"]["prompt_id"] for a in actions)
 
     @pytest.mark.asyncio
     async def test_stores_confirm_state(self):
@@ -167,6 +183,7 @@ class TestFeishuSendSlashConfirm:
         assert state["confirm_id"] == "gw-7"
         assert state["message_id"] == "msg_sc_002"
         assert state["chat_id"] == "oc_12345"
+        assert "created_at" in state
 
 
 # ===========================================================================
@@ -181,15 +198,10 @@ class TestHandleSlashConfirmCardAction:
         adapter._loop = MagicMock()
         adapter._loop.is_closed = MagicMock(return_value=False)
         adapter._allowed_group_users = {"ou_bob"}
-        adapter._slash_confirm_state["1"] = {
-            "session_key": "sess-1",
-            "confirm_id": "gw-1",
-            "message_id": "msg-1",
-            "chat_id": "oc_12345",
-        }
+        adapter._slash_confirm_state["1"] = _make_state()
         adapter._sender_name_cache["ou_bob"] = ("Bob", 9999999999)
         data = _make_card_action_data(
-            {"hermes_slash_confirm_action": "once", "confirm_id": "1"},
+            {"hermes_slash_confirm_action": "once", "prompt_id": "1"},
             open_id="ou_bob",
         )
 
@@ -208,15 +220,10 @@ class TestHandleSlashConfirmCardAction:
         adapter._loop = MagicMock()
         adapter._loop.is_closed = MagicMock(return_value=False)
         adapter._allowed_group_users = {"ou_bob"}
-        adapter._slash_confirm_state["2"] = {
-            "session_key": "sess-2",
-            "confirm_id": "gw-2",
-            "message_id": "msg-2",
-            "chat_id": "oc_12345",
-        }
+        adapter._slash_confirm_state["2"] = _make_state()
         adapter._sender_name_cache["ou_bob"] = ("Bob", 9999999999)
         data = _make_card_action_data(
-            {"hermes_slash_confirm_action": "cancel", "confirm_id": "2"},
+            {"hermes_slash_confirm_action": "cancel", "prompt_id": "2"},
             open_id="ou_bob",
         )
 
@@ -232,14 +239,9 @@ class TestHandleSlashConfirmCardAction:
         adapter._loop = MagicMock()
         adapter._loop.is_closed = MagicMock(return_value=False)
         adapter._allowed_group_users = {"ou_allowed"}
-        adapter._slash_confirm_state["3"] = {
-            "session_key": "sess-3",
-            "confirm_id": "gw-3",
-            "message_id": "msg-3",
-            "chat_id": "oc_12345",
-        }
+        adapter._slash_confirm_state["3"] = _make_state()
         data = _make_card_action_data(
-            {"hermes_slash_confirm_action": "once", "confirm_id": "3"},
+            {"hermes_slash_confirm_action": "once", "prompt_id": "3"},
             open_id="ou_attacker",
         )
 
@@ -255,14 +257,9 @@ class TestHandleSlashConfirmCardAction:
         adapter._loop = MagicMock()
         adapter._loop.is_closed = MagicMock(return_value=False)
         adapter._allowed_group_users = {"ou_bob"}
-        adapter._slash_confirm_state["4"] = {
-            "session_key": "sess-4",
-            "confirm_id": "gw-4",
-            "message_id": "msg-4",
-            "chat_id": "oc_expected",
-        }
+        adapter._slash_confirm_state["4"] = _make_state(chat_id="oc_expected")
         data = _make_card_action_data(
-            {"hermes_slash_confirm_action": "once", "confirm_id": "4"},
+            {"hermes_slash_confirm_action": "once", "prompt_id": "4"},
             chat_id="oc_mismatch",
             open_id="ou_bob",
         )
@@ -273,6 +270,24 @@ class TestHandleSlashConfirmCardAction:
         assert response.card is None
         mock_submit.assert_not_called()
         assert "4" in adapter._slash_confirm_state
+
+    def test_expired_confirm_is_dropped(self):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_bob"}
+        adapter._slash_confirm_state["9"] = _make_state(created_at=time.time() - 1000)
+        data = _make_card_action_data(
+            {"hermes_slash_confirm_action": "once", "prompt_id": "9"},
+            open_id="ou_bob",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response.card is None
+        mock_submit.assert_not_called()
+        assert "9" not in adapter._slash_confirm_state
 
 
 # ===========================================================================
@@ -285,12 +300,8 @@ class TestResolveSlashConfirm:
     @pytest.mark.asyncio
     async def test_resolves_once(self):
         adapter = _make_adapter()
-        adapter._slash_confirm_state["1"] = {
-            "session_key": "sess-1",
-            "confirm_id": "gw-1",
-            "message_id": "msg-1",
-            "chat_id": "oc_12345",
-        }
+        adapter._admins = {"ou_bob"}
+        adapter._slash_confirm_state["1"] = _make_state()
 
         with patch("tools.slash_confirm.resolve", new_callable=AsyncMock, return_value="ok") as mock_resolve:
             await adapter._resolve_slash_confirm("1", "once", "Bob", open_id="ou_bob", chat_id="oc_12345")
@@ -302,15 +313,39 @@ class TestResolveSlashConfirm:
     async def test_unauthorized_click_does_not_resolve(self):
         adapter = _make_adapter()
         adapter._admins = {"ou_admin"}
-        adapter._slash_confirm_state["5"] = {
-            "session_key": "sess-5",
-            "confirm_id": "gw-5",
-            "message_id": "msg-5",
-            "chat_id": "oc_12345",
-        }
+        adapter._slash_confirm_state["5"] = _make_state()
 
         with patch("tools.slash_confirm.resolve", new_callable=AsyncMock) as mock_resolve:
             await adapter._resolve_slash_confirm("5", "once", "Mallory", open_id="ou_intruder", chat_id="oc_12345")
 
         mock_resolve.assert_not_called()
-        assert "5" in adapter._slash_confirm_state
+        # State is claimed atomically at coroutine entry, so the unauthorized
+        # click still consumes it even though the resolver refuses to run.
+        assert "5" not in adapter._slash_confirm_state
+
+    @pytest.mark.asyncio
+    async def test_double_resolve_runs_once(self):
+        adapter = _make_adapter()
+        adapter._admins = {"ou_bob"}
+        adapter._slash_confirm_state["1"] = _make_state()
+
+        with patch("tools.slash_confirm.resolve", new_callable=AsyncMock, return_value="ok") as mock_resolve:
+            await adapter._resolve_slash_confirm("1", "once", "Bob", open_id="ou_bob", chat_id="oc_12345")
+            await adapter._resolve_slash_confirm("1", "once", "Bob", open_id="ou_bob", chat_id="oc_12345")
+
+        mock_resolve.assert_called_once_with("sess-1", "gw-1", "once")
+
+    @pytest.mark.asyncio
+    async def test_resolve_none_sends_expiry_notice(self):
+        adapter = _make_adapter()
+        adapter._admins = {"ou_bob"}
+        adapter._slash_confirm_state["6"] = _make_state()
+
+        with patch("tools.slash_confirm.resolve", new_callable=AsyncMock, return_value=None) as mock_resolve, \
+             patch.object(adapter, "send", new_callable=AsyncMock) as mock_send:
+            await adapter._resolve_slash_confirm("6", "once", "Bob", open_id="ou_bob", chat_id="oc_12345")
+
+        mock_resolve.assert_called_once()
+        mock_send.assert_awaited_once()
+        notice = mock_send.call_args[0][1]
+        assert "expired" in notice


### PR DESCRIPTION
## Summary

`FeishuAdapter` lacked `send_slash_confirm`, so destructive slash commands (`/clear`, `/new`, `/reset`, `/undo`) and `/reload-mcp` fell back to a plain-text prompt requiring the user to type `/approve` / `/always` / `/cancel`.

This adds the same three-button interactive card that Discord, Slack and Telegram already ship:

- `send_slash_confirm()` renders an interactive card with **Approve Once / Always Approve / Cancel** buttons carrying `hermes_slash_confirm_action`.
- `_handle_slash_confirm_card_action()` validates the operator and chat, schedules resolution, and returns the resolved card inline.
- `_resolve_slash_confirm()` pops state and runs the pending handler via `tools.slash_confirm.resolve()`.

Includes tests mirroring the existing Feishu approval-button suite.

## Test plan

- `pytest tests/gateway/test_feishu_slash_confirm.py tests/gateway/test_feishu_approval_buttons.py` — 21 passed.

## Notes

Authorisation checks (operator + chat mismatch) and stale/expired handling follow the existing `send_exec_approval` / `send_update_prompt` card-action paths.