### PR TITLE
fix(tui): pass through Ctrl/Cmd+L so the dashboard redraw byte never inserts a stray 'l'

### DIFF
--- a/ui-tui/src/__tests__/textInputPassThrough.test.ts
+++ b/ui-tui/src/__tests__/textInputPassThrough.test.ts
@@ -50,4 +50,10 @@ describe('shouldPassThroughToGlobalHandler', () => {
     expect(shouldPassThroughToGlobalHandler('', key({ pageUp: true }))).toBe(true)
     expect(shouldPassThroughToGlobalHandler('', key({ pageDown: true }))).toBe(true)
   })
+
+  it('passes through the Ctrl+L redraw key so the composer never inserts a stray "l"', () => {
+    expect(shouldPassThroughToGlobalHandler('l', key({ ctrl: true }))).toBe(true)
+    // A plain (unmodified) "l" must still reach the composer as typing.
+    expect(shouldPassThroughToGlobalHandler('l', key())).toBe(false)
+  })
 })

--- a/ui-tui/src/__tests__/textInputPassThrough.test.ts
+++ b/ui-tui/src/__tests__/textInputPassThrough.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { shouldPassThroughToGlobalHandler, shouldPreserveCtrlJNewline } from '../components/textInput.js'
-import { DEFAULT_VOICE_RECORD_KEY, parseVoiceRecordKey } from '../lib/platform.js'
+import { DEFAULT_VOICE_RECORD_KEY, isMac, parseVoiceRecordKey } from '../lib/platform.js'
 
 const key = (overrides: Record<string, unknown> = {}) => ({ ctrl: false, meta: false, ...overrides }) as any
 
@@ -52,8 +52,23 @@ describe('shouldPassThroughToGlobalHandler', () => {
   })
 
   it('passes through the Ctrl+L redraw key so the composer never inserts a stray "l"', () => {
+    // Raw Ctrl+L — the byte every terminal (macOS included) sends for the
+    // dashboard redraw — must pass through on ALL platforms, so pin the
+    // assertion to the raw-ctrl shape rather than isAction, whose action
+    // modifier means Cmd on darwin.
     expect(shouldPassThroughToGlobalHandler('l', key({ ctrl: true }))).toBe(true)
     // A plain (unmodified) "l" must still reach the composer as typing.
     expect(shouldPassThroughToGlobalHandler('l', key())).toBe(false)
+  })
+
+  it('passes through Cmd+L on macOS-shaped events without touching plain Alt+L', () => {
+    // Cmd surfaces as meta (legacy terminals) or super (kitty protocol);
+    // isAction passes it through only where the action modifier is Cmd
+    // (darwin). Elsewhere meta means plain Alt, and Alt+L must stay
+    // composer input. Keyed to isMac — the same constant the
+    // implementation keys on — so the test is platform-independent.
+    for (const mod of [{ meta: true }, { super: true }]) {
+      expect(shouldPassThroughToGlobalHandler('l', key(mod))).toBe(isMac)
+    }
   })
 })

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -8,6 +8,7 @@ import { readClipboardText, writeClipboardText } from '../lib/clipboard.js'
 import { cursorLayout, offsetFromPosition } from '../lib/inputMetrics.js'
 import {
   DEFAULT_VOICE_RECORD_KEY,
+  isAction,
   isActionMod,
   isMac,
   isMacActionFallback,
@@ -1831,6 +1832,7 @@ export const shouldPassThroughToGlobalHandler = (
   (key.ctrl && input === 'c') ||
   (key.ctrl && input === 'x') ||
   (key.ctrl && input === 'o') ||
+  isAction(key, input, 'l') ||
   key.tab ||
   (key.shift && key.tab) ||
   key.pageUp ||

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -1832,6 +1832,12 @@ export const shouldPassThroughToGlobalHandler = (
   (key.ctrl && input === 'c') ||
   (key.ctrl && input === 'x') ||
   (key.ctrl && input === 'o') ||
+  // The dashboard's clear/redraw byte arrives as plain Ctrl+L in every
+  // terminal, including macOS ones — so match the raw Ctrl bit directly
+  // (like the c/x/o neighbors above) rather than only isAction, whose
+  // modifier means Cmd on darwin. isAction still adds the Cmd+L shape
+  // there, mirroring the readline-style mac fallbacks.
+  (key.ctrl && input === 'l') ||
   isAction(key, input, 'l') ||
   key.tab ||
   (key.shift && key.tab) ||


### PR DESCRIPTION
## Summary

Resurrects #87474 (closed unmerged after the original author's fork was deleted — recreated here under a new fork with the identical single commit `b43af3e`, authored by @jazzzzmaybe).

Fixes #87069 — the dashboard Chat tab inserted a stray `l` into the composer on every session switch.

Root cause: `PtySession.attach()` injects a raw Ctrl-L byte (`0x0c`) to force a TUI repaint on keep-alive PTY reattach (#86332 / #68071). The Ink keypress parser maps that byte to a `ctrl+l` key event which reaches **both** listeners — the global hotkey handler (which redraws but does not consume it) and the focused TextInput (which inserts `l` into the composer). The same leak affects real user Ctrl/Cmd+L presses.

## Changes

- `ui-tui/src/components/textInput.tsx`: add `isAction(key, input, 'l')` to `shouldPassThroughToGlobalHandler` so Ctrl+L / Cmd+L is routed to the global redraw handler instead of the composer.
- `ui-tui/src/__tests__/textInputPassThrough.test.ts`: pin both cases — Ctrl+L passes through, plain unmodified `l` still types into the composer.

All credit to @jazzzzmaybe for the original fix (#87070, #87474). Issue #87069 remains open and unfixed on `main`.