### PR TITLE
fix(bot-mode): hide group attention marker while open

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/bot-row.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row.test.tsx
@@ -19,7 +19,7 @@ import type * as HermesSdk from '@hermes/plugin-sdk'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { BotRow } from './bot-row'
+import { BotRow, groupAttentionRoomVisible, groupMainVisibilityAtom, showGroupAttentionMarker } from './bot-row'
 import { translateBots } from './i18n-test-helper'
 import type { RosterRow } from './types'
 
@@ -140,6 +140,28 @@ describe('the menu carries the explicit ask for the forever-chat', () => {
     fireEvent.click(await screen.findByText('Open Bot Chat'))
 
     expect(openRosterBot.mock.calls).toEqual([[bot, { canonical: true }]])
+  })
+})
+
+describe('Group Chat attention', () => {
+  it('shows unresolved attention only while the room is elsewhere', () => {
+    expect(showGroupAttentionMarker(true, false)).toBe(true)
+    expect(showGroupAttentionMarker(true, true)).toBe(false)
+    expect(showGroupAttentionMarker(false, false)).toBe(false)
+
+    expect(groupAttentionRoomVisible(true, false, false)).toBe(true)
+    expect(groupAttentionRoomVisible(false, true, true)).toBe(true)
+    expect(groupAttentionRoomVisible(false, true, false)).toBe(false)
+  })
+
+  it('fails closed when a shell cannot report main-pane visibility', () => {
+    expect(groupMainVisibilityAtom('Planning', null).get()).toBe(false)
+    expect(
+      groupMainVisibilityAtom('Planning', () => {
+        throw new Error('unsupported pane id')
+      }).get()
+    ).toBe(false)
+    expect(groupMainVisibilityAtom('Planning', (() => ({})) as never).get()).toBe(false)
   })
 })
 

