### PR TITLE
fix(desktop): keep macOS local backend alive through readiness

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -224,7 +224,8 @@ import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 import {
   createParentStartMarkerResolver,
   electronProcessStartMarker,
-  parentWatchdogEnv
+  parentWatchdogEnv,
+  stablePosixProcessMarkerEnv
 } from './parent-process-identity'
 import { registerPetOverlayIpc } from './pet-overlay-ipc'
 import {
@@ -3160,9 +3161,9 @@ function writeBackendOwnership(contents) {
   }
 }
 
-function execText(command, args, { timeout = 3000 } = {}) {
+function execText(command, args, { env = process.env, timeout = 3000 } = {}) {
   return new Promise<string>((resolve, reject) => {
-    execFile(command, args, hiddenWindowsChildOptions({ encoding: 'utf8', timeout }), (error, stdout) => {
+    execFile(command, args, hiddenWindowsChildOptions({ encoding: 'utf8', env, timeout }), (error, stdout) => {
       if (error) {
         reject(error)
       } else {
@@ -3216,7 +3217,9 @@ async function processStartMarker(pid) {
     return `win:${ticks}`
   }
 
-  const started = await execText('ps', ['-p', String(pid), '-o', 'lstart='])
+  const started = await execText('ps', ['-p', String(pid), '-o', 'lstart='], {
+    env: stablePosixProcessMarkerEnv(process.env)
+  })
 
   if (!started) {
     throw new Error(`Missing process start marker for PID ${pid}`)

--- a/apps/desktop/electron/parent-process-identity.test.ts
+++ b/apps/desktop/electron/parent-process-identity.test.ts
@@ -6,7 +6,8 @@ import {
   createParentStartMarkerResolver,
   electronProcessStartMarker,
   parentWatchdogEnv,
-  spawnTag
+  spawnTag,
+  stablePosixProcessMarkerEnv
 } from './parent-process-identity'
 
 test('electronProcessStartMarker uses Electron creation time only for its own PID', () => {
@@ -83,4 +84,15 @@ test('spawnTag derives seconds from a winms marker and dashes without one', () =
   assert.equal(spawnTag(42, null), 'v1:-:serve:42:-')
   assert.equal(spawnTag(42, 'win:638908765432100000'), 'v1:-:serve:42:-')
   assert.equal(spawnTag(42, 'winms:garbage'), 'v1:-:serve:42:-')
+})
+
+test('POSIX process markers ignore the caller locale and timezone', () => {
+  assert.deepEqual(
+    stablePosixProcessMarkerEnv({ LANG: 'fr_FR.UTF-8', LC_ALL: 'ja_JP.UTF-8', TZ: 'Pacific/Honolulu' }),
+    {
+      LANG: 'fr_FR.UTF-8',
+      LC_ALL: 'C',
+      TZ: 'UTC'
+    }
+  )
 })

--- a/apps/desktop/electron/parent-process-identity.ts
+++ b/apps/desktop/electron/parent-process-identity.ts
@@ -13,6 +13,11 @@ export interface ParentStartMarkerResolverOptions {
   onError?: (error: unknown) => void
 }
 
+/** Keep BSD/Linux `ps lstart` output identical across the parent and child. */
+export function stablePosixProcessMarkerEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return { ...env, LC_ALL: 'C', TZ: 'UTC' }
+}
+
 /**
  * Build the cross-runtime marker for Electron's own process without spawning
  * an OS helper. Electron reports milliseconds since the Unix epoch; the Python

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -48,7 +48,7 @@ import zipfile
 from hermes_cli._subprocess_compat import windows_detach_flags, windows_hide_flags
 import urllib.request
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple
+from typing import Any, Dict, List, Literal, Mapping, Optional, Tuple
 
 import yaml
 
@@ -139,6 +139,11 @@ WEB_DIST = Path(os.environ["HERMES_WEB_DIST"]) if "HERMES_WEB_DIST" in os.enviro
 _log = logging.getLogger(__name__)
 
 
+def _stable_ps_environment(source: Mapping[str, str]) -> Dict[str, str]:
+    """Keep BSD/Linux ``ps lstart`` stable across the Desktop and backend."""
+    return {**source, "LC_ALL": "C", "TZ": "UTC"}
+
+
 def _process_start_marker(pid: int) -> str:
     """Return a cross-runtime marker for the current incarnation of ``pid``.
 
@@ -206,6 +211,7 @@ def _process_start_marker(pid: int) -> str:
     result = subprocess.run(
         ["ps", "-p", str(pid), "-o", "lstart="],
         capture_output=True,
+        env=_stable_ps_environment(os.environ),
         text=True,
         check=False,
     )

--- a/tests/hermes_cli/test_serve_parent_watchdog.py
+++ b/tests/hermes_cli/test_serve_parent_watchdog.py
@@ -1,6 +1,12 @@
 """Regression tests for Desktop-owned ``hermes serve`` lifecycle tracking."""
 
-from hermes_cli.web_server import _is_serve_orphaned, _valid_parent_start_marker
+import os
+
+from hermes_cli.web_server import (
+    _is_serve_orphaned,
+    _stable_ps_environment,
+    _valid_parent_start_marker,
+)
 
 
 def test_parent_watchdog_tracks_recorded_desktop_pid_not_immediate_ppid():
@@ -57,3 +63,18 @@ def test_parent_watchdog_preserves_legacy_exact_windows_marker():
         )
         is False
     )
+
+
+def test_posix_process_marker_environment_is_locale_and_timezone_stable():
+    env = _stable_ps_environment(
+        {
+            **os.environ,
+            "LANG": "fr_FR.UTF-8",
+            "LC_ALL": "ja_JP.UTF-8",
+            "TZ": "Pacific/Honolulu",
+        }
+    )
+
+    assert env["LANG"] == "fr_FR.UTF-8"
+    assert env["LC_ALL"] == "C"
+    assert env["TZ"] == "UTC"


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop local mode on macOS could launch `hermes serve`, receive its port announcement, and then lose the backend to a clean parent-watchdog exit before readiness completed. This change makes the parent process marker independent of locale and timezone on both sides of the Desktop/backend boundary, so a live Electron owner is not mistaken for a reused PID.

### Symptom

On macOS, the local backend announces `HERMES_BACKEND_READY port=<port>` and then exits with code 0. Desktop reports `Hermes backend exited before it became ready (0)` and enters its recovery path, while the same `hermes serve` runtime stays healthy when launched manually.

### Impact

Affected macOS users cannot use Desktop local mode and must run a backend manually and connect through remote mode.

### Bug Cause

**Trigger:** `apps/desktop/electron/main.ts:processStartMarker` and `hermes_cli/web_server.py:_process_start_marker` when the Desktop launches a local backend on macOS.

**Causal chain:**
1. Electron records its own start marker using BSD `ps -o lstart=` and passes that string to the backend.
2. The backend independently runs the same display-oriented `ps` field without pinning locale or timezone. Different process environments can render the same start time differently.
3. The watchdog treats the unequal strings as proof of PID reuse and calls `os._exit(0)`, terminating a healthy backend before Desktop readiness completes.

**Why it is wrong:** `lstart` is formatted process metadata. Comparing it across runtimes is safe only when both probes use the same locale and timezone.

**Working sibling / contrast:** Linux uses the numeric `/proc/<pid>/stat` start tick, and Windows normalizes Electron milliseconds against the exact process FILETIME. Neither depends on localized display text.

**Ruled out:** The backend itself is not crashing: the reported exit is code 0 from the watchdog path, and the same runtime stays alive when launched manually. Remote mode also works against that manual process.

### Fix

- Pin `LC_ALL=C` and `TZ=UTC` for Electron's POSIX parent-marker probe.
- Apply the identical environment contract to the Python watchdog probe.
- Cover both helpers with regression tests using intentionally conflicting caller locale and timezone values.

## Related Issue

N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/main.ts` - run POSIX process-marker probes with a stable environment.
- `apps/desktop/electron/parent-process-identity.ts` - define the shared Desktop-side environment contract.
- `hermes_cli/web_server.py` - mirror that contract in the backend watchdog.
- `apps/desktop/electron/parent-process-identity.test.ts` and `tests/hermes_cli/test_serve_parent_watchdog.py` - add regression coverage.

## How to Test

1. Launch Hermes Desktop in local mode on macOS with a non-default locale or timezone environment.
2. Verify the announced local backend remains alive and Desktop completes readiness.
3. Run the automated regression suites:

```bash
scripts/run_tests.sh tests/hermes_cli/test_serve_parent_watchdog.py -q
cd apps/desktop && npx vitest run electron/parent-process-identity.test.ts
cd apps/desktop && npm run typecheck
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the related Python tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested the implementation and type checks on Windows 11; macOS runtime verification remains for CI/review

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no user-facing configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A. This is a backend lifecycle fix covered by targeted automated tests and the issue's sanitized launch log.
