### PR TITLE
feat(gateway): expose read-only cron status

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16475,6 +16475,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "footer": self._handle_footer_command,
                 "help": self._handle_help_command,
                 "commands": self._handle_commands_command,
+                "cron": self._handle_cron_command,
                 "profile": self._handle_profile_command,
                 "update": self._handle_update_command,
                 "version": self._handle_version_command,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17613,6 +17613,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "commands":
             return await self._handle_commands_command(event)
+
+        if canonical == "cron":
+            return await self._handle_cron_command(event)
         
         if canonical == "profile":
             return await self._handle_profile_command(event)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1748,6 +1748,20 @@ class GatewaySlashCommandsMixin:
             getattr(getattr(event, "source", None), "platform", None),
         )
 
+    async def _handle_cron_command(self, event: MessageEvent) -> str:
+        """Handle gateway /cron — read-only cron job listing."""
+        from hermes_cli.slash_exec import CommandContext, execute_command
+
+        reply = execute_command(
+            "cron",
+            CommandContext(
+                surface="gateway",
+                args=event.get_command_args(),
+                options={"max_chars": 3800},
+            ),
+        )
+        return reply.text
+
     async def _handle_model_command(self, event: MessageEvent) -> Optional[str]:
         """Handle /model command — switch model.
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1752,15 +1752,24 @@ class GatewaySlashCommandsMixin:
         """Handle gateway /cron — read-only cron job listing."""
         from hermes_cli.slash_exec import CommandContext, execute_command
 
-        reply = execute_command(
-            "cron",
-            CommandContext(
-                surface="gateway",
-                args=event.get_command_args(),
-                options={"max_chars": 3800},
-            ),
-        )
-        return reply.text
+        def _execute() -> str:
+            return execute_command(
+                "cron",
+                CommandContext(
+                    surface="gateway",
+                    args=event.get_command_args(),
+                    options={"max_chars": 3800},
+                ),
+            ).text
+
+        if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            return _execute()
+
+        from gateway.run import _profile_runtime_scope
+
+        profile_home = self._resolve_profile_home_for_source(event.source)
+        with _profile_runtime_scope(profile_home):
+            return _execute()
 
     async def _handle_model_command(self, event: MessageEvent) -> Optional[str]:
         """Handle /model command — switch model.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -324,8 +324,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
                "Tools & Skills", args_hint="<what to learn from>"),
     CommandDef("init", "Generate or update AGENTS.md project instructions from a repo scan",
                "Tools & Skills", args_hint="[notes]"),
