### PR TITLE
fix(display): clamp spinner frames to terminal width

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -7,9 +7,11 @@ Used by AIAgent._execute_tool_calls for CLI feedback.
 import logging
 import os
 import re
+import shutil
 import sys
 import threading
 import time
+import unicodedata
 from dataclasses import dataclass, field
 from difflib import unified_diff
 from pathlib import Path
@@ -27,6 +29,34 @@ _RESET = "\033[0m"
 logger = logging.getLogger(__name__)
 
 _ANSI_RESET = "\033[0m"
+
+
+def _terminal_cell_width(text: str) -> int:
+    """Return the approximate terminal cell width of ``text``."""
+    width = 0
+    for char in text:
+        if unicodedata.combining(char):
+            continue
+        width += 2 if unicodedata.east_asian_width(char) in {"F", "W"} else 1
+    return width
+
+
+def _truncate_to_terminal_cells(text: str, max_columns: int) -> str:
+    """Clip ``text`` so it cannot enter the terminal autowrap column."""
+    if max_columns <= 0:
+        return ""
+    used = 0
+    out: list[str] = []
+    for char in text:
+        if unicodedata.combining(char):
+            char_width = 0
+        else:
+            char_width = 2 if unicodedata.east_asian_width(char) in {"F", "W"} else 1
+        if used + char_width > max_columns:
+            break
+        out.append(char)
+        used += char_width
+    return "".join(out)
 
 
 def _display_url(value: Any) -> str:
@@ -1210,6 +1240,26 @@ class KawaiiSpinner:
         except ImportError:
             return False
 
+    def _terminal_columns(self) -> int:
+        """Return the captured output stream's terminal width, falling back safely."""
+        try:
+            if hasattr(self._out, "fileno"):
+                return max(1, os.get_terminal_size(self._out.fileno()).columns)
+        except (OSError, ValueError):
+            pass
+        try:
+            return max(1, shutil.get_terminal_size((80, 20)).columns)
+        except (OSError, ValueError):
+            return 80
+
+    def _clamp_spinner_line(self, line: str) -> str:
+        """Clip a spinner frame before the terminal autowrap column."""
+        # Avoid the final column: writing there can trigger autowrap on Windows
+        # consoles, and \r then returns to the wrapped continuation line instead
+        # of the original spinner row.
+        max_columns = max(1, self._terminal_columns() - 1)
+        return _truncate_to_terminal_cells(line, max_columns)
+
     def _animate(self):
         # When stdout is not a real terminal (e.g. Docker, systemd, pipe),
         # skip the animation entirely — it creates massive log bloat.
@@ -1245,9 +1295,11 @@ class KawaiiSpinner:
                 line = f"  {left} {frame} {self.message} {right} ({elapsed:.1f}s)"
             else:
                 line = f"  {frame} {self.message} ({elapsed:.1f}s)"
-            pad = max(self.last_line_len - len(line), 0)
+            line = self._clamp_spinner_line(line)
+            line_width = _terminal_cell_width(line)
+            pad = max(self.last_line_len - line_width, 0)
             self._write(f"\r{line}{' ' * pad}", end='', flush=True)
-            self.last_line_len = len(line)
+            self.last_line_len = line_width
             self.frame_idx += 1
             time.sleep(0.12)
 

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import agent.display as display_module
 from agent.display import (
+    KawaiiSpinner,
     build_tool_preview,
     capture_local_edit_snapshot,
     extract_edit_diff,
@@ -15,6 +16,7 @@ from agent.display import (
     set_tool_preview_max_len,
     _render_inline_unified_diff,
     _summarize_rendered_diff_sections,
+    _terminal_cell_width,
     render_edit_diff_with_delta,
 )
 
@@ -35,6 +37,27 @@ def test_cute_tool_message_falls_back_when_renderer_raises(monkeypatch):
     assert get_cute_tool_message("web_extract", {"urls": []}, 0.25) == (
         "┊ ⚡ web_extra completed  0.2s"
     )
+
+
+def test_kawaii_spinner_clamps_long_frame_before_terminal_wrap(monkeypatch):
+    spinner = KawaiiSpinner(
+        'Running head -5 "C:/Users/Leo/.hermes/profiles/dfs-lead/skills/software/example.md"'
+    )
+    monkeypatch.setattr(spinner, "_terminal_columns", lambda: 40)
+
+    line = spinner._clamp_spinner_line(f"  ⠋ {spinner.message} (0.1s)")
+
+    assert _terminal_cell_width(line) <= 39
+    assert "\n" not in line
+
+
+def test_kawaii_spinner_clamp_respects_wide_char_cells(monkeypatch):
+    spinner = KawaiiSpinner("你" * 40)
+    monkeypatch.setattr(spinner, "_terminal_columns", lambda: 12)
+
+    line = spinner._clamp_spinner_line(f"  ⠋ {spinner.message} (0.1s)")
+
+    assert _terminal_cell_width(line) <= 11
 
 
 class TestBuildToolPreview:


### PR DESCRIPTION
Summary
`KawaiiSpinner` wrote every TTY animation frame with `` while allowing the rendered message to exceed the terminal width. In narrow PowerShell/Windows consoles a long tool preview can wrap, and carriage return then rewrites the wrapped continuation row instead of the original spinner row, flooding scrollback. This clamps spinner frames to the captured terminal width minus one autowrap cell, tracks padding by terminal cell width, and keeps wide-character frames within the same boundary.

Changes
agent/display.py: adds terminal-cell width helpers, resolves the captured output stream width safely, clamps spinner frames before the autowrap column, and pads using display cells rather than raw string length.
tests/agent/test_display.py: adds regression coverage for long PowerShell-style paths and wide-character spinner content.

How to Test
/data/data/com.termux/files/home/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_display.py -q
# ✅ 25/25 passed
ruff check agent/display.py tests/agent/test_display.py
# ✅ passed
git diff --check
# ✅ passed
python scripts/check-windows-footguns.py --diff upstream/main
# ✅ passed
scripts/run_tests.sh
# ⚠️ blocked by Termux runner PermissionError(13, 'Permission denied') environment issue; targeted tests above passed

Checklist
- [x] Tests pass — 25/25 targeted
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed (Linux / macOS / WSL2 / Windows / Termux)
- [x] profile-safe paths used — no hardcoded ~/.hermes
- [x] .env not used for non-credential settings (behavioral settings → config.yaml)

Risk & Impact
Low. The change only shortens transient spinner frames before terminal autowrap; non-TTY output remains unchanged and wide-character padding is more accurate.
Type: Bug fix
Closes: #93999
