### PR TITLE
fix(compaction): preserve native capability across switches

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2779,9 +2779,10 @@ def init_agent(
     agent.codex_responses_native_compaction = codex_responses_native_compaction
     agent.codex_responses_compact_threshold = codex_responses_compact_threshold
     from agent.native_compaction import resolve_native_compaction_capabilities
-    agent.capabilities = resolve_native_compaction_capabilities(
+    agent.runtime_capabilities = resolve_native_compaction_capabilities(
         model=agent.model,
         base_url=agent.base_url,
+        provider=agent.provider,
         is_codex_backend=(agent.provider or "").strip().lower() == "openai-codex",
     )
     agent.max_compression_attempts = compression_max_attempts

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2778,6 +2778,12 @@ def init_agent(
     agent.codex_app_server_auto_compaction = codex_app_server_auto_compaction
     agent.codex_responses_native_compaction = codex_responses_native_compaction
     agent.codex_responses_compact_threshold = codex_responses_compact_threshold
+    from agent.native_compaction import resolve_native_compaction_capabilities
+    agent.capabilities = resolve_native_compaction_capabilities(
+        model=agent.model,
+        base_url=agent.base_url,
+        is_codex_backend=(agent.provider or "").strip().lower() == "openai-codex",
+    )
     agent.max_compression_attempts = compression_max_attempts
     agent.compression_idle_compact_after_seconds = (
         compression_idle_compact_after_seconds

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1614,8 +1614,17 @@ def restore_primary_runtime(agent) -> bool:
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
-        if "capabilities" in rt:
-            agent.capabilities = dict(rt.get("capabilities") or {})
+        if "runtime_capabilities" in rt:
+            raw_capabilities = rt["runtime_capabilities"]
+            if not isinstance(raw_capabilities, dict):
+                logger.warning("Ignoring malformed runtime capabilities snapshot")
+            else:
+                agent.runtime_capabilities = dict(raw_capabilities)
+        elif "capabilities" in rt:
+            # Read snapshots written by the initial capability propagation patch.
+            raw_capabilities = rt["capabilities"]
+            if isinstance(raw_capabilities, dict):
+                agent.runtime_capabilities = dict(raw_capabilities)
         agent._reasoning_echo_flag = rt.get("reasoning_echo_flag", False)
         agent._client_kwargs = dict(rt["client_kwargs"])
         agent._use_prompt_caching = rt["use_prompt_caching"]
@@ -2725,6 +2734,11 @@ def switch_model(
     if not api_mode:
         api_mode = determine_api_mode(new_provider, base_url, model=new_model)
 
+    normalized_new_provider = (new_provider or "").strip().lower()
+    if not base_url and normalized_new_provider == "openai":
+        # An omitted URL means the provider's canonical direct endpoint.
+        base_url = "https://api.openai.com/v1"
+
     # Same-provider switches may omit base_url intentionally (for example, a
     # direct caller refreshing credentials). Resolve capabilities from the
     # endpoint that the normalization below will retain, not from the empty
@@ -2741,6 +2755,7 @@ def switch_model(
         else resolve_native_compaction_capabilities(
             model=new_model,
             base_url=effective_base_url,
+            provider=new_provider,
             is_codex_backend=(new_provider or '').strip().lower() == 'openai-codex',
         )
     )
@@ -2788,7 +2803,7 @@ def switch_model(
             "_is_anthropic_oauth",
             "_config_context_length",
             "_reasoning_echo_flag",
-            "capabilities",
+            "runtime_capabilities",
         )
     }
     # _client_kwargs is a dict — snapshot a shallow copy so mutating the
@@ -3099,7 +3114,7 @@ def switch_model(
 
     # Publish the destination capability map only after every runtime setup
     # above has succeeded. Failed switches must leave the old map intact.
-    agent.capabilities = destination_capabilities
+    agent.runtime_capabilities = destination_capabilities
 
     # ── Reset the cross-turn stale-call circuit breaker (#58962) ──
     # The breaker's error text tells the user to "switch models ... then
@@ -3123,7 +3138,7 @@ def switch_model(
         "use_native_cache_layout": agent._use_native_cache_layout,
         "reasoning_config": dict(agent.reasoning_config) if getattr(agent, "reasoning_config", None) else None,
         "reasoning_echo_flag": getattr(agent, "_reasoning_echo_flag", False),
-        "capabilities": dict(getattr(agent, "capabilities", {}) or {}),
+        "runtime_capabilities": dict(getattr(agent, "runtime_capabilities", {}) or {}),
         "compressor_model": getattr(_cc, "model", agent.model) if _cc else agent.model,
         "compressor_base_url": getattr(_cc, "base_url", agent.base_url) if _cc else agent.base_url,
         "compressor_api_key": getattr(_cc, "api_key", "") if _cc else "",

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3020,23 +3020,32 @@ def switch_model(
     except Exception:
         _destination_context_intent = None
     agent._config_context_length = _destination_context_intent
-    try:
-        _runtime_context_length = agent._ensure_lmstudio_runtime_loaded(
-            _destination_context_intent
-        )
-    except Exception:
-        _restore_snapshot()
-        raise
-    if agent._lmstudio_load_was_unverified(_runtime_context_length):
+    if hasattr(agent, "_ensure_lmstudio_runtime_loaded"):
+        try:
+            _runtime_context_length = agent._ensure_lmstudio_runtime_loaded(
+                _destination_context_intent
+            )
+        except Exception:
+            _restore_snapshot()
+            raise
+    else:
+        _runtime_context_length = None
+    if (
+        hasattr(agent, "_lmstudio_load_was_unverified")
+        and agent._lmstudio_load_was_unverified(_runtime_context_length)
+    ):
         logger.warning(
             "LM Studio model activation was rejected or completed without a "
             "verifiable active context length during model switch; continuing "
             "with configured context"
         )
-    _effective_context_length = agent._effective_lmstudio_context_length(
-        _destination_context_intent,
-        _runtime_context_length,
-    )
+    if hasattr(agent, "_effective_lmstudio_context_length"):
+        _effective_context_length = agent._effective_lmstudio_context_length(
+            _destination_context_intent,
+            _runtime_context_length,
+        )
+    else:
+        _effective_context_length = _destination_context_intent
 
     # ── Re-evaluate prompt caching ──
     # Refresh the custom-provider snapshot from the config just loaded above

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1614,6 +1614,8 @@ def restore_primary_runtime(agent) -> bool:
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
+        if "capabilities" in rt:
+            agent.capabilities = dict(rt.get("capabilities") or {})
         agent._reasoning_echo_flag = rt.get("reasoning_echo_flag", False)
         agent._client_kwargs = dict(rt["client_kwargs"])
         agent._use_prompt_caching = rt["use_prompt_caching"]
@@ -2688,7 +2690,15 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     return client
 
 
-def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mode=''):
+def switch_model(
+    agent,
+    new_model,
+    new_provider,
+    api_key='',
+    base_url='',
+    api_mode='',
+    capabilities=None,
+):
     """Switch the model/provider in-place for a live agent.
 
     Called by the /model command handlers (CLI and gateway) after
@@ -2703,6 +2713,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     turn-scoped).
     """
     from hermes_cli.providers import determine_api_mode
+    from agent.native_compaction import resolve_native_compaction_capabilities
 
     # ── Determine api_mode if not provided ──
     # Pass model so dual-wire providers (Nous Portal anthropic/* → Messages)
@@ -2710,6 +2721,16 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     # openai_chat overlay default.
     if not api_mode:
         api_mode = determine_api_mode(new_provider, base_url, model=new_model)
+
+    destination_capabilities = (
+        dict(capabilities)
+        if isinstance(capabilities, dict)
+        else resolve_native_compaction_capabilities(
+            model=new_model,
+            base_url=base_url,
+            is_codex_backend=(new_provider or '').strip().lower() == 'openai-codex',
+        )
+    )
 
     # Defense-in-depth: ensure OpenCode base_url doesn't carry a trailing
     # /v1 into the anthropic_messages client, which would cause the SDK to
@@ -2757,6 +2778,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             "_is_anthropic_oauth",
             "_config_context_length",
             "_reasoning_echo_flag",
+            "capabilities",
         )
     }
     # _client_kwargs is a dict — snapshot a shallow copy so mutating the
@@ -2973,9 +2995,13 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     except Exception:
         _destination_context_intent = None
     agent._config_context_length = _destination_context_intent
-    _runtime_context_length = agent._ensure_lmstudio_runtime_loaded(
-        _destination_context_intent
-    )
+    try:
+        _runtime_context_length = agent._ensure_lmstudio_runtime_loaded(
+            _destination_context_intent
+        )
+    except Exception:
+        _restore_snapshot()
+        raise
     if agent._lmstudio_load_was_unverified(_runtime_context_length):
         logger.warning(
             "LM Studio model activation was rejected or completed without a "
@@ -3019,22 +3045,26 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         # length normally resolves via config or static catalogs and
         # never hits a probe, but coerce to empty string defensively.
         _ctx_api_key = agent.api_key if isinstance(agent.api_key, str) else ""
-        new_context_length = get_model_context_length(
-            agent.model,
-            base_url=agent.base_url,
-            api_key=_ctx_api_key,
-            provider=agent.provider,
-            config_context_length=_effective_context_length,
-            custom_providers=_sm_custom_providers,
-        )
-        agent.context_compressor.update_model(
-            model=agent.model,
-            context_length=new_context_length,
-            base_url=agent.base_url,
-            api_key=agent.api_key,  # context_compressor forwards to call_llm; callable preserved
-            provider=agent.provider,
-            api_mode=agent.api_mode,
-        )
+        try:
+            new_context_length = get_model_context_length(
+                agent.model,
+                base_url=agent.base_url,
+                api_key=_ctx_api_key,
+                provider=agent.provider,
+                config_context_length=_effective_context_length,
+                custom_providers=_sm_custom_providers,
+            )
+            agent.context_compressor.update_model(
+                model=agent.model,
+                context_length=new_context_length,
+                base_url=agent.base_url,
+                api_key=agent.api_key,  # context_compressor forwards to call_llm; callable preserved
+                provider=agent.provider,
+                api_mode=agent.api_mode,
+            )
+        except Exception:
+            _restore_snapshot()
+            raise
 
     # ── Re-resolve reasoning_config from per-model override ──
     # The new model may have a different reasoning_effort override. Re-read
@@ -3056,6 +3086,10 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
     # ── Invalidate cached system prompt so it rebuilds next turn ──
     agent._cached_system_prompt = None
+
+    # Publish the destination capability map only after every runtime setup
+    # above has succeeded. Failed switches must leave the old map intact.
+    agent.capabilities = destination_capabilities
 
     # ── Reset the cross-turn stale-call circuit breaker (#58962) ──
     # The breaker's error text tells the user to "switch models ... then
@@ -3079,6 +3113,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         "use_native_cache_layout": agent._use_native_cache_layout,
         "reasoning_config": dict(agent.reasoning_config) if getattr(agent, "reasoning_config", None) else None,
         "reasoning_echo_flag": getattr(agent, "_reasoning_echo_flag", False),
+        "capabilities": dict(getattr(agent, "capabilities", {}) or {}),
         "compressor_model": getattr(_cc, "model", agent.model) if _cc else agent.model,
         "compressor_base_url": getattr(_cc, "base_url", agent.base_url) if _cc else agent.base_url,
         "compressor_api_key": getattr(_cc, "api_key", "") if _cc else "",

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2715,6 +2715,9 @@ def switch_model(
     from hermes_cli.providers import determine_api_mode
     from agent.native_compaction import resolve_native_compaction_capabilities
 
+    old_model = agent.model
+    old_provider = agent.provider
+
     # ── Determine api_mode if not provided ──
     # Pass model so dual-wire providers (Nous Portal anthropic/* → Messages)
     # resolve correctly; without it determine_api_mode falls back to the
@@ -2722,12 +2725,22 @@ def switch_model(
     if not api_mode:
         api_mode = determine_api_mode(new_provider, base_url, model=new_model)
 
+    # Same-provider switches may omit base_url intentionally (for example, a
+    # direct caller refreshing credentials). Resolve capabilities from the
+    # endpoint that the normalization below will retain, not from the empty
+    # raw argument.
+    effective_base_url = base_url
+    if not effective_base_url and (old_provider or "").strip().lower() == (
+        new_provider or ""
+    ).strip().lower():
+        effective_base_url = getattr(agent, "base_url", "")
+
     destination_capabilities = (
         dict(capabilities)
         if isinstance(capabilities, dict)
         else resolve_native_compaction_capabilities(
             model=new_model,
-            base_url=base_url,
+            base_url=effective_base_url,
             is_codex_backend=(new_provider or '').strip().lower() == 'openai-codex',
         )
     )
@@ -2746,9 +2759,6 @@ def switch_model(
         and base_url
     ):
         base_url = re.sub(r"/v1/?$", "", base_url)
-
-    old_model = agent.model
-    old_provider = agent.provider
 
     # ── Snapshot all fields the swap+rebuild can mutate ──
     # If the rebuild raises (bad API key, network error, build_anthropic_client

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2838,9 +2838,10 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # single stream attempt.
         _reset_stale_streak(agent)
         from agent.native_compaction import resolve_native_compaction_capabilities
-        agent.capabilities = resolve_native_compaction_capabilities(
+        agent.runtime_capabilities = resolve_native_compaction_capabilities(
             model=agent.model,
             base_url=agent.base_url,
+            provider=fb_provider,
             is_codex_backend=fb_provider == "openai-codex",
         )
         return True

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2837,6 +2837,12 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # short-circuit the freshly activated fallback before it gets a
         # single stream attempt.
         _reset_stale_streak(agent)
+        from agent.native_compaction import resolve_native_compaction_capabilities
+        agent.capabilities = resolve_native_compaction_capabilities(
+            model=agent.model,
+            base_url=agent.base_url,
+            is_codex_backend=fb_provider == "openai-codex",
+        )
         return True
     except Exception as e:
         if fb_provider == "nous":

--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -71,6 +71,7 @@ def resolve_native_compaction_capabilities(
     *,
     model: Optional[str],
     base_url: Optional[str],
+    provider: Optional[str] = None,
     is_codex_backend: bool = False,
 ) -> Dict[str, bool]:
     """Resolve the native-compaction capability for a runtime destination.
@@ -78,9 +79,11 @@ def resolve_native_compaction_capabilities(
     The result is deliberately explicit: a resolved ``False`` is different
     from an unresolved capability and must survive model switches unchanged.
     """
-    eligible = is_native_compaction_model(model) and is_direct_openai_route(
-        base_url,
-        is_codex_backend=is_codex_backend,
+    normalized_provider = (provider or "").strip().lower()
+    direct_default = normalized_provider == "openai" and not base_url
+    eligible = is_native_compaction_model(model) and (
+        direct_default
+        or is_direct_openai_route(base_url, is_codex_backend=is_codex_backend)
     )
     return {"native_compaction": eligible}
 
@@ -149,7 +152,7 @@ def native_compaction_context_management(
     (``agent.codex_responses_native_compaction = False``, set by the
     conversation loop's rejection recovery) takes effect on the next call.
     """
-    capabilities = getattr(agent, "capabilities", None)
+    capabilities = getattr(agent, "runtime_capabilities", None)
     if isinstance(capabilities, dict):
         if not bool(capabilities.get("native_compaction", False)):
             return None

--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -67,6 +67,24 @@ def is_native_compaction_model(model: Optional[str]) -> bool:
     return _ELIGIBLE_MODEL_MARKER in (model or "").lower()
 
 
+def resolve_native_compaction_capabilities(
+    *,
+    model: Optional[str],
+    base_url: Optional[str],
+    is_codex_backend: bool = False,
+) -> Dict[str, bool]:
+    """Resolve the native-compaction capability for a runtime destination.
+
+    The result is deliberately explicit: a resolved ``False`` is different
+    from an unresolved capability and must survive model switches unchanged.
+    """
+    eligible = is_native_compaction_model(model) and is_direct_openai_route(
+        base_url,
+        is_codex_backend=is_codex_backend,
+    )
+    return {"native_compaction": eligible}
+
+
 def is_direct_openai_route(
     base_url: Optional[str],
     *,
@@ -131,6 +149,10 @@ def native_compaction_context_management(
     (``agent.codex_responses_native_compaction = False``, set by the
     conversation loop's rejection recovery) takes effect on the next call.
     """
+    capabilities = getattr(agent, "capabilities", None)
+    if isinstance(capabilities, dict):
+        if not bool(capabilities.get("native_compaction", False)):
+            return None
     if not bool(getattr(agent, "codex_responses_native_compaction", False)):
         return None
     # compression.enabled: false disables ALL automatic compaction, native

--- a/cli.py
+++ b/cli.py
@@ -9929,7 +9929,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                             api_key=_reset_result.api_key,
                             base_url=_reset_result.base_url,
                             api_mode=_reset_result.api_mode,
-                            capabilities=_reset_result.runtime_capabilities,
+                            capabilities=getattr(
+                                _reset_result, "runtime_capabilities", None
+                            ),
                         )
                     self.model = _reset_result.new_model
                     self.provider = _reset_result.target_provider
@@ -11249,7 +11251,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
-                    capabilities=result.runtime_capabilities,
+                    capabilities=getattr(result, "runtime_capabilities", None),
                 )
             except Exception as exc:
                 # The agent rolled itself back to the old working model/client.
@@ -11640,7 +11642,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
-                    capabilities=result.runtime_capabilities,
+                    capabilities=getattr(result, "runtime_capabilities", None),
                 )
             except Exception as exc:
                 # Agent rolled itself back; roll the CLI back too and abort so a

--- a/cli.py
+++ b/cli.py
@@ -9929,6 +9929,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                             api_key=_reset_result.api_key,
                             base_url=_reset_result.base_url,
                             api_mode=_reset_result.api_mode,
+                            capabilities=_reset_result.runtime_capabilities,
                         )
                     self.model = _reset_result.new_model
                     self.provider = _reset_result.target_provider
@@ -11103,6 +11104,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     api_key=snapshot.get("api_key", ""),
                     base_url=snapshot.get("base_url", ""),
                     api_mode=snapshot.get("api_mode", ""),
+                    capabilities=snapshot.get("capabilities"),
                 )
             except Exception as exc:
                 logger.warning("CLI one-turn model restore failed: %s", exc)
@@ -11247,6 +11249,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
+                    capabilities=result.runtime_capabilities,
                 )
             except Exception as exc:
                 # The agent rolled itself back to the old working model/client.
@@ -11637,6 +11640,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
+                    capabilities=result.runtime_capabilities,
                 )
             except Exception as exc:
                 # Agent rolled itself back; roll the CLI back too and abort so a

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1950,7 +1950,9 @@ class GatewaySlashCommandsMixin:
                                     api_key=result.api_key,
                                     base_url=result.base_url,
                                     api_mode=result.api_mode,
-                                    capabilities=result.runtime_capabilities,
+                                    capabilities=getattr(
+                                        result, "runtime_capabilities", None
+                                    ),
                                 )
                             except Exception as exc:
                                 # The in-place swap rolled the agent back to the
@@ -2264,7 +2266,7 @@ class GatewaySlashCommandsMixin:
                         api_key=result.api_key,
                         base_url=result.base_url,
                         api_mode=result.api_mode,
-                        capabilities=result.runtime_capabilities,
+                        capabilities=getattr(result, "runtime_capabilities", None),
                     )
                 except Exception as exc:
                     # In-place swap rolled the agent back to the OLD working

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1950,6 +1950,7 @@ class GatewaySlashCommandsMixin:
                                     api_key=result.api_key,
                                     base_url=result.base_url,
                                     api_mode=result.api_mode,
+                                    capabilities=result.runtime_capabilities,
                                 )
                             except Exception as exc:
                                 # The in-place swap rolled the agent back to the
@@ -2263,6 +2264,7 @@ class GatewaySlashCommandsMixin:
                         api_key=result.api_key,
                         base_url=result.base_url,
                         api_mode=result.api_mode,
+                        capabilities=result.runtime_capabilities,
                     )
                 except Exception as exc:
                     # In-place swap rolled the agent back to the OLD working

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2176,6 +2176,7 @@ def switch_model(
     runtime_capabilities = resolve_native_compaction_capabilities(
         model=new_model,
         base_url=base_url,
+        provider=target_provider,
         is_codex_backend=target_provider.strip().lower() == "openai-codex",
     )
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -625,6 +625,7 @@ class ModelSwitchResult:
     provider_label: str = ""
     resolved_via_alias: str = ""
     capabilities: Optional[ModelCapabilities] = None
+    runtime_capabilities: Optional[dict[str, bool]] = None
     model_info: Optional[ModelInfo] = None
     is_global: bool = False
 
@@ -2171,6 +2172,12 @@ def switch_model(
 
     # --- Get capabilities (legacy) ---
     capabilities = get_model_capabilities(target_provider, new_model, allow_network=True)
+    from agent.native_compaction import resolve_native_compaction_capabilities
+    runtime_capabilities = resolve_native_compaction_capabilities(
+        model=new_model,
+        base_url=base_url,
+        is_codex_backend=target_provider.strip().lower() == "openai-codex",
+    )
 
     # --- Get full model info from models.dev ---
     model_info = get_model_info(target_provider, new_model, allow_network=True)
@@ -2196,6 +2203,7 @@ def switch_model(
         provider_label=provider_label,
         resolved_via_alias=resolved_alias,
         capabilities=capabilities,
+        runtime_capabilities=runtime_capabilities,
         model_info=model_info,
         is_global=is_global,
     )

--- a/run_agent.py
+++ b/run_agent.py
@@ -894,10 +894,26 @@ class AIAgent:
             return_load_result=True,
         )
 
-    def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode=''):
+    def switch_model(
+        self,
+        new_model,
+        new_provider,
+        api_key='',
+        base_url='',
+        api_mode='',
+        capabilities=None,
+    ):
         """Forwarder — see ``agent.agent_runtime_helpers.switch_model``."""
         from agent.agent_runtime_helpers import switch_model
