### PR TITLE
feat(plugins): add hermes-rbac to community plugin index

### DIFF
--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -63,6 +63,18 @@
       "capabilities": ["tools"],
       "api_version": 1,
       "added_at": "2026-08-12"
+    },
+    {
+      "name": "hermes-rbac",
+      "description": "Role-based access control for multi-user Hermes gateways — per-user tool/skill permissions, role inheritance, cross-platform identity linking, fail-closed by default, audit log.",
+      "author": "TTomas78",
+      "tags": ["rbac", "multi-user", "permissions", "security", "gateway"],
+      "repo": "TTomas78/hermes-rbac",
+      "ref": "5e86465076df8b681f2871a05c1b76e0fbc729e3",
+      "homepage": "https://github.com/TTomas78/hermes-rbac",
+      "capabilities": ["commands", "hooks"],
+      "api_version": 1,
+      "added_at": "2026-08-24"
     }
   ]
 }

--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -70,7 +70,7 @@
       "author": "TTomas78",
       "tags": ["rbac", "multi-user", "permissions", "security", "gateway"],
       "repo": "TTomas78/hermes-rbac",
-      "ref": "5e86465076df8b681f2871a05c1b76e0fbc729e3",
+      "ref": "c1d6b33ef5d08be17e7b2c8cec00f19c9f232d94",
       "homepage": "https://github.com/TTomas78/hermes-rbac",
       "capabilities": ["commands", "hooks"],
       "api_version": 1,


### PR DESCRIPTION
Adds one entry to `hermes_cli/data/plugin_index.json` (the bundled seed / offline fallback for the community plugin index) for a new third-party plugin:

- **name**: `hermes-rbac`
- **repo**: `TTomas78/hermes-rbac`
- **What it does**: role-based access control for multi-user Hermes gateways — per-user tool/skill permissions with glob support, role inheritance, cross-platform identity linking (OTP challenge), fail-closed by default with bootstrap admins, and an audit log of every gate decision. Goes beyond the core platform allowlists (binary in/out) for shared deployments.
- **ref**: pinned to a 40-char commit SHA (`5e86465076df8b681f2871a05c1b76e0fbc729e3`) on the plugin's `main`, per the existing entries' convention and `test_bundled_seed_parses`.
- 74 tests, zero third-party Python packages beyond PyYAML, MIT licensed.

Only the new object was added; the five existing entries are untouched. Not a memory provider and not a wrapper around a third-party product/SaaS, so the "ship as a standalone plugin" note in CONTRIBUTING.md doesn't apply the other way — this *is* the standalone plugin, this PR only lists it.

Tested: `pytest tests/hermes_cli/test_plugin_index_search.py -q` locally against the edited file (38 passed).

Ref-update cadence

The `ref` pin will be bumped on each tested plugin release (tagged on the plugin repo), via a follow-up PR to this index. The plugin is pre-1.0 — bumps accompany meaningful changes, not every docs push.
