### PR TITLE
fix(bot-mode): pin the registry-owning profile on peer DM deliveries

### DIFF
--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -263,6 +263,35 @@ def test_local_delivery_command_and_ack(tmp_path, monkeypatch):
     assert '$(and this is not shell)' in content
 
 
+def test_peer_delivery_command_pins_registry_profile_for_secondary_bots(
+    tmp_path, monkeypatch
+):
+    """A secondary-profile bot's peer DM must run in the registry-owning
+    profile (#93935). `hermes peer` resolves bot_peers through
+    profile-scoped load_config(); unpinned, the subprocess inherits the
+    calling bot's profile and dies with "No peer named" even though the
+    tool-side roster (read from the machine-root config) validated the
+    target."""
+    calls = _capture_spawn(monkeypatch)
+    home = _managed_home(tmp_path, peers=("spark",))
+    # A reviewer-profile gateway context: the agent's session db lives under
+    # that profile's home, so _agent_home() resolves there while the
+    # machine-root config (home/config.yaml) still holds the registry.
+    reviewer_home = home / "profiles" / "reviewer"
+    reviewer_home.mkdir(parents=True)
+    agent = _FakeAgent(reviewer_home, title="Bot Chat")
+
+    result = json.loads(
+        bot_mode_dm.message_agent_tool(target="spark", message="ping", agent=agent)
+    )
+    assert result["status"] == "sent"
+    mode, _dm_file, transport_argv = _runner_parts(calls[0]["command"])
+    assert mode == "stdin"
+    # The registry the tool validated against is the machine root's — the
+    # default profile's home — so the CLI runs there, not in reviewer.
+    assert transport_argv == ["hermes", "-p", "default", "peer", "dm", "spark"]
+
+
 def test_peer_delivery_command(tmp_path, monkeypatch):
     calls = _capture_spawn(monkeypatch)
     home = _managed_home(tmp_path, peers=("spark",))
@@ -275,7 +304,7 @@ def test_peer_delivery_command(tmp_path, monkeypatch):
     assert "spark" in result["to"]
     mode, _dm_file, transport_argv = _runner_parts(calls[0]["command"])
     assert mode == "stdin"
-    assert transport_argv == ["hermes", "peer", "dm", "spark/researcher"]
+    assert transport_argv == ["hermes", "-p", "default", "peer", "dm", "spark/researcher"]
 
     # bare peer name targets the peer's main agent
     result2 = json.loads(
@@ -284,7 +313,7 @@ def test_peer_delivery_command(tmp_path, monkeypatch):
     assert result2["status"] == "sent"
     mode, _dm_file, transport_argv = _runner_parts(calls[1]["command"])
     assert mode == "stdin"
-    assert transport_argv == ["hermes", "peer", "dm", "spark"]
+    assert transport_argv == ["hermes", "-p", "default", "peer", "dm", "spark"]
 
 
 def test_named_profile_sender_prefix(tmp_path, monkeypatch):

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -303,8 +303,23 @@ def message_agent_tool(
             )
         dm_target = f"{peer_name}/{peer_profile}" if peer_profile else peer_name
         label = f"@{peer_profile or peer_name} on peer '{peer_name}'"
+        # Pin the registry-owning profile (#93935): `hermes peer` resolves
+        # bot_peers through load_config(), which is profile-scoped — an
+        # unpinned subprocess inherits THIS gateway's profile context, so a
+        # secondary-profile bot's peer DM ran against an empty registry and
+        # died with "No peer named". The tool-side roster above reads the
+        # machine-root config (the default profile's home), so the CLI must
+        # run in that same profile to see the same registry. Mirrors the
+        # local-teammate path's `-p <resolved>` pin below.
         return _start_delivery(
-            ["hermes", "peer", "dm", dm_target],
+            [
+                "hermes",
+                "-p",
+                _self_profile_name(root),
+                "peer",
+                "dm",
+                dm_target,
+            ],
             prefix + body,
             label,
             stdin_file=True,


### PR DESCRIPTION
## What does this PR do?

`message_agent`'s peer path built `hermes peer dm <target>` without a profile pin (#93935). `hermes peer` resolves `bot_peers` through profile-scoped `load_config()`, so the delivery subprocess inherited the calling gateway's profile context — on a multi-profile Bot Mode install, every non-default bot's peer DM ran against an empty registry and died with `No peer named '<peer>'`, even though the tool-side roster (read from the machine-root config) had validated the target. Cross-machine peer messaging silently worked only from the default profile. The local-teammate path in the same function already pins `-p <resolved>`; this gives the peer path the same treatment, pinning the profile that owns the registry the tool validated against (`_self_profile_name(root)` — the machine-root/default home whose `config.yaml` both the roster probe and the CLI read).

## Related Issue

Fixes #93935

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/bot_mode_dm.py` — the peer-delivery argv becomes `["hermes", "-p", _self_profile_name(root), "peer", "dm", dm_target]`, with a comment documenting the registry-ownership chain (tool roster reads machine-root config; CLI reads profile-scoped config; both must agree). Bare-name and `peer/profile` targets, the stdin delivery mode, and the waiter path are unchanged.
- `tests/tools/test_bot_mode_dm.py` — new `test_peer_delivery_command_pins_registry_profile_for_secondary_bots`: an agent whose session db lives under `profiles/reviewer` (the `_agent_home` derivation, no env patching) still emits the peer argv pinned to `default` — the profile whose config holds the registry. The existing `test_peer_delivery_command` is updated to the new argv shape for both the `peer/profile` and bare-name forms.

## How to Test

- New: `.venv/bin/python -m pytest tests/tools/test_bot_mode_dm.py -q` — should pass (40 tests). On unpatched `main`, the secondary-profile test fails (the argv carries no `-p`), pinning the regression.
- Regression: `.venv/bin/python -m pytest tests/tools/test_bot_mode_dm.py tests/tools/test_bot_relay.py tests/tools/test_bot_turn_lock.py tests/tools/test_bot_retry_policy.py -q` — should pass (102 tests), including the turn-lock recognition (the pinned argv still matches `_delivery_lock`'s basename form from #93658) and the retry-policy argv filters.
- Reporter's repro shape: from a session running under a non-default profile, `message_agent(target="<registered-peer>", ...)` now spawns `hermes -p default peer dm <peer>` — the same registry `hermes -p default peer list` shows.

Observed result: locally, the reviewer-home agent's peer delivery runs pinned to the default profile's registry, the default-profile control case is unchanged, and all 102 bot-mode tests stay green.

## Checklist

- [x] Code follows project style (no unrelated changes)
- [x] Self-reviewed the diff
- [x] Added/updated tests covering the fix
- [x] All new and existing tests pass locally (40 in-suite + 102 across the four bot-mode suites)
- [x] PR targets `upstream/main` from a fork branch
