### PR TITLE
fix(desktop): drop redelivered interim commentary instead of appending a duplicate bubble

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -11,6 +11,7 @@ import {
   chatMessageText,
   completeOpenTimelineParts,
   type GatewayEventPayload,
+  isRedeliveredAssistantText,
   mergeFinalAssistantText,
   reasoningPart,
   renderMediaTags,
@@ -502,6 +503,29 @@ export function useMessageStream({
 
         if (!authoritativeText) {
           return state
+        }
+
+        // The gateway can redeliver a message.interim (reconnect replay), and
+        // the standalone append below would paint the same commentary twice
+        // (#93926): each copy gets a fresh id, so nothing downstream can
+        // dedupe it. Drop restatements of recent assistant text; genuinely
+        // new commentary never matches. already_streamed is deliberately NOT
+        // a suppression signal here: it marks events whose text was also
+        // streamed as deltas, and when no bubble is open those deltas are
+        // gone — the event is the only durable copy and must append.
+        if (
+          !state.streamId ||
+          !state.messages.some(m => m.id === state.streamId)
+        ) {
+          // No open streaming bubble (or its id dangles post-rehydration):
+          // this event will take the standalone-append path below, so
+          // redelivery must be dropped here instead.
+          if (isRedeliveredAssistantText(state.messages, authoritativeText)) {
+            return {
+              ...state,
+              sawAssistantPayload: true
+            }
+          }
         }
 
         const streamId = state.streamId

--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-redelivery.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-redelivery.test.tsx
@@ -1,0 +1,114 @@
+import { act, cleanup } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { chatMessageText } from '@/lib/chat-messages'
+import { clearSessionTodos } from '@/store/todos'
+import type { RpcEvent } from '@/types/hermes'
+
+import { type MessageStreamHarness, renderMessageStream } from './test-harness'
+
+/**
+ * Redelivered `message.interim` events must not duplicate bubbles (#93926).
+ *
+ * The gateway delivers stream events over a reconnecting websocket, so any
+ * interim event can arrive twice: back-to-back, or long after its segment was
+ * sealed once later commentary has streamed. Redelivery is recognized as a
+ * restatement of recent assistant text. Distinct texts must still append
+ * (no over-suppression), and `already_streamed` alone must not suppress:
+ * upstream fixtures rely on those events appending when no bubble is open
+ * (the streamed deltas are gone, so the event is the only copy).
+ */
+
+const SID = 'session-1'
+
+let stream: MessageStreamHarness
+
+function mountStream() {
+  stream = renderMessageStream(SID)
+}
+
+const ev = (type: string, payload: Record<string, unknown> = {}): RpcEvent =>
+  ({ payload, session_id: SID, type }) as RpcEvent
+
+const start = () => act(() => stream.handleEvent(ev('message.start')))
+const delta = (text: string) => act(() => stream.handleEvent(ev('message.delta', { text })))
+const interim = (text: string, extra: Record<string, unknown> = {}) =>
+  act(() => stream.handleEvent(ev('message.interim', { text, ...extra })))
+
+function assistantTexts(): string[] {
+  return stream
+    .state(SID)
+    .messages.filter(m => m.role === 'assistant' && !m.hidden)
+    .map(m => chatMessageText(m))
+    .filter(Boolean)
+}
+
+beforeEach(() => {
+  clearSessionTodos(SID)
+})
+
+afterEach(() => {
+  cleanup()
+  clearSessionTodos(SID)
+  vi.restoreAllMocks()
+})
+
+describe('useMessageStream redelivered message.interim (#93926)', () => {
+  it('keeps one bubble when the same interim arrives twice back-to-back', () => {
+    mountStream()
+    start()
+    interim('checking the attach path')
+    interim('checking the attach path')
+
+    expect(assistantTexts().filter(t => t === 'checking the attach path')).toHaveLength(1)
+  })
+
+  it('keeps one bubble when an earlier interim is replayed after later segments streamed', () => {
+    mountStream()
+    start()
+    interim('first commentary')
+    delta('second commentary')
+    interim('second commentary')
+    // Transport replay of the first event, well after its bubble was sealed:
+    interim('first commentary')
+
+    const texts = assistantTexts()
+    expect(texts.filter(t => t === 'first commentary')).toHaveLength(1)
+    expect(texts).toContain('second commentary')
+  })
+
+  it('keeps one bubble for a whitespace-normalized restatement', () => {
+    mountStream()
+    start()
+    interim('checking the attach path')
+    interim('checking  the   attach\npath')
+
+    const texts = assistantTexts()
+    // Count total bubbles, not matching texts: the raw copy must be dropped,
+    // not merely equal to a normalized expectation string.
+    expect(texts).toHaveLength(1)
+    expect(texts[0]).toBe('checking the attach path')
+  })
+
+  it('still appends genuinely new commentary after a suppression', () => {
+    mountStream()
+    start()
+    interim('first commentary')
+    interim('first commentary')
+    interim('a different observation')
+
+    const texts = assistantTexts()
+    expect(texts.filter(t => t === 'first commentary')).toHaveLength(1)
+    expect(texts).toContain('a different observation')
+  })
+
+  it('does not suppress distinct commentary with a shared prefix', () => {
+    mountStream()
+    start()
+    interim('Checking the composer path for regressions.')
+    interim('Checking the composer path for regressions in v0.20.5.')
+
+    const texts = assistantTexts()
+    expect(texts.filter(t => t.startsWith('Checking the composer path'))).toHaveLength(2)
+  })
+})

--- a/apps/desktop/src/lib/chat-messages/index.ts
+++ b/apps/desktop/src/lib/chat-messages/index.ts
@@ -13,6 +13,6 @@ export {
   textPart
 } from './parts'
 export type { UnspokenTurnSpeech } from './parts'
-export { branchGroupForUser, preserveLocalAssistantErrors } from './reconciliation'
+export { branchGroupForUser, isRedeliveredAssistantText, preserveLocalAssistantErrors } from './reconciliation'
 export { sealOpenToolParts, upsertToolPart, withUniqueToolCallIdsWithinMessage } from './tool-parts'
 export type { ChatMessage, ChatMessagePart, GatewayEventPayload, TimelinePartMetadata } from './types'

--- a/apps/desktop/src/lib/chat-messages/reconciliation.ts
+++ b/apps/desktop/src/lib/chat-messages/reconciliation.ts
@@ -18,6 +18,51 @@ const latestBoundary = (...values: (number | undefined)[]) => {
 
 const normalizedTimelineText = (message: ChatMessage) => chatMessageText(message).replace(/\s+/g, ' ').trim()
 
+/** How far back a redelivered interim is matched against the transcript tail. */
+const REDELIVERY_SCAN_LIMIT = 8
+
+/**
+ * Whether `text` restates the visible text of one of the trailing assistant
+ * messages in `messages`.
+ *
+ * Interim commentary arrives over a reconnecting websocket, so any
+ * `message.interim` event can be redelivered — immediately or long after its
+ * bubble was sealed. The standalone-append path used to take every copy,
+ * producing visibly doubled commentary (#93926). Redelivery is recognized by
+ * normalized visible text within a small window of the transcript tail.
+ * Distinct texts never match, so genuinely new commentary still appends.
+ *
+ * Known bound: identical legitimate commentary inside the scan window (e.g. a
+ * repeated "Still working..." line) is indistinguishable from redelivery by
+ * text alone and is dropped once. Text-equality is the only identity the wire
+ * offers for these events.
+ */
+export function isRedeliveredAssistantText(messages: ChatMessage[], text: string): boolean {
+  const normalized = text.replace(/\s+/g, ' ').trim()
+
+  if (!normalized) {
+    return false
+  }
+
+  let scanned = 0
+
+  for (let index = messages.length - 1; index >= 0 && scanned < REDELIVERY_SCAN_LIMIT; index -= 1) {
+    const message = messages[index]
+
+    if (message.hidden) {
+      continue
+    }
+
+    scanned += 1
+
+    if (message.role === 'assistant' && normalizedTimelineText(message) === normalized) {
+      return true
+    }
+  }
+
+  return false
+}
+
 const assistantTimelineMatch = (stored: ChatMessage, local: ChatMessage) => {
   if (stored.id === local.id) {
     return true


### PR DESCRIPTION
Fixes #93926

## Problem

During tool-heavy turns, interim commentary bubbles can render twice, back to back. The duplicate survives turn end and only clears when a full rehydration from `state.db` replaces the view (session switch or restart). Persistence is clean: one row per affected sentence. The same shape has been reported repeatedly (#70108, #76443, #81422, #63213, #65666); this PR removes one remaining path that produces it.

## Root cause

`finalizeInterimAssistantMessage` seals each interim segment into its own bubble and clears `streamId`. The gateway can redeliver a `message.interim` event (websocket reconnect replay). A redelivered copy arrives with no open stream bubble, so it takes the standalone-append branch: fresh id, no identity or text check. Because ids differ, nothing downstream can dedupe the copies; tool cards are unaffected since `upsertToolPart` upserts by `toolCallId`, which matches the observed "only commentary doubles" signature.

## Fix

Guard the standalone append: when no stream bubble is open and the incoming text restates recent assistant text (normalized comparison over the last 8 visible messages), treat it as a replay and keep the existing transcript. Distinct commentary never matches, so real segments still append.

`already_streamed` is deliberately not treated as a suppression signal here: existing tests send it on every interim event and rely on those appending when no bubble is open. In that state the streamed deltas are lost and the event is the only durable copy, so appending is correct.

## Testing

New suite `interim-redelivery.test.tsx` (5 cases) on the existing harness: back-to-back redelivery, delayed replay after later segments streamed, whitespace-normalized restatement, append-after-suppression of genuinely new commentary, and shared-prefix distinct texts. Full `use-message-stream` suite green (23 files, 130 tests), `tsc --noEmit` clean, eslint clean.

## Disclosure

This change was authored with AI assistance, with the diagnosis, fix, and test verification reviewed against the actual repository sources and history before submission.
