### PR TITLE
fix(disk-cleanup): protect configured durable roots

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -10,6 +10,12 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
+    # Durable roots below HERMES_HOME that disk-cleanup must never classify as
+    # ephemeral artifacts or remove when empty. Entries are immediate directory
+    # names, not paths (for example: "workspaces").
+    "disk_cleanup": {
+        "protected_roots": [],
+    },
     # SQLite journal mode used by every Hermes database opener. WAL is the
     # normal default; set DELETE for weak-fsync/shared filesystems where WAL is
     # not crash-safe (for example macOS virtiofs, NFS, or SMB).

--- a/plugins/disk-cleanup/README.md
+++ b/plugins/disk-cleanup/README.md
@@ -39,6 +39,22 @@ Deletion rules (same as the original PR):
 /disk-cleanup forget <path>              # stop tracking
 ```
 
+## Configuration
+
+Add durable top-level directories under `$HERMES_HOME` to
+`disk_cleanup.protected_roots`. Protected roots are neither auto-tracked nor
+removed by the empty-directory sweep:
+
+```yaml
+disk_cleanup:
+  protected_roots:
+    - workspaces
+    - scripts
+    - data
+```
+
+Entries are directory names relative to `$HERMES_HOME`, not filesystem paths.
+
 ## Safety
 
 - `is_safe_path()` rejects anything outside `HERMES_HOME` or `/tmp/hermes-*`

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -158,6 +158,14 @@ _EMPTY_DIR_SWEEP_PRUNE_DIRS = frozenset({
     "site-packages", "__pycache__",
 })
 
+_BUILTIN_PROTECTED_TOP_LEVEL_ROOTS = frozenset({
+    "disk-cleanup", "logs", "memories", "sessions", "config.yaml",
+    "skills", "plugins", ".env", "USER.md", "MEMORY.md", "SOUL.md",
+    "auth.json", "hermes-agent", "patches", "projects", "skins", "themes",
+    "contributors", "profiles", "backups", "optional-skills",
+})
+
+
 
 # Paths under $HERMES_HOME that must NEVER be deleted by quick(),
 # regardless of what the stored category says.  This is a defense-in-depth
@@ -197,6 +205,33 @@ def fmt_size(n: float) -> str:
             return f"{n:.1f} {unit}"
         n /= 1024
     return f"{n:.1f} PB"
+
+
+def _protected_top_level_roots() -> set[str]:
+    """Return built-in and user-configured durable HERMES_HOME roots."""
+    roots = set(_BUILTIN_PROTECTED_TOP_LEVEL_ROOTS)
+    try:
+        from hermes_cli.config import load_config
+
+        configured = (load_config() or {}).get("disk_cleanup", {}).get(
+            "protected_roots", []
+        )
+    except Exception:
+        return roots
+    if not isinstance(configured, (list, tuple, set)):
+        return roots
+    for value in configured:
+        if not isinstance(value, str):
+            continue
+        root = value.strip()
+        if (
+            root
+            and root not in {".", ".."}
+            and "/" not in root
+            and "\\" not in root
+        ):
+            roots.add(root)
+    return roots
 
 
 # ---------------------------------------------------------------------------
@@ -395,6 +430,7 @@ def quick() -> Dict[str, Any]:
                 top.is_dir()
                 and not top.is_symlink()
                 and top.name not in _EMPTY_DIR_PROTECTED_TOP_LEVEL
+                and top.name not in _protected_top_level_roots()
                 and top.name not in _EMPTY_DIR_SWEEP_PRUNE_DIRS
             ):
                 sweep_stack.append((top, False))
@@ -577,16 +613,7 @@ def guess_category(path: Path) -> Optional[str]:
     try:
         rel = path.resolve().relative_to(hermes_home)
         top = rel.parts[0] if rel.parts else ""
-        if top in {
-            "disk-cleanup", "logs", "memories", "sessions", "config.yaml",
-            "skills", "plugins", ".env", "USER.md", "MEMORY.md", "SOUL.md",
-            "auth.json", "hermes-agent",
-            # User-authored and project trees — never auto-delete files
-            # inside these just because they happen to be named test_* or
-            # tmp_* (#75403, also #32164, #37721).
-            "patches", "projects", "skins", "themes", "contributors",
-            "profiles", "backups", "optional-skills",
-        }:
+        if top in _protected_top_level_roots():
             return None
         if top == "cron" or top == "cronjobs":
             # Only files under the disposable ``output/`` subtree are

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -115,6 +115,29 @@ class TestGuessCategory:
         # Even though it matches test_* pattern, logs/ is excluded.
         assert dg.guess_category(p) is None
 
+    def test_respects_configured_protected_root(self, _isolate_env):
+        (_isolate_env / "config.yaml").write_text(
+            "disk_cleanup:\n  protected_roots:\n    - workspaces\n"
+        )
+        dg = _load_lib()
+        p = _isolate_env / "workspaces" / "project" / "test_persistent.py"
+        p.parent.mkdir(parents=True)
+        p.write_text("x")
+
+        assert dg.guess_category(p) is None
+
+    def test_configured_protected_root_is_not_empty_swept(self, _isolate_env):
+        (_isolate_env / "config.yaml").write_text(
+            "disk_cleanup:\n  protected_roots:\n    - workspaces\n"
+        )
+        dg = _load_lib()
+        empty_project_dir = _isolate_env / "workspaces" / "project"
+        empty_project_dir.mkdir(parents=True)
+
+        dg.quick()
+
+        assert empty_project_dir.exists()
+
     def test_cron_subtree_categorised(self, _isolate_env):
         dg = _load_lib()
         # Only files under ``cron/output/`` are disposable run artifacts.


### PR DESCRIPTION
## Summary
- Add `disk_cleanup.protected_roots` for durable top-level `$HERMES_HOME` directories.
- Exclude configured roots from both automatic test/temp classification and the empty-directory sweep.
- Document the setting and preserve existing built-in protections.

## Verification
- `./scripts/run_tests.sh tests/plugins/test_disk_cleanup_plugin.py tests/hermes_cli/test_config.py -q` (107 passed)
- `ruff check plugins/disk-cleanup/disk_cleanup.py tests/plugins/test_disk_cleanup_plugin.py hermes_cli/config_defaults.py`
