### PR TITLE
fix(memory): emit canonical OpenViking user URIs

### DIFF
--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -96,8 +96,10 @@ Hermes sends `OPENVIKING_ACCOUNT` and `OPENVIKING_USER` as identity headers.
 and `mode=create`. It creates peer-scoped memory files under explicit-uid
 `viking://user/<user>/peers/${OPENVIKING_AGENT}/memories/...` URIs, where
 `<user>` is resolved client-side from `/api/v1/system/status` (server-asserted
-current user, `default` fallback) — explicit-uid URIs are canonical and work
-under every OpenViking auth mode and version; the `viking://~` alias only
+current user). Hermes caches a confirmed user only for the active connection.
+If the probe fails, Hermes uses the configured user, or `default`, for that
+operation and retries the probe later. Explicit-uid URIs are canonical and
+work under every OpenViking auth mode and version; the `viking://~` alias only
 expands for USER/ADMIN roles, not the default dev mode.
 Explicit remembers do not depend on session commit extraction.
 

--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -93,10 +93,12 @@ Hermes sends `OPENVIKING_ACCOUNT` and `OPENVIKING_USER` as identity headers.
 ## Memory Writes And Deletes
 
 `viking_remember` writes directly to OpenViking with `POST /api/v1/content/write`
-and `mode=create`. It creates peer-scoped memory files under
-`viking://~/peers/${OPENVIKING_AGENT}/memories/...` (`~` is the current-user
-home alias); OpenViking may return a canonical user-scoped form such as
-`viking://user/default/peers/${OPENVIKING_AGENT}/memories/...` in API-key mode.
+and `mode=create`. It creates peer-scoped memory files under explicit-uid
+`viking://user/<user>/peers/${OPENVIKING_AGENT}/memories/...` URIs, where
+`<user>` is resolved client-side from `/api/v1/system/status` (server-asserted
+current user, `default` fallback) — explicit-uid URIs are canonical and work
+under every OpenViking auth mode and version; the `viking://~` alias only
+expands for USER/ADMIN roles, not the default dev mode.
 Explicit remembers do not depend on session commit extraction.
 
 Hermes built-in `memory` tool additions are mirrored to OpenViking after the
@@ -113,8 +115,9 @@ memory URI.
 
 `viking_forget` is intentionally narrow. It only accepts concrete user memory
 file URIs, such as
-`viking://~/peers/hermes/memories/preferences/mem_abc123.md` or the canonical
-`viking://user/default/peers/hermes/memories/preferences/mem_abc123.md`. Files
+`viking://user/default/peers/hermes/memories/preferences/mem_abc123.md` (any
+explicit user id works; `viking://~/...` input is passed through untouched for
+deployments where the server expands the home alias). Files
 directly under `memories/`, such as `viking://user/default/memories/profile.md`,
 are also allowed because OpenViking supports them. The tool rejects directories,
 resources, skills, sessions, generated summary files, and URIs with query

--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -94,8 +94,8 @@ Hermes sends `OPENVIKING_ACCOUNT` and `OPENVIKING_USER` as identity headers.
 
 `viking_remember` writes directly to OpenViking with `POST /api/v1/content/write`
 and `mode=create`. It creates peer-scoped memory files under
-`viking://user/peers/${OPENVIKING_AGENT}/memories/...`; OpenViking may return a
-canonical user-scoped form such as
+`viking://~/peers/${OPENVIKING_AGENT}/memories/...` (`~` is the current-user
+home alias); OpenViking may return a canonical user-scoped form such as
 `viking://user/default/peers/${OPENVIKING_AGENT}/memories/...` in API-key mode.
 Explicit remembers do not depend on session commit extraction.
 
@@ -113,7 +113,7 @@ memory URI.
 
 `viking_forget` is intentionally narrow. It only accepts concrete user memory
 file URIs, such as
-`viking://user/peers/hermes/memories/preferences/mem_abc123.md` or the canonical
+`viking://~/peers/hermes/memories/preferences/mem_abc123.md` or the canonical
 `viking://user/default/peers/hermes/memories/preferences/mem_abc123.md`. Files
 directly under `memories/`, such as `viking://user/default/memories/profile.md`,
 are also allowed because OpenViking supports them. The tool rejects directories,

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -93,13 +93,40 @@ _RECALL_QUERY_MIN_CHARS = 5
 _RECALL_MIN_TIMEOUT_SECONDS = 0.05
 _READ_BATCH_LIMIT = 3
 _READ_BATCH_FULL_LIMIT = 2500
-# `viking://~` is the current-user home alias (OpenViking #4167, server 0.4.16+).
-# The uid-less `viking://user/<segment>` shorthand was removed upstream (#4196,
-# 2026-08-21): reserved segments like `memories`/`peers` no longer expand to the
-# caller's space and the server rejects them with HTTP 400.
-_PROFILE_URI = "viking://~/memories/profile.md"
-_PREFERENCES_URI = "viking://~/memories/preferences"
-_ENTITIES_URI = "viking://~/memories/entities"
+# Explicit-uid URIs are canonical and work under every OpenViking auth mode
+# (dev/ROOT, trusted/USER, api-key) on every server version. The `~` home
+# alias only expands for USER/ADMIN roles (#4167/#4196): the DEFAULT dev auth
+# mode resolves every request as ROOT, and the canonical parser rejects `~`
+# with 400 — so `~` must not be the primary spelling the plugin emits. The
+# user space is resolved client-side from /api/v1/system/status (server-
+# asserted), mirroring the upstream first-party plugin pattern (#91995).
+_PROFILE_SUFFIX = "memories/profile.md"
+_PREFERENCES_SUFFIX = "memories/preferences"
+_ENTITIES_SUFFIX = "memories/entities"
+
+
+def _resolve_user_space(client) -> str:
+    """Server-asserted current user for explicit-uid URIs.
+
+    Falls back to ``"default"`` (the trusted-mode default user, identical to
+    the on-disk layout ``viking/default/user/default/...``) when the probe
+    fails or reports no user.
+    """
+    try:
+        status = client.get("/api/v1/system/status")
+        result = (status or {}).get("result") or {}
+        user = str(result.get("user") or "").strip()
+        if user:
+            return user
+    except Exception:
+        logger.debug(
+            "OpenViking user-space probe failed; using 'default'", exc_info=True
+        )
+    return "default"
+
+
+def _user_scoped_uri(user_space: str, suffix: str) -> str:
+    return f"viking://user/{user_space}/{suffix}"
 _SESSION_START_LIST_PARAMS = {
     "output": "agent",
     "recursive": True,
@@ -2241,6 +2268,9 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._agent = ""
         self._session_id = ""
         self._turn_count = 0
+        # Server-asserted user space for explicit-uid URIs (#91995); resolved
+        # lazily from /api/v1/system/status on first use.
+        self._user_space_cache: Optional[str] = None
         self._hermes_home = ""
         self._run_id = uuid.uuid4().hex
         self._run_lock_file: Optional[Any] = None
@@ -3875,6 +3905,26 @@ class OpenVikingMemoryProvider(MemoryProvider):
         ).lstrip()
         return f"{head}{marker}{tail}" if tail else _head_only()
 
