### PR TITLE
fix(model_normalize): strip foreign vendor prefix on bare-name providers (#93980)

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -109,6 +109,20 @@ _MATCHING_PREFIX_STRIP_PROVIDERS: frozenset[str] = frozenset({
     "xai",
 })
 
+# Bare-name providers that never serve aggregator-style ``vendor/model`` ids,
+# so a *foreign* vendor prefix is a copy-paste artifact rather than routing
+# information and must be stripped.  ollama.com serves the bare ``glm-5.2``;
+# the OpenRouter spelling ``z-ai/glm-5.2`` reaches it verbatim and returns
+# HTTP 404 ``model "z-ai/glm-5.2" not found`` (#93980).
+#
+# Deliberately a narrow subset of ``_MATCHING_PREFIX_STRIP_PROVIDERS`` rather
+# than a blanket rule over it: ``custom`` in particular MUST keep a foreign
+# prefix, because ``ollama/glm-5.2`` may be the routing prefix a LiteLLM-style
+# proxy fronting the endpoint requires (see ``_strip_matching_provider_prefix``).
+_FOREIGN_VENDOR_STRIP_PROVIDERS: frozenset[str] = frozenset({
+    "ollama-cloud",
+})
+
 # Providers whose API serves ``vendor/model`` ids but whose endpoint can also
 # front arbitrary self-hosted models, so a bare name cannot be prefixed
 # blindly. A bare id is repaired only when the curated catalogue for that
@@ -285,6 +299,27 @@ def _strip_matching_provider_prefix(model_name: str, target_provider: str) -> st
     if normalized_prefix and normalized_prefix == normalized_target:
         return remainder.strip()
     return model_name
+
+
+def _strip_any_vendor_prefix(model_name: str) -> str:
+    """Strip any leading ``vendor/`` segment, matching or not.
+
+    For providers in ``_FOREIGN_VENDOR_STRIP_PROVIDERS`` the API serves bare
+    ids only, so a vendor segment is an aggregator spelling the endpoint will
+    404 on -- ``z-ai/glm-5.2`` (the OpenRouter form of GLM) instead of the
+    ``glm-5.2`` ollama.com actually serves.  Mirrors the OpenCode
+    flat-namespace handling in ``normalize_model_for_provider``.
+
+    A malformed id with an empty side (``/model``, ``vendor/``) is left
+    untouched, the same guard ``_strip_matching_provider_prefix`` applies.
+    """
+    if "/" not in model_name:
+        return model_name
+
+    prefix, remainder = model_name.split("/", 1)
+    if not prefix.strip() or not remainder.strip():
+        return model_name
+    return remainder.strip()
 
 
 def detect_vendor(model_name: str) -> Optional[str]:
@@ -485,6 +520,9 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
 
         >>> normalize_model_for_provider("MiMo-V2.5-Pro", "xiaomi")
         'mimo-v2.5-pro'
+
+        >>> normalize_model_for_provider("z-ai/glm-5.2", "ollama-cloud")
+        'glm-5.2'
     """
     name = (model_input or "").strip()
     if not name:
@@ -558,6 +596,11 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
 
     # --- Direct providers: repair matching provider prefixes only ---
     if provider in _MATCHING_PREFIX_STRIP_PROVIDERS:
+        # Bare-name-only providers additionally shed a foreign vendor slug:
+        # an aggregator spelling like ``z-ai/glm-5.2`` 404s on ollama.com,
+        # which serves ``glm-5.2``.  Not applied to ``custom`` (#93980).
+        if provider in _FOREIGN_VENDOR_STRIP_PROVIDERS:
+            name = _strip_any_vendor_prefix(name)
         result = _strip_matching_provider_prefix(name, provider)
         # Some providers require lowercase model IDs (e.g. Xiaomi's API
         # rejects "MiMo-V2.5-Pro" but accepts "mimo-v2.5-pro").

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -187,3 +187,63 @@ class TestIssue78796NvidiaPrefixRepair:
             == "anthropic/claude-sonnet-4.6"
         )
 
+
+# ── Regression: issue #93980 ───────────────────────────────────────────
+
+class TestIssue93980ForeignVendorPrefixOnBareNameProviders:
+    """A foreign ``vendor/`` prefix must be stripped for ollama-cloud.
+
+    ``z-ai/glm-5.2`` is the *OpenRouter* spelling of GLM; ollama.com serves
+    the bare ``glm-5.2``.  The prefix used to survive to the endpoint and
+    return HTTP 404 ``model "z-ai/glm-5.2" not found``, which the goal judge
+    then reported as a transport failure and auto-paused the goal on.
+    """
+
+    @pytest.mark.parametrize("model,expected", [
+        ("z-ai/glm-5.2", "glm-5.2"),
+        ("moonshotai/kimi-k2.5", "kimi-k2.5"),
+        ("qwen/qwen3-max", "qwen3-max"),
+    ])
+    def test_foreign_vendor_prefix_is_stripped(self, model, expected):
+        assert normalize_model_for_provider(model, "ollama-cloud") == expected
+
+    @pytest.mark.parametrize("model", [
+        "glm-5.2",
+        "kimi-k2.5",
+        "some-local-finetune-v2",
+    ])
+    def test_bare_names_pass_through(self, model):
+        assert normalize_model_for_provider(model, "ollama-cloud") == model
+
+    def test_dots_are_preserved(self):
+        """The strip must not disturb dot-bearing version tags."""
+        assert normalize_model_for_provider("z-ai/glm-5.2", "ollama-cloud") == "glm-5.2"
+
+    @pytest.mark.parametrize("model", [
+        "/glm-5.2",
+        "z-ai/",
+    ])
+    def test_malformed_ids_are_left_alone(self, model):
+        """An empty side is not a vendor prefix -- don't invent an id."""
+        assert normalize_model_for_provider(model, "ollama-cloud") == model
+
+    def test_custom_still_preserves_a_foreign_prefix(self):
+        """``custom`` is excluded from the strip on purpose: ``ollama/`` may be
+        the routing prefix a LiteLLM-style proxy fronting the endpoint needs."""
+        assert (
+            normalize_model_for_provider("ollama/glm-5.2", "custom")
+            == "ollama/glm-5.2"
+        )
+
+    def test_aggregator_spelling_is_still_produced_for_openrouter(self):
+        """The two spellings must keep coexisting -- the bug is a user
+        bouncing between openrouter and ollama-cloud with one config."""
+        assert (
+            normalize_model_for_provider("glm-5.2", "openrouter") == "z-ai/glm-5.2"
+        )
+
+    def test_lowercase_providers_still_lowercase_after_strip(self):
+        """Regression guard: the ``_LOWERCASE_MODEL_PROVIDERS`` step runs after
+        the new strip, not instead of it."""
+        assert normalize_model_for_provider("MiMo-V2.5-Pro", "xiaomi") == "mimo-v2.5-pro"
+


### PR DESCRIPTION
Fixes #93980.

## Problem

When the active model is the OpenRouter spelling of GLM (`z-ai/glm-5.2`) but the
provider resolves to `ollama-cloud`, every call — the main loop *and* the goal
judge — 404s with `model "z-ai/glm-5.2" not found`. `ollama-cloud` is in
`_MATCHING_PREFIX_STRIP_PROVIDERS`, and that branch only calls
`_strip_matching_provider_prefix(name, provider)`, which strips a prefix **only
when it normalizes equal to the target provider**. A foreign `z-ai/` prefix is
therefore left intact and reaches ollama.com verbatim, which serves the bare
`glm-5.2`. Because `auxiliary.goal_judge` runs with `provider: auto` it inherits
the mismatched id, the `NotFoundError` is classified as a transport failure, and
after N consecutive failures the goal auto-pauses pointing at the `goal_judge`
config — which is not the problem. 15 logged failures in 3 bursts.

## Approach

Adds a new `_FOREIGN_VENDOR_STRIP_PROVIDERS` frozenset and, in the
`_MATCHING_PREFIX_STRIP_PROVIDERS` branch, strips any leading `vendor/` segment
for members of that set before the existing matching-prefix repair runs. The
`_LOWERCASE_MODEL_PROVIDERS` lowercasing still runs after the strip, unchanged.

**The set contains exactly one provider: `ollama-cloud`.** This is deliberately
scoped rather than a blanket any-vendor strip across the whole
`_MATCHING_PREFIX_STRIP_PROVIDERS` set, because a blanket rule could regress a
provider that legitimately accepts vendor-prefixed ids or uses a prefix for
routing. The other members (`zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`,
`minimax-oauth`, `minimax-cn`, `alibaba`, `qwen-oauth`, `xiaomi`, `arcee`,
`custom`, `gemini`, `xai`) keep their current behavior exactly.

`custom` is **excluded on purpose** and must stay excluded:
`_strip_matching_provider_prefix` deliberately preserves prefixes there, since
`ollama/glm-5.2` may be the actual routing prefix a LiteLLM-style proxy in front
of a custom endpoint requires. There is an explicit regression test for this.

New behavior:

```python
normalize_model_for_provider('z-ai/glm-5.2', 'ollama-cloud')  # -> 'glm-5.2'
normalize_model_for_provider('ollama/glm-5.2', 'custom')      # -> 'ollama/glm-5.2'  (preserved)
```

Malformed ids with an empty side (`/glm-5.2`, `z-ai/`) are left untouched, using
the same guard `_strip_matching_provider_prefix` already applies.

## ⚠️ Test / confidence caveat — please read before merging

**This is a proposed fix that has NOT been validated in real-world use, and the
author is not confident in it.** Stating that up front rather than burying it:

- It has **not** been exercised against real provider endpoints, and **not**
  against the full provider matrix. Only the repo's unit tests and the repro
  one-liner were run (see Tests).
- The author filed the bug report and this fix with the explicit caveat that he
  has not tested it in real usage. The narrow scoping (one provider, `custom`
  explicitly excluded) is the mitigation for that uncertainty, but it is not a
  substitute for validation.

**Requested of a reviewer:** please exercise this against a real `ollama-cloud`
↔ `openrouter` switch — set the model to `z-ai/glm-5.2` on ollama-cloud, confirm
the main loop and the goal judge both resolve to `glm-5.2` and stop 404ing, then
switch to openrouter and confirm the `z-ai/` spelling is still produced — and
run the test file before merging. If a maintainer would rather widen or narrow
the provider set, that judgment call is better made by someone who can test it.

## Tests

- Added `TestIssue93980ForeignVendorPrefixOnBareNameProviders` to
  `tests/hermes_cli/test_model_normalize.py`: foreign prefix stripped
  (`z-ai/`, `moonshotai/`, `qwen/`), bare names pass through, dots preserved,
  malformed ids untouched, `custom` still preserves `ollama/`, openrouter still
  produces the `z-ai/` aggregator spelling, and `xiaomi` still lowercases after
  the strip.
- Assertions are behavior-level (`normalize_model_for_provider` in/out) rather
  than assertions about the contents of the new frozenset, per the
  "behavior contracts over snapshots" guidance in AGENTS.md.
- **Executed and green:** the full test file passes (35 passed, `pytest
  tests/hermes_cli/test_model_normalize.py`), the repro one-liner confirms
  `normalize_model_for_provider('z-ai/glm-5.2','ollama-cloud') -> 'glm-5.2'`
  and `('ollama/glm-5.2','custom')` preserved, and a sabotage run confirmed the
  new tests fail against the pre-fix code (so they genuinely bite).
- What remains **unvalidated**: any real provider endpoint, the full provider
  matrix, and real-world behavior. That is the gap a reviewer should close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
