### PR TITLE
fix(cron): require persisted terminal result before completion

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -36,6 +36,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 import httpx
+from agent.transports.types import map_finish_reason
 
 logger = logging.getLogger(__name__)
 
@@ -914,7 +915,7 @@ def convert_messages_to_converse(
 # Response format conversion: Bedrock Converse → OpenAI
 # ---------------------------------------------------------------------------
 
-def _converse_stop_reason_to_openai(stop_reason: str) -> str:
+def _converse_stop_reason_to_openai(stop_reason: str | None) -> str | None:
     """Map Bedrock Converse stop reasons to OpenAI finish_reason values."""
     mapping = {
         "end_turn": "stop",
@@ -924,7 +925,7 @@ def _converse_stop_reason_to_openai(stop_reason: str) -> str:
         "content_filtered": "content_filter",
         "guardrail_intervened": "content_filter",
     }
-    return mapping.get(stop_reason, "stop")
+    return map_finish_reason(stop_reason, mapping)
 
 
 def normalize_converse_response(response: Dict) -> SimpleNamespace:
@@ -942,7 +943,9 @@ def normalize_converse_response(response: Dict) -> SimpleNamespace:
     output = response.get("output", {})
     message = output.get("message", {})
     content_blocks = message.get("content", [])
-    stop_reason = response.get("stopReason", "end_turn")
+    # Bedrock normally supplies stopReason, but an absent field is not proof of
+    # a terminal turn. Preserve it so durable consumers can fail closed.
+    stop_reason = response.get("stopReason")
 
     text_parts = []
     reasoning_parts = []
@@ -1074,7 +1077,8 @@ def stream_converse_with_callbacks(
     current_tool: Optional[Dict] = None
     current_text_buffer: List[str] = []
     has_tool_use = False
-    stop_reason = "end_turn"
+    # A stream that closes without messageStop has no terminal proof.
+    stop_reason = None
     usage_data: Dict[str, int] = {}
 
     for event in event_stream.get("stream", []):
@@ -1149,7 +1153,7 @@ def stream_converse_with_callbacks(
                 current_text_buffer = []
 
         elif "messageStop" in event:
-            stop_reason = event["messageStop"].get("stopReason", "end_turn")
+            stop_reason = event["messageStop"].get("stopReason")
 
         elif "metadata" in event:
             meta_usage = event["metadata"].get("usage", {})

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3994,7 +3994,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             "reasoning_content": "".join(reasoning_parts) or None,
                             "tool_calls": tool_calls or None,
                         },
-                        "finish_reason": finish_reason or "stop",
+                        # A stream without a terminal reason is not proof of
+                        # normal completion. Preserve the missing value for
+                        # durable consumers such as cron settlement.
+                        "finish_reason": finish_reason,
                     }
                 ],
                 "usage": usage_obj,
@@ -4354,8 +4357,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     # arguments never received a single byte (name arrived,
                     # argument generation never started before the connection
                     # died). Left unflagged, this fell through to
-                    # `effective_finish_reason = finish_reason or "stop"`
-                    # below — a normal "stop" turn carrying a tool call whose
+                    # the explicit ``length`` marker below — a normal
+                    # ``stop`` turn carrying a tool call whose
                     # empty arguments string later gets silently coerced to
                     # "{}" at the dispatch boundary and executed with no
                     # arguments and no retry (#80498). Route it through the
@@ -4446,7 +4449,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 model_name, usage_obj,
             )
 
-        effective_finish_reason = finish_reason or "stop"
+        # Keep an absent stream terminator absent. The partial-tool-call
+        # branch below upgrades only the specifically detected truncation
+        # shape to ``length``; it must not turn every clean-but-unreasoned
+        # stream close into a false terminal ``stop``.
+        effective_finish_reason = finish_reason
         if has_truncated_tool_args:
             effective_finish_reason = "length"
 

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -7,7 +7,10 @@ This transport owns format conversion and normalization — NOT client lifecycle
 from typing import Any, Dict, List, Optional
 
 from agent.transports.base import ProviderTransport
-from agent.transports.types import NormalizedResponse
+from agent.transports.types import (
+    NormalizedResponse,
+    map_finish_reason as _map_finish_reason,
+)
 
 
 class AnthropicTransport(ProviderTransport):
@@ -159,7 +162,9 @@ class AnthropicTransport(ProviderTransport):
                     )
                 )
 
-        finish_reason = self._STOP_REASON_MAP.get(response.stop_reason, "stop")
+        finish_reason = _map_finish_reason(
+            getattr(response, "stop_reason", None), self._STOP_REASON_MAP
+        )
 
         provider_data = {}
         if reasoning_details:
@@ -240,9 +245,9 @@ class AnthropicTransport(ProviderTransport):
         "model_context_window_exceeded": "length",
     }
 
-    def map_finish_reason(self, raw_reason: str) -> str:
+    def map_finish_reason(self, raw_reason: str | None) -> str | None:
         """Map Anthropic stop_reason to OpenAI finish_reason."""
-        return self._STOP_REASON_MAP.get(raw_reason, "stop")
+        return _map_finish_reason(raw_reason, self._STOP_REASON_MAP)
 
 
 # Auto-register on import

--- a/agent/transports/base.py
+++ b/agent/transports/base.py
@@ -80,7 +80,7 @@ class ProviderTransport(ABC):
         """
         return None
 
-    def map_finish_reason(self, raw_reason: str) -> str:
+    def map_finish_reason(self, raw_reason: str | None) -> str | None:
         """Optional: map provider-specific stop reason to OpenAI equivalent.
 
         Default returns the raw reason unchanged.  Override for providers

--- a/agent/transports/bedrock.py
+++ b/agent/transports/bedrock.py
@@ -9,7 +9,12 @@ boto3 calls stay on AIAgent.
 from typing import Any, Dict, List, Optional
 
 from agent.transports.base import ProviderTransport
-from agent.transports.types import NormalizedResponse, ToolCall, Usage
+from agent.transports.types import (
+    NormalizedResponse,
+    ToolCall,
+    Usage,
+    map_finish_reason as _map_finish_reason,
+)
 
 
 class BedrockTransport(ProviderTransport):
@@ -83,7 +88,7 @@ class BedrockTransport(ProviderTransport):
 
         choice = ns.choices[0]
         msg = choice.message
-        finish_reason = choice.finish_reason or "stop"
+        finish_reason = getattr(choice, "finish_reason", None)
 
         tool_calls = None
         if msg.tool_calls:
@@ -131,7 +136,7 @@ class BedrockTransport(ProviderTransport):
             return bool(response.choices)
         return False
 
-    def map_finish_reason(self, raw_reason: str) -> str:
+    def map_finish_reason(self, raw_reason: str | None) -> str | None:
         """Map Bedrock stop reason to OpenAI finish_reason.
 
         The adapter already does this mapping inside normalize_converse_response,
@@ -145,7 +150,7 @@ class BedrockTransport(ProviderTransport):
             "guardrail_intervened": "content_filter",
             "content_filtered": "content_filter",
         }
-        return _MAP.get(raw_reason, "stop")
+        return _map_finish_reason(raw_reason, _MAP)
 
 
 # Auto-register on import

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -891,7 +891,10 @@ class ChatCompletionsTransport(ProviderTransport):
         _fr = getattr(choice, "finish_reason", None)
         if isinstance(_fr, int):
             _fr = str(_fr)
-        finish_reason = _fr or "stop"
+        # A missing provider finish_reason is uncertainty, not proof of a
+        # normal terminal response. Preserve it for durable consumers such as
+        # cron settlement; known provider values remain unchanged here.
+        finish_reason = _fr
 
         tool_calls = None
         message_tool_calls = getattr(msg, "tool_calls", None)

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -35,7 +35,11 @@ from agent.reasoning_effort import (
     codex_supported_efforts,
 )
 from agent.transports.base import ProviderTransport
-from agent.transports.types import NormalizedResponse, ToolCall
+from agent.transports.types import (
+    NormalizedResponse,
+    ToolCall,
+    map_finish_reason as _map_finish_reason,
+)
 
 
 def _bounded_prompt_cache_key(value: Any) -> Optional[str]:
@@ -891,7 +895,7 @@ class ResponsesApiTransport(ProviderTransport):
                 extra_body.pop("prompt_cache_key", None)
         return normalized
 
-    def map_finish_reason(self, raw_reason: str) -> str:
+    def map_finish_reason(self, raw_reason: str | None) -> str | None:
         """Map Codex response.status to OpenAI finish_reason.
 
         Codex uses response.status ('completed', 'incomplete') +
