### PR TITLE
fix(models): make the live Ollama Cloud listing authoritative over models.dev

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -6232,10 +6232,15 @@ def fetch_ollama_cloud_models(
     """Fetch Ollama Cloud models by merging live API + models.dev, with disk cache.
 
     Resolution order:
-      1. Disk cache (if fresh, < 1 hour, and not force_refresh)
-      2. Live ``/v1/models`` endpoint (primary — freshest source)
-      3. models.dev registry (secondary — fills gaps for unlisted models)
-      4. Merge: live models first, then models.dev additions (deduped)
+      1. Disk cache (if fresh, ``_OLLAMA_CLOUD_CACHE_TTL``, and not force_refresh)
+      2. Live ``/v1/models`` endpoint (primary — freshest source, and
+         authoritative for existence when it returns a non-empty list)
+      3. models.dev registry (secondary — full fallback when the live probe
+         yields no models: no key, probe failure, or empty listing)
+      4. Merge: live models (deduped, order-preserving). models.dev never
+         adds IDs the live listing doesn't already carry — models.dev lags
+         retirements, so unioning its only-here IDs would resurrect retired
+         models in the picker (#94041).
 
     Returns a list of model IDs (never None — empty list on total failure).
     """
@@ -6265,7 +6270,8 @@ def fetch_ollama_cloud_models(
     except Exception:
         pass
 
-    # 4. Merge: live first, then models.dev additions (deduped, order-preserving)
+    # 4. Merge: live first; models.dev only fills a fully-failed live probe
+    #    (deduped, order-preserving) — see docstring note on #94041.
     if live_models or mdev_models:
         seen: set[str] = set()
         merged: list[str] = []
@@ -6276,6 +6282,11 @@ def fetch_ollama_cloud_models(
         for m in mdev_models:
             normalized = _strip_ollama_cloud_suffix(m)
             if normalized and normalized not in seen:
+                if live_models:
+                    # Existence is the live API's call: a models.dev-only ID
+                    # means Ollama retired (or never had) the model, and
+                    # selecting it fails at runtime (#94041).
+                    continue
                 seen.add(normalized)
                 merged.append(normalized)
         if merged:

--- a/tests/hermes_cli/test_ollama_cloud_provider.py
+++ b/tests/hermes_cli/test_ollama_cloud_provider.py
@@ -149,8 +149,13 @@ class TestOllamaCloudModelPicker:
 # ── Merged Model Discovery ──
 
 class TestOllamaCloudMergedDiscovery:
-    def test_merges_live_and_models_dev(self, tmp_path, monkeypatch):
-        """Live API models appear first, models.dev additions fill gaps."""
+    def test_live_listing_authoritative_models_dev_only_entries_dropped(self, tmp_path, monkeypatch):
+        """Live API models come first; models.dev-only IDs stay out (#94041).
+
+        Supersedes the old union pin ("models.dev additions fill gaps"):
+        models.dev lags retirements, so unioning its only-here IDs resurrects
+        retired models in the picker that fail at runtime when selected.
+        """
         from hermes_cli.models import fetch_ollama_cloud_models
 
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -169,12 +174,39 @@ class TestOllamaCloudMergedDiscovery:
              patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev):
             result = fetch_ollama_cloud_models(force_refresh=True)
 
-        # Live models first, then models.dev additions (deduped)
-        assert result[0] == "qwen3.5:397b"  # from live API
-        assert result[1] == "glm-5"          # from live API (also in models.dev)
-        assert "kimi-k2.5" in result         # from models.dev only
-        assert "nemotron-3-super" in result  # from models.dev only
-        assert result.count("glm-5") == 1    # no duplicates
+        # Live models first, deduped; models.dev adds nothing on its own
+        assert result == ["qwen3.5:397b", "glm-5"]
+        assert "kimi-k2.5" not in result         # retired upstream, models.dev-only
+        assert "nemotron-3-super" not in result  # models.dev-only
+
+    def test_retired_ids_not_readded_on_refresh_after_cache_clear(self, tmp_path, monkeypatch):
+        """The reporter's TTL loop: the cache holds phantom IDs; a force
+        refresh rebuilt from the live listing must purge them instead of
+        re-unioning models.dev (#94041)."""
+        import json as _json
+        from hermes_cli.models import _ollama_cloud_cache_path, fetch_ollama_cloud_models
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("OLLAMA_API_KEY", "test-key")
+
+        cache_path = _ollama_cloud_cache_path()
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(_json.dumps({
+            "models": ["kimi-k2.5", "qwen3.5:397b"], "cached_at": 0,
+        }))
+
+        mock_mdev = {
+            "ollama-cloud": {
+                "models": {"kimi-k2.5": {"tool_call": True}}
+            }
+        }
+        with patch("hermes_cli.models.fetch_api_models", return_value=["qwen3.5:397b"]), \
+             patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev):
+            result = fetch_ollama_cloud_models(force_refresh=True)
+
+        assert result == ["qwen3.5:397b"]
+        persisted = _json.loads(cache_path.read_text())
+        assert persisted["models"] == ["qwen3.5:397b"]
 
     def test_falls_back_to_models_dev_without_api_key(self, tmp_path, monkeypatch):
         """Without API key, only models.dev results are returned."""


### PR DESCRIPTION
## What does this PR do?

`fetch_ollama_cloud_models()` unioned models.dev-only IDs onto the live `/v1/models` listing. models.dev lags Ollama's retirements, so retired models (the reporter's examples: `kimi-k2.5`, `deepseek-v4-pro`, `deepseek-v4-flash`, `minimax-m2.5` — 4 phantom entries vs the 19-model live listing) persisted in the `/model` picker indefinitely. Selecting one fails at runtime with `Model '<name>' was not found in this provider's model listing`, and manually deleting the IDs from `ollama_cloud_models_cache.json` only helps until TTL expiry, when the next refresh re-unioned models.dev.

