### PR TITLE
feat(mcp): add Loppee discovery catalog entry

### DIFF
--- a/optional-mcps/loppee/manifest.yaml
+++ b/optional-mcps/loppee/manifest.yaml
@@ -1,0 +1,32 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: loppee
+description: >-
+  Public business lookup, trust cards, reviews, and comparisons.
+source: https://github.com/4dwebspro-cell/loppee-mcp
+
+# Loppee hosts this public, read-only MCP over Streamable HTTP. The discovery
+# endpoint requires no credentials and exposes no personal, business-owner,
+# administrator, or precise-location surface.
+transport:
+  type: http
+  url: https://loppee.com/mcp/discovery
+
+auth:
+  type: none
+
+# The discovery endpoint exposes only these five public research tools. Keep
+# the explicit list as a least-privilege contract if the endpoint evolves.
+tools:
+  default_enabled:
+    - lookup_business
+    - get_trust_card
+    - get_business_reviews
+    - explain_recommendation
+    - compare_businesses
+
+post_install: |
+  No authentication or local installation is required. Start a new Hermes
+  session after installing so the five public, read-only tools are loaded.


### PR DESCRIPTION
## What does this PR do?

Adds Loppee's public, read-only discovery MCP to the optional MCP catalog.

This is a URL-only Streamable HTTP entry: it requires no authentication and runs no local command, package, clone, or bootstrap step. The catalog default is the endpoint's complete five-tool surface, limited to named-business lookup, public Trust Cards, public reviews, recommendation explanations, and business comparisons.

The `source` points to Loppee's public metadata repository. Because the server is vendor-hosted rather than installed by Hermes, that repository provides the inspectable endpoint, auth, tool-boundary, privacy, security, and registry metadata without implying that Hermes downloads or executes backend code.

## Related Issue

No related issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `optional-mcps/loppee/manifest.yaml`.
- Configured remote HTTP transport at `https://loppee.com/mcp/discovery` with `auth.type: none`.
- Enabled exactly five public, read-only tools by default:
  - `lookup_business`
  - `get_trust_card`
  - `get_business_reviews`
  - `explain_recommendation`
  - `compare_businesses`
- Kept personal, business-owner, administrator, write, and precise-location surfaces out of the entry.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py -q`.
2. Confirm all shipped manifests parse and satisfy catalog pinning contracts (25 tests passed locally).
3. Probe `https://loppee.com/mcp/discovery` through Hermes's MCP probe and confirm `tools/list` returns exactly the five names above.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1 arm64

Focused test note: the repository-wide suite was not run; the complete 25-test MCP catalog module passed through the required `scripts/run_tests.sh` wrapper on the exact PR commit.
Existing catalog contract tests already load every shipped manifest, so no new test file was added for this data-only entry.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the catalog is manifest-discovered and the manifest contains its setup guidance
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — URL-only remote HTTP entry; no platform-specific command
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; this PR adds catalog metadata only

## Screenshots / Logs

```text
tests/hermes_cli/test_mcp_catalog.py: 25 passed, 0 failed
live tools/list: lookup_business, get_trust_card, get_business_reviews,
                 explain_recommendation, compare_businesses
git diff --check origin/main...HEAD: clean
```
