### PR TITLE
fix(models): honor excluded_providers for the virtual MoA picker row

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2655,7 +2655,7 @@ def list_authenticated_providers(
     # Compared against hermes_id / mdev_id (section 1), pid / hermes_slug
     # (section 2) and canonical slug (section 2b) so a single entry like
     # ``copilot`` hides the provider regardless of which key it surfaces under.
-    _excluded: set = {str(p).strip().lower() for p in (excluded_providers or []) if p}
+    _excluded: set = _normalize_excluded_providers(excluded_providers)
     # Effective base URLs of every built-in row we emit (normalized lower+rstrip).
     # Section 4 uses this to hide ``custom_providers`` entries that point at the
     # same endpoint as a built-in (e.g. a user-defined "my-dashscope" on
@@ -3903,6 +3903,17 @@ def list_authenticated_providers(
     return results
 
 
+def _normalize_excluded_providers(excluded_providers: list | None) -> set:
+    """Normalize provider-exclusion entries for membership checks.
+
+    Shared by ``list_authenticated_providers`` and the virtual-MoA
+    membership check in ``list_picker_providers`` so both sides normalize
+    identically (lowercase, whitespace-stripped, falsy entries dropped) —
+    a change to one side cannot silently desync the other.
+    """
+    return {str(p).strip().lower() for p in (excluded_providers or []) if p}
+
+
 def _prepend_moa_picker_provider(providers: List[dict], current_provider: str = "") -> List[dict]:
     """Add the virtual MoA provider row used by interactive model pickers.
 
@@ -3967,9 +3978,12 @@ def list_picker_providers(
     # The virtual MoA row is prepended outside the exclusion-filtered
     # ``list_authenticated_providers`` path, so it needs its own membership
     # check against the same normalized ``excluded_providers`` set (#94068).
-    _excluded_moa = {str(p).strip().lower() for p in (excluded_providers or []) if p}
-    if include_moa and "moa" not in _excluded_moa:
-        providers = _prepend_moa_picker_provider(providers, current_provider=current_provider)
+    # The ``"moa"`` literal mirrors the slug emitted by
+    # ``_prepend_moa_picker_provider`` / ``inventory._moa_provider_row``.
+    if include_moa:
+        _excluded_moa = _normalize_excluded_providers(excluded_providers)
+        if "moa" not in _excluded_moa:
+            providers = _prepend_moa_picker_provider(providers, current_provider=current_provider)
 
     filtered: List[dict] = []
     for p in providers:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -3964,7 +3964,11 @@ def list_picker_providers(
         for_picker=True,
         excluded_providers=excluded_providers,
     )
-    if include_moa:
+    # The virtual MoA row is prepended outside the exclusion-filtered
+    # ``list_authenticated_providers`` path, so it needs its own membership
+    # check against the same normalized ``excluded_providers`` set (#94068).
+    _excluded_moa = {str(p).strip().lower() for p in (excluded_providers or []) if p}
+    if include_moa and "moa" not in _excluded_moa:
         providers = _prepend_moa_picker_provider(providers, current_provider=current_provider)
 
     filtered: List[dict] = []

--- a/tests/hermes_cli/test_list_picker_providers.py
+++ b/tests/hermes_cli/test_list_picker_providers.py
@@ -232,3 +232,68 @@ def test_distinct_kimi_china_credential_still_listed(monkeypatch):
     assert slugs.count("kimi-coding") == 1
     assert "kimi" not in slugs          # alias collapsed into the canonical row
     assert "kimi-coding-cn" in slugs    # distinct China endpoint preserved
+
+
+# ── Virtual MoA row vs model_catalog.excluded_providers (#94068) ──
+
+
+def _patch_moa_prepend(monkeypatch):
+    """Isolate the picker from the inventory: fixed virtual MoA row."""
+    moa_row = _make_provider("moa", name="Mixture of Agents", models=["balanced", "deep"])
+
+    def _prepend(providers, current_provider=""):
+        return [moa_row] + [p for p in providers if str(p.get("slug", "")).lower() != "moa"]
+
+    def _base(**kw):
+        excluded = {str(p).strip().lower() for p in (kw.get("excluded_providers") or []) if p}
+        rows = [_make_provider("openai", models=["gpt-x"])]
+        return [r for r in rows if r["slug"] not in excluded]
+
+    monkeypatch.setattr(model_switch, "_prepend_moa_picker_provider", _prepend)
+    monkeypatch.setattr(model_switch, "list_authenticated_providers", _base)
+
+
+def test_moa_row_hidden_when_excluded(monkeypatch):
+    """The gateway picker passes include_moa=True unconditionally; the virtual
+    row must still honor model_catalog.excluded_providers (#94068)."""
+    _patch_moa_prepend(monkeypatch)
+
+    rows = model_switch.list_picker_providers(
+        include_moa=True, excluded_providers=["moa"]
+    )
+
+    assert "moa" not in [r["slug"] for r in rows]
+    assert "openai" in [r["slug"] for r in rows]
+
+
+def test_moa_row_hidden_with_case_and_whitespace_variant(monkeypatch):
+    """Exclusion matching normalizes like list_authenticated_providers."""
+    _patch_moa_prepend(monkeypatch)
+
+    rows = model_switch.list_picker_providers(
+        include_moa=True, excluded_providers=["  MOA "]
+    )
+
+    assert "moa" not in [r["slug"] for r in rows]
+
+
+def test_moa_row_present_without_exclusion(monkeypatch):
+    """Default: the virtual row is still prepended first for gateway pickers."""
+    _patch_moa_prepend(monkeypatch)
+
+    rows = model_switch.list_picker_providers(include_moa=True)
+
+    assert rows[0]["slug"] == "moa"
+
+
+def test_moa_row_survives_other_provider_exclusion(monkeypatch):
+    """Excluding an unrelated provider must not hide the MoA row."""
+    _patch_moa_prepend(monkeypatch)
+
+    rows = model_switch.list_picker_providers(
+        include_moa=True, excluded_providers=["openai"]
+    )
+
+    slugs = [r["slug"] for r in rows]
+    assert "moa" in slugs
+    assert "openai" not in slugs


### PR DESCRIPTION
## What does this PR do?

`list_picker_providers()` applies `model_catalog.excluded_providers` inside `list_authenticated_providers()` and then prepends the virtual MoA row afterwards — so the gateway `/model` picker (Telegram/Discord), which passes `include_moa=True` unconditionally, always showed the "Mixture of Agents" button even when the user excluded `moa`. The CLI `hermes model` picker already honors the exclusion; only the gateway path bypassed it, because the virtual MoA row is the one provider row constructed outside the exclusion-filtered path.

This guards the prepend with the same normalized membership check `list_authenticated_providers()` uses for its exclusion set (`str(p).strip().lower()`), so `excluded_providers: ["moa"]` (or a case/whitespace variant) now hides the row on gateway pickers too. No gateway-side change is needed — `gateway/slash_commands.py` already forwards `excluded_providers`.

## Related Issue

Fixes #94068

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `hermes_cli/model_switch.py` (`list_picker_providers`) — the MoA prepend is now also gated on `"moa"` not appearing in the normalized `excluded_providers` set, with a comment naming the bypass (#94068). Normalization matches the existing set construction in `list_authenticated_providers`.
- `tests/hermes_cli/test_list_picker_providers.py` — new tests for the virtual-row exclusion:
  - `test_moa_row_hidden_when_excluded` — the reported gateway scenario (`include_moa=True` + `excluded_providers=["moa"]` → no MoA row).
  - `test_moa_row_hidden_with_case_and_whitespace_variant` — pins the normalization contract.
  - `test_moa_row_present_without_exclusion` — default prepend behaviour unchanged (row first).
  - `test_moa_row_survives_other_provider_exclusion` — excluding an unrelated provider does not hide the MoA row.

## How to Test

- Run: `.venv/bin/python -m pytest tests/hermes_cli/test_list_picker_providers.py -q`
- Observed result: `8 passed`. Fail-on-main check (`git stash` of the source change): the two exclusion tests fail against unpatched `main`; the two behaviour-preservation tests pass both ways.
- Regression sweep (`test_list_picker_providers.py`, `test_model_catalog.py`, `test_model_switch_custom_providers.py`, `tests/gateway/test_model_picker_persist.py`, `tests/gateway/test_25107_stale_base_url_api_mode.py`): `100 passed` total.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of the completed code performed
- [x] New and existing unit tests pass locally
- [x] Changes are backward-compatible (MoA row still prepended unless explicitly excluded)
