### PR TITLE
fix(web): add pure-Python DuckDuckGo HTML search fallback for Android Termux (#85972)

### DIFF
--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -45,6 +45,88 @@ _POLL_INTERVAL_SECS = 0.1
 _TERMINATE_GRACE_SECS = 1.0
 
 
+def _is_termux_env() -> bool:
+    """Return True if running inside Android Termux or Android environment."""
+    prefix = os.environ.get("PREFIX", "")
+    return bool(
+        os.environ.get("TERMUX_VERSION")
+        or "com.termux/files/usr" in prefix
+        or prefix.startswith("/data/data/com.termux/")
+        or sys.platform == "android"
+        or os.path.exists("/data/data/com.termux")
+    )
+
+
+def _run_ddgs_html_search(query: str, safe_limit: int) -> list[dict[str, Any]]:
+    """Execute search via DuckDuckGo HTML endpoint without native/Rust dependencies.
+
+    Used on Android/Termux where the native ``primp``/``ndk-context`` library panics
+    with ``android context was not initialized`` (#85972), or as a fallback when
+    the ddgs package fails.
+    """
+    import html as html_lib
+    import re
+    import urllib.parse
+    import urllib.request
+
+    url = "https://html.duckduckgo.com/html/"
+    data = urllib.parse.urlencode({"q": query}).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "User-Agent": (
+                "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
+            ),
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        },
+    )
+
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        content = resp.read().decode("utf-8", errors="replace")
+
+    results: list[dict[str, Any]] = []
+    links = re.findall(
+        r'<a[^>]+class="[^"]*result__a[^"]*"[^>]+href="([^"]+)"[^>]*>(.*?)</a>',
+        content,
+        re.DOTALL,
+    )
+    snippets = re.findall(
+        r'<a[^>]+class="[^"]*result__snippet[^"]*"[^>]*>(.*?)</a>',
+        content,
+        re.DOTALL,
+    )
+
+    for i, (href, raw_title) in enumerate(links[:safe_limit]):
+        actual_url = href
+        if "uddg=" in href:
+            match = re.search(r"[?&]uddg=([^&]+)", href)
+            if match:
+                actual_url = urllib.parse.unquote(match.group(1))
+
+        title = re.sub(r"<[^>]+>", "", raw_title)
+        title = html_lib.unescape(title).strip()
+
+        snippet = ""
+        if i < len(snippets):
+            raw_snippet = snippets[i]
+            snippet = re.sub(r"<[^>]+>", "", raw_snippet)
+            snippet = html_lib.unescape(snippet).strip()
+
+        results.append(
+            {
+                "title": title,
+                "url": actual_url,
+                "description": snippet,
+                "position": i + 1,
+            }
+        )
+
+    return results
+
+
 class _SearchInterrupted(Exception):
     """Raised when tools.interrupt.is_interrupted() trips during a search wait."""
 
