### PR TITLE
fix(desktop): keep loopback token WS when public_url is set

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -732,7 +732,18 @@ def should_require_dashboard_auth(
     ``dashboard.public_url`` requires authentication even when a reverse proxy
     reaches a backend bound to loopback. Callers may pass the already-resolved
     host set so startup and request validation use the same snapshot.
+
+    Desktop-spawned backends are an exception: they bind an ephemeral loopback
+    port and authenticate with ``HERMES_DASHBOARD_SESSION_TOKEN`` over
+    ``/api/ws?token=``. They inherit the operator ``config.yaml``, including a
+    ``dashboard.public_url`` meant for a *separate* reverse-proxied
+    ``hermes dashboard`` process. Applying that URL to the Desktop child
+    switches the WS path to ticket auth and rejects the spawn token
+    (``d3df14a7e`` / local Desktop boot overlay). ``HERMES_DESKTOP=1`` is set
+    only by the Electron spawn paths.
     """
+    if host in _LOOPBACK_HOST_VALUES and os.environ.get("HERMES_DESKTOP") == "1":
+        return False
     if trusted_public_hosts is None:
         trusted_public_hosts = _dashboard_public_hosts()
     return should_require_auth(host) or any(

--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -255,6 +255,40 @@ def test_public_url_aware_gate_preserves_local_only_mode(monkeypatch):
     assert should_require_dashboard_auth("127.0.0.1") is False
 
 
+def test_desktop_loopback_ignores_public_url_gate(monkeypatch):
+    """Desktop's ephemeral loopback child keeps token WS when public_url is set.
+
+    ``HERMES_DESKTOP=1`` is injected by Electron next to the spawn token.
+    A Tailscale/reverse-proxy ``dashboard.public_url`` must still gate a
+    standalone ``hermes dashboard`` on loopback, but must not switch the
+    Desktop child's ``/api/ws?token=`` path to ticket auth.
+    """
+    from hermes_cli.web_server import should_require_dashboard_auth
+
+    monkeypatch.setenv(
+        "HERMES_DASHBOARD_PUBLIC_URL",
+        "https://dash.example.ts.net",
+    )
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    assert should_require_dashboard_auth("127.0.0.1") is False
+    assert should_require_dashboard_auth("localhost") is False
+    assert should_require_dashboard_auth("::1") is False
+    # A public Desktop bind (should not happen) still requires the gate.
+    assert should_require_dashboard_auth("0.0.0.0") is True
+
+
+def test_public_url_loopback_gate_still_applies_without_desktop_marker(monkeypatch):
+    """Unmarked loopback processes keep the reverse-proxy public_url gate."""
+    from hermes_cli.web_server import should_require_dashboard_auth
+
+    monkeypatch.setenv(
+        "HERMES_DASHBOARD_PUBLIC_URL",
+        "https://dash.example.test",
+    )
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+    assert should_require_dashboard_auth("127.0.0.1") is True
+
+
 def test_start_server_loopback_public_url_enables_gate(monkeypatch):
     """A declared external URL turns a loopback reverse proxy into gated mode."""
     from hermes_cli.dashboard_auth import clear_providers, register_provider


### PR DESCRIPTION
## Summary
- `d3df14a7e` (`fix(dashboard): secure loopback public URL proxy mode`) engages the dashboard auth gate whenever `dashboard.public_url` is a non-loopback host, **including** a `127.0.0.1` bind.
- Hermes Desktop spawns its own `hermes serve` child on an ephemeral loopback port and authenticates `/api/ws` with the spawn-injected `?token=`. That child inherits operator `config.yaml`, so a Tailscale/reverse-proxy `public_url` meant for a **separate** `hermes dashboard` process switches the Desktop child to ticket auth.
- Symptom: HTTP `/api/status` succeeds, then Desktop boot fails with `Local Hermes backend is HTTP-reachable but the WebSocket (/api/ws) rejected the session token`.
- Fix: when `HERMES_DESKTOP=1` (set only by Electron spawn) **and** the bind is loopback, skip the `public_url` gate so token WS still works. A standalone loopback dashboard behind a reverse proxy is unchanged. A public Desktop bind still requires the gate.

## Test plan
- [x] `pytest tests/hermes_cli/test_dashboard_auth_gate.py::test_desktop_loopback_ignores_public_url_gate`
- [x] `pytest tests/hermes_cli/test_dashboard_auth_gate.py::test_public_url_loopback_gate_still_applies_without_desktop_marker`
- [x] existing `should_require_dashboard_auth` truth table still passes
- [ ] Launch Hermes Desktop with `dashboard.public_url` set to a Tailscale hostname; local boot should connect over `/api/ws?token=`
- [ ] `hermes dashboard` on loopback with `public_url` set and `HERMES_DESKTOP` unset still engages the auth gate


Made with [Cursor](https://cursor.com)