### PR TITLE
fix(web): expose resolved provider in tool results

### DIFF
--- a/plugins/web/keyless_mcp.py
+++ b/plugins/web/keyless_mcp.py
@@ -861,6 +861,10 @@ def extract_with_failover(name: str, urls: List[str]) -> List[Dict[str, Any]]:
             e and _is_rate_limitish(e) for e in errors
         )
         if not all_throttled:
+            if vendor != name:
+                for result in results:
+                    if isinstance(result, dict):
+                        result.setdefault("metadata", {})["served_by"] = vendor
             return results
         last = results
         nxt = order[i + 1] if i + 1 < len(order) else None

--- a/tests/tools/test_web_keyless_fallback.py
+++ b/tests/tools/test_web_keyless_fallback.py
@@ -526,7 +526,8 @@ class TestKeylessFailover:
         monkeypatch.setitem(keyless_mcp._KEYLESS_EXTRACTORS, "exa", lambda urls: throttled)
         monkeypatch.setitem(keyless_mcp._KEYLESS_EXTRACTORS, "parallel", lambda urls: good)
         out = keyless_mcp.extract_with_failover("exa", ["https://a", "https://b"])
-        assert out == good
+        assert [r["content"] for r in out] == ["x", "y"]
+        assert all(r["metadata"]["served_by"] == "parallel" for r in out)
 
     def test_extract_partial_failure_stays_on_primary(self, monkeypatch):
         self._pin(monkeypatch, "exa")

--- a/tests/tools/test_web_keyless_rescue.py
+++ b/tests/tools/test_web_keyless_rescue.py
@@ -68,7 +68,13 @@ def _keyed_tavily_env(monkeypatch):
 
 
 def _ring_ok(vendor="exa"):
-    return {"success": True, "data": {"web": [{"url": f"https://{vendor}.example"}]}}
+    return {
+        "success": True,
+        "data": {
+            "web": [{"url": f"https://{vendor}.example"}],
+            "served_by": vendor,
+        },
+    }
 
 
 class TestEligibility:
@@ -116,6 +122,7 @@ class TestSearchRescue:
         ) as ring:
             out = self._dispatch(monkeypatch, _KeyedBoomProvider())
         assert out["success"] is True
+        assert out["provider"] == "exa"
         assert out["data"]["rescued_from"] == "tavily"
         assert "HTTP 500" in out["data"]["backend_error"]
         assert "next call" in out["data"]["backend_error"].lower()
@@ -181,25 +188,28 @@ class TestExtractRescue:
 
         monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_all)
         raw = await web_tools.web_extract_tool(list(urls))
-        data = json.loads(raw)
-        return data["results"] if isinstance(data, dict) and "results" in data else data
+        return json.loads(raw)
 
     @pytest.mark.asyncio
     async def test_whole_batch_failure_rescued(self, monkeypatch):
         good = [
             {"url": "https://a", "title": "A", "content": "x" * 50,
-             "raw_content": "x" * 50, "metadata": {"sourceURL": "https://a"}},
+             "raw_content": "x" * 50,
+             "metadata": {"sourceURL": "https://a", "served_by": "exa"}},
             {"url": "https://b", "title": "B", "content": "y" * 50,
-             "raw_content": "y" * 50, "metadata": {"sourceURL": "https://b"}},
+             "raw_content": "y" * 50,
+             "metadata": {"sourceURL": "https://b", "served_by": "exa"}},
         ]
         with patch.object(
             keyless_mcp, "extract_with_failover", return_value=good
         ) as ring:
-            results = await self._dispatch(
+            data = await self._dispatch(
                 monkeypatch, _KeyedBoomProvider(), ["https://a", "https://b"]
             )
+        results = data["results"]
         assert all(not r.get("error") for r in results)
         assert results[0]["content"].startswith("x")
+        assert data["provider"] == "exa"
         ring.assert_called_once()
 
     def test_rescue_extract_annotates_results(self, monkeypatch):
@@ -226,9 +236,10 @@ class TestExtractRescue:
                 ]
 
         with patch.object(keyless_mcp, "extract_with_failover") as ring:
