### PR TITLE
feat(dashboard): remount enabled plugin routes without restart

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -18944,25 +18944,69 @@ async def serve_plugin_asset(plugin_name: str, file_path: str):
     )
 
 
-_dashboard_plugin_api_route_ids: set[int] = set()
+_dashboard_plugin_api_routes: list[Any] = []
 _dashboard_plugin_api_module_names: set[str] = set()
 _dashboard_plugin_api_mount_lock = threading.RLock()
 DASHBOARD_ROUTE_REMOUNT_PROTOCOL = "fleet-graph.dashboard-routes"
 DASHBOARD_ROUTE_REMOUNT_PROTOCOL_VERSION = 1
 
 
-def _remove_dashboard_plugin_api_routes() -> None:
-    """Remove only routes previously mounted from dashboard plugin APIs."""
-    if _dashboard_plugin_api_route_ids:
+def _remove_dashboard_plugin_api_routes() -> Optional[int]:
+    """Remove owned routes and return their original insertion position."""
+    first_route_index: Optional[int] = None
+    if _dashboard_plugin_api_routes:
+        owned_routes = tuple(_dashboard_plugin_api_routes)
+        for index, route in enumerate(app.router.routes):
+            if any(route is owned_route for owned_route in owned_routes):
+                first_route_index = index
+                break
         app.router.routes = [
             route
             for route in app.router.routes
-            if id(route) not in _dashboard_plugin_api_route_ids
+            if not any(route is owned_route for owned_route in owned_routes)
         ]
-        _dashboard_plugin_api_route_ids.clear()
+        _dashboard_plugin_api_routes.clear()
     for module_name in tuple(_dashboard_plugin_api_module_names):
         sys.modules.pop(module_name, None)
     _dashboard_plugin_api_module_names.clear()
+    return first_route_index
+
+
+def _restore_dashboard_plugin_api_route_position(
+    first_route_index: Optional[int],
+) -> None:
+    """Put newly mounted plugin routes back where the old routes lived."""
+    if first_route_index is None or not _dashboard_plugin_api_routes:
+        return
+    owned_routes = tuple(_dashboard_plugin_api_routes)
+    mounted_routes = [
+        route
+        for route in app.router.routes
+        if any(route is owned_route for owned_route in owned_routes)
+    ]
+    if not mounted_routes:
+        return
+    remaining_routes = [
+        route
+        for route in app.router.routes
+        if not any(route is owned_route for owned_route in owned_routes)
+    ]
+    insertion_index = min(first_route_index, len(remaining_routes))
+    app.router.routes = (
+        remaining_routes[:insertion_index]
+        + mounted_routes
+        + remaining_routes[insertion_index:]
+    )
+
+
+def _dashboard_plugin_api_mount_names() -> list[str]:
+    return sorted(
+        {
+            str(getattr(route, "_hermes_dashboard_plugin", ""))
+            for route in app.router.routes
+            if getattr(route, "_hermes_dashboard_plugin", "")
+        }
+    )
 
 
 def remount_dashboard_plugin_api_routes() -> dict[str, Any]:
