### PR TITLE
fix(desktop): resolve symlinked venv interpreter before shebang comparison

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -98,16 +98,26 @@ def _needs_interpreter(bin_path: Path) -> bool:
         # Native binary (uv tool shim, PyInstaller, distro package) — its own
         # loader is self-sufficient.
         return False
-    shebang = head.decode("utf-8", errors="replace").strip().lower()
-    if "python" not in shebang:
+    shebang_line = head.decode("utf-8", errors="replace").strip()
+    shebang_interp = shebang_line[2:].split()[0] if len(shebang_line) > 2 else ""
+    if "python" not in shebang_interp.lower():
         # A shell wrapper (e.g. the installer's bash launcher) execs the venv
         # python itself — leave it alone.
         return False
     # A python shebang pointing INSIDE the running interpreter's environment
     # already resolves correctly; anything else (``/usr/bin/env python3``,
-    # a system path) would escape the venv when spawned by the DE.
+    # a system path) would escape the venv when spawned by the DE. Resolve
+    # both sides before comparing: uv-created venvs symlink ``bin/python3``
+    # to the base interpreter, so the raw shebang text and the resolved
+    # ``sys.executable`` point at the same binary but differ textually
+    # (#90292 follow-up) — a plain substring check false-positives on that
+    # and wrongly prefixes Exec with a foreign interpreter.
+    try:
+        shebang_dir = str(Path(shebang_interp).resolve().parent)
+    except OSError:
+        shebang_dir = ""
     exe_dir = str(Path(sys.executable).resolve().parent)
-    return exe_dir not in shebang
+    return shebang_dir != exe_dir
 
 
 def _quote_exec_arg(arg: str) -> str:


### PR DESCRIPTION
## Problem

`_needs_interpreter()` in `hermes_cli/linux_desktop_entry.py` decides whether the generated `hermes.desktop` `Exec=` line needs an explicit interpreter prefix by comparing the **raw shebang text** of the resolved `hermes` binary against the **resolved** `sys.executable` path:

```python
exe_dir = str(Path(sys.executable).resolve().parent)
return exe_dir not in shebang
```

On a venv created by `uv venv` (the default for this project's `venv/`), `venv/bin/python3` is a **symlink** to the base interpreter (e.g. `~/.local/share/uv/python/cpython-3.11.15-.../bin/python3.11`) rather than a copy. When Hermes is launched by exec'ing `venv/bin/hermes` directly (e.g. from the `.desktop` file itself, or any DE launcher), the kernel resolves the shebang and `sys.executable` ends up as the **resolved** base-interpreter path, while the shebang line in the script still reads the **unresolved** `venv/bin/python3` path. The substring comparison then always mismatches even though it's the same interpreter, so `_needs_interpreter()` returns `True` and `resolve_exec_command()` prefixes `Exec=` with a foreign interpreter that has no access to Hermes' venv site-packages.

Since `install_desktop_entry()` runs on every `hermes desktop` launch (`_register_linux_desktop_entry()` in `main.py`), this is a stable reproduction, not a one-off race:

1. User launches Hermes via the `.desktop` icon → it works, and rewrites `hermes.desktop` with a broken `Exec=<foreign-python3.11> <venv>/bin/hermes desktop`.
2. Next click on the icon execs that broken line directly → `ModuleNotFoundError: No module named 'hermes_cli'` (silently, since `Terminal=false`) → the app never starts, so it never gets a chance to self-heal the entry it just wrote.

This affects any `uv`-managed venv, which is increasingly the default for Python tooling.

## Fix

Resolve the shebang's interpreter path the same way `sys.executable` is resolved, before comparing directories, so a symlinked venv interpreter is correctly recognized as already correct:

```python
shebang_interp = shebang_line[2:].split()[0] if len(shebang_line) > 2 else ""
...
shebang_dir = str(Path(shebang_interp).resolve().parent)
exe_dir = str(Path(sys.executable).resolve().parent)
return shebang_dir != exe_dir
```

## Testing

Reproduced by execing `venv/bin/hermes` directly (mirroring how the `.desktop` `Exec=` line and most DE launchers invoke it) and calling `resolve_exec_command()`:

- Before: `Exec=<uv-base-python3.11> <repo>/venv/bin/hermes desktop` (broken, `ModuleNotFoundError` on next launch)
- After: `Exec=<repo>/venv/bin/hermes desktop` (correct, uses its own shebang)

Verified end-to-end: killed all running Hermes/Electron processes, launched via `gtk-launch hermes` (same code path as clicking the app icon) both before and after the patch, and confirmed the app now starts and the self-regenerated `.desktop` entry stays correct across repeated launches.