### PR TITLE
feat(cli): image/file push over an SSH media bridge (shellctl)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -372,6 +372,13 @@ DEFAULT_CONFIG = {
         "reasoning_echo": False,
     },
 
+    "shellctl": {
+        # Optional path on the SSH client machine. When set, the generated
+        # daemon command restricts /pull to this directory tree. Empty keeps
+        # intentional arbitrary-path pulls for backwards compatibility.
+        "allowed_root": "",
+    },
+
     "terminal": {
         "backend": "local",
         "modal_mode": "auto",

--- a/hermes_cli/install_cmd.py
+++ b/hermes_cli/install_cmd.py
@@ -1,0 +1,175 @@
+"""`hermes install` — install the SSH-layer file/image bridge client.
+
+`hermes install shellctl` is run on the HERMES HOST (the box you SSH
+into). It:
+
+  1. ensures the bridge assets exist under the workspace,
+  2. generates (or reuses) a shared bridge token,
+  3. prints the exact `~/.ssh/config` snippet + the one-line client
+     install command the user pastes on THEIR machine
+     (Mac/Linux/WSL/PuTTY host).
+
+Design: zero-dependency client (Python stdlib only), no sudo, no
+ControlMaster requirement (per-connection RemoteForward works for plain
+`ssh` and tmux-wrapping `sshp` alike). The client is served for copy
+via `hermes install shellctl --print-client`.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import secrets
+import shutil
+import sys
+from pathlib import Path
+
+# Bridge assets live in the workspace so they survive Hermes updates.
+_SHELLCTL_DIR = Path(
+    os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes"))
+) / "shellctl"
+_TOKEN_FILE = _SHELLCTL_DIR / "bridge-token"
+_CLIENT_FILE = _SHELLCTL_DIR / "hermes-shellctl"
+_BRIDGE_FILE = _SHELLCTL_DIR / "hermes-shellbridge"
+_DEFAULT_PORT = 8765
+
+# Canonical source location (ships with the hermes_cli package).
+_CANONICAL_DIR = Path(__file__).resolve().parent / "shellctl_assets"
+
+
+def _ensure_assets() -> None:
+    _SHELLCTL_DIR.mkdir(parents=True, exist_ok=True)
+    for name in ("hermes-shellctl", "hermes-shellbridge"):
+        src = _CANONICAL_DIR / name
+        dst = _SHELLCTL_DIR / name
+        # When HERMES_HOME points somewhere whose shellctl dir IS the
+        # canonical dir, src == dst — nothing to copy, just fix perms.
+        if src.resolve() != dst.resolve():
+            if src.is_file() and (
+                not dst.is_file()
+                or src.stat().st_mtime > dst.stat().st_mtime
+            ):
+                shutil.copy2(src, dst)
+        if dst.is_file():
+            dst.chmod(0o755)
+
+
+def _get_or_make_token() -> str:
+    if _TOKEN_FILE.is_file():
+        tok = _TOKEN_FILE.read_text(encoding="utf-8").strip()
+        if tok:
+            return tok
+    tok = secrets.token_hex(24)
+    _TOKEN_FILE.write_text(tok + "\n", encoding="utf-8")
+    _TOKEN_FILE.chmod(0o600)
+    return tok
+
+
+def _print_client() -> int:
+    if not _CLIENT_FILE.is_file():
+        _ensure_assets()
+    if not _CLIENT_FILE.is_file():
+        print("error: client asset missing", file=sys.stderr)
+        return 1
+    sys.stdout.write(_CLIENT_FILE.read_text(encoding="utf-8"))
+    return 0
+
+
+def cmd_install_shellctl(args: argparse.Namespace) -> int:
+    if getattr(args, "print_client", False):
+        return _print_client()
+
+    _ensure_assets()
+    token = _get_or_make_token()
+    port = int(getattr(args, "port", _DEFAULT_PORT) or _DEFAULT_PORT)
+    # The hostname/alias the user SSHes to — best effort; user edits.
+    host_hint = getattr(args, "ssh_host", "") or "your-hermes-host"
+
+    bar = "=" * 72
+    print(bar)
+    print(" Hermes shellctl — SSH-layer file/image bridge")
+    print(bar)
+    print()
+    print("Bridge token (shared secret, keep private):")
+    print(f"  {token}")
+    print()
+    print("STEP 1 — On YOUR machine (Mac/Linux/WSL), save the client:")
+    print(
+        f"  ssh {host_hint} 'hermes install shellctl "
+        "--print-client' > ~/.hermes-shellctl"
+    )
+    print("  chmod +x ~/.hermes-shellctl")
+    print()
+    print("STEP 2 — Add this ONE block to ~/.ssh/config on YOUR machine")
+    print("         (works for plain `ssh` AND tmux-wrapping helpers")
+    print("          like sshp; no ControlMaster required):")
+    print()
+    print(f"  Host {host_hint}")
+    print(
+        f"      RemoteForward 127.0.0.1:{port} 127.0.0.1:{port}"
+    )
+    print()
+    print("STEP 3 — Start the client daemon on YOUR machine (one")
+    print("         command, leave it running in a tab — or add to")
+    print("         login items):")
+    print(f"  HERMES_SHELLCTL_TOKEN={token} \\")
+    print(f"    python3 ~/.hermes-shellctl daemon --port {port}")
+    print()
+    print("STEP 4 — SSH in normally. The reverse forward makes your")
+    print("         machine's bridge reachable at 127.0.0.1:%d ON the"
+          % port)
+    print("         Hermes host. Verify:")
+    print(f"  HERMES_SHELLCTL_TOKEN={token} \\")
+    print(f"    HERMES_SHELLCTL_URL=http://127.0.0.1:{port} \\")
+    print(f"    python3 {_BRIDGE_FILE} ping")
+    print()
+    print("Then in the TUI:  /get <local-path> · /send <file> · /paste")
+    print(bar)
+
+    # Persist the resolved config so the TUI bridge glue can read it.
+    cfg = _SHELLCTL_DIR / "bridge.env"
+    cfg.write_text(
+        f"HERMES_SHELLCTL_URL=http://127.0.0.1:{port}\n"
+        f"HERMES_SHELLCTL_TOKEN={token}\n"
+        f"HERMES_SHELLCTL_PORT={port}\n",
+        encoding="utf-8",
+    )
+    cfg.chmod(0o600)
+    return 0
+
+
+def register_cli(install_parser: argparse.ArgumentParser) -> None:
+    """Attach `install` subcommands to the given parser."""
+    sub = install_parser.add_subparsers(
+        dest="install_target", required=True
+    )
+    sc = sub.add_parser(
+        "shellctl",
+        help="Install the SSH file/image bridge client (image/pdf "
+             "over SSH)",
+    )
+    sc.add_argument(
+        "--port",
+        type=int,
+        default=_DEFAULT_PORT,
+        help=f"bridge port (default {_DEFAULT_PORT})",
+    )
+    sc.add_argument(
+        "--ssh-host",
+        default="",
+        help="the Host alias you SSH to (for the printed snippet)",
+    )
+    sc.add_argument(
+        "--print-client",
+        action="store_true",
+        help="print the client script to stdout (for piping to a "
+             "file)",
+    )
+    sc.set_defaults(func=cmd_install_shellctl)
+
+
+def install_command(args: argparse.Namespace) -> int:
+    func = getattr(args, "func", None)
+    if func is None or func is install_command:
+        print("usage: hermes install shellctl", file=sys.stderr)
+        return 2
+    return func(args)

--- a/hermes_cli/install_cmd.py
+++ b/hermes_cli/install_cmd.py
@@ -18,29 +18,42 @@ from __future__ import annotations
 
 import argparse
 import os
+import shlex
 import secrets
 import shutil
 import sys
 from pathlib import Path
 
-# Bridge assets live in the workspace so they survive Hermes updates.
-_SHELLCTL_DIR = Path(
-    os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes"))
-) / "shellctl"
-_TOKEN_FILE = _SHELLCTL_DIR / "bridge-token"
-_CLIENT_FILE = _SHELLCTL_DIR / "hermes-shellctl"
-_BRIDGE_FILE = _SHELLCTL_DIR / "hermes-shellbridge"
+from hermes_constants import get_hermes_home
+
 _DEFAULT_PORT = 8765
 
 # Canonical source location (ships with the hermes_cli package).
 _CANONICAL_DIR = Path(__file__).resolve().parent / "shellctl_assets"
 
 
+def _shellctl_dir() -> Path:
+    return get_hermes_home() / "shellctl"
+
+
+def _token_file() -> Path:
+    return _shellctl_dir() / "bridge-token"
+
+
+def _client_file() -> Path:
+    return _shellctl_dir() / "hermes-shellctl"
+
+
+def _bridge_file() -> Path:
+    return _shellctl_dir() / "hermes-shellbridge"
+
+
 def _ensure_assets() -> None:
-    _SHELLCTL_DIR.mkdir(parents=True, exist_ok=True)
+    shellctl_dir = _shellctl_dir()
+    shellctl_dir.mkdir(parents=True, exist_ok=True)
     for name in ("hermes-shellctl", "hermes-shellbridge"):
         src = _CANONICAL_DIR / name
-        dst = _SHELLCTL_DIR / name
+        dst = shellctl_dir / name
         # When HERMES_HOME points somewhere whose shellctl dir IS the
         # canonical dir, src == dst — nothing to copy, just fix perms.
         if src.resolve() != dst.resolve():
@@ -54,23 +67,53 @@ def _ensure_assets() -> None:
 
 
 def _get_or_make_token() -> str:
-    if _TOKEN_FILE.is_file():
-        tok = _TOKEN_FILE.read_text(encoding="utf-8").strip()
+    token_file = _token_file()
+    if token_file.is_file():
+        tok = token_file.read_text(encoding="utf-8").strip()
         if tok:
+            token_file.chmod(0o600)
             return tok
     tok = secrets.token_hex(24)
-    _TOKEN_FILE.write_text(tok + "\n", encoding="utf-8")
-    _TOKEN_FILE.chmod(0o600)
+    try:
+        fd = os.open(
+            token_file,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+    except FileExistsError:
+        existing = token_file.read_text(encoding="utf-8").strip()
+        if existing:
+            token_file.chmod(0o600)
+            return existing
+        raise RuntimeError(f"empty shellctl token file: {token_file}")
+    with os.fdopen(fd, "w", encoding="utf-8") as stream:
+        stream.write(tok + "\n")
     return tok
 
 
+def _write_private(path: Path, content: str) -> None:
+    """Atomically replace a private file without a permissive creation window."""
+    tmp = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(content)
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+
+
 def _print_client() -> int:
-    if not _CLIENT_FILE.is_file():
+    client_file = _client_file()
+    if not client_file.is_file():
         _ensure_assets()
-    if not _CLIENT_FILE.is_file():
+    if not client_file.is_file():
         print("error: client asset missing", file=sys.stderr)
         return 1
-    sys.stdout.write(_CLIENT_FILE.read_text(encoding="utf-8"))
+    sys.stdout.write(client_file.read_text(encoding="utf-8"))
     return 0
 
 
@@ -81,59 +124,79 @@ def cmd_install_shellctl(args: argparse.Namespace) -> int:
     _ensure_assets()
     token = _get_or_make_token()
     port = int(getattr(args, "port", _DEFAULT_PORT) or _DEFAULT_PORT)
-    # The hostname/alias the user SSHes to — best effort; user edits.
     host_hint = getattr(args, "ssh_host", "") or "your-hermes-host"
+    allowed_root = str(getattr(args, "allowed_root", "") or "").strip()
+    if not allowed_root:
+        from hermes_cli.config import load_config
+
+        shellctl_cfg = (load_config() or {}).get("shellctl") or {}
+        if isinstance(shellctl_cfg, dict):
+            allowed_root = str(shellctl_cfg.get("allowed_root") or "").strip()
+
+    token_file = _token_file()
+    bridge_file = _bridge_file()
+    bridge_env = _shellctl_dir() / "bridge.env"
+    remote_client_cmd = "hermes install shellctl --print-client"
+    remote_token_cmd = "cat " + shlex.quote(str(token_file))
+    daemon_cmd = (
+        "python3 ~/.hermes-shellctl daemon --port %d "
+        "--token-file ~/.hermes-shellctl-token" % port
+    )
+    if allowed_root:
+        daemon_cmd += " --allowed-root " + shlex.quote(allowed_root)
 
     bar = "=" * 72
     print(bar)
-    print(" Hermes shellctl — SSH-layer file/image bridge")
+    print(" Hermes shellctl: SSH file and image bridge")
     print(bar)
     print()
-    print("Bridge token (shared secret, keep private):")
-    print(f"  {token}")
+    print("The bridge token is a shared secret stored only in:")
+    print(f"  {token_file} (mode 0600)")
+    print("The commands below copy it over SSH without putting its value in")
+    print("shell history or a process argument.")
     print()
-    print("STEP 1 — On YOUR machine (Mac/Linux/WSL), save the client:")
+    print("STEP 1: On YOUR machine, save the client and token:")
     print(
-        f"  ssh {host_hint} 'hermes install shellctl "
-        "--print-client' > ~/.hermes-shellctl"
+        "  ssh %s %s > ~/.hermes-shellctl"
+        % (shlex.quote(host_hint), shlex.quote(remote_client_cmd))
     )
-    print("  chmod +x ~/.hermes-shellctl")
+    print(
+        "  (umask 077; ssh %s %s > ~/.hermes-shellctl-token)"
+        % (shlex.quote(host_hint), shlex.quote(remote_token_cmd))
+    )
+    print("  chmod 700 ~/.hermes-shellctl")
+    print("  chmod 600 ~/.hermes-shellctl-token")
     print()
-    print("STEP 2 — Add this ONE block to ~/.ssh/config on YOUR machine")
-    print("         (works for plain `ssh` AND tmux-wrapping helpers")
-    print("          like sshp; no ControlMaster required):")
+    print("STEP 2: Add this block to ~/.ssh/config on YOUR machine:")
     print()
     print(f"  Host {host_hint}")
+    print(f"      RemoteForward 127.0.0.1:{port} 127.0.0.1:{port}")
+    print("      ExitOnForwardFailure yes")
+    print()
+    print("STEP 3: Start the client daemon on YOUR machine:")
+    print(f"  {daemon_cmd}")
+    print()
+    print("STEP 4: SSH in normally, then verify on the Hermes host:")
     print(
-        f"      RemoteForward 127.0.0.1:{port} 127.0.0.1:{port}"
+        "  set -a; . %s; set +a; python3 %s ping"
+        % (shlex.quote(str(bridge_env)), shlex.quote(str(bridge_file)))
     )
     print()
-    print("STEP 3 — Start the client daemon on YOUR machine (one")
-    print("         command, leave it running in a tab — or add to")
-    print("         login items):")
-    print(f"  HERMES_SHELLCTL_TOKEN={token} \\")
-    print(f"    python3 ~/.hermes-shellctl daemon --port {port}")
+    print("If SSH reports 'remote port forwarding failed', another SSH")
+    print("session already owns that RemoteForward. Close the old session or")
+    print("choose a different --port, update both endpoints, and reinstall.")
     print()
-    print("STEP 4 — SSH in normally. The reverse forward makes your")
-    print("         machine's bridge reachable at 127.0.0.1:%d ON the"
-          % port)
-    print("         Hermes host. Verify:")
-    print(f"  HERMES_SHELLCTL_TOKEN={token} \\")
-    print(f"    HERMES_SHELLCTL_URL=http://127.0.0.1:{port} \\")
-    print(f"    python3 {_BRIDGE_FILE} ping")
-    print()
-    print("Then in the TUI:  /get <local-path> · /send <file> · /paste")
+    print("Then in the TUI: /get <local-path>, /send <file>, or /paste")
     print(bar)
 
-    # Persist the resolved config so the TUI bridge glue can read it.
-    cfg = _SHELLCTL_DIR / "bridge.env"
-    cfg.write_text(
+    # Persist the resolved config so host bridge callers can load it.
+    cfg = bridge_env
+    _write_private(
+        cfg,
         f"HERMES_SHELLCTL_URL=http://127.0.0.1:{port}\n"
         f"HERMES_SHELLCTL_TOKEN={token}\n"
         f"HERMES_SHELLCTL_PORT={port}\n",
-        encoding="utf-8",
     )
-    cfg.chmod(0o600)
     return 0
 
 
@@ -157,6 +220,14 @@ def register_cli(install_parser: argparse.ArgumentParser) -> None:
         "--ssh-host",
         default="",
         help="the Host alias you SSH to (for the printed snippet)",
+    )
+    sc.add_argument(
+        "--allowed-root",
+        default="",
+        help=(
+            "restrict client-side pulls to this directory tree; defaults "
+            "to shellctl.allowed_root in config.yaml"
+        ),
     )
     sc.add_argument(
         "--print-client",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12331,7 +12331,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "computer-use",
         "config", "console", "cron", "curator", "dashboard", "serve", "debug", "doctor",
         "dump", "egress", "fallback", "gateway", "hooks", "import", "import-agent", "insights",
-        "gui", "desktop", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate", "moa",
+        "gui", "desktop", "install", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate", "moa",
         "journey", "memory-graph", "learning",
         "model", "monitoring", "pairing", "pause", "peer", "pets", "plugins", "portal", "profile",
         "project", "proxy",
@@ -13315,6 +13315,28 @@ def main():
         return 0
 
     egress_parser.set_defaults(func=_dispatch_egress)
+
+    # =========================================================================
+    # install command — SSH-layer file/image bridge client (shellctl)
+    # =========================================================================
+    install_parser = subparsers.add_parser(
+        "install",
+        help="Install optional Hermes companions (e.g. the SSH "
+             "file/image bridge)",
+        description=(
+            "Install optional Hermes companion tools. `hermes install "
+            "shellctl` sets up the SSH-layer bridge so a remote TUI "
+            "can move images, PDFs, and any file between the Hermes "
+            "host and your local machine over your existing SSH "
+            "connection."
+        ),
+    )
+    from hermes_cli.install_cmd import (
+        install_command,
+        register_cli as _install_register,
+    )
+    _install_register(install_parser)
+    install_parser.set_defaults(func=install_command)
 
     # =========================================================================
     # migrate command

--- a/hermes_cli/shellctl_assets/README.md
+++ b/hermes_cli/shellctl_assets/README.md
@@ -1,0 +1,105 @@
+# Hermes shellctl — SSH-layer file & image bridge
+
+Move **images, PDFs, and any file** between the Hermes host (the box you
+SSH into, running the TUI) and **your local machine** — over your
+**existing SSH connection**, with no extra tunnel, no ControlMaster
+requirement, and no dependency on iTerm2 / a specific terminal / a
+specific OS.
+
+Works on macOS, Linux, WSL, and any host that runs `ssh` (PuTTY
+included). The client is a **single zero-dependency Python 3 file**
+(stdlib only) — installs on a locked-down corporate Mac with no
+admin/sudo and no package manager.
+
+> This bridge is one slice of a general SSH media bridge. This branch
+> ships the **file/image** transfer path. The **audio** path (TTS +
+> mic) is a sibling feature that reuses the same daemon + install
+> scaffolding.
+
+## Why this exists
+
+The Hermes TUI runs on the *remote* host, so its "clipboard" and
+filesystem are the **remote host's**, not yours. shellctl bridges that
+gap: a tiny HTTP listener on your machine, reachable by the remote host
+through a reverse SSH forward, so the agent can pull/push bytes to/from
+*your* machine.
+
+```
+Your machine (Mac/Linux/WSL)     existing SSH (any transport)   Hermes host
+┌────────────────────────┐                                     ┌──────────────┐
+│ hermes-shellctl daemon │  ◄── RemoteForward 127.0.0.1:8765 ─►│ TUI /get      │
+│  • serves local files  │      (reverse: host reaches you)    │ hermes-shell- │
+│  • clipboard image/file│                                     │   bridge      │
+└────────────────────────┘                                     └──────────────┘
+```
+
+## Install (run on the HERMES host)
+
+```sh
+hermes install shellctl --ssh-host <the-host-alias-you-ssh-to>
+```
+
+This prints a token + the exact 4 steps. Summary:
+
+1. **Save the client on your machine:**
+   ```sh
+   ssh <host> 'hermes install shellctl --print-client' > ~/.hermes-shellctl
+   chmod +x ~/.hermes-shellctl
+   ```
+2. **Add ONE block to `~/.ssh/config` on your machine** (covers plain
+   `ssh` and tmux-wrapping helpers like `sshp`; **no ControlMaster
+   needed**):
+   ```
+   Host <host>
+       RemoteForward 127.0.0.1:8765 127.0.0.1:8765
+   ```
+3. **Run the daemon on your machine** (leave it in a tab, or add to
+   Login Items):
+   ```sh
+   HERMES_SHELLCTL_TOKEN=<token> python3 ~/.hermes-shellctl daemon --port 8765
+   ```
+4. **SSH in normally.** Verify from the host:
+   ```sh
+   <bridge> ping     # → {"ok": true, "caps": {...}}
+   ```
+
+## Use (in the TUI)
+
+| Command | What it does |
+|---|---|
+| `/get <local-path>` | Pull a file FROM your machine; auto-attaches it to the turn (image/pdf/any) |
+| `/paste` | Pull your machine's **clipboard image/file** and attach it |
+| `/send <host-path>` | Push a Hermes-side file TO your machine and open it locally |
+
+Image files land in the gateway images dir and carry an `/image` hint so
+the TUI attaches them as visual content; everything else lands in the
+downloads dir with a plain-path hint.
+
+## Optional local helpers (better fidelity, not required)
+
+- **Clipboard images:** macOS `pngpaste` (`brew install pngpaste`) or
+  Linux `xclip`. Without them, macOS falls back to AppleScript.
+
+`hermes-shellctl daemon` reports which capabilities are available at
+startup and via `/ping`.
+
+## Security
+
+- The listener binds **127.0.0.1 only** and is reached solely through
+  your SSH reverse-forward — nothing on the network can reach it.
+- Every request is gated by a **shared token**
+  (`HERMES_SHELLCTL_TOKEN`), generated per-install and stored `0600`.
+- 64 MB per-transfer cap.
+
+## Files
+
+- Client (your machine): `~/.hermes-shellctl` (single file, stdlib only)
+- Host orchestrator: `<HERMES_HOME>/shellctl/hermes-shellbridge`
+- Token + config: `<HERMES_HOME>/shellctl/bridge-token`, `bridge.env`
+  (both `0600`)
+- Canonical source (ships with hermes_cli): `hermes_cli/shellctl_assets/`
+
+## Notes
+
+- Pulled files land in the gateway images/downloads dir so the normal
+  attach pipeline handles them (the TUI `/image` and `/get` commands).

--- a/hermes_cli/shellctl_assets/README.md
+++ b/hermes_cli/shellctl_assets/README.md
@@ -39,29 +39,46 @@ Your machine (Mac/Linux/WSL)     existing SSH (any transport)   Hermes host
 hermes install shellctl --ssh-host <the-host-alias-you-ssh-to>
 ```
 
-This prints a token + the exact 4 steps. Summary:
+This prints the exact setup steps. It does not print the raw token inside a
+command. The generated commands copy the `0600` token file over SSH and pass it
+to the daemon with `--token-file`, so the value does not enter shell history or
+the process argument list.
 
-1. **Save the client on your machine:**
+1. **Save the client and token on your machine:**
    ```sh
    ssh <host> 'hermes install shellctl --print-client' > ~/.hermes-shellctl
-   chmod +x ~/.hermes-shellctl
+   (umask 077; ssh <host> 'cat <profile-home>/shellctl/bridge-token' \
+       > ~/.hermes-shellctl-token)
+   chmod 700 ~/.hermes-shellctl
+   chmod 600 ~/.hermes-shellctl-token
    ```
-2. **Add ONE block to `~/.ssh/config` on your machine** (covers plain
-   `ssh` and tmux-wrapping helpers like `sshp`; **no ControlMaster
-   needed**):
+2. **Add one block to `~/.ssh/config` on your machine:**
    ```
    Host <host>
        RemoteForward 127.0.0.1:8765 127.0.0.1:8765
+       ExitOnForwardFailure yes
    ```
-3. **Run the daemon on your machine** (leave it in a tab, or add to
-   Login Items):
+3. **Run the daemon on your machine:**
    ```sh
-   HERMES_SHELLCTL_TOKEN=<token> python3 ~/.hermes-shellctl daemon --port 8765
+   python3 ~/.hermes-shellctl daemon --port 8765 \
+       --token-file ~/.hermes-shellctl-token
    ```
-4. **SSH in normally.** Verify from the host:
-   ```sh
-   <bridge> ping     # → {"ok": true, "caps": {...}}
-   ```
+4. **SSH in normally.** Load the generated `bridge.env`, then run the host
+   bridge's `ping` command. `/ping` requires the same token as every other
+   endpoint.
+
+To restrict reads from the client machine, set the following on the Hermes
+host before running the installer:
+
+```yaml
+shellctl:
+  allowed_root: ~/Documents/hermes-share
+```
+
+The path is interpreted on the SSH client machine. You can override it for one
+installation with `hermes install shellctl --allowed-root <client-path>`. The
+installer adds `--allowed-root` to the generated daemon command. Symlinks that
+resolve outside the root are rejected.
 
 ## Use (in the TUI)
 
@@ -83,13 +100,43 @@ downloads dir with a plain-path hint.
 `hermes-shellctl daemon` reports which capabilities are available at
 startup and via `/ping`.
 
-## Security
+## Security and threat boundary
 
-- The listener binds **127.0.0.1 only** and is reached solely through
-  your SSH reverse-forward — nothing on the network can reach it.
-- Every request is gated by a **shared token**
-  (`HERMES_SHELLCTL_TOKEN`), generated per-install and stored `0600`.
-- 64 MB per-transfer cap.
+The exact bearer credential is the random value in
+`<profile-home>/shellctl/bridge-token` on the Hermes host and
+`~/.hermes-shellctl-token` on the client. It is sent in the
+`X-Shellctl-Token` HTTP header. Every endpoint, including `/ping`, requires it.
+Keep both token files mode `0600` and rotate the token by deleting the host
+copy, rerunning the installer, and recopying it.
+
+Possession of that token plus access to the listener grants the ability to:
+
+* read any file readable by the user running the client daemon through `/pull`,
+  unless `shellctl.allowed_root` or `--allowed-root` restricts it;
+* read clipboard file or image content through `/clipboard`;
+* write files into the configured download directory and request that the OS
+  open them through `/push`.
+
+The listener binds to `127.0.0.1`, but the SSH `RemoteForward` deliberately
+makes it reachable from the Hermes host. A process on a compromised Hermes host
+can read `bridge.env`, obtain the token, and use the forwarded listener with
+all permissions above. The token does not protect the client from a compromised
+Hermes host. The optional allowed root limits file pulls, but it does not remove
+clipboard or push access. Do not run the bridge for an untrusted host. Stop the
+daemon and SSH session to remove access.
+
+Each transfer is capped at 64 MB. Existing destination files are never
+replaced; shellctl allocates a numbered filename instead.
+
+## RemoteForward troubleshooting
+
+With `ExitOnForwardFailure yes`, SSH exits rather than silently connecting
+without the bridge. If SSH reports `remote port forwarding failed for listen
+port 8765`, another active SSH connection usually owns that listen address.
+Close the stale connection, or choose a new port with `--port` and update both
+sides of the `RemoteForward`. Check for duplicate `RemoteForward` lines in
+included SSH config files as well. `ssh -vv <host>` shows which forwarding rule
+was applied.
 
 ## Files
 

--- a/hermes_cli/shellctl_assets/hermes-shellbridge
+++ b/hermes_cli/shellctl_assets/hermes-shellbridge
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""hermes-shellbridge - HOST half of the Hermes SSH file/image bridge.
+
+Runs on the Hermes host. Talks to the hermes-shellctl daemon on the
+user's machine through a reverse SSH forward (RemoteForward
+127.0.0.1:8765 -> the user's daemon). Commands:
+
+  get <local-path>   pull a file from the user's machine into the
+                     gateway images/downloads dir; print the gateway
+                     path the TUI attaches.
+  paste              pull the user's clipboard image/file into the
+                     gateway and print an attach hint.
+  send <gateway-path> push a gateway file to the user's machine and
+                     open it.
+  ping               check the client daemon + capabilities.
+
+Image files land in the gateway images dir and carry an ``/image``
+hint so the TUI attaches them as visual content; everything else
+(pdf, zip, csv, docx, arbitrary binaries) lands in the downloads dir
+with a plain-path hint. stdlib only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from urllib.parse import quote
+
+CLIENT_URL = os.environ.get(
+    "HERMES_SHELLCTL_URL", "http://127.0.0.1:8765"
+)
+_CLIENT_TOK_VAR = "HERMES_SHELLCTL_" + "TOKEN"
+CLIENT_TOKEN = os.environ.get(_CLIENT_TOK_VAR, "")
+IMAGES_DIR = os.environ.get(
+    "HERMES_SHELLBRIDGE_IMAGES_DIR",
+    os.path.join(
+        os.path.expanduser(
+            os.environ.get("HERMES_HOME", "~/.hermes")
+        ),
+        "images",
+    ),
+)
+FILES_DIR = os.environ.get(
+    "HERMES_SHELLBRIDGE_FILES_DIR",
+    os.path.join(
+        os.path.expanduser(
+            os.environ.get("HERMES_HOME", "~/.hermes")
+        ),
+        "downloads",
+    ),
+)
+
+# Image extensions that should land in IMAGES_DIR + carry an `/image`
+# hint so the TUI attaches them as visual content. Everything else is
+# a general file -> FILES_DIR + a plain-path hint.
+_IMAGE_EXTS = {
+    ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp",
+    ".tiff", ".tif", ".heic", ".heif", ".svg",
+}
+
+
+def _is_image_name(name):
+    return os.path.splitext(name or "")[1].lower() in _IMAGE_EXTS
+
+
+def _client_req(method, path, body=None, timeout=130):
+    req = urllib.request.Request(
+        CLIENT_URL + path, data=body, method=method
+    )
+    if CLIENT_TOKEN:
+        req.add_header("X-Shellctl-Token", CLIENT_TOKEN)
+    if body is not None:
+        req.add_header("Content-Type", "application/octet-stream")
+    return urllib.request.urlopen(req, timeout=timeout)
+
+
+def _emit(obj):
+    print(json.dumps(obj), flush=True)
+
+
+def _save_into(target_dir, data, name):
+    os.makedirs(target_dir, exist_ok=True)
+    safe = os.path.basename(name) or ("shellctl-%d" % int(time.time()))
+    dest = os.path.join(target_dir, safe)
+    if os.path.exists(dest):
+        stem, ext = os.path.splitext(safe)
+        dest = os.path.join(
+            target_dir, "%s-%d%s" % (stem, int(time.time()), ext)
+        )
+    with open(dest, "wb") as f:
+        f.write(data)
+    return dest
+
+
+def _save_into_images(data, name):
+    return _save_into(IMAGES_DIR, data, name)
+
+
+def _save_into_files(data, name):
+    return _save_into(FILES_DIR, data, name)
+
+
+def cmd_ping(args):
+    try:
+        with _client_req("GET", "/ping", timeout=8) as r:
+            _emit({"ok": True, **json.loads(r.read())})
+        return 0
+    except Exception as e:  # noqa: BLE001
+        _emit({
+            "ok": False,
+            "error": "client unreachable at %s: %s" % (CLIENT_URL, e),
+        })
+        return 1
+
+
+def cmd_get(args):
+    try:
+        with _client_req(
+            "GET", "/pull?path=" + quote(args.path), timeout=130
+        ) as r:
+            data = r.read()
+    except urllib.error.HTTPError as e:
+        _emit({
+            "ok": False,
+            "error": "pull failed: HTTP %d %r" % (
+                e.code, e.read()[:200]
+            ),
+        })
+        return 1
+    except Exception as e:  # noqa: BLE001
+        _emit({"ok": False, "error": "pull failed: %s" % e})
+        return 1
+    name = os.path.basename(args.path)
+    is_image = _is_image_name(args.path)
+    dest = (
+        _save_into_images(data, name)
+        if is_image
+        else _save_into_files(data, name)
+    )
+    hint = ("/image " + dest) if is_image else dest
+    _emit({
+        "ok": True, "path": dest, "bytes": len(data), "hint": hint,
+    })
+    return 0
+
+
+def cmd_paste(args):
+    try:
+        with _client_req("GET", "/clipboard", timeout=60) as r:
+            data = r.read()
+            hdr_name = r.headers.get("X-Clipboard-Filename") or ""
+            hdr_kind = (
+                r.headers.get("X-Clipboard-Kind") or ""
+            ).lower()
+    except urllib.error.HTTPError as e:
+        _emit({
+            "ok": False,
+            "error": "no clipboard content: HTTP %d %s" % (
+                e.code, e.read()[:200]
+            ),
+        })
+        return 1
+    except Exception as e:  # noqa: BLE001
+        _emit({
+            "ok": False, "error": "clipboard pull failed: %s" % e,
+        })
+        return 1
+    # Save bytes VERBATIM under the real filename the daemon reported,
+    # so an image keeps its format and a pdf/zip lands intact. Legacy
+    # daemons send no headers -> fall back to the historical
+    # clip-<ts>.png image behavior.
+    name = (
+        os.path.basename(hdr_name)
+        if hdr_name
+        else ("clip-%d.png" % int(time.time()))
+    )
+    is_image = hdr_kind == "image" or (
+        not hdr_kind and _is_image_name(name)
+    )
+    dest = (
+        _save_into_images(data, name)
+        if is_image
+        else _save_into_files(data, name)
+    )
+    hint = ("/image " + dest) if is_image else ("/get " + dest)
+    _emit({
+        "ok": True,
+        "path": dest,
+        "bytes": len(data),
+        "kind": "image" if is_image else "file",
+        "hint": hint,
+    })
+    return 0
+
+
+def cmd_send(args):
+    path = os.path.expanduser(args.path)
+    if not os.path.isfile(path):
+        _emit({"ok": False, "error": "gateway file not found: " + path})
+        return 1
+    with open(path, "rb") as f:
+        data = f.read()
+    openq = "0" if args.no_open else "1"
+    try:
+        with _client_req(
+            "POST",
+            "/push?name=%s&open=%s" % (
+                quote(os.path.basename(path)), openq
+            ),
+            body=data,
+            timeout=130,
+        ) as r:
+            _emit({"ok": True, **json.loads(r.read())})
+        return 0
+    except Exception as e:  # noqa: BLE001
+        _emit({"ok": False, "error": "push failed: %s" % e})
+        return 1
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(
+        prog="hermes-shellbridge", description=__doc__
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("ping").set_defaults(func=cmd_ping)
+    g = sub.add_parser("get")
+    g.add_argument("path")
+    g.set_defaults(func=cmd_get)
+    sub.add_parser("paste").set_defaults(func=cmd_paste)
+    s = sub.add_parser("send")
+    s.add_argument("path")
+    s.add_argument("--no-open", action="store_true")
+    s.set_defaults(func=cmd_send)
+    args = p.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hermes_cli/shellctl_assets/hermes-shellbridge
+++ b/hermes_cli/shellctl_assets/hermes-shellbridge
@@ -84,15 +84,17 @@ def _emit(obj):
 def _save_into(target_dir, data, name):
     os.makedirs(target_dir, exist_ok=True)
     safe = os.path.basename(name) or ("shellctl-%d" % int(time.time()))
-    dest = os.path.join(target_dir, safe)
-    if os.path.exists(dest):
-        stem, ext = os.path.splitext(safe)
-        dest = os.path.join(
-            target_dir, "%s-%d%s" % (stem, int(time.time()), ext)
-        )
-    with open(dest, "wb") as f:
-        f.write(data)
-    return dest
+    stem, ext = os.path.splitext(safe)
+    for suffix in range(10000):
+        candidate = safe if suffix == 0 else "%s-%d%s" % (stem, suffix, ext)
+        dest = os.path.join(target_dir, candidate)
+        try:
+            with open(dest, "xb") as f:
+                f.write(data)
+            return dest
+        except FileExistsError:
+            continue
+    raise OSError("could not allocate a unique destination filename")
 
 
 def _save_into_images(data, name):

--- a/hermes_cli/shellctl_assets/hermes-shellctl
+++ b/hermes_cli/shellctl_assets/hermes-shellctl
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""hermes-shellctl - CLIENT half of the Hermes SSH file/image bridge.
+
+Runs on YOUR machine (Mac / Linux / WSL / PuTTY host) - the box you
+SSH FROM. It is a tiny HTTP server (Python 3 stdlib only, zero
+dependencies) that the Hermes host (the box you SSH INTO, running the
+TUI + dashboard) reaches back through a reverse SSH forward
+(RemoteForward). That lets the remote Hermes:
+
+  - PULL a local file from this machine  (image / pdf / any file ->
+    attach in the TUI)
+  - PUSH a file to this machine and open it  (agent-produced image /
+    artifact)
+  - read this machine's CLIPBOARD image or file  (paste)
+
+Design: stdlib only, no sudo, no ControlMaster dependency,
+localhost-bound + token-gated.
+
+Run:  hermes-shellctl daemon --port 8765 --token <tok>
+"""
+from __future__ import annotations
+
+import argparse
+import hmac
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+SHELLCTL_VERSION = "0.2.0"
+_IS_MAC = platform.system() == "Darwin"
+
+_TOKEN = ""
+_DOWNLOAD_DIR = os.path.expanduser("~/Downloads")
+_MAX_BYTES = 64 * 1024 * 1024  # 64 MB cap per transfer
+
+
+def _which(*cands: str):
+    for c in cands:
+        p = shutil.which(c)
+        if p:
+            return p
+    return None
+
+
+def _open_file(path: str):
+    opener = "open" if _IS_MAC else _which("xdg-open", "gio")
+    if not opener:
+        return False, "no opener (install xdg-utils on Linux)"
+    try:
+        subprocess.Popen(
+            [opener, path],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return True, "opened"
+    except Exception as e:  # noqa: BLE001
+        return False, str(e)
+
+
+_MIME_BY_EXT = {
+    ".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+    ".gif": "image/gif", ".webp": "image/webp", ".bmp": "image/bmp",
+    ".tiff": "image/tiff", ".tif": "image/tiff", ".heic": "image/heic",
+    ".heif": "image/heif", ".svg": "image/svg+xml",
+    ".pdf": "application/pdf",
+}
+
+
+def _guess_ctype(name):
+    import mimetypes
+
+    ext = os.path.splitext(name or "")[1].lower()
+    if ext in _MIME_BY_EXT:
+        return _MIME_BY_EXT[ext]
+    return (
+        mimetypes.guess_type(name or "")[0]
+        or "application/octet-stream"
+    )
+
+
+def _macos_clipboard_file_paths():
+    """Return POSIX paths of files currently on the macOS clipboard.
+
+    When you Cmd+C a file in Finder (or copy a file from most apps),
+    the pasteboard carries a ``public.file-url`` reference to the
+    ORIGINAL file on disk, not a re-rendered bitmap. Reading those
+    bytes straight off disk is byte-perfect and works for ANY type
+    (pdf, zip, high-res image), which is exactly the as-is transfer
+    the user wants. AppleScript's ``the clipboard as class furl``
+    returns the file URL(s); a list when several files are copied. We
+    ask for a newline-joined POSIX path list.
+    """
+    script = (
+        'set out to ""\n'
+        'try\n'
+        '  set theFiles to (the clipboard as \xc2\xabclass furl\xc2\xbb)\n'
+        '  if class of theFiles is not list then '
+        'set theFiles to {theFiles}\n'
+        '  repeat with f in theFiles\n'
+        '    set out to out & POSIX path of f & linefeed\n'
+        '  end repeat\n'
+        'end try\n'
+        'return out'
+    )
+    try:
+        r = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True,
+            timeout=10,
+        )
+        if r.returncode != 0:
+            return []
+        raw = (r.stdout or b"").decode("utf-8", "replace")
+        return [
+            p
+            for p in (line.strip() for line in raw.splitlines())
+            if p
+        ]
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def _clipboard_grab():
+    """Grab clipboard contents losslessly.
+
+    Returns (data, filename, ctype, msg). Priority, highest fidelity
+    first:
+      1. A FILE on the clipboard (Finder copy / file URL) -> read the
+         ORIGINAL bytes off disk, keep the real name + extension.
+         Byte-perfect, any type.
+      2. Raw image data on the clipboard (screenshot, copy from
+         Preview) with no backing file -> extract as PNG (lossless
+         container; the only representation the OS actually holds for
+         a screenshot, so it is as-is).
+    """
+    if _IS_MAC:
+        # 1. Real file(s) on the clipboard -> transfer the original
+        # bytes as-is.
+        for path in _macos_clipboard_file_paths():
+            try:
+                if os.path.isfile(path):
+                    sz = os.path.getsize(path)
+                    if sz > _MAX_BYTES:
+                        return (
+                            None, None, None,
+                            "clipboard file too large (%d bytes)" % sz,
+                        )
+                    with open(path, "rb") as f:
+                        data = f.read()
+                    name = os.path.basename(path) or "clipboard-file"
+                    return data, name, _guess_ctype(name), "ok"
+            except Exception:  # noqa: BLE001
+                continue  # fall through to the bitmap path
+
+        # 2. No backing file: raw image bitmap (screenshot etc).
+        pp = _which("pngpaste")
+        tmp = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+        tmp.close()
+        try:
+            if pp:
+                r = subprocess.run(
+                    [pp, tmp.name], capture_output=True, timeout=10
+                )
+                if r.returncode != 0:
+                    return None, None, None, "no image on clipboard"
+            else:
+                script = (
+                    'set p to (POSIX file "%s")\n'
+                    'set d to the clipboard as '
+                    '\xc2\xabclass PNGf\xc2\xbb\n'
+                    'set fh to open for access p with write '
+                    'permission\n'
+                    'write d to fh\nclose access fh'
+                ) % tmp.name
+                r = subprocess.run(
+                    ["osascript", "-e", script],
+                    capture_output=True,
+                    timeout=10,
+                )
+                if r.returncode != 0:
+                    return (
+                        None, None, None,
+                        "no image on clipboard (or osascript denied)",
+                    )
+            with open(tmp.name, "rb") as f:
+                data = f.read()
+            if not data:
+                return None, None, None, "clipboard image empty"
+            return (
+                data, "clip-%d.png" % int(time.time()),
+                "image/png", "ok",
+            )
+        except Exception as e:  # noqa: BLE001
+            return None, None, None, str(e)
+        finally:
+            try:
+                os.unlink(tmp.name)
+            except OSError:
+                pass
+    else:
+        # Linux/WSL. 1. File(s) copied in a file manager land on the
+        # clipboard as text/uri-list; read the original bytes off disk
+        # (byte-perfect, any type).
+        xc = _which("xclip")
+        if xc:
+            try:
+                r = subprocess.run(
+                    [
+                        xc, "-selection", "clipboard",
+                        "-t", "text/uri-list", "-o",
+                    ],
+                    capture_output=True,
+                    timeout=10,
+                )
+                if r.returncode == 0 and r.stdout:
+                    for line in r.stdout.decode(
+                        "utf-8", "replace"
+                    ).splitlines():
+                        line = line.strip()
+                        if line.startswith("file://"):
+                            from urllib.parse import (
+                                unquote,
+                                urlparse as _up,
+                            )
+                            p = unquote(_up(line).path)
+                            if os.path.isfile(p):
+                                sz = os.path.getsize(p)
+                                if sz > _MAX_BYTES:
+                                    return (
+                                        None, None, None,
+                                        "clipboard file too large "
+                                        "(%d bytes)" % sz,
+                                    )
+                                with open(p, "rb") as f:
+                                    data = f.read()
+                                name = (
+                                    os.path.basename(p)
+                                    or "clipboard-file"
+                                )
+                                return (
+                                    data, name,
+                                    _guess_ctype(name), "ok",
+                                )
+            except Exception:  # noqa: BLE001
+                pass
+            # 2. Raw image bitmap on the clipboard.
+            try:
+                r = subprocess.run(
+                    [
+                        xc, "-selection", "clipboard",
+                        "-t", "image/png", "-o",
+                    ],
+                    capture_output=True,
+                    timeout=10,
+                )
+                if r.returncode == 0 and r.stdout:
+                    return (
+                        r.stdout, "clip-%d.png" % int(time.time()),
+                        "image/png", "ok",
+                    )
+            except Exception as e:  # noqa: BLE001
+                return None, None, None, str(e)
+            return None, None, None, "no image on clipboard"
+        return None, None, None, "install xclip for clipboard images"
+
+
+def _capabilities():
+    return {
+        "open": bool(
+            "open" if _IS_MAC else _which("xdg-open", "gio")
+        ),
+        "clipboard": bool(
+            _which("pngpaste") or _IS_MAC or _which("xclip")
+        ),
+    }
+
+
+class _Handler(BaseHTTPRequestHandler):
+    server_version = "hermes-shellctl/" + SHELLCTL_VERSION
+
+    def log_message(self, *a):
+        pass
+
+    def _auth_ok(self):
+        tok = self.headers.get("X-Shellctl-Token", "")
+        return bool(_TOKEN) and hmac.compare_digest(tok, _TOKEN)
+
+    def _send(
+        self,
+        code,
+        payload=None,
+        raw=None,
+        ctype="application/json",
+        extra_headers=None,
+    ):
+        body = (
+            raw if raw is not None
+            else json.dumps(payload or {}).encode()
+        )
+        self.send_response(code)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(body)))
+        for k, v in (extra_headers or {}).items():
+            self.send_header(k, str(v))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _read_body(self):
+        n = int(self.headers.get("Content-Length", 0) or 0)
+        if n > _MAX_BYTES:
+            return b""
+        return self.rfile.read(n) if n else b""
+
+    def do_GET(self):
+        u = urlparse(self.path)
+        if u.path == "/ping":
+            return self._send(200, {
+                "ok": True,
+                "version": SHELLCTL_VERSION,
+                "os": platform.system(),
+                "caps": _capabilities(),
+            })
+        if not self._auth_ok():
+            return self._send(401, {"error": "unauthorized"})
+        q = parse_qs(u.query)
+        if u.path == "/pull":
+            path = os.path.expanduser((q.get("path") or [""])[0])
+            if not path or not os.path.isfile(path):
+                return self._send(
+                    404, {"error": "file not found: " + path}
+                )
+            sz = os.path.getsize(path)
+            if sz > _MAX_BYTES:
+                return self._send(
+                    413, {"error": "file too large (%d bytes)" % sz}
+                )
+            with open(path, "rb") as f:
+                return self._send(
+                    200,
+                    raw=f.read(),
+                    ctype="application/octet-stream",
+                )
+        if u.path == "/clipboard":
+            data, name, ctype, msg = _clipboard_grab()
+            if data is None:
+                return self._send(404, {"error": msg})
+            # Carry the real filename + content-type so the remote
+            # side saves the bytes verbatim with the correct extension
+            # (image, pdf, anything), instead of assuming .png. Legacy
+            # remotes that ignore these headers still get the raw
+            # bytes unchanged.
+            extra = {
+                "X-Clipboard-Filename": name or "clipboard-file",
+                "X-Clipboard-Kind": (
+                    "image"
+                    if (ctype or "").startswith("image/")
+                    else "file"
+                ),
+            }
+            return self._send(
+                200,
+                raw=data,
+                ctype=ctype or "application/octet-stream",
+                extra_headers=extra,
+            )
+        return self._send(404, {"error": "no such endpoint"})
+
+    def do_POST(self):
+        u = urlparse(self.path)
+        if not self._auth_ok():
+            return self._send(401, {"error": "unauthorized"})
+        q = parse_qs(u.query)
+        if u.path == "/push":
+            name = (
+                os.path.basename(
+                    (q.get("name") or ["hermes-file"])[0]
+                )
+                or "hermes-file"
+            )
+            data = self._read_body()
+            if not data:
+                return self._send(
+                    400, {"error": "empty body or too large"}
+                )
+            os.makedirs(_DOWNLOAD_DIR, exist_ok=True)
+            dest = os.path.join(_DOWNLOAD_DIR, name)
+            with open(dest, "wb") as f:
+                f.write(data)
+            opened = (q.get("open") or ["1"])[0] not in (
+                "0", "false", "no"
+            )
+            if opened:
+                _open_file(dest)
+            return self._send(200, {
+                "ok": True,
+                "path": dest,
+                "opened": opened,
+                "bytes": len(data),
+            })
+        return self._send(404, {"error": "no such endpoint"})
+
+
+def cmd_daemon(args):
+    global _TOKEN, _DOWNLOAD_DIR
+    _TOKEN = args.token or os.environ.get(
+        "HERMES_SHELLCTL_TOKEN", ""
+    )
+    if not _TOKEN:
+        print(
+            "FATAL: no token (pass --token or set "
+            "HERMES_SHELLCTL_TOKEN)",
+            file=sys.stderr,
+        )
+        return 2
+    if args.download_dir:
+        _DOWNLOAD_DIR = os.path.expanduser(args.download_dir)
+    srv = ThreadingHTTPServer((args.host, args.port), _Handler)
+    print(
+        "hermes-shellctl %s listening on %s:%d (%s, caps=%s)" % (
+            SHELLCTL_VERSION,
+            args.host,
+            args.port,
+            platform.system(),
+            _capabilities(),
+        ),
+        flush=True,
+    )
+    try:
+        srv.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(
+        prog="hermes-shellctl", description=__doc__
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+    d = sub.add_parser("daemon", help="run the bridge listener")
+    d.add_argument("--host", default="127.0.0.1")
+    d.add_argument("--port", type=int, default=8765)
+    d.add_argument("--token", default="")
+    d.add_argument("--download-dir", default="")
+    d.set_defaults(func=cmd_daemon)
+    v = sub.add_parser("version", help="print version")
+    v.set_defaults(func=lambda a: (print(SHELLCTL_VERSION), 0)[1])
+    args = p.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hermes_cli/shellctl_assets/hermes-shellctl
+++ b/hermes_cli/shellctl_assets/hermes-shellctl
@@ -16,7 +16,14 @@ TUI + dashboard) reaches back through a reverse SSH forward
 Design: stdlib only, no sudo, no ControlMaster dependency,
 localhost-bound + token-gated.
 