-        return switch_model(self, new_model, new_provider, api_key, base_url, api_mode)
+        return switch_model(
+            self,
+            new_model,
+            new_provider,
+            api_key,
+            base_url,
+            api_mode,
+            capabilities,
+        )
 
     def _safe_print(self, *args, **kwargs):
         """Print that silently handles broken pipes / closed stdout.

--- a/tests/run_agent/test_fallback_reasoning_override.py
+++ b/tests/run_agent/test_fallback_reasoning_override.py
@@ -75,6 +75,7 @@ class TestFallbackReasoningOverride:
             "client_kwargs": {},
             "use_prompt_caching": False,
             "use_native_cache_layout": False,
+            "capabilities": {"native_compaction": True},
             "reasoning_config": {"enabled": True, "effort": "medium"},
             "compressor_model": "gemini-flash",
             "compressor_base_url": "",
@@ -95,6 +96,7 @@ class TestFallbackReasoningOverride:
         agent.model = "claude-opus-4.5"
         agent.provider = "anthropic"
         agent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+        agent.capabilities = {"native_compaction": False}
         agent.context_compressor = MagicMock()
         agent.base_url = ""
         agent._anthropic_prompt_cache_policy = MagicMock(return_value=(False, False))
@@ -105,6 +107,7 @@ class TestFallbackReasoningOverride:
         assert result is True
         # reasoning_config should be restored to primary's value (medium)
         assert agent.reasoning_config == {"enabled": True, "effort": "medium"}
+        assert agent.capabilities == {"native_compaction": True}
 
     def test_fallback_global_fallback_with_yaml_false(self):
         """Fallback global fallback must not coerce YAML boolean False.

