### PR TITLE
docs(dashboard): align OAuth refresh token contract

### DIFF
--- a/hermes_cli/dashboard_auth/cookies.py
+++ b/hermes_cli/dashboard_auth/cookies.py
@@ -1,10 +1,11 @@
 """Cookie helpers for dashboard auth.
 
-Three cookies in play:
+The OAuth round trip uses four primary cookies:
   - hermes_session_at:   the OAuth access token
                          (HttpOnly, lifetime = token TTL, ~15 min)
   - hermes_session_rt:   the OAuth refresh token
-                         (HttpOnly, lifetime = 24h, ROTATING + reuse-detected)
+                         (HttpOnly, browser Max-Age = 30 days; Portal token TTL
+                         = 24h, rotating + reuse-detected)
                          Nous Portal issues a rotating refresh token for the
                          dashboard auth-code grant (Portal NAS #293 / hermes
                          #37247). ``set_session_cookies`` writes this cookie
@@ -14,11 +15,13 @@ Three cookies in play:
                          provider that omits the refresh token (empty string)
                          degrades gracefully to access-token-only sessions —
                          the RT cookie is simply not written.
+  - hermes_session_provider: non-secret refresh-routing hint
+                         (HttpOnly, browser Max-Age = 30 days)
   - hermes_session_pkce: short-lived PKCE state + CSRF nonce + provider
                          hint (HttpOnly, lifetime = 10 minutes)
 
-The two session cookies are ``SameSite=Lax`` and live under the prefix's
-Path. The PKCE cookie is the exception: ``SameSite=None`` over HTTPS,
+The token and provider-hint cookies are ``SameSite=Lax`` and live under the
+prefix's Path. The PKCE cookie is the exception: ``SameSite=None`` over HTTPS,
 falling back to ``Lax`` on plain HTTP (where ``SameSite=None`` is invalid
 without ``Secure``). It is set on the ``/auth/login`` 302 and must survive
 the cross-site redirect chain out to the IDP and back to
@@ -204,7 +207,8 @@ def set_session_cookies(
         max_age=access_token_expires_in,
         **_common_attrs(use_https=use_https, prefix=prefix),
     )
-    # Contract v1: empty refresh token means "don't persist RT cookie".
+    # An empty refresh token means "don't persist an RT cookie" for providers
+    # that do not issue one.
     # Keeping a literal empty-value cookie around would be dead state at
     # best, attack surface at worst.
     if refresh_token:

--- a/plugins/dashboard_auth/nous/__init__.py
+++ b/plugins/dashboard_auth/nous/__init__.py
@@ -245,9 +245,8 @@ class NousDashboardAuthProvider(DashboardAuthProvider):
         """Rotate the access token using the refresh token.
 
         Posts ``grant_type=refresh_token`` to Portal's token endpoint. The
-        refresh token is sent in the ``X-Refresh-Token`` header (not the body)
-        so it never lands in Portal's request-body access logs — mirroring the
-        device-flow CLI convention; Portal reconciles header vs. body and
+        endpoint requires the refresh token in the form body and in the exact
+        ``x-nous-refresh-token`` header. Portal reconciles the two values and
         rejects conflicts.
 
         Portal rotates the refresh token on every successful refresh, so the
