### PR TITLE
fix(api-server): resolve session-persisted model with requested provider

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2963,7 +2963,9 @@ class APIServerAdapter(BasePlatformAdapter):
         if session_override:
             override_model = resolve_effective_model(session_override, None, model)
             session_provider = _clean_request_string(session_override.get("provider"))
-            current_provider = _clean_request_string(runtime_kwargs.get("provider"))
+            current_provider = _clean_request_string(
+                runtime_kwargs.get("requested_provider") or runtime_kwargs.get("provider")
+            )
             provider_runtime = _resolve_provider_runtime(
                 session_provider or current_provider,
                 target_model=override_model,
@@ -2983,7 +2985,9 @@ class APIServerAdapter(BasePlatformAdapter):
             # alias).  Pins this session's turns ahead of per-request body
             # values — a session's chosen model is a standing selection,
             # matching the native gateway's session-model semantics.
-            current_provider = _clean_request_string(runtime_kwargs.get("provider"))
+            current_provider = _clean_request_string(
+                runtime_kwargs.get("requested_provider") or runtime_kwargs.get("provider")
+            )
             provider_runtime = _resolve_provider_runtime(
                 current_provider,
                 target_model=session_row_model,
@@ -3006,7 +3010,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 effective_model = route_model or model
             else:
                 effective_model = request_model or model
-            current_provider = _clean_request_string(runtime_kwargs.get("provider"))
+            current_provider = _clean_request_string(
+                runtime_kwargs.get("requested_provider") or runtime_kwargs.get("provider")
+            )
             effective_provider = request_provider or route_provider or current_provider
             provider_runtime = None
             if effective_provider and (

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2592,6 +2592,71 @@ class TestModelRoutesAgentCreation:
         assert captured["api_key"] == "sk-session"
 
 
+class TestSessionPersistedModelProviderResolution:
+    """A session row that persisted a model with a *named custom provider*
+    must re-resolve the provider runtime using the original requested
+    provider (``custom:inference``), not the normalized runtime label
+    (``custom``). Found live (Aug 2026): after the first successful
+    ``hermes peer dm`` turn persisted the GGUF model on the session row,
+    every later chat on that session failed with ``modelCode: does not
+    exist`` because ``current_provider`` re-fed the label ``custom`` into
+    ``_resolve_provider_runtime``, which fell through to a default endpoint
+    (Z.AI / DeepSeek / OpenRouter) instead of the named custom provider.
+    """
+
+    def test_session_model_resolves_with_requested_provider(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        # Global runtime resolution returns the normalized provider label
+        # ("custom") for a named custom provider — but it also carries the
+        # original requested provider ("custom:inference"). The session-model
+        # branch must prefer the latter when re-resolving credentials.
+        _patch_create_agent_runtime(monkeypatch, captured, FakeAgent)
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "custom",
+                "requested_provider": "custom:inference",
+                "api_key": "no-key-required",
+                "base_url": "http://192.168.1.116:8080/v1",
+                "api_mode": "chat_completions",
+            },
+        )
+        resolved_providers = []
+
+        def _fake_request_runtime(provider, target_model=None):
+            resolved_providers.append(provider)
+            return {
+                "provider": provider,
+                "api_key": "no-key-required",
+                "base_url": f"https://{provider}.example/v1",
+                "api_mode": "chat_completions",
+            }
+
+        monkeypatch.setattr(
+            "gateway.platforms.api_server._resolve_request_runtime_agent_kwargs",
+            _fake_request_runtime,
+        )
+        adapter = _make_routing_adapter({})
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+        monkeypatch.setattr(adapter, "_session_model_override_for", lambda *_: None)
+
+        adapter._create_agent(
+            session_id="s1",
+            session_model="/home/andrewho/models/Qwopus3.6-27B-v2-MTP-Q6_K.gguf",
+        )
+
+        # The session-model branch must feed the ORIGINAL provider name into
+        # provider-runtime resolution — not the normalized label "custom".
+        assert "custom:inference" in resolved_providers
+        assert "custom" not in resolved_providers
+        assert captured["base_url"] == "https://custom:inference.example/v1"
+
+
 class TestStoredSessionModelFilter:
     """A session row that persisted the advertised virtual model must read as
     "no stored model" — replaying "hermes-agent" upstream 400s. Found live


### PR DESCRIPTION
## Problem

After the first successful `hermes peer dm` turn against a gateway running the `api_server` platform, every subsequent chat on the same session fails with a provider-level 400 (e.g. `modelCode: does not exist` from Z.AI, or "The supported API model names are ... but you passed <gguf>" from DeepSeek).

Root cause: `api_server._create_agent`'s session-model precedence branches resolve the provider runtime using the **normalized runtime label** from `_resolve_runtime_agent_kwargs()` (`provider: "custom"` for any named custom provider) instead of the **original requested provider** (`requested_provider: "custom:inference"`). The label `custom` is not a resolvable provider name, so `resolve_runtime_provider(requested="custom", ...)` falls through to a default provider endpoint — Z.AI, DeepSeek, OpenRouter, whichever wins the fallback — and the persisted GGUF/custom model id gets sent there, producing a 400.

Timeline that reproduces it:
1. First DM on a fresh session → session row has no persisted model → global path resolves the named custom provider correctly → works.
2. The first turn persists the resolved model (`/path/to/model.gguf`) onto the session row.
3. Every later DM on that session → `session_row_model` branch re-resolves credentials with the label `custom` → wrong endpoint → HTTP 400.

## Fix

In all three `current_provider` resolution sites of `_create_agent` (session-override, session-persisted-model, and per-request selection branches), prefer `runtime_kwargs["requested_provider"]` (the original named custom provider) and fall back to the runtime label only when the requested name is absent:

```python
current_provider = _clean_request_string(
    runtime_kwargs.get("requested_provider") or runtime_kwargs.get("provider")
)
```

This mirrors the native gateway path where the named custom provider identity is preserved through resolution.

## Test

`TestSessionPersistedModelProviderResolution.test_session_model_resolves_with_requested_provider` — regression test that:
- Simulates a session row with a persisted model under a named custom provider (`custom:inference`)
- Captures the provider name fed into `_resolve_request_runtime_agent_kwargs`
- Asserts the original `custom:inference` is used, not the label `custom`
- Asserts the resulting agent runtime points at the custom provider's base URL

Verified the test fails on unpatched code and passes with the fix.

## Verification

- Live reproduction: `hermes peer dm rio` (Wintermute → bayview) and `hermes peer dm wintermute` (bayview → Wintermute) both failed on turn 2+ with provider 400s before the fix; both directions work across repeated turns after the fix.
- `python -m pytest tests/gateway/test_api_server.py::TestSessionPersistedModelProviderResolution tests/gateway/test_api_server.py::TestModelRoutesAgentCreation tests/gateway/test_api_server.py::TestStoredSessionModelFilter -q` → 6 passed.
