### PR TITLE
fix(profiles): remove Windows alias on profile delete

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1668,7 +1668,15 @@ def delete_profile(name: str, yes: bool = False) -> Path:
     ]
 
     # Check for service
-    wrapper_path = _get_wrapper_dir() / canon
+    wrapper_dir = _get_wrapper_dir()
+    wrapper_candidates = (
+        wrapper_dir / canon,
+        wrapper_dir / f"{canon}.bat",
+    )
+    wrapper_path = next(
+        (candidate for candidate in wrapper_candidates if candidate.exists()),
+        wrapper_candidates[0],
+    )
     has_wrapper = wrapper_path.exists()
     if has_wrapper:
         items.append(f"Command alias ({wrapper_path})")

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -259,6 +259,31 @@ class TestBackfillProfileEnvs:
 class TestDeleteProfile:
     """Tests for delete_profile()."""
 
+    def test_delete_removes_windows_bat_wrapper(self, profile_env, monkeypatch):
+        """Deleting an imported/created profile removes its Windows alias."""
+        monkeypatch.setattr("hermes_cli.profiles.sys.platform", "win32")
+        profile_dir = create_profile("imported", no_alias=True)
+        wrapper = create_wrapper_script("imported")
+        assert wrapper is not None
+        assert wrapper.name == "imported.bat"
+        assert wrapper.exists()
+
+        monkeypatch.setattr(
+            "hermes_cli.profiles._cleanup_gateway_service", lambda *a, **k: None
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles._maybe_unregister_gateway_service",
+            lambda *a, **k: None,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles._stop_profile_backends", lambda *a, **k: None
+        )
+
+        delete_profile("imported", yes=True)
+
+        assert not profile_dir.exists()
+        assert not wrapper.exists()
+
 
     def test_rmtree_failure_raises(self, profile_env):
         profile_dir = create_profile("coder", no_alias=True)


### PR DESCRIPTION
## Summary

On Windows, profile aliases are `.bat` files. `delete_profile()` checks only the extensionless wrapper path before deciding whether to call the existing `remove_wrapper_script()` helper. As a result, deleting an imported or created profile removes the profile directory but leaves `<profile>.bat` orphaned.

The helper already safely recognizes and removes both extensionless and `.bat` wrappers. This change makes `delete_profile()` detect both candidates before displaying/removing the alias.

## Reproduction

1. Create/import profile `demo` and generate its Windows alias `demo.bat`.
2. Run `hermes profile delete demo --yes`.
3. Profile directory is removed, but `demo.bat` remains.

This was observed in a real isolated profile export/import cleanup.

## Duplicate check

PR #90987 fixes `profile alias --remove` when the profile is already gone. That is a useful recovery path but does not fix `delete_profile()` leaving the alias behind in the first place.

## Verification

- New regression fails on current `main`: wrapper still exists after `delete_profile()`.
- Regression passes after the two-candidate detection fix.
- Existing `test_remove_finds_bat_on_windows` passes.
- `ruff`, `py_compile`, and `git diff --check` pass for changed files.

## Risk

Low. Actual removal still goes through `remove_wrapper_script()`, retaining its path validation and wrapper-marker safety checks.

Related: #90983 / #90987
