### PR TITLE
fix(agent): stop free models from exhausting empty-response retries

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7891,7 +7891,7 @@ def run_conversation(
                             _empty_retry_budget, wait_time, agent.model,
                         )
                         _budget_note = (
-                            " — high-cost request, reduced retry budget"
+                            " — empty-response guard reduced retry budget"
                             if _empty_retry_budget < _empty_guard.DEFAULT_EMPTY_RETRY_BUDGET
                             else ""
                         )

--- a/agent/empty_response_guard.py
+++ b/agent/empty_response_guard.py
@@ -1,4 +1,4 @@
-"""Deterministic-empty detection and cost-aware retry budgets (NS-503).
+"""Deterministic-empty detection and evidence-aware retry budgets (NS-503).
 
 When a provider returns an empty completion, the agent loop retries up to
 3 times and then walks the fallback chain. Every attempt re-sends the full
@@ -25,11 +25,11 @@ Two independent guards, both failing OPEN to today's behaviour:
    stripping, whitespace, flaky decoding) never classify as deterministic
    and keep the full retry budget.
 
-2. **Cost-aware retry budget** — when the estimated input cost of a
-   single empty attempt exceeds the configured threshold (default
-   $0.25), the empty-retry budget for this streak drops from 3 to 1.
-   Unknown pricing, missing usage, or included/subscription routes
-   leave the budget untouched.
+2. **Evidence-aware retry budget** — the empty-retry budget for a streak
+   drops from 3 to 1 after two zero-output attempts from the same route,
+   or when one attempt's estimated input cost exceeds the configured
+   threshold (default $0.25). This keeps the guard reachable for free and
+   unknown-priced models while missing usage still fails open.
 
 Configured via the additive ``agent.empty_response_guard`` section in
 ``config.yaml`` (resolved once at agent init by ``agent_init``)::
@@ -251,11 +251,31 @@ def deterministic_empty(agent: Any) -> bool:
     )
 
 
+def _repeated_zero_output_route(agent: Any) -> bool:
+    """Whether repeated zero-output attempts came from one model route.
+
+    Finish reasons are intentionally excluded: providers may vary generic
+    reasons across otherwise identical empty completions. Route changes,
+    missing usage, and generated output continue to fail open.
+    """
+    attempts = getattr(agent, _ATTEMPTS_ATTR, None) or []
+    if len(attempts) < 2:
+        return False
+    first_route = (attempts[0].model, attempts[0].provider)
+    return all(
+        attempt.usage_present
+        and attempt.zero_output
+        and (attempt.model, attempt.provider) == first_route
+        for attempt in attempts
+    )
+
+
 def empty_retry_budget(agent: Any, response: Any) -> int:
-    """Empty-retry budget for the current streak (3, or 1 when a single
-    attempt is estimated to cost more than the configured threshold)."""
+    """Return 1 after repeated route empties or costly input; otherwise 3."""
     if not guard_enabled(agent):
         return DEFAULT_EMPTY_RETRY_BUDGET
+    if _repeated_zero_output_route(agent):
+        return REDUCED_EMPTY_RETRY_BUDGET
     cost = _estimate_attempt_cost(agent, response)
     if cost is None:
         return DEFAULT_EMPTY_RETRY_BUDGET

--- a/tests/agent/test_empty_response_guard.py
+++ b/tests/agent/test_empty_response_guard.py
@@ -159,6 +159,45 @@ class TestDeterministicEmpty:
 
 
 class TestEmptyRetryBudget:
+    def test_zero_priced_route_reduces_after_repeated_zero_output(self, monkeypatch):
+        monkeypatch.setattr(
+            guard, "_estimate_attempt_cost", lambda a, r: Decimal("0")
+        )
+        agent = _agent()
+        _record_streak(
+            agent,
+            [_response(), _response()],
+            finish_reasons=["stop", "length"],
+        )
+
+        assert (
+            guard.empty_retry_budget(agent, _response())
+            == guard.REDUCED_EMPTY_RETRY_BUDGET
+        )
+
+    def test_unknown_pricing_reduces_after_repeated_zero_output(self, monkeypatch):
+        monkeypatch.setattr(guard, "_estimate_attempt_cost", lambda a, r: None)
+        agent = _agent()
+        _record_streak(agent, [_response(), _response()])
+
+        assert (
+            guard.empty_retry_budget(agent, _response())
+            == guard.REDUCED_EMPTY_RETRY_BUDGET
+        )
+
+    def test_behavioral_reduction_requires_same_route(self, monkeypatch):
+        monkeypatch.setattr(guard, "_estimate_attempt_cost", lambda a, r: None)
+        agent = _agent()
+        guard.record_empty_attempt(agent, finish_reason="stop", response=_response())
+        agent._empty_content_retries += 1
+        agent.model = "other/model"
+        guard.record_empty_attempt(agent, finish_reason="stop", response=_response())
+
+        assert (
+            guard.empty_retry_budget(agent, _response())
+            == guard.DEFAULT_EMPTY_RETRY_BUDGET
+        )
+
     def test_default_budget_when_cost_unknown(self, monkeypatch):
         monkeypatch.setattr(guard, "_estimate_attempt_cost", lambda a, r: None)
         assert (

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3518,6 +3518,35 @@ class TestRunConversation:
         # proves determinism, remaining retries are skipped.
         assert result["api_calls"] == 2
 
+    def test_zero_priced_route_stops_after_repeated_zero_output(self, agent):
+        """Route-level evidence reduces retries even when generic finish
+        reasons vary and cost cannot provide a positive signal."""
+        self._setup_agent(agent)
+        agent.base_url = "http://127.0.0.1:1234/v1"
+        zero_usage = {
+            "prompt_tokens": 25_900,
+            "completion_tokens": 0,
+            "total_tokens": 25_900,
+        }
+        responses = [
+            _mock_response(content=None, finish_reason=reason, usage=zero_usage)
+            for reason in ("stop", "unknown", "stop", "unknown")
+        ]
+        agent.client.chat.completions.create.side_effect = responses
+        with (
+            patch(
+                "agent.empty_response_guard._estimate_attempt_cost",
+                return_value=0,
+            ),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("answer me")
+
+        assert result["completed"] is True
+        assert result["api_calls"] == 2
+
     def test_guard_disabled_via_config_restores_legacy_retries(self, agent):
         """NS-503: agent.empty_response_guard.enabled: false in config.yaml
         (resolved to _empty_guard_enabled at init) restores the legacy


### PR DESCRIPTION
## What does this PR do?

Free and unknown-priced models now reduce their empty-response retry budget after two zero-output attempts from the same model/provider route. Previously, the reduced budget depended only on a positive cost estimate, so a route priced at zero or without pricing could consume the full retry budget even after repeated empty completions.

### Symptom

When a free model repeatedly returns no content, no reasoning, and zero output tokens, Hermes can run all three empty-response retries before fallback. Generic finish-reason changes can also prevent the stricter deterministic-empty signature from stopping the streak.

### Impact

Affected turns spend avoidable backoff time and resend the full conversation before fallback. The reported OpenRouter incident observed this across 17 turns during a prolonged free-model outage.

### Bug Cause

**Trigger:** `agent/empty_response_guard.py` / `empty_retry_budget()` / a zero or unknown attempt-cost estimate.

**Causal chain:**
1. The conversation loop records repeated zero-output empty attempts from the same model/provider route.
2. `empty_retry_budget()` checks only whether the current attempt cost reaches the configured threshold.
3. Zero and unknown cost estimates cannot reach that threshold, so the budget remains at three retries even when route-level behavior already shows repeated empties.

**Why it is wrong:** Cost is only one signal that another retry is wasteful. Repeated zero-output results from the same route provide behavior evidence independently of price.

**Working sibling / contrast:** Paid attempts above `cost_threshold_usd` already receive the reduced budget on the first empty response.

**Ruled out:** Missing usage is not treated as evidence because the guard cannot distinguish a true zero-output completion from incomplete provider telemetry. That fail-open behavior remains unchanged.

### Fix

Use the existing per-streak attempt history to reduce the retry budget after two usage-backed zero-output attempts from the same model/provider route. Finish reason is deliberately excluded from this budget signal, while route changes, missing usage, generated output, the cost threshold, and `enabled: false` retain their existing behavior.

## Related Issue

Closes #93991

## Type of Change

- [x] Bug fix

## Changes Made

- `agent/empty_response_guard.py` - add route-level repeated-zero-output evidence to retry-budget selection.
- `agent/conversation_loop.py` - make the reduced-budget status message accurate for cost and behavior signals.
- `tests/agent/test_empty_response_guard.py` - cover zero-priced, unknown-priced, and route-change cases.
- `tests/run_agent/test_run_agent.py` - verify the conversation loop stops after two route-consistent zero-output attempts even when finish reasons vary.

## How to Test

1. Run the guard unit tests.
2. Run the focused conversation-loop empty-response tests.

```bash
scripts/run_tests.sh tests/agent/test_empty_response_guard.py -q
scripts/run_tests.sh tests/run_agent/test_run_agent.py -k 'empty_response or deterministic_empty or zero_priced_route' -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the repository test entry on relevant tests and all relevant tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant docstrings
- [x] `cli-config.yaml.example` changes are N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` changes are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; the changed logic is platform-independent
- [x] Tool description and schema changes are N/A because no model tool changed

## Screenshots / Logs

N/A - behavior is covered by unit and conversation-loop regression tests.