-            results = await self._dispatch(
+            data = await self._dispatch(
                 monkeypatch, _Partial(), ["https://a", "https://b"]
             )
+        results = data["results"]
         assert results[1].get("error")
         ring.assert_not_called()
 
@@ -241,7 +252,8 @@ class TestExtractRescue:
         with patch.object(
             keyless_mcp, "extract_with_failover", return_value=still_bad
         ):
-            results = await self._dispatch(
+            data = await self._dispatch(
                 monkeypatch, _KeyedBoomProvider(), ["https://a", "https://b"]
             )
+        results = data["results"]
         assert all("HTTP 500" in r.get("error", "") for r in results)

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -441,7 +441,11 @@ class TestWebSearchSchema:
              patch.object(tools.web_tools._debug, "save"):
             result = json.loads(tools.web_tools.web_search_tool("docs", limit=500))
 
-        assert result == {"success": True, "data": {"web": []}}
+        assert result == {
+            "success": True,
+            "data": {"web": []},
+            "provider": "parallel",
+        }
         fake_search.assert_called_once_with("docs", 100)
 
 

--- a/tests/tools/test_web_tools_dict_urls.py
+++ b/tests/tools/test_web_tools_dict_urls.py
@@ -73,6 +73,7 @@ async def test_web_extract_dispatches_urls_from_search_result_objects(extract_pr
         "https://example.org/b",
     ]
     assert [entry["url"] for entry in result["results"]] == extract_provider.received_urls
+    assert result["provider"] == "dict-url-test"
 
 
 def test_web_extract_registry_dispatch_accepts_search_result_objects(

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -578,6 +578,30 @@ def _rescue_extract(provider_name: str, urls: list, results: list) -> list:
     return rescued
 
 
+def _resolved_search_provider(provider_name: str, response: dict) -> str:
+    """Return the backend that actually served a search response."""
+    data = response.get("data")
+    if isinstance(data, dict):
+        served_by = data.get("served_by")
+        if isinstance(served_by, str) and served_by.strip():
+            return served_by.strip()
+    return provider_name
+
+
+def _resolved_extract_provider(provider_name: str, results: list) -> str:
+    """Return the backend that actually served an extract batch."""
+    for result in results:
+        if not isinstance(result, dict):
+            continue
+        metadata = result.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+        served_by = metadata.get("served_by")
+        if isinstance(served_by, str) and served_by.strip():
+            return served_by.strip()
+    return provider_name
+
+
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
@@ -853,6 +877,7 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         str: JSON string containing search results with the following structure:
              {
                  "success": bool,
+                 "provider": str,
                  "data": {
                      "web": [
                          {
@@ -988,6 +1013,11 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                         limit,
                     )
 
+            response_data = dict(response_data)
+            response_data["provider"] = _resolved_search_provider(
+                provider.name, response_data
+            )
+
         debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
         debug_call_data["final_response_size"] = len(result_json)
@@ -1032,7 +1062,7 @@ async def web_extract_tool(
     Security: URLs are checked for embedded secrets before fetching.
 
     Returns:
-        str: JSON string with a ``results`` list; each entry has
+        str: JSON string with ``provider`` plus a ``results`` list; each entry has
              ``url``, ``title``, ``content``, ``error``. ``content`` is the
              (possibly truncated) clean page text.
 
@@ -1100,6 +1130,7 @@ async def web_extract_tool(
         "processing_applied": []
     }
     
+    provider_name: Optional[str] = None
     try:
         logger.info("Extracting content from %d URL(s)", len(normalized_urls))
 
@@ -1225,6 +1256,7 @@ async def web_extract_tool(
             logger.info(
                 "Web extract via %s: %d URL(s)", provider.name, len(safe_urls)
             )
+            provider_name = provider.name
 
             # Async-or-sync dispatch: parallel + firecrawl have async
             # extract(); exa + tavily are sync.
@@ -1262,6 +1294,8 @@ async def web_extract_tool(
                         _rescue_extract, provider.name, safe_urls, results
                     )
 
+            provider_name = _resolved_extract_provider(provider.name, results)
+
         # Reconstruct the original input order across invalid, blocked, and
         # provider-processed entries. Providers are expected to preserve the
         # order of the safe URL list they receive.
@@ -1282,7 +1316,9 @@ async def web_extract_tool(
             by_index = {**safe_results, **ssrf_blocked, **invalid_urls}
             results = [by_index[index] for index in range(len(urls))]
 
-        response = {"results": results}
+        response: Dict[str, Any] = {"results": results}
+        if provider_name is not None:
+            response["provider"] = provider_name
         
         pages_extracted = len(response.get('results', []))
         logger.info("Extracted content from %d pages", pages_extracted)
@@ -1333,7 +1369,9 @@ async def web_extract_tool(
             }
             for r in response.get("results", [])
         ]
-        trimmed_response = {"results": trimmed_results}
+        trimmed_response: Dict[str, Any] = {"results": trimmed_results}
+        if provider_name is not None:
+            trimmed_response["provider"] = provider_name
 
         if trimmed_response.get("results") == []:
             result_json = tool_error("Content was inaccessible or not found")
@@ -1531,7 +1569,7 @@ from tools.registry import registry, tool_error
 
 WEB_SEARCH_SCHEMA = {
     "name": "web_search",
-    "description": "Search the web for information. Returns up to 5 results by default with titles, URLs, and descriptions. The query is passed through to the configured backend, so operators such as site:domain, filetype:pdf, intitle:word, -term, and \"exact phrase\" may work when the backend supports them.",
+    "description": "Search the web for information. Returns the resolved provider plus up to 5 results by default with titles, URLs, and descriptions. The query is passed through to the configured backend, so operators such as site:domain, filetype:pdf, intitle:word, -term, and \"exact phrase\" may work when the backend supports them.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -1553,7 +1591,7 @@ WEB_SEARCH_SCHEMA = {
 
 WEB_EXTRACT_SCHEMA = {
     "name": "web_extract",
-    "description": "Extract content from web page URLs. Returns clean page content in markdown/text (no LLM summarization — fast). Also works with PDF URLs (arxiv papers, documents) — pass the PDF link directly. Pages within the char budget (default 15000) return whole; larger pages return a head+tail window with a footer telling you the full text's saved file path and the read_file call to page through the omitted middle. Inline images appear as [IMAGE: alt] placeholders; real image URLs are kept as links. If a URL fails or times out, use the browser tool instead.",
+    "description": "Extract content from web page URLs. Returns the resolved provider plus clean page content in markdown/text (no LLM summarization — fast). Also works with PDF URLs (arxiv papers, documents) — pass the PDF link directly. Pages within the char budget (default 15000) return whole; larger pages are head+tail truncated with a footer telling you the full text's saved file path and the read_file call to page through the omitted middle. Inline images appear as [IMAGE: alt] placeholders; real image URLs are kept as links. If a URL fails or times out, use the browser tool instead.",
     "parameters": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## What does this PR do?

Adds model-visible provider attribution to successful `web_search` and `web_extract` results.

The generic tool names currently hide which backend actually served a request. This is especially ambiguous when the keyless ring or one-shot rescue path falls back from the configured provider. The tool wrappers now return a top-level `provider` field resolved from the actual response, while preserving the existing result envelopes.

A standalone provider plugin cannot solve this generically: provider plugins implement one backend, while attribution belongs at the shared wrapper after native selection, keyless failover, rescue, URL reconstruction, and truncation. A `transform_tool_result` hook also lacks the actual backend for normal dispatch and keyless extract failover. This narrow core change therefore covers every provider without overriding the built-in tools.

This complements #48135: that PR adds CLI progress labels, while this change makes the resolved provider visible to the model and all non-CLI surfaces through the tool result itself.

## Related Issue

Related to #48125

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/web_tools.py`
  - Add top-level `provider` to successful search and extract responses.
  - Resolve keyless search/rescue attribution from `data.served_by`.
  - Resolve extract attribution from per-result `metadata.served_by`.
  - Preserve attribution in truncated extract responses.
  - Update tool docstrings and model-visible schema descriptions.
- `plugins/web/keyless_mcp.py`
  - Annotate successful cross-vendor extract failover results with the backend that served them.
- Focused tests cover configured search/extract providers and keyless search/extract rescue/failover.

## How to Test

1. Run the focused web-tool suite:
   ```bash
   HERMES_PYTHON=/path/to/python-with-pytest scripts/run_tests.sh tests/tools/test_web*.py
   ```
2. Confirm `web_search` success includes `{"provider": "<resolved-backend>", ...}`.
3. Confirm `web_extract` success includes `{"provider": "<resolved-backend>", "results": [...]}` and that keyless fallback reports the backend that actually served the request.

Local result on Ubuntu 24.04 / Python 3.11:

```text
12 files, 202 tests passed, 0 failed
Ruff: All checks passed
scripts/audit_pr_attribution.py: All contributor emails mapped
git diff --check: passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused canonical test suite and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on Ubuntu 24.04 with Python 3.11

### Documentation & Housekeeping

- [x] N/A — tool docstrings and schemas are updated; no user setup changes
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow changes
- [x] Cross-platform impact considered: pure Python/JSON behavior with no OS-specific code
- [x] Tool descriptions/schemas updated for the new response field
