### PR TITLE
feat: add canonical cross-surface session routing

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5429,6 +5429,25 @@ def run_job(
         return True, "", SILENT_MARKER, None
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
 
+    # Resolve the profile-local classification route before constructing the
+    # agent. This binds by exact job_id and never mutates _job_workdir,
+    # _SESSION_CWD, or TERMINAL_CWD (those remain execution concerns below).
+    _cron_project_binding = None
+    from gateway.project_routes import bind_inbound_session, sync_route_table
+    from hermes_cli import projects_db as _projects_db
+
+    _projects_conn = _projects_db.connect(_get_hermes_home() / "projects.db")
+    try:
+        sync_route_table(_projects_conn, _get_hermes_home())
+        _cron_project_binding = bind_inbound_session(
+            _projects_conn,
+            session_id=_cron_session_id,
+            origin_kind="cron",
+            origin_key=str(job_id),
+        )
+    finally:
+        _projects_conn.close()
+
     logger.info("Running job '%s' (ID: %s)", job_name, job_id)
     logger.info("Prompt: %s", prompt[:100])
 
@@ -6096,7 +6115,25 @@ def run_job(
             session_id=_cron_session_id,
             session_db=_session_db,
         )
-        
+
+        # AIAgent has now created/reopened the state.db row. Stamp only the
+        # Desktop classification cwd; the cron execution cwd remains the job's
+        # independently resolved _job_workdir.
+        if _cron_project_binding and _cron_project_binding.cwd:
+            if _session_db is None:
+                raise RuntimeError(
+                    f"Cron route for {job_id} requires a session store for classification"
+                )
+            generation = _session_db.update_session_cwd(
+                _cron_session_id, _cron_project_binding.cwd
+            )
+            if generation is None:
+                from gateway.project_routes import InvalidProjectRouteError
+
+                raise InvalidProjectRouteError(
+                    f"cannot persist project route cwd for missing cron session {_cron_session_id}"
+                )
+
         # Run the agent with an *inactivity*-based timeout: the job can run
         # for hours if it's actively calling tools / receiving stream tokens,
         # but a hung API call or stuck tool with no activity for the configured

--- a/gateway/project_routes.py
+++ b/gateway/project_routes.py
@@ -1,0 +1,635 @@
+"""Canonical, profile-scoped routing for cross-surface sessions.
+
+Routes and exact session bindings live beside Projects in ``projects.db``.  The
+module never derives a session identity from a project: Telegram, cron and
+webhook runs remain distinct rows and merely share project metadata.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+from hermes_cli import projects_db
+from hermes_cli.sqlite_util import write_txn
+
+_SUPPORTED_ORIGINS = frozenset({"telegram", "cron", "webhook"})
+logger = logging.getLogger(__name__)
+
+
+class InvalidProjectRouteError(RuntimeError):
+    """A matching configured route is invalid and must fail closed."""
+
+
+@dataclass(frozen=True)
+class ProjectRoute:
+    origin_kind: str
+    origin_key: str
+    project_id: str
+    cwd: str
+    telegram_chat_id: Optional[str] = None
+    telegram_thread_id: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class SessionRouteBinding:
+    session_id: str
+    origin_kind: str
+    origin_key: str
+    project_id: Optional[str]
+    cwd: Optional[str]
+    telegram_chat_id: Optional[str]
+    telegram_thread_id: Optional[str]
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS project_session_routes (
+    origin_kind TEXT NOT NULL,
+    origin_key TEXT NOT NULL,
+    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    cwd TEXT NOT NULL,
+    telegram_chat_id TEXT,
+    telegram_thread_id TEXT,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (origin_kind, origin_key)
+);
+CREATE TABLE IF NOT EXISTS project_session_bindings (
+    session_id TEXT PRIMARY KEY,
+    origin_kind TEXT NOT NULL,
+    origin_key TEXT NOT NULL,
+    project_id TEXT,
+    cwd TEXT,
+    telegram_chat_id TEXT,
+    telegram_thread_id TEXT,
+    updated_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_project_session_bindings_origin
+    ON project_session_bindings(origin_kind, origin_key);
+CREATE TABLE IF NOT EXISTS project_session_mirror_deliveries (
+    session_id TEXT NOT NULL,
+    message_key TEXT NOT NULL,
+    state TEXT NOT NULL CHECK(state IN ('pending', 'sent')),
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (session_id, message_key)
+);
+"""
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(_SCHEMA)
+
+
+def _clean_origin(origin_kind: str, origin_key: str) -> tuple[str, str]:
+    kind = str(origin_kind or "").strip().lower()
+    key = str(origin_key or "").strip()
+    if kind not in _SUPPORTED_ORIGINS:
+        raise ValueError(f"unsupported route origin: {origin_kind!r}")
+    if not key:
+        raise ValueError("route origin key must not be empty")
+    return kind, key
+
+
+def telegram_origin_key(chat_id: object, thread_id: object = None) -> str:
+    chat = str(chat_id or "").strip()
+    thread = str(thread_id or "").strip()
+    if not chat:
+        raise ValueError("Telegram chat_id must not be empty")
+    return f"{chat}:{thread}"
+
+
+def _normalize_existing_dir(value: object) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        raise InvalidProjectRouteError("project route has no working directory")
+    path = Path(raw).expanduser()
+    if not path.is_dir():
+        raise InvalidProjectRouteError(
+            f"project route working directory does not exist: {raw}"
+        )
+    return str(path.resolve())
+
+
+def _validated_project_cwd(
+    conn: sqlite3.Connection, project_id: str, cwd: object = None
+) -> str:
+    project = projects_db.get_project(conn, str(project_id or ""))
+    if project is None or project.archived:
+        raise InvalidProjectRouteError(
+            f"project does not exist or is archived: {project_id}"
+        )
+    candidate = cwd or project.primary_path or (
+        project.folders[0].path if project.folders else None
+    )
+    resolved = _normalize_existing_dir(candidate)
+    owner = projects_db.project_for_path(conn, resolved)
+    if owner is None or owner.id != project.id:
+        raise InvalidProjectRouteError(
+            f"working directory does not belong to project {project.id}: {resolved}"
+        )
+    return resolved
+
+
+def set_project_route(
+    conn: sqlite3.Connection,
+    *,
+    origin_kind: str,
+    origin_key: str,
+    project_id: str,
+    cwd: object = None,
+    telegram_chat_id: object = None,
+    telegram_thread_id: object = None,
+) -> ProjectRoute:
+    """Validate and upsert one exact event route."""
+    _ensure_schema(conn)
+    kind, key = _clean_origin(origin_kind, origin_key)
+    resolved = _validated_project_cwd(conn, project_id, cwd)
+    chat = str(telegram_chat_id).strip() if telegram_chat_id not in (None, "") else None
+    thread = (
+        str(telegram_thread_id).strip()
+        if telegram_thread_id not in (None, "")
+        else None
+    )
+    now = int(time.time())
+    with write_txn(conn):
+        conn.execute(
+            """INSERT INTO project_session_routes
+               (origin_kind, origin_key, project_id, cwd, telegram_chat_id,
+                telegram_thread_id, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(origin_kind, origin_key) DO UPDATE SET
+                 project_id=excluded.project_id, cwd=excluded.cwd,
+                 telegram_chat_id=excluded.telegram_chat_id,
+                 telegram_thread_id=excluded.telegram_thread_id,
+                 updated_at=excluded.updated_at""",
+            (kind, key, project_id, resolved, chat, thread, now),
+        )
+    return ProjectRoute(kind, key, project_id, resolved, chat, thread)
+
+
+def _telegram_delivery_fields(
+    kind: str, key: str, value: dict
+) -> tuple[Optional[str], Optional[str]]:
+    chat = value.get("telegram_chat_id")
+    thread = value.get("telegram_thread_id")
+    if kind == "telegram":
+        parts = key.split(":", 1)
+        if len(parts) != 2 or not parts[0].strip():
+            raise InvalidProjectRouteError(
+                f"invalid Telegram route key (expected chat_id:thread_id): {key!r}"
+            )
+        chat = chat or parts[0]
+        thread = thread if thread not in (None, "") else (parts[1] or None)
+    deliver = str(value.get("deliver") or "").strip()
+    if deliver.lower().startswith("telegram:"):
+        parts = deliver.split(":", 2)
+        if len(parts) < 2 or not parts[1]:
+            raise InvalidProjectRouteError(f"invalid Telegram delivery target: {deliver!r}")
+        chat = parts[1]
+        thread = parts[2] if len(parts) == 3 and parts[2] else None
+    extra = value.get("deliver_extra")
+    if extra is not None:
+        if not isinstance(extra, dict):
+            raise InvalidProjectRouteError("deliver_extra must be an object")
+        chat = extra.get("chat_id", chat)
+        thread = extra.get("thread_id", thread)
+    clean_chat = str(chat).strip() if chat not in (None, "") else None
+    clean_thread = str(thread).strip() if thread not in (None, "") else None
+    return clean_chat, clean_thread
+
+
+def sync_route_table(conn: sqlite3.Connection, profile_home: Path) -> int:
+    """Atomically synchronize a profile-local v2 JSON route table."""
+    path = Path(profile_home) / "session_project_routes.json"
+    if not path.is_file():
+        return 0
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise InvalidProjectRouteError(f"cannot read v2 project route table: {exc}") from exc
+    if not isinstance(payload, dict) or payload.get("version") != 2:
+        raise InvalidProjectRouteError("session_project_routes.json must use version 2")
+
+    validated: list[ProjectRoute] = []
+    seen: set[tuple[str, str]] = set()
+    raw_routes: list[tuple[str, object, dict]] = []
+    if "routes" in payload:
+        routes = payload.get("routes")
+        if not isinstance(routes, list):
+            raise InvalidProjectRouteError("v2 routes must be a list")
+        for value in routes:
+            if not isinstance(value, dict):
+                raise InvalidProjectRouteError("each v2 route must be an object")
+            origin = value.get("origin")
+            if not isinstance(origin, dict):
+                raise InvalidProjectRouteError("each v2 route must have an origin object")
+            kind = str(origin.get("source") or "").strip().lower()
+            if kind == "telegram":
+                key = telegram_origin_key(origin.get("chat_id"), origin.get("thread_id"))
+            elif kind == "cron":
+                key = origin.get("job_id")
+            elif kind == "webhook":
+                key = origin.get("subscription")
+            else:
+                raise InvalidProjectRouteError(f"unsupported route origin: {kind!r}")
+            raw_routes.append((kind, key, value))
+    else:
+        # Transitional map shape accepted for early v2 generators.
+        for kind in ("telegram", "cron", "webhook"):
+            entries = payload.get(kind, {})
+            if entries is None:
+                entries = {}
+            if not isinstance(entries, dict):
+                raise InvalidProjectRouteError(f"{kind} routes must be an object")
+            raw_routes.extend((kind, key, value) for key, value in entries.items())
+
+    for kind, raw_key, value in raw_routes:
+        if not isinstance(value, dict):
+            raise InvalidProjectRouteError(f"{kind} route {raw_key!r} must be an object")
+        clean_kind, key = _clean_origin(kind, str(raw_key or ""))
+        identity = (clean_kind, key)
+        if identity in seen:
+            raise InvalidProjectRouteError(f"duplicate project route: {kind}:{key}")
+        seen.add(identity)
+        project_id = str(value.get("project_id") or "").strip()
+        if not project_id:
+            raise InvalidProjectRouteError(f"{kind} route {key!r} has no project_id")
+        cwd = _validated_project_cwd(conn, project_id, value.get("cwd"))
+        chat, thread = _telegram_delivery_fields(kind, key, value)
+        validated.append(ProjectRoute(kind, key, project_id, cwd, chat, thread))
+
+    _ensure_schema(conn)
+    now = int(time.time())
+    with write_txn(conn):
+        conn.execute("DELETE FROM project_session_routes")
+        conn.executemany(
+            """INSERT INTO project_session_routes
+               (origin_kind, origin_key, project_id, cwd, telegram_chat_id,
+                telegram_thread_id, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            [
+                (
+                    route.origin_kind,
+                    route.origin_key,
+                    route.project_id,
+                    route.cwd,
+                    route.telegram_chat_id,
+                    route.telegram_thread_id,
+                    now,
+                )
+                for route in validated
+            ],
+        )
+    return len(validated)
+
+
+def resolve_event_route(
+    conn: sqlite3.Connection, origin_kind: str, origin_key: str
+) -> Optional[ProjectRoute]:
+    """Resolve one exact route; absence is normal, a matching invalid row is not."""
+    _ensure_schema(conn)
+    kind, key = _clean_origin(origin_kind, origin_key)
+    row = conn.execute(
+        "SELECT * FROM project_session_routes WHERE origin_kind=? AND origin_key=?",
+        (kind, key),
+    ).fetchone()
+    if row is None:
+        return None
+    project_id = str(row["project_id"])
+    cwd = _validated_project_cwd(conn, project_id, row["cwd"])
+    return ProjectRoute(
+        kind,
+        key,
+        project_id,
+        cwd,
+        row["telegram_chat_id"],
+        row["telegram_thread_id"],
+    )
+
+
+def bind_inbound_session(
+    conn: sqlite3.Connection,
+    *,
+    session_id: str,
+    origin_kind: str,
+    origin_key: str,
+    telegram_chat_id: object = None,
+    telegram_thread_id: object = None,
+) -> SessionRouteBinding:
+    """Bind an exact session to its route without coalescing by project."""
+    _ensure_schema(conn)
+    sid = str(session_id or "").strip()
+    if not sid:
+        raise ValueError("session_id must not be empty")
+    kind, key = _clean_origin(origin_kind, origin_key)
+    route = resolve_event_route(conn, kind, key)
+
+    # Telegram-origin sessions always mirror back to the exact inbound peer.
+    if kind == "telegram":
+        chat = str(telegram_chat_id or "").strip()
+        if not chat:
+            raise InvalidProjectRouteError(
+                "Telegram session cannot be bound without an exact chat_id"
+            )
+        thread = str(telegram_thread_id or "").strip() or None
+    else:
+        chat = route.telegram_chat_id if route else None
+        thread = route.telegram_thread_id if route else None
+
+    binding = SessionRouteBinding(
+        session_id=sid,
+        origin_kind=kind,
+        origin_key=key,
+        project_id=route.project_id if route else None,
+        cwd=route.cwd if route else None,
+        telegram_chat_id=chat,
+        telegram_thread_id=thread,
+    )
+    with write_txn(conn):
+        conn.execute(
+            """INSERT INTO project_session_bindings
+               (session_id, origin_kind, origin_key, project_id, cwd,
+                telegram_chat_id, telegram_thread_id, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(session_id) DO UPDATE SET
+                 origin_kind=excluded.origin_kind, origin_key=excluded.origin_key,
+                 project_id=excluded.project_id, cwd=excluded.cwd,
+                 telegram_chat_id=excluded.telegram_chat_id,
+                 telegram_thread_id=excluded.telegram_thread_id,
+                 updated_at=excluded.updated_at""",
+            (
+                binding.session_id,
+                binding.origin_kind,
+                binding.origin_key,
+                binding.project_id,
+                binding.cwd,
+                binding.telegram_chat_id,
+                binding.telegram_thread_id,
+                int(time.time()),
+            ),
+        )
+    return binding
+
+
+def bind_gateway_session(
+    conn: sqlite3.Connection, session_id: str, source: object
+) -> Optional[SessionRouteBinding]:
+    """Resolve and bind one gateway source using its canonical event identity."""
+    platform = getattr(getattr(source, "platform", None), "value", None)
+    platform = str(platform or getattr(source, "platform", "") or "").lower()
+    if platform == "telegram":
+        chat_id = getattr(source, "chat_id", None)
+        thread_id = getattr(source, "thread_id", None)
+        return bind_inbound_session(
+            conn,
+            session_id=session_id,
+            origin_kind="telegram",
+            origin_key=telegram_origin_key(chat_id, thread_id),
+            telegram_chat_id=chat_id,
+            telegram_thread_id=thread_id,
+        )
+    if platform == "webhook":
+        route_name = str(getattr(source, "user_name", "") or "").strip()
+        if not route_name:
+            raise InvalidProjectRouteError(
+                "Webhook session cannot be routed without a subscription name"
+            )
+        return bind_inbound_session(
+            conn,
+            session_id=session_id,
+            origin_kind="webhook",
+            origin_key=route_name,
+        )
+    return None
+
+
+def apply_gateway_session_route(
+    conn: sqlite3.Connection, session_db: object, context: object
+) -> Optional[SessionRouteBinding]:
+    """Bind a gateway session and stamp its classification cwd before the turn."""
+    source = getattr(context, "source", None)
+    binding = bind_gateway_session(conn, getattr(context, "session_id", ""), source)
+    if binding is None:
+        return None
+    if binding.cwd:
+        setattr(context, "cwd", binding.cwd)
+        updater = getattr(session_db, "update_session_cwd", None)
+        if not callable(updater):
+            raise InvalidProjectRouteError(
+                f"cannot persist project route cwd for session {binding.session_id}: no durable updater"
+            )
+        generation = updater(binding.session_id, binding.cwd)
+        if generation is None:
+            raise InvalidProjectRouteError(
+                f"cannot persist project route cwd for missing session {binding.session_id}"
+            )
+    return binding
+
+
+def apply_cron_session_route(
+    conn: sqlite3.Connection,
+    session_db: object,
+    session_id: str,
+    job_id: str,
+) -> Optional[SessionRouteBinding]:
+    """Classify one cron session without changing the job execution cwd."""
+    binding = bind_inbound_session(
+        conn,
+        session_id=session_id,
+        origin_kind="cron",
+        origin_key=str(job_id),
+    )
+    if binding.cwd:
+        updater = getattr(session_db, "update_session_cwd", None)
+        if not callable(updater):
+            raise InvalidProjectRouteError(
+                f"cannot persist project route cwd for session {binding.session_id}: no durable updater"
+            )
+        generation = updater(binding.session_id, binding.cwd)
+        if generation is None:
+            raise InvalidProjectRouteError(
+                f"cannot persist project route cwd for missing session {binding.session_id}"
+            )
+    return binding
+
+
+def get_session_binding(
+    conn: sqlite3.Connection, session_id: str
+) -> Optional[SessionRouteBinding]:
+    _ensure_schema(conn)
+    row = conn.execute(
+        "SELECT * FROM project_session_bindings WHERE session_id=?",
+        (str(session_id),),
+    ).fetchone()
+    if row is None:
+        return None
+    return SessionRouteBinding(
+        session_id=row["session_id"],
+        origin_kind=row["origin_kind"],
+        origin_key=row["origin_key"],
+        project_id=row["project_id"],
+        cwd=row["cwd"],
+        telegram_chat_id=row["telegram_chat_id"],
+        telegram_thread_id=row["telegram_thread_id"],
+    )
+
+
+def copy_session_binding(
+    conn: sqlite3.Connection, source_session_id: str, target_session_id: str
+) -> Optional[SessionRouteBinding]:
+    source = get_session_binding(conn, source_session_id)
+    if source is None:
+        return None
+    _ensure_schema(conn)
+    with write_txn(conn):
+        conn.execute(
+            """INSERT INTO project_session_bindings
+               (session_id, origin_kind, origin_key, project_id, cwd,
+                telegram_chat_id, telegram_thread_id, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(session_id) DO NOTHING""",
+            (
+                str(target_session_id),
+                source.origin_kind,
+                source.origin_key,
+                source.project_id,
+                source.cwd,
+                source.telegram_chat_id,
+                source.telegram_thread_id,
+                int(time.time()),
+            ),
+        )
+    return get_session_binding(conn, target_session_id)
+
+
+def claim_mirror_delivery(
+    conn: sqlite3.Connection, session_id: str, message_key: str
+) -> bool:
+    """Atomically claim one stable session/message identity."""
+    _ensure_schema(conn)
+    now = int(time.time())
+    with write_txn(conn):
+        cur = conn.execute(
+            """INSERT OR IGNORE INTO project_session_mirror_deliveries
+               (session_id, message_key, state, updated_at)
+               VALUES (?, ?, 'pending', ?)""",
+            (str(session_id), str(message_key), now),
+        )
+    return cur.rowcount == 1
+
+
+def complete_mirror_delivery(
+    conn: sqlite3.Connection, session_id: str, message_key: str
+) -> None:
+    _ensure_schema(conn)
+    with write_txn(conn):
+        conn.execute(
+            """UPDATE project_session_mirror_deliveries
+               SET state='sent', updated_at=?
+               WHERE session_id=? AND message_key=?""",
+            (int(time.time()), str(session_id), str(message_key)),
+        )
+
+
+def release_mirror_delivery(
+    conn: sqlite3.Connection, session_id: str, message_key: str
+) -> None:
+    """Release only a failed pending claim; sent receipts are immutable."""
+    _ensure_schema(conn)
+    with write_txn(conn):
+        conn.execute(
+            """DELETE FROM project_session_mirror_deliveries
+               WHERE session_id=? AND message_key=? AND state='pending'""",
+            (str(session_id), str(message_key)),
+        )
+
+
+def _send_exact_telegram(
+    profile_home: Path,
+    chat_id: str,
+    thread_id: Optional[str],
+    text: str,
+) -> None:
+    """Use Hermes' in-process standalone Telegram delivery implementation."""
+    from gateway.run import _profile_runtime_scope
+    from gateway.config import Platform, load_gateway_config
+    from model_tools import _run_async
+    from tools.send_message_tool import _send_to_platform
+
+    with _profile_runtime_scope(Path(profile_home)):
+        config = load_gateway_config()
+        pconfig = config.platforms.get(Platform.TELEGRAM)
+        if pconfig is None or not pconfig.enabled:
+            raise RuntimeError("Telegram is not configured for this profile")
+        result = _run_async(
+            _send_to_platform(
+                Platform.TELEGRAM,
+                pconfig,
+                str(chat_id),
+                str(text),
+                thread_id=str(thread_id) if thread_id else None,
+                media_files=[],
+                force_document=False,
+            )
+        )
+    if not isinstance(result, dict) or not result.get("success"):
+        error = result.get("error") if isinstance(result, dict) else result
+        raise RuntimeError(str(error or "Telegram delivery failed"))
+
+
+def mirror_desktop_turn(
+    profile_home: Path,
+    session_id: str,
+    *,
+    user_text: str,
+    assistant_text: str,
+    user_message_key: str,
+    assistant_message_key: str,
+    send: Optional[Callable[[str, Optional[str], str], None]] = None,
+) -> dict[str, bool]:
+    """Mirror a persisted Desktop turn for a Telegram-origin session only."""
+    result = {"user": False, "assistant": False}
+    conn = projects_db.connect(Path(profile_home) / "projects.db")
+    try:
+        binding = get_session_binding(conn, session_id)
+        if (
+            binding is None
+            or binding.origin_kind != "telegram"
+            or not binding.telegram_chat_id
+        ):
+            return result
+        sender = send or (
+            lambda chat_id, thread_id, text: _send_exact_telegram(
+                Path(profile_home), chat_id, thread_id, text
+            )
+        )
+        messages = (
+            ("user", user_message_key, str(user_text or "")),
+            ("assistant", assistant_message_key, str(assistant_text or "")),
+        )
+        for role, key, text in messages:
+            if not text.strip() or not str(key or "").strip():
+                continue
+            if not claim_mirror_delivery(conn, session_id, key):
+                continue
+            try:
+                sender(binding.telegram_chat_id, binding.telegram_thread_id, text)
+            except Exception as exc:
+                release_mirror_delivery(conn, session_id, key)
+                logger.warning(
+                    "Desktop Telegram mirror failed for session=%s role=%s: %s",
+                    session_id,
+                    role,
+                    exc,
+                )
+                if role == "user":
+                    break
+            else:
+                complete_mirror_delivery(conn, session_id, key)
+                result[role] = True
+        return result
+    finally:
+        conn.close()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19208,6 +19208,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Build session context
         context = build_session_context(source, self.config, session_entry)
         
+        # Resolve the canonical event route before any turn context is bound.
+        # A missing route is normal; a matching invalid route raises and the
+        # turn fails closed without falling back to an unrelated project.
+        self._apply_project_session_route(context)
+
         # Set session context variables for tools (task-local, concurrency-safe)
         _session_env_tokens = self._set_session_env(context)
         
@@ -24643,6 +24648,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     home.chat_id,
                     exc,
                 )
+
+    def _apply_project_session_route(self, context: SessionContext):
+        """Resolve one profile-local route and persist its Desktop cwd."""
+        from gateway.project_routes import apply_gateway_session_route
+        from hermes_cli import projects_db
+
+        profile_home = self._resolve_profile_home_for_source(context.source)
+        conn = projects_db.connect(profile_home / "projects.db")
+        try:
+            from gateway.project_routes import sync_route_table
+
+            sync_route_table(conn, profile_home)
+            store = getattr(self, "session_store", None)
+            session_db = getattr(store, "_db", None) if store is not None else None
+            if session_db is None:
+                session_db = getattr(self, "_session_db", None)
+            return apply_gateway_session_route(conn, session_db, context)
+        finally:
+            conn.close()
 
     def _set_session_env(self, context: SessionContext) -> list:
         """Set session context variables for the current async task.

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -331,6 +331,7 @@ class SessionContext:
     # Session metadata
     session_key: str = ""
     session_id: str = ""
+    cwd: Optional[str] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
     
@@ -344,6 +345,7 @@ class SessionContext:
             "shared_multi_user_session": self.shared_multi_user_session,
             "session_key": self.session_key,
             "session_id": self.session_id,
+            "cwd": self.cwd,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
+from hermes_cli import projects_db
 from cron.scheduler import (
     SILENT_MARKER,
     _build_job_prompt,
@@ -583,6 +584,42 @@ class TestRunJobSessionPersistence:
         assert call_args[0][1] == "cron_complete"
         fake_db.close.assert_called_once()
         mock_agent.close.assert_called_once()
+
+    def test_run_job_fails_closed_when_routed_session_cwd_is_not_persisted(
+        self, tmp_path
+    ):
+        cwd = tmp_path / "classification"
+        cwd.mkdir()
+        conn = projects_db.connect(tmp_path / "projects.db")
+        project_id = projects_db.create_project(
+            conn,
+            name="Cron routing",
+            slug="cron-routing",
+            primary_path=str(cwd),
+        )
+        conn.close()
+        (tmp_path / "session_project_routes.json").write_text(
+            json.dumps(
+                {
+                    "version": 2,
+                    "routes": [
+                        {
+                            "origin": {"source": "cron", "job_id": "test-job"},
+                            "project_id": project_id,
+                            "cwd": str(cwd),
+                        }
+                    ],
+                }
+            )
+        )
+        job = {"id": "test-job", "name": "test", "prompt": "hello"}
+
+        with self._run_job_patches(tmp_path) as (fake_db, _mock_agent_cls):
+            fake_db.update_session_cwd.return_value = None
+            success, _output, _final_response, error = run_job(job)
+
+        assert success is False
+        assert "cannot persist project route cwd" in str(error)
 
 
     @contextlib.contextmanager

--- a/tests/gateway/test_project_routes.py
+++ b/tests/gateway/test_project_routes.py
@@ -1,0 +1,620 @@
+import contextlib
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import projects_db
+from gateway import project_routes
+from gateway.config import Platform
+from gateway.project_routes import (
+    InvalidProjectRouteError,
+    apply_gateway_session_route,
+    apply_cron_session_route,
+    bind_gateway_session,
+    bind_inbound_session,
+    claim_mirror_delivery,
+    complete_mirror_delivery,
+    get_session_binding,
+    release_mirror_delivery,
+    resolve_event_route,
+    set_project_route,
+    sync_route_table,
+    mirror_desktop_turn,
+)
+from gateway.run import GatewayRunner
+
+
+def _project(conn, path: Path) -> str:
+    path.mkdir()
+    return projects_db.create_project(
+        conn,
+        name="Routing project",
+        slug="routing-project",
+        primary_path=str(path),
+    )
+
+
+def test_exact_routes_resolve_for_each_supported_origin(tmp_path):
+    conn = projects_db.connect(tmp_path / "projects.db")
+    cwd = tmp_path / "workspace"
+    project_id = _project(conn, cwd)
+    for kind, key in (
+        ("telegram", "-1001:44"),
+        ("cron", "job-123"),
+        ("webhook", "github-push"),
+    ):
+        set_project_route(
+            conn,
+            origin_kind=kind,
+            origin_key=key,
+            project_id=project_id,
+            cwd=str(cwd),
+            telegram_chat_id="-1001",
+            telegram_thread_id="44",
+        )
+
+    assert resolve_event_route(conn, "telegram", "-1001:44").project_id == project_id
+    assert resolve_event_route(conn, "cron", "job-123").cwd == str(cwd.resolve())
+    assert resolve_event_route(conn, "webhook", "github-push").telegram_thread_id == "44"
+    assert resolve_event_route(conn, "cron", "unknown") is None
+
+
+def test_route_write_rejects_missing_project_and_cwd_outside_project(tmp_path):
+    conn = projects_db.connect(tmp_path / "projects.db")
+    cwd = tmp_path / "workspace"
+    project_id = _project(conn, cwd)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    with pytest.raises(InvalidProjectRouteError, match="project does not exist"):
+        set_project_route(
+            conn, origin_kind="cron", origin_key="job", project_id="p_missing"
+        )
+    with pytest.raises(InvalidProjectRouteError, match="does not belong"):
+        set_project_route(
+            conn,
+            origin_kind="cron",
+            origin_key="job",
+            project_id=project_id,
+            cwd=str(outside),
+        )
+
+
+def test_matching_corrupt_route_fails_closed_but_absence_is_normal(tmp_path):
+    conn = projects_db.connect(tmp_path / "projects.db")
+    cwd = tmp_path / "workspace"
+    project_id = _project(conn, cwd)
+    set_project_route(
+        conn,
+        origin_kind="webhook",
+        origin_key="route-a",
+        project_id=project_id,
+        cwd=str(cwd),
+    )
+    cwd.rmdir()
+
+    with pytest.raises(InvalidProjectRouteError, match="working directory"):
+        resolve_event_route(conn, "webhook", "route-a")
+    assert resolve_event_route(conn, "webhook", "route-b") is None
+
+
+def test_telegram_session_always_gets_exact_mirror_destination_without_project_route(tmp_path):
+    conn = projects_db.connect(tmp_path / "projects.db")
+
+    binding = bind_inbound_session(
+        conn,
+        session_id="telegram-session",
+        origin_kind="telegram",
+        origin_key="-1001:44",
+        telegram_chat_id="-1001",
+        telegram_thread_id="44",
+    )
+
+    assert binding.project_id is None
+    assert get_session_binding(conn, "telegram-session").telegram_chat_id == "-1001"
+    assert get_session_binding(conn, "telegram-session").telegram_thread_id == "44"
+
+
+def test_telegram_new_session_keeps_route_but_never_reuses_session_identity(tmp_path):
+    conn = projects_db.connect(tmp_path / "projects.db")
+    cwd = tmp_path / "workspace"
+    project_id = _project(conn, cwd)
+    set_project_route(
+        conn,
+        origin_kind="telegram",
+        origin_key="-1001:44",
+        project_id=project_id,
+        cwd=str(cwd),
+    )
+
+    first = bind_inbound_session(
+        conn,
+        session_id="before-new",
+        origin_kind="telegram",
+        origin_key="-1001:44",
+        telegram_chat_id="-1001",
+        telegram_thread_id="44",
+    )
+    second = bind_inbound_session(
+        conn,
+        session_id="after-new",
+        origin_kind="telegram",
+        origin_key="-1001:44",
+        telegram_chat_id="-1001",
+        telegram_thread_id="44",
+    )
+
+    assert first.session_id != second.session_id
+    assert first.project_id == second.project_id == project_id
+    assert first.cwd == second.cwd == str(cwd.resolve())
+    assert first.telegram_thread_id == second.telegram_thread_id == "44"
+
+
+def test_cron_and_webhook_sessions_remain_distinct_even_in_same_project(tmp_path):
+    conn = projects_db.connect(tmp_path / "projects.db")
+    cwd = tmp_path / "workspace"
+    project_id = _project(conn, cwd)
+    for kind, key in (("cron", "nightly"), ("webhook", "push")):
+        set_project_route(
+            conn,
+            origin_kind=kind,
+            origin_key=key,
+            project_id=project_id,
+            cwd=str(cwd),
+            telegram_chat_id="-1001",
+            telegram_thread_id="44",
+        )
+        bind_inbound_session(
+            conn,
+            session_id=f"{kind}-session",
+            origin_kind=kind,
+            origin_key=key,
+        )
+
+    assert get_session_binding(conn, "cron-session").session_id == "cron-session"
+    assert get_session_binding(conn, "webhook-session").session_id == "webhook-session"
+    assert get_session_binding(conn, "cron-session").project_id == project_id
+    assert get_session_binding(conn, "webhook-session").project_id == project_id
+
+
+def test_mirror_delivery_claim_is_idempotent_and_failure_can_retry(tmp_path):
+    conn = projects_db.connect(tmp_path / "projects.db")
+
+    assert claim_mirror_delivery(conn, "s1", "desktop-user:m1") is True
+    assert claim_mirror_delivery(conn, "s1", "desktop-user:m1") is False
+    release_mirror_delivery(conn, "s1", "desktop-user:m1")
+    assert claim_mirror_delivery(conn, "s1", "desktop-user:m1") is True
+    complete_mirror_delivery(conn, "s1", "desktop-user:m1")
+    assert claim_mirror_delivery(conn, "s1", "desktop-user:m1") is False
+
+
+def test_gateway_source_binding_uses_exact_origin_identity(tmp_path):
+    conn = projects_db.connect(tmp_path / "projects.db")
+    cwd = tmp_path / "workspace"
+    project_id = _project(conn, cwd)
+    set_project_route(
+        conn,
+        origin_kind="telegram",
+        origin_key="-1001:44",
+        project_id=project_id,
+        cwd=str(cwd),
+    )
+    telegram = SimpleNamespace(
+        platform=SimpleNamespace(value="telegram"),
+        chat_id="-1001",
+        thread_id="44",
+        user_name="Thibaut",
+    )
+
+    binding = bind_gateway_session(conn, "s-telegram", telegram)
+
+    assert binding.project_id == project_id
+    assert binding.telegram_chat_id == "-1001"
+    assert binding.telegram_thread_id == "44"
+
+
+def test_gateway_webhook_binding_routes_by_subscription_not_delivery_chat(tmp_path):
+    conn = projects_db.connect(tmp_path / "projects.db")
+    cwd = tmp_path / "workspace"
+    project_id = _project(conn, cwd)
+    set_project_route(
+        conn,
+        origin_kind="webhook",
+        origin_key="github-push",
+        project_id=project_id,
+        cwd=str(cwd),
+    )
+    webhook = SimpleNamespace(
+        platform=SimpleNamespace(value="webhook"),
+        chat_id="webhook:github-push:delivery-1",
+        thread_id=None,
+        user_name="github-push",
+    )
+
+    assert bind_gateway_session(conn, "s-webhook", webhook).project_id == project_id
+
+
+def test_gateway_ignores_ordinary_desktop_source(tmp_path):
+    conn = projects_db.connect(tmp_path / "projects.db")
+    desktop = SimpleNamespace(
+        platform=SimpleNamespace(value="desktop"),
+        chat_id="local",
+        thread_id=None,
+        user_name="user",
+    )
+
+    assert bind_gateway_session(conn, "s-desktop", desktop) is None
+    assert get_session_binding(conn, "s-desktop") is None
+
+
+def test_gateway_uses_served_named_profile_when_source_profile_is_empty(
+    tmp_path, monkeypatch
+):
+    default_home = tmp_path / "default"
+    named_home = tmp_path / "profiles" / "named"
+    default_home.mkdir(parents=True)
+    named_home.mkdir(parents=True)
+
+    def configure(home, folder_name):
+        conn = projects_db.connect(home / "projects.db")
+        cwd = home / folder_name
+        project_id = _project(conn, cwd)
+        conn.close()
+        (home / "session_project_routes.json").write_text(
+            json.dumps(
+                {
+                    "version": 2,
+                    "routes": [
+                        {
+                            "origin": {
+                                "source": "telegram",
+                                "chat_id": "-1001",
+                                "thread_id": "44",
+                            },
+                            "project_id": project_id,
+                            "cwd": str(cwd),
+                        }
+                    ],
+                }
+            )
+        )
+        return cwd
+
+    default_cwd = configure(default_home, "wrong-default")
+    named_cwd = configure(named_home, "right-named")
+
+    class SessionDB:
+        def __init__(self):
+            self.updated = []
+
+        def update_session_cwd(self, session_id, cwd):
+            self.updated.append((session_id, cwd))
+            return 1
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    db = SessionDB()
+    runner.session_store = SimpleNamespace(_db=db)
+    monkeypatch.setattr(
+        runner, "_resolve_profile_home_for_source", lambda _source: named_home
+    )
+    source = SimpleNamespace(
+        platform=SimpleNamespace(value="telegram"),
+        chat_id="-1001",
+        thread_id="44",
+        profile=None,
+    )
+    context = SimpleNamespace(session_id="s-named", cwd=None, source=source)
+
+    binding = runner._apply_project_session_route(context)
+
+    assert binding.cwd == str(named_cwd.resolve())
+    assert binding.cwd != str(default_cwd.resolve())
+    assert context.cwd == str(named_cwd.resolve())
+
+
+def test_gateway_route_is_applied_before_turn_and_persisted_on_session(tmp_path):
+    conn = projects_db.connect(tmp_path / "projects.db")
+    cwd = tmp_path / "workspace"
+    project_id = _project(conn, cwd)
+    set_project_route(
+        conn,
+        origin_kind="telegram",
+        origin_key="-1001:",
+        project_id=project_id,
+        cwd=str(cwd),
+    )
+    context = SimpleNamespace(
+        session_id="s-telegram",
+        cwd=None,
+        source=SimpleNamespace(
+            platform=SimpleNamespace(value="telegram"),
+            chat_id="-1001",
+            thread_id=None,
+            user_name="Thibaut",
+        ),
+    )
+
+    class FakeSessionDB:
+        def __init__(self):
+            self.updated = []
+
+        def update_session_cwd(self, session_id, route_cwd):
+            self.updated.append((session_id, route_cwd))
+            return 1
+
+    session_db = FakeSessionDB()
+    binding = apply_gateway_session_route(conn, session_db, context)
+
+    assert binding.project_id == project_id
+    assert context.cwd == str(cwd.resolve())
+    assert session_db.updated == [("s-telegram", str(cwd.resolve()))]
+
+
+def test_v2_route_table_syncs_all_origins_idempotently(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    conn = projects_db.connect(tmp_path / "projects.db")
+    cwd = tmp_path / "workspace"
+    project_id = _project(conn, cwd)
+    table = {
+        "version": 2,
+        "routes": [
+            {
+                "origin": {"source": "telegram", "chat_id": "-1001", "thread_id": "44"},
+                "project_id": project_id,
+                "cwd": str(cwd),
+                "deliver": "telegram:-1001:44",
+            },
+            {
+                "origin": {"source": "cron", "job_id": "job-1"},
+                "project_id": project_id,
+                "cwd": str(cwd),
+                "deliver": "telegram:-1001:44",
+            },
+            {
+                "origin": {"source": "webhook", "subscription": "github-push"},
+                "project_id": project_id,
+                "cwd": str(cwd),
+                "deliver_extra": {"chat_id": "-1001", "thread_id": "44"},
+            },
+        ],
+    }
+    (tmp_path / "session_project_routes.json").write_text(json.dumps(table))
+
+    assert sync_route_table(conn, tmp_path) == 3
+    assert sync_route_table(conn, tmp_path) == 3
+    assert resolve_event_route(conn, "telegram", "-1001:44").project_id == project_id
+    assert resolve_event_route(conn, "cron", "job-1").telegram_thread_id == "44"
+    assert resolve_event_route(conn, "webhook", "github-push").telegram_chat_id == "-1001"
+
+
+def test_v2_route_table_fails_closed_without_partial_sync(tmp_path):
+    conn = projects_db.connect(tmp_path / "projects.db")
+    cwd = tmp_path / "workspace"
+    project_id = _project(conn, cwd)
+    set_project_route(
+        conn,
+        origin_kind="cron",
+        origin_key="existing",
+        project_id=project_id,
+        cwd=str(cwd),
+    )
+    table = {
+        "version": 2,
+        "routes": [
+            {
+                "origin": {"source": "cron", "job_id": "valid"},
+                "project_id": project_id,
+                "cwd": str(cwd),
+            },
+            {
+                "origin": {"source": "cron", "job_id": "invalid"},
+                "project_id": "missing",
+                "cwd": str(cwd),
+            },
+        ],
+    }
+    (tmp_path / "session_project_routes.json").write_text(json.dumps(table))
+
+    with pytest.raises(InvalidProjectRouteError, match="project does not exist"):
+        sync_route_table(conn, tmp_path)
+    assert resolve_event_route(conn, "cron", "existing") is not None
+    assert resolve_event_route(conn, "cron", "valid") is None
+
+
+def test_cron_route_only_updates_session_classification_cwd(tmp_path, monkeypatch):
+    conn = projects_db.connect(tmp_path / "projects.db")
+    cwd = tmp_path / "classification"
+    project_id = _project(conn, cwd)
+    set_project_route(
+        conn,
+        origin_kind="cron",
+        origin_key="job-1",
+        project_id=project_id,
+        cwd=str(cwd),
+    )
+    monkeypatch.setenv("TERMINAL_CWD", "/job/runtime")
+
+    class FakeSessionDB:
+        def __init__(self):
+            self.updated = []
+
+        def update_session_cwd(self, session_id, route_cwd):
+            self.updated.append((session_id, route_cwd))
+            return 1
+
+    session_db = FakeSessionDB()
+    binding = apply_cron_session_route(conn, session_db, "cron-session", "job-1")
+
+    assert binding.cwd == str(cwd.resolve())
+    assert session_db.updated == [("cron-session", str(cwd.resolve()))]
+    assert os.environ["TERMINAL_CWD"] == "/job/runtime"
+
+
+def test_matching_cron_route_fails_closed_when_session_row_is_missing(tmp_path):
+    conn = projects_db.connect(tmp_path / "projects.db")
+    cwd = tmp_path / "classification"
+    project_id = _project(conn, cwd)
+    set_project_route(
+        conn,
+        origin_kind="cron",
+        origin_key="job-1",
+        project_id=project_id,
+        cwd=str(cwd),
+    )
+
+    class MissingSessionDB:
+        def update_session_cwd(self, _session_id, _route_cwd):
+            return None
+
+    with pytest.raises(InvalidProjectRouteError, match="missing session"):
+        apply_cron_session_route(
+            conn, MissingSessionDB(), "missing-cron-session", "job-1"
+        )
+
+
+def test_matching_routes_fail_closed_without_durable_updater(tmp_path):
+    conn = projects_db.connect(tmp_path / "projects.db")
+    cwd = tmp_path / "classification"
+    project_id = _project(conn, cwd)
+    for kind, key in (("telegram", "-1001:44"), ("cron", "job-1")):
+        set_project_route(
+            conn,
+            origin_kind=kind,
+            origin_key=key,
+            project_id=project_id,
+            cwd=str(cwd),
+        )
+    source = SimpleNamespace(
+        platform=SimpleNamespace(value="telegram"),
+        chat_id="-1001",
+        thread_id="44",
+    )
+    context = SimpleNamespace(session_id="telegram-session", cwd=None, source=source)
+    with pytest.raises(InvalidProjectRouteError, match="no durable updater"):
+        apply_gateway_session_route(conn, object(), context)
+    with pytest.raises(InvalidProjectRouteError, match="no durable updater"):
+        apply_cron_session_route(conn, object(), "cron-session", "job-1")
+
+
+def test_desktop_turn_mirrors_only_telegram_inherited_session_in_order(tmp_path):
+    conn = projects_db.connect(tmp_path / "projects.db")
+    bind_inbound_session(
+        conn,
+        session_id="telegram-session",
+        origin_kind="telegram",
+        origin_key="-1001:44",
+        telegram_chat_id="-1001",
+        telegram_thread_id="44",
+    )
+    conn.close()
+    sent = []
+
+    def send(chat_id, thread_id, text):
+        sent.append((chat_id, thread_id, text))
+
+    result = mirror_desktop_turn(
+        tmp_path,
+        "telegram-session",
+        user_text="Desktop question",
+        assistant_text="Final answer",
+        user_message_key="row:10",
+        assistant_message_key="row:11",
+        send=send,
+    )
+
+    assert result == {"user": True, "assistant": True}
+    assert sent == [
+        ("-1001", "44", "Desktop question"),
+        ("-1001", "44", "Final answer"),
+    ]
+    assert mirror_desktop_turn(
+        tmp_path,
+        "telegram-session",
+        user_text="Desktop question",
+        assistant_text="Final answer",
+        user_message_key="row:10",
+        assistant_message_key="row:11",
+        send=send,
+    ) == {"user": False, "assistant": False}
+    assert len(sent) == 2
+
+
+def test_exact_telegram_send_runs_inside_requested_profile_scope(tmp_path, monkeypatch):
+    entered = []
+
+    @contextlib.contextmanager
+    def fake_scope(profile_home):
+        entered.append(Path(profile_home))
+        yield
+
+    fake_platform = SimpleNamespace(enabled=True)
+    fake_config = SimpleNamespace(platforms={Platform.TELEGRAM: fake_platform})
+    sent = []
+    monkeypatch.setattr("gateway.run._profile_runtime_scope", fake_scope)
+    monkeypatch.setattr("gateway.config.load_gateway_config", lambda: fake_config)
+    monkeypatch.setattr(
+        "tools.send_message_tool._send_to_platform",
+        lambda *args, **kwargs: sent.append((args, kwargs)) or object(),
+    )
+    monkeypatch.setattr("model_tools._run_async", lambda _awaitable: {"success": True})
+
+    project_routes._send_exact_telegram(tmp_path, "-1001", "44", "hello")
+
+    assert entered == [tmp_path]
+    assert sent[0][0][1] is fake_platform
+
+
+def test_desktop_turn_does_not_mirror_ordinary_desktop_session(tmp_path):
+    projects_db.connect(tmp_path / "projects.db").close()
+    sent = []
+
+    assert mirror_desktop_turn(
+        tmp_path,
+        "desktop-session",
+        user_text="question",
+        assistant_text="answer",
+        user_message_key="row:1",
+        assistant_message_key="row:2",
+        send=lambda *args: sent.append(args),
+    ) == {"user": False, "assistant": False}
+    assert sent == []
+
+
+def test_desktop_mirror_network_failure_never_blocks_retry(tmp_path):
+    conn = projects_db.connect(tmp_path / "projects.db")
+    bind_inbound_session(
+        conn,
+        session_id="telegram-session",
+        origin_kind="telegram",
+        origin_key="-1001:",
+        telegram_chat_id="-1001",
+    )
+    conn.close()
+
+    def fail(*_args):
+        raise OSError("network down")
+
+    assert mirror_desktop_turn(
+        tmp_path,
+        "telegram-session",
+        user_text="question",
+        assistant_text="answer",
+        user_message_key="row:1",
+        assistant_message_key="row:2",
+        send=fail,
+    ) == {"user": False, "assistant": False}
+
+    sent = []
+    assert mirror_desktop_turn(
+        tmp_path,
+        "telegram-session",
+        user_text="question",
+        assistant_text="answer",
+        user_message_key="row:1",
+        assistant_message_key="row:2",
+        send=lambda chat, thread, text: sent.append((chat, thread, text)),
+    ) == {"user": True, "assistant": True}
+    assert [item[2] for item in sent] == ["question", "answer"]

--- a/tests/tui_gateway/test_project_route_mirror.py
+++ b/tests/tui_gateway/test_project_route_mirror.py
@@ -1,0 +1,188 @@
+import sqlite3
+from types import SimpleNamespace
+
+from gateway.project_routes import bind_inbound_session
+from hermes_cli import projects_db
+from tui_gateway import server
+
+
+def test_desktop_surface_mirrors_telegram_source_session(tmp_path, monkeypatch):
+    conn = projects_db.connect(tmp_path / "projects.db")
+    bind_inbound_session(
+        conn,
+        session_id="telegram-session",
+        origin_kind="telegram",
+        origin_key="-1001:44",
+        telegram_chat_id="-1001",
+        telegram_thread_id="44",
+    )
+    conn.close()
+    session = {
+        "source": "telegram",
+        "session_key": "telegram-session",
+        "agent": SimpleNamespace(session_id="telegram-session"),
+        "profile_home": str(tmp_path),
+    }
+    calls = []
+    monkeypatch.setattr(server, "_resolve_session_platform", lambda: "desktop")
+    monkeypatch.setattr(
+        server, "_persisted_turn_row_ids", lambda *args, **kwargs: (10, 11)
+    )
+    monkeypatch.setattr(
+        "gateway.project_routes.mirror_desktop_turn",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    server._mirror_desktop_turn_after_persist(
+        session,
+        prior_session_id="telegram-session",
+        user_text="question",
+        assistant_text="answer",
+        status="complete",
+        status_note=None,
+        display_kind=None,
+        turn_start_row_id=9,
+    )
+
+    assert len(calls) == 1
+    args, kwargs = calls[0]
+    assert args[1] == "telegram-session"
+    assert kwargs["user_message_key"] == "row:10"
+    assert kwargs["assistant_message_key"] == "row:11"
+
+
+def test_non_desktop_surface_never_mirrors(monkeypatch):
+    calls = []
+    monkeypatch.setattr(server, "_resolve_session_platform", lambda: "tui")
+    monkeypatch.setattr(
+        "gateway.project_routes.mirror_desktop_turn",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+    server._mirror_desktop_turn_after_persist(
+        {"source": "telegram", "session_key": "s", "agent": SimpleNamespace(session_id="s")},
+        prior_session_id="s",
+        user_text="question",
+        assistant_text="answer",
+        status="complete",
+        status_note=None,
+        display_kind=None,
+        turn_start_row_id=0,
+    )
+    assert calls == []
+
+
+def test_persisted_turn_rows_must_be_new_exact_and_ordered(tmp_path):
+    db = sqlite3.connect(tmp_path / "state.db")
+    db.execute(
+        "create table messages(id integer primary key, session_id text, role text, content text)"
+    )
+    db.executemany(
+        "insert into messages(id,session_id,role,content) values(?,?,?,?)",
+        [
+            (1, "s", "user", "question"),
+            (2, "s", "assistant", "answer"),
+            (10, "s", "user", "question"),
+            (11, "s", "assistant", "answer"),
+        ],
+    )
+    db.commit()
+    db.close()
+    assert server._persisted_turn_row_ids(
+        tmp_path,
+        prior_session_id="s",
+        current_session_id="s",
+        after_row_id=2,
+        user_text="question",
+        assistant_text="answer",
+    ) == (10, 11)
+    assert (
+        server._persisted_turn_row_ids(
+            tmp_path,
+            prior_session_id="s",
+            current_session_id="s",
+            after_row_id=11,
+            user_text="question",
+            assistant_text="answer",
+        )
+        is None
+    )
+
+
+def test_persisted_turn_rows_reject_interleaving_and_wrong_rotation_lineage(tmp_path):
+    db = sqlite3.connect(tmp_path / "state.db")
+    db.execute(
+        "create table messages(id integer primary key, session_id text, role text, content text)"
+    )
+    db.executemany(
+        "insert into messages(id,session_id,role,content) values(?,?,?,?)",
+        [
+            (20, "prior", "user", "question"),
+            (21, "prior", "user", "other"),
+            (22, "current", "assistant", "answer"),
+            (30, "current", "user", "question"),
+            (31, "prior", "assistant", "answer"),
+        ],
+    )
+    db.commit()
+    db.close()
+    assert (
+        server._persisted_turn_row_ids(
+            tmp_path,
+            prior_session_id="prior",
+            current_session_id="current",
+            after_row_id=19,
+            user_text="question",
+            assistant_text="answer",
+        )
+        is None
+    )
+
+
+def test_persisted_turn_rows_allow_tools_and_foreign_session_interleaving(tmp_path):
+    db = sqlite3.connect(tmp_path / "state.db")
+    db.execute(
+        "create table messages(id integer primary key, session_id text, role text, content text)"
+    )
+    db.executemany(
+        "insert into messages(id,session_id,role,content) values(?,?,?,?)",
+        [
+            (10, "s", "user", "question"),
+            (11, "s", "assistant", None),
+            (12, "foreign", "assistant", "unrelated"),
+            (13, "s", "tool", "tool output"),
+            (14, "s", "assistant", "answer"),
+        ],
+    )
+    db.commit()
+    db.close()
+    assert server._persisted_turn_row_ids(
+        tmp_path,
+        prior_session_id="s",
+        current_session_id="s",
+        after_row_id=9,
+        user_text="question",
+        assistant_text="answer",
+    ) == (10, 14)
+
+
+def test_desynchronized_turn_never_mirrors(monkeypatch):
+    calls = []
+    monkeypatch.setattr(server, "_resolve_session_platform", lambda: "desktop")
+    monkeypatch.setattr(
+        server, "_persisted_turn_row_ids", lambda *args, **kwargs: (10, 11)
+    )
+    monkeypatch.setattr(
+        "gateway.project_routes.mirror_desktop_turn",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+    server._mirror_desktop_turn_after_persist(
+        {"source": "telegram", "session_key": "s", "agent": SimpleNamespace(session_id="s")},
+        prior_session_id="s",
+        user_text="question",
+        assistant_text="answer",
+        status="complete",
+        status_note="not persisted",
+        display_kind=None,
+        turn_start_row_id=9,
+    )
+    assert calls == []

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import queue
+import sqlite3
 import subprocess
 import sys
 import threading
@@ -8540,6 +8541,149 @@ def _session_home(session: dict) -> Path:
     return Path(profile_home) if profile_home else Path(_hermes_home)
 
 
+def _max_persisted_message_row_id(profile_home: Path) -> int | None:
+    """Capture a global row barrier before one Desktop turn starts."""
+    try:
+        with sqlite3.connect(profile_home / "state.db", timeout=5) as conn:
+            row = conn.execute("SELECT COALESCE(MAX(id), 0) FROM messages").fetchone()
+        return int(row[0]) if row else 0
+    except (OSError, sqlite3.Error, TypeError, ValueError):
+        return None
+
+
+def _persisted_turn_row_ids(
+    profile_home: Path,
+    *,
+    prior_session_id: str,
+    current_session_id: str,
+    after_row_id: int,
+    user_text: str,
+    assistant_text: str,
+) -> tuple[int, int] | None:
+    """Prove one exact conversational pair from the current turn.
+
+    Consecutive means within user/assistant rows of the allowed session
+    lineage. Tool rows are expected inside a real agent turn, and writes from
+    other sessions may interleave globally; neither may supply or invalidate
+    this turn's durable identity.
+    """
+    clean_ids = tuple(
+        dict.fromkeys(sid for sid in (prior_session_id, current_session_id) if sid)
+    )
+    if not clean_ids:
+        return None
+    placeholders = ",".join("?" for _ in clean_ids)
+    try:
+        with sqlite3.connect(profile_home / "state.db", timeout=5) as conn:
+            rows = conn.execute(
+                f"""SELECT id, session_id, role, content FROM messages
+                    WHERE id > ? AND session_id IN ({placeholders})
+                      AND role IN ('user', 'assistant')
+                    ORDER BY id""",
+                (after_row_id, *clean_ids),
+            ).fetchall()
+    except (OSError, sqlite3.Error):
+        return None
+
+    if prior_session_id == current_session_id:
+        allowed_lineages = {(prior_session_id, current_session_id)}
+    else:
+        # A rotation may persist the prompt in the old session and the final
+        # answer in the continuation, or persist both rows in the continuation.
+        allowed_lineages = {
+            (prior_session_id, current_session_id),
+            (current_session_id, current_session_id),
+        }
+    pairs: list[tuple[int, int]] = []
+    for index, left in enumerate(rows):
+        user_id, user_session_id, user_role, user_content = left
+        if user_role != "user" or user_content != user_text:
+            continue
+        for right in rows[index + 1 :]:
+            assistant_id, assistant_session_id, assistant_role, assistant_content = right
+            if assistant_role == "user":
+                # A second user row starts another turn in this lineage.
+                break
+            if (
+                assistant_role == "assistant"
+                and assistant_content == assistant_text
+                and (user_session_id, assistant_session_id) in allowed_lineages
+            ):
+                pairs.append((int(user_id), int(assistant_id)))
+                break
+    return pairs[0] if len(pairs) == 1 else None
+
+
+def _mirror_desktop_turn_after_persist(
+    session: dict,
+    *,
+    prior_session_id: str,
+    user_text: Any,
+    assistant_text: Any,
+    status: str,
+    status_note: str | None,
+    display_kind: str | None,
+    turn_start_row_id: int | None,
+) -> None:
+    """Best-effort mirror of an exact persisted Desktop turn to Telegram."""
+    if (
+        _resolve_session_platform() != "desktop"
+        or display_kind is not None
+        or status != "complete"
+        or status_note is not None
+        or turn_start_row_id is None
+        or not isinstance(user_text, str)
+        or not isinstance(assistant_text, str)
+        or not user_text.strip()
+        or not assistant_text.strip()
+    ):
+        return
+    current_session_id = str(
+        getattr(session.get("agent"), "session_id", "")
+        or session.get("session_key")
+        or ""
+    )
+    if not current_session_id:
+        return
+    try:
+        from gateway.project_routes import (
+            copy_session_binding,
+            mirror_desktop_turn,
+            sync_route_table,
+        )
+        from hermes_cli import projects_db
+
+        profile_home = _session_home(session)
+        with projects_db.connect_closing(profile_home / "projects.db") as conn:
+            sync_route_table(conn, profile_home)
+            if prior_session_id and prior_session_id != current_session_id:
+                copy_session_binding(conn, prior_session_id, current_session_id)
+
+        row_ids = _persisted_turn_row_ids(
+            profile_home,
+            prior_session_id=prior_session_id,
+            current_session_id=current_session_id,
+            after_row_id=turn_start_row_id,
+            user_text=user_text,
+            assistant_text=assistant_text,
+        )
+        if row_ids is None:
+            return
+        user_row_id, assistant_row_id = row_ids
+        mirror_desktop_turn(
+            profile_home,
+            current_session_id,
+            user_text=user_text,
+            assistant_text=assistant_text,
+            user_message_key=f"row:{user_row_id}",
+            assistant_message_key=f"row:{assistant_row_id}",
+        )
+    except Exception:
+        # The local turn is already durable. Routing/config/network failures
+        # must never turn a successful Desktop response into a failed turn.
+        logger.warning("Desktop Telegram mirror failed", exc_info=True)
+
+
 def _retire_turn_marker(session: dict, *keys: str) -> None:
     """Drop the crash marker for a turn whose outcome is about to reach the client.
 
@@ -11429,6 +11573,7 @@ def _run_prompt_submit(
         # session.resume auto-continues from it. Compression can rotate
         # session_key mid-turn, so remember the key we wrote under.
         marker_home = _session_home(session)
+        turn_start_message_row_id = _max_persisted_message_row_id(marker_home)
         marker_key = str(session.get("session_key") or "")
         marker_attempt = int(session.pop("_auto_continue_attempt", 0) or 0)
         marker_text = session.pop("_auto_continue_prompt", None) or text
@@ -11941,6 +12086,16 @@ def _run_prompt_submit(
                     payload["error_surface"] = _error_surface
             _retire_turn_marker(session, marker_key)
             _emit("message.complete", sid, payload)
+            _mirror_desktop_turn_after_persist(
+                session,
+                prior_session_id=marker_key,
+                user_text=text,
+                assistant_text=raw,
+                status=status,
+                status_note=status_note,
+                display_kind=display_kind,
+                turn_start_row_id=turn_start_message_row_id,
+            )
 
             # ── /goal continuation (Ralph-style loop) ─────────────────
             # After every TUI turn, if a /goal is active, ask the judge


### PR DESCRIPTION
## Summary

Add a profile-safe canonical routing layer that maps Telegram topics, Cron jobs, and Webhook subscriptions to Desktop projects without merging their sessions.

Also add an opt-in-by-origin Desktop-to-Telegram mirror: when Desktop resumes an exact Telegram-origin session, the persisted user message and final assistant response are sent back to the same chat/thread.

## What changes

- Add a v2 `session_project_routes.json` loader with strict validation and atomic sync into `projects.db`.
- Resolve Telegram by `chat_id:thread_id`, Cron by `job_id`, and Webhook by subscription name.
- Persist only the Desktop classification `cwd`; Cron `workdir` and execution context remain unchanged.
- Fail closed when a matching route is invalid or its session `cwd` cannot be persisted.
- Keep sessions distinct across all origins, including successive Telegram `/new` sessions.
- Bind exact Telegram mirror destinations to sessions and copy the binding across compression rotation.
- Mirror only from the Desktop surface, only after proving the exact persisted user/final rows for the current turn.
- Skip mirroring for ordinary Desktop sessions, desynchronized or unpersisted turns, tool/reasoning rows, unknown destinations, and failed turns.
- Deduplicate delivery with durable per-session row keys; a Telegram failure never rolls back the local Desktop turn.
- Scope route databases, configuration, and Telegram credentials to the served Hermes profile.

## Safety properties

- No project fallback for an invalid matching route.
- No route means existing behavior.
- No cross-profile route or credential lookup.
- No session merging by project.
- No `TERMINAL_CWD` mutation for Cron classification.
- No mirror without a certain `chat_id` and `thread_id` binding.
- No tool, reasoning, or internal-log mirroring.

## Tests

Canonical runner:

```text
scripts/run_tests.sh \
  tests/gateway/test_project_routes.py \
  tests/tui_gateway/test_project_route_mirror.py \
  tests/cron/test_scheduler.py -q

131 passed, 0 failed
```

Expanded relevant suite:

```text
748 passed, 3 deselected
```

The three deselected tests are unrelated environment-sensitive plugin/tool tests that already fail under this machine's local plugin configuration.

Additional checks:

```text
ruff: passed
git diff --check: passed
real v2 table import into a copied projects.db: 71 routes synced
```

## Deployment

No local core patch was installed. This change is intended to ship through the standard upstream update path.
