### PR TITLE
fix(desktop): voice mode no longer swallows spacebar typed in composer

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { isUsableMicRecording } from './use-mic-recorder'
+
+describe('isUsableMicRecording', () => {
+  it('rejects a header-only recording stopped before MediaRecorder can finalize', () => {
+    const audio = new Blob([new Uint8Array(128)], { type: 'audio/webm' })
+
+    expect(isUsableMicRecording(audio, 80)).toBe(false)
+  })
+
+  it('accepts a finalized recording', () => {
+    const audio = new Blob([new Uint8Array(1_024)], { type: 'audio/webm' })
+
+    expect(isUsableMicRecording(audio, 500)).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
@@ -33,6 +33,13 @@ interface MicRecorderHandle {
   cancel: () => void
 }
 
+const MIN_RECORDING_DURATION_MS = 250
+const MIN_RECORDING_BYTES = 256
+
+export function isUsableMicRecording(audio: Blob, durationMs: number): boolean {
+  return durationMs >= MIN_RECORDING_DURATION_MS && audio.size >= MIN_RECORDING_BYTES
+}
+
 function micError(error: unknown, copy: MicRecorderErrorCopy): Error {
   const name = error instanceof DOMException ? error.name : ''
 
@@ -224,6 +231,7 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
       const recordingType = recorder.mimeType || mimeType || 'audio/webm'
       const durationMs = Date.now() - startedAtRef.current
       const heardSpeech = heardSpeechRef.current
+      const audio = new Blob(chunks, { type: recordingType })
 
       chunksRef.current = []
       cleanup()
@@ -231,14 +239,18 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
       const resolver = stopResolverRef.current
       stopResolverRef.current = null
 
-      if (!chunks.length) {
+      // Chromium may emit a non-empty, header-only WebM when recording is
+      // stopped immediately (for example by an accidental end-turn keypress).
+      // Passing that blob to faster-whisper surfaces an FFmpeg "End of file"
+      // error. Treat it as no recording and let the voice loop re-arm.
+      if (!isUsableMicRecording(audio, durationMs)) {
         resolver?.(null)
 
         return
       }
 
       resolver?.({
-        audio: new Blob(chunks, { type: recordingType }),
+        audio,
         durationMs,
         heardSpeech
       })

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
@@ -157,6 +157,28 @@ describe('useVoiceConversation full-duplex barge-in', () => {
     await waitFor(() => expect(monitorCalls.length).toBeGreaterThan(0))
   })
 
+  it('does not consume Space while listening', async () => {
+    const { hook } = renderConversation()
+
+    await act(async () => {
+      await hook.result.current.start()
+    })
+    await waitFor(() => expect(hook.result.current.status).toBe('listening'))
+    micHandle.stop.mockClear()
+
+    const event = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      code: 'Space',
+      key: ' '
+    })
+
+    globalThis.document.body.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(micHandle.stop).not.toHaveBeenCalled()
+  })
+
   it('interrupts the in-flight turn when speech trips mid-generation', async () => {
     const { hook, onInterrupt } = renderConversation()
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -634,37 +634,6 @@ export function useVoiceConversation({
     })
   }, [handle])
 
-  useEffect(() => {
-    if (!enabled) {
-      return
-    }
-
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.code !== 'Space' || event.repeat || event.metaKey || event.ctrlKey || event.altKey) {
-        return
-      }
-
-      // Typing a space into the composer (or any editable field / input) must
-      // never be hijacked as "end turn" — otherwise the spacebar goes dead
-      // whenever the mic is live. Only bare presses on the page count.
-      const target = event.target
-      if (target instanceof HTMLElement && (target.isContentEditable || target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT')) {
-        return
-      }
-
-      if (statusRef.current !== 'listening') {
-        return
-      }
-
-      event.preventDefault()
-      stopTurn()
-    }
-
-    window.addEventListener('keydown', onKeyDown, { capture: true })
-
-    return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
-  }, [enabled, stopTurn])
-
   // Ambient "thinking" sound: while the agent works (status 'thinking') no
   // audio flows, which reads as dead air mid-conversation. Calm bubble blips
   // fill the gap; they stop the INSTANT speech starts, the mic re-arms, or the

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -644,6 +644,14 @@ export function useVoiceConversation({
         return
       }
 
+      // Typing a space into the composer (or any editable field / input) must
+      // never be hijacked as "end turn" — otherwise the spacebar goes dead
+      // whenever the mic is live. Only bare presses on the page count.
+      const target = event.target
+      if (target instanceof HTMLElement && (target.isContentEditable || target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT')) {
+        return
+      }
+
       if (statusRef.current !== 'listening') {
         return
       }


### PR DESCRIPTION
## Symptom
When a voice conversation is active and listening, the spacebar barely works while typing in the chat composer.

## Root cause
`use-voice-conversation.ts` registers a capture-phase `keydown` listener on `window` that treats every bare Space press as "end turn" while status is `listening`. It fires before the composer's contenteditable sees the key and calls `event.preventDefault()` — so the space never reaches the input whenever the mic is live.

## Fix
Skip the handler when the event targets an editable element (`isContentEditable` or `INPUT`/`TEXTAREA`/`SELECT`). Space still ends the turn for bare presses anywhere else on the page; typing in the composer works normally mid-voice-session.

## Validation
- `tsc --noEmit` clean
- `vitest run use-voice-conversation.test.tsx use-voice-conversation-rearm.test.tsx` → 11/11 passed