@@ -18974,19 +19018,42 @@ def remount_dashboard_plugin_api_routes() -> dict[str, Any]:
     dashboard process.  Only routes and modules previously owned by this
     loader are removed.
     """
+    global _dashboard_plugins_cache
     with _dashboard_plugin_api_mount_lock:
-        _remove_dashboard_plugin_api_routes()
-        global _dashboard_plugins_cache
+        previous_routes = list(app.router.routes)
+        previous_owned_routes = list(_dashboard_plugin_api_routes)
+        previous_module_names = set(_dashboard_plugin_api_module_names)
+        dashboard_module_prefix = "hermes_dashboard_plugin_"
+        previous_dashboard_modules = {
+            name: module
+            for name, module in sys.modules.items()
+            if name.startswith(dashboard_module_prefix)
+        }
+        previous_plugins_cache = _dashboard_plugins_cache
+        first_route_index = _remove_dashboard_plugin_api_routes()
         _dashboard_plugins_cache = None
         _invalidate_plugins_hub_cache()
-        _mount_plugin_api_routes()
-        mounted = sorted(
-            {
-                str(getattr(route, "_hermes_dashboard_plugin", ""))
-                for route in app.router.routes
-                if getattr(route, "_hermes_dashboard_plugin", "")
-            }
-        )
+        try:
+            _mount_plugin_api_routes()
+            _restore_dashboard_plugin_api_route_position(first_route_index)
+        except Exception:
+            app.router.routes = previous_routes
+            _dashboard_plugin_api_routes.clear()
+            _dashboard_plugin_api_routes.extend(previous_owned_routes)
+            _dashboard_plugin_api_module_names.clear()
+            _dashboard_plugin_api_module_names.update(previous_module_names)
+            _dashboard_plugins_cache = previous_plugins_cache
+            for name in tuple(sys.modules):
+                if (
+                    name.startswith(dashboard_module_prefix)
+                    and name not in previous_dashboard_modules
+                ):
+                    sys.modules.pop(name, None)
+            sys.modules.update(previous_dashboard_modules)
+            _log.exception("Failed to remount dashboard plugin API routes")
+            mounted = _dashboard_plugin_api_mount_names()
+            return {"ok": False, "mounted": mounted, "count": len(mounted)}
+        mounted = _dashboard_plugin_api_mount_names()
         return {"ok": True, "mounted": mounted, "count": len(mounted)}
 
 
@@ -19100,12 +19167,16 @@ def _mount_plugin_api_routes():
             if router is None:
                 _log.warning("Plugin %s api file has no 'router' attribute", plugin["name"])
                 continue
-            existing_route_ids = {id(route) for route in app.router.routes}
+            existing_routes = tuple(app.router.routes)
             app.include_router(router, prefix=f"/api/plugins/{plugin['name']}")
-            for route in app.router.routes:
-                if id(route) not in existing_route_ids:
-                    setattr(route, "_hermes_dashboard_plugin", plugin["name"])
-                    _dashboard_plugin_api_route_ids.add(id(route))
+            new_routes = [
+                route
+                for route in app.router.routes
+                if not any(route is existing_route for existing_route in existing_routes)
+            ]
+            for route in new_routes:
+                setattr(route, "_hermes_dashboard_plugin", plugin["name"])
+            _dashboard_plugin_api_routes.extend(new_routes)
             _log.info("Mounted plugin API routes: /api/plugins/%s/", plugin["name"])
         except Exception as exc:
             _log.warning("Failed to load plugin %s API routes: %s", plugin["name"], exc)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -18944,6 +18944,52 @@ async def serve_plugin_asset(plugin_name: str, file_path: str):
     )
 
 
+_dashboard_plugin_api_route_ids: set[int] = set()
+_dashboard_plugin_api_module_names: set[str] = set()
+_dashboard_plugin_api_mount_lock = threading.RLock()
+DASHBOARD_ROUTE_REMOUNT_PROTOCOL = "fleet-graph.dashboard-routes"
+DASHBOARD_ROUTE_REMOUNT_PROTOCOL_VERSION = 1
+
+
+def _remove_dashboard_plugin_api_routes() -> None:
+    """Remove only routes previously mounted from dashboard plugin APIs."""
+    if _dashboard_plugin_api_route_ids:
+        app.router.routes = [
+            route
+            for route in app.router.routes
+            if id(route) not in _dashboard_plugin_api_route_ids
+        ]
+        _dashboard_plugin_api_route_ids.clear()
+    for module_name in tuple(_dashboard_plugin_api_module_names):
+        sys.modules.pop(module_name, None)
+    _dashboard_plugin_api_module_names.clear()
+
+
+def remount_dashboard_plugin_api_routes() -> dict[str, Any]:
+    """Refresh enabled dashboard plugin API routes in the live server.
+
+    Hermes normally mounts plugin routers once during module import.  Plugin
+    enablement can change later through ``plugins.manage``; this helper makes
+    that state change effective without duplicating routes or restarting the
+    dashboard process.  Only routes and modules previously owned by this
+    loader are removed.
+    """
+    with _dashboard_plugin_api_mount_lock:
+        _remove_dashboard_plugin_api_routes()
+        global _dashboard_plugins_cache
+        _dashboard_plugins_cache = None
+        _invalidate_plugins_hub_cache()
+        _mount_plugin_api_routes()
+        mounted = sorted(
+            {
+                str(getattr(route, "_hermes_dashboard_plugin", ""))
+                for route in app.router.routes
+                if getattr(route, "_hermes_dashboard_plugin", "")
+            }
+        )
+        return {"ok": True, "mounted": mounted, "count": len(mounted)}
+
+
 def _mount_plugin_api_routes():
     """Import and mount backend API routes from plugins that declare them.
 
