### PR TITLE
fix(cli): make string-valued ANSI mappings insert the mapped character

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -83,13 +83,15 @@ try:
         install_ignored_terminal_sequences,
         install_modify_other_keys_aliases,
         install_shift_enter_alias,
+        install_vt100_str_key_data_fix,
     )
     install_shift_enter_alias()
     install_ctrl_enter_alias()
     install_cmd_backspace_alias()
     install_modify_other_keys_aliases()
     install_ignored_terminal_sequences()
-    del install_shift_enter_alias, install_ctrl_enter_alias, install_cmd_backspace_alias, install_modify_other_keys_aliases, install_ignored_terminal_sequences
+    install_vt100_str_key_data_fix()
+    del install_shift_enter_alias, install_ctrl_enter_alias, install_cmd_backspace_alias, install_modify_other_keys_aliases, install_ignored_terminal_sequences, install_vt100_str_key_data_fix
 except Exception:
     pass
 import threading

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -48,6 +48,49 @@ def _clear_vt100_prefix_cache() -> None:
         pass
 
 
+def install_vt100_str_key_data_fix() -> bool:
+    """Make string-valued ``ANSI_SEQUENCES`` mappings insert the mapped text.
+
+    ``Vt100Parser._call_handler`` always passes the raw matched byte
+    sequence as ``KeyPress.data``. For ``Keys.*`` targets that is fine —
+    bound handlers ignore ``data`` — but for mappings whose value is a
+    plain string (Hermes' Shift+letter table: ``ESC[27;2;97~`` → ``"A"``)
+    the default self-insert binding inserts ``event.data``, i.e. the
+    literal escape text, which is exactly the #92343 symptom: Shift+letter
+    leaks ``[27;2;97~`` into the prompt buffer even though the parser now
+    decodes the sequence.
+
+    Stock prompt_toolkit has zero plain-string mappings (every one of the
+    180 string values is a ``Keys`` member), so overriding ``data`` for
+    string keys affects only Hermes' own tables. Idempotent.
+
+    Returns True when the patch was applied by this call.
+    """
+    try:
+        from prompt_toolkit.input.vt100_parser import Vt100Parser
+        from prompt_toolkit.keys import Keys
+    except Exception:
+        return False
+    if getattr(Vt100Parser, "_hermes_str_key_data_fix", False):
+        return False
+
+    original = Vt100Parser._call_handler
+
+    def _call_handler(self, key, insert_text):  # type: ignore[no-untyped-def]
+        # ``Keys`` members ARE str subclasses, so exclude them explicitly:
+        # only plain-string mapped values (Hermes' Shift+letter table) get
+        # data rewritten; every Keys.* mapping keeps its raw-byte data.
+        if isinstance(key, str) and not isinstance(key, Keys):
+            # The mapped value IS the intended text; the raw matched
+            # prefix is what used to leak into the buffer (#92343).
+            insert_text = key
+        original(self, key, insert_text)
+
+    Vt100Parser._call_handler = _call_handler  # type: ignore[method-assign]
+    Vt100Parser._hermes_str_key_data_fix = True  # type: ignore[attr-defined]
+    return True
+
+
 def install_shift_enter_alias() -> int:
     """Map Shift+Enter byte sequences to the (Escape, ControlM) key tuple
     that Alt+Enter produces, so the existing Alt+Enter newline handler

--- a/tests/hermes_cli/test_pt_input_extras_str_key_data.py
+++ b/tests/hermes_cli/test_pt_input_extras_str_key_data.py
@@ -1,0 +1,92 @@
+"""Regression tests for the VT100 string-key data fix (#92343).
+
+``ANSI_SEQUENCES`` mappings whose value is a plain string (Hermes'
+Shift+letter table) produce ``KeyPress(key, data)`` where prompt_toolkit
+sets ``data`` to the RAW matched byte sequence. The default self-insert
+binding inserts ``event.data``, so Shift+a leaked ``ESC[27;2;97~`` into
+the prompt buffer even after the sequence itself was decoded correctly.
+"""
+
+import pytest
+
+from hermes_cli.pt_input_extras import (
+    install_vt100_str_key_data_fix,
+    _clear_vt100_prefix_cache,
+)
+
+
+@pytest.fixture
+def parser_factory():
+    """Yield a factory building Vt100Parser instances that collect keys.
+
+    Installs Hermes' real ANSI_SEQUENCES mappings (as cli.py does at
+    startup) so the Shift+letter sequence is actually decoded, applies the
+    string-key data fix for the duration of each parser, and restores the
+    original ``_call_handler`` afterwards so the global class mutation
+    never leaks into other tests.
+    """
+    from prompt_toolkit.input.vt100_parser import Vt100Parser
+
+    from hermes_cli.pt_input_extras import install_modify_other_keys_aliases
+
+    install_modify_other_keys_aliases()
+    original = Vt100Parser._call_handler
+    created = []
+
+    def factory(with_fix: bool):
+        if with_fix:
+            install_vt100_str_key_data_fix()
+        presses: list = []
+        parser = Vt100Parser(presses.append)
+        created.append((parser, presses))
+        return parser, presses
+
+    yield factory
+
+    Vt100Parser._call_handler = original
+    if hasattr(Vt100Parser, "_hermes_str_key_data_fix"):
+        del Vt100Parser._hermes_str_key_data_fix
+    _clear_vt100_prefix_cache()
+
+
+def _feed_sequence(parser, presses) -> str:
+    """Feed the Shift+a modifyOtherKeys sequence and return inserted data."""
+    parser.feed("\x1b[27;2;97~")
+    parser.flush()
+    assert len(presses) == 1, f"expected 1 press, got {presses!r}"
+    press = presses[0]
+    assert press.key == "A"  # the mapping resolves to the uppercase letter
+    return press.data
+
+
+def test_without_fix_data_is_the_raw_sequence(parser_factory):
+    parser, presses = parser_factory(with_fix=False)
+    data = _feed_sequence(parser, presses)
+    assert data == "\x1b[27;2;97~"  # the leak (#92343)
+
+
+def test_with_fix_data_is_the_mapped_character(parser_factory):
+    parser, presses = parser_factory(with_fix=True)
+    data = _feed_sequence(parser, presses)
+    assert data == "A"  # self-insert now types the letter
+
+
+def test_keys_valued_mappings_keep_raw_data(parser_factory):
+    """Keys.* targets are untouched: ControlA keeps its raw byte as data."""
+    from prompt_toolkit.keys import Keys
+
+    parser, presses = parser_factory(with_fix=True)
+    parser.feed("\x01")  # Ctrl+A
+    parser.flush()
+    assert len(presses) == 1
+    assert presses[0].key is Keys.ControlA
+    assert presses[0].data == "\x01"
+
+
+def test_install_is_idempotent(parser_factory):
+    from prompt_toolkit.input.vt100_parser import Vt100Parser
+
+    first = install_vt100_str_key_data_fix()
+    second = install_vt100_str_key_data_fix()
+    assert first is True or hasattr(Vt100Parser, "_hermes_str_key_data_fix")
+    assert second is False or hasattr(Vt100Parser, "_hermes_str_key_data_fix")


### PR DESCRIPTION
Fixes #92343

## What & why

After #87511 mapped the Shift+letter CSI sequences in `ANSI_SEQUENCES`, the parser emits the right *key* — but `Vt100Parser._call_handler` always passes the **raw matched byte sequence** as `KeyPress.data`. The default self-insert binding inserts `event.data`, so Shift+letter still leaked `[27;2;97~` into the prompt buffer on Ghostty.

Stock prompt_toolkit has **zero** plain-string mappings (all 180 string values in `ANSI_SEQUENCES` are `Keys` members — verified against 3.0.52), so the only plain-string values are Hermes' own Shift+letter table. That gives the fix a perfect blast radius:

`install_vt100_str_key_data_fix()` patches `_call_handler` so a plain-string mapped value becomes its own `data` payload. `Keys` members are str subclasses and are excluded explicitly — every `Keys.*` mapping keeps its raw-byte data. Wired into the existing startup install block in `cli.py`; idempotent.

## How to test

```
scripts/run_tests.sh tests/hermes_cli/test_pt_input_extras_str_key_data.py -q
```

Tests drive a **real `Vt100Parser`** with Hermes' actual mappings installed: without the fix, feeding `ESC[27;2;97~` yields `KeyPress("A", "\x1b[27;2;97~")` (the leak); with it, `KeyPress("A", "A")`. Also covered: `Keys.*` data payloads unchanged, install idempotency.

Manual repro: Ghostty + `hermes` → type Shift+M. Before: `[27;2;109~` lands in the buffer. After: `M`.

## Platforms tested

- Windows 11, Python 3.12: new suite 4/4.
- Parser semantics are host-independent; the reported terminal was macOS/Ghostty, but the data-payload defect is in the parser, not the terminal.
