### PR TITLE
fix(cli): stop named profiles from killing SSH-owned serves

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -17,6 +17,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from hermes_constants import get_desktop_ssh_runtime_root
+
 
 def _m():
     """Lazy ``hermes_cli.main`` reference (call-time; keeps patches working)."""
@@ -725,17 +727,8 @@ def _exclude_pids_from_env() -> set[int]:
 # mismatched-schema record is simply ignored (never used to kill).
 _LOCKFILE_SCHEMA_VERSION = 2
 _PROTOCOL_VERSION = 1
-_REMOTE_LOCK_SUBDIR = "desktop-ssh"
 _HEX32 = set("0123456789abcdef")
 _HEX16 = _HEX32
-
-
-def _hermes_home_dir() -> Path:
-    """Resolved Hermes home (HERMES_HOME override or ~/.hermes)."""
-    override = os.environ.get("HERMES_HOME", "").strip()
-    if override:
-        return Path(override).expanduser()
-    return Path.home() / ".hermes"
 
 
 def _valid_lockfile_payload(parsed: object, ownership_id: str) -> bool:
@@ -786,19 +779,17 @@ def _valid_lockfile_payload(parsed: object, ownership_id: str) -> bool:
 def _lock_owned_serve_pids(base_dir: Path | None = None) -> set[int]:
     """PIDs claimed as owners by valid ``backend.lock.json`` records on this host.
 
-    Scans ``{hermes_home}/desktop-ssh/<ownershipId>/backend.lock.json`` (the
-    same directory the Desktop SSH runtime writes to). Any PID a valid lock
-    names is a legitimately-owned backend — including backends another client
-    or machine started over SSH — and must be spared by the orphan reap.
+    Scans the machine-scoped Desktop SSH runtime root, independent of the
+    active profile's ``HERMES_HOME``. Any PID a valid lock names is a
+    legitimately-owned backend — including backends another client or machine
+    started over SSH — and must be spared by the orphan reap.
 
     Best-effort: any read/parse/IO error for a single record is swallowed and
     that record contributes no PID. Never raises.
     """
     import json
 
-    root = base_dir if base_dir is not None else (
-        _hermes_home_dir() / _REMOTE_LOCK_SUBDIR
-    )
+    root = base_dir if base_dir is not None else get_desktop_ssh_runtime_root()
     owned: set[int] = set()
     if not root.is_dir():
         return owned

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11418,14 +11418,13 @@ def _read_ssh_session_token_file(path: str) -> str:
         raise SystemExit("--ssh-session-token-file must be absolute")
 
     token_path = _Path(path)
-    # The Desktop client writes the token under $HOME/.hermes/desktop-ssh: a
-    # literal "~/.hermes/desktop-ssh" in apps/desktop/electron/remote-lifecycle.ts
-    # expanded against the account's $HOME, independent of HERMES_HOME and the
-    # active profile. Anchor validation to that same OS-home path, NOT to
-    # get_hermes_home(): a non-default sticky profile (or any HERMES_HOME pointing
-    # elsewhere, e.g. a Docker /opt/data root) re-homes get_hermes_home() and
-    # would otherwise reject every token the client legitimately wrote (#69551).
-    token_root = _Path.home() / ".hermes" / "desktop-ssh"
+    # The Desktop client writes the token under a machine-scoped runtime root,
+    # independent of HERMES_HOME and the active profile. The same authority is
+    # used by ownership-lock readers so token validation and lifecycle reapers
+    # cannot drift onto different roots (#69551, #94032).
+    from hermes_constants import get_desktop_ssh_runtime_root
+
+    token_root = get_desktop_ssh_runtime_root()
     try:
         relative = token_path.relative_to(token_root)
     except ValueError as exc:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -60,11 +60,12 @@ def _get_platform_default_hermes_home() -> Path:
 
 
 def get_desktop_ssh_runtime_root() -> Path:
-    """Return the machine-scoped runtime root used by Desktop SSH.
+    """Return the machine-scoped runtime root used by POSIX Desktop SSH.
 
-    The Desktop writer expands the literal ``~/.hermes/desktop-ssh`` on the
-    target host.  This path must never follow ``HERMES_HOME`` or a context-local
-    profile override: ownership records coordinate every profile on a machine.
+    The POSIX Desktop writer expands the literal ``~/.hermes/desktop-ssh`` on
+    the target host.  This path must never follow ``HERMES_HOME`` or a
+    context-local profile override: ownership records coordinate every profile
+    on a machine.  Native Windows SSH uses its separate platform runtime root.
     """
     return Path.home() / ".hermes" / "desktop-ssh"
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -59,6 +59,16 @@ def _get_platform_default_hermes_home() -> Path:
     return Path.home() / ".hermes"
 
 
+def get_desktop_ssh_runtime_root() -> Path:
+    """Return the machine-scoped runtime root used by Desktop SSH.
+
+    The Desktop writer expands the literal ``~/.hermes/desktop-ssh`` on the
+    target host.  This path must never follow ``HERMES_HOME`` or a context-local
+    profile override: ownership records coordinate every profile on a machine.
+    """
+    return Path.home() / ".hermes" / "desktop-ssh"
+
+
 def _hermes_home_from_env() -> Path:
     """Resolve HERMES_HOME from the process environment only.
 