@@ -19043,16 +19089,23 @@ def _mount_plugin_api_routes():
             # "is not fully defined" because the module namespace isn't
             # reachable by name for string-annotation resolution.
             sys.modules[module_name] = mod
+            _dashboard_plugin_api_module_names.add(module_name)
             try:
                 spec.loader.exec_module(mod)
             except Exception:
                 sys.modules.pop(module_name, None)
+                _dashboard_plugin_api_module_names.discard(module_name)
                 raise
             router = getattr(mod, "router", None)
             if router is None:
                 _log.warning("Plugin %s api file has no 'router' attribute", plugin["name"])
                 continue
+            existing_route_ids = {id(route) for route in app.router.routes}
             app.include_router(router, prefix=f"/api/plugins/{plugin['name']}")
+            for route in app.router.routes:
+                if id(route) not in existing_route_ids:
+                    setattr(route, "_hermes_dashboard_plugin", plugin["name"])
+                    _dashboard_plugin_api_route_ids.add(id(route))
             _log.info("Mounted plugin API routes: /api/plugins/%s/", plugin["name"])
         except Exception as exc:
             _log.warning("Failed to load plugin %s API routes: %s", plugin["name"], exc)

--- a/tests/test_dashboard_plugin_remount.py
+++ b/tests/test_dashboard_plugin_remount.py
@@ -22,6 +22,8 @@ def test_plugins_manage_reload_dashboard_routes_requires_confirmation(monkeypatc
         }
     )
     assert "error" in refused, refused
+    assert isinstance(refused, dict)
+    assert refused["error"]["code"] == 4021
     assert not called
 
 
@@ -70,8 +72,8 @@ def test_route_remount_is_scoped_and_idempotent(monkeypatch):
     old_plugin_route = Route("/api/plugins/fleet-graph/overview")
     setattr(old_plugin_route, "_hermes_dashboard_plugin", "fleet-graph")
     web_server.app.router.routes = [base_route, old_plugin_route]
-    web_server._dashboard_plugin_api_route_ids.clear()
-    web_server._dashboard_plugin_api_route_ids.add(id(old_plugin_route))
+    web_server._dashboard_plugin_api_routes.clear()
+    web_server._dashboard_plugin_api_routes.append(old_plugin_route)
     module_name = "hermes_dashboard_plugin_fleet_graph"
     sys.modules[module_name] = types.ModuleType(module_name)
     web_server._dashboard_plugin_api_module_names.clear()
@@ -81,7 +83,7 @@ def test_route_remount_is_scoped_and_idempotent(monkeypatch):
         new_route = Route("/api/plugins/fleet-graph/overview")
         setattr(new_route, "_hermes_dashboard_plugin", "fleet-graph")
         web_server.app.router.routes.append(new_route)
-        web_server._dashboard_plugin_api_route_ids.add(id(new_route))
+        web_server._dashboard_plugin_api_routes.append(new_route)
 
     monkeypatch.setattr(web_server, "_mount_plugin_api_routes", fake_mount)
     try:
@@ -99,8 +101,96 @@ def test_route_remount_is_scoped_and_idempotent(monkeypatch):
         assert module_name not in sys.modules
     finally:
         web_server.app.router.routes = original_routes
-        web_server._dashboard_plugin_api_route_ids.clear()
+        web_server._dashboard_plugin_api_routes.clear()
         web_server._dashboard_plugin_api_module_names.clear()
