### PR TITLE
feat(gateway): add session-scoped SSH mode foundation

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1391,6 +1391,32 @@ def _clear_backend_probe_cache() -> None:
     _BACKEND_PROBE_CACHE.clear()
 
 
+def _current_task_backend(default: str) -> str:
+    """Resolve the prompt's backend from task-scoped tool overrides."""
+
+    try:
+        from gateway.session_context import get_session_env
+
+        task_id = (
+            get_session_env("HERMES_SESSION_ID", "")
+            or os.getenv("HERMES_SESSION_ID", "")
+        )
+    except Exception:
+        task_id = os.getenv("HERMES_SESSION_ID", "")
+    if not task_id:
+        return default
+    try:
+        from tools.terminal_tool import get_effective_env_config
+
+        return (
+            str(get_effective_env_config(task_id).get("env_type") or default)
+            .strip()
+            .lower()
+        )
+    except Exception:
+        return default
+
+
 def build_environment_hints() -> str:
     """Return environment-specific guidance for the system prompt.
 
@@ -1412,7 +1438,9 @@ def build_environment_hints() -> str:
 
     hints: list[str] = []
 
-    backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
+    backend = _current_task_backend(
+        (os.getenv("TERMINAL_ENV") or "local").strip().lower()
+    )
     is_remote_backend = backend in _REMOTE_TERMINAL_BACKENDS
 
     if not is_remote_backend:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2675,6 +2675,7 @@ from gateway.session_state import (
 from gateway.authz_mixin import GatewayAuthorizationMixin
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 from gateway.slash_commands import GatewaySlashCommandsMixin
+from gateway.ssh_mode import GatewaySshModeMixin
 from gateway.turn_context import TurnContext
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -5519,7 +5520,18 @@ class TurnRunner:
                 log_message="interim_assistant_callback scheduling error",
             )
 
-        turn_route = self._runner._resolve_turn_agent_config(ctx.message, model, runtime_kwargs)
+        # Resolve the durable session binding before constructing or reusing
+        # the agent so terminal, file, and execute_code share one backend.
+        self._runner._prepare_ssh_runtime(
+            session_key=ctx.session_key or "",
+            task_id=ctx.session_id or ctx.session_key or "default",
+        )
+
+        turn_route = self._runner._resolve_turn_agent_config(
+            ctx.message,
+            model,
+            runtime_kwargs,
+        )
 
         # Per-platform skip_context_files — messaging platforms can opt out
         # of filesystem-heavy context-file discovery (SOUL.md, AGENTS.md,
@@ -5541,12 +5553,18 @@ class TurnRunner:
         # Check agent cache — reuse the AIAgent from the previous message
         # in this session to preserve the frozen system prompt and tool
         # schemas for prompt cache hits.
+        _cache_busting = dict(
+            self._runner._extract_cache_busting_config(ctx.user_config) or {}
+        )
+        _cache_busting.update(
+            self._runner._ssh_backend_signature(ctx.session_key or "")
+        )
         _sig = self._runner._agent_config_signature(
             turn_route["model"],
             turn_route["runtime"],
             ctx.enabled_toolsets,
             combined_ephemeral,
-            cache_keys=self._runner._extract_cache_busting_config(ctx.user_config),
+            cache_keys=_cache_busting,
             user_id=getattr(ctx.source, "user_id", None),
             user_id_alt=getattr(ctx.source, "user_id_alt", None),
             skip_context_files=skip_context_files,
@@ -6726,7 +6744,12 @@ class TurnRunner:
 _SESSION_DB_UNPINNED = object()
 
 
-class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
+class GatewayRunner(
+    GatewayAuthorizationMixin,
+    GatewayKanbanWatchersMixin,
+    GatewaySlashCommandsMixin,
+    GatewaySshModeMixin,
+):
     """
     Main gateway controller.
 
@@ -16478,6 +16501,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "profile": self._handle_profile_command,
                 "update": self._handle_update_command,
                 "version": self._handle_version_command,
+                "ssh": self._handle_ssh_command,
             }.get(name)
             if plain is not None:
                 return await plain(event)
@@ -17603,6 +17627,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "topic":
             return await self._handle_topic_command(event)
+
+        if canonical == "ssh":
+            return await self._handle_ssh_command(event)
         
         if canonical == "help":
             return await self._handle_help_command(event)
@@ -24677,6 +24704,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             user_name=str(context.source.user_name) if context.source.user_name else "",
             scope_id=str(getattr(context.source, "scope_id", "") or ""),
             session_key=context.session_key,
+            session_id=context.session_id,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
             async_delivery=_async_delivery,

--- a/gateway/ssh_bindings.py
+++ b/gateway/ssh_bindings.py
@@ -1,0 +1,273 @@
+"""Profile-scoped gateway session bindings for SSH Mode."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import threading
+import time
+from typing import Any
+
+from hermes_constants import get_hermes_home
+from gateway.ssh_targets import (
+    SshTarget,
+    find_ssh_target,
+    load_ssh_targets,
+    validate_ssh_target_for_runtime,
+)
+
+LOCAL_BACKEND = "local"
+_STORE_LOCK = threading.RLock()
+
+
+@dataclass(frozen=True)
+class SshBinding:
+    """A gateway session binding to one Hermes-managed SSH target."""
+
+    session_key: str
+    alias: str
+    cwd: str | None = None
+    source: str = "user"
+    created_at: float | None = None
+    updated_at: float | None = None
+
+
+def default_ssh_bindings_path() -> Path:
+    """Return the profile-scoped binding store path."""
+
+    return get_hermes_home() / "ssh" / "bindings.json"
+
+
+def _empty_store() -> dict[str, Any]:
+    return {"bindings": {}}
+
+
+def _read_store(path: str | Path | None = None) -> dict[str, Any]:
+    store_path = (
+        Path(path).expanduser()
+        if path is not None
+        else default_ssh_bindings_path()
+    )
+    try:
+        data = json.loads(store_path.read_text(encoding="utf-8") or "{}")
+    except (OSError, ValueError):
+        return _empty_store()
+    if not isinstance(data, dict) or not isinstance(data.get("bindings"), dict):
+        return _empty_store()
+    return data
+
+
+def _write_store(
+    data: dict[str, Any],
+    path: str | Path | None = None,
+) -> None:
+    store_path = (
+        Path(path).expanduser()
+        if path is not None
+        else default_ssh_bindings_path()
+    )
+    store_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    try:
+        store_path.parent.chmod(0o700)
+    except OSError:
+        pass
+    text = json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    tmp_path = store_path.with_suffix(store_path.suffix + ".tmp")
+    tmp_path.write_text(text, encoding="utf-8")
+    try:
+        tmp_path.chmod(0o600)
+    except OSError:
+        pass
+    tmp_path.replace(store_path)
+    try:
+        store_path.chmod(0o600)
+    except OSError:
+        pass
+
+
+def _coerce_binding(session_key: str, raw: Any) -> SshBinding | None:
+    if not session_key or not isinstance(raw, dict):
+        return None
+    alias = str(raw.get("alias") or "").strip()
+    if not alias:
+        return None
+    cwd = str(raw.get("cwd") or "").strip() or None
+    source = str(raw.get("source") or "user").strip() or "user"
+    created_at = raw.get("created_at")
+    updated_at = raw.get("updated_at")
+    return SshBinding(
+        session_key=session_key,
+        alias=alias,
+        cwd=cwd,
+        source=source,
+        created_at=created_at if isinstance(created_at, (int, float)) else None,
+        updated_at=updated_at if isinstance(updated_at, (int, float)) else None,
+    )
+
+
+def get_ssh_binding(
+    session_key: str,
+    *,
+    path: str | Path | None = None,
+) -> SshBinding | None:
+    """Return the SSH binding for *session_key*, if one exists."""
+
+    if not session_key:
+        return None
+    with _STORE_LOCK:
+        data = _read_store(path)
+        return _coerce_binding(session_key, data["bindings"].get(session_key))
+
+
+def set_ssh_binding(
+    session_key: str,
+    *,
+    alias: str,
+    cwd: str | None = None,
+    source: str = "user",
+    path: str | Path | None = None,
+) -> SshBinding:
+    """Persist an explicit user-selected SSH binding."""
+
+    clean_alias = str(alias or "").strip()
+    if not session_key:
+        raise ValueError("session_key is required")
+    if not clean_alias or clean_alias.lower() == LOCAL_BACKEND:
+        raise ValueError("alias must name a non-local SSH target")
+
+    with _STORE_LOCK:
+        data = _read_store(path)
+        bindings = data["bindings"]
+        existing = (
+            bindings.get(session_key)
+            if isinstance(bindings.get(session_key), dict)
+            else {}
+        )
+        now = time.time()
+        created_at = existing.get("created_at")
+        if not isinstance(created_at, (int, float)):
+            created_at = now
+        record: dict[str, Any] = {
+            "alias": clean_alias,
+            "source": str(source or "user").strip() or "user",
+            "created_at": created_at,
+            "updated_at": now,
+        }
+        clean_cwd = str(cwd or "").strip()
+        if clean_cwd:
+            record["cwd"] = clean_cwd
+        bindings[session_key] = record
+        _write_store(data, path)
+    binding = _coerce_binding(session_key, record)
+    assert binding is not None
+    return binding
+
+
+def clear_ssh_binding(
+    session_key: str,
+    *,
+    path: str | Path | None = None,
+) -> bool:
+    """Remove a session binding, returning whether one existed."""
+
+    if not session_key:
+        return False
+    with _STORE_LOCK:
+        data = _read_store(path)
+        bindings = data["bindings"]
+        existed = session_key in bindings
+        if existed:
+            bindings.pop(session_key, None)
+            _write_store(data, path)
+    return existed
+
+
+def resolve_binding_target(
+    session_key: str,
+    *,
+    targets: list[SshTarget] | None = None,
+    path: str | Path | None = None,
+) -> tuple[SshBinding, SshTarget] | None:
+    """Resolve a stored binding against the current target registry."""
+
+    binding = get_ssh_binding(session_key, path=path)
+    if binding is None:
+        return None
+    target = find_ssh_target(
+        targets if targets is not None else load_ssh_targets(),
+        binding.alias,
+    )
+    if target is None:
+        return None
+    return binding, target
+
+
+def binding_to_task_overrides(
+    binding: SshBinding,
+    target: SshTarget,
+) -> dict[str, Any]:
+    """Convert a validated binding into terminal/file/code overrides."""
+
+    validation_error = validate_ssh_target_for_runtime(target)
+    if validation_error:
+        return {
+            "env_type": "ssh",
+            "ssh_alias": binding.alias,
+            "ssh_host": "",
+            "ssh_user": "",
+            "ssh_port": target.port or 22,
+            "ssh_key": "",
+            "ssh_persistent": True,
+            "ssh_binding_error": validation_error,
+        }
+
+    overrides: dict[str, Any] = {
+        "env_type": "ssh",
+        "ssh_alias": binding.alias,
+        "ssh_host": target.host,
+        "ssh_user": target.user,
+        "ssh_port": target.port or 22,
+        "ssh_key": target.identity_file or "",
+        "ssh_persistent": True,
+    }
+    cwd = binding.cwd or target.cwd
+    if cwd:
+        overrides["cwd"] = cwd
+    return overrides
+
+
+def resolve_binding_task_overrides(
+    session_key: str,
+    *,
+    targets: list[SshTarget] | None = None,
+    path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Return task overrides for a session binding, or local defaults.
+
+    A binding whose target was removed from the registry remains an SSH
+    override with empty connection fields.  That deliberately makes backend
+    construction fail instead of silently falling back to local execution.
+    """
+
+    binding = get_ssh_binding(session_key, path=path)
+    if binding is None:
+        return {}
+    target = find_ssh_target(
+        targets if targets is not None else load_ssh_targets(),
+        binding.alias,
+    )
+    if target is None:
+        return {
+            "env_type": "ssh",
+            "ssh_alias": binding.alias,
+            "ssh_host": "",
+            "ssh_user": "",
+            "ssh_port": 22,
+            "ssh_key": "",
+            "ssh_persistent": True,
+            "ssh_binding_error": (
+                f"SSH target `{binding.alias}` is no longer configured"
+            ),
+        }
+    return binding_to_task_overrides(binding, target)

