### PR TITLE
fix: restart launchd surfaces after agent updates

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3174,6 +3174,114 @@ def launchd_gateway_labels_for_install() -> list[str]:
     return root_label + sorted(profile_labels)
 
 
+def _launchd_plist_strings(value) -> list[str]:
+    """Flatten launchd plist values into strings for dependency matching."""
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        strings: list[str] = []
+        for item in value.values():
+            strings.extend(_launchd_plist_strings(item))
+        return strings
+    if isinstance(value, (list, tuple)):
+        strings: list[str] = []
+        for item in value:
+            strings.extend(_launchd_plist_strings(item))
+        return strings
+    return []
+
+
+def _text_references_path_under_project(text: str, project_root: Path) -> bool:
+    """Return True if *text* names PROJECT_ROOT or a path inside it.
+
+    LaunchAgent plists commonly store either a direct ProgramArgument such as
+    ``.../hermes-agent/venv/bin/python`` or an env var/PATH-like string.  Check
+    both raw substrings and resolved path segments so local symlinks such as
+    ``~/.hermes/hermes-agent -> ~/personal-projects/hermes-agent`` still match.
+    """
+    if not text:
+        return False
+    raw_root = str(project_root)
+    resolved_root = project_root.resolve()
+    if raw_root in text or str(resolved_root) in text:
+        return True
+
+    # PATH-style variables are common in launchd plists. Split on os.pathsep
+    # first, then also consider the full value for ordinary single paths.
+    parts = [text]
+    if os.pathsep in text:
+        parts.extend(part for part in text.split(os.pathsep) if part)
+    for part in parts:
+        if not part.startswith(("/", "~")):
+            continue
+        try:
+            candidate = Path(part).expanduser().resolve(strict=False)
+            candidate.relative_to(resolved_root)
+            return True
+        except (OSError, ValueError):
+            continue
+    return False
+
+
+def launchd_agent_dependent_labels_for_install() -> list[str]:
+    """Return non-gateway launchd labels that load this Hermes Agent checkout.
+
+    Some local surfaces are not Hermes gateways but still import Hermes Agent
+    into a long-lived launchd process.  Hermes WebUI is the concrete macOS
+    failure mode: its LaunchAgent runs this checkout's venv Python plus the
+    WebUI bootstrap, so when ``hermes update`` moves the Agent HEAD, WebUI must
+    be kickstarted too or ``api.agent_runtime`` correctly refuses the next
+    action with "Hermes Agent was updated while Hermes WebUI was running".
+
+    Scope this to KeepAlive LaunchAgents whose executable/env explicitly
+    references this exact checkout (including symlink-resolved paths), and
+    exclude ``ai.hermes.gateway*`` labels because the gateway fleet path already
+    handles those deliberately.  Timer-only helpers that merely put the venv on
+    ``PATH`` are skipped: they are not long-lived old-code processes, and
+    kickstarting them would trigger unrelated scheduled work during updates.
+    Best-effort and read-only: malformed plists or unreadable files are skipped.
+    """
+    if not sys.platform == "darwin":
+        return []
+    launch_agents = _launchd_user_home() / "Library" / "LaunchAgents"
+    if not launch_agents.is_dir():
+        return []
+
+    labels: list[str] = []
+    try:
+        import plistlib
+
+        for plist_path in sorted(launch_agents.glob("*.plist")):
+            try:
+                with plist_path.open("rb") as fh:
+                    payload = plistlib.load(fh)
+            except Exception:
+                continue
+            if not isinstance(payload, dict):
+                continue
+            label = payload.get("Label")
+            if not isinstance(label, str) or not label:
+                continue
+            if label.startswith("ai.hermes.gateway"):
+                continue
+            if not payload.get("KeepAlive"):
+                continue
+            values = []
+            for key in ("Program", "ProgramArguments"):
+                values.extend(_launchd_plist_strings(payload.get(key)))
+            env = payload.get("EnvironmentVariables")
+            if isinstance(env, dict):
+                for key, value in env.items():
+                    if str(key).upper() == "PATH":
+                        continue
+                    values.extend(_launchd_plist_strings(value))
+            if any(_text_references_path_under_project(value, PROJECT_ROOT) for value in values):
+                labels.append(label)
+    except Exception as exc:
+        logger.debug("Launchd Agent-dependent service scan failed: %s", exc)
+    return labels
+
+
 def _detect_venv_dir() -> Path | None:
     """Detect the active virtualenv directory.
 

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -5166,6 +5166,7 @@ def _restart_macos_launchd_gateways(
         get_launchd_plist_path,
         launchd_restart,
         launchd_gateway_labels_for_install,
+        launchd_agent_dependent_labels_for_install,
         _graceful_restart_via_sigusr1,
         _launchd_kickstart,
         _launchd_service_registered,
@@ -5224,10 +5225,25 @@ def _restart_macos_launchd_gateways(
     except (FileNotFoundError, subprocess.TimeoutExpired):
         pass
 
-    # --- Sibling profiles ---------------------------------------------------
+    # --- Sibling profiles and Agent-dependent companion services ------------
+    # Gateways support SIGUSR1 drain semantics; companion launchd services
+    # (notably Hermes WebUI) do not necessarily implement the gateway protocol
+    # but still import this checkout into long-lived Python processes, so they
+    # must be hard-kickstarted after an Agent HEAD move.
+    seen_labels = {current_label}
+    labels_to_restart: list[tuple[str, bool]] = []
     for label in launchd_gateway_labels_for_install():
-        if label == current_label:
+        if label in seen_labels:
             continue
+        seen_labels.add(label)
+        labels_to_restart.append((label, True))
+    for label in launchd_agent_dependent_labels_for_install():
+        if label in seen_labels:
+            continue
+        seen_labels.add(label)
+        labels_to_restart.append((label, False))
+
+    for label, drain_supported in labels_to_restart:
         try:
             # Locate = liveness + domain in one domain-explicit probe; the
             # kickstart and fresh-PID verification below reuse the located
@@ -5239,7 +5255,7 @@ def _restart_macos_launchd_gateways(
                 # mid-way) — nothing is running old code here.
                 continue
             graceful_ok = False
-            if old_pid is not None and old_pid > 0:
+            if drain_supported and old_pid is not None and old_pid > 0:
                 print(f"  → {label}: draining (up to {int(drain_budget)}s)...")
                 graceful_ok = _graceful_restart_via_sigusr1(
                     old_pid, drain_timeout=drain_budget

--- a/tests/hermes_cli/test_update_launchd_fleet_restart.py
+++ b/tests/hermes_cli/test_update_launchd_fleet_restart.py
@@ -20,6 +20,7 @@ in a domain it does not live in.
 
 from __future__ import annotations
 
+import plistlib
 import subprocess
 import sys
 
@@ -106,6 +107,49 @@ class TestLaunchdGatewayLabelsForInstall:
     def test_no_profiles_means_no_fleet(self, monkeypatch):
         monkeypatch.setattr(hermes_cli.profiles, "list_profiles", lambda: [])
         assert launchd_gateway_labels_for_install() == []
+
+
+class TestLaunchdAgentDependentLabelsForInstall:
+    def test_discovers_webui_plist_bound_to_this_agent_checkout(self, monkeypatch, tmp_path):
+        launch_agents = tmp_path / "Library" / "LaunchAgents"
+        launch_agents.mkdir(parents=True)
+        agent_root = tmp_path / "hermes-agent"
+        venv_python = agent_root / "venv" / "bin" / "python"
+        webui_plist = launch_agents / "com.parantoux.hermes-webui.plist"
+        webui_plist.write_bytes(
+            plistlib.dumps(
+                {
+                    "Label": "com.parantoux.hermes-webui",
+                    "KeepAlive": True,
+                    "ProgramArguments": [str(venv_python), "/tmp/webui/bootstrap.py"],
+                    "EnvironmentVariables": {
+                        "HERMES_WEBUI_AGENT_DIR": str(agent_root),
+                    },
+                }
+            )
+        )
+        gateway_plist = launch_agents / "ai.hermes.gateway-zero.plist"
+        gateway_plist.write_bytes(
+            plistlib.dumps(
+                {
+                    "Label": "ai.hermes.gateway-zero",
+                    "ProgramArguments": [str(venv_python), "-m", "hermes_cli.main"],
+                }
+            )
+        )
+        unrelated_plist = launch_agents / "com.example.other.plist"
+        unrelated_plist.write_bytes(
+            plistlib.dumps(
+                {"Label": "com.example.other", "ProgramArguments": ["/usr/bin/true"]}
+            )
+        )
+
+        monkeypatch.setattr(gw, "_launchd_user_home", lambda: tmp_path)
+        monkeypatch.setattr(gw, "PROJECT_ROOT", agent_root)
+
+        assert gw.launchd_agent_dependent_labels_for_install() == [
+            "com.parantoux.hermes-webui"
+        ]
 
 
 class TestParseLaunchdPidFromPrintOutput:
@@ -288,6 +332,7 @@ def _fleet(monkeypatch, tmp_path, *, current, labels, located,
     monkeypatch.setattr(gw, "get_launchd_label", lambda: current)
     monkeypatch.setattr(gw, "get_launchd_plist_path", lambda: plist)
     monkeypatch.setattr(gw, "launchd_gateway_labels_for_install", lambda: list(labels))
+    monkeypatch.setattr(gw, "launchd_agent_dependent_labels_for_install", lambda: [])
     monkeypatch.setattr(gw, "_locate_launchd_gateway_service", fake_locate)
     monkeypatch.setattr(gw, "_launchd_service_registered", fake_registered)
     monkeypatch.setattr(
@@ -328,6 +373,37 @@ def _fleet(monkeypatch, tmp_path, *, current, labels, located,
 
 
 class TestRestartMacosLaunchdGateways:
+    def test_restarts_non_gateway_launchd_services_bound_to_agent_checkout(
+        self, monkeypatch, tmp_path
+    ):
+        """WebUI is not a gateway, but it imports Hermes Agent into a
+        long-lived launchd process. Agent HEAD changes must kickstart it too,
+        or api.agent_runtime's HEAD guard trips on the next WebUI action."""
+        rec = _fleet(
+            monkeypatch,
+            tmp_path,
+            current="ai.hermes.gateway-zero",
+            labels=["ai.hermes.gateway-zero"],
+            located={
+                "ai.hermes.gateway-zero": (f"gui/{UID}", 100),
+                "com.parantoux.hermes-webui": (f"gui/{UID}", 8787),
+            },
+        )
+        monkeypatch.setattr(
+            gw,
+            "launchd_agent_dependent_labels_for_install",
+            lambda: ["com.parantoux.hermes-webui"],
+        )
+        restarted: list[str] = []
+        failed: list[str] = []
+
+        _restart_macos_launchd_gateways(restarted, failed, drain_budget=0.0)
+
+        assert f"gui/{UID}/com.parantoux.hermes-webui" in rec.kickstarts
+        assert "com.parantoux.hermes-webui" in restarted
+        assert 8787 not in rec.drains
+        assert failed == []
+
     def test_current_delegates_and_siblings_kickstart_in_own_domains(
         self, monkeypatch, tmp_path
     ):


### PR DESCRIPTION
## Summary
- restart non-gateway macOS LaunchAgents that load the Hermes Agent checkout after `hermes update` moves HEAD
- detect KeepAlive companion services such as Hermes WebUI by Program/ProgramArguments or non-PATH env references to the checkout
- skip gateway labels already handled by the gateway fleet path and skip timer-only PATH helpers

## Why
Hermes WebUI imports Hermes Agent into a long-lived launchd process. If Agent HEAD changes without restarting WebUI, WebUI can correctly refuse the next action with:

`Hermes Agent was updated while Hermes WebUI was running. Restart Hermes WebUI before retrying this action.`

## Verification
- targeted launchd restart/discovery tests passed
- broader filtered launchd fleet restart slice passed: 26 passed
- `py_compile` passed for changed Python files
- live Zero operational guard separately verified local/Tailscale WebUI health after restart
- external Claude Team read-only verification: PASS for local operational guard, PARTIAL only because this source fix is pending integration