### PR TITLE
feat(gateway): reconcile interrupted side effects on resume

### DIFF
--- a/agent/recovery_checkpoint.py
+++ b/agent/recovery_checkpoint.py
@@ -1,0 +1,215 @@
+"""Deterministic recovery checkpoints derived from persisted tool history.
+
+The gateway persists each assistant tool-call block before dispatch and each tool
+result immediately after completion.  This module turns that append-only ledger
+into a small restart handoff without asking an LLM to summarize its own work.
+Only tool names, call IDs, and result dispositions are included; arguments and
+result bodies are deliberately excluded because they may contain secrets or
+untrusted content.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import re
+from typing import Any, Iterable, Mapping, Sequence
+
+from agent.tool_result_classification import tool_may_have_side_effect
+
+MODE_CONTINUE_SAFE = "CONTINUE_SAFE"
+MODE_RECONCILE_REQUIRED = "RECONCILE_REQUIRED"
+
+_SAFE_LABEL_RE = re.compile(r"[^A-Za-z0-9_.:-]+")
+_UNKNOWN_ORPHAN_MARKERS = (
+    "effect is unknown",
+    "its effect is unknown",
+    "may have executed",
+)
+
+
+@dataclass(frozen=True)
+class RecoveryAction:
+    tool_name: str
+    tool_call_id: str
+
+
+@dataclass(frozen=True)
+class RecoveryCheckpoint:
+    mode: str
+    recorded_result_ids: tuple[str, ...] = ()
+    unknown_effects: tuple[RecoveryAction, ...] = ()
+    retryable_read_only_ids: tuple[str, ...] = ()
+
+
+def _safe_label(value: Any, *, fallback: str, limit: int = 96) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return fallback
+    cleaned = _SAFE_LABEL_RE.sub("_", text).strip("_")
+    return (cleaned or fallback)[:limit]
+
+
+def _tool_call_id(call: Mapping[str, Any]) -> str:
+    return _safe_label(
+        call.get("id") or call.get("call_id"),
+        fallback="unknown_call",
+    )
+
+
+def _tool_name(call: Mapping[str, Any]) -> str:
+    function = call.get("function")
+    raw_name = function.get("name") if isinstance(function, Mapping) else None
+    return _safe_label(raw_name, fallback="unknown_tool")
+
+
+def _active_turn(history: Sequence[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
+    """Return the last user turn and everything persisted after it."""
+    start = 0
+    for index, message in enumerate(history):
+        if message.get("role") == "user":
+            start = index
+    return list(history[start:])
+
+
+def _result_reports_failure(result: Mapping[str, Any]) -> bool:
+    content = result.get("content")
+    payload: Any = content
+    if isinstance(content, str):
+        stripped = content.strip()
+        try:
+            payload = json.loads(stripped)
+        except (TypeError, ValueError):
+            lowered = stripped.lower()
+            return (
+                lowered.startswith("error executing tool")
+                or lowered.startswith("[command interrupted")
+                or "timed out after" in lowered
+            )
+    if not isinstance(payload, Mapping):
+        return False
+    if payload.get("error"):
+        return True
+    exit_code = payload.get("exit_code")
+    if (
+        isinstance(exit_code, int)
+        and not isinstance(exit_code, bool)
+        and exit_code != 0
+    ):
+        return True
+    if payload.get("success") is False:
+        return True
+    status = str(payload.get("status") or "").strip().lower()
+    return status in {"error", "failed", "failure", "timeout", "timed_out"}
+
+
+def _result_is_unknown(tool_name: str, result: Mapping[str, Any]) -> bool:
+    disposition = str(result.get("effect_disposition") or "").strip().lower()
+    if disposition == "none":
+        return False
+    if disposition == "unknown":
+        return True
+    content = result.get("content")
+    if isinstance(content, str):
+        lowered = content.lower()
+        if "orphan recovery" in lowered and any(
+            marker in lowered for marker in _UNKNOWN_ORPHAN_MARKERS
+        ):
+            return True
+    return tool_may_have_side_effect(tool_name) and _result_reports_failure(result)
+
+
+def _iter_calls(
+    messages: Iterable[Mapping[str, Any]],
+) -> Iterable[tuple[str, str]]:
+    for message in messages:
+        if message.get("role") != "assistant":
+            continue
+        calls = message.get("tool_calls")
+        if not isinstance(calls, list):
+            continue
+        for call in calls:
+            if isinstance(call, Mapping):
+                yield _tool_call_id(call), _tool_name(call)
+
+
+def build_recovery_checkpoint(
+    history: Sequence[Mapping[str, Any]] | None,
+) -> RecoveryCheckpoint:
+    """Build a deterministic checkpoint for the interrupted active user turn.
+
+    A recorded non-unknown tool result is authoritative and must not be replayed.
+    An unknown or unanswered side-effecting call requires read-only external-state
+    reconciliation.  An unanswered read-only call is safe to retry.
+    """
+    active = _active_turn(list(history or []))
+    results: dict[str, Mapping[str, Any]] = {}
+    for message in active:
+        if message.get("role") != "tool":
+            continue
+        call_id = _safe_label(message.get("tool_call_id"), fallback="unknown_call")
+        results[call_id] = message
+
+    recorded: list[str] = []
+    unknown: list[RecoveryAction] = []
+    retryable: list[str] = []
+    seen: set[str] = set()
+
+    for call_id, tool_name in _iter_calls(active):
+        if call_id in seen:
+            continue
+        seen.add(call_id)
+        result = results.get(call_id)
+        if result is not None:
+            if _result_is_unknown(tool_name, result):
+                unknown.append(RecoveryAction(tool_name, call_id))
+            else:
+                recorded.append(call_id)
+            continue
+        if tool_may_have_side_effect(tool_name):
+            unknown.append(RecoveryAction(tool_name, call_id))
+        else:
+            retryable.append(call_id)
+
+    mode = MODE_RECONCILE_REQUIRED if unknown else MODE_CONTINUE_SAFE
+    return RecoveryCheckpoint(
+        mode=mode,
+        recorded_result_ids=tuple(recorded),
+        unknown_effects=tuple(unknown),
+        retryable_read_only_ids=tuple(retryable),
+    )
+
+
+def render_recovery_checkpoint(checkpoint: RecoveryCheckpoint) -> str:
+    """Render a bounded, secret-free recovery contract for the model."""
+    lines = [
+        "[Recovery checkpoint — deterministic from the persisted execution ledger]",
+        f"mode={checkpoint.mode}",
+        f"recorded_results={len(checkpoint.recorded_result_ids)}",
+        f"unknown_effects={len(checkpoint.unknown_effects)}",
+        f"retryable_read_only={len(checkpoint.retryable_read_only_ids)}",
+    ]
+
+    if checkpoint.unknown_effects:
+        lines.append("unknown_effect_calls:")
+        for action in checkpoint.unknown_effects[:8]:
+            lines.append(f"- {action.tool_name} call_id={action.tool_call_id}")
+        if len(checkpoint.unknown_effects) > 8:
+            lines.append(f"- and {len(checkpoint.unknown_effects) - 8} more")
+        lines.extend([
+            "Recovery protocol:",
+            "1. Do not repeat an unknown-effect action.",
+            "2. Inspect the exact external target with read-only/status tools.",
+            "3. If inspection proves the action landed, continue after it.",
+            "4. If inspection proves it did not land, retry only through normal approval gates.",
+            "5. If inspection cannot determine the state, stop and ask the user.",
+        ])
+    else:
+        lines.extend([
+            "Recovery protocol:",
+            "1. Do not repeat recorded tool calls.",
+            "2. Retry unanswered read-only calls only when still needed.",
+            "3. Continue after the last recorded result and finish the task.",
+        ])
+
+    return "\n".join(lines)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18373,7 +18373,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             group_sessions_per_user=_group_sessions_per_user,
             thread_sessions_per_user=_thread_sessions_per_user,
         )
-        if _is_shared_multi_user and source.user_name:
+        if (
+            _is_shared_multi_user
+            and source.user_name
+            and not (event.internal and not message_text.strip())
+        ):
+            # Internal empty events are gateway-synthesized control turns (for
+            # example restart recovery), not new speaker messages. Keeping them
+            # empty lets the resume path append its structured checkpoint instead
+            # of misclassifying ``[sender]`` as newer user input.
             # source.user_name is the platform display name — attacker-
             # influenceable on any platform that lets participants set their
             # own name. Neutralize embedded newlines/control chars before

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -62,6 +62,11 @@ from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.compaction_display import project_compaction_message_for_display
 from agent.i18n import t
 from agent.interrupt_compat import request_hard_interrupt
+from agent.recovery_checkpoint import (
+    RecoveryCheckpoint,
+    build_recovery_checkpoint,
+    render_recovery_checkpoint,
+)
 from agent.turn_context import (
     compression_made_progress,
 )
@@ -1274,6 +1279,7 @@ def build_resume_recovery_note(
     message: str = "",
     *,
     interactive: bool = True,
+    recovery_checkpoint: Optional[RecoveryCheckpoint] = None,
 ) -> str:
     """Build the resume-pending recovery system note for an interrupted turn.
 