@@ -257,8 +256,9 @@ class NousDashboardAuthProvider(DashboardAuthProvider):
         — trips reuse-detection and revokes the whole session.
 
         Raises ``RefreshExpiredError`` on a 400 (expired / revoked / reuse-
-        detected), so the middleware clears cookies and forces re-login.
-        Raises ``ProviderError`` if Portal is unreachable.
+        detected), which lets the middleware clear the dead session cookies and
+        require fresh authentication. Raises ``ProviderError`` if Portal is
+        unreachable.
         """
         if not refresh_token:
             # No RT to present — treat as a dead session so middleware
@@ -268,17 +268,11 @@ class NousDashboardAuthProvider(DashboardAuthProvider):
         try:
             response = httpx.post(
                 self._token_url,
-                # The refresh token goes in BOTH the body and the
-                # ``x-nous-refresh-token`` header. Portal's token endpoint
-                # requires ``refresh_token`` in the body (its request schema
-                # rejects a header-only request as ``invalid_request``), and
-                # additionally reconciles the header against the body — sending
-                # both lets Portal keep the value out of body-access-logs while
-                # still satisfying the schema. The header name must match
-                # Portal's ``REFRESH_TOKEN_HEADER`` exactly (``x-nous-refresh-
-                # token``); any other name is silently ignored. (Verified
-                # against the NAS #293 preview deploy: header-only → 400
-                # invalid_request; body → accepted.)
+                # Portal's request schema requires ``refresh_token`` in the
+                # body. Its refresh contract also reconciles the exact
+                # ``x-nous-refresh-token`` header against that value. Send the
+                # same opaque token on both surfaces; a header-only request is
+                # rejected as ``invalid_request`` and conflicting values fail.
                 data={
                     "grant_type": "refresh_token",
                     "client_id": self._client_id,

--- a/tests/hermes_cli/test_dashboard_auth_401_reauth.py
+++ b/tests/hermes_cli/test_dashboard_auth_401_reauth.py
@@ -11,8 +11,8 @@ Verifies the contract documented in Phase 6 v2 of the plan:
     loops back to ``/login`` / ``/auth/*`` are dropped.
   - Invalid/expired cookies are cleared on 401 so the browser doesn't
     keep replaying them.
-  - ``set_session_cookies(refresh_token="")`` does NOT emit the
-    ``hermes_session_rt`` cookie (contract V1: no RT to persist).
+  - Providers that return ``refresh_token=""`` do not emit a dead
+    ``hermes_session_rt`` cookie; Nous sessions use their rotating token.
   - ``/auth/callback?next=…`` honours the same-origin landing path.
 """
 
@@ -72,7 +72,7 @@ def gated_app():
 # ---------------------------------------------------------------------------
 
 
-class TestRefreshTokenCookieDeprecation:
+class TestOptionalRefreshTokenCookie:
     def _build_app(self, *, refresh_token: str):
         app = FastAPI()
 
@@ -99,9 +99,7 @@ class TestRefreshTokenCookieDeprecation:
 
 
     def test_clear_session_cookies_still_emits_rt_deletion(self):
-        """Even when we never wrote the RT cookie, logout/clear should
-        emit a Max-Age=0 deletion to flush stale cookies from old
-        deployments."""
+        """Logout always deletes the RT cookie, including stale rotations."""
         app = FastAPI()
 
         @app.get("/clear")

--- a/tests/plugins/dashboard_auth/test_nous_provider.py
+++ b/tests/plugins/dashboard_auth/test_nous_provider.py
@@ -8,8 +8,8 @@ Covers four shapes from Phase 4 of ``.hermes/plans/2026-05-21-dashboard-oauth-au
 4. ``verify_session`` JWT verification — RSA keypair, audience/issuer pinning,
    ``agent_instance_id`` cross-check, ``oauth_contract_version`` tolerance.
 