@@ -56,24 +138,34 @@ def _run_ddgs_search(query: str, safe_limit: int) -> list[dict[str, Any]]:
     tests can patch it for in-process unit tests. ``DDGS(timeout=…)`` bounds
     each individual HTTP request; the overall wall-clock cap is enforced by
     the parent via process timeout (#68096).
-    """
-    from ddgs import DDGS  # type: ignore
 
-    results: list[dict[str, Any]] = []
-    with DDGS(timeout=10) as client:
-        for i, hit in enumerate(client.text(query, max_results=safe_limit)):
-            if i >= safe_limit:
-                break
-            url = str(hit.get("href") or hit.get("url") or "")
-            results.append(
-                {
-                    "title": str(hit.get("title", "")),
-                    "url": url,
-                    "description": str(hit.get("body", "")),
-                    "position": i + 1,
-                }
-            )
-    return results
+    On Termux / Android (or if the native ddgs/primp package panics or fails),
+    falls back to direct HTTP HTML search without native dependencies (#85972).
+    """
+    if _is_termux_env():
+        return _run_ddgs_html_search(query, safe_limit)
+
+    try:
+        from ddgs import DDGS  # type: ignore
+
+        results: list[dict[str, Any]] = []
+        with DDGS(timeout=10) as client:
+            for i, hit in enumerate(client.text(query, max_results=safe_limit)):
+                if i >= safe_limit:
+                    break
+                url = str(hit.get("href") or hit.get("url") or "")
+                results.append(
+                    {
+                        "title": str(hit.get("title", "")),
+                        "url": url,
+                        "description": str(hit.get("body", "")),
+                        "position": i + 1,
+                    }
+                )
+        return results
+    except Exception as exc:
+        logger.debug("DDGS package search failed (%s); falling back to HTML search", exc)
+        return _run_ddgs_html_search(query, safe_limit)
 
 
 # Optional test-only hook name forwarded to the child (see _search_worker.py).
@@ -281,12 +373,14 @@ class DDGSWebSearchProvider(WebSearchProvider):
         return "DuckDuckGo (ddgs)"
 
     def is_available(self) -> bool:
-        """Return True when the ``ddgs`` package is importable.
+        """Return True when the ``ddgs`` package is importable or on Termux.
 
-        Probes the import once; cheap because Python caches the import. Must
-        NOT perform network I/O — runs at tool-registration time and on every
-        ``hermes tools`` paint.
+        On Termux / Android, search uses the pure-Python HTTP scraper which has
+        no package prerequisites (#85972). On other platforms, probes package
+        importability.
         """
+        if _is_termux_env():
+            return True
         try:
             import ddgs  # noqa: F401
 
@@ -307,13 +401,14 @@ class DDGSWebSearchProvider(WebSearchProvider):
         a hard wall-clock timeout (``_SEARCH_TIMEOUT_SECS``) so a hung native
         ``primp`` call cannot freeze the Hermes process (#36776, #68096).
         """
-        try:
-            import ddgs  # type: ignore  # noqa: F401 — availability probe
-        except ImportError:
-            return {
-                "success": False,
-                "error": "ddgs package is not installed — run `pip install ddgs`",
-            }
+        if not _is_termux_env():
+            try:
+                import ddgs  # type: ignore  # noqa: F401 — availability probe
+            except ImportError:
+                return {
+                    "success": False,
+                    "error": "ddgs package is not installed — run `pip install ddgs`",
+                }
 
         # DDGS().text yields at most `max_results` items; we cap defensively
         # in case the package ignores the hint.

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -291,3 +291,83 @@ class TestDDGSSearchOnlyErrors:
         assert result["success"] is False
         assert "search-only" in result["error"].lower()
         assert "duckduckgo" in result["error"].lower() or "ddgs" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Termux / Android HTML fallback tests (#85972)
+# ---------------------------------------------------------------------------
+
+
+class TestDDGSTermuxFallback:
+    def test_termux_is_available_without_package(self, monkeypatch):
+        monkeypatch.setenv("TERMUX_VERSION", "0.118.0")
+        monkeypatch.delitem(sys.modules, "ddgs", raising=False)
+        from plugins.web.ddgs.provider import DDGSWebSearchProvider
+        assert DDGSWebSearchProvider().is_available() is True
+
+    def test_termux_env_detection(self, monkeypatch):
+        import plugins.web.ddgs.provider as prov
+        monkeypatch.delenv("TERMUX_VERSION", raising=False)
+        monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+        assert prov._is_termux_env() is True
+
+        monkeypatch.setenv("PREFIX", "/usr/local")
+        assert prov._is_termux_env() is False
+
+    def test_html_search_parsing(self, monkeypatch):
+        import io
+        import plugins.web.ddgs.provider as prov
+
+        fake_html = """
+        <html><body>
+        <div class="result results_links">
+          <h2 class="result__title">
+            <a class="result__a" href="/l/?kh=-1&uddg=https%3A%2F%2Fexample.com%2Fpage">Example <b>Title</b> &amp; More</a>
+          </h2>
+          <a class="result__snippet">This is an <b>example</b> description snippet.</a>
+        </div>
+        <div class="result results_links">
+          <h2 class="result__title">
+            <a class="result__a" href="https://direct.example.org/about">Direct Link</a>
+          </h2>
+          <a class="result__snippet">Second snippet text.</a>
+        </div>
+        </body></html>
+        """
+
+        class _FakeResponse:
+            def read(self):
+                return fake_html.encode("utf-8")
+            def __enter__(self):
+                return self
+            def __exit__(self, *args):
+                pass
+
+        monkeypatch.setattr("urllib.request.urlopen", lambda req, timeout=10: _FakeResponse())
+        results = prov._run_ddgs_html_search("test query", safe_limit=5)
+        assert len(results) == 2
+        assert results[0]["title"] == "Example Title & More"
+        assert results[0]["url"] == "https://example.com/page"
+        assert results[0]["description"] == "This is an example description snippet."
+        assert results[0]["position"] == 1
+
+        assert results[1]["title"] == "Direct Link"
+        assert results[1]["url"] == "https://direct.example.org/about"
+        assert results[1]["description"] == "Second snippet text."
+        assert results[1]["position"] == 2
+
+    def test_search_falls_back_when_ddgs_raises(self, monkeypatch):
+        import plugins.web.ddgs.provider as prov
+
+        monkeypatch.setattr(prov, "_is_termux_env", lambda: False)
+        # Install a fake DDGS that throws an exception simulating primp panic
+        _install_fake_ddgs(monkeypatch, text_raises=RuntimeError("android context was not initialized"))
+
+        fallback_hits = [
+            {"title": "Fallback", "url": "https://fallback.org", "description": "desc", "position": 1}
+        ]
+        monkeypatch.setattr(prov, "_run_ddgs_html_search", lambda query, limit: fallback_hits)
+
+        results = prov._run_ddgs_search("query", safe_limit=3)
+        assert results == fallback_hits
+


### PR DESCRIPTION
## Summary
Fixes #85972.

Adds a pure-Python DuckDuckGo HTML search fallback in `plugins/web/ddgs/provider.py` to resolve unhandled native Rust `primp` / `ndk-context` panics (`SIGABRT 134: android context was not initialized`) on Android / Termux.

### Problem
DuckDuckGo is the default zero-API-key web search provider in Hermes Agent. On Android Termux:
1. The `ddgs` package depends on `primp`, which invokes `ndk-context` in native Rust.
2. Because Termux does not initialize the Android NDK context, calling `DDGS().text()` causes an instant native `SIGABRT`, crashing the search worker process and rendering default web search unusable on Android.

### Solution
1. **Termux Environment Detection**: Added `_is_termux_env()` in `plugins/web/ddgs/provider.py` (checking `TERMUX_VERSION`, Termux prefixes, and Android OS environment).
2. **Pure-Python HTML Scraper (`_run_ddgs_html_search`)**: Implemented direct scraping against DuckDuckGo's HTML search endpoint (`https://html.duckduckgo.com/html/`), unquoting wrapped `uddg=` URLs and extracting clean titles, URLs, and snippet descriptions with zero native/Rust dependencies.
3. **Graceful Fallback**: `_run_ddgs_search()` automatically routes to the HTML parser on Termux or when the native `ddgs` package fails at runtime.
4. **Availability Probe**: Updated `DDGSWebSearchProvider.is_available()` and `search()` so Termux users have instant web search available out-of-the-box without manual package installations.
5. **Unit Tests**: Added comprehensive test suite in `tests/tools/test_web_providers_ddgs.py` covering Termux detection, HTML payload parsing, and runtime fallback logic.
