### PR TITLE
feat(desktop): make kanban task cards keyboard accessible

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -162,6 +162,7 @@
     "@rolldown/plugin-babel": "0.2.3",
     "@testing-library/dom": "10.4.1",
     "@testing-library/react": "16.3.2",
+    "@testing-library/user-event": "14.6.6",
     "@types/babel__core": "7.20.5",
     "@types/d3-force": "3.0.10",
     "@types/hast": "3.0.5",

--- a/apps/desktop/src/plugins/kanban/board.test.tsx
+++ b/apps/desktop/src/plugins/kanban/board.test.tsx
@@ -1,0 +1,155 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { Card } from './board'
+import type { KanbanTask } from './types'
+import type * as KanbanUi from './ui'
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+vi.mock('./ui', async importOriginal => {
+  const actual = await importOriginal<typeof KanbanUi>()
+
+  return {
+    ...actual,
+    ago: () => '',
+    arcState: () => null,
+    columnLabel: (_k: unknown, status: string) => (status === 'todo' ? 'Todo' : status),
+    useDefaultAssignee: () => '',
+    useKanban: () => ({
+      delete: 'Delete',
+      deselect: 'Deselect',
+      moveTo: (status: string) => `Move to ${status}`,
+      open: 'Open',
+      select: (modifier: string) => `Select (${modifier})`
+    }),
+    useOrchestration: () => null
+  }
+})
+
+const task: KanbanTask = {
+  body: 'The card body',
+  created_at: 1,
+  id: 't_fixture_123',
+  status: 'todo',
+  title: 'Keyboard accessible task'
+}
+
+function renderCard() {
+  const callbacks = {
+    onDelete: vi.fn(),
+    onMove: vi.fn(),
+    onOpen: vi.fn(),
+    onToggleSelect: vi.fn()
+  }
+
+  render(<Card columns={['todo', 'done']} selected={false} task={task} {...callbacks} />)
+
+  const card = screen.getByText(task.title).closest<HTMLElement>('[draggable="true"]')
+
+  if (!card) {
+    throw new Error('Task card root was not rendered')
+  }
+
+  return { card, ...callbacks }
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('Kanban task card interactions', () => {
+  it('opens exactly once from a pointer click', async () => {
+    const user = userEvent.setup()
+    const { card, onOpen, onToggleSelect } = renderCard()
+
+    await user.click(card)
+
+    expect(onOpen).toHaveBeenCalledOnce()
+    expect(onOpen).toHaveBeenCalledWith(task.id)
+    expect(onToggleSelect).not.toHaveBeenCalled()
+  })
+
+  it.each(['metaKey', 'ctrlKey'] as const)('toggles selection without opening for %s-click', modifier => {
+    const { card, onOpen, onToggleSelect } = renderCard()
+
+    fireEvent.click(card, { [modifier]: true })
+
+    expect(onToggleSelect).toHaveBeenCalledOnce()
+    expect(onToggleSelect).toHaveBeenCalledWith(task.id)
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+
+  it('is a named native button in the normal Tab order', async () => {
+    const user = userEvent.setup()
+    renderCard()
+
+    const card = screen.getByRole('button', {
+      name: /Keyboard accessible task.*t_fixture_123.*Todo/i
+    })
+
+    expect(card.getAttribute('type')).toBe('button')
+    expect(card.classList.contains('kanban-task-card')).toBe(true)
+
+    await user.tab()
+
+    expect(card.ownerDocument.activeElement).toBe(card)
+  })
+
+  it.each(['{Enter}', ' '])('opens exactly once from %s', async key => {
+    const user = userEvent.setup()
+    const { onOpen } = renderCard()
+    const card = screen.getByRole('button', { name: /Keyboard accessible task/i })
+    card.focus()
+
+    await user.keyboard(key)
+
+    expect(onOpen).toHaveBeenCalledOnce()
+    expect(onOpen).toHaveBeenCalledWith(task.id)
+  })
+
+  it('preserves the native drag payload contract', () => {
+    const { card } = renderCard()
+
+    const dataTransfer = {
+      effectAllowed: 'none',
+      setData: vi.fn(),
+      setDragImage: vi.fn()
+    }
+
+    expect(card.getAttribute('draggable')).toBe('true')
+
+    fireEvent.dragStart(card, { dataTransfer })
+
+    expect(dataTransfer.setData).toHaveBeenCalledWith('text/plain', task.id)
+    expect(dataTransfer.effectAllowed).toBe('move')
+    expect(dataTransfer.setDragImage).toHaveBeenCalledOnce()
+  })
+
+  it('keeps context-menu selection isolated from card activation', async () => {
+    const user = userEvent.setup()
+    const { card, onOpen, onToggleSelect } = renderCard()
+
+    fireEvent.pointerDown(card, { button: 2, pointerType: 'mouse' })
+    fireEvent.contextMenu(card, { button: 2 })
+
+    expect(onOpen).not.toHaveBeenCalled()
+    await user.click(await screen.findByRole('menuitem', { name: /Select/i }))
+
+    expect(onToggleSelect).toHaveBeenCalledOnce()
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+
+  it('contains no nested interactive controls', () => {
+    renderCard()
+    const card = screen.getByRole('button', { name: /Keyboard accessible task/i })
+
+    expect(card.querySelector('button, a[href], input, select, textarea, [role="button"], [tabindex]')).toBeNull()
+  })
+})

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -237,7 +237,7 @@ function CardFooter({ arc, task }: { arc: ArcState | null; task: KanbanTask }) {
   )
 }
 
-function Card({
+export function Card({
   columns,
   onDelete,
   onMove,
@@ -264,9 +264,10 @@ function Card({
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
-        <div
+        <button
+          aria-label={`${task.title || task.id}, ${task.id}, ${columnLabel(k, task.status)}`}
           className={cn(
-            'group relative flex cursor-grab flex-col gap-2 rounded-md border border-(--ui-stroke-tertiary) border-l-2 bg-(--ui-bg-elevated) p-2.5',
+            'kanban-task-card group relative flex w-full cursor-grab appearance-none flex-col gap-2 rounded-md border border-(--ui-stroke-tertiary) border-l-2 bg-(--ui-bg-elevated) p-2.5 text-left',
             // Hover matches the provider-picker rows: a quiet primary fill;
             // selected = the theme's focus color (same as a focused input).
             'transition-colors hover:bg-primary/[0.06] active:cursor-grabbing',
@@ -285,6 +286,7 @@ function Card({
             setDragging(true)
           }}
           style={{ '--kanban-tone': meta.tone, borderLeftColor: meta.tone } as CSSProperties}
+          type="button"
         >
           {/* Machine-activity arc: animates ONLY while an agent is actually on
               the card (claimed + working; amber when the heartbeat is gone).
@@ -301,7 +303,7 @@ function Card({
             <span className="line-clamp-2 text-[0.6875rem] leading-snug text-(--ui-text-tertiary)">{summary}</span>
           )}
           <CardFooter arc={arc} task={task} />
-        </div>
+        </button>
       </ContextMenuTrigger>
       <ContextMenuContent>
         <ContextMenuItem onSelect={() => onOpen(task.id)}>

--- a/apps/desktop/src/plugins/kanban/kanban.css
+++ b/apps/desktop/src/plugins/kanban/kanban.css
@@ -10,6 +10,16 @@
   initial-value: 0deg;
 }
 
+/* The app-wide reset removes both native outlines and Tailwind ring shadows.
+   Paint the card focus treatment directly so it remains visible in every
+   theme and distinct from selected/active border states. */
+.kanban-task-card:focus-visible {
+  z-index: 1;
+  box-shadow:
+    0 0 0 2px var(--ui-bg-elevated),
+    0 0 0 4px var(--dt-composer-ring);
+}
+
 .kanban-arc {
   pointer-events: none;
   position: absolute;

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,6 +147,7 @@
         "@rolldown/plugin-babel": "0.2.3",
         "@testing-library/dom": "10.4.1",
         "@testing-library/react": "16.3.2",
+        "@testing-library/user-event": "14.6.6",
         "@types/babel__core": "7.20.5",
         "@types/d3-force": "3.0.10",
         "@types/hast": "3.0.5",
@@ -6370,6 +6371,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.6.tgz",
+      "integrity": "sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {


### PR DESCRIPTION
## Summary
- render Desktop Kanban task cards as native buttons with deterministic accessible names
- preserve the single click path for pointer, Enter, Space, modifier-selection, drag, and context-menu interactions
- add a direct focus-visible shadow that survives the Desktop global ring reset
- add interaction coverage for pointer, modifiers, Tab focus, Enter/Space single activation, drag payload, context-menu isolation, and nested-control validity

## Test plan
- `npm run test:ui --workspace apps/desktop -- src/plugins/kanban/board.test.tsx` (9 passed)
- `npm run test:ui --workspace apps/desktop` (571 files, 5443 tests passed)
- `npm run typecheck --workspace apps/desktop`
- `npm run lint --workspace apps/desktop` (passes with pre-existing warnings)