### PR TITLE
skills: add two community skills for OpenDesign↔Hermes session integration (session reuse + fragment consolidation)

### DIFF
--- a/skills/opendesign-fragment-consolidator/SKILL.md
+++ b/skills/opendesign-fragment-consolidator/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: od-fragment-consolidator
+author: ox-alpha (design profile)
+description: Use when the Hermes sidebar is full of OD session fragments and they should be merged into per-project ledgers.
+version: 1.0.0
+license: MIT
+metadata:
+  hermes:
+    tags: [opendesign, acp, consolidation, fragments, cleanup, transcript]
+    category: integration
+---
+
+# OD Fragment Consolidator (merge fragments into per-project ledgers)
+
+## Overview
+
+After the session-reuse patches stop new fragments from spawning, the sidebar still shows the historical debris: dozens of one-message sessions titled `# Instructions (read first)` or `Set up OpenDesign ask mode #7`. This skill merges that debris into one readable "ledger" session per OD project, renames each ledger to the OD project's name, and asks the user before touching the emptied fragments.
+
+## When to Use
+
+- The sidebar is full of OD session fragments and the user wants them organized by project
+- The user asks "can these be merged into one session per project?"
+- After applying the session-reuse patches (see the sibling skill `od-hermes-session-reuse`), to clean up history
+
+## How It Works (verified mechanics)
+
+1. **Project assignment** — every charter envelope embeds the OD project path (`projects/<uuid>/`). Extract it per session; majority vote wins for sessions touching multiple projects. Fallback when envelopes were already translated away: align each session's activity window to OD conversations (coverage ≥ 50% of the session's lifespan; ties go to the tighter, more specific window).
+2. **Ledger choice** — the newest session in each project (max message id) becomes the ledger; all sibling fragments merge into it.
+3. **Merge** — rewrite `messages.session_id` in one transaction. Hermes resumes conversations by auto-increment row id (`ORDER BY id`), so the merged timeline is automatically chronological. Alternation breaks (`user;user` from turns that produced no reply) are auto-repaired by Hermes' built-in `repair_alternation` on resume.
+4. **Rename** — ledger title := the OD project's display name (`title_source='user'`), so the sidebar mirrors the OD project list.
+5. **Mapping pre-fill** — write conversation→ledger pairs into OD's `agent_sessions` so the next message in each OD window resumes the ledger. The table has no unique constraint: use DELETE+INSERT in a transaction. If OD holds the lock, skip gracefully — resume failure just falls back to a fresh session.
+6. **Interactive cleanup** — after merging, ask the user what to do with the emptied fragments: **archive** (recommended; `archived=1`, reversible), **keep**, or **delete** (requires typing `DELETE`). Never decide for them.
+
+## Usage
+
+```bash
+python scripts/consolidate.py            # dry-run: assignment + merge plan, no writes
+python scripts/consolidate.py --apply    # execute; still prompts before cleanup
+python scripts/consolidate.py --apply --yes  # execute; auto-confirm archive cleanup
+```
+
+Env overrides: `HERMES_STATE_DB`, `OD_DATA_DIR` (defaults match a standard Windows install).
+
+## Safety Model
+
+- Timestamped full-DB backup before the first write
+- Dry-run by default; the merge plan is printed for review
+- Merge is re-attributing rows, never deleting them
+- Cleanup is a separate, explicit, user-confirmed step
+- Idempotent: running against an already-consolidated DB yields an empty plan
+
+## Pitfalls
+
+| Pitfall | Detail |
+|---------|--------|
+| `group_concat` truncation | Aggregating all user messages per session to search for project paths silently truncates on big sessions — scan messages row by row instead |
+| Envelope-less DBs | If transcripts were already translated, project UUIDs are gone; use the activity-window fallback |
+| Long-lived window bias | Raw max-overlap assignment favors projects that stay open longest; normalize by coverage ratio and tie-break by tighter window |
+| `ON CONFLICT` on `agent_sessions` | The table has no PRIMARY KEY/UNIQUE — upserts fail; DELETE+INSERT instead |
+| Locked OD DB | OD holds the lock while running; pre-fill is best-effort and safe to skip |
+| Ledger = active session | Merging into the live session is fine; the envelope of every new turn re-injects project context, so old envelopes in history are redundant anyway |
+
+## Verification
+
+- Every ledger: `min(id)` → `max(id)` monotonic (timeline order preserved)
+- Alternation health: count `user;user` breaks per ledger (informational; auto-repaired)
+- Post-merge resume: the model recalls context from hours-old turns
+- Sidebar: one session per OD project, named exactly like the OD project

