### PR TITLE
fix(tui): resolve session lineage for kanban notification delivery

### DIFF
--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -114,6 +114,25 @@ class TestCollectKanbanNotifications:
         assert _collect_kanban_notifications(_session()) == []
         assert _sub_rows(tid) == []
 
+    def test_collect_kanban_notifications_lineage_resolution(self):
+        parent_key = "tui-parent-session-1"
+        child_key = "tui-child-session-1"
+        tid = _create_subscribed_task(chat_id=parent_key)
+        _complete(tid, summary="parent session task done")
+
+        # Mock SessionDB lineage so child_key resolves parent_key as ancestor
+        class DummyDB:
+            def _session_lineage_root_to_tip(self, key):
+                if key == child_key:
+                    return [parent_key, child_key]
+                return [key]
+
+        with patch("hermes_state.SessionDB", return_value=DummyDB()):
+            texts = _collect_kanban_notifications(_session(child_key))
+
+        assert len(texts) == 1
+        assert "parent session task done" in texts[0]
+
     def test_matching_tui_sub_delivers_and_advances_cursor(self):
         tid = _create_subscribed_task()
         pre_cursor = _sub_rows(tid)[0]["last_event_id"]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10679,6 +10679,20 @@ def _collect_kanban_notifications(session: dict) -> list:
     session_key = str(session.get("session_key") or "")
     if not session_key or session.get("_finalized"):
         return []
+
+    # Include session_key and any ancestral keys from the compression lineage
+    # so continuation sessions receive terminal events for tasks subscribed
+    # under an earlier session_key.
+    active_keys: set[str] = {session_key}
+    try:
+        from hermes_state import SessionDB
+        db = SessionDB()
+        chain = db._session_lineage_root_to_tip(session_key) if hasattr(db, "_session_lineage_root_to_tip") else []
+        for k in chain:
+            if k:
+                active_keys.add(str(k))
+    except Exception:
+        pass
     try:
         from hermes_cli import kanban_db as _kb
     except Exception:
@@ -10709,14 +10723,19 @@ def _collect_kanban_notifications(session: dict) -> list:
             continue
         seen_db_paths.add(resolved)
         # A poller runs per live TUI/Desktop session. Avoid opening this board
-        # writable unless it has a subscription owned by this exact session;
+        # writable unless it has a subscription owned by this exact session lineage;
         # subscriptions for gateways or other sessions are not actionable here.
         try:
-            if _kb.count_notify_subs(
-                board=slug,
-                platform="tui",
-                chat_id=session_key,
-            ) == 0:
+            has_matching_sub = False
+            for k in active_keys:
+                if _kb.count_notify_subs(
+                    board=slug,
+                    platform="tui",
+                    chat_id=k,
+                ) > 0:
+                    has_matching_sub = True
+                    break
+            if not has_matching_sub:
                 continue
         except Exception:
             # Preserve delivery if the read-only probe cannot inspect a
@@ -10734,7 +10753,7 @@ def _collect_kanban_notifications(session: dict) -> list:
             for sub in subs:
                 if (sub.get("platform") or "").lower() != "tui":
                     continue
-                if sub.get("chat_id") != session_key:
+                if sub.get("chat_id") not in active_keys:
                     continue
                 _old, _new, events = _kb.claim_unseen_events_for_sub(
                     conn,


### PR DESCRIPTION
## Problem
When a desktop/TUI chat undergoes context compression, the active `session_key` rotates to a new continuation session ID. Kanban notification subscriptions (`kanban_notify_subs`) registered under the ancestral session key are skipped by `_collect_kanban_notifications` because it did an exact equality check (`chat_id == session_key`). As a result, terminal task events for tasks created prior to compaction are never delivered to the active conversation.

## Solution
- Resolve the session lineage chain (`_session_lineage_root_to_tip`) in `_collect_kanban_notifications` to populate `active_keys`.
- Check `chat_id in active_keys` for both the `count_notify_subs` probe and the subscription loop.
- Add targeted regression tests in `test_kanban_notify_poller.py` verifying lineage resolution and delivery.

## Verification
- `tests/tui_gateway/test_kanban_notify_poller.py` passes 15/15.
- `tests/hermes_cli/test_kanban_notify.py` and `tests/tools/test_kanban_tools.py` pass 58/58.