### PR TITLE
Add Forge and Atlas Mission Control operating layer

### DIFF
--- a/MISSION_CONTROL_OPERATING_LAYER_v1.md
+++ b/MISSION_CONTROL_OPERATING_LAYER_v1.md
@@ -30,6 +30,24 @@ The contract is not a replacement for entitlement, billing, wallet, ledger,
 customer-data, approval, or runtime authorities. Mission Control consumes the
 projection; it does not become a second source of truth.
 
+## Capability routing
+
+Paco routes Home Team agents, sessions, tasks, tools, channels, approvals,
+runtime health, and workspace activity through the existing MC-02/04/05/10
+and HOS-04 authorities. Forge routes tenant-safe Player work, runs, usage,
+connections, approvals, outcomes, and sanitized health through MC-20/22/23/24
+and the existing SaaS authorities. Atlas publishes bounded worker/process,
+host-metric, deployment, recovery, and failure health through the read-only
+MC-29 observer. Locker Room consumes customer-safe MC-20 and health
+projections. None of these mappings creates a new store or execution engine.
+
+Command inputs follow the shared lifecycle `ASK → RECOMMEND_BUILD → DECIDE →
+IMPLEMENT → PREVIEW → APPROVE`. Attachment inputs are metadata-only references
+(allowlisted media type, bounded size, SHA-256 digest); bytes, paths, secrets,
+and prompts never enter the control-plane contract. Telegram and Buzz preserve
+conversation identity as context-only channels until an explicit actionable
+bridge is implemented; actionable work remains deny-by-default.
+
 ## Independence acceptance
 
 1. Paco disconnected: Forge and Atlas remain healthy in the adapter contract.

--- a/MISSION_CONTROL_OPERATING_LAYER_v1.md
+++ b/MISSION_CONTROL_OPERATING_LAYER_v1.md
@@ -36,7 +36,8 @@ Paco routes Home Team agents, sessions, tasks, tools, channels, approvals,
 runtime health, and workspace activity through the existing MC-02/04/05/10
 and HOS-04 authorities. Forge routes tenant-safe Player work, runs, usage,
 connections, approvals, outcomes, and sanitized health through MC-20/22/23/24
-and the existing SaaS authorities. Atlas publishes bounded worker/process,
+and the existing SaaS authorities. Governed Digital Experience work remains on
+the existing DE/Project Builder authorities and approval gates. Atlas publishes bounded worker/process,
 host-metric, deployment, recovery, and failure health through the read-only
 MC-29 observer. Locker Room consumes customer-safe MC-20 and health
 projections. None of these mappings creates a new store or execution engine.

--- a/MISSION_CONTROL_OPERATING_LAYER_v1.md
+++ b/MISSION_CONTROL_OPERATING_LAYER_v1.md
@@ -1,0 +1,40 @@
+# Mission Control Operating Layer v1
+
+Status: authoritative for the Forge/Atlas SaaS bundle. Approved by RJ on
+2026-08-24. This document supersedes conflicting Forge/Atlas ownership text in
+the legacy shared governance files; historical text remains retained there.
+
+## Ownership
+
+| System | Authority | Scope |
+|---|---|---|
+| Paco | Home Team / Parent IP Mission Control | Internal work, parent IP, Home Team agents |
+| Forge | SaaS business control plane | Tenant-safe business state, approvals, governed execution decisions, sanitized usage/outcomes |
+| Atlas | SaaS infrastructure Mission Control | VPS/process/runtime health, recovery, telemetry, sanitized incidents |
+| Forge + Atlas | Divestable SaaS Operations bundle | Normal SaaS operation without Paco |
+
+Paco is not a required dependency for SaaS availability. Forge and Atlas must
+not exchange tenant records, billing authority, wallet/ledger state,
+credentials, prompts, memory, or raw diagnostics through this layer.
+
+## Contract and adapters
+
+The `mission_control_operating_layer` projection is additive and read-only. It
+uses explicit allowlists, emits `healthy`, `degraded`, or `unavailable`, and
+fails workloads safe when Atlas is unavailable while preserving customer
+state. Atlas continues infrastructure monitoring/protection when Forge is
+degraded. A disconnected Paco is represented as an optional dependency, not a
+reason to block Forge or Atlas.
+
+The contract is not a replacement for entitlement, billing, wallet, ledger,
+customer-data, approval, or runtime authorities. Mission Control consumes the
+projection; it does not become a second source of truth.
+
+## Independence acceptance
+
+1. Paco disconnected: Forge and Atlas remain healthy in the adapter contract.
+2. Forge degraded: Atlas retains monitoring and recovery-protection capability.
+3. Atlas degraded: Forge reports `fail_safe` and preserves customer state.
+
+Live deployment is a separate gate. This candidate does not restart services,
+alter customer data, or activate a new production route.

