### PR TITLE
fix(profiles): scrub opaque credentials from exported config

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -2111,6 +2111,32 @@ _EXPORT_REDACT_NAMES = frozenset({
     ".cursorrules",
 })
 
+# Exact config keys whose scalar values are credentials. Text-pattern
+# redaction is insufficient here: opaque signing secrets/password hashes may
+# have no vendor prefix, and replacing a YAML scalar with bare ``***`` can make
+# the exported config syntactically invalid. Clear these fields structurally
+# before the generic text scrub. ``password_hash`` is intentionally included —
+# it is credential verifier material even though it is not plaintext.
+_EXPORT_SECRET_CONFIG_KEYS = frozenset({
+    "api_key",
+    "apikey",
+    "key",
+    "token",
+    "access_token",
+    "refresh_token",
+    "id_token",
+    "secret",
+    "client_secret",
+    "password",
+    "password_hash",
+    "passwd",
+    "auth",
+    "authorization",
+    "private_key",
+    "bearer",
+    "jwt",
+})
+
 
 def _should_redact_export_file(path: Path) -> bool:
     """True when *path* is a text-ish file we should secret-scrub on export."""
@@ -2120,6 +2146,61 @@ def _should_redact_export_file(path: Path) -> bool:
     if name.lower().endswith(".env.example"):
         return True
     return path.suffix.lower() in _EXPORT_REDACT_SUFFIXES
