### PR TITLE
fix(desktop): strip poisoned Python env vars before desktop-driven update

### DIFF
--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -564,6 +564,20 @@ start_ui
 HERMES_BIN="$INSTALL_ROOT/venv/bin/hermes"
 [ -x "$HERMES_BIN" ] || { FINAL_CODE=3 FINAL_MSG="Update aborted: $HERMES_BIN is missing. The install needs repair (run the Hermes installer or hermes doctor)."; log "$FINAL_MSG"; exit 3; }
 
+# Sanitize inherited Python environment state before ANY $HERMES_BIN call
+# (the --help probe below included). The Desktop app carries whatever shell
+# environment launched it, and macOS sets __PYVENV_LAUNCHER__ when the parent
+# chain went through a non-framework python3 (CommandLineTools, Homebrew).
+# Inside a venv, that variable makes python resolve its home against the
+# WRONG prefix: site-packages is skipped entirely, the editable install's
+# .pth finder never loads, and the update child dies before argparse with
+#   ModuleNotFoundError: No module named 'hermes_cli'
+# -- which reads like a broken install and fails the retry identically, so
+# the Desktop reports an unfixable update. PYTHONHOME poisons the same way;
+# PYTHONPATH can leak host site-packages ahead of the venv's. This is the
+# same trio ~/.local/bin/hermes unsets before exec'ing the venv python.
+unset __PYVENV_LAUNCHER__ PYTHONHOME PYTHONPATH
+
 # Run FROM the install root: `hermes update` resolves the tree it mutates
 # from the working directory, and we inherit the Desktop's cwd (which can be
 # an unrelated repo — updating THAT instead of the install is the failure

--- a/tests/test_desktop_update_shim_progress.py
+++ b/tests/test_desktop_update_shim_progress.py
@@ -126,6 +126,8 @@ for f in "$TMPDIR"/hermes-update-status.[0-9]*; do
   case "$f" in *.tmp) continue ;; esac
   cp "$f" "$HERMES_TEST_CAPTURE.$n" 2>/dev/null
 done
+# Record whether the poisoned-Python-env trio survived to the update child.
+printf '%s' "${__PYVENV_LAUNCHER__+set}" > "$HERMES_TEST_LAUNCHER.$n" 2>/dev/null
 exit "$(cat "$HERMES_TEST_EXITS.$n" 2>/dev/null || echo 0)"
 """
 
@@ -149,6 +151,11 @@ def _run_handoff(tmp_path, exits: dict[int, int]) -> list[dict]:
         "HERMES_TEST_CAPTURE": str(capture),
         "HERMES_TEST_CALLS": str(calls),
         "HERMES_TEST_EXITS": str(tmp_path / "exits"),
+        "HERMES_TEST_LAUNCHER": str(tmp_path / "launcher"),
+        # The real caller (Electron) often carries macOS's __PYVENV_LAUNCHER__
+        # out of a CommandLineTools/Homebrew parent shell; keep the simulation
+        # honest even for tests that don't assert on it.
+        "__PYVENV_LAUNCHER__": "/usr/bin/python3",
     }
     # The hand-off daemonizes and the launcher exits immediately; the result
     # file is the orchestrator's own completion signal.
@@ -197,3 +204,25 @@ def test_retry_gate_publishes_a_distinct_stage(tmp_path):
         "Updating code and dependencies",
         "Retrying update",
     ]
+
+
+@requires_posix_handoff
+def test_handoff_strips_poisoned_python_env_before_update(tmp_path):
+    """The update child must never inherit __PYVENV_LAUNCHER__.
+
+    A Desktop launched from a CommandLineTools/Homebrew python3 parent shell
+    carries __PYVENV_LAUNCHER__; inside the venv that var makes python resolve
+    its prefix against the wrong home, site-packages is skipped, and the very
+    first `hermes update` import dies with ModuleNotFoundError before argparse
+    (observed on macOS 26.5, 2026-08-22..24: every desktop-driven update,
+    both attempts, identical traceback). The hand-off must strip it -- with
+    its two sibling poisons -- before any $HERMES_BIN call.
+    """
+    _run_handoff(tmp_path, {1: 0})
+
+    seen = sorted(tmp_path.glob("launcher.*"), key=lambda p: int(p.suffix[1:]))
+    assert seen, "update child never ran"
+    for capture in seen:
+        assert capture.read_text() == "", (
+            f"{capture.name}: poisoned env survived into the update child"
+        )


### PR DESCRIPTION
## Summary

Desktop-driven updates fail **every time** on macOS whenever the Desktop app was launched from a shell whose parent chain went through a non-framework `python3` (CommandLineTools, Homebrew). The app inherits macOS's `__PYVENV_LAUNCHER__`; the update hand-off (`scripts/desktop-update/posix.sh`) then invokes `venv/bin/hermes` **directly** with that environment still set. Inside a venv, that variable makes CPython resolve its home against the wrong prefix — site-packages is skipped entirely, the editable install's `.pth` finder never loads, and the update child dies on its very first import:

```
Traceback (most recent call last):
  File "/Users/<user>/.hermes/hermes-agent/venv/bin/hermes", line 4, in <module>
    from hermes_cli.main import main
ModuleNotFoundError: No module named 'hermes_cli'
```

This reads like a broken install. The hand-off's built-in retry re-runs with the same poisoned env and fails identically, so the user is stuck: every "Update" click fails, while `hermes update` from a terminal works fine — because the `~/.local/bin/hermes` launcher wrapper already unsets this exact trio.

## Root cause

1. A shell exports `__PYVENV_LAUNCHER__` when it execs a venv/CLI python (macOS framework-Python behavior).
2. `hermes desktop` launched from that shell passes it to Electron.
3. Electron spawns `scripts/desktop-update/posix.sh` detached, env inherited verbatim.
4. posix.sh calls `"$INSTALL_ROOT/venv/bin/hermes" update` directly (no env sanitization).
5. The venv python mis-resolves its prefix → no site-packages → import dies before argparse.

Reproduced byte-for-byte:

```console
$ __PYVENV_LAUNCHER__=/Library/Developer/CommandLineTools/usr/bin/python3 \
    ~/.hermes/hermes-agent/venv/bin/hermes --version
ModuleNotFoundError: No module named 'hermes_cli'
```

The live Desktop process confirmed carrying `__PYVENV_LAUNCHER__=/Library/Developer/CommandLineTools/usr/bin/python3`, and `~/.hermes/logs/desktop-update-handoff.log` shows the identical failure on every attempt across multiple days (both attempts failing each time).

## Fix

`posix.sh` unsets `__PYVENV_LAUNCHER__`, `PYTHONHOME`, and `PYTHONPATH` once, right after resolving `$HERMES_BIN` and before any `$HERMES_BIN` invocation (the `update --help` probe included) — mirroring what `~/.local/bin/hermes` already does before exec'ing the venv python. The Windows hand-off drives its update through raw `python.exe -m ...` for an analogous platform reason; this gives POSIX the equivalent guard for this failure class.

## Test plan

- [x] New regression test `test_handoff_strips_poisoned_python_env_before_update` drives the **real** `posix.sh` end-to-end (same harness as the existing stage tests) with `__PYVENV_LAUNCHER__` present and asserts the update child never inherits it.
- [x] RED→GREEN verified: test fails against unfixed `posix.sh` (`set` observed surviving into the child), passes with the fix.
- [x] Full file suite green: `6 passed`.
- [x] `bash -n scripts/desktop-update/posix.sh` clean.