### PR TITLE
fix(restart-loop-guard): use continue instead of break for distant future entries (addresses reviewer concern on #93427)

### DIFF
--- a/gateway/restart_loop_guard.py
+++ b/gateway/restart_loop_guard.py
@@ -110,8 +110,15 @@ def _chain_ending_at(boots: List[float], ts: float, gap: float) -> List[float]:
     prev = ts
     for t in sorted(boots, reverse=True):
         if t > ts:
-            # Clock moved backwards (NTP step, restored state file). Treat the
-            # future entry as adjacent rather than dropping the whole chain.
+            # Clock moved backwards (NTP step, restored state file). Treat a
+            # *recent* future entry as adjacent rather than dropping the whole
+            # chain — but bound it by ``gap`` like any other link. Without a
+            # bound here, an arbitrarily old entry (weeks back) chains in
+            # after one large backward step and trips the breaker on
+            # unrelated history, turning the documented fail-open contract
+            # into fail-closed.
+            if t - ts > gap:
+                continue
             chain.append(t)
             continue
         if prev - t > gap:

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -1160,6 +1160,20 @@ class TestRestartLoopGuard:
             assert rlg.check_and_record(0, 60, now=ts) is False
         assert rlg.is_restart_loop_tripped(0, 60, now=1451.0) is False
 
+    def test_clock_rollback_does_not_self_prune_valid_chain(self):
+        """PR #93427: 'break' on distant future entries would exit the loop
+        before reaching valid earlier boots, silently losing the chain.
+        The fix must use 'continue' to skip only the distant entry."""
+        import gateway.restart_loop_guard as rlg
+
+        # Distant future boot (940s ahead) + two recent boots within gap.
+        # Sorted reverse iteration sees [2000, 1100, 1050]:
+        #   - With 'break': 2000 is 940s > 300 → break → chain=[] (LOST!)
+        #   - With 'continue': 2000 skipped, then 1100/1050 chained → chain=[1050,1100]
+        assert rlg._chain_ending_at(
+            [2000.0, 1100.0, 1050.0], 1060.0, 300.0
+        ) == [1050.0, 1100.0]
+
 class TestTerminalToolGatewayLifecycleGuardRemote:
     """Remote-backend and two-session cwd regression coverage."""
 


### PR DESCRIPTION
## Summary

Follow-up to review on #93427: the clock-rollback guard added there used `break` on a distant future entry, which exits the loop and **self-prunes valid earlier boots** — silently turning the documented fail-open contract into fail-closed on a single large backward NTP step.

This PR bounds the future-entry handling by the same `gap` used for every other link: `if t - ts > gap: continue` skips only the too-distant entry and keeps walking the rest of the chain.

## Before / After

For `boots=[2000, 1100, 1050]`, `ts=1060`, `gap=300` (sorted reverse: `2000, 1100, 1050`):

- **before (break):** `2000` is `940 > gap` → `break` → whole chain dropped → `chain=[]` — **lost**
- **after (continue):** `2000` skipped, then `1100`/`1050` chain together → `[1050, 1100]`

## Tests
- Added `test_clock_rollback_does_not_self_prune_valid_chain` asserting the above.
- Full `test_gateway_restart_loop.py`: **132 passed**.

This is the same change previously submitted under a branch polluted with unrelated history; this PR is clean (single commit, based on latest `main`).
