### PR TITLE
fix(ollama-cloud): hide retired models from picker

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3993,9 +3993,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         # safe source for the chat picker, including its empty/failure result.
         return _fetch_deepinfra_models(force_refresh=force_refresh) or []
     if normalized == "ollama-cloud":
-        live = fetch_ollama_cloud_models(force_refresh=force_refresh)
-        if live:
-            return live
+        return fetch_ollama_cloud_models(force_refresh=force_refresh)
     if normalized in ("openai", "openai-api"):
         api_key = os.getenv("OPENAI_API_KEY", "").strip()
         if api_key:
@@ -4420,6 +4418,11 @@ def cached_provider_model_ids(
     normalized = requested if requested == "ollama" else (normalize_provider(provider) or (provider or ""))
     if not normalized:
         return []
+    if normalized == "ollama-cloud":
+        # Ollama Cloud owns a dedicated cache that distinguishes a successful
+        # empty live catalog from discovery failure. The generic cache cannot
+        # represent that distinction and may contain retired pre-fix rows.
+        return provider_model_ids(normalized, force_refresh=force_refresh)
     if normalized == "ollama":
         ttl_seconds = min(ttl_seconds, _OLLAMA_LOCAL_MODELS_CACHE_TTL)
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -6200,7 +6200,7 @@ def _load_ollama_cloud_cache(*, ignore_ttl: bool = False) -> Optional[dict]:
         if not isinstance(data, dict):
             return None
         models = data.get("models")
-        if not (isinstance(models, list) and models):
+        if not isinstance(models, list):
             return None
         if not ignore_ttl:
             cached_at = data.get("cached_at", 0)
@@ -6213,7 +6213,7 @@ def _load_ollama_cloud_cache(*, ignore_ttl: bool = False) -> Optional[dict]:
 
 
 def _save_ollama_cloud_cache(models: list[str]) -> None:
-    """Persist the merged Ollama Cloud model list to disk."""
+    """Persist the resolved Ollama Cloud model list to disk."""
     try:
         from utils import atomic_json_write
         cache_path = _ollama_cloud_cache_path()
@@ -6229,13 +6229,13 @@ def fetch_ollama_cloud_models(
     *,
     force_refresh: bool = False,
 ) -> list[str]:
-    """Fetch Ollama Cloud models by merging live API + models.dev, with disk cache.
+    """Fetch Ollama Cloud models from the live API, with cached fallbacks.
 
     Resolution order:
-      1. Disk cache (if fresh, < 1 hour, and not force_refresh)
-      2. Live ``/v1/models`` endpoint (primary — freshest source)
-      3. models.dev registry (secondary — fills gaps for unlisted models)
-      4. Merge: live models first, then models.dev additions (deduped)
+      1. Disk cache (if fresh according to ``_OLLAMA_CLOUD_CACHE_TTL``)
+      2. Live ``/v1/models`` endpoint (authoritative when available)
+      3. models.dev registry (fallback when live discovery is unavailable)
+      4. Stale disk cache (last-resort fallback)
 
     Returns a list of model IDs (never None — empty list on total failure).
     """
@@ -6251,11 +6251,17 @@ def fetch_ollama_cloud_models(
     if not base_url:
         base_url = os.getenv("OLLAMA_BASE_URL", "") or "https://ollama.com/v1"
 
-    live_models: list[str] = []
     if api_key:
         result = fetch_api_models(api_key, base_url, timeout=8.0)
-        if result:
-            live_models = result
+        if result is not None:
+            seen: set[str] = set()
+            live_models: list[str] = []
+            for model in result:
+                if model and model not in seen:
+                    seen.add(model)
+                    live_models.append(model)
+            _save_ollama_cloud_cache(live_models)
+            return live_models
 
     # 3. models.dev registry
     mdev_models: list[str] = []
@@ -6265,14 +6271,10 @@ def fetch_ollama_cloud_models(
     except Exception:
         pass
 
-    # 4. Merge: live first, then models.dev additions (deduped, order-preserving)
-    if live_models or mdev_models:
+    # 4. Normalise the models.dev fallback (deduped, order-preserving)
+    if mdev_models:
         seen: set[str] = set()
         merged: list[str] = []
-        for m in live_models:
-            if m and m not in seen:
-                seen.add(m)
-                merged.append(m)
         for m in mdev_models:
             normalized = _strip_ollama_cloud_suffix(m)
             if normalized and normalized not in seen:

--- a/tests/hermes_cli/test_ollama_cloud_provider.py
+++ b/tests/hermes_cli/test_ollama_cloud_provider.py
@@ -193,6 +193,31 @@ class TestOllamaCloudResolvedDiscovery:
         assert cached == []
         fetch_mdev.assert_not_called()
 
+    def test_picker_cache_does_not_resurrect_retired_generic_row(self, tmp_path, monkeypatch):
+        """The picker must preserve an authoritative empty cloud catalog."""
+        import hermes_cli.models as models
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("OLLAMA_API_KEY", "test-key")
+        models._save_provider_models_cache({
+            "ollama-cloud": {
+                "fp": models._credential_fingerprint("ollama-cloud"),
+                "at": 0,
+                "models": ["retired-model"],
+            }
+        })
+
+        with patch("hermes_cli.models.fetch_api_models", return_value=[]), \
+             patch("providers.get_provider_profile") as generic_profile:
+            refreshed = models.cached_provider_model_ids(
+                "ollama-cloud", force_refresh=True
+            )
+            cached = models.cached_provider_model_ids("ollama-cloud")
+
+        assert refreshed == []
+        assert cached == []
+        generic_profile.assert_not_called()
+
     def test_falls_back_to_models_dev_without_api_key(self, tmp_path, monkeypatch):
         """Without API key, only models.dev results are returned."""
         from hermes_cli.models import fetch_ollama_cloud_models

--- a/tests/hermes_cli/test_ollama_cloud_provider.py
+++ b/tests/hermes_cli/test_ollama_cloud_provider.py
@@ -146,11 +146,11 @@ class TestOllamaCloudModelPicker:
         assert ollama is None, "ollama-cloud should not appear without OLLAMA_API_KEY"
 
 
-# ── Merged Model Discovery ──
+# ── Resolved Model Discovery ──
 
-class TestOllamaCloudMergedDiscovery:
-    def test_merges_live_and_models_dev(self, tmp_path, monkeypatch):
-        """Live API models appear first, models.dev additions fill gaps."""
+class TestOllamaCloudResolvedDiscovery:
+    def test_live_api_is_authoritative_over_models_dev(self, tmp_path, monkeypatch):
+        """Models absent from the live API must not reappear from models.dev."""
         from hermes_cli.models import fetch_ollama_cloud_models
 
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -166,15 +166,32 @@ class TestOllamaCloudMergedDiscovery:
             }
         }
         with patch("hermes_cli.models.fetch_api_models", return_value=["qwen3.5:397b", "glm-5"]), \
-             patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev):
+             patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev) as fetch_mdev:
             result = fetch_ollama_cloud_models(force_refresh=True)
 
-        # Live models first, then models.dev additions (deduped)
-        assert result[0] == "qwen3.5:397b"  # from live API
-        assert result[1] == "glm-5"          # from live API (also in models.dev)
-        assert "kimi-k2.5" in result         # from models.dev only
-        assert "nemotron-3-super" in result  # from models.dev only
-        assert result.count("glm-5") == 1    # no duplicates
+        assert result == ["qwen3.5:397b", "glm-5"]
+        fetch_mdev.assert_not_called()
+
+    def test_empty_live_catalog_replaces_stale_fallbacks(self, tmp_path, monkeypatch):
+        """A successful empty live response remains authoritative in the cache."""
+        from hermes_cli.models import fetch_ollama_cloud_models
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("OLLAMA_API_KEY", "test-key")
+        mock_mdev = {
+            "ollama-cloud": {
+                "models": {"retired-model": {"tool_call": True}}
+            }
+        }
+
+        with patch("hermes_cli.models.fetch_api_models", return_value=[]), \
+             patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev) as fetch_mdev:
+            refreshed = fetch_ollama_cloud_models(force_refresh=True)
+            cached = fetch_ollama_cloud_models()
+
+        assert refreshed == []
+        assert cached == []
+        fetch_mdev.assert_not_called()
 
     def test_falls_back_to_models_dev_without_api_key(self, tmp_path, monkeypatch):
         """Without API key, only models.dev results are returned."""


### PR DESCRIPTION
## What does this PR do?

Ollama Cloud's model picker can list retired models that the live API no longer serves, causing users to select entries that fail provider validation. This change makes a successful `/v1/models` response authoritative, using models.dev only when live discovery is unavailable, and caches authoritative empty catalogs so stale fallback entries cannot reappear.

### Symptom

When models.dev still indexes a retired Ollama Cloud model, the picker includes it even though the live API omits it. Selecting that entry fails with `Model '<name>' was not found in this provider's model listing`.

### Impact

Users with Ollama Cloud credentials can be offered unusable models after cache refreshes until models.dev removes the retired entries.

### Bug Cause

**Trigger:** `hermes_cli/models.py:6268` / `fetch_ollama_cloud_models()` / a successful live response alongside models.dev-only entries

**Causal chain:**
1. The picker refreshes the Ollama Cloud catalog from `/v1/models`.
2. `fetch_ollama_cloud_models()` appends every models.dev-only entry to the successful live result.
3. Retired IDs are saved to disk and remain selectable even though provider validation rejects them.

**Why it is wrong:** models.dev is a secondary registry and can lag provider retirements, so it cannot define model existence when the provider's live catalog is available.

**Working sibling / contrast:** When live discovery is unavailable, models.dev remains a useful fallback and continues to populate the picker.

**Ruled out:** Suffix normalization was not the cause. `_strip_ollama_cloud_suffix()` prevents duplicate `:cloud` and `-cloud` aliases but intentionally leaves unrelated models.dev-only IDs unchanged.

### Fix

Return the de-duplicated live catalog immediately after a successful probe and persist it as the authoritative cache value. Only consult models.dev when the live probe is unavailable. Treat a successful empty response as authoritative and cacheable so an old non-empty fallback cannot be resurrected.

## Related Issue

Closes #94041

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/models.py` - make successful Ollama Cloud discovery authoritative and reserve models.dev for fallback.
- `tests/hermes_cli/test_ollama_cloud_provider.py` - cover retired models.dev entries and authoritative empty live catalogs.

## How to Test

1. Run the Ollama Cloud provider regression suite.
2. Confirm the authoritative-live test returns only IDs from the mocked live API and never calls models.dev.
3. Confirm an empty live catalog remains empty after a cache read.

```bash
scripts/run_tests.sh tests/hermes_cli/test_ollama_cloud_provider.py -q
```

Result: 24 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - docstrings updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - platform-independent model-list logic
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - deterministic regression tests cover the model discovery and cache behavior.