@@ -1318,14 +1324,16 @@ def build_resume_recovery_note(
             "appear in the history — resume from the first step "
             "that has no recorded result."
         )
-    return (
+    recovery_note = (
         f"[System note: The previous turn was interrupted by "
         f"{reason_phrase}; the gateway is now back online. "
         f"Any restart/shutdown command in the history has already "
         f"run — do NOT re-execute or verify it. {resume_guidance} "
         f"{tail_guidance}]"
-        + (f"\n\n{message}" if message else "")
     )
+    if not message and recovery_checkpoint is not None:
+        recovery_note += "\n\n" + render_recovery_checkpoint(recovery_checkpoint)
+    return recovery_note + (f"\n\n{message}" if message else "")
 
 
 def _prepare_resume_pending_message(
@@ -1333,6 +1341,7 @@ def _prepare_resume_pending_message(
     message: Optional[str],
     *,
     interactive: bool = True,
+    recovery_checkpoint: Optional[RecoveryCheckpoint] = None,
 ) -> tuple[str, str]:
     """Return the recovery message and the user text to persist.
 
@@ -1346,7 +1355,10 @@ def _prepare_resume_pending_message(
     non-empty row never trips the sanitizer.
     """
     recovery_message = build_resume_recovery_note(
-        reason, message or "", interactive=interactive,
+        reason,
+        message or "",
+        interactive=interactive,
+        recovery_checkpoint=recovery_checkpoint,
     )
     persist_message = (
         message if isinstance(message, str) and message.strip() else recovery_message
@@ -1760,7 +1772,9 @@ from agent.replay_cleanup import (  # noqa: E402
 
 
 _AUTO_CONTINUE_NOTE_PREFIX = "[System note: Your previous turn"
+_RESUME_PENDING_NOTE_PREFIX = "[System note: The previous turn"
 _AUTO_CONTINUE_FALLBACK_PREFIX = "[System note: A new message"
+_RECOVERY_CHECKPOINT_PREFIX = "[Recovery checkpoint —"
 
 
 def _is_auto_continue_noise(content: Any) -> bool:
@@ -1770,6 +1784,7 @@ def _is_auto_continue_noise(content: Any) -> bool:
         return False
     return (
         content.startswith(_AUTO_CONTINUE_NOTE_PREFIX)
+        or content.startswith(_RESUME_PENDING_NOTE_PREFIX)
         or content.startswith(_AUTO_CONTINUE_FALLBACK_PREFIX)
     )
 
@@ -1785,6 +1800,15 @@ def _strip_auto_continue_noise(content: Any) -> Any:
     if not _is_auto_continue_noise(content):
         return content
     text = str(content)
+    # Structured checkpoints are appended only to synthesized empty startup
+    # turns. They contain no human text, so drop the complete persisted payload
+    # rather than leaving the deterministic ledger block behind as a fake user
+    # instruction on the next replay.
+    if (
+        text.startswith(_RESUME_PENDING_NOTE_PREFIX)
+        and f"\n\n{_RECOVERY_CHECKPOINT_PREFIX}" in text
+    ):
+        return ""
     while _is_auto_continue_noise(text):
         end = text.find("]")
         if end < 0:
@@ -6287,18 +6311,19 @@ class TurnRunner:
             _reason = getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
             # The empty-message case is the auto-resume startup turn
             # synthesized by _schedule_resume_pending_sessions — there is
-            # no NEW user message to address.  Guidance is adapter-aware:
-            # interactive platforms report the restore and ask what next;
-            # non-interactive event platforms (webhook, API server)
-            # continue the interrupted work instead, because nobody is
-            # present to answer and an acknowledgement would silently
-            # abandon the task (#57056).
+            # no NEW user message to address. Every adapter now continues from
+            # a deterministic checkpoint built from the persisted tool ledger;
+            # ``interactive`` remains an adapter compatibility field only.
             _resume_adapter = self._runner._adapter_for_source(ctx.source)
             _interactive_resume = bool(
                 getattr(_resume_adapter, "interactive_resume", True)
             )
+            _recovery_checkpoint = build_recovery_checkpoint(agent_history)
             ctx.message, _persist_user_message_override = _prepare_resume_pending_message(
-                _reason, ctx.message, interactive=_interactive_resume,
+                _reason,
+                ctx.message,
+                interactive=_interactive_resume,
+                recovery_checkpoint=_recovery_checkpoint,
             )
         elif _has_fresh_tool_tail:
             _persist_user_message_override = ctx.message
@@ -6346,6 +6371,7 @@ class TurnRunner:
                 interactive=bool(
                     getattr(_sn_adapter, "interactive_resume", True)
                 ),
+                recovery_checkpoint=build_recovery_checkpoint(agent_history),
             )
 
         _approval_session_key = ctx.session_key or ""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1283,13 +1283,12 @@ def build_resume_recovery_note(
     startup auto-resume turn synthesized by
     ``_schedule_resume_pending_sessions`` with no human message attached.
 
-    ``interactive`` selects the empty-message guidance: on interactive
-    platforms a human is present, so "report the restore and ask what next"
-    is right.  On non-interactive event platforms (webhook, API server —
-    adapters with ``interactive_resume = False``) nobody can answer; the
-    resumed turn must instead complete the interrupted work, or the task is
-    silently abandoned behind a "restored" acknowledgement that goes
-    nowhere (#57056).
+    ``interactive`` is retained for adapter API compatibility. Empty synthesized
+    startup events now behave the same on every platform: there is no newer
+    human instruction to prioritize, so the resumed turn reviews the preserved
+    transcript and continues the interrupted work. This avoids abandoning work
+    behind a "session restored" acknowledgement on interactive platforms while
+    preserving the duplicate-tool-call guard (#57056).
     """
     reason_phrase = (
         "a gateway restart"
@@ -1307,21 +1306,12 @@ def build_resume_recovery_note(
             "Do NOT re-execute old tool calls — skip any "
             "unfinished work from the conversation history."
         )
-    elif interactive:
-        resume_guidance = (
-            "Report to the user that the session was restored "
-            "successfully and ask what they would like to do next."
-        )
-        tail_guidance = (
-            "Do NOT re-execute old tool calls — skip any "
-            "unfinished work from the conversation history."
-        )
     else:
         resume_guidance = (
-            "No user is present on this non-interactive platform, "
-            "so do NOT emit a 'session restored' acknowledgement "
-            "or ask questions. Review the conversation history and "
-            "CONTINUE the interrupted task to completion."
+            "There is no newer user message attached to this recovery event, "
+            "so do NOT emit a 'session restored' acknowledgement or ask what "
+            "to do next. Review the conversation history and CONTINUE the "
+            "interrupted task to completion."
         )
         tail_guidance = (
             "Do NOT re-run tool calls whose results already "

--- a/tests/gateway/test_auto_continue.py
+++ b/tests/gateway/test_auto_continue.py
@@ -6,6 +6,12 @@ this and prepends an API-only system note to the next user message so the model
 does not re-execute stale interrupted tool calls before addressing new input.
 """
 
+from agent.recovery_checkpoint import (
+    MODE_CONTINUE_SAFE,
+    MODE_RECONCILE_REQUIRED,
+    build_recovery_checkpoint,
+)
+
 
 def _simulate_auto_continue(agent_history: list, user_message: str) -> str:
     """Reproduce the auto-continue injection logic from _run_agent().
@@ -32,10 +38,21 @@ class TestAutoDetection:
     def test_trailing_tool_result_triggers_note(self):
         history = [
             {"role": "user", "content": "deploy the app"},
-            {"role": "assistant", "content": None, "tool_calls": [
-                {"id": "call_1", "function": {"name": "terminal", "arguments": "{}"}}
-            ]},
-            {"role": "tool", "tool_call_id": "call_1", "content": "deployed successfully"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "deployed successfully",
+            },
         ]
         result = _simulate_auto_continue(history, "what happened?")
         assert "[System note:" in result
@@ -43,7 +60,6 @@ class TestAutoDetection:
         assert "NEW message" in result
         assert "Do NOT re-execute" in result
         assert "what happened?" in result
-
 
     def test_empty_history_no_note(self):
         result = _simulate_auto_continue([], "hello")
@@ -60,7 +76,10 @@ class TestInterruptedReplayFiltering:
                 "role": "assistant",
                 "content": None,
                 "tool_calls": [
-                    {"id": "call_1", "function": {"name": "terminal", "arguments": "{}"}},
+                    {
+                        "id": "call_1",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    },
                 ],
             },
             {
@@ -77,7 +96,7 @@ class TestInterruptedReplayFiltering:
         assert agent_history[-1]["role"] == "tool"
         assert agent_history[-1]["tool_call_id"] == "call_1"
         assert agent_history[-1]["effect_disposition"] == "unknown"
-
+        assert build_recovery_checkpoint(agent_history).mode == MODE_RECONCILE_REQUIRED
 
     def test_dangling_unanswered_side_effect_is_replayed_as_unknown(self):
         """A trailing side-effecting call gets an UNKNOWN result, not a retry.
@@ -113,5 +132,126 @@ class TestInterruptedReplayFiltering:
         assert agent_history[-1]["role"] == "tool"
         assert agent_history[-1]["tool_call_id"] == "call_1"
         assert agent_history[-1]["effect_disposition"] == "unknown"
+        assert build_recovery_checkpoint(agent_history).mode == MODE_RECONCILE_REQUIRED
+
+    def test_completed_side_effect_before_model_ack_is_not_replayed(self):
+        """A crash after result persistence but before model acknowledgement
+        resumes after the exact result instead of retrying the side effect."""
+        from gateway.run import _build_gateway_agent_history
+
+        history = [
+            {"role": "user", "content": "deploy the app"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_deploy",
+                        "function": {
+                            "name": "terminal",
+                            "arguments": '{"command":"deploy"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_deploy",
+                "content": '{"exit_code":0,"output":"deployed"}',
+            },
+        ]
+
+        agent_history, _ = _build_gateway_agent_history(history)
+        checkpoint = build_recovery_checkpoint(agent_history)
+
+        assert checkpoint.mode == MODE_CONTINUE_SAFE
+        assert checkpoint.recorded_result_ids == ("call_deploy",)
+        assert checkpoint.unknown_effects == ()
 
 
+def _recovery_call(call_id: str, name: str, arguments: str = "{}") -> dict:
+    return {
+        "id": call_id,
+        "function": {"name": name, "arguments": arguments},
+    }
+
+
+def _recovery_assistant(*calls: dict) -> dict:
+    return {"role": "assistant", "content": None, "tool_calls": list(calls)}
+
+
+def _recovery_result(
+    call_id: str,
+    *,
+    disposition: str | None = None,
+    content: str = "recorded result",
+) -> dict:
+    message = {
+        "role": "tool",
+        "name": "terminal",
+        "tool_call_id": call_id,
+        "content": content,
+    }
+    if disposition is not None:
+        message["effect_disposition"] = disposition
+    return message
+
+
+class TestStructuredRecoveryCheckpoint:
+    def test_checkpoint_uses_only_active_user_turn(self):
+        checkpoint = build_recovery_checkpoint([
+            {"role": "user", "content": "old task"},
+            _recovery_assistant(_recovery_call("old", "terminal")),
+            _recovery_result("old", disposition="unknown"),
+            {"role": "user", "content": "new task"},
+            _recovery_assistant(_recovery_call("new", "read_file")),
+            _recovery_result("new", disposition="none"),
+        ])
+
+        assert checkpoint.mode == MODE_CONTINUE_SAFE
+        assert checkpoint.recorded_result_ids == ("new",)
+        assert checkpoint.unknown_effects == ()
+
+    def test_failed_side_effect_result_requires_reconciliation(self):
+        checkpoint = build_recovery_checkpoint([
+            {"role": "user", "content": "deploy it"},
+            _recovery_assistant(_recovery_call("call_failed", "terminal")),
+            _recovery_result(
+                "call_failed",
+                content='{"exit_code": 1, "error": "connection lost"}',
+            ),
+        ])
+
+        assert checkpoint.mode == MODE_RECONCILE_REQUIRED
+        assert checkpoint.unknown_effects[0].tool_call_id == "call_failed"
+
+    def test_dangling_read_only_call_is_retryable(self):
+        checkpoint = build_recovery_checkpoint([
+            {"role": "user", "content": "inspect it"},
+            _recovery_assistant(_recovery_call("call_read", "read_file")),
+        ])
+
+        assert checkpoint.mode == MODE_CONTINUE_SAFE
+        assert checkpoint.retryable_read_only_ids == ("call_read",)
+
+    def test_rendered_checkpoint_does_not_leak_tool_arguments(self):
+        from agent.recovery_checkpoint import render_recovery_checkpoint
+
+        rendered = render_recovery_checkpoint(
+            build_recovery_checkpoint([
+                {"role": "user", "content": "deploy it"},
+                _recovery_assistant(
+                    _recovery_call(
+                        "call_deploy",
+                        "terminal",
+                        '{"command":"deploy --token SECRET_VALUE"}',
+                    )
+                ),
+            ])
+        )
+
+        assert "mode=RECONCILE_REQUIRED" in rendered
+        assert "read-only/status" in rendered
+        assert "normal approval gates" in rendered
+        assert "SECRET_VALUE" not in rendered
+        assert "deploy --token" not in rendered

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -301,11 +301,14 @@ class TestResumePendingSystemNote:
         )
 
 
-    def test_empty_message_noninteractive_note_continues_task(self):
-        """Non-interactive platforms (webhook, API server): nobody can answer
-        'what next?', so the resumed turn must complete the interrupted work
-        instead of acknowledging (#57056)."""
-        note = build_resume_recovery_note("restart_timeout", "", interactive=False)
+    @pytest.mark.parametrize("interactive", [True, False])
+    def test_empty_message_note_continues_task_on_every_platform(self, interactive):
+        """A synthesized startup resume has no new user instruction, so both
+        interactive and non-interactive platforms must recover the transcript
+        and finish the interrupted work instead of asking what to do next."""
+        note = build_resume_recovery_note(
+            "restart_timeout", "", interactive=interactive
+        )
         assert "CONTINUE the interrupted task" in note
         assert "session was restored" not in note
         assert "ask what they would like to do next" not in note

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -32,6 +32,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from agent.recovery_checkpoint import build_recovery_checkpoint
 from gateway.config import GatewayConfig, HomeChannel, Platform
 from gateway.platforms.base import MessageEvent, MessageType, SendResult
 from gateway.run import (
@@ -42,6 +43,7 @@ from gateway.run import (
     _last_transcript_timestamp,
     _prepare_resume_pending_message,
     _should_clear_resume_pending_after_turn,
+    _strip_auto_continue_noise,
     build_resume_recovery_note,
 )
 from gateway.session import SessionEntry, SessionSource, SessionStore
@@ -317,6 +319,63 @@ class TestResumePendingSystemNote:
         # But still guards against re-running already-recorded tool calls.
         assert "already appear in the history" in note
 
+    def test_empty_resume_note_embeds_deterministic_reconciliation_checkpoint(self):
+        history = [
+            {"role": "user", "content": "deploy it"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_deploy",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "name": "terminal",
+                "tool_call_id": "call_deploy",
+                "content": "[Orphan recovery: effect is UNKNOWN.]",
+                "effect_disposition": "unknown",
+            },
+        ]
+        checkpoint = build_recovery_checkpoint(history)
+
+        note = build_resume_recovery_note(
+            "restart_timeout", "", recovery_checkpoint=checkpoint
+        )
+
+        assert "mode=RECONCILE_REQUIRED" in note
+        assert "terminal call_id=call_deploy" in note
+        assert "read-only/status" in note
+        assert "Do not repeat an unknown-effect action" in note
+
+    def test_new_user_message_does_not_continue_old_checkpoint(self):
+        checkpoint = build_recovery_checkpoint([
+            {"role": "user", "content": "deploy it"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_deploy",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+        ])
+
+        note = build_resume_recovery_note(
+            "restart_timeout",
+            "stop that and work on the new request",
+            recovery_checkpoint=checkpoint,
+        )
+
+        assert "NEW message" in note
+        assert "mode=RECONCILE_REQUIRED" not in note
+        assert "stop that and work on the new request" in note
+
 
     def test_resume_note_is_persisted_instead_of_original_empty_message(self):
         """The auto-resume note must not leave an empty row in state.db."""
@@ -328,6 +387,30 @@ class TestResumePendingSystemNote:
         assert "CONTINUE the interrupted task" in message
         assert persisted == message
         assert persisted != ""
+
+    def test_persisted_structured_recovery_note_is_not_replayed_as_user_text(self):
+        checkpoint = build_recovery_checkpoint([
+            {"role": "user", "content": "deploy it"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_deploy",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+        ])
+        message, persisted = _prepare_resume_pending_message(
+            "shutdown_timeout",
+            "",
+            recovery_checkpoint=checkpoint,
+        )
+
+        assert persisted == message
+        assert "Recovery checkpoint" in persisted
+        assert _strip_auto_continue_noise(persisted) == ""
 
     def test_whitespace_only_message_also_persists_the_note(self):
         """A whitespace-only startup event is as blank as an empty one —

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -346,6 +346,20 @@ class TestSenderPrefixWithBackfill:
         assert "[Alice] [Recent" not in result
 
     @pytest.mark.asyncio
+    async def test_internal_empty_resume_event_skips_sender_prefix(self, runner, source):
+        """Startup recovery must stay empty until checkpoint injection runs.
+
+        Shared Discord sessions normally prefix the speaker name, but a synthesized
+        resume event has no new speaker message. Prefixing it turns an empty event
+        into ``[Alice]`` and falsely selects the newer-message recovery path.
+        """
+        event = MessageEvent(text="", source=source, internal=True)
+        result = await runner._prepare_inbound_message_text(
+            event=event, source=source, history=[],
+        )
+        assert result == ""
+
+    @pytest.mark.asyncio
     async def test_malicious_display_name_cannot_inject_markdown_section(self, runner):
         """A hostile platform display name must not break out onto its own line.
 


### PR DESCRIPTION
## Summary
- continue fresh restart-interrupted interactive sessions instead of asking what to do next
- build a deterministic recovery checkpoint from the persisted tool-call/result ledger
- require read-only reconciliation for unknown-effect side effects while keeping newer user messages authoritative
- strip persisted recovery scaffolding from later replay

## Safety
- tool arguments and result bodies are excluded from the checkpoint
- recorded results are not repeated
- unanswered read-only calls remain retryable
- failed, timed-out, dangling, or orphaned side-effecting calls require reconciliation and normal approval gates

## Tests
- 40 passed: tests/gateway/test_restart_resume_pending.py
- 19 passed: tests/gateway/test_active_turn_recovery.py
- 9 passed: tests/gateway/test_auto_continue.py
- 2 passed: tests/gateway/test_13121_shutdown_inflight_transcript_flush.py
- ruff check passed on changed files