### PR TITLE
fix(desktop): surface /review in the slash popover and /help

### DIFF
--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -168,8 +168,8 @@ describe('desktop slash command curation', () => {
   })
 
   it('surfaces /review in the popover and routes it through the slash worker', () => {
-    // Backend /review (#93339) is live on tui_gateway; Desktop just needs the
-    // curated allowlist entry so autocomplete + /help show it.
+    // Backend /review (#93339) is live on tui_gateway. Curating the row makes
+    // it a first-class Command with free-text arg expansion (not a no-arg skill chip).
     expect(isDesktopSlashSuggestion('/review')).toBe(true)
     expect(isDesktopSlashCommand('/review')).toBe(true)
     expect(resolveDesktopCommand('/review')?.surface).toEqual({ kind: 'exec' })

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -155,6 +155,7 @@ describe('desktop slash command curation', () => {
       '/personality',
       '/queue',
       '/retry',
+      '/review',
       '/rollback',
       '/tools',
       '/undo',
@@ -166,10 +167,24 @@ describe('desktop slash command curation', () => {
     }
   })
 
+  it('surfaces /review in the popover and routes it through the slash worker', () => {
+    // Backend /review (#93339) is live on tui_gateway; Desktop just needs the
+    // curated allowlist entry so autocomplete + /help show it.
+    expect(isDesktopSlashSuggestion('/review')).toBe(true)
+    expect(isDesktopSlashCommand('/review')).toBe(true)
+    expect(resolveDesktopCommand('/review')?.surface).toEqual({ kind: 'exec' })
+    expect(desktopSlashCommandArgumentMode('/review')).toBe('text')
+    expect(desktopSlashUnavailableMessage('/review')).toBeNull()
+    expect(desktopSlashDescription('/review', 'backend desc')).toBe(
+      'Spawn an independent reviewer subagent for the work just discussed'
+    )
+  })
+
   it('distinguishes free prose from finite slash option lists', () => {
     expect(desktopSlashCommandArgumentMode('/goal')).toBe('mixed')
     expect(desktopSlashCommandArgumentMode('/steer')).toBe('text')
     expect(desktopSlashCommandArgumentMode('/queue')).toBe('text')
+    expect(desktopSlashCommandArgumentMode('/review')).toBe('text')
     expect(desktopSlashCommandArgumentMode('/personality')).toBe('options')
     expect(desktopSlashCommandArgumentMode('/handoff')).toBe('options')
     expect(desktopSlashCommandArgumentMode('/version')).toBeNull()

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -273,9 +273,11 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     surface: exec(),
     argumentMode: 'mixed'
   },
-  // /review ships on CLI/gateway/TUI via agent/review_engine.py (#93339) but
-  // Desktop keeps its own allowlist — without this entry the slash popover and
-  // /help hide it even though tui_gateway live-dispatches the command.
+  // /review ships on CLI/gateway/TUI via agent/review_engine.py (#93339) and
+  // tui_gateway already live-dispatches it. Without a curated row it still
+  // appears as an extension/skill-shaped entry; promote it to a first-class
+  // Command with free-text args so the composer expands for optional
+  // instructions instead of chipping bare `/review` as a no-arg skill.
   {
     name: '/review',
     description: 'Spawn an independent reviewer subagent for the work just discussed',

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -273,6 +273,15 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     surface: exec(),
     argumentMode: 'mixed'
   },
+  // /review ships on CLI/gateway/TUI via agent/review_engine.py (#93339) but
+  // Desktop keeps its own allowlist — without this entry the slash popover and
+  // /help hide it even though tui_gateway live-dispatches the command.
+  {
+    name: '/review',
+    description: 'Spawn an independent reviewer subagent for the work just discussed',
+    surface: exec(),
+    argumentMode: 'text'
+  },
   {
     name: '/personality',
     description: 'Switch personality for this session',


### PR DESCRIPTION
## Summary

- Promote `/review` onto Desktop’s curated slash table as a first-class `exec` Command with free-text `argumentMode`
- Pin suggestion + exec + argument-mode routing in unit tests

## Motivation

#93339 shipped the independent reviewer subagent (CLI/gateway/TUI; Desktop live-dispatch via `tui_gateway`). An unlisted built-in still surfaces as an extension-shaped entry, but without a curated row Desktop treats it like a no-arg skill chip — free-text instructions after pick don’t expand cleanly.

This PR promotes `/review` to a first-class Command with `argumentMode: 'text'` so the composer stays editable for optional focus notes (`/review focus on the PR security notes`), matching CLI `args_hint="[review instructions]"`.

## Changes

- `apps/desktop/src/lib/desktop-slash-commands.ts` — `/review` entry next to session orchestration commands (`/loop`, `/goal`)
- `apps/desktop/src/lib/desktop-slash-commands.test.ts` — suggestion/exec/argumentMode coverage

No backend, gateway, or engine changes.

## Test Plan

- [x] `cd apps/desktop && npx vitest run src/lib/desktop-slash-commands.test.ts` — **29 passed**
- [ ] Manual: type `/` → `/review` appears under Commands (not only Skills)
- [ ] Manual: pick `/review` → composer expands for optional instructions (does not chip bare no-arg)
- [ ] Manual: `/review` and `/review focus on the PR security notes` dispatch a live review note

## Notes for Reviewers

- Backend path already exists (`agent/review_engine.py`, `tui_gateway` live dispatch). This is Desktop UX/classification only.
- Reviewer model remains configurable via Settings → Auxiliary models → Review (#93390).
- Did **not** add `/refine` (background skill/memory review) — separate product surface if desired later.