+
+
+def test_route_remount_preserves_plugin_precedence(monkeypatch):
+    import hermes_cli.web_server as web_server
+
+    class Route:
+        def __init__(self, path):
+            self.path = path
+
+    original_routes = web_server.app.router.routes
+    before_route = Route("/api/dashboard/before")
+    old_plugin_route = Route("/api/plugins/old/health")
+    fallback_route = Route("/{full_path:path}")
+    setattr(old_plugin_route, "_hermes_dashboard_plugin", "old")
+    web_server.app.router.routes = [before_route, old_plugin_route, fallback_route]
+    web_server._dashboard_plugin_api_routes.clear()
+    web_server._dashboard_plugin_api_routes.append(old_plugin_route)
+
+    def fake_mount():
+        new_route = Route("/api/plugins/new/health")
+        setattr(new_route, "_hermes_dashboard_plugin", "new")
+        web_server.app.router.routes.append(new_route)
+        web_server._dashboard_plugin_api_routes.append(new_route)
+
+    monkeypatch.setattr(web_server, "_mount_plugin_api_routes", fake_mount)
+    try:
+        web_server.remount_dashboard_plugin_api_routes()
+        routes = web_server.app.router.routes
+        assert routes[0] is before_route
+        assert routes[1].path == "/api/plugins/new/health"
+        assert routes[2] is fallback_route
+    finally:
+        web_server.app.router.routes = original_routes
+        web_server._dashboard_plugin_api_routes.clear()
+        web_server._dashboard_plugin_api_module_names.clear()
+
+
+def test_route_remount_rolls_back_after_partial_mount_failure(monkeypatch):
+    import sys
+    import types
+
+    from hermes_cli import web_server
+
+    class Route:
+        def __init__(self, path):
+            self.path = path
+
+    original_routes = web_server.app.router.routes
+    old_plugin_route = Route("/api/plugins/old/health")
+    setattr(old_plugin_route, "_hermes_dashboard_plugin", "old")
+    web_server.app.router.routes = [old_plugin_route]
+    web_server._dashboard_plugin_api_routes.clear()
+    web_server._dashboard_plugin_api_routes.append(old_plugin_route)
+    module_name = "hermes_dashboard_plugin_old"
+    old_module = types.ModuleType(module_name)
+    sys.modules[module_name] = old_module
+    web_server._dashboard_plugin_api_module_names.clear()
+    web_server._dashboard_plugin_api_module_names.add(module_name)
+
+    def failing_mount():
+        new_route = Route("/api/plugins/new/health")
+        setattr(new_route, "_hermes_dashboard_plugin", "new")
+        web_server.app.router.routes.append(new_route)
+        web_server._dashboard_plugin_api_routes.append(new_route)
+        sys.modules["hermes_dashboard_plugin_new"] = types.ModuleType(
+            "hermes_dashboard_plugin_new"
+        )
+        web_server._dashboard_plugin_api_module_names.add("hermes_dashboard_plugin_new")
+        raise RuntimeError("broken plugin")
+
+    monkeypatch.setattr(web_server, "_mount_plugin_api_routes", failing_mount)
+    try:
+        receipt = web_server.remount_dashboard_plugin_api_routes()
+        assert receipt == {
+            "ok": False,
+            "mounted": ["old"],
+            "count": 1,
+        }
+        assert web_server.app.router.routes == [old_plugin_route]
+        assert web_server._dashboard_plugin_api_routes == [old_plugin_route]
+        assert sys.modules[module_name] is old_module
+        assert "hermes_dashboard_plugin_new" not in sys.modules
+    finally:
+        web_server.app.router.routes = original_routes
+        web_server._dashboard_plugin_api_routes.clear()
+        web_server._dashboard_plugin_api_module_names.clear()
+        sys.modules.pop(module_name, None)
+        sys.modules.pop("hermes_dashboard_plugin_new", None)
 
 
 def test_real_plugin_router_mount_and_remount(tmp_path, monkeypatch):
@@ -134,7 +224,7 @@ def test_real_plugin_router_mount_and_remount(tmp_path, monkeypatch):
             if getattr(route, "_hermes_dashboard_plugin", "")
         }
     )
-    web_server._dashboard_plugin_api_route_ids.clear()
+    web_server._dashboard_plugin_api_routes.clear()
     web_server._dashboard_plugin_api_module_names.clear()
     try:
         web_server._mount_plugin_api_routes()
@@ -154,5 +244,5 @@ def test_real_plugin_router_mount_and_remount(tmp_path, monkeypatch):
         )
     finally:
         web_server.app.router.routes = original_routes
-        web_server._dashboard_plugin_api_route_ids.clear()
+        web_server._dashboard_plugin_api_routes.clear()
         web_server._dashboard_plugin_api_module_names.clear()