--- a/gateway/ssh_mode.py
+++ b/gateway/ssh_mode.py
@@ -1,0 +1,274 @@
+"""Gateway control plane for session-scoped SSH execution.
+
+This is intentionally a user-owned control plane.  Selecting an SSH target
+requires an explicit ``/ssh use`` command; ordinary agent turns never switch
+targets on their own.  The selected alias is persisted by durable gateway
+session key while connection details continue to live in the profile-scoped
+SSH target registry.
+"""
+
+from __future__ import annotations
+
+import shlex
+from typing import Any
+
+from gateway.platforms.base import MessageEvent
+from gateway.ssh_bindings import (
+    LOCAL_BACKEND,
+    clear_ssh_binding,
+    get_ssh_binding,
+    resolve_binding_target,
+    set_ssh_binding,
+)
+from gateway.ssh_targets import (
+    find_ssh_target,
+    load_ssh_targets,
+    render_ssh_targets,
+    validate_ssh_target_for_runtime,
+)
+
+
+def _parse_ssh_args(raw_args: str) -> tuple[list[str], str | None]:
+    try:
+        return shlex.split(raw_args), None
+    except ValueError as exc:
+        return [], f"Invalid /ssh arguments: {exc}"
+
+
+def _parse_use_args(parts: list[str]) -> tuple[str, str | None, str | None]:
+    """Return ``(alias, cwd, error)`` for ``/ssh use`` arguments."""
+
+    if not parts:
+        return "", None, "Usage: /ssh use <alias> [--cwd <remote-path>]"
+    alias = parts[0].strip()
+    cwd = None
+    index = 1
+    while index < len(parts):
+        token = parts[index]
+        if token != "--cwd":
+            return "", None, f"Unknown /ssh use option: `{token}`"
+        if cwd is not None or index + 1 >= len(parts):
+            return "", None, "Usage: /ssh use <alias> [--cwd <remote-path>]"
+        cwd = parts[index + 1].strip() or None
+        index += 2
+    return alias, cwd, None
+
+
+class GatewaySshModeMixin:
+    """Session-scoped SSH command handling and runtime preparation."""
+
+    @staticmethod
+    def _ssh_help() -> str:
+        return (
+            "Usage:\n"
+            "/ssh list — list local and configured SSH backends\n"
+            "/ssh status — inspect this session's active backend\n"
+            "/ssh test <alias> — validate a target configuration without switching\n"
+            "/ssh use <alias> [--cwd <remote-path>] — use SSH for this session\n"
+            "/ssh local — return this session to local execution\n"
+            "/ssh off — alias for /ssh local"
+        )
+
+    def _ssh_session_key(self, event: MessageEvent) -> str:
+        return self._session_key_for_source(event.source)
+
+    def _ssh_backend_signature(self, session_key: str) -> dict[str, Any]:
+        """Return cache-busting fields for the session's effective backend."""
+
+        binding = get_ssh_binding(session_key)
+        if binding is None:
+            return {"terminal.session_backend": LOCAL_BACKEND}
+        resolved = resolve_binding_target(
+            session_key,
+            targets=load_ssh_targets(),
+        )
+        if resolved is None:
+            return {
+                "terminal.session_backend": "ssh",
+                "terminal.session_ssh_alias": binding.alias,
+                "terminal.session_ssh_error": "target_unavailable",
+            }
+        _, target = resolved
+        validation_error = validate_ssh_target_for_runtime(target)
+        return {
+            "terminal.session_backend": "ssh",
+            "terminal.session_ssh_alias": binding.alias,
+            "terminal.session_ssh_host": target.host,
+            "terminal.session_ssh_user": target.user,
+            "terminal.session_ssh_port": target.port or 22,
+            "terminal.session_cwd": binding.cwd or target.cwd,
+            "terminal.session_ssh_error": validation_error,
+        }
+
+    def _prepare_ssh_runtime(
+        self,
+        *,
+        session_key: str,
+        task_id: str,
+    ) -> dict[str, Any]:
+        """Apply the persisted binding to this turn's tool task.
+
+        Invalid or removed targets resolve to an SSH override with empty
+        connection fields.  Environment construction then fails closed instead
+        of silently running the turn's tools on the local host.
+        """
+
+        from gateway.ssh_bindings import resolve_binding_task_overrides
+        from tools.terminal_tool import (
+            clear_task_env_overrides,
+            register_task_env_overrides,
+            resolve_task_overrides,
+        )
+
+        overrides = resolve_binding_task_overrides(session_key)
+        runtime_task_id = task_id or session_key
+        if overrides:
+            # This runs before every ordinary turn.  Re-registering an
+            # unchanged cwd override would reseed the session cwd and undo a
+            # ``cd`` performed by the previous turn, so only mutate the task
+            # registry when the effective binding actually changed.
+            if dict(resolve_task_overrides(runtime_task_id)) != overrides:
+                register_task_env_overrides(runtime_task_id, overrides)
+        elif resolve_task_overrides(runtime_task_id).get("env_type") == "ssh":
+            clear_task_env_overrides(runtime_task_id)
+        return overrides
+
+    async def _handle_ssh_command(self, event: MessageEvent) -> str:
+        """Handle the explicit gateway ``/ssh`` control plane."""
+
+        parts, parse_error = _parse_ssh_args(event.get_command_args().strip())
+        if parse_error:
+            return parse_error
+        action = parts[0].lower() if parts else "help"
+        args = parts[1:]
+
+        if action in {"help", ""}:
+            return self._ssh_help()
+
+        session_key = self._ssh_session_key(event)
+        binding = get_ssh_binding(session_key)
+        current_alias = binding.alias if binding else LOCAL_BACKEND
+
+        if action == "list":
+            if args:
+                return "Usage: /ssh list"
+            return render_ssh_targets(
+                load_ssh_targets(),
+                current_alias=current_alias,
+            )
+
+        if action == "status":
+            if args:
+                return "Usage: /ssh status"
+            if binding is None:
+                return (
+                    "SSH status:\n"
+                    "- current backend: `local`\n"
+                    "- session binding: none"
+                )
+            resolved = resolve_binding_target(
+                session_key,
+                targets=load_ssh_targets(),
+            )
+            if resolved is None:
+                return (
+                    "SSH status:\n"
+                    f"- requested backend: `{binding.alias}`\n"
+                    "- current backend: unavailable (target is missing from the registry)\n"
+                    "- execution: blocked until the target is restored or `/ssh local` is used"
+                )
+            _, target = resolved
+            validation_error = validate_ssh_target_for_runtime(target)
+            if validation_error:
+                return (
+                    "SSH status:\n"
+                    f"- requested backend: `{binding.alias}`\n"
+                    f"- current backend: unavailable ({validation_error})\n"
+                    "- execution: blocked until the target is fixed or `/ssh local` is used"
+                )
+            lines = [
+                "SSH status:",
+                f"- current backend: `{binding.alias}` (ssh)",
+                f"- host: {target.host}",
+                f"- user: {target.user}",
+                f"- port: {target.port or 22}",
+            ]
+            cwd = binding.cwd or target.cwd
+            if cwd:
+                lines.append(f"- cwd: {cwd}")
+            if target.identity_file:
+                lines.append("- identity: [REDACTED_PATH]")
+            return "\n".join(lines)
+
+        if action == "test":
+            if len(args) != 1:
+                return "Usage: /ssh test <alias>"
+            alias = args[0]
+            if alias.lower() == LOCAL_BACKEND:
+                return "SSH test: `local` backend configuration is valid."
+            target = find_ssh_target(load_ssh_targets(), alias)
+            if target is None:
+                return (
+                    f"Unknown SSH target: `{alias}`. No backend change was made. "
+                    "Use `/ssh list` to see configured targets."
+                )
+            target_error = validate_ssh_target_for_runtime(target)
+            if target_error:
+                return target_error
+            return (
+                f"SSH test: `{alias}` configuration is valid. "
+                "No connection was opened and no backend change was made."
+            )
+
+        if action in {"local", "off"}:
+            if args:
+                return f"Usage: /ssh {action}"
+            clear_ssh_binding(session_key)
+            # The cached agent owns the old task id/environment.  Eviction is
+            # the existing session-safe resource teardown path; the next turn
+            # also clears any remaining task override before tool dispatch.
+            self._evict_cached_agent(session_key)
+            return "SSH disabled for this session. Current backend: `local`."
+
+        if action == "use":
+            alias, cwd, use_error = _parse_use_args(args)
+            if use_error:
+                return use_error
+            if alias.lower() == LOCAL_BACKEND:
+                return "Use `/ssh local` to return to local execution."
+            targets = load_ssh_targets()
+            target = find_ssh_target(targets, alias)
+            if target is None:
+                return (
+                    f"Unknown SSH target: `{alias}`. No backend change was made. "
+                    "Use `/ssh list` to see configured targets."
+                )
+            target_error = validate_ssh_target_for_runtime(target)
+            if target_error:
+                return target_error
+
+            selected = set_ssh_binding(
+                session_key,
+                alias=alias,
+                cwd=cwd,
+                source="user",
+            )
+            # Changing backend changes prompt environment facts and tool
+            # routing. Rebuild the per-session agent on the next turn.
+            self._evict_cached_agent(session_key)
+            lines = [
+                f"SSH enabled for this session: `{selected.alias}`",
+                "- backend: ssh",
+            ]
+            effective_cwd = selected.cwd or target.cwd
+            if effective_cwd:
+                lines.append(f"- cwd: {effective_cwd}")
+            if target.identity_file:
+                lines.append("- identity: [REDACTED_PATH]")
+            lines.append(
+                "Future terminal, file, and execute_code calls in this session "
+                "will use the SSH backend."
+            )
+            return "\n".join(lines)
+
+        return self._ssh_help()

