### PR TITLE
fix(desktop): expose ElevenLabs v3 and gpt-transcribe in Voice pickers

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -341,7 +341,15 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
   'stt.openai.model': ['whisper-1', 'gpt-4o-mini-transcribe', 'gpt-4o-transcribe', 'gpt-transcribe'],
   'stt.mistral.model': ['voxtral-mini-latest', 'voxtral-mini-2602'],
   'tts.openai.model': ['gpt-4o-mini-tts', 'tts-1', 'tts-1-hd'],
-  'tts.elevenlabs.model_id': ['eleven_multilingual_v2', 'eleven_turbo_v2_5', 'eleven_flash_v2_5'],
+  'tts.elevenlabs.model_id': [
+    'eleven_v3',
+    'eleven_ttv_v3',
+    'eleven_multilingual_v2',
+    'eleven_turbo_v2',
+    'eleven_turbo_v2_5',
+    'eleven_flash_v2',
+    'eleven_flash_v2_5'
+  ],
   // NeuTTS local inference device.
   'tts.neutts.device': ['cpu', 'cuda', 'mps'],
   'updates.non_interactive_local_changes': ['stash', 'discard']
@@ -357,6 +365,8 @@ export const FREE_INPUT_KEYS = new Set([
   'tts.openai.model',
   'tts.openai.voice',
   'tts.elevenlabs.voice_id',
+  'tts.elevenlabs.model_id',
+  'stt.openai.model',
   'tts.gemini.model',
   'tts.gemini.voice',
   'tts.xai.voice_id',

--- a/apps/desktop/src/app/settings/helpers.ts
+++ b/apps/desktop/src/app/settings/helpers.ts
@@ -137,7 +137,11 @@ export function voiceFieldVisible(key: string, config: HermesConfigRecord): bool
     return false
   }
 
-  return provider === String(getNested(config, `${domain}.provider`) ?? '')
+  const selected = String(getNested(config, `${domain}.provider`) ?? '')
+  // Backend defaults when the key is unset: TTS → edge, STT → local.
+  // An empty string used to hide every nested model field.
+  const fallback = domain === 'tts' ? 'edge' : domain === 'stt' ? 'local' : ''
+  return provider === (selected || fallback)
 }
 
 export function inferFieldSchema(value: unknown): ConfigFieldSchema {

--- a/apps/desktop/src/app/settings/voice-field-visible.test.ts
+++ b/apps/desktop/src/app/settings/voice-field-visible.test.ts
@@ -33,6 +33,20 @@ describe('voiceFieldVisible', () => {
     expect(voiceFieldVisible('stt.groq.model', config)).toBe(false)
   })
 
+  it('falls back to backend defaults when provider is unset so model fields stay visible', () => {
+    const unset = { tts: {}, stt: { enabled: true } } as unknown as HermesConfigRecord
+    expect(voiceFieldVisible('tts.edge.voice', unset)).toBe(true)
+    expect(voiceFieldVisible('tts.openai.voice', unset)).toBe(false)
+    expect(voiceFieldVisible('stt.local.model', unset)).toBe(true)
+    expect(voiceFieldVisible('stt.openai.model', unset)).toBe(false)
+  })
+
+  it('shows OpenAI STT models including gpt-transcribe once that provider is selected', () => {
+    const config = cfg({ stt: { enabled: true, provider: 'openai', openai: {} } })
+    expect(voiceFieldVisible('stt.openai.model', config)).toBe(true)
+    expect(voiceFieldVisible('stt.local.model', config)).toBe(false)
+  })
+
   it('hides every STT provider sub-field when STT is disabled', () => {
     const config = cfg({ stt: { enabled: false, provider: 'local', local: {} } })
     expect(voiceFieldVisible('stt.local.model', config)).toBe(false)

--- a/apps/desktop/src/app/settings/voice-provider-fields.test.ts
+++ b/apps/desktop/src/app/settings/voice-provider-fields.test.ts
@@ -52,12 +52,34 @@ describe('voice field option coverage', () => {
       'tts.openai.voice',
       'tts.openai.model',
       'tts.elevenlabs.voice_id',
+      'tts.elevenlabs.model_id',
+      'stt.openai.model',
       'tts.edge.voice',
       'tts.xai.voice_id',
       'tts.piper.voice'
     ]) {
       expect(FREE_INPUT_KEYS.has(key), key).toBe(true)
     }
+  })
+
+  it('suggests ElevenLabs v3 and current flash/turbo ids, not just multilingual v2', () => {
+    const models = ENUM_OPTIONS['tts.elevenlabs.model_id']
+
+    for (const model of [
+      'eleven_v3',
+      'eleven_ttv_v3',
+      'eleven_multilingual_v2',
+      'eleven_turbo_v2',
+      'eleven_turbo_v2_5',
+      'eleven_flash_v2',
+      'eleven_flash_v2_5'
+    ]) {
+      expect(models).toContain(model)
+    }
+  })
+
+  it('suggests gpt-transcribe as an OpenAI STT model', () => {
+    expect(ENUM_OPTIONS['stt.openai.model']).toContain('gpt-transcribe')
   })
 
   it('keeps closed enums (devices, providers) out of the free-input set', () => {


### PR DESCRIPTION
## Problem

Desktop Settings → Voice hid current speech models:

- ElevenLabs `model_id` was a closed select of only `eleven_multilingual_v2` / `eleven_turbo_v2_5` / `eleven_flash_v2_5`. Backend already accepts `eleven_v3` (and related ids).
- `stt.openai.model` already listed `gpt-transcribe`, but `voiceFieldVisible` compared against an empty provider string when `stt.provider` was unset, so **no** STT model field rendered.

## Approach

- Expand ElevenLabs suggestions to include v3 / ttv_v3 / turbo v2 / flash v2.
- Treat `tts.elevenlabs.model_id` and `stt.openai.model` as free-input comboboxes (same policy as `tts.openai.model` and ElevenLabs voice IDs).
- Fall back unset TTS/STT providers to backend defaults (`edge` / `local`) so nested fields stay visible.

## Tests

- Vitest: `voice-provider-fields`, `voice-field-visible`, `helpers` (52 passed).
- Sabotage: dropping `eleven_v3` from `ENUM_OPTIONS` fails the new suggestion test; restoring it passes.

## Risk

UI-only. Does not change TTS/STT dispatch. Custom typed model ids already work on the backend.

## Exclusions

Does not add `gpt-live-transcribe` to the STT backend. Does not change live ElevenLabs synthesis.

Closes #94012