--- a/skills/opendesign-hermes-session-reuse/SKILL.md
+++ b/skills/opendesign-hermes-session-reuse/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: od-hermes-session-reuse
+author: ox-alpha (design profile)
+description: Use when OD chat spawns a Hermes session per message.
+version: 1.1.0
+license: MIT
+metadata:
+  hermes:
+    tags: [opendesign, acp, session-reuse, resume, envelope, transcript, entropy]
+    category: integration
+---
+
+# OD ↔ Hermes Session Reuse (one project = one session)
+
+## Overview
+
+OpenDesign (OD) drives Hermes Agent over ACP. The stock integration has 8 defects that compound into unusable session entropy: a new session per message, template-named titles, history replay spam, and envelopes burying the user's actual words. This skill is the complete diagnosis + repair playbook. Every change is reversible.
+
+**Core mental model**: OD wraps every user turn in a "charter envelope" (an English instruction pack: project context + workspace + rules) with the user's real words at the tail. The tail marker comes in two variants: `## user` and `# User request`.
+
+## When to Use
+
+- The OD sidebar spawns a new session per message, titled `# Instructions (read first)` / `Set up OpenDesign ask mode` etc.
+- The user asks "why can't I see my own words in Hermes?"
+- Resume replays hours-old replies into the OD window before answering
+- `hermes sessions list` ACP count balloons
+- The user wants "one OD project window = one Hermes session"
+- Historical fragments need consolidation into per-project ledgers
+
+## The 8-Defect Map (diagnosis order = repair order)
+
+| # | Defect | Symptom | Fix location |
+|---|--------|---------|--------------|
+| ② | Session reuse not enabled for Hermes | `session/new` every turn | OD: `hermesAgentDef` + `resumesSessionViaAcpLoad: true` |
+| ③ | Capture reads only OpenCode's `openCodeSessionId` | `agent_sessions` table stays 0 rows | OD: fallback to standard `result.sessionId` |
+| ④ | `session/load` missing `mcpServers` | OD shows `json-rpc id 2: Invalid params` | OD: add `mcpServers: mcpServers ?? []` |
+| ⑤ | Load response lacks `sessionId` | OD: `invalid session/new response` (JSON contains `currentHermesSessionId` = resume already worked) | Hermes: `acp/schema.py` add field + echo |
+| ⑥ | Full envelope persisted | titles/transcripts/search show English boilerplate | Hermes: `_extract_user_voice()` keeps only the tail |
+| ⑦ | Resume replays all history | OD re-renders old replies every message | Hermes: skip `_replay_session_history` for OD clients |
+| ⑥b | Envelope tail has two marker variants | extraction silently no-ops | regex `#{1,4}\s*(?:user|User request)\s*\r?\n` covers both |
+
+②③④ live on the OD side; ⑤⑥⑦ on the Hermes side.
+
+## Key Paths
+
+```
+OD runtime payload (patch HERE — not the install dir!):
+  %APPDATA%\Open Design\launcher\channels\stable\namespaces\
+    release-stable-win\versions\<VERSION>\payload\resources\app\prebundled\daemon\chunks\
+  - chunk-4IN7PJG2.mjs   → hermesAgentDef          (defect ②)
+  - chunk-EER2BOWK.mjs   → ACP client transport    (defects ③④)
+  - chunk-N7AF5FHP.mjs   → image size mapping      (bonus, unrelated)
+
+⚠ Copies under the OD install directory (D:\...\prebundled\daemon\) are used
+  only by the CLI/MCP bridge — patching them changes nothing for chat.
+  Prove the runtime path from the daemon-sidecar process command line.
+
+Hermes side:
+- <hermes-agent>/venv/Lib/site-packages/acp/schema.py   → LoadSessionResponse (⑤)
+- <hermes-agent>/acp_adapter/server.py                  → load/resume/prompt  (⑤⑥⑦)
+- <hermes-agent>/acp_adapter/session.py                 → SessionState fields (⑦)
+```
+
+## Repair Steps (each: backup → edit → node --check / py_compile → restart & verify)
+
+### OD side (②③④) — full OD restart required
+
+1. **Prove the runtime path** from the daemon-sidecar process command line.
+2. **Backup**: `chunk-X.mjs → chunk-X.mjs.bak-<date>`.
+3. **②** in `hermesAgentDef`, after `buildArgs`: `resumesSessionViaAcpLoad: true,`
+4. **③** `durableSessionId = typeof result.openCodeSessionId === "string" ? result.openCodeSessionId : (typeof result.sessionId === "string" ? result.sessionId : null);`
+5. **④** `writeRpc(nextId, "session/load", { sessionId: resumeSessionId, cwd: effectiveCwd, mcpServers: mcpServers ?? [] }, "session/load");`
+6. **Restart**: close the OD GUI gracefully (all OD processes exit with it), relaunch via PowerShell `Start-Process`.
+   - ⚠️ Never launch OD from a bash background job — the stdout pipe dies with the terminal and the Electron main process crashes with EPIPE.
+
+### Hermes side (⑤⑥⑦) — live on the next message, no restart
+
+5. **⑤** `schema.py` `LoadSessionResponse`: `session_id: Annotated[Optional[str], Field(alias="sessionId")] = None`; echo it in `load_session`'s return.
+6. **⑥** add to `server.py` and use at the `run_conversation` call site:
+
+```python
+def _extract_user_voice(text: str) -> str:
+    import re as _re
+    if not text:
+        return text
+    m = _re.search(r"(?:^|\n)#{1,4}\s*(?:user|User request)\s*\r?\n(?:\r?\n)?", text)
+    if m:
+        tail = text[m.end():].strip()
+        if tail:
+            return tail
+    return text
+
+persist_user_message=_extract_user_voice(user_text) or "[Image attachment]",
+```
+
+- ⚠️ `import re` inside the function (or verify the module header) — a missing import kills the turn with `name 're' is not defined`.
+- ⚠️ The model still receives the full envelope (`user_content` untouched); only the archive is cleaned.
+
+7. **⑦** `session.py` `SessionState`: `skip_history_replay: bool = False`. In `server.py` `initialize`: `self._od_client_name = client_name`. In `load_session`/`resume_session` after `update_cwd`: `state.skip_history_replay = "open-design" in client_name.lower()`. Wrap both `_replay_session_history(state)` calls in `if not getattr(state, "skip_history_replay", False):` (indent the except bodies one level deeper).
+
+### Verification per defect
+
+| Defect | Acceptance |
+|--------|-----------|
+| ②③ | Two messages in one OD window → `hermes sessions list` grows by exactly 1; OD `agent_sessions` gains a row |
+| ④⑤ | No more Invalid params / invalid session/new response |
+| ⑥ | Desktop transcript shows the user's words; auto-title = topic of the actual prompt |
+| ⑦ | No replay spam; direct answer to the new message |
+| Final | One OD project window maps to one session long-term; answers recall hours-old context = true resume |
+
+## Fragment Consolidation (history cleanup)
+
+Hand off to the sibling skill `od-fragment-consolidator` (and `scripts/consolidate.py`): envelope-to-voice translation, per-project merge, ledger renaming, OD mapping pre-fill, and interactive cleanup of the emptied fragments.
+
+## Pitfalls (all hit in production)
+
+| Pitfall | Consequence | Prevention |
+|---------|-------------|------------|
+| Patching the install directory | No effect; a wasted test cycle | Prove the daemon-sidecar command line first |
+| Launching OD from a bash background job | EPIPE crash dialog | PowerShell `Start-Process` |
+| Regex covering only `## user` | Silent failure; half the envelopes stay | Regression-test with a REAL envelope from the DB |
+| Helper uses `re` without import | Runtime `name 're' is not defined` | Import inside the function |
+| Smoke tests injecting dependencies manually | Masks real import errors | Verify via real import: `from acp_adapter.server import X` |
+| Restoring from a stale backup mid-fix | Wipes already-applied patches | Keep backups in sync with the latest good state |
+| Killing the daemon process | It's the ancestor of live sessions and changes ports on restart | Close the OD GUI instead; daemon exits with it |
+| OD auto-update (new version dir) | Disk patches lost | Re-apply ②③④; Hermes update/reinstall wipes ⑤⑥⑦ |
+
+## Related
+
+- Image size mapping (16:9 → 2752x1536 in `chunk-N7AF5FHP.mjs`) is an independent neighbor patch.
+- Archive sweeps: `hermes sessions archive --title <template-name> --dry-run` first, always.
+- Architecture: OD→Hermes syncs in real time; Hermes→OD has no text channel (product architecture). Knowledge flows through the shared brain (memory + session search on the same HERMES_HOME).