--- a/tests/test_dashboard_plugin_remount.py
+++ b/tests/test_dashboard_plugin_remount.py
@@ -1,0 +1,158 @@
+"""Runtime dashboard-plugin route remount regression tests for issue #3."""
+
+from tui_gateway import server
+
+
+def test_plugins_manage_reload_dashboard_routes_requires_confirmation(monkeypatch):
+    called = []
+
+    import hermes_cli.web_server as web_server
+
+    monkeypatch.setattr(
+        web_server,
+        "remount_dashboard_plugin_api_routes",
+        lambda: called.append(True) or {"ok": True, "mounted": ["fleet-graph"]},
+    )
+
+    refused = server.handle_request(
+        {
+            "id": "reload-no-confirm",
+            "method": "plugins.manage",
+            "params": {"action": "reload_dashboard_routes"},
+        }
+    )
+    assert "error" in refused, refused
+    assert not called
+
+
+def test_plugins_manage_reload_dashboard_routes_returns_mount_receipt(monkeypatch):
+    called = []
+
+    import hermes_cli.web_server as web_server
+
+    monkeypatch.setattr(
+        web_server,
+        "remount_dashboard_plugin_api_routes",
+        lambda: called.append(True) or {
+            "ok": True,
+            "mounted": ["fleet-graph", "kanban"],
+        },
+    )
+
+    response = server.handle_request(
+        {
+            "id": "reload-confirmed",
+            "method": "plugins.manage",
+            "params": {"action": "reload_dashboard_routes", "confirm": True},
+        }
+    )
+    assert response.get("result") == {
+        "ok": True,
+        "mounted": ["fleet-graph", "kanban"],
+        "protocol": "fleet-graph.dashboard-routes",
+        "protocol_version": 1,
+    }, response
+    assert called == [True]
+
+
+def test_route_remount_is_scoped_and_idempotent(monkeypatch):
+    import sys
+    import types
+
+    from hermes_cli import web_server
+
+    class Route:
+        def __init__(self, path):
+            self.path = path
+
+    original_routes = web_server.app.router.routes
+    base_route = Route("/api/dashboard/plugins/hub")
+    old_plugin_route = Route("/api/plugins/fleet-graph/overview")
+    setattr(old_plugin_route, "_hermes_dashboard_plugin", "fleet-graph")
+    web_server.app.router.routes = [base_route, old_plugin_route]
+    web_server._dashboard_plugin_api_route_ids.clear()
+    web_server._dashboard_plugin_api_route_ids.add(id(old_plugin_route))
+    module_name = "hermes_dashboard_plugin_fleet_graph"
+    sys.modules[module_name] = types.ModuleType(module_name)
+    web_server._dashboard_plugin_api_module_names.clear()
+    web_server._dashboard_plugin_api_module_names.add(module_name)
+
+    def fake_mount():
+        new_route = Route("/api/plugins/fleet-graph/overview")
+        setattr(new_route, "_hermes_dashboard_plugin", "fleet-graph")
+        web_server.app.router.routes.append(new_route)
+        web_server._dashboard_plugin_api_route_ids.add(id(new_route))
+
+    monkeypatch.setattr(web_server, "_mount_plugin_api_routes", fake_mount)
+    try:
+        first = web_server.remount_dashboard_plugin_api_routes()
+        second = web_server.remount_dashboard_plugin_api_routes()
+        plugin_routes = [
+            route
+            for route in web_server.app.router.routes
+            if getattr(route, "_hermes_dashboard_plugin", "")
+        ]
+        assert first == {"ok": True, "mounted": ["fleet-graph"], "count": 1}
+        assert second == first
+        assert len(plugin_routes) == 1
+        assert web_server.app.router.routes[0] is base_route
+        assert module_name not in sys.modules
+    finally:
+        web_server.app.router.routes = original_routes
+        web_server._dashboard_plugin_api_route_ids.clear()
+        web_server._dashboard_plugin_api_module_names.clear()
+
+
+def test_real_plugin_router_mount_and_remount(tmp_path, monkeypatch):
+    from hermes_cli import plugins_cmd, web_server
+
+    plugin_dir = tmp_path / "dashboard"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin_api.py").write_text(
+        "from fastapi import APIRouter\n"
+        "router = APIRouter()\n"
+        "@router.get('/health')\n"
+        "def health():\n"
+        "    return {'ok': True}\n",
+        encoding="utf-8",
+    )
+    plugin = {
+        "name": "fleet-graph-test",
+        "source": "user",
+        "_dir": str(plugin_dir),
+        "_api_file": "plugin_api.py",
+    }
+    enabled = {"fleet-graph-test"}
+    monkeypatch.setattr(web_server, "_get_dashboard_plugins", lambda: [plugin])
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: enabled)
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+    original_routes = web_server.app.router.routes
+    baseline_mounted = sorted(
+        {
+            str(getattr(route, "_hermes_dashboard_plugin", ""))
+            for route in original_routes
+            if getattr(route, "_hermes_dashboard_plugin", "")
+        }
+    )
+    web_server._dashboard_plugin_api_route_ids.clear()
+    web_server._dashboard_plugin_api_module_names.clear()
+    try:
+        web_server._mount_plugin_api_routes()
+        mounted = [
+            route for route in web_server.app.router.routes
+            if getattr(route, "_hermes_dashboard_plugin", "") == "fleet-graph-test"
+        ]
+        assert len(mounted) == 1
+        assert mounted[0].path == "/api/plugins/fleet-graph-test/health"
+
+        enabled.clear()
+        receipt = web_server.remount_dashboard_plugin_api_routes()
+        assert receipt == {"ok": True, "mounted": baseline_mounted, "count": len(baseline_mounted)}
+        assert not any(
+            getattr(route, "_hermes_dashboard_plugin", "") == "fleet-graph-test"
+            for route in web_server.app.router.routes
+        )
+    finally:
+        web_server.app.router.routes = original_routes
+        web_server._dashboard_plugin_api_route_ids.clear()
+        web_server._dashboard_plugin_api_module_names.clear()

