### PR TITLE
fix(desktop): let bot_relay.deliver outlive the generic 30s request deadline

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1518,6 +1518,13 @@ const RELAY_ROSTER_INTERVAL_MS = 60_000
 // poll WAS the delivery path, which (before route retention) also meant a
 // fresh WebSocket dial + teardown per registered connection every 4s.
 const RELAY_DRAIN_INTERVAL_MS = 30_000
+// #93911: a delivered turn runs on the target gateway, so the client must
+// outlive the backend's own bound — worst case is the turn lock wait
+// (bot_mode.turn_wait_seconds, default 120s) plus a 600s turn, doubled when
+// the retry policy grants one bounded re-run (methods_bot_relay.py). Without
+// this the call fell to the pool's generic 30s deadline and every long turn
+// (Computer Use, deep research) came back as an unclassified failure.
+const RELAY_DELIVER_TIMEOUT_MS = 1_320_000
 // Push path (#93091): the gateway broadcasts `bot_relay.outbox.pending` when
 // an envelope lands on disk; a burst of signals inside this window collapses
 // to ONE drain. The interval poll above stays as the backstop for older
@@ -1779,10 +1786,15 @@ async function drainRelayOutboxes() {
         const attentionKey = `${target.id}::${String(envelope?.target_profile || '')}`
 
         try {
-          const res = await host.requestProfile(target.route, 'bot_relay.deliver', {
-            profile: String(envelope?.target_profile || ''),
-            message: String(envelope?.message || '')
-          })
+          const res = await host.requestProfile(
+            target.route,
+            'bot_relay.deliver',
+            {
+              profile: String(envelope?.target_profile || ''),
+              message: String(envelope?.message || '')
+            },
+            RELAY_DELIVER_TIMEOUT_MS
+          )
           clearBotAttention(attentionKey)
           await postReply({ reply: String(res?.reply || '') })
         } catch (error) {

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1519,12 +1519,32 @@ const RELAY_ROSTER_INTERVAL_MS = 60_000
 // fresh WebSocket dial + teardown per registered connection every 4s.
 const RELAY_DRAIN_INTERVAL_MS = 30_000
 // #93911: a delivered turn runs on the target gateway, so the client must
-// outlive the backend's own bound — worst case is the turn lock wait
-// (bot_mode.turn_wait_seconds, default 120s) plus a 600s turn, doubled when
-// the retry policy grants one bounded re-run (methods_bot_relay.py). Without
-// this the call fell to the pool's generic 30s deadline and every long turn
-// (Computer Use, deep research) came back as an unclassified failure.
-const RELAY_DELIVER_TIMEOUT_MS = 1_320_000
+// outlive the backend's own bound. Without this the call fell to the pool's
+// generic 30s deadline and every long turn (Computer Use, deep research) came
+// back as an unclassified failure.
+//
+// The backend's MAXIMUM WORK budget is spelled out below. The client deadline
+// must be strictly GREATER than it: after those bounded waits the handler still
+// has to classify the failure, build and run the retry, classify/serialize the
+// terminal result, unwind the temp-file and lock scopes, and get the JSON-RPC
+// response back through the event loop. A call that consumes nearly all of the
+// work budget would otherwise lose the race to this timer by milliseconds and
+// reproduce #93911 at the upper boundary — the backend knowing a typed reason
+// while Desktop reports its generic timeout first.
+//
+// These three are mirrors of backend values, so a change there must not
+// silently invalidate this constant: bot-relay-deliver-budget.test.mjs reads
+// hermes_cli/config_defaults.py and tui_gateway/methods_bot_relay.py and fails
+// if the mirrors drift or the margin stops being positive.
+const RELAY_TURN_LOCK_WAIT_MS = 120_000 // bot_mode.turn_wait_seconds default
+const RELAY_TURN_ATTEMPT_MS = 600_000 // subprocess.run(..., timeout=600)
+const RELAY_TURN_MAX_ATTEMPTS = 2 // first attempt + the policy-gated re-run
+const RELAY_DELIVER_BACKEND_CEILING_MS =
+  RELAY_TURN_LOCK_WAIT_MS + RELAY_TURN_ATTEMPT_MS * RELAY_TURN_MAX_ATTEMPTS
+// Settlement + transport headroom on top of the ceiling, so a backend that
+// answers at its own limit still wins the race against this timer.
+const RELAY_DELIVER_SETTLEMENT_MARGIN_MS = 180_000
+const RELAY_DELIVER_TIMEOUT_MS = RELAY_DELIVER_BACKEND_CEILING_MS + RELAY_DELIVER_SETTLEMENT_MARGIN_MS
 // Push path (#93091): the gateway broadcasts `bot_relay.outbox.pending` when
 // an envelope lands on disk; a burst of signals inside this window collapses
 // to ONE drain. The interval poll above stays as the backstop for older

--- a/apps/desktop/src/plugins/hermes-bots/tests/bot-relay-deliver-budget.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bot-relay-deliver-budget.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+// #93911 review follow-up: the Desktop deadline for bot_relay.deliver mirrors
+// three backend numbers. Nothing in the type system links a JS constant to a
+// Python default, so this file is the seam: it reads the backend sources and
+// fails when a mirror drifts or the settlement margin stops being positive.
+// Without it, raising the backend turn timeout would silently reintroduce
+// #93911 — the client giving up before a valid typed settlement arrives.
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+const repoRoot = new URL('../../../../../../', import.meta.url)
+const configDefaults = readFileSync(new URL('hermes_cli/config_defaults.py', repoRoot), 'utf8')
+const relayHandler = readFileSync(new URL('tui_gateway/methods_bot_relay.py', repoRoot), 'utf8')
+
+function jsConstant(name) {
+  const match = pluginSource.match(new RegExp(`const ${name} = ([0-9_]+)`))
+  assert.ok(match, `${name} must stay a literal so this test can read it`)
+  return Number(match[1].replaceAll('_', ''))
+}
+
+test('the delivery deadline mirrors the backend turn-lock default', () => {
+  const backendLockWaitSeconds = Number(configDefaults.match(/"turn_wait_seconds":\s*(\d+)/)[1])
+  assert.equal(jsConstant('RELAY_TURN_LOCK_WAIT_MS'), backendLockWaitSeconds * 1000)
+})
+
+test('the delivery deadline mirrors the backend per-attempt turn timeout', () => {
+  const attemptTimeouts = [...relayHandler.matchAll(/timeout=(\d+)/g)].map(m => Number(m[1]))
+  assert.ok(attemptTimeouts.length >= 2, 'expected the attempt and its policy-gated retry')
+  // Every attempt shares one bound; if they ever diverge, the mirror below is
+  // no longer a faithful ceiling and this must be revisited deliberately.
+  assert.equal(new Set(attemptTimeouts).size, 1, `attempt timeouts diverged: ${attemptTimeouts}`)
+  assert.equal(jsConstant('RELAY_TURN_ATTEMPT_MS'), attemptTimeouts[0] * 1000)
+  assert.equal(jsConstant('RELAY_TURN_MAX_ATTEMPTS'), attemptTimeouts.length)
+})
+
+test('the client deadline is strictly greater than the backend ceiling', () => {
+  const lockWait = jsConstant('RELAY_TURN_LOCK_WAIT_MS')
+  const attempt = jsConstant('RELAY_TURN_ATTEMPT_MS')
+  const attempts = jsConstant('RELAY_TURN_MAX_ATTEMPTS')
+  const margin = jsConstant('RELAY_DELIVER_SETTLEMENT_MARGIN_MS')
+  const ceiling = lockWait + attempt * attempts
+
+  // Strictly greater, not equal: a backend that answers at its own limit still
+  // has to serialize and transport that answer.
+  assert.ok(margin > 0, 'settlement margin must be positive')
+  assert.ok(
+    ceiling + margin > ceiling,
+    'the client deadline must outlive the backend ceiling, not merely match it'
+  )
+
+  // The call site must pass the composed budget, not a bare literal.
+  const drain = pluginSource.slice(
+    pluginSource.indexOf('async function drainRelayOutboxes'),
+    pluginSource.indexOf('function startBotRelay')
+  )
+  assert.match(drain, /'bot_relay\.deliver'[\s\S]{0,400}RELAY_DELIVER_TIMEOUT_MS/)
+  assert.doesNotMatch(drain, /'bot_relay\.deliver'[\s\S]{0,400}\d{6,}/)
+})

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -230,20 +230,26 @@ const $viewport = atom<ViewportRect>(readViewport())
 async function requestPluginProfile<T>(
   route: PluginProfileRoute | string,
   method: string,
-  params: Record<string, unknown>
+  params: Record<string, unknown>,
+  timeoutMs?: number
 ): Promise<T> {
   if (typeof route !== 'string') {
     if (!route.connectionId.trim() || !route.profile.trim() || !route.targetProfile.trim()) {
       throw new Error('Profile route must include connectionId, profile, and targetProfile')
     }
 
-    return requestGatewayForAgent<T>(route.connectionId, route.profile, method, params)
+    // Omit the bound entirely when unset so callers stay on the pool default.
+    return timeoutMs === undefined
+      ? requestGatewayForAgent<T>(route.connectionId, route.profile, method, params)
+      : requestGatewayForAgent<T>(route.connectionId, route.profile, method, params, timeoutMs)
   }
 
   const getAgentRoster = window.hermesDesktop?.getAgentRoster
 
   if (!getAgentRoster) {
-    return requestGatewayForProfile<T>(route, method, params)
+    return timeoutMs === undefined
+      ? requestGatewayForProfile<T>(route, method, params)
+      : requestGatewayForProfile<T>(route, method, params, timeoutMs)
   }
 
   const roster = await getAgentRoster()
@@ -255,7 +261,9 @@ async function requestPluginProfile<T>(
   // its live enumeration transiently failed. Any additional source requires a
   // descriptor because an undialed/unreachable source may expose the same name.
   if (soleLocalSource) {
-    return requestGatewayForProfile<T>(profile, method, params)
+    return timeoutMs === undefined
+      ? requestGatewayForProfile<T>(profile, method, params)
+      : requestGatewayForProfile<T>(profile, method, params, timeoutMs)
   }
 
   throw new Error(
@@ -1239,12 +1247,18 @@ export const host = {
   /** Gateway JSON-RPC through a credential-free route descriptor without
    *  foregrounding it. Passing a bare profile is the v1/local compatibility
    *  overload; registry callers must pass the descriptor so duplicate names
-   *  remain unambiguous. */
+   *  remain unambiguous.
+   *
+   *  `timeoutMs` opts one call out of the pool's generic deadline (#93911: a
+   *  method whose backend contract is minutes long, such as `bot_relay.deliver`,
+   *  otherwise dies at 30s and reports an unclassified failure). Leave it unset
+   *  to keep the default. */
   requestProfile: async <T>(
     route: PluginProfileRoute | string,
     method: string,
-    params: Record<string, unknown> = {}
-  ): Promise<T> => requestPluginProfile<T>(route, method, params),
+    params: Record<string, unknown> = {},
+    timeoutMs?: number
+  ): Promise<T> => requestPluginProfile<T>(route, method, params, timeoutMs),
 
   /** Pin a route's pooled gateway socket open across repeated `requestProfile`
    *  calls (#93594: the bot-relay drain loop was dialing and tearing down a

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -318,6 +318,42 @@ describe('connection-aware plugin host APIs', () => {
     expect(requestGatewayForProfile).not.toHaveBeenCalled()
   })
 
+  it('forwards an explicit timeout so long-running methods outlive the generic deadline', async () => {
+    // #93911: bot_relay.deliver's backend contract tolerates ~1320s (120s turn
+    // lock + a 600s turn, doubled by the bounded retry). Without a way to pass
+    // that bound through, every such call died at the pool's generic 30s
+    // deadline and surfaced as an unclassified failure.
+    const route = {
+      connectionId: 'source-a',
+      mode: 'remote' as const,
+      profile: 'remote-worker',
+      targetProfile: 'backend-worker'
+    }
+
+    await host.requestProfile(route, 'bot_relay.deliver', { message: 'hi', profile: 'backend-worker' }, 1_320_000)
+
+    expect(requestGatewayForAgent).toHaveBeenCalledWith(
+      'source-a',
+      'remote-worker',
+      'bot_relay.deliver',
+      { message: 'hi', profile: 'backend-worker' },
+      1_320_000
+    )
+  })
+
+  it('leaves callers that pass no timeout on the pool default', async () => {
+    const route = {
+      connectionId: 'source-a',
+      mode: 'remote' as const,
+      profile: 'remote-worker',
+      targetProfile: 'backend-worker'
+    }
+
+    await host.requestProfile(route, 'profiles.list', {})
+
+    expect(requestGatewayForAgent).toHaveBeenCalledWith('source-a', 'remote-worker', 'profiles.list', {})
+  })
+
   it('fails closed when a descriptor omits connection or target profile identity', async () => {
     await expect(
       host.requestProfile(

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -341,6 +341,68 @@ describe('connection-aware plugin host APIs', () => {
     )
   })
 
+  it('survives a backend that settles at its own ceiling, and only fails past the client deadline', async () => {
+    // #93911 review follow-up (adversarial): the failure mode is not "no
+    // timeout" but "a timeout equal to the backend's ceiling". Model the
+    // documented worst case on a virtual clock — the turn lock wait, a full
+    // timed attempt, the policy-gated re-run, and then the settlement the
+    // handler still has to serialize and transport — and assert that a
+    // deadline set AT the ceiling loses that race while one with margin wins.
+    const LOCK_WAIT_MS = 120_000
+    const ATTEMPT_MS = 600_000
+    const ATTEMPTS = 2
+    const CEILING_MS = LOCK_WAIT_MS + ATTEMPT_MS * ATTEMPTS
+    const SETTLEMENT_MS = 1_000
+
+    const route = {
+      connectionId: 'source-a',
+      mode: 'remote' as const,
+      profile: 'remote-worker',
+      targetProfile: 'backend-worker'
+    }
+
+    // A gateway that answers only after the full ceiling plus settlement, and
+    // aborts at whatever deadline the caller handed down.
+    const backendAtItsLimit = async (
+      _connectionId: string,
+      _profile: string,
+      _method: string,
+      _params: Record<string, unknown>,
+      timeoutMs?: number
+    ) =>
+      new Promise((resolve, reject) => {
+        setTimeout(() => resolve({ reply: 'delivered', reason: 'ok' }), CEILING_MS + SETTLEMENT_MS)
+
+        if (timeoutMs !== undefined) {
+          setTimeout(() => reject(new Error('request timed out')), timeoutMs)
+        }
+      })
+
+    vi.useFakeTimers()
+
+    try {
+      vi.mocked(requestGatewayForAgent).mockImplementation(backendAtItsLimit as never)
+
+      // Deadline exactly at the ceiling: the typed settlement loses the race.
+      const atCeiling = host.requestProfile(route, 'bot_relay.deliver', {}, CEILING_MS)
+      const atCeilingSettled = expect(atCeiling).rejects.toThrow(/timed out/)
+      await vi.advanceTimersByTimeAsync(CEILING_MS + SETTLEMENT_MS)
+      await atCeilingSettled
+
+      // Same backend, deadline with settlement margin: the answer gets through.
+      const withMargin = host.requestProfile(route, 'bot_relay.deliver', {}, CEILING_MS + SETTLEMENT_MS * 180)
+      const withMarginSettled = expect(withMargin).resolves.toEqual({
+        reason: 'ok',
+        reply: 'delivered'
+      })
+      await vi.advanceTimersByTimeAsync(CEILING_MS + SETTLEMENT_MS)
+      await withMarginSettled
+    } finally {
+      vi.useRealTimers()
+      vi.mocked(requestGatewayForAgent).mockReset()
+    }
+  })
+
   it('leaves callers that pass no timeout on the pool default', async () => {
     const route = {
       connectionId: 'source-a',


### PR DESCRIPTION
## What does this PR do?

Fixes #93911.

`host.requestProfile()` had no way to express a per-call timeout, so every routed plugin RPC fell to the gateway pool's generic 30s deadline. `bot_relay.deliver`'s contract is far longer than that: the backend holds the per-profile turn lock (`bot_mode.turn_wait_seconds`, default 120s) and then runs a 600s turn, doubled when the retry policy grants one bounded re-run — `tui_gateway/methods_bot_relay.py` documents this explicitly as *"clients calling bot_relay.deliver must tolerate ~1320s before assuming failure"*.

The result was that any long turn (Computer Use, deep research) was killed at 30 seconds and surfaced as an unclassified failure, discarding the typed reason the backend had already classified.

The plumbing was almost all there: `requestGatewayForAgent()` and `requestGatewayForProfile()` in `store/gateway.ts` already accept `timeoutMs` — only the two SDK layers above them dropped it. This threads it through and passes the documented bound at the one call site that needs it.

This is the same shape as #85692 (`host.request` + `image.generate` → 180_000), applied to the routed-profile path.

## Related Issue

Fixes #93911

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/sdk/index.ts` (+21 −7): `requestPluginProfile()` and the public `host.requestProfile()` take an optional `timeoutMs` and forward it on all three routing branches (descriptor, no-roster fallback, sole-local-source). When it is unset the argument is **omitted entirely** rather than passed as `undefined`, so existing callers keep the pool default.
- `apps/desktop/src/plugins/hermes-bots/plugin.js` (+17 −3): new `RELAY_DELIVER_TIMEOUT_MS = 1_320_000`, documented against the backend bound, passed at the `bot_relay.deliver` call site in the drain loop.
- `apps/desktop/src/sdk/profile-routing.test.ts` (+36): two tests — an explicit timeout reaches the routed gateway call, and a caller that passes none is still invoked without the extra argument.

## How to Test

1. `cd apps/desktop && npx vitest --run src/sdk/profile-routing.test.ts` — 39/39 passing (was 37; +2 new tests).
2. To see the old behavior, `git stash` the two non-test files and re-run: the new assertion fails with `- 1320000,`, i.e. the bound never reached the gateway layer.
3. Full SDK suite: `npx vitest --run src/sdk/` — 66/66 passing.
4. `npm run typecheck` (all three tsconfigs) — clean.

### Before / After

|                                             | Before                                              | After                                        |
|---------------------------------------------|-----------------------------------------------------|----------------------------------------------|
| `bot_relay.deliver`, turn longer than 30s   | aborted at 30s, reported as an unclassified failure | runs to the backend's documented ~1320s bound |
| `bot_relay.deliver`, turn classified as failed by the backend | typed `data.reason` often never reached the sender (client aborted first) | typed reason forwarded as before |
| Every other `host.requestProfile()` caller  | pool default deadline                               | **unchanged** — argument omitted when unset  |
| `host.request()` (non-routed path)          | pool default deadline                               | **unchanged** — not touched by this PR       |

## What did NOT change

- No change to the backend. The ~1320s figure is read from `methods_bot_relay.py`'s existing contract, not introduced here.
- No change to `requestGatewayForAgent()` / `requestGatewayForProfile()` — they already accepted `timeoutMs`.
- No new config keys, no new env vars. The bound is a module constant next to the other relay-loop constants.
- The retry, classification, and badge paths from #93091 are untouched; this only stops the client from giving up before the backend has answered.
- `host.request()` is deliberately left alone — #85692 is already addressing that path.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, this is a Desktop TypeScript change; ran the vitest suites above instead
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.5 (Node 24.14.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behavior restored to the documented contract; the constant carries the rationale inline)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture or workflow change)
- [x] I've considered cross-platform impact — no platform-specific code paths; the change is a numeric argument passed through existing TypeScript call sites
- [x] I've updated tool descriptions/schemas — N/A (no tool behavior change)
