### PR TITLE
fix(model_metadata): probe /v1/models for context length on vulpy provider

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3335,6 +3335,17 @@ def get_model_context_length(
         ctx = _resolve_endpoint_context_length(model, base_url, api_key=api_key)
         if ctx is not None:
             return ctx
+    if effective_provider == "vulpy" and base_url:
+        # Vulpy-branded OpenAI-compatible gateways (e.g. gateway.vulpy.io)
+        # advertise authoritative per-model context windows via /v1/models
+        # (max_input_tokens field) when their underlying LiteLLM version
+        # supports it.  Probe the live endpoint so clients automatically
+        # pick up the correct window without needing a hardcoded override.
+        ctx = _resolve_endpoint_context_length(model, base_url, api_key=api_key)
+        if ctx is not None:
+            if not _skip_persistent_context_cache(base_url, provider):
+                save_context_length(model, base_url, ctx)
+            return ctx
     # 5e. Ollama native /api/show probe — runs for providers whose base_url
     # is NOT a known non-Ollama provider.  Ollama-compatible servers expose
     # this endpoint regardless of hostname (local Ollama, Ollama Cloud,


### PR DESCRIPTION
## Summary

Adds a `vulpy` provider branch to `get_model_context_length` so that
Vulpy-branded OpenAI-compatible gateways are probed via their live
`/v1/models` endpoint instead of falling through to the 256K default.

## Motivation

Hermes already handles this pattern for other custom-endpoint providers:
the `gmi` branch (step 5d) calls `_resolve_endpoint_context_length` because
GMI's `/v1/models` response carries authoritative `context_length` that
isn't in models.dev. The same is true for any provider registered under
the `"vulpy"` name — its gateway advertises per-model `max_input_tokens`
in the standard OpenAI `/v1/models` shape.

Without this branch, when `effective_provider == "vulpy"` the resolver
skips the endpoint probe entirely and falls back to `DEFAULT_FALLBACK_CONTEXT`
(256 K), misrepresenting the actual window (typically 1 M for modern
DeepSeek/Kimi deployments behind such gateways). Users then hit premature
context-compression or see a misleading context-bar reading.

## Changes

**`agent/model_metadata.py`** — 11 lines added immediately after the `gmi`
branch at step 5d:

```python
if effective_provider == "vulpy" and base_url:
    # Vulpy-branded OpenAI-compatible gateways (e.g. gateway.vulpy.io)
    # advertise authoritative per-model context windows via /v1/models
    # (max_input_tokens field) when their underlying LiteLLM version
    # supports it.  Probe the live endpoint so clients automatically
    # pick up the correct window without needing a hardcoded override.
    ctx = _resolve_endpoint_context_length(model, base_url, api_key=api_key)
    if ctx is not None:
        if not _skip_persistent_context_cache(base_url, provider):
            save_context_length(model, base_url, ctx)
        return ctx
```

The probe is the same `_resolve_endpoint_context_length` call used by `gmi`
and `novita`. The result is persisted to the on-disk cache (same as novita,
but not `gmi` which skips caching) so the round-trip only happens once.

## Design decisions

- **Why not add to `_URL_TO_PROVIDER`?** — The hostname-to-provider mapping
  belongs in whichever plugin registers the gateway; the resolver branch
  handles the case where `provider: vulpy` is set explicitly in config.
  Adding the hostname here would couple the core resolver to a
  provider-specific domain.
- **Why cache the result?** — The gateway advertises a stable, config-driven
  value; caching avoids a probe on every session start. The same pattern is
  used by `novita`.
- **Why not a fallback in `DEFAULT_CONTEXT_LENGTHS`?** — A hardcoded entry
  would become wrong the moment the operator changes their deployment config.
  A live probe is always correct.

## Backwards compatibility

Zero breaking changes. The branch only fires when `effective_provider`
resolves to `"vulpy"` and a `base_url` is present. All other providers,
including unregistered custom endpoints, are unaffected.

## Testing

1. Configure Hermes with `model.provider: vulpy` and `model.base_url` pointing
   at a gateway that returns `max_input_tokens` in `/v1/models`.
2. On first call, `get_model_context_length` returns the gateway-advertised
   value and caches it.
3. Without this patch, the same configuration returns 256 K (the fallback).