--- a/gateway/ssh_targets.py
+++ b/gateway/ssh_targets.py
@@ -1,0 +1,224 @@
+"""Hermes-managed SSH target discovery for the gateway control plane.
+
+Targets are loaded only from ``$HERMES_HOME/ssh/targets.yaml``. Hermes does
+not implicitly import the user's OpenSSH config: making a host available to an
+agent is an explicit configuration decision.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from hermes_constants import display_hermes_home, get_hermes_home
+
+
+@dataclass(frozen=True)
+class SshTarget:
+    """A redaction-safe view of one configured SSH target."""
+
+    alias: str
+    host: str | None = None
+    user: str | None = None
+    port: int | None = None
+    identity_file: str | None = None
+    cwd: str | None = None
+    source: str = "hermes"
+    errors: tuple[str, ...] = ()
+
+
+def _clean_optional(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _coerce_port(value: Any) -> tuple[int | None, str | None]:
+    if value in (None, ""):
+        return None, None
+    try:
+        port = int(value)
+    except (TypeError, ValueError):
+        return None, "port must be an integer"
+    if not 1 <= port <= 65535:
+        return None, "port must be between 1 and 65535"
+    return port, None
+
+
+def _coerce_target(
+    alias: str,
+    data: Any,
+    *,
+    source: str = "hermes",
+) -> SshTarget | None:
+    clean_alias = str(alias or "").strip()
+    if not clean_alias or not isinstance(data, dict):
+        return None
+
+    errors: list[str] = []
+    if any(char.isspace() for char in clean_alias):
+        errors.append("alias must not contain whitespace")
+    if clean_alias.lower() == "local":
+        errors.append("alias `local` is reserved")
+
+    port, port_error = _coerce_port(data.get("port"))
+    if port_error:
+        errors.append(port_error)
+
+    return SshTarget(
+        alias=clean_alias,
+        host=_clean_optional(data.get("host") or data.get("hostname")),
+        user=_clean_optional(data.get("user")),
+        port=port,
+        identity_file=_clean_optional(
+            data.get("identity_file")
+            or data.get("identityfile")
+            or data.get("key")
+        ),
+        cwd=_clean_optional(data.get("cwd") or data.get("remote_cwd")),
+        source=source,
+        errors=tuple(errors),
+    )
+
+
+def _targets_from_mapping(
+    raw_targets: Any,
+    *,
+    source: str = "hermes",
+) -> list[SshTarget]:
+    targets: list[SshTarget] = []
+    if isinstance(raw_targets, dict):
+        entries = raw_targets.items()
+    elif isinstance(raw_targets, list):
+        entries = (
+            (item.get("alias") or item.get("name") or "", item)
+            for item in raw_targets
+            if isinstance(item, dict)
+        )
+    else:
+        return targets
+
+    for alias, data in entries:
+        target = _coerce_target(str(alias), data, source=source)
+        if target is not None:
+            targets.append(target)
+    return targets
+
+
+def parse_hermes_ssh_targets(
+    config_text: str,
+    *,
+    source: str = "hermes",
+) -> list[SshTarget]:
+    """Parse the supported target registry YAML shapes."""
+
+    try:
+        import yaml
+
+        data = yaml.safe_load(config_text) or {}
+    except Exception:
+        return []
+    if not isinstance(data, dict):
+        return []
+
+    ssh_section = data.get("ssh")
+    if isinstance(ssh_section, dict) and "targets" in ssh_section:
+        return _targets_from_mapping(ssh_section.get("targets"), source=source)
+    return _targets_from_mapping(data.get("targets"), source=source)
+
+
+def default_ssh_targets_path() -> Path:
+    """Return the profile-scoped SSH target registry path."""
+
+    return get_hermes_home() / "ssh" / "targets.yaml"
+
+
+def load_ssh_targets(
+    config_path: str | Path | None = None,
+) -> list[SshTarget]:
+    """Load targets from the Hermes registry, never ``~/.ssh/config``."""
+
+    path = (
+        Path(config_path).expanduser()
+        if config_path is not None
+        else default_ssh_targets_path()
+    )
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    return parse_hermes_ssh_targets(text)
+
+
+def find_ssh_target(
+    targets: Iterable[SshTarget],
+    alias: str,
+) -> SshTarget | None:
+    """Return the exact configured alias, if present."""
+
+    wanted = str(alias or "").strip()
+    if not wanted:
+        return None
+    return next((target for target in targets if target.alias == wanted), None)
+
+
+def validate_ssh_target_for_runtime(target: SshTarget) -> str | None:
+    """Return a user-facing error when a target cannot safely be selected."""
+
+    errors = list(target.errors)
+    if not target.host:
+        errors.append("missing host")
+    if not target.user:
+        errors.append("missing user")
+    if not errors:
+        return None
+    return (
+        f"SSH target `{target.alias}` is invalid: {', '.join(errors)}. "
+        "No backend change was made."
+    )
+
+
+def render_ssh_targets(
+    targets: Iterable[SshTarget],
+    *,
+    current_alias: str = "local",
+) -> str:
+    """Render local plus configured SSH targets without exposing key paths."""
+
+    target_list = list(targets)
+    lines = ["SSH backends:"]
+    local_mark = " (current)" if current_alias == "local" else ""
+    lines.append(f"- `local` — local execution{local_mark}")
+
+    for target in target_list:
+        marks: list[str] = []
+        if target.alias == current_alias:
+            marks.append("current")
+        if validate_ssh_target_for_runtime(target):
+            marks.append("invalid")
+        mark_text = f" ({', '.join(marks)})" if marks else ""
+        details: list[str] = []
+        if target.host:
+            details.append(f"host={target.host}")
+        if target.user:
+            details.append(f"user={target.user}")
+        if target.port:
+            details.append(f"port={target.port}")
+        if target.cwd:
+            details.append(f"cwd={target.cwd}")
+        if target.identity_file:
+            details.append("identity=[REDACTED_PATH]")
+        suffix = f" — {'; '.join(details)}" if details else ""
+        lines.append(f"- `{target.alias}` — SSH{mark_text}{suffix}")
+
+    if not target_list:
+        lines.extend(
+            [
+                "",
+                "No SSH targets configured.",
+                f"Registry: {display_hermes_home()}/ssh/targets.yaml",
+            ]
+        )
+    return "\n".join(lines)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -148,6 +148,11 @@ COMMAND_REGISTRY: list[CommandDef] = [
                busy_policy="interrupt_then_dispatch", busy_handler="new"),
     CommandDef("topic", "Enable or inspect Telegram DM topic sessions", "Session",
                gateway_only=True, args_hint="[off|help|session-id]"),
+    CommandDef("ssh", "Manage session SSH backend targets", "Session",
+               gateway_only=True,
+               args_hint="[list|status|test <alias>|use <alias> [--cwd <path>]|local]",
+               subcommands=("list", "status", "test", "use", "off", "local", "help"),
+               busy_policy="interrupt_then_dispatch"),
     CommandDef("clear", "Clear screen and start a new session", "Session",
                cli_only=True),
     CommandDef("redraw", "Force a full UI repaint (recovers from terminal drift)", "Session",
@@ -1368,7 +1373,9 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #     (session export is an interactive surface; platform is a rare
 #     informational lookup) — without this entry /save tips the registry
 #     past the 50-cap and silently clamps /platform, breaking parity.
-_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat", "refine", "review", "pause", "whoami", "platform"})
+#   - ssh: backend control is available through /hermes ssh on Slack so the
+#     new session surface does not displace an existing native command.
+_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat", "refine", "review", "pause", "whoami", "platform", "ssh"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -43,7 +43,13 @@ def test_set_session_env_sets_contextvars(monkeypatch):
         user_name="alice",
         thread_id="17585",
     )
-    context = SessionContext(source=source, connected_platforms=[], home_channels={})
+    context = SessionContext(
+        source=source,
+        connected_platforms=[],
+        home_channels={},
+        session_key="telegram:dm:-1001:123456",
+        session_id="session-123",
+    )
 
     monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
     monkeypatch.delenv("HERMES_SESSION_SOURCE", raising=False)
@@ -65,6 +71,8 @@ def test_set_session_env_sets_contextvars(monkeypatch):
     assert get_session_env("HERMES_SESSION_USER_ID") == "123456"
     assert get_session_env("HERMES_SESSION_USER_NAME") == "alice"
     assert get_session_env("HERMES_SESSION_THREAD_ID") == "17585"
+    assert get_session_env("HERMES_SESSION_KEY") == "telegram:dm:-1001:123456"
+    assert get_session_env("HERMES_SESSION_ID") == "session-123"
 
     # os.environ should NOT be touched
     assert os.getenv("HERMES_SESSION_PLATFORM") is None

--- a/tests/gateway/test_ssh_mode.py
+++ b/tests/gateway/test_ssh_mode.py
@@ -1,0 +1,201 @@
+"""Behavior tests for the session-scoped gateway SSH control plane."""
+
+from __future__ import annotations
+
+import asyncio
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+from gateway.ssh_mode import GatewaySshModeMixin
+from gateway.ssh_targets import SshTarget
+
+
+SESSION_KEY = "agent:main:telegram:dm:chat-1:user-1"
+
+
+class _Runner(GatewaySshModeMixin):
+    def __init__(self) -> None:
+        self.evicted: list[str] = []
+
+    def _session_key_for_source(self, source) -> str:
+        return SESSION_KEY
+
+    def _evict_cached_agent(self, session_key: str) -> None:
+        self.evicted.append(session_key)
+
+
+def _event(text: str) -> MessageEvent:
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-1",
+        chat_type="dm",
+        user_id="user-1",
+        user_name="Tester",
+    )
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="message-1",
+    )
+
+
+def _target() -> SshTarget:
+    return SshTarget(
+        alias="build-box",
+        host="build.example",
+        user="runner",
+        port=2222,
+        identity_file="/keys/id_ed25519",
+        cwd="/srv/project",
+    )
+
+
+def test_ssh_command_is_registered_and_wired_to_gateway():
+    from gateway.run import GatewayRunner
+    from hermes_cli.commands import (
+        ACTIVE_SESSION_BYPASS_COMMANDS,
+        is_interrupt_then_dispatch,
+        resolve_command,
+    )
+
+    command = resolve_command("ssh")
+
+    assert command is not None
+    assert command.gateway_only is True
+    assert set(command.subcommands) >= {
+        "list",
+        "status",
+        "test",
+        "use",
+        "off",
+        "local",
+        "help",
+    }
+    assert "ssh" in ACTIVE_SESSION_BYPASS_COMMANDS
+    assert is_interrupt_then_dispatch("ssh") is True
+    assert issubclass(GatewayRunner, GatewaySshModeMixin)
+
+
+def test_target_registry_is_explicit_and_redacts_identity_path(tmp_path):
+    from gateway.ssh_targets import load_ssh_targets, render_ssh_targets
+
+    registry = tmp_path / "targets.yaml"
+    registry.write_text(
+        """
+ssh:
+  targets:
+    build-box:
+      host: build.example
+      user: runner
+      port: 2222
+      identity_file: /keys/id_ed25519
+      cwd: /srv/project
+""",
+        encoding="utf-8",
+    )
+
+    targets = load_ssh_targets(registry)
+    rendered = render_ssh_targets(targets, current_alias="build-box")
+
+    assert targets == [_target()]
+    assert "`build-box`" in rendered
+    assert "(current)" in rendered
+    assert "build.example" in rendered
+    assert "/keys/id_ed25519" not in rendered
+    assert "[REDACTED_PATH]" in rendered
+
+
+def test_use_status_and_local_are_scoped_to_one_session(
+    monkeypatch,
+    tmp_path,
+):
+    import gateway.ssh_mode as ssh_mode
+    from gateway.ssh_bindings import get_ssh_binding
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(ssh_mode, "load_ssh_targets", lambda: [_target()])
+    runner = _Runner()
+
+    enabled = asyncio.run(
+        runner._handle_ssh_command(
+            _event('/ssh use build-box --cwd "/srv/project with spaces"')
+        )
+    )
+    binding = get_ssh_binding(SESSION_KEY)
+    status = asyncio.run(runner._handle_ssh_command(_event("/ssh status")))
+    disabled = asyncio.run(runner._handle_ssh_command(_event("/ssh local")))
+
+    assert "SSH enabled for this session" in enabled
+    assert binding is not None
+    assert binding.alias == "build-box"
+    assert binding.cwd == "/srv/project with spaces"
+    assert "current backend: `build-box` (ssh)" in status
+    assert "/keys/id_ed25519" not in status
+    assert "[REDACTED_PATH]" in status
+    assert "Current backend: `local`" in disabled
+    assert get_ssh_binding(SESSION_KEY) is None
+    assert runner.evicted == [SESSION_KEY, SESSION_KEY]
+
+
+def test_unknown_or_invalid_target_never_changes_binding(
+    monkeypatch,
+    tmp_path,
+):
+    import gateway.ssh_mode as ssh_mode
+    from gateway.ssh_bindings import get_ssh_binding
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    runner = _Runner()
+
+    monkeypatch.setattr(ssh_mode, "load_ssh_targets", lambda: [])
+    unknown = asyncio.run(
+        runner._handle_ssh_command(_event("/ssh use missing"))
+    )
+
+    monkeypatch.setattr(
+        ssh_mode,
+        "load_ssh_targets",
+        lambda: [SshTarget(alias="broken", host="build.example")],
+    )
+    invalid = asyncio.run(
+        runner._handle_ssh_command(_event("/ssh use broken"))
+    )
+
+    assert "Unknown SSH target" in unknown
+    assert "missing user" in invalid
+    assert get_ssh_binding(SESSION_KEY) is None
+    assert runner.evicted == []
+
+
+def test_removed_or_invalid_bound_target_fails_closed(tmp_path):
+    from gateway.ssh_bindings import (
+        resolve_binding_task_overrides,
+        set_ssh_binding,
+    )
+
+    bindings = tmp_path / "bindings.json"
+    set_ssh_binding(
+        SESSION_KEY,
+        alias="build-box",
+        path=bindings,
+    )
+
+    missing = resolve_binding_task_overrides(
+        SESSION_KEY,
+        targets=[],
+        path=bindings,
+    )
+    invalid = resolve_binding_task_overrides(
+        SESSION_KEY,
+        targets=[SshTarget(alias="build-box", host="build.example")],
+        path=bindings,
+    )
+
+    assert missing["env_type"] == "ssh"
+    assert missing["ssh_host"] == ""
+    assert "no longer configured" in missing["ssh_binding_error"]
+    assert invalid["env_type"] == "ssh"
+    assert invalid["ssh_host"] == ""
+    assert "missing user" in invalid["ssh_binding_error"]

--- a/tests/tools/test_ssh_session_routing.py
+++ b/tests/tools/test_ssh_session_routing.py
@@ -1,0 +1,365 @@
+"""Routing contracts for task-scoped SSH gateway bindings."""
+
+from __future__ import annotations
+
+
+def _ssh_overrides(host: str = "build.example") -> dict:
+    return {
+        "env_type": "ssh",
+        "ssh_alias": "build-box",
+        "ssh_host": host,
+        "ssh_user": "runner",
+        "ssh_port": 2222,
+        "ssh_key": "/keys/id_ed25519",
+        "ssh_persistent": True,
+        "cwd": "/srv/project",
+    }
+
+
+def test_effective_terminal_config_uses_task_ssh_binding(monkeypatch):
+    from tools import terminal_tool as terminal
+
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    task_id = "ssh-config-session"
+    terminal.register_task_env_overrides(task_id, _ssh_overrides())
+    try:
+        config = terminal.get_effective_env_config(task_id)
+    finally:
+        terminal.clear_task_env_overrides(task_id)
+
+    assert config["env_type"] == "ssh"
+    assert config["ssh_host"] == "build.example"
+    assert config["ssh_user"] == "runner"
+    assert config["ssh_port"] == 2222
+    assert config["ssh_key"] == "/keys/id_ed25519"
+    assert config["cwd"] == "/srv/project"
+
+
+def test_backend_change_evicts_environment_but_identical_binding_does_not():
+    from tools import terminal_tool as terminal
+
+    task_id = "ssh-eviction-session"
+
+    class FakeEnvironment:
+        cleaned = False
+
+        def cleanup(self):
+            self.cleaned = True
+
+    stable = FakeEnvironment()
+    terminal.register_task_env_overrides(task_id, _ssh_overrides())
+    with terminal._env_lock:
+        terminal._active_environments[task_id] = stable
+    try:
+        terminal.register_task_env_overrides(task_id, _ssh_overrides())
+        with terminal._env_lock:
+            assert terminal._active_environments.get(task_id) is stable
+        assert stable.cleaned is False
+
+        terminal.register_task_env_overrides(
+            task_id,
+            _ssh_overrides(host="replacement.example"),
+        )
+        with terminal._env_lock:
+            assert task_id not in terminal._active_environments
+        assert stable.cleaned is True
+    finally:
+        terminal.clear_task_env_overrides(task_id)
+        with terminal._env_lock:
+            terminal._active_environments.pop(task_id, None)
+            terminal._last_activity.pop(task_id, None)
+
+
+def test_file_tools_create_ssh_environment_from_task_binding(monkeypatch):
+    from tools import file_tools
+    from tools import terminal_tool as terminal
+
+    captured: dict = {}
+    task_id = "ssh-file-session"
+    terminal.register_task_env_overrides(task_id, _ssh_overrides())
+
+    class FakeEnvironment:
+        cwd = "/srv/project"
+
+    class FakeFileOperations:
+        def __init__(self, env):
+            self.env = env
+
+    def fake_create_environment(**kwargs):
+        captured.update(kwargs)
+        return FakeEnvironment()
+
+    monkeypatch.setattr(terminal, "_create_environment", fake_create_environment)
+    monkeypatch.setattr(file_tools, "ShellFileOperations", FakeFileOperations)
+    try:
+        operations = file_tools._get_file_ops(task_id)
+    finally:
+        terminal.clear_task_env_overrides(task_id)
+        file_tools.clear_file_ops_cache(task_id)
+        with terminal._env_lock:
+            terminal._active_environments.pop(task_id, None)
+            terminal._last_activity.pop(task_id, None)
+
+    assert isinstance(operations.env, FakeEnvironment)
+    assert captured["env_type"] == "ssh"
+    assert captured["cwd"] == "/srv/project"
+    assert captured["ssh_config"] == {
+        "host": "build.example",
+        "user": "runner",
+        "port": 2222,
+        "key": "/keys/id_ed25519",
+        "persistent": True,
+        "binding_error": "",
+    }
+
+
+def test_file_paths_are_never_resolved_on_host_for_ssh(monkeypatch):
+    from tools import file_tools
+
+    monkeypatch.setattr(file_tools, "_is_ssh_backend_task", lambda task_id: True)
+    monkeypatch.setattr(
+        file_tools,
+        "_authoritative_workspace_root",
+        lambda task_id: "/srv/project",
+    )
+
+    lock_key, shell_path, display_path = file_tools._file_tool_paths_for_task(
+        "src/app.py",
+        "ssh-file-session",
+    )
+
+    assert lock_key == "/srv/project/src/app.py"
+    assert shell_path == "src/app.py"
+    assert display_path == "/srv/project/src/app.py"
+
+    monkeypatch.setattr(
+        file_tools,
+        "_authoritative_workspace_root",
+        lambda task_id: "~/project",
+    )
+    lock_key, shell_path, display_path = file_tools._file_tool_paths_for_task(
+        "src/app.py",
+        "ssh-file-session",
+    )
+
+    assert lock_key == "~/project/src/app.py"
+    assert shell_path == "src/app.py"
+    assert display_path == "~/project/src/app.py"
+
+
+def test_execute_code_dispatches_to_task_ssh_backend(monkeypatch):
+    from tools import code_execution_tool as code_execution
+    from tools import terminal_tool as terminal
+
+    task_id = "ssh-code-session"
+    calls = []
+    terminal.register_task_env_overrides(task_id, _ssh_overrides())
+
+    def fake_execute_remote(code, remote_task_id, enabled_tools):
+        calls.append((code, remote_task_id, enabled_tools))
+        return '{"status":"success","remote":true}'
+
+    monkeypatch.setattr(code_execution, "_execute_remote", fake_execute_remote)
+    monkeypatch.setattr(
+        "tools.approval.check_execute_code_guard",
+        lambda code, env_type, **kwargs: {"approved": True},
+    )
+    try:
+        result = code_execution.execute_code(
+            "print('hello')",
+            task_id=task_id,
+            enabled_tools=["terminal"],
+        )
+    finally:
+        terminal.clear_task_env_overrides(task_id)
+
+    assert calls == [("print('hello')", task_id, ["terminal"])]
+    assert '"remote":true' in result
+
+
+def test_removed_target_blocks_terminal_without_local_fallback(monkeypatch):
+    from tools import terminal_tool as terminal
+
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    task_id = "removed-ssh-target"
+    terminal.register_task_env_overrides(
+        task_id,
+        {
+            "env_type": "ssh",
+            "ssh_alias": "retired-box",
+            "ssh_host": "",
+            "ssh_user": "",
+            "ssh_binding_error": (
+                "SSH target `retired-box` is no longer configured"
+            ),
+        },
+    )
+    try:
+        result = terminal.terminal_tool("pwd", task_id=task_id)
+    finally:
+        terminal.clear_task_env_overrides(task_id)
+
+    assert "no longer configured" in result
+    assert '"status": "error"' in result
+    assert '"cwd"' not in result
+
+
+def test_execute_code_environment_uses_task_ssh_connection(monkeypatch):
+    from tools import code_execution_tool as code_execution
+    from tools import terminal_tool as terminal
+
+    captured: dict = {}
+    task_id = "ssh-code-environment"
+    terminal.register_task_env_overrides(task_id, _ssh_overrides())
+
+    class FakeEnvironment:
+        pass
+
+    def fake_create_environment(**kwargs):
+        captured.update(kwargs)
+        return FakeEnvironment()
+
+    monkeypatch.setattr(terminal, "_create_environment", fake_create_environment)
+    try:
+        environment, env_type = code_execution._get_or_create_env(task_id)
+    finally:
+        terminal.clear_task_env_overrides(task_id)
+        with terminal._env_lock:
+            terminal._active_environments.pop(task_id, None)
+            terminal._last_activity.pop(task_id, None)
+
+    assert isinstance(environment, FakeEnvironment)
+    assert env_type == "ssh"
+    assert captured["env_type"] == "ssh"
+    assert captured["cwd"] == "/srv/project"
+    assert captured["ssh_config"]["host"] == "build.example"
+    assert captured["ssh_config"]["user"] == "runner"
+
+
+def test_execute_code_restores_bound_remote_cwd(monkeypatch):
+    from tools import code_execution_tool as code_execution
+
+    class FakeEnvironment:
+        def __init__(self):
+            self.cwd = "/srv/project"
+
+        def get_temp_dir(self):
+            return "/tmp"
+
+        def execute(self, command, cwd="", timeout=None, **kwargs):
+            effective_cwd = cwd or self.cwd
+            if command.startswith("cd /tmp/hermes_exec_"):
+                self.cwd = command.split(" && ", 1)[0].removeprefix("cd ")
+                return {"output": "script output\n", "returncode": 0}
+            self.cwd = effective_cwd
+            if "command -v python3" in command:
+                return {"output": "OK\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+    environment = FakeEnvironment()
+    monkeypatch.setattr(
+        code_execution,
+        "_get_or_create_env",
+        lambda task_id: (environment, "ssh"),
+    )
+    monkeypatch.setattr(
+        code_execution,
+        "_load_config",
+        lambda: {"timeout": 30, "max_tool_calls": 5},
+    )
+
+    result = code_execution._execute_remote(
+        "print('hello')",
+        task_id="ssh-code-session",
+        enabled_tools=[],
+    )
+
+    assert '"status": "success"' in result
+    assert environment.cwd == "/srv/project"
+
+
+def test_prompt_environment_hints_use_task_backend(monkeypatch):
+    from agent import prompt_builder
+    from tools import terminal_tool as terminal
+
+    task_id = "ssh-prompt-session"
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("HERMES_SESSION_ID", task_id)
+    monkeypatch.setattr(
+        prompt_builder,
+        "_probe_remote_backend",
+        lambda backend: "  User: runner\n  Working directory: /srv/project",
+    )
+    terminal.register_task_env_overrides(task_id, _ssh_overrides())
+    try:
+        hints = prompt_builder.build_environment_hints()
+    finally:
+        terminal.clear_task_env_overrides(task_id)
+
+    assert "Terminal backend: ssh" in hints
+    assert "all operate inside this ssh environment" in hints
+    assert "Current working directory:" not in hints
+
+
+def test_local_runtime_preparation_preserves_unrelated_session_cwd(
+    monkeypatch,
+    tmp_path,
+):
+    from gateway.ssh_mode import GatewaySshModeMixin
+    from tools import terminal_tool as terminal
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    task_id = "local-session"
+    terminal.record_session_cwd(task_id, "/workspace/local")
+
+    GatewaySshModeMixin()._prepare_ssh_runtime(
+        session_key="unbound-session",
+        task_id=task_id,
+    )
+
+    assert terminal.get_session_cwd(task_id) == "/workspace/local"
+    terminal.clear_session_cwd(task_id)
+
+
+def test_repeated_runtime_preparation_preserves_live_remote_cwd(
+    monkeypatch,
+    tmp_path,
+):
+    from gateway import ssh_bindings
+    from gateway.ssh_bindings import set_ssh_binding
+    from gateway.ssh_mode import GatewaySshModeMixin
+    from gateway.ssh_targets import SshTarget
+    from tools import terminal_tool as terminal
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    target = SshTarget(
+        alias="build",
+        host="build.example.invalid",
+        user="builder",
+        cwd="/srv/repo",
+    )
+    monkeypatch.setattr(
+        ssh_bindings,
+        "load_ssh_targets",
+        lambda: [target],
+    )
+    session_key = "bound-session"
+    task_id = "bound-task"
+    set_ssh_binding(session_key, alias=target.alias)
+
+    runner = GatewaySshModeMixin()
+    try:
+        runner._prepare_ssh_runtime(
+            session_key=session_key,
+            task_id=task_id,
+        )
+        terminal.record_session_cwd(task_id, "/srv/repo/subdir")
+
+        runner._prepare_ssh_runtime(
+            session_key=session_key,
+            task_id=task_id,
+        )
+
+        assert terminal.get_session_cwd(task_id) == "/srv/repo/subdir"
+    finally:
+        terminal.clear_task_env_overrides(task_id)

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -790,9 +790,10 @@ def _get_or_create_env(task_id: str):
     """
     from tools.terminal_tool import (
         _active_environments, _env_lock, _create_environment,
-        _get_env_config, _last_activity, _start_cleanup_thread,
-        _creation_locks, _creation_locks_lock, _task_env_overrides,
+        get_effective_env_config, _last_activity, _start_cleanup_thread,
+        _creation_locks, _creation_locks_lock,
         _resolve_container_task_id, _resolve_task_host_cwd,
+        _ssh_config_from_config, resolve_task_overrides,
     )
 
     effective_task_id = _resolve_container_task_id(task_id)