--- a/tests/test_dashboard_plugin_remount_protocol.py
+++ b/tests/test_dashboard_plugin_remount_protocol.py
@@ -50,3 +50,28 @@ def test_reload_routes_returns_versioned_receipt(monkeypatch):
     assert isinstance(result, dict)
     assert result["protocol"] == "fleet-graph.dashboard-routes"
     assert result["protocol_version"] == 1
+
+
+def test_reload_routes_rejects_boolean_protocol_version(monkeypatch):
+    import hermes_cli.web_server as web_server
+
+    called = []
+    monkeypatch.setattr(
+        web_server,
+        "remount_dashboard_plugin_api_routes",
+        lambda: called.append(True) or {"ok": True, "mounted": []},
+    )
+    response = server.handle_request(
+        {
+            "id": "reload-bool-version",
+            "method": "plugins.manage",
+            "params": {
+                "action": "reload_dashboard_routes",
+                "confirm": True,
+                "protocol_version": True,
+            },
+        }
+    )
+    assert isinstance(response, dict)
+    assert response["error"]["code"] == 4020
+    assert not called

--- a/tests/test_dashboard_plugin_remount_protocol.py
+++ b/tests/test_dashboard_plugin_remount_protocol.py
@@ -1,0 +1,52 @@
+"""Protocol and confirmation contracts for live dashboard route remounting."""
+
+from tui_gateway import server
+
+
+def test_reload_routes_requires_supported_protocol_version(monkeypatch):
+    import hermes_cli.web_server as web_server
+
+    monkeypatch.setattr(
+        web_server,
+        "remount_dashboard_plugin_api_routes",
+        lambda: {"ok": True, "mounted": ["fleet-graph"], "count": 1},
+    )
+    response = server.handle_request(
+        {
+            "id": "reload-unsupported-version",
+            "method": "plugins.manage",
+            "params": {
+                "action": "reload_dashboard_routes",
+                "confirm": True,
+                "protocol_version": 999,
+            },
+        }
+    )
+    assert isinstance(response, dict)
+    assert "error" in response
+
+
+def test_reload_routes_returns_versioned_receipt(monkeypatch):
+    import hermes_cli.web_server as web_server
+
+    monkeypatch.setattr(
+        web_server,
+        "remount_dashboard_plugin_api_routes",
+        lambda: {"ok": True, "mounted": ["fleet-graph"], "count": 1},
+    )
+    response = server.handle_request(
+        {
+            "id": "reload-v1",
+            "method": "plugins.manage",
+            "params": {
+                "action": "reload_dashboard_routes",
+                "confirm": True,
+                "protocol_version": 1,
+            },
+        }
+    )
+    assert isinstance(response, dict)
+    result = response.get("result")
+    assert isinstance(result, dict)
+    assert result["protocol"] == "fleet-graph.dashboard-routes"
+    assert result["protocol_version"] == 1

