### PR TITLE
fix(mcp): detect WAL-only session writes

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -72,6 +72,22 @@ def _get_sessions_dir() -> Path:
         return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "sessions"
 
 
+def _state_db_change_marker(db_file: Path) -> tuple[int, int, int, int]:
+    """Return a cheap marker that changes for main-database or WAL writes.
+
+    SQLite commits in WAL mode update ``state.db-wal`` without necessarily
+    changing the main database file's mtime until a checkpoint occurs.
+    """
+    def stat_marker(path: Path) -> tuple[int, int]:
+        try:
+            stat = path.stat()
+            return stat.st_mtime_ns, stat.st_size
+        except OSError:
+            return 0, 0
+
+    return (*stat_marker(db_file), *stat_marker(db_file.with_name(f"{db_file.name}-wal")))
+
+
 def _get_session_db():
     """Get a SessionDB instance for reading message transcripts."""
     try:
@@ -350,8 +366,9 @@ class EventBridge:
         self._last_poll_timestamps: Dict[str, float] = {}  # session_key -> unix timestamp
         # In-memory approval tracking (populated from events)
         self._pending_approvals: Dict[str, dict] = {}
-        # mtime cache — skip expensive work when state.db hasn't changed
-        self._state_db_mtime: float = 0.0
+        # Change marker for state.db and its WAL sidecar — a WAL commit may not
+        # update the main database mtime until a later checkpoint.
+        self._state_db_mtime: tuple[int, int, int, int] = (0, 0, 0, 0)
         self._cached_sessions_index: dict = {}
 
     def start(self):
@@ -493,10 +510,7 @@ class EventBridge:
             db_file = get_hermes_home() / "state.db"
         except ImportError:
             db_file = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "state.db"
-        try:
-            self._state_db_mtime = db_file.stat().st_mtime if db_file.exists() else 0.0
-        except OSError:
-            self._state_db_mtime = 0.0
+        self._state_db_mtime = _state_db_change_marker(db_file)
         try:
             self._cached_sessions_index = _load_sessions_index()
         except Exception:
@@ -537,13 +551,14 @@ class EventBridge:
     def _poll_once(self, db):
         """Check for new messages across all sessions.
 
-        Uses a single mtime check on state.db to skip work when nothing
-        has changed — makes 200ms polling essentially free.  Since #9006
-        the routing index itself lives in state.db (session rows carry
-        session_key/origin metadata), so a new conversation and its first
-        message land in the SAME file and one mtime check covers both —
-        eliminating the old dual-file (sessions.json + state.db) race that
-        could drop brand-new conversations (#8925).
+        Uses a combined mtime marker for state.db and state.db-wal to skip
+        work when nothing has changed — makes 200ms polling essentially free
+        while still observing commits that remain in SQLite's WAL until a
+        checkpoint. Since #9006 the routing index itself lives in state.db
+        (session rows carry session_key/origin metadata), so a new conversation
+        and its first message land in the same database and one marker covers
+        both — eliminating the old dual-file (sessions.json + state.db) race
+        that could drop brand-new conversations (#8925).
         """
         try:
             from hermes_constants import get_hermes_home
@@ -551,14 +566,14 @@ class EventBridge:
         except ImportError:
             db_file = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "state.db"
 
-        try:
-            db_mtime = db_file.stat().st_mtime if db_file.exists() else 0.0
-        except OSError:
-            db_mtime = 0.0
+        db_mtime = _state_db_change_marker(db_file)
 
         if db_mtime == self._state_db_mtime:
             return  # Nothing changed since last poll — skip entirely
 
+        # Acknowledge only the marker observed before reading. A write that
+        # lands while the index/messages are being read must leave a changed
+        # marker for the next poll instead of being silently skipped.
         self._state_db_mtime = db_mtime
         # Refresh the routing index from state.db on every change tick —
         # it's a single indexed query and it can never lag the messages
@@ -614,7 +629,6 @@ class EventBridge:
                 latest = max(all_ts)
                 if latest > last_seen:
                     self._last_poll_timestamps[session_key] = latest
-
 
 # ---------------------------------------------------------------------------
 # MCP Server

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -1202,10 +1202,13 @@ class TestEventBridgePollE2E:
         first_calls = db.call_count
         assert first_calls >= 1
 
-        # Second poll — files unchanged, should skip entirely
+        # SessionDB may materialize its WAL sidecar during the first index read.
+        # One follow-up tick records that new marker; steady-state polls skip.
         bridge._poll_once(db)
-        assert db.call_count == first_calls, \
-            "Second poll should skip DB queries when files unchanged"
+        calls_after_wal_initialization = db.call_count
+        bridge._poll_once(db)
+        assert db.call_count == calls_after_wal_initialization, \
+            "Steady-state polls should skip DB queries when files are unchanged"
 
     def test_poll_detects_new_message_after_db_write(self, tmp_path, monkeypatch):
         """Write a new message to the DB after first poll, verify it's detected."""
@@ -1259,7 +1262,10 @@ class TestEventBridgePollE2E:
         conn.commit()
         conn.close()
         # Touch the DB file to update mtime (WAL mode may not update mtime on small writes)
-        os.utime(db_path, None)
+        os.utime(
+            db_path,
+            ns=(db_path.stat().st_atime_ns, db_path.stat().st_mtime_ns + 1_000_000_000),
+        )
 
         # Update sessions.json updated_at to trigger re-check
         sessions_data["agent:main:telegram:dm:new"]["updated_at"] = "2026-03-29T15:00:10"
@@ -1374,7 +1380,10 @@ class TestEventBridgePollE2E:
             "id": 2, "role": "assistant", "content": "arrived after start",
             "timestamp": "2026-03-29T15:05:00",
         })
