### PR TITLE
fix(agent): keep configured default in session recovery order

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1550,6 +1550,11 @@ def init_agent(
         agent._fallback_chain = []
     agent._fallback_index = 0
     agent._fallback_activated = getattr(agent, "_fallback_activated", False)
+    agent._configured_default_route = {
+        "provider": getattr(agent, "requested_provider", None) or agent.provider,
+        "model": agent.model,
+        "base_url": agent.base_url,
+    }
     # Legacy attribute kept for backward compat (tests, external callers)
     agent._fallback_model = agent._fallback_chain[0] if agent._fallback_chain else None
     if agent._fallback_chain and not agent.quiet_mode:

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1550,11 +1550,11 @@ def init_agent(
         agent._fallback_chain = []
     agent._fallback_index = 0
     agent._fallback_activated = getattr(agent, "_fallback_activated", False)
-    agent._configured_default_route = {
-        "provider": getattr(agent, "requested_provider", None) or agent.provider,
-        "model": agent.model,
-        "base_url": agent.base_url,
-    }
+    # Generic agents do not have a separate configured-default route. Gateway
+    # and API session overrides assign this explicitly after resolving the
+    # global default; treating every agent's initial primary as that route
+    # would reinsert a provider an ordinary /model switch deliberately left.
+    agent._configured_default_route = None
     # Legacy attribute kept for backward compat (tests, external callers)
     agent._fallback_model = agent._fallback_chain[0] if agent._fallback_chain else None
     if agent._fallback_chain and not agent.quiet_mode:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3113,6 +3113,19 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             entry for entry in fallback_chain
             if (entry.get("provider") or "").strip().lower() not in {old_norm, new_norm}
         ]
+    configured_default = getattr(agent, "_configured_default_route", None)
+    if configured_default:
+        from hermes_cli.fallback_config import compose_fallback_chain
+
+        fallback_chain = compose_fallback_chain(
+            fallback_chain,
+            primary={
+                "provider": getattr(agent, "requested_provider", None) or new_provider,
+                "model": new_model,
+                "base_url": agent.base_url,
+            },
+            configured_default=configured_default,
+        )
     agent._fallback_chain = fallback_chain
     agent._fallback_model = fallback_chain[0] if fallback_chain else None
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2884,6 +2884,16 @@ class APIServerAdapter(BasePlatformAdapter):
         except RuntimeError as exc:
             raise _ProviderAuthResolutionError(str(exc)) from exc
         model = _resolve_gateway_model()
+        user_config = _load_gateway_config()
+        from hermes_cli.fallback_config import (
+            compose_fallback_chain,
+            get_configured_default_route,
+        )
+
+        configured_default_route = get_configured_default_route(
+            user_config,
+            runtime=runtime_kwargs,
+        )
 
         # When the primary provider's auth fails (expired token / 429 quota
         # cap), _resolve_runtime_agent_kwargs() falls through to the fallback
@@ -3090,18 +3100,25 @@ class APIServerAdapter(BasePlatformAdapter):
                     self._last_resolved_model[_resolved_key] = model
                 self._last_resolved_model["*"] = model
 
-        user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
 
         max_iterations = _current_max_iterations()
 
         # Load fallback provider chain so the API server platform has the
         # same fallback behaviour as Telegram/Discord/Slack (fixes #4954).
-        fallback_model = (
-            None
-            if confirmed_runtime_lock
-            else GatewayRunner._load_fallback_model()
-        )
+        if confirmed_runtime_lock:
+            fallback_model = None
+        else:
+            fallback_model = compose_fallback_chain(
+                GatewayRunner._load_fallback_model(),
+                primary={
+                    "provider": runtime_kwargs.get("requested_provider")
+                    or runtime_kwargs.get("provider"),
+                    "model": model,
+                    "base_url": runtime_kwargs.get("base_url"),
+                },
+                configured_default=configured_default_route,
+            ) or None
 
         # Resolve reasoning against the model this request will actually
         # run. Per-model ``agent.reasoning_overrides`` key off that model,
@@ -3141,6 +3158,7 @@ class APIServerAdapter(BasePlatformAdapter):
             agent_kwargs["service_tier"] = request_service_tier
 
         agent = AIAgent(**agent_kwargs)
+        agent._configured_default_route = configured_default_route
         agent._hermes_api_runtime = {
             "provider": runtime_kwargs.get("provider") or getattr(agent, "provider", "") or "",
             "model": getattr(agent, "model", None) or model,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5737,13 +5737,16 @@ class TurnRunner:
         # must reach the next turn (#60955).  Per-session turn
         # serialization (_running_agents) keeps this safe post-lock.
         if reused_cached_agent and agent is not None:
-            agent._configured_default_route = _configured_default_route
+            refreshed_chain = self._runner._refresh_fallback_model(
+                primary_route=_fallback_primary_route,
+                configured_default_route=_configured_default_route,
+            )
+            agent._configured_default_route = getattr(
+                self._runner, "_configured_default_route", _configured_default_route
+            )
             self._runner._apply_fallback_chain_to_agent(
                 agent,
-                self._runner._refresh_fallback_model(
-                    primary_route=_fallback_primary_route,
-                    configured_default_route=_configured_default_route,
-                ),
+                refreshed_chain,
             )
 
         # Lock released — now schedule cleanup of any cross-process-evicted
@@ -5822,7 +5825,9 @@ class TurnRunner:
                     self._runner._enforce_agent_cache_cap()
             logger.debug("Created new agent for session %s (sig=%s)", ctx.session_key, _sig)
 
-        agent._configured_default_route = _configured_default_route
+        agent._configured_default_route = getattr(
+            self._runner, "_configured_default_route", _configured_default_route
+        )
 
         # Per-message state — callbacks and reasoning config change every
         # turn and must not be baked into the cached agent constructor.
@@ -6912,6 +6917,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._cron_drain_timeout = self._load_cron_drain_timeout()
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
+        self._configured_default_route = None
 
         # Wire process registry into session store for reset protection.
         # A background process older than the configured threshold (default 24h,
@@ -8111,6 +8117,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "credential_pool": override.get("credential_pool"),
             }
             if override_runtime.get("api_key"):
+                if configured_default_route is None and model:
+                    # Legacy ``model: <id>`` and default-only model blocks rely
+                    # on runtime provider inference. The inline-key override
+                    # returns before the normal runtime path below, so resolve
+                    # only enough of the configured route to retain it for
+                    # recovery. A broken default must not block this override.
+                    try:
+                        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+                        default_runtime = resolve_runtime_provider(target_model=model)
+                    except Exception:
+                        logger.debug(
+                            "Could not resolve configured default route for fast session override",
+                            exc_info=True,
+                        )
+                    else:
+                        configured_default_route = get_configured_default_route(
+                            user_config,
+                            runtime=default_runtime,
+                        )
                 if override_runtime.get("credential_pool") is None:
                     override_runtime["credential_pool"] = _credential_pool_for_provider(
                         override.get("provider")
@@ -9902,10 +9928,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             cfg_path = _hermes_home / "config.yaml"
             if not cfg_path.exists():
                 self._fallback_model = None
+                self._configured_default_route = None
                 return compose_fallback_chain(
                     None,
                     primary=primary_route,
-                    configured_default=configured_default_route,
+                    configured_default=None,
                 ) or None
             # Raw primitive (raises on parse failure) is required here: the
             # canonical fail-open loader would return {} on a torn mid-edit
@@ -9933,13 +9960,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return compose_fallback_chain(
                 self._fallback_model,
                 primary=primary_route,
-                configured_default=configured_default_route,
+                configured_default=getattr(
+                    self, "_configured_default_route", configured_default_route
+                ),
             ) or None
         self._fallback_model = get_fallback_chain(cfg) or None
+        self._configured_default_route = configured_default_route
         return compose_fallback_chain(
             self._fallback_model,
             primary=primary_route,
-            configured_default=configured_default_route,
+            configured_default=self._configured_default_route,
         ) or None
 
     @staticmethod
@@ -22790,6 +22820,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         logger.warning("Background task vision enrichment failed: %s", e)
 
             def run_sync():
+                fallback_model = self._refresh_fallback_model(
+                    primary_route=_fallback_primary_route,
+                    configured_default_route=_configured_default_route,
+                )
                 agent = AIAgent(
                     model=turn_route["model"],
                     **turn_route["runtime"],
@@ -22819,12 +22853,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     thread_id=source.thread_id,
                     session_db=getattr(self._session_db, "_db", self._session_db),
                     # Reload from disk — do not reuse the startup snapshot (#60955).
-                    fallback_model=self._refresh_fallback_model(
-                        primary_route=_fallback_primary_route,
-                        configured_default_route=_configured_default_route,
-                    ),
+                    fallback_model=fallback_model,
                 )
-                agent._configured_default_route = _configured_default_route
+                agent._configured_default_route = self._configured_default_route
                 try:
                     return agent.run_conversation(
                         user_message=enriched_prompt,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5531,6 +5531,7 @@ class TurnRunner:
             "base_url": turn_route["runtime"].get("base_url"),
         }
         _configured_default_route = turn_route.get("configured_default_route")
+        _effective_configured_default_route = _configured_default_route
 
         # Per-platform skip_context_files — messaging platforms can opt out
         # of filesystem-heavy context-file discovery (SOUL.md, AGENTS.md,
@@ -5737,13 +5738,14 @@ class TurnRunner:
         # must reach the next turn (#60955).  Per-session turn
         # serialization (_running_agents) keeps this safe post-lock.
         if reused_cached_agent and agent is not None:
-            refreshed_chain = self._runner._refresh_fallback_model(
+            (
+                refreshed_chain,
+                _effective_configured_default_route,
+            ) = self._runner._refresh_fallback_state(
                 primary_route=_fallback_primary_route,
                 configured_default_route=_configured_default_route,
             )
-            agent._configured_default_route = getattr(
-                self._runner, "_configured_default_route", _configured_default_route
-            )
+            agent._configured_default_route = _effective_configured_default_route
             self._runner._apply_fallback_chain_to_agent(
                 agent,
                 refreshed_chain,
@@ -5771,6 +5773,13 @@ class TurnRunner:
 
         if agent is None:
             # Config changed or first message — create fresh agent
+            (
+                refreshed_chain,
+                _effective_configured_default_route,
+            ) = self._runner._refresh_fallback_state(
+                primary_route=_fallback_primary_route,
+                configured_default_route=_configured_default_route,
+            )
             agent = ctx.AIAgent(
                 model=turn_route["model"],
                 **turn_route["runtime"],
@@ -5803,10 +5812,7 @@ class TurnRunner:
                 gateway_session_key=ctx.session_key,
                 session_db=getattr(self._runner._session_db, "_db", self._runner._session_db),
                 # Reload from disk — do not reuse the startup snapshot (#60955).
-                fallback_model=self._runner._refresh_fallback_model(
-                    primary_route=_fallback_primary_route,
-                    configured_default_route=_configured_default_route,
-                ),
+                fallback_model=refreshed_chain,
                 skip_context_files=skip_context_files,
                 # Keep the persona even with minimal context: soul identity is
                 # a single small file, not part of the expensive walk.
@@ -5825,9 +5831,7 @@ class TurnRunner:
                     self._runner._enforce_agent_cache_cap()
             logger.debug("Created new agent for session %s (sig=%s)", ctx.session_key, _sig)
 
-        agent._configured_default_route = getattr(
-            self._runner, "_configured_default_route", _configured_default_route
-        )
+        agent._configured_default_route = _effective_configured_default_route
 
         # Per-message state — callbacks and reasoning config change every
         # turn and must not be baked into the cached agent constructor.
@@ -6917,7 +6921,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._cron_drain_timeout = self._load_cron_drain_timeout()
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
-        self._configured_default_route = None
+        self._fallback_state_by_home = {
+            str(_gateway_config_home().resolve()): (self._fallback_model, None)
+        }
 
         # Wire process registry into session store for reset protection.
         # A background process older than the configured threshold (default 24h,
@@ -9904,13 +9910,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             pass
         return None
 
-    def _refresh_fallback_model(
+    def _refresh_fallback_state(
         self,
         *,
         primary_route: dict | None = None,
         configured_default_route: dict | None = None,
-    ) -> list | None:
-        """Re-read fallback_providers from disk for the next agent create/reuse.
+    ) -> tuple[list | None, dict | None]:
+        """Return the active profile's effective chain and retained default.
 
         Cron already does this per job via ``get_fallback_chain``; the gateway
         previously froze ``self._fallback_model`` at process start, so a chain
@@ -9921,19 +9927,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         A TRANSIENT read/parse failure (user mid-edit of config.yaml with a
         non-atomic write) keeps the last known-good chain instead of wiping a
         cached agent's working fallback for that turn.  Only a successful read
-        that genuinely lacks the key clears the chain.
+        that genuinely lacks the key clears the chain. Last-known-good state is
+        keyed by the context-local profile home so multiplexed profiles cannot
+        consume each other's fallback policy after a transient parse failure.
         """
+        home = _gateway_config_home()
+        state_key = str(home.resolve())
+        states = getattr(self, "_fallback_state_by_home", None)
+        if states is None:
+            # Backward compatibility for lightweight test doubles and callers
+            # constructed before this state became profile-scoped.
+            states = {
+                state_key: (
+                    getattr(self, "_fallback_model", None),
+                    getattr(self, "_configured_default_route", None),
+                )
+            }
+            self._fallback_state_by_home = states
+        last_fallback, last_default = states.get(state_key, (None, None))
         try:
             from hermes_cli.config import read_user_config_raw
-            cfg_path = _hermes_home / "config.yaml"
+            cfg_path = home / "config.yaml"
             if not cfg_path.exists():
-                self._fallback_model = None
-                self._configured_default_route = None
-                return compose_fallback_chain(
+                states[state_key] = (None, None)
+                chain = compose_fallback_chain(
                     None,
                     primary=primary_route,
                     configured_default=None,
                 ) or None
+                return chain, None
             # Raw primitive (raises on parse failure) is required here: the
             # canonical fail-open loader would return {} on a torn mid-edit
             # write and WIPE the last known-good chain. The overlay/expansion
@@ -9957,20 +9979,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "fallback_providers refresh: config.yaml read failed; "
                 "keeping last known-good chain", exc_info=True,
             )
-            return compose_fallback_chain(
-                self._fallback_model,
+            chain = compose_fallback_chain(
+                last_fallback,
                 primary=primary_route,
-                configured_default=getattr(
-                    self, "_configured_default_route", configured_default_route
-                ),
+                configured_default=last_default,
             ) or None
-        self._fallback_model = get_fallback_chain(cfg) or None
-        self._configured_default_route = configured_default_route
-        return compose_fallback_chain(
-            self._fallback_model,
+            return chain, last_default
+        fallback_model = get_fallback_chain(cfg) or None
+        states[state_key] = (fallback_model, configured_default_route)
+        # Preserve the legacy process-level snapshot for external/test
+        # introspection only. Runtime consumers use the turn-local tuple above.
+        self._fallback_model = fallback_model
+        chain = compose_fallback_chain(
+            fallback_model,
             primary=primary_route,
-            configured_default=self._configured_default_route,
+            configured_default=configured_default_route,
         ) or None
+        return chain, configured_default_route
+
+    def _refresh_fallback_model(
+        self,
+        *,
+        primary_route: dict | None = None,
+        configured_default_route: dict | None = None,
+    ) -> list | None:
+        """Re-read and compose the active profile's fallback provider chain."""
+        chain, _ = GatewayRunner._refresh_fallback_state(
+            self,
+            primary_route=primary_route,
+            configured_default_route=configured_default_route,
+        )
+        return chain
 
     @staticmethod
     def _apply_fallback_chain_to_agent(agent: Any, chain: list | None) -> None:
@@ -22820,7 +22859,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         logger.warning("Background task vision enrichment failed: %s", e)
 
             def run_sync():
-                fallback_model = self._refresh_fallback_model(
+                (
+                    fallback_model,
+                    effective_configured_default_route,
+                ) = self._refresh_fallback_state(
                     primary_route=_fallback_primary_route,
                     configured_default_route=_configured_default_route,
                 )
@@ -22855,7 +22897,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # Reload from disk — do not reuse the startup snapshot (#60955).
                     fallback_model=fallback_model,
                 )
-                agent._configured_default_route = self._configured_default_route
+                agent._configured_default_route = effective_configured_default_route
                 try:
                     return agent.run_conversation(
                         user_message=enriched_prompt,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -66,7 +66,11 @@ from agent.turn_context import (
     compression_made_progress,
 )
 from hermes_cli.config import _is_ssh_remote_tilde_cwd, cfg_get
-from hermes_cli.fallback_config import get_fallback_chain
+from hermes_cli.fallback_config import (
+    compose_fallback_chain,
+    get_configured_default_route,
+    get_fallback_chain,
+)
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -5520,6 +5524,13 @@ class TurnRunner:
             )
 
         turn_route = self._runner._resolve_turn_agent_config(ctx.message, model, runtime_kwargs)
+        _fallback_primary_route = {
+            "provider": turn_route["runtime"].get("requested_provider")
+            or turn_route["runtime"].get("provider"),
+            "model": turn_route["model"],
+            "base_url": turn_route["runtime"].get("base_url"),
+        }
+        _configured_default_route = turn_route.get("configured_default_route")
 
         # Per-platform skip_context_files — messaging platforms can opt out
         # of filesystem-heavy context-file discovery (SOUL.md, AGENTS.md,
@@ -5726,8 +5737,13 @@ class TurnRunner:
         # must reach the next turn (#60955).  Per-session turn
         # serialization (_running_agents) keeps this safe post-lock.
         if reused_cached_agent and agent is not None:
+            agent._configured_default_route = _configured_default_route
             self._runner._apply_fallback_chain_to_agent(
-                agent, self._runner._refresh_fallback_model(),
+                agent,
+                self._runner._refresh_fallback_model(
+                    primary_route=_fallback_primary_route,
+                    configured_default_route=_configured_default_route,
+                ),
             )
 
         # Lock released — now schedule cleanup of any cross-process-evicted
@@ -5784,7 +5800,10 @@ class TurnRunner:
                 gateway_session_key=ctx.session_key,
                 session_db=getattr(self._runner._session_db, "_db", self._runner._session_db),
                 # Reload from disk — do not reuse the startup snapshot (#60955).
-                fallback_model=self._runner._refresh_fallback_model(),
+                fallback_model=self._runner._refresh_fallback_model(
+                    primary_route=_fallback_primary_route,
+                    configured_default_route=_configured_default_route,
+                ),
                 skip_context_files=skip_context_files,
                 # Keep the persona even with minimal context: soul identity is
                 # a single small file, not part of the expensive walk.
@@ -5802,6 +5821,8 @@ class TurnRunner:
                     )
                     self._runner._enforce_agent_cache_cap()
             logger.debug("Created new agent for session %s (sig=%s)", ctx.session_key, _sig)
+
+        agent._configured_default_route = _configured_default_route
 
         # Per-message state — callbacks and reasoning config change every
         # turn and must not be baked into the cached agent constructor.
@@ -8068,6 +8089,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 resolved_session_key = None
 
         model = _resolve_gateway_model(user_config)
+        configured_default_route = get_configured_default_route(user_config)
         if resolved_session_key:
             self._rehydrate_session_model_override(resolved_session_key)
         _override_state = (
@@ -8098,6 +8120,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     resolved_session_key or "", model, override_model,
                     override_runtime.get("provider"),
                 )
+                if configured_default_route:
+                    override_runtime["_configured_default_route"] = configured_default_route
                 return override_model, override_runtime
             # Override exists but has no api_key — fall through to env-based
             # resolution and apply model/provider from the override on top.
@@ -8117,6 +8141,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
+        configured_default_route = get_configured_default_route(
+            user_config,
+            runtime=runtime_kwargs,
+        )
         runtime_model = runtime_kwargs.pop("model", None)
         if runtime_model:
             logger.info(
@@ -8213,6 +8241,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 ).conversation.last_resolved_model = model
             self._session_state("*").conversation.last_resolved_model = model
 
+        if configured_default_route:
+            runtime_kwargs["_configured_default_route"] = configured_default_route
         return model, runtime_kwargs
 
     def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
@@ -8239,6 +8269,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         route = {
             "model": model,
             "runtime": runtime,
+            "configured_default_route": runtime_kwargs.get("_configured_default_route"),
             "signature": (
                 model,
                 runtime["provider"],
@@ -9847,7 +9878,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             pass
         return None
 
-    def _refresh_fallback_model(self) -> list | None:
+    def _refresh_fallback_model(
+        self,
+        *,
+        primary_route: dict | None = None,
+        configured_default_route: dict | None = None,
+    ) -> list | None:
         """Re-read fallback_providers from disk for the next agent create/reuse.
 
         Cron already does this per job via ``get_fallback_chain``; the gateway
@@ -9866,7 +9902,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             cfg_path = _hermes_home / "config.yaml"
             if not cfg_path.exists():
                 self._fallback_model = None
-                return self._fallback_model
+                return compose_fallback_chain(
+                    None,
+                    primary=primary_route,
+                    configured_default=configured_default_route,
+                ) or None
             # Raw primitive (raises on parse failure) is required here: the
             # canonical fail-open loader would return {} on a torn mid-edit
             # write and WIPE the last known-good chain. The overlay/expansion
@@ -9890,9 +9930,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "fallback_providers refresh: config.yaml read failed; "
                 "keeping last known-good chain", exc_info=True,
             )
-            return self._fallback_model
+            return compose_fallback_chain(
+                self._fallback_model,
+                primary=primary_route,
+                configured_default=configured_default_route,
+            ) or None
         self._fallback_model = get_fallback_chain(cfg) or None
-        return self._fallback_model
+        return compose_fallback_chain(
+            self._fallback_model,
+            primary=primary_route,
+            configured_default=configured_default_route,
+        ) or None
 
     @staticmethod
     def _apply_fallback_chain_to_agent(agent: Any, chain: list | None) -> None:
@@ -22716,6 +22764,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._reasoning_config = reasoning_config
             self._service_tier = self._resolve_session_service_tier(source=source)
             turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            _fallback_primary_route = {
+                "provider": turn_route["runtime"].get("requested_provider")
+                or turn_route["runtime"].get("provider"),
+                "model": turn_route["model"],
+                "base_url": turn_route["runtime"].get("base_url"),
+            }
+            _configured_default_route = turn_route.get("configured_default_route")
 
             # Enrich the prompt with image descriptions so the background
             # agent can see user-attached images (same as the main flow).
@@ -22764,8 +22819,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     thread_id=source.thread_id,
                     session_db=getattr(self._session_db, "_db", self._session_db),
                     # Reload from disk — do not reuse the startup snapshot (#60955).
-                    fallback_model=self._refresh_fallback_model(),
+                    fallback_model=self._refresh_fallback_model(
+                        primary_route=_fallback_primary_route,
+                        configured_default_route=_configured_default_route,
+                    ),
                 )
+                agent._configured_default_route = _configured_default_route
                 try:
                     return agent.run_conversation(
                         user_message=enriched_prompt,

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -106,6 +106,14 @@ def get_configured_default_route(
     else:
         return None
 
+    runtime_model = str(runtime.get("model") or "").strip()
+    if runtime_model and runtime_model.lower() != model.lower():
+        # Gateway auth recovery returns the selected fallback model alongside
+        # its runtime. That provider describes the fallback route, not a
+        # provider-less configured default, so combining the two would invent
+        # a route that was never configured.
+        runtime = {}
+
     provider = str(
         model_route.get("provider")
         or (model_cfg.get("provider") if isinstance(model_cfg, dict) else "")

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -107,11 +107,12 @@ def get_configured_default_route(
         return None
 
     runtime_model = str(runtime.get("model") or "").strip()
-    if runtime_model and runtime_model.lower() != model.lower():
+    if runtime_model:
         # Gateway auth recovery returns the selected fallback model alongside
         # its runtime. That provider describes the fallback route, not a
-        # provider-less configured default, so combining the two would invent
-        # a route that was never configured.
+        # provider-less configured default. This remains true when both routes
+        # use the same model ID, so combining them would invent a route that
+        # was never configured.
         runtime = {}
 
     provider = str(

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -77,6 +77,90 @@ def _entry_identity(entry: dict[str, Any]) -> tuple[str, str, str]:
     )
 
 
+def get_configured_default_route(
+    config: dict[str, Any] | None,
+    *,
+    runtime: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Return the configured primary route in fallback-entry form."""
+
+    config = config or {}
+    runtime = runtime or {}
+    model_cfg = config.get("model", {})
+    if isinstance(model_cfg, str):
+        model = model_cfg.strip()
+        model_route: dict[str, Any] = {}
+    elif isinstance(model_cfg, dict):
+        raw_default = model_cfg.get("default") or model_cfg.get("model")
+        if isinstance(raw_default, dict):
+            model_route = raw_default
+            model = str(
+                raw_default.get("model")
+                or raw_default.get("name")
+                or raw_default.get("default")
+                or ""
+            ).strip()
+        else:
+            model_route = {}
+            model = str(raw_default or "").strip()
+    else:
+        return None
+
+    provider = str(
+        model_route.get("provider")
+        or (model_cfg.get("provider") if isinstance(model_cfg, dict) else "")
+        or runtime.get("requested_provider")
+        or runtime.get("provider")
+        or ""
+    ).strip()
+    if not model or not provider:
+        return None
+
+    route: dict[str, Any] = {"provider": provider, "model": model}
+    base_url = _normalized_base_url(
+        model_route.get("base_url")
+        or (model_cfg.get("base_url") if isinstance(model_cfg, dict) else "")
+        or runtime.get("base_url")
+    )
+    if base_url:
+        route["base_url"] = base_url
+    api_mode = str(
+        model_route.get("api_mode")
+        or (model_cfg.get("api_mode") if isinstance(model_cfg, dict) else "")
+        or runtime.get("api_mode")
+        or ""
+    ).strip()
+    if api_mode:
+        route["api_mode"] = api_mode
+    return route
+
+
+def compose_fallback_chain(
+    chain: Any,
+    *,
+    primary: dict[str, Any] | None,
+    configured_default: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    """Seat the configured default behind an overridden primary.
+
+    Routes are de-duplicated by provider/model/base URL. The active primary is
+    omitted, while a distinct configured default precedes configured fallbacks.
+    """
+
+    primary_entries = _iter_fallback_entries(primary)
+    primary_identity = _entry_identity(primary_entries[0]) if primary_entries else None
+    candidates = [*_iter_fallback_entries(configured_default), *_iter_fallback_entries(chain)]
+    result: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for entry in candidates:
+        identity = _entry_identity(entry)
+        if identity == primary_identity or identity in seen:
+            continue
+        seen.add(identity)
+        result.append(entry)
+    return result
+
+
 def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
     """Return the effective fallback chain merged across old and new config keys.
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2531,6 +2531,52 @@ class TestModelRoutesHandlers:
 
 class TestModelRoutesAgentCreation:
 
+    def test_equal_model_auth_fallback_does_not_manufacture_default_route(
+        self, monkeypatch
+    ):
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.model = kwargs["model"]
+                self.provider = kwargs["provider"]
+
+        _patch_create_agent_runtime(monkeypatch, captured, FakeAgent)
+        fallback_route = {
+            "provider": "fallback-b",
+            "requested_provider": "fallback-b",
+            "model": "shared-model",
+            "api_key": "fallback-key",
+            "base_url": "https://fallback.example/v1",
+            "api_mode": "chat_completions",
+        }
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: fallback_route.copy(),
+        )
+        monkeypatch.setattr(
+            "gateway.run._resolve_gateway_model", lambda: "shared-model"
+        )
+        monkeypatch.setattr(
+            "gateway.run._load_gateway_config",
+            lambda: {"model": {"default": "shared-model"}},
+        )
+        monkeypatch.setattr(
+            "gateway.run.GatewayRunner._load_fallback_model",
+            staticmethod(lambda: [fallback_route]),
+        )
+        adapter = _make_routing_adapter({})
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+        monkeypatch.setattr(adapter, "_session_model_override_for", lambda *_: None)
+
+        agent = adapter._create_agent(session_id="s1")
+
+        assert captured["provider"] == "fallback-b"
+        assert captured["model"] == "shared-model"
+        assert captured["fallback_model"] is None
+        assert agent._configured_default_route is None
+
     def test_route_provider_resolves_provider_credentials(self, monkeypatch):
         captured = {}
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2592,6 +2592,57 @@ class TestModelRoutesAgentCreation:
         assert captured["api_key"] == "sk-session"
 
 
+    def test_session_model_override_falls_back_through_configured_default(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        _patch_create_agent_runtime(monkeypatch, captured, FakeAgent)
+        monkeypatch.setattr(
+            "gateway.run._load_gateway_config",
+            lambda: {
+                "model": {
+                    "default": "global/model",
+                    "provider": "openrouter",
+                    "base_url": "https://openrouter.ai/api/v1",
+                }
+            },
+        )
+        monkeypatch.setattr(
+            "gateway.run.GatewayRunner._load_fallback_model",
+            staticmethod(
+                lambda: [{"provider": "nous", "model": "Hermes-4"}]
+            ),
+        )
+        adapter = _make_routing_adapter({})
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+        monkeypatch.setattr(
+            adapter,
+            "_session_model_override_for",
+            lambda _key: {
+                "model": "session/override-model",
+                "provider": "sessionprov",
+                "api_key": "sk-session",
+                "base_url": "https://session.example/v1",
+            },
+        )
+
+        agent = adapter._create_agent(session_id="s1")
+
+        assert captured["fallback_model"] == [
+            {
+                "provider": "openrouter",
+                "model": "global/model",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_mode": "chat_completions",
+            },
+            {"provider": "nous", "model": "Hermes-4"},
+        ]
+        assert agent._configured_default_route == captured["fallback_model"][0]
+
+
 class TestStoredSessionModelFilter:
     """A session row that persisted the advertised virtual model must read as
     "no stored model" — replaying "hermes-agent" upstream 400s. Found live

--- a/tests/gateway/test_fallback_chain_reload.py
+++ b/tests/gateway/test_fallback_chain_reload.py
@@ -109,16 +109,15 @@ def test_refresh_preserves_last_known_default_on_transient_parse_failure(
         _fallback_model=None,
         _configured_default_route=None,
     )
-    bound = GatewayRunner._refresh_fallback_model.__get__(runner)
     primary = {"provider": "openrouter", "model": "override-model"}
     configured_default = {"provider": "commandcode", "model": "model-a"}
 
-    initial = bound(
+    initial, initial_default = GatewayRunner._refresh_fallback_state.__get__(runner)(
         primary_route=primary,
         configured_default_route=configured_default,
     )
     cfg.write_text("model: [unterminated")
-    retained = bound(
+    retained, retained_default = GatewayRunner._refresh_fallback_state.__get__(runner)(
         primary_route=primary,
         configured_default_route=None,
     )
@@ -127,7 +126,7 @@ def test_refresh_preserves_last_known_default_on_transient_parse_failure(
         configured_default,
         {"provider": "openai-codex", "model": "gpt-5.6-luna"},
     ]
-    assert runner._configured_default_route == configured_default
+    assert initial_default == retained_default == configured_default
 
 
 def test_refresh_clears_last_known_default_after_successful_removal(
@@ -143,15 +142,70 @@ def test_refresh_clears_last_known_default_after_successful_removal(
         _fallback_model=None,
         _configured_default_route=configured_default,
     )
-    bound = GatewayRunner._refresh_fallback_model.__get__(runner)
-
-    chain = bound(
+    chain, effective_default = GatewayRunner._refresh_fallback_state.__get__(runner)(
         primary_route={"provider": "openrouter", "model": "override-model"},
         configured_default_route=None,
     )
 
     assert chain is None
-    assert runner._configured_default_route is None
+    assert effective_default is None
+
+
+def test_refresh_state_isolated_by_multiplex_profile_home(tmp_path, monkeypatch):
+    from gateway.run import GatewayRunner
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    homes = {name: tmp_path / name for name in ("profile-a", "profile-b")}
+    for home in homes.values():
+        home.mkdir()
+    (homes["profile-a"] / "config.yaml").write_text(
+        "fallback_providers:\n  - provider: fallback-a\n    model: rescue-a\n"
+    )
+    (homes["profile-b"] / "config.yaml").write_text(
+        "fallback_providers:\n  - provider: fallback-b\n    model: rescue-b\n"
+    )
+    runner = SimpleNamespace(_fallback_model=None)
+    refresh = GatewayRunner._refresh_fallback_state.__get__(runner)
+    primary = {"provider": "override", "model": "session-model"}
+    defaults = {
+        "profile-a": {"provider": "provider-a", "model": "default-a"},
+        "profile-b": {"provider": "provider-b", "model": "default-b"},
+    }
+
+    token = set_hermes_home_override(str(homes["profile-a"]))
+    try:
+        refresh(primary_route=primary, configured_default_route=defaults["profile-a"])
+    finally:
+        reset_hermes_home_override(token)
+    token = set_hermes_home_override(str(homes["profile-b"]))
+    try:
+        chain_b, effective_b = refresh(
+            primary_route=primary,
+            configured_default_route=defaults["profile-b"],
+        )
+    finally:
+        reset_hermes_home_override(token)
+
+    (homes["profile-a"] / "config.yaml").write_text("model: [unterminated")
+    token = set_hermes_home_override(str(homes["profile-a"]))
+    try:
+        chain_a, effective_a = refresh(
+            primary_route=primary,
+            configured_default_route=None,
+        )
+    finally:
+        reset_hermes_home_override(token)
+
+    assert effective_b == defaults["profile-b"]
+    assert chain_b == [
+        defaults["profile-b"],
+        {"provider": "fallback-b", "model": "rescue-b"},
+    ]
+    assert effective_a == defaults["profile-a"]
+    assert chain_a == [
+        defaults["profile-a"],
+        {"provider": "fallback-a", "model": "rescue-a"},
+    ]
 
 
 def test_load_fallback_model_static_unchanged_contract(tmp_path, monkeypatch):

--- a/tests/gateway/test_fallback_chain_reload.py
+++ b/tests/gateway/test_fallback_chain_reload.py
@@ -93,6 +93,67 @@ def test_refresh_composes_configured_default_for_session_override(tmp_path, monk
     ]
 
 
+def test_refresh_preserves_last_known_default_on_transient_parse_failure(
+    tmp_path, monkeypatch
+):
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "fallback_providers:\n"
+        "  - provider: openai-codex\n"
+        "    model: gpt-5.6-luna\n"
+    )
+    runner = SimpleNamespace(
+        _fallback_model=None,
+        _configured_default_route=None,
+    )
+    bound = GatewayRunner._refresh_fallback_model.__get__(runner)
+    primary = {"provider": "openrouter", "model": "override-model"}
+    configured_default = {"provider": "commandcode", "model": "model-a"}
+
+    initial = bound(
+        primary_route=primary,
+        configured_default_route=configured_default,
+    )
+    cfg.write_text("model: [unterminated")
+    retained = bound(
+        primary_route=primary,
+        configured_default_route=None,
+    )
+
+    assert initial == retained == [
+        configured_default,
+        {"provider": "openai-codex", "model": "gpt-5.6-luna"},
+    ]
+    assert runner._configured_default_route == configured_default
+
+
+def test_refresh_clears_last_known_default_after_successful_removal(
+    tmp_path, monkeypatch
+):
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("fallback_providers: []\n")
+    configured_default = {"provider": "commandcode", "model": "model-a"}
+    runner = SimpleNamespace(
+        _fallback_model=None,
+        _configured_default_route=configured_default,
+    )
+    bound = GatewayRunner._refresh_fallback_model.__get__(runner)
+
+    chain = bound(
+        primary_route={"provider": "openrouter", "model": "override-model"},
+        configured_default_route=None,
+    )
+
+    assert chain is None
+    assert runner._configured_default_route is None
+
+
 def test_load_fallback_model_static_unchanged_contract(tmp_path, monkeypatch):
     """_load_fallback_model remains a pure static reader used by refresh."""
     from gateway.run import GatewayRunner

--- a/tests/gateway/test_fallback_chain_reload.py
+++ b/tests/gateway/test_fallback_chain_reload.py
@@ -70,33 +70,27 @@ def test_apply_fallback_chain_skips_while_cooldown_holds_fallback():
     assert agent._fallback_activated is True
 
 
-def test_background_and_main_agent_paths_call_refresh():
-    """Both AIAgent construction sites must pass a refreshed chain, not the
-    startup snapshot, and the cached-agent reuse path must apply the refreshed
-    chain. Source-level invariant for call sites that resist unit testing.
-    """
-    from pathlib import Path
+def test_refresh_composes_configured_default_for_session_override(tmp_path, monkeypatch):
+    from gateway.run import GatewayRunner
 
-    source = (
-        Path(__file__).resolve().parent.parent.parent / "gateway" / "run.py"
-    ).read_text(encoding="utf-8")
-    # The agent-construction site inside TurnRunner.run_sync (extracted from
-    # the old _run_agent_inner closure) references the runner as
-    # ``self._runner``; the background-agent site still uses bare ``self``.
-    _refresh_calls = (
-        source.count("fallback_model=self._refresh_fallback_model()")
-        + source.count("fallback_model=self._runner._refresh_fallback_model()")
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text(
+        "fallback_providers:\n"
+        "  - provider: openai-codex\n"
+        "    model: gpt-5.6-luna\n"
     )
-    assert _refresh_calls >= 2
-    # The cached-agent reuse path (the load-bearing fix for a long-lived
-    # session in a running gateway) must apply the refreshed chain.
-    assert (
-        "self._apply_fallback_chain_to_agent(" in source
-        or "self._runner._apply_fallback_chain_to_agent(" in source
+    runner = SimpleNamespace(_fallback_model=None)
+    bound = GatewayRunner._refresh_fallback_model.__get__(runner)
+
+    chain = bound(
+        primary_route={"provider": "openrouter", "model": "override-model"},
+        configured_default_route={"provider": "commandcode", "model": "model-a"},
     )
-    # The stale startup-snapshot form must not remain at create sites.
-    assert "fallback_model=self._fallback_model," not in source
-    assert "fallback_model=self._runner._fallback_model," not in source
+
+    assert chain == [
+        {"provider": "commandcode", "model": "model-a"},
+        {"provider": "openai-codex", "model": "gpt-5.6-luna"},
+    ]
 
 
 def test_load_fallback_model_static_unchanged_contract(tmp_path, monkeypatch):

--- a/tests/gateway/test_session_model_override_credential_pool.py
+++ b/tests/gateway/test_session_model_override_credential_pool.py
@@ -139,7 +139,9 @@ def test_fast_session_override_survives_unresolvable_default(monkeypatch):
     assert "_configured_default_route" not in runtime
 
 
-def test_auth_fallback_does_not_supply_provider_for_legacy_default(monkeypatch):
+def test_equal_model_auth_fallback_does_not_supply_provider_for_legacy_default(
+    monkeypatch,
+):
     runner = object.__new__(GatewayRunner)
     runner._session_model_overrides = {
         "sess-1": {
@@ -150,7 +152,7 @@ def test_auth_fallback_does_not_supply_provider_for_legacy_default(monkeypatch):
     fallback_runtime = {
         "provider": "openrouter",
         "requested_provider": "openrouter",
-        "model": "fallback-model",
+        "model": "global-model",
         "api_key": "fallback-key",
         "base_url": "https://openrouter.ai/api/v1",
     }

--- a/tests/gateway/test_session_model_override_credential_pool.py
+++ b/tests/gateway/test_session_model_override_credential_pool.py
@@ -138,3 +138,36 @@ def test_fast_session_override_survives_unresolvable_default(monkeypatch):
     assert model == "override-model"
     assert "_configured_default_route" not in runtime
 
+
+def test_auth_fallback_does_not_supply_provider_for_legacy_default(monkeypatch):
+    runner = object.__new__(GatewayRunner)
+    runner._session_model_overrides = {
+        "sess-1": {
+            "model": "override-model",
+            "provider": "openrouter",
+        }
+    }
+    fallback_runtime = {
+        "provider": "openrouter",
+        "requested_provider": "openrouter",
+        "model": "fallback-model",
+        "api_key": "fallback-key",
+        "base_url": "https://openrouter.ai/api/v1",
+    }
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs",
+        lambda: fallback_runtime.copy(),
+    )
+    runner._apply_session_model_override = (
+        lambda _session_key, _model, runtime: ("override-model", runtime)
+    )
+
+    model, runtime = runner._resolve_session_agent_runtime(
+        session_key="sess-1",
+        user_config={"model": "global-model"},
+    )
+
+    assert model == "override-model"
+    assert runtime["provider"] == "openrouter"
+    assert "_configured_default_route" not in runtime
+

--- a/tests/gateway/test_session_model_override_credential_pool.py
+++ b/tests/gateway/test_session_model_override_credential_pool.py
@@ -70,3 +70,71 @@ def test_fast_session_override_carries_configured_default_route(monkeypatch):
     assert "_configured_default_route" not in route["runtime"]
 
 
+def test_fast_session_override_infers_default_provider_for_legacy_configs(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: {
+            "provider": "openai",
+            "requested_provider": "openai",
+            "base_url": "https://api.openai.com/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(
+        "gateway.run._credential_pool_for_provider",
+        lambda _provider: None,
+    )
+
+    for model_config in ("global-model", {"default": "global-model"}):
+        runner = object.__new__(GatewayRunner)
+        runner._session_model_overrides = {
+            "sess-1": {
+                "model": "override-model",
+                "provider": "openrouter",
+                "api_key": "sk-test",
+            }
+        }
+
+        model, runtime = runner._resolve_session_agent_runtime(
+            session_key="sess-1",
+            user_config={"model": model_config},
+        )
+
+        assert model == "override-model"
+        assert runtime["_configured_default_route"] == {
+            "provider": "openai",
+            "model": "global-model",
+            "base_url": "https://api.openai.com/v1",
+            "api_mode": "chat_completions",
+        }
+
+
+def test_fast_session_override_survives_unresolvable_default(monkeypatch):
+    def fail_default(**_kwargs):
+        raise RuntimeError("default credentials unavailable")
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        fail_default,
+    )
+    monkeypatch.setattr(
+        "gateway.run._credential_pool_for_provider",
+        lambda _provider: None,
+    )
+    runner = object.__new__(GatewayRunner)
+    runner._session_model_overrides = {
+        "sess-1": {
+            "model": "override-model",
+            "provider": "openrouter",
+            "api_key": "sk-test",
+        }
+    }
+
+    model, runtime = runner._resolve_session_agent_runtime(
+        session_key="sess-1",
+        user_config={"model": "global-model"},
+    )
+
+    assert model == "override-model"
+    assert "_configured_default_route" not in runtime
+

--- a/tests/gateway/test_session_model_override_credential_pool.py
+++ b/tests/gateway/test_session_model_override_credential_pool.py
@@ -35,3 +35,38 @@ def test_fast_session_override_includes_credential_pool(monkeypatch):
     assert runtime.get("credential_pool") is fake_pool
 
 
+def test_fast_session_override_carries_configured_default_route(monkeypatch):
+    runner = object.__new__(GatewayRunner)
+    override = {
+        "model": "override-model",
+        "provider": "openrouter",
+        "api_key": "sk-test",
+    }
+    runner._session_model_overrides = {"sess-1": override}
+    monkeypatch.setattr(
+        "gateway.run._credential_pool_for_provider",
+        lambda _provider: None,
+    )
+
+    model, runtime = runner._resolve_session_agent_runtime(
+        session_key="sess-1",
+        user_config={
+            "model": {
+                "default": "model-a",
+                "provider": "commandcode",
+                "base_url": "https://commandcode.ai/v1",
+            }
+        },
+    )
+
+    assert model == override["model"]
+    assert runtime["_configured_default_route"] == {
+        "provider": "commandcode",
+        "model": "model-a",
+        "base_url": "https://commandcode.ai/v1",
+    }
+    route = runner._resolve_turn_agent_config("hello", model, runtime)
+    assert route["configured_default_route"] == runtime["_configured_default_route"]
+    assert "_configured_default_route" not in route["runtime"]
+
+

--- a/tests/gateway/test_turn_context.py
+++ b/tests/gateway/test_turn_context.py
@@ -112,7 +112,7 @@ class TestTurnRunner:
         }
         gateway_runner._agent_config_signature.return_value = ("test-signature",)
         gateway_runner._extract_cache_busting_config.return_value = {}
-        gateway_runner._refresh_fallback_model.return_value = None
+        gateway_runner._refresh_fallback_state.return_value = (None, None)
         gateway_runner._consume_pending_native_image_paths.return_value = []
         gateway_runner._consume_pending_turn_sidecar_notes.return_value = []
         gateway_runner._is_telegram_topic_lane.return_value = False

--- a/tests/hermes_cli/test_fallback_config.py
+++ b/tests/hermes_cli/test_fallback_config.py
@@ -1,7 +1,77 @@
 """Tests for hermes_cli/fallback_config.py — fallback entry API-key resolution."""
 
 from agent.secret_scope import reset_secret_scope, set_secret_scope
-from hermes_cli.fallback_config import resolve_entry_api_key
+from hermes_cli.fallback_config import (
+    compose_fallback_chain,
+    get_configured_default_route,
+    resolve_entry_api_key,
+)
+
+
+def test_configured_default_precedes_fallbacks_for_session_override():
+    configured_default = {
+        "provider": "commandcode",
+        "model": "deepseek-v4-flash",
+        "base_url": "https://commandcode.ai/v1/",
+    }
+    chain = [
+        {"provider": "openai-codex", "model": "gpt-5.6-luna"},
+        {"provider": "deepseek", "model": "deepseek-v4-flash"},
+    ]
+
+    effective = compose_fallback_chain(
+        chain,
+        primary={"provider": "openrouter", "model": "override-model"},
+        configured_default=configured_default,
+    )
+
+    assert effective == [
+        {
+            "provider": "commandcode",
+            "model": "deepseek-v4-flash",
+            "base_url": "https://commandcode.ai/v1",
+        },
+        *chain,
+    ]
+
+
+def test_configured_default_is_not_duplicated_as_primary_or_fallback():
+    configured_default = {
+        "provider": "commandcode",
+        "model": "deepseek-v4-flash",
+    }
+    configured_chain = [configured_default, configured_default.copy()]
+
+    assert compose_fallback_chain(
+        configured_chain,
+        primary=configured_default,
+        configured_default=configured_default,
+    ) == []
+
+
+def test_get_configured_default_route_uses_requested_runtime_provider():
+    route = get_configured_default_route(
+        {
+            "model": {
+                "default": "model-a",
+                "provider": "custom:free-lane",
+                "base_url": "https://free.example/v1/",
+            }
+        },
+        runtime={
+            "provider": "custom",
+            "requested_provider": "custom:resolved-lane",
+            "base_url": "https://resolved.example/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+
+    assert route == {
+        "provider": "custom:free-lane",
+        "model": "model-a",
+        "base_url": "https://free.example/v1",
+        "api_mode": "chat_completions",
+    }
 
 
 class TestResolveEntryApiKey:

--- a/tests/hermes_cli/test_fallback_config.py
+++ b/tests/hermes_cli/test_fallback_config.py
@@ -74,6 +74,20 @@ def test_get_configured_default_route_uses_requested_runtime_provider():
     }
 
 
+def test_configured_default_does_not_borrow_auth_fallback_provider():
+    route = get_configured_default_route(
+        {"model": {"default": "model-a"}},
+        runtime={
+            "provider": "openrouter",
+            "requested_provider": "openrouter",
+            "model": "fallback-model",
+            "base_url": "https://openrouter.ai/api/v1",
+        },
+    )
+
+    assert route is None
+
+
 class TestResolveEntryApiKey:
     def test_inline_api_key_wins(self, monkeypatch):
         monkeypatch.setenv("FB_KEY", "env-key")

--- a/tests/hermes_cli/test_fallback_config.py
+++ b/tests/hermes_cli/test_fallback_config.py
@@ -75,17 +75,18 @@ def test_get_configured_default_route_uses_requested_runtime_provider():
 
 
 def test_configured_default_does_not_borrow_auth_fallback_provider():
-    route = get_configured_default_route(
-        {"model": {"default": "model-a"}},
-        runtime={
-            "provider": "openrouter",
-            "requested_provider": "openrouter",
-            "model": "fallback-model",
-            "base_url": "https://openrouter.ai/api/v1",
-        },
-    )
+    for fallback_model in ("fallback-model", "model-a"):
+        route = get_configured_default_route(
+            {"model": {"default": "model-a"}},
+            runtime={
+                "provider": "openrouter",
+                "requested_provider": "openrouter",
+                "model": fallback_model,
+                "base_url": "https://openrouter.ai/api/v1",
+            },
+        )
 
-    assert route is None
+        assert route is None
 
 
 class TestResolveEntryApiKey:

--- a/tests/run_agent/test_switch_model_fallback_prune.py
+++ b/tests/run_agent/test_switch_model_fallback_prune.py
@@ -69,6 +69,28 @@ def test_switch_drops_old_primary_from_fallback_chain():
     assert agent._fallback_model == {"provider": "nous", "model": "hermes-4"}
 
 
+def test_switch_retains_configured_default_as_first_fallback():
+    default = {
+        "provider": "openrouter",
+        "model": "x-ai/grok-4",
+        "base_url": "https://openrouter.ai/api/v1",
+    }
+    agent = _make_agent([
+        default,
+        {"provider": "nous", "model": "hermes-4"},
+        default.copy(),
+    ])
+    agent._configured_default_route = default
+
+    _switch_to_anthropic(agent)
+
+    assert agent._fallback_chain == [
+        default,
+        {"provider": "nous", "model": "hermes-4"},
+    ]
+    assert agent._fallback_model == default
+
+
 def test_switch_with_empty_chain_stays_empty():
     agent = _make_agent([])
 

--- a/tests/run_agent/test_switch_model_fallback_prune.py
+++ b/tests/run_agent/test_switch_model_fallback_prune.py
@@ -37,6 +37,26 @@ def _make_agent(chain):
     return agent
 
 
+def _make_initialized_agent(chain):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            provider="openrouter",
+            model="x-ai/grok-4",
+            api_key="or-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=chain,
+        )
+    agent.client = MagicMock()
+    return agent
+
+
 def _switch_to_anthropic(agent):
     with (
         patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
@@ -67,6 +87,21 @@ def test_switch_drops_old_primary_from_fallback_chain():
     assert "anthropic" not in providers, "new primary is redundant in the chain"
     assert providers == ["nous"]
     assert agent._fallback_model == {"provider": "nous", "model": "hermes-4"}
+
+
+def test_initialized_generic_agent_does_not_restore_old_primary_on_switch():
+    agent = _make_initialized_agent([
+        {"provider": "openrouter", "model": "x-ai/grok-4"},
+        {"provider": "nous", "model": "hermes-4"},
+    ])
+
+    assert agent._configured_default_route is None
+
+    _switch_to_anthropic(agent)
+
+    assert agent._fallback_chain == [
+        {"provider": "nous", "model": "hermes-4"},
+    ]
 
 
 def test_switch_retains_configured_default_as_first_fallback():


### PR DESCRIPTION
## What does this PR do?

A session-scoped `/model` selection now falls back through the healthy configured `model.default` before trying `fallback_providers`. Previously, an override changed the primary route but left the recovery chain authored for the global primary, making the configured default unreachable and potentially sending work to slower or paid last-resort providers.

### Symptom

With configured default A, fallback providers B/C, and session override X, a failure on X recovered as `X -> B -> C` instead of `X -> A -> B -> C`.

### Impact

Users with session model overrides could skip a healthy preferred provider during recovery. The reported production case reached paid and local last-resort routes while the configured default remained healthy and unused.

### Bug Cause

**Trigger:** `gateway/run.py` session override resolution and `agent/agent_runtime_helpers.py` in-place model switching.

**Causal chain:**
1. The gateway resolves the session override as the agent primary.
2. The fallback chain is loaded only from `fallback_providers`, while in-place switching prunes the old provider without identifying whether it is the configured default.
3. Recovery starts at the first explicit fallback and never attempts `model.default`.

**Why it is wrong:** A session selection is a primary preference for that conversation, not removal of the configured default from recovery policy.

**Working sibling / contrast:** Without an override, `model.default` is already the primary, so the omission is hidden. The fix applies the same route composition to native gateway turns, cached agents, background turns, API sessions, and in-place switches.

**Ruled out:** Adding the default manually to `fallback_providers` is not a reliable workaround because it duplicates the primary in normal sessions and the switch pruning path can remove it.

### Fix

Added a shared route composer that places a distinct configured default at the front of the fallback chain and deduplicates routes by provider, model, and base URL. Gateway runtime resolution carries the configured default separately from session overrides, refreshes cached chains without losing config updates, and preserves that identity during in-place model switches. Confirmed runtime locks continue to disable fallback entirely.

## Related Issue

Closes #93988

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/fallback_config.py` - resolve configured-default route identity and compose deduplicated effective chains.
- `gateway/run.py` - thread configured defaults through native, cached, and background session agents.
- `gateway/platforms/api_server.py` - apply the same recovery order to API sessions while preserving confirmed model locks.
- `agent/agent_init.py`, `agent/agent_runtime_helpers.py` - retain the configured default across in-place model switches.
- `tests/` - cover override ordering, deduplication, config refresh, API sessions, and switch pruning.

## How to Test

1. Configure default A and fallbacks B/C, then select session model X.
2. Verify the effective fallback chain is A/B/C, while a session using A omits A from its own fallback chain.
3. Run:

```bash
scripts/run_tests.sh tests/gateway/test_api_server.py tests/gateway/test_fallback_chain_reload.py tests/gateway/test_session_model_override_credential_pool.py tests/gateway/test_session_model_override_routing.py tests/gateway/test_channel_overrides.py tests/hermes_cli/test_fallback_config.py tests/run_agent/test_switch_model_fallback_prune.py tests/run_agent/test_provider_fallback.py -q
```

Result: 149 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update is N/A; behavior and regression tests document the contract
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no workflow changed
- [x] I've considered cross-platform impact; the change is platform-independent route composition
- [x] Tool description/schema updates are N/A; no model tool behavior changed

## Screenshots / Logs

N/A - verified with focused automated regression tests.
