### PR TITLE
feat(voice): SSH audio bridge for remote-TUI mic/speakers over an existing SSH connection

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -372,6 +372,13 @@ DEFAULT_CONFIG = {
         "reasoning_echo": False,
     },
 
+    "shellctl": {
+        # Optional path on the SSH client machine. When set, the generated
+        # daemon command restricts /pull to this directory tree. Empty keeps
+        # intentional arbitrary-path pulls for backwards compatibility.
+        "allowed_root": "",
+    },
+
     "terminal": {
         "backend": "local",
         "modal_mode": "auto",

--- a/hermes_cli/install_cmd.py
+++ b/hermes_cli/install_cmd.py
@@ -1,0 +1,175 @@
+"""`hermes install` — install the SSH-layer file/image bridge client.
+
+`hermes install shellctl` is run on the HERMES HOST (the box you SSH
+into). It:
+
+  1. ensures the bridge assets exist under the workspace,
+  2. generates (or reuses) a shared bridge token,
+  3. prints the exact `~/.ssh/config` snippet + the one-line client
+     install command the user pastes on THEIR machine
+     (Mac/Linux/WSL/PuTTY host).
+
+Design: zero-dependency client (Python stdlib only), no sudo, no
+ControlMaster requirement (per-connection RemoteForward works for plain
+`ssh` and tmux-wrapping `sshp` alike). The client is served for copy
+via `hermes install shellctl --print-client`.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import secrets
+import shutil
+import sys
+from pathlib import Path
+
+# Bridge assets live in the workspace so they survive Hermes updates.
+_SHELLCTL_DIR = Path(
+    os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes"))
+) / "shellctl"
+_TOKEN_FILE = _SHELLCTL_DIR / "bridge-token"
+_CLIENT_FILE = _SHELLCTL_DIR / "hermes-shellctl"
+_BRIDGE_FILE = _SHELLCTL_DIR / "hermes-shellbridge"
+_DEFAULT_PORT = 8765
+
+# Canonical source location (ships with the hermes_cli package).
+_CANONICAL_DIR = Path(__file__).resolve().parent / "shellctl_assets"
+
+
+def _ensure_assets() -> None:
+    _SHELLCTL_DIR.mkdir(parents=True, exist_ok=True)
+    for name in ("hermes-shellctl", "hermes-shellbridge"):
+        src = _CANONICAL_DIR / name
+        dst = _SHELLCTL_DIR / name
+        # When HERMES_HOME points somewhere whose shellctl dir IS the
+        # canonical dir, src == dst — nothing to copy, just fix perms.
+        if src.resolve() != dst.resolve():
+            if src.is_file() and (
+                not dst.is_file()
+                or src.stat().st_mtime > dst.stat().st_mtime
+            ):
+                shutil.copy2(src, dst)
+        if dst.is_file():
+            dst.chmod(0o755)
+
+
+def _get_or_make_token() -> str:
+    if _TOKEN_FILE.is_file():
+        tok = _TOKEN_FILE.read_text(encoding="utf-8").strip()
+        if tok:
+            return tok
+    tok = secrets.token_hex(24)
+    _TOKEN_FILE.write_text(tok + "\n", encoding="utf-8")
+    _TOKEN_FILE.chmod(0o600)
+    return tok
+
+
+def _print_client() -> int:
+    if not _CLIENT_FILE.is_file():
+        _ensure_assets()
+    if not _CLIENT_FILE.is_file():
+        print("error: client asset missing", file=sys.stderr)
+        return 1
+    sys.stdout.write(_CLIENT_FILE.read_text(encoding="utf-8"))
+    return 0
+
+
+def cmd_install_shellctl(args: argparse.Namespace) -> int:
+    if getattr(args, "print_client", False):
+        return _print_client()
+
+    _ensure_assets()
+    token = _get_or_make_token()
+    port = int(getattr(args, "port", _DEFAULT_PORT) or _DEFAULT_PORT)
+    # The hostname/alias the user SSHes to — best effort; user edits.
+    host_hint = getattr(args, "ssh_host", "") or "your-hermes-host"
+
+    bar = "=" * 72
+    print(bar)
+    print(" Hermes shellctl — SSH-layer file/image bridge")
+    print(bar)
+    print()
+    print("Bridge token (shared secret, keep private):")
+    print(f"  {token}")
+    print()
+    print("STEP 1 — On YOUR machine (Mac/Linux/WSL), save the client:")
+    print(
+        f"  ssh {host_hint} 'hermes install shellctl "
+        "--print-client' > ~/.hermes-shellctl"
+    )
+    print("  chmod +x ~/.hermes-shellctl")
+    print()
+    print("STEP 2 — Add this ONE block to ~/.ssh/config on YOUR machine")
+    print("         (works for plain `ssh` AND tmux-wrapping helpers")
+    print("          like sshp; no ControlMaster required):")
+    print()
+    print(f"  Host {host_hint}")
+    print(
+        f"      RemoteForward 127.0.0.1:{port} 127.0.0.1:{port}"
+    )
+    print()
+    print("STEP 3 — Start the client daemon on YOUR machine (one")
+    print("         command, leave it running in a tab — or add to")
+    print("         login items):")
+    print(f"  HERMES_SHELLCTL_TOKEN={token} \\")
+    print(f"    python3 ~/.hermes-shellctl daemon --port {port}")
+    print()
+    print("STEP 4 — SSH in normally. The reverse forward makes your")
+    print("         machine's bridge reachable at 127.0.0.1:%d ON the"
+          % port)
+    print("         Hermes host. Verify:")
+    print(f"  HERMES_SHELLCTL_TOKEN={token} \\")
+    print(f"    HERMES_SHELLCTL_URL=http://127.0.0.1:{port} \\")
+    print(f"    python3 {_BRIDGE_FILE} ping")
+    print()
+    print("Then in the TUI:  /get <local-path> · /send <file> · /paste")
+    print(bar)
+
+    # Persist the resolved config so the TUI bridge glue can read it.
+    cfg = _SHELLCTL_DIR / "bridge.env"
+    cfg.write_text(
+        f"HERMES_SHELLCTL_URL=http://127.0.0.1:{port}\n"
+        f"HERMES_SHELLCTL_TOKEN={token}\n"
+        f"HERMES_SHELLCTL_PORT={port}\n",
+        encoding="utf-8",
+    )
+    cfg.chmod(0o600)
+    return 0
+
+
+def register_cli(install_parser: argparse.ArgumentParser) -> None:
+    """Attach `install` subcommands to the given parser."""
+    sub = install_parser.add_subparsers(
+        dest="install_target", required=True
+    )
+    sc = sub.add_parser(
+        "shellctl",
+        help="Install the SSH file/image bridge client (image/pdf "
+             "over SSH)",
+    )
+    sc.add_argument(
+        "--port",
+        type=int,
+        default=_DEFAULT_PORT,
+        help=f"bridge port (default {_DEFAULT_PORT})",
+    )
+    sc.add_argument(
+        "--ssh-host",
+        default="",
+        help="the Host alias you SSH to (for the printed snippet)",
+    )
+    sc.add_argument(
+        "--print-client",
+        action="store_true",
+        help="print the client script to stdout (for piping to a "
+             "file)",
+    )
+    sc.set_defaults(func=cmd_install_shellctl)
+
+
+def install_command(args: argparse.Namespace) -> int:
+    func = getattr(args, "func", None)
+    if func is None or func is install_command:
+        print("usage: hermes install shellctl", file=sys.stderr)
+        return 2
+    return func(args)

--- a/hermes_cli/install_cmd.py
+++ b/hermes_cli/install_cmd.py
@@ -126,12 +126,27 @@ def cmd_install_shellctl(args: argparse.Namespace) -> int:
     port = int(getattr(args, "port", _DEFAULT_PORT) or _DEFAULT_PORT)
     host_hint = getattr(args, "ssh_host", "") or "your-hermes-host"
     allowed_root = str(getattr(args, "allowed_root", "") or "").strip()
-    if not allowed_root:
+    max_capture_secs = getattr(args, "max_open_capture_secs", None)
+    if not allowed_root or max_capture_secs is None:
         from hermes_cli.config import load_config
 
         shellctl_cfg = (load_config() or {}).get("shellctl") or {}
         if isinstance(shellctl_cfg, dict):
-            allowed_root = str(shellctl_cfg.get("allowed_root") or "").strip()
+            if not allowed_root:
+                allowed_root = str(shellctl_cfg.get("allowed_root") or "").strip()
+            if max_capture_secs is None:
+                max_capture_secs = shellctl_cfg.get("max_open_capture_secs", 300)
+    try:
+        max_capture_secs = int(max_capture_secs if max_capture_secs is not None else 300)
+    except (TypeError, ValueError):
+        print("error: shellctl.max_open_capture_secs must be an integer", file=sys.stderr)
+        return 2
+    if not 1 <= max_capture_secs <= 3600:
+        print(
+            "error: shellctl.max_open_capture_secs must be between 1 and 3600",
+            file=sys.stderr,
+        )
+        return 2
 
     token_file = _token_file()
     bridge_file = _bridge_file()
@@ -140,14 +155,15 @@ def cmd_install_shellctl(args: argparse.Namespace) -> int:
     remote_token_cmd = "cat " + shlex.quote(str(token_file))
     daemon_cmd = (
         "python3 ~/.hermes-shellctl daemon --port %d "
-        "--token-file ~/.hermes-shellctl-token" % port
+        "--token-file ~/.hermes-shellctl-token "
+        "--max-open-capture-secs %d" % (port, max_capture_secs)
     )
     if allowed_root:
         daemon_cmd += " --allowed-root " + shlex.quote(allowed_root)
 
     bar = "=" * 72
     print(bar)
-    print(" Hermes shellctl: SSH file and image bridge")
+    print(" Hermes shellctl: SSH file, image, and audio bridge")
     print(bar)
     print()
     print("The bridge token is a shared secret stored only in:")
@@ -186,7 +202,8 @@ def cmd_install_shellctl(args: argparse.Namespace) -> int:
     print("session already owns that RemoteForward. Close the old session or")
     print("choose a different --port, update both endpoints, and reinstall.")
     print()
-    print("Then in the TUI: /get <local-path>, /send <file>, or /paste")
+    print("Then in the TUI use /get, /send, or /paste. For audio, run")
+    print("hermes-shellbridge say/listen/listen-start/listen-stop/stop-play.")
     print(bar)
 
     # Persist the resolved config so host bridge callers can load it.
@@ -227,6 +244,15 @@ def register_cli(install_parser: argparse.ArgumentParser) -> None:
         help=(
             "restrict client-side pulls to this directory tree; defaults "
             "to shellctl.allowed_root in config.yaml"
+        ),
+    )
+    sc.add_argument(
+        "--max-open-capture-secs",
+        type=int,
+        default=None,
+        help=(
+            "maximum open microphone capture duration; defaults to "
+            "shellctl.max_open_capture_secs in config.yaml, then 300 seconds"
         ),
     )
     sc.add_argument(

--- a/hermes_cli/install_cmd.py
+++ b/hermes_cli/install_cmd.py
@@ -18,29 +18,42 @@ from __future__ import annotations
 
 import argparse
 import os
+import shlex
 import secrets
 import shutil
 import sys
 from pathlib import Path
 
-# Bridge assets live in the workspace so they survive Hermes updates.
-_SHELLCTL_DIR = Path(
-    os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes"))
-) / "shellctl"
-_TOKEN_FILE = _SHELLCTL_DIR / "bridge-token"
-_CLIENT_FILE = _SHELLCTL_DIR / "hermes-shellctl"
-_BRIDGE_FILE = _SHELLCTL_DIR / "hermes-shellbridge"
+from hermes_constants import get_hermes_home
+
 _DEFAULT_PORT = 8765
 
 # Canonical source location (ships with the hermes_cli package).
 _CANONICAL_DIR = Path(__file__).resolve().parent / "shellctl_assets"
 
 
+def _shellctl_dir() -> Path:
+    return get_hermes_home() / "shellctl"
+
+
+def _token_file() -> Path:
+    return _shellctl_dir() / "bridge-token"
+
+
+def _client_file() -> Path:
+    return _shellctl_dir() / "hermes-shellctl"
+
+
+def _bridge_file() -> Path:
+    return _shellctl_dir() / "hermes-shellbridge"
+
+
 def _ensure_assets() -> None:
-    _SHELLCTL_DIR.mkdir(parents=True, exist_ok=True)
+    shellctl_dir = _shellctl_dir()
+    shellctl_dir.mkdir(parents=True, exist_ok=True)
     for name in ("hermes-shellctl", "hermes-shellbridge"):
         src = _CANONICAL_DIR / name
-        dst = _SHELLCTL_DIR / name
+        dst = shellctl_dir / name
         # When HERMES_HOME points somewhere whose shellctl dir IS the
         # canonical dir, src == dst — nothing to copy, just fix perms.
         if src.resolve() != dst.resolve():
@@ -54,23 +67,53 @@ def _ensure_assets() -> None:
 
 
 def _get_or_make_token() -> str:
-    if _TOKEN_FILE.is_file():
-        tok = _TOKEN_FILE.read_text(encoding="utf-8").strip()
+    token_file = _token_file()
+    if token_file.is_file():
+        tok = token_file.read_text(encoding="utf-8").strip()
         if tok:
+            token_file.chmod(0o600)
             return tok
     tok = secrets.token_hex(24)
-    _TOKEN_FILE.write_text(tok + "\n", encoding="utf-8")
-    _TOKEN_FILE.chmod(0o600)
+    try:
+        fd = os.open(
+            token_file,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+    except FileExistsError:
+        existing = token_file.read_text(encoding="utf-8").strip()
+        if existing:
+            token_file.chmod(0o600)
+            return existing
+        raise RuntimeError(f"empty shellctl token file: {token_file}")
+    with os.fdopen(fd, "w", encoding="utf-8") as stream:
+        stream.write(tok + "\n")
     return tok
 
 
+def _write_private(path: Path, content: str) -> None:
+    """Atomically replace a private file without a permissive creation window."""
+    tmp = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(content)
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+
+
 def _print_client() -> int:
-    if not _CLIENT_FILE.is_file():
+    client_file = _client_file()
+    if not client_file.is_file():
         _ensure_assets()
-    if not _CLIENT_FILE.is_file():
+    if not client_file.is_file():
         print("error: client asset missing", file=sys.stderr)
         return 1
-    sys.stdout.write(_CLIENT_FILE.read_text(encoding="utf-8"))
+    sys.stdout.write(client_file.read_text(encoding="utf-8"))
     return 0
 
 
@@ -81,59 +124,79 @@ def cmd_install_shellctl(args: argparse.Namespace) -> int:
     _ensure_assets()
     token = _get_or_make_token()
     port = int(getattr(args, "port", _DEFAULT_PORT) or _DEFAULT_PORT)
-    # The hostname/alias the user SSHes to — best effort; user edits.
     host_hint = getattr(args, "ssh_host", "") or "your-hermes-host"
+    allowed_root = str(getattr(args, "allowed_root", "") or "").strip()
+    if not allowed_root:
+        from hermes_cli.config import load_config
+
+        shellctl_cfg = (load_config() or {}).get("shellctl") or {}
+        if isinstance(shellctl_cfg, dict):
+            allowed_root = str(shellctl_cfg.get("allowed_root") or "").strip()
+
+    token_file = _token_file()
+    bridge_file = _bridge_file()
+    bridge_env = _shellctl_dir() / "bridge.env"
+    remote_client_cmd = "hermes install shellctl --print-client"
+    remote_token_cmd = "cat " + shlex.quote(str(token_file))
+    daemon_cmd = (
+        "python3 ~/.hermes-shellctl daemon --port %d "
+        "--token-file ~/.hermes-shellctl-token" % port
+    )
+    if allowed_root:
+        daemon_cmd += " --allowed-root " + shlex.quote(allowed_root)
 
     bar = "=" * 72
     print(bar)
-    print(" Hermes shellctl — SSH-layer file/image bridge")
+    print(" Hermes shellctl: SSH file and image bridge")
     print(bar)
     print()
-    print("Bridge token (shared secret, keep private):")
-    print(f"  {token}")
+    print("The bridge token is a shared secret stored only in:")
+    print(f"  {token_file} (mode 0600)")
+    print("The commands below copy it over SSH without putting its value in")
+    print("shell history or a process argument.")
     print()
-    print("STEP 1 — On YOUR machine (Mac/Linux/WSL), save the client:")
+    print("STEP 1: On YOUR machine, save the client and token:")
     print(
-        f"  ssh {host_hint} 'hermes install shellctl "
-        "--print-client' > ~/.hermes-shellctl"
+        "  ssh %s %s > ~/.hermes-shellctl"
+        % (shlex.quote(host_hint), shlex.quote(remote_client_cmd))
     )
-    print("  chmod +x ~/.hermes-shellctl")
+    print(
+        "  (umask 077; ssh %s %s > ~/.hermes-shellctl-token)"
+        % (shlex.quote(host_hint), shlex.quote(remote_token_cmd))
+    )
+    print("  chmod 700 ~/.hermes-shellctl")
+    print("  chmod 600 ~/.hermes-shellctl-token")
     print()
-    print("STEP 2 — Add this ONE block to ~/.ssh/config on YOUR machine")
-    print("         (works for plain `ssh` AND tmux-wrapping helpers")
-    print("          like sshp; no ControlMaster required):")
+    print("STEP 2: Add this block to ~/.ssh/config on YOUR machine:")
     print()
     print(f"  Host {host_hint}")
+    print(f"      RemoteForward 127.0.0.1:{port} 127.0.0.1:{port}")
+    print("      ExitOnForwardFailure yes")
+    print()
+    print("STEP 3: Start the client daemon on YOUR machine:")
+    print(f"  {daemon_cmd}")
+    print()
+    print("STEP 4: SSH in normally, then verify on the Hermes host:")
     print(
-        f"      RemoteForward 127.0.0.1:{port} 127.0.0.1:{port}"
+        "  set -a; . %s; set +a; python3 %s ping"
+        % (shlex.quote(str(bridge_env)), shlex.quote(str(bridge_file)))
     )
     print()
-    print("STEP 3 — Start the client daemon on YOUR machine (one")
-    print("         command, leave it running in a tab — or add to")
-    print("         login items):")
-    print(f"  HERMES_SHELLCTL_TOKEN={token} \\")
-    print(f"    python3 ~/.hermes-shellctl daemon --port {port}")
+    print("If SSH reports 'remote port forwarding failed', another SSH")
+    print("session already owns that RemoteForward. Close the old session or")
+    print("choose a different --port, update both endpoints, and reinstall.")
     print()
-    print("STEP 4 — SSH in normally. The reverse forward makes your")
-    print("         machine's bridge reachable at 127.0.0.1:%d ON the"
-          % port)
-    print("         Hermes host. Verify:")
-    print(f"  HERMES_SHELLCTL_TOKEN={token} \\")
-    print(f"    HERMES_SHELLCTL_URL=http://127.0.0.1:{port} \\")
-    print(f"    python3 {_BRIDGE_FILE} ping")
-    print()
-    print("Then in the TUI:  /get <local-path> · /send <file> · /paste")
+    print("Then in the TUI: /get <local-path>, /send <file>, or /paste")
     print(bar)
 
-    # Persist the resolved config so the TUI bridge glue can read it.
-    cfg = _SHELLCTL_DIR / "bridge.env"
-    cfg.write_text(
+    # Persist the resolved config so host bridge callers can load it.
+    cfg = bridge_env
+    _write_private(
+        cfg,
         f"HERMES_SHELLCTL_URL=http://127.0.0.1:{port}\n"
         f"HERMES_SHELLCTL_TOKEN={token}\n"
         f"HERMES_SHELLCTL_PORT={port}\n",
-        encoding="utf-8",
     )
-    cfg.chmod(0o600)
     return 0
 
 
@@ -157,6 +220,14 @@ def register_cli(install_parser: argparse.ArgumentParser) -> None:
         "--ssh-host",
         default="",
         help="the Host alias you SSH to (for the printed snippet)",
+    )
+    sc.add_argument(
+        "--allowed-root",
+        default="",
+        help=(
+            "restrict client-side pulls to this directory tree; defaults "
+            "to shellctl.allowed_root in config.yaml"
+        ),
     )
     sc.add_argument(
         "--print-client",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12331,7 +12331,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "computer-use",
         "config", "console", "cron", "curator", "dashboard", "serve", "debug", "doctor",
         "dump", "egress", "fallback", "gateway", "hooks", "import", "import-agent", "insights",
-        "gui", "desktop", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate", "moa",
+        "gui", "desktop", "install", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate", "moa",
         "journey", "memory-graph", "learning",
         "model", "monitoring", "pairing", "pause", "peer", "pets", "plugins", "portal", "profile",
         "project", "proxy",
@@ -13315,6 +13315,28 @@ def main():
         return 0
 
     egress_parser.set_defaults(func=_dispatch_egress)
+
+    # =========================================================================
+    # install command — SSH-layer file/image bridge client (shellctl)
+    # =========================================================================
+    install_parser = subparsers.add_parser(
+        "install",
+        help="Install optional Hermes companions (e.g. the SSH "
+             "file/image bridge)",
+        description=(
+            "Install optional Hermes companion tools. `hermes install "
+            "shellctl` sets up the SSH-layer bridge so a remote TUI "
+            "can move images, PDFs, and any file between the Hermes "
+            "host and your local machine over your existing SSH "
+            "connection."
+        ),
+    )
+    from hermes_cli.install_cmd import (
+        install_command,
+        register_cli as _install_register,
+    )
+    _install_register(install_parser)
+    install_parser.set_defaults(func=install_command)
 
     # =========================================================================
     # migrate command

--- a/hermes_cli/shellctl_assets/README.md
+++ b/hermes_cli/shellctl_assets/README.md
@@ -1,20 +1,19 @@
-# Hermes shellctl — SSH-layer file & image bridge
+# Hermes shellctl: SSH file, image, and audio bridge
 
-Move **images, PDFs, and any file** between the Hermes host (the box you
-SSH into, running the TUI) and **your local machine** — over your
-**existing SSH connection**, with no extra tunnel, no ControlMaster
-requirement, and no dependency on iTerm2 / a specific terminal / a
-specific OS.
+Move images, PDFs, arbitrary files, microphone input, and speaker output between
+the Hermes host (the box you SSH into, running the TUI) and **your local
+machine** over your **existing SSH connection**, with no extra tunnel, no
+ControlMaster requirement, and no dependency on iTerm2, a specific terminal,
+or a specific OS.
 
 Works on macOS, Linux, WSL, and any host that runs `ssh` (PuTTY
 included). The client is a **single zero-dependency Python 3 file**
 (stdlib only) — installs on a locked-down corporate Mac with no
 admin/sudo and no package manager.
 
-> This bridge is one slice of a general SSH media bridge. This branch
-> ships the **file/image** transfer path. The **audio** path (TTS +
-> mic) is a sibling feature that reuses the same daemon + install
-> scaffolding.
+> This bridge now includes the file/image foundation and the stacked audio
+> extension. Audio routes gateway TTS to local speakers and local microphone
+> capture back to gateway STT through the same authenticated daemon.
 
 ## Why this exists
 
@@ -73,12 +72,15 @@ host before running the installer:
 ```yaml
 shellctl:
   allowed_root: ~/Documents/hermes-share
+  max_open_capture_secs: 300
 ```
 
 The path is interpreted on the SSH client machine. You can override it for one
 installation with `hermes install shellctl --allowed-root <client-path>`. The
 installer adds `--allowed-root` to the generated daemon command. Symlinks that
-resolve outside the root are rejected.
+resolve outside the root are rejected. `max_open_capture_secs` defaults to five
+minutes and accepts values from 1 through 3600 seconds. The installer passes it
+to the client daemon as `--max-open-capture-secs`.
 
 ## Use (in the TUI)
 
@@ -87,6 +89,11 @@ resolve outside the root are rejected.
 | `/get <local-path>` | Pull a file FROM your machine; auto-attaches it to the turn (image/pdf/any) |
 | `/paste` | Pull your machine's **clipboard image/file** and attach it |
 | `/send <host-path>` | Push a Hermes-side file TO your machine and open it locally |
+| `hermes-shellbridge say <text>` | Generate gateway TTS and play it on your local speakers |
+| `hermes-shellbridge listen [secs]` | Record your local microphone and send the WAV to gateway STT |
+| `hermes-shellbridge listen-start` | Begin a local microphone capture, bounded by the configured maximum |
+| `hermes-shellbridge listen-stop` | Stop the open capture and send it to gateway STT |
+| `hermes-shellbridge stop-play` | Interrupt local playback with a short silent WAV |
 
 Image files land in the gateway images dir and carry an `/image` hint so
 the TUI attaches them as visual content; everything else lands in the
@@ -115,7 +122,15 @@ Possession of that token plus access to the listener grants the ability to:
   unless `shellctl.allowed_root` or `--allowed-root` restricts it;
 * read clipboard file or image content through `/clipboard`;
 * write files into the configured download directory and request that the OS
-  open them through `/push`.
+  open them through `/push`;
+* play supplied audio through local speakers and activate the local microphone
+  remotely through `/record` or `/record-start`. Token possession therefore
+  permits remote microphone activation while the daemon is running.
+
+A compromised Hermes host can obtain the token and activate the microphone
+without another local confirmation. Each open capture stops after the configured
+maximum even if no stop request arrives. Daemon shutdown and a failed start
+response also terminate the recorder and delete its temporary WAV.
 
 The listener binds to `127.0.0.1`, but the SSH `RemoteForward` deliberately
 makes it reachable from the Hermes host. A process on a compromised Hermes host
@@ -125,8 +140,10 @@ Hermes host. The optional allowed root limits file pulls, but it does not remove
 clipboard or push access. Do not run the bridge for an untrusted host. Stop the
 daemon and SSH session to remove access.
 
-Each transfer is capped at 64 MB. Existing destination files are never
-replaced; shellctl allocates a numbered filename instead.
+Each transfer and captured WAV is capped at 64 MB. The daemon checks a capture's
+size before reading it, and the host bridge bounds response reads as a second
+line of defense. Existing destination files are never replaced; shellctl
+allocates a numbered filename instead.
 
 ## RemoteForward troubleshooting
 

--- a/hermes_cli/shellctl_assets/README.md
+++ b/hermes_cli/shellctl_assets/README.md
@@ -1,0 +1,105 @@
+# Hermes shellctl — SSH-layer file & image bridge
+
+Move **images, PDFs, and any file** between the Hermes host (the box you
+SSH into, running the TUI) and **your local machine** — over your
+**existing SSH connection**, with no extra tunnel, no ControlMaster
+requirement, and no dependency on iTerm2 / a specific terminal / a
+specific OS.
+
+Works on macOS, Linux, WSL, and any host that runs `ssh` (PuTTY
+included). The client is a **single zero-dependency Python 3 file**
+(stdlib only) — installs on a locked-down corporate Mac with no
+admin/sudo and no package manager.
+
+> This bridge is one slice of a general SSH media bridge. This branch
+> ships the **file/image** transfer path. The **audio** path (TTS +
+> mic) is a sibling feature that reuses the same daemon + install
+> scaffolding.
+
+## Why this exists
+
+The Hermes TUI runs on the *remote* host, so its "clipboard" and
+filesystem are the **remote host's**, not yours. shellctl bridges that
+gap: a tiny HTTP listener on your machine, reachable by the remote host
+through a reverse SSH forward, so the agent can pull/push bytes to/from
+*your* machine.
+
+```
+Your machine (Mac/Linux/WSL)     existing SSH (any transport)   Hermes host
+┌────────────────────────┐                                     ┌──────────────┐
+│ hermes-shellctl daemon │  ◄── RemoteForward 127.0.0.1:8765 ─►│ TUI /get      │
+│  • serves local files  │      (reverse: host reaches you)    │ hermes-shell- │
+│  • clipboard image/file│                                     │   bridge      │
+└────────────────────────┘                                     └──────────────┘
+```
+
+## Install (run on the HERMES host)
+
+```sh
+hermes install shellctl --ssh-host <the-host-alias-you-ssh-to>
+```
+
+This prints a token + the exact 4 steps. Summary:
+
+1. **Save the client on your machine:**
+   ```sh
+   ssh <host> 'hermes install shellctl --print-client' > ~/.hermes-shellctl
+   chmod +x ~/.hermes-shellctl
+   ```
+2. **Add ONE block to `~/.ssh/config` on your machine** (covers plain
+   `ssh` and tmux-wrapping helpers like `sshp`; **no ControlMaster
+   needed**):
+   ```
+   Host <host>
+       RemoteForward 127.0.0.1:8765 127.0.0.1:8765
+   ```
+3. **Run the daemon on your machine** (leave it in a tab, or add to
+   Login Items):
+   ```sh
+   HERMES_SHELLCTL_TOKEN=<token> python3 ~/.hermes-shellctl daemon --port 8765
+   ```
+4. **SSH in normally.** Verify from the host:
+   ```sh
+   <bridge> ping     # → {"ok": true, "caps": {...}}
+   ```
+
+## Use (in the TUI)
+
+| Command | What it does |
+|---|---|
+| `/get <local-path>` | Pull a file FROM your machine; auto-attaches it to the turn (image/pdf/any) |
+| `/paste` | Pull your machine's **clipboard image/file** and attach it |
+| `/send <host-path>` | Push a Hermes-side file TO your machine and open it locally |
+
+Image files land in the gateway images dir and carry an `/image` hint so
+the TUI attaches them as visual content; everything else lands in the
+downloads dir with a plain-path hint.
+
+## Optional local helpers (better fidelity, not required)
+
+- **Clipboard images:** macOS `pngpaste` (`brew install pngpaste`) or
+  Linux `xclip`. Without them, macOS falls back to AppleScript.
+
+`hermes-shellctl daemon` reports which capabilities are available at
+startup and via `/ping`.
+
+## Security
+
+- The listener binds **127.0.0.1 only** and is reached solely through
+  your SSH reverse-forward — nothing on the network can reach it.
+- Every request is gated by a **shared token**
+  (`HERMES_SHELLCTL_TOKEN`), generated per-install and stored `0600`.
+- 64 MB per-transfer cap.
+
+## Files
+
+- Client (your machine): `~/.hermes-shellctl` (single file, stdlib only)
+- Host orchestrator: `<HERMES_HOME>/shellctl/hermes-shellbridge`
+- Token + config: `<HERMES_HOME>/shellctl/bridge-token`, `bridge.env`
+  (both `0600`)
+- Canonical source (ships with hermes_cli): `hermes_cli/shellctl_assets/`
+
+## Notes
+
+- Pulled files land in the gateway images/downloads dir so the normal
+  attach pipeline handles them (the TUI `/image` and `/get` commands).

--- a/hermes_cli/shellctl_assets/README.md
+++ b/hermes_cli/shellctl_assets/README.md
@@ -39,29 +39,46 @@ Your machine (Mac/Linux/WSL)     existing SSH (any transport)   Hermes host
 hermes install shellctl --ssh-host <the-host-alias-you-ssh-to>
 ```
 
-This prints a token + the exact 4 steps. Summary:
+This prints the exact setup steps. It does not print the raw token inside a
+command. The generated commands copy the `0600` token file over SSH and pass it
+to the daemon with `--token-file`, so the value does not enter shell history or
+the process argument list.
 
-1. **Save the client on your machine:**
+1. **Save the client and token on your machine:**
    ```sh
    ssh <host> 'hermes install shellctl --print-client' > ~/.hermes-shellctl
-   chmod +x ~/.hermes-shellctl
+   (umask 077; ssh <host> 'cat <profile-home>/shellctl/bridge-token' \
+       > ~/.hermes-shellctl-token)
+   chmod 700 ~/.hermes-shellctl
+   chmod 600 ~/.hermes-shellctl-token
    ```
-2. **Add ONE block to `~/.ssh/config` on your machine** (covers plain
-   `ssh` and tmux-wrapping helpers like `sshp`; **no ControlMaster
-   needed**):
+2. **Add one block to `~/.ssh/config` on your machine:**
    ```
    Host <host>
        RemoteForward 127.0.0.1:8765 127.0.0.1:8765
+       ExitOnForwardFailure yes
    ```
-3. **Run the daemon on your machine** (leave it in a tab, or add to
-   Login Items):
+3. **Run the daemon on your machine:**
    ```sh
-   HERMES_SHELLCTL_TOKEN=<token> python3 ~/.hermes-shellctl daemon --port 8765
+   python3 ~/.hermes-shellctl daemon --port 8765 \
+       --token-file ~/.hermes-shellctl-token
    ```
-4. **SSH in normally.** Verify from the host:
-   ```sh
-   <bridge> ping     # → {"ok": true, "caps": {...}}
-   ```
+4. **SSH in normally.** Load the generated `bridge.env`, then run the host
+   bridge's `ping` command. `/ping` requires the same token as every other
+   endpoint.
+
+To restrict reads from the client machine, set the following on the Hermes
+host before running the installer:
+
+```yaml
+shellctl:
+  allowed_root: ~/Documents/hermes-share
+```
+
+The path is interpreted on the SSH client machine. You can override it for one
+installation with `hermes install shellctl --allowed-root <client-path>`. The
+installer adds `--allowed-root` to the generated daemon command. Symlinks that
+resolve outside the root are rejected.
 
 ## Use (in the TUI)
 
@@ -83,13 +100,43 @@ downloads dir with a plain-path hint.
 `hermes-shellctl daemon` reports which capabilities are available at
 startup and via `/ping`.
 
-## Security
+## Security and threat boundary
 
-- The listener binds **127.0.0.1 only** and is reached solely through
-  your SSH reverse-forward — nothing on the network can reach it.
-- Every request is gated by a **shared token**
-  (`HERMES_SHELLCTL_TOKEN`), generated per-install and stored `0600`.
-- 64 MB per-transfer cap.
+The exact bearer credential is the random value in
+`<profile-home>/shellctl/bridge-token` on the Hermes host and
+`~/.hermes-shellctl-token` on the client. It is sent in the
+`X-Shellctl-Token` HTTP header. Every endpoint, including `/ping`, requires it.
+Keep both token files mode `0600` and rotate the token by deleting the host
+copy, rerunning the installer, and recopying it.
+
+Possession of that token plus access to the listener grants the ability to:
+
+* read any file readable by the user running the client daemon through `/pull`,
+  unless `shellctl.allowed_root` or `--allowed-root` restricts it;
+* read clipboard file or image content through `/clipboard`;
+* write files into the configured download directory and request that the OS
+  open them through `/push`.
+
+The listener binds to `127.0.0.1`, but the SSH `RemoteForward` deliberately
+makes it reachable from the Hermes host. A process on a compromised Hermes host
+can read `bridge.env`, obtain the token, and use the forwarded listener with
+all permissions above. The token does not protect the client from a compromised
+Hermes host. The optional allowed root limits file pulls, but it does not remove
+clipboard or push access. Do not run the bridge for an untrusted host. Stop the
+daemon and SSH session to remove access.
+
+Each transfer is capped at 64 MB. Existing destination files are never
+replaced; shellctl allocates a numbered filename instead.
+
+## RemoteForward troubleshooting
+
+With `ExitOnForwardFailure yes`, SSH exits rather than silently connecting
+without the bridge. If SSH reports `remote port forwarding failed for listen
+port 8765`, another active SSH connection usually owns that listen address.
+Close the stale connection, or choose a new port with `--port` and update both
+sides of the `RemoteForward`. Check for duplicate `RemoteForward` lines in
+included SSH config files as well. `ssh -vv <host>` shows which forwarding rule
+was applied.
 
 ## Files
 

--- a/hermes_cli/shellctl_assets/hermes-shellbridge
+++ b/hermes_cli/shellctl_assets/hermes-shellbridge
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""hermes-shellbridge - HOST half of the Hermes SSH file/image bridge.
+
+Runs on the Hermes host. Talks to the hermes-shellctl daemon on the
+user's machine through a reverse SSH forward (RemoteForward
+127.0.0.1:8765 -> the user's daemon). Commands:
+
+  get <local-path>   pull a file from the user's machine into the
+                     gateway images/downloads dir; print the gateway
+                     path the TUI attaches.
+  paste              pull the user's clipboard image/file into the
+                     gateway and print an attach hint.
+  send <gateway-path> push a gateway file to the user's machine and
+                     open it.
+  ping               check the client daemon + capabilities.
+
+Image files land in the gateway images dir and carry an ``/image``
+hint so the TUI attaches them as visual content; everything else
+(pdf, zip, csv, docx, arbitrary binaries) lands in the downloads dir
+with a plain-path hint. stdlib only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from urllib.parse import quote
+
+CLIENT_URL = os.environ.get(
+    "HERMES_SHELLCTL_URL", "http://127.0.0.1:8765"
+)
+_CLIENT_TOK_VAR = "HERMES_SHELLCTL_" + "TOKEN"
+CLIENT_TOKEN = os.environ.get(_CLIENT_TOK_VAR, "")
+IMAGES_DIR = os.environ.get(
+    "HERMES_SHELLBRIDGE_IMAGES_DIR",
+    os.path.join(
+        os.path.expanduser(
+            os.environ.get("HERMES_HOME", "~/.hermes")
+        ),
+        "images",
+    ),
+)
+FILES_DIR = os.environ.get(
+    "HERMES_SHELLBRIDGE_FILES_DIR",
+    os.path.join(
+        os.path.expanduser(
+            os.environ.get("HERMES_HOME", "~/.hermes")
+        ),
+        "downloads",
+    ),
+)
+
+# Image extensions that should land in IMAGES_DIR + carry an `/image`
+# hint so the TUI attaches them as visual content. Everything else is
+# a general file -> FILES_DIR + a plain-path hint.
+_IMAGE_EXTS = {
+    ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp",
+    ".tiff", ".tif", ".heic", ".heif", ".svg",
+}
+
+
+def _is_image_name(name):
+    return os.path.splitext(name or "")[1].lower() in _IMAGE_EXTS
+
+
+def _client_req(method, path, body=None, timeout=130):
+    req = urllib.request.Request(
+        CLIENT_URL + path, data=body, method=method
+    )
+    if CLIENT_TOKEN:
+        req.add_header("X-Shellctl-Token", CLIENT_TOKEN)
+    if body is not None:
+        req.add_header("Content-Type", "application/octet-stream")
+    return urllib.request.urlopen(req, timeout=timeout)
+
+
+def _emit(obj):
+    print(json.dumps(obj), flush=True)
+
+
+def _save_into(target_dir, data, name):
+    os.makedirs(target_dir, exist_ok=True)
+    safe = os.path.basename(name) or ("shellctl-%d" % int(time.time()))
+    dest = os.path.join(target_dir, safe)
+    if os.path.exists(dest):
+        stem, ext = os.path.splitext(safe)
+        dest = os.path.join(
+            target_dir, "%s-%d%s" % (stem, int(time.time()), ext)
+        )
+    with open(dest, "wb") as f:
+        f.write(data)
+    return dest
+
+
+def _save_into_images(data, name):
+    return _save_into(IMAGES_DIR, data, name)
+
+
+def _save_into_files(data, name):
+    return _save_into(FILES_DIR, data, name)
+
+
+def cmd_ping(args):
+    try:
+        with _client_req("GET", "/ping", timeout=8) as r:
+            _emit({"ok": True, **json.loads(r.read())})
+        return 0
+    except Exception as e:  # noqa: BLE001
+        _emit({
+            "ok": False,
+            "error": "client unreachable at %s: %s" % (CLIENT_URL, e),
+        })
+        return 1
+
+
+def cmd_get(args):
+    try:
+        with _client_req(
+            "GET", "/pull?path=" + quote(args.path), timeout=130
+        ) as r:
+            data = r.read()
+    except urllib.error.HTTPError as e:
+        _emit({
+            "ok": False,
+            "error": "pull failed: HTTP %d %r" % (
+                e.code, e.read()[:200]
+            ),
+        })
+        return 1
+    except Exception as e:  # noqa: BLE001
+        _emit({"ok": False, "error": "pull failed: %s" % e})
+        return 1
+    name = os.path.basename(args.path)
+    is_image = _is_image_name(args.path)
+    dest = (
+        _save_into_images(data, name)
+        if is_image
+        else _save_into_files(data, name)
+    )
+    hint = ("/image " + dest) if is_image else dest
+    _emit({
+        "ok": True, "path": dest, "bytes": len(data), "hint": hint,
+    })
+    return 0
+
+
+def cmd_paste(args):
+    try:
+        with _client_req("GET", "/clipboard", timeout=60) as r:
+            data = r.read()
+            hdr_name = r.headers.get("X-Clipboard-Filename") or ""
+            hdr_kind = (
+                r.headers.get("X-Clipboard-Kind") or ""
+            ).lower()
+    except urllib.error.HTTPError as e:
+        _emit({
+            "ok": False,
+            "error": "no clipboard content: HTTP %d %s" % (
+                e.code, e.read()[:200]
+            ),
+        })
+        return 1
+    except Exception as e:  # noqa: BLE001
+        _emit({
+            "ok": False, "error": "clipboard pull failed: %s" % e,
+        })
+        return 1
+    # Save bytes VERBATIM under the real filename the daemon reported,
+    # so an image keeps its format and a pdf/zip lands intact. Legacy
+    # daemons send no headers -> fall back to the historical
+    # clip-<ts>.png image behavior.
+    name = (
+        os.path.basename(hdr_name)
+        if hdr_name
+        else ("clip-%d.png" % int(time.time()))
+    )
+    is_image = hdr_kind == "image" or (
+        not hdr_kind and _is_image_name(name)
+    )
+    dest = (
+        _save_into_images(data, name)
+        if is_image
+        else _save_into_files(data, name)
+    )
+    hint = ("/image " + dest) if is_image else ("/get " + dest)
+    _emit({
+        "ok": True,
+        "path": dest,
+        "bytes": len(data),
+        "kind": "image" if is_image else "file",
+        "hint": hint,
+    })
+    return 0
+
+
+def cmd_send(args):
+    path = os.path.expanduser(args.path)
+    if not os.path.isfile(path):
+        _emit({"ok": False, "error": "gateway file not found: " + path})
+        return 1
+    with open(path, "rb") as f:
+        data = f.read()
+    openq = "0" if args.no_open else "1"
+    try:
+        with _client_req(
+            "POST",
+            "/push?name=%s&open=%s" % (
+                quote(os.path.basename(path)), openq
+            ),
+            body=data,
+            timeout=130,
+        ) as r:
+            _emit({"ok": True, **json.loads(r.read())})
+        return 0
+    except Exception as e:  # noqa: BLE001
+        _emit({"ok": False, "error": "push failed: %s" % e})
+        return 1
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(
+        prog="hermes-shellbridge", description=__doc__
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("ping").set_defaults(func=cmd_ping)
+    g = sub.add_parser("get")
+    g.add_argument("path")
+    g.set_defaults(func=cmd_get)
+    sub.add_parser("paste").set_defaults(func=cmd_paste)
+    s = sub.add_parser("send")
+    s.add_argument("path")
+    s.add_argument("--no-open", action="store_true")
+    s.set_defaults(func=cmd_send)
+    args = p.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hermes_cli/shellctl_assets/hermes-shellbridge
+++ b/hermes_cli/shellctl_assets/hermes-shellbridge
@@ -84,15 +84,17 @@ def _emit(obj):
 def _save_into(target_dir, data, name):
     os.makedirs(target_dir, exist_ok=True)
     safe = os.path.basename(name) or ("shellctl-%d" % int(time.time()))
-    dest = os.path.join(target_dir, safe)
-    if os.path.exists(dest):
-        stem, ext = os.path.splitext(safe)
-        dest = os.path.join(
-            target_dir, "%s-%d%s" % (stem, int(time.time()), ext)
-        )
-    with open(dest, "wb") as f:
-        f.write(data)
-    return dest
+    stem, ext = os.path.splitext(safe)
+    for suffix in range(10000):
+        candidate = safe if suffix == 0 else "%s-%d%s" % (stem, suffix, ext)
+        dest = os.path.join(target_dir, candidate)
+        try:
+            with open(dest, "xb") as f:
+                f.write(data)
+            return dest
+        except FileExistsError:
+            continue
+    raise OSError("could not allocate a unique destination filename")
 
 
 def _save_into_images(data, name):

--- a/hermes_cli/shellctl_assets/hermes-shellbridge
+++ b/hermes_cli/shellctl_assets/hermes-shellbridge
@@ -22,6 +22,7 @@ with a plain-path hint. stdlib only.
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 import os
 import time
@@ -29,29 +30,24 @@ import urllib.error
 import urllib.request
 from urllib.parse import quote
 
+from hermes_constants import get_hermes_home
+
 CLIENT_URL = os.environ.get(
     "HERMES_SHELLCTL_URL", "http://127.0.0.1:8765"
 )
 _CLIENT_TOK_VAR = "HERMES_SHELLCTL_" + "TOKEN"
 CLIENT_TOKEN = os.environ.get(_CLIENT_TOK_VAR, "")
+_HERMES_HOME = get_hermes_home()
 IMAGES_DIR = os.environ.get(
-    "HERMES_SHELLBRIDGE_IMAGES_DIR",
-    os.path.join(
-        os.path.expanduser(
-            os.environ.get("HERMES_HOME", "~/.hermes")
-        ),
-        "images",
-    ),
+    "HERMES_SHELLBRIDGE_IMAGES_DIR", str(_HERMES_HOME / "images")
 )
 FILES_DIR = os.environ.get(
-    "HERMES_SHELLBRIDGE_FILES_DIR",
-    os.path.join(
-        os.path.expanduser(
-            os.environ.get("HERMES_HOME", "~/.hermes")
-        ),
-        "downloads",
-    ),
+    "HERMES_SHELLBRIDGE_FILES_DIR", str(_HERMES_HOME / "downloads")
 )
+DASH_URL = os.environ.get("HERMES_DASHBOARD_URL", "http://127.0.0.1:9192")
+_DASH_TOK_VAR = "HERMES_DASHBOARD_SESSION_" + "TOKEN"
+DASH_TOKEN = os.environ.get(_DASH_TOK_VAR, "")
+_MAX_AUDIO_BYTES = 64 * 1024 * 1024
 
 # Image extensions that should land in IMAGES_DIR + carry an `/image`
 # hint so the TUI attaches them as visual content. Everything else is
@@ -222,6 +218,184 @@ def cmd_send(args):
         return 1
 
 
+def _dash_req(method, path, body=None, ctype="application/json", timeout=130):
+    req = urllib.request.Request(DASH_URL + path, data=body, method=method)
+    if DASH_TOKEN:
+        req.add_header("X-Hermes-Session-Token", DASH_TOKEN)
+    if body is not None:
+        req.add_header("Content-Type", ctype)
+    return urllib.request.urlopen(req, timeout=timeout)
+
+
+def _strip_markdown_for_speech(text):
+    """Remove common Markdown syntax before sending text to TTS."""
+    import re
+
+    result = re.sub(r"```[\s\S]*?```", " ", text)
+    result = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", result)
+    result = re.sub(r"https?://\S+", "", result)
+    result = re.sub(r"\*\*(.+?)\*\*", r"\1", result)
+    result = re.sub(r"\*(.+?)\*", r"\1", result)
+    result = re.sub(r"`(.+?)`", r"\1", result)
+    result = re.sub(r"^#+\s*", "", result, flags=re.MULTILINE)
+    result = re.sub(r"^\s*[-*]\s+", "", result, flags=re.MULTILINE)
+    result = re.sub(r"^\s*\d+\.\s+", "", result, flags=re.MULTILINE)
+    result = re.sub(r"_{1,2}(.+?)_{1,2}", r"\1", result)
+    result = re.sub(r"~~(.+?)~~", r"\1", result)
+    result = re.sub(r"^>\s*", "", result, flags=re.MULTILINE)
+    result = re.sub(r"[|#]", " ", result)
+    return re.sub(r"\n{3,}", "\n\n", result).strip()
+
+
+def cmd_say(args):
+    text = _strip_markdown_for_speech(args.text)
+    if not text:
+        _emit({"ok": True, "played": False, "bytes": 0})
+        return 0
+    try:
+        with _dash_req(
+            "POST", "/api/audio/speak",
+            body=json.dumps({"text": text}).encode(), timeout=60,
+        ) as response:
+            result = json.loads(response.read())
+        data_url = result.get("data_url") or result.get("audio") or ""
+        if not data_url.startswith("data:"):
+            raise ValueError("TTS returned no audio data URL")
+        header, encoded = data_url.split(",", 1)
+        audio = base64.b64decode(encoded, validate=True)
+        fmt = "mp3"
+        if "audio/" in header:
+            fmt = header.split("audio/", 1)[1].split(";", 1)[0] or fmt
+        with _client_req(
+            "POST", "/play?fmt=" + quote(fmt), body=audio, timeout=600
+        ) as response:
+            played = json.loads(response.read())
+        ok = bool(played.get("ok"))
+        _emit({"ok": ok, "played": ok, "bytes": len(audio)})
+        return 0 if ok else 1
+    except Exception as exc:  # noqa: BLE001
+        _emit({"ok": False, "error": "speak failed: %s" % exc})
+        return 1
+
+
+def _transcribe_and_emit(wav):
+    data_url = "data:audio/wav;base64," + base64.b64encode(wav).decode()
+    try:
+        with _dash_req(
+            "POST", "/api/audio/transcribe",
+            body=json.dumps({
+                "data_url": data_url, "mime_type": "audio/wav",
+            }).encode(), timeout=130,
+        ) as response:
+            result = json.loads(response.read())
+        _emit({
+            "ok": True, "transcript": result.get("transcript", ""),
+            "bytes": len(wav),
+        })
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        _emit({"ok": False, "error": "transcription failed: %s" % exc})
+        return 1
+
+
+def _read_audio_response(response):
+    """Read a WAV response with a fixed allocation ceiling."""
+    length = (
+        response.headers.get("Content-Length")
+        if hasattr(response, "headers") else None
+    )
+    if length is not None:
+        try:
+            length = int(length)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("invalid recording Content-Length") from exc
+        if length > _MAX_AUDIO_BYTES:
+            raise ValueError(
+                "recording exceeds %d byte limit" % _MAX_AUDIO_BYTES
+            )
+    wav = response.read(_MAX_AUDIO_BYTES + 1)
+    if len(wav) > _MAX_AUDIO_BYTES:
+        raise ValueError("recording exceeds %d byte limit" % _MAX_AUDIO_BYTES)
+    return wav
+
+
+def cmd_listen(args):
+    try:
+        seconds = int(args.secs)
+    except (TypeError, ValueError):
+        _emit({"ok": False, "error": "secs must be an integer"})
+        return 1
+    try:
+        with _client_req(
+            "POST", "/record?secs=%d" % seconds,
+            timeout=max(seconds, 1) + 30,
+        ) as response:
+            wav = _read_audio_response(response)
+    except Exception as exc:  # noqa: BLE001
+        _emit({"ok": False, "error": "record failed: %s" % exc})
+        return 1
+    if not wav:
+        _emit({"ok": False, "error": "no audio recorded"})
+        return 1
+    return _transcribe_and_emit(wav)
+
+
+def cmd_listen_start(args):
+    try:
+        with _client_req(
+            "POST", "/record-start", body=b"", timeout=15
+        ) as response:
+            result = json.loads(response.read())
+        ok = bool(result.get("ok"))
+        _emit({"ok": ok, "status": result.get("status")})
+        return 0 if ok else 1
+    except Exception as exc:  # noqa: BLE001
+        _emit({"ok": False, "error": "record-start failed: %s" % exc})
+        return 1
+
+
+def cmd_listen_stop(args):
+    try:
+        with _client_req(
+            "POST", "/record-stop", body=b"", timeout=40
+        ) as response:
+            wav = _read_audio_response(response)
+    except Exception as exc:  # noqa: BLE001
+        _emit({"ok": False, "error": "record-stop failed: %s" % exc})
+        return 1
+    if not wav:
+        _emit({"ok": False, "error": "no audio recorded"})
+        return 1
+    return _transcribe_and_emit(wav)
+
+
+def _silent_wav(ms=60, rate=8000):
+    import struct
+
+    samples = max(1, int(rate * ms / 1000))
+    data = b"\x00\x00" * samples
+    return (
+        b"RIFF" + struct.pack("<I", 36 + len(data)) + b"WAVE"
+        + b"fmt "
+        + struct.pack("<IHHIIHH", 16, 1, 1, rate, rate * 2, 2, 16)
+        + b"data" + struct.pack("<I", len(data)) + data
+    )
+
+
+def cmd_stop_play(args):
+    try:
+        with _client_req(
+            "POST", "/play?fmt=wav", body=_silent_wav(), timeout=15
+        ) as response:
+            result = json.loads(response.read())
+        ok = bool(result.get("ok"))
+        _emit({"ok": ok, "stopped": ok})
+        return 0 if ok else 1
+    except Exception as exc:  # noqa: BLE001
+        _emit({"ok": False, "error": "stop-play failed: %s" % exc})
+        return 1
+
+
 def main(argv=None):
     p = argparse.ArgumentParser(
         prog="hermes-shellbridge", description=__doc__
@@ -236,6 +410,15 @@ def main(argv=None):
     s.add_argument("path")
     s.add_argument("--no-open", action="store_true")
     s.set_defaults(func=cmd_send)
+    say = sub.add_parser("say")
+    say.add_argument("text")
+    say.set_defaults(func=cmd_say)
+    listen = sub.add_parser("listen")
+    listen.add_argument("secs", nargs="?", default="8")
+    listen.set_defaults(func=cmd_listen)
+    sub.add_parser("listen-start").set_defaults(func=cmd_listen_start)
+    sub.add_parser("listen-stop").set_defaults(func=cmd_listen_stop)
+    sub.add_parser("stop-play").set_defaults(func=cmd_stop_play)
     args = p.parse_args(argv)
     return args.func(args)
 

--- a/hermes_cli/shellctl_assets/hermes-shellctl
+++ b/hermes_cli/shellctl_assets/hermes-shellctl
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""hermes-shellctl - CLIENT half of the Hermes SSH file/image bridge.
+
+Runs on YOUR machine (Mac / Linux / WSL / PuTTY host) - the box you
+SSH FROM. It is a tiny HTTP server (Python 3 stdlib only, zero
+dependencies) that the Hermes host (the box you SSH INTO, running the
+TUI + dashboard) reaches back through a reverse SSH forward
+(RemoteForward). That lets the remote Hermes:
+
+  - PULL a local file from this machine  (image / pdf / any file ->
+    attach in the TUI)
+  - PUSH a file to this machine and open it  (agent-produced image /
+    artifact)
+  - read this machine's CLIPBOARD image or file  (paste)
+
+Design: stdlib only, no sudo, no ControlMaster dependency,
+localhost-bound + token-gated.
+
+Run:  hermes-shellctl daemon --port 8765 --token <tok>
+"""
+from __future__ import annotations
+
+import argparse
+import hmac
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+SHELLCTL_VERSION = "0.2.0"
+_IS_MAC = platform.system() == "Darwin"
+
+_TOKEN = ""
+_DOWNLOAD_DIR = os.path.expanduser("~/Downloads")
+_MAX_BYTES = 64 * 1024 * 1024  # 64 MB cap per transfer
+
+
+def _which(*cands: str):
+    for c in cands:
+        p = shutil.which(c)
+        if p:
+            return p
+    return None
+
+
+def _open_file(path: str):
+    opener = "open" if _IS_MAC else _which("xdg-open", "gio")
+    if not opener:
+        return False, "no opener (install xdg-utils on Linux)"
+    try:
+        subprocess.Popen(
+            [opener, path],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return True, "opened"
+    except Exception as e:  # noqa: BLE001
+        return False, str(e)
+
+
+_MIME_BY_EXT = {
+    ".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+    ".gif": "image/gif", ".webp": "image/webp", ".bmp": "image/bmp",
+    ".tiff": "image/tiff", ".tif": "image/tiff", ".heic": "image/heic",
+    ".heif": "image/heif", ".svg": "image/svg+xml",
+    ".pdf": "application/pdf",
+}
+
+
+def _guess_ctype(name):
+    import mimetypes
+
+    ext = os.path.splitext(name or "")[1].lower()
+    if ext in _MIME_BY_EXT:
+        return _MIME_BY_EXT[ext]
+    return (
+        mimetypes.guess_type(name or "")[0]
+        or "application/octet-stream"
+    )
+
+
+def _macos_clipboard_file_paths():
+    """Return POSIX paths of files currently on the macOS clipboard.
+
+    When you Cmd+C a file in Finder (or copy a file from most apps),
+    the pasteboard carries a ``public.file-url`` reference to the
+    ORIGINAL file on disk, not a re-rendered bitmap. Reading those
+    bytes straight off disk is byte-perfect and works for ANY type
+    (pdf, zip, high-res image), which is exactly the as-is transfer
+    the user wants. AppleScript's ``the clipboard as class furl``
+    returns the file URL(s); a list when several files are copied. We
+    ask for a newline-joined POSIX path list.
+    """
+    script = (
+        'set out to ""\n'
+        'try\n'
+        '  set theFiles to (the clipboard as \xc2\xabclass furl\xc2\xbb)\n'
+        '  if class of theFiles is not list then '
+        'set theFiles to {theFiles}\n'
+        '  repeat with f in theFiles\n'
+        '    set out to out & POSIX path of f & linefeed\n'
+        '  end repeat\n'
+        'end try\n'
+        'return out'
+    )
+    try:
+        r = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True,
+            timeout=10,
+        )
+        if r.returncode != 0:
+            return []
+        raw = (r.stdout or b"").decode("utf-8", "replace")
+        return [
+            p
+            for p in (line.strip() for line in raw.splitlines())
+            if p
+        ]
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def _clipboard_grab():
+    """Grab clipboard contents losslessly.
+
+    Returns (data, filename, ctype, msg). Priority, highest fidelity
+    first:
+      1. A FILE on the clipboard (Finder copy / file URL) -> read the
+         ORIGINAL bytes off disk, keep the real name + extension.
+         Byte-perfect, any type.
+      2. Raw image data on the clipboard (screenshot, copy from
+         Preview) with no backing file -> extract as PNG (lossless
+         container; the only representation the OS actually holds for
+         a screenshot, so it is as-is).
+    """
+    if _IS_MAC:
+        # 1. Real file(s) on the clipboard -> transfer the original
+        # bytes as-is.
+        for path in _macos_clipboard_file_paths():
+            try:
+                if os.path.isfile(path):
+                    sz = os.path.getsize(path)
+                    if sz > _MAX_BYTES:
+                        return (
+                            None, None, None,
+                            "clipboard file too large (%d bytes)" % sz,
+                        )
+                    with open(path, "rb") as f:
+                        data = f.read()
+                    name = os.path.basename(path) or "clipboard-file"
+                    return data, name, _guess_ctype(name), "ok"
+            except Exception:  # noqa: BLE001
+                continue  # fall through to the bitmap path
+
+        # 2. No backing file: raw image bitmap (screenshot etc).
+        pp = _which("pngpaste")
+        tmp = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+        tmp.close()
+        try:
+            if pp:
+                r = subprocess.run(
+                    [pp, tmp.name], capture_output=True, timeout=10
+                )
+                if r.returncode != 0:
+                    return None, None, None, "no image on clipboard"
+            else:
+                script = (
+                    'set p to (POSIX file "%s")\n'
+                    'set d to the clipboard as '
+                    '\xc2\xabclass PNGf\xc2\xbb\n'
+                    'set fh to open for access p with write '
+                    'permission\n'
+                    'write d to fh\nclose access fh'
+                ) % tmp.name
+                r = subprocess.run(
+                    ["osascript", "-e", script],
+                    capture_output=True,
+                    timeout=10,
+                )
+                if r.returncode != 0:
+                    return (
+                        None, None, None,
+                        "no image on clipboard (or osascript denied)",
+                    )
+            with open(tmp.name, "rb") as f:
+                data = f.read()
+            if not data:
+                return None, None, None, "clipboard image empty"
+            return (
+                data, "clip-%d.png" % int(time.time()),
+                "image/png", "ok",
+            )
+        except Exception as e:  # noqa: BLE001
+            return None, None, None, str(e)
+        finally:
+            try:
+                os.unlink(tmp.name)
+            except OSError:
+                pass
+    else:
+        # Linux/WSL. 1. File(s) copied in a file manager land on the
+        # clipboard as text/uri-list; read the original bytes off disk
+        # (byte-perfect, any type).
+        xc = _which("xclip")
+        if xc:
+            try:
+                r = subprocess.run(
+                    [
+                        xc, "-selection", "clipboard",
+                        "-t", "text/uri-list", "-o",
+                    ],
+                    capture_output=True,
+                    timeout=10,
+                )
+                if r.returncode == 0 and r.stdout:
+                    for line in r.stdout.decode(
+                        "utf-8", "replace"
+                    ).splitlines():
+                        line = line.strip()
+                        if line.startswith("file://"):
+                            from urllib.parse import (
+                                unquote,
+                                urlparse as _up,
+                            )
+                            p = unquote(_up(line).path)
+                            if os.path.isfile(p):
+                                sz = os.path.getsize(p)
+                                if sz > _MAX_BYTES:
+                                    return (
+                                        None, None, None,
+                                        "clipboard file too large "
+                                        "(%d bytes)" % sz,
+                                    )
+                                with open(p, "rb") as f:
+                                    data = f.read()
+                                name = (
+                                    os.path.basename(p)
+                                    or "clipboard-file"
+                                )
+                                return (
+                                    data, name,
+                                    _guess_ctype(name), "ok",
+                                )
+            except Exception:  # noqa: BLE001
+                pass
+            # 2. Raw image bitmap on the clipboard.
+            try:
+                r = subprocess.run(
+                    [
+                        xc, "-selection", "clipboard",
+                        "-t", "image/png", "-o",
+                    ],
+                    capture_output=True,
+                    timeout=10,
+                )
+                if r.returncode == 0 and r.stdout:
+                    return (
+                        r.stdout, "clip-%d.png" % int(time.time()),
+                        "image/png", "ok",
+                    )
+            except Exception as e:  # noqa: BLE001
+                return None, None, None, str(e)
+            return None, None, None, "no image on clipboard"
+        return None, None, None, "install xclip for clipboard images"
+
+
+def _capabilities():
+    return {
+        "open": bool(
+            "open" if _IS_MAC else _which("xdg-open", "gio")
+        ),
+        "clipboard": bool(
+            _which("pngpaste") or _IS_MAC or _which("xclip")
+        ),
+    }
+
+
+class _Handler(BaseHTTPRequestHandler):
+    server_version = "hermes-shellctl/" + SHELLCTL_VERSION
+
+    def log_message(self, *a):
+        pass
+
+    def _auth_ok(self):
+        tok = self.headers.get("X-Shellctl-Token", "")
+        return bool(_TOKEN) and hmac.compare_digest(tok, _TOKEN)
+
+    def _send(
+        self,
+        code,
+        payload=None,
+        raw=None,
+        ctype="application/json",
+        extra_headers=None,
+    ):
+        body = (
+            raw if raw is not None
+            else json.dumps(payload or {}).encode()
+        )
+        self.send_response(code)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(body)))
+        for k, v in (extra_headers or {}).items():
+            self.send_header(k, str(v))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _read_body(self):
+        n = int(self.headers.get("Content-Length", 0) or 0)
+        if n > _MAX_BYTES:
+            return b""
+        return self.rfile.read(n) if n else b""
+
+    def do_GET(self):
+        u = urlparse(self.path)
+        if u.path == "/ping":
+            return self._send(200, {
+                "ok": True,
+                "version": SHELLCTL_VERSION,
+                "os": platform.system(),
+                "caps": _capabilities(),
+            })
+        if not self._auth_ok():
+            return self._send(401, {"error": "unauthorized"})
+        q = parse_qs(u.query)
+        if u.path == "/pull":
+            path = os.path.expanduser((q.get("path") or [""])[0])
+            if not path or not os.path.isfile(path):
+                return self._send(
+                    404, {"error": "file not found: " + path}
+                )
+            sz = os.path.getsize(path)
+            if sz > _MAX_BYTES:
+                return self._send(
+                    413, {"error": "file too large (%d bytes)" % sz}
+                )
+            with open(path, "rb") as f:
+                return self._send(
+                    200,
+                    raw=f.read(),
+                    ctype="application/octet-stream",
+                )
+        if u.path == "/clipboard":
+            data, name, ctype, msg = _clipboard_grab()
+            if data is None:
+                return self._send(404, {"error": msg})
+            # Carry the real filename + content-type so the remote
+            # side saves the bytes verbatim with the correct extension
+            # (image, pdf, anything), instead of assuming .png. Legacy
+            # remotes that ignore these headers still get the raw
+            # bytes unchanged.
+            extra = {
+                "X-Clipboard-Filename": name or "clipboard-file",
+                "X-Clipboard-Kind": (
+                    "image"
+                    if (ctype or "").startswith("image/")
+                    else "file"
+                ),
+            }
+            return self._send(
+                200,
+                raw=data,
+                ctype=ctype or "application/octet-stream",
+                extra_headers=extra,
+            )
+        return self._send(404, {"error": "no such endpoint"})
+
+    def do_POST(self):
+        u = urlparse(self.path)
+        if not self._auth_ok():
+            return self._send(401, {"error": "unauthorized"})
+        q = parse_qs(u.query)
+        if u.path == "/push":
+            name = (
+                os.path.basename(
+                    (q.get("name") or ["hermes-file"])[0]
+                )
+                or "hermes-file"
+            )
+            data = self._read_body()
+            if not data:
+                return self._send(
+                    400, {"error": "empty body or too large"}
+                )
+            os.makedirs(_DOWNLOAD_DIR, exist_ok=True)
+            dest = os.path.join(_DOWNLOAD_DIR, name)
+            with open(dest, "wb") as f:
+                f.write(data)
+            opened = (q.get("open") or ["1"])[0] not in (
+                "0", "false", "no"
+            )
+            if opened:
+                _open_file(dest)
+            return self._send(200, {
+                "ok": True,
+                "path": dest,
+                "opened": opened,
+                "bytes": len(data),
+            })
+        return self._send(404, {"error": "no such endpoint"})
+
+
+def cmd_daemon(args):
+    global _TOKEN, _DOWNLOAD_DIR
+    _TOKEN = args.token or os.environ.get(
+        "HERMES_SHELLCTL_TOKEN", ""
+    )
+    if not _TOKEN:
+        print(
+            "FATAL: no token (pass --token or set "
+            "HERMES_SHELLCTL_TOKEN)",
+            file=sys.stderr,
+        )
+        return 2
+    if args.download_dir:
+        _DOWNLOAD_DIR = os.path.expanduser(args.download_dir)
+    srv = ThreadingHTTPServer((args.host, args.port), _Handler)
+    print(
+        "hermes-shellctl %s listening on %s:%d (%s, caps=%s)" % (
+            SHELLCTL_VERSION,
+            args.host,
+            args.port,
+            platform.system(),
+            _capabilities(),
+        ),
+        flush=True,
+    )
+    try:
+        srv.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(
+        prog="hermes-shellctl", description=__doc__
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+    d = sub.add_parser("daemon", help="run the bridge listener")
+    d.add_argument("--host", default="127.0.0.1")
+    d.add_argument("--port", type=int, default=8765)
+    d.add_argument("--token", default="")
+    d.add_argument("--download-dir", default="")
+    d.set_defaults(func=cmd_daemon)
+    v = sub.add_parser("version", help="print version")
+    v.set_defaults(func=lambda a: (print(SHELLCTL_VERSION), 0)[1])
+    args = p.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hermes_cli/shellctl_assets/hermes-shellctl
+++ b/hermes_cli/shellctl_assets/hermes-shellctl
@@ -21,9 +21,12 @@ Run:  hermes-shellctl daemon --port 8765 --token-file <path>
 The token is a bearer credential for every endpoint. A caller with the token
 and listener access can pull any file readable by this process unless
 ``--allowed-root`` is set, read clipboard content, and push files into the
-download directory. The SSH reverse forward intentionally gives the remote
-Hermes host listener access, so a compromised host is inside this trust
-boundary.
+download directory. The audio extension also lets that caller play audio and
+activate the local microphone remotely. Token possession permits remote
+microphone activation, and compromise of the Hermes host permits eavesdropping
+while the daemon and SSH reverse forward are running. The SSH reverse forward
+intentionally gives the remote Hermes host listener access, so a compromised
+host is inside this trust boundary.
 """
 from __future__ import annotations
 
@@ -33,9 +36,11 @@ import json
 import os
 import platform
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import parse_qs, urlparse
@@ -47,6 +52,14 @@ _TOKEN = ""
 _DOWNLOAD_DIR = os.path.expanduser("~/Downloads")
 _ALLOWED_ROOT = ""
 _MAX_BYTES = 64 * 1024 * 1024  # 64 MB cap per transfer
+_MAX_AUDIO_BYTES = 64 * 1024 * 1024
+_MAX_OPEN_CAPTURE_SECS = 300
+_MAX_CONFIGURED_CAPTURE_SECS = 3600
+_AUDIO_EXTENSIONS = frozenset({"aac", "aiff", "flac", "m4a", "mp3", "ogg", "opus", "wav"})
+_OPEN_CAPTURE = {
+    "out_wav": None, "active": False, "process": None, "watchdog": None,
+}
+_CAPTURE_LOCK = threading.Lock()
 
 
 class _BodyTooLarge(ValueError):
@@ -287,6 +300,223 @@ def _clipboard_grab():
         return None, None, None, "install xclip for clipboard images"
 
 
+def _play_audio(path):
+    if _IS_MAC:
+        player = _which("afplay")
+        args = [player, path] if player else None
+    else:
+        player = _which("paplay", "aplay", "ffplay", "mpv")
+        if player and player.endswith("ffplay"):
+            args = [player, "-nodisp", "-autoexit", "-loglevel", "quiet", path]
+        else:
+            args = [player, path] if player else None
+    if not args:
+        return False, "no audio player found"
+    try:
+        subprocess.run(
+            args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            timeout=600,
+        )
+        return True, "played"
+    except Exception as exc:  # noqa: BLE001
+        return False, str(exc)
+
+
+def _find_micrec():
+    candidates = [
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "micrec"),
+        os.path.expanduser("~/.hermes/shellctl/micrec"),
+    ]
+    for candidate in candidates:
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def _record_mic(seconds):
+    seconds = max(1, min(seconds, 120))
+    tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+    tmp.close()
+    try:
+        if _IS_MAC:
+            recorder = _find_micrec()
+            if recorder:
+                args = [recorder, tmp.name, str(seconds)]
+            else:
+                recorder = _which("rec", "sox")
+                if recorder:
+                    args = [recorder, "-q", "-d", tmp.name, "trim", "0", str(seconds)]
+                else:
+                    ffmpeg = _which("ffmpeg")
+                    if not ffmpeg:
+                        return None, "no recorder (install sox or ffmpeg)"
+                    args = [
+                        ffmpeg, "-y", "-f", "avfoundation", "-i", ":default",
+                        "-t", str(seconds), "-loglevel", "quiet", tmp.name,
+                    ]
+        else:
+            recorder = _which("arecord")
+            if recorder:
+                args = [
+                    recorder, "-q", "-d", str(seconds), "-f", "cd", tmp.name,
+                ]
+            else:
+                ffmpeg = _which("ffmpeg")
+                if not ffmpeg:
+                    return None, "no recorder (install alsa-utils or ffmpeg)"
+                args = [
+                    ffmpeg, "-y", "-f", "pulse", "-i", "default", "-t",
+                    str(seconds), "-loglevel", "quiet", tmp.name,
+                ]
+        subprocess.run(
+            args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            timeout=seconds + 15,
+        )
+        return _read_audio_file(tmp.name)
+    except Exception as exc:  # noqa: BLE001
+        return None, str(exc)
+    finally:
+        try:
+            os.unlink(tmp.name)
+        except OSError:
+            pass
+
+
+def _read_audio_file(path):
+    """Read a captured WAV without allowing an unbounded allocation."""
+    size = os.path.getsize(path)
+    if size > _MAX_AUDIO_BYTES:
+        return None, "capture exceeds %d byte limit" % _MAX_AUDIO_BYTES
+    with open(path, "rb") as stream:
+        data = stream.read(_MAX_AUDIO_BYTES + 1)
+    if len(data) > _MAX_AUDIO_BYTES:
+        return None, "capture exceeds %d byte limit" % _MAX_AUDIO_BYTES
+    if not data:
+        return None, "capture produced no audio"
+    return data, "ok"
+
+
+def _claim_open_capture(expected_process=None):
+    """Atomically detach one capture so only one caller can clean it up."""
+    with _CAPTURE_LOCK:
+        if not _OPEN_CAPTURE["active"]:
+            return None
+        if (
+            expected_process is not None
+            and _OPEN_CAPTURE["process"] is not expected_process
+        ):
+            return None
+        claimed = dict(_OPEN_CAPTURE)
+        _OPEN_CAPTURE.update({
+            "active": False, "out_wav": None, "process": None,
+            "watchdog": None,
+        })
+    watchdog = claimed.get("watchdog")
+    if watchdog is not None:
+        watchdog.cancel()
+    return claimed
+
+
+def _terminate_process(process):
+    """Terminate a recorder and escalate to kill if it does not exit."""
+    try:
+        process.terminate()
+        process.wait(timeout=10)
+    except Exception:  # noqa: BLE001
+        try:
+            process.kill()
+            process.wait(timeout=5)
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def _discard_open_capture(expected_process=None):
+    """Stop and remove a capture without returning its audio."""
+    claimed = _claim_open_capture(expected_process)
+    if claimed is None:
+        return False
+    _terminate_process(claimed["process"])
+    try:
+        os.unlink(claimed["out_wav"])
+    except OSError:
+        pass
+    return True
+
+
+def _record_start_open():
+    """Start one bounded open capture while holding the state lock."""
+    with _CAPTURE_LOCK:
+        if _OPEN_CAPTURE["active"]:
+            return False, "capture already active", None
+        tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        tmp.close()
+        if _IS_MAC:
+            recorder = _which("rec", "sox")
+            if recorder:
+                args = [recorder, "-q", "-d", tmp.name]
+            else:
+                recorder = _which("ffmpeg")
+                args = (
+                    [
+                        recorder, "-y", "-f", "avfoundation", "-i",
+                        ":default", "-loglevel", "quiet", tmp.name,
+                    ]
+                    if recorder else None
+                )
+        else:
+            recorder = _which("arecord")
+            if recorder:
+                args = [recorder, "-q", "-f", "cd", tmp.name]
+            else:
+                recorder = _which("ffmpeg")
+                args = (
+                    [
+                        recorder, "-y", "-f", "pulse", "-i", "default",
+                        "-loglevel", "quiet", tmp.name,
+                    ]
+                    if recorder else None
+                )
+        if not args:
+            os.unlink(tmp.name)
+            return False, "no recorder available", None
+        try:
+            process = subprocess.Popen(
+                args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+            )
+        except Exception as exc:  # noqa: BLE001
+            os.unlink(tmp.name)
+            return False, str(exc), None
+        watchdog = threading.Timer(
+            _MAX_OPEN_CAPTURE_SECS, _discard_open_capture, args=(process,)
+        )
+        watchdog.daemon = True
+        _OPEN_CAPTURE.update({
+            "active": True, "out_wav": tmp.name, "process": process,
+            "watchdog": watchdog,
+        })
+    watchdog.start()
+    return True, "recording", process
+
+
+def _record_stop_open():
+    """Claim and stop the active capture without racing another request."""
+    claimed = _claim_open_capture()
+    if claimed is None:
+        return None, "no open capture"
+    process = claimed["process"]
+    out_wav = claimed["out_wav"]
+    try:
+        _terminate_process(process)
+        return _read_audio_file(out_wav)
+    except Exception as exc:  # noqa: BLE001
+        return None, str(exc)
+    finally:
+        try:
+            os.unlink(out_wav)
+        except OSError:
+            pass
+
+
 def _capabilities():
     return {
         "open": bool(
@@ -294,6 +524,10 @@ def _capabilities():
         ),
         "clipboard": bool(
             _which("pngpaste") or _IS_MAC or _which("xclip")
+        ),
+        "play": bool(_which("afplay", "paplay", "aplay", "ffplay", "mpv")),
+        "record": bool(
+            _find_micrec() or _which("rec", "sox", "arecord", "ffmpeg")
         ),
     }
 
@@ -320,13 +554,17 @@ class _Handler(BaseHTTPRequestHandler):
             raw if raw is not None
             else json.dumps(payload or {}).encode()
         )
-        self.send_response(code)
-        self.send_header("Content-Type", ctype)
-        self.send_header("Content-Length", str(len(body)))
-        for k, v in (extra_headers or {}).items():
-            self.send_header(k, str(v))
-        self.end_headers()
-        self.wfile.write(body)
+        try:
+            self.send_response(code)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(body)))
+            for k, v in (extra_headers or {}).items():
+                self.send_header(k, str(v))
+            self.end_headers()
+            self.wfile.write(body)
+            return True
+        except (BrokenPipeError, ConnectionResetError):
+            return False
 
     def _read_body(self):
         raw_length = self.headers.get("Content-Length")
@@ -416,7 +654,61 @@ class _Handler(BaseHTTPRequestHandler):
         u = urlparse(self.path)
         if not self._auth_ok():
             return self._send(401, {"error": "unauthorized"})
-        q = parse_qs(u.query)
+        q = parse_qs(u.query, keep_blank_values=True)
+        if u.path == "/play":
+            try:
+                data = self._read_body()
+            except _BodyTooLarge:
+                return self._send(413, {"error": "request body too large"})
+            except _MalformedBody as exc:
+                return self._send(400, {"error": str(exc)})
+            if not data:
+                return self._send(400, {"error": "empty body"})
+            extension = (q.get("fmt") or ["mp3"])[0].lower().lstrip(".")
+            if extension not in _AUDIO_EXTENSIONS:
+                return self._send(400, {"error": "unsupported audio format"})
+            tmp = tempfile.NamedTemporaryFile(
+                suffix="." + extension, delete=False
+            )
+            try:
+                tmp.write(data)
+                tmp.close()
+                ok, msg = _play_audio(tmp.name)
+                return self._send(
+                    200 if ok else 500, {"ok": ok, "msg": msg}
+                )
+            finally:
+                try:
+                    os.unlink(tmp.name)
+                except OSError:
+                    pass
+        if u.path == "/record":
+            raw_seconds = (q.get("secs") or ["8"])[0]
+            try:
+                seconds = int(raw_seconds)
+            except (TypeError, ValueError):
+                return self._send(400, {"error": "secs must be an integer"})
+            if not 1 <= seconds <= 120:
+                return self._send(400, {"error": "secs must be between 1 and 120"})
+            data, msg = _record_mic(seconds)
+            if data is None:
+                code = 413 if "byte limit" in msg else 500
+                return self._send(code, {"error": msg})
+            return self._send(200, raw=data, ctype="audio/wav")
+        if u.path == "/record-start":
+            ok, msg, process = _record_start_open()
+            if not ok:
+                return self._send(409, {"error": msg})
+            sent = self._send(200, {"ok": True, "status": msg})
+            if not sent:
+                _discard_open_capture(process)
+            return sent
+        if u.path == "/record-stop":
+            data, msg = _record_stop_open()
+            if data is None:
+                code = 413 if "byte limit" in msg else 409
+                return self._send(code, {"error": msg})
+            return self._send(200, raw=data, ctype="audio/wav")
         if u.path == "/push":
             name = (
                 os.path.basename(
@@ -478,7 +770,7 @@ def _read_token_file(path):
 
 
 def cmd_daemon(args):
-    global _TOKEN, _DOWNLOAD_DIR, _ALLOWED_ROOT
+    global _TOKEN, _DOWNLOAD_DIR, _ALLOWED_ROOT, _MAX_OPEN_CAPTURE_SECS
     _TOKEN = args.token or _read_token_file(args.token_file) or os.environ.get(
         "HERMES_SHELLCTL_TOKEN", ""
     )
@@ -500,7 +792,24 @@ def cmd_daemon(args):
             )
             return 2
         _ALLOWED_ROOT = root
+    if not 1 <= args.max_open_capture_secs <= _MAX_CONFIGURED_CAPTURE_SECS:
+        print(
+            "FATAL: max open capture seconds must be between 1 and %d"
+            % _MAX_CONFIGURED_CAPTURE_SECS,
+            file=sys.stderr,
+        )
+        return 2
+    _MAX_OPEN_CAPTURE_SECS = args.max_open_capture_secs
     srv = ThreadingHTTPServer((args.host, args.port), _Handler)
+    old_signal_handlers = {}
+
+    def stop_daemon(signum, frame):
+        raise KeyboardInterrupt
+
+    if threading.current_thread() is threading.main_thread():
+        for signum in (signal.SIGTERM, getattr(signal, "SIGHUP", None)):
+            if signum is not None:
+                old_signal_handlers[signum] = signal.signal(signum, stop_daemon)
     print(
         "hermes-shellctl %s listening on %s:%d (%s, caps=%s)" % (
             SHELLCTL_VERSION,
@@ -515,6 +824,11 @@ def cmd_daemon(args):
         srv.serve_forever()
     except KeyboardInterrupt:
         pass
+    finally:
+        _discard_open_capture()
+        srv.server_close()
+        for signum, handler in old_signal_handlers.items():
+            signal.signal(signum, handler)
     return 0
 
 
@@ -529,6 +843,12 @@ def main(argv=None):
     d.add_argument("--token", default="")
     d.add_argument("--token-file", default="")
     d.add_argument("--download-dir", default="")
+    d.add_argument(
+        "--max-open-capture-secs",
+        type=int,
+        default=_MAX_OPEN_CAPTURE_SECS,
+        help="stop an unclosed microphone capture after this many seconds",
+    )
     d.add_argument(
         "--allowed-root",
         default="",

--- a/hermes_cli/shellctl_assets/hermes-shellctl
+++ b/hermes_cli/shellctl_assets/hermes-shellctl
@@ -16,7 +16,14 @@ TUI + dashboard) reaches back through a reverse SSH forward
 Design: stdlib only, no sudo, no ControlMaster dependency,
 localhost-bound + token-gated.
 
-Run:  hermes-shellctl daemon --port 8765 --token <tok>
+Run:  hermes-shellctl daemon --port 8765 --token-file <path>
+
+The token is a bearer credential for every endpoint. A caller with the token
+and listener access can pull any file readable by this process unless
+``--allowed-root`` is set, read clipboard content, and push files into the
+download directory. The SSH reverse forward intentionally gives the remote
+Hermes host listener access, so a compromised host is inside this trust
+boundary.
 """
 from __future__ import annotations
 
@@ -38,7 +45,16 @@ _IS_MAC = platform.system() == "Darwin"
 
 _TOKEN = ""
 _DOWNLOAD_DIR = os.path.expanduser("~/Downloads")
+_ALLOWED_ROOT = ""
 _MAX_BYTES = 64 * 1024 * 1024  # 64 MB cap per transfer
+
+
+class _BodyTooLarge(ValueError):
+    pass
+
+
+class _MalformedBody(ValueError):
+    pass
 
 
 def _which(*cands: str):
@@ -313,13 +329,37 @@ class _Handler(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
     def _read_body(self):
-        n = int(self.headers.get("Content-Length", 0) or 0)
+        raw_length = self.headers.get("Content-Length")
+        if raw_length is None:
+            raise _MalformedBody("missing Content-Length")
+        try:
+            n = int(raw_length)
+        except (TypeError, ValueError) as exc:
+            raise _MalformedBody("invalid Content-Length") from exc
+        if n < 0:
+            raise _MalformedBody("negative Content-Length")
         if n > _MAX_BYTES:
-            return b""
-        return self.rfile.read(n) if n else b""
+            raise _BodyTooLarge("request body too large")
+        data = self.rfile.read(n) if n else b""
+        if len(data) != n:
+            raise _MalformedBody("incomplete request body")
+        return data
+
+    @staticmethod
+    def _pull_path_allowed(path):
+        if not _ALLOWED_ROOT:
+            return True
+        try:
+            return os.path.commonpath(
+                (os.path.realpath(path), _ALLOWED_ROOT)
+            ) == _ALLOWED_ROOT
+        except (OSError, ValueError):
+            return False
 
     def do_GET(self):
         u = urlparse(self.path)
+        if not self._auth_ok():
+            return self._send(401, {"error": "unauthorized"})
         if u.path == "/ping":
             return self._send(200, {
                 "ok": True,
@@ -327,11 +367,11 @@ class _Handler(BaseHTTPRequestHandler):
                 "os": platform.system(),
                 "caps": _capabilities(),
             })
-        if not self._auth_ok():
-            return self._send(401, {"error": "unauthorized"})
         q = parse_qs(u.query)
         if u.path == "/pull":
             path = os.path.expanduser((q.get("path") or [""])[0])
+            if path and not self._pull_path_allowed(path):
+                return self._send(403, {"error": "path outside allowed root"})
             if not path or not os.path.isfile(path):
                 return self._send(
                     404, {"error": "file not found: " + path}
@@ -384,15 +424,19 @@ class _Handler(BaseHTTPRequestHandler):
                 )
                 or "hermes-file"
             )
-            data = self._read_body()
+            try:
+                data = self._read_body()
+            except _BodyTooLarge:
+                return self._send(413, {"error": "request body too large"})
+            except _MalformedBody as exc:
+                return self._send(400, {"error": str(exc)})
             if not data:
-                return self._send(
-                    400, {"error": "empty body or too large"}
-                )
+                return self._send(400, {"error": "empty body"})
             os.makedirs(_DOWNLOAD_DIR, exist_ok=True)
-            dest = os.path.join(_DOWNLOAD_DIR, name)
-            with open(dest, "wb") as f:
-                f.write(data)
+            try:
+                dest = _write_deduplicated(_DOWNLOAD_DIR, name, data)
+            except OSError as exc:
+                return self._send(500, {"error": str(exc)})
             opened = (q.get("open") or ["1"])[0] not in (
                 "0", "false", "no"
             )
@@ -407,9 +451,35 @@ class _Handler(BaseHTTPRequestHandler):
         return self._send(404, {"error": "no such endpoint"})
 
 
+def _write_deduplicated(directory, name, data):
+    """Write data without replacing an existing destination."""
+    stem, ext = os.path.splitext(name)
+    for suffix in range(10000):
+        candidate = name if suffix == 0 else "%s-%d%s" % (stem, suffix, ext)
+        dest = os.path.join(directory, candidate)
+        try:
+            with open(dest, "xb") as f:
+                f.write(data)
+            return dest
+        except FileExistsError:
+            continue
+    raise OSError("could not allocate a unique destination filename")
+
+
+def _read_token_file(path):
+    if not path:
+        return ""
+    try:
+        with open(os.path.expanduser(path), encoding="utf-8") as f:
+            return f.read().strip()
+    except OSError as exc:
+        print("FATAL: cannot read token file: %s" % exc, file=sys.stderr)
+        return ""
+
+
 def cmd_daemon(args):
-    global _TOKEN, _DOWNLOAD_DIR
-    _TOKEN = args.token or os.environ.get(
+    global _TOKEN, _DOWNLOAD_DIR, _ALLOWED_ROOT
+    _TOKEN = args.token or _read_token_file(args.token_file) or os.environ.get(
         "HERMES_SHELLCTL_TOKEN", ""
     )
     if not _TOKEN:
@@ -421,6 +491,15 @@ def cmd_daemon(args):
         return 2
     if args.download_dir:
         _DOWNLOAD_DIR = os.path.expanduser(args.download_dir)
+    if args.allowed_root:
+        root = os.path.realpath(os.path.expanduser(args.allowed_root))
+        if not os.path.isdir(root):
+            print(
+                "FATAL: allowed root is not a directory: %s" % root,
+                file=sys.stderr,
+            )
+            return 2
+        _ALLOWED_ROOT = root
     srv = ThreadingHTTPServer((args.host, args.port), _Handler)
     print(
         "hermes-shellctl %s listening on %s:%d (%s, caps=%s)" % (
@@ -448,7 +527,13 @@ def main(argv=None):
     d.add_argument("--host", default="127.0.0.1")
     d.add_argument("--port", type=int, default=8765)
     d.add_argument("--token", default="")
+    d.add_argument("--token-file", default="")
     d.add_argument("--download-dir", default="")
+    d.add_argument(
+        "--allowed-root",
+        default="",
+        help="optionally restrict /pull to this directory tree",
+    )
     d.set_defaults(func=cmd_daemon)
     v = sub.add_parser("version", help="print version")
     v.set_defaults(func=lambda a: (print(SHELLCTL_VERSION), 0)[1])

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1398,6 +1398,9 @@ _CATEGORY_MERGE: Dict[str, str] = {
     # `session.terminal_continue` is the only schema-surfaced session field —
     # fold it into general rather than spawning a one-field orphan category.
     "session": "general",
+    # `shellctl.allowed_root` is the only schema-surfaced shellctl field. Keep
+    # it with the terminal settings that own the SSH bridge workflow.
+    "shellctl": "terminal",
 }
 
 # Display order for tabs — unlisted categories sort alphabetically after these.

--- a/tests/hermes_cli/test_shellctl_audio.py
+++ b/tests/hermes_cli/test_shellctl_audio.py
@@ -1,0 +1,352 @@
+"""HTTP security, lifecycle, and concurrency tests for shellctl audio."""
+from __future__ import annotations
+
+import concurrent.futures
+import http.client
+import importlib.machinery
+import importlib.util
+import json
+import os
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+_ASSET = Path(__file__).resolve().parents[2] / "hermes_cli/shellctl_assets/hermes-shellctl"
+
+
+def _load():
+    loader = importlib.machinery.SourceFileLoader("shellctl_audio_test", str(_ASSET))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def server():
+    module = _load()
+    module._TOKEN = "audio-token"
+    module._OPEN_CAPTURE.update({
+        "active": False, "out_wav": None, "process": None,
+        "watchdog": None,
+    })
+    instance = module.ThreadingHTTPServer(("127.0.0.1", 0), module._Handler)
+    thread = threading.Thread(target=instance.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield module, instance.server_port
+    finally:
+        module._discard_open_capture()
+        instance.shutdown()
+        instance.server_close()
+        thread.join(timeout=5)
+
+
+def _http(port, method, path, body=None, token="audio-token"):
+    headers = {}
+    if token is not None:
+        headers["X-Shellctl-Token"] = token
+    connection = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    connection.request(method, path, body=body, headers=headers)
+    response = connection.getresponse()
+    result = response.status, response.read()
+    connection.close()
+    return result
+
+
+class _Process:
+    def __init__(self):
+        self.terminated = threading.Event()
+        self.killed = False
+
+    def terminate(self):
+        self.terminated.set()
+
+    def wait(self, timeout):
+        if not self.terminated.wait(timeout):
+            raise TimeoutError
+
+    def kill(self):
+        self.killed = True
+        self.terminated.set()
+
+
+def _mock_recorder(module, monkeypatch, process=None):
+    process = process or _Process()
+    monkeypatch.setattr(module, "_which", lambda *args: "/usr/bin/arecord")
+    monkeypatch.setattr(module.subprocess, "Popen", lambda *args, **kwargs: process)
+    return process
+
+
+def test_ping_and_audio_share_authentication(server):
+    _, port = server
+    assert _http(port, "GET", "/ping", token=None)[0] == 401
+    assert _http(port, "GET", "/ping", token="wrong")[0] == 401
+    assert _http(port, "GET", "/ping")[0] == 200
+    assert _http(port, "POST", "/record?secs=1", b"", token=None)[0] == 401
+
+
+@pytest.mark.parametrize("value", ["abc", "1.5", "", "0", "121", "-2"])
+def test_malformed_seconds_return_400(server, value):
+    _, port = server
+    status, payload = _http(port, "POST", "/record?secs=" + value, b"")
+    assert status == 400
+    assert "secs" in json.loads(payload)["error"]
+
+
+@pytest.mark.parametrize("extension", ["py", "../wav", "wav/../../x", "exe"])
+def test_play_rejects_extension_outside_allowlist(server, extension):
+    _, port = server
+    status, payload = _http(port, "POST", "/play?fmt=" + extension, b"audio")
+    assert status == 400
+    assert json.loads(payload)["error"] == "unsupported audio format"
+
+
+def test_play_accepts_allowlisted_extension(server, monkeypatch):
+    module, port = server
+    observed = {}
+
+    def play(path):
+        observed["suffix"] = Path(path).suffix
+        return True, "played"
+
+    monkeypatch.setattr(module, "_play_audio", play)
+    status, payload = _http(port, "POST", "/play?fmt=WAV", b"RIFFaudio")
+    assert status == 200
+    assert json.loads(payload)["ok"] is True
+    assert observed["suffix"] == ".wav"
+
+
+def test_concurrent_capture_allows_one_start_and_normal_stop(server, monkeypatch):
+    module, port = server
+    barrier = threading.Barrier(2)
+    _mock_recorder(module, monkeypatch)
+
+    def start():
+        barrier.wait(timeout=5)
+        return _http(port, "POST", "/record-start", b"")[0]
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(start), pool.submit(start)]
+        statuses = sorted(future.result() for future in futures)
+    assert statuses == [200, 409]
+
+    Path(module._OPEN_CAPTURE["out_wav"]).write_bytes(b"RIFFaudio")
+    assert _http(port, "POST", "/record-stop", b"") == (200, b"RIFFaudio")
+    assert module._OPEN_CAPTURE["active"] is False
+
+
+def test_watchdog_expires_and_removes_capture(server, monkeypatch):
+    module, port = server
+    process = _mock_recorder(module, monkeypatch)
+    module._MAX_OPEN_CAPTURE_SECS = 0.03
+    assert _http(port, "POST", "/record-start", b"")[0] == 200
+    output = Path(module._OPEN_CAPTURE["out_wav"])
+    assert output.exists()
+    assert process.terminated.wait(2)
+    deadline = time.monotonic() + 2
+    while output.exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert module._OPEN_CAPTURE["active"] is False
+    assert not output.exists()
+
+
+def test_capture_size_cap_returns_controlled_error(server, monkeypatch):
+    module, port = server
+    module._MAX_AUDIO_BYTES = 8
+    _mock_recorder(module, monkeypatch)
+    assert _http(port, "POST", "/record-start", b"")[0] == 200
+    output = Path(module._OPEN_CAPTURE["out_wav"])
+    output.write_bytes(b"RIFF" + b"x" * 8)
+    status, payload = _http(port, "POST", "/record-stop", b"")
+    assert status == 413
+    assert json.loads(payload)["error"] == "capture exceeds 8 byte limit"
+    assert not output.exists()
+
+
+def test_concurrent_stops_claim_capture_once(server, monkeypatch):
+    module, port = server
+    _mock_recorder(module, monkeypatch)
+    assert _http(port, "POST", "/record-start", b"")[0] == 200
+    Path(module._OPEN_CAPTURE["out_wav"]).write_bytes(b"RIFFaudio")
+    barrier = threading.Barrier(2)
+
+    def stop():
+        barrier.wait(timeout=5)
+        return _http(port, "POST", "/record-stop", b"")[0]
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(stop), pool.submit(stop)]
+        statuses = sorted(future.result() for future in futures)
+    assert statuses == [200, 409]
+
+
+def test_daemon_shutdown_discards_active_capture(tmp_path, monkeypatch):
+    module = _load()
+    process = _Process()
+    output = tmp_path / "open.wav"
+    output.write_bytes(b"RIFFaudio")
+    module._OPEN_CAPTURE.update({
+        "active": True, "out_wav": str(output), "process": process,
+        "watchdog": None,
+    })
+
+    class _Server:
+        def serve_forever(self):
+            return None
+
+        def server_close(self):
+            pass
+
+    monkeypatch.setattr(module, "ThreadingHTTPServer", lambda *args: _Server())
+    args = SimpleNamespace(
+        token="audio-token", token_file="", download_dir="",
+        allowed_root="", max_open_capture_secs=300,
+        host="127.0.0.1", port=0,
+    )
+    assert module.cmd_daemon(args) == 0
+    assert process.terminated.is_set()
+    assert module._OPEN_CAPTURE["active"] is False
+    assert not output.exists()
+
+
+def test_failed_start_response_discards_capture(monkeypatch):
+    module = _load()
+    process = _mock_recorder(module, monkeypatch)
+    handler = object.__new__(module._Handler)
+    handler.path = "/record-start"
+    handler._auth_ok = lambda: True
+    handler._send = lambda *args, **kwargs: False
+    assert handler.do_POST() is False
+    assert process.terminated.is_set()
+    assert module._OPEN_CAPTURE["active"] is False
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX signal lifecycle test")
+def test_sigterm_shutdown_reaps_real_recorder(tmp_path):
+    recorder = tmp_path / "arecord"
+    pid_file = tmp_path / "recorder.pid"
+    recorder.write_text(
+        "#!/usr/bin/env python3\n"
+        "import os, sys, time\n"
+        "open(os.environ['RECORDER_PID'], 'w').write(str(os.getpid()))\n"
+        "open(sys.argv[-1], 'wb').write(b'RIFFaudio')\n"
+        "while True: time.sleep(1)\n",
+        encoding="utf-8",
+    )
+    recorder.chmod(0o755)
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+    env = os.environ.copy()
+    env["PATH"] = str(tmp_path) + os.pathsep + env.get("PATH", "")
+    env["RECORDER_PID"] = str(pid_file)
+    daemon = subprocess.Popen(
+        [
+            sys.executable, str(_ASSET), "daemon", "--port", str(port),
+            "--token", "audio-token", "--max-open-capture-secs", "300",
+        ],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            try:
+                if _http(port, "GET", "/ping")[0] == 200:
+                    break
+            except OSError:
+                time.sleep(0.02)
+        else:
+            pytest.fail("shellctl daemon did not start")
+        assert _http(port, "POST", "/record-start", b"")[0] == 200
+        deadline = time.monotonic() + 5
+        while not pid_file.exists() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        recorder_pid = int(pid_file.read_text(encoding="utf-8"))
+        daemon.terminate()
+        assert daemon.wait(timeout=5) == 0
+        with pytest.raises(ProcessLookupError):
+            os.kill(recorder_pid, 0)
+    finally:
+        if daemon.poll() is None:
+            daemon.kill()
+            daemon.wait(timeout=5)
+
+
+def test_malformed_audio_content_length_returns_400(server):
+    _, port = server
+    connection = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    connection.putrequest("POST", "/play?fmt=wav")
+    connection.putheader("X-Shellctl-Token", "audio-token")
+    connection.putheader("Content-Length", "not-a-number")
+    connection.endheaders()
+    response = connection.getresponse()
+    assert response.status == 400
+    assert json.loads(response.read())["error"] == "invalid Content-Length"
+    connection.close()
+
+
+class _Response:
+    def __init__(self, body):
+        self.body = body
+
+    def read(self, size=-1):
+        return self.body if size < 0 else self.body[:size]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def test_host_bridge_routes_tts_to_local_play(monkeypatch, capsys):
+    import argparse
+    import base64
+
+    bridge_path = _ASSET.with_name("hermes-shellbridge")
+    loader = importlib.machinery.SourceFileLoader("shellbridge_audio_test", str(bridge_path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    assert spec is not None
+    bridge = importlib.util.module_from_spec(spec)
+    loader.exec_module(bridge)
+    audio = b"ID3audio"
+    encoded = base64.b64encode(audio).decode()
+    calls = {}
+
+    def dash(*args, **kwargs):
+        return _Response(
+            json.dumps({"data_url": "data:audio/mp3;base64," + encoded}).encode()
+        )
+
+    def client(method, path, body=None, **kwargs):
+        calls["client"] = method, path, body
+        return _Response(b'{"ok": true}')
+
+    monkeypatch.setattr(bridge, "_dash_req", dash)
+    monkeypatch.setattr(bridge, "_client_req", client)
+    assert bridge.cmd_say(argparse.Namespace(text="Hello **world**")) == 0
+    assert json.loads(capsys.readouterr().out)["played"] is True
+    assert calls["client"] == ("POST", "/play?fmt=mp3", audio)
+    assert Path(bridge.IMAGES_DIR).parent == bridge._HERMES_HOME
+
+
+def test_host_bridge_bounded_audio_read_rejects_large_response():
+    bridge_path = _ASSET.with_name("hermes-shellbridge")
+    loader = importlib.machinery.SourceFileLoader("shellbridge_size_test", str(bridge_path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    assert spec is not None
+    bridge = importlib.util.module_from_spec(spec)
+    loader.exec_module(bridge)
+    setattr(bridge, "_MAX_AUDIO_BYTES", 4)
+    with pytest.raises(ValueError, match="4 byte limit"):
+        bridge._read_audio_response(_Response(b"12345"))

--- a/tests/hermes_cli/test_shellctl_bridge.py
+++ b/tests/hermes_cli/test_shellctl_bridge.py
@@ -1,33 +1,23 @@
-"""Tests for the shellctl file/image bridge (host + install glue).
-
-Covers the image-vs-file classification + attach-hint emission in the
-host-side ``hermes-shellbridge`` orchestrator, plus a smoke test of the
-``hermes install shellctl`` asset/token setup. The bridge script has no
-``.py`` extension (it is copied to the client verbatim), so it is loaded
-from source via ``importlib``.
-"""
+"""Tests for the shellctl file/image bridge and install glue."""
 from __future__ import annotations
 
+import http.client
 import importlib.machinery
 import importlib.util
 import json
 import os
 from pathlib import Path
+import threading
+from urllib.parse import quote
 
 import pytest
 
-_ASSETS = (
-    Path(__file__).resolve().parents[2]
-    / "hermes_cli"
-    / "shellctl_assets"
-)
+_ASSETS = Path(__file__).resolve().parents[2] / "hermes_cli" / "shellctl_assets"
 
 
-def _load_shellbridge():
-    src = _ASSETS / "hermes-shellbridge"
-    loader = importlib.machinery.SourceFileLoader(
-        "hermes_shellbridge_under_test", str(src)
-    )
+def _load_asset(name: str, module_name: str):
+    src = _ASSETS / name
+    loader = importlib.machinery.SourceFileLoader(module_name, str(src))
     spec = importlib.util.spec_from_loader(loader.name, loader)
     mod = importlib.util.module_from_spec(spec)
     loader.exec_module(mod)
@@ -36,15 +26,46 @@ def _load_shellbridge():
 
 @pytest.fixture(scope="module")
 def bridge():
-    return _load_shellbridge()
+    return _load_asset("hermes-shellbridge", "hermes_shellbridge_under_test")
+
+
+@pytest.fixture
+def shellctl_server(tmp_path):
+    """Run the real stdlib HTTP handler on an OS-assigned port."""
+    mod = _load_asset("hermes-shellctl", "hermes_shellctl_under_test")
+    mod._TOKEN = "test-token"
+    mod._DOWNLOAD_DIR = str(tmp_path / "downloads")
+    mod._ALLOWED_ROOT = ""
+    server = mod.ThreadingHTTPServer(("127.0.0.1", 0), mod._Handler)
+    assert server.server_port != 0
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield mod, server.server_port
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _http(port, method, path, body=None, token="test-token", headers=None):
+    request_headers = dict(headers or {})
+    if token is not None:
+        request_headers["X-Shellctl-Token"] = token
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    conn.request(method, path, body=body, headers=request_headers)
+    response = conn.getresponse()
+    payload = response.read()
+    status = response.status
+    conn.close()
+    return status, payload
 
 
 @pytest.mark.parametrize(
     "name",
     [
-        "photo.png", "shot.JPG", "a.jpeg", "x.gif", "y.webp",
-        "z.bmp", "scan.tiff", "scan.tif", "pic.heic", "pic.heif",
-        "logo.svg",
+        "photo.png", "shot.JPG", "a.jpeg", "x.gif", "y.webp", "z.bmp",
+        "scan.tiff", "scan.tif", "pic.heic", "pic.heif", "logo.svg",
     ],
 )
 def test_image_names_are_images(bridge, name):
@@ -59,47 +80,35 @@ def test_non_image_names_are_not_images(bridge, name):
     assert bridge._is_image_name(name) is False
 
 
-def test_get_image_emits_image_hint(bridge, tmp_path, monkeypatch,
-                                     capsys):
-    """A pulled image lands in IMAGES_DIR + carries an `/image` hint."""
+def test_get_image_emits_image_hint(bridge, tmp_path, monkeypatch, capsys):
     images = tmp_path / "images"
     files = tmp_path / "files"
     monkeypatch.setattr(bridge, "IMAGES_DIR", str(images))
     monkeypatch.setattr(bridge, "FILES_DIR", str(files))
 
     class _Resp:
-        def __init__(self, data):
-            self._data = data
-
         def read(self):
-            return self._data
+            return b"\x89PNG fake bytes"
 
         def __enter__(self):
             return self
 
-        def __exit__(self, *a):
+        def __exit__(self, *args):
             return False
 
-    monkeypatch.setattr(
-        bridge, "_client_req",
-        lambda *a, **k: _Resp(b"\x89PNG fake bytes"),
-    )
+    monkeypatch.setattr(bridge, "_client_req", lambda *args, **kwargs: _Resp())
 
     class _Args:
         path = "/home/user/screenshot.png"
 
-    rc = bridge.cmd_get(_Args())
-    assert rc == 0
+    assert bridge.cmd_get(_Args()) == 0
     out = json.loads(capsys.readouterr().out.strip())
-    assert out["ok"] is True
     assert out["hint"].startswith("/image ")
     assert os.path.dirname(out["path"]) == str(images)
     assert out["bytes"] == len(b"\x89PNG fake bytes")
 
 
-def test_get_non_image_emits_plain_hint(bridge, tmp_path, monkeypatch,
-                                        capsys):
-    """A pulled pdf lands in FILES_DIR + carries a plain-path hint."""
+def test_get_non_image_emits_plain_hint(bridge, tmp_path, monkeypatch, capsys):
     images = tmp_path / "images"
     files = tmp_path / "files"
     monkeypatch.setattr(bridge, "IMAGES_DIR", str(images))
@@ -112,51 +121,154 @@ def test_get_non_image_emits_plain_hint(bridge, tmp_path, monkeypatch,
         def __enter__(self):
             return self
 
-        def __exit__(self, *a):
+        def __exit__(self, *args):
             return False
 
-    monkeypatch.setattr(
-        bridge, "_client_req", lambda *a, **k: _Resp()
-    )
+    monkeypatch.setattr(bridge, "_client_req", lambda *args, **kwargs: _Resp())
 
     class _Args:
         path = "/home/user/report.pdf"
 
-    rc = bridge.cmd_get(_Args())
-    assert rc == 0
+    assert bridge.cmd_get(_Args()) == 0
     out = json.loads(capsys.readouterr().out.strip())
-    assert out["ok"] is True
-    assert not out["hint"].startswith("/image ")
     assert out["hint"] == out["path"]
     assert os.path.dirname(out["path"]) == str(files)
 
 
-def test_install_shellctl_writes_assets_and_token(tmp_path,
-                                                  monkeypatch, capsys):
-    """`hermes install shellctl` copies assets + mints a 0600 token."""
+def test_host_pull_deduplicates_existing_name(bridge, tmp_path):
+    first = Path(bridge._save_into(str(tmp_path), b"one", "same.txt"))
+    second = Path(bridge._save_into(str(tmp_path), b"two", "same.txt"))
+    assert first.name == "same.txt"
+    assert second.name == "same-1.txt"
+    assert first.read_bytes() == b"one"
+    assert second.read_bytes() == b"two"
+
+
+def test_http_authentication_and_pull(shellctl_server, tmp_path):
+    mod, port = shellctl_server
+    status, _ = _http(port, "GET", "/ping", token=None)
+    assert status == 401
+    status, payload = _http(port, "GET", "/ping")
+    assert status == 200
+    assert json.loads(payload)["ok"] is True
+
+    source = tmp_path / "arbitrary.txt"
+    source.write_bytes(b"arbitrary client bytes")
+    status, payload = _http(port, "GET", "/pull?path=" + quote(str(source)))
+    assert status == 200
+    assert payload == source.read_bytes()
+
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    mod._ALLOWED_ROOT = os.path.realpath(allowed)
+    status, _ = _http(port, "GET", "/pull?path=" + quote(str(source)))
+    assert status == 403
+
+    symlink = allowed / "escape.txt"
+    try:
+        symlink.symlink_to(source)
+    except OSError:
+        pass
+    else:
+        status, _ = _http(port, "GET", "/pull?path=" + quote(str(symlink)))
+        assert status == 403
+
+
+def test_http_push_deduplicates_collisions(shellctl_server):
+    mod, port = shellctl_server
+    status, first = _http(
+        port, "POST", "/push?name=result.txt&open=0", b"one"
+    )
+    assert status == 200
+    status, second = _http(
+        port, "POST", "/push?name=result.txt&open=0", b"two"
+    )
+    assert status == 200
+    first_path = Path(json.loads(first)["path"])
+    second_path = Path(json.loads(second)["path"])
+    assert first_path != second_path
+    assert first_path.read_bytes() == b"one"
+    assert second_path.read_bytes() == b"two"
+    assert second_path.name == "result-1.txt"
+    assert first_path.parent == Path(mod._DOWNLOAD_DIR)
+
+
+def test_http_oversized_and_malformed_bodies(shellctl_server):
+    mod, port = shellctl_server
+    status, payload = _http(
+        port,
+        "POST",
+        "/push?name=huge.bin&open=0",
+        headers={"Content-Length": str(mod._MAX_BYTES + 1)},
+    )
+    assert status == 413
+    assert json.loads(payload)["error"] == "request body too large"
+
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    conn.putrequest("POST", "/push?name=bad.bin&open=0")
+    conn.putheader("X-Shellctl-Token", "test-token")
+    conn.putheader("Content-Length", "not-a-number")
+    conn.endheaders()
+    response = conn.getresponse()
+    assert response.status == 400
+    assert json.loads(response.read())["error"] == "invalid Content-Length"
+    conn.close()
+
+
+def test_install_cli_parser_accepts_shellctl_options():
     import argparse
 
-    home = tmp_path / "hhome"
-    monkeypatch.setenv("HERMES_HOME", str(home))
-    import importlib
+    from hermes_cli.install_cmd import register_cli
 
-    import hermes_cli.install_cmd as install_cmd
-    importlib.reload(install_cmd)
-
-    args = argparse.Namespace(
-        print_client=False, port=8765, ssh_host="myhost"
+    parser = argparse.ArgumentParser()
+    install_parser = parser.add_subparsers(dest="command", required=True).add_parser(
+        "install"
     )
-    rc = install_cmd.cmd_install_shellctl(args)
-    assert rc == 0
+    register_cli(install_parser)
+    args = parser.parse_args(
+        [
+            "install", "shellctl", "--port", "9001", "--ssh-host", "remote",
+            "--allowed-root", "/safe/files",
+        ]
+    )
+    assert args.install_target == "shellctl"
+    assert args.port == 9001
+    assert args.ssh_host == "remote"
+    assert args.allowed_root == "/safe/files"
+
+
+def test_install_shellctl_writes_assets_and_token(tmp_path, capsys):
+    import argparse
+
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+    import hermes_cli.install_cmd as install_cmd
+
+    home = tmp_path / "profile-home"
+    override = set_hermes_home_override(home)
+    try:
+        args = argparse.Namespace(
+            print_client=False,
+            port=8765,
+            ssh_host="myhost",
+            allowed_root="~/shared",
+        )
+        assert install_cmd.cmd_install_shellctl(args) == 0
+    finally:
+        reset_hermes_home_override(override)
 
     sc = home / "shellctl"
     assert (sc / "hermes-shellctl").is_file()
     assert (sc / "hermes-shellbridge").is_file()
     token = (sc / "bridge-token").read_text(encoding="utf-8").strip()
     assert len(token) >= 32
-    # Token file is chmod 0600.
-    mode = (sc / "bridge-token").stat().st_mode & 0o777
-    assert mode == 0o600
+    assert (sc / "bridge-token").stat().st_mode & 0o777 == 0o600
+    assert (sc / "bridge.env").stat().st_mode & 0o777 == 0o600
     out = capsys.readouterr().out
     assert "RemoteForward 127.0.0.1:8765" in out
-    assert token in out
+    assert "ExitOnForwardFailure yes" in out
+    assert "--token-file ~/.hermes-shellctl-token" in out
+    assert "--allowed-root '~/shared'" in out
+    assert token not in out

--- a/tests/hermes_cli/test_shellctl_bridge.py
+++ b/tests/hermes_cli/test_shellctl_bridge.py
@@ -1,0 +1,162 @@
+"""Tests for the shellctl file/image bridge (host + install glue).
+
+Covers the image-vs-file classification + attach-hint emission in the
+host-side ``hermes-shellbridge`` orchestrator, plus a smoke test of the
+``hermes install shellctl`` asset/token setup. The bridge script has no
+``.py`` extension (it is copied to the client verbatim), so it is loaded
+from source via ``importlib``.
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+_ASSETS = (
+    Path(__file__).resolve().parents[2]
+    / "hermes_cli"
+    / "shellctl_assets"
+)
+
+
+def _load_shellbridge():
+    src = _ASSETS / "hermes-shellbridge"
+    loader = importlib.machinery.SourceFileLoader(
+        "hermes_shellbridge_under_test", str(src)
+    )
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def bridge():
+    return _load_shellbridge()
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "photo.png", "shot.JPG", "a.jpeg", "x.gif", "y.webp",
+        "z.bmp", "scan.tiff", "scan.tif", "pic.heic", "pic.heif",
+        "logo.svg",
+    ],
+)
+def test_image_names_are_images(bridge, name):
+    assert bridge._is_image_name(name) is True
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["doc.pdf", "sheet.csv", "notes.txt", "a.zip", "bin", "", None],
+)
+def test_non_image_names_are_not_images(bridge, name):
+    assert bridge._is_image_name(name) is False
+
+
+def test_get_image_emits_image_hint(bridge, tmp_path, monkeypatch,
+                                     capsys):
+    """A pulled image lands in IMAGES_DIR + carries an `/image` hint."""
+    images = tmp_path / "images"
+    files = tmp_path / "files"
+    monkeypatch.setattr(bridge, "IMAGES_DIR", str(images))
+    monkeypatch.setattr(bridge, "FILES_DIR", str(files))
+
+    class _Resp:
+        def __init__(self, data):
+            self._data = data
+
+        def read(self):
+            return self._data
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(
+        bridge, "_client_req",
+        lambda *a, **k: _Resp(b"\x89PNG fake bytes"),
+    )
+
+    class _Args:
+        path = "/home/user/screenshot.png"
+
+    rc = bridge.cmd_get(_Args())
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["ok"] is True
+    assert out["hint"].startswith("/image ")
+    assert os.path.dirname(out["path"]) == str(images)
+    assert out["bytes"] == len(b"\x89PNG fake bytes")
+
+
+def test_get_non_image_emits_plain_hint(bridge, tmp_path, monkeypatch,
+                                        capsys):
+    """A pulled pdf lands in FILES_DIR + carries a plain-path hint."""
+    images = tmp_path / "images"
+    files = tmp_path / "files"
+    monkeypatch.setattr(bridge, "IMAGES_DIR", str(images))
+    monkeypatch.setattr(bridge, "FILES_DIR", str(files))
+
+    class _Resp:
+        def read(self):
+            return b"%PDF-1.4 fake"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(
+        bridge, "_client_req", lambda *a, **k: _Resp()
+    )
+
+    class _Args:
+        path = "/home/user/report.pdf"
+
+    rc = bridge.cmd_get(_Args())
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["ok"] is True
+    assert not out["hint"].startswith("/image ")
+    assert out["hint"] == out["path"]
+    assert os.path.dirname(out["path"]) == str(files)
+
+
+def test_install_shellctl_writes_assets_and_token(tmp_path,
+                                                  monkeypatch, capsys):
+    """`hermes install shellctl` copies assets + mints a 0600 token."""
+    import argparse
+
+    home = tmp_path / "hhome"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import importlib
+
+    import hermes_cli.install_cmd as install_cmd
+    importlib.reload(install_cmd)
+
+    args = argparse.Namespace(
+        print_client=False, port=8765, ssh_host="myhost"
+    )
+    rc = install_cmd.cmd_install_shellctl(args)
+    assert rc == 0
+
+    sc = home / "shellctl"
+    assert (sc / "hermes-shellctl").is_file()
+    assert (sc / "hermes-shellbridge").is_file()
+    token = (sc / "bridge-token").read_text(encoding="utf-8").strip()
+    assert len(token) >= 32
+    # Token file is chmod 0600.
+    mode = (sc / "bridge-token").stat().st_mode & 0o777
+    assert mode == 0o600
+    out = capsys.readouterr().out
+    assert "RemoteForward 127.0.0.1:8765" in out
+    assert token in out

--- a/tests/hermes_cli/test_shellctl_bridge.py
+++ b/tests/hermes_cli/test_shellctl_bridge.py
@@ -237,7 +237,7 @@ def test_install_cli_parser_accepts_shellctl_options():
     assert args.allowed_root == "/safe/files"
 
 
-def test_install_shellctl_writes_assets_and_token(tmp_path, capsys):
+def test_install_shellctl_writes_assets_and_token(tmp_path, capsys, monkeypatch):
     import argparse
 
     from hermes_constants import (
@@ -245,6 +245,13 @@ def test_install_shellctl_writes_assets_and_token(tmp_path, capsys):
         set_hermes_home_override,
     )
     import hermes_cli.install_cmd as install_cmd
+    import hermes_cli.config as hermes_config
+
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"shellctl": {"max_open_capture_secs": 42}},
+    )
 
     home = tmp_path / "profile-home"
     override = set_hermes_home_override(home)
@@ -254,6 +261,7 @@ def test_install_shellctl_writes_assets_and_token(tmp_path, capsys):
             port=8765,
             ssh_host="myhost",
             allowed_root="~/shared",
+            max_open_capture_secs=None,
         )
         assert install_cmd.cmd_install_shellctl(args) == 0
     finally:
@@ -270,5 +278,6 @@ def test_install_shellctl_writes_assets_and_token(tmp_path, capsys):
     assert "RemoteForward 127.0.0.1:8765" in out
     assert "ExitOnForwardFailure yes" in out
     assert "--token-file ~/.hermes-shellctl-token" in out
+    assert "--max-open-capture-secs 42" in out
     assert "--allowed-root '~/shared'" in out
     assert token not in out


### PR DESCRIPTION
## Stack relationship

This PR is intentionally stacked on #94060. Its base commit is `986073e948426dbb45c45ed4933594fd6c2d6a97`, the remediated shellctl file/image foundation from #94060.

Review the audio-only change with:

```bash
git diff 986073e948426dbb45c45ed4933594fd6c2d6a97...audit/pr-94059
```

Do not compare this branch directly with `main` while #94060 is still open, since that view also includes the foundation.

## Audio-only changes

This stack adds authenticated audio transport to the existing shellctl daemon and host bridge:

* `say` sends text to the existing gateway TTS endpoint and plays the returned audio on the SSH client machine.
* `listen`, `listen-start`, and `listen-stop` capture the SSH client microphone and send WAV audio to the existing gateway STT endpoint.
* `stop-play` interrupts playback with a short silent WAV.
* Host-side default paths use the profile-aware `get_hermes_home()` helper.
* `/ping` uses the same bearer-token authentication as every other daemon endpoint.
* Audio filename extensions are restricted to an explicit allowlist.
* Invalid `secs` values and malformed audio HTTP bodies return controlled `400` responses.
* Open capture start and stop state is protected by a lock for `ThreadingHTTPServer` requests.

## Bounded capture and cleanup

Open microphone capture now has a five-minute default ceiling. `shellctl.max_open_capture_secs` in `config.yaml` configures the limit from 1 through 3600 seconds, and the installer carries the resolved value into the client daemon command.

Each capture owns a watchdog. If no stop request arrives, it atomically claims the capture, terminates the recorder, waits for it, escalates to kill when needed, clears shared state, and removes the temporary WAV. Normal stop, concurrent stop, failed start-response delivery, daemon return, SIGTERM, SIGHUP, and Ctrl+C use the same cleanup path. A watchdog from an older capture cannot terminate a newer one.

Captured WAV files have a 64 MB ceiling. The daemon checks file size before reading and performs a bounded read to close the size-check race. The host bridge also bounds HTTP response reads. Oversized captures return a controlled `413` response and their recorder and temporary file are cleaned up.

## Security boundary

Possession of the shellctl token and access to the listener permits remote microphone activation while the daemon runs. A compromised Hermes host can read the bridge token through the active reverse SSH trust boundary. Each activation is bounded by the configured ceiling, even if the caller disconnects or never sends `listen-stop`. The daemon should only be used with a trusted host and stopped when that access is not needed.

## Validation

All tests used `scripts/run_tests.sh`:

* Foundation shellctl and installer tests: 26 passed.
* Audio HTTP, lifecycle, signal cleanup, concurrency, size-cap, and host bridge tests: 22 passed.
* Voice wrapper tests: 23 passed.
* Ruff lint passed for all changed Python and executable Python files.
* Python bytecode compilation passed for all changed Python and executable Python files.
* `git diff --check` passed.

The focused total is 71 passing tests. The branch contains one audio commit above #94060's foundation commit.