@@ -801,7 +802,8 @@ def _get_or_create_env(task_id: str):
     with _env_lock:
         if effective_task_id in _active_environments:
             _last_activity[effective_task_id] = time.time()
-            return _active_environments[effective_task_id], _get_env_config()["env_type"]
+            config = get_effective_env_config(task_id)
+            return _active_environments[effective_task_id], config["env_type"]
 
     # Slow path: create environment (same pattern as file_tools._get_file_ops)
     with _creation_locks_lock:
@@ -813,11 +815,12 @@ def _get_or_create_env(task_id: str):
         with _env_lock:
             if effective_task_id in _active_environments:
                 _last_activity[effective_task_id] = time.time()
-                return _active_environments[effective_task_id], _get_env_config()["env_type"]
+                config = get_effective_env_config(task_id)
+                return _active_environments[effective_task_id], config["env_type"]
 
-        config = _get_env_config()
+        config = get_effective_env_config(task_id)
         env_type = config["env_type"]
-        overrides = _task_env_overrides.get(effective_task_id, {})
+        overrides = resolve_task_overrides(task_id)
 
         if env_type == "docker":
             image = overrides.get("docker_image") or config["docker_image"]
@@ -845,15 +848,11 @@ def _get_or_create_env(task_id: str):
                 "docker_network": config.get("docker_network", True),
             }
 
