### PR TITLE
fix: raise RLIMIT_NOFILE soft limit at every entrypoint

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30879,6 +30879,16 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     from hermes_logging import setup_logging, _safe_stderr
     setup_logging(hermes_home=_hermes_home, mode="gateway")
 
+    # Raise the soft RLIMIT_NOFILE ceiling. hermes_cli.main already does
+    # this for CLI-driven starts; calling again here covers direct
+    # start_gateway() consumers and is a no-op when the limit is high.
+    # launchd hands services soft=256 by default (EMFILE, July 2026).
+    try:
+        from hermes_logging import raise_nofile_soft_limit
+        raise_nofile_soft_limit()
+    except Exception:
+        pass
+
     # Startup security posture audit — warn-on-load, never blocks. Surfaces
     # root / weak-SSH / ephemeral-container / unauthenticated-listener posture
     # so operators get the "you're exposed" signal the June 2026 MCP-config

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3589,6 +3589,7 @@ KillSignal=SIGTERM
 ExecReload=/bin/kill -USR1 $MAINPID
 ExecStopPost=-{python_path} -m gateway.cgroup_cleanup
 TimeoutStopSec={restart_timeout}
+LimitNOFILE=65536
 StandardOutput=journal
 StandardError=journal
 
@@ -3627,6 +3628,7 @@ KillSignal=SIGTERM
 ExecReload=/bin/kill -USR1 $MAINPID
 ExecStopPost=-{python_path} -m gateway.cgroup_cleanup
 TimeoutStopSec={restart_timeout}
+LimitNOFILE=65536
 StandardOutput=journal
 StandardError=journal
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -789,6 +789,17 @@ try:
 except Exception:
     pass  # best-effort — don't crash the CLI if logging setup fails
 
+# Raise the soft file-descriptor ceiling early, before any clients, MCP
+# connections or tool subprocesses exist. macOS gives shells and launchd
+# children a 256 soft limit, which one concurrent-delegation turn can
+# exhaust (EMFILE) — see hermes_logging.raise_nofile_soft_limit.
+try:
+    from hermes_logging import raise_nofile_soft_limit as _raise_nofile
+
+    _raise_nofile()
+except Exception:
+    pass  # best-effort — never block startup on a resource-limit tweak
+
 # Apply IPv4 preference early, before any HTTP clients are created.
 # We already determined whether to force IPv4 from the raw yaml read above —
 # this just calls the toggle without a redundant load_config() round trip.

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -253,6 +253,47 @@ COMPONENT_PREFIXES = {
 
 
 # ---------------------------------------------------------------------------
+# Process resource limits
+# ---------------------------------------------------------------------------
+
+def raise_nofile_soft_limit(target: int = 65536) -> None:
+    """Raise the soft RLIMIT_NOFILE toward *target* (never lower it).
+
+    macOS hands most processes a 256 soft file limit — launchd services and
+    plain terminal shells alike. Agent turns run in-process, and a single
+    turn that fans out concurrent subagent delegations holds hundreds of
+    fds at once (httpx clients, MCP connections, SQLite handles, tool
+    subprocess pipes): an interactive ``hermes`` session EMFILE'd mid-turn
+    minutes after an 8-way delegation burst (2026-08-03), and the gateway
+    hit the same wall under launchd's default in July 2026. Called early
+    from ``hermes_cli.main`` so every entrypoint (chat TUI, gateway,
+    dashboard, cron) is covered regardless of what the shell or service
+    definition provided. Best-effort: never raises, no-op on Windows.
+    """
+    try:
+        import resource
+
+        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        cap = target if hard == resource.RLIM_INFINITY else min(target, hard)
+        if soft < cap:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (cap, hard))
+            logging.getLogger(__name__).info(
+                "Raised RLIMIT_NOFILE soft limit %d -> %d (hard=%s)",
+                soft,
+                cap,
+                "inf" if hard == resource.RLIM_INFINITY else hard,
+            )
+        else:
+            logging.getLogger(__name__).debug(
+                "RLIMIT_NOFILE soft limit already %d (hard=%s)",
+                soft,
+                "inf" if hard == resource.RLIM_INFINITY else hard,
+            )
+    except Exception as exc:
+        logging.getLogger(__name__).debug("Could not raise RLIMIT_NOFILE: %s", exc)
+
+
+# ---------------------------------------------------------------------------
 # Main setup
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- macOS gives launchd services and plain terminal shells a 256 soft file-descriptor limit. A single turn with concurrent subagent delegations holds hundreds of fds (httpx clients, MCP connections, SQLite handles, tool subprocess pipes), which EMFILEs interactive sessions and gateways under load.
- Adds `hermes_logging.raise_nofile_soft_limit()` — raises the soft limit toward 65536, capped at the hard limit, never lowers, best-effort, no-op on Windows — called early from `hermes_cli.main` (covers chat TUI, gateway, dashboard, cron entrypoints) and from `start_gateway()` for direct consumers.
- Adds `LimitNOFILE=65536` to the generated systemd units, matching the `SoftResourceLimits` the launchd plist already sets on main.
- Complements the fd-leak reports #80792 and #60859: those leaks hit the wall far sooner under the 256 default.

## Test plan
- `python -m py_compile hermes_logging.py hermes_cli/main.py gateway/run.py hermes_cli/gateway.py` — clean
- On a live macOS install: CLI and gateway log the raised limit at startup; no EMFILE recurrence under delegation bursts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)