+    def _user_space(self, client=None) -> str:
+        """Resolve (and cache) the server-asserted user space for URIs."""
+        if getattr(self, "_user_space_cache", None) is None:
+            active = client or getattr(self, "_client", None)
+            self._user_space_cache = (
+                _resolve_user_space(active) if active is not None else "default"
+            )
+        return self._user_space_cache
+
+    def _user_scoped_uri(self, suffix: str, client=None) -> str:
+        return _user_scoped_uri(self._user_space(client), suffix)
+
+    def _session_start_uris(self) -> tuple:
+        user = self._user_space()
+        return (
+            _user_scoped_uri(user, _PROFILE_SUFFIX),
+            _user_scoped_uri(user, _PREFERENCES_SUFFIX),
+            _user_scoped_uri(user, _ENTITIES_SUFFIX),
+        )
+
     def _read_session_start_profile(
         self,
         client: _VikingClient,
@@ -3886,7 +3936,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             timeout = self._remaining_recall_timeout(deadline, request_timeout)
             resp = client.get(
                 "/api/v1/content/read",
-                params={"uri": _PROFILE_URI},
+                params={"uri": self._user_scoped_uri(_PROFILE_SUFFIX, client)},
                 timeout=timeout,
             )
         except Exception as e:
@@ -3936,13 +3986,13 @@ class OpenVikingMemoryProvider(MemoryProvider):
             "profile": profile,
             "preferences": self._list_session_start_memories(
                 active_client,
-                _PREFERENCES_URI,
+                self._user_scoped_uri(_PREFERENCES_SUFFIX, active_client),
                 deadline=deadline,
                 request_timeout=request_timeout,
             ),
             "entities": self._list_session_start_memories(
                 active_client,
-                _ENTITIES_URI,
+                self._user_scoped_uri(_ENTITIES_SUFFIX, active_client),
                 deadline=deadline,
                 request_timeout=request_timeout,
             ),
@@ -3953,11 +4003,12 @@ class OpenVikingMemoryProvider(MemoryProvider):
         profile: str,
         preference_lines: List[str],
         entity_lines: List[str],
+        profile_uri: str = "viking://user/default/memories/profile.md",
     ) -> str:
         lines: List[str] = []
         if profile:
             lines.extend([
-                f'<user-profile uri="{_PROFILE_URI}">',
+                f'<user-profile uri="{profile_uri}">',
                 profile,
                 "</user-profile>",
             ])
@@ -4013,7 +4064,13 @@ class OpenVikingMemoryProvider(MemoryProvider):
         preferences: List[Dict[str, str]],
         entities: List[Dict[str, str]],
         token_budget: int,
+        uris: Optional[tuple] = None,
     ) -> str:
+        profile_uri, preferences_uri, entities_uri = uris or (
+            _user_scoped_uri("default", _PROFILE_SUFFIX),
+            _user_scoped_uri("default", _PREFERENCES_SUFFIX),
+            _user_scoped_uri("default", _ENTITIES_SUFFIX),
+        )
         profile = profile.strip()
         if not profile and not preferences and not entities:
             return ""
@@ -4023,6 +4080,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             placeholder if profile else "",
             [placeholder] if preferences else [],
             [placeholder] if entities else [],
+            profile_uri=profile_uri,
         )
         placeholder_count = int(bool(profile)) + int(bool(preferences)) + int(bool(entities))
         overhead_units = cls._token_units(scaffold) - placeholder_count
@@ -4041,13 +4099,13 @@ class OpenVikingMemoryProvider(MemoryProvider):
         else:
             preference_budget = available_units
         preference_lines, preference_units = cls._format_memory_listing(
-            _PREFERENCES_URI,
+            preferences_uri,
             preferences,
             preference_budget,
         )
         available_units -= preference_units
         entity_lines, _ = cls._format_memory_listing(
-            _ENTITIES_URI,
+            entities_uri,
             entities,
             available_units,
         )
@@ -4056,6 +4114,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             profile_text,
             preference_lines,
             entity_lines,
+            profile_uri=profile_uri,
         )
 
     def _session_start_memory_context(self, session_id: str) -> str:
@@ -4081,6 +4140,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             preferences=raw_parts.get("preferences") or [],
             entities=raw_parts.get("entities") or [],
             token_budget=self._profile_token_budget(),
+            uris=self._session_start_uris(),
         )
 
     @staticmethod
@@ -4783,9 +4843,13 @@ class OpenVikingMemoryProvider(MemoryProvider):
     def _build_memory_uri(self, subdir: str) -> str:
         """Build a viking:// memory URI under the configured peer namespace."""
         slug = uuid.uuid4().hex[:12]
-        # `~` home alias: `viking://user/peers/...` is uid-less and was removed
-        # upstream (#4196) — the memory-mirroring write path 400s on new servers.
-        return f"viking://~/peers/{self._agent}/memories/{subdir}/mem_{slug}.md"
+        # Explicit-uid URIs are canonical under every auth mode; the uid-less
+        # `viking://user/peers/...` shorthand was removed upstream (#4196) and
+        # `viking://~/...` only expands for USER/ADMIN roles, not dev/ROOT.
+        return _user_scoped_uri(
+            self._user_space(),
+            f"peers/{self._agent}/memories/{subdir}/mem_{slug}.md",
+        )
 
     def on_memory_write(
         self,

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -105,7 +105,7 @@ _PREFERENCES_SUFFIX = "memories/preferences"
 _ENTITIES_SUFFIX = "memories/entities"
 
 
-def _resolve_user_space(client) -> Optional[str]:
+def _resolve_user_space(client, *, timeout: Optional[float] = None) -> Optional[str]:
     """Server-asserted current user for explicit-uid URIs.
 
     Return ``None`` when the probe fails or reports no user. Callers can use a
@@ -113,7 +113,8 @@ def _resolve_user_space(client) -> Optional[str]:
     identity because a later probe can succeed.
     """
     try:
-        status = client.get("/api/v1/system/status")
+        kwargs = {"timeout": timeout} if timeout is not None else {}
+        status = client.get("/api/v1/system/status", **kwargs)
         result = (status or {}).get("result") or {}
         user = str(result.get("user") or "").strip()
         if user:
@@ -3910,7 +3911,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         ).lstrip()
         return f"{head}{marker}{tail}" if tail else _head_only()
 
-    def _user_space(self, client=None) -> str:
+    def _user_space(self, client=None, *, timeout: Optional[float] = None) -> str:
         """Resolve the user space, caching only a confirmed client identity."""
         active = client if client is not None else getattr(self, "_client", None)
         cached = getattr(self, "_user_space_cache", None)
@@ -3918,7 +3919,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             return cached[1]
 
         if active is not None:
-            resolved = _resolve_user_space(active)
+            resolved = _resolve_user_space(active, timeout=timeout)
             if resolved:
                 # The probe can overlap a config reload. Only publish it when
                 # this is still the provider's active client. Old in-flight
@@ -3938,8 +3939,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
     def _user_scoped_uri(self, suffix: str, client=None) -> str:
         return _user_scoped_uri(self._user_space(client), suffix)
 