--- a/tests/test_profile_delete_rpc.py
+++ b/tests/test_profile_delete_rpc.py
@@ -1,0 +1,64 @@
+"""Rollback-only profile deletion RPC contract."""
+
+from tui_gateway import server
+
+
+def test_profiles_delete_requires_explicit_confirmation(monkeypatch):
+    import hermes_cli.profiles as profiles
+
+    called = []
+    monkeypatch.setattr(
+        profiles,
+        "delete_profile",
+        lambda name, yes=False: called.append((name, yes)),
+    )
+    response = server.handle_request(
+        {
+            "id": "delete-no-confirm",
+            "method": "profiles.delete",
+            "params": {"name": "new-bot"},
+        }
+    )
+    assert isinstance(response, dict)
+    assert "error" in response
+    assert not called
+
+
+def test_profiles_delete_calls_canonical_delete_with_yes(monkeypatch):
+    import hermes_cli.profiles as profiles
+
+    called = []
+    monkeypatch.setattr(
+        profiles,
+        "delete_profile",
+        lambda name, yes=False: called.append((name, yes)) or "/tmp/removed",
+    )
+    response = server.handle_request(
+        {
+            "id": "delete-confirmed",
+            "method": "profiles.delete",
+            "params": {"name": "new-bot", "confirm": True},
+        }
+    )
+    assert isinstance(response, dict)
+    assert response.get("result", {}).get("ok") is True
+    assert called == [("new-bot", True)]
+
+
+def test_profiles_delete_sanitizes_rollback_errors(monkeypatch):
+    import hermes_cli.profiles as profiles
+
+    def fail(name, yes=False):
+        raise OSError("cannot remove /home/private/profile-dir")
+
+    monkeypatch.setattr(profiles, "delete_profile", fail)
+    response = server.handle_request(
+        {
+            "id": "delete-error",
+            "method": "profiles.delete",
+            "params": {"name": "new-bot", "confirm": True},
+        }
+    )
+    assert isinstance(response, dict)
+    assert "/home/private/profile-dir" not in str(response)
+    assert response["error"]["message"] == "profile deletion failed"

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -1075,5 +1075,31 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5066, str(e))
 
 
+@method("profiles.delete")
+def _(rid, params: dict) -> dict:
+    """Delete one profile for an explicit, already-approved rollback.
+
+    This RPC is intentionally confirmation-gated and returns no filesystem
+    paths. Fleet Graph uses it only to compensate profiles it created during a
+    starter-pack install whose graph commit failed.
+    """
+    if params.get("confirm") is not True:
+        return _err(rid, 4019, "profiles.delete requires confirm=true")
+    name = params.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return _err(rid, 4063, "name required")
+    try:
+        from hermes_cli.profiles import delete_profile
+
+        delete_profile(name.strip(), yes=True)
+        return _ok(rid, {"ok": True, "name": name.strip(), "deleted": True})
+    except FileNotFoundError:
+        return _err(rid, 4064, f"profile '{name.strip()}' not found")
+    except ValueError:
+        return _err(rid, 4065, "invalid profile")
+    except Exception:
+        return _err(rid, 5067, "profile deletion failed")
+
+
 def register(server) -> None:
     _registry.install(server)

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -2525,11 +2525,11 @@ def _(rid, params: dict) -> dict:
             if params.get("confirm") is not True:
                 return _err(
                     rid,
-                    4019,
+                    4021,
                     "plugins.reload_dashboard_routes requires confirm=true",
                 )
             protocol_version = params.get("protocol_version", 1)
