### PR TITLE
fix(desktop): tolerate macOS parent marker drift

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -250,6 +250,19 @@ def _parent_start_markers_match(actual: str, expected: str) -> bool:
     return actual_unix_ms == expected_unix_ms
 
 
+def _parent_start_marker_mismatch_is_conclusive(actual: str, expected: str) -> bool:
+    """Whether a marker mismatch proves the Desktop parent was replaced.
+
+    Linux ``/proc`` jiffies and Windows FILETIME markers are machine values.
+    A mismatch there is strong PID-reuse evidence. The POSIX fallback uses
+    ``ps -o lstart=`` because macOS has no ``/proc``; that marker is a
+    presentation string whose spacing/locale can differ across runtimes. Treat
+    ``ps:`` mismatches as inconclusive so the watchdog degrades to PID liveness
+    instead of cleanly exiting a healthy Desktop-spawned backend (#93958).
+    """
+    return not (actual.startswith("ps:") or expected.startswith("ps:"))
+
+
 # ---------------------------------------------------------------------------
 # Per-channel subscriber registry used by /api/pub (PTY-side gateway → dashboard)
 # and /api/events (dashboard → browser sidebar).  Keyed by an opaque channel id
@@ -19189,8 +19202,13 @@ def _is_serve_orphaned(
     try:
         if expected_start_marker is not None:
             probe = process_start_marker or _process_start_marker
-            return not _parent_start_markers_match(
-                probe(int(desktop_pid)), expected_start_marker
+            actual_start_marker = probe(int(desktop_pid))
+            if _parent_start_markers_match(
+                actual_start_marker, expected_start_marker
+            ):
+                return False
+            return _parent_start_marker_mismatch_is_conclusive(
+                actual_start_marker, expected_start_marker
             )
 
         if pid_exists is None:

--- a/tests/hermes_cli/test_serve_parent_watchdog.py
+++ b/tests/hermes_cli/test_serve_parent_watchdog.py
@@ -1,6 +1,10 @@
 """Regression tests for Desktop-owned ``hermes serve`` lifecycle tracking."""
 
-from hermes_cli.web_server import _is_serve_orphaned, _valid_parent_start_marker
+from hermes_cli.web_server import (
+    _is_serve_orphaned,
+    _parent_start_marker_mismatch_is_conclusive,
+    _valid_parent_start_marker,
+)
 
 
 def test_parent_watchdog_tracks_recorded_desktop_pid_not_immediate_ppid():
@@ -56,4 +60,35 @@ def test_parent_watchdog_preserves_legacy_exact_windows_marker():
             process_start_marker=lambda _pid: marker,
         )
         is False
+    )
+
+
+def test_parent_watchdog_treats_ps_marker_mismatch_as_inconclusive():
+    """macOS ps lstart formatting drift must not kill a healthy backend."""
+
+    assert _parent_start_marker_mismatch_is_conclusive(
+        "ps:Mon Aug 24 14:30:30 2026",
+        "ps:Mon  Aug 24 14:30:30 2026",
+    ) is False
+    assert (
+        _is_serve_orphaned(
+            4242,
+            "ps:Mon Aug 24 14:30:30 2026",
+            process_start_marker=lambda _pid: "ps:Mon  Aug 24 14:30:30 2026",
+        )
+        is False
+    )
+
+
+def test_parent_watchdog_keeps_machine_marker_mismatches_conclusive():
+    """Linux/Windows machine markers still protect against PID reuse."""
+
+    assert _parent_start_marker_mismatch_is_conclusive("linux:123", "linux:456") is True
+    assert (
+        _is_serve_orphaned(
+            4242,
+            "linux:123",
+            process_start_marker=lambda _pid: "linux:456",
+        )
+        is True
     )


### PR DESCRIPTION
Summary
Desktop local mode uses a parent-death watchdog so a backend exits when the Electron owner is gone. On macOS both Electron and Python use the POSIX `ps -o lstart=` fallback marker, which is a presentation string; spacing/locale drift can make the backend treat a live Desktop parent as PID reuse and cleanly exit with code 0 immediately after announcing its port. This change keeps exact matches as before but treats `ps:` marker mismatches as inconclusive, degrading to fail-safe liveness behavior instead of killing a healthy backend, while preserving conclusive Linux/Windows machine-marker mismatches.

Changes
hermes_cli/web_server.py: route parent-start marker mismatches through a conclusive/inconclusive classifier; `ps:` mismatches now fail safe instead of exiting the backend.
tests/hermes_cli/test_serve_parent_watchdog.py: adds regression coverage for macOS `ps:` marker drift and confirms Linux-style machine-marker mismatches still protect against PID reuse.

How to Test
/data/data/com.termux/files/home/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_serve_parent_watchdog.py -q
# ✅ 7/7 passed
ruff check hermes_cli/web_server.py tests/hermes_cli/test_serve_parent_watchdog.py
# ✅ passed
git diff --check
# ✅ passed
python scripts/check-windows-footguns.py --diff upstream/main
# ✅ passed

Checklist
- [x] Tests pass — 7/7 targeted
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed (Linux / macOS / WSL2 / Windows / Termux)
- [x] profile-safe paths used — no hardcoded ~/.hermes
- [x] .env not used for non-credential settings (behavioral settings → config.yaml)

Risk & Impact
Low. The change only relaxes non-machine `ps:` marker mismatches to fail safe; Linux and Windows machine markers still conclusively detect PID reuse.
Type: Bug fix
Closes: #93958