-Also exercises ``revoke_session`` (no-op) and ``refresh_session``
-(unconditional ``RefreshExpiredError``).
+Also exercises refresh-token rotation, reuse rejection, and the Nous
+``revoke_session`` no-op.
 
 All HTTP is mocked: nothing in this file talks to a real Portal.
 """
@@ -492,11 +492,9 @@ class TestCompleteLogin:
                     redirect_uri="https://hermes.fly.dev/auth/callback",
                 )
 
-    def test_captures_refresh_token_if_present_forward_compat(
-        self, provider, rsa_keypair
-    ):
-        """Forward-compat: contract V1 doesn't issue, but if a future Portal
-        does, we should preserve it in the Session for later use."""
+    def test_auth_code_grant_preserves_refresh_token(self, provider, rsa_keypair):
+        """The v1 grant's opaque refresh token must reach the cookie layer
+        unchanged."""
         access_token = _mint_token(rsa_keypair)
         mock_resp = self._mock_post(
             200,
@@ -649,17 +647,31 @@ class TestRefreshAndRevoke:
         assert session.refresh_token == "rt_rotated_value"
         assert session.provider == "nous"
 
-        # Posts grant_type=refresh_token with the RT in BOTH the body (Portal's
-        # schema requires it there) and the X-Refresh-Token header (log
-        # redaction). Verified against the live preview deploy.
+        # Portal requires the same token in both the form body and the exact
+        # x-nous-refresh-token header.
         _, kwargs = mock_post.call_args
         assert kwargs["data"]["grant_type"] == "refresh_token"
         assert kwargs["data"]["client_id"] == "agent:inst123"
         assert kwargs["data"]["refresh_token"] == "rt_old_value"
         assert kwargs["headers"]["x-nous-refresh-token"] == "rt_old_value"
 
+    def test_reuse_detected_invalid_grant_maps_to_refresh_expired(self, provider):
+        """Map a synthetic replay-related ``invalid_grant`` response to
+        ``RefreshExpiredError``. Portal revocation itself is server-side and is
+        not exercised by this provider-boundary test."""
+        mock_resp = self._mock_post(
+            400,
+            {
+                "error": "invalid_grant",
+                "error_description": "refresh token reuse detected",
+            },
+        )
+        with patch("plugins.dashboard_auth.nous.httpx.post", return_value=mock_resp):
+            with pytest.raises(RefreshExpiredError, match="invalid_grant"):
+                provider.refresh_session(refresh_token="rt_replayed_value")
 
-    def test_revoke_is_noop(self, provider):
+
+    def test_logout_revoke_is_noop_without_portal_endpoint(self, provider):
         # Must not raise; returns None implicitly.
         assert provider.revoke_session(refresh_token="anything") is None
         assert provider.revoke_session(refresh_token="") is None

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -988,24 +988,29 @@ The provider implements the [Nous Portal OAuth contract v1](https://github.com/N
 2. Login page shows a "Continue with Nous Research" button → `/auth/login?provider=nous`.
 3. Server stashes PKCE state in a short-lived cookie, redirects user to `https://portal.nousresearch.com/oauth/authorize?…`.
 4. User authenticates with Portal, lands at `/auth/callback?code=…&state=…`.
-5. Server exchanges the code for an access token at `POST /api/oauth/token`, verifies the JWT signature against the Portal's JWKS (`/.well-known/jwks.json`), and sets the `hermes_session_at` cookie.
+5. Server exchanges the code for an access token and a rotating refresh token at `POST /api/oauth/token`, verifies the access-token JWT against the Portal's JWKS (`/.well-known/jwks.json`), and sets the session cookies.
 6. User is redirected to `/` (or to the original deep-link path via the `next=` query parameter).
 
-Access tokens have a 15-minute TTL. **There is no refresh token in contract v1** — when the token expires, the SPA's fetch wrapper detects the 401 envelope and full-page-navigates back to `/login` to re-run the flow.
+Portal access tokens expire after 15 minutes. Refresh tokens expire server-side after 24 hours. When the browser no longer has a valid access token, the dashboard gate submits the refresh token to `POST /api/oauth/token` with `grant_type=refresh_token`. A successful refresh replaces both token cookies, so the next refresh uses the rotated token rather than replaying the previous one.
+
+Portal permits a 60-second grace window for an in-flight request that races with rotation. Reusing an older refresh token outside that window revokes the whole Portal dashboard session. Expired, revoked, and reuse-detected refresh tokens all produce a 400 response from Portal; Hermes clears its session cookies and requires a fresh login.
 
 ### Cookies set
 
 | Name | Lifetime | Notes |
 |------|----------|-------|
 | `hermes_session_at` | Token TTL (15 min) | HttpOnly, SameSite=Lax, Secure-when-HTTPS |
+| `hermes_session_rt` | Browser Max-Age: 30 days; Portal token TTL: 24 hours | HttpOnly, SameSite=Lax, Secure-when-HTTPS. Replaced after every successful refresh. The longer browser lifetime does not extend the server-side token TTL. |
+| `hermes_session_provider` | 30 days | HttpOnly, SameSite=Lax, Secure-when-HTTPS. Non-secret hint that routes refresh to the provider that issued the token. |
 | `hermes_session_pkce` | 10 min | HttpOnly; holds the PKCE verifier + provider hint during the round trip. SameSite=None + Secure over HTTPS (must survive the cross-site IDP redirect chain — Chromium drops SameSite=Lax cookies set on a 302 in a cross-site chain); SameSite=Lax on loopback HTTP |
-| `hermes_session_rt` | unused in v1 | Reserved for forward-compat; not written when `refresh_token` is empty |
 
-All three are `Path=/`. The session cookies are `SameSite=Lax`; the PKCE cookie is `SameSite=None` when set over HTTPS (see table). The `Secure` flag is set when the dashboard is reached over HTTPS (detected via the request URL scheme — honours `X-Forwarded-Proto` from an upstream TLS terminator under `proxy_headers=True`).
+Cookie paths follow the active dashboard prefix: `Path=/` for a direct deployment and the configured prefix, such as `Path=/hermes`, behind a prefixed reverse proxy. The session and provider-hint cookies are `SameSite=Lax`; the PKCE cookie is `SameSite=None` when set over HTTPS (see table). The `Secure` flag is set when the dashboard is reached over HTTPS, as detected from the request URL scheme. This honours `X-Forwarded-Proto` from an upstream TLS terminator under `proxy_headers=True`.
 
 ### Logout
 
-The sidebar widget shows `Logged in as <user_id…> via nous` with a logout icon. Clicking it POSTs `/auth/logout`, which clears all dashboard-auth cookies and redirects back to `/login`.
+The sidebar widget shows `Logged in as <user_id…> via nous` with a logout icon. Clicking it POSTs `/auth/logout`, asks each registered provider to revoke the refresh token, clears the access-token, refresh-token, provider-hint, and PKCE cookies, and redirects back to `/login`.
+
+Nous Portal does not currently expose a token-revocation endpoint to Hermes, so the Nous provider's revoke operation is a no-op. Logging out removes the browser's token copies but does not invalidate the refresh token at Portal. That token remains valid until its 24-hour expiry unless Portal revokes the session through reuse detection or an operator revokes the Portal session. Use Portal's **Sessions** page when server-side invalidation is required.
 
 ### Audit log
 


### PR DESCRIPTION
## Summary

- document the existing 15-minute access-token and 24-hour rotating refresh-token contract
- distinguish the refresh cookie's 30-day browser `Max-Age` from Portal's 24-hour server-side token TTL
- document rotation, reuse detection, cookie replacement, and the current Nous logout/revocation limit
- align stale provider and test comments, and add a synthetic `invalid_grant` mapping test for the replay-revocation boundary

## Why

The dashboard guide still says, "There is no refresh token in contract v1," even though the Nous provider has issued and rotated refresh tokens since #37247. That mismatch gives operators the wrong expectations for session duration, cookie persistence, replay handling, and logout.

This change documents the shipped behavior without changing runtime authentication logic. It also makes the test boundary explicit: the repository test verifies the provider's error mapping with synthetic values; Portal-side replay detection and revocation remain server-side behavior.

Fingerprint: `HERMES-DASHBOARD-OAUTH-REFRESH-DOC-CODE-DRIFT-001`

Related operations issue: FAIRCOREeG/hermes-jan-ops#9

## Verification

- immutable baseline `v2026.8.19` (`fcbd1076a93841fa88855acce810e342a5b78101`): original drift probe exits `1` with `contract_consistent=false`
- candidate `49ae169b7135e9fe4a60e00be6edd02382bef1bf`: the unchanged probe exits `0` with `contract_consistent=true`
- `scripts/run_tests.sh tests/plugins/dashboard_auth/ tests/hermes_cli/test_dashboard_auth_*.py -q`: 271 passed
- `venv/bin/ruff check` on changed Python files: passed
- `ascii-guard==2.3.0 lint --exclude-code-blocks docs`: 410 files checked, 0 errors
- `npm run build:fast` in `website`: passed; Docusaurus still reports the two existing `/docs/llms*.txt` link warnings
- `git diff --cached --check`: passed
- `gitleaks git --staged --redact=100`: no leaks
- independent pre-commit review: passed with no security concerns or logic errors

The repository-wide Python suite was also attempted in a local `.[dev]` environment. It was not green: 187 unrelated failures across 61 files plus 45 files with no tests collected, primarily optional-provider, platform, and local-tooling failures. The dashboard-auth slice above is fully green; GitHub CI remains the authoritative full-lane result.

## Security and compatibility

No real tokens or live Portal calls are used. The test values are synthetic, and the change does not activate OAuth, alter cookie behavior, or change the provider protocol. The documented limitation is intentional and existing: Nous logout clears local cookies, but Portal currently exposes no token-revocation endpoint to Hermes, so server-side invalidation requires Portal session revocation or token expiry.
