### PR TITLE
fix: keep venv interpreter path in desktop entry Exec

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -26,6 +26,7 @@ Electron main process both use this without loading the full CLI.
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -78,9 +79,13 @@ def _is_python_interpreter(bin_path: Path) -> bool:
 
     Distinguishes the updater's ``python -m hermes_cli.main ...`` drive form
     (where ``argv[0]`` is the interpreter itself) from console-scripts and
-    native launchers, which take ``desktop`` as a plain argument.
+    native launchers, which take ``desktop`` as a plain argument. Matches
+    ``python``, ``python3``, ``python3.11``, ``python2.7`` — and rejects
+    lookalikes like ``python3-config``.
     """
-    return bin_path.name.startswith("python")
+    return bin_path.name == "python" or re.fullmatch(
+        r"python[23](\d+)?(\.\d+)?", bin_path.name
+    ) is not None
 
 
 def resolve_exec_command() -> str:

--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -57,6 +57,32 @@ def icon_path(project_root: Path) -> Path:
     return project_root / "apps" / "desktop" / "assets" / "icon.png"
 
 
+def _resolve_exec_path(path: Path) -> Path:
+    """Resolve ``path`` to a real executable, keeping venv symlinks intact.
+
+    ``uv venv`` (and pip) create ``bin/python`` as a symlink into a shared
+    base-interpreter tree. ``Path.resolve()`` follows that link, turning
+    ``sys.executable`` into a bare interpreter that no longer activates the
+    venv: CPython discovers ``pyvenv.cfg`` from the *unresolved* argv[0], so
+    a ``.desktop`` Exec prefixed with the resolved path boots without the
+    venv's site-packages and dies on the first third-party import.
+    """
+    for base in (path.parent, *path.parent.parents):
+        if (base / "pyvenv.cfg").is_file():
+            return path
+    return path.resolve()
+
+
+def _is_python_interpreter(bin_path: Path) -> bool:
+    """Whether ``bin_path`` is a Python interpreter binary, not a script.
+
+    Distinguishes the updater's ``python -m hermes_cli.main ...`` drive form
+    (where ``argv[0]`` is the interpreter itself) from console-scripts and
+    native launchers, which take ``desktop`` as a plain argument.
+    """
+    return bin_path.name.startswith("python")
+
+
 def resolve_exec_command() -> str:
     """Build the absolute ``Exec=`` command line for ``hermes desktop``.
 
