### PR TITLE
fix(cron): make recurring cron run execute on the next tick

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2434,6 +2434,7 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
             f"Create a new occurrence with 'hermes cron resume {name} "
             "--run-now' or '--at <ISO-8601>'."
         )
+    manual_run_at = _hermes_now().isoformat()
     return update_job(
         job["id"],
         {
@@ -2441,7 +2442,10 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
             "state": "scheduled",
             "paused_at": None,
             "paused_reason": None,
-            "next_run_at": _hermes_now().isoformat(),
+            "next_run_at": manual_run_at,
+            # Persist run-now intent alongside the arbitrary instant so cron
+            # expression/TZ repair guards do not mistake it for stale state.
+            "manual_run_at": manual_run_at,
         },
     )
 
@@ -2693,6 +2697,7 @@ def _mark_job_run_locked(
                         return False
                 now = _hermes_now().isoformat()
                 job["last_run_at"] = now
+                job.pop("manual_run_at", None)
                 job["last_status"] = status or ("ok" if success else "error")
                 job["last_error"] = error if not success else None
                 # A healthy run means the configuration validates again — drop
@@ -3548,6 +3553,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
             kind = schedule.get("kind")
 
             next_run_dt = _ensure_aware(raw_next_run_dt)
+            manual_run = job.get("manual_run_at") == next_run
             # Migration repair: a cron job persists next_run_at as an absolute
             # instant, but the cron expr describes local wall-clock intent. If the
             # configured/system timezone changed after persistence, the stored
@@ -3565,6 +3571,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
             # rare relative to the double-fire bug this prevents (#28934).
             if (
                 kind == "cron"
+                and not manual_run
                 and next_run_dt <= now
                 and _timezone_offset_mismatch(raw_next_run_dt, now)
                 and _stored_wall_clock_is_future(raw_next_run_dt, now)
@@ -3651,7 +3658,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                 # so re-anchor before either can fire. Recomputation uses the
                 # current expression, so this converges — it cannot defer
                 # forever.
-                if kind == "cron" and not _cron_next_run_matches_expr(
+                if not manual_run and kind == "cron" and not _cron_next_run_matches_expr(
                     schedule, next_run_dt
                 ):
                     new_next = compute_next_run(schedule, now.isoformat())
@@ -3676,7 +3683,11 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                 # (gateway was down and missed the window). Fast-forward to
                 # the next future occurrence instead of firing a stale run.
                 grace = _compute_grace_seconds(schedule)
-                if kind in {"cron", "interval"} and (now - next_run_dt).total_seconds() > grace:
+                if (
+                    not manual_run
+                    and kind in {"cron", "interval"}
+                    and (now - next_run_dt).total_seconds() > grace
+                ):
                     # Job is past its catch-up grace window — skip accumulated
                     # missed runs but still execute once now to avoid deferring
                     # indefinitely (e.g. a long-running job just finished).

--- a/tests/cron/test_due_stale_cron_edit.py
+++ b/tests/cron/test_due_stale_cron_edit.py
@@ -76,6 +76,65 @@ def test_matching_next_run_still_fires(temp_home, monkeypatch):
     assert jid in [j["id"] for j in due]
 
 
+def test_manual_trigger_bypasses_stale_schedule_guard(temp_home, monkeypatch):
+    """An explicit run-now instant need not occur in the cron expression."""
+    from cron.jobs import create_job, get_due_jobs, get_job, mark_job_run, trigger_job
+
+    now = _SATURDAY_0700 + timedelta(seconds=30)
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+    job = create_job(prompt="x", schedule="0 7 * * 1-5", name="manual")
+
+    triggered = trigger_job(job["id"])
+    due = get_due_jobs()
+
+    assert triggered is not None
+    assert job["id"] in [candidate["id"] for candidate in due]
+    assert triggered["manual_run_at"] == triggered["next_run_at"]
+
+    mark_job_run(job["id"], success=True)
+
+    assert "manual_run_at" not in get_job(job["id"])
+
+
+def test_delayed_manual_trigger_is_not_counted_as_catch_up(temp_home, monkeypatch):
+    """Run-now intent remains explicit even when the next scan is hours later."""
+    from cron.jobs import (
+        create_job,
+        get_catch_up_occurrence_count,
+        get_due_jobs,
+        trigger_job,
+    )
+
+    trigger_time = _SATURDAY_0700 + timedelta(seconds=30)
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: trigger_time)
+    job = create_job(prompt="x", schedule="0 7 * * 1-5", name="delayed")
+    trigger_job(job["id"])
+    monkeypatch.setattr(
+        "cron.jobs._hermes_now", lambda: trigger_time + timedelta(hours=5)
+    )
+
+    due = get_due_jobs()
+
+    assert job["id"] in [candidate["id"] for candidate in due]
+    assert get_catch_up_occurrence_count() == 0
+
+
+def test_manual_trigger_survives_timezone_change_before_tick(temp_home, monkeypatch):
+    """TZ migration repair must not replace an explicit run-now instant."""
+    from cron.jobs import create_job, get_due_jobs, trigger_job
+
+    trigger_time = datetime.fromisoformat("2026-08-22T21:00:00+10:00")
+    scan_time = datetime.fromisoformat("2026-08-22T13:00:00+02:00")
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: trigger_time)
+    job = create_job(prompt="x", schedule="0 7 * * 1-5", name="tz-manual")
+    trigger_job(job["id"])
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: scan_time)
+
+    due = get_due_jobs()
+
+    assert job["id"] in [candidate["id"] for candidate in due]
+
+
 def test_stale_next_run_skips_even_inside_catchup_window(temp_home, monkeypatch):
     """The catch-up 'run once now' policy must not resurrect a stale instant:
     hours after the stored time, the drifted job re-anchors without firing."""


