### PR TITLE
feat: allow Discord tool to post messages

### DIFF
--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from tools.discord_tool import (
+    DISCORD_MESSAGE_CONTENT_MAX_LENGTH,
     DiscordAPIError,
     _ACTIONS,
     _ADMIN_ACTIONS,
@@ -305,6 +306,132 @@ class TestCreateThread:
             "POST", "/channels/11/messages/1001/threads", "test-token",
             body={"name": "Discussion", "auto_archive_duration": 1440},
         )
+
+
+# ---------------------------------------------------------------------------
+# Action: send_message
+# ---------------------------------------------------------------------------
+
+class TestSendMessageSchema:
+    def test_send_message_in_core_actions(self):
+        assert "send_message" in _CORE_ACTIONS
+        assert "send_message" not in _ADMIN_ACTIONS
+
+    def test_send_message_required_params(self):
+        from tools.discord_tool import _REQUIRED_PARAMS
+        assert _REQUIRED_PARAMS["send_message"] == ["channel_id", "content"]
+
+    @patch("tools.discord_tool._discord_request")
+    def test_send_message_in_core_schema(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"server_actions": ""}},
+        )
+        mock_req.return_value = {"flags": (1 << 14) | (1 << 18)}
+        schema = get_dynamic_schema_core()
+        actions = schema["parameters"]["properties"]["action"]["enum"]
+        assert "send_message" in actions
+        assert "content" in schema["parameters"]["properties"]
+
+
+class TestSendMessageValidation:
+    def test_missing_channel_id(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_core(action="send_message", content="hi"))
+        assert "error" in result
+        assert "channel_id" in result["error"]
+
+    def test_missing_content(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_core(action="send_message", channel_id="11"))
+        assert "error" in result
+        assert "content" in result["error"]
+
+    def test_empty_string_content_is_treated_as_missing(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_core(action="send_message", channel_id="11", content=""))
+        assert "error" in result
+        assert "content" in result["error"]
+
+    @patch("tools.discord_tool._discord_request")
+    def test_content_over_2000_chars_rejected(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        long_content = "x" * (DISCORD_MESSAGE_CONTENT_MAX_LENGTH + 1)
+        result = json.loads(discord_core(action="send_message", channel_id="11", content=long_content))
+        assert "error" in result
+        assert "2000" in result["error"]
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_content_at_exactly_2000_chars_allowed(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "999"}
+        exact_content = "x" * DISCORD_MESSAGE_CONTENT_MAX_LENGTH
+        result = json.loads(discord_core(action="send_message", channel_id="11", content=exact_content))
+        assert result["success"] is True
+        mock_req.assert_called_once()
+
+
+class TestSendMessageSuccess:
+    @patch("tools.discord_tool._discord_request")
+    def test_send_message_payload_and_response(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "123456789"}
+        result = json.loads(discord_core(action="send_message", channel_id="11", content="Hello there"))
+
+        assert result == {"success": True, "channel_id": "11", "message_id": "123456789"}
+
+        mock_req.assert_called_once_with(
+            "POST", "/channels/11/messages", "test-token",
+            body={"content": "Hello there", "allowed_mentions": {"parse": []}},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_mentions_suppressed_by_default(self, mock_req, monkeypatch):
+        """Agent-authored text containing @everyone/@role/@user must never ping."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "1"}
+        discord_core(action="send_message", channel_id="11", content="@everyone hi <@123> <@&456>")
+
+        body = mock_req.call_args[1]["body"]
+        assert body["allowed_mentions"] == {"parse": []}
+
+    @patch("tools.discord_tool._discord_request")
+    def test_thread_id_treated_exactly_as_channel_id(self, mock_req, monkeypatch):
+        """Discord thread IDs use the same /channels/{id}/messages endpoint —
+        no special-casing needed since threads ARE channels in the API."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "42"}
+        thread_id = "999888777"
+        result = json.loads(discord_core(action="send_message", channel_id=thread_id, content="in-thread"))
+
+        assert result["success"] is True
+        assert result["channel_id"] == thread_id
+        mock_req.assert_called_once_with(
+            "POST", f"/channels/{thread_id}/messages", "test-token",
+            body={"content": "in-thread", "allowed_mentions": {"parse": []}},
+        )
+
+
+class TestSendMessageApiFailure:
+    @patch("tools.discord_tool._discord_request")
+    def test_403_forbidden_returns_structured_error(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = DiscordAPIError(403, '{"message": "Missing Access"}')
+        result = json.loads(discord_core(action="send_message", channel_id="11", content="hi"))
+        assert "error" in result
+        assert "403" in result["error"]
+        assert "success" not in result
+
+    @patch("tools.discord_tool._discord_request")
+    def test_404_unknown_channel_returns_structured_error(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = DiscordAPIError(404, '{"message": "Unknown Channel"}')
+        result = json.loads(discord_core(action="send_message", channel_id="bad-id", content="hi"))
+        assert "error" in result
+        assert "404" in result["error"]
+        assert "Unknown Channel" in result["error"]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -45,6 +45,9 @@ DISCORD_API_BASE = "https://discord.com/api/v10"
 _DISCORD_RESPONSE_BODY_MAX_BYTES = 4 * 1024 * 1024
 _DISCORD_ERROR_BODY_MAX_BYTES = 64 * 1024
 
+# Discord's hard cap on a message's `content` field.
+DISCORD_MESSAGE_CONTENT_MAX_LENGTH = 2000
+
 # Application flag bits (from GET /applications/@me → "flags").
 # Source: https://discord.com/developers/docs/resources/application#application-object-application-flags
 _FLAG_GATEWAY_GUILD_MEMBERS = 1 << 14
@@ -583,6 +586,26 @@ def _delete_message(token: str, channel_id: str, message_id: str, **_kwargs: Any
     return json.dumps({"success": True, "message": f"Message {message_id} deleted."})
 
 
+def _send_message(token: str, channel_id: str, content: str, **_kwargs: Any) -> str:
+    """Post a text message to a channel or thread.
+
+    Discord thread IDs are channel IDs — POST /channels/{id}/messages works
+    identically whether {id} names a text channel or a thread. Mentions are
+    suppressed by default (``allowed_mentions.parse: []``) so agent-authored
+    content can never ping @everyone/@here, a role, or a user unexpectedly.
+    """
+    body = {
+        "content": content,
+        "allowed_mentions": {"parse": []},
+    }
+    msg = _discord_request("POST", f"/channels/{channel_id}/messages", token, body=body)
+    return json.dumps({
+        "success": True,
+        "channel_id": channel_id,
+        "message_id": msg["id"],
+    })
+
+
 def _create_thread(
     token: str, channel_id: str, name: str,
     message_id: Optional[str] = None,
@@ -643,11 +666,12 @@ _ACTIONS = {
     "unpin_message": _unpin_message,
     "delete_message": _delete_message,
     "create_thread": _create_thread,
+    "send_message": _send_message,
     "add_role": _add_role,
     "remove_role": _remove_role,
 }
 
-_CORE_ACTION_NAMES = frozenset({"fetch_messages", "search_members", "create_thread"})
+_CORE_ACTION_NAMES = frozenset({"fetch_messages", "search_members", "create_thread", "send_message"})
 _ADMIN_ACTION_NAMES = frozenset(_ACTIONS.keys()) - _CORE_ACTION_NAMES
 
 _CORE_ACTIONS = {k: v for k, v in _ACTIONS.items() if k in _CORE_ACTION_NAMES}
@@ -670,6 +694,7 @@ _ACTION_MANIFEST: List[Tuple[str, str, str]] = [
     ("unpin_message", "(channel_id, message_id)", "unpin a message"),
     ("delete_message", "(channel_id, message_id)", "delete a message"),
     ("create_thread", "(channel_id, name)", "create a public thread; optional message_id anchor"),
+    ("send_message", "(channel_id, content)", "post a text message to a channel or thread (max 2000 chars; mentions suppressed)"),
     ("add_role", "(guild_id, user_id, role_id)", "assign a role"),
     ("remove_role", "(guild_id, user_id, role_id)", "remove a role"),
 ]
@@ -691,6 +716,7 @@ _REQUIRED_PARAMS: Dict[str, List[str]] = {
     "unpin_message": ["channel_id", "message_id"],
     "delete_message": ["channel_id", "message_id"],
     "create_thread": ["channel_id", "name"],
+    "send_message": ["channel_id", "content"],
     "add_role": ["guild_id", "user_id", "role_id"],
     "remove_role": ["guild_id", "user_id", "role_id"],
 }
@@ -852,6 +878,15 @@ def _build_schema(
             "type": "string",
             "description": "New thread name (create_thread).",
         },
+        "content": {
+            "type": "string",
+            "maxLength": DISCORD_MESSAGE_CONTENT_MAX_LENGTH,
+            "description": (
+                "Message text to send (send_message). "
+                f"Max {DISCORD_MESSAGE_CONTENT_MAX_LENGTH} characters. "
+                "Mentions (@everyone, @here, roles, users) are always suppressed."
+            ),
+        },
         "limit": {
             "type": "integer",
             "minimum": 1,
@@ -994,6 +1029,7 @@ def _run_discord_action(
     message_id: str = "",
     query: str = "",
     name: str = "",
+    content: str = "",
     limit: int = 50,
     before: str = "",
     after: str = "",
@@ -1029,12 +1065,19 @@ def _run_discord_action(
         "message_id": message_id,
         "query": query,
         "name": name,
+        "content": content,
     }
 
     missing = [p for p in _REQUIRED_PARAMS.get(action, []) if not local_vars.get(p)]
     if missing:
         return tool_error(
             f"Missing required parameters for '{action}': {', '.join(missing)}"
+        )
+
+    if action == "send_message" and len(content) > DISCORD_MESSAGE_CONTENT_MAX_LENGTH:
+        return tool_error(
+            f"content exceeds Discord's {DISCORD_MESSAGE_CONTENT_MAX_LENGTH}-character "
+            f"limit ({len(content)} characters)."
         )
 
     try:
@@ -1047,6 +1090,7 @@ def _run_discord_action(
             message_id=message_id,
             query=query,
             name=name,
+            content=content,
             limit=limit,
             before=before,
             after=after,
@@ -1063,7 +1107,11 @@ def _run_discord_action(
 
 
 def discord_core(action: str, **kwargs) -> str:
-    """Execute a core Discord action (fetch_messages, search_members, create_thread)."""
+    """Execute a core Discord action.
+
+    Core actions fetch messages, search members, create threads, and post text
+    messages to channels or threads.
+    """
     return _run_discord_action(action, _CORE_ACTIONS, "discord", **kwargs)
 
 
@@ -1078,7 +1126,7 @@ def discord_admin_handler(action: str, **kwargs) -> str:
 
 _HANDLER_DEFAULTS = {
     "action": "", "guild_id": "", "channel_id": "", "user_id": "",
-    "role_id": "", "message_id": "", "query": "", "name": "",
+    "role_id": "", "message_id": "", "query": "", "name": "", "content": "",
     "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440,
 }
 


### PR DESCRIPTION
## Summary
- add `send_message` to the agent-facing Discord core tool
- support channel and thread IDs through Discord’s channel message endpoint
- suppress all mentions by default and enforce Discord’s 2,000-character limit
- return channel/message IDs and structured API errors

## Verification
- `scripts/run_tests.sh tests/tools/test_discord_tool.py` — 58 passed
- `.venv/bin/ruff check tools/discord_tool.py tests/tools/test_discord_tool.py` — passed

## Broader-suite environment note
`tests/tools/` was also started in this SSH environment, but unrelated baseline files fail because this runner initially lacked optional messaging dependencies and uses a Python runtime where `TarFile.extractall(filter=...)` is unavailable. The focused Discord suite is fully green.
