### PR TITLE
fix(agent): classify masked Codex replay rejection as invalid_encrypted_content

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1559,6 +1559,31 @@ def _classify_402(error_msg: str, result_fn) -> ClassifiedError:
     )
 
 
+def _is_codex_masked_replay_rejection(
+    error_msg: str, error_code: str, provider: str
+) -> bool:
+    """True when a Codex OAuth 400 masks an encrypted-reasoning replay rejection.
+
+    The ChatGPT Codex backend masks certain failures behind a generic
+    ``400 invalid_prompt "Request blocked."`` envelope. After the
+    Harmony-token defang (#68087, salvaged via #75860) the primary trigger
+    is fixed at the source, but a rejected encrypted-reasoning replay still
+    surfaces this way, and the generic format-error bucket burns retries
+    and force-falls back although the strip-replay repair for the sibling
+    ``invalid_encrypted_content`` reason applies verbatim (#92353).
+
+    Deliberately narrow: exact error code + exact message + codex provider
+    slug, so a genuine ``invalid_prompt`` from any other route (or any
+    other provider) is untouched.
+    """
+    if (error_code or "").strip().lower() != "invalid_prompt":
+        return False
+    if "request blocked" not in (error_msg or ""):
+        return False
+    provider_slug = (provider or "").strip().lower()
+    return "codex" in provider_slug
+
+
 def _classify_400(
     error_msg: str,
     error_code: str,
@@ -1633,6 +1658,22 @@ def _classify_400(
             retryable=True,
             # The request shape was fine — never route this into compression.
             should_compress=False,
+        )
+
+    # Masked Codex replay rejection: the ChatGPT Codex OAuth backend hides
+    # encrypted-reasoning replay failures behind a generic 400
+    # ``invalid_prompt "Request blocked."`` envelope. Classify it as the
+    # sibling invalid_encrypted_content reason so the existing one-shot
+    # strip-replay-and-retry recovery applies (#92353). The repair path is
+    # self-guarding — it fires only in codex_responses mode with actual
+    # cached codex_reasoning_items and only once — so a genuinely
+    # unrelated "Request blocked." still reaches the normal retry path
+    # after the single repair attempt instead of looping.
+    if _is_codex_masked_replay_rejection(error_msg, error_code, provider):
+        return result_fn(
+            FailoverReason.invalid_encrypted_content,
+            retryable=True,
+            should_fallback=False,
         )
 
     # Request-validation errors (unsupported / unknown parameter) MUST be

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1579,3 +1579,57 @@ class TestServerInjectedParameterRejection:
         assert result.retryable is False
 
 
+
+
+class TestCodexMaskedReplayRejection:
+    """#92353 - the Codex OAuth backend masks encrypted-reasoning replay
+    failures behind a generic 400 ``invalid_prompt "Request blocked."``
+    envelope. It must classify as invalid_encrypted_content so the existing
+    one-shot strip-replay-and-retry recovery fires instead of burning
+    retries and force-falling back."""
+
+    MASKED_BODY = {"error": {"code": "invalid_prompt", "message": "Request blocked."}}
+
+    def test_masked_envelope_routes_to_invalid_encrypted_content(self):
+        e = MockAPIError("Request blocked.", status_code=400, body=self.MASKED_BODY)
+        result = classify_api_error(e, provider="openai-codex")
+        assert result.reason == FailoverReason.invalid_encrypted_content
+        assert result.retryable is True
+        assert result.should_fallback is False
+
+    def test_same_envelope_from_other_provider_is_untouched(self):
+        e = MockAPIError("Request blocked.", status_code=400, body=self.MASKED_BODY)
+        result = classify_api_error(e, provider="openrouter")
+        assert result.reason != FailoverReason.invalid_encrypted_content
+
+    def test_invalid_prompt_with_other_message_is_untouched(self):
+        e = MockAPIError(
+            "Missing required parameter: 'model'.",
+            status_code=400,
+            body={"error": {"code": "invalid_prompt",
+                            "message": "Missing required parameter: 'model'."}},
+        )
+        result = classify_api_error(e, provider="openai-codex")
+        assert result.reason != FailoverReason.invalid_encrypted_content
+
+    def test_request_blocked_with_other_code_is_untouched(self):
+        e = MockAPIError(
+            "Request blocked.",
+            status_code=400,
+            body={"error": {"code": "content_policy_violation",
+                            "message": "Request blocked."}},
+        )
+        result = classify_api_error(e, provider="openai-codex")
+        assert result.reason != FailoverReason.invalid_encrypted_content
+
+    def test_cybersecurity_refusal_still_wins(self):
+        """#18028 refusal phrasing must not be swept into the replay repair."""
+        e = MockAPIError(
+            "Request blocked. flagged for possible cybersecurity risk",
+            status_code=400,
+            body={"error": {"code": "invalid_prompt",
+                            "message": "Request blocked. flagged for possible "
+                                       "cybersecurity risk"}},
+        )
+        result = classify_api_error(e, provider="openai-codex")
+        assert result.reason != FailoverReason.invalid_encrypted_content


### PR DESCRIPTION
Fixes #92353

## What & why

The ChatGPT Codex OAuth backend masks certain failures behind a generic `400 invalid_prompt "Request blocked."` envelope. After the Harmony-token defang (#68087, salvaged via #75860) the primary trigger is fixed at the source — but a rejected **encrypted-reasoning replay** still surfaces this way, and `classify_api_error` bucketed it as a generic `format_error`: the turn burns retries and force-falls back although the one-shot **strip-`codex_reasoning_items`-and-retry** repair for the sibling `invalid_encrypted_content` reason applies verbatim.

Adds `_is_codex_masked_replay_rejection()` — deliberately narrow: exact error code (`invalid_prompt`) + exact `"request blocked"` message + codex provider slug — and classifies the envelope as `FailoverReason.invalid_encrypted_content` so the existing `conversation_loop` recovery fires.

**Safety analysis:** the repair path is self-guarding — it fires only in `codex_responses` mode, requires actual cached `codex_reasoning_items` in history, and is one-shot — so a genuinely unrelated "Request blocked." still reaches the normal retry path after the single repair attempt instead of looping. The #18028 cybersecurity-refusal classification runs earlier in the pipeline and is unaffected (covered by a dedicated test).

## How to test

```
scripts/run_tests.sh tests/agent/test_error_classifier.py -q
```

Five new tests: the masked envelope routes to `invalid_encrypted_content` (retryable, no fallback); same envelope from a non-codex provider untouched; `invalid_prompt` with a different message untouched; "Request blocked." with a different code untouched; the #18028 refusal phrasing still wins.

## Platforms tested

- Windows 11, Python 3.12: full classifier suite 127/127.
- Classification is host-independent.
