### PR TITLE
fix(mattermost): preserve thread typing and DM sessions

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1998,6 +1998,34 @@ class SessionStore:
             profile=self._resolve_profile_for_key(source),
         )
 
+    def _legacy_mattermost_dm_session_key(self, source: SessionSource) -> Optional[str]:
+        """Return the pre-thread-root key for a Mattermost DM source.
+
+        Before Mattermost synthetic thread roots were applied to DMs, a
+        top-level post was routed to the bare DM key and its threaded follow-up
+        was routed to ``<bare DM key>:<root_id>``. A legacy entry is safe to
+        adopt only when its origin message is exactly the incoming thread root;
+        otherwise another Mattermost thread in the same DM could inherit the
+        wrong transcript.
+        """
+        if (
+            source.platform != Platform.MATTERMOST
+            or source.chat_type != "dm"
+            or not source.thread_id
+        ):
+            return None
+        legacy_source = replace(source, thread_id=None)
+        return build_session_key(
+            legacy_source,
+            group_sessions_per_user=getattr(
+                self.config, "group_sessions_per_user", True
+            ),
+            thread_sessions_per_user=getattr(
+                self.config, "thread_sessions_per_user", False
+            ),
+            profile=self._resolve_profile_for_key(source),
+        )
+
     def _legacy_slack_session_key(self, source: SessionSource) -> Optional[str]:
         """Return the pre-workspace Slack key for an explicitly scoped source.
 
@@ -2680,6 +2708,44 @@ class SessionStore:
         #     across workspaces and a shared transcript leaking to a second
         #     tenant is exactly the bug this fix removes.
         migrated_legacy_entry: Optional[SessionEntry] = None
+
+        # Mattermost DM sessions created before top-level posts became
+        # synthetic thread roots used the bare DM key. Adopt that entry when
+        # the recorded origin post is the exact root of this incoming thread.
+        # This preserves continuity across the routing-key fix without
+        # allowing one DM thread to borrow another thread's transcript.
+        mattermost_legacy_key = self._legacy_mattermost_dm_session_key(source)
+        if mattermost_legacy_key and not force_new:
+            with self._lock:
+                self._ensure_loaded_locked()
+                legacy_entry = self._entries.get(mattermost_legacy_key)
+                legacy_origin = getattr(legacy_entry, "origin", None)
+                adopt = bool(
+                    session_key not in self._entries
+                    and legacy_entry is not None
+                    and legacy_origin is not None
+                    and legacy_origin.platform == Platform.MATTERMOST
+                    and legacy_origin.chat_type == "dm"
+                    and legacy_origin.chat_id == source.chat_id
+                    and str(legacy_origin.message_id or "")
+                    == str(source.thread_id)
+                )
+                if adopt:
+                    migrated_legacy_entry = self._entries.pop(mattermost_legacy_key)
+                    migrated_legacy_entry.session_key = session_key
+                    migrated_legacy_entry.origin = source
+                    migrated_legacy_entry.platform = source.platform
+                    migrated_legacy_entry.chat_type = source.chat_type
+                    self._entries[session_key] = migrated_legacy_entry
+            if migrated_legacy_entry is not None:
+                self._save_entries()
+                self._record_gateway_session_peer(
+                    migrated_legacy_entry.session_id,
+                    session_key,
+                    source,
+                    display_name=migrated_legacy_entry.display_name,
+                )
+
         legacy_key = self._legacy_slack_session_key(source)
         if legacy_key and not force_new:
             with self._lock:

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -431,9 +431,14 @@ class MattermostAdapter(BasePlatformAdapter):
         self, chat_id: str, metadata: Optional[Dict[str, Any]] = None
     ) -> None:
         """Send a typing indicator."""
+        payload = {"channel_id": chat_id}
+        if self._reply_mode == "thread" and isinstance(metadata, dict):
+            thread_id = metadata.get("thread_id") or metadata.get("root_id")
+            if thread_id:
+                payload["parent_id"] = str(thread_id)
         await self._api_post(
             f"users/{self._bot_user_id}/typing",
-            {"channel_id": chat_id},
+            payload,
         )
 
     async def edit_message(
@@ -918,14 +923,14 @@ class MattermostAdapter(BasePlatformAdapter):
         sender_name = data.get("sender_name", "").lstrip("@") or sender_id
 
         # Thread support: if the post is in a thread, use root_id. In
-        # thread mode, top-level channel posts are valid roots for progress.
+        # thread mode, every top-level post is also a synthetic thread root,
+        # including Mattermost DMs. Outbound replies already use the triggering
+        # post id as root_id in this mode; using the same id here keeps the
+        # initial turn and all follow-ups on one Hermes session key. The old
+        # channel-only guard caused DM replies to switch from the bare DM key
+        # to a new ``...:<root_id>`` key on the first follow-up.
         thread_id = post.get("root_id") or None
-        if (
-            not thread_id
-            and self._reply_mode == "thread"
-            and channel_type_raw != "D"
-            and post_id
-        ):
+        if not thread_id and self._reply_mode == "thread" and post_id:
             thread_id = post_id
 
         # Determine message type.

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -262,6 +262,38 @@ class TestMattermostSend:
         assert payload["root_id"] == "bad_root"
 
 
+class TestMattermostTyping:
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._bot_user_id = "bot_user_id"
+        self.adapter._api_post = AsyncMock()
+
+    @pytest.mark.asyncio
+    async def test_typing_in_thread_uses_same_root_as_reply(self):
+        self.adapter._reply_mode = "thread"
+
+        await self.adapter.send_typing(
+            "channel_1",
+            metadata={"thread_id": "root_post"},
+        )
+
+        self.adapter._api_post.assert_awaited_once_with(
+            "users/bot_user_id/typing",
+            {"channel_id": "channel_1", "parent_id": "root_post"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_typing_without_thread_stays_in_channel(self):
+        self.adapter._reply_mode = "thread"
+
+        await self.adapter.send_typing("channel_1")
+
+        self.adapter._api_post.assert_awaited_once_with(
+            "users/bot_user_id/typing",
+            {"channel_id": "channel_1"},
+        )
+
+
 # ---------------------------------------------------------------------------
 # WebSocket event parsing
 # ---------------------------------------------------------------------------
@@ -298,6 +330,56 @@ class TestMattermostWebSocketParsing:
         # @mention is stripped from the message text
         assert msg_event.text == "Hello from Matrix!"
         assert msg_event.message_id == "post_abc"
+
+
+    @pytest.mark.asyncio
+    async def test_top_level_dm_in_thread_mode_uses_post_as_thread_root(self):
+        """DM roots and replies must resolve to the same Hermes session key."""
+        self.adapter._reply_mode = "thread"
+        post_data = {
+            "id": "dm_root",
+            "user_id": "user_123",
+            "channel_id": "dm_channel",
+            "message": "hello",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "D",
+                "sender_name": "@alice",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.source.thread_id == "dm_root"
+
+    @pytest.mark.asyncio
+    async def test_thread_reply_keeps_mattermost_root_id(self):
+        """Replies continue to use the original Mattermost root id."""
+        self.adapter._reply_mode = "thread"
+        post_data = {
+            "id": "dm_reply",
+            "root_id": "dm_root",
+            "user_id": "user_123",
+            "channel_id": "dm_channel",
+            "message": "follow-up",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "D",
+                "sender_name": "@alice",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.source.thread_id == "dm_root"
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -628,6 +628,71 @@ class TestSlackWorkspaceSessionIsolation:
         )
 
 
+class TestMattermostThreadSessionContinuity:
+    @pytest.fixture()
+    def store(self, tmp_path):
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            session_store = SessionStore(sessions_dir=tmp_path, config=config)
+        session_store._db = None
+        session_store._loaded = True
+        return session_store
+
+    def test_legacy_bare_dm_is_adopted_by_its_thread_root(self, store):
+        root = SessionSource(
+            platform=Platform.MATTERMOST,
+            chat_id="dm_channel",
+            chat_type="dm",
+            user_id="user_123",
+            message_id="root_post",
+        )
+        reply = replace(root, thread_id="root_post", message_id="reply_post")
+        legacy_key = build_session_key(root)
+        thread_key = build_session_key(reply)
+        legacy_entry = SessionEntry(
+            session_key=legacy_key,
+            session_id="legacy-session",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=root,
+            platform=Platform.MATTERMOST,
+            chat_type="dm",
+        )
+        store._entries[legacy_key] = legacy_entry
+
+        resolved = store.get_or_create_session(reply)
+
+        assert resolved.session_id == "legacy-session"
+        assert resolved.session_key == thread_key
+        assert legacy_key not in store._entries
+        assert store._entries[thread_key] is resolved
+
+    def test_other_mattermost_dm_root_does_not_adopt_legacy_session(self, store):
+        root = SessionSource(
+            platform=Platform.MATTERMOST,
+            chat_id="dm_channel",
+            chat_type="dm",
+            user_id="user_123",
+            message_id="root_post",
+        )
+        reply = replace(root, thread_id="different_root", message_id="reply_post")
+        legacy_key = build_session_key(root)
+        store._entries[legacy_key] = SessionEntry(
+            session_key=legacy_key,
+            session_id="legacy-session",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=root,
+            platform=Platform.MATTERMOST,
+            chat_type="dm",
+        )
+
+        resolved = store.get_or_create_session(reply)
+
+        assert resolved.session_id != "legacy-session"
+        assert legacy_key in store._entries
+
+
 class TestWhatsAppSessionKeyConsistency:
     """Regression: WhatsApp session keys must collapse JID/LID aliases to a
     single stable identity for both DM chat_ids and group participant_ids."""


### PR DESCRIPTION
## Summary

- Scope Mattermost typing indicators to the active thread by forwarding the thread root as `parent_id`.
- Treat top-level Mattermost DMs as synthetic thread roots when thread reply mode is enabled.
- Migrate legacy bare DM sessions only when the recorded origin exactly matches the incoming thread root, preserving continuity without cross-thread history leakage.

## Testing

- `scripts/run_tests.sh tests/gateway/test_mattermost.py tests/gateway/test_session.py -q` — 94 passed
- `git diff --check` — clean

## Notes

The typing portion overlaps the open typing-only PR #79273; this PR also carries the recovered Mattermost DM/session-continuity work that keeps the initial DM turn and threaded follow-ups on one Hermes session. PR #91811 contains a separate larger Mattermost feature set with overlapping typing behavior as well.