+
+
+def _scrub_export_config_credentials(staged: Path) -> None:
+    """Clear credential-valued config fields in the staged export.
+
+    This operates only on the staged copy. Parsing failures stop the export:
+    emitting an archive we could not structurally inspect would violate the
+    credential-free export contract.
+    """
+    import yaml
+
+    config_path = staged / "config.yaml"
+    if not config_path.is_file():
+        return
+    try:
+        is_link = config_path.is_symlink()
+    except OSError:
+        is_link = False
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise ValueError(
+            "Cannot safely export profile: config.yaml could not be parsed "
+            "for credential scrubbing"
+        ) from exc
+    if data is None:
+        return
+
+    def _clear(value):
+        if isinstance(value, dict):
+            return {
+                key: (
+                    ""
+                    if isinstance(key, str)
+                    and key.lower() in _EXPORT_SECRET_CONFIG_KEYS
+                    and isinstance(child, str)
+                    and child
+                    else _clear(child)
+                )
+                for key, child in value.items()
+            }
+        if isinstance(value, list):
+            return [_clear(child) for child in value]
+        return value
+
+    scrubbed = _clear(data)
+    if is_link:
+        # ``copytree(..., symlinks=True)`` preserves profile symlinks. Never
+        # write through the staged link into the live profile or an external
+        # dotfiles target; materialize the scrubbed config inside staging.
+        config_path.unlink()
+    config_path.write_text(
+        yaml.safe_dump(scrubbed, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
 
 
 def _scrub_export_secrets(staged: Path) -> None:
@@ -2193,10 +2274,22 @@ def export_profile(name: str, output_path: str, extra_files: Optional[Dict[str, 
     base = str(output).removesuffix(".tar.gz").removesuffix(".tgz")
 
     def _stage_extras(staged: Path) -> None:
+        staged_root = staged.resolve()
         for rel, content in (extra_files or {}).items():
             parts = _normalize_profile_archive_parts(rel)
             target = staged.joinpath(*parts)
+            try:
+                target.parent.resolve(strict=False).relative_to(staged_root)
+            except (OSError, RuntimeError, ValueError) as exc:
+                raise ValueError(
+                    f"Unsafe extra file target outside the staged profile: {rel}"
+                ) from exc
             target.parent.mkdir(parents=True, exist_ok=True)
+            if target.is_symlink():
+                # Never write through a profile symlink into the live profile
+                # or an external dotfiles target. The caller supplied this
+                # overlay, so materialize it as a regular staged file.
+                target.unlink()
             target.write_text(content, encoding="utf-8")
 
     if canon == "default":
@@ -2212,6 +2305,7 @@ def export_profile(name: str, output_path: str, extra_files: Optional[Dict[str, 
                 ignore=_default_export_ignore(profile_dir),
             )
             _stage_extras(staged)
+            _scrub_export_config_credentials(staged)
             _scrub_export_secrets(staged)
             result = _make_profile_archive(base, tmpdir, "default")
             return Path(result)
@@ -2227,6 +2321,7 @@ def export_profile(name: str, output_path: str, extra_files: Optional[Dict[str, 
             ignore=lambda d, contents: _CREDENTIAL_FILES & set(contents),
         )
         _stage_extras(staged)
+        _scrub_export_config_credentials(staged)
         _scrub_export_secrets(staged)
         result = _make_profile_archive(base, tmpdir, canon)
         return Path(result)

--- a/tests/hermes_cli/test_profile_export_credentials.py
+++ b/tests/hermes_cli/test_profile_export_credentials.py
@@ -9,7 +9,11 @@ force-redacted in the staged archive (same pass as sessions --redact).
 The live profile on disk must stay untouched.
 """
 
+import sys
 import tarfile
+
+import pytest
+import yaml
 
 from hermes_cli.profiles import export_profile, _DEFAULT_EXPORT_EXCLUDE_ROOT
 
@@ -60,6 +64,118 @@ class TestCredentialExclusion:
 
 
 class TestExportSecretScrub:
+
+    def test_named_profile_export_clears_structural_config_credentials(
+        self, tmp_path, monkeypatch
+    ):
+        """Opaque config credentials are cleared even without vendor prefixes."""
+        profiles_root = tmp_path / "profiles"
+        profile_dir = profiles_root / "scrubconfig"
+        profile_dir.mkdir(parents=True)
+        (profile_dir / "config.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "providers": {"ollama": {"api_key": "opaque-api-value"}},
+                    "dashboard": {
+                        "basic_auth": {
+                            "username": "operator",
+                            "password_hash": "opaque-password-hash",
+                            "secret": "opaque-session-secret",
+                            "session_ttl_seconds": 43200,
+                        }
+                    },
+                },
+                sort_keys=False,
+            )
+        )
+
+        _patch_named_profile(monkeypatch, profiles_root, profile_dir)
+
+        result = export_profile(
+            "scrubconfig", str(tmp_path / "scrubconfig.tar.gz")
+        )
+
+        with tarfile.open(result, "r:gz") as tf:
+            config_name = next(
+                name for name in tf.getnames() if name.endswith("/config.yaml")
+            )
+            exported = yaml.safe_load(
+                tf.extractfile(config_name).read().decode("utf-8")
+            )
+
+        assert exported["providers"]["ollama"]["api_key"] == ""
+        basic = exported["dashboard"]["basic_auth"]
+        assert basic["password_hash"] == ""
+        assert basic["secret"] == ""
+        assert basic["username"] == "operator"
+        assert basic["session_ttl_seconds"] == 43200
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Symlinks require elevated privileges on Windows",
+    )
+    def test_structural_config_scrub_materializes_symlink_without_touching_source(
+        self, tmp_path, monkeypatch
+    ):
+        """A symlinked config is scrubbed in staging, never through its target."""
+        profiles_root = tmp_path / "profiles"
+        profile_dir = profiles_root / "linkconfig"
+        profile_dir.mkdir(parents=True)
+        outside = tmp_path / "outside-config.yaml"
+        outside.write_text(
+            yaml.safe_dump({"dashboard": {"basic_auth": {"secret": "opaque"}}})
+        )
+        (profile_dir / "config.yaml").symlink_to(outside)
+
+        _patch_named_profile(monkeypatch, profiles_root, profile_dir)
+
+        result = export_profile(
+            "linkconfig",
+            str(tmp_path / "linkconfig.tar.gz"),
+            extra_files={
+                "config.yaml": yaml.safe_dump(
+                    {"dashboard": {"basic_auth": {"secret": "overlay-secret"}}}
+                )
+            },
+        )
+
+        with tarfile.open(result, "r:gz") as tf:
+            config_name = next(
+                name for name in tf.getnames() if name.endswith("/config.yaml")
+            )
+            member = tf.getmember(config_name)
+            exported = yaml.safe_load(
+                tf.extractfile(member).read().decode("utf-8")
+            )
+
+        assert not member.issym()
+        assert exported["dashboard"]["basic_auth"]["secret"] == ""
+        assert yaml.safe_load(outside.read_text())["dashboard"]["basic_auth"]["secret"] == "opaque"
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Symlinks require elevated privileges on Windows",
+    )
+    def test_extra_files_reject_symlinked_parent_escape(self, tmp_path, monkeypatch):
+        """An overlay cannot write through a staged directory symlink."""
+        profiles_root = tmp_path / "profiles"
+        profile_dir = profiles_root / "linkparent"
+        profile_dir.mkdir(parents=True)
+        (profile_dir / "config.yaml").write_text("model: gpt-4\n")
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (profile_dir / "overlay").symlink_to(outside, target_is_directory=True)
+
+        _patch_named_profile(monkeypatch, profiles_root, profile_dir)
+
+        with pytest.raises(ValueError, match="outside the staged profile"):
+            export_profile(
+                "linkparent",
+                str(tmp_path / "linkparent.tar.gz"),
+                extra_files={"overlay/injected.txt": "must not escape"},
+            )
+
+        assert not (outside / "injected.txt").exists()
 
     def test_named_profile_export_redacts_secrets_in_text(self, tmp_path, monkeypatch):
         """Leaked keys in skills / SOUL / memories must not leave the archive."""


### PR DESCRIPTION
## Summary

Profile exports currently rely on generic text-pattern redaction after staging. That leaves two credential-safety gaps in `config.yaml`:

- opaque credential values such as Dashboard password hashes/signing secrets can survive because they do not match vendor token patterns;
- assignment-style redaction can replace a YAML value with bare `***`, producing an archive whose `config.yaml` cannot be parsed on import.

This PR structurally parses the staged `config.yaml`, clears exact credential-valued scalar fields, writes valid YAML, and only then runs the existing generic text scrub. If staged `config.yaml` is a symlink, it is materialized as a regular scrubbed file before writing so the source/live target is never modified. `extra_files` overlay targets are containment-checked against the staged root; leaf symlinks are materialized and parent-symlink escapes fail closed. If staged config cannot be parsed, export fails closed.

## Scope and duplicate check

PR #35601 already covers the broader path/token-store filtering class, including `mcp-tokens/`. This PR intentionally does **not** duplicate that work. It covers the uncovered opaque-config-credential and invalid-YAML boundary; the #35601 head contains no `password_hash`/Dashboard structural config scrub.

## Verification

- New regression test fails on current `main` with YAML `ScannerError` (`api_key: ***`).
- The same test passes with this change restored.
- A POSIX symlink regression verifies the archived config becomes a regular scrubbed file while the external target remains unchanged.
- A second POSIX regression verifies `extra_files` cannot write through a symlinked parent outside the staged profile.
- `scripts/run_tests.sh tests/hermes_cli/test_profile_export_credentials.py` passes in the local runtime when the existing Windows symlink test is appropriately skipped; the focused clean-worktree test passes on current upstream.
- `ruff`, `py_compile`, and `git diff --check` pass for changed files.
- A real stopped-profile export/import smoke on v0.20.5 confirmed Dashboard hash/secret and provider API-key fields were cleared before import; temporary profile/archive were removed.

## Risk

`config.yaml` in the staged archive is re-serialized with `safe_dump`, so comments/formatting are not preserved in the portable copy. Key order and non-credential values are preserved. The source profile file is untouched.

## Non-goals

- No path/token-directory filtering; see #35601.
- No change to runtime config or live redaction.
- No PII scrubbing.
