### PR TITLE
fix(cli): preserve OSC-8 hyperlinks through ChatConsole

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4665,10 +4665,20 @@ def _collect_query_images(query: str | None, image_arg: str | None = None) -> tu
     return message, deduped
 
 
-# Strip OSC escape sequences (e.g. OSC-8 hyperlinks) that prompt_toolkit's
-# ANSI parser can't handle — it strips \x1b but passes the payload through
-# as literal text, garbling the TUI output.
+# prompt_toolkit's ANSI parser cannot parse OSC commands directly. Preserve
+# OSC-8 hyperlinks as zero-width escapes (SOH/STX), which prompt_toolkit writes
+# through to the terminal without counting them toward the rendered width.
+# Unsupported OSC commands are still removed.
 _OSC_ESCAPE_RE = re.compile(r"\x1b\][\s\S]*?(?:\x07|\x1b\\)")
+
+
+def _preserve_osc8_hyperlinks(output: str) -> str:
+    """Keep OSC-8 links for the terminal while stripping unsupported OSC."""
+    def _replace(match: re.Match) -> str:
+        sequence = match.group(0)
+        return f"\x01{sequence}\x02" if sequence.startswith("\x1b]8;") else ""
+
+    return _OSC_ESCAPE_RE.sub(_replace, output)
 
 
 class ChatConsole:
@@ -4697,10 +4707,9 @@ class ChatConsole:
         self._inner.width = shutil.get_terminal_size((80, 24)).columns
         self._inner.print(*args, **kwargs)
         output = self._buffer.getvalue()
-        # Strip OSC escape sequences (e.g. OSC-8 hyperlinks) before
-        # routing through prompt_toolkit's ANSI parser, which only
-        # handles CSI/SGR and passes OSC payload through as literal text.
-        output = _OSC_ESCAPE_RE.sub("", output)
+        # Keep OSC-8 links as prompt_toolkit zero-width escapes so the
+        # terminal receives the URI; remove other unsupported OSC commands.
+        output = _preserve_osc8_hyperlinks(output)
         for line in output.rstrip("\n").split("\n"):
             _cprint(line)
 

--- a/tests/cli/test_cli_markdown_rendering.py
+++ b/tests/cli/test_cli_markdown_rendering.py
@@ -3,6 +3,7 @@ from io import StringIO
 from rich.console import Console
 from rich.markdown import Markdown
 
+import cli
 from cli import _render_final_assistant_content
 
 
@@ -34,6 +35,31 @@ def test_final_assistant_content_keeps_non_path_markdown_escapes():
 
 
 
+
+
+def test_chat_console_preserves_markdown_hyperlink_for_terminal(monkeypatch):
+    printed = []
+    monkeypatch.setattr(cli, "_cprint", printed.append)
+
+    cli.ChatConsole().print(
+        _render_final_assistant_content(
+            "[OWC Express 1M2 80G enclosure](https://example.com/owc)"
+        )
+    )
+
+    output = "\n".join(printed)
+    assert "OWC Express 1M2 80G enclosure" in output
+    assert "https://example.com/owc" in output
+    assert "\x01\x1b]8;" in output
+    assert "\x02" in output
+
+
+def test_non_hyperlink_osc_remains_stripped():
+    output = cli._preserve_osc8_hyperlinks(
+        "title\x1b]0;hidden title\x07 body"
+    )
+
+    assert output == "title body"
 
 
 def test_strip_mode_preserves_lists():


### PR DESCRIPTION
## Summary
- ChatConsole strips every OSC sequence before routing Rich output through prompt_toolkit, so OSC-8 hyperlinks rendered by Rich never reach the terminal and links are not clickable in the classic CLI (related: #22895, #50697).
- prompt_toolkit writes zero-width escapes (SOH/STX) through to the terminal without counting them toward rendered width. Wrap OSC-8 sequences in `\x01...\x02` and keep stripping every other OSC command, so unsupported OSC payloads still never garble the TUI.

## Test plan
- `pytest tests/cli/test_cli_markdown_rendering.py -q` — 9 passed, including two new tests: a markdown hyperlink survives ChatConsole with the zero-width-wrapped OSC-8 sequence, and non-hyperlink OSC (window-title) is still stripped.
- Live smoke on a Ghostty + tmux host: assistant-rendered markdown links are Cmd+Clickable in `hermes` chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)