### PR TITLE
fix(desktop): keep long cross-connection bot deliveries alive

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1500,6 +1500,10 @@ function handleSessionsGatewayTransition() {
 // Older backends without the RPCs fail per-call and are skipped — the
 // relay degrades to whatever subset of connections supports it.
 const RELAY_ROSTER_INTERVAL_MS = 60_000
+// The backend can wait 120s for the profile turn lock, then run one 600s
+// turn and one policy-gated 600s retry. Keep only bot_relay.deliver on this
+// bounded 1,320s contract; every other plugin RPC keeps the generic deadline.
+const RELAY_DELIVER_TIMEOUT_MS = 22 * 60 * 1000
 // Backstop cadence only (#93594): the push path below carries envelope latency,
 // so the interval poll exists for older backends and missed events — 30s
 // matches LIVE_SESSION_STATUS_BACKSTOP_INTERVAL_MS. It was 4s back when the
@@ -1770,7 +1774,7 @@ async function drainRelayOutboxes() {
           const res = await host.requestProfile(target.route, 'bot_relay.deliver', {
             profile: String(envelope?.target_profile || ''),
             message: String(envelope?.message || '')
-          })
+          }, RELAY_DELIVER_TIMEOUT_MS)
           clearBotAttention(attentionKey)
           await postReply({ reply: String(res?.reply || '') })
         } catch (error) {

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -227,20 +227,25 @@ const $viewport = atom<ViewportRect>(readViewport())
 async function requestPluginProfile<T>(
   route: PluginProfileRoute | string,
   method: string,
-  params: Record<string, unknown>
+  params: Record<string, unknown>,
+  timeoutMs?: number
 ): Promise<T> {
   if (typeof route !== 'string') {
     if (!route.connectionId.trim() || !route.profile.trim() || !route.targetProfile.trim()) {
       throw new Error('Profile route must include connectionId, profile, and targetProfile')
     }
 
-    return requestGatewayForAgent<T>(route.connectionId, route.profile, method, params)
+    return timeoutMs === undefined
+      ? requestGatewayForAgent<T>(route.connectionId, route.profile, method, params)
+      : requestGatewayForAgent<T>(route.connectionId, route.profile, method, params, timeoutMs)
   }
 
   const getAgentRoster = window.hermesDesktop?.getAgentRoster
 
   if (!getAgentRoster) {
-    return requestGatewayForProfile<T>(route, method, params)
+    return timeoutMs === undefined
+      ? requestGatewayForProfile<T>(route, method, params)
+      : requestGatewayForProfile<T>(route, method, params, timeoutMs)
   }
 
   const roster = await getAgentRoster()
@@ -252,7 +257,9 @@ async function requestPluginProfile<T>(
   // its live enumeration transiently failed. Any additional source requires a
   // descriptor because an undialed/unreachable source may expose the same name.
   if (soleLocalSource) {
-    return requestGatewayForProfile<T>(profile, method, params)
+    return timeoutMs === undefined
+      ? requestGatewayForProfile<T>(profile, method, params)
+      : requestGatewayForProfile<T>(profile, method, params, timeoutMs)
   }
 
   throw new Error(
@@ -1127,12 +1134,14 @@ export const host = {
   /** Gateway JSON-RPC through a credential-free route descriptor without
    *  foregrounding it. Passing a bare profile is the v1/local compatibility
    *  overload; registry callers must pass the descriptor so duplicate names
-   *  remain unambiguous. */
+   *  remain unambiguous. Long-running methods may opt into a bounded timeout;
+   *  ordinary calls retain the gateway client's default deadline. */
   requestProfile: async <T>(
     route: PluginProfileRoute | string,
     method: string,
-    params: Record<string, unknown> = {}
-  ): Promise<T> => requestPluginProfile<T>(route, method, params),
+    params: Record<string, unknown> = {},
+    timeoutMs?: number
+  ): Promise<T> => requestPluginProfile<T>(route, method, params, timeoutMs),
 
   /** Pin a route's pooled gateway socket open across repeated `requestProfile`
    *  calls (#93594: the bot-relay drain loop was dialing and tearing down a

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -151,6 +151,7 @@ const profile = (name: string): ProfileInfo => ({
 })
 
 afterEach(() => {
+  vi.useRealTimers()
   vi.clearAllMocks()
   $activeGatewayProfile.set('remote-worker')
   $gatewaySwapTarget.set(null)
@@ -255,6 +256,52 @@ describe('connection-aware plugin host APIs', () => {
     expect(requestGatewayForProfile).not.toHaveBeenCalled()
   })
 
+  it('keeps an explicitly bounded relay request alive beyond the generic 30-second deadline', async () => {
+    const route = {
+      connectionId: 'source-a',
+      mode: 'remote' as const,
+      profile: 'remote-worker',
+      targetProfile: 'backend-worker'
+    }
+    vi.useFakeTimers()
+    vi.mocked(requestGatewayForAgent).mockImplementationOnce(
+      async (_connectionId, _profile, _method, _params, timeoutMs) =>
+        new Promise((resolve, reject) => {
+          setTimeout(() => reject(new Error('request timed out')), timeoutMs)
+          setTimeout(() => resolve({ reply: 'completed after 31s' }), 31_000)
+        })
+    )
+
+    const request = host.requestProfile<{ reply: string }>(
+      route,
+      'bot_relay.deliver',
+      { message: 'hello' },
+      1_320_000
+    )
+
+    let settled = false
+    void request.finally(() => {
+      settled = true
+    })
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(settled).toBe(false)
+    await vi.advanceTimersByTimeAsync(1_000)
+    await expect(request).resolves.toEqual({ reply: 'completed after 31s' })
+
+    expect(requestGatewayForAgent).toHaveBeenCalledWith(
+      'source-a',
+      'remote-worker',
+      'bot_relay.deliver',
+      { message: 'hello' },
+      1_320_000
+    )
+
+    vi.useRealTimers()
+    vi.mocked(requestGatewayForAgent).mockClear()
+    await host.requestProfile(route, 'profiles.list', {})
+    expect(requestGatewayForAgent).toHaveBeenCalledWith('source-a', 'remote-worker', 'profiles.list', {})
+  })
+
   it('fails closed when a descriptor omits connection or target profile identity', async () => {
     await expect(
       host.requestProfile(
@@ -351,6 +398,17 @@ describe('connection-aware plugin host APIs', () => {
     expect(requestGatewayForProfile).toHaveBeenCalledWith('legacy-worker', 'profiles.list', {
       include_sessions: true
     })
+  })
+
+  it('forwards an explicit deadline through the profile-only compatibility path', async () => {
+    await host.requestProfile('legacy-worker', 'bot_relay.deliver', { message: 'hello' }, 1_320_000)
+
+    expect(requestGatewayForProfile).toHaveBeenCalledWith(
+      'legacy-worker',
+      'bot_relay.deliver',
+      { message: 'hello' },
+      1_320_000
+    )
   })
 
   it('rejects a profile-only request when the current registry makes it ambiguous', async () => {


### PR DESCRIPTION
## What does this PR do?

Desktop cross-connection Bot Mode deliveries no longer fail at the generic 30-second plugin RPC deadline while a healthy target bot is still running. The plugin SDK now accepts an optional bounded per-call timeout, and only `bot_relay.deliver` opts into the backend's 1,320-second lock, turn, and retry budget.

### Symptom

A cross-connection `message_agent` delivery that takes longer than 30 seconds reports `request timed out after 30s: bot_relay.deliver`, even though the target Bot Chat turn is still healthy and may continue after Desktop abandons the request.

### Impact

Users relaying work to bots on another Desktop connection can receive a false failure and lose the eventual reply for legitimate long-running turns, including Computer Use tasks.

### Bug Cause

**Trigger:** `apps/desktop/src/sdk/index.ts:1138` / `host.requestProfile` when `apps/desktop/src/plugins/hermes-bots/plugin.js:1771` dispatches `bot_relay.deliver`.

**Causal chain:**
1. Desktop claims a cross-connection envelope and sends `bot_relay.deliver` through `host.requestProfile`.
2. `requestProfile` previously exposed no timeout override, so the routed gateway request used the generic 30-second client deadline.
3. The backend intentionally permits up to 120 seconds of lock wait plus two bounded 600-second turns, so Desktop could discard a valid in-flight response long before the backend budget ended.

**Why it is wrong:** The client deadline was shorter than the method's bounded backend execution contract.

**Working sibling / contrast:** Ordinary plugin RPCs complete within the generic deadline and continue using the unchanged default call shape; direct/local and peer delivery do not use this Desktop cross-connection request path.

**Ruled out:** This is not a target profile, model, tool, authentication, or runtime failure. The issue's direct local and peer delivery controls succeed, and the observed error fires at the exact generic client deadline.

### Fix

Thread an optional timeout through both descriptor-based and legacy local `requestProfile` routes while preserving the existing arity for ordinary calls. Apply a 1,320,000 ms deadline only to `bot_relay.deliver`; existing structured JSON-RPC errors, including typed failure reasons, continue through unchanged.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/sdk/index.ts` - forward optional profile-request deadlines without changing ordinary request behavior.
- `apps/desktop/src/plugins/hermes-bots/plugin.js` - align relay delivery with the backend's bounded 1,320-second contract.
- `apps/desktop/src/sdk/profile-routing.test.ts` - cover descriptor and legacy timeout forwarding, the unchanged default arity, and a relay response that arrives after 31 seconds.

## How to Test

1. Run the profile-routing regression test; its virtual clock advances beyond 30 seconds and confirms the relay response still resolves.
2. Run all Desktop plugin contract tests.
3. Run the Desktop TypeScript checks.

```bash
cd apps/desktop
npx vitest run --project ui src/sdk/profile-routing.test.ts
npm run check:test:plugins
npm run typecheck
```

Results: 39 profile-routing tests passed, 556 plugin tests passed, and all three TypeScript projects passed type checking.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant Desktop test entries and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; the SDK comment documents the optional deadline.
- [x] Config example update is N/A; no config keys changed.
- [x] CONTRIBUTING.md and AGENTS.md updates are N/A; no workflow changed.
- [x] I considered cross-platform impact; the change is transport-level TypeScript/JavaScript with no OS-specific branch.
- [x] Tool description/schema updates are N/A; no model tool behavior changed.
