### PR TITLE
fix(cron): honor trigger_job's fire-now intent against the stale-schedule guard

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2442,6 +2442,13 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
             "paused_at": None,
             "paused_reason": None,
             "next_run_at": _hermes_now().isoformat(),
+            # One-shot marker: the arbitrary "now" instant written above is
+            # (almost surely) not an occurrence of the job's cron expression,
+            # and the stale-schedule guard added for #93049 would re-anchor it
+            # without firing — turning every manual trigger into a silent
+            # no-op (#94010). _get_due_jobs_locked consumes the marker to
+            # bypass the guard for exactly this fire, then clears it.
+            "fire_now": True,
         },
     )
 
@@ -3651,8 +3658,20 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                 # so re-anchor before either can fire. Recomputation uses the
                 # current expression, so this converges — it cannot defer
                 # forever.
-                if kind == "cron" and not _cron_next_run_matches_expr(
-                    schedule, next_run_dt
+                #
+                # The one deliberate exception is trigger_job()'s "run now"
+                # (#94010): its next_run_at is an arbitrary second chosen by
+                # the operator, which is exactly the mismatch this guard
+                # exists to correct — without the fire_now marker every
+                # manual trigger of a recurring cron job became a silent
+                # no-op that still reported success. Consume the marker here
+                # (in both the working record and storage) and fall through
+                # to the fire path.
+                _fire_now = job.pop("fire_now", None)
+                if (
+                    kind == "cron"
+                    and not _cron_next_run_matches_expr(schedule, next_run_dt)
+                    and not _fire_now
                 ):
                     new_next = compute_next_run(schedule, now.isoformat())
                     logger.info(
@@ -3668,9 +3687,22 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                         for rj in raw_jobs:
                             if rj["id"] == job["id"]:
                                 rj["next_run_at"] = new_next
+                                rj.pop("fire_now", None)
                                 needs_save = True
                                 break
                     continue
+                elif _fire_now:
+                    for rj in raw_jobs:
+                        if rj["id"] == job["id"]:
+                            rj.pop("fire_now", None)
+                            needs_save = True
+                            break
+                    logger.info(
+                        "Job '%s' fire-now marker honored; firing manual run "
+                        "despite non-occurrence next_run_at %s.",
+                        job.get("name", job.get("id", "?")),
+                        next_run,
+                    )
 
                 # For recurring jobs, check if the scheduled time is stale
                 # (gateway was down and missed the window). Fast-forward to

--- a/tests/cron/test_trigger_fire_now.py
+++ b/tests/cron/test_trigger_fire_now.py
@@ -1,0 +1,84 @@
+"""trigger_job() must survive the stale-schedule guard (#94010).
+
+The guard added for #93049 re-anchors any cron next_run_at that is not an
+occurrence of the job's current expression. trigger_job() deliberately writes
+next_run_at = "now" — an arbitrary second that is (almost surely) not an
+occurrence — so every manual trigger of a recurring cron job was re-anchored
+without firing, while trigger_job still returned a truthy job dict: a silent
+no-op reported as success on every "run now" path (CLI `hermes cron run`,
+REST POST /api/jobs/{id}/run). The fix stamps a one-shot ``fire_now`` marker
+that the guard consumes to fall through to the fire path exactly once.
+"""
+
+import json
+from datetime import datetime, timedelta
+
+import pytest
+
+import cron.jobs as jobs_mod
+from cron import jobs as cron_jobs
+
+
+@pytest.fixture
+def cron_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _reload_store():
+    """Read the current store's job records via the module's path resolution."""
+    doc = json.loads(cron_jobs._current_cron_store().jobs_file.read_text())
+    return doc["jobs"] if isinstance(doc, dict) else doc
+
+
+def _create_recurring_job(monkeypatch, expr="0 7 * * *"):
+    """Create a cron job through the public create_job surface."""
+    return cron_jobs.create_job(
+        prompt="say hi",
+        schedule=expr,
+        name="recurring job",
+    )
+
+
+def test_trigger_job_stamps_fire_now_marker(cron_home, monkeypatch):
+    job = _create_recurring_job(monkeypatch)
+    result = cron_jobs.trigger_job(job["id"])
+    assert result is not None
+    stored = _reload_store()
+    assert stored[0].get("fire_now") is True
+
+
+def test_fire_now_bypasses_reanchor_and_fires(cron_home, monkeypatch):
+    """The exact #94010 shape: a manual-trigger next_run_at that is not an
+    expression occurrence must still surface as due (fire), not re-anchor."""
+    job = _create_recurring_job(monkeypatch, expr="0 7 1 * *")
+    cron_jobs.trigger_job(job["id"])
+
+    due = cron_jobs.get_due_jobs()
+    due_ids = [d.get("id") or d.get("job", {}).get("id") for d in due]
+    assert job["id"] in due_ids
+
+    stored = _reload_store()[0]
+    # The marker is consumed by the fire decision — it must not linger to
+    # neutralize the guard for a later genuine schedule edit.
+    assert stored.get("fire_now") is None
+
+
+def test_stale_schedule_without_marker_still_reanchors(cron_home, monkeypatch):
+    """The #93049 protection is intact: a next_run_at from a jobs.json edit
+    (no marker) still re-anchors without firing."""
+    job = _create_recurring_job(monkeypatch, expr="0 7 1 * * *")
+    stored = _reload_store()
+    # Simulate the direct edit: a wrong-instant next_run_at in the past, no
+    # fire_now marker.
+    stored[0]["next_run_at"] = (
+        (datetime.now() - timedelta(minutes=5)).isoformat()
+    )
+    cron_jobs._current_cron_store().jobs_file.write_text(json.dumps(stored))
+
+    due = cron_jobs.get_due_jobs()
+    due_ids = [d.get("id") or d.get("job", {}).get("id") for d in due]
+    assert job["id"] not in due_ids
+    after = _reload_store()[0]
+    assert after["next_run_at"] != stored[0]["next_run_at"]
+    assert not after.get("fire_now")


### PR DESCRIPTION
## What does this PR do?

The stale-schedule guard added for #93049 re-anchors any cron `next_run_at` that is not an occurrence of the job's current expression. `trigger_job()` deliberately writes `next_run_at = "now"` — an arbitrary second that is almost never an occurrence — so since that guard landed, **every manual trigger of a recurring cron job was re-anchored without firing** (on every host, every timezone — the reporter's four manual triggers produced four skips and two jobs with `last_run_at: null`), while `trigger_job` still returned a truthy job dict: a silent no-op reported as success on all three public "run now" paths (CLI `hermes cron run`, REST `POST /api/jobs/{id}/run`, direct importers). This stamps a one-shot `fire_now` marker alongside the trigger instant; the guard consumes it — popping the marker from both the working record and storage — and falls through to the fire path exactly once. A `next_run_at` without the marker (a genuine direct `jobs.json` edit) still re-anchors without firing, so the #93049 protection is unchanged.

## Related Issue

Fixes #94010

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `cron/jobs.py`:
  - `trigger_job()`: the update payload now also sets `"fire_now": True`, with a comment naming the guard interaction (#94010).
  - `_get_due_jobs_locked()` stale-schedule guard: the marker is popped from the working record first (`_fire_now = job.pop(...)`), the guard's mismatch branch requires `not _fire_now`, and a new honored-branch clears the marker from `raw_jobs` (persisting via the existing `needs_save`) and logs that the manual run fired despite the non-occurrence instant. The #93049 re-anchor branch also strips the marker when it re-anchors, so a stale record never carries it.
- `tests/cron/test_trigger_fire_now.py` — new (3 tests): `trigger_job` stamps the marker in storage; the exact reporter shape — a manual-trigger instant that is not an occurrence of `0 7 1 * *` — surfaces as due (fires) with the marker consumed; a marker-less hand-edited past `next_run_at` still re-anchors without firing (the #93049 contract).

## How to Test

- New: `.venv/bin/python -m pytest tests/cron/test_trigger_fire_now.py -q` — should pass (3 tests). On unpatched `main`, the marker and fire tests fail (the trigger writes no marker and the guard skips the fire), pinning the regression.
- Regression: `.venv/bin/python -m pytest tests/cron/test_due_stale_cron_edit.py tests/cron/test_trigger_fire_now.py -q` — should pass (7 tests), confirming the #93049 direct-edit re-anchor behavior is intact. The full `tests/cron/` suite runs 940 passed with 5 failures (`test_script_claim_heartbeat` process-tree kills and `test_media_send_timeout` fallback naming) that fail identically on clean `main` in this environment (process-table probing, unrelated).
- Probe (the reporter's flow): create a `0 7 1 * *` job, `trigger_job(id)`, then `get_due_jobs()` — the job surfaces as due and the stored marker is gone; a second `get_due_jobs()` returns nothing (the guard resumes for the natural schedule).

Observed result: locally, the manual trigger fires on the next due-scan exactly once, the marker is consumed in storage, and the stale-edit re-anchor contract is untouched.

## Checklist

- [x] Code follows project style (no unrelated changes)
- [x] Self-reviewed the diff
- [x] Added/updated tests covering the fix
- [x] All new and existing tests pass locally (940 passed across tests/cron; the 5 pre-existing failures are identical on clean `main` — process-table probing, unrelated)
- [x] PR targets `upstream/main` from a fork branch
