### PR TITLE
fix(desktop): keep local profile chats working with remote dashboard URLs

### DIFF
--- a/apps/desktop/electron/backend-env.test.ts
+++ b/apps/desktop/electron/backend-env.test.ts
@@ -111,6 +111,7 @@ test('buildDesktopBackendEnv extends PYTHONPATH and backend PATH together', () =
     pythonPathEntries: ['/repo/hermes-agent'],
     venvRoot: '/Users/test/.hermes/hermes-agent/venv',
     currentEnv: {
+      HERMES_DASHBOARD_PUBLIC_URL: 'https://remote.example.test/hermes',
       PATH: '/usr/bin:/bin',
       PYTHONPATH: '/existing/pythonpath'
     },
@@ -125,6 +126,7 @@ test('buildDesktopBackendEnv extends PYTHONPATH and backend PATH together', () =
     )
   )
   assert.ok(env.PATH.includes('/opt/homebrew/bin'))
+  assert.equal(env.HERMES_DASHBOARD_PUBLIC_URL, 'http://127.0.0.1')
 })
 
 test('buildDesktopBackendEnv forces PYTHONUTF8 unless the user set it explicitly', () => {

--- a/apps/desktop/electron/backend-env.ts
+++ b/apps/desktop/electron/backend-env.ts
@@ -131,6 +131,11 @@ function buildDesktopBackendEnv({
   const key = pathEnvKey(currentEnv, platform)
 
   return {
+    // A Desktop-spawned backend is a distinct loopback control plane, not the
+    // profile's browser-facing dashboard. Override inherited/configured remote
+    // public URLs so this child keeps its session-token WebSocket; separately
+    // launched dashboards still use the profile's gated public URL.
+    HERMES_DASHBOARD_PUBLIC_URL: 'http://127.0.0.1',
     PYTHONPATH: appendUniquePathEntries([...pythonPathEntries, currentPythonPath], { delimiter }),
     // Force PEP 540 UTF-8 mode in the spawned Python backend so its stdio and
     // subprocess defaults are UTF-8 even on non-UTF-8 Windows locales (GBK,


### PR DESCRIPTION
## What does this PR do?

Profiles with a non-loopback `dashboard.public_url` can be opened in Hermes Desktop again. The Desktop-spawned `hermes serve` child now identifies its own browser-facing authority as loopback, so it keeps the local session-token WebSocket contract without weakening authentication on separately launched remote dashboards.

### Symptom

Desktop reaches the profile backend over HTTP, but `/api/ws?token=...` is rejected because the profile's remote `dashboard.public_url` puts the otherwise-local child into gated auth mode. Desktop then tears down the backend and the profile chat does not open.

### Impact

Desktop users cannot open local profile chats when the same profile is configured for a remote dashboard URL.

### Bug Cause

**Trigger:** `apps/desktop/electron/backend-env.ts` / `buildDesktopBackendEnv()` inherits a profile's non-loopback `HERMES_DASHBOARD_PUBLIC_URL` or `dashboard.public_url` into a Desktop-spawned loopback backend.

**Causal chain:**
1. Desktop spawns `hermes serve --host 127.0.0.1` with the profile's dashboard configuration.
2. The server treats the configured non-loopback public URL as an external exposure boundary and activates gated auth.
3. Desktop probes the local backend with its session token, but gated WebSockets require a ticket, so the probe fails and the chat backend is removed.

**Why it is wrong:** the Desktop child is a separate loopback control plane, not the profile's browser-facing dashboard process. Reusing the remote authority metadata changes the child's auth protocol even though Desktop deliberately spawned it for local token-authenticated access.

**Working sibling / contrast:** profiles without a non-loopback public URL remain in loopback token mode and their Desktop chats open normally.

**Ruled out:** the shared gated WebSocket policy is not relaxed. Normal dashboard launches still derive their public authority from profile configuration and continue to require gated authentication.

### Fix

`buildDesktopBackendEnv()` now supplies a valid loopback public URL override. Because that environment is merged last into both primary and pooled Desktop backend spawns, it wins over inherited environment values and profile config for only those local child processes. A regression test covers replacement of an inherited remote URL.

## Related Issue

Closes #93981

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/backend-env.ts` - isolate Desktop-spawned local backends from profile remote public URL metadata.
- `apps/desktop/electron/backend-env.test.ts` - verify a remote public URL is replaced by the loopback authority.

## How to Test

1. Configure a profile with a non-loopback `dashboard.public_url`.
2. Open that profile in Desktop and verify its local backend reports `auth_required: false` and accepts the session-token WebSocket.
3. Run the focused automated checks:

```bash
cd apps/desktop
npx vitest run electron/backend-env.test.ts
npm run typecheck
npx eslint electron/backend-env.ts electron/backend-env.test.ts
npx prettier --check electron/backend-env.ts electron/backend-env.test.ts
cd ../..
scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_gate.py tests/hermes_cli/test_dashboard_auth_ws_auth.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant Desktop and dashboard auth tests and all pass
- [x] I've added a regression test for the changed behavior
- [x] I've tested the automated path on Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are N/A; the behavior is internal to Desktop backend spawning
- [x] `cli-config.yaml.example` updates are N/A; no config key changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no workflow changed
- [x] Cross-platform impact was considered; the environment override is platform-independent
- [x] Tool descriptions and schemas are N/A; no tool behavior changed