@@ -905,7 +909,7 @@ class ResponsesApiTransport(ProviderTransport):
             "failed": "stop",
             "cancelled": "stop",
         }
-        return _MAP.get(raw_reason, "stop")
+        return _map_finish_reason(raw_reason, _MAP)
 
 
 # Auto-register on import

--- a/agent/transports/types.py
+++ b/agent/transports/types.py
@@ -109,7 +109,10 @@ class NormalizedResponse:
 
     content: str | None
     tool_calls: list[ToolCall] | None
-    finish_reason: str  # "stop", "tool_calls", "length", "content_filter"
+    # Known provider reasons are normalized to the shared vocabulary. Unknown
+    # reasons are preserved verbatim and an absent reason stays None so a
+    # downstream durability check cannot mistake uncertainty for "stop".
+    finish_reason: str | None  # "stop", "tool_calls", "length", "content_filter"
     reasoning: str | None = None
     usage: Usage | None = None
     provider_data: dict[str, Any] | None = field(default=None, repr=False)
@@ -170,14 +173,18 @@ def build_tool_call(
     return ToolCall(id=id, name=name, arguments=args_str, provider_data=pd)
 
 
-def map_finish_reason(reason: str | None, mapping: dict[str, str]) -> str:
+def map_finish_reason(reason: str | None, mapping: dict[str, str]) -> str | None:
     """Translate a provider-specific stop reason to the normalised set.
 
-    Falls back to ``"stop"`` for unknown or ``None`` reasons.
+    Preserve unknown provider values and missing reasons.  Falling back to
+    ``"stop"`` would convert an unverified provider response into positive
+    terminal proof for consumers such as cron settlement.
     """
     if reason is None:
-        return "stop"
-    return mapping.get(reason, "stop")
+        return None
+    if not isinstance(reason, str):
+        reason = str(reason)
+    return mapping.get(reason, reason)
 
 
 def is_normalized_terminal_finish_reason(reason: str | None) -> bool:

--- a/agent/transports/types.py
+++ b/agent/transports/types.py
@@ -15,6 +15,12 @@ from dataclasses import dataclass, field
 from typing import Any
 
 
+# Only this normalized reason proves that a provider response reached a
+# terminal assistant answer. ``length``/``incomplete`` are continuation or
+# partial states; tool-call reasons still require another model turn.
+NORMALIZED_TERMINAL_FINISH_REASONS = frozenset({"stop"})
+
+
 @dataclass
 class ToolCall:
     """A normalized tool call from any provider.
@@ -172,3 +178,11 @@ def map_finish_reason(reason: str | None, mapping: dict[str, str]) -> str:
     if reason is None:
         return "stop"
     return mapping.get(reason, "stop")
+
+
+def is_normalized_terminal_finish_reason(reason: str | None) -> bool:
+    """Return whether *reason* positively proves a terminal model answer."""
+    return (
+        isinstance(reason, str)
+        and reason.strip().lower() in NORMALIZED_TERMINAL_FINISH_REASONS
+    )

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -347,9 +347,22 @@ def finalize_turn(
             if _tail_role != "assistant":
                 # Tail is not an assistant row — append the final response
                 # so the durable turn closes with the answer (#43849/#44100).
+                # Recovery-generated rows must carry an explicit normalized
+                # reason: cron settlement rejects absent/unknown reasons. A
+                # partial-stream recovery is still non-terminal even when it
+                # has visible recovered text, so preserve that outcome.
+                _persisted_finish_reason = (
+                    "incomplete"
+                    if str(_turn_exit_reason) == "partial_stream_recovery"
+                    else "stop"
+                )
                 append_message(
                     messages,
-                    {"role": "assistant", "content": final_response},
+                    {
+                        "role": "assistant",
+                        "content": final_response,
+                        "finish_reason": _persisted_finish_reason,
+                    },
                 )
             elif isinstance(_tail, dict) and _tail.get("content") != final_response and _is_pure_tool_call_tail(_tail):
                 # The tail IS an assistant row, but a *pure tool-call turn*:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -56,6 +56,7 @@ from hermes_cli.config import (
 from hermes_cli.fallback_config import get_fallback_chain
 from hermes_time import now as _hermes_now
 from agent.interrupt_compat import request_hard_interrupt
+from agent.transports.types import is_normalized_terminal_finish_reason
 from agent.delegation_context import (
     enter_non_dispatcher_owned_context,
     exit_non_dispatcher_owned_context,
@@ -587,15 +588,6 @@ _CRON_SETTLEMENT_COMPLETE = "complete"
 _CRON_SETTLEMENT_SILENT = "silent"
 _CRON_SETTLEMENT_INCOMPLETE = "incomplete"
 _CRON_SETTLEMENT_UNVERIFIED = "unverified"
-_CRON_NON_TERMINAL_FINISH_REASONS = frozenset({
-    "error",
-    "agent_error",
-    "content_filter",
-    "incomplete",
-    "tool_calls",
-    "verification_required",
-    "verify_hook_continue",
-})
 
 
 def _classify_persisted_cron_final_message(message: Optional[dict]) -> str:
@@ -609,8 +601,6 @@ def _classify_persisted_cron_final_message(message: Optional[dict]) -> str:
         return _CRON_SETTLEMENT_INCOMPLETE
     if message.get("tool_calls"):
         return _CRON_SETTLEMENT_INCOMPLETE
-    if str(message.get("finish_reason") or "").strip().lower() in _CRON_NON_TERMINAL_FINISH_REASONS:
-        return _CRON_SETTLEMENT_INCOMPLETE
 
     content = message.get("content")
     try:
@@ -623,6 +613,8 @@ def _classify_persisted_cron_final_message(message: Optional[dict]) -> str:
         return _CRON_SETTLEMENT_INCOMPLETE
     if text == SILENT_MARKER:
         return _CRON_SETTLEMENT_SILENT
+    if not is_normalized_terminal_finish_reason(message.get("finish_reason")):
+        return _CRON_SETTLEMENT_INCOMPLETE
     return _CRON_SETTLEMENT_COMPLETE
 
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -613,6 +613,8 @@ def _classify_persisted_cron_final_message(message: Optional[dict]) -> str:
         return _CRON_SETTLEMENT_INCOMPLETE
     if text == SILENT_MARKER:
         return _CRON_SETTLEMENT_SILENT
+    # Do not turn a denylist into a success predicate: a missing or new
+    # provider reason is not proof that this assistant answer is terminal.
     if not is_normalized_terminal_finish_reason(message.get("finish_reason")):
         return _CRON_SETTLEMENT_INCOMPLETE
     return _CRON_SETTLEMENT_COMPLETE

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -166,7 +166,8 @@ def _failure_streak_nudge(job: dict) -> str:
     Threshold config: ``cron.failure_nudge_threshold`` (default 3, ``0``
     disables the nudge). One-shot jobs never nudge — they don't recur.
     """
-    schedule_kind = (job.get("schedule") or {}).get("kind")
+    schedule = job.get("schedule")
+    schedule_kind = schedule.get("kind") if isinstance(schedule, dict) else None
     if schedule_kind not in {"cron", "interval"}:
         return ""
     try:
@@ -580,6 +581,85 @@ def _is_cron_silence_response(text: str) -> bool:
     from gateway.response_filters import is_autonomous_silence_response
 
     return is_autonomous_silence_response(text)
+
+
+_CRON_SETTLEMENT_COMPLETE = "complete"
+_CRON_SETTLEMENT_SILENT = "silent"
+_CRON_SETTLEMENT_INCOMPLETE = "incomplete"
+_CRON_SETTLEMENT_UNVERIFIED = "unverified"
+_CRON_NON_TERMINAL_FINISH_REASONS = frozenset({
+    "error",
+    "agent_error",
+    "content_filter",
+    "incomplete",
+    "tool_calls",
+    "verification_required",
+    "verify_hook_continue",
+})
+
+
+def _classify_persisted_cron_final_message(message: Optional[dict]) -> str:
+    """Classify the exact persisted tail of an agent-backed cron turn.
+
+    This is deliberately stricter than ``session_lifecycle_statuses``. That
+    picker helper is allowed to fail open for unknown message shapes; cron
+    booking needs positive evidence that the user-visible result was durable.
+    """
+    if not isinstance(message, dict) or message.get("role") != "assistant":
+        return _CRON_SETTLEMENT_INCOMPLETE
+    if message.get("tool_calls"):
+        return _CRON_SETTLEMENT_INCOMPLETE
+    if str(message.get("finish_reason") or "").strip().lower() in _CRON_NON_TERMINAL_FINISH_REASONS:
+        return _CRON_SETTLEMENT_INCOMPLETE
+
+    content = message.get("content")
+    try:
+        from agent.message_content import flatten_message_text
+
+        text = flatten_message_text(content).strip()
+    except Exception:
+        text = content.strip() if isinstance(content, str) else ""
+    if not text:
+        return _CRON_SETTLEMENT_INCOMPLETE
+    if text == SILENT_MARKER:
+        return _CRON_SETTLEMENT_SILENT
+    return _CRON_SETTLEMENT_COMPLETE
+
+
+def _verify_persisted_cron_final_message(session_db, session_id: str) -> str:
+    """Return a settlement status from one exact session's persisted tail.
+
+    ``get_messages(... latest=True, limit=1)`` performs a bounded tail read;
+    it does not scan or infer from the in-memory agent result. Any malformed
+    result is a verification failure and is raised so the caller can record
+    ``unverified`` rather than booking a false success.
+    """
+    messages = session_db.get_messages(session_id, latest=True, limit=1)
+    if not isinstance(messages, list):
+        raise TypeError("SessionDB.get_messages returned a non-list result")
+    return _classify_persisted_cron_final_message(messages[0] if messages else None)
+
+
+def _publish_cron_settlement(
+    settlement: Optional[dict],
+    *,
+    session_id: str,
+    status: str,
+    end_reason: str,
+    error: Optional[str] = None,
+) -> None:
+    """Publish the one-fire settlement to the caller before delivery."""
+    if not isinstance(settlement, dict):
+        return
+    settlement.clear()
+    settlement.update(
+        session_id=session_id,
+        status=status,
+        end_reason=end_reason,
+    )
+    if error:
+        settlement["error"] = error
+
 
 # ---------------------------------------------------------------------------
 # Persistent thread pool for parallel cron jobs.
@@ -5066,6 +5146,7 @@ def run_job(
     defer_agent_teardown: Optional[list] = None,
     extra_prompt: Optional[str] = None,
     cancel_event: Optional[_CancelEventLike] = None,
+    settlement: Optional[dict] = None,
 ) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
@@ -5083,6 +5164,10 @@ def run_job(
     ``extra_prompt``: optional per-run context from ``cronjob(action='run',
     prompt=...)`` (#57331). Appended to the stored prompt for this fire only —
     never persisted to the job definition.
+
+    ``settlement``: optional per-fire holder populated after the exact cron
+    session tail has been verified. ``run_one_job`` consumes it before saving
+    delivery state, so lifecycle completion cannot outrun durable output.
 
     Returns:
         Tuple of (success, full_output_doc, final_response, error_message)
@@ -5311,6 +5396,8 @@ def run_job(
     # the whole gateway process is restarted, silently skipping every
     # scheduled fire in between with "already running — skipping".
     _session_db = None
+    _cron_session_id: Optional[str] = None
+    _cron_run_failed = False
     try:
         from hermes_state import SessionDB
 
@@ -5428,6 +5515,17 @@ def run_job(
         logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
         return True, "", SILENT_MARKER, None
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
+    if _session_db is None:
+        _publish_cron_settlement(
+            settlement,
+            session_id=_cron_session_id,
+            status=_CRON_SETTLEMENT_UNVERIFIED,
+            end_reason="cron_unverified",
+            error=(
+                f"Cron job '{job_id}' has no available session store; its "
+                "final assistant result cannot be verified as persisted."
+            ),
+        )
 
     logger.info("Running job '%s' (ID: %s)", job_name, job_id)
     logger.info("Prompt: %s", prompt[:100])
@@ -6356,6 +6454,7 @@ def run_job(
         return True, output, final_response, None
 
     except Exception as e:
+        _cron_run_failed = True
         error_msg = f"{type(e).__name__}: {str(e)}"
         logger.exception("Job '%s' failed: %s", job_name, error_msg)
         # Best-effort audit write on failure path. _audit_fire_id
@@ -6423,7 +6522,12 @@ def run_job(
             exit_non_dispatcher_owned_context(_non_dispatcher_token)
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
-        if _session_db:
+        if _session_db and not _cron_session_id:
+            try:
+                _session_db.close()
+            except (Exception, KeyboardInterrupt) as e:
+                logger.debug("Job '%s': failed to close unused SQLite session store: %s", job_id, e)
+        if _session_db and _cron_session_id:
             # The agent turn has already returned. Bound every subsequent DB
             # operation so storage failure cannot hold the dispatch guard.
             _session_db = _BoundedCronSessionDB(_session_db, job_id)
@@ -6486,12 +6590,68 @@ def run_job(
                             break
                     except (Exception, KeyboardInterrupt):
                         continue
-            try:
-                _session_db.end_session(
-                    _final_cron_session_id, "cron_complete"
+            if _cron_run_failed:
+                _settlement_status = "failed"
+                _end_reason = "cron_failed"
+                _settlement_error = (
+                    f"Cron job '{job_id}' failed before terminal completion."
                 )
+            else:
+                try:
+                    _settlement_status = _verify_persisted_cron_final_message(
+                        _session_db, _final_cron_session_id
+                    )
+                    _end_reason = (
+                        "cron_complete"
+                        if _settlement_status
+                        in {_CRON_SETTLEMENT_COMPLETE, _CRON_SETTLEMENT_SILENT}
+                        else "cron_incomplete_no_output"
+                    )
+                    _settlement_error = (
+                        None
+                        if _end_reason == "cron_complete"
+                        else (
+                            f"Cron job '{job_id}' ended without a persisted final "
+                            "assistant message."
+                        )
+                    )
+                except (Exception, KeyboardInterrupt) as e:
+                    _settlement_status = _CRON_SETTLEMENT_UNVERIFIED
+                    _end_reason = "cron_unverified"
+                    _settlement_error = (
+                        f"Cron job '{job_id}' could not verify its persisted final "
+                        "assistant message."
+                    )
+                    logger.warning(
+                        "Job '%s': cron terminal settlement could not be verified: %s",
+                        job_id,
+                        e,
+                    )
+
+            _publish_cron_settlement(
+                settlement,
+                session_id=_final_cron_session_id,
+                status=_settlement_status,
+                end_reason=_end_reason,
+                error=_settlement_error,
+            )
+            try:
+                _session_db.end_session(_final_cron_session_id, _end_reason)
             except (Exception, KeyboardInterrupt) as e:
-                logger.debug("Job '%s': failed to end session: %s", job_id, e)
+                # The proof itself is not durable if the terminal session write
+                # cannot be committed. Reclassify the fire so run history does
+                # not report a green result while the session remains open.
+                _publish_cron_settlement(
+                    settlement,
+                    session_id=_final_cron_session_id,
+                    status=_CRON_SETTLEMENT_UNVERIFIED,
+                    end_reason="cron_unverified",
+                    error=(
+                        f"Cron job '{job_id}' could not persist its terminal "
+                        "session state."
+                    ),
+                )
+                logger.warning("Job '%s': failed to end session: %s", job_id, e)
             try:
                 _session_db.close()
             except (Exception, KeyboardInterrupt) as e:
@@ -6803,12 +6963,14 @@ def _run_one_job_body(
         # below once delivery is done. Defense-in-depth alongside the
         # interpreter-shutdown guard in _deliver_result.
         _deferred_agents: list = []
+        settlement: dict = {}
         try:
             if fire_claim_lost is None:
                 success, output, final_response, error = run_job(
                     job,
                     defer_agent_teardown=_deferred_agents,
                     extra_prompt=extra_prompt,
+                    settlement=settlement,
                 )
             else:
                 success, output, final_response, error = run_job(
@@ -6816,6 +6978,7 @@ def _run_one_job_body(
                     defer_agent_teardown=_deferred_agents,
                     extra_prompt=extra_prompt,
                     cancel_event=fire_claim_lost,
+                    settlement=settlement,
                 )
         except BaseException:
             # run_job's finally still hands back the agent when it raises; tear
@@ -6859,6 +7022,23 @@ def _run_one_job_body(
                     error="Fire claim ownership lost; stale result was discarded.",
                 )
             return True
+
+        # A run is not successful until the exact session fired above has a
+        # durable assistant tail (or the deliberate [SILENT] sentinel). This
+        # verdict is produced by run_job's finalization boundary and must be
+        # consumed before delivery/last_status/execution bookkeeping.
+        _settlement_status = settlement.get("status")
+        if success and _settlement_status not in {
+            None,
+            _CRON_SETTLEMENT_COMPLETE,
+            _CRON_SETTLEMENT_SILENT,
+        }:
+            success = False
+            final_response = ""
+            error = settlement.get("error") or (
+                f"Cron job '{job['id']}' did not produce a verified terminal "
+                "session result."
+            )
 
         # Everything from here through delivery runs with the agent still live
         # (deferred teardown). Wrap it ALL in a try/finally so that if any step

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -611,12 +611,12 @@ def _classify_persisted_cron_final_message(message: Optional[dict]) -> str:
         text = content.strip() if isinstance(content, str) else ""
     if not text:
         return _CRON_SETTLEMENT_INCOMPLETE
-    if text == SILENT_MARKER:
-        return _CRON_SETTLEMENT_SILENT
     # Do not turn a denylist into a success predicate: a missing or new
     # provider reason is not proof that this assistant answer is terminal.
     if not is_normalized_terminal_finish_reason(message.get("finish_reason")):
         return _CRON_SETTLEMENT_INCOMPLETE
+    if text == SILENT_MARKER:
+        return _CRON_SETTLEMENT_SILENT
     return _CRON_SETTLEMENT_COMPLETE
 
 

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -402,6 +402,22 @@ class TestNormalizeConverseStreamEvents:
         assert tc[0].function.name == "read_file"
         assert json.loads(tc[0].function.arguments) == {"path": "/tmp/f"}
 
+    def test_text_stream_without_message_stop_is_not_terminal(self):
+        from agent.bedrock_adapter import normalize_converse_stream_events
+
+        events = {"stream": [
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockStart": {"contentBlockIndex": 0, "start": {}}},
+            {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "partial"}}},
+            {"contentBlockStop": {"contentBlockIndex": 0}},
+            {"metadata": {"usage": {"inputTokens": 5, "outputTokens": 3}}},
+        ]}
+
+        result = normalize_converse_stream_events(events)
+
+        assert result.choices[0].message.content == "partial"
+        assert result.choices[0].finish_reason is None
+
 
 
 

--- a/tests/agent/test_turn_finalizer_final_response_persistence.py
+++ b/tests/agent/test_turn_finalizer_final_response_persistence.py
@@ -130,6 +130,36 @@ def test_final_response_closes_tool_tail_before_persistence(monkeypatch):
     assert agent.persisted_messages[-1] == result["messages"][-1]
 
 
+def test_partial_stream_recovery_persists_non_terminal_reason(monkeypatch):
+    """Recovered partial text must not become a durable successful answer."""
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+    messages = [
+        {"role": "user", "content": "do it"},
+        {"role": "tool", "tool_call_id": "call-1", "content": "ok"},
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response="partial answer",
+        api_call_count=2,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="do it",
+        original_user_message="do it",
+        _should_review_memory=False,
+        _turn_exit_reason="partial_stream_recovery",
+    )
+
+    assert result["messages"][-1]["finish_reason"] == "incomplete"
+    assert agent.persisted_messages is not None
+    assert agent.persisted_messages[-1]["finish_reason"] == "incomplete"
+
+
 def test_fallback_timestamp_survives_delayed_sqlite_persistence(
     monkeypatch, tmp_path
 ):

--- a/tests/agent/transports/test_bedrock_transport.py
+++ b/tests/agent/transports/test_bedrock_transport.py
@@ -83,6 +83,8 @@ class TestBedrockMapFinishReason:
 
     def test_end_turn(self, transport):
         assert transport.map_finish_reason("end_turn") == "stop"
+        assert transport.map_finish_reason("provider_new") == "provider_new"
+        assert transport.map_finish_reason(None) is None
 
 
 
@@ -122,6 +124,22 @@ class TestBedrockNormalize:
         assert nr.finish_reason == "tool_calls"
         assert len(nr.tool_calls) == 1
         assert nr.tool_calls[0].name == "terminal"
+
+    @pytest.mark.parametrize("stop_reason", [None, "provider_new"])
+    def test_normalize_preserves_unverified_stop_reason(self, transport, stop_reason):
+        raw = self._make_bedrock_response(stop_reason=stop_reason)
+        normalized = transport.normalize_response(raw)
+
+        assert normalized.content == "Hello"
+        assert normalized.finish_reason == stop_reason
+
+    def test_normalize_missing_stop_reason_stays_unverified(self, transport):
+        raw = self._make_bedrock_response()
+        raw.pop("stopReason")
+
+        normalized = transport.normalize_response(raw)
+
+        assert normalized.finish_reason is None
 
 
     def test_already_normalized_response(self, transport):

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -31,7 +31,23 @@ class TestChatCompletionsBasic:
 
         assert normalized.content is None
         assert normalized.tool_calls is None
-        assert normalized.finish_reason == "stop"
+        assert normalized.finish_reason is None
+
+    def test_normalize_response_preserves_unknown_finish_reason(self, transport):
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="partial", tool_calls=None),
+                    finish_reason="provider_new",
+                )
+            ],
+            usage=None,
+        )
+
+        normalized = transport.normalize_response(response)
+
+        assert normalized.content == "partial"
+        assert normalized.finish_reason == "provider_new"
 
     def test_normalize_response_allows_sparse_tool_call_fields(self, transport):
         response = SimpleNamespace(
@@ -65,7 +81,7 @@ class TestChatCompletionsBasic:
 
         normalized = transport.normalize_response(response)
 
-        assert normalized.finish_reason == "stop"
+        assert normalized.finish_reason is None
         assert normalized.tool_calls is not None
         assert [tool.id for tool in normalized.tool_calls] == [
             "call-3",

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -1025,6 +1025,10 @@ class TestCodexMapFinishReason:
     def test_completed(self, transport):
         assert transport.map_finish_reason("completed") == "stop"
 
+    def test_unknown_and_missing_reasons_are_preserved(self, transport):
+        assert transport.map_finish_reason("provider_new") == "provider_new"
+        assert transport.map_finish_reason(None) is None
+
 
 
 

--- a/tests/agent/transports/test_transport.py
+++ b/tests/agent/transports/test_transport.py
@@ -113,7 +113,8 @@ class TestAnthropicTransport:
         assert transport.map_finish_reason("stop_sequence") == "stop"
         assert transport.map_finish_reason("refusal") == "content_filter"
         assert transport.map_finish_reason("model_context_window_exceeded") == "length"
-        assert transport.map_finish_reason("unknown") == "stop"
+        assert transport.map_finish_reason("unknown") == "unknown"
+        assert transport.map_finish_reason(None) is None
 
 
 
@@ -131,6 +132,31 @@ class TestAnthropicTransport:
         assert nr.content == "Hello world"
         assert nr.tool_calls is None or nr.tool_calls == []
         assert nr.finish_reason == "stop"
+
+    @pytest.mark.parametrize("raw_reason", [None, "provider_new"])
+    def test_normalize_response_preserves_unverified_reason(self, transport, raw_reason):
+        response = SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="partial")],
+            stop_reason=raw_reason,
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+            model="claude-sonnet-4-6",
+        )
+
+        normalized = transport.normalize_response(response)
+
+        assert normalized.content == "partial"
+        assert normalized.finish_reason == raw_reason
+
+    def test_normalize_response_missing_reason_attribute_is_unverified(self, transport):
+        response = SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="partial")],
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+            model="claude-sonnet-4-6",
+        )
+
+        normalized = transport.normalize_response(response)
+
+        assert normalized.finish_reason is None
 
     def test_normalize_response_tool_calls(self, transport):
         """Test normalization of a tool-use response."""

--- a/tests/agent/transports/test_types.py
+++ b/tests/agent/transports/test_types.py
@@ -116,11 +116,11 @@ class TestMapFinishReason:
         assert map_finish_reason("max_tokens", self.ANTHROPIC_MAP) == "length"
         assert map_finish_reason("refusal", self.ANTHROPIC_MAP) == "content_filter"
 
-    def test_unknown_reason_defaults_to_stop(self):
-        assert map_finish_reason("something_new", self.ANTHROPIC_MAP) == "stop"
+    def test_unknown_reason_is_preserved(self):
+        assert map_finish_reason("something_new", self.ANTHROPIC_MAP) == "something_new"
 
     def test_none_reason(self):
-        assert map_finish_reason(None, self.ANTHROPIC_MAP) == "stop"
+        assert map_finish_reason(None, self.ANTHROPIC_MAP) is None
 
 
 class TestNormalizedTerminalFinishReason:

--- a/tests/agent/transports/test_types.py
+++ b/tests/agent/transports/test_types.py
@@ -7,6 +7,7 @@ from agent.transports.types import (
     ToolCall,
     Usage,
     build_tool_call,
+    is_normalized_terminal_finish_reason,
     map_finish_reason,
 )
 
@@ -120,6 +121,14 @@ class TestMapFinishReason:
 
     def test_none_reason(self):
         assert map_finish_reason(None, self.ANTHROPIC_MAP) == "stop"
+
+
+class TestNormalizedTerminalFinishReason:
+    def test_only_normalized_stop_is_terminal(self):
+        assert is_normalized_terminal_finish_reason("stop") is True
+        assert is_normalized_terminal_finish_reason(" length ") is False
+        assert is_normalized_terminal_finish_reason("provider_new") is False
+        assert is_normalized_terminal_finish_reason(None) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cron/test_cron_drift_alert_once.py
+++ b/tests/cron/test_cron_drift_alert_once.py
@@ -47,6 +47,9 @@ def _job(**overrides):
 def _tick(job, tmp_path, current_provider, deliveries):
     """Run one run_one_job tick with the provider resolution pinned."""
     fake_db = MagicMock()
+    fake_db.get_messages.return_value = [
+        {"role": "assistant", "content": "ok", "finish_reason": "stop"}
+    ]
 
     def fake_deliver(job, content, adapters=None, loop=None):
         deliveries.append(content)

--- a/tests/cron/test_cron_settlement.py
+++ b/tests/cron/test_cron_settlement.py
@@ -1,0 +1,282 @@
+"""Durable settlement proof for agent-backed cron runs."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ({"role": "assistant", "content": "done", "finish_reason": "stop"}, "complete"),
+        ({"role": "assistant", "content": "[SILENT]", "finish_reason": "stop"}, "silent"),
+        ({"role": "assistant", "content": "", "finish_reason": "stop"}, "incomplete"),
+        ({"role": "assistant", "content": None, "tool_calls": [{"id": "c1"}]}, "incomplete"),
+        ({"role": "assistant", "content": "partial", "finish_reason": "incomplete"}, "incomplete"),
+        ({"role": "tool", "content": "ok"}, "incomplete"),
+        ({"role": "user", "content": "run it"}, "incomplete"),
+        (None, "incomplete"),
+    ],
+)
+def test_cron_terminal_message_requires_persisted_assistant_text(message, expected):
+    from cron.scheduler import _classify_persisted_cron_final_message
+
+    assert _classify_persisted_cron_final_message(message) == expected
+
+
+def test_real_sessiondb_verification_reads_only_the_persisted_tail(tmp_path):
+    from cron.scheduler import _verify_persisted_cron_final_message
+
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        db.create_session("cron-tool-tail", source="cron")
+        db.append_message("cron-tool-tail", "user", "run it")
+        db.append_message(
+            "cron-tool-tail",
+            "assistant",
+            None,
+            tool_calls=[{"id": "c1", "function": {"name": "terminal", "arguments": "{}"}}],
+            finish_reason="tool_calls",
+        )
+        db.append_message("cron-tool-tail", "tool", "ok", tool_call_id="c1")
+
+        db.create_session("cron-complete", source="cron")
+        db.append_message("cron-complete", "user", "run it")
+        db.append_message("cron-complete", "assistant", "done", finish_reason="stop")
+
+        db.create_session("cron-silent", source="cron")
+        db.append_message("cron-silent", "user", "check it")
+        db.append_message("cron-silent", "assistant", "[SILENT]", finish_reason="stop")
+
+        assert _verify_persisted_cron_final_message(db, "cron-tool-tail") == "incomplete"
+        assert _verify_persisted_cron_final_message(db, "cron-complete") == "complete"
+        assert _verify_persisted_cron_final_message(db, "cron-silent") == "silent"
+    finally:
+        db.close()
+
+
+def test_run_one_job_consumes_incomplete_settlement_before_delivery(monkeypatch):
+    import cron.scheduler as scheduler
+
+    events: list[tuple[str, object]] = []
+
+    def fake_run_job(job, *, settlement=None, **_kwargs):
+        assert settlement is not None
+        settlement.update(
+            {
+                "session_id": "cron-exact-fire",
+                "status": "incomplete",
+                "end_reason": "cron_incomplete_no_output",
+                "error": "Cron run ended without a persisted final assistant message.",
+            }
+        )
+        return True, "normal output", "visible answer", None
+
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(
+        scheduler,
+        "mark_execution_running",
+        lambda execution_id: events.append(("running", execution_id)),
+    )
+    monkeypatch.setattr(scheduler, "run_job", fake_run_job)
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_args: None)
+    monkeypatch.setattr(scheduler, "_deliver_result", lambda *_args, **_kwargs: events.append(("delivery", _args[1])))
+    monkeypatch.setattr(
+        scheduler,
+        "mark_job_run",
+        lambda *args, **kwargs: events.append(("mark", (args, kwargs))),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "finish_execution",
+        lambda execution_id, **kwargs: events.append(("finish", (execution_id, kwargs))),
+    )
+
+    assert scheduler.run_one_job({"id": "job-incomplete", "execution_id": "exec-incomplete"}) is True
+
+    marked = next(value for kind, value in events if kind == "mark")
+    assert marked[0][1] is False
+    finished = next(value for kind, value in events if kind == "finish")
+    assert finished[1]["success"] is False
+    assert "persisted final assistant" in finished[1]["error"]
+    delivered = next(value for kind, value in events if kind == "delivery")
+    assert "visible answer" not in delivered
+
+
+def test_run_one_job_keeps_exact_silent_settlement_successful(monkeypatch):
+    import cron.scheduler as scheduler
+
+    events: list[tuple[str, object]] = []
+
+    def fake_run_job(job, *, settlement=None, **_kwargs):
+        assert settlement is not None
+        settlement.update(
+            {
+                "session_id": "cron-silent-fire",
+                "status": "silent",
+                "end_reason": "cron_complete",
+            }
+        )
+        return True, "audit output", "[SILENT]", None
+
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(scheduler, "mark_execution_running", lambda *_args: None)
+    monkeypatch.setattr(scheduler, "run_job", fake_run_job)
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_args: None)
+    monkeypatch.setattr(scheduler, "_deliver_result", lambda *_args, **_kwargs: events.append(("delivery", True)))
+    monkeypatch.setattr(scheduler, "mark_job_run", lambda *args, **kwargs: events.append(("mark", (args, kwargs))))
+    monkeypatch.setattr(scheduler, "finish_execution", lambda execution_id, **kwargs: events.append(("finish", kwargs)))
+
+    assert scheduler.run_one_job({"id": "job-silent", "execution_id": "exec-silent"}) is True
+
+    marked = next(value for kind, value in events if kind == "mark")
+    assert marked[0][1] is True
+    finished = next(value for kind, value in events if kind == "finish")
+    assert finished["success"] is True
+    assert not any(kind == "delivery" for kind, _value in events)
+
+
+def test_failure_reporting_accepts_legacy_string_schedule():
+    from cron.scheduler import _failure_streak_nudge
+
+    assert _failure_streak_nudge({"id": "legacy", "schedule": "every 5m"}) == ""
+
+
+class _RecordingSessionDB:
+    next_tail = [{"role": "tool", "content": "ok"}]
+    probe_error = None
+
+    def __init__(self, *args, **kwargs):
+        self.ended: list[tuple[str, str]] = []
+
+    def set_session_title(self, *args, **kwargs):
+        return True
+
+    def get_compression_tip(self, session_id):
+        return session_id
+
+    def get_messages(self, *args, **kwargs):
+        if type(self).probe_error is not None:
+            raise type(self).probe_error
+        return list(type(self).next_tail)
+
+    def end_session(self, session_id, reason):
+        self.ended.append((session_id, reason))
+
+    def close(self):
+        pass
+
+
+class _FakeCronAgent:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def run_conversation(self, prompt):
+        return {
+            "completed": True,
+            "failed": False,
+            "final_response": "done",
+            "turn_exit_reason": "",
+        }
+
+    def close(self):
+        pass
+
+
+class _FailingCronAgent(_FakeCronAgent):
+    def run_conversation(self, prompt):
+        raise RuntimeError("provider failed")
+
+
+def _run_job_with_persisted_tail(
+    monkeypatch, tmp_path, tail, *, probe_error=None, agent_cls=_FakeCronAgent
+):
+    import hermes_state
+    import run_agent
+    import cron.scheduler as scheduler
+
+    _RecordingSessionDB.next_tail = tail
+    _RecordingSessionDB.probe_error = probe_error
+    instances: list[_RecordingSessionDB] = []
+    real_init = _RecordingSessionDB.__init__
+
+    def capture_init(self, *args, **kwargs):
+        real_init(self, *args, **kwargs)
+        instances.append(self)
+
+    monkeypatch.setattr(_RecordingSessionDB, "__init__", capture_init)
+    monkeypatch.setattr(hermes_state, "SessionDB", _RecordingSessionDB)
+    monkeypatch.setattr(run_agent, "AIAgent", agent_cls)
+    monkeypatch.setattr(scheduler, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(scheduler, "get_fallback_chain", lambda _cfg: [])
+    monkeypatch.setattr(scheduler, "_guard_job_credential_exfil", lambda _job: None)
+    monkeypatch.setattr(
+        "hermes_constants.resolve_reasoning_config", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", lambda: [])
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: {
+            "api_key": "test-key",
+            "base_url": None,
+            "provider": "test-provider",
+            "api_mode": None,
+            "command": None,
+            "args": None,
+        },
+    )
+
+    result = scheduler.run_job(
+        {
+            "id": "job-tail-proof",
+            "name": "Tail proof",
+            "prompt": "Do the thing",
+            "schedule_display": "manual",
+        }
+    )
+    return result, instances
+
+
+def test_run_job_downgrades_a_tool_tail_and_probe_failure(monkeypatch, tmp_path):
+    result, instances = _run_job_with_persisted_tail(
+        monkeypatch, tmp_path, [{"role": "tool", "content": "ok"}]
+    )
+
+    assert result[0] is True
+    assert len(instances[0].ended) == 1
+    assert instances[0].ended[0][1] == "cron_incomplete_no_output"
+
+    result, instances = _run_job_with_persisted_tail(
+        monkeypatch,
+        tmp_path,
+        [{"role": "tool", "content": "ok"}],
+        probe_error=RuntimeError("db busy"),
+    )
+    assert result[0] is True
+    assert instances[0].ended[0][1] == "cron_unverified"
+
+
+def test_run_job_failure_never_books_cron_complete(monkeypatch, tmp_path):
+    result, instances = _run_job_with_persisted_tail(
+        monkeypatch,
+        tmp_path,
+        [{"role": "tool", "content": "ok"}],
+        agent_cls=_FailingCronAgent,
+    )
+
+    assert result[0] is False
+    assert instances[0].ended[0][1] == "cron_failed"
+
+
+def test_run_job_accepts_exact_silent_assistant_tail(monkeypatch, tmp_path):
+    result, instances = _run_job_with_persisted_tail(
+        monkeypatch, tmp_path, [{"role": "assistant", "content": "[SILENT]", "finish_reason": "stop"}]
+    )
+
+    assert result[0] is True
+    assert instances[0].ended[0][1] == "cron_complete"

--- a/tests/cron/test_cron_settlement.py
+++ b/tests/cron/test_cron_settlement.py
@@ -85,6 +85,95 @@ def test_real_sessiondb_verification_reads_only_the_persisted_tail(tmp_path):
 
 
 @pytest.mark.parametrize(
+    ("raw_reason", "expected"),
+    [
+        (None, "incomplete"),
+        ("provider_new", "incomplete"),
+        ("length", "incomplete"),
+        ("stop", "complete"),
+    ],
+)
+def test_raw_chat_reason_survives_normalization_persistence_and_settlement(
+    tmp_path, raw_reason, expected
+):
+    """The real OpenAI-compatible path must not erase finality uncertainty."""
+    from agent.transports import get_transport
+    from cron.scheduler import _verify_persisted_cron_final_message
+
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="answer", tool_calls=None),
+                finish_reason=raw_reason,
+            )
+        ],
+        usage=None,
+    )
+    normalized = get_transport("chat_completions").normalize_response(response)
+
+    db = SessionDB(tmp_path / f"chat-{raw_reason or 'missing'}.db")
+    try:
+        session_id = "cron-raw-chat"
+        db.create_session(session_id, source="cron")
+        db.append_message(session_id, "user", "run it")
+        db.append_message(
+            session_id,
+            "assistant",
+            normalized.content,
+            finish_reason=normalized.finish_reason,
+        )
+
+        assert _verify_persisted_cron_final_message(db, session_id) == expected
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize("raw_reason", [None, "provider_new"])
+def test_raw_anthropic_reason_survives_normalization_persistence_and_settlement(
+    tmp_path, raw_reason
+):
+    """Anthropic's provider-specific mapper must preserve unknown finality."""
+    from agent.transports import get_transport
+    from cron.scheduler import _verify_persisted_cron_final_message
+
+    response = SimpleNamespace(
+        content=[SimpleNamespace(type="text", text="partial answer")],
+        stop_reason=raw_reason,
+        usage=None,
+    )
+    normalized = get_transport("anthropic_messages").normalize_response(response)
+
+    db = SessionDB(tmp_path / f"anthropic-{raw_reason or 'missing'}.db")
+    try:
+        session_id = "cron-raw-anthropic"
+        db.create_session(session_id, source="cron")
+        db.append_message(session_id, "user", "run it")
+        db.append_message(
+            session_id,
+            "assistant",
+            normalized.content,
+            finish_reason=normalized.finish_reason,
+        )
+
+        assert _verify_persisted_cron_final_message(db, session_id) == "incomplete"
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize("finish_reason", [None, "length", "provider_new", "tool_calls"])
+def test_silent_marker_requires_terminal_finish_reason(finish_reason):
+    from cron.scheduler import _classify_persisted_cron_final_message
+
+    assert _classify_persisted_cron_final_message(
+        {
+            "role": "assistant",
+            "content": "[SILENT]",
+            "finish_reason": finish_reason,
+        }
+    ) == "incomplete"
+
+
+@pytest.mark.parametrize(
     "tail",
     [
         {"role": "assistant", "content": "partial", "finish_reason": "length"},

--- a/tests/cron/test_cron_settlement.py
+++ b/tests/cron/test_cron_settlement.py
@@ -84,17 +84,27 @@ def test_real_sessiondb_verification_reads_only_the_persisted_tail(tmp_path):
         db.close()
 
 
-def test_run_one_job_consumes_incomplete_settlement_before_delivery(monkeypatch):
+@pytest.mark.parametrize(
+    "tail",
+    [
+        {"role": "assistant", "content": "partial", "finish_reason": "length"},
+        {"role": "assistant", "content": "partial", "finish_reason": "provider_new"},
+        {"role": "assistant", "content": "partial"},
+    ],
+)
+def test_run_one_job_consumes_incomplete_settlement_before_delivery(monkeypatch, tail):
     import cron.scheduler as scheduler
 
     events: list[tuple[str, object]] = []
 
     def fake_run_job(job, *, settlement=None, **_kwargs):
         assert settlement is not None
+        status = scheduler._classify_persisted_cron_final_message(tail)
+        assert status == "incomplete"
         settlement.update(
             {
                 "session_id": "cron-exact-fire",
-                "status": "incomplete",
+                "status": status,
                 "end_reason": "cron_incomplete_no_output",
                 "error": "Cron run ended without a persisted final assistant message.",
             }

--- a/tests/cron/test_cron_settlement.py
+++ b/tests/cron/test_cron_settlement.py
@@ -18,6 +18,11 @@ from hermes_state import SessionDB
         ({"role": "assistant", "content": "", "finish_reason": "stop"}, "incomplete"),
         ({"role": "assistant", "content": None, "tool_calls": [{"id": "c1"}]}, "incomplete"),
         ({"role": "assistant", "content": "partial", "finish_reason": "incomplete"}, "incomplete"),
+        # A partial-stream stub is normalized to length and is not terminal.
+        ({"role": "assistant", "content": "partial", "finish_reason": "length"}, "incomplete"),
+        # Unknown and absent reasons are not positive proof of finality.
+        ({"role": "assistant", "content": "partial", "finish_reason": "provider_new"}, "incomplete"),
+        ({"role": "assistant", "content": "partial"}, "incomplete"),
         ({"role": "tool", "content": "ok"}, "incomplete"),
         ({"role": "user", "content": "run it"}, "incomplete"),
         (None, "incomplete"),
@@ -53,9 +58,28 @@ def test_real_sessiondb_verification_reads_only_the_persisted_tail(tmp_path):
         db.append_message("cron-silent", "user", "check it")
         db.append_message("cron-silent", "assistant", "[SILENT]", finish_reason="stop")
 
+        # Real persisted partial/unknown/absent finish-reason tails must all
+        # remain non-success, even when they carry visible text.
+        for session_id, finish_reason in (
+            ("cron-length", "length"),
+            ("cron-unknown", "provider_new"),
+            ("cron-absent", None),
+        ):
+            db.create_session(session_id, source="cron")
+            db.append_message(session_id, "user", "continue")
+            db.append_message(
+                session_id,
+                "assistant",
+                "partial answer",
+                finish_reason=finish_reason,
+            )
+
         assert _verify_persisted_cron_final_message(db, "cron-tool-tail") == "incomplete"
         assert _verify_persisted_cron_final_message(db, "cron-complete") == "complete"
         assert _verify_persisted_cron_final_message(db, "cron-silent") == "silent"
+        assert _verify_persisted_cron_final_message(db, "cron-length") == "incomplete"
+        assert _verify_persisted_cron_final_message(db, "cron-unknown") == "incomplete"
+        assert _verify_persisted_cron_final_message(db, "cron-absent") == "incomplete"
     finally:
         db.close()
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -543,6 +543,9 @@ class TestRunJobSessionPersistence:
             "prompt": "hello",
         }
         fake_db = MagicMock()
+        fake_db.get_messages.return_value = [
+            {"role": "assistant", "content": "ok", "finish_reason": "stop"}
+        ]
         fake_db.get_compression_tip.side_effect = lambda session_id: session_id
 
         with patch("cron.scheduler._hermes_home", tmp_path), \

--- a/tests/cron/test_script_claim_heartbeat.py
+++ b/tests/cron/test_script_claim_heartbeat.py
@@ -369,7 +369,14 @@ def test_lost_fire_claim_stops_stale_delivery(monkeypatch):
         lost_seen.set()
         return False
 
-    def _run_job(job, *, defer_agent_teardown=None, extra_prompt=None, cancel_event=None):
+    def _run_job(
+        job,
+        *,
+        defer_agent_teardown=None,
+        extra_prompt=None,
+        cancel_event=None,
+        settlement=None,
+    ):
         assert lost_seen.wait(timeout=2)
         return True, "stale output", "stale response", None
 
@@ -533,7 +540,9 @@ def test_repeated_heartbeat_errors_cancel_after_bounded_grace(monkeypatch):
     monkeypatch.setattr(scheduler, "heartbeat_fire_claim", heartbeat)
     monkeypatch.setattr(scheduler, "_run_one_job_body", run_body)
     monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
-    monkeypatch.setattr(scheduler, "_FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS", 0.03)
+    # Leave a generous wall-clock margin on Windows CI: the heartbeat thread
+    # must observe multiple failed renewals, not just one scheduler tick.
+    monkeypatch.setattr(scheduler, "_FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS", 0.1)
 
     assert scheduler.run_one_job(job) is True
     assert calls >= 3

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -149,9 +149,38 @@ class TestCleanStreamEndMidToolCall:
         assert getattr(response, "_dropped_tool_names", None) == ["execute_code"]
 
 
+class TestCleanStreamEndWithoutFinishReason:
+    """A text stream that closes without a terminator must stay unverified."""
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_text_only_clean_close_does_not_become_stop(
+        self, _mock_close, mock_create, monkeypatch
+    ):
+        def _clean_ending_stream():
+            yield _make_stream_chunk(content="answer without terminator")
+            # Clean generator close: no finish_reason and no [DONE].
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _clean_ending_stream()
+        )
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent._fire_stream_delta = lambda text: None
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].message.content == "answer without terminator"
+        assert response.choices[0].finish_reason == FINISH_REASON_LENGTH
 
 
-# ── Clean stream-end before any argument byte arrives (#80498) ─────────────
+
+
+# ── Clean stream-end before any tool args arrives (#80498) ─────────────
 
 class TestCleanStreamEndBeforeAnyToolArgs:
     """The upstream closes the SSE stream cleanly right after delivering the


### PR DESCRIPTION
## What does this PR do?

Cron execution previously treated the worker lifecycle as proof of success. A run could end on a tool-call tail, during an API wait, or after transcript persistence failed, while the session was still stamped `cron_complete` and the execution history remained green.

This PR makes cron completion a durable, session-bound settlement decision: completion requires a persisted final assistant text message whose normalized finish reason positively proves terminality, or the exact `[SILENT]` sentinel after that proof.

## Related Issue

Fixes #93820

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`
  - Reads the exact persisted tail of the final cron session with a bounded `latest=True, limit=1` query.
  - Requires assistant text, no pending `tool_calls`, and the canonical normalized terminal reason `stop`.
  - Validates terminality before accepting `[SILENT]`; `[SILENT]` with `length`, missing, unknown, tool-call, or interrupted finality remains non-success.
  - Publishes typed per-fire settlement state (`complete`, `silent`, `incomplete`, `unverified`, and `failed`) to the delivery and execution bookkeeping path.
  - Uses `cron_incomplete_no_output`, `cron_unverified`, and `cron_failed` instead of projecting those outcomes as `cron_complete`.
  - Preserves deliberate terminal `[SILENT]` completion.
  - Makes failure-streak reporting tolerate legacy string schedules.
- `agent/transports/types.py`
  - Makes `map_finish_reason` the canonical positive-preservation mapper: known provider values are normalized, unknown values are preserved, and missing values remain `None`.
  - Defines the canonical terminal predicate: only normalized `stop` proves terminal assistant completion.
- Provider and stream boundaries
  - Anthropic, Chat Completions, Bedrock, and Codex transport mappers no longer convert missing/provider-new reasons into `stop`.
  - Bedrock synchronous and streaming adapters preserve missing/unknown `stopReason` values.
  - Chat Completions streaming preserves an absent terminator; existing partial-stream protection still emits the deliberate `partial-stream-stub`/`length` result for a dropped text stream.
- `agent/turn_finalizer.py`
  - Stamps synthetic recovered assistant rows explicitly as `stop`.
  - Preserves `partial_stream_recovery` as `incomplete` even when recovered text exists.
- Tests
  - Added raw provider → normalization → SQLite persistence → cron settlement regressions.
  - Added `[SILENT]` non-terminal regressions.
  - Added Anthropic, Chat Completions, Bedrock, Codex, Bedrock-stream, and partial-stream boundary coverage.
  - Updated affected cron and transport expectations to model the fail-closed contract.

## Non-duplicate scope

PR #93829 is an open concurrent implementation for this issue. This PR intentionally does not copy it: its lifecycle classifier is fail-open for unknown/probe-error states and its diff does not propagate the terminal proof into `run_one_job`, `mark_job_run`, or `finish_execution`. This PR closes those remaining green-history paths at the shared scheduler/session settlement boundary and preserves the provenance of the related work.

## How to Test

Focused canonical wrapper:

```text
scripts/run_tests.sh tests/cron/test_cron_settlement.py tests/agent/transports/test_types.py tests/agent/transports/test_transport.py tests/agent/transports/test_chat_completions.py tests/agent/transports/test_bedrock_transport.py tests/agent/transports/test_codex_transport.py tests/agent/test_bedrock_adapter.py tests/run_agent/test_partial_stream_finish_reason.py -q
```

Result: 316 passed, 0 failed.

Adjacent canonical wrapper:

```text
scripts/run_tests.sh tests/cron/test_scheduler.py tests/cron/test_execution_ledger.py tests/cron/test_sessiondb_init_hang.py tests/agent/test_turn_finalizer_final_response_persistence.py tests/agent/test_anthropic_adapter.py tests/run_agent/test_anthropic_truncation_continuation.py tests/run_agent/test_run_agent_codex_responses.py -q
```

Result: 293 passed, 0 failed, 1 skipped.

Additional checks:

- Ruff on all changed Python files — passed.
- `py_compile` on all changed Python files — passed.
- `git diff --check` — passed.

The full `tests/cron/` sweep on the Windows host has unrelated host-specific baseline failures in permission-mode, HOME/tilde, path-escaping, and process-tree tests; those files are outside the production settlement change. The live PR CI runs the supported Linux, macOS, and Windows lanes separately.

## Hardening record

- **GitHub priority:** P1 (`type/bug`, `comp/cron`, `risk-session-state`, `risk-message-delivery`).
- **Check-in 1 — premise/root cause:** traced `run_job` finalization through `SessionDB`, `run_one_job`, execution history, and delivery; inspected concurrent PR #93829 and related cron/session work.
- **Check-in 2 — failure modes/bottlenecks:** covered tool-call tails, empty/no-row sessions, API-wait uncertainty, persistence/read failures, agent exceptions, compression-tip session identity, `[SILENT]`, per-fire concurrency isolation, raw `length`, unknown, absent, and stream terminator loss across supported transports.
- **Check-in 3 — simplification/regression:** reused the existing `map_finish_reason` authority instead of adding a parallel mapper, kept the bounded SQLite tail read, made terminal proof explicit, and added real raw-to-persistence regressions for transport and scheduler boundaries.

## Infographic (required)

<!-- pr-infographic: generated by scripts/generate_pr_infographic.py; theme=pixel-terminal-02; roulette=52/100; seed=4008674034 -->
![PR infographic — durable cron settlement](https://gist.githubusercontent.com/JoaoMarcos44/ec8171d3752593283f93e7197c2a7217/raw/d50e40877b061a884492a6e684e9b2879f83925b/pr-cron-93820-infographic.svg)

**Visual theme:** Retro Terminal — 16-bit three-stage workstation  
**Why it fits:** cron settlement, persisted state, run history

- [x] The infographic explains the problem, change, and verification.
- [x] The image is hosted at a public HTTPS URL and is not committed to git.