-        os.utime(db_path, None)  # bump mtime so the poll gate opens
+        os.utime(
+            db_path,
+            ns=(db_path.stat().st_atime_ns, db_path.stat().st_mtime_ns + 1_000_000_000),
+        )  # bump mtime so the poll gate opens
         bridge._poll_once(DB())
         events = bridge.poll_events(after_cursor=0)["events"]
         assert len(events) == 1
@@ -1412,13 +1421,114 @@ class TestEventBridgePollE2E:
             "id": 1, "role": "user", "content": "hello after baseline",
             "timestamp": "2026-03-29T15:10:00",
         }]
-        os.utime(db_path, None)
+        os.utime(
+            db_path,
+            ns=(db_path.stat().st_atime_ns, db_path.stat().st_mtime_ns + 1_000_000_000),
+        )
         bridge._poll_once(DB())
 
         events = bridge.poll_events(after_cursor=0)["events"]
         assert len(events) == 1
         assert events[0]["session_key"] == "agent:main:telegram:dm:fresh"
         assert events[0]["content"] == "hello after baseline"
+
+    def test_poll_detects_wal_only_message_write(self, tmp_path, monkeypatch):
+        """A committed SQLite WAL write must invalidate the polling fast path."""
+        import mcp_serve
+
+        db_path = tmp_path / "state.db"
+        session_id = "20260329_150000_wal_only"
+        session_key = "agent:main:telegram:dm:wal_only"
+        _create_test_db(db_path, session_id, [])
+        monkeypatch.setattr(
+            mcp_serve,
+            "_load_sessions_index",
+            lambda: {session_key: {"session_id": session_id}},
+        )
+
+        class TestDB:
+            def get_messages(self, sid):
+                conn = sqlite3.connect(str(db_path))
+                conn.row_factory = sqlite3.Row
+                rows = conn.execute(
+                    "SELECT * FROM messages WHERE session_id = ? ORDER BY id", (sid,)
+                ).fetchall()
+                conn.close()
+                return [dict(row) for row in rows]
+
+        writer = sqlite3.connect(str(db_path))
+        assert writer.execute("PRAGMA journal_mode=WAL").fetchone()[0].lower() == "wal"
+        # Create an initial WAL frame before taking the main-file baseline.
+        writer.execute("UPDATE sessions SET message_count = 1 WHERE id = ?", (session_id,))
+        writer.commit()
+        main_mtime = db_path.stat().st_mtime_ns
+        wal_path = db_path.with_name(f"{db_path.name}-wal")
+        wal_mtime = wal_path.stat().st_mtime_ns
+        bridge = mcp_serve.EventBridge()
+        baseline_marker = mcp_serve._state_db_change_marker(db_path)
+        bridge._state_db_mtime = baseline_marker
+
+        writer.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            (session_id, "user", "written only to WAL", "2026-03-29T15:00:01"),
+        )
+        writer.commit()
+        assert db_path.stat().st_mtime_ns == main_mtime
+        assert wal_path.stat().st_mtime_ns >= wal_mtime
+        assert mcp_serve._state_db_change_marker(db_path) != baseline_marker
+
+        bridge._poll_once(TestDB())
+        writer.close()
+
+        events = bridge.poll_events(after_cursor=0)["events"]
+        assert [event["content"] for event in events] == ["written only to WAL"]
+
+    def test_poll_retries_a_write_that_arrives_while_reading(self, tmp_path, monkeypatch):
+        """A write during a change tick must remain visible to the next poll."""
+        import mcp_serve
+
+        db_path = tmp_path / "state.db"
+        session_id = "20260329_150000_poll_race"
+        session_key = "agent:main:telegram:dm:poll_race"
+        _create_test_db(db_path, session_id, [])
+        monkeypatch.setattr(
+            mcp_serve,
+            "_load_sessions_index",
+            lambda: {session_key: {"session_id": session_id}},
+        )
+        writer = sqlite3.connect(str(db_path))
+        assert writer.execute("PRAGMA journal_mode=WAL").fetchone()[0].lower() == "wal"
+
+        class RacingDB:
+            wrote = False
+
+            def get_messages(self, sid):
+                conn = sqlite3.connect(str(db_path))
+                conn.row_factory = sqlite3.Row
+                rows = conn.execute(
+                    "SELECT * FROM messages WHERE session_id = ? ORDER BY id", (sid,)
+                ).fetchall()
+                conn.close()
+                if not self.wrote:
+                    self.wrote = True
+                    writer.execute(
+                        "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+                        (sid, "user", "written during poll", "2026-03-29T15:00:01"),
+                    )
+                    writer.commit()
+                return [dict(row) for row in rows]
+
+        bridge = mcp_serve.EventBridge()
+        # Force the first tick; RacingDB commits after it has read no messages.
+        bridge._state_db_mtime = (0, 0, 0, 0)
+        db = RacingDB()
+        bridge._poll_once(db)
+        assert bridge.poll_events(after_cursor=0)["events"] == []
+
+        bridge._poll_once(db)
+        writer.close()
+        events = bridge.poll_events(after_cursor=0)["events"]
+        assert [event["content"] for event in events] == ["written during poll"]
 
     def test_poll_interval_is_200ms(self):
         """Verify the poll interval constant."""


### PR DESCRIPTION
## Summary
- invalidate EventBridge polling when SQLite WAL sidecar changes, including WAL size for a robust filesystem marker
- retain the marker observed before reading so a concurrent write is polled on the next tick
- cover WAL-only commits, steady-state fast-path behavior, and a write that arrives during a poll

## Validation
- `~/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_mcp_serve.py::TestEventBridgePollE2E -q` (9 passed)
- `~/.hermes/hermes-agent/venv/bin/python -m ruff check mcp_serve.py tests/test_mcp_serve.py`
- `git diff --check`