--- a/MISSION_CONTROL_OPERATING_LAYER_v1.md
+++ b/MISSION_CONTROL_OPERATING_LAYER_v1.md
@@ -46,7 +46,8 @@ IMPLEMENT → PREVIEW → APPROVE`. Attachment inputs are metadata-only referenc
 (allowlisted media type, bounded size, SHA-256 digest); bytes, paths, secrets,
 and prompts never enter the control-plane contract. Telegram and Buzz preserve
 conversation identity as context-only channels until an explicit actionable
-bridge is implemented; actionable work remains deny-by-default.
+bridge is implemented; actionable work remains deny-by-default. Buzz here
+means the `buzz.xyz` product, not a generic or fabricated transport.
 
 ## Independence acceptance
 

--- a/mission_control_operating_layer.py
+++ b/mission_control_operating_layer.py
@@ -1,0 +1,102 @@
+"""Bounded Mission Control contracts for the Forge/Atlas SaaS bundle.
+
+This module is deliberately a pure projection layer. It does not read tenant
+data, billing state, credentials, prompts, or Hermes session memory, and it
+does not execute work. Runtime adapters may pass in already-authorized health
+facts and publish the resulting contract to Mission Control.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any, Mapping
+
+CONTRACT_VERSION = "hermes-os-forge-atlas-operating-layer-v1"
+FORBIDDEN = {
+    "tenant_id", "company_id", "customer_id", "entitlement", "wallet",
+    "ledger", "credential", "secret", "api_key", "prompt", "memory",
+    "filesystem_path", "raw_output", "session_data",
+}
+
+
+def _safe_text(value: Any, fallback: str = "unknown") -> str:
+    return value if isinstance(value, str) and len(value) <= 120 else fallback
+
+
+def _assert_safe(value: Any) -> None:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            assert str(key).lower() not in FORBIDDEN, f"forbidden field: {key}"
+            _assert_safe(child)
+    elif isinstance(value, list):
+        for child in value:
+            _assert_safe(child)
+
+
+def sanitize_atlas_health(raw: Mapping[str, Any]) -> dict[str, Any]:
+    """Project Atlas health to fields safe for Forge, MC, and Locker Room."""
+    checks = raw.get("checks") if isinstance(raw.get("checks"), Mapping) else {}
+    result = {
+        "status": _safe_text(raw.get("status"), "unavailable"),
+        "version": _safe_text(raw.get("version")),
+        "service": _safe_text(raw.get("service")),
+        "checks": {
+            name: _safe_text(checks.get(name), "unknown")
+            for name in ("gateway", "configuration", "telemetry")
+        },
+    }
+    _assert_safe(result)
+    return result
+
+
+def build_consumer_contract(
+    role: str,
+    health: Mapping[str, Any],
+    *,
+    atlas_health: Mapping[str, Any] | None = None,
+    forge_health: Mapping[str, Any] | None = None,
+    paco_connected: bool = False,
+) -> dict[str, Any]:
+    """Build a role-scoped operating-layer projection with fail-safe status."""
+    if role not in {"forge", "atlas"}:
+        raise ValueError("role must be forge or atlas")
+    status = _safe_text(health.get("status"), "unavailable")
+    result: dict[str, Any] = {
+        "schema": CONTRACT_VERSION,
+        "role": role,
+        "status": status if status in {"healthy", "degraded", "unavailable"} else "unavailable",
+        "runtime": {
+            "version": _safe_text(health.get("version")),
+            "service": _safe_text(health.get("service")),
+        },
+        "paco": "connected" if paco_connected else "disconnected",
+        "mission_control": "saas_forge" if role == "forge" else "saas_atlas",
+    }
+    if role == "atlas":
+        # Atlas remains capable of infra monitoring when Forge is degraded.
+        result["dependencies"] = {"forge": "unavailable"}
+        if forge_health is not None:
+            result["dependencies"]["forge"] = _safe_text(forge_health.get("status"), "unavailable")
+        result["capabilities"] = ["infrastructure_health", "recovery_protection", "sanitized_incidents"]
+        result["workload_policy"] = "monitor_and_protect"
+    else:
+        atlas = sanitize_atlas_health(atlas_health or {"status": "unavailable"})
+        result["dependencies"] = {"atlas": atlas["status"]}
+        result["capabilities"] = ["business_control", "approvals", "sanitized_usage", "customer_state_preservation"]
+        result["workload_policy"] = "fail_safe" if atlas["status"] != "healthy" else "normal"
+    _assert_safe(result)
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a sanitized MC operating-layer projection")
+    parser.add_argument("--role", choices=("forge", "atlas"), required=True)
+    parser.add_argument("--health", default="{}", help="JSON health facts supplied by the runtime adapter")
+    args = parser.parse_args()
+    print(json.dumps(build_consumer_contract(args.role, json.loads(args.health)), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mission_control_operating_layer.py
+++ b/mission_control_operating_layer.py
@@ -13,6 +13,24 @@ import json
 from typing import Any, Mapping
 
 CONTRACT_VERSION = "hermes-os-forge-atlas-operating-layer-v1"
+CAPABILITY_REGISTRY = {
+    "forge": {
+        "player_execution": ("tenant_safe_player_authority",),
+        "runs_tasks": ("governed_run_authority",),
+        "usage_cost": ("existing_saas_usage_authority",),
+        "connections": ("existing_connection_authority",),
+        "approvals": ("governed_approval_authority",),
+        "outcomes": ("existing_outcome_authority",),
+        "sanitized_health": ("atlas_contract",),
+    },
+    "atlas": {
+        "worker_process_health": ("atlas_runtime",),
+        "host_metrics": ("atlas_runtime",),
+        "deployment_state": ("atlas_runtime",),
+        "self_healing": ("atlas_runtime",),
+        "runtime_failures": ("atlas_runtime",),
+    },
+}
 FORBIDDEN = {
     "tenant_id", "company_id", "customer_id", "entitlement", "wallet",
     "ledger", "credential", "secret", "api_key", "prompt", "memory",
@@ -72,6 +90,7 @@ def build_consumer_contract(
         },
         "paco": "connected" if paco_connected else "disconnected",
         "mission_control": "saas_forge" if role == "forge" else "saas_atlas",
+        "capability_manifest": build_capability_manifest(role),
     }
     if role == "atlas":
         # Atlas remains capable of infra monitoring when Forge is degraded.
@@ -87,6 +106,21 @@ def build_consumer_contract(
         result["workload_policy"] = "fail_safe" if atlas["status"] != "healthy" else "normal"
     _assert_safe(result)
     return result
+
+
+def build_capability_manifest(role: str, observed: Mapping[str, str] | None = None) -> dict[str, Any]:
+    """Expose routing metadata while keeping execution and authority elsewhere."""
+    if role not in CAPABILITY_REGISTRY:
+        raise ValueError("role must be forge or atlas")
+    observed = observed or {}
+    capabilities = []
+    for name, authorities in CAPABILITY_REGISTRY[role].items():
+        status = str(observed.get(name, "declared")).lower()
+        if status not in {"declared", "observed", "degraded", "unavailable"}:
+            status = "unavailable"
+        capabilities.append({"name": name, "status": status, "authorities": list(authorities)})
+    return {"schema": CONTRACT_VERSION, "role": role, "capabilities": capabilities,
+            "execution_enabled": False, "source_of_truth": "existing_authorities"}
 
 
 def main() -> int:

--- a/test_mission_control_operating_layer.py
+++ b/test_mission_control_operating_layer.py
@@ -1,0 +1,58 @@
+import unittest
+
+from mission_control_operating_layer import (
+    build_consumer_contract,
+    sanitize_atlas_health,
+)
+
+
+class OperatingLayerTests(unittest.TestCase):
+  def test_forge_consumes_only_sanitized_atlas_health_and_fails_safe(self):
+    result = build_consumer_contract(
+        "forge",
+        {"status": "healthy", "version": "0.20.5", "service": "forge"},
+        atlas_health={
+            "status": "degraded",
+            "version": "0.20.5",
+            "service": "atlas",
+            "checks": {"gateway": "healthy", "configuration": "degraded", "telemetry": "healthy"},
+            "tenant_id": "must-not-cross-boundary",
+        },
+    )
+    self.assertEqual(result["dependencies"], {"atlas": "degraded"})
+    self.assertEqual(result["workload_policy"], "fail_safe")
+    self.assertNotIn("tenant_id", repr(result))
+
+
+  def test_atlas_remains_independent_when_forge_is_degraded(self):
+    result = build_consumer_contract(
+        "atlas",
+        {"status": "healthy", "version": "0.20.5", "service": "atlas"},
+        forge_health={"status": "unavailable"},
+    )
+    self.assertEqual(result["dependencies"], {"forge": "unavailable"})
+    self.assertEqual(result["workload_policy"], "monitor_and_protect")
+    self.assertIn("recovery_protection", result["capabilities"])
+
+
+  def test_paco_is_optional_and_not_a_runtime_dependency(self):
+    result = build_consumer_contract(
+        "forge", {"status": "healthy", "version": "0.20.5", "service": "forge"}
+    )
+    self.assertEqual(result["paco"], "disconnected")
+    self.assertEqual(result["status"], "healthy")
+
+
+  def test_atlas_projection_has_explicit_allowlist(self):
+    result = sanitize_atlas_health({"status": "healthy", "version": "0.20.5", "service": "atlas", "secret": "x"})
+    self.assertEqual(set(result), {"status", "version", "service", "checks"})
+    self.assertTrue(all(value == "unknown" for value in result["checks"].values()))
+
+
+  def test_unknown_role_fails_closed(self):
+    with self.assertRaises(ValueError):
+        build_consumer_contract("paco", {"status": "healthy"})
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/test_mission_control_operating_layer.py
+++ b/test_mission_control_operating_layer.py
@@ -1,12 +1,20 @@
 import unittest
 
 from mission_control_operating_layer import (
+    build_capability_manifest,
     build_consumer_contract,
     sanitize_atlas_health,
 )
 
 
 class OperatingLayerTests(unittest.TestCase):
+  def test_capability_manifest_is_explicit_and_non_executing(self):
+    result = build_capability_manifest("forge")
+    self.assertFalse(result["execution_enabled"])
+    names = {item["name"] for item in result["capabilities"]}
+    self.assertIn("approvals", names)
+    self.assertIn("sanitized_health", names)
+
   def test_forge_consumes_only_sanitized_atlas_health_and_fails_safe(self):
     result = build_consumer_contract(
         "forge",


### PR DESCRIPTION
## Summary
- add a read-only, explicit-allowlist Forge/Atlas Mission Control projection
- preserve Paco as optional Parent-IP control plane
- fail safe when Atlas is degraded and keep Atlas monitoring when Forge is unavailable
- include focused independence and sanitization tests

## Scope
No runtime restart, customer data, billing, wallet, ledger, entitlement, credential, or database changes. Candidate built from Hermes main 057dcdf2.