--- a/tests/run_agent/test_fallback_reasoning_override.py
+++ b/tests/run_agent/test_fallback_reasoning_override.py
@@ -75,7 +75,7 @@ class TestFallbackReasoningOverride:
             "client_kwargs": {},
             "use_prompt_caching": False,
             "use_native_cache_layout": False,
-            "capabilities": {"native_compaction": True},
+            "runtime_capabilities": {"native_compaction": True},
             "reasoning_config": {"enabled": True, "effort": "medium"},
             "compressor_model": "gemini-flash",
             "compressor_base_url": "",
@@ -96,7 +96,7 @@ class TestFallbackReasoningOverride:
         agent.model = "claude-opus-4.5"
         agent.provider = "anthropic"
         agent.reasoning_config = {"enabled": True, "effort": "xhigh"}
-        agent.capabilities = {"native_compaction": False}
+        agent.runtime_capabilities = {"native_compaction": False}
         agent.context_compressor = MagicMock()
         agent.base_url = ""
         agent._anthropic_prompt_cache_policy = MagicMock(return_value=(False, False))
@@ -107,7 +107,7 @@ class TestFallbackReasoningOverride:
         assert result is True
         # reasoning_config should be restored to primary's value (medium)
         assert agent.reasoning_config == {"enabled": True, "effort": "medium"}