-    def _session_start_uris(self) -> tuple:
-        user = self._user_space()
+    def _session_start_uris(self, user: Optional[str] = None) -> tuple:
+        user = user or self._user_space()
         return (
             _user_scoped_uri(user, _PROFILE_SUFFIX),
             _user_scoped_uri(user, _PREFERENCES_SUFFIX),
@@ -3949,6 +3950,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
     def _read_session_start_profile(
         self,
         client: _VikingClient,
+        uri: str,
         *,
         deadline: float,
         request_timeout: float,
@@ -3957,7 +3959,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             timeout = self._remaining_recall_timeout(deadline, request_timeout)
             resp = client.get(
                 "/api/v1/content/read",
-                params={"uri": self._user_scoped_uri(_PROFILE_SUFFIX, client)},
+                params={"uri": uri},
                 timeout=timeout,
             )
         except Exception as e:
@@ -3996,8 +3998,16 @@ class OpenVikingMemoryProvider(MemoryProvider):
         if not active_client:
             return {}
 
+        try:
+            identity_timeout = self._remaining_recall_timeout(deadline, request_timeout)
+            user = self._user_space(active_client, timeout=identity_timeout)
+        except Exception:
+            return {"profile": None, "preferences": [], "entities": []}
+        uris = self._session_start_uris(user)
+
         profile = self._read_session_start_profile(
             active_client,
+            uris[0],
             deadline=deadline,
             request_timeout=request_timeout,
         )
@@ -4007,16 +4017,17 @@ class OpenVikingMemoryProvider(MemoryProvider):
             "profile": profile,
             "preferences": self._list_session_start_memories(
                 active_client,
-                self._user_scoped_uri(_PREFERENCES_SUFFIX, active_client),
+                uris[1],
                 deadline=deadline,
                 request_timeout=request_timeout,
             ),
             "entities": self._list_session_start_memories(
                 active_client,
-                self._user_scoped_uri(_ENTITIES_SUFFIX, active_client),
+                uris[2],
                 deadline=deadline,
                 request_timeout=request_timeout,
             ),
+            "uris": uris,
         }
 
     @staticmethod
@@ -4161,7 +4172,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             preferences=raw_parts.get("preferences") or [],
             entities=raw_parts.get("entities") or [],
             token_budget=self._profile_token_budget(),
-            uris=self._session_start_uris(),
+            uris=raw_parts["uris"],
         )
 
     @staticmethod
@@ -4861,15 +4872,21 @@ class OpenVikingMemoryProvider(MemoryProvider):
             old_session_id, new_id, parent_session_id, reset,
         )
 
-    def _build_memory_uri(self, subdir: str) -> str:
+    def _build_memory_uri(self, subdir: str, *, client=None) -> str:
         """Build a viking:// memory URI under the configured peer namespace."""
         slug = uuid.uuid4().hex[:12]
         # Explicit-uid URIs are canonical under every auth mode; the uid-less
         # `viking://user/peers/...` shorthand was removed upstream (#4196) and
         # `viking://~/...` only expands for USER/ADMIN roles, not dev/ROOT.