This makes the live listing authoritative for *existence*: when the live probe returns a non-empty list, models.dev no longer adds IDs of its own (the merge dedupe/suffix-stripping is unchanged). models.dev keeps its intended role as the full fallback when the live probe yields no models at all (no key, probe failure, empty listing) — that path is unchanged.

Also per the issue: the docstring's hardcoded "< 1 hour" now references `_OLLAMA_CLOUD_CACHE_TTL`, and the resolution-order notes match the actual merge semantics.

## Related Issue

Fixes #94041

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `hermes_cli/models.py` (`fetch_ollama_cloud_models`):
  - In the merge loop, a models.dev entry that normalizes to an ID not already in the live list is skipped whenever `live_models` is non-empty, with a comment naming the retired-model failure mode (#94041). When `live_models` is empty the previous fallback behaviour (full models.dev list) is preserved.
  - Docstring updated: cache TTL now referenced via the constant; steps 3/4 describe models.dev as a full fallback rather than a gap-filler that adds IDs.
- `tests/hermes_cli/test_ollama_cloud_provider.py`:
  - `test_merges_live_and_models_dev` rewritten as `test_live_listing_authoritative_models_dev_only_entries_dropped` — same fixture, now pins that models.dev-only IDs stay out while live order/dedupe is preserved (docstring notes it supersedes the old union pin).
  - New `test_retired_ids_not_readded_on_refresh_after_cache_clear` — the reporter's TTL loop: a cache pre-seeded with a phantom ID plus a live listing without it must end with both the returned list and the persisted cache free of the phantom ID.

## How to Test

- Run: `.venv/bin/python -m pytest tests/hermes_cli/test_ollama_cloud_provider.py -q`
- Observed result: `24 passed`. Fail-on-main check (`git stash` of the source change): the two new/rewritten tests fail against unpatched `main`; all green with the fix.
- Regression sweep across the models/picker test files (`test_model_switch_custom_providers.py`, `test_model_switch_filter_unresolved.py`, `test_provider_section3_grouping.py`, `test_xai_curated_models.py`, `test_gemini_provider.py`, `test_gmi_provider.py`, `test_openai_discovery_endpoint.py`, plus the ollama file): `149 passed`. `test_tui_gateway_server.py` shows 29 failures both with and without this change (stash-compared) — pre-existing local-environment failures, unrelated to the ollama-cloud merge path.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of the completed code performed
- [x] New and existing unit tests pass locally
- [x] Changes are backward-compatible (live-probe-failure fallback behaviour unchanged)