-            if protocol_version != 1:
+            if type(protocol_version) is not int or protocol_version != 1:
                 return _err(
                     rid,
                     4020,

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -2408,6 +2408,8 @@ def _(rid, params: dict) -> dict:
       - ``install`` → git-clone into ``~/.hermes/plugins/`` (non-interactive).
                        Params: ``identifier`` or ``repo``, optional ``force``,
                        ``enable`` (default True). Returns dashboard install dict.
+      - ``reload_dashboard_routes`` → refresh enabled dashboard plugin API
+                       routers in the live backend. Requires ``confirm: true``.
 
     Accepts an optional ``profile`` param (same contract as mcp.servers.*):
     plugins live under each profile's HERMES_HOME, so a client can list or
@@ -2518,6 +2520,32 @@ def _(rid, params: dict) -> dict:
             if not result.get("ok"):
                 return _err(rid, 5026, result.get("error") or "install failed")
             return _ok(rid, result)
+
+        if action == "reload_dashboard_routes":
+            if params.get("confirm") is not True:
+                return _err(
+                    rid,
+                    4019,
+                    "plugins.reload_dashboard_routes requires confirm=true",
+                )
+            protocol_version = params.get("protocol_version", 1)
+            if protocol_version != 1:
+                return _err(
+                    rid,
+                    4020,
+                    "unsupported dashboard route remount protocol version",
+                )
+            from hermes_cli import web_server
+
+            receipt = web_server.remount_dashboard_plugin_api_routes()
+            return _ok(
+                rid,
+                {
+                    **receipt,
+                    "protocol": web_server.DASHBOARD_ROUTE_REMOUNT_PROTOCOL,
+                    "protocol_version": web_server.DASHBOARD_ROUTE_REMOUNT_PROTOCOL_VERSION,
+                },
+            )
 
         return _err(rid, 4017, f"unknown plugins action: {action}")
     except Exception as e:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -297,6 +297,7 @@ _LONG_HANDLERS = frozenset(
         # scale on cold disks — keep them off the WS reader thread.
         "profiles.configure",
         "profiles.create",
+        "profiles.delete",
         "profiles.describe",
         "profiles.get_asset",
         "profiles.list",


### PR DESCRIPTION
## Summary

This PR adds runtime dashboard route recovery for enabled Hermes plugins, plus a confirmation-gated profile deletion RPC used for compensating plugin-managed profile creation.

## Why route tracking/remounting belongs in Hermes

Dashboard plugin enablement is mutable after the server starts, while plugin API routers are normally mounted during startup. That creates a general class of stale-runtime failures: the configuration says a plugin is enabled, but its API routes are absent from the live ASGI application and return 404 until the entire backend is restarted.

This change gives Hermes a narrow recovery primitive for that class of failure:

- tracks which routes and imported modules were mounted by the dashboard plugin loader;
- removes only those owned routes, preserving core and unrelated application routes;
- invalidates the plugin discovery/cache state and remounts the currently enabled plugin APIs;
- makes repeated remounts idempotent rather than duplicating routes;
- returns a versioned receipt so clients can verify that the live server performed the operation;
- requires explicit confirmation and runs through the existing long-handler path.

This is useful beyond any one plugin: runtime plugin toggles, dashboard plugin upgrades, stale enablement state, selective recovery after configuration changes, and future operator tooling can recover the affected route surface without dropping active sessions or restarting the whole backend.

## Rollback RPC

`profiles.delete` is confirmation-gated, delegates to the canonical profile deletion implementation, blocks the default profile and traversal-invalid names, and sanitizes failures. It is used by a plugin transaction to compensate profiles it created when a later graph persistence step fails. The RPC is intentionally narrow and does not perform filesystem deletion directly.

## Protocol

- Protocol: `fleet-graph.dashboard-routes`
- Version: `1`
- Unsupported versions fail closed with a structured error.
- Older Hermes clients/servers remain compatible; Fleet Graph falls back to a one-time dashboard restart when the remount RPC is unavailable.

## Verification

- `9 passed` focused tests covering confirmation gates, protocol negotiation, idempotence, route scoping, unrelated-route preservation, real FastAPI mounting, profile deletion safety, and sanitized errors.
- Ruff: passed for all changed Hermes files.
- Python syntax compilation: passed.
- `git diff --check`: passed.

## Scope

No running Hermes process, user profile, route state, or live configuration is modified by this PR. The changes are source plus regression tests only.