-        ssh_config = None
-        if env_type == "ssh":
-            ssh_config = {
-                "host": config.get("ssh_host", ""),
-                "user": config.get("ssh_user", ""),
-                "port": config.get("ssh_port", 22),
-                "key": config.get("ssh_key", ""),
-                "persistent": config.get("ssh_persistent", False),
-            }
+        ssh_config = (
+            _ssh_config_from_config(config)
+            if env_type == "ssh"
+            else None
+        )
 
         local_config = None
         if env_type == "local":
@@ -1096,6 +1095,7 @@ def _execute_remote(
 
     effective_task_id = task_id or "default"
     env, env_type = _get_or_create_env(effective_task_id)
+    original_cwd = getattr(env, "cwd", None)
 
     sandbox_id = uuid.uuid4().hex[:12]
     temp_dir = _env_temp_dir(env)
@@ -1206,10 +1206,18 @@ def _execute_remote(
         # Clean up remote sandbox dir
         try:
             env.execute(
-                f"rm -rf {quoted_sandbox_dir}", cwd="/", timeout=15,
+                f"rm -rf {quoted_sandbox_dir}",
+                cwd=original_cwd or "/",
+                timeout=15,
             )
         except Exception:
             logger.debug("Failed to clean up remote sandbox %s", sandbox_dir)
+        finally:
+            # Internal RPC setup uses / and a temporary sandbox, but those
+            # implementation details must not change the session's cwd for the
+            # next terminal/file call.
+            if original_cwd:
+                env.cwd = original_cwd
 
     duration = round(time.monotonic() - exec_start, 2)
 
@@ -1314,9 +1322,10 @@ def execute_code(
                 "Run the lifecycle command from a shell outside the gateway."
             )
 
-    # Dispatch: remote backends use file-based RPC, local uses UDS
-    from tools.terminal_tool import _get_env_config, _docker_has_host_access
-    _env_config = _get_env_config()
+    # Dispatch by the task/session backend. A gateway SSH binding must route
+    # the top-level Python process remotely too, not only nested tool calls.
+    from tools.terminal_tool import get_effective_env_config, _docker_has_host_access
+    _env_config = get_effective_env_config(task_id)
     env_type = _env_config["env_type"]
 
     # execute_code runs arbitrary Python (subprocess/os.system/...) that never

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -178,7 +178,7 @@ def _terminal_env_type_for_task(task_id: str = "default") -> str:
         from tools.terminal_tool import (
             _active_environments,
             _env_lock,
-            _get_env_config,
+            get_effective_env_config,
             _resolve_container_task_id,
         )
 
@@ -202,7 +202,7 @@ def _terminal_env_type_for_task(task_id: str = "default") -> str:
                 return "modal"
             if "daytona" in name:
                 return "daytona"
-        cfg = _get_env_config()
+        cfg = get_effective_env_config(task_id)
         return str(cfg.get("env_type") or os.getenv("TERMINAL_ENV") or "local").lower()
     except Exception:
         return str(os.getenv("TERMINAL_ENV") or "local").lower()
@@ -401,6 +401,47 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
         return p.resolve()
     resolved = _resolve_base_dir(task_id, container_paths=False) / p
     return resolved.resolve()
+
+
+def _is_ssh_backend_task(task_id: str = "default") -> bool:
+    """Return True when file operations target an SSH filesystem."""
+
+    return _terminal_env_type_for_task(task_id) == "ssh"
+
+
+def _remote_display_path_for_task(
+    filepath: str,
+    task_id: str = "default",
+) -> str:
+    """Return a lexical backend path without dereferencing it on the host."""
+
+    raw = str(filepath or "")
+    if raw.startswith("~"):
+        return raw
+    if posixpath.isabs(raw):
+        return posixpath.normpath(raw)
+    root = _authoritative_workspace_root(task_id)
+    if root:
+        return posixpath.normpath(posixpath.join(str(root), raw))
+    return posixpath.normpath(raw)
+
+
+def _file_tool_paths_for_task(
+    filepath: str,
+    task_id: str = "default",
+) -> tuple[str, str, str]:
+    """Return lock, shell, and display paths for one file operation.
+
+    Local operations use the host-resolved absolute path. Remote operations
+    keep the caller's backend path for shell I/O and use only a lexical path
+    for local locking/bookkeeping.
+    """
+
+    if _is_ssh_backend_task(task_id):
+        display_path = _remote_display_path_for_task(filepath, task_id)
+        return display_path, filepath, display_path
+    resolved = str(_resolve_path_for_task(filepath, task_id))
+    return resolved, resolved, resolved
 
 
 def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "default") -> str | None:
@@ -1419,11 +1460,12 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
     """
     from tools.terminal_tool import (
         _active_environments, _env_lock, _create_environment,
-        _get_env_config, _last_activity, _start_cleanup_thread,
+        get_effective_env_config, _last_activity, _start_cleanup_thread,
         _creation_locks,
         _creation_locks_lock,
         _resolve_container_task_id,
         _resolve_task_host_cwd,
+        _ssh_config_from_config,
         _is_unusable_container_cwd,
         _CONTAINER_BACKENDS,
     )
@@ -1486,7 +1528,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
         if terminal_env is None:
             from tools.terminal_tool import resolve_task_overrides
 
-            config = _get_env_config()
+            config = get_effective_env_config(raw_task_id)
             env_type = config["env_type"]
             overrides = resolve_task_overrides(raw_task_id)
 
@@ -1544,15 +1586,11 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "docker_network": config.get("docker_network", True),
                 }
 
-            ssh_config = None
-            if env_type == "ssh":
-                ssh_config = {
-                    "host": config.get("ssh_host", ""),
-                    "user": config.get("ssh_user", ""),
-                    "port": config.get("ssh_port", 22),
-                    "key": config.get("ssh_key", ""),
-                    "persistent": config.get("ssh_persistent", False),
-                }
+            ssh_config = (
+                _ssh_config_from_config(config)
+                if env_type == "ssh"
+                else None
+            )
 
             local_config = None
             if env_type == "local":
@@ -1642,7 +1680,15 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
                 "block or produce infinite output."
             )
 
-        _resolved = _resolve_path_for_task(path, task_id)
+        if _is_ssh_backend_task(task_id):
+            _, _shell_path, _display_path = _file_tool_paths_for_task(
+                path,
+                task_id,
+            )
+            _resolved = PurePosixPath(_display_path)
+        else:
+            _resolved = _resolve_path_for_task(path, task_id)
+            _shell_path = str(_resolved)
 
         # ── Special-file type guard (stat-based) ──────────────────────
         # The name blocklist above catches /dev/* and /proc/* aliases; this
@@ -1677,7 +1723,8 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
             file_ops = _get_file_ops(task_id)
             try:
                 binary = file_ops.read_file_bytes(
-                    str(_resolved), max_bytes=MAX_DOCUMENT_BYTES
+                    _shell_path,
+                    max_bytes=MAX_DOCUMENT_BYTES,
                 )
                 if binary.error or binary.base64_content is None:
                     raise ExtractionError(binary.error or "Document bytes unavailable")
@@ -1852,7 +1899,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
 
         # ── Perform the read ──────────────────────────────────────────
         file_ops = _get_file_ops(task_id)
-        result = file_ops.read_file(path, offset, limit)
+        result = file_ops.read_file(_shell_path, offset, limit)
         result_dict = result.to_dict()
 
         # ── Populate negative-result cache on not-found ───────────────
@@ -2259,15 +2306,17 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             "file contents before writing."
         )
     try:
-        # Resolve once for the registry lock + stale check.  Failures here
-        # fall back to the legacy path — write proceeds, per-task staleness
-        # check below still runs.
+        # Resolve once for locking/bookkeeping. Remote paths must stay in the
+        # backend namespace and must never be host-resolved before shell I/O.
         try:
-            _resolved = str(_resolve_path_for_task(path, task_id))
+            _lock_key, _shell_path, _display_path = _file_tool_paths_for_task(
+                path,
+                task_id,
+            )
         except Exception:
-            _resolved = None
+            _lock_key = _shell_path = _display_path = None
 
-        if _resolved is None:
+        if _lock_key is None:
             stale_warning = _check_file_staleness(path, task_id)
             file_ops = _get_file_ops(task_id)
             result = file_ops.write_file(path, content)
@@ -2278,36 +2327,46 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
                 _mark_verification_stale(task_id, [path], session_id=session_id)
             _update_read_timestamp(path, task_id)
             return json.dumps(result_dict, ensure_ascii=False)
+        assert _shell_path is not None
+        assert _display_path is not None
 
         # Serialize the read→modify→write region per-path so concurrent
         # subagents can't interleave on the same file.  Different paths
         # remain fully parallel.
-        with file_state.lock_path(_resolved):
+        with file_state.lock_path(_lock_key):
             # Cross-agent staleness wins over per-task warning when both
             # fire — its message names the sibling subagent.
-            cross_warning = file_state.check_stale(task_id, _resolved)
+            cross_warning = file_state.check_stale(task_id, _lock_key)
             stale_warning = _check_file_staleness(path, task_id)
             # Workspace-divergence warning: relative path resolving outside the
-            # terminal's cwd (the worktree-cwd bug). Lowest priority of the three.
-            cwd_warning = _path_resolution_warning(path, Path(_resolved), task_id)
+            # terminal's cwd. It is meaningful only when Python and the tool
+            # operate on the same host filesystem.
+            cwd_warning = None
+            if not _is_ssh_backend_task(task_id):
+                cwd_warning = _path_resolution_warning(
+                    path,
+                    Path(_lock_key),
+                    task_id,
+                )
             file_ops = _get_file_ops(task_id)
-            result = file_ops.write_file(_resolved, content)
+            result = file_ops.write_file(_shell_path, content)
             result_dict = result.to_dict()
             effective_warning = cross_warning or stale_warning or cwd_warning
             if effective_warning:
                 result_dict["_warning"] = effective_warning
-            # Always report the ABSOLUTE path actually written, so a wrong-cwd
-            # mismatch is visible in the response instead of silently routing
-            # the edit to the wrong checkout.
-            result_dict["resolved_path"] = _resolved
+            result_dict["resolved_path"] = _display_path
             if not result_dict.get("error"):
-                result_dict["files_modified"] = [_resolved]
-                _mark_verification_stale(task_id, [_resolved], session_id=session_id)
+                result_dict["files_modified"] = [_display_path]
+                _mark_verification_stale(
+                    task_id,
+                    [_display_path],
+                    session_id=session_id,
+                )
             # Refresh stamps after the successful write so consecutive
             # writes by this task don't trigger false staleness warnings.
             _update_read_timestamp(path, task_id)
             if not result_dict.get("error"):
-                file_state.note_write(task_id, _resolved)
+                file_state.note_write(task_id, _lock_key)
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         if _is_expected_write_exception(e):
@@ -2405,14 +2464,25 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         # multi-file V4A patches.
         _resolved_paths: list[str] = []
         _seen: set[str] = set()
+        _path_to_lock: dict[str, str | None] = {}
+        _path_to_shell: dict[str, str] = {}
+        _path_to_display: dict[str, str] = {}
         for _p in _paths_to_check:
             try:
-                _r = str(_resolve_path_for_task(_p, task_id))
+                _lock, _shell, _display = _file_tool_paths_for_task(
+                    _p,
+                    task_id,
+                )
             except Exception:
-                _r = None
-            if _r and _r not in _seen:
-                _resolved_paths.append(_r)
-                _seen.add(_r)
+                _lock = None
+                _shell = _p
+                _display = _p
+            _path_to_lock[_p] = _lock
+            _path_to_shell[_p] = _shell
+            _path_to_display[_p] = _display
+            if _lock and _lock not in _seen:
+                _resolved_paths.append(_lock)
+                _seen.add(_lock)
         _resolved_paths.sort()
 
         # Acquire per-path locks in sorted order via ExitStack.  On single
@@ -2426,18 +2496,14 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             # Collect warnings — cross-agent registry first (names sibling),
             # then per-task tracker as a fallback.
             stale_warnings: list[str] = []
-            _path_to_resolved: dict[str, str] = {}
             for _p in _paths_to_check:
-                try:
-                    _r = str(_resolve_path_for_task(_p, task_id))
-                except Exception:
-                    _r = None
-                _path_to_resolved[_p] = _r
+                _r = _path_to_lock.get(_p)
                 _cross = file_state.check_stale(task_id, _r) if _r else None
                 _sw = _cross or _check_file_staleness(_p, task_id)
-                if not _sw and _r:
+                if not _sw and _r and not _is_ssh_backend_task(task_id):
                     # Workspace-divergence warning (worktree-cwd bug): relative
-                    # path resolving outside the terminal's cwd.
+                    # path resolving outside the terminal's cwd. Host-only:
+                    # Python cannot resolve paths inside SSH/container backends.
                     _sw = _path_resolution_warning(_p, Path(_r), task_id)
                 if _sw:
                     stale_warnings.append(_sw)
@@ -2449,12 +2515,7 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                     return tool_error("path required")
                 if old_string is None or new_string is None:
                     return tool_error("old_string and new_string required")
-                # Pass the resolved ABSOLUTE path to the shell layer so it
-                # operates on the exact file the tool layer resolved — the
-                # shell's own cwd may differ (worktree-cwd bug), and a relative
-                # path would let the two layers disagree about which file is
-                # being edited.
-                _replace_target = _path_to_resolved.get(path) or path
+                _replace_target = _path_to_shell.get(path) or path
                 result = file_ops.patch_replace(_replace_target, old_string, new_string, replace_all)
             elif mode == "patch":
                 if not patch:
@@ -2465,7 +2526,12 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 # against the shell's cwd, which can differ from the workspace
                 # (git-worktree cwd bug) — landing the edit elsewhere.
                 patch_for_ops = _rewrite_v4a_patch_paths_for_host(
-                    patch, _path_to_resolved, file_ops
+                    patch,
+                    {
+                        original: _path_to_shell.get(original) or original
+                        for original in _paths_to_check
+                    },
+                    file_ops,
                 )
                 result = file_ops.patch_v4a(patch_for_ops)
             else:
@@ -2474,11 +2540,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             result_dict = result.to_dict()
             if stale_warnings:
                 result_dict["_warning"] = stale_warnings[0] if len(stale_warnings) == 1 else " | ".join(stale_warnings)
-            # Report the ABSOLUTE path(s) actually patched so a wrong-cwd
-            # mismatch (e.g. a worktree session editing the main checkout) is
-            # visible in the response instead of silently landing elsewhere.
+            # Report paths in the execution backend's namespace.
             _resolved_modified = [
-                _path_to_resolved.get(_p) or _p for _p in _paths_to_check
+                _path_to_display.get(_p) or _p for _p in _paths_to_check
             ]
             # Refresh stored timestamps for all successfully-patched paths so
             # consecutive edits by this task don't trigger false warnings.
@@ -2489,14 +2553,18 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 _mark_verification_stale(task_id, _resolved_modified, session_id=session_id)
                 for _p in _paths_to_check:
                     _update_read_timestamp(_p, task_id)
-                    _r = _path_to_resolved.get(_p)
+                    _r = _path_to_lock.get(_p)
                     if _r:
                         file_state.note_write(task_id, _r)
                 # Successful patch: clear any prior consecutive-failure
                 # counters for the touched paths so a future failure on
                 # the same path starts the escalation cycle fresh.
                 _reset_patch_failures(task_id, [
-                    _r for _r in (_path_to_resolved.get(_p) for _p in _paths_to_check) if _r
+                    _r
+                    for _r in (
+                        _path_to_lock.get(_p) for _p in _paths_to_check
+                    )
+                    if _r
                 ])
         # Hint when old_string not found — saves iterations where the agent
         # retries with stale content instead of re-reading the file.
@@ -2509,7 +2577,7 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             # are far rarer and the existing _hint covers them adequately.
             failure_count = 0
             if mode == "replace" and path:
-                resolved = _path_to_resolved.get(path) or path
+                resolved = _path_to_lock.get(path) or path
                 failure_count = _record_patch_failure(task_id, resolved)
 
             if failure_count >= 3:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1223,6 +1223,80 @@ def _maybe_reap_docker_orphans(container_config: Dict[str, Any]) -> None:
 # Thread-safe because each task_id is unique per rollout.
 _task_env_overrides: Dict[str, Dict[str, Any]] = {}
 
+_BACKEND_OVERRIDE_KEYS = frozenset({
+    "env_type",
+    "ssh_alias",
+    "ssh_host",
+    "ssh_user",
+    "ssh_port",
+    "ssh_key",
+    "ssh_persistent",
+    "ssh_binding_error",
+})
+
+
+def _task_environment_cache_keys(task_id: str) -> set[str]:
+    """Return every environment/cache key that may represent *task_id*."""
+
+    raw = str(task_id or "default")
+    keys = {raw}
+    try:
+        keys.add(_resolve_container_task_id(raw))
+    except Exception:
+        pass
+    session_key = _current_session_key()
+    if session_key:
+        keys.add(f"session:{session_key}")
+    return {key for key in keys if key}
+
+
+def evict_task_environment(
+    task_id: str,
+    *,
+    cache_keys: set[str] | None = None,
+) -> None:
+    """Evict cached terminal/file environments after a backend change."""
+
+    keys = set(cache_keys or ())
+    keys.update(_task_environment_cache_keys(task_id))
+    evicted: list[Any] = []
+    seen_envs: set[int] = set()
+    with _env_lock:
+        for key in keys:
+            env = _active_environments.pop(key, None)
+            _last_activity.pop(key, None)
+            if env is not None and id(env) not in seen_envs:
+                seen_envs.add(id(env))
+                evicted.append(env)
+    with _creation_locks_lock:
+        for key in keys:
+            _creation_locks.pop(key, None)
+    try:
+        from tools.file_tools import clear_file_ops_cache
+
+        for key in keys:
+            clear_file_ops_cache(key)
+    except Exception:
+        logger.debug(
+            "Could not clear file cache for backend change on %s",
+            task_id,
+            exc_info=True,
+        )
+    for env in evicted:
+        try:
+            if hasattr(env, "cleanup"):
+                env.cleanup()
+            elif hasattr(env, "stop"):
+                env.stop()
+            elif hasattr(env, "terminate"):
+                env.terminate()
+        except Exception:
+            logger.debug(
+                "Error cleaning evicted environment for task %s",
+                task_id,
+                exc_info=True,
+            )
+
 # ── Per-session cwd records (cwd rearchitecture, step 1) ────────────────────
 #
 # The durable source of truth for "which directory is THIS session working
@@ -1281,25 +1355,41 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
     Register environment overrides for a specific task/rollout.
 
     Called by Atropos environments before the agent loop to configure
-    per-task sandbox settings (e.g., a custom Dockerfile for the Modal image).
+    per-task sandbox settings (e.g., a custom Dockerfile for the Modal image),
+    and by the gateway to apply an explicit session-scoped SSH binding.
 
     Supported override keys:
         - modal_image: str -- Path to Dockerfile or Docker Hub image name
         - docker_image: str -- Docker image name
         - cwd: str -- Working directory inside the sandbox
+        - env_type: str -- Per-task backend selection (for example ``ssh``)
+        - ssh_host/user/port/key: Per-task SSH connection settings
 
     Args:
         task_id: The rollout's unique task identifier
         overrides: Dict of config keys to override
     """
-    _task_env_overrides[task_id] = overrides
+    previous = dict(_task_env_overrides.get(task_id) or {})
+    previous_keys = _task_environment_cache_keys(task_id)
+    next_overrides = dict(overrides or {})
+    _task_env_overrides[task_id] = next_overrides
+    next_keys = _task_environment_cache_keys(task_id)
+
+    if any(
+        previous.get(key) != next_overrides.get(key)
+        for key in _BACKEND_OVERRIDE_KEYS
+    ):
+        evict_task_environment(
+            task_id,
+            cache_keys=previous_keys | next_keys,
+        )
 
     # If a live environment already exists for this task, a freshly registered
     # ``cwd`` override (e.g. the ACP client switching the editor's project root
     # mid-session via ``session/load`` / ``session/resume``) must take effect
     # immediately. The session record is what commands resolve against;
     # the live env's cwd is also updated so env-side seeding stays consistent.
-    new_cwd = overrides.get("cwd")
+    new_cwd = next_overrides.get("cwd")
     if isinstance(new_cwd, str) and new_cwd.strip():
         # A registered workspace cwd IS the session's working directory until
         # a `cd` changes it.
@@ -1322,10 +1412,14 @@ def clear_task_env_overrides(task_id: str):
 
     Called during cleanup to avoid stale entries accumulating.
     """
+    previous = dict(_task_env_overrides.get(task_id) or {})
+    previous_keys = _task_environment_cache_keys(task_id)
     _task_env_overrides.pop(task_id, None)
     clear_session_cwd(task_id)
     with _container_alias_lock:
         _container_aliases.pop(task_id, None)
+    if set(previous) & _BACKEND_OVERRIDE_KEYS:
+        evict_task_environment(task_id, cache_keys=previous_keys)
 
 
 # Subagent → parent container aliasing.  delegate_task children get their own
@@ -1762,6 +1856,56 @@ def _get_env_config() -> Dict[str, Any]:
     }
 
 
+def apply_task_env_overrides(
+    config: Dict[str, Any],
+    overrides: Dict[str, Any] | None,
+) -> Dict[str, Any]:
+    """Return a copy of terminal config with task-scoped overrides applied."""
+
+    merged = dict(config or {})
+    task_overrides = dict(overrides or {})
+    previous_env_type = str(merged.get("env_type") or "local")
+    if task_overrides.get("env_type"):
+        merged["env_type"] = str(task_overrides["env_type"]).strip().lower()
+        if (
+            merged["env_type"] == "ssh"
+            and previous_env_type != "ssh"
+            and not task_overrides.get("cwd")
+        ):
+            # A process-global local cwd is a host path and must never become
+            # the implicit cwd of a newly selected remote backend.
+            merged["cwd"] = "~"
+            merged["host_cwd"] = None
+    if task_overrides.get("cwd"):
+        merged["cwd"] = str(task_overrides["cwd"])
+    for key in (
+        "ssh_alias",
+        "ssh_host",
+        "ssh_user",
+        "ssh_key",
+        "ssh_binding_error",
+    ):
+        if key in task_overrides:
+            merged[key] = str(task_overrides.get(key) or "")
+    if "ssh_port" in task_overrides:
+        try:
+            merged["ssh_port"] = int(task_overrides.get("ssh_port") or 22)
+        except (TypeError, ValueError):
+            merged["ssh_port"] = 22
+    if "ssh_persistent" in task_overrides:
+        merged["ssh_persistent"] = bool(task_overrides.get("ssh_persistent"))
+    return merged
+
+
+def get_effective_env_config(task_id: Optional[str] = None) -> Dict[str, Any]:
+    """Resolve global terminal config plus task/session backend overrides."""
+
+    return apply_task_env_overrides(
+        _get_env_config(),
+        resolve_task_overrides(task_id),
+    )
+
+
 def _get_modal_backend_state(modal_mode: object | None) -> Dict[str, Any]:
     """Resolve direct vs managed Modal backend selection."""
     return resolve_modal_backend_state(
@@ -1784,6 +1928,7 @@ def _ssh_config_from_config(config: Dict[str, Any]) -> dict:
         "port": config.get("ssh_port", 22),
         "key": config.get("ssh_key", ""),
         "persistent": config.get("ssh_persistent", False),
+        "binding_error": config.get("ssh_binding_error", ""),
     }
 
 
@@ -1987,6 +2132,9 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
         )
 
     elif env_type == "ssh":
+        binding_error = str((ssh_config or {}).get("binding_error") or "").strip()
+        if binding_error:
+            raise ValueError(binding_error)
         if not ssh_config or not ssh_config.get("host") or not ssh_config.get("user"):
             raise ValueError("SSH environment requires ssh_host and ssh_user to be configured")
         return _SSHEnvironment(
@@ -2126,7 +2274,7 @@ def ensure_task_env(task_id: Optional[str] = None):
     instance, or ``None`` when local or when creation fails (best-effort: a
     failure leaves the caller's fail-closed error path intact).
     """
-    config = _get_env_config()
+    config = get_effective_env_config(task_id)
     env_type = config["env_type"]
     if env_type == "local":
         return None
@@ -2717,8 +2865,8 @@ def terminal_tool(
                 "status": "error",
             }, ensure_ascii=False)
 