-Run:  hermes-shellctl daemon --port 8765 --token <tok>
+Run:  hermes-shellctl daemon --port 8765 --token-file <path>
+
+The token is a bearer credential for every endpoint. A caller with the token
+and listener access can pull any file readable by this process unless
+``--allowed-root`` is set, read clipboard content, and push files into the
+download directory. The SSH reverse forward intentionally gives the remote
+Hermes host listener access, so a compromised host is inside this trust
+boundary.
 """
 from __future__ import annotations
 
@@ -38,7 +45,16 @@ _IS_MAC = platform.system() == "Darwin"
 
 _TOKEN = ""
 _DOWNLOAD_DIR = os.path.expanduser("~/Downloads")
+_ALLOWED_ROOT = ""
 _MAX_BYTES = 64 * 1024 * 1024  # 64 MB cap per transfer
+
+
+class _BodyTooLarge(ValueError):
+    pass
+
+
+class _MalformedBody(ValueError):
+    pass
 
 
 def _which(*cands: str):
@@ -313,13 +329,37 @@ class _Handler(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
     def _read_body(self):
-        n = int(self.headers.get("Content-Length", 0) or 0)
+        raw_length = self.headers.get("Content-Length")
+        if raw_length is None:
+            raise _MalformedBody("missing Content-Length")
+        try:
+            n = int(raw_length)
+        except (TypeError, ValueError) as exc:
+            raise _MalformedBody("invalid Content-Length") from exc
+        if n < 0:
+            raise _MalformedBody("negative Content-Length")
         if n > _MAX_BYTES:
-            return b""
-        return self.rfile.read(n) if n else b""
+            raise _BodyTooLarge("request body too large")
+        data = self.rfile.read(n) if n else b""
+        if len(data) != n:
+            raise _MalformedBody("incomplete request body")
+        return data
+
+    @staticmethod
+    def _pull_path_allowed(path):
+        if not _ALLOWED_ROOT:
+            return True
+        try:
+            return os.path.commonpath(
+                (os.path.realpath(path), _ALLOWED_ROOT)
+            ) == _ALLOWED_ROOT
+        except (OSError, ValueError):
+            return False
 
     def do_GET(self):
         u = urlparse(self.path)
+        if not self._auth_ok():
+            return self._send(401, {"error": "unauthorized"})
         if u.path == "/ping":
             return self._send(200, {
                 "ok": True,
@@ -327,11 +367,11 @@ class _Handler(BaseHTTPRequestHandler):
                 "os": platform.system(),
                 "caps": _capabilities(),
             })
-        if not self._auth_ok():
-            return self._send(401, {"error": "unauthorized"})
         q = parse_qs(u.query)
         if u.path == "/pull":
             path = os.path.expanduser((q.get("path") or [""])[0])
+            if path and not self._pull_path_allowed(path):
+                return self._send(403, {"error": "path outside allowed root"})
             if not path or not os.path.isfile(path):
                 return self._send(
                     404, {"error": "file not found: " + path}
@@ -384,15 +424,19 @@ class _Handler(BaseHTTPRequestHandler):
                 )
                 or "hermes-file"
             )
-            data = self._read_body()
+            try:
+                data = self._read_body()
+            except _BodyTooLarge:
+                return self._send(413, {"error": "request body too large"})
+            except _MalformedBody as exc:
+                return self._send(400, {"error": str(exc)})
             if not data:
-                return self._send(
-                    400, {"error": "empty body or too large"}
-                )
+                return self._send(400, {"error": "empty body"})
             os.makedirs(_DOWNLOAD_DIR, exist_ok=True)
-            dest = os.path.join(_DOWNLOAD_DIR, name)
-            with open(dest, "wb") as f:
-                f.write(data)
+            try:
+                dest = _write_deduplicated(_DOWNLOAD_DIR, name, data)
+            except OSError as exc:
+                return self._send(500, {"error": str(exc)})
             opened = (q.get("open") or ["1"])[0] not in (
                 "0", "false", "no"
             )
@@ -407,9 +451,35 @@ class _Handler(BaseHTTPRequestHandler):
         return self._send(404, {"error": "no such endpoint"})
 
 
+def _write_deduplicated(directory, name, data):
+    """Write data without replacing an existing destination."""
+    stem, ext = os.path.splitext(name)
+    for suffix in range(10000):
+        candidate = name if suffix == 0 else "%s-%d%s" % (stem, suffix, ext)
+        dest = os.path.join(directory, candidate)
+        try:
+            with open(dest, "xb") as f:
+                f.write(data)
+            return dest
+        except FileExistsError:
+            continue
+    raise OSError("could not allocate a unique destination filename")
+
+
+def _read_token_file(path):
+    if not path:
+        return ""
+    try:
+        with open(os.path.expanduser(path), encoding="utf-8") as f:
+            return f.read().strip()
+    except OSError as exc:
+        print("FATAL: cannot read token file: %s" % exc, file=sys.stderr)
+        return ""
+
+
 def cmd_daemon(args):
-    global _TOKEN, _DOWNLOAD_DIR
-    _TOKEN = args.token or os.environ.get(
+    global _TOKEN, _DOWNLOAD_DIR, _ALLOWED_ROOT
+    _TOKEN = args.token or _read_token_file(args.token_file) or os.environ.get(
         "HERMES_SHELLCTL_TOKEN", ""
     )
     if not _TOKEN:
@@ -421,6 +491,15 @@ def cmd_daemon(args):
         return 2
     if args.download_dir:
         _DOWNLOAD_DIR = os.path.expanduser(args.download_dir)
+    if args.allowed_root:
+        root = os.path.realpath(os.path.expanduser(args.allowed_root))
+        if not os.path.isdir(root):
+            print(
+                "FATAL: allowed root is not a directory: %s" % root,
+                file=sys.stderr,
+            )
+            return 2
+        _ALLOWED_ROOT = root
     srv = ThreadingHTTPServer((args.host, args.port), _Handler)
     print(
         "hermes-shellctl %s listening on %s:%d (%s, caps=%s)" % (
@@ -448,7 +527,13 @@ def main(argv=None):
     d.add_argument("--host", default="127.0.0.1")
     d.add_argument("--port", type=int, default=8765)
     d.add_argument("--token", default="")
+    d.add_argument("--token-file", default="")
     d.add_argument("--download-dir", default="")
+    d.add_argument(
+        "--allowed-root",
+        default="",
+        help="optionally restrict /pull to this directory tree",
+    )
     d.set_defaults(func=cmd_daemon)
     v = sub.add_parser("version", help="print version")
     v.set_defaults(func=lambda a: (print(SHELLCTL_VERSION), 0)[1])

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1398,6 +1398,9 @@ _CATEGORY_MERGE: Dict[str, str] = {
     # `session.terminal_continue` is the only schema-surfaced session field —
     # fold it into general rather than spawning a one-field orphan category.
     "session": "general",
+    # `shellctl.allowed_root` is the only schema-surfaced shellctl field. Keep
+    # it with the terminal settings that own the SSH bridge workflow.
+    "shellctl": "terminal",
 }
 
 # Display order for tabs — unlisted categories sort alphabetically after these.

--- a/tests/hermes_cli/test_shellctl_bridge.py
+++ b/tests/hermes_cli/test_shellctl_bridge.py
@@ -1,33 +1,23 @@
-"""Tests for the shellctl file/image bridge (host + install glue).
-
-Covers the image-vs-file classification + attach-hint emission in the
-host-side ``hermes-shellbridge`` orchestrator, plus a smoke test of the
-``hermes install shellctl`` asset/token setup. The bridge script has no
-``.py`` extension (it is copied to the client verbatim), so it is loaded
-from source via ``importlib``.
-"""
+"""Tests for the shellctl file/image bridge and install glue."""
 from __future__ import annotations
 
+import http.client
 import importlib.machinery
 import importlib.util
 import json
 import os
 from pathlib import Path
+import threading
+from urllib.parse import quote
 
 import pytest
 
-_ASSETS = (
-    Path(__file__).resolve().parents[2]
-    / "hermes_cli"
-    / "shellctl_assets"
-)
+_ASSETS = Path(__file__).resolve().parents[2] / "hermes_cli" / "shellctl_assets"
 
 
-def _load_shellbridge():
-    src = _ASSETS / "hermes-shellbridge"
-    loader = importlib.machinery.SourceFileLoader(
-        "hermes_shellbridge_under_test", str(src)
-    )
+def _load_asset(name: str, module_name: str):
+    src = _ASSETS / name
+    loader = importlib.machinery.SourceFileLoader(module_name, str(src))
     spec = importlib.util.spec_from_loader(loader.name, loader)
     mod = importlib.util.module_from_spec(spec)
     loader.exec_module(mod)
@@ -36,15 +26,46 @@ def _load_shellbridge():
 
 @pytest.fixture(scope="module")
 def bridge():
-    return _load_shellbridge()
+    return _load_asset("hermes-shellbridge", "hermes_shellbridge_under_test")
+
+
+@pytest.fixture
+def shellctl_server(tmp_path):
+    """Run the real stdlib HTTP handler on an OS-assigned port."""
+    mod = _load_asset("hermes-shellctl", "hermes_shellctl_under_test")
+    mod._TOKEN = "test-token"
+    mod._DOWNLOAD_DIR = str(tmp_path / "downloads")
+    mod._ALLOWED_ROOT = ""
+    server = mod.ThreadingHTTPServer(("127.0.0.1", 0), mod._Handler)
+    assert server.server_port != 0
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield mod, server.server_port
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _http(port, method, path, body=None, token="test-token", headers=None):
+    request_headers = dict(headers or {})
+    if token is not None:
+        request_headers["X-Shellctl-Token"] = token
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    conn.request(method, path, body=body, headers=request_headers)
+    response = conn.getresponse()
+    payload = response.read()
+    status = response.status
+    conn.close()
+    return status, payload
 
 
 @pytest.mark.parametrize(
     "name",
     [
-        "photo.png", "shot.JPG", "a.jpeg", "x.gif", "y.webp",
-        "z.bmp", "scan.tiff", "scan.tif", "pic.heic", "pic.heif",
-        "logo.svg",
+        "photo.png", "shot.JPG", "a.jpeg", "x.gif", "y.webp", "z.bmp",
+        "scan.tiff", "scan.tif", "pic.heic", "pic.heif", "logo.svg",
     ],
 )
 def test_image_names_are_images(bridge, name):
@@ -59,47 +80,35 @@ def test_non_image_names_are_not_images(bridge, name):
     assert bridge._is_image_name(name) is False
 
 
-def test_get_image_emits_image_hint(bridge, tmp_path, monkeypatch,
-                                     capsys):
-    """A pulled image lands in IMAGES_DIR + carries an `/image` hint."""
+def test_get_image_emits_image_hint(bridge, tmp_path, monkeypatch, capsys):
     images = tmp_path / "images"
     files = tmp_path / "files"
     monkeypatch.setattr(bridge, "IMAGES_DIR", str(images))
     monkeypatch.setattr(bridge, "FILES_DIR", str(files))
 
     class _Resp:
-        def __init__(self, data):
-            self._data = data
-
         def read(self):
-            return self._data
+            return b"\x89PNG fake bytes"
 
         def __enter__(self):
             return self
 
-        def __exit__(self, *a):
+        def __exit__(self, *args):
             return False
 
-    monkeypatch.setattr(
-        bridge, "_client_req",
-        lambda *a, **k: _Resp(b"\x89PNG fake bytes"),
-    )
+    monkeypatch.setattr(bridge, "_client_req", lambda *args, **kwargs: _Resp())
 
     class _Args:
         path = "/home/user/screenshot.png"
 
-    rc = bridge.cmd_get(_Args())
-    assert rc == 0
+    assert bridge.cmd_get(_Args()) == 0
     out = json.loads(capsys.readouterr().out.strip())
-    assert out["ok"] is True
     assert out["hint"].startswith("/image ")
     assert os.path.dirname(out["path"]) == str(images)
     assert out["bytes"] == len(b"\x89PNG fake bytes")
 
 
-def test_get_non_image_emits_plain_hint(bridge, tmp_path, monkeypatch,
-                                        capsys):
-    """A pulled pdf lands in FILES_DIR + carries a plain-path hint."""
+def test_get_non_image_emits_plain_hint(bridge, tmp_path, monkeypatch, capsys):
     images = tmp_path / "images"
     files = tmp_path / "files"
     monkeypatch.setattr(bridge, "IMAGES_DIR", str(images))
@@ -112,51 +121,154 @@ def test_get_non_image_emits_plain_hint(bridge, tmp_path, monkeypatch,
         def __enter__(self):
             return self
 
-        def __exit__(self, *a):
+        def __exit__(self, *args):
             return False
 
-    monkeypatch.setattr(
-        bridge, "_client_req", lambda *a, **k: _Resp()
-    )
+    monkeypatch.setattr(bridge, "_client_req", lambda *args, **kwargs: _Resp())
 
     class _Args:
         path = "/home/user/report.pdf"
 
-    rc = bridge.cmd_get(_Args())
-    assert rc == 0
+    assert bridge.cmd_get(_Args()) == 0
     out = json.loads(capsys.readouterr().out.strip())
-    assert out["ok"] is True
-    assert not out["hint"].startswith("/image ")
     assert out["hint"] == out["path"]
     assert os.path.dirname(out["path"]) == str(files)
 
 
-def test_install_shellctl_writes_assets_and_token(tmp_path,
-                                                  monkeypatch, capsys):
-    """`hermes install shellctl` copies assets + mints a 0600 token."""
+def test_host_pull_deduplicates_existing_name(bridge, tmp_path):
+    first = Path(bridge._save_into(str(tmp_path), b"one", "same.txt"))
+    second = Path(bridge._save_into(str(tmp_path), b"two", "same.txt"))
+    assert first.name == "same.txt"
+    assert second.name == "same-1.txt"
+    assert first.read_bytes() == b"one"
+    assert second.read_bytes() == b"two"
+
+
+def test_http_authentication_and_pull(shellctl_server, tmp_path):
+    mod, port = shellctl_server
+    status, _ = _http(port, "GET", "/ping", token=None)
+    assert status == 401
+    status, payload = _http(port, "GET", "/ping")
+    assert status == 200
+    assert json.loads(payload)["ok"] is True
+
+    source = tmp_path / "arbitrary.txt"
+    source.write_bytes(b"arbitrary client bytes")
+    status, payload = _http(port, "GET", "/pull?path=" + quote(str(source)))
+    assert status == 200
+    assert payload == source.read_bytes()
+
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    mod._ALLOWED_ROOT = os.path.realpath(allowed)
+    status, _ = _http(port, "GET", "/pull?path=" + quote(str(source)))
+    assert status == 403
+
+    symlink = allowed / "escape.txt"
+    try:
+        symlink.symlink_to(source)
+    except OSError:
+        pass
+    else:
+        status, _ = _http(port, "GET", "/pull?path=" + quote(str(symlink)))
+        assert status == 403
+
+
+def test_http_push_deduplicates_collisions(shellctl_server):
+    mod, port = shellctl_server
+    status, first = _http(
+        port, "POST", "/push?name=result.txt&open=0", b"one"
+    )
+    assert status == 200
+    status, second = _http(
+        port, "POST", "/push?name=result.txt&open=0", b"two"
+    )
+    assert status == 200
+    first_path = Path(json.loads(first)["path"])
+    second_path = Path(json.loads(second)["path"])
+    assert first_path != second_path
+    assert first_path.read_bytes() == b"one"
+    assert second_path.read_bytes() == b"two"
+    assert second_path.name == "result-1.txt"
+    assert first_path.parent == Path(mod._DOWNLOAD_DIR)
+
+
+def test_http_oversized_and_malformed_bodies(shellctl_server):
+    mod, port = shellctl_server
+    status, payload = _http(
+        port,
+        "POST",
+        "/push?name=huge.bin&open=0",
+        headers={"Content-Length": str(mod._MAX_BYTES + 1)},
+    )
+    assert status == 413
+    assert json.loads(payload)["error"] == "request body too large"
+
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    conn.putrequest("POST", "/push?name=bad.bin&open=0")
+    conn.putheader("X-Shellctl-Token", "test-token")
+    conn.putheader("Content-Length", "not-a-number")
+    conn.endheaders()
+    response = conn.getresponse()
+    assert response.status == 400
+    assert json.loads(response.read())["error"] == "invalid Content-Length"
+    conn.close()
+
+
+def test_install_cli_parser_accepts_shellctl_options():
     import argparse
 
-    home = tmp_path / "hhome"
-    monkeypatch.setenv("HERMES_HOME", str(home))
-    import importlib
+    from hermes_cli.install_cmd import register_cli
 
-    import hermes_cli.install_cmd as install_cmd
-    importlib.reload(install_cmd)
-
-    args = argparse.Namespace(
-        print_client=False, port=8765, ssh_host="myhost"
+    parser = argparse.ArgumentParser()
+    install_parser = parser.add_subparsers(dest="command", required=True).add_parser(
+        "install"
     )
-    rc = install_cmd.cmd_install_shellctl(args)
-    assert rc == 0
+    register_cli(install_parser)
+    args = parser.parse_args(
+        [
+            "install", "shellctl", "--port", "9001", "--ssh-host", "remote",
+            "--allowed-root", "/safe/files",
+        ]
+    )
+    assert args.install_target == "shellctl"
+    assert args.port == 9001
+    assert args.ssh_host == "remote"
+    assert args.allowed_root == "/safe/files"
+
+
+def test_install_shellctl_writes_assets_and_token(tmp_path, capsys):
+    import argparse
+
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+    import hermes_cli.install_cmd as install_cmd
+
+    home = tmp_path / "profile-home"
+    override = set_hermes_home_override(home)
+    try:
+        args = argparse.Namespace(
+            print_client=False,
+            port=8765,
+            ssh_host="myhost",
+            allowed_root="~/shared",
+        )
+        assert install_cmd.cmd_install_shellctl(args) == 0
+    finally:
+        reset_hermes_home_override(override)
 
     sc = home / "shellctl"
     assert (sc / "hermes-shellctl").is_file()
     assert (sc / "hermes-shellbridge").is_file()
     token = (sc / "bridge-token").read_text(encoding="utf-8").strip()
     assert len(token) >= 32
-    # Token file is chmod 0600.
-    mode = (sc / "bridge-token").stat().st_mode & 0o777
-    assert mode == 0o600
+    assert (sc / "bridge-token").stat().st_mode & 0o777 == 0o600
+    assert (sc / "bridge.env").stat().st_mode & 0o777 == 0o600
     out = capsys.readouterr().out
     assert "RemoteForward 127.0.0.1:8765" in out
-    assert token in out
+    assert "ExitOnForwardFailure yes" in out
+    assert "--token-file ~/.hermes-shellctl-token" in out
+    assert "--allowed-root '~/shared'" in out
+    assert token not in out

--- a/tests/hermes_cli/test_shellctl_bridge.py
+++ b/tests/hermes_cli/test_shellctl_bridge.py
@@ -1,0 +1,162 @@
+"""Tests for the shellctl file/image bridge (host + install glue).
+
+Covers the image-vs-file classification + attach-hint emission in the
+host-side ``hermes-shellbridge`` orchestrator, plus a smoke test of the
+``hermes install shellctl`` asset/token setup. The bridge script has no
+``.py`` extension (it is copied to the client verbatim), so it is loaded
+from source via ``importlib``.
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+_ASSETS = (
+    Path(__file__).resolve().parents[2]
+    / "hermes_cli"
+    / "shellctl_assets"
+)
+
+
+def _load_shellbridge():
+    src = _ASSETS / "hermes-shellbridge"
+    loader = importlib.machinery.SourceFileLoader(
+        "hermes_shellbridge_under_test", str(src)
+    )
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def bridge():
+    return _load_shellbridge()
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "photo.png", "shot.JPG", "a.jpeg", "x.gif", "y.webp",
+        "z.bmp", "scan.tiff", "scan.tif", "pic.heic", "pic.heif",
+        "logo.svg",
+    ],
+)
+def test_image_names_are_images(bridge, name):
+    assert bridge._is_image_name(name) is True
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["doc.pdf", "sheet.csv", "notes.txt", "a.zip", "bin", "", None],
+)
+def test_non_image_names_are_not_images(bridge, name):
+    assert bridge._is_image_name(name) is False
+
+
+def test_get_image_emits_image_hint(bridge, tmp_path, monkeypatch,
+                                     capsys):
+    """A pulled image lands in IMAGES_DIR + carries an `/image` hint."""
+    images = tmp_path / "images"
+    files = tmp_path / "files"
+    monkeypatch.setattr(bridge, "IMAGES_DIR", str(images))
+    monkeypatch.setattr(bridge, "FILES_DIR", str(files))
+
+    class _Resp:
+        def __init__(self, data):
+            self._data = data
+
+        def read(self):
+            return self._data
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(
+        bridge, "_client_req",
+        lambda *a, **k: _Resp(b"\x89PNG fake bytes"),
+    )
+
+    class _Args:
+        path = "/home/user/screenshot.png"
+
+    rc = bridge.cmd_get(_Args())
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["ok"] is True
+    assert out["hint"].startswith("/image ")
+    assert os.path.dirname(out["path"]) == str(images)
+    assert out["bytes"] == len(b"\x89PNG fake bytes")
+
+
+def test_get_non_image_emits_plain_hint(bridge, tmp_path, monkeypatch,
+                                        capsys):
+    """A pulled pdf lands in FILES_DIR + carries a plain-path hint."""
+    images = tmp_path / "images"
+    files = tmp_path / "files"
+    monkeypatch.setattr(bridge, "IMAGES_DIR", str(images))
+    monkeypatch.setattr(bridge, "FILES_DIR", str(files))
+
+    class _Resp:
+        def read(self):
+            return b"%PDF-1.4 fake"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(
+        bridge, "_client_req", lambda *a, **k: _Resp()
+    )
+
+    class _Args:
+        path = "/home/user/report.pdf"
+
+    rc = bridge.cmd_get(_Args())
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["ok"] is True
+    assert not out["hint"].startswith("/image ")
+    assert out["hint"] == out["path"]
+    assert os.path.dirname(out["path"]) == str(files)
+
+
+def test_install_shellctl_writes_assets_and_token(tmp_path,
+                                                  monkeypatch, capsys):
+    """`hermes install shellctl` copies assets + mints a 0600 token."""
+    import argparse
+
+    home = tmp_path / "hhome"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import importlib
+
+    import hermes_cli.install_cmd as install_cmd
+    importlib.reload(install_cmd)
+
+    args = argparse.Namespace(
+        print_client=False, port=8765, ssh_host="myhost"
+    )
+    rc = install_cmd.cmd_install_shellctl(args)
+    assert rc == 0
+
+    sc = home / "shellctl"
+    assert (sc / "hermes-shellctl").is_file()
+    assert (sc / "hermes-shellbridge").is_file()
+    token = (sc / "bridge-token").read_text(encoding="utf-8").strip()
+    assert len(token) >= 32
+    # Token file is chmod 0600.
+    mode = (sc / "bridge-token").stat().st_mode & 0o777
+    assert mode == 0o600
+    out = capsys.readouterr().out
+    assert "RemoteForward 127.0.0.1:8765" in out
+    assert token in out