### PR DESCRIPTION
## What does this PR do?

Manual runs of recurring cron jobs now execute on the next scheduler tick instead of being silently re-anchored to the next natural schedule occurrence. The fix persists explicit run-now intent beside `next_run_at`, lets only that exact instant bypass schedule and timezone repair guards, and clears the intent after the run completes.

### Symptom

`hermes cron run <job>`, `POST /api/jobs/{job_id}/run`, and direct `trigger_job()` calls reported success for recurring cron jobs, but the next due scan returned no job and `last_run_at` remained unchanged.

### Impact

Operators could not manually run recurring jobs through the CLI or REST path. The command appeared successful while no execution occurred.

### Bug Cause

**Trigger:** `cron/jobs.py:trigger_job()` writes the current instant into `next_run_at`.

**Causal chain:**
1. A user requests an immediate run of a recurring cron job.
2. `trigger_job()` stores an arbitrary wall-clock instant that usually is not an occurrence of the cron expression.
3. `_get_due_jobs_locked()` treats that instant as stale schedule state, re-anchors it, and skips dispatch.

**Why it is wrong:** The due scan conflated explicit operator intent with a stale `next_run_at` left by a direct schedule edit.

**Working sibling / contrast:** The agent-facing `cron_job(action="run")` path claims and executes immediately instead of routing through `trigger_job()` and the due scan.

**Ruled out:** Timezone mismatch is not required to reproduce the failure. The focused regression uses one timezone and reproduces the stale-expression guard directly; a second regression covers a timezone change before the tick.

### Fix

`trigger_job()` now stores `manual_run_at` equal to the requested `next_run_at`. The due scan recognizes only that exact persisted pair as explicit run-now intent, bypasses stale-expression, timezone-repair, and catch-up accounting for it, and preserves all existing guards for ordinary persisted schedule values. `mark_job_run()` removes the marker after completion.

## Related Issue

Closes #94010

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/jobs.py` - persist and consume explicit recurring run-now intent without weakening stale-schedule protection.
- `tests/cron/test_due_stale_cron_edit.py` - cover trigger-to-due dispatch, delayed ticks, timezone changes, marker cleanup, and the existing stale-edit controls.

## How to Test

1. Create a recurring cron job whose next natural occurrence is in the future.
2. Call `trigger_job(job_id)` and run `get_due_jobs()` at the requested instant.
3. Verify the job is due, then verify a directly edited non-matching `next_run_at` still re-anchors without firing.

Automated verification (101 passed):

```bash
scripts/run_tests.sh tests/cron/test_due_stale_cron_edit.py tests/cron/test_recurring_eagain_redispatch.py tests/cron/test_claim_job_for_fire.py tests/cron/test_jobs.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all 101 tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A; behavior and persisted intent are documented in code and regression tests
- [x] `cli-config.yaml.example` updates are N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact; the implementation uses timezone-aware ISO timestamps and existing store primitives
- [x] Tool description/schema updates are N/A; no model-tool contract changed

## Screenshots / Logs

N/A - automated real-store regressions cover the scheduler behavior.