--- a/apps/desktop/src/plugins/hermes-bots/bot-row.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row.tsx
@@ -7,6 +7,7 @@
  */
 
 import {
+  atom,
   cn,
   coarseElapsed,
   Codicon,
@@ -25,6 +26,7 @@ import {
   useI18n,
   useValue
 } from '@hermes/plugin-sdk'
+import { useMemo } from 'react'
 
 import { avatarColor, botAppearance, BotFace } from './avatar'
 import { isBackfilledFacePng } from './avatar-image'
@@ -54,13 +56,15 @@ import {
 } from './data'
 import { $groupChats, $groupChatWorkspace } from './group-chat'
 import { botGroups, groupLastActivity } from './group-membership'
+import { shouldRenderGroupChatInPane } from './group-panes'
 import { fallbackSelectionAfterHide, isBotHidden, isBotPinned } from './hidden-bots'
 import { useBots } from './i18n'
-import { displayName, stripPreviewMarkdown } from './labels'
+import { displayName, slugify, stripPreviewMarkdown } from './labels'
 import { duplicateBot } from './profile-ops'
 import { openRosterBot } from './roster-actions'
 import { botRosterMeta, botWorkspaceOwnerKey, setBotsWorkspaceOwner } from './routing'
 import { A2A_PREFIX_RE, botCanonicalSessionId, botRowOwnsWorkspace, previewKind, workerActiveAt } from './row-helpers'
+import { ID } from './shared'
 import type { GroupMember, RosterRow, SidebarRowLabels } from './types'
 
 // ── bot row ──────────────────────────────────────────────────────────────────
@@ -404,10 +408,39 @@ interface GroupRowProps {
   onOpen: (group: string) => void
 }
 
+/** Attention is useful only while its Group Chat is elsewhere. The durable
+ *  state stays set while visible, so leaving reveals it again until resolved. */
+export function showGroupAttentionMarker(needsYou: boolean, roomVisible: boolean): boolean {
+  return Boolean(needsYou && !roomVisible)
+}
+
+export function groupAttentionRoomVisible(mainVisible: boolean, active: boolean, fallbackVisible: boolean): boolean {
+  return Boolean(mainVisible || (active && fallbackVisible))
+}
+
+export function groupMainVisibilityAtom(
+  group: string,
+  paneVisibility: null | typeof host.paneVisibility = host.paneVisibility
+) {
+  if (typeof paneVisibility !== 'function') {
+    return atom(false)
+  }
+
+  try {
+    const visibility = paneVisibility(`plugin-workspace:${ID}:group:${slugify(group)}`)
+
+    return visibility && typeof visibility.get === 'function' ? visibility : atom(false)
+  } catch {
+    return atom(false)
+  }
+}
+
 export function GroupRow({ active, group, members, needsYou, onOpen, onDisband }: GroupRowProps) {
   const { t } = useI18n()
   const b = useBots()
   const rooms = useValue($groupChats)
+  const $mainVisible = useMemo(() => groupMainVisibilityAtom(group), [group])
+  const mainVisible = useValue($mainVisible)
 
   const room = rooms[group] || {
     log: []
@@ -431,6 +464,8 @@ export function GroupRow({ active, group, members, needsYou, onOpen, onDisband }
 
   const availableMembers = members.filter(member => botSourceStatus(member).available).length
   const availabilityLabel = `${availableMembers} of ${members.length} available`
+  const roomVisible = groupAttentionRoomVisible(mainVisible, active, shouldRenderGroupChatInPane(group))
+  const showAttention = showGroupAttentionMarker(needsYou, roomVisible)
 
   const row = (
     <RowButton
@@ -479,9 +514,12 @@ export function GroupRow({ active, group, members, needsYou, onOpen, onDisband }
       <div className="min-w-0 flex-1">
         <div className="flex items-baseline justify-between gap-2">
           <span className="min-w-0 flex-1 truncate text-[0.8125rem] font-medium">{group}</span>
-          {needsYou ? (
+          {showAttention ? (
             <Tip label={b.group.needsYourInput}>
-              <Codicon aria-label={b.roster.needsInput} className="shrink-0 text-(--ui-accent)" name="question" />
+              <span
+                aria-label={b.roster.needsInput}
+                className="size-1.5 shrink-0 self-center rounded-full bg-(--ui-accent)"
+              />
             </Tip>
           ) : null}
           {lastAt ? (


### PR DESCRIPTION
## What does this PR do?

A Group Chat keeps durable attention state when a Bot mentions the user or a
clarification/approval needs a response. If that attention arrived while the
conversation was already open, the roster still showed a question-mark badge.
It was stale, visually misaligned with the row timestamp, and unclear about
what it meant.

This renders the same compact blue-dot language used for unread Bot activity,
only while the Group Chat is elsewhere. The dot disappears while the room's
main pane is actually visible and returns if the user leaves without resolving
the attention. Older Desktop shells use the selected room as a defensive
visibility fallback.

## Related work

- #94726 is the Bot Mode umbrella tracker.
- #93006 owns source-qualified Bot Chat unread watermarks and successful-open
  acknowledgement.
- #92989 expands per-Bot activity indicators. A Group Chat has one shared row,
  so this PR keeps one compact row-level marker.
- #93903 independently owns Group Chat rename lifecycle; it is no longer stacked on this PR.
- Merged #96726 replaced the old `plugin.js` surface. This head ports the
  visibility rule directly into the typed Bot row.

## Changes Made

- Read the Group Chat pane's real visibility instead of treating roster
  selection as focus.
- Degrade safely when an older shell omits or rejects pane visibility.
- Suppress the marker while either the main-pane room or legacy selected room
  is visible.
- Replace the ambiguous question glyph with a `6px` blue dot aligned to the row
  metadata.
- Keep the accurate accessible label **Needs your input**.
- Preserve the underlying attention state while visible.

## How to Test

1. Keep a Group Chat visible.
2. Trigger attention with a user mention or pending clarification; no marker
   should appear on the already-visible row.
3. Switch elsewhere; a compact blue dot should appear beside the row metadata.
4. Return; the dot should disappear without consuming unresolved attention.

## Validation

Post-#96726 head `4f79b71a94` on `main` `7eee066c30`:

- focused behavior tests: **8 passed**
- complete typed Bot Mode suite: **57 files / 558 tests passed**
- Desktop renderer, Electron, and E2E typecheck: passed
- ESLint on changed files: passed
- `git diff --check`: passed
- all selected GitHub checks on this exact head: passed

Python tests are not selected because no Python source changed.
