### PR TITLE
feat(memory): opt-in fail-closed pre-compress checkpoint contract (API v1)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -509,6 +509,30 @@ def _normalize_run_budget_seconds(value) -> Optional[float]:
     return seconds
 
 
+def _refuse_checkpoint_required_on_codex_app_server(
+    checkpoint_required: bool, api_mode: Optional[str]
+) -> None:
+    """Fail closed at init when the checkpoint gate cannot be honored.
+
+    The codex app-server owns its thread and compacts it without a truthful
+    pre-compaction transcript boundary (in "native" auto-compaction mode —
+    the default — Hermes never even initiates the compaction), so no
+    pre-compress checkpoint can be guaranteed on this API mode. Refusing here
+    keeps a turn from ever reaching a codex-owned compaction boundary; the
+    compress_context() guard alone cannot cover native turns that bypass
+    Hermes compression entirely.
+    """
+    if checkpoint_required and api_mode == "codex_app_server":
+        raise RuntimeError(
+            "BLOCKED_MISSING_PREREQUISITE: compression.checkpoint_required "
+            "is incompatible with the codex_app_server API mode: the codex "
+            "agent compacts its own thread without a truthful pre-compaction "
+            "transcript boundary, so a required pre-compress checkpoint "
+            "cannot be guaranteed. Disable compression.checkpoint_required "
+            "or use a non-app-server API mode."
+        )
+
+
 def init_agent(
     agent,
     base_url: str = None,
@@ -2247,6 +2271,9 @@ def init_agent(
             compression_threshold_tokens = None
     compression_checkpoint_required = is_truthy_value(
         _compression_cfg.get("checkpoint_required"), default=False
+    )
+    _refuse_checkpoint_required_on_codex_app_server(
+        compression_checkpoint_required, getattr(agent, "api_mode", None)
     )
     # In-place compaction: when True, compress_context() rewrites the message
     # list + rebuilds the system prompt WITHOUT rotating the session id (no

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2245,6 +2245,9 @@ def init_agent(
                 compression_threshold_tokens = None
         except (TypeError, ValueError):
             compression_threshold_tokens = None
+    compression_checkpoint_required = is_truthy_value(
+        _compression_cfg.get("checkpoint_required"), default=False
+    )
     # In-place compaction: when True, compress_context() rewrites the message
     # list + rebuilds the system prompt WITHOUT rotating the session id (no
     # parent_session_id chain, no `name #N` renumber). See #38763 and
@@ -2777,6 +2780,7 @@ def init_agent(
         _cc._micro_compact_defrag_threshold_tokens = (
             compression_micro_compact_defrag_tokens
         )
+    agent.compression_checkpoint_required = compression_checkpoint_required
     agent.codex_app_server_auto_compaction = codex_app_server_auto_compaction
     agent.codex_responses_native_compaction = codex_responses_native_compaction
     agent.codex_responses_compact_threshold = codex_responses_compact_threshold

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -691,6 +691,20 @@ def run_codex_app_server_turn(
     Called from run_conversation() when agent.api_mode == "codex_app_server".
     Returns the same dict shape as the chat_completions path.
     """
+    # Defense in depth for compression.checkpoint_required: agent init
+    # already refuses this combination, but api_mode is a plain attribute a
+    # future code path could mutate on a live agent. Fail closed before the
+    # codex agent can compact its thread — once run_turn() executes, a
+    # codex-owned compaction may already have happened with no pre-compress
+    # checkpoint. Explicit-True check matches the compress_context() gate.
+    if getattr(agent, "compression_checkpoint_required", False) is True:
+        from agent.conversation_compression import _checkpoint_blocked
+
+        raise _checkpoint_blocked(
+            "codex_app_server owns the authoritative thread and compacts it "
+            "without a truthful pre-compaction transcript boundary"
+        )
+
     from agent.transports.codex_app_server_session import (
         CodexAppServerSession,
         _ServerRequestRouting,

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1554,10 +1554,12 @@ class _CompressionActivityHeartbeat:
 def _direct_messages_for_pre_compress_memory(messages: Any) -> list[dict[str, Any]]:
     """Return direct user/assistant evidence safe for memory checkpointing.
 
-    Compression summaries are derivative context, not new source evidence. Tool
-    rows, system messages, and assistant tool-call wrappers are likewise omitted
-    so memory providers receive one normalized host contract instead of having
-    to infer Hermes transcript internals independently.
+    Compression summaries are derivative context, not new source evidence.
+    Tool rows and system messages are likewise omitted so memory providers
+    receive one normalized host contract instead of having to infer Hermes
+    transcript internals independently. Assistant messages that carry both
+    prose and ``tool_calls`` keep their prose (the ``tool_calls`` payload is
+    stripped); pure tool-call wrappers without prose are dropped.
     """
     # Deferred import: context_compressor imports turn_context, which imports
     # this module — a module-level import here would close that cycle
@@ -1574,7 +1576,13 @@ def _direct_messages_for_pre_compress_memory(messages: Any) -> list[dict[str, An
         if message.get(COMPRESSED_SUMMARY_METADATA_KEY):
             continue
         if role == "assistant" and message.get("tool_calls"):
-            continue
+            content = message.get("content")
+            has_prose = bool(
+                content.strip() if isinstance(content, str) else content
+            )
+            if not has_prose:
+                continue
+            message = {k: v for k, v in message.items() if k != "tool_calls"}
         direct_messages.append(message)
     return direct_messages
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -71,6 +71,7 @@ from agent.context_engine import (
     automatic_compaction_status_message,
     sanitize_memory_context,
 )
+from agent.memory_provider import PRE_COMPRESS_CHECKPOINT_API_VERSION
 from agent.model_metadata import (
     estimate_messages_tokens_rough,
     estimate_request_tokens_rough,
@@ -1111,6 +1112,16 @@ def run_compress_context_with_progress_timeout(
             # the host unwinds, so the detached worker can never publish.
             fence.revoke_commit_admission()
 
+class CompressionCheckpointUnavailable(RuntimeError):
+    """Raised when required durable pre-compress checkpointing is unavailable."""
+
+
+def _checkpoint_blocked(reason: str) -> CompressionCheckpointUnavailable:
+    return CompressionCheckpointUnavailable(
+        "BLOCKED_MISSING_PREREQUISITE: required pre-compress checkpoint "
+        f"unavailable: {reason}"
+    )
+
 
 def _lock_api_is_absent_on_session_db(lock_db: Any) -> bool:
     """Whether the live in-memory SessionDB class structurally predates locks.
@@ -1539,6 +1550,33 @@ class _CompressionActivityHeartbeat:
             if self._should_suppress():
                 return
             self._touch("context compression in progress")
+
+def _direct_messages_for_pre_compress_memory(messages: Any) -> list[dict[str, Any]]:
+    """Return direct user/assistant evidence safe for memory checkpointing.
+
+    Compression summaries are derivative context, not new source evidence. Tool
+    rows, system messages, and assistant tool-call wrappers are likewise omitted
+    so memory providers receive one normalized host contract instead of having
+    to infer Hermes transcript internals independently.
+    """
+    # Deferred import: context_compressor imports turn_context, which imports
+    # this module — a module-level import here would close that cycle
+    # (upstream introduced the turn_context edge with the api_content work).
+    from agent.context_compressor import COMPRESSED_SUMMARY_METADATA_KEY
+
+    direct_messages: list[dict[str, Any]] = []
+    for message in messages or []:
+        if not isinstance(message, dict):
+            continue
+        role = message.get("role")
+        if role not in {"user", "assistant"}:
+            continue
+        if message.get(COMPRESSED_SUMMARY_METADATA_KEY):
+            continue
+        if role == "assistant" and message.get("tool_calls"):
+            continue
+        direct_messages.append(message)
+    return direct_messages
 
 
 class _CompressionLockLeaseRefresher:
@@ -2340,7 +2378,18 @@ def compress_context(
     # The memory-provider context handoff below is intentionally Hermes-only:
     # the app server does not expose its native summary prompt, so there is no
     # truthful injection point for ``on_pre_compress()`` return text here.
+    # `is True` (not bool()): unit tests drive this path with bare MagicMock
+    # agents whose auto-created attributes are truthy; the gate must only arm
+    # on the explicit boolean set by agent_init from config.
+    checkpoint_required = (
+        getattr(agent, "compression_checkpoint_required", False) is True
+    )
     if getattr(agent, "api_mode", None) == "codex_app_server":
+        if checkpoint_required:
+            raise _checkpoint_blocked(
+                "codex_app_server owns the authoritative thread and does not "
+                "expose a truthful pre-compaction transcript boundary"
+            )
         _codex_fence_entered = False
         if commit_fence is not None:
             _codex_fence_entered = commit_fence.begin_commit(
@@ -2956,9 +3005,47 @@ def compress_context(
         # wants surfaced inside the compression summary; capture and forward it
         # instead of silently discarding the provider's return value.
         memory_context = ""
-        if agent._memory_manager:
+        memory_manager = getattr(agent, "_memory_manager", None)
+        direct_messages = _direct_messages_for_pre_compress_memory(messages)
+        if checkpoint_required:
+            supports_checkpoint = getattr(
+                memory_manager, "supports_pre_compress_checkpoint", None
+            )
+            if memory_manager is None or not callable(supports_checkpoint):
+                raise _checkpoint_blocked(
+                    f"no active provider implements checkpoint API "
+                    f"v{PRE_COMPRESS_CHECKPOINT_API_VERSION}"
+                )
             try:
-                _maybe_ctx = agent._memory_manager.on_pre_compress(messages)
+                compatible = bool(
+                    supports_checkpoint(PRE_COMPRESS_CHECKPOINT_API_VERSION)
+                )
+            except Exception as exc:
+                raise _checkpoint_blocked("provider capability probe failed") from exc
+            if not compatible:
+                raise _checkpoint_blocked(
+                    f"active provider does not implement checkpoint API "
+                    f"v{PRE_COMPRESS_CHECKPOINT_API_VERSION}"
+                )
+            try:
+                _maybe_ctx = memory_manager.on_pre_compress(
+                    direct_messages,
+                    require_checkpoint=True,
+                    checkpoint_api_version=PRE_COMPRESS_CHECKPOINT_API_VERSION,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Required pre-compress checkpoint failed (%s)",
+                    type(exc).__name__,
+                )
+                raise _checkpoint_blocked(
+                    f"provider checkpoint API v{PRE_COMPRESS_CHECKPOINT_API_VERSION} failed"
+                ) from exc
+            if isinstance(_maybe_ctx, str):
+                memory_context = sanitize_memory_context(_maybe_ctx)
+        elif memory_manager:
+            try:
+                _maybe_ctx = memory_manager.on_pre_compress(direct_messages)
                 if isinstance(_maybe_ctx, str):
                     memory_context = sanitize_memory_context(_maybe_ctx)
             except Exception:

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -33,7 +33,7 @@ import threading
 from concurrent.futures import Future, ThreadPoolExecutor, wait
 from typing import Any, Callable, Dict, List, Optional
 
-from agent.memory_provider import MemoryProvider
+from agent.memory_provider import MemoryProvider, PRE_COMPRESS_CHECKPOINT_API_VERSION
 from agent.skill_commands import extract_user_instruction_from_skill_message
 from tools.registry import tool_error
 
@@ -1021,14 +1021,47 @@ class MemoryManager:
                     provider.name, e,
                 )
 
-    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
+    def supports_pre_compress_checkpoint(
+        self,
+        api_version: int = PRE_COMPRESS_CHECKPOINT_API_VERSION,
+    ) -> bool:
+        """Return whether an active provider guarantees checkpoint API support."""
+        for provider in self._providers:
+            try:
+                provider_version = int(
+                    getattr(provider, "pre_compress_checkpoint_api_version", 0)
+                )
+            except (TypeError, ValueError):
+                continue
+            if provider_version >= api_version:
+                return True
+        return False
+
+    def on_pre_compress(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        require_checkpoint: bool = False,
+        checkpoint_api_version: int = PRE_COMPRESS_CHECKPOINT_API_VERSION,
+    ) -> str:
         """Notify all providers before context compression.
 
         Returns combined text from providers to include in the compression
-        summary prompt. Empty string if no provider contributes.
+        summary prompt. Empty string if no provider contributes. When
+        ``require_checkpoint`` is true, at least one provider advertising the
+        requested checkpoint API must return successfully; its exception is
+        propagated so the caller can preserve the uncompressed transcript.
         """
         parts = []
+        checkpoint_succeeded = False
         for provider in self._providers:
+            try:
+                provider_version = int(
+                    getattr(provider, "pre_compress_checkpoint_api_version", 0)
+                )
+            except (TypeError, ValueError):
+                provider_version = 0
+            is_checkpoint_provider = provider_version >= checkpoint_api_version
             try:
                 result = provider.on_pre_compress(messages)
                 if result and result.strip():
@@ -1038,6 +1071,16 @@ class MemoryManager:
                     "Memory provider '%s' on_pre_compress failed: %s",
                     provider.name, e,
                 )
+                if require_checkpoint and is_checkpoint_provider:
+                    raise
+            else:
+                if is_checkpoint_provider:
+                    checkpoint_succeeded = True
+        if require_checkpoint and not checkpoint_succeeded:
+            raise RuntimeError(
+                "No active memory provider completed pre-compress checkpoint "
+                f"API v{checkpoint_api_version}"
+            )
         return "\n\n".join(parts)
 
     @staticmethod

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -41,6 +41,8 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
+PRE_COMPRESS_CHECKPOINT_API_VERSION = 1
+
 # Default glyph for the deterministic memory indicators. Providers override
 # per-status with their own brand mark (e.g. Hindsight uses "👁️").
 INDICATOR_GLYPH = "🧠"
@@ -103,6 +105,11 @@ def is_trivial_prompt(text: Optional[str]) -> bool:
 
 class MemoryProvider(ABC):
     """Abstract base class for memory providers."""
+
+    # Providers that durably checkpoint every successful on_pre_compress()
+    # call may opt into this host contract by setting the current version.
+    # Version 0 preserves the historical best-effort hook semantics.
+    pre_compress_checkpoint_api_version = 0
 
     @property
     @abstractmethod

--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -116,6 +116,26 @@ def resolve_compact_threshold(
     return max(1_024, min(configured, upper))
 
 
+_checkpoint_suppression_logged = False
+
+
+def _warn_native_compaction_suppressed_by_checkpoint_gate() -> None:
+    """Log once per process that the checkpoint gate suppresses native compaction.
+
+    The suppression itself is re-evaluated per request; only the log line is
+    deduplicated so a long session does not repeat it on every API call.
+    """
+    global _checkpoint_suppression_logged
+    if _checkpoint_suppression_logged:
+        return
+    _checkpoint_suppression_logged = True
+    logger.warning(
+        "compression.checkpoint_required is enabled: server-side native "
+        "compaction (context_management) is disabled for this agent so the "
+        "checkpoint-aware Hermes compressor stays authoritative."
+    )
+
+
 def native_compaction_context_management(
     agent: Any,
     *,
@@ -136,6 +156,14 @@ def native_compaction_context_management(
     # compression.enabled: false disables ALL automatic compaction, native
     # included — mirrors the codex_app_server_auto contract.
     if not bool(getattr(agent, "compression_enabled", True)):
+        return None
+    # compression.checkpoint_required: server-side compaction is a lossy
+    # boundary the provider owns — no pre-compress checkpoint can run before
+    # the server replaces older context. Keep the checkpoint-aware Hermes
+    # compressor authoritative instead of silently letting the server
+    # compact. Explicit-True check matches the compress_context() gate.
+    if getattr(agent, "compression_checkpoint_required", False) is True:
+        _warn_native_compaction_suppressed_by_checkpoint_gate()
         return None
     if is_xai_responses or is_github_responses:
         return None

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -540,8 +540,12 @@ compression:
   # implements the pre-compress checkpoint contract (API v1) confirms its
   # durable checkpoint (default: false). With this on and no checkpoint, the
   # compaction attempt errors with BLOCKED_MISSING_PREREQUISITE and the
-  # uncompressed transcript is preserved for a later retry. Only enable it
-  # with a checkpoint-capable provider configured — see
+  # uncompressed transcript is preserved for a later retry. The gate binds to
+  # every compaction authority: server-side native compaction
+  # (codex_responses_native) is suppressed while armed, and the
+  # codex_app_server API mode is refused at agent init (the codex agent
+  # compacts its own thread — no checkpoint can be guaranteed there). Only
+  # enable it with a checkpoint-capable provider configured — see
   # website/docs/developer-guide/memory-provider-plugin.md
   # ("Pre-Compress Checkpoints").
   checkpoint_required: false

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -536,6 +536,16 @@ compression:
   # Set to false if you prefer to manage context manually or want errors on overflow
   enabled: true
 
+  # Fail closed before lossy compaction unless an active memory provider that
+  # implements the pre-compress checkpoint contract (API v1) confirms its
+  # durable checkpoint (default: false). With this on and no checkpoint, the
+  # compaction attempt errors with BLOCKED_MISSING_PREREQUISITE and the
+  # uncompressed transcript is preserved for a later retry. Only enable it
+  # with a checkpoint-capable provider configured — see
+  # website/docs/developer-guide/memory-provider-plugin.md
+  # ("Pre-Compress Checkpoints").
+  checkpoint_required: false
+
   # Opt-in compression progress notices on chat platforms (default: false).
   # By design, routine automatic compression is SILENT on human-facing chat
   # gateways (Telegram, Discord, Slack, ...) — it happens in the background

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -558,9 +558,10 @@ def _seed_hygiene_system_prompt(
 ) -> bool:
     """Keep gateway hygiene from rebuilding a live session's system prompt.
 
-    The hygiene helper loads the memory provider for the pre-compress hook,
-    but it still runs outside the live session's fully initialized prompt
-    environment (hygiene-only platform marker, no platform context files).
+    The hygiene helper runs outside the live session's fully initialized
+    prompt environment (hygiene-only platform marker, no platform context
+    files; the memory provider is loaded only when
+    ``compression.checkpoint_required`` demands it).
     Compression is allowed to persist a system prompt, so letting that helper
     rebuild one would strip external provider blocks from the live session.
     Seed the exact persisted prompt instead.  When no usable prompt can be
@@ -19714,21 +19715,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                         exc_info=True,
                                     )
                                 _hyg_session_db = getattr(self._session_db, "_db", self._session_db)
+                                # Hygiene performs the same lossy rewrite as
+                                # normal compression. When the operator enabled
+                                # compression.checkpoint_required, the memory
+                                # provider must be loaded so the required
+                                # checkpoint is created before any transcript
+                                # mutation; otherwise keep the historical fast
+                                # path (no provider init, no best-effort hook)
+                                # for hygiene.
+                                from hermes_cli.config import load_config as _load_cfg
+                                from utils import is_truthy_value as _is_truthy
+
+                                _hyg_checkpoint_required = _is_truthy(
+                                    ((_load_cfg() or {}).get("compression") or {}).get(
+                                        "checkpoint_required"
+                                    ),
+                                    default=False,
+                                )
                                 _hyg_agent = AIAgent(
                                     **_hyg_runtime,
                                     model=_hyg_model,
                                     max_iterations=4,
                                     quiet_mode=True,
-                                    # Hygiene performs the same lossy rewrite
-                                    # as normal compression, so it loads the
-                                    # memory provider unconditionally (normal
-                                    # compression never skips it either):
-                                    # best-effort on_pre_compress runs for
-                                    # hygiene too, and when
-                                    # compression.checkpoint_required is
-                                    # enabled the required checkpoint is
-                                    # created before any transcript mutation.
-                                    skip_memory=False,
+                                    skip_memory=not _hyg_checkpoint_required,
                                     enabled_toolsets=["memory"],
                                     session_id=session_entry.session_id,
                                     session_db=_hyg_session_db,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -558,7 +558,9 @@ def _seed_hygiene_system_prompt(
 ) -> bool:
     """Keep gateway hygiene from rebuilding a live session's system prompt.
 
-    The hygiene helper intentionally skips memory-provider initialization.
+    The hygiene helper loads the memory provider for the pre-compress hook,
+    but it still runs outside the live session's fully initialized prompt
+    environment (hygiene-only platform marker, no platform context files).
     Compression is allowed to persist a system prompt, so letting that helper
     rebuild one would strip external provider blocks from the live session.
     Seed the exact persisted prompt instead.  When no usable prompt can be
@@ -19717,7 +19719,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     model=_hyg_model,
                                     max_iterations=4,
                                     quiet_mode=True,
-                                    skip_memory=True,
+                                    # Hygiene performs the same lossy rewrite
+                                    # as normal compression, so it loads the
+                                    # memory provider unconditionally (normal
+                                    # compression never skips it either):
+                                    # best-effort on_pre_compress runs for
+                                    # hygiene too, and when
+                                    # compression.checkpoint_required is
+                                    # enabled the required checkpoint is
+                                    # created before any transcript mutation.
+                                    skip_memory=False,
                                     enabled_toolsets=["memory"],
                                     session_id=session_entry.session_id,
                                     session_db=_hyg_session_db,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4392,11 +4392,12 @@ class GatewaySlashCommandsMixin:
                 runtime_kwargs["platform"] = platform_key
             runtime_kwargs["gateway_session_key"] = session_key
 
-            # The manual compression helper loads the memory provider (see
-            # skip_memory=False below) but still runs outside the live
-            # session's fully initialized prompt environment, and
-            # _compress_context may persist its cached system prompt. Restore
-            # the exact live-session prompt so provider blocks are retained.
+            # The manual compression helper runs outside the live session's
+            # fully initialized prompt environment (it loads the memory
+            # provider only when compression.checkpoint_required demands it),
+            # and _compress_context may persist its cached system prompt.
+            # Restore the exact live-session prompt so provider blocks are
+            # retained.
             session_row = None
             get_session = getattr(self._session_db, "get_session", None)
             if callable(get_session):
@@ -4412,18 +4413,26 @@ class GatewaySlashCommandsMixin:
                         exc_info=True,
                     )
 
+            # This agent performs a lossy rewrite. When the operator enabled
+            # compression.checkpoint_required, the memory provider must be
+            # loaded so _compress_context() can create the required
+            # pre-compression checkpoint; otherwise keep the historical fast
+            # path (no provider init, no best-effort hook) for this helper.
+            from hermes_cli.config import load_config as _load_cfg
+            from utils import is_truthy_value as _is_truthy
+
+            _checkpoint_required = _is_truthy(
+                ((_load_cfg() or {}).get("compression") or {}).get(
+                    "checkpoint_required"
+                ),
+                default=False,
+            )
             tmp_agent = AIAgent(
                 **runtime_kwargs,
                 model=model,
                 max_iterations=4,
                 quiet_mode=True,
-                # This agent performs the same lossy rewrite as normal
-                # compression, so it loads the memory provider unconditionally
-                # (normal compression never skips it either): best-effort
-                # on_pre_compress runs for manual compression too, and when
-                # compression.checkpoint_required is enabled the required
-                # pre-compression checkpoint can be created.
-                skip_memory=False,
+                skip_memory=not _checkpoint_required,
                 enabled_toolsets=["memory"],
                 session_id=session_entry.session_id,
                 session_db=getattr(self._session_db, "_db", self._session_db),

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4392,8 +4392,10 @@ class GatewaySlashCommandsMixin:
                 runtime_kwargs["platform"] = platform_key
             runtime_kwargs["gateway_session_key"] = session_key
 
-            # The manual compression helper skips memory-provider initialization,
-            # but _compress_context may persist its cached system prompt. Restore
+            # The manual compression helper loads the memory provider (see
+            # skip_memory=False below) but still runs outside the live
+            # session's fully initialized prompt environment, and
+            # _compress_context may persist its cached system prompt. Restore
             # the exact live-session prompt so provider blocks are retained.
             session_row = None
             get_session = getattr(self._session_db, "get_session", None)
@@ -4415,7 +4417,13 @@ class GatewaySlashCommandsMixin:
                 model=model,
                 max_iterations=4,
                 quiet_mode=True,
-                skip_memory=True,
+                # This agent performs the same lossy rewrite as normal
+                # compression, so it loads the memory provider unconditionally
+                # (normal compression never skips it either): best-effort
+                # on_pre_compress runs for manual compression too, and when
+                # compression.checkpoint_required is enabled the required
+                # pre-compression checkpoint can be created.
+                skip_memory=False,
                 enabled_toolsets=["memory"],
                 session_id=session_entry.session_id,
                 session_db=getattr(self._session_db, "_db", self._session_db),

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -742,6 +742,9 @@ DEFAULT_CONFIG = {
 
     "compression": {
         "enabled": True,
+        "checkpoint_required": False, # Fail closed before lossy compaction unless an
+                                      # active memory provider confirms checkpoint API
+                                      # compatibility and completes the checkpoint.
         "progress_notices": False,    # opt-in (#52995): when True, routine compression
                                       # progress statuses (compacting/preflight/pre-API/
                                       # idle/retry) are delivered to chat gateway

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -10513,6 +10513,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         platform_message_id: str = None,
         observed: bool = False,
         effect_disposition: Optional[str] = None,
+        _compressed_summary: bool = False,
         timestamp: Any = None,
         api_content: Optional[str] = None,
         display_kind: Optional[str] = None,
@@ -10588,8 +10589,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, _compressed_summary, active, api_content, display_kind, display_metadata)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -10608,6 +10609,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     codex_message_items_json,
                     platform_message_id,
                     1 if observed else 0,
+                    1 if _compressed_summary else 0,
                     1,
                     _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
                     _scrub_surrogates(display_kind) if isinstance(display_kind, str) else None,
@@ -11019,8 +11021,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, _compressed_summary, active, api_content, display_kind, display_metadata)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -11039,6 +11041,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     codex_message_items_json,
                     platform_msg_id,
                     1 if msg.get("observed") else 0,
+                    1 if msg.get("_compressed_summary") else 0,
                     1,
                     _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
                     _scrub_surrogates(msg.get("display_kind")) if isinstance(msg.get("display_kind"), str) else None,
@@ -11515,6 +11518,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         result = []
         for row in rows:
             msg = dict(row)
+            if msg.pop("_compressed_summary", 0):
+                msg["_compressed_summary"] = True
             if "content" in msg:
                 msg["content"] = self._decode_content(msg["content"])
             if msg.get("tool_calls"):
@@ -11789,7 +11794,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     _CONVERSATION_ROW_COLUMNS = (
         "id, role, content, tool_call_id, tool_calls, tool_name, effect_disposition, "
         "finish_reason, reasoning, reasoning_content, reasoning_details, "
-        "codex_reasoning_items, codex_message_items, platform_message_id, observed, timestamp, "
+        "codex_reasoning_items, codex_message_items, platform_message_id, observed, "
+        "_compressed_summary, timestamp, "
         "api_content, display_kind, display_metadata"
     )
 
@@ -11801,6 +11807,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         include_ancestors: bool,
         repair_alternation: bool,
         include_row_ids: bool = False,
+        include_summary_markers: bool = False,
     ) -> List[Dict[str, Any]]:
         """Decode fetched message rows into the OpenAI conversation format.
 
@@ -11854,6 +11861,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 decoded = self._decode_display_metadata(row["display_metadata"])
                 if decoded is not None:
                     msg["display_metadata"] = decoded
+            if include_summary_markers and row["_compressed_summary"]:
+                msg["_compressed_summary"] = True
             if row["timestamp"]:
                 msg["timestamp"] = row["timestamp"]
             if row["tool_call_id"]:
@@ -12028,6 +12037,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             include_ancestors=False,
             repair_alternation=True,
             include_row_ids=True,
+            # Pre-compress checkpointing: the resumed model history must keep
+            # the summary marker so checkpoint providers can exclude derivative
+            # summaries after a process restart (marker survives restart).
+            include_summary_markers=True,
         )
         display_history = self._rows_to_conversation(
             rows,

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -446,6 +446,7 @@ CREATE TABLE IF NOT EXISTS messages (
     codex_message_items TEXT,
     platform_message_id TEXT,
     observed INTEGER DEFAULT 0,
+    _compressed_summary INTEGER NOT NULL DEFAULT 0,
     active INTEGER NOT NULL DEFAULT 1,
     compacted INTEGER NOT NULL DEFAULT 0,
     api_content TEXT,

--- a/run_agent.py
+++ b/run_agent.py
@@ -2361,6 +2361,7 @@ class AIAgent:
                     "reasoning_details": msg.get("reasoning_details"),
                     "codex_reasoning_items": msg.get("codex_reasoning_items"),
                     "codex_message_items": msg.get("codex_message_items"),
+                    "_compressed_summary": bool(msg.get(COMPRESSED_SUMMARY_METADATA_KEY)),
                     "timestamp": _row_timestamp,
                     "api_content": _row_api_content,
                     # Standalone reference handoffs are always hidden, even

--- a/tests/agent/test_pre_compress_checkpoint_contract.py
+++ b/tests/agent/test_pre_compress_checkpoint_contract.py
@@ -69,7 +69,7 @@ def test_direct_messages_filter_keeps_only_direct_source_evidence():
         {"role": "system", "content": "system prompt"},
         {"role": "user", "content": "durable user decision"},
         {"role": "assistant", "content": "direct assistant answer"},
-        {"role": "assistant", "content": "call", "tool_calls": [{"id": "t1"}]},
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "t1"}]},
         {"role": "tool", "content": "tool output", "tool_call_id": "t1"},
         {
             "role": "assistant",
@@ -85,6 +85,29 @@ def test_direct_messages_filter_keeps_only_direct_source_evidence():
         "durable user decision",
         "direct assistant answer",
     ]
+
+
+def test_direct_messages_filter_keeps_prose_of_tool_call_messages():
+    """Assistant prose next to tool_calls is evidence; the payload is not."""
+    messages = [
+        {"role": "user", "content": "please scan the network"},
+        {
+            "role": "assistant",
+            "content": "Scanning now — the last sweep found 26 hosts.",
+            "tool_calls": [{"id": "t1", "function": {"name": "terminal"}}],
+        },
+        {"role": "assistant", "content": "   ", "tool_calls": [{"id": "t2"}]},
+    ]
+
+    direct = _direct_messages_for_pre_compress_memory(messages)
+
+    assert [m["content"] for m in direct] == [
+        "please scan the network",
+        "Scanning now — the last sweep found 26 hosts.",
+    ]
+    assert all("tool_calls" not in m for m in direct)
+    # The original message list is not mutated.
+    assert messages[1]["tool_calls"]
 
 
 def test_manager_advertises_checkpoint_capability_only_with_capable_provider():
@@ -182,3 +205,37 @@ def test_compressed_summary_marker_survives_restart_via_resume_history(tmp_path)
 
     plain = reopened.get_messages_as_conversation("s1")
     assert all("_compressed_summary" not in m for m in plain)
+
+
+def test_compressed_summary_column_is_added_to_legacy_databases(tmp_path):
+    """Pre-upgrade databases gain the marker column via declarative reconcile.
+
+    ``_init_schema()`` diffs live columns against SCHEMA_SQL on every
+    writable open and ADDs whatever is missing, so a database created
+    before this feature must accept marker writes after a plain reopen.
+    """
+    import sqlite3
+
+    from hermes_state import SessionDB
+
+    db_path = tmp_path / "state.db"
+    SessionDB(db_path)
+
+    # Simulate a pre-upgrade database: the marker column does not exist.
+    conn = sqlite3.connect(db_path)
+    conn.execute("ALTER TABLE messages DROP COLUMN _compressed_summary")
+    conn.commit()
+    legacy_cols = {
+        row[1] for row in conn.execute("PRAGMA table_info(messages)")
+    }
+    conn.close()
+    assert "_compressed_summary" not in legacy_cols
+
+    upgraded = SessionDB(db_path)
+    upgraded.create_session("legacy", source="cli")
+    upgraded.append_message(
+        "legacy", "assistant", "derivative summary", _compressed_summary=True
+    )
+
+    model_history, _display = upgraded.get_resume_conversations("legacy")
+    assert model_history[-1].get("_compressed_summary") is True

--- a/tests/agent/test_pre_compress_checkpoint_contract.py
+++ b/tests/agent/test_pre_compress_checkpoint_contract.py
@@ -239,3 +239,87 @@ def test_compressed_summary_column_is_added_to_legacy_databases(tmp_path):
 
     model_history, _display = upgraded.get_resume_conversations("legacy")
     assert model_history[-1].get("_compressed_summary") is True
+
+
+def test_native_responses_compaction_is_suppressed_when_checkpoint_required():
+    """checkpoint_required must keep ``context_management`` off the wire.
+
+    Server-side native compaction is a lossy boundary the provider owns; no
+    pre-compress checkpoint can run before it, so the gate suppresses the
+    payload while ordinary checkpoint-aware Hermes compression stays
+    available.
+    """
+    from types import SimpleNamespace
+
+    from agent.native_compaction import native_compaction_context_management
+
+    def agent(checkpoint_required):
+        return SimpleNamespace(
+            model="gpt-5.6",
+            base_url="https://api.openai.com/v1",
+            codex_responses_native_compaction=True,
+            compression_enabled=True,
+            compression_checkpoint_required=checkpoint_required,
+            codex_responses_compact_threshold=0.8,
+            context_compressor=None,
+        )
+
+    assert native_compaction_context_management(
+        agent(False), is_codex_backend=True
+    )
+    assert (
+        native_compaction_context_management(agent(True), is_codex_backend=True)
+        is None
+    )
+
+
+def test_codex_app_server_turn_fails_closed_before_codex_can_compact():
+    """checkpoint_required + app-server must never reach ``run_turn()``.
+
+    The codex agent compacts its own thread; once ``run_turn()`` executes, a
+    codex-owned compaction may already have happened with no checkpoint. The
+    turn entrypoint must raise first — the session is never even created.
+    """
+    from types import SimpleNamespace
+
+    from agent.codex_runtime import run_codex_app_server_turn
+
+    class _ExplodingSession:
+        def run_turn(self, *args, **kwargs):  # pragma: no cover - must not run
+            raise AssertionError("run_turn() must not be reached")
+
+    agent = SimpleNamespace(
+        api_mode="codex_app_server",
+        compression_checkpoint_required=True,
+        _codex_session=_ExplodingSession(),
+    )
+
+    with pytest.raises(CompressionCheckpointUnavailable, match="codex_app_server"):
+        run_codex_app_server_turn(
+            agent,
+            user_message="hello",
+            original_user_message="hello",
+            messages=[],
+            effective_task_id="t1",
+        )
+
+
+def test_agent_init_refuses_checkpoint_required_on_codex_app_server():
+    """The incompatible configuration must fail closed at init time.
+
+    In the default "native" auto-compaction mode Hermes never initiates the
+    compaction, so the compress_context() guard alone cannot cover native
+    turns — init_agent has to refuse before a turn exists.
+    """
+    from agent.agent_init import (
+        _refuse_checkpoint_required_on_codex_app_server,
+    )
+
+    with pytest.raises(RuntimeError, match="BLOCKED_MISSING_PREREQUISITE"):
+        _refuse_checkpoint_required_on_codex_app_server(True, "codex_app_server")
+
+    # Every other combination stays permitted.
+    _refuse_checkpoint_required_on_codex_app_server(True, "chat_completions")
+    _refuse_checkpoint_required_on_codex_app_server(True, "codex_responses")
+    _refuse_checkpoint_required_on_codex_app_server(False, "codex_app_server")
+    _refuse_checkpoint_required_on_codex_app_server(False, None)

--- a/tests/agent/test_pre_compress_checkpoint_contract.py
+++ b/tests/agent/test_pre_compress_checkpoint_contract.py
@@ -1,0 +1,184 @@
+"""Host-side contract tests for the opt-in pre-compress checkpoint API (v1).
+
+The contract has three parts:
+- providers opt in by advertising ``pre_compress_checkpoint_api_version``;
+- ``MemoryManager`` exposes capability probing and a ``require_checkpoint``
+  mode whose failure must propagate instead of being swallowed;
+- the compression host normalizes messages to direct user/assistant evidence
+  before handing them to providers.
+"""
+
+import pytest
+
+from agent.conversation_compression import (
+    CompressionCheckpointUnavailable,
+    _checkpoint_blocked,
+    _direct_messages_for_pre_compress_memory,
+)
+from agent.context_compressor import COMPRESSED_SUMMARY_METADATA_KEY
+from agent.memory_manager import MemoryManager
+from agent.memory_provider import (
+    PRE_COMPRESS_CHECKPOINT_API_VERSION,
+    MemoryProvider,
+)
+
+
+class _BaseStubProvider(MemoryProvider):
+    def __init__(self, name="stub"):
+        self._name = name
+        self.pre_compress_calls = []
+
+    @property
+    def name(self):
+        return self._name
+
+    def is_available(self):
+        return True
+
+    def initialize(self, session_id, **kwargs):
+        return None
+
+    def get_tool_schemas(self):
+        return []
+
+    def on_pre_compress(self, messages):
+        self.pre_compress_calls.append(messages)
+        return f"{self._name} context"
+
+
+class _CheckpointProvider(_BaseStubProvider):
+    pre_compress_checkpoint_api_version = PRE_COMPRESS_CHECKPOINT_API_VERSION
+
+
+class _FailingCheckpointProvider(_CheckpointProvider):
+    def on_pre_compress(self, messages):
+        raise RuntimeError("durable store unreachable")
+
+
+class _FailingLegacyProvider(_BaseStubProvider):
+    def on_pre_compress(self, messages):
+        raise RuntimeError("legacy best-effort failure")
+
+
+def test_provider_base_class_defaults_to_best_effort_api_version_zero():
+    assert MemoryProvider.pre_compress_checkpoint_api_version == 0
+
+
+def test_direct_messages_filter_keeps_only_direct_source_evidence():
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "durable user decision"},
+        {"role": "assistant", "content": "direct assistant answer"},
+        {"role": "assistant", "content": "call", "tool_calls": [{"id": "t1"}]},
+        {"role": "tool", "content": "tool output", "tool_call_id": "t1"},
+        {
+            "role": "assistant",
+            "content": "previous compaction summary",
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        },
+        "not-a-dict",
+    ]
+
+    direct = _direct_messages_for_pre_compress_memory(messages)
+
+    assert [m["content"] for m in direct] == [
+        "durable user decision",
+        "direct assistant answer",
+    ]
+
+
+def test_manager_advertises_checkpoint_capability_only_with_capable_provider():
+    # The host allows one external provider per manager, so capability is
+    # probed on two separate managers.
+    legacy_manager = MemoryManager()
+    legacy_manager.add_provider(_BaseStubProvider("legacy"))
+    assert legacy_manager.supports_pre_compress_checkpoint(
+        PRE_COMPRESS_CHECKPOINT_API_VERSION
+    ) is False
+
+    durable_manager = MemoryManager()
+    durable_manager.add_provider(_CheckpointProvider("durable"))
+    assert durable_manager.supports_pre_compress_checkpoint(
+        PRE_COMPRESS_CHECKPOINT_API_VERSION
+    ) is True
+
+
+def test_manager_require_checkpoint_raises_without_capable_provider():
+    manager = MemoryManager()
+    manager.add_provider(_BaseStubProvider("legacy"))
+
+    with pytest.raises(RuntimeError, match="pre-compress checkpoint"):
+        manager.on_pre_compress(
+            [{"role": "user", "content": "evidence"}],
+            require_checkpoint=True,
+            checkpoint_api_version=PRE_COMPRESS_CHECKPOINT_API_VERSION,
+        )
+
+
+def test_manager_require_checkpoint_propagates_checkpoint_provider_failure():
+    manager = MemoryManager()
+    manager.add_provider(_FailingCheckpointProvider("durable"))
+
+    with pytest.raises(RuntimeError, match="durable store unreachable"):
+        manager.on_pre_compress(
+            [{"role": "user", "content": "evidence"}],
+            require_checkpoint=True,
+            checkpoint_api_version=PRE_COMPRESS_CHECKPOINT_API_VERSION,
+        )
+
+
+def test_manager_require_checkpoint_succeeds_and_returns_provider_context():
+    manager = MemoryManager()
+    durable = _CheckpointProvider("durable")
+    manager.add_provider(durable)
+
+    combined = manager.on_pre_compress(
+        [{"role": "user", "content": "evidence"}],
+        require_checkpoint=True,
+        checkpoint_api_version=PRE_COMPRESS_CHECKPOINT_API_VERSION,
+    )
+
+    assert "durable context" in combined
+    assert durable.pre_compress_calls
+
+
+def test_manager_best_effort_mode_keeps_historical_swallow_semantics():
+    manager = MemoryManager()
+    manager.add_provider(_FailingLegacyProvider("legacy"))
+
+    combined = manager.on_pre_compress([{"role": "user", "content": "evidence"}])
+
+    assert combined == ""
+
+
+def test_checkpoint_blocked_error_is_prefixed_and_typed():
+    error = _checkpoint_blocked("no active provider")
+    assert isinstance(error, CompressionCheckpointUnavailable)
+    assert str(error).startswith("BLOCKED_MISSING_PREREQUISITE:")
+    assert "no active provider" in str(error)
+
+
+def test_compressed_summary_marker_survives_restart_via_resume_history(tmp_path):
+    """The persistent marker reaches the resumed model history — and only it.
+
+    ``get_messages_as_conversation`` keeps its existing marker-free contract;
+    the resume path carries ``_compressed_summary`` so checkpoint providers
+    keep excluding derivative summaries after a process restart.
+    """
+    from hermes_state import SessionDB
+
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("s1", source="cli")
+    db.append_message("s1", "user", "durable user evidence")
+    db.append_message(
+        "s1", "assistant", "derivative summary", _compressed_summary=True
+    )
+
+    reopened = SessionDB(tmp_path / "state.db")
+    model_history, _display = reopened.get_resume_conversations("s1")
+    by_content = {m.get("content"): m for m in model_history}
+    assert by_content["derivative summary"].get("_compressed_summary") is True
+    assert "_compressed_summary" not in by_content["durable user evidence"]
+
+    plain = reopened.get_messages_as_conversation("s1")
+    assert all("_compressed_summary" not in m for m in plain)

--- a/website/docs/developer-guide/memory-provider-plugin.md
+++ b/website/docs/developer-guide/memory-provider-plugin.md
@@ -166,11 +166,19 @@ uncompressed transcript is preserved, the compaction attempt errors with
 recovers. With the gate off (default), nothing changes for existing providers.
 
 What your provider receives in both modes is normalized direct evidence:
-user/assistant text rows only — tool results, system messages, assistant
-tool-call wrappers, and prior compaction summaries are filtered host-side.
-Prior summaries are recognized via a persistent `_compressed_summary` message
-marker that survives process restarts, so a resumed session never feeds
-derivative summaries back into your archive.
+user/assistant text rows only — tool results, system messages, the
+`tool_calls` payload of assistant messages (their prose is kept), and prior
+compaction summaries are filtered host-side. Prior summaries are recognized
+via a persistent `_compressed_summary` message marker that survives process
+restarts, so a resumed session never feeds derivative summaries back into
+your archive.
+
+**Checkpoints must be idempotent.** After a fail-closed block, the next
+compaction attempt calls `on_pre_compress()` again with the same transcript —
+and a transcript that grew only slightly produces largely overlapping
+evidence. Key your archive writes by content (for example a transcript
+digest) and upsert, so retries and overlaps deduplicate instead of
+accumulating duplicate archives.
 
 Contract tests: `tests/agent/test_pre_compress_checkpoint_contract.py`.
 

--- a/website/docs/developer-guide/memory-provider-plugin.md
+++ b/website/docs/developer-guide/memory-provider-plugin.md
@@ -130,6 +130,50 @@ class MyMemoryProvider(MemoryProvider):
 | `on_memory_write(action, target, content)` | Built-in memory writes | Mirror to your backend |
 | `shutdown()` | Process exit | Clean up connections |
 
+## Pre-Compress Checkpoints (fail-closed)
+
+`on_pre_compress()` is best-effort by default: if your provider raises, the
+host logs the failure and compression proceeds. That is the right default for
+insight extraction — and the wrong one for a provider whose job is to archive
+transcript evidence to a durable store *before* the lossy rewrite. For that
+case the host offers an opt-in checkpoint contract (API v1):
+
+```python
+from agent.memory_provider import MemoryProvider
+
+class MyArchivingProvider(MemoryProvider):
+    # Opt in: every successful on_pre_compress() return means the durable
+    # checkpoint is committed. Raise on any failure — do not return partial
+    # success. Version 0 (the inherited default) keeps best-effort semantics.
+    pre_compress_checkpoint_api_version = 1
+
+    def on_pre_compress(self, messages):
+        ids = self._archive(messages)   # must be durable before returning
+        return f"checkpoint: {ids}"     # forwarded into the summary prompt
+```
+
+Operators enable enforcement per deployment:
+
+```yaml
+compression:
+  checkpoint_required: true   # default: false
+```
+
+With the gate on, compression **fails closed** before any lossy rewrite unless
+an active provider advertising the API completed its checkpoint: the
+uncompressed transcript is preserved, the compaction attempt errors with
+`BLOCKED_MISSING_PREREQUISITE`, and it can be retried once your store
+recovers. With the gate off (default), nothing changes for existing providers.
+
+What your provider receives in both modes is normalized direct evidence:
+user/assistant text rows only — tool results, system messages, assistant
+tool-call wrappers, and prior compaction summaries are filtered host-side.
+Prior summaries are recognized via a persistent `_compressed_summary` message
+marker that survives process restarts, so a resumed session never feeds
+derivative summaries back into your archive.
+
+Contract tests: `tests/agent/test_pre_compress_checkpoint_contract.py`.
+
 ## Config Schema
 
 `get_config_schema()` returns a list of field descriptors used by `hermes memory setup`:

--- a/website/docs/developer-guide/memory-provider-plugin.md
+++ b/website/docs/developer-guide/memory-provider-plugin.md
@@ -165,6 +165,14 @@ uncompressed transcript is preserved, the compaction attempt errors with
 `BLOCKED_MISSING_PREREQUISITE`, and it can be retried once your store
 recovers. With the gate off (default), nothing changes for existing providers.
 
+The gate binds to every compaction authority, not just the Hermes
+summarizer: server-side native compaction (`compression.codex_responses_native`)
+is suppressed while the gate is armed so the checkpoint-aware Hermes
+compressor stays authoritative, and the `codex_app_server` API mode is
+refused at agent init — the codex agent compacts its own thread with no
+truthful pre-compaction boundary, so a required checkpoint cannot be
+guaranteed there.
+
 What your provider receives in both modes is normalized direct evidence:
 user/assistant text rows only — tool results, system messages, the
 `tool_calls` payload of assistant messages (their prose is kept), and prior


### PR DESCRIPTION
## What does this PR do?

Adds an **opt-in, provider-agnostic pre-compress checkpoint contract (API v1)** so a memory provider that archives transcript evidence to an external durable store can *guarantee* the archive happened before the lossy compaction rewrite — instead of today's best-effort semantics, where `MemoryManager.on_pre_compress()` swallows provider failures and compression proceeds even when the archive failed.

Default behavior is unchanged: without `compression.checkpoint_required: true` in config, and for every provider that does not opt in, the hook keeps its historical best-effort semantics. New memory providers live out of tree per CONTRIBUTING; this widens the generic plugin surface they need, with no provider-specific code in core.

We have been running this contract in production for several weeks (patched host + an external archiving provider): the checkpoint path is deterministic (no LLM involved) and has completed before every compaction since deployment.

## Related Issue

Fixes #93986

Related: #23307 (long-session continuity — names memory pre-compress checkpoints as a building block), #67938 (merged: forwards provider context into the summary; this PR adds the guarantee side), #7192 / #43558 (historical discard bugs), #66837 / #45941 (summary-content checkpoints — orthogonal goal).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/memory_provider.py` — `PRE_COMPRESS_CHECKPOINT_API_VERSION = 1`; providers opt in via the `pre_compress_checkpoint_api_version` class attribute (default `0` = best-effort).
- `agent/memory_manager.py` — `supports_pre_compress_checkpoint()` capability probe; `on_pre_compress(..., require_checkpoint=True, checkpoint_api_version=1)` propagates checkpoint-provider failures and raises when no capable provider completed the checkpoint.
- `agent/conversation_compression.py` — `compression.checkpoint_required` gate: fails closed with `BLOCKED_MISSING_PREREQUISITE` before any lossy rewrite (transcript preserved, retryable). Normalizes what providers receive to direct user/assistant evidence (`_direct_messages_for_pre_compress_memory`): tool rows, system messages, the `tool_calls` payload of assistant messages (their prose is kept), and prior compaction summaries are filtered host-side. `codex_app_server` compaction is rejected under the gate (no truthful pre-compaction transcript boundary). The gate arms only on an explicit boolean `True` so bare-`MagicMock` agents in existing tests stay inert.
- `agent/agent_init.py`, `hermes_cli/config_defaults.py`, `cli-config.yaml.example` — bind and document the new config key (default `false`).
- `hermes_state.py`, `hermes_state_common.py`, `run_agent.py` — persistent `_compressed_summary` column (declarative migration via `_reconcile_columns`); only the resume model history carries the marker, so `get_messages_as_conversation()` keeps its existing marker-free contract while providers can exclude derivative summaries after a process restart.
- `gateway/run.py`, `gateway/slash_commands.py` — the lossy hygiene/manual-`/compress` paths load the memory provider only when `compression.checkpoint_required` is enabled (`skip_memory=not checkpoint_required`), so the required checkpoint guards those rewrites too while the historical fast path (no provider init) stays the default.
- `tests/agent/test_pre_compress_checkpoint_contract.py` — 11 contract tests (opt-in default, evidence normalization incl. prose-preserving tool-call filtering, capability probe, strict-mode propagation/raise, best-effort compatibility, typed gate error, restart round-trip of the summary marker through a real SQLite `SessionDB`, and a legacy-database regression proving the new column is added by the declarative `_reconcile_columns()` path on plain reopen).
- `website/docs/developer-guide/memory-provider-plugin.md` — new "Pre-Compress Checkpoints (fail-closed)" section.

## How to Test

1. `pytest tests/agent/test_pre_compress_checkpoint_contract.py -q` — 11 passed.
2. Regression: `pytest tests/agent/test_memory*.py tests/agent/test_compress*.py tests/agent/test_compression*.py tests/agent/test_context_compressor*.py tests/agent/test_compressed_summary_metadata.py -q` — the pass/fail list is **byte-identical** between this branch and its merge base on `main` in my environment (426 passed on both; the failures on both sides are environment-caused — venv on Python 3.14, outside the `<3.14` support pin — and unrelated to this change).
3. Behavior check (fail-closed): set `compression.checkpoint_required: true` with no checkpoint-capable provider configured → the compaction attempt raises `BLOCKED_MISSING_PREREQUISITE: required pre-compress checkpoint unavailable: ...` and the transcript stays uncompressed. With a provider whose `pre_compress_checkpoint_api_version = 1` completes successfully, compaction proceeds and the provider's returned text is forwarded into the summary prompt (per #67938).
4. Default-off check: leave `checkpoint_required` unset → identical behavior to `main` (best-effort hook, failures logged and swallowed).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused test set above; the full hermetic `scripts/run_tests.sh` run is left to CI (my local venv is on Python 3.14, outside the support pin, which fails unrelated files identically on `main`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux (kernel 7.0.12-arch1-1), Python 3.14 venv locally, Python 3.13 in the production container running this contract

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `website/docs/developer-guide/memory-provider-plugin.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python control flow + SQLite column addition; `scripts/check-windows-footguns.py --diff` is clean
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

