### PR TITLE
fix(update): never respawn backends from a foreign HERMES_HOME

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -249,27 +249,60 @@ def _profile_key_for_respawn(
     return "profile:default"
 
 
+def _normalized_home_for_compare(home: str) -> str:
+    """Resolve *home* for install-identity comparison (#94030).
+
+    Same normalization ``_profile_key_for_respawn`` applies to ``home:``
+    keys, so symlinked / differently-spelled roots compare equal.
+    """
+    try:
+        return os.path.normcase(str(Path(home).resolve()))
+    except (OSError, RuntimeError, ValueError):
+        return os.path.normcase(home)
+
+
 def _filter_dashboard_respawn_candidates(
     candidates: list[tuple[int, list[str], str | None]],
+    *,
+    own_home: str | None = None,
 ) -> list[list[str]]:
     """Select which killed manual backends to respawn after ``hermes update``.
 
-    Each candidate is ``(pid, argv, hermes_home)``.
+    Each candidate is ``(pid, argv, hermes_home)``.  *own_home* is the
+    updating install's home; it defaults to this process's
+    ``get_hermes_home()`` and exists as a parameter so tests can pin it.
 
-    Rules (#78821):
+    Rules (#78821, #94030):
     1. Never resurrect Desktop ephemeral ``serve|dashboard --port 0``
        backends — Desktop (``HERMES_DESKTOP_CHILD_PID``) owns their
        lifecycle.  These are also the PPID-1 orphans that previously
        multiplied across updates because ``--port 0`` always binds a
        fresh free port.
-    2. Dedupe by normalized cmdline (identical argv → one respawn).
-    3. Cap at most one managed backend per profile / ``HERMES_HOME``.
+    2. Never replay a backend from a **foreign** ``HERMES_HOME``.  The
+       respawn below is argv-only (no ``env=`` replay), so a foreign
+       backend would come back running on the *updating* install's home
+       and steal the foreign install's fixed port, leaving its own
+       supervisor (launchd/systemd/...) to crash-loop on ``EADDRINUSE``
+       (#94030).  A foreign install's backend is owned by that install's
+       supervisor/user.  An unreadable home (``None``) stays eligible —
+       keep the pre-#94030 behaviour when we cannot tell.
+    3. Dedupe by normalized cmdline (identical argv → one respawn).
+    4. Cap at most one managed backend per profile / ``HERMES_HOME``.
 
     Intentionally does **not** blanket-skip every PPID-1 process: a prior
     ``hermes update`` respawn detaches with ``start_new_session=True``, so
     fixed-port manual backends are reparented to init and must still be
     eligible for the next update's #40449 restart.
     """
+    if own_home is None:
+        try:
+            from hermes_constants import get_hermes_home
+
+            own_home = str(get_hermes_home())
+        except Exception:
+            own_home = ""
+    own_key = _normalized_home_for_compare(own_home) if own_home else ""
+
     selected: list[list[str]] = []
     seen_cmdlines: set[tuple[str, ...]] = set()
     seen_profiles: set[str] = set()
@@ -278,6 +311,8 @@ def _filter_dashboard_respawn_candidates(
         if not argv:
             continue
         if _is_ephemeral_port_zero_backend(argv):
+            continue
+        if own_key and hermes_home and _normalized_home_for_compare(hermes_home) != own_key:
             continue
         norm = _normalize_dashboard_cmdline(argv)
         if norm in seen_cmdlines:

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -571,10 +571,13 @@ class TestFilterDashboardRespawnCandidates:
         home = "/tmp/hermes-home-a"
         a = ["hermes", "dashboard", "--port", "8300"]
         b = ["hermes", "dashboard", "--port", "8301"]
-        out = _filter_dashboard_respawn_candidates([
-            (1, a, home),
-            (2, b, home),
-        ])
+        out = _filter_dashboard_respawn_candidates(
+            [
+                (1, a, home),
+                (2, b, home),
+            ],
+            own_home=home,
+        )
         assert out == [a]
 
     def test_profile_flag_and_profiles_home_share_cap(self):
@@ -594,22 +597,108 @@ class TestFilterDashboardRespawnCandidates:
         a = ["hermes", "--profile", "default", "dashboard", "--port", "8300"]
         b = ["hermes", "dashboard", "--port", "8301"]
         home = "/home/u/.hermes"
-        out = _filter_dashboard_respawn_candidates([
-            (1, a, home),
-            (2, b, home),
-        ])
+        out = _filter_dashboard_respawn_candidates(
+            [
+                (1, a, home),
+                (2, b, home),
+            ],
+            own_home=home,
+        )
         assert out == [a]
 
-    def test_distinct_dot_hermes_homes_do_not_share_cap(self):
+    def test_foreign_home_backend_is_not_replayed(self):
+        """A backend from another HERMES_HOME is never respawned (#94030).
+
+        Its supervisor/user owns its lifecycle; an argv-only replay would
+        run on the updating install's home and steal the foreign install's
+        fixed port.  Supersedes the old "distinct homes don't share a cap"
+        pin — a foreign home is no longer replayed at all.
+        """
         from hermes_cli.dashboard_procs import _filter_dashboard_respawn_candidates
 
         a = ["hermes", "dashboard", "--port", "8300"]
         b = ["hermes", "dashboard", "--port", "8301"]
-        out = _filter_dashboard_respawn_candidates([
-            (1, a, "/home/u/.hermes"),
-            (2, b, "/work/project/.hermes"),
+        out = _filter_dashboard_respawn_candidates(
+            [
+                (1, a, "/home/u/.hermes"),
+                (2, b, "/work/project/.hermes"),
+            ],
+            own_home="/home/u/.hermes",
+        )
+        assert out == [a]
+
+    def test_skips_sidecar_fixed_port_serve_on_foreign_home(self):
+        """The reported case: launchd-supervised sidecar serve, fixed port."""
+        from hermes_cli.dashboard_procs import _filter_dashboard_respawn_candidates
+
+        argv = [
+            "/Users/u/.hermes-sidecar/hermes-agent/venv/bin/python",
+            "-m", "hermes_cli.main",
+            "serve", "--host", "127.0.0.1", "--port", "9118", "--skip-build",
+        ]
+        out = _filter_dashboard_respawn_candidates(
+            [(15364, argv, "/Users/u/.hermes-lifeos")],
+            own_home="/Users/u/.hermes",
+        )
+        assert out == []
+
+    def test_matching_hermes_home_is_kept(self):
+        from hermes_cli.dashboard_procs import _filter_dashboard_respawn_candidates
+
+        argv = ["hermes", "serve", "--host", "127.0.0.1", "--port", "9118"]
+        out = _filter_dashboard_respawn_candidates(
+            [(15364, argv, "/Users/u/.hermes")],
+            own_home="/Users/u/.hermes",
+        )
+        assert out == [argv]
+
+    def test_symlinked_hermes_home_compares_equal(self, tmp_path):
+        from hermes_cli.dashboard_procs import _filter_dashboard_respawn_candidates
+
+        real = tmp_path / "real-home"
+        real.mkdir()
+        link = tmp_path / "linked-home"
+        try:
+            link.symlink_to(real, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform")
+
+        argv = ["hermes", "serve", "--port", "9118"]
+        out = _filter_dashboard_respawn_candidates(
+            [(15364, argv, str(real))],
+            own_home=str(link),
+        )
+        assert out == [argv]
+
+    def test_unknown_home_stays_eligible(self):
+        """Unreadable HERMES_HOME (env probe failed) keeps pre-#94030 behaviour."""
+        from hermes_cli.dashboard_procs import _filter_dashboard_respawn_candidates
+
+        argv = ["hermes", "dashboard", "--port", "8300"]
+        out = _filter_dashboard_respawn_candidates(
+            [(1, argv, None)],
+            own_home="/home/u/.hermes",
+        )
+        assert out == [argv]
+
+    def test_own_home_defaults_to_get_hermes_home(self, monkeypatch):
+        from pathlib import Path
+
+        import hermes_constants
+        from hermes_cli.dashboard_procs import _filter_dashboard_respawn_candidates
+
+        monkeypatch.setattr(
+            hermes_constants, "get_hermes_home", lambda: Path("/home/u/.hermes")
+        )
+        argv = ["hermes", "serve", "--port", "9118"]
+        foreign = _filter_dashboard_respawn_candidates([
+            (1, argv, "/Users/u/.hermes-lifeos"),
         ])
-        assert out == [a, b]
+        assert foreign == []
+        own = _filter_dashboard_respawn_candidates([
+            (1, argv, "/home/u/.hermes"),
+        ])
+        assert own == [argv]
 
     def test_keeps_fixed_port_serve(self):
         from hermes_cli.dashboard_procs import _filter_dashboard_respawn_candidates


### PR DESCRIPTION
## What does this PR do?

`hermes update`'s stale-dashboard sweep snapshots each killed backend's `HERMES_HOME` (`_hermes_home_for_pid`) but only used it as the per-profile dedupe key. `_respawn_dashboard_processes` replays the argv with **no `env=`**, so on a multi-install machine a backend belonging to a second `HERMES_HOME` (e.g. a launchd `KeepAlive`-supervised sidecar) was resurrected running on the *updating* install's default home, stealing the sidecar's fixed port. The sidecar's supervisor then crash-looped on `EADDRINUSE` and clients pointed at that port (Hermes Desktop remote-gateway) silently talked to the wrong backend.

This implements option (1) from the issue: candidates whose captured `HERMES_HOME` differs from the updater's own `get_hermes_home()` are no longer replayed at all — a foreign install's backend is owned by that install's supervisor/user. The needed value was already captured per-PID; only the comparison was missing.

## Related Issue

Fixes #94030

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `hermes_cli/dashboard_procs.py`:
  - New `_normalized_home_for_compare()` helper — `Path.resolve()` + `os.path.normcase`, the same normalization `_profile_key_for_respawn` applies to `home:` keys, so symlinked / differently-spelled roots compare equal.
  - `_filter_dashboard_respawn_candidates()` gains a keyword-only `own_home` parameter (defaults to this process's `get_hermes_home()`; exists so tests can pin it) and a new rule 2: skip any candidate whose captured `hermes_home` normalizes differently from the updater's own home. An unreadable home (`None`) stays eligible, keeping the pre-fix fail-open behaviour when we cannot tell.
- Deliberately out of scope: replaying the killed process's `HERMES_*` env via `env=` (option (2) in the issue — residual env-loss class for *same-home* respawns), and narrowing the kill-side scan. The kill itself stays as-is: a foreign supervised backend is simply restarted correctly by its own supervisor once the impostor no longer holds its port.

## How to Test

- New tests in `tests/hermes_cli/test_update_stale_dashboard.py` (`TestFilterDashboardRespawnCandidates`):
  - `test_skips_sidecar_fixed_port_serve_on_foreign_home` — the reported case: fixed-port sidecar serve, foreign home → not replayed.
  - `test_matching_hermes_home_is_kept` / `test_symlinked_hermes_home_compares_equal` — own-home candidates (including via symlink) still respawn.
  - `test_unknown_home_stays_eligible` — `None` home pins the fail-open branch.
  - `test_own_home_defaults_to_get_hermes_home` — pins the production default resolution (monkeypatched `get_hermes_home`).
  - `test_foreign_home_backend_is_not_replayed` — replaces the old `test_distinct_dot_hermes_homes_do_not_share_cap` pin: a foreign home is no longer replayed at all, which supersedes the cross-install cap question.
  - `test_caps_one_per_hermes_home` / `test_default_profile_same_root_home_caps` adapted to pin `own_home` explicitly (their cap semantics are unchanged).
- Run: `.venv/bin/python -m pytest tests/hermes_cli/test_update_stale_dashboard.py tests/hermes_cli/test_orphan_desktop_serve_reap.py tests/hermes_cli/test_lazy_command_exports.py tests/hermes_cli/test_dashboard_lifecycle_flags.py -q`
- Observed result: `62 passed, 2 skipped`. Fail-on-main check (`git stash` of the source change): the 6 new/updated tests fail against unpatched `main`, all green with the fix.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of the completed code performed
- [x] New and existing unit tests pass locally
- [x] Changes are backward-compatible (no API/schema changes)