--- a/tests/hermes_cli/test_orphan_desktop_serve_reap.py
+++ b/tests/hermes_cli/test_orphan_desktop_serve_reap.py
@@ -175,7 +175,12 @@ def test_lock_owned_serve_pids_uses_machine_root_for_named_profile(
     )
 
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    monkeypatch.setenv("HERMES_HOME", str(machine_root / "profiles" / "reviewer"))
+    profile_home = machine_root / "profiles" / "reviewer"
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    (profile_home / "desktop-ssh" / oid).mkdir(parents=True)
+    (profile_home / "desktop-ssh" / oid / "backend.lock.json").write_text(
+        json.dumps(_valid_lock_payload(8888, oid, nonce))
+    )
 
     assert _lock_owned_serve_pids() == {7777}
 

--- a/tests/hermes_cli/test_orphan_desktop_serve_reap.py
+++ b/tests/hermes_cli/test_orphan_desktop_serve_reap.py
@@ -9,6 +9,7 @@ boot must clear those corpses without touching intentional fixed-port serves
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 from hermes_cli.dashboard_procs import (
@@ -159,6 +160,24 @@ def test_lock_owned_serve_pids_reads_valid_backend_lock(tmp_path):
         json.dumps({**_valid_lock_payload(8888, other_oid, nonce), "schemaVersion": 99})
     )
     assert _lock_owned_serve_pids(base_dir=lock_root) == {7777}
+
+
+def test_lock_owned_serve_pids_uses_machine_root_for_named_profile(
+    tmp_path, monkeypatch
+):
+    oid = "f" * 32
+    nonce = "d" * 16
+    machine_root = tmp_path / ".hermes"
+    lock_root = machine_root / "desktop-ssh"
+    (lock_root / oid).mkdir(parents=True)
+    (lock_root / oid / "backend.lock.json").write_text(
+        json.dumps(_valid_lock_payload(7777, oid, nonce))
+    )
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(machine_root / "profiles" / "reviewer"))
+
+    assert _lock_owned_serve_pids() == {7777}
 
 
 def test_valid_lockfile_payload_rejects_wrong_owner_and_shape():


### PR DESCRIPTION
## What does this PR do?

Named-profile `hermes serve` startups no longer kill valid SSH-owned ephemeral serves from another profile. Desktop SSH ownership records are machine-scoped, so the CLI now resolves one shared machine runtime root instead of scanning the active profile's `HERMES_HOME`.

### Symptom

After an SSH-owned isolated serve becomes older than the orphan-reaper grace period, starting a named-profile serve on the remote machine can terminate it even though it has a valid `backend.lock.json` ownership record.

### Impact

The Desktop loses its remote backend and subsequent gateway requests fail until the connection is rebuilt. The observed incident affected a default-profile remote backend when named-profile serves started on the same host.

### Bug Cause

**Trigger:** `hermes_cli/dashboard_procs.py` / `_lock_owned_serve_pids()` during named-profile serve startup.

**Causal chain:**
1. Desktop writes SSH ownership records under the machine-scoped `~/.hermes/desktop-ssh` runtime root.
2. A named-profile process resolves the scanner root from its profile-scoped `HERMES_HOME`, so the valid ownership record is absent from both reaper ownership checks.
3. The older ppid-1 ephemeral serve matches the remaining orphan predicates and is terminated.

**Why it is wrong:** A machine-wide ownership protocol was read through profile-scoped configuration, so reader and writer used different directories.

**Working sibling / contrast:** The SSH token validator already anchored its runtime path to the OS home and ignored the active profile.

**Ruled out:** The minimum-age guard is not the cause; it delays eligibility but cannot make a valid record visible in the wrong directory.

### Fix

Add a shared `get_desktop_ssh_runtime_root()` authority, use it in both token validation and ownership-lock scanning, and cover a pre-set named-profile `HERMES_HOME` without injecting a scanner base directory.

## Related Issue

Closes #94032

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_constants.py` - define the machine-scoped Desktop SSH runtime root.
- `hermes_cli/dashboard_procs.py` - scan ownership locks from that root regardless of the active profile.
- `hermes_cli/main.py` - keep token validation on the same shared authority.
- `tests/hermes_cli/test_orphan_desktop_serve_reap.py` - reproduce the profile-scope mismatch with the real scanner default.

## How to Test

1. Run the focused lifecycle and token-path tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_orphan_desktop_serve_reap.py -q
```

2. Confirm all 12 tests pass, including the named-profile machine-root regression.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo test entry on the focused regression suite and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A beyond affected docstrings
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