-    CommandDef("cron", "Manage scheduled tasks", "Tools & Skills",
-               cli_only=True, args_hint="[subcommand]",
+    CommandDef("cron", "Manage scheduled tasks (gateway: read-only list)", "Tools & Skills",
+               args_hint="[subcommand]", busy_policy="dispatch",
+               execute="gateway_cron",
                subcommands=("list", "add", "create", "edit", "pause", "resume", "run", "remove")),
     CommandDef("suggestions", "Review suggested automations (accept/dismiss)",
                "Tools & Skills", aliases=("suggest",), args_hint="[accept|dismiss N | catalog]",
@@ -1368,7 +1369,12 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #     (session export is an interactive surface; platform is a rare
 #     informational lookup) — without this entry /save tips the registry
 #     past the 50-cap and silently clamps /platform, breaking parity.
-_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat", "refine", "review", "pause", "whoami", "platform"})
+#   - cron: read-only scheduled-job inspection; reached via /hermes cron on
+#     Slack so it does not displace an existing native slash at the 50-cap.
+_SLACK_VIA_HERMES_ONLY = frozenset({
+    "topup", "moa", "debug", "egress", "init", "version", "diff", "update",
+    "heartbeat", "refine", "review", "pause", "whoami", "platform", "cron",
+})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/hermes_cli/slash_exec.py
+++ b/hermes_cli/slash_exec.py
@@ -323,7 +323,8 @@ def _exec_cron(ctx: CommandContext) -> CommandReply:
     except ValueError:
         return CommandReply(
             "Usage: /cron list [--all]\n"
-            "Gateway /cron is read-only; use the CLI for create/edit/pause/run/remove.",
+            "Gateway /cron is read-only; use the CLI for "
+            "add/create/edit/pause/resume/run/remove.",
             format="markdown",
         )
 
@@ -338,7 +339,8 @@ def _exec_cron(ctx: CommandContext) -> CommandReply:
     else:
         return CommandReply(
             "Gateway /cron is read-only.\n"
-            "Use /cron list [--all] here, or use the CLI for create/edit/pause/run/remove.",
+            "Use /cron list [--all] here, or use the CLI for "
+            "add/create/edit/pause/resume/run/remove.",
             data={"blocked_subcommand": subcommand},
             format="markdown",
         )

--- a/hermes_cli/slash_exec.py
+++ b/hermes_cli/slash_exec.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
+import shlex
 from typing import Any
 
 __all__ = [
@@ -242,6 +243,157 @@ def _exec_commands(ctx: CommandContext) -> CommandReply:
     return CommandReply("\n".join(lines), format="markdown")
 
 
+def _short_text(value: Any, limit: int = 140) -> str:
+    """Return a single-line display value bounded for gateway messages."""
+    text = " ".join(str(value or "").split())
+    if not text:
+        return "-"
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)] + "..."
+
+
+def _schedule_display(job: Mapping[str, Any]) -> str:
+    schedule = job.get("schedule") or {}
+    if isinstance(schedule, Mapping):
+        return _short_text(
+            job.get("schedule_display")
+            or schedule.get("display")
+            or schedule.get("expr")
+            or schedule.get("value")
+        )
+    return _short_text(job.get("schedule_display") or schedule)
+
+
+def _job_mode(job: Mapping[str, Any]) -> str:
+    if job.get("no_agent"):
+        return "script-only"
+    if job.get("script"):
+        return "agent+script"
+    return "agent"
+
+
+def _format_cron_job(job: Mapping[str, Any]) -> list[str]:
+    job_id = _short_text(job.get("id") or job.get("job_id") or "?", 18)
+    name = _short_text(job.get("name") or "(unnamed)", 80)
+    state = _short_text(
+        job.get("state") or ("scheduled" if job.get("enabled", True) else "paused"), 24
+    )
+    enabled = "enabled" if job.get("enabled", True) else "disabled"
+    lines = [f"- {name} ({job_id}) [{state}, {enabled}, {_job_mode(job)}]"]
+    lines.append(f"  schedule: {_schedule_display(job)}")
+    lines.append(f"  next: {_short_text(job.get('next_run_at'), 48)}")
+    last_status = job.get("last_status")
+    last_run = job.get("last_run_at")
+    if last_status or last_run:
+        last = _short_text(last_run, 48)
+        status = _short_text(last_status or "unknown", 32)
+        last_error = job.get("last_error")
+        if last_error:
+            status = f"{status}: {_short_text(last_error, 120)}"
+        lines.append(f"  last: {last} {status}")
+    else:
+        lines.append("  last: never")
+    delivery_error = job.get("last_delivery_error")
+    if delivery_error:
+        lines.append(f"  delivery_error: {_short_text(delivery_error, 180)}")
+    script = job.get("script")
+    if script:
+        lines.append(f"  script: {_short_text(script, 80)}")
+    workdir = job.get("workdir")
+    if workdir:
+        lines.append(f"  workdir: {_short_text(workdir, 120)}")
+    latest_execution = job.get("latest_execution")
+    if isinstance(latest_execution, Mapping):
+        latest_status = latest_execution.get("status")
+        latest_id = latest_execution.get("id")
+        if latest_status or latest_id:
+            lines.append(
+                "  execution: "
+                f"{_short_text(latest_status or '?', 24)} {_short_text(latest_id or '?', 28)}"
+            )
+    return lines
+
+
+def _exec_cron(ctx: CommandContext) -> CommandReply:
+    """Gateway-safe read-only cron listing."""
+    raw_args = (ctx.args or "").strip()
+    try:
+        tokens = shlex.split(raw_args) if raw_args else []
+    except ValueError:
+        return CommandReply(
+            "Usage: /cron list [--all]\n"
+            "Gateway /cron is read-only; use the CLI for create/edit/pause/run/remove.",
+            format="markdown",
+        )
+
+    if not tokens:
+        tokens = ["list"]
+    subcommand = tokens[0].lower()
+    show_all = False
+    if subcommand in {"list", "ls", "jobs"}:
+        rest = tokens[1:]
+    elif subcommand in {"--all", "-a", "all"}:
+        rest = tokens
+    else:
+        return CommandReply(
+            "Gateway /cron is read-only.\n"
+            "Use /cron list [--all] here, or use the CLI for create/edit/pause/run/remove.",
+            data={"blocked_subcommand": subcommand},
+            format="markdown",
+        )
+    for token in rest:
+        if token in {"--all", "-a", "all"}:
+            show_all = True
+        else:
+            return CommandReply("Usage: /cron list [--all]", format="markdown")
+
+    try:
+        from cron.jobs import list_jobs
+
+        jobs = list_jobs(include_disabled=show_all)
+    except Exception as exc:  # pragma: no cover - environment-specific failure
+        return CommandReply(
+            f"Cron jobs unavailable: {_short_text(exc, 200)}",
+            data={"error": str(exc)},
+        )
+
+    if not jobs:
+        return CommandReply(
+            "No scheduled cron jobs found."
+            if show_all
+            else "No active cron jobs found. Use /cron list --all to include disabled jobs.",
+            data={"count": 0, "include_disabled": show_all},
+        )
+
+    lines = [
+        f"Cron jobs ({len(jobs)} {'total' if show_all else 'active'}):",
+        "",
+    ]
+    any_no_agent = False
+    for job in jobs:
+        any_no_agent = any_no_agent or bool(job.get("no_agent"))
+        lines.extend(_format_cron_job(job))
+    if any_no_agent:
+        lines.extend([
+            "",
+            "Note: script-only jobs can be intentionally silent when stdout is empty.",
+        ])
+    text = "\n".join(lines)
+    try:
+        max_chars = int(ctx.options.get("max_chars", 3800))
+    except (TypeError, ValueError):
+        max_chars = 3800
+    max_chars = max(500, max_chars)
+    if len(text) > max_chars:
+        text = text[: max_chars - 80].rstrip() + "\n... truncated; use CLI `hermes cron list --all` for full details."
+    return CommandReply(
+        text,
+        data={"count": len(jobs), "include_disabled": show_all},
+        format="markdown",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Registry + resolution
 # ---------------------------------------------------------------------------
@@ -253,6 +405,7 @@ EXECUTORS: dict[str, Callable[[CommandContext], CommandReply]] = {
     "bundles": _exec_bundles,
     "gateway_help": _exec_help,
     "gateway_commands": _exec_commands,
+    "gateway_cron": _exec_cron,
 }
 
 

--- a/tests/gateway/test_cron_command.py
+++ b/tests/gateway/test_cron_command.py
@@ -1,0 +1,35 @@
+"""Gateway /cron read-only handler coverage."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.slash_commands import GatewaySlashCommandsMixin
+
+
+@pytest.mark.asyncio
+async def test_gateway_cron_command_lists_jobs(monkeypatch):
+    def fake_list_jobs(*, include_disabled=False):
+        assert include_disabled is False
+        return [
+            {
+                "id": "job123",
+                "name": "daily report",
+                "enabled": True,
+                "state": "scheduled",
+                "schedule_display": "0 9 * * *",
+                "next_run_at": "2026-08-25T09:00:00+08:00",
+                "last_run_at": "2026-08-24T09:00:00+08:00",
+                "last_status": "ok",
+            }
+        ]
+
+    monkeypatch.setattr("cron.jobs.list_jobs", fake_list_jobs)
+    runner = object.__new__(GatewaySlashCommandsMixin)
+    event = SimpleNamespace(get_command_args=lambda: "list")
+
+    text = await runner._handle_cron_command(event)
+
+    assert "Cron jobs (1 active)" in text
+    assert "daily report" in text
+    assert "last: 2026-08-24T09:00:00+08:00 ok" in text

--- a/tests/gateway/test_cron_command.py
+++ b/tests/gateway/test_cron_command.py
@@ -1,35 +1,91 @@
 """Gateway /cron read-only handler coverage."""
 
+import asyncio
 from types import SimpleNamespace
-
-import pytest
+from unittest.mock import AsyncMock
 
 from gateway.slash_commands import GatewaySlashCommandsMixin
+from hermes_cli.commands import resolve_command, should_bypass_active_session
 
 
-@pytest.mark.asyncio
-async def test_gateway_cron_command_lists_jobs(monkeypatch):
+def _active_job():
+    return {
+        "id": "job123",
+        "name": "daily report",
+        "enabled": True,
+        "state": "scheduled",
+        "schedule_display": "0 9 * * *",
+        "next_run_at": "2026-08-25T09:00:00+08:00",
+        "last_run_at": "2026-08-24T09:00:00+08:00",
+        "last_status": "ok",
+    }
+
+
+def test_gateway_cron_command_lists_jobs(monkeypatch):
     def fake_list_jobs(*, include_disabled=False):
         assert include_disabled is False
-        return [
-            {
-                "id": "job123",
-                "name": "daily report",
-                "enabled": True,
-                "state": "scheduled",
-                "schedule_display": "0 9 * * *",
-                "next_run_at": "2026-08-25T09:00:00+08:00",
-                "last_run_at": "2026-08-24T09:00:00+08:00",
-                "last_status": "ok",
-            }
-        ]
+        return [_active_job()]
 
     monkeypatch.setattr("cron.jobs.list_jobs", fake_list_jobs)
     runner = object.__new__(GatewaySlashCommandsMixin)
+    runner.config = SimpleNamespace(multiplex_profiles=False)
     event = SimpleNamespace(get_command_args=lambda: "list")
 
-    text = await runner._handle_cron_command(event)
+    text = asyncio.run(runner._handle_cron_command(event))
 
     assert "Cron jobs (1 active)" in text
     assert "daily report" in text
     assert "last: 2026-08-24T09:00:00+08:00 ok" in text
+
+
+def test_gateway_cron_command_uses_source_profile(tmp_path, monkeypatch):
+    from cron.jobs import save_jobs, use_cron_store
+
+    default_home = tmp_path / "default"
+    profile_home = tmp_path / "profiles" / "research"
+    default_home.mkdir(parents=True)
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+
+    default_job = {**_active_job(), "id": "default-job", "name": "default only"}
+    profile_job = {**_active_job(), "id": "profile-job", "name": "research only"}
+    with use_cron_store(default_home):
+        save_jobs([default_job], replace=True)
+    with use_cron_store(profile_home):
+        save_jobs([profile_job], replace=True)
+    profile_jobs_file = profile_home / "cron" / "jobs.json"
+    jobs_before = profile_jobs_file.read_bytes()
+
+    runner = object.__new__(GatewaySlashCommandsMixin)
+    runner.config = SimpleNamespace(multiplex_profiles=True)
+    runner._resolve_profile_home_for_source = lambda source: profile_home
+    event = SimpleNamespace(
+        source=SimpleNamespace(profile="research"),
+        get_command_args=lambda: "list",
+    )
+
+    text = asyncio.run(runner._handle_cron_command(event))
+
+    assert "research only" in text
+    assert "default only" not in text
+    assert profile_jobs_file.read_bytes() == jobs_before
+
+
+def test_gateway_cron_command_dispatches_while_agent_is_busy():
+    from gateway.run import GatewayRunner
+
+    command = resolve_command("cron")
+    assert command is not None
+    assert command.busy_policy == "dispatch"
+    assert should_bypass_active_session("cron") is True
+
+    runner = object.__new__(GatewayRunner)
+    runner._handle_cron_command = AsyncMock(return_value="Cron jobs (1 active)")
+    event = SimpleNamespace()
+
+    result = asyncio.run(
+        runner._dispatch_busy_slash_command(event, command, "session", event)
+    )
+
+    assert result == "Cron jobs (1 active)"
+    runner._handle_cron_command.assert_awaited_once_with(event)

--- a/tests/hermes_cli/test_commands_execute.py
+++ b/tests/hermes_cli/test_commands_execute.py
@@ -26,7 +26,7 @@ SURFACES = ("cli", "gateway", "tui")
 def test_some_commands_are_migrated():
     names = {cmd.name for cmd in MIGRATED}
     # The thin-slice set — extend as more commands migrate.
-    assert {"version", "egress", "profile", "bundles", "help", "commands"} <= names
+    assert {"version", "egress", "profile", "bundles", "help", "commands", "cron"} <= names
 
 
 

--- a/tests/hermes_cli/test_gateway_cron_command.py
+++ b/tests/hermes_cli/test_gateway_cron_command.py
@@ -1,0 +1,82 @@
+"""Gateway read-only /cron command coverage."""
+
+from hermes_cli.commands import resolve_command
+from hermes_cli.slash_exec import CommandContext, execute_command
+
+
+def test_cron_is_gateway_available_read_only():
+    cmd = resolve_command("cron")
+    assert cmd is not None
+    assert cmd.cli_only is False
+    assert cmd.execute == "gateway_cron"
+
+
+def test_gateway_cron_list_includes_last_run_and_delivery(monkeypatch):
+    calls = []
+
+    def fake_list_jobs(*, include_disabled=False):
+        calls.append(include_disabled)
+        return [
+            {
+                "id": "abc123",
+                "name": "chatmemory-branch-refresh-sync",
+                "enabled": True,
+                "state": "scheduled",
+                "schedule_display": "15 10 * * *",
+                "next_run_at": "2026-08-25T10:15:00+08:00",
+                "last_run_at": "2026-08-24T10:17:29+08:00",
+                "last_status": "ok",
+                "last_delivery_error": "Feishu field validation failed",
+                "no_agent": False,
+                "workdir": "/workspace/project",
+            },
+            {
+                "id": "watchdog",
+                "name": "script watchdog",
+                "enabled": True,
+                "state": "scheduled",
+                "schedule_display": "every 5m",
+                "next_run_at": "2026-08-25T10:20:00+08:00",
+                "last_run_at": None,
+                "last_status": None,
+                "script": "watch.py",
+                "no_agent": True,
+            },
+        ]
+
+    monkeypatch.setattr("cron.jobs.list_jobs", fake_list_jobs)
+    reply = execute_command("cron", CommandContext(surface="gateway", args="list"))
+
+    assert calls == [False]
+    assert "Cron jobs (2 active)" in reply.text
+    assert "chatmemory-branch-refresh-sync" in reply.text
+    assert "2026-08-24T10:17:29+08:00 ok" in reply.text
+    assert "delivery_error: Feishu field validation failed" in reply.text
+    assert "script-only jobs can be intentionally silent" in reply.text
+    assert reply.data == {"count": 2, "include_disabled": False}
+
+
+def test_gateway_cron_list_all_passes_include_disabled(monkeypatch):
+    calls = []
+
+    def fake_list_jobs(*, include_disabled=False):
+        calls.append(include_disabled)
+        return []
+
+    monkeypatch.setattr("cron.jobs.list_jobs", fake_list_jobs)
+    reply = execute_command("cron", CommandContext(surface="gateway", args="list --all"))
+
+    assert calls == [True]
+    assert "No scheduled cron jobs found" in reply.text
+    assert reply.data == {"count": 0, "include_disabled": True}
+
+
+def test_gateway_cron_blocks_mutating_subcommands(monkeypatch):
+    def fail_list_jobs(*, include_disabled=False):  # pragma: no cover - must not run
+        raise AssertionError("mutating subcommands must not list jobs")
+
+    monkeypatch.setattr("cron.jobs.list_jobs", fail_list_jobs)
+    reply = execute_command("cron", CommandContext(surface="gateway", args="run abc123"))
+
+    assert "read-only" in reply.text
+    assert "create/edit/pause/run/remove" in reply.text

--- a/tests/hermes_cli/test_gateway_cron_command.py
+++ b/tests/hermes_cli/test_gateway_cron_command.py
@@ -1,6 +1,8 @@
 """Gateway read-only /cron command coverage."""
 
-from hermes_cli.commands import resolve_command
+import pytest
+
+from hermes_cli.commands import gateway_help_lines, resolve_command
 from hermes_cli.slash_exec import CommandContext, execute_command
 
 
@@ -9,6 +11,10 @@ def test_cron_is_gateway_available_read_only():
     assert cmd is not None
     assert cmd.cli_only is False
     assert cmd.execute == "gateway_cron"
+    assert any(
+        "`/cron" in line and "read-only" in line.lower()
+        for line in gateway_help_lines()
+    )
 
 
 def test_gateway_cron_list_includes_last_run_and_delivery(monkeypatch):
@@ -19,16 +25,16 @@ def test_gateway_cron_list_includes_last_run_and_delivery(monkeypatch):
         return [
             {
                 "id": "abc123",
-                "name": "chatmemory-branch-refresh-sync",
+                "name": "daily report",
                 "enabled": True,
                 "state": "scheduled",
                 "schedule_display": "15 10 * * *",
                 "next_run_at": "2026-08-25T10:15:00+08:00",
                 "last_run_at": "2026-08-24T10:17:29+08:00",
                 "last_status": "ok",
-                "last_delivery_error": "Feishu field validation failed",
+                "last_delivery_error": "delivery endpoint unavailable",
                 "no_agent": False,
-                "workdir": "/workspace/project",
+                "workdir": "/srv/reports",
             },
             {
                 "id": "watchdog",
@@ -49,9 +55,9 @@ def test_gateway_cron_list_includes_last_run_and_delivery(monkeypatch):
 
     assert calls == [False]
     assert "Cron jobs (2 active)" in reply.text
-    assert "chatmemory-branch-refresh-sync" in reply.text
+    assert "daily report" in reply.text
     assert "2026-08-24T10:17:29+08:00 ok" in reply.text
-    assert "delivery_error: Feishu field validation failed" in reply.text
+    assert "delivery_error: delivery endpoint unavailable" in reply.text
     assert "script-only jobs can be intentionally silent" in reply.text
     assert reply.data == {"count": 2, "include_disabled": False}
 
@@ -71,12 +77,20 @@ def test_gateway_cron_list_all_passes_include_disabled(monkeypatch):
     assert reply.data == {"count": 0, "include_disabled": True}
 
 
-def test_gateway_cron_blocks_mutating_subcommands(monkeypatch):
+@pytest.mark.parametrize(
+    "subcommand",
+    ["add", "create", "edit", "pause", "resume", "run", "remove"],
+)
+def test_gateway_cron_blocks_mutating_subcommands(monkeypatch, subcommand):
     def fail_list_jobs(*, include_disabled=False):  # pragma: no cover - must not run
         raise AssertionError("mutating subcommands must not list jobs")
 
     monkeypatch.setattr("cron.jobs.list_jobs", fail_list_jobs)
-    reply = execute_command("cron", CommandContext(surface="gateway", args="run abc123"))
+    reply = execute_command(
+        "cron",
+        CommandContext(surface="gateway", args=f"{subcommand} abc123"),
+    )
 
     assert "read-only" in reply.text
-    assert "create/edit/pause/run/remove" in reply.text
+    assert "add/create/edit/pause/resume/run/remove" in reply.text
+    assert reply.data == {"blocked_subcommand": subcommand}


### PR DESCRIPTION
## Summary
- add gateway-safe `/cron list` and `/cron list --all` commands that run without an agent turn
- show schedule, next/last run, delivery errors, execution mode, script, and workdir with minimal structured metadata
- reject every mutating cron subcommand and keep busy-session plus multiplex-profile routing safe

Closes #93955

## Test plan
- [x] `scripts/run_tests.sh tests/hermes_cli/test_commands.py tests/hermes_cli/test_commands_execute.py tests/hermes_cli/test_gateway_cron_command.py tests/hermes_cli/test_busy_policy_invariants.py tests/hermes_cli/test_cron.py tests/gateway/test_cron_command.py -q` (84 passed)
- [x] `git diff --check official/main...HEAD`

Made with [Cursor](https://cursor.com)