+        active_client = client if client is not None else getattr(self, "_client", None)
+        agent = str(
+            getattr(active_client, "_agent", "")
+            or getattr(self, "_agent", "")
+            or _DEFAULT_AGENT
+        ).strip()
         return _user_scoped_uri(
-            self._user_space(),
-            f"peers/{self._agent}/memories/{subdir}/mem_{slug}.md",
+            self._user_space(active_client),
+            f"peers/{agent}/memories/{subdir}/mem_{slug}.md",
         )
 
     def on_memory_write(
@@ -4884,11 +4901,17 @@ class OpenVikingMemoryProvider(MemoryProvider):
             return
 
         subdir = _MEMORY_WRITE_TARGET_SUBDIR_MAP.get(target, _DEFAULT_MEMORY_SUBDIR)
-        uri = self._build_memory_uri(subdir)
+        try:
+            # Keep identity resolution, URI construction, and the write on one
+            # connection snapshot even if the active profile reloads.
+            client = self._new_client()
+        except Exception as e:
+            logger.debug("OpenViking memory mirror client creation failed: %s", e)
+            return
 
         def _write():
             try:
-                client = self._new_client()
+                uri = self._build_memory_uri(subdir, client=client)
                 client.post("/api/v1/content/write", {
                     "uri": uri,
                     "content": content,

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -105,12 +105,12 @@ _PREFERENCES_SUFFIX = "memories/preferences"
 _ENTITIES_SUFFIX = "memories/entities"
 
 
-def _resolve_user_space(client) -> str:
+def _resolve_user_space(client) -> Optional[str]:
     """Server-asserted current user for explicit-uid URIs.
 
-    Falls back to ``"default"`` (the trusted-mode default user, identical to
-    the on-disk layout ``viking/default/user/default/...``) when the probe
-    fails or reports no user.
+    Return ``None`` when the probe fails or reports no user. Callers can use a
+    configured fallback for that operation, but must not cache an unverified
+    identity because a later probe can succeed.
     """
     try:
         status = client.get("/api/v1/system/status")
@@ -120,9 +120,11 @@ def _resolve_user_space(client) -> str:
             return user
     except Exception:
         logger.debug(
-            "OpenViking user-space probe failed; using 'default'", exc_info=True
+            "OpenViking user-space probe failed; using configured fallback for "
+            "this operation and retrying later",
+            exc_info=True,
         )
-    return "default"
+    return None
 
 
 def _user_scoped_uri(user_space: str, suffix: str) -> str:
@@ -2268,9 +2270,12 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._agent = ""
         self._session_id = ""
         self._turn_count = 0
-        # Server-asserted user space for explicit-uid URIs (#91995); resolved
-        # lazily from /api/v1/system/status on first use.
-        self._user_space_cache: Optional[str] = None
+        # Server-asserted user space for explicit-uid URIs (#91995). Bind the
+        # cached value to the client object that supplied it: /reload can swap
+        # endpoint, credentials, and identity on this provider instance, and
+        # an in-flight probe from the old client must not populate the new
+        # connection's cache.
+        self._user_space_cache: Optional[tuple[Any, str]] = None
         self._hermes_home = ""
         self._run_id = uuid.uuid4().hex
         self._run_lock_file: Optional[Any] = None
@@ -3906,13 +3911,29 @@ class OpenVikingMemoryProvider(MemoryProvider):
         return f"{head}{marker}{tail}" if tail else _head_only()
 
     def _user_space(self, client=None) -> str:
-        """Resolve (and cache) the server-asserted user space for URIs."""
-        if getattr(self, "_user_space_cache", None) is None:
-            active = client or getattr(self, "_client", None)
-            self._user_space_cache = (
-                _resolve_user_space(active) if active is not None else "default"
-            )
-        return self._user_space_cache
+        """Resolve the user space, caching only a confirmed client identity."""
+        active = client if client is not None else getattr(self, "_client", None)
+        cached = getattr(self, "_user_space_cache", None)
+        if active is not None and cached is not None and cached[0] is active:
+            return cached[1]
+
+        if active is not None:
+            resolved = _resolve_user_space(active)
+            if resolved:
+                # The probe can overlap a config reload. Only publish it when
+                # this is still the provider's active client. Old in-flight
+                # work can use its resolved value without contaminating the
+                # replacement client's cache.
+                if active is getattr(self, "_client", None):
+                    self._user_space_cache = (active, resolved)
+                return resolved
+
+        configured = str(
+            getattr(active, "_user", "")
+            or getattr(self, "_user", "")
+            or "default"
+        ).strip()
+        return configured or "default"
 
     def _user_scoped_uri(self, suffix: str, client=None) -> str:
         return _user_scoped_uri(self._user_space(client), suffix)

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -93,9 +93,13 @@ _RECALL_QUERY_MIN_CHARS = 5
 _RECALL_MIN_TIMEOUT_SECONDS = 0.05
 _READ_BATCH_LIMIT = 3
 _READ_BATCH_FULL_LIMIT = 2500
-_PROFILE_URI = "viking://user/memories/profile.md"
-_PREFERENCES_URI = "viking://user/memories/preferences"
-_ENTITIES_URI = "viking://user/memories/entities"
+# `viking://~` is the current-user home alias (OpenViking #4167, server 0.4.16+).
+# The uid-less `viking://user/<segment>` shorthand was removed upstream (#4196,
+# 2026-08-21): reserved segments like `memories`/`peers` no longer expand to the
+# caller's space and the server rejects them with HTTP 400.
+_PROFILE_URI = "viking://~/memories/profile.md"
+_PREFERENCES_URI = "viking://~/memories/preferences"
+_ENTITIES_URI = "viking://~/memories/entities"
 _SESSION_START_LIST_PARAMS = {
     "output": "agent",
     "recursive": True,
@@ -573,7 +577,7 @@ BROWSE_SCHEMA = {
             },
             "path": {
                 "type": "string",
-                "description": "Viking URI path (default: viking://). Examples: 'viking://resources/', 'viking://user/memories/'.",
+                "description": "Viking URI path (default: viking://). Examples: 'viking://resources/', 'viking://~/memories/'.",
             },
         },
         "required": ["action"],
@@ -4779,7 +4783,9 @@ class OpenVikingMemoryProvider(MemoryProvider):
     def _build_memory_uri(self, subdir: str) -> str:
         """Build a viking:// memory URI under the configured peer namespace."""
         slug = uuid.uuid4().hex[:12]
-        return f"viking://user/peers/{self._agent}/memories/{subdir}/mem_{slug}.md"
+        # `~` home alias: `viking://user/peers/...` is uid-less and was removed
+        # upstream (#4196) — the memory-mirroring write path 400s on new servers.
+        return f"viking://~/peers/{self._agent}/memories/{subdir}/mem_{slug}.md"
 
     def on_memory_write(
         self,

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -657,7 +657,7 @@ class TestOpenVikingAutoRecallPrefetch:
                 if parsed.path == "/api/v1/content/read":
                     query = parse_qs(parsed.query)
                     uri = query.get("uri", [""])[0]
-                    if uri == "viking://~/memories/profile.md":
+                    if uri == "viking://user/default/memories/profile.md":
                         self._send_json({"result": "E2E user profile."})
                         return
                     records["reads"].append(uri)
@@ -667,7 +667,7 @@ class TestOpenVikingAutoRecallPrefetch:
                     query = {key: values[0] for key, values in parse_qs(parsed.query).items()}
                     records["listings"].append(query)
                     uri = query.get("uri")
-                    if uri == "viking://~/memories/preferences":
+                    if uri == "viking://user/default/memories/preferences":
                         self._send_json({
                             "result": [
                                 {"isDir": True, "rel_path": "owner", "abstract": "ignored"},
@@ -679,7 +679,7 @@ class TestOpenVikingAutoRecallPrefetch:
                             ]
                         })
                         return
-                    if uri == "viking://~/memories/entities":
+                    if uri == "viking://user/default/memories/entities":
                         self._send_json({
                             "result": [
                                 {
@@ -758,8 +758,8 @@ class TestOpenVikingAutoRecallPrefetch:
         assert "E2E abstract should not be injected." not in block
         assert records["reads"] == ["viking://user/peers/hermes/memories/e2e-full.md"]
         assert [listing["uri"] for listing in records["listings"]] == [
-            "viking://~/memories/preferences",
-            "viking://~/memories/entities",
+            "viking://user/default/memories/preferences",
+            "viking://user/default/memories/entities",
         ]
         assert all(listing["output"] == "agent" for listing in records["listings"])
         assert all(listing["recursive"].lower() == "true" for listing in records["listings"])
@@ -818,7 +818,7 @@ class TestOpenVikingMemoryUriBuilder:
     """Regression tests for _build_memory_uri — fixes #36969.
 
     OpenViking's current memory layout stores peer-scoped memories under
-    viking://~/peers/{peer_id}/...
+    viking://user/{user}/peers/{peer_id}/...
     """
 
     def _make_provider(self, user="alice", agent="coder"):
@@ -831,7 +831,7 @@ class TestOpenVikingMemoryUriBuilder:
         """URI must contain /peers/{peer_id}/ between user and memories."""
         p = self._make_provider(user="alice", agent="coder")
         uri = p._build_memory_uri("preferences")
-        assert uri.startswith("viking://~/peers/coder/memories/preferences/mem_")
+        assert uri.startswith("viking://user/default/peers/coder/memories/preferences/mem_")
         assert uri.endswith(".md")
 
 
@@ -921,7 +921,7 @@ class TestEnsureClientReloadsEnv:
         assert instances[1].posts[0][1]["content"] == "stable fact"
         assert instances[1].posts[0][1]["mode"] == "create"
         assert instances[1].posts[0][1]["uri"].startswith(
-            "viking://~/peers/hermes/memories/"
+            "viking://user/default/peers/hermes/memories/"
         )
 
     def test_concurrent_refresh_does_not_return_stale_client(self, monkeypatch):
@@ -1287,3 +1287,47 @@ class TestUnavailableWarningsPromiseRetry:
         assert client is not None
         assert client.endpoint == "https://remote.example"
         assert len(probes) == 2
+
+
+# ===================================================================
+# Explicit-uid URIs (#91995 review) — `~` only expands for USER/ADMIN
+# ===================================================================
+
+class TestResolveUserSpace:
+    def test_uses_server_asserted_user(self):
+        from plugins.memory.openviking import _resolve_user_space
+
+        class _Client:
+            def get(self, path):
+                assert path == "/api/v1/system/status"
+                return {"status": "ok", "result": {"user": "alice"}}
+
+        assert _resolve_user_space(_Client()) == "alice"
+
+    def test_probe_failure_falls_back_to_default(self):
+        from plugins.memory.openviking import _resolve_user_space
+
+        class _Client:
+            def get(self, path):
+                raise RuntimeError("probe down")
+
+        assert _resolve_user_space(_Client()) == "default"
+
+    def test_missing_user_field_falls_back_to_default(self):
+        from plugins.memory.openviking import _resolve_user_space
+
+        class _Client:
+            def get(self, path):
+                return {"status": "ok", "result": {}}
+
+        assert _resolve_user_space(_Client()) == "default"
+
+
+class TestOpenVikingMemoryUriBuilderUserSpace:
+    def test_cached_user_space_flows_into_uri(self):
+        p = OpenVikingMemoryProvider.__new__(OpenVikingMemoryProvider)
+        p._agent = "coder"
+        p._user_space_cache = "alice"
+        uri = p._build_memory_uri("preferences")
+        assert uri.startswith("viking://user/alice/peers/coder/memories/preferences/mem_")
+        assert uri.endswith(".md")

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -657,7 +657,7 @@ class TestOpenVikingAutoRecallPrefetch:
                 if parsed.path == "/api/v1/content/read":
                     query = parse_qs(parsed.query)
                     uri = query.get("uri", [""])[0]
-                    if uri == "viking://user/memories/profile.md":
+                    if uri == "viking://~/memories/profile.md":
                         self._send_json({"result": "E2E user profile."})
                         return
                     records["reads"].append(uri)
@@ -667,7 +667,7 @@ class TestOpenVikingAutoRecallPrefetch:
                     query = {key: values[0] for key, values in parse_qs(parsed.query).items()}
                     records["listings"].append(query)
                     uri = query.get("uri")
-                    if uri == "viking://user/memories/preferences":
+                    if uri == "viking://~/memories/preferences":
                         self._send_json({
                             "result": [
                                 {"isDir": True, "rel_path": "owner", "abstract": "ignored"},
@@ -679,7 +679,7 @@ class TestOpenVikingAutoRecallPrefetch:
                             ]
                         })
                         return
-                    if uri == "viking://user/memories/entities":
+                    if uri == "viking://~/memories/entities":
                         self._send_json({
                             "result": [
                                 {
@@ -758,8 +758,8 @@ class TestOpenVikingAutoRecallPrefetch:
         assert "E2E abstract should not be injected." not in block
         assert records["reads"] == ["viking://user/peers/hermes/memories/e2e-full.md"]
         assert [listing["uri"] for listing in records["listings"]] == [
-            "viking://user/memories/preferences",
-            "viking://user/memories/entities",
+            "viking://~/memories/preferences",
+            "viking://~/memories/entities",
         ]
         assert all(listing["output"] == "agent" for listing in records["listings"])
         assert all(listing["recursive"].lower() == "true" for listing in records["listings"])
@@ -818,7 +818,7 @@ class TestOpenVikingMemoryUriBuilder:
     """Regression tests for _build_memory_uri — fixes #36969.
 
     OpenViking's current memory layout stores peer-scoped memories under
-    viking://user/peers/{peer_id}/...
+    viking://~/peers/{peer_id}/...
     """
 
     def _make_provider(self, user="alice", agent="coder"):
@@ -831,7 +831,7 @@ class TestOpenVikingMemoryUriBuilder:
         """URI must contain /peers/{peer_id}/ between user and memories."""
         p = self._make_provider(user="alice", agent="coder")
         uri = p._build_memory_uri("preferences")
-        assert uri.startswith("viking://user/peers/coder/memories/preferences/mem_")
+        assert uri.startswith("viking://~/peers/coder/memories/preferences/mem_")
         assert uri.endswith(".md")
 
 
@@ -921,7 +921,7 @@ class TestEnsureClientReloadsEnv:
         assert instances[1].posts[0][1]["content"] == "stable fact"
         assert instances[1].posts[0][1]["mode"] == "create"
         assert instances[1].posts[0][1]["uri"].startswith(
-            "viking://user/peers/hermes/memories/"
+            "viking://~/peers/hermes/memories/"
         )
 
     def test_concurrent_refresh_does_not_return_stale_client(self, monkeypatch):

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -654,10 +654,13 @@ class TestOpenVikingAutoRecallPrefetch:
                 if parsed.path == "/health":
                     self._send_json({"status": "ok", "healthy": True, "version": "test"})
                     return
+                if parsed.path == "/api/v1/system/status":
+                    self._send_json({"status": "ok", "result": {"user": "user"}})
+                    return
                 if parsed.path == "/api/v1/content/read":
                     query = parse_qs(parsed.query)
                     uri = query.get("uri", [""])[0]
-                    if uri == "viking://user/default/memories/profile.md":
+                    if uri == "viking://user/user/memories/profile.md":
                         self._send_json({"result": "E2E user profile."})
                         return
                     records["reads"].append(uri)
@@ -667,7 +670,7 @@ class TestOpenVikingAutoRecallPrefetch:
                     query = {key: values[0] for key, values in parse_qs(parsed.query).items()}
                     records["listings"].append(query)
                     uri = query.get("uri")
-                    if uri == "viking://user/default/memories/preferences":
+                    if uri == "viking://user/user/memories/preferences":
                         self._send_json({
                             "result": [
                                 {"isDir": True, "rel_path": "owner", "abstract": "ignored"},
@@ -679,7 +682,7 @@ class TestOpenVikingAutoRecallPrefetch:
                             ]
                         })
                         return
-                    if uri == "viking://user/default/memories/entities":
+                    if uri == "viking://user/user/memories/entities":
                         self._send_json({
                             "result": [
                                 {
@@ -758,8 +761,8 @@ class TestOpenVikingAutoRecallPrefetch:
         assert "E2E abstract should not be injected." not in block
         assert records["reads"] == ["viking://user/peers/hermes/memories/e2e-full.md"]
         assert [listing["uri"] for listing in records["listings"]] == [
-            "viking://user/default/memories/preferences",
-            "viking://user/default/memories/entities",
+            "viking://user/user/memories/preferences",
+            "viking://user/user/memories/entities",
         ]
         assert all(listing["output"] == "agent" for listing in records["listings"])
         assert all(listing["recursive"].lower() == "true" for listing in records["listings"])
@@ -831,7 +834,7 @@ class TestOpenVikingMemoryUriBuilder:
         """URI must contain /peers/{peer_id}/ between user and memories."""
         p = self._make_provider(user="alice", agent="coder")
         uri = p._build_memory_uri("preferences")
-        assert uri.startswith("viking://user/default/peers/coder/memories/preferences/mem_")
+        assert uri.startswith("viking://user/alice/peers/coder/memories/preferences/mem_")
         assert uri.endswith(".md")
 
 
@@ -878,6 +881,40 @@ class TestEnsureClientReloadsEnv:
         assert rebuilt is not first
         assert rebuilt.api_key == "sk-fresh"
         assert len(constructions) == 2
+
+    def test_rebuilt_client_resolves_its_own_user_space(self, monkeypatch):
+        class _StubClient:
+            def __init__(self, endpoint, api_key="", account="", user="", agent="hermes"):
+                self.endpoint = endpoint
+                self.api_key = api_key
+                self.account = account
+                self.user = user
+                self.agent = agent
+
+            def health(self):
+                return True
+
+            def get(self, path):
+                assert path == "/api/v1/system/status"
+                return {"status": "ok", "result": {"user": self.user}}
+
+        monkeypatch.setattr("plugins.memory.openviking._VikingClient", _StubClient)
+        monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://srv:31933")
+        monkeypatch.setenv("OPENVIKING_API_KEY", "")
+        monkeypatch.setenv("OPENVIKING_USER", "alice")
+
+        provider = OpenVikingMemoryProvider()
+        provider._env_refresh_enabled = True
+        alice_client = provider._ensure_client()
+        alice_uri = provider._build_memory_uri("preferences")
+
+        monkeypatch.setenv("OPENVIKING_USER", "bob")
+        bob_client = provider._ensure_client()
+        bob_uri = provider._build_memory_uri("preferences")
+
+        assert bob_client is not alice_client
+        assert alice_uri.startswith("viking://user/alice/peers/hermes/")
+        assert bob_uri.startswith("viking://user/bob/peers/hermes/")
 
 
     def test_handle_tool_call_reconnects_after_startup_health_failure(self, monkeypatch):
@@ -1304,30 +1341,123 @@ class TestResolveUserSpace:
 
         assert _resolve_user_space(_Client()) == "alice"
 
-    def test_probe_failure_falls_back_to_default(self):
+    def test_probe_failure_returns_unresolved(self):
         from plugins.memory.openviking import _resolve_user_space
 
         class _Client:
             def get(self, path):
                 raise RuntimeError("probe down")
 
-        assert _resolve_user_space(_Client()) == "default"
+        assert _resolve_user_space(_Client()) is None
 
-    def test_missing_user_field_falls_back_to_default(self):
+    def test_missing_user_field_returns_unresolved(self):
         from plugins.memory.openviking import _resolve_user_space
 
         class _Client:
             def get(self, path):
                 return {"status": "ok", "result": {}}
 
-        assert _resolve_user_space(_Client()) == "default"
+        assert _resolve_user_space(_Client()) is None
 
 
 class TestOpenVikingMemoryUriBuilderUserSpace:
-    def test_cached_user_space_flows_into_uri(self):
+    def test_confirmed_user_space_flows_into_uri(self):
+        class _Client:
+            def get(self, path):
+                assert path == "/api/v1/system/status"
+                return {"status": "ok", "result": {"user": "alice"}}
+
         p = OpenVikingMemoryProvider.__new__(OpenVikingMemoryProvider)
         p._agent = "coder"
-        p._user_space_cache = "alice"
+        p._user = "default"
+        p._client = _Client()
+        p._user_space_cache = None
         uri = p._build_memory_uri("preferences")
         assert uri.startswith("viking://user/alice/peers/coder/memories/preferences/mem_")
         assert uri.endswith(".md")
+
+    def test_transient_probe_failure_is_not_cached(self):
+        class _Client:
+            def __init__(self):
+                self.calls = 0
+
+            def get(self, path):
+                assert path == "/api/v1/system/status"
+                self.calls += 1
+                if self.calls == 1:
+                    raise RuntimeError("temporary failure")
+                return {"status": "ok", "result": {"user": "alice"}}
+
+        p = OpenVikingMemoryProvider.__new__(OpenVikingMemoryProvider)
+        p._agent = "coder"
+        p._user = "fallback-user"
+        p._client = _Client()
+        p._user_space_cache = None
+
+        first = p._build_memory_uri("preferences")
+        second = p._build_memory_uri("preferences")
+
+        assert first.startswith("viking://user/fallback-user/peers/coder/")
+        assert second.startswith("viking://user/alice/peers/coder/")
+        assert p._client.calls == 2
+
+    def test_cache_is_bound_to_the_client_that_asserted_the_user(self):
+        class _Client:
+            def __init__(self, user):
+                self.user = user
+                self.calls = 0
+
+            def get(self, path):
+                assert path == "/api/v1/system/status"
+                self.calls += 1
+                return {"status": "ok", "result": {"user": self.user}}
+
+        p = OpenVikingMemoryProvider.__new__(OpenVikingMemoryProvider)
+        p._agent = "coder"
+        p._user = "default"
+        p._user_space_cache = None
+        alice = _Client("alice")
+        bob = _Client("bob")
+
+        p._client = alice
+        assert "/user/alice/" in p._build_memory_uri("preferences")
+        p._client = bob
+        assert "/user/bob/" in p._build_memory_uri("preferences")
+        assert (alice.calls, bob.calls) == (1, 1)
+
+    def test_old_inflight_probe_cannot_replace_new_client_cache(self):
+        old_probe_started = threading.Event()
+        release_old_probe = threading.Event()
+
+        class _Client:
+            def __init__(self, user, wait=False):
+                self.user = user
+                self.wait = wait
+
+            def get(self, path):
+                assert path == "/api/v1/system/status"
+                if self.wait:
+                    old_probe_started.set()
+                    assert release_old_probe.wait(2.0)
+                return {"status": "ok", "result": {"user": self.user}}
+
+        p = OpenVikingMemoryProvider.__new__(OpenVikingMemoryProvider)
+        p._user = "default"
+        p._user_space_cache = None
+        alice = _Client("alice", wait=True)
+        bob = _Client("bob")
+        p._client = alice
+        old_result = []
+
+        worker = threading.Thread(target=lambda: old_result.append(p._user_space(alice)))
+        worker.start()
+        assert old_probe_started.wait(2.0)
+
+        p._client = bob
+        assert p._user_space() == "bob"
+        release_old_probe.set()
+        worker.join(timeout=2.0)
+
+        assert not worker.is_alive()
+        assert old_result == ["alice"]
+        assert p._user_space() == "bob"

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1313,6 +1313,60 @@ def test_shutdown_waits_for_memory_write_worker(monkeypatch):
     assert provider._memory_write_threads == set()
 
 
+def test_memory_write_uses_one_connection_for_identity_uri_and_post(monkeypatch):
+    import threading
+
+    provider = OpenVikingMemoryProvider()
+    provider._agent = "alice-agent"
+    provider._ensure_client = lambda: True
+
+    identity_started = threading.Event()
+    release_identity = threading.Event()
+    write_finished = threading.Event()
+    writes = []
+
+    class StubClient:
+        def __init__(self, user, agent):
+            self._user = user
+            self._agent = agent
+
+        def get(self, path, **kwargs):
+            assert path == "/api/v1/system/status"
+            identity_started.set()
+            assert release_identity.wait(timeout=2.0)
+            return {"status": "ok", "result": {"user": self._user}}
+
+        def post(self, path, payload=None, **kwargs):
+            writes.append((self._user, self._agent, path, payload))
+            write_finished.set()
+            return {"status": "ok"}
+
+    alice = StubClient("alice", "alice-agent")
+    bob = StubClient("bob", "bob-agent")
+    provider._client = alice
+    monkeypatch.setattr(provider, "_new_client", lambda: alice)
+
+    provider.on_memory_write("add", "user", "remember this")
+    assert identity_started.wait(timeout=2.0), "identity probe did not start"
+
+    # Simulate a profile reload while the write worker is resolving identity.
+    provider._client = bob
+    provider._agent = "bob-agent"
+    release_identity.set()
+
+    assert write_finished.wait(timeout=2.0), "memory write did not finish"
+    for worker in list(provider._memory_write_threads):
+        worker.join(timeout=2.0)
+
+    assert len(writes) == 1
+    user, agent, path, payload = writes[0]
+    assert (user, agent, path) == ("alice", "alice-agent", "/api/v1/content/write")
+    assert payload["uri"].startswith(
+        "viking://user/alice/peers/alice-agent/memories/preferences/mem_"
+    )
+    assert provider._memory_write_threads == set()
+
+
 def _make_prefetch_provider() -> OpenVikingMemoryProvider:
     provider = OpenVikingMemoryProvider()
     provider._client = MagicMock()
@@ -1430,6 +1484,48 @@ def test_prefetch_prepends_session_start_memory_context_once_per_session():
         ),
     ]
     assert provider._search_prefetch_context.call_count == 2
+
+
+def test_session_start_reuses_one_fallback_user_after_status_probe_failure():
+    provider = _make_prefetch_provider()
+    provider._user = "configured-user"
+    provider._client._user = "configured-user"
+    provider._search_prefetch_context = MagicMock(return_value="")
+    status_calls = 0
+    status_timeouts = []
+    read_uris = []
+
+    def fake_get(path, params=None, **kwargs):
+        nonlocal status_calls
+        if path == "/api/v1/system/status":
+            status_calls += 1
+            status_timeouts.append(kwargs.get("timeout"))
+            if status_calls == 1:
+                raise RuntimeError("temporary status failure")
+            return {"status": "ok", "result": {"user": "alice"}}
+
+        uri = (params or {}).get("uri", "")
+        read_uris.append(uri)
+        if path == "/api/v1/content/read":
+            return {"result": "Configured-user profile."}
+        return {"result": []}
+
+    provider._client.get.side_effect = fake_get
+
+    block = provider.prefetch("What should we recall?", session_id="sid-fallback")
+
+    assert status_calls == 1
+    assert len(status_timeouts) == 1
+    assert 0 < status_timeouts[0] <= 3.0
+    assert read_uris == [
+        "viking://user/configured-user/memories/profile.md",
+        "viking://user/configured-user/memories/preferences",
+        "viking://user/configured-user/memories/entities",
+    ]
+    assert (
+        '<user-profile uri="viking://user/configured-user/memories/profile.md">'
+        in block
+    )
 
 
 def test_prefetch_reinjects_after_in_place_compression_same_session():

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1369,10 +1369,10 @@ def test_prefetch_prepends_session_start_memory_context_once_per_session():
     calls = _mock_session_start_reads(
         provider,
         {
-            ("/api/v1/content/read", "viking://~/memories/profile.md"): (
+            ("/api/v1/content/read", "viking://user/default/memories/profile.md"): (
                 "User prefers concise answers."
             ),
-            ("/api/v1/fs/ls", "viking://~/memories/preferences"): _memory_listing(
+            ("/api/v1/fs/ls", "viking://user/default/memories/preferences"): _memory_listing(
                 {"isDir": True, "rel_path": "owner"},
                 {
                     "isDir": False,
@@ -1386,7 +1386,7 @@ def test_prefetch_prepends_session_start_memory_context_once_per_session():
                 },
                 {"isDir": False, "rel_path": "owner/ignored.txt", "abstract": "ignore"},
             ),
-            ("/api/v1/fs/ls", "viking://~/memories/entities"): _memory_listing(
+            ("/api/v1/fs/ls", "viking://user/default/memories/entities"): _memory_listing(
                 {
                     "isDir": False,
                     "rel_path": "people/ada.md",
@@ -1400,13 +1400,13 @@ def test_prefetch_prepends_session_start_memory_context_once_per_session():
     first = provider.prefetch("What should we recall?", session_id="sid-123")
     second = provider.prefetch("What should we recall?", session_id="sid-123")
 
-    assert '<user-profile uri="viking://~/memories/profile.md">' in first
+    assert '<user-profile uri="viking://user/default/memories/profile.md">' in first
     assert "User prefers concise answers." in first
     assert "<available-memories>" in first
-    assert "viking://~/memories/preferences/" in first
+    assert "viking://user/default/memories/preferences/" in first
     assert "owner/z-last.md — Keep replies compact." in first
     assert first.index("owner/a-first.md") < first.index("owner/z-last.md")
-    assert "viking://~/memories/entities/" in first
+    assert "viking://user/default/memories/entities/" in first
     assert "people/ada.md — Ada Lovelace is a collaborator." in first
     assert "owner/ignored.txt" not in first
     assert "<preferences" not in first
@@ -1415,14 +1415,16 @@ def test_prefetch_prepends_session_start_memory_context_once_per_session():
     assert "<user-profile" not in second
     assert "recalled context" in second
     assert [(path, params) for path, params, _timeout in calls] == [
-        ("/api/v1/content/read", {"uri": "viking://~/memories/profile.md"}),
+        # The user-space probe runs once, before the first URI is built.
+        ("/api/v1/system/status", {}),
+        ("/api/v1/content/read", {"uri": "viking://user/default/memories/profile.md"}),
         (
             "/api/v1/fs/ls",
-            {"uri": "viking://~/memories/preferences", **_SESSION_START_LIST_PARAMS},
+            {"uri": "viking://user/default/memories/preferences", **_SESSION_START_LIST_PARAMS},
         ),
         (
             "/api/v1/fs/ls",
-            {"uri": "viking://~/memories/entities", **_SESSION_START_LIST_PARAMS},
+            {"uri": "viking://user/default/memories/entities", **_SESSION_START_LIST_PARAMS},
         ),
     ]
     assert provider._search_prefetch_context.call_count == 2
@@ -1435,7 +1437,7 @@ def test_prefetch_reinjects_after_in_place_compression_same_session():
 
     def fake_get(path, params=None, **kwargs):
         uri = (params or {}).get("uri", "")
-        if uri == "viking://~/memories/profile.md":
+        if uri == "viking://user/default/memories/profile.md":
             return {"result": next(profiles)}
         return {"result": []}
 

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -753,18 +753,18 @@ def test_viking_client_delete_uses_identity_headers(monkeypatch):
         return SimpleNamespace(
             status_code=200,
             text="",
-            json=lambda: {"status": "ok", "result": {"uri": "viking://user/memories/x.md"}},
+            json=lambda: {"status": "ok", "result": {"uri": "viking://~/memories/x.md"}},
             raise_for_status=lambda: None,
         )
 
     monkeypatch.setattr(client._httpx, "delete", capture_delete)
 
-    assert client.delete("/api/v1/fs", params={"uri": "viking://user/memories/x.md"}) == {
+    assert client.delete("/api/v1/fs", params={"uri": "viking://~/memories/x.md"}) == {
         "status": "ok",
-        "result": {"uri": "viking://user/memories/x.md"},
+        "result": {"uri": "viking://~/memories/x.md"},
     }
     assert captured["url"] == "https://example.com/api/v1/fs"
-    assert captured["kwargs"]["params"] == {"uri": "viking://user/memories/x.md"}
+    assert captured["kwargs"]["params"] == {"uri": "viking://~/memories/x.md"}
     assert captured["kwargs"]["headers"]["Authorization"] == "Bearer test-key"
     assert captured["kwargs"]["headers"]["X-OpenViking-Actor-Peer"] == "hermes"
 
@@ -1369,10 +1369,10 @@ def test_prefetch_prepends_session_start_memory_context_once_per_session():
     calls = _mock_session_start_reads(
         provider,
         {
-            ("/api/v1/content/read", "viking://user/memories/profile.md"): (
+            ("/api/v1/content/read", "viking://~/memories/profile.md"): (
                 "User prefers concise answers."
             ),
-            ("/api/v1/fs/ls", "viking://user/memories/preferences"): _memory_listing(
+            ("/api/v1/fs/ls", "viking://~/memories/preferences"): _memory_listing(
                 {"isDir": True, "rel_path": "owner"},
                 {
                     "isDir": False,
@@ -1386,7 +1386,7 @@ def test_prefetch_prepends_session_start_memory_context_once_per_session():
                 },
                 {"isDir": False, "rel_path": "owner/ignored.txt", "abstract": "ignore"},
             ),
-            ("/api/v1/fs/ls", "viking://user/memories/entities"): _memory_listing(
+            ("/api/v1/fs/ls", "viking://~/memories/entities"): _memory_listing(
                 {
                     "isDir": False,
                     "rel_path": "people/ada.md",
@@ -1400,13 +1400,13 @@ def test_prefetch_prepends_session_start_memory_context_once_per_session():
     first = provider.prefetch("What should we recall?", session_id="sid-123")
     second = provider.prefetch("What should we recall?", session_id="sid-123")
 
-    assert '<user-profile uri="viking://user/memories/profile.md">' in first
+    assert '<user-profile uri="viking://~/memories/profile.md">' in first
     assert "User prefers concise answers." in first
     assert "<available-memories>" in first
-    assert "viking://user/memories/preferences/" in first
+    assert "viking://~/memories/preferences/" in first
     assert "owner/z-last.md — Keep replies compact." in first
     assert first.index("owner/a-first.md") < first.index("owner/z-last.md")
-    assert "viking://user/memories/entities/" in first
+    assert "viking://~/memories/entities/" in first
     assert "people/ada.md — Ada Lovelace is a collaborator." in first
     assert "owner/ignored.txt" not in first
     assert "<preferences" not in first
@@ -1415,14 +1415,14 @@ def test_prefetch_prepends_session_start_memory_context_once_per_session():
     assert "<user-profile" not in second
     assert "recalled context" in second
     assert [(path, params) for path, params, _timeout in calls] == [
-        ("/api/v1/content/read", {"uri": "viking://user/memories/profile.md"}),
+        ("/api/v1/content/read", {"uri": "viking://~/memories/profile.md"}),
         (
             "/api/v1/fs/ls",
-            {"uri": "viking://user/memories/preferences", **_SESSION_START_LIST_PARAMS},
+            {"uri": "viking://~/memories/preferences", **_SESSION_START_LIST_PARAMS},
         ),
         (
             "/api/v1/fs/ls",
-            {"uri": "viking://user/memories/entities", **_SESSION_START_LIST_PARAMS},
+            {"uri": "viking://~/memories/entities", **_SESSION_START_LIST_PARAMS},
         ),
     ]
     assert provider._search_prefetch_context.call_count == 2
@@ -1435,7 +1435,7 @@ def test_prefetch_reinjects_after_in_place_compression_same_session():
 
     def fake_get(path, params=None, **kwargs):
         uri = (params or {}).get("uri", "")
-        if uri == "viking://user/memories/profile.md":
+        if uri == "viking://~/memories/profile.md":
             return {"result": next(profiles)}
         return {"result": []}
 

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1346,6 +1346,8 @@ def _mock_session_start_reads(
         request_params = dict(params or {})
         uri = request_params.get("uri", "")
         calls.append((path, request_params, kwargs.get("timeout")))
+        if path == "/api/v1/system/status":
+            return {"status": "ok", "result": {"user": "default"}}
         response = responses.get((path, uri), "")
         if isinstance(response, Exception):
             raise response
@@ -1437,6 +1439,8 @@ def test_prefetch_reinjects_after_in_place_compression_same_session():
 
     def fake_get(path, params=None, **kwargs):
         uri = (params or {}).get("uri", "")
+        if path == "/api/v1/system/status":
+            return {"status": "ok", "result": {"user": "default"}}
         if uri == "viking://user/default/memories/profile.md":
             return {"result": next(profiles)}
         return {"result": []}


### PR DESCRIPTION
## What

- Replace removed uid-less OpenViking user paths with canonical `viking://user/{user}/...` URIs.
- Resolve the authenticated user from `/api/v1/system/status`.
- Resolve one user for each session-start recall within the existing recall deadline, then reuse it for all reads and labels.
- Bind the resolved-user cache to the active OpenViking client, so a profile, endpoint, or credential reload cannot reuse another connection's user ID.
- Keep each mirrored memory URI and write on one captured connection snapshot.
- Do not cache an unverified fallback after a failed status probe; retry on a later operation.

This PR includes both commits from #91998 by @liuhao1024 with authorship preserved. The two follow-up commits add connection-scoped identity handling, operation consistency, and regression tests.

## Why

OpenViking main removed `viking://user/<reserved-segment>` as a current-user shorthand. Hermes still emits that form for session-start reads and memory writes, which will return HTTP 400 after the next OpenViking release.

Using `viking://~` alone is not sufficient because it is not expanded for ROOT requests in the default development mode. Explicit-user URIs work in ROOT, ADMIN, USER, trusted, and API-key configurations.

Hermes can reload OpenViking profiles and credentials without recreating the provider. The selected user, generated URI, request deadline, and client identity must therefore stay consistent for each recall or write operation.

## Test plan

- `python -m pytest tests/openviking_plugin/test_openviking.py tests/plugins/memory/test_openviking_provider.py tests/plugins/memory/test_openviking_shutdown.py tests/plugins/memory/test_openviking_endpoint_always_blocked.py -q`
  - 115 passed, 0 failed
- The same 115 focused tests passed after a temporary merge with current upstream `main` (`64a6f42c`).
- `ruff check` on the changed Python files
- `python scripts/check-windows-footguns.py --diff upstream/main`
- `git diff --check`
- OpenViking source compatibility checks against:
  - `v0.4.16` (`499995f3`)
  - upstream `main` (`234a2d9f`)

For both OpenViking revisions, the real namespace parser accepted the emitted profile, preferences, entities, and peer-memory URIs for ROOT, ADMIN, and USER roles. The real system status route returned the authenticated user ID used in those URIs.

### Live OpenViking compatibility

On precursor head `17c05c5eb1`, each OpenViking revision was started as an isolated server with valid Doubao model configuration and exercised through Hermes over HTTP:

| OpenViking | DEV | TRUSTED | API key |
| --- | --- | --- | --- |
| `v0.4.16` (`499995f3`) | pass | pass | pass |
| upstream `main` (`234a2d9f`) | pass | pass | pass |

Each of the six cases verified:

- `/api/v1/system/status` and Hermes authenticated-user resolution
- canonical explicit-user peer-memory URI generation
- real `/api/v1/content/write` and `/api/v1/content/read` round trips
- canonical user preference and entity paths used by session-start recall

The API-key cases configured an intentionally incorrect user in Hermes and confirmed that Hermes used the user identity asserted by OpenViking instead. The focused follow-up commit `7056a12766` does not change the HTTP or URI contracts; its operation-level timeout and connection-consistency paths are covered by the current 115-test suite.

## Platforms

Tested on macOS. The change is platform-independent HTTP and URI handling.

Fixes #91995.