-        assert agent.capabilities == {"native_compaction": True}
+        assert agent.runtime_capabilities == {"native_compaction": True}
 
     def test_fallback_global_fallback_with_yaml_false(self):
         """Fallback global fallback must not coerce YAML boolean False.

--- a/tests/run_agent/test_native_compaction_switch_capabilities.py
+++ b/tests/run_agent/test_native_compaction_switch_capabilities.py
@@ -1,0 +1,48 @@
+from types import SimpleNamespace
+
+from agent.native_compaction import (
+    native_compaction_context_management,
+    resolve_native_compaction_capabilities,
+)
+
+
+def _agent(capabilities):
+    return SimpleNamespace(
+        model="gpt-5.6",
+        base_url="https://proxy.example/v1",
+        codex_responses_native_compaction=True,
+        compression_enabled=True,
+        codex_responses_compact_threshold=200_000,
+        context_compressor=None,
+        capabilities=capabilities,
+    )
+
+
+def test_trusted_destination_capabilities_are_explicitly_enabled():
+    capabilities = resolve_native_compaction_capabilities(
+        model="gpt-5.6",
+        base_url="https://api.openai.com/v1",
+    )
+
+    assert capabilities == {"native_compaction": True}
+
+
+def test_untrusted_destination_capabilities_are_explicitly_denied():
+    capabilities = resolve_native_compaction_capabilities(
+        model="gpt-5.6",
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert capabilities == {"native_compaction": False}
+
+
+def test_explicit_false_capability_denies_native_payload():
+    agent = _agent({"native_compaction": False})
+
+    assert native_compaction_context_management(agent, is_codex_backend=False) is None
+
+
+def test_missing_capability_keeps_default_deny():
+    agent = _agent({})
+
+    assert native_compaction_context_management(agent, is_codex_backend=False) is None

--- a/tests/run_agent/test_native_compaction_switch_capabilities.py
+++ b/tests/run_agent/test_native_compaction_switch_capabilities.py
@@ -36,6 +36,16 @@ def test_untrusted_destination_capabilities_are_explicitly_denied():
     assert capabilities == {"native_compaction": False}
 
 
+def test_default_openai_destination_is_enabled_without_explicit_base_url():
+    capabilities = resolve_native_compaction_capabilities(
+        model="gpt-5.6",
+        base_url="",
+        provider="openai",
+    )
+
+    assert capabilities == {"native_compaction": True}
+
+
 def test_explicit_false_capability_denies_native_payload():
     agent = _agent({"native_compaction": False})
 

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -133,6 +133,22 @@ def test_switch_model_without_config_context_length():
         assert call_kwargs.get("config_context_length") is None
 
 
+def test_switch_model_omitted_base_url_preserves_direct_openai_capability():
+    """A same-provider switch resolves capabilities from the retained URL."""
+    agent = _make_agent_with_compressor(config_context_length=None)
+    agent.provider = "openai"
+    agent.model = "gpt-5.6"
+    agent.base_url = "https://api.openai.com/v1"
+    agent.capabilities = {"native_compaction": True}
+    agent._create_openai_client = lambda *_args, **_kwargs: MagicMock()
+
+    with patch("agent.model_metadata.get_model_context_length", return_value=128_000):
+        agent.switch_model("gpt-5.6", "openai", api_key="sk-new")
+
+    assert agent.base_url == "https://api.openai.com/v1"
+    assert agent.capabilities == {"native_compaction": True}
+
+
 def test_direct_start_model_override_does_not_inherit_profile_context_length():
     """A CLI ``--model`` startup override must not inherit another model's window."""
     cfg = {

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -139,14 +139,29 @@ def test_switch_model_omitted_base_url_preserves_direct_openai_capability():
     agent.provider = "openai"
     agent.model = "gpt-5.6"
     agent.base_url = "https://api.openai.com/v1"
-    agent.capabilities = {"native_compaction": True}
+    agent.runtime_capabilities = {"native_compaction": True}
     agent._create_openai_client = lambda *_args, **_kwargs: MagicMock()
 
     with patch("agent.model_metadata.get_model_context_length", return_value=128_000):
         agent.switch_model("gpt-5.6", "openai", api_key="sk-new")
 
     assert agent.base_url == "https://api.openai.com/v1"
-    assert agent.capabilities == {"native_compaction": True}
+    assert agent.runtime_capabilities == {"native_compaction": True}
+
+
+def test_cross_provider_switch_to_default_openai_preserves_native_capability():
+    agent = _make_agent_with_compressor(config_context_length=None)
+    agent.provider = "openrouter"
+    agent.model = "gpt-5.5"
+    agent.base_url = "https://openrouter.ai/api/v1"
+    agent.runtime_capabilities = {"native_compaction": False}
+    agent._create_openai_client = lambda *_args, **_kwargs: MagicMock()
+
+    with patch("agent.model_metadata.get_model_context_length", return_value=128_000):
+        agent.switch_model("gpt-5.6", "openai", api_key="sk-new")
+
+    assert agent.base_url == "https://api.openai.com/v1"
+    assert agent.runtime_capabilities == {"native_compaction": True}
 
 
 def test_direct_start_model_override_does_not_inherit_profile_context_length():
@@ -304,7 +319,7 @@ def test_lmstudio_switch_uses_destination_context_and_verified_runtime(monkeypat
 
 def test_later_lmstudio_failure_restores_runtime_capabilities(monkeypatch):
     agent = _make_agent_with_compressor(config_context_length=32_768)
-    agent.capabilities = {"native_compaction": True}
+    agent.runtime_capabilities = {"native_compaction": True}
     original_client = agent.client
 
     monkeypatch.setattr(
@@ -326,4 +341,4 @@ def test_later_lmstudio_failure_restores_runtime_capabilities(monkeypatch):
     assert agent.model == "primary-model"
     assert agent.provider == "openrouter"
     assert agent.client is original_client
-    assert agent.capabilities == {"native_compaction": True}
+    assert agent.runtime_capabilities == {"native_compaction": True}

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -284,3 +284,30 @@ def test_lmstudio_switch_uses_destination_context_and_verified_runtime(monkeypat
     assert call_kwargs.get("config_context_length") == 100_000
     assert agent._config_context_length == 120_000
     assert agent.context_compressor.context_length == 100_000
+
+
+def test_later_lmstudio_failure_restores_runtime_capabilities(monkeypatch):
+    agent = _make_agent_with_compressor(config_context_length=32_768)
+    agent.capabilities = {"native_compaction": True}
+    original_client = agent.client
+
+    monkeypatch.setattr(
+        AIAgent,
+        "_ensure_lmstudio_runtime_loaded",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("simulated LM Studio failure")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="simulated LM Studio failure"):
+        agent.switch_model(
+            "new-model",
+            "openrouter",
+            api_key="sk-new",
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+    assert agent.model == "primary-model"
+    assert agent.provider == "openrouter"
+    assert agent.client is original_client
+    assert agent.capabilities == {"native_compaction": True}

--- a/tests/run_agent/test_switch_model_rollback.py
+++ b/tests/run_agent/test_switch_model_rollback.py
@@ -46,6 +46,7 @@ def _make_agent_openrouter():
     agent._fallback_chain = []
     agent._fallback_model = None
     agent._config_context_length = None
+    agent.capabilities = {"native_compaction": False}
 
     return agent
 
@@ -73,6 +74,7 @@ def _make_agent_anthropic():
     agent._fallback_chain = []
     agent._fallback_model = None
     agent._config_context_length = None
+    agent.capabilities = {"native_compaction": False}
 
     return agent
 
@@ -108,6 +110,7 @@ def test_openai_client_rebuild_failure_rolls_back_to_original_state():
     assert agent.api_key == "or-key-original"
     assert agent.client is original_client
     assert agent._client_kwargs == original_kwargs
+    assert agent.capabilities == {"native_compaction": False}
 
 
 def test_anthropic_client_rebuild_failure_rolls_back_to_original_state():

--- a/tests/run_agent/test_switch_model_rollback.py
+++ b/tests/run_agent/test_switch_model_rollback.py
@@ -46,7 +46,7 @@ def _make_agent_openrouter():
     agent._fallback_chain = []
     agent._fallback_model = None
     agent._config_context_length = None
-    agent.capabilities = {"native_compaction": False}
+    agent.runtime_capabilities = {"native_compaction": False}
 
     return agent
 
@@ -74,7 +74,7 @@ def _make_agent_anthropic():
     agent._fallback_chain = []
     agent._fallback_model = None
     agent._config_context_length = None
-    agent.capabilities = {"native_compaction": False}
+    agent.runtime_capabilities = {"native_compaction": False}
 
     return agent
 
@@ -110,7 +110,7 @@ def test_openai_client_rebuild_failure_rolls_back_to_original_state():
     assert agent.api_key == "or-key-original"
     assert agent.client is original_client
     assert agent._client_kwargs == original_kwargs
-    assert agent.capabilities == {"native_compaction": False}
+    assert agent.runtime_capabilities == {"native_compaction": False}
 
 
 def test_anthropic_client_rebuild_failure_rolls_back_to_original_state():

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5631,7 +5631,7 @@ def _apply_model_switch(
                 api_key=result.api_key,
                 base_url=result.base_url,
                 api_mode=result.api_mode,
-                capabilities=result.runtime_capabilities,
+                capabilities=getattr(result, "runtime_capabilities", None),
             )
         except Exception as exc:
             # The in-place swap rolled the agent back to the old working

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5470,6 +5470,7 @@ def _restore_agent_model_runtime(agent, snapshot: dict | None) -> None:
             api_key=snapshot.get("api_key", ""),
             base_url=snapshot.get("base_url", ""),
             api_mode=snapshot.get("api_mode", ""),
+            capabilities=snapshot.get("capabilities"),
         )
 
 
@@ -5630,6 +5631,7 @@ def _apply_model_switch(
                 api_key=result.api_key,
                 base_url=result.base_url,
                 api_mode=result.api_mode,
+                capabilities=result.runtime_capabilities,
             )
         except Exception as exc:
             # The in-place swap rolled the agent back to the old working


### PR DESCRIPTION
## What does this PR do?

Preserves native compaction capability when the runtime model changes. The switch path now derives capability from the effective endpoint when a same-provider direct endpoint is omitted, while provider-changing or unresolved endpoint switches remain default-deny. Rollback and fallback restoration preserve the prior capability state.

## Related Issue

Related prior art: #83272. This PR is independent: #83272 addresses a global trusted-origin allowlist and has no code dependency on this change.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/agent_init.py`, `agent/agent_runtime_helpers.py`, `agent/chat_completion_helpers.py`, `agent/native_compaction.py`, `run_agent.py`: preserve and restore native compaction capability across runtime model switches, rollback, and fallback paths.
- `hermes_cli/model_switch.py`, `gateway/slash_commands.py`, `cli.py`, `tui_gateway/server.py`: resolve capability from the effective switch URL and keep ambiguous or provider-changing routes default-deny.
- `tests/run_agent/test_native_compaction_switch_capabilities.py`, `tests/run_agent/test_switch_model_context.py`, `tests/run_agent/test_switch_model_rollback.py`, `tests/run_agent/test_fallback_reasoning_override.py`: add regression coverage for direct endpoints, effective URLs, rollback, fallback restoration, and default-deny behavior.
- `tests/run_agent/test_switch_model_context.py`: update compatibility fixtures for the preserved runtime capability state.

## How to Test

1. Run the focused native-compaction regression tests. Result: 12 passed.
2. Run the expanded switch and fallback regression set. Result: 109 passed.
3. Run `ruff` on the touched Python files and `git diff --check`. Both passed.
4. CI completed successfully, including Linux, macOS, Windows, e2e, lint, and required-check jobs.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - Searched for `native compaction`, `compaction capability`, `model switch`, and `compaction`; reviewed #83272 in particular. It addresses trusted proxy origins, while this PR addresses capability preservation across runtime switches.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Focused and expanded regression suites are documented above. A clean local full-suite run is not claimed.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: CI covers Linux, macOS, and Windows

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (no user-facing documentation change was needed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (no contributor workflow changed)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — CI includes OS-specific checks
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool schema changed)

## Screenshots / Logs

Not applicable. This is an internal runtime behavior change; verification results are listed above.