### PR DESCRIPTION
## Problem

When Hermes runs on a remote machine over SSH, paths and clipboard data on the user's local machine are outside the remote process. Moving a screenshot, document, or generated result between the two machines requires a separate manual transfer.

## Solution

This PR is the shared shellctl foundation for SSH bridged local capabilities. It ships a dependency free Python client daemon, a host side bridge command, installer integration, configuration, and the authenticated reverse forwarding contract used by file, image, clipboard, and related shellctl consumers.

`hermes install shellctl` installs the assets under the active profile home, creates or reuses a private random token, writes a private `bridge.env`, and prints setup commands for the local client and an SSH `RemoteForward`. The token is copied through SSH into a mode `0600` file rather than printed in shell history or passed as its value on the daemon command line.

The host bridge supports:

1. Pulling a local file into the remote Hermes images or downloads directory, with an image hint for recognized image formats.
2. Pulling local clipboard file or image data without text transcoding.
3. Pushing a remote file into the local download directory, optionally opening it.
4. An authenticated capability probe.

Transfers are binary safe, capped at 64 MB on both request paths, and use collision safe numbered destination names rather than overwriting existing files. Malformed body lengths and oversized bodies return distinct errors.

## Shared foundation and overlapping work

This is intentionally the common shellctl transport and installation layer. #94059 adds remote voice behavior on top of the same bridge. It should be reviewed as a consumer stacked on this foundation rather than as a second copy of the shellctl scaffolding.

The current PR does not depend on terminal image escape protocols such as Kitty or Sixel. It transfers files over an authenticated HTTP listener carried by the existing SSH connection.

## Security and trust boundary

The daemon binds only to `127.0.0.1`, and every endpoint, including the capability probe, requires the shared token. Host token and environment files are created with mode `0600` through private creation or atomic replacement. Each transfer has a 64 MB cap.

Possession of the token and access to the forwarded listener grants the Hermes host the local daemon user's file, clipboard, download, and open capabilities. By default `/pull` can read any file that user can read. `shellctl.allowed_root` or `--allowed-root` can restrict pulls to one real path tree and rejects symlink escapes, but it does not remove clipboard or push access. A compromised Hermes host can read `bridge.env`, so this bridge must not be used with an untrusted host. Stopping the daemon and SSH session removes forwarded access.

## Validation

The current focused rerun passed the real stdlib HTTP handler, installer, authentication, path restriction, collision, size limit, and image classification cases in `tests/hermes_cli/test_shellctl_bridge.py`: `26 passed`.