### PR TITLE
fix(api_server): /health honors API_SERVER_KEY like every other route

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3161,7 +3161,18 @@ class APIServerAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def _handle_health(self, request: "web.Request") -> "web.Response":
-        """GET /health — simple health check."""
+        """GET /health — simple health check.
+
+        Requires the same Bearer as every other route when API_SERVER_KEY is
+        configured (#90315): an unauthenticated 200 made the listener look
+        open while chat was gated, and contradicted the documented
+        key-required contract. Without a configured key the endpoint stays
+        open (plain orchestrator probes keep working) — ``_check_auth``
+        already implements exactly that split.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
         return web.json_response(
             {"status": "ok", "platform": "hermes-agent", "version": _hermes_version()}
         )

--- a/tests/gateway/test_api_health_auth.py
+++ b/tests/gateway/test_api_health_auth.py
@@ -1,0 +1,92 @@
+"""/health must honor API_SERVER_KEY like every other route (#90315).
+
+The simple ``GET /health`` handler skipped ``_check_auth`` entirely, so a
+key-configured listener answered 200 to anonymous probes while
+``/v1/models`` and ``/v1/chat/completions`` correctly returned 401 — and
+while the sibling ``/health/detailed`` already enforced the bearer. An
+unauthenticated 200 made the listener look open when chat was gated.
+
+Contract here: with a key configured, all three health routes (``/health``,
+``/health/detailed``, ``/v1/health``) require the Bearer; without one,
+they stay open so plain orchestrator probes keep working.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+
+
+def _make_adapter(api_key: str = "") -> APIServerAdapter:
+    extra = {"key": api_key} if api_key else {}
+    return APIServerAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _bare_app(adapter: APIServerAdapter):
+    from aiohttp import web
+
+    app = web.Application()
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/health", adapter._handle_health)
+    app.router.add_get("/health/detailed", adapter._handle_health_detailed)
+    app.router.add_get("/v1/health", adapter._handle_health)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_health_with_key_requires_bearer():
+    adapter = _make_adapter("sk-secret")
+    app = _bare_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        anon = await cli.get("/health")
+        assert anon.status == 401
+
+        wrong = await cli.get(
+            "/health", headers={"Authorization": "Bearer sk-wrong"}
+        )
+        assert wrong.status == 401
+
+        good = await cli.get(
+            "/health", headers={"Authorization": "Bearer sk-secret"}
+        )
+        assert good.status == 200
+        data = await good.json()
+        assert data["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_v1_health_with_key_requires_bearer():
+    adapter = _make_adapter("sk-secret")
+    app = _bare_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        assert (await cli.get("/v1/health")).status == 401
+        ok = await cli.get(
+            "/v1/health", headers={"Authorization": "Bearer sk-secret"}
+        )
+        assert ok.status == 200
+
+
+@pytest.mark.asyncio
+async def test_health_without_key_stays_open_for_probes():
+    """No key configured → plain orchestrator healthchecks keep working."""
+    adapter = _make_adapter("")
+    app = _bare_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get("/health")
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_no_key_regression_existing_health_tests_unaffected():
+    """Parity guard mirroring TestHealthEndpoint's no-key expectations."""
+    adapter = _make_adapter("")
+    app = _bare_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        for path in ("/health", "/v1/health"):
+            resp = await cli.get(path)
+            assert resp.status == 200


### PR DESCRIPTION
## What does this PR do?

Fixes an auth-contract inconsistency on the API server (#90315): the simple `GET /health` handler skipped `_check_auth` entirely. With `API_SERVER_KEY` configured, `/health` answered **200 to anonymous probes** while every other route on the same listener (`/v1/models`, `/v1/chat/completions`) correctly returned 401 — and while the sibling **`/health/detailed` already enforced** the Bearer. An unauthenticated 200 made the listener look open when chat was gated, and contradicted the documented key-required contract.

The fix routes `/health` and `/v1/health` through `_check_auth`. That helper's existing no-key branch keeps the endpoint open when no key is configured, so plain orchestrator healthchecks and no-key test/manual wiring keep working — deployments that set a key get uniform enforcement across all three health routes.

## Related Issue

Fixes #90315

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Tests

## Changes Made

- `gateway/platforms/api_server.py`: `_handle_health()` now calls `self._check_auth(request)` first (same as `_handle_health_detailed`), with a comment citing #90315 and explaining the no-key open behavior is preserved via `_check_auth`'s existing branch.
- `tests/gateway/test_api_health_auth.py` — 4 new tests:
  - with a key: anonymous `/health` → 401; wrong bearer → 401; correct bearer → 200 `{"status": "ok", ...}`;
  - with a key: `/v1/health` behaves identically;
  - without a key: `/health` stays 200 for plain orchestrator probes;
  - parity guard for both paths mirroring the existing no-key expectations.

Existing `TestHealthEndpoint` tests (no-key adapter) pass unchanged, confirming zero impact for unkeyed deployments.

## How to Test

1. `uv run python -m pytest tests/gateway/test_api_health_auth.py -q` → 4 passed.
2. Full api-server suite neighbors: `uv run python -m pytest tests/gateway/test_api_server.py -q` → green.
3. `ruff check gateway/platforms/api_server.py tests/gateway/test_api_health_auth.py` → clean.
4. Manual: with `API_SERVER_KEY` set, `curl -o /dev/null -w '%{http_code}' http://127.0.0.1:8642/health` → 401; with `-H "Authorization: Bearer $API_SERVER_KEY"` → 200.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls?q=is%3Apr) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run targeted test suites locally and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Docs N/A (behavior now matches the documented key-required contract; handler docstring updated)
- [x] cli-config.yaml.example N/A
- [x] CONTRIBUTING/AGENTS N/A
- [x] Cross-platform impact: none
- [x] No tool schema change → N/A

## Screenshots / Logs

N/A
