### PR TITLE
fix(desktop): reject slash input in bot group rooms with a visible notice

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -7889,23 +7889,43 @@ async function harvestStrandedUntilSettled(group, members, thread) {
  *  Returns the thread id the message landed in. */
 // Slash commands typed in a group room have no handler: the room composer
 // submits verbatim into sendToGroupChat, so "/new" lands in every member's
-// session as literal chat text (#93947). The 1:1 composer reroutes /new via
-// its middleware; rooms have no such path and reset semantics are ambiguous
-// at room scope (member sessions are keyed per-room, shared across threads).
-// Until a design decision lands, reject slash-style input visibly instead of
-// delivering it as a prompt the bots answer literally.
-const GROUP_SLASH_INPUT_RE = /^\/\S/
+// session as literal chat text (#93947). The 1:1 composer does NOT broadly
+// intercept slash input either — its middleware only reroutes /new|/reset —
+// but there a stray command degrades to one session's chat text, while a
+// room fans it out to EVERY member. Rooms therefore reject command-shaped
+// input visibly instead of delivering it as prompts the bots answer
+// literally. The shape is deliberately narrower than "starts with /": paths
+// like "/etc/hosts — what is this?" or "/usr/bin/env python3 …" are common
+// prose openers, so only a command-like first token (a letter-led word,
+// optionally followed by args) trips the guard.
+const GROUP_SLASH_INPUT_RE = /^\/[a-z][\w-]*(?:\s|$)/i
 
 function isGroupSlashInput(text) {
   return GROUP_SLASH_INPUT_RE.test(String(text || '').trim())
 }
 
-function notifyGroupSlashUnsupported() {
+function notifyGroupSlashUnsupported(text) {
+  const token = String(text || '').trim().split(/\s+/)[0]?.slice(0, 24) || ''
+
   host.notify?.({
     kind: 'info',
     title: 'Slash commands aren’t supported in group rooms',
-    message: 'The text was not sent — it would reach every bot as a literal message.'
+    message: token
+      ? `“${token}” was not sent — it would reach every bot as a literal message.`
+      : 'The text was not sent — it would reach every bot as a literal message.'
   })
+}
+
+// One shared rejection point for both room composers (and any future one):
+// adding an allow-list later becomes a one-line edit HERE.
+function rejectGroupSlashIfNeeded(text) {
+  if (!isGroupSlashInput(text)) {
+    return false
+  }
+
+  notifyGroupSlashUnsupported(text)
+
+  return true
 }
 
 function sendToGroupChat(group, members, text, thread, images) {
@@ -7913,6 +7933,16 @@ function sendToGroupChat(group, members, text, thread, images) {
   const attached = Array.isArray(images) ? images.filter(img => img && img.data) : []
 
   if ((!trimmed && !attached.length) || !members.length) {
+    return null
+  }
+
+  // Defense-in-depth backstop (#93947): the composers guard before they
+  // submit; if a future non-composer caller ever lands here with slash
+  // input, refuse delivery rather than reintroduce literal-command fan-out.
+  // Returning null reuses the established "nothing was sent" contract.
+  if (!attached.length && isGroupSlashInput(trimmed)) {
+    console.warn('[hermes-bots] blocked slash-style input from reaching sendToGroupChat')
+
     return null
   }
 
@@ -12828,9 +12858,7 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
       return
     }
 
-    if (isGroupSlashInput(text)) {
-      notifyGroupSlashUnsupported()
-
+    if (rejectGroupSlashIfNeeded(text)) {
       return
     }
 
@@ -12864,9 +12892,7 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
       return
     }
 
-    if (isGroupSlashInput(text)) {
-      notifyGroupSlashUnsupported()
-
+    if (rejectGroupSlashIfNeeded(text)) {
       return
     }
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -7887,6 +7887,27 @@ async function harvestStrandedUntilSettled(group, members, thread) {
  *  Appends, bumps the room epoch (supersedes any running loop at its next
  *  member boundary), and starts the turn drive for the target thread.
  *  Returns the thread id the message landed in. */
+// Slash commands typed in a group room have no handler: the room composer
+// submits verbatim into sendToGroupChat, so "/new" lands in every member's
+// session as literal chat text (#93947). The 1:1 composer reroutes /new via
+// its middleware; rooms have no such path and reset semantics are ambiguous
+// at room scope (member sessions are keyed per-room, shared across threads).
+// Until a design decision lands, reject slash-style input visibly instead of
+// delivering it as a prompt the bots answer literally.
+const GROUP_SLASH_INPUT_RE = /^\/\S/
+
+function isGroupSlashInput(text) {
+  return GROUP_SLASH_INPUT_RE.test(String(text || '').trim())
+}
+
+function notifyGroupSlashUnsupported() {
+  host.notify?.({
+    kind: 'info',
+    title: 'Slash commands aren’t supported in group rooms',
+    message: 'The text was not sent — it would reach every bot as a literal message.'
+  })
+}
+
 function sendToGroupChat(group, members, text, thread, images) {
   const trimmed = String(text || '').trim()
   const attached = Array.isArray(images) ? images.filter(img => img && img.data) : []
@@ -12807,6 +12828,12 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
       return
     }
 
+    if (isGroupSlashInput(text)) {
+      notifyGroupSlashUnsupported()
+
+      return
+    }
+
     const before = groupComposerDraftSnapshot(composerKeyRef.current)
     const cleared = updateComposerDraft(current => ({
       ...current,
@@ -12834,6 +12861,12 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
     const images = imagesFor(thread)
 
     if (!text && !images.length) {
+      return
+    }
+
+    if (isGroupSlashInput(text)) {
+      notifyGroupSlashUnsupported()
+
       return
     }
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-slash-guard.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-slash-guard.test.mjs
@@ -5,69 +5,146 @@ import test from 'node:test'
 // Group-room slash-input guard (#93947): slash commands typed in a group
 // composer have no handler — sendToGroupChat delivers them verbatim as each
 // member's prompt, so "/new" reached bots as literal chat text. The fix
-// rejects slash-style input in BOTH room composers (new thread + thread
-// reply) with a visible notice instead of submitting it.
+// rejects COMMAND-SHAPED input ("/new", "/model opus") in BOTH room
+// composers while letting prose that merely starts with a path ("/etc/hosts
+// — what is this?", "/usr/bin/env python3 …") through, backed by a
+// defense-in-depth refusal inside sendToGroupChat itself.
+//
+// The guard functions are single-file by loader constraint (plugin.js loads
+// as a blob import, so sibling modules cannot resolve), so these tests
+// evaluate the ACTUAL plugin source slices instead of re-typing the logic:
+// the regex under test IS the regex that ships.
 
 const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
-test('both group composers reject slash input before clearing drafts', () => {
-  const mainSubmit = source.slice(
-    source.indexOf('  const submit = () => {'),
-    source.indexOf('sendToGroupChat(group, memberDescriptors(), text, null, images)')
+/** Evaluate a slice of the real plugin.js with the given dependencies in scope.
+ *  Returns the names listed in `extract` (defaults to the dep names). */
+function evalSlice(startMarker, endMarker, deps = {}, extract = null) {
+  const start = source.indexOf(startMarker)
+  const end = source.indexOf(endMarker)
+
+  assert.ok(start >= 0, `start marker not found: ${startMarker}`)
+  assert.ok(end > start, `end marker not found or out of order: ${endMarker}`)
+
+  const names = Object.keys(deps)
+  const extracted = extract || names
+  const factory = new Function(
+    ...names,
+    `${source.slice(start, end)}\nreturn { ${extracted.join(', ')} };`
   )
-  assert.ok(mainSubmit.includes('isGroupSlashInput(text)'), 'main composer must guard slash input')
-  // The guard must run BEFORE the draft is cleared — a rejected command has to
-  // stay in the box so the user can edit it rather than losing what they typed.
-  const guardAt = mainSubmit.indexOf('isGroupSlashInput(text)')
-  const clearAt = mainSubmit.indexOf('updateComposerDraft(')
-  assert.ok(guardAt >= 0 && clearAt > guardAt, 'slash guard must precede the draft clear')
 
-  const replySubmit = source.slice(
-    source.indexOf('  const submitReply = thread => {'),
-    source.indexOf('sendToGroupChat(group, memberDescriptors(), text, thread, images)')
-  )
-  assert.ok(replySubmit.includes('isGroupSlashInput(text)'), 'thread reply box must guard slash input')
-})
+  return factory(...names.map(n => deps[n]))
+}
 
-test('guard detects slash-style first tokens and passes normal chat', () => {
-  const start = source.indexOf('const GROUP_SLASH_INPUT_RE')
-  const end = source.indexOf('function sendToGroupChat')
-  assert.ok(start > 0 && end > start)
+const { isGroupSlashInput } = evalSlice(
+  'const GROUP_SLASH_INPUT_RE',
+  'function notifyGroupSlashUnsupported',
+  {},
+  ['isGroupSlashInput']
+)
 
-  const { isGroupSlashInput } = (() => {
-    const fnSource = source
-      .slice(start, end)
-      .replace(/^const GROUP_SLASH_INPUT_RE = (.+)$/m, '')
-      .replace(
-        "function isGroupSlashInput",
-        "exports.isGroupSlashInput = function isGroupSlashInput"
-      )
-    const fn = new Function('exports', 'GROUP_SLASH_INPUT_RE', `${fnSource};`)
-    const exportsObj = {}
-    fn(exportsObj, /^\/\S/)
-    return exportsObj
-  })()
-
-  // Slash-style first token: blocked.
+test('guard blocks command-shaped first tokens and passes normal chat', () => {
+  // Slash commands: blocked.
   assert.equal(isGroupSlashInput('/new'), true)
   assert.equal(isGroupSlashInput('/reset'), true)
   assert.equal(isGroupSlashInput('  /compact  '), true) // trimmed before matching
-  assert.equal(isGroupSlashInput('/model opus'), true)
-  // Mid-message slashes are ordinary prose (paths, code): delivered as-is.
+  assert.equal(isGroupSlashInput('/model opus'), true) // args allowed
+  assert.equal(isGroupSlashInput('/Model'), true) // case-insensitive command word
+
+  // Path-like prose openers are ordinary chat: delivered as-is. These were
+  // FALSE-blocked by the original /^\S/ shape.
+  assert.equal(isGroupSlashInput('/usr/bin/env python3 --version'), false)
+  assert.equal(isGroupSlashInput('/etc/hosts — what is this?'), false)
+
+  // Mid-message slashes were never guarded.
   assert.equal(isGroupSlashInput('check /var/log for me'), false)
   assert.equal(isGroupSlashInput('run npm /s something'), false)
   assert.equal(isGroupSlashInput('what does /etc/hosts do?'), false)
-  // Empty/nothing-to-send shapes never trip the guard.
+
+  // Non-command shapes never trip the guard.
+  assert.equal(isGroupSlashInput('/'), false) // bare slash, no token
+  assert.equal(isGroupSlashInput('/2 fast'), false) // digit-led, not a command word
   assert.equal(isGroupSlashInput(''), false)
   assert.equal(isGroupSlashInput(null), false)
   assert.equal(isGroupSlashInput(undefined), false)
 })
 
-test('rejection notifies visibly instead of silently dropping', () => {
-  const helper = source.slice(
-    source.indexOf('function notifyGroupSlashUnsupported'),
-    source.indexOf('function sendToGroupChat')
+test('rejection notice names the tripped token', () => {
+  const seen = []
+  const host = { notify: n => seen.push(n) }
+
+  const { notifyGroupSlashUnsupported } = evalSlice(
+    'function notifyGroupSlashUnsupported',
+    '// One shared rejection point',
+    { host },
+    ['notifyGroupSlashUnsupported']
   )
-  assert.ok(helper.includes("host.notify?.("), 'rejection must surface a visible notice')
-  assert.ok(helper.includes("kind: 'info'"), 'notice is informational, not an error')
+
+  notifyGroupSlashUnsupported('/model opus')
+
+  assert.equal(seen.length, 1)
+  assert.equal(seen[0].kind, 'info', 'notice is informational, not an error')
+  assert.match(seen[0].message, /\/model/, 'notice should name what tripped the guard')
+
+  seen.length = 0
+  notifyGroupSlashUnsupported('')
+
+  assert.match(seen[0].message, /was not sent/, 'fallback wording survives empty input')
+})
+
+test('shared helper rejects visibly once and passes plain text silently', () => {
+  const seen = []
+  const host = { notify: n => seen.push(n) }
+
+  const { rejectGroupSlashIfNeeded } = evalSlice(
+    '// One shared rejection point',
+    'function sendToGroupChat',
+    {
+      host,
+      isGroupSlashInput,
+      notifyGroupSlashUnsupported: text => {
+        seen.push(text)
+      }
+    },
+    ['rejectGroupSlashIfNeeded']
+  )
+
+  assert.equal(rejectGroupSlashIfNeeded('/new'), true)
+  assert.deepEqual(seen, ['/new'])
+
+  seen.length = 0
+  assert.equal(rejectGroupSlashIfNeeded('hello team'), false)
+  assert.deepEqual(seen, [], 'plain text must not notify')
+})
+
+test('both group composers route rejection through the shared helper before clearing drafts', () => {
+  const mainStart = source.indexOf('  const submit = () => {')
+  const mainEnd = source.indexOf('sendToGroupChat(group, memberDescriptors(), text, null, images)')
+  assert.ok(mainStart > 0 && mainEnd > mainStart, 'main composer submit not found')
+
+  const mainSubmit = source.slice(mainStart, mainEnd)
+  assert.ok(mainSubmit.includes('rejectGroupSlashIfNeeded(text)'), 'main composer must use the shared guard')
+  const guardAt = mainSubmit.indexOf('rejectGroupSlashIfNeeded(text)')
+  const clearAt = mainSubmit.indexOf('updateComposerDraft(')
+  assert.ok(guardAt >= 0 && clearAt > guardAt, 'slash guard must precede the draft clear')
+
+  const replyStart = source.indexOf('  const submitReply = thread => {')
+  const replyEnd = source.indexOf('sendToGroupChat(group, memberDescriptors(), text, thread, images)')
+  assert.ok(replyStart > 0 && replyEnd > replyStart, 'reply composer submit not found')
+
+  const replySubmit = source.slice(replyStart, replyEnd)
+  assert.ok(replySubmit.includes('rejectGroupSlashIfNeeded(text)'), 'thread reply box must use the shared guard')
+  const replyGuardAt = replySubmit.indexOf('rejectGroupSlashIfNeeded(text)')
+  const replyClearAt = replySubmit.indexOf('updateComposerDraft(')
+  assert.ok(replyGuardAt >= 0 && replyClearAt > replyGuardAt, 'slash guard must precede the draft clear')
+})
+
+test('sendToGroupChat refuses slash input before delivery (backstop)', () => {
+  const start = source.indexOf('function sendToGroupChat')
+  const deliverAt = source.indexOf('appendGroupChatEntry(group,', start)
+  assert.ok(start > 0 && deliverAt > start, 'sendToGroupChat delivery path not found')
+
+  const head = source.slice(start, deliverAt)
+  const backstopAt = head.indexOf('isGroupSlashInput(trimmed)')
+  assert.ok(backstopAt > 0, 'delivery entry point must refuse command-shaped input')
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-slash-guard.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-slash-guard.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+// Group-room slash-input guard (#93947): slash commands typed in a group
+// composer have no handler — sendToGroupChat delivers them verbatim as each
+// member's prompt, so "/new" reached bots as literal chat text. The fix
+// rejects slash-style input in BOTH room composers (new thread + thread
+// reply) with a visible notice instead of submitting it.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+test('both group composers reject slash input before clearing drafts', () => {
+  const mainSubmit = source.slice(
+    source.indexOf('  const submit = () => {'),
+    source.indexOf('sendToGroupChat(group, memberDescriptors(), text, null, images)')
+  )
+  assert.ok(mainSubmit.includes('isGroupSlashInput(text)'), 'main composer must guard slash input')
+  // The guard must run BEFORE the draft is cleared — a rejected command has to
+  // stay in the box so the user can edit it rather than losing what they typed.
+  const guardAt = mainSubmit.indexOf('isGroupSlashInput(text)')
+  const clearAt = mainSubmit.indexOf('updateComposerDraft(')
+  assert.ok(guardAt >= 0 && clearAt > guardAt, 'slash guard must precede the draft clear')
+
+  const replySubmit = source.slice(
+    source.indexOf('  const submitReply = thread => {'),
+    source.indexOf('sendToGroupChat(group, memberDescriptors(), text, thread, images)')
+  )
+  assert.ok(replySubmit.includes('isGroupSlashInput(text)'), 'thread reply box must guard slash input')
+})
+
+test('guard detects slash-style first tokens and passes normal chat', () => {
+  const start = source.indexOf('const GROUP_SLASH_INPUT_RE')
+  const end = source.indexOf('function sendToGroupChat')
+  assert.ok(start > 0 && end > start)
+
+  const { isGroupSlashInput } = (() => {
+    const fnSource = source
+      .slice(start, end)
+      .replace(/^const GROUP_SLASH_INPUT_RE = (.+)$/m, '')
+      .replace(
+        "function isGroupSlashInput",
+        "exports.isGroupSlashInput = function isGroupSlashInput"
+      )
+    const fn = new Function('exports', 'GROUP_SLASH_INPUT_RE', `${fnSource};`)
+    const exportsObj = {}
+    fn(exportsObj, /^\/\S/)
+    return exportsObj
+  })()
+
+  // Slash-style first token: blocked.
+  assert.equal(isGroupSlashInput('/new'), true)
+  assert.equal(isGroupSlashInput('/reset'), true)
+  assert.equal(isGroupSlashInput('  /compact  '), true) // trimmed before matching
+  assert.equal(isGroupSlashInput('/model opus'), true)
+  // Mid-message slashes are ordinary prose (paths, code): delivered as-is.
+  assert.equal(isGroupSlashInput('check /var/log for me'), false)
+  assert.equal(isGroupSlashInput('run npm /s something'), false)
+  assert.equal(isGroupSlashInput('what does /etc/hosts do?'), false)
+  // Empty/nothing-to-send shapes never trip the guard.
+  assert.equal(isGroupSlashInput(''), false)
+  assert.equal(isGroupSlashInput(null), false)
+  assert.equal(isGroupSlashInput(undefined), false)
+})
+
+test('rejection notifies visibly instead of silently dropping', () => {
+  const helper = source.slice(
+    source.indexOf('function notifyGroupSlashUnsupported'),
+    source.indexOf('function sendToGroupChat')
+  )
+  assert.ok(helper.includes("host.notify?.("), 'rejection must surface a visible notice')
+  assert.ok(helper.includes("kind: 'info'"), 'notice is informational, not an error')
+})


### PR DESCRIPTION
Fixes #93947

## Problem

Slash commands typed in a Bot-mode group room were delivered to every member session as literal chat text. The room composer (`GroupMentionInput` → `submit`/`submitReply`) calls `sendToGroupChat(...)` directly with no slash parsing anywhere on that path — the only `/new` interception lives in the 1:1 composer middleware, which matches `^/(new|reset)$ ` but only reroutes canonical bot chats.

Reported failure mode: a user typed `/new` expecting to reset a degraded room; every bot instead received `/new` as an ordinary prompt and answered it literally (or returned empty when their room session had already outgrown context).

## Why reject rather than implement

Reset semantics at room scope are genuinely ambiguous: member sessions are keyed at **room scope** (`room.sessions[groupMemberKey(member)]`), shared across all threads of the room — `${'/'}new` cannot mean "fresh session for this thread" without a design decision. Until that decision lands, this PR takes the issue's explicitly-acceptable minimal fix: **reject slash-style input visibly** so nothing is silently delivered as chat text.

## Change

- New `isGroupSlashInput()` guard (`/^\/\S/` on the trimmed draft) + `notifyGroupSlashUnsupported()` info notice.
- Wired into **both** group-room composers (new-thread `submit` and thread-reply `submitReply`), **before** the draft-clear step — a rejected command stays in the box for editing.
- Mid-message slashes (paths like `/var/log`, `/etc/hosts`) pass through untouched; only a slash-first token is blocked.

## Verification

- New regression tests (`group-slash-guard.test.mjs`, following the plugin suite's source-shape style): both composers guard before clearing drafts; tokenizer accepts `/new`, `/reset`, `/compact`, `/model x`, rejects prose with mid-message slashes; rejection surfaces a visible info notice. 3/3 pass.
- Full plugin suite green: `npm run check:test:plugins` → 559 passed, 0 failed.
- eslint clean on touched files.