@@ -66,9 +92,10 @@ def resolve_exec_command() -> str:
     """
     from hermes_cli.relaunch import resolve_hermes_bin
 
+    exe = _resolve_exec_path(Path(sys.executable))
     bin_path = resolve_hermes_bin()
     if bin_path:
-        resolved = Path(bin_path).resolve()
+        resolved = _resolve_exec_path(Path(bin_path))
         if _needs_interpreter(resolved):
             # The resolved launcher is a Python script whose shebang points at
             # a NON-venv interpreter (e.g. the repo's `hermes` script with
@@ -78,11 +105,17 @@ def resolve_exec_command() -> str:
             # third-party import (#90292) — silently, since Terminal=false.
             # sys.executable is the interpreter actually running Hermes (the
             # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            argv = [str(exe), str(resolved), "desktop"]
+        elif _is_python_interpreter(resolved):
+            # argv[0] was the interpreter itself (e.g. the updater drives
+            # `python -m hermes_cli.main desktop --build-only`). Bare
+            # ``<python> desktop`` would treat `desktop` as a script path;
+            # pass the CLI module instead.
+            argv = [str(exe), "-m", "hermes_cli.main", "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        argv = [str(exe), "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
 
 
@@ -106,7 +139,7 @@ def _needs_interpreter(bin_path: Path) -> bool:
     # A python shebang pointing INSIDE the running interpreter's environment
     # already resolves correctly; anything else (``/usr/bin/env python3``,
     # a system path) would escape the venv when spawned by the DE.
-    exe_dir = str(Path(sys.executable).resolve().parent)
+    exe_dir = str(_resolve_exec_path(Path(sys.executable)).parent)
     return exe_dir not in shebang
 
 

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -107,7 +107,9 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    interpreter = str(Path(sys.executable).resolve())
+    # The venv-preserving executable (see _resolve_exec_path), not the
+    # resolved base interpreter that would escape the venv.
+    interpreter = str(lde._resolve_exec_path(Path(sys.executable)))
     assert exec_line.split(" ")[0].strip('"') == interpreter
     assert str(hermes_bin) in exec_line
     assert exec_line.endswith("desktop")
@@ -135,7 +137,7 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
     root = _make_project(tmp_path)
     hermes_bin = tmp_path / "bin" / "hermes"
     hermes_bin.parent.mkdir()
-    interpreter = str(Path(sys.executable).resolve())
+    interpreter = str(lde._resolve_exec_path(Path(sys.executable)))
     hermes_bin.write_text(f"#!{interpreter}\nimport hermes_cli\n", encoding="utf-8")
     hermes_bin.chmod(0o755)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
@@ -147,6 +149,72 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
     # Console-script with the venv's own interpreter in the shebang: correct
     # as-is, prefixing would only add noise.
     assert exec_line == f"{hermes_bin} desktop"
+
+
+def test_exec_keeps_venv_symlink_in_interpreter_prefix(tmp_path, xdg_home, monkeypatch):
+    """uv-style venv symlink must stay in the Exec, not resolve to the base.
+
+    ``uv venv`` (and pip) make ``bin/python`` a symlink into a shared base
+    interpreter tree. Resolving it escapes the venv: pyvenv.cfg is discovered
+    from the *unresolved* argv[0], so the .desktop Exec would boot a bare
+    interpreter and crash on the first third-party import (ModuleNotFoundError
+    for yaml/dotenv — exactly the reported flash-crash on launch).
+    """
+    root = _make_project(tmp_path)
+    base = tmp_path / "uv-python" / "bin"
+    base.mkdir(parents=True)
+    base_python = base / "python3.11"
+    base_python.write_bytes(b"\x7fELF\x02\x01\x01 fake base python")
+    venv = tmp_path / "venv"
+    venv.mkdir()
+    (venv / "pyvenv.cfg").write_text("home = /shared/base\n")
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin" / "python").symlink_to(base_python)
+    monkeypatch.setattr(lde.sys, "executable", str(venv / "bin" / "python"))
+    hermes_bin = tmp_path / "bin" / "hermes"
+    hermes_bin.parent.mkdir()
+    hermes_bin.write_text("#!/usr/bin/env python3\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    # The venv path is preserved — NOT the resolved base interpreter.
+    assert exec_line.startswith(str(venv / "bin" / "python"))
+    assert str(base_python) not in exec_line
+    assert str(hermes_bin) in exec_line
+    assert exec_line.endswith("desktop")
+
+
+def test_exec_uses_module_form_when_bin_is_python_interpreter(tmp_path, xdg_home, monkeypatch):
+    """argv[0] == the interpreter itself (updater drive form) → ``-m`` form.
+
+    The updater runs ``python -m hermes_cli.main desktop --build-only``, so
+    resolve_hermes_bin() returns the interpreter. A bare ``<python> desktop``
+    Exec would treat ``desktop`` as a script path and crash.
+    """
+    root = _make_project(tmp_path)
+    base = tmp_path / "base" / "bin"
+    base.mkdir(parents=True)
+    base_python = base / "python3.11"
+    base_python.write_bytes(b"\x7fELF fake")
+    venv = tmp_path / "venv"
+    venv.mkdir()
+    (venv / "pyvenv.cfg").write_text("home = /shared/base\n")
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin" / "python").symlink_to(base_python)
+    monkeypatch.setattr(lde.sys, "executable", str(venv / "bin" / "python"))
+    monkeypatch.setattr(
+        "hermes_cli.relaunch.resolve_hermes_bin", lambda: str(venv / "bin" / "python")
+    )
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert exec_line == f"{venv / 'bin' / 'python'} -m hermes_cli.main desktop"
 
 
 def test_install_is_idempotent_and_skips_cache_refresh(tmp_path, xdg_home, monkeypatch):

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -92,11 +92,21 @@ def test_exec_falls_back_to_interpreter_module(tmp_path, xdg_home, monkeypatch):
 # python script whose `#!/usr/bin/env python3` shebang resolves to the SYSTEM
 # interpreter when the DE spawns the .desktop entry → ModuleNotFoundError,
 # silent (Terminal=false). The Exec line must prefix sys.executable for any
-# resolved bin that is a python script escaping the running venv.
+# resolved bin that is a python script escaping the running venv. Runs inside
+# a simulated uv-style venv so the expected prefix is a concrete path, not a
+# mirror of the implementation.
 def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_home, monkeypatch):
-    import sys
-
     root = _make_project(tmp_path)
+    base = tmp_path / "base" / "bin"
+    base.mkdir(parents=True)
+    base_python = base / "python3.11"
+    base_python.write_bytes(b"\x7fELF fake base python")
+    venv = tmp_path / "venv"
+    venv.mkdir()
+    (venv / "pyvenv.cfg").write_text("home = /shared/base\n")
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin" / "python").symlink_to(base_python)
+    monkeypatch.setattr(lde.sys, "executable", str(venv / "bin" / "python"))
     hermes_bin = tmp_path / "bin" / "hermes"
     hermes_bin.parent.mkdir()
     hermes_bin.write_text("#!/usr/bin/env python3\nimport hermes_cli\n", encoding="utf-8")
@@ -107,12 +117,22 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    # The venv-preserving executable (see _resolve_exec_path), not the
-    # resolved base interpreter that would escape the venv.
-    interpreter = str(lde._resolve_exec_path(Path(sys.executable)))
-    assert exec_line.split(" ")[0].strip('"') == interpreter
+    # The venv-preserving interpreter is prefixed — the resolved base
+    # interpreter that would escape the venv must NOT appear.
+    assert exec_line.split(" ")[0].strip('"') == str(venv / "bin" / "python")
+    assert str(base_python) not in exec_line
     assert str(hermes_bin) in exec_line
     assert exec_line.endswith("desktop")
+
+
+def test_is_python_interpreter_distinguishes_binary_from_launcher():
+    assert lde._is_python_interpreter(Path("python"))
+    assert lde._is_python_interpreter(Path("python3"))
+    assert lde._is_python_interpreter(Path("python3.11"))
+    assert lde._is_python_interpreter(Path("python2.7"))
+    assert not lde._is_python_interpreter(Path("python3-config"))
+    assert not lde._is_python_interpreter(Path("python-hermes"))
+    assert not lde._is_python_interpreter(Path("hermes"))
 
 
 def test_exec_leaves_shell_wrapper_launchers_alone(tmp_path, xdg_home, monkeypatch):
@@ -132,13 +152,21 @@ def test_exec_leaves_shell_wrapper_launchers_alone(tmp_path, xdg_home, monkeypat
 
 
 def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch):
-    import sys
-
     root = _make_project(tmp_path)
+    base = tmp_path / "base" / "bin"
+    base.mkdir(parents=True)
+    base_python = base / "python3.11"
+    base_python.write_bytes(b"\x7fELF fake base python")
+    venv = tmp_path / "venv"
+    venv.mkdir()
+    (venv / "pyvenv.cfg").write_text("home = /shared/base\n")
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin" / "python").symlink_to(base_python)
+    monkeypatch.setattr(lde.sys, "executable", str(venv / "bin" / "python"))
     hermes_bin = tmp_path / "bin" / "hermes"
     hermes_bin.parent.mkdir()
-    interpreter = str(lde._resolve_exec_path(Path(sys.executable)))
-    hermes_bin.write_text(f"#!{interpreter}\nimport hermes_cli\n", encoding="utf-8")
+    # Console-script shebang points at the venv interpreter itself.
+    hermes_bin.write_text(f"#!{venv / 'bin' / 'python'}\nimport hermes_cli\n", encoding="utf-8")
     hermes_bin.chmod(0o755)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
     monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])


### PR DESCRIPTION
## What does this PR do?

Fixes the Linux desktop-entry `Exec` line being rewritten with a bare (non-venv) Python interpreter, which made launching Hermes Desktop from the launcher icon crash **silently** after every upgrade on uv-created venvs.

**Root cause:** `resolve_exec_command()` in `hermes_cli/linux_desktop_entry.py` called `Path(sys.executable).resolve()`. `uv venv` (and pip) make `bin/python` a symlink into a shared base-interpreter tree, and `.resolve()` follows that link — so the generated `Exec` prefixed the *bare* base interpreter (e.g. `~/.local/share/uv/python/.../bin/python3.11`). That interpreter never activates the venv (CPython discovers `pyvenv.cfg` from the *unresolved* argv[0]), so it crashes on the first third-party import (`ModuleNotFoundError: yaml`), with nothing on screen because `Terminal=false`.

Every `hermes desktop` run re-installs the desktop entry (`main.py` → `_register_linux_desktop_entry()`), and `hermes update` rebuilds it through `python -m hermes_cli.main desktop --build-only`. So after each upgrade the icon entry was broken again, while `hermes desktop` from a shell kept working — confusing: "works in terminal, flashes and dies from the icon".

**Fix:**
- Add `_resolve_exec_path()`: when the executable sits inside a venv (a `pyvenv.cfg` exists above it), keep the *unresolved* venv path; resolve only otherwise. Use it for both `sys.executable` and the resolved hermes binary, so the `Exec` prefix stays on the venv interpreter that actually loads site-packages.
- Add `_is_python_interpreter()`: when the resolved bin is the interpreter itself (the updater drives `python -m hermes_cli.main desktop --build-only`, so `argv[0]` is the interpreter), emit `<venv-python> -m hermes_cli.main desktop` instead of `<venv-python> desktop` (which would treat `desktop` as a script path).

## Related Issue

Fixes #94058

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/linux_desktop_entry.py`:
  - add `_resolve_exec_path()` — venv-symlink-preserving path resolution
  - add `_is_python_interpreter()` — detect interpreter-drive form
  - use both in `resolve_exec_command()` and `_needs_interpreter()`
- `tests/hermes_cli/test_linux_desktop_entry.py`:
  - update two assertions to use the venv-preserving executable
  - add `test_exec_keeps_venv_symlink_in_interpreter_prefix` (uv-style symlink regression)
  - add `test_exec_uses_module_form_when_bin_is_python_interpreter` (updater drive form)
  - follow-up: tighten `_is_python_interpreter()` to real interpreter names; tests assert concrete venv paths instead of mirroring the implementation

## How to Test

1. Reproduce on any uv-created venv (`uv venv`): run `hermes desktop` once, then inspect `~/.local/share/applications/hermes.desktop` — before the fix, `Exec` starts with the resolved base interpreter (`~/.local/share/uv/python/.../bin/python3.11`); after, it starts with the venv python (`.../venv/bin/python`).
2. Launch from the launcher icon → app starts (before: instant silent crash).
3. `hermes update` → entry survives with the venv path intact.
4. `pytest tests/hermes_cli/test_linux_desktop_entry.py -q` → 17 passed, 2 skipped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora Linux x86_64, uv venv (python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
