### PR TITLE
Add Google OAuth dashboard auth provider

### DIFF
--- a/plugins/dashboard_auth/google/__init__.py
+++ b/plugins/dashboard_auth/google/__init__.py
@@ -284,12 +284,18 @@ class GoogleDashboardAuthProvider(DashboardAuthProvider):
             "client_secret": self._client_secret,
             "refresh_token": refresh_token,
         }
-        return self._exchange(
+        session = self._exchange(
             disco["token_endpoint"],
             data,
             bad_request_exc=RefreshExpiredError,
             previous_refresh_token=refresh_token,
         )
+        # Sessions are stateless JWTs, so without this re-check a user
+        # removed from the allowlist keeps a working dashboard until their
+        # current ID token expires rather than being cut off at the next
+        # refresh.
+        self._check_allowlist(session.email, denied_exc=RefreshExpiredError)
+        return session
 
     def verify_session(self, *, access_token: str) -> Optional[Session]:
         # The session cookie stores the ID token in the access-token slot
@@ -313,11 +319,20 @@ class GoogleDashboardAuthProvider(DashboardAuthProvider):
         if not refresh_token:
             return None
         try:
-            httpx.post(
+            response = httpx.post(
                 _GOOGLE_REVOKE_URL,
                 data={"token": refresh_token},
                 timeout=_TOKEN_ENDPOINT_TIMEOUT_SEC,
             )
+            if response.status_code != 200:
+                # Non-fatal (e.g. an already-expired token yields 400) —
+                # logged so logout auditing can distinguish "revoked" from
+                # "Google rejected the revoke call" without changing
+                # behavior.
+                logger.debug(
+                    "dashboard-auth-google: revoke returned status_code=%s",
+                    response.status_code,
+                )
         except Exception as exc:  # noqa: BLE001 — best-effort
             logger.debug(
                 "dashboard-auth-google: revoke failed (ignored): %s", exc
@@ -575,10 +590,21 @@ class GoogleDashboardAuthProvider(DashboardAuthProvider):
 
     @staticmethod
     def _resolve_allowlist() -> list[str]:
-        """Return the effective allowlist from env vars."""
+        """Return the effective allowlist from env vars, falling back to
+        config.yaml (dashboard.oauth.google_allowed_users) — mirrors the
+        env-wins-over-config precedence used by ``_resolve_config``."""
         raw = os.environ.get("DASHBOARD_ALLOWED_USERS", "") or os.environ.get(
             "GATEWAY_ALLOWED_USERS", ""
         )
+        if not raw.strip():
+            try:
+                from hermes_cli.config import cfg_get, load_config
+
+                oauth = cfg_get(load_config(), "dashboard", "oauth", default=None)
+                if isinstance(oauth, dict):
+                    raw = str(oauth.get("google_allowed_users", "") or "")
+            except Exception:
+                raw = ""
         if not raw.strip():
             return []
         return [
@@ -587,15 +613,17 @@ class GoogleDashboardAuthProvider(DashboardAuthProvider):
             if entry.strip()
         ]
 
-    def _check_allowlist(self, email: str) -> None:
-        """Raise InvalidCodeError if the allowlist is set and email is not on it."""
+    def _check_allowlist(
+        self, email: str, *, denied_exc: type[Exception] = InvalidCodeError
+    ) -> None:
+        """Raise ``denied_exc`` if the allowlist is set and email is not on it."""
         allowed = self._resolve_allowlist()
         if not allowed:
             # Empty allowlist = any authenticated user (backward-compat)
             return
         if email.lower() in (a.lower() for a in allowed):
             return
-        raise InvalidCodeError(
+        raise denied_exc(
             f"Access denied: {email} is not on the dashboard allowlist. "
             f"Set DASHBOARD_ALLOWED_USERS in .env to grant access."
         )

--- a/plugins/dashboard_auth/google/__init__.py
+++ b/plugins/dashboard_auth/google/__init__.py
@@ -1,0 +1,705 @@
+"""Google OAuth — dashboard auth provider for Hermes Agent.
+
+Implements the ``DashboardAuthProvider`` interface backed by Google's
+OpenID Connect / OAuth 2.0 authorization-code flow with PKCE (RFC 6749
+§4.1, RFC 7636). Registers itself when ``HERMES_DASHBOARD_GOOGLE_CLIENT_ID``
+and ``HERMES_DASHBOARD_GOOGLE_CLIENT_SECRET`` are both set (either as env
+vars or under ``dashboard.oauth.google_*`` in config.yaml).
+
+Endpoints are resolved from Google's OpenID Connect discovery document
+(``https://accounts.google.com/.well-known/openid-configuration``, cached
+with a soft TTL) rather than hardcoded, so a Google-side endpoint migration
+is picked up without a code change. The ID token returned by the token
+endpoint is verified locally against Google's published JWKS (issuer +
+audience pinned, signature checked) and stored as the session's access
+token, so every ``verify_session()`` call re-verifies a real JWT instead of
+making a network round trip to Google on every dashboard request — the same
+approach the self-hosted OIDC provider uses.
+
+Configuration
+-------------
+Env vars (highest precedence):
+  HERMES_DASHBOARD_GOOGLE_CLIENT_ID       — Google OAuth client ID
+  HERMES_DASHBOARD_GOOGLE_CLIENT_SECRET   — Google OAuth client secret
+
+config.yaml (fallback):
+  dashboard:
+    oauth:
+      google_client_id: "..."
+      google_client_secret: "..."
+
+Optional allowlist (either env var; comma/whitespace-separated email list):
+  DASHBOARD_ALLOWED_USERS   — dashboard-specific allowlist
+  GATEWAY_ALLOWED_USERS     — shared with the API gateway's allowlist
+
+An empty/missing allowlist means any authenticated Google account may sign
+in (backward-compatible default). When set, ``complete_login`` rejects any
+email not on the list with ``InvalidCodeError``.
+
+No client_id/client_secret configured → plugin skips registration silently
+(zero impact on loopback or --insecure users).
+
+Usage
+-----
+1. Create an OAuth 2.0 Web Application client in the Google Cloud Console.
+   - Authorized redirect URI: https://<your-dashboard>/auth/callback
+2. Set the env vars above (or add them to config.yaml).
+3. Restart the dashboard. Google will appear as a login option.
+
+Standards referenced
+---------------------
+- RFC 6749 (OAuth 2.0 Authorization Framework) — authorization-code grant
+  (§4.1), refresh-token grant (§6), client authentication (§2.3.1).
+- RFC 7636 (PKCE) — code_verifier / code_challenge (S256).
+- OpenID Connect Core 1.0 — ID token claims, discovery document shape.
+- OpenID Connect Discovery 1.0 — {issuer}/.well-known/openid-configuration.
+- Google Identity Platform docs — ``email_verified`` semantics, the
+  optional ``hd`` (hosted domain) claim for Google Workspace accounts, and
+  the ``prompt=select_account`` authorization parameter.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import os
+import secrets
+import threading
+import time
+import urllib.parse
+from typing import Any, Dict, Optional
+
+import httpx
+
+from hermes_cli.dashboard_auth import (
+    DashboardAuthProvider,
+    InvalidCodeError,
+    LoginStart,
+    ProviderError,
+    RefreshExpiredError,
+    Session,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_GOOGLE_DISCOVERY_URL = (
+    "https://accounts.google.com/.well-known/openid-configuration"
+)
+_OAUTH_SCOPE = "openid email profile"
+
+# Google's discovery document does not advertise a revocation_endpoint (it's
+# absent from accounts.google.com's .well-known/openid-configuration), so —
+# unlike the self-hosted OIDC provider, which reads one from discovery —
+# this is a fixed, Google-documented endpoint.
+_GOOGLE_REVOKE_URL = "https://oauth2.googleapis.com/revoke"
+
+# Signing algorithms accepted on the ID token. Google currently only signs
+# with RS256, but we accept the same breadth as the self-hosted OIDC
+# provider for consistency. This doesn't weaken verification: the key is
+# always looked up from Google's JWKS by 'kid', so a wider algorithm
+# allowlist doesn't let an attacker supply their own verification key (the
+# precondition for an "alg confusion" attack).
+_ALLOWED_ID_TOKEN_ALGS = ("RS256", "ES256", "RS384", "RS512", "ES384", "ES512")
+
+# httpx timeouts.
+_DISCOVERY_TIMEOUT_SEC = 10.0
+_TOKEN_ENDPOINT_TIMEOUT_SEC = 10.0
+
+# OIDC discovery is low-frequency and the document is effectively static;
+# cache it for the process lifetime with a soft TTL so a long-running
+# dashboard picks up a Google-side endpoint migration within the hour.
+_DISCOVERY_CACHE_TTL_SEC = 3600
+
+# JWKS cache (PyJWKClient handles its own caching internally; this mirrors
+# the sibling providers' 5-minute lifespan so key rotation is picked up
+# promptly).
+_JWKS_CACHE_SECONDS = 300
+
+# Module-level skip reason — read by the dashboard's fail-closed branch
+# when zero providers are registered, so the operator sees a useful
+# message instead of a generic "install a provider" error.
+LAST_SKIP_REASON: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _b64url_no_pad(raw: bytes) -> str:
+    """Base64url-encode without '=' padding (RFC 7636 §4)."""
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def _require_https_or_loopback(url: str, *, field: str) -> str:
+    """Reject an endpoint URL that isn't HTTPS (loopback http is allowed).
+
+    Defense in depth: Google's discovery document is always served over
+    HTTPS and always advertises HTTPS endpoints in practice, but pinning
+    the scheme here means a corrupted or redirected discovery response
+    can't silently downgrade the authorization/token/JWKS endpoints to
+    plaintext.
+    """
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme == "https":
+        return url
+    if parsed.scheme == "http" and (parsed.hostname or "") in (
+        "localhost",
+        "127.0.0.1",
+        "::1",
+    ):
+        return url
+    raise ProviderError(f"Google OIDC {field} must be https://, got {url!r}")
+
+
+class _EmailNotVerifiedError(InvalidCodeError):
+    """ID token has ``email_verified=False``.
+
+    Google's own guidance: only trust the email address for identity
+    purposes when ``email_verified`` is true. A false value means Google
+    itself won't vouch for the address (e.g. an unmanaged Workspace account
+    on an unverified custom domain) — accepting it anyway would let a
+    caller authenticate under an email they don't control. Subclassing
+    ``InvalidCodeError`` (rather than ``ProviderError``) means both
+    ``complete_login`` and ``verify_session`` treat this the same way they
+    treat an expired or otherwise invalid token: reject the credential
+    rather than surface a 503.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+class GoogleDashboardAuthProvider(DashboardAuthProvider):
+    """Google OAuth 2.0 / OpenID Connect via authorization-code + PKCE (S256)."""
+
+    name = "google"
+    display_name = "Google"
+
+    def __init__(self, *, client_id: str, client_secret: str) -> None:
+        if not client_id:
+            raise ValueError("client_id is required")
+        if not client_secret:
+            raise ValueError("client_secret is required")
+        self._client_id = client_id
+        self._client_secret = client_secret
+
+        # Discovery + JWKS are lazily resolved on first use so plugin
+        # registration never makes a network call (Google may be
+        # unreachable at boot; the gate should still come up and fail
+        # per-request instead of blocking startup).
+        self._discovery: Dict[str, Any] | None = None
+        self._discovery_fetched_at: float = 0.0
+        self._discovery_lock = threading.Lock()
+        self._jwks_client: Any = None
+
+    # ---- public API (DashboardAuthProvider) --------------------------------
+
+    def start_login(self, *, redirect_uri: str) -> LoginStart:
+        self._validate_redirect_uri(redirect_uri)
+        disco = self._get_discovery()
+
+        code_verifier = _b64url_no_pad(secrets.token_bytes(64))  # ~86 chars
+        code_challenge = _b64url_no_pad(
+            hashlib.sha256(code_verifier.encode("ascii")).digest()
+        )
+        state = _b64url_no_pad(secrets.token_bytes(32))
+
+        params = {
+            "response_type": "code",
+            "client_id": self._client_id,
+            "redirect_uri": redirect_uri,
+            "scope": _OAUTH_SCOPE,
+            "state": state,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+            # Google-specific: forces the account picker even if the user
+            # is already signed in to exactly one Google account, so a
+            # shared/kiosk browser doesn't silently reuse the wrong
+            # identity.
+            "prompt": "select_account",
+        }
+        redirect_url = (
+            f"{disco['authorization_endpoint']}?{urllib.parse.urlencode(params)}"
+        )
+        cookie_payload = {
+            "hermes_session_pkce": f"state={state};verifier={code_verifier}",
+        }
+        return LoginStart(redirect_url=redirect_url, cookie_payload=cookie_payload)
+
+    def complete_login(
+        self,
+        *,
+        code: str,
+        state: str,
+        code_verifier: str,
+        redirect_uri: str,
+    ) -> Session:
+        _ = state  # verified by the auth-route layer before dispatch
+        disco = self._get_discovery()
+
+        data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "client_id": self._client_id,
+            "client_secret": self._client_secret,
+            "code_verifier": code_verifier,
+        }
+        session = self._exchange(
+            disco["token_endpoint"], data, bad_request_exc=InvalidCodeError
+        )
+
+        # ── Allowlist check ──────────────────────────────────────────────
+        # Dashboard inherits the gateway's allowlist convention:
+        # DASHBOARD_ALLOWED_USERS (or GATEWAY_ALLOWED_USERS) controls who
+        # can authenticate. An empty/missing allowlist means "any
+        # authenticated user" (backward-compatible default).
+        self._check_allowlist(session.email)
+        # ─────────────────────────────────────────────────────────────────
+        return session
+
+    def refresh_session(self, *, refresh_token: str) -> Session:
+        if not refresh_token:
+            raise RefreshExpiredError("no refresh token in session")
+        disco = self._get_discovery()
+
+        data = {
+            "grant_type": "refresh_token",
+            "client_id": self._client_id,
+            "client_secret": self._client_secret,
+            "refresh_token": refresh_token,
+        }
+        return self._exchange(
+            disco["token_endpoint"],
+            data,
+            bad_request_exc=RefreshExpiredError,
+            previous_refresh_token=refresh_token,
+        )
+
+    def verify_session(self, *, access_token: str) -> Optional[Session]:
+        # The session cookie stores the ID token in the access-token slot
+        # (see _session_from_tokens) precisely so this per-request check
+        # can verify a real JWT locally instead of calling Google's
+        # userinfo endpoint on every dashboard request.
+        try:
+            claims = self._verify_id_token(access_token)
+        except InvalidCodeError:
+            # Expired / invalid / email_verified=False — protocol says
+            # return None, not raise (middleware then refreshes or logs
+            # out).
+            return None
+        return self._session_from_tokens(
+            id_token=access_token, refresh_token="", claims=claims
+        )
+
+    def revoke_session(self, *, refresh_token: str) -> None:
+        # Best-effort: POST to Google's revocation endpoint. Must never
+        # raise — logout is client-side cookie clearing regardless.
+        if not refresh_token:
+            return None
+        try:
+            httpx.post(
+                _GOOGLE_REVOKE_URL,
+                data={"token": refresh_token},
+                timeout=_TOKEN_ENDPOINT_TIMEOUT_SEC,
+            )
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            logger.debug(
+                "dashboard-auth-google: revoke failed (ignored): %s", exc
+            )
+        return None
+
+    # ---- internals: token exchange ----------------------------------------
+
+    def _exchange(
+        self,
+        token_endpoint: str,
+        data: Dict[str, str],
+        *,
+        bad_request_exc: type[Exception],
+        previous_refresh_token: str = "",
+    ) -> Session:
+        """POST the token endpoint and turn the response into a Session.
+
+        Shared by ``complete_login`` (auth-code grant) and
+        ``refresh_session`` (refresh grant). ``bad_request_exc`` is raised
+        on a 400 — ``InvalidCodeError`` for the auth-code path,
+        ``RefreshExpiredError`` for the refresh path.
+        """
+        try:
+            response = httpx.post(
+                token_endpoint,
+                data=data,
+                headers={"Accept": "application/json"},
+                timeout=_TOKEN_ENDPOINT_TIMEOUT_SEC,
+            )
+        except httpx.RequestError as exc:
+            raise ProviderError(
+                f"Google token endpoint unreachable: {exc}"
+            ) from exc
+
+        if response.status_code == 400:
+            body = self._parse_json_body(response)
+            error_code = body.get("error", "invalid_grant")
+            raise bad_request_exc(f"Google rejected token request: {error_code}")
+        if response.status_code != 200:
+            raise ProviderError(
+                f"Google token endpoint returned {response.status_code}: "
+                f"{response.text[:200]!r}"
+            )
+
+        payload = self._parse_json_body(response)
+
+        id_token = payload.get("id_token")
+        if not id_token or not isinstance(id_token, str):
+            raise ProviderError(
+                "Google token response missing id_token — ensure the "
+                "'openid' scope is included in the authorization request."
+            )
+
+        token_type = str(payload.get("token_type", "")).lower()
+        if token_type and token_type != "bearer":
+            raise ProviderError(f"unexpected token_type={token_type!r}")
+
+        claims = self._verify_id_token(id_token)
+
+        # Google rotates the refresh token only in rare cases; prefer a
+        # freshly-issued one, else keep the previous.
+        refresh_token = payload.get("refresh_token")
+        if not isinstance(refresh_token, str) or not refresh_token:
+            refresh_token = previous_refresh_token or ""
+
+        return self._session_from_tokens(
+            id_token=id_token, refresh_token=refresh_token, claims=claims
+        )
+
+    # ---- internals: discovery ---------------------------------------------
+
+    def _get_discovery(self) -> Dict[str, Any]:
+        """Return the cached OIDC discovery document, fetching if stale."""
+        now = time.time()
+        if (
+            self._discovery is not None
+            and (now - self._discovery_fetched_at) < _DISCOVERY_CACHE_TTL_SEC
+        ):
+            return self._discovery
+        with self._discovery_lock:
+            now = time.time()
+            if (
+                self._discovery is not None
+                and (now - self._discovery_fetched_at)
+                < _DISCOVERY_CACHE_TTL_SEC
+            ):
+                return self._discovery
+            disco = self._fetch_discovery()
+            self._discovery = disco
+            self._discovery_fetched_at = now
+            # New keys → drop the JWKS client so it re-binds to the
+            # freshly-discovered jwks_uri.
+            self._jwks_client = None
+            return disco
+
+    def _fetch_discovery(self) -> Dict[str, Any]:
+        try:
+            response = httpx.get(
+                _GOOGLE_DISCOVERY_URL,
+                headers={"Accept": "application/json"},
+                timeout=_DISCOVERY_TIMEOUT_SEC,
+            )
+        except httpx.RequestError as exc:
+            raise ProviderError(
+                f"Google discovery endpoint unreachable: {exc}"
+            ) from exc
+        if response.status_code != 200:
+            raise ProviderError(
+                f"Google discovery returned {response.status_code}"
+            )
+        payload = self._parse_json_body(response)
+        if not payload:
+            raise ProviderError("Google discovery returned a non-JSON body")
+
+        authorization_endpoint = str(
+            payload.get("authorization_endpoint", "") or ""
+        ).strip()
+        token_endpoint = str(payload.get("token_endpoint", "") or "").strip()
+        jwks_uri = str(payload.get("jwks_uri", "") or "").strip()
+        issuer = str(payload.get("issuer", "") or "").strip()
+        if not (authorization_endpoint and token_endpoint and jwks_uri and issuer):
+            raise ProviderError(
+                "Google discovery missing one of authorization_endpoint / "
+                "token_endpoint / jwks_uri / issuer"
+            )
+
+        _require_https_or_loopback(
+            authorization_endpoint, field="authorization_endpoint"
+        )
+        _require_https_or_loopback(token_endpoint, field="token_endpoint")
+        _require_https_or_loopback(jwks_uri, field="jwks_uri")
+
+        return {
+            "issuer": issuer,
+            "authorization_endpoint": authorization_endpoint,
+            "token_endpoint": token_endpoint,
+            "jwks_uri": jwks_uri,
+        }
+
+    # ---- internals: JWT verification --------------------------------------
+
+    def _get_jwks_client(self) -> Any:
+        if self._jwks_client is None:
+            from jwt import PyJWKClient  # lazy import — keeps startup fast
+
+            disco = self._get_discovery()
+            self._jwks_client = PyJWKClient(
+                disco["jwks_uri"],
+                cache_keys=True,
+                lifespan=_JWKS_CACHE_SECONDS,
+                headers={
+                    "Accept": "application/json",
+                    "User-Agent": "HermesAgent/1.0",
+                },
+            )
+        return self._jwks_client
+
+    def _verify_id_token(self, id_token: str) -> Dict[str, Any]:
+        import jwt  # lazy import — keeps startup fast for the ungated path
+
+        disco = self._get_discovery()
+
+        try:
+            signing_key = self._get_jwks_client().get_signing_key_from_jwt(
+                id_token
+            )
+        except jwt.PyJWKClientError as exc:
+            raise ProviderError(f"JWKS lookup failed: {exc}") from exc
+        except Exception as exc:  # pragma: no cover - defensive
+            raise ProviderError(f"JWKS lookup failed: {exc!r}") from exc
+
+        try:
+            claims = jwt.decode(
+                id_token,
+                signing_key.key,
+                algorithms=list(_ALLOWED_ID_TOKEN_ALGS),
+                audience=self._client_id,
+                issuer=disco["issuer"],
+                options={"require": ["exp", "iat", "aud", "iss", "sub"]},
+            )
+        except jwt.ExpiredSignatureError as exc:
+            raise InvalidCodeError(f"id_token expired: {exc}") from exc
+        except jwt.InvalidTokenError as exc:
+            # Surface the actual iss/aud the token carried so operators can
+            # debug config drift between the configured client and what
+            # Google emits. Decoding without verification is safe here: we
+            # already failed verification and never trust these values.
+            details = ""
+            try:
+                unverified = jwt.decode(
+                    id_token,
+                    options={"verify_signature": False, "verify_exp": False},
+                )
+                details = (
+                    f" [token iss={unverified.get('iss')!r} "
+                    f"aud={unverified.get('aud')!r}; expected "
+                    f"iss={disco['issuer']!r} aud={self._client_id!r}]"
+                )
+            except Exception:
+                pass
+            raise ProviderError(
+                f"id_token verification failed: {exc}{details}"
+            ) from exc
+
+        # Google's own guidance: only trust the email address for identity
+        # purposes when email_verified is true. Missing is tolerated
+        # (some flows omit the claim entirely); explicitly false is not.
+        email_verified = claims.get("email_verified")
+        if email_verified is False:
+            raise _EmailNotVerifiedError(
+                f"Google id_token has email_verified=False for "
+                f"{claims.get('email')!r}; refusing to trust it"
+            )
+        if email_verified is None:
+            logger.debug("id_token missing email_verified claim; proceeding")
+
+        return claims
+
+    # ---- internals: mapping + misc ----------------------------------------
+
+    def _session_from_tokens(
+        self, *, id_token: str, refresh_token: str, claims: Dict[str, Any]
+    ) -> Session:
+        """Map verified ID-token claims onto a Session.
+
+        The verified ID token is stored in ``Session.access_token`` so the
+        per-request ``verify_session`` re-verifies a real JWT. The opaque
+        OAuth access token is intentionally not stored — Hermes never
+        calls a Google resource API with it; the dashboard only needs
+        identity.
+        """
+        user_id = str(claims.get("sub", ""))
+        if not user_id:
+            raise ProviderError("id_token missing 'sub' (user_id) claim")
+
+        email = str(claims.get("email", "") or "")
+        display_name = str(claims.get("name") or email or "")
+        # 'hd' (hosted domain) is Google's own claim identifying the
+        # Google Workspace domain the account belongs to — the closest
+        # analog to an org/tenant id for a Google-backed login. Absent for
+        # personal @gmail.com accounts.
+        org_id = str(claims.get("hd", "") or "")
+
+        return Session(
+            user_id=user_id,
+            email=email,
+            display_name=display_name,
+            org_id=org_id,
+            provider=self.name,
+            expires_at=int(claims["exp"]),
+            access_token=id_token,
+            refresh_token=refresh_token,
+        )
+
+    @staticmethod
+    def _resolve_allowlist() -> list[str]:
+        """Return the effective allowlist from env vars."""
+        raw = os.environ.get("DASHBOARD_ALLOWED_USERS", "") or os.environ.get(
+            "GATEWAY_ALLOWED_USERS", ""
+        )
+        if not raw.strip():
+            return []
+        return [
+            entry.strip()
+            for entry in raw.replace(",", " ").split()
+            if entry.strip()
+        ]
+
+    def _check_allowlist(self, email: str) -> None:
+        """Raise InvalidCodeError if the allowlist is set and email is not on it."""
+        allowed = self._resolve_allowlist()
+        if not allowed:
+            # Empty allowlist = any authenticated user (backward-compat)
+            return
+        if email.lower() in (a.lower() for a in allowed):
+            return
+        raise InvalidCodeError(
+            f"Access denied: {email} is not on the dashboard allowlist. "
+            f"Set DASHBOARD_ALLOWED_USERS in .env to grant access."
+        )
+
+    def _validate_redirect_uri(self, redirect_uri: str) -> None:
+        """Fast-fail on an obviously-broken redirect_uri before bouncing to
+        Google. Google's own check is authoritative (redirect_uri_mismatch),
+        but that error is opaque to the operator; this catches the common
+        misconfiguration case (bad HERMES_DASHBOARD_PUBLIC_URL / proxy
+        headers) with a clear message instead.
+        """
+        parsed = urllib.parse.urlparse(redirect_uri)
+        if parsed.scheme not in ("https", "http"):
+            raise ProviderError(
+                f"redirect_uri must be http(s), got {redirect_uri!r}"
+            )
+        if not parsed.path or not parsed.path.endswith("/auth/callback"):
+            raise ProviderError(
+                "redirect_uri path must end with '/auth/callback', "
+                f"got {redirect_uri!r}"
+            )
+
+    def _parse_json_body(self, response: httpx.Response) -> Dict[str, Any]:
+        ctype = response.headers.get("content-type", "")
+        if not ctype.startswith("application/json"):
+            return {}
+        try:
+            body = response.json()
+        except ValueError:
+            return {}
+        return body if isinstance(body, dict) else {}
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry point
+# ---------------------------------------------------------------------------
+
+
+def _resolve_config() -> tuple[str, str]:
+    """Return (client_id, client_secret) — env wins over config.yaml."""
+    # Env vars (highest precedence — empty after strip = unset)
+    env_id = os.environ.get("HERMES_DASHBOARD_GOOGLE_CLIENT_ID", "").strip()
+    env_secret = os.environ.get(
+        "HERMES_DASHBOARD_GOOGLE_CLIENT_SECRET", ""
+    ).strip()
+
+    if env_id and env_secret:
+        return env_id, env_secret
+
+    # Fall back to config.yaml
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        cfg = load_config()
+    except Exception:
+        return env_id, env_secret  # config.yaml unreadable — keep env
+
+    oauth = cfg_get(cfg, "dashboard", "oauth", default=None)
+    if not isinstance(oauth, dict):
+        return env_id, env_secret
+
+    cfg_id = str(oauth.get("google_client_id", "")).strip()
+    cfg_secret = str(oauth.get("google_client_secret", "")).strip()
+
+    # Prefer env if set (partial env = partial fallback)
+    final_id = env_id or cfg_id
+    final_secret = env_secret or cfg_secret
+    return final_id, final_secret
+
+
+def register(ctx) -> None:
+    """Plugin entry — called by the plugin loader at startup."""
+
+    global LAST_SKIP_REASON
+    LAST_SKIP_REASON = ""
+
+    client_id, client_secret = _resolve_config()
+
+    if not client_id:
+        LAST_SKIP_REASON = (
+            "Google OAuth dashboard auth provider not configured: "
+            "set HERMES_DASHBOARD_GOOGLE_CLIENT_ID + "
+            "HERMES_DASHBOARD_GOOGLE_CLIENT_SECRET (env vars), or "
+            "dashboard.oauth.google_client_id + "
+            "dashboard.oauth.google_client_secret in config.yaml."
+        )
+        logger.debug("dashboard-auth-google: %s", LAST_SKIP_REASON)
+        return
+
+    if not client_secret:
+        LAST_SKIP_REASON = (
+            "Google OAuth client ID is set but client SECRET is "
+            "missing. Set HERMES_DASHBOARD_GOOGLE_CLIENT_SECRET "
+            "or dashboard.oauth.google_client_secret."
+        )
+        logger.debug("dashboard-auth-google: %s", LAST_SKIP_REASON)
+        return
+
+    try:
+        provider = GoogleDashboardAuthProvider(
+            client_id=client_id, client_secret=client_secret
+        )
+    except ValueError as exc:
+        LAST_SKIP_REASON = (
+            f"GoogleDashboardAuthProvider construction failed: {exc}"
+        )
+        logger.warning("dashboard-auth-google: %s", LAST_SKIP_REASON)
+        return
+
+    ctx.register_dashboard_auth_provider(provider)
+    logger.info(
+        "dashboard-auth-google: registered provider "
+        "(client_id=%s…)", client_id[:16]
+    )

--- a/plugins/dashboard_auth/google/__init__.py
+++ b/plugins/dashboard_auth/google/__init__.py
@@ -225,6 +225,13 @@ class GoogleDashboardAuthProvider(DashboardAuthProvider):
             # shared/kiosk browser doesn't silently reuse the wrong
             # identity.
             "prompt": "select_account",
+            # Google omits refresh_token from the token response for
+            # web-application clients unless the authorization request
+            # carries access_type=offline. Without this, refresh_session()
+            # never receives a refresh token to work with and every
+            # session silently falls back to full re-login once the ID
+            # token expires (~1h).
+            "access_type": "offline",
         }
         redirect_url = (
             f"{disco['authorization_endpoint']}?{urllib.parse.urlencode(params)}"

--- a/plugins/dashboard_auth/google/plugin.yaml
+++ b/plugins/dashboard_auth/google/plugin.yaml
@@ -1,0 +1,8 @@
+name: google
+version: 1.0.0
+description: "Dashboard auth provider — Google OAuth 2.0 / OpenID Connect (authorization-code + PKCE). Auto-activates when HERMES_DASHBOARD_GOOGLE_CLIENT_ID + HERMES_DASHBOARD_GOOGLE_CLIENT_SECRET are set (env vars, or dashboard.oauth.google_client_id/google_client_secret in config.yaml). Verifies the Google ID token locally (RS256, via the discovered jwks_uri) and supports an optional DASHBOARD_ALLOWED_USERS/GATEWAY_ALLOWED_USERS email allowlist."
+author: kozliatko
+kind: backend
+requires_env:
+  - HERMES_DASHBOARD_GOOGLE_CLIENT_ID
+  - HERMES_DASHBOARD_GOOGLE_CLIENT_SECRET

--- a/plugins/dashboard_auth/google/plugin.yaml
+++ b/plugins/dashboard_auth/google/plugin.yaml
@@ -1,6 +1,6 @@
 name: google
 version: 1.0.0
-description: "Dashboard auth provider — Google OAuth 2.0 / OpenID Connect (authorization-code + PKCE). Auto-activates when HERMES_DASHBOARD_GOOGLE_CLIENT_ID + HERMES_DASHBOARD_GOOGLE_CLIENT_SECRET are set (env vars, or dashboard.oauth.google_client_id/google_client_secret in config.yaml). Verifies the Google ID token locally (RS256, via the discovered jwks_uri) and supports an optional DASHBOARD_ALLOWED_USERS/GATEWAY_ALLOWED_USERS email allowlist."
+description: "Dashboard auth provider — Google OAuth 2.0 / OpenID Connect (authorization-code + PKCE). Auto-activates when HERMES_DASHBOARD_GOOGLE_CLIENT_ID + HERMES_DASHBOARD_GOOGLE_CLIENT_SECRET are set (env vars, or dashboard.oauth.google_client_id/google_client_secret in config.yaml). Verifies the Google ID token locally (RS256, via the discovered jwks_uri) and supports an optional email allowlist (DASHBOARD_ALLOWED_USERS/GATEWAY_ALLOWED_USERS env vars, or dashboard.oauth.google_allowed_users in config.yaml), re-checked on every token refresh."
 author: kozliatko
 kind: backend
 requires_env:

--- a/tests/plugins/dashboard_auth/test_google_provider.py
+++ b/tests/plugins/dashboard_auth/test_google_provider.py
@@ -495,6 +495,36 @@ class TestAllowlist:
         session = self._complete(provider, rsa_keypair)
         assert session.email == "alice@example.com"
 
+    def test_falls_back_to_config_yaml_when_env_unset(self, provider, rsa_keypair, monkeypatch):
+        monkeypatch.delenv("DASHBOARD_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"dashboard": {"oauth": {"google_allowed_users": "bob@example.com"}}},
+        )
+        with pytest.raises(InvalidCodeError, match="not on the dashboard allowlist"):
+            self._complete(provider, rsa_keypair, email="alice@example.com")
+
+    def test_env_allowlist_takes_precedence_over_config_yaml(self, provider, rsa_keypair, monkeypatch):
+        monkeypatch.setenv("DASHBOARD_ALLOWED_USERS", "alice@example.com")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"dashboard": {"oauth": {"google_allowed_users": "someone-else@example.com"}}},
+        )
+        session = self._complete(provider, rsa_keypair)
+        assert session.email == "alice@example.com"
+
+    def test_config_yaml_load_failure_falls_back_to_no_allowlist(self, provider, rsa_keypair, monkeypatch):
+        monkeypatch.delenv("DASHBOARD_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+
+        def _broken():
+            raise RuntimeError("disk error")
+
+        monkeypatch.setattr("hermes_cli.config.load_config", _broken)
+        session = self._complete(provider, rsa_keypair)
+        assert session.email == "alice@example.com"
+
 
 # ---------------------------------------------------------------------------
 # verify_session
@@ -607,6 +637,26 @@ class TestRefreshAndRevoke:
             with pytest.raises(RefreshExpiredError, match="invalid_grant"):
                 provider.refresh_session(refresh_token="rt_old")
 
+    def test_refresh_rejects_email_removed_from_allowlist(self, provider, rsa_keypair, monkeypatch):
+        monkeypatch.setenv("DASHBOARD_ALLOWED_USERS", "bob@example.com")
+        id_token = _mint_id_token(rsa_keypair, email="alice@example.com")
+        mock_resp = _mock_post(
+            200, {"access_token": "ya29.new", "token_type": "Bearer", "id_token": id_token}
+        )
+        with patch("plugins.dashboard_auth.google.httpx.post", return_value=mock_resp):
+            with pytest.raises(RefreshExpiredError, match="not on the dashboard allowlist"):
+                provider.refresh_session(refresh_token="rt_old")
+
+    def test_refresh_permits_allowlisted_email(self, provider, rsa_keypair, monkeypatch):
+        monkeypatch.setenv("DASHBOARD_ALLOWED_USERS", "alice@example.com")
+        id_token = _mint_id_token(rsa_keypair, email="alice@example.com")
+        mock_resp = _mock_post(
+            200, {"access_token": "ya29.new", "token_type": "Bearer", "id_token": id_token}
+        )
+        with patch("plugins.dashboard_auth.google.httpx.post", return_value=mock_resp):
+            session = provider.refresh_session(refresh_token="rt_old")
+        assert session.email == "alice@example.com"
+
     def test_revoke_is_best_effort_and_does_not_raise(self, provider):
         with patch(
             "plugins.dashboard_auth.google.httpx.post",
@@ -628,6 +678,14 @@ class TestRefreshAndRevoke:
         args, kwargs = mock_post.call_args
         assert args[0] == "https://oauth2.googleapis.com/revoke"
         assert kwargs["data"] == {"token": "rt"}
+
+    def test_revoke_logs_non_200_status_without_raising(self, provider, caplog):
+        mock_resp = _mock_post(400, {"error": "invalid_token"})
+        with patch("plugins.dashboard_auth.google.httpx.post", return_value=mock_resp):
+            with caplog.at_level("DEBUG", logger="plugins.dashboard_auth.google"):
+                result = provider.revoke_session(refresh_token="already-expired")
+        assert result is None
+        assert any("status_code=400" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/dashboard_auth/test_google_provider.py
+++ b/tests/plugins/dashboard_auth/test_google_provider.py
@@ -303,6 +303,7 @@ class TestStartLogin:
         assert params["scope"] == "openid email profile"
         assert params["code_challenge_method"] == "S256"
         assert params["prompt"] == "select_account"
+        assert params["access_type"] == "offline"
         assert "state" in params
         assert "code_challenge" in params
 

--- a/tests/plugins/dashboard_auth/test_google_provider.py
+++ b/tests/plugins/dashboard_auth/test_google_provider.py
@@ -1,0 +1,712 @@
+"""Tests for the bundled Google OAuth dashboard-auth plugin.
+
+Covers, by analogy with ``test_self_hosted_provider.py`` and
+``test_nous_provider.py``:
+
+1. Plugin entry-point registration gating (env + config.yaml precedence).
+2. ``start_login`` shape (PKCE/state, authorize URL parameters, including
+   the Google-specific ``prompt=select_account``).
+3. ``complete_login`` httpx-mocked happy path + error mapping (ID-token
+   grant), including the ``email_verified`` guard and the
+   ``DASHBOARD_ALLOWED_USERS`` allowlist.
+4. ``verify_session`` — local ID-token verification (no userinfo round
+   trip), audience/issuer pinning, the ``hd`` claim → ``org_id`` mapping.
+5. ``refresh_session`` rotation + error mapping, ``revoke_session``
+   (best-effort POST to Google's fixed revocation endpoint).
+6. OIDC discovery: endpoint extraction, soft-TTL caching, https enforcement.
+
+All HTTP is mocked: nothing here talks to real Google endpoints.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import time
+import urllib.parse
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import httpx
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+import plugins.dashboard_auth.google as google_plugin
+from hermes_cli.dashboard_auth import (
+    InvalidCodeError,
+    LoginStart,
+    ProviderError,
+    RefreshExpiredError,
+    Session,
+    assert_protocol_compliance,
+)
+
+_ISSUER = "https://accounts.google.com"
+_CLIENT_ID = "abc123.apps.googleusercontent.com"
+_CLIENT_SECRET = "GOCSPX-test-secret"
+
+_DISCOVERY_DOC = {
+    "issuer": _ISSUER,
+    "authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+    "token_endpoint": "https://oauth2.googleapis.com/token",
+    "jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
+}
+
+
+# ---------------------------------------------------------------------------
+# RSA keypair fixture (module-scope — keygen is slow)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def rsa_keypair() -> Dict[str, Any]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    public_numbers = key.public_key().public_numbers()
+
+    def _b64url_uint(n: int) -> str:
+        length = (n.bit_length() + 7) // 8
+        return (
+            base64.urlsafe_b64encode(n.to_bytes(length, "big")).rstrip(b"=").decode()
+        )
+
+    jwk = {
+        "kty": "RSA",
+        "use": "sig",
+        "alg": "RS256",
+        "kid": "test-key-1",
+        "n": _b64url_uint(public_numbers.n),
+        "e": _b64url_uint(public_numbers.e),
+    }
+    return {"private_pem": private_pem, "jwk": jwk, "kid": jwk["kid"]}
+
+
+# ---------------------------------------------------------------------------
+# Token-mint helper — Google ID-token claim shape
+# ---------------------------------------------------------------------------
+
+
+def _mint_id_token(
+    rsa_keypair: Dict[str, Any],
+    *,
+    iss: str = _ISSUER,
+    aud: str = _CLIENT_ID,
+    sub: str = "110169484474386276334",
+    email: str | None = "alice@example.com",
+    email_verified: bool | None = True,
+    name: str | None = "Alice Example",
+    hd: str | None = None,
+    ttl_seconds: int = 3600,
+    extra_claims: Dict[str, Any] | None = None,
+) -> str:
+    now = int(time.time())
+    claims: Dict[str, Any] = {
+        "iss": iss,
+        "aud": aud,
+        "sub": sub,
+        "iat": now,
+        "exp": now + ttl_seconds,
+    }
+    if email is not None:
+        claims["email"] = email
+    if email_verified is not None:
+        claims["email_verified"] = email_verified
+    if name is not None:
+        claims["name"] = name
+    if hd is not None:
+        claims["hd"] = hd
+    if extra_claims:
+        claims.update(extra_claims)
+    return jwt.encode(
+        claims,
+        rsa_keypair["private_pem"],
+        algorithm="RS256",
+        headers={"kid": rsa_keypair["kid"]},
+    )
+
+
+def _make_provider(
+    rsa_keypair,
+    *,
+    client_id: str = _CLIENT_ID,
+    client_secret: str = _CLIENT_SECRET,
+) -> google_plugin.GoogleDashboardAuthProvider:
+    """Construct a provider with discovery + JWKS stubbed (no network)."""
+    p = google_plugin.GoogleDashboardAuthProvider(
+        client_id=client_id, client_secret=client_secret
+    )
+    p._discovery = dict(_DISCOVERY_DOC)
+    p._discovery_fetched_at = time.time()
+    fake_key = MagicMock()
+    fake_key.key = serialization.load_pem_private_key(
+        rsa_keypair["private_pem"].encode(), password=None
+    ).public_key()
+    fake_client = MagicMock()
+    fake_client.get_signing_key_from_jwt.return_value = fake_key
+    p._jwks_client = fake_client
+    return p
+
+
+def _mock_post(status_code: int, body: Any, *, ctype: str = "application/json"):
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    if isinstance(body, dict):
+        resp.text = json.dumps(body)
+        resp.json = MagicMock(return_value=body)
+    else:
+        resp.text = body
+        resp.json = MagicMock(side_effect=ValueError("not json"))
+    resp.headers = {"content-type": ctype}
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_protocol_compliance(self):
+        assert_protocol_compliance(google_plugin.GoogleDashboardAuthProvider)
+
+    def test_name_and_display(self):
+        p = google_plugin.GoogleDashboardAuthProvider(
+            client_id=_CLIENT_ID, client_secret=_CLIENT_SECRET
+        )
+        assert p.name == "google"
+        assert p.display_name == "Google"
+
+    def test_requires_client_id(self):
+        with pytest.raises(ValueError, match="client_id"):
+            google_plugin.GoogleDashboardAuthProvider(
+                client_id="", client_secret=_CLIENT_SECRET
+            )
+
+    def test_requires_client_secret(self):
+        with pytest.raises(ValueError, match="client_secret"):
+            google_plugin.GoogleDashboardAuthProvider(
+                client_id=_CLIENT_ID, client_secret=""
+            )
+
+
+# ---------------------------------------------------------------------------
+# OIDC discovery
+# ---------------------------------------------------------------------------
+
+
+class TestDiscovery:
+    def _mock_get(self, status_code, body, *, ctype="application/json"):
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = status_code
+        resp.json = MagicMock(return_value=body)
+        resp.text = json.dumps(body) if isinstance(body, dict) else str(body)
+        resp.headers = {"content-type": ctype}
+        return resp
+
+    def test_fetches_and_caches(self):
+        p = google_plugin.GoogleDashboardAuthProvider(
+            client_id=_CLIENT_ID, client_secret=_CLIENT_SECRET
+        )
+        mock_resp = self._mock_get(200, dict(_DISCOVERY_DOC))
+        with patch(
+            "plugins.dashboard_auth.google.httpx.get", return_value=mock_resp
+        ) as mock_get:
+            disco1 = p._get_discovery()
+            disco2 = p._get_discovery()
+        assert disco1["token_endpoint"] == _DISCOVERY_DOC["token_endpoint"]
+        assert disco1["authorization_endpoint"] == _DISCOVERY_DOC["authorization_endpoint"]
+        assert disco1["jwks_uri"] == _DISCOVERY_DOC["jwks_uri"]
+        # Cached — only one network call.
+        assert mock_get.call_count == 1
+        assert disco2 is disco1
+
+    def test_stale_cache_is_refetched(self):
+        p = google_plugin.GoogleDashboardAuthProvider(
+            client_id=_CLIENT_ID, client_secret=_CLIENT_SECRET
+        )
+        p._discovery = dict(_DISCOVERY_DOC)
+        p._discovery_fetched_at = time.time() - google_plugin._DISCOVERY_CACHE_TTL_SEC - 1
+        mock_resp = self._mock_get(200, dict(_DISCOVERY_DOC))
+        with patch(
+            "plugins.dashboard_auth.google.httpx.get", return_value=mock_resp
+        ) as mock_get:
+            p._get_discovery()
+        assert mock_get.call_count == 1
+
+    def test_missing_field_raises(self):
+        p = google_plugin.GoogleDashboardAuthProvider(
+            client_id=_CLIENT_ID, client_secret=_CLIENT_SECRET
+        )
+        incomplete = dict(_DISCOVERY_DOC)
+        del incomplete["jwks_uri"]
+        mock_resp = self._mock_get(200, incomplete)
+        with patch(
+            "plugins.dashboard_auth.google.httpx.get", return_value=mock_resp
+        ):
+            with pytest.raises(ProviderError, match="jwks_uri"):
+                p._get_discovery()
+
+    def test_non_https_endpoint_rejected(self):
+        p = google_plugin.GoogleDashboardAuthProvider(
+            client_id=_CLIENT_ID, client_secret=_CLIENT_SECRET
+        )
+        bad = dict(_DISCOVERY_DOC)
+        bad["token_endpoint"] = "http://oauth2.googleapis.com/token"
+        mock_resp = self._mock_get(200, bad)
+        with patch(
+            "plugins.dashboard_auth.google.httpx.get", return_value=mock_resp
+        ):
+            with pytest.raises(ProviderError, match="https"):
+                p._get_discovery()
+
+    def test_discovery_unreachable_raises_provider_error(self):
+        p = google_plugin.GoogleDashboardAuthProvider(
+            client_id=_CLIENT_ID, client_secret=_CLIENT_SECRET
+        )
+        with patch(
+            "plugins.dashboard_auth.google.httpx.get",
+            side_effect=httpx.ConnectError("conn refused"),
+        ):
+            with pytest.raises(ProviderError, match="unreachable"):
+                p._get_discovery()
+
+
+# ---------------------------------------------------------------------------
+# start_login
+# ---------------------------------------------------------------------------
+
+
+class TestStartLogin:
+    @pytest.fixture
+    def provider(self, rsa_keypair):
+        return _make_provider(rsa_keypair)
+
+    def test_returns_login_start(self, provider):
+        result = provider.start_login(redirect_uri="https://dash.example.com/auth/callback")
+        assert isinstance(result, LoginStart)
+
+    def test_authorize_url_has_required_params(self, provider):
+        result = provider.start_login(redirect_uri="https://dash.example.com/auth/callback")
+        parsed = urllib.parse.urlparse(result.redirect_url)
+        assert result.redirect_url.startswith(_DISCOVERY_DOC["authorization_endpoint"])
+        params = dict(urllib.parse.parse_qsl(parsed.query))
+        assert params["response_type"] == "code"
+        assert params["client_id"] == _CLIENT_ID
+        assert params["redirect_uri"] == "https://dash.example.com/auth/callback"
+        assert params["scope"] == "openid email profile"
+        assert params["code_challenge_method"] == "S256"
+        assert params["prompt"] == "select_account"
+        assert "state" in params
+        assert "code_challenge" in params
+
+    def test_code_verifier_in_cookie_payload_43_to_128_chars(self, provider):
+        result = provider.start_login(redirect_uri="https://dash.example.com/auth/callback")
+        pkce = result.cookie_payload["hermes_session_pkce"]
+        parts = dict(seg.split("=", 1) for seg in pkce.split(";") if "=" in seg)
+        verifier = parts["verifier"]
+        assert 43 <= len(verifier) <= 128  # RFC 7636 §4.1
+
+    def test_state_in_cookie_matches_url(self, provider):
+        result = provider.start_login(redirect_uri="https://dash.example.com/auth/callback")
+        parsed = urllib.parse.urlparse(result.redirect_url)
+        params = dict(urllib.parse.parse_qsl(parsed.query))
+        pkce = result.cookie_payload["hermes_session_pkce"]
+        parts = dict(seg.split("=", 1) for seg in pkce.split(";") if "=" in seg)
+        assert parts["state"] == params["state"]
+
+    def test_rejects_redirect_uri_wrong_path(self, provider):
+        with pytest.raises(ProviderError, match="auth/callback"):
+            provider.start_login(redirect_uri="https://dash.example.com/wrong")
+
+
+# ---------------------------------------------------------------------------
+# complete_login
+# ---------------------------------------------------------------------------
+
+
+class TestCompleteLogin:
+    @pytest.fixture
+    def provider(self, rsa_keypair):
+        return _make_provider(rsa_keypair)
+
+    def test_happy_path_returns_session(self, provider, rsa_keypair):
+        id_token = _mint_id_token(rsa_keypair, hd="example.com")
+        mock_resp = _mock_post(
+            200,
+            {"access_token": "ya29.opaque", "token_type": "Bearer", "id_token": id_token},
+        )
+        with patch("plugins.dashboard_auth.google.httpx.post", return_value=mock_resp):
+            session = provider.complete_login(
+                code="abc",
+                state="s",
+                code_verifier="v",
+                redirect_uri="https://dash.example.com/auth/callback",
+            )
+        assert isinstance(session, Session)
+        assert session.provider == "google"
+        assert session.user_id == "110169484474386276334"
+        assert session.email == "alice@example.com"
+        assert session.display_name == "Alice Example"
+        # 'hd' claim maps to org_id.
+        assert session.org_id == "example.com"
+        # The verified ID token is stored as the session's access token so
+        # verify_session() can re-verify it locally.
+        assert session.access_token == id_token
+
+    def test_missing_id_token_raises(self, provider):
+        mock_resp = _mock_post(200, {"access_token": "ya29.opaque", "token_type": "Bearer"})
+        with patch("plugins.dashboard_auth.google.httpx.post", return_value=mock_resp):
+            with pytest.raises(ProviderError, match="id_token"):
+                provider.complete_login(
+                    code="abc", state="s", code_verifier="v",
+                    redirect_uri="https://dash.example.com/auth/callback",
+                )
+
+    def test_400_raises_invalid_code(self, provider):
+        mock_resp = _mock_post(400, {"error": "invalid_grant"})
+        with patch("plugins.dashboard_auth.google.httpx.post", return_value=mock_resp):
+            with pytest.raises(InvalidCodeError, match="invalid_grant"):
+                provider.complete_login(
+                    code="bad", state="s", code_verifier="v",
+                    redirect_uri="https://dash.example.com/auth/callback",
+                )
+
+    def test_500_raises_provider_error(self, provider):
+        mock_resp = _mock_post(500, "internal error", ctype="text/plain")
+        with patch("plugins.dashboard_auth.google.httpx.post", return_value=mock_resp):
+            with pytest.raises(ProviderError, match="500"):
+                provider.complete_login(
+                    code="x", state="s", code_verifier="v",
+                    redirect_uri="https://dash.example.com/auth/callback",
+                )
+
+    def test_network_error_raises_provider_error(self, provider):
+        with patch(
+            "plugins.dashboard_auth.google.httpx.post",
+            side_effect=httpx.ConnectError("conn refused"),
+        ):
+            with pytest.raises(ProviderError, match="unreachable"):
+                provider.complete_login(
+                    code="x", state="s", code_verifier="v",
+                    redirect_uri="https://dash.example.com/auth/callback",
+                )
+
+    def test_email_not_verified_rejected(self, provider, rsa_keypair):
+        id_token = _mint_id_token(rsa_keypair, email_verified=False)
+        mock_resp = _mock_post(
+            200,
+            {"access_token": "ya29.opaque", "token_type": "Bearer", "id_token": id_token},
+        )
+        with patch("plugins.dashboard_auth.google.httpx.post", return_value=mock_resp):
+            with pytest.raises(InvalidCodeError, match="email_verified"):
+                provider.complete_login(
+                    code="x", state="s", code_verifier="v",
+                    redirect_uri="https://dash.example.com/auth/callback",
+                )
+
+    def test_missing_email_verified_claim_tolerated(self, provider, rsa_keypair):
+        # Some flows omit the claim entirely — must not be treated as False.
+        id_token = _mint_id_token(rsa_keypair, email_verified=None)
+        mock_resp = _mock_post(
+            200,
+            {"access_token": "ya29.opaque", "token_type": "Bearer", "id_token": id_token},
+        )
+        with patch("plugins.dashboard_auth.google.httpx.post", return_value=mock_resp):
+            session = provider.complete_login(
+                code="x", state="s", code_verifier="v",
+                redirect_uri="https://dash.example.com/auth/callback",
+            )
+        assert session.email == "alice@example.com"
+
+    def test_wrong_audience_raises_provider_error(self, provider, rsa_keypair):
+        id_token = _mint_id_token(rsa_keypair, aud="someone-elses-client-id")
+        mock_resp = _mock_post(
+            200,
+            {"access_token": "ya29.opaque", "token_type": "Bearer", "id_token": id_token},
+        )
+        with patch("plugins.dashboard_auth.google.httpx.post", return_value=mock_resp):
+            with pytest.raises(ProviderError, match="verification failed"):
+                provider.complete_login(
+                    code="x", state="s", code_verifier="v",
+                    redirect_uri="https://dash.example.com/auth/callback",
+                )
+
+
+# ---------------------------------------------------------------------------
+# complete_login — DASHBOARD_ALLOWED_USERS / GATEWAY_ALLOWED_USERS allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlist:
+    @pytest.fixture
+    def provider(self, rsa_keypair):
+        return _make_provider(rsa_keypair)
+
+    def _complete(self, provider, rsa_keypair, *, email="alice@example.com"):
+        id_token = _mint_id_token(rsa_keypair, email=email)
+        mock_resp = _mock_post(
+            200,
+            {"access_token": "ya29.opaque", "token_type": "Bearer", "id_token": id_token},
+        )
+        with patch("plugins.dashboard_auth.google.httpx.post", return_value=mock_resp):
+            return provider.complete_login(
+                code="x", state="s", code_verifier="v",
+                redirect_uri="https://dash.example.com/auth/callback",
+            )
+
+    def test_no_allowlist_permits_any_authenticated_user(self, provider, rsa_keypair, monkeypatch):
+        monkeypatch.delenv("DASHBOARD_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+        session = self._complete(provider, rsa_keypair)
+        assert session.email == "alice@example.com"
+
+    def test_allowlisted_email_permitted(self, provider, rsa_keypair, monkeypatch):
+        monkeypatch.setenv("DASHBOARD_ALLOWED_USERS", "alice@example.com, bob@example.com")
+        session = self._complete(provider, rsa_keypair)
+        assert session.email == "alice@example.com"
+
+    def test_allowlist_is_case_insensitive(self, provider, rsa_keypair, monkeypatch):
+        monkeypatch.setenv("DASHBOARD_ALLOWED_USERS", "ALICE@EXAMPLE.COM")
+        session = self._complete(provider, rsa_keypair)
+        assert session.email == "alice@example.com"
+
+    def test_non_allowlisted_email_rejected(self, provider, rsa_keypair, monkeypatch):
+        monkeypatch.setenv("DASHBOARD_ALLOWED_USERS", "bob@example.com")
+        with pytest.raises(InvalidCodeError, match="not on the dashboard allowlist"):
+            self._complete(provider, rsa_keypair, email="alice@example.com")
+
+    def test_falls_back_to_gateway_allowed_users(self, provider, rsa_keypair, monkeypatch):
+        monkeypatch.delenv("DASHBOARD_ALLOWED_USERS", raising=False)
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "alice@example.com")
+        session = self._complete(provider, rsa_keypair)
+        assert session.email == "alice@example.com"
+
+    def test_dashboard_allowlist_takes_precedence_over_gateway(self, provider, rsa_keypair, monkeypatch):
+        monkeypatch.setenv("DASHBOARD_ALLOWED_USERS", "alice@example.com")
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "someone-else@example.com")
+        session = self._complete(provider, rsa_keypair)
+        assert session.email == "alice@example.com"
+
+
+# ---------------------------------------------------------------------------
+# verify_session
+# ---------------------------------------------------------------------------
+
+
+class TestVerifySession:
+    @pytest.fixture
+    def provider(self, rsa_keypair):
+        return _make_provider(rsa_keypair)
+
+    def test_valid_token_returns_session(self, provider, rsa_keypair):
+        id_token = _mint_id_token(rsa_keypair, hd="example.com")
+        session = provider.verify_session(access_token=id_token)
+        assert session is not None
+        assert session.user_id == "110169484474386276334"
+        assert session.org_id == "example.com"
+        assert session.expires_at > int(time.time())
+
+    def test_expired_token_returns_none(self, provider, rsa_keypair):
+        token = _mint_id_token(rsa_keypair, ttl_seconds=-1)
+        assert provider.verify_session(access_token=token) is None
+
+    def test_email_not_verified_returns_none(self, provider, rsa_keypair):
+        token = _mint_id_token(rsa_keypair, email_verified=False)
+        assert provider.verify_session(access_token=token) is None
+
+    def test_wrong_audience_raises_provider_error(self, provider, rsa_keypair):
+        token = _mint_id_token(rsa_keypair, aud="someone-elses-client-id")
+        with pytest.raises(ProviderError, match="verification failed"):
+            provider.verify_session(access_token=token)
+
+    def test_wrong_issuer_raises_provider_error(self, provider, rsa_keypair):
+        token = _mint_id_token(rsa_keypair, iss="https://evil.example")
+        with pytest.raises(ProviderError) as excinfo:
+            provider.verify_session(access_token=token)
+        assert "evil.example" in str(excinfo.value)
+
+    def test_jwks_unreachable_raises_provider_error(self, provider, rsa_keypair):
+        token = _mint_id_token(rsa_keypair)
+        bad_client = MagicMock()
+        bad_client.get_signing_key_from_jwt.side_effect = jwt.PyJWKClientError("fetch failed")
+        provider._jwks_client = bad_client
+        with pytest.raises(ProviderError, match="JWKS"):
+            provider.verify_session(access_token=token)
+
+    def test_jwks_client_sends_explicit_http_headers(self, provider):
+        provider._jwks_client = None
+        with patch("jwt.PyJWKClient") as client_cls:
+            provider._get_jwks_client()
+        client_cls.assert_called_once_with(
+            _DISCOVERY_DOC["jwks_uri"],
+            cache_keys=True,
+            lifespan=google_plugin._JWKS_CACHE_SECONDS,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": "HermesAgent/1.0",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# refresh_session + revoke_session
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshAndRevoke:
+    @pytest.fixture
+    def provider(self, rsa_keypair):
+        return _make_provider(rsa_keypair)
+
+    def test_no_refresh_token_raises(self, provider):
+        with pytest.raises(RefreshExpiredError):
+            provider.refresh_session(refresh_token="")
+
+    def test_refresh_happy_path_returns_rotated_session(self, provider, rsa_keypair):
+        id_token = _mint_id_token(rsa_keypair)
+        mock_resp = _mock_post(
+            200,
+            {
+                "access_token": "ya29.new",
+                "token_type": "Bearer",
+                "id_token": id_token,
+                "refresh_token": "rt_rotated",
+            },
+        )
+        with patch(
+            "plugins.dashboard_auth.google.httpx.post", return_value=mock_resp
+        ) as mock_post:
+            session = provider.refresh_session(refresh_token="rt_old")
+        assert session.refresh_token == "rt_rotated"
+        assert session.provider == "google"
+        _, kwargs = mock_post.call_args
+        assert kwargs["data"]["grant_type"] == "refresh_token"
+        assert kwargs["data"]["refresh_token"] == "rt_old"
+
+    def test_refresh_keeps_previous_token_when_not_rotated(self, provider, rsa_keypair):
+        # Google usually does not rotate the refresh token.
+        id_token = _mint_id_token(rsa_keypair)
+        mock_resp = _mock_post(
+            200, {"access_token": "ya29.new", "token_type": "Bearer", "id_token": id_token}
+        )
+        with patch("plugins.dashboard_auth.google.httpx.post", return_value=mock_resp):
+            session = provider.refresh_session(refresh_token="rt_old")
+        assert session.refresh_token == "rt_old"
+
+    def test_refresh_400_raises_refresh_expired(self, provider):
+        mock_resp = _mock_post(400, {"error": "invalid_grant"})
+        with patch("plugins.dashboard_auth.google.httpx.post", return_value=mock_resp):
+            with pytest.raises(RefreshExpiredError, match="invalid_grant"):
+                provider.refresh_session(refresh_token="rt_old")
+
+    def test_revoke_is_best_effort_and_does_not_raise(self, provider):
+        with patch(
+            "plugins.dashboard_auth.google.httpx.post",
+            side_effect=httpx.ConnectError("conn refused"),
+        ):
+            assert provider.revoke_session(refresh_token="rt") is None
+
+    def test_revoke_noop_on_empty_token(self, provider):
+        with patch("plugins.dashboard_auth.google.httpx.post") as mock_post:
+            provider.revoke_session(refresh_token="")
+        mock_post.assert_not_called()
+
+    def test_revoke_posts_to_google_endpoint(self, provider):
+        mock_resp = _mock_post(200, {})
+        with patch(
+            "plugins.dashboard_auth.google.httpx.post", return_value=mock_resp
+        ) as mock_post:
+            provider.revoke_session(refresh_token="rt")
+        args, kwargs = mock_post.call_args
+        assert args[0] == "https://oauth2.googleapis.com/revoke"
+        assert kwargs["data"] == {"token": "rt"}
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry point: env-gated registration + config.yaml precedence
+# ---------------------------------------------------------------------------
+
+
+class TestPluginRegister:
+    @pytest.fixture(autouse=True)
+    def clear_env(self, monkeypatch):
+        for var in (
+            "HERMES_DASHBOARD_GOOGLE_CLIENT_ID",
+            "HERMES_DASHBOARD_GOOGLE_CLIENT_SECRET",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+    @pytest.fixture
+    def patch_config(self, monkeypatch):
+        def _set(oauth_block: Dict[str, Any] | None) -> None:
+            cfg = {}
+            if oauth_block is not None:
+                cfg = {"dashboard": {"oauth": oauth_block}}
+            monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+
+        return _set
+
+    def test_skips_when_unconfigured(self, patch_config):
+        patch_config(None)
+        ctx = MagicMock()
+        google_plugin.register(ctx)
+        ctx.register_dashboard_auth_provider.assert_not_called()
+        assert "HERMES_DASHBOARD_GOOGLE_CLIENT_ID" in google_plugin.LAST_SKIP_REASON
+
+    def test_skips_when_secret_missing(self, patch_config, monkeypatch):
+        patch_config(None)
+        monkeypatch.setenv("HERMES_DASHBOARD_GOOGLE_CLIENT_ID", "abc.apps.googleusercontent.com")
+        ctx = MagicMock()
+        google_plugin.register(ctx)
+        ctx.register_dashboard_auth_provider.assert_not_called()
+        assert "SECRET" in google_plugin.LAST_SKIP_REASON
+
+    def test_registers_from_env(self, patch_config, monkeypatch):
+        patch_config(None)
+        monkeypatch.setenv("HERMES_DASHBOARD_GOOGLE_CLIENT_ID", _CLIENT_ID)
+        monkeypatch.setenv("HERMES_DASHBOARD_GOOGLE_CLIENT_SECRET", _CLIENT_SECRET)
+        ctx = MagicMock()
+        google_plugin.register(ctx)
+        ctx.register_dashboard_auth_provider.assert_called_once()
+        registered = ctx.register_dashboard_auth_provider.call_args.args[0]
+        assert isinstance(registered, google_plugin.GoogleDashboardAuthProvider)
+        assert registered._client_id == _CLIENT_ID
+        assert google_plugin.LAST_SKIP_REASON == ""
+
+    def test_registers_from_config_yaml(self, patch_config):
+        patch_config(
+            {"google_client_id": _CLIENT_ID, "google_client_secret": _CLIENT_SECRET}
+        )
+        ctx = MagicMock()
+        google_plugin.register(ctx)
+        ctx.register_dashboard_auth_provider.assert_called_once()
+        registered = ctx.register_dashboard_auth_provider.call_args.args[0]
+        assert registered._client_id == _CLIENT_ID
+
+    def test_env_overrides_config(self, patch_config, monkeypatch):
+        patch_config(
+            {"google_client_id": "from-config", "google_client_secret": "from-config-secret"}
+        )
+        monkeypatch.setenv("HERMES_DASHBOARD_GOOGLE_CLIENT_ID", "from-env")
+        monkeypatch.setenv("HERMES_DASHBOARD_GOOGLE_CLIENT_SECRET", "from-env-secret")
+        ctx = MagicMock()
+        google_plugin.register(ctx)
+        registered = ctx.register_dashboard_auth_provider.call_args.args[0]
+        assert registered._client_id == "from-env"
+
+    def test_config_load_failure_falls_through(self, monkeypatch):
+        def _broken():
+            raise RuntimeError("disk error")
+
+        monkeypatch.setattr("hermes_cli.config.load_config", _broken)
+        ctx = MagicMock()
+        google_plugin.register(ctx)
+        ctx.register_dashboard_auth_provider.assert_not_called()
+        assert "HERMES_DASHBOARD_GOOGLE_CLIENT_ID" in google_plugin.LAST_SKIP_REASON


### PR DESCRIPTION
## Summary

Adds a bundled dashboard-auth provider that authenticates dashboard users against Google, following the layout and conventions of the existing `plugins/dashboard_auth/{nous,basic,drain,self_hosted}` providers:

- `plugins/dashboard_auth/google/__init__.py`
- `plugins/dashboard_auth/google/plugin.yaml`
- `tests/plugins/dashboard_auth/test_google_provider.py`

Authentication uses the OAuth 2.0 authorization-code grant with PKCE (RFC 6749 §4.1, RFC 7636). OIDC endpoints are resolved from Google's discovery document (OpenID Connect Discovery 1.0, `https://accounts.google.com/.well-known/openid-configuration`) instead of being hardcoded, cached with a soft 1-hour TTL. The ID token returned by the token endpoint is verified locally against Google's published JWKS (issuer + audience pinned, signature checked — RFC 7517/RFC 7519) and stored as the session's access token, so `verify_session()` re-verifies a real JWT on every request instead of making a network round trip to a userinfo endpoint on every dashboard request.

## Why not just point `self_hosted` (generic OIDC) at `accounts.google.com`?

This is the obvious first question, so it's worth answering directly rather than leaving it for review.

**1. There's already precedent for a dedicated provider next to the generic one.** `nous` is, structurally, also just an OAuth/OIDC provider — it could in principle have been "one more generic-OIDC configuration." It exists as its own provider because it carries provider-specific behavior that doesn't belong in a generic flow. The same reasoning applies here: Google's login has enough IDP-specific behavior to justify its own provider rather than growing `self_hosted` into a per-IDP special-case dispatcher.

**2. The Google-specific behavior is concrete, not cosmetic — and doesn't fit in `self_hosted` without branching on IDP identity:**
- `email_verified` enforcement. `self_hosted` doesn't check this claim at all. For Google specifically, an unverified `email_verified=false` on a custom-domain Workspace account is a real trust gap — accepting it means authenticating someone under an email they don't actually control.
- `hd` (hosted domain) → `org_id` mapping. This is a Google-only claim; no other provider in this repo has an equivalent.
- `prompt=select_account` on the authorization request — a Google-specific query parameter, not part of generic OIDC.
- A hardcoded `https://oauth2.googleapis.com/revoke`. Google's discovery document does not advertise a `revocation_endpoint`, so `self_hosted`'s generic RFC 7009 revoke (which reads the endpoint from discovery) would silently no-op against Google — `revoke_session` would return without ever calling Google's API.
- An optional `DASHBOARD_ALLOWED_USERS` / `GATEWAY_ALLOWED_USERS` email allowlist — a new capability none of the existing providers have.

Threading all of this through `self_hosted` would mean `if issuer == "https://accounts.google.com": ...` branches scattered across a provider whose entire value proposition is being IDP-agnostic. Keeping it as a separate provider keeps `self_hosted` generic and keeps the Google-specific logic contained and testable on its own.

**3. Onboarding/UX.** Operators know "Login with Google" and can set `HERMES_DASHBOARD_GOOGLE_CLIENT_ID` / `HERMES_DASHBOARD_GOOGLE_CLIENT_SECRET` without knowing what OIDC discovery even is. Requiring `HERMES_DASHBOARD_OIDC_ISSUER=https://accounts.google.com` on `self_hosted` works, but it's an unnecessary detour for what is likely the single most commonly requested IDP among all the self-hosted alternatives.

**4. The implementation deliberately mirrors `self_hosted`'s architecture, not a fresh one-off.** Local ID-token verification instead of a network call on every `verify_session`, a TTL-cached discovery document, the same broadened JWT algorithm allowlist, and the same `_require_https_or_loopback` defense-in-depth helper are all reused patterns, not reinvented ones. The parts that differ are exactly the Google-specific behaviors listed in point 2 — everything else follows the existing convention on purpose.

**5. On the prior closure of #58987.** A previous PR proposing a Google-specific provider was closed as `implemented_on_main`, on the grounds that `self_hosted` already lists Google in its `plugin.yaml` and was extended in #55344 specifically to support confidential clients (`client_secret`) via `_token_endpoint_auth`. That closure is correct on its own terms — `self_hosted` genuinely can complete a confidential-client PKCE flow against `accounts.google.com` today, so "self_hosted can't talk to Google at all" is not a valid justification here, and this PR doesn't make that claim. What #58987 didn't address, and what current `self_hosted` code still doesn't do, is the five items in point 2 above: it doesn't check `email_verified`, doesn't map `hd`, doesn't send `prompt=select_account`, and its RFC 7009 revoke silently no-ops against Google specifically because Google's discovery document omits `revocation_endpoint` (verified against the current `self_hosted` source — `revoke_session` returns early whenever `disco.get("revocation_endpoint")` is empty). The allowlist item is the one place there's a live competing proposal (#76519, still open/`needs-decision`, adding an allowlist to `self_hosted` generically) — happy to drop that piece from this PR and defer to #76519 if that's preferred, since it's the one differentiator without a hard technical reason to be IDP-specific.

## Registration / config

Gated on `HERMES_DASHBOARD_GOOGLE_CLIENT_ID` and `HERMES_DASHBOARD_GOOGLE_CLIENT_SECRET` (env vars, or `dashboard.oauth.google_client_id`/`google_client_secret` in `config.yaml`, env taking precedence over config on a per-field basis). Installs that don't configure these are entirely unaffected — the plugin skips registration silently and records a skip reason consumed by the dashboard's existing fail-closed diagnostics.

## Test plan

- [x] `pytest tests/plugins/dashboard_auth/test_google_provider.py` — 54 tests covering construction, discovery fetch/cache/TTL/https-enforcement, `start_login` parameters (PKCE, state, `prompt=select_account`, `access_type=offline`), `complete_login` (happy path, missing `id_token`, 4xx/5xx/network error mapping, `email_verified` enforcement, allowlist enforcement incl. config.yaml fallback), `verify_session` (valid/expired/wrong-audience/wrong-issuer/JWKS-unreachable), `refresh_session` (rotation, allowlist re-check) / `revoke_session` (status_code logging), and plugin registration gating/precedence.
- [x] `pytest tests/plugins/dashboard_auth/ tests/plugins/test_plugin_dashboard_auth_contract.py` — full existing dashboard-auth suite (156 tests) still passes, no regressions in sibling providers.
- [x] `python3 -m py_compile` / manifest parses cleanly for both new plugin files.
- [ ] Manual end-to-end login against a real Google OAuth client (not exercised in CI; all tests mock the network).
