### PR TITLE
fix(tui): require double Ctrl+C to exit an idle session

### DIFF
--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -3,7 +3,7 @@ import { useStore } from '@nanostores/react'
 import { useEffect, useRef } from 'react'
 
 import { DASHBOARD_TUI_MODE } from '../config/env.js'
-import { DOUBLE_ESC_MS, TYPING_IDLE_MS } from '../config/timing.js'
+import { DOUBLE_CTRL_C_EXIT_MS, DOUBLE_ESC_MS, TYPING_IDLE_MS } from '../config/timing.js'
 import { applyCompletion } from '../domain/slash.js'
 import type {
   ApprovalRespondResponse,
@@ -362,6 +362,11 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
   // still the dedicated discard (pushes the draft to history so Up recalls it).
   const lastEscRef = useRef(0)
 
+  // Idle Ctrl+C double-press gate: hosts like herdr translate Cmd+C into
+  // plain Ctrl+C for the pane app, so a single press must never end the
+  // session. First press hints; second within the window exits.
+  const lastIdleCtrlCRef = useRef(0)
+
   useInput((ch, key) => {
     const live = getUiState()
 
@@ -632,6 +637,15 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
     }
 
     if (key.ctrl && ch.toLowerCase() === 'c') {
+      // A live TUI selection means this Ctrl+C is a copy request, not an
+      // interrupt: herdr's copy bridge sends Ctrl+C after a forwarded drag
+      // (Cmd+C in a herdr pane), matching Claude Code's ctrl+c-copies
+      // behavior. copySelection() clears the selection, so a repeat press
+      // falls through to interrupt/exit as usual.
+      if (terminal.hasSelection) {
+        return copySelection()
+      }
+
       const ctrlC = resolveCtrlCComposerAction({
         busy: live.busy,
         hasDraft: Boolean(cState.input || cState.inputBuf.length),
@@ -649,6 +663,15 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
           sid: live.sid,
           sys: actions.sys
         })
+      }
+
+      const now = Date.now()
+      const isDouble = now - lastIdleCtrlCRef.current <= DOUBLE_CTRL_C_EXIT_MS
+
+      lastIdleCtrlCRef.current = isDouble ? 0 : now
+
+      if (!isDouble) {
+        return actions.sys('press Ctrl+C again to exit')
       }
 
       return handleIdleHotkeyExit(actions, DASHBOARD_TUI_MODE, () => {

--- a/ui-tui/src/config/timing.ts
+++ b/ui-tui/src/config/timing.ts
@@ -18,3 +18,9 @@ export const RESIZE_COALESCE_MS = 32
 // enough that two unrelated Escs — dismissing a completion, then a
 // selection — don't silently clear the composer.
 export const DOUBLE_ESC_MS = 500
+
+// Idle Ctrl+C must be pressed twice within this window to end the session
+// (Claude Code parity). Multiplexer hosts (herdr, tmux copy bindings)
+// translate a copy chord into plain Ctrl+C for the pane app, so a single
+// stray press must never tear the session down.
+export const DOUBLE_CTRL_C_EXIT_MS = 2000


### PR DESCRIPTION
## Summary
- A single idle Ctrl+C exits the TUI instantly. Hosts that rewrite copy chords into plain Ctrl+C (tmux copy bindings, pane multiplexers forwarding Cmd+C after a drag selection) can kill a session with what the user meant as a copy. Selection-copy protection already landed on main; this adds the missing idle-exit gate.
- Idle exit now requires a second Ctrl+C within 2s (`DOUBLE_CTRL_C_EXIT_MS`, mirroring the existing `DOUBLE_ESC_MS` pattern). The first press prints 'press Ctrl+C again to exit'. Busy-interrupt and draft-clear paths are unchanged, as is Ctrl+D.

## Test plan
- `npx vitest run src/__tests__/useInputHandlers.test.ts` — 20/20 pass
- `npx tsc --noEmit` — clean
- Manual pty smoke on a live install: single idle Ctrl+C leaves the process alive with the hint rendered; double press exits with the resume banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)