### PR DESCRIPTION
## Summary

Hi Hermes team! I'm an individual user (this is my own personal project, not affiliated with anyone). While using [OpenDesign](https://github.com/nexu-io/open-design) as an ACP client for Hermes, I ran into two pain points that I believe affect many other users in the same setup. I documented the full diagnosis, built the fixes, and packaged them as **two community skills**. I'd be honored if you'd consider adopting or linking them.

## The two problems & the skills

### 1. `opendesign-hermes-session-reuse` — a new session per message

OpenDesign spawns a fresh Hermes session for **every message** (105 fragments in 5 days on my machine). Root-cause analysis of the OD daemon shows session reuse is gated per agent: of **26 OD-connected agents, only 6 have it enabled** — every plain-ACP agent (Hermes, Cursor, Kimi, Qwen, Copilot CLI, and 14 more) spawns a session per turn. The skill documents the full patch chain (OD side: `resumesSessionViaAcpLoad`, `openCodeSessionId`→`sessionId` fallback, `mcpServers` on `session/load`; Hermes side: `LoadSessionResponse.sessionId` echo, envelope→user-voice persistence, replay skip for clients that keep their own transcript).

### 2. `opendesign-fragment-consolidator` — cleaning up the debris

After the patches, history is still a mess: envelope-wrapped transcripts (English charter text burying the user's actual words), template-named titles, and dozens of orphan fragments. The skill + script auto-assign fragments to OD projects via the project UUID embedded in envelopes (fallback: activity-window alignment), merge them into one ledger per project (timelines verified chronological — Hermes resumes by row id), rename ledgers to the OD project's name, pre-fill the OD mapping table, and **always ask the user** before touching the emptied fragments (archive by default, reversible).

## What's in this PR

Two new skills under `skills/`, self-contained, no core changes:

- `skills/opendesign-hermes-session-reuse/SKILL.md`
- `skills/opendesign-fragment-consolidator/SKILL.md`

Full implementation (diagnose/consolidate scripts, patch docs, troubleshooting) lives in my personal repo: **https://github.com/mijiu1807-ops/opendesign-hermes-session-fix**

## Verification

Real-world tested on a 105-session / 3,455-message install: 94 fragments assigned to 4 projects, 95 envelopes translated to user voice, 1,933 messages merged into 5 ledgers, timelines monotonic, post-merge resume recalls hours-old context.

## A humble feature wish: Hermes beyond code

While I'm here — as a design-focused user (e-commerce visuals, UI, PPT, video thumbnails), I'd love for Hermes to keep growing beyond the code workspace toward **design / image / video** workflows. The "all-in-one workbench" vision is what makes the agent ecosystem exciting: one brain, many canvases. OpenDesign-style ACP clients are an early glimpse of that future; making first-class design-media skills and integrations a priority would mean a lot to many of us. 🙏

Thanks for considering this — happy to iterate on anything (naming, structure, docs) per your conventions.