-        # Get configuration
-        config = _get_env_config()
+        # Get configuration, including an explicit per-session backend binding.
+        config = get_effective_env_config(task_id)
         env_type = config["env_type"]
 
         # Use task_id for environment isolation. By default all subagent

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -363,6 +363,30 @@ TERMINAL_SSH_USER=ubuntu
 | `TERMINAL_SSH_KEY` | (system default) | Path to SSH private key |
 | `TERMINAL_SSH_PERSISTENT` | `true` | Enable persistent shell |
 
+#### Per-session SSH Mode (gateway)
+
+Gateway conversations can opt into SSH without changing the process-wide
+terminal backend. Define an explicit, profile-scoped target registry at
+`$HERMES_HOME/ssh/targets.yaml` (`~/.hermes/ssh/targets.yaml` by default):
+
+```yaml
+ssh:
+  targets:
+    build-box:
+      host: build.example.com
+      user: builder
+      port: 22
+      identity_file: ~/.ssh/id_ed25519
+      cwd: /srv/project
+```
+
+Then use `/ssh list`, `/ssh use build-box`, `/ssh status`, and `/ssh local`
+in a gateway chat. The binding belongs only to that conversation and routes
+`terminal`, file tools, and `execute_code` together. Hermes does not import
+targets from `~/.ssh/config`; a missing or invalid bound target blocks remote
+tool execution instead of silently falling back to the gateway host. Identity
+file paths are redacted from `/ssh` responses.
+
 **How it works:** Connects at init time with `BatchMode=yes` and `StrictHostKeyChecking=accept-new`. Persistent shell keeps a single `bash -l` process alive on the remote host, communicating via temporary files. Commands that need `stdin_data` or `sudo` automatically fall back to one-shot mode.
 
 ### Modal Backend


### PR DESCRIPTION
## Summary
- add an explicit, profile-scoped SSH target registry and durable per-conversation `/ssh` bindings
- route `terminal`, file tools, and `execute_code` through one task-scoped backend while preserving cwd isolation and failing closed on removed or invalid targets
- document the gateway workflow and cover control-plane, cache-eviction, path-routing, prompt, and cwd contracts

## Staged scope
This is the first upstreamable foundation slice for #93954. Follow-up PRs will add per-target grants and remote process lifecycle hardening, then bounded remote artifact/media materialization and delivery.

## Testing
- `scripts/run_tests.sh tests/gateway/test_ssh_mode.py tests/tools/test_ssh_session_routing.py -q` — 16 passed
- adjacent gateway/tool/SSH regression selection — 459 passed, 9 skipped, 7 subtests passed
- Ruff, bytecode compilation, diff checks, and the Windows-footgun scan passed

## Attribution
Adapted from ChatArch's section-scoped SSH runtime binding by @LooKeng and @rexwzh, then reworked for current `official/main` session context, environment cache, file-path, and command-registry contracts.
