### PR TITLE
fix(gateway): restore governed plain-English project progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,7 @@ models-dev-upstream/
 .codex/
 .cursor/
 .gemini/
+.serena/
 .zed/
 .mcp.json
 opencode.json

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -63,34 +63,26 @@ def _record_kanban_budget_exhausted(
     max_iterations: int,
     logger: logging.Logger,
 ) -> None:
-    """Record a terminal ``timed_out`` outcome for a kanban worker that
-    exhausted its iteration budget.
+    """Park a Kanban task when its worker exhausts its iteration budget.
 
-    This is a bounded fallback (#87096): the CAS invariant in ``_end_run``
-    (``WHERE ended_at IS NULL``) guarantees idempotence — if another path
-    already closed the run this is a no-op — so it is safe to call from
-    multiple exit paths.
+    An iteration budget is not a process-spawn failure or a transient runtime
+    timeout: blindly re-queuing the same task just starts the same exploration
+    again with a fresh context.  Use a sticky ``needs_input`` block so an
+    operator can provide narrower evidence or scope before resuming.
     """
     try:
         from hermes_cli import kanban_db as _kb
         _conn = _kb.connect()
         try:
-            _kb._record_task_failure(
+            _kb.block_task(
                 _conn,
                 kanban_task,
-                error=(
+                reason=(
                     f"Iteration budget exhausted "
                     f"({api_call_count}/{max_iterations}) — "
-                    "task could not complete within the allowed "
-                    "iterations"
+                    "provide narrower evidence or scope before resuming"
                 ),
-                outcome="timed_out",
-                release_claim=True,
-                end_run=True,
-                event_payload_extra={
-                    "budget_used": api_call_count,
-                    "budget_max": max_iterations,
-                },
+                kind="needs_input",
             )
         finally:
             try:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1713,6 +1713,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["allowed_topics"] = platform_cfg["allowed_topics"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
+                if plat == Platform.DISCORD and "specialist_routing" in platform_cfg:
+                    bridged["specialist_routing"] = platform_cfg["specialist_routing"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if "exclusive_bot_mentions" in platform_cfg:

--- a/gateway/configured_board.py
+++ b/gateway/configured_board.py
@@ -1,0 +1,21 @@
+"""Canonical paths for explicitly configured gateway Kanban boards."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_BOARD_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+def configured_board_db_path(board: object) -> Path:
+    """Resolve one explicit board without honoring the per-process DB override."""
+    if not isinstance(board, str) or not _BOARD_RE.fullmatch(board):
+        raise ValueError("an explicit valid Kanban board is required")
+
+    from hermes_cli import kanban_db as kb
+
+    if board == kb.DEFAULT_BOARD:
+        return kb.kanban_home().expanduser() / "kanban.db"
+    return kb.boards_root().expanduser() / board / "kanban.db"

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -95,6 +95,34 @@ async def _to_thread_process_service(func: Callable[..., Any], /, *args: Any) ->
     return await asyncio.to_thread(_run_in_fresh_context, func, *args)
 
 
+def _format_gave_up_notification(
+    *,
+    board_tag: str,
+    tag: str,
+    task_id: str,
+    payload: Optional[dict],
+) -> str:
+    """Render a truthful terminal notice for a circuit-breaker give-up."""
+    payload = payload or {}
+    trigger = str(payload.get("trigger_outcome") or "")
+    error = str(payload.get("error") or "")[:200]
+    if trigger == "timed_out" and payload.get("budget_used") is not None:
+        used = payload["budget_used"]
+        maximum = payload.get("budget_max", "?")
+        return (
+            f"✖ {board_tag}{tag}Kanban {task_id} gave up: iteration budget "
+            f"exhausted ({used}/{maximum}) after repeated attempts"
+        )
+    if trigger == "spawn_failed":
+        reason = "after repeated spawn failures"
+    elif trigger:
+        reason = f"after repeated {trigger} failures"
+    else:
+        reason = "after repeated worker failures"
+    suffix = f"\n{error}" if error else ""
+    return f"✖ {board_tag}{tag}Kanban {task_id} gave up {reason}{suffix}"
+
+
 def _acquire_singleton_lock(lock_path) -> "tuple[Optional[object], str]":
     """Take an exclusive, non-blocking advisory lock for the sole dispatcher.
 
@@ -239,7 +267,7 @@ class GatewayKanbanWatchersMixin:
         # but is not a block (see kanban_db.request_review); the task is not
         # archived, so the subscription stays alive and later review
         # cycles keep notifying.
-        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked", "block_loop_detected", "review_requested")
+        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked", "block_loop_detected", "review_requested", "decomposed")
         # Subscriptions are removed only when the task reaches the irreversible
         # archived status. ``done`` is reversible in review/controller flows,
         # so removing its subscription would silence a later reopen. We used
@@ -583,12 +611,11 @@ class GatewayKanbanWatchersMixin:
                                 reason = f": {str(ev.payload['reason'])[:160]}"
                             msg = f"⏸ {board_tag}{tag}Kanban {sub['task_id']} blocked{reason}"
                         elif kind == "gave_up":
-                            err = ""
-                            if ev.payload and ev.payload.get("error"):
-                                err = f"\n{str(ev.payload['error'])[:200]}"
-                            msg = (
-                                f"✖ {board_tag}{tag}Kanban {sub['task_id']} gave up "
-                                f"after repeated spawn failures{err}"
+                            msg = _format_gave_up_notification(
+                                board_tag=board_tag,
+                                tag=tag,
+                                task_id=sub["task_id"],
+                                payload=ev.payload,
                             )
                         elif kind == "crashed":
                             msg = (
@@ -608,6 +635,13 @@ class GatewayKanbanWatchersMixin:
                             if ev.payload and ev.payload.get("status"):
                                 new_status = str(ev.payload["status"])
                             msg = f"🔄 {board_tag}{tag}Kanban {sub['task_id']} → {new_status}"
+                        elif kind == "decomposed":
+                            child_ids = ev.payload.get("child_ids") if ev.payload else []
+                            worker_count = len(child_ids) if isinstance(child_ids, list) else 0
+                            msg = (
+                                f"🧭 {board_tag}Kanban {sub['task_id']} planned "
+                                f"{worker_count} coordinated worker{'s' if worker_count != 1 else ''}"
+                            )
                         elif kind == "review_requested":
                             # Implementation complete; task moved to the
                             # first-class review lane. Wake the origin thread.

--- a/gateway/progress_queries.py
+++ b/gateway/progress_queries.py
@@ -1,0 +1,680 @@
+"""Deterministic, read-only Kanban progress replies for trusted chat sources.
+
+This is deliberately a gateway edge helper, rather than a model prompt or a
+Kanban tool.  It reads only cards that explicitly subscribed the current
+platform/chat/thread source and produces a bounded response without creating
+work, following paths, or interpreting prose as authority.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+import stat
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+from gateway.configured_board import configured_board_db_path
+
+
+MAX_PROGRESS_RESPONSE_CHARS = 1_600
+_MAX_GRAPH_TASKS = 24
+_MAX_NEXT_TASKS = 3
+_MAX_AMBIGUOUS_ROOTS = 3
+_MAX_RECEIPT_CHARS = 280
+_MAX_SNAPSHOT_BYTES = 256 * 1024 * 1024
+_SNAPSHOT_COPY_CHUNK_BYTES = 1024 * 1024
+_SNAPSHOT_ATTEMPTS = 3
+_BOARD_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+_TASK_ID_RE = re.compile(r"\bt_[a-z0-9]+\b", re.IGNORECASE)
+_WORD_RE = re.compile(r"[a-z0-9]{3,}")
+_SECRET_KEY_PATTERN = (
+    r"[a-z0-9_-]*(?:(?:access|private)[_-]?key|secret|token|password|credential|"
+    r"api[_-]?key|database[_-]?url|connection[_-]?string|authorization)[a-z0-9_-]*"
+)
+_SECRET_LINE_RE = re.compile(
+    rf"(?i)^(\s*(?:{_SECRET_KEY_PATTERN})\s*(?:=|:)\s*).*$"
+)
+_SECRET_RE = re.compile(
+    rf"(?i)\b(?:{_SECRET_KEY_PATTERN})"
+    r"\s*(?:=|:)\s*(?:bearer\s+)?[^\n]*"
+)
+_BARE_BEARER_RE = re.compile(r"(?i)\bbearer(?:\s+[^\s,;]+)?")
+_URI_USERINFO_RE = re.compile(
+    r"(?i)\b([a-z][a-z0-9+.-]*://)[^/@\s:]+:[^/@\s]+@"
+)
+_GITHUB_TOKEN_RE = re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{8,}\b")
+_PRIVATE_KEY_BLOCK_RE = re.compile(
+    r"-----BEGIN[A-Z ]*PRIVATE KEY-----[\s\S]*?-----END[A-Z ]*PRIVATE KEY-----",
+    re.IGNORECASE,
+)
+_PATH_RE = re.compile(
+    r"(?:(?:[A-Za-z]:)?[\\/](?:Users|home|private|tmp|var|etc|root|opt)[^\s,;]*)"
+)
+_PROSE_COMMIT_RE = re.compile(r"\b[0-9a-f]{7,64}\b", re.IGNORECASE)
+_COMMIT_RE = re.compile(r"^[0-9a-f]{7,64}$", re.IGNORECASE)
+_BRANCH_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,119}$")
+_STOP_WORDS = frozenset(
+    {
+        "about", "also", "and", "could", "did", "does", "else", "from",
+        "have", "how", "need", "progress", "project", "status", "that", "the", "this",
+        "what", "when", "where", "with", "work", "would", "your",
+    }
+)
+_TOPIC_WORD = r"[a-z0-9][a-z0-9_'./:-]*"
+_TOPIC = rf"{_TOPIC_WORD}(?:\s+{_TOPIC_WORD})*"
+_STRUCTURAL_TOPIC_TAIL_RE = re.compile(r"(?:^|\s)(?:and|while|then|so|to)(?:\s|$)")
+_READ_ONLY_PROGRESS_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        rf"how did (?P<topic>{_TOPIC}) go(?: and what else do we need to do)?\?",
+        rf"how(?:'s| is| are) (?P<topic>{_TOPIC}) going(?:,? (?:and )?how much "
+        rf"(?:more )?(?:work )?do we (?:have|need) to do(?: (?:until|till) we can "
+        rf"(?:send|open|submit) (?:a )?(?:pr|pull request))?)?\??",
+        rf"(?:can|could|would) you update me on (?P<topic>{_TOPIC}) (?:progress|status)\?",
+        rf"give me an update on (?P<topic>{_TOPIC})",
+        rf"what remains (?P<topic>{_TOPIC})\?",
+        rf"what's left (?P<topic>{_TOPIC})\?",
+        rf"where are we (?P<topic>{_TOPIC})\?",
+        rf"status of (?P<topic>{_TOPIC})\?",
+        rf"progress on (?P<topic>{_TOPIC})\?",
+        rf"is (?P<topic>{_TOPIC}) complete\?",
+    )
+)
+_GENERIC_PROGRESS_RE = re.compile(r"^how did it go\?$", re.IGNORECASE)
+_NONTERMINAL_STATUSES = frozenset({"triage", "scheduled", "todo", "ready", "review"})
+_FAILED_RUN_STATES = frozenset(
+    {"spawn_failed", "gave_up", "failed", "timed_out", "crashed"}
+)
+
+
+@dataclass(frozen=True)
+class ProgressSource:
+    """Trusted ingress identity used for exact subscription matching."""
+
+    platform: str
+    chat_id: str
+    thread_id: Optional[str] = None
+    reply_to_message_id: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ProgressQueryResult:
+    """A handled reply is safe to send without invoking the normal agent."""
+
+    handled: bool
+    response: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class _ParsedProgressQuery:
+    """A recognized status template and its untrusted topic text."""
+
+    normalized: str
+    topic: Optional[str]
+
+
+class _SnapshotChangedError(OSError):
+    """The captured source identity or byte extent changed during copy."""
+
+
+def _parse_progress_query(request: object) -> Optional[_ParsedProgressQuery]:
+    """Parse a complete status template without deciding topic authority."""
+    if not isinstance(request, str):
+        return None
+    normalized = " ".join(request.casefold().replace("’", "'").split())
+    if not normalized or len(normalized) > 4_000:
+        return None
+    if _GENERIC_PROGRESS_RE.fullmatch(normalized):
+        return _ParsedProgressQuery(normalized, None)
+    for pattern in _READ_ONLY_PROGRESS_PATTERNS:
+        match = pattern.fullmatch(normalized)
+        if match:
+            topic = match.group("topic")
+            if _STRUCTURAL_TOPIC_TAIL_RE.search(topic):
+                return None
+            return _ParsedProgressQuery(normalized, topic)
+    return None
+
+
+def is_progress_query(request: object) -> bool:
+    """Recognize complete project-status templates, independent of authority."""
+    return _parse_progress_query(request) is not None
+
+
+def _safe_text(value: object, *, limit: int = _MAX_RECEIPT_CHARS) -> str:
+    raw = str(value or "").replace("\x00", " ")
+    try:
+        from agent.redact import redact_sensitive_text
+
+        canonical = redact_sensitive_text(
+            raw,
+            force=True,
+            redact_url_credentials=True,
+        )
+    except Exception:
+        return "[redacted]"
+    if not isinstance(canonical, str):
+        return "[redacted]"
+    raw = _GITHUB_TOKEN_RE.sub("[redacted]", canonical)
+    raw = _PRIVATE_KEY_BLOCK_RE.sub("[redacted]", raw)
+    redacted_lines = []
+    for line in raw.splitlines() or [raw]:
+        line = _SECRET_LINE_RE.sub(lambda match: match.group(1) + "[redacted]", line)
+        line = _SECRET_RE.sub("[redacted]", line)
+        line = _BARE_BEARER_RE.sub("[redacted]", line)
+        line = _URI_USERINFO_RE.sub(r"\1[userinfo redacted]@", line)
+        redacted_lines.append(line)
+    text = " ".join("\n".join(redacted_lines).split())
+    text = _PATH_RE.sub("[path redacted]", text)
+    # A hash mentioned in a free-form worker receipt is not provenance. Only
+    # the explicit structured metadata fields below may identify a commit.
+    text = _PROSE_COMMIT_RE.sub("[unverified commit]", text)
+    return text[:limit].rstrip()
+
+
+def _safe_structured_identifier(value: object) -> Optional[str]:
+    candidate = str(value or "").strip()
+    if (
+        not candidate
+        or _GITHUB_TOKEN_RE.search(candidate)
+        or _PRIVATE_KEY_BLOCK_RE.search(candidate)
+    ):
+        return None
+    try:
+        from agent.redact import redact_sensitive_text
+
+        canonical = redact_sensitive_text(
+            candidate,
+            force=True,
+            redact_url_credentials=True,
+        )
+    except Exception:
+        return None
+    return candidate if canonical == candidate else None
+
+
+def _safe_commit(value: object) -> Optional[str]:
+    candidate = _safe_structured_identifier(value)
+    if candidate is None:
+        return None
+    return candidate if _COMMIT_RE.fullmatch(candidate) else None
+
+
+def _safe_branch(value: object) -> Optional[str]:
+    candidate = _safe_structured_identifier(value)
+    if candidate is None:
+        return None
+    if not _BRANCH_RE.fullmatch(candidate) or ".." in candidate or candidate.startswith("/"):
+        return None
+    return candidate
+
+
+def _source_subscription_rows(conn, source: ProgressSource) -> list[sqlite3.Row]:
+    rows = conn.execute(
+        """
+        SELECT task_id, delivery_metadata FROM kanban_notify_subs
+         WHERE platform = ? AND chat_id = ? AND thread_id = ?
+         ORDER BY task_id ASC
+        """,
+        (source.platform, source.chat_id, source.thread_id or ""),
+    ).fetchall()
+    return list(rows)
+
+
+def _regular_file_signature(path: Path) -> tuple[int, int, int, int]:
+    file_stat = path.lstat()
+    if stat.S_ISLNK(file_stat.st_mode) or not stat.S_ISREG(file_stat.st_mode):
+        raise OSError("Kanban snapshot source must be a regular non-symlink file")
+    return (file_stat.st_dev, file_stat.st_ino, file_stat.st_size, file_stat.st_mtime_ns)
+
+
+def _optional_file_signature(path: Path) -> Optional[tuple[int, int, int, int]]:
+    try:
+        return _regular_file_signature(path)
+    except FileNotFoundError:
+        return None
+
+
+def _snapshot_source_state(
+    source: Path,
+) -> tuple[tuple[int, int, int, int], Optional[tuple[int, int, int, int]]]:
+    return _regular_file_signature(source), _optional_file_signature(Path(str(source) + "-wal"))
+
+
+def _copy_snapshot_file(
+    source: Path,
+    destination: Path,
+    expected: tuple[int, int, int, int],
+) -> None:
+    """Copy the captured byte extent, then perform one bounded EOF probe."""
+    expected_size = expected[2]
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(source, flags)
+    except OSError as exc:
+        raise _SnapshotChangedError("Kanban snapshot source changed before copy") from exc
+    try:
+        opened_stat = os.fstat(descriptor)
+        opened_signature = (
+            opened_stat.st_dev,
+            opened_stat.st_ino,
+            opened_stat.st_size,
+            opened_stat.st_mtime_ns,
+        )
+        if opened_signature != expected or not stat.S_ISREG(opened_stat.st_mode):
+            raise _SnapshotChangedError("Kanban snapshot source changed before copy")
+        remaining = expected_size
+        with destination.open("xb") as writer:
+            while remaining:
+                chunk = os.read(descriptor, min(_SNAPSHOT_COPY_CHUNK_BYTES, remaining))
+                if not chunk:
+                    raise _SnapshotChangedError(
+                        "Kanban snapshot source changed during copy"
+                    )
+                if writer.write(chunk) != len(chunk):
+                    raise OSError("Kanban snapshot destination write was incomplete")
+                remaining -= len(chunk)
+            if os.read(descriptor, 1):
+                raise _SnapshotChangedError("Kanban snapshot source changed during copy")
+
+        closed_stat = os.fstat(descriptor)
+        closed_signature = (
+            closed_stat.st_dev,
+            closed_stat.st_ino,
+            closed_stat.st_size,
+            closed_stat.st_mtime_ns,
+        )
+        try:
+            path_signature = _regular_file_signature(source)
+        except OSError as exc:
+            raise _SnapshotChangedError("Kanban snapshot source changed after copy") from exc
+        if closed_signature != expected or path_signature != expected:
+            raise _SnapshotChangedError("Kanban snapshot source changed after copy")
+    finally:
+        os.close(descriptor)
+    if destination.stat().st_size != expected_size:
+        raise _SnapshotChangedError("Kanban snapshot source changed during copy")
+
+
+@contextmanager
+def _open_existing_board_readonly(board: str):
+    """Query a validated private DB+WAL snapshot without opening the source DB."""
+    source = configured_board_db_path(board)
+    wal_source = Path(str(source) + "-wal")
+
+    for _attempt in range(_SNAPSHOT_ATTEMPTS):
+        before = _snapshot_source_state(source)
+        total_size = before[0][2] + (before[1][2] if before[1] is not None else 0)
+        if total_size > _MAX_SNAPSHOT_BYTES:
+            raise OSError("Kanban snapshot exceeds the bounded copy limit")
+
+        with tempfile.TemporaryDirectory(prefix="hermes-progress-") as temp_dir:
+            try:
+                snapshot = Path(temp_dir) / "kanban.db"
+                _copy_snapshot_file(source, snapshot, before[0])
+                if before[1] is not None:
+                    _copy_snapshot_file(wal_source, Path(str(snapshot) + "-wal"), before[1])
+                if _snapshot_source_state(source) != before:
+                    raise _SnapshotChangedError(
+                        "Kanban board changed during snapshot copy"
+                    )
+
+            except _SnapshotChangedError:
+                continue
+
+            conn = sqlite3.connect(snapshot.as_uri() + "?mode=ro", uri=True)
+            try:
+                conn.row_factory = sqlite3.Row
+                checks = conn.execute("PRAGMA quick_check").fetchall()
+                if not checks or any(str(row[0]).casefold() != "ok" for row in checks):
+                    raise sqlite3.DatabaseError("Kanban snapshot integrity check failed")
+                yield conn
+                return
+            finally:
+                conn.close()
+    raise OSError("Kanban board changed during bounded snapshot attempts")
+
+
+def _roots_for_tasks(conn, task_ids: Iterable[str]) -> list[str]:
+    """Walk parent links so child subscriptions still recall their root graph."""
+    from hermes_cli import kanban_db as kb
+
+    roots: set[str] = set()
+    for task_id in task_ids:
+        seen: set[str] = set()
+        frontier = [task_id]
+        terminal: set[str] = set()
+        while frontier and len(seen) < _MAX_GRAPH_TASKS:
+            current = frontier.pop()
+            if current in seen:
+                continue
+            seen.add(current)
+            parents = kb.parent_ids(conn, current)
+            if not parents:
+                terminal.add(current)
+            else:
+                frontier.extend(parents)
+        roots.update(terminal)
+    return sorted(roots)
+
+
+def _graph_task_ids(conn, root_id: str) -> tuple[list[str], bool]:
+    """Return bounded graph IDs and whether unvisited descendants remain."""
+    from hermes_cli import kanban_db as kb
+
+    ordered: list[str] = []
+    seen: set[str] = set()
+    frontier = [root_id]
+    while frontier and len(ordered) < _MAX_GRAPH_TASKS:
+        task_id = frontier.pop(0)
+        if task_id in seen:
+            continue
+        seen.add(task_id)
+        ordered.append(task_id)
+        frontier.extend(kb.child_ids(conn, task_id))
+    truncated = any(task_id not in seen for task_id in frontier)
+    return ordered, truncated
+
+
+def _query_terms(request: str) -> set[str]:
+    without_card_ids = _TASK_ID_RE.sub(" ", request.casefold())
+    return {
+        word for word in _WORD_RE.findall(without_card_ids)
+        if word not in _STOP_WORDS
+    }
+
+
+def _root_has_trusted_linkage(
+    conn,
+    root_id: str,
+    source: ProgressSource,
+    subscription_rows: list[sqlite3.Row],
+) -> bool:
+    """Bind a generic follow-up to structured reply provenance only."""
+    from hermes_cli import kanban_db as kb
+
+    graph_ids = set(_graph_task_ids(conn, root_id)[0])
+    reply_id = str(source.reply_to_message_id or "")
+    if not reply_id:
+        return False
+    for row in subscription_rows:
+        if str(row["task_id"]) not in graph_ids:
+            continue
+        try:
+            metadata = json.loads(row["delivery_metadata"] or "{}")
+        except (TypeError, ValueError, json.JSONDecodeError):
+            metadata = {}
+        if isinstance(metadata, dict) and any(
+            str(metadata.get(key) or "") == reply_id
+            for key in ("origin_message_id", "message_id", "reply_to_message_id", "prompt_message_id")
+        ):
+            return True
+    for task_id in graph_ids:
+        task = kb.get_task(conn, task_id)
+        key = str(task.idempotency_key or "") if task is not None else ""
+        if (
+            task is not None
+            and task.created_by == "specialist-routing"
+            and key.startswith("specialist-routing:")
+            and key.rsplit(":", 1)[-1] == reply_id
+        ):
+            return True
+    return False
+
+
+def _select_root(
+    conn,
+    root_ids: list[str],
+    query: _ParsedProgressQuery,
+    *,
+    source: ProgressSource,
+    subscription_rows: list[sqlite3.Row],
+):
+    """Return one fully topic-bound root, or ambiguity. Never guess ties."""
+    from hermes_cli import kanban_db as kb
+
+    topic = query.topic or ""
+    explicit_ids = {match.casefold() for match in _TASK_ID_RE.findall(topic)}
+    terms = _query_terms(topic)
+    ranked = []
+    for root_id in root_ids:
+        graph_ids, _truncated = _graph_task_ids(conn, root_id)
+        tasks = [kb.get_task(conn, task_id) for task_id in graph_ids]
+        tasks = [task for task in tasks if task is not None]
+        graph_id_set = {task.id.casefold() for task in tasks}
+        title_words = (
+            set().union(*(_query_terms(task.title) for task in tasks))
+            if tasks
+            else set()
+        )
+        ids_explained = explicit_ids <= graph_id_set
+        terms_explained = terms <= title_words
+        score = len(terms) + (100 * len(explicit_ids))
+        if not (score and ids_explained and terms_explained):
+            score = 0
+        if score:
+            root = kb.get_task(conn, root_id)
+            if root is not None:
+                ranked.append((score, root.created_at, root))
+
+    if not ranked:
+        if query.topic is None:
+            linked = [
+                kb.get_task(conn, root_id)
+                for root_id in root_ids
+                if _root_has_trusted_linkage(
+                    conn, root_id, source, subscription_rows
+                )
+            ]
+            linked = [task for task in linked if task is not None]
+            if len(linked) == 1:
+                return "resolved", linked[0]
+            if len(linked) > 1:
+                return "ambiguous", linked
+        return "no_match", None
+    top_score = max(item[0] for item in ranked)
+    top = [item for item in ranked if item[0] == top_score]
+    if len(top) != 1:
+        return "ambiguous", [item[2] for item in sorted(top, key=lambda item: (-item[1], item[2].id))]
+    return "resolved", top[0][2]
+
+
+def _task_receipt(
+    conn, task
+) -> tuple[Optional[tuple[int, int, int]], Optional[str], list[str]]:
+    """Read the newest safe receipt key plus structured commit identities."""
+    from hermes_cli import kanban_db as kb
+
+    receipt = None
+    receipt_key = None
+    commits: list[str] = []
+    branch = _safe_branch(task.branch_name)
+    if branch:
+        commits.append(f"branch {branch}")
+    for run in kb.list_runs(conn, task.id):
+        candidate = _safe_text(run.summary or run.error)
+        key = (
+            run.ended_at if run.ended_at is not None else run.started_at,
+            run.started_at,
+            run.id,
+        )
+        if candidate and (receipt_key is None or key > receipt_key):
+            receipt = candidate
+            receipt_key = key
+        metadata = run.metadata if isinstance(run.metadata, dict) else {}
+        commit = _safe_commit(metadata.get("commit") or metadata.get("commit_sha"))
+        if commit:
+            commits.append(f"commit {commit}")
+        run_branch = _safe_branch(metadata.get("branch") or metadata.get("branch_name"))
+        if run_branch:
+            commits.append(f"branch {run_branch}")
+    return receipt_key, receipt, list(dict.fromkeys(commits))
+
+
+def _bounded(response: str) -> str:
+    return response if len(response) <= MAX_PROGRESS_RESPONSE_CHARS else response[:MAX_PROGRESS_RESPONSE_CHARS].rstrip()
+
+
+def _format_multiple_progress(conn, roots: Iterable[object]) -> str:
+    """Summarize source-authorized matching roots without requiring card IDs."""
+    selected = list(roots)[:_MAX_AMBIGUOUS_ROOTS]
+    if not selected:
+        return ""
+    heading = f"I found {len(selected)} matching subscribed workstreams."
+    per_root_limit = max(
+        240,
+        (MAX_PROGRESS_RESPONSE_CHARS - len(heading) - len(selected)) // len(selected),
+    )
+    summaries = []
+    for root in selected:
+        summary = _format_progress(conn, root)
+        if len(summary) > per_root_limit:
+            summary = summary[:per_root_limit].rstrip()
+        summaries.append(summary)
+    return _bounded(" ".join((heading, *summaries)))
+
+
+def _failed_run_attempt_count(conn, tasks: Iterable[object]) -> int:
+    """Count failed execution attempts once per run row, including retries.
+
+    ``task_runs.outcome`` is the semantic authority when present; ``status``
+    is its legacy fallback. A row whose outcome and status both name failure
+    still contributes one attempt, while separate retry rows each contribute
+    their own attempt.
+    """
+    from hermes_cli import kanban_db as kb
+
+    failed = 0
+    for task in tasks:
+        for run in kb.list_runs(conn, task.id):
+            state = str(run.outcome or run.status or "").casefold()
+            failed += state in _FAILED_RUN_STATES
+    return failed
+
+
+def _format_progress(conn, root) -> str:
+    from hermes_cli import kanban_db as kb
+
+    graph_ids, truncated = _graph_task_ids(conn, root.id)
+    tasks = [kb.get_task(conn, task_id) for task_id in graph_ids]
+    tasks = [task for task in tasks if task is not None]
+    completed = sum(task.status == "done" for task in tasks)
+    failed_attempts = _failed_run_attempt_count(conn, tasks)
+    blocked = sum(task.status == "blocked" for task in tasks)
+    running = sum(task.status == "running" for task in tasks)
+    next_tasks = [task for task in tasks if task.status in _NONTERMINAL_STATUSES]
+    next_tasks.sort(key=lambda task: (task.priority * -1, task.created_at, task.id))
+
+    failure_label = "failed attempt" if failed_attempts == 1 else "failed attempts"
+    lines = [
+        f"Progress for `{root.id}` — {_safe_text(root.title, limit=160)}: "
+        f"{completed} completed, {failed_attempts} {failure_label}, "
+        f"{blocked} blocked, {running} running."
+    ]
+    if truncated:
+        lines.append(
+            f"Scope: counts and receipt cover only the first {len(tasks)} tasks "
+            "in this bounded graph traversal."
+        )
+    if next_tasks:
+        next_text = "; ".join(
+            f"`{task.id}` {_safe_text(task.title, limit=100)} ({task.status})"
+            for task in next_tasks[:_MAX_NEXT_TASKS]
+        )
+        next_label = (
+            f"Next (partial; first {len(tasks)} tasks only)" if truncated else "Next"
+        )
+        lines.append(f"{next_label}: {next_text}.")
+
+    receipt = None
+    identifiers: list[str] = []
+    receipt_task_id = None
+    receipt_key = None
+    latest_comment = None
+    for task in tasks:
+        task_receipt_key, task_receipt, task_identifiers = _task_receipt(conn, task)
+        if task_receipt and (receipt_key is None or task_receipt_key > receipt_key):
+            receipt_key = task_receipt_key
+            receipt = task_receipt
+            receipt_task_id = task.id
+        identifiers.extend(task_identifiers)
+        for comment in kb.list_comments(conn, task.id):
+            candidate_key = (comment.created_at, comment.id)
+            if latest_comment is None or candidate_key > (latest_comment.created_at, latest_comment.id):
+                latest_comment = comment
+    if receipt and receipt_task_id:
+        if truncated:
+            lines.append(
+                f"Newest receipt within first {len(tasks)} tasks for "
+                f"`{receipt_task_id}`: {receipt}"
+            )
+        else:
+            lines.append(f"Latest receipt for `{receipt_task_id}`: {receipt}")
+    if identifiers:
+        lines.append("Structured metadata: " + ", ".join(dict.fromkeys(identifiers)) + ".")
+    if latest_comment is not None:
+        if truncated:
+            lines.append(
+                f"Newest note within first {len(tasks)} tasks: "
+                + _safe_text(latest_comment.body)
+                + "."
+            )
+        else:
+            lines.append("Latest note: " + _safe_text(latest_comment.body) + ".")
+    return _bounded(" ".join(lines))
+
+
+def resolve_progress_query(
+    request: object,
+    *,
+    source: ProgressSource,
+    board: object,
+) -> ProgressQueryResult:
+    """Resolve a project-status question from one configured board, or fall through.
+
+    The query executes no model/tool/git action and makes no Kanban mutation.
+    Only a valid configured board and exact trusted source subscription enter the
+    lookup path. Database failures deliberately preserve ordinary chat.
+    """
+    parsed = _parse_progress_query(request)
+    if parsed is None:
+        return ProgressQueryResult(False, "", "irrelevant")
+    if (
+        not isinstance(board, str)
+        or not _BOARD_RE.fullmatch(board)
+        or not source.platform
+        or not source.chat_id
+    ):
+        return ProgressQueryResult(False, "", "unavailable")
+    try:
+        with _open_existing_board_readonly(board) as conn:
+            subscription_rows = _source_subscription_rows(conn, source)
+            subscribed_ids = [str(row["task_id"]) for row in subscription_rows]
+            root_ids = _roots_for_tasks(conn, subscribed_ids)
+            if not root_ids:
+                return ProgressQueryResult(False, "", "no_match")
+            selection, value = _select_root(
+                conn,
+                root_ids,
+                parsed,
+                source=source,
+                subscription_rows=subscription_rows,
+            )
+            if selection == "no_match":
+                return ProgressQueryResult(False, "", "no_match")
+            if selection == "ambiguous":
+                return ProgressQueryResult(
+                    True,
+                    _format_multiple_progress(conn, value),
+                    "resolved_multiple",
+                )
+            return ProgressQueryResult(True, _format_progress(conn, value), "resolved")
+    except Exception:
+        return ProgressQueryResult(False, "", "unavailable")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5534,7 +5534,28 @@ class TurnRunner:
         if cfg_channel_prompt:
             combined_ephemeral = (combined_ephemeral + "\n\n" + cfg_channel_prompt).strip()
 
+        voice_fast_lane = bool(getattr(ctx.source, "_voice_fast_lane", False))
+        voice_fast_lane_task = (
+            voice_fast_lane
+            and self._runner._voice_fast_lane_requests_work(ctx.message or "")
+        )
+        if voice_fast_lane:
+            if voice_fast_lane_task:
+                lane_prompt = (
+                    "[Voice fast lane: the user explicitly requested work. "
+                    "Proceed normally, but acknowledge the task briefly before details.]"
+                )
+            else:
+                lane_prompt = (
+                    "[Voice fast lane: answer in one to three brief, natural spoken "
+                    "sentences. Do not offer or attempt tools, background work, or a "
+                    "multi-step plan unless the user explicitly asks you to perform work.]"
+                )
+            combined_ephemeral = (combined_ephemeral + "\n\n" + lane_prompt).strip()
+
         max_iterations = _current_max_iterations()
+        if voice_fast_lane and not voice_fast_lane_task:
+            max_iterations = min(max_iterations, 2)
 
         try:
             model, runtime_kwargs = self._runner._resolve_session_agent_runtime(
@@ -5677,6 +5698,10 @@ class TurnRunner:
         _plat_gw_cfg = _platforms_gw_cfg.get(platform_key) or {}
         _skip_context = _plat_gw_cfg.get("skip_context_files")
         skip_context_files = bool(_skip_context) if _skip_context is not None else False
+        if voice_fast_lane and not voice_fast_lane_task:
+            # The persona remains loaded, while expensive project-context
+            # discovery stays out of short spoken exchanges.
+            skip_context_files = True
 
         # Check agent cache — reuse the AIAgent from the previous message
         # in this session to preserve the frozen system prompt and tool
@@ -10491,6 +10516,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         _busy_state = self._peek_session_state(session_key)
         running_agent = _busy_state.turn.agent if _busy_state else None
+
+        # Discord's voice fast lane always queues a later utterance. The
+        # global default is intentionally interrupt for typed correction
+        # workflows, but speech often arrives in several STT chunks and an
+        # interrupt here otherwise discards a nearly-complete spoken answer.
+        # The FIFO retains MessageType.VOICE so the eventual reply still goes
+        # through TTS. Explicit /stop and /new take their separate command
+        # path before this handler and remain forceful controls.
+        if self._is_voice_fast_lane_event(event):
+            self._queue_or_replace_pending_event(session_key, event)
+            logger.info("Queued voice fast-lane follow-up for busy session %s", session_key)
+            return True
 
         busy_text_mode = self._effective_busy_text_mode(event.source)
         if (
@@ -22313,6 +22350,75 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         recent_store[key] = recent[-5:]
         return False
 
+    @staticmethod
+    def _voice_fast_lane_requests_work(transcript: str) -> bool:
+        """Return True only for an explicit operational request in voice.
+
+        The voice fast lane is deliberately fail-closed: ordinary conversation
+        gets no tool schemas, which avoids model tool loops and makes the
+        prompt much smaller. Operators retain a natural escape hatch by plainly
+        asking Hermes to inspect, change, test, or otherwise perform work.
+        This is a routing guard, not an authorization grant; normal tool
+        approvals and platform permissions still apply.
+        """
+        text = (transcript or "").strip().lower()
+        if not text:
+            return False
+        return bool(
+            re.search(
+                r"\b(?:analy[sz]e|build|change|check|commit|configure|create|"
+                r"debug|deploy|diagnose|edit|fix|implement|inspect|install|"
+                r"investigate|look\s+up|merge|patch|pull|push|review|run|"
+                r"search|test|update|write)\b",
+                text,
+            )
+        )
+
+    @staticmethod
+    def _voice_fast_lane_config() -> dict:
+        """Read the optional Discord-only voice fast-lane configuration."""
+        try:
+            config = _load_gateway_config()
+        except Exception:
+            return {}
+        discord = config.get("discord") if isinstance(config, dict) else None
+        if not isinstance(discord, dict):
+            return {}
+        policy = discord.get("voice_fast_lane")
+        return dict(policy) if isinstance(policy, dict) else {}
+
+    def _voice_fast_lane_matches(
+        self, adapter, guild_id: int, user_id: int
+    ) -> tuple[bool, str]:
+        """Match an inbound speaker to the configured Discord voice fast lane.
+
+        Matching requires the exact configured voice channel and an allowlisted
+        speaker. Missing/malformed config or incomplete Discord state disables
+        the lane rather than broadening it to another guild/channel.
+        """
+        policy = self._voice_fast_lane_config()
+        if policy.get("enabled") is not True:
+            return False, ""
+        channel_id = str(policy.get("channel_id") or "").strip()
+        user_ids = policy.get("user_ids")
+        if not channel_id or not isinstance(user_ids, list):
+            return False, ""
+        if str(user_id) not in {str(item) for item in user_ids}:
+            return False, ""
+        clients = getattr(adapter, "_voice_clients", None)
+        client = clients.get(guild_id) if isinstance(clients, dict) else None
+        actual_channel_id = str(getattr(getattr(client, "channel", None), "id", "") or "")
+        if actual_channel_id != channel_id:
+            return False, ""
+        return True, channel_id
+
+    @staticmethod
+    def _is_voice_fast_lane_event(event: MessageEvent) -> bool:
+        return bool(
+            getattr(event, "message_type", None) == MessageType.VOICE
+            and getattr(getattr(event, "source", None), "_voice_fast_lane", False)
+        )
+
     async def _handle_voice_channel_input(
         self, guild_id: int, user_id: int, transcript: str
     ):
@@ -22389,6 +22495,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             raw_message=SimpleNamespace(guild_id=guild_id, guild=None),
             channel_prompt=channel_prompt,
         )
+
+        fast_lane, voice_channel_id = self._voice_fast_lane_matches(
+            adapter, guild_id, user_id
+        )
+        if fast_lane:
+            # Keep delivery in the bound text channel while assigning this
+            # spoken conversation its own small session. These are private
+            # transport hints and intentionally do not serialize with Source.
+            source._voice_fast_lane = True
+            source._session_key_lane = f"discord-voice:{voice_channel_id}"
+            event.metadata["voice_fast_lane"] = True
+            logger.info(
+                "Voice fast lane enabled for guild=%s channel=%s user=%s",
+                guild_id,
+                voice_channel_id,
+                user_id,
+            )
 
         await adapter.handle_message(event)
 
@@ -28492,6 +28615,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         from agent.skill_utils import parse_config_string_list
 
         disabled_toolsets = parse_config_string_list(agent_cfg_local.get("disabled_toolsets")) or None
+        if (
+            bool(getattr(source, "_voice_fast_lane", False))
+            and not self._voice_fast_lane_requests_work(message)
+        ):
+            # No autonomous tool loop for conversational voice. An explicit
+            # operation request retains the configured Discord toolsets and
+            # every downstream approval/authorization guard.
+            enabled_toolsets = []
 
         display_config = user_config.get("display", {})
         if not isinstance(display_config, dict):

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1208,6 +1208,16 @@ def build_session_key(
     if isolate_user and participant_id:
         key_parts.append(str(participant_id))
 
+    # A receiving adapter may attach a private lane marker for a distinct
+    # conversational surface that still replies through the same platform
+    # channel (for example, the Discord voice fast lane). Keep it out of
+    # SessionSource serialization and delivery metadata: it affects only
+    # durable conversation identity, so a short spoken exchange cannot pull
+    # a long text-task transcript into its prompt.
+    lane = str(getattr(source, "_session_key_lane", "") or "").strip()
+    if lane:
+        key_parts.extend(("lane", lane))
+
     return ":".join(str(part) for part in key_parts)
 
 
@@ -2164,10 +2174,17 @@ class SessionStore:
         resurrected as freshly active.
         """
         legacy_key = self._legacy_slack_session_key(source)
+        # A private lane is an intentional conversation boundary.  Its key
+        # may share platform/chat/user fields with an ordinary session, but a
+        # peer fallback would silently reattach the old transcript and defeat
+        # the boundary (notably the Discord voice fast lane).
+        allow_peer_fallback = legacy_key is None and not bool(
+            getattr(source, "_session_key_lane", "")
+        )
         recovered = self._find_gateway_session_row(
             session_key=session_key,
             source=source,
-            allow_peer_fallback=legacy_key is None,
+            allow_peer_fallback=allow_peer_fallback,
             raise_on_lookup_error=raise_on_lookup_error,
         )
         migrated_legacy = False
@@ -2243,10 +2260,15 @@ class SessionStore:
         evaluates the reset policy first and decides reset vs resume.
         """
         legacy_key = self._legacy_slack_session_key(source)
+        # See _recover_session_from_db: private lanes must only recover an
+        # exact matching key, never a same-peer transcript.
+        allow_peer_fallback = legacy_key is None and not bool(
+            getattr(source, "_session_key_lane", "")
+        )
         recovered = self._find_gateway_session_row(
             session_key=session_key,
             source=source,
-            allow_peer_fallback=legacy_key is None,
+            allow_peer_fallback=allow_peer_fallback,
         )
         migrated_legacy = False
         if (

--- a/gateway/specialist_handoff.py
+++ b/gateway/specialist_handoff.py
@@ -1,0 +1,114 @@
+"""Transactional, deterministic Kanban handoff for specialist routing."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Optional
+
+from gateway.configured_board import configured_board_db_path
+from gateway.specialist_routing import SpecialistRouteDecision
+
+
+_ORCHESTRATION_GOAL_MAX_TURNS = 12
+
+
+@dataclass(frozen=True)
+class HandoffSource:
+    """Trusted source fields needed to create a task notification route."""
+
+    platform: str
+    chat_id: str
+    chat_type: str
+    user_id: Optional[str]
+    message_id: str
+    guild_id: Optional[str] = None
+    thread_id: Optional[str] = None
+    user_id_alt: Optional[str] = None
+    notifier_profile: Optional[str] = None
+    session_id: Optional[str] = None
+    delivery_metadata: Optional[dict] = None
+
+
+@dataclass(frozen=True)
+class HandoffResult:
+    ok: bool
+    task_id: Optional[str] = None
+    created: bool = False
+    reason: str = ""
+
+
+def _idempotency_key(source: HandoffSource) -> Optional[str]:
+    if not source.message_id or not source.platform or not source.chat_id:
+        return None
+    return "specialist-routing:" + ":".join(
+        (source.platform, source.guild_id or "", source.chat_id, source.thread_id or "", source.message_id)
+    )
+
+
+def _body(*, decision: SpecialistRouteDecision, source: HandoffSource, request: str, router_model: str) -> str:
+    return json.dumps(
+        {
+            "schema": "specialist_routing.v1",
+            "request": request[:4_000],
+            "profile": decision.profile,
+            "confidence": decision.confidence,
+            "reason": decision.reason,
+            "router_model": router_model or "configured_auxiliary",
+            "ingress": {
+                "platform": source.platform,
+                "guild_id": source.guild_id,
+                "chat_id": source.chat_id,
+                "thread_id": source.thread_id,
+                "message_id": source.message_id,
+                "user_id": source.user_id,
+            },
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+
+
+def create_specialist_handoff(*, decision: SpecialistRouteDecision, source: HandoffSource, request: str, router_model: str = "", board: Optional[str] = None) -> HandoffResult:
+    """Create a subscribed, durable triage root for specialist orchestration."""
+    if not decision.dispatches:
+        return HandoffResult(False, reason="non_dispatch_decision")
+    if not source.platform or not source.chat_id or not source.message_id:
+        return HandoffResult(False, reason="incomplete_source")
+    if not isinstance(request, str) or not request.strip():
+        return HandoffResult(False, reason="empty_request")
+    try:
+        from hermes_cli import kanban_db as kb
+
+        key = _idempotency_key(source)
+        conn = kb.connect(db_path=configured_board_db_path(board), board=board)
+        try:
+            existing_id = None
+            if key:
+                row = conn.execute(
+                    "SELECT id FROM tasks WHERE idempotency_key = ? AND status != 'archived' ORDER BY created_at DESC LIMIT 1",
+                    (key,),
+                ).fetchone()
+                existing_id = row["id"] if row else None
+            with kb.write_txn(conn):
+                task_id = kb.create_task(
+                    conn, title=decision.title,
+                    body=_body(decision=decision, source=source, request=request, router_model=router_model),
+                    assignee=decision.profile, created_by="specialist-routing",
+                    idempotency_key=key, session_id=source.session_id, board=board,
+                    triage=True,
+                    goal_mode=True,
+                    goal_max_turns=_ORCHESTRATION_GOAL_MAX_TURNS,
+                )
+                kb.add_notify_sub(
+                    conn, task_id=task_id, platform=source.platform, chat_id=source.chat_id,
+                    chat_type=source.chat_type, thread_id=source.thread_id,
+                    user_id=source.user_id, user_id_alt=source.user_id_alt,
+                    notifier_profile=source.notifier_profile, delivery_mode="notify",
+                    delivery_metadata=source.delivery_metadata, allow_nested=True,
+                )
+            return HandoffResult(True, task_id=task_id, created=existing_id is None)
+        finally:
+            conn.close()
+    except Exception as exc:
+        return HandoffResult(False, reason=f"handoff_error:{type(exc).__name__}")

--- a/gateway/specialist_routing.py
+++ b/gateway/specialist_routing.py
@@ -1,0 +1,212 @@
+"""Fail-closed natural-language routing for guarded Kanban specialists.
+
+This module deliberately owns no Discord, database, or provider state. It
+turns a bounded auxiliary-model answer into a typed decision; the caller owns
+all side effects. Invalid answers always fall through to normal chat.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import math
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Awaitable, Callable, Optional
+
+
+SPECIALIST_PROFILES: dict[str, str] = {
+    "task-orchestrator": "broad actionable work needing a plan, specialist handoffs, and final verification",
+    "burndown-patch-steward": "exception burndowns and narrow corrective patches",
+    "acceptance-gate-verifier": "acceptance evidence and release-gate verification",
+    "paper-safety-guardian": "paper-trading safety and live-boundary review",
+    "market-data-authority-auditor": "market-data authority, freshness, and provenance",
+    "route-execution-boundary-auditor": "route and execution-boundary verification",
+    "dependency-tooling-health-sentinel": "dependency and development-tooling health",
+    "copilot-learning-steward": "governed Luna copilot learning and memory",
+    "mission-control-ux-auditor": "Mission Control operator UX evidence",
+    "research-scout": "read-only research and evidence gathering",
+    "performance-sentinel": "performance and latency diagnostics",
+}
+
+_RESPONSE_FIELDS = frozenset({"kind", "profile", "confidence", "reason", "title"})
+_MAX_REQUEST_CHARS = 4_000
+_MAX_REASON_CHARS = 500
+_MAX_TITLE_CHARS = 160
+
+
+class RouteKind(str, Enum):
+    SPECIALIST = "specialist"
+    GENERAL = "general"
+    CLARIFY = "clarify"
+
+
+@dataclass(frozen=True)
+class SpecialistRouteDecision:
+    """One fail-closed classifier decision suitable for gateway audit logs."""
+
+    kind: RouteKind
+    profile: Optional[str] = None
+    confidence: Optional[float] = None
+    reason: str = ""
+    title: str = ""
+    audit_reason: str = ""
+
+    @property
+    def dispatches(self) -> bool:
+        return self.kind is RouteKind.SPECIALIST and self.profile is not None
+
+
+def _general(audit_reason: str) -> SpecialistRouteDecision:
+    return SpecialistRouteDecision(kind=RouteKind.GENERAL, audit_reason=audit_reason)
+
+
+def classify_explicit_burndown_patch_request(request: str) -> Optional[SpecialistRouteDecision]:
+    """Route the one unambiguous exception-burndown instruction without an LLM.
+
+    This is intentionally narrower than natural-language routing in general.
+    When the local classifier is occupied by a long-running model request, an
+    explicit request to perform an exception burndown *and* patch confirmed
+    failures must not fall through to the general chat agent and duplicate the
+    work.  Ordinary questions about exceptions, burndowns, or patches remain
+    model-classified (or normal chat).
+    """
+    if not isinstance(request, str):
+        return None
+    normalized = " ".join(request.casefold().split())
+    if (
+        "exception" not in normalized
+        or "burndown" not in normalized
+        or re.search(r"\bpatch(?:es|ed|ing)?\b", normalized) is None
+    ):
+        return None
+    return SpecialistRouteDecision(
+        kind=RouteKind.SPECIALIST,
+        profile="burndown-patch-steward",
+        confidence=1.0,
+        reason="explicit exception burndown and patch request",
+        title="Narrow Exception Burndown and Patching",
+        audit_reason="deterministic_burndown_patch",
+    )
+
+
+def build_classifier_messages(request: str) -> list[dict[str, str]]:
+    """Build a cache-independent, tool-free JSON-only auxiliary request."""
+    routes = "\n".join(
+        f"- {name}: {description}" for name, description in SPECIALIST_PROFILES.items()
+    )
+    system = (
+        "Classify whether the authorized user's message is a bounded task for one "
+        "specialist route. Do not use tools and do not answer the request. Return exactly "
+        "one JSON object with only these fields: kind, profile, confidence, reason, "
+        "title. kind must be specialist, general, or clarify. Use specialist only "
+        "when exactly one listed profile clearly owns an actionable task. Route broad "
+        "multi-step work with no narrower owner to task-orchestrator. Keep ordinary "
+        "conversation, questions, and requests lacking an actionable outcome as general. "
+        "For specialist, title "
+        "must be a short non-empty task title. For general or clarify "
+        "set profile to null, confidence to 0, and title to an empty string. "
+        "Do not infer missing scope or turn ordinary conversation into a task.\n\n"
+        f"Available specialists:\n{routes}"
+    )
+    return [
+        {"role": "system", "content": system},
+        {"role": "user", "content": request[:_MAX_REQUEST_CHARS]},
+    ]
+
+
+def parse_specialist_response(
+    raw: str, *, threshold: float = 0.80, fallback_title: str = ""
+) -> SpecialistRouteDecision:
+    """Validate an untrusted classifier answer without repair or coercion."""
+    if not isinstance(raw, str):
+        return _general("invalid_classifier_output")
+    try:
+        value = json.loads(raw)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return _general("malformed_json")
+    if not isinstance(value, dict):
+        return _general("invalid_classifier_output")
+    if set(value) != _RESPONSE_FIELDS:
+        return _general("unexpected_fields")
+
+    kind_value = value.get("kind")
+    try:
+        kind = RouteKind(kind_value)
+    except (TypeError, ValueError):
+        return _general("invalid_kind")
+
+    profile = value.get("profile")
+    confidence = value.get("confidence")
+    reason = value.get("reason")
+    title = value.get("title")
+    if not isinstance(reason, str) or not reason.strip() or len(reason) > _MAX_REASON_CHARS:
+        return _general("invalid_reason")
+    if not isinstance(title, str) or len(title) > _MAX_TITLE_CHARS:
+        return _general("invalid_title")
+    if isinstance(confidence, bool) or not isinstance(confidence, (int, float)):
+        return _general("invalid_confidence")
+    confidence = float(confidence)
+    if not math.isfinite(confidence) or not 0.0 <= confidence <= 1.0:
+        return _general("invalid_confidence")
+
+    if kind is RouteKind.SPECIALIST:
+        if not isinstance(profile, str) or profile not in SPECIALIST_PROFILES:
+            return _general("unknown_profile")
+        if not title.strip():
+            title = " ".join(fallback_title.split())[:_MAX_TITLE_CHARS]
+            if not title:
+                return _general("invalid_title")
+        if confidence < threshold:
+            return _general("low_confidence")
+        return SpecialistRouteDecision(
+            kind=kind,
+            profile=profile,
+            confidence=confidence,
+            reason=reason.strip(),
+            title=title.strip(),
+            audit_reason="specialist",
+        )
+
+    if profile is not None or confidence != 0.0 or title:
+        return _general("inconsistent_non_specialist")
+    return SpecialistRouteDecision(
+        kind=kind,
+        reason=reason.strip(),
+        confidence=confidence,
+        audit_reason=kind.value,
+    )
+
+
+ClassifierCall = Callable[[list[dict[str, str]]], Awaitable[str]]
+
+
+async def classify_specialist_request(
+    request: str,
+    classifier: ClassifierCall,
+    *,
+    threshold: float = 0.80,
+    timeout: float = 12.0,
+) -> SpecialistRouteDecision:
+    """Run one bounded classifier call and turn every failure into fallback."""
+    if not isinstance(request, str) or not request.strip():
+        return _general("empty_request")
+    explicit_burndown = classify_explicit_burndown_patch_request(request)
+    if explicit_burndown is not None:
+        return explicit_burndown
+    if not callable(classifier):
+        return _general("classifier_unavailable")
+    try:
+        pending = classifier(build_classifier_messages(request))
+        if not inspect.isawaitable(pending):
+            return _general("invalid_classifier_output")
+        raw = await asyncio.wait_for(pending, timeout=max(0.01, float(timeout)))
+    except asyncio.TimeoutError:
+        return _general("classifier_timeout")
+    except Exception:
+        return _general("classifier_error")
+    if not isinstance(raw, str):
+        return _general("invalid_classifier_output")
+    return parse_specialist_response(raw, threshold=threshold, fallback_title=request)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1173,6 +1173,17 @@ DEFAULT_CONFIG = {
             "extra_body": {},
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
         },
+        # Short, tool-free classifier used by explicitly opted-in specialist
+        # task routing. Invalid/unavailable results always fall back to chat.
+        "specialist_router": {
+            "provider": "auto",
+            "model": "",
+            "base_url": "",
+            "api_key": "",
+            "timeout": 12,
+            "extra_body": {},
+            "reasoning_effort": "none",
+        },
         # Kanban decomposer — decomposes a triage task into a graph of
         # child tasks routed to specialist profiles by description.
         # Invoked by ``hermes kanban decompose`` and the kanban
@@ -2268,6 +2279,14 @@ DEFAULT_CONFIG = {
         "bots_require_inline_mention": False,  # Multi-bot rooms: if True, another bot must type @thisbot in its message to trigger a reply; a Discord reply/quote alone won't. Prevents two bots auto-replying to each other forever. Does not affect humans.
         "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
         "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block
+        # Disabled by default. When enabled, only high-confidence bounded
+        # task requests create a subscribed Kanban card; all other messages
+        # retain the ordinary chat path.
+        "specialist_routing": {
+            "enabled": False,
+            "confidence_threshold": 0.80,
+            "timeout_seconds": 12,
+        },
         "missed_message_backfill": {
             "enabled": False,             # Replay missed Discord messages after reconnect/startup
             "channels": "",               # Comma-separated channel IDs; empty uses free_response_channels

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7370,7 +7370,7 @@ def decompose_triage_task(
     child_ids: list[str] = []
     with write_txn(conn):
         root_row = conn.execute(
-            "SELECT id, status, tenant, workspace_kind, workspace_path "
+            "SELECT id, status, tenant, workspace_kind, workspace_path, goal_mode, goal_max_turns, skills "
             "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
@@ -7385,6 +7385,13 @@ def decompose_triage_task(
         # override with its own 'workspace_kind' / 'workspace_path'.
         root_ws_kind = root_row["workspace_kind"] or "scratch"
         root_ws_path = root_row["workspace_path"]
+        # A goal-mode root represents a durable objective, not a one-shot
+        # dispatch.  Its children must keep the same continuation contract;
+        # otherwise the first fan-out silently loses the goal loop and the
+        # coordinator receives premature worker exits instead of handoffs.
+        root_goal_mode = 1 if root_row["goal_mode"] else 0
+        root_goal_max_turns = root_row["goal_max_turns"]
+        root_skills = root_row["skills"]
 
         # Create children. Status is 'todo' regardless of parents — we
         # link them under the root AFTER creation so the dispatcher
@@ -7419,8 +7426,8 @@ def decompose_triage_task(
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "
-                " workspace_path, tenant, created_at, created_by) "
-                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
+                " workspace_path, tenant, created_at, created_by, goal_mode, goal_max_turns, skills) "
+                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     new_id,
                     title,
@@ -7431,6 +7438,9 @@ def decompose_triage_task(
                     tenant,
                     now,
                     (author or "decomposer"),
+                    root_goal_mode,
+                    root_goal_max_turns,
+                    root_skills,
                 ),
             )
             _append_event(
@@ -11395,6 +11405,7 @@ def add_notify_sub(
     notifier_profile: Optional[str] = None,
     delivery_mode: Optional[str] = None,
     delivery_metadata: Optional[Mapping[str, Any]] = None,
+    allow_nested: bool = False,
 ) -> None:
     """Register a gateway source that wants terminal-state notifications
     for ``task_id``. Idempotent on (task, platform, chat, thread).
@@ -11437,7 +11448,10 @@ def add_notify_sub(
     insert_chat_type = chat_type or "dm"
     now = int(time.time())
     metadata_json = _encode_notify_delivery_metadata(delivery_metadata)
-    with write_txn(conn):
+    # A caller that creates a task and its notification subscription as one
+    # durable handoff may opt into savepoint composition. The default remains
+    # deliberately loud for accidental nested writes.
+    with write_txn(conn, allow_nested=allow_nested):
         conn.execute(
             """
             INSERT OR IGNORE INTO kanban_notify_subs

--- a/hermes_cli/projects_cmd.py
+++ b/hermes_cli/projects_cmd.py
@@ -330,6 +330,10 @@ def _sync_board_default_workdir(proj, board_slug: str) -> None:
             return
         if slug != kb.DEFAULT_BOARD and not kb.board_exists(slug):
             return
-        kb.write_board_metadata(slug, default_workdir=proj.primary_path)
+        kb.write_board_metadata(
+            slug,
+            default_workdir=proj.primary_path,
+            project_id=proj.id,
+        )
     except Exception:
         pass

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -797,6 +797,13 @@ class VoiceReceiver:
         if self._dave_session:
             with self._lock:
                 user_id = self._ssrc_to_user.get(ssrc, 0)
+            if not user_id:
+                # Discord may not resend SPEAKING after a voice reconnect.
+                # Infer a sole permitted member before decrypting the first
+                # packet; waiting until check_silence() is too late because
+                # DAVE ciphertext has already been sent through Opus decode
+                # and becomes a silent WAV that VAD correctly rejects.
+                user_id = self._infer_user_for_ssrc(ssrc)
             if user_id:
                 try:
                     import davey
@@ -1097,6 +1104,11 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_timeout_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> timeout task
         self._voice_timeout_seconds = self._load_voice_timeout()
         self._playback_timeout_seconds = self._load_playback_timeout()
+        (
+            self._voice_auto_join_channel_id,
+            self._voice_auto_join_user_ids,
+            self._voice_auto_join_text_channel_id,
+        ) = self._load_voice_auto_join_config()
         # Phase 2: voice listening
         self._voice_receivers: Dict[int, VoiceReceiver] = {}  # guild_id -> VoiceReceiver
         self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
@@ -1426,15 +1438,28 @@ class DiscordAdapter(BasePlatformAdapter):
             @self._client.event
             async def on_voice_state_update(member, before, after):
                 """Track voice channel join/leave events."""
-                # Only track channels where the bot is connected
-                bot_guild_ids = set(adapter_self._voice_clients.keys())
-                if not bot_guild_ids:
-                    return
                 guild_id = member.guild.id
-                if guild_id not in bot_guild_ids:
-                    return
-                # Ignore the bot itself
                 if member == adapter_self._client.user:
+                    # A move performed outside this adapter (for example from
+                    # Discord's UI or REST API) makes discord.py replace the
+                    # UDP packet reader while retaining the VoiceClient.  The
+                    # existing VoiceReceiver remains attached to the old
+                    # reader, so it can still see websocket SPEAKING events
+                    # but receives no audio packets.  Refresh the receiver
+                    # after discord.py has completed its reconnect.
+                    if before.channel != after.channel and after.channel is not None:
+                        asyncio.ensure_future(
+                            adapter_self._refresh_voice_receiver_after_forced_move(guild_id)
+                        )
+                    return
+
+                await adapter_self._auto_join_voice_for_member(member, before, after)
+
+                # Only log ordinary member state changes while the bot is in
+                # this guild. Auto-join above runs before this guard because
+                # it is how an initially disconnected bot enters the room.
+                bot_guild_ids = set(adapter_self._voice_clients.keys())
+                if guild_id not in bot_guild_ids:
                     return
 
                 joined = before.channel is None and after.channel is not None
@@ -2408,6 +2433,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not self._client:
             return
         try:
+            await self._auto_join_configured_voice_channel_if_user_present()
             sync_policy = self._get_discord_command_sync_policy()
             if sync_policy == "off":
                 logger.info("[%s] Skipping Discord slash command sync (policy=off)", self.name)
@@ -4355,6 +4381,33 @@ class DiscordAdapter(BasePlatformAdapter):
             minimum=0,
         )
 
+    def _load_voice_auto_join_config(self) -> tuple[Optional[int], set[str], Optional[int]]:
+        """Load the voice room, user allowlist, and optional text reply channel.
+
+        Both values must be valid. A partial or malformed configuration stays
+        disabled so Hermes can never join a room merely because voice-state
+        events are enabled.
+        """
+        try:
+            from hermes_cli.config import read_raw_config
+
+            discord_cfg = (read_raw_config() or {}).get("discord") or {}
+            channel_id = int(discord_cfg.get("voice_auto_join_channel_id"))
+            text_channel_id_raw = discord_cfg.get("voice_auto_join_text_channel_id")
+            text_channel_id = int(text_channel_id_raw) if text_channel_id_raw else None
+            raw_user_ids = discord_cfg.get("voice_auto_join_user_ids") or []
+            if isinstance(raw_user_ids, str):
+                raw_user_ids = raw_user_ids.split(",")
+            user_ids = {str(value).strip() for value in raw_user_ids if str(value).strip().isdigit()}
+            if channel_id <= 0 or not user_ids:
+                return None, set(), None
+            if text_channel_id is not None and text_channel_id <= 0:
+                text_channel_id = None
+            return channel_id, user_ids, text_channel_id
+        except Exception as e:
+            logger.debug("Could not load Discord voice auto-join config: %s", e)
+            return None, set(), None
+
     def _load_playback_timeout(self) -> int:
         """Return minimum playback wait seconds for Discord VC audio."""
         return self._load_discord_int_config(
@@ -4607,6 +4660,99 @@ class DiscordAdapter(BasePlatformAdapter):
                     logger.warning("Voice mixer failed to start: %s", e)
 
             return True
+
+    async def _refresh_voice_receiver_after_forced_move(self, guild_id: int) -> None:
+        """Attach a new packet receiver after discord.py reconnects a moved bot.
+
+        Discord can force-move a bot without going through ``move_to``.  In
+        that case the VoiceClient survives but its UDP SocketReader changes;
+        the previous VoiceReceiver must be stopped and reattached.
+        """
+        # Give discord.py's voice-state handler time to replace the transport.
+        await asyncio.sleep(0.5)
+        vc = self._voice_clients.get(guild_id)
+        if not vc or not vc.is_connected():
+            logger.warning("Voice receiver refresh skipped: no connected client for guild %s", guild_id)
+            return
+
+        previous_receiver = self._voice_receivers.pop(guild_id, None)
+        if previous_receiver:
+            previous_receiver.stop()
+        previous_task = self._voice_listen_tasks.pop(guild_id, None)
+        if previous_task:
+            previous_task.cancel()
+
+        try:
+            receiver = VoiceReceiver(vc, allowed_user_ids=self._allowed_user_ids)
+            receiver.start()
+            self._voice_receivers[guild_id] = receiver
+            self._voice_listen_tasks[guild_id] = asyncio.ensure_future(
+                self._voice_listen_loop(guild_id)
+            )
+            logger.info("Voice receiver refreshed after forced move (guild=%s)", guild_id)
+        except Exception as e:
+            logger.warning("Voice receiver refresh failed after forced move: %s", e)
+
+    async def _auto_join_voice_for_member(self, member, before, after) -> None:
+        """Join or leave the configured room when its configured user moves."""
+        channel_id = getattr(self, "_voice_auto_join_channel_id", None)
+        user_ids = getattr(self, "_voice_auto_join_user_ids", set())
+        if not channel_id or str(getattr(member, "id", "")) not in user_ids:
+            return
+
+        before_channel = getattr(before, "channel", None)
+        after_channel = getattr(after, "channel", None)
+        was_in_configured_channel = getattr(before_channel, "id", None) == channel_id
+        is_in_configured_channel = getattr(after_channel, "id", None) == channel_id
+
+        if is_in_configured_channel and not was_in_configured_channel:
+            text_channel_id = int(
+                getattr(self, "_voice_auto_join_text_channel_id", None) or channel_id
+            )
+            await self.join_voice_channel(
+                after_channel,
+                text_channel_id=text_channel_id,
+                source=self._voice_auto_join_source(text_channel_id, member.id),
+            )
+            return
+
+        if was_in_configured_channel and not is_in_configured_channel:
+            await self.leave_voice_channel(member.guild.id)
+
+    async def _auto_join_configured_voice_channel_if_user_present(self) -> None:
+        """Restore the configured voice session after Gateway startup."""
+        channel_id = getattr(self, "_voice_auto_join_channel_id", None)
+        user_ids = getattr(self, "_voice_auto_join_user_ids", set())
+        if not channel_id or not user_ids or not self._client:
+            return
+        channel = self._client.get_channel(channel_id)
+        if channel is None:
+            logger.warning("Configured voice auto-join channel %s is unavailable", channel_id)
+            return
+        for member in getattr(channel, "members", []):
+            if str(getattr(member, "id", "")) not in user_ids:
+                continue
+            text_channel_id = int(
+                getattr(self, "_voice_auto_join_text_channel_id", None) or channel_id
+            )
+            await self.join_voice_channel(
+                channel,
+                text_channel_id=text_channel_id,
+                source=self._voice_auto_join_source(text_channel_id, member.id),
+            )
+            return
+
+    @staticmethod
+    def _voice_auto_join_source(text_channel_id: int, user_id: int) -> Dict[str, str]:
+        """Build valid session metadata for a voice auto-join reply destination."""
+        user_id_str = str(user_id)
+        return {
+            "platform": Platform.DISCORD.value,
+            "chat_id": str(text_channel_id),
+            "user_id": user_id_str,
+            "user_name": user_id_str,
+            "chat_type": "channel",
+        }
 
     async def leave_voice_channel(self, guild_id: int) -> None:
         """Disconnect from the voice channel in a guild."""
@@ -6879,6 +7025,152 @@ class DiscordAdapter(BasePlatformAdapter):
         except (ValueError, TypeError):
             return 50
 
+    def _specialist_routing_settings(self) -> dict[str, Any]:
+        """Return validated, explicitly opt-in Discord specialist routing settings."""
+        raw = self.config.extra.get("specialist_routing")
+        if not isinstance(raw, dict):
+            return {"enabled": False}
+        enabled = raw.get("enabled", False)
+        if isinstance(enabled, str):
+            enabled = enabled.strip().lower() in {"true", "1", "yes", "on"}
+        if not enabled:
+            return {"enabled": False}
+        board = raw.get("board")
+        if not isinstance(board, str) or not board.strip():
+            return {"enabled": False}
+        board = board.strip()
+        try:
+            threshold = float(raw.get("confidence_threshold", 0.80))
+        except (TypeError, ValueError):
+            threshold = 0.80
+        if not math.isfinite(threshold) or not 0.0 <= threshold <= 1.0:
+            threshold = 0.80
+        try:
+            timeout = float(raw.get("timeout_seconds", 12))
+        except (TypeError, ValueError):
+            timeout = 12.0
+        return {"enabled": True, "confidence_threshold": threshold,
+                "timeout_seconds": max(1.0, min(30.0, timeout)),
+                "model": str(raw.get("model") or "").strip(), "board": board}
+
+    async def _maybe_answer_progress_event(self, event: MessageEvent) -> bool:
+        """Answer a source-scoped status question before model specialist routing."""
+        settings = self._specialist_routing_settings()
+        if not settings.get("enabled") or event.message_type is not MessageType.TEXT:
+            return False
+        if not (event.text or "").strip() or getattr(event.source, "is_bot", False):
+            return False
+        try:
+            from gateway.progress_queries import (
+                ProgressSource,
+                is_progress_query,
+                resolve_progress_query,
+            )
+
+            if not is_progress_query(event.text):
+                return False
+            platform = getattr(event.source.platform, "value", event.source.platform)
+            source = ProgressSource(
+                platform=str(platform),
+                chat_id=str(event.source.chat_id),
+                thread_id=(str(event.source.thread_id) if event.source.thread_id else None),
+                reply_to_message_id=(
+                    str(event.reply_to_message_id) if event.reply_to_message_id else None
+                ),
+            )
+            result = await asyncio.to_thread(
+                resolve_progress_query,
+                event.text,
+                source=source,
+                board=settings["board"],
+            )
+        except Exception:
+            logger.warning("[Discord] progress query lookup failed", exc_info=True)
+            return False
+        if not result.handled:
+            return False
+        await self.send(event.source.chat_id, content=result.response, reply_to=event.message_id)
+        return True
+
+    async def _classify_specialist_event(self, event: MessageEvent):
+        """Ask the bounded auxiliary router for one typed routing decision."""
+        settings = self._specialist_routing_settings()
+        from agent.auxiliary_client import async_call_llm, extract_content_or_reasoning
+        from gateway.specialist_routing import classify_specialist_request
+
+        async def _classifier(messages):
+            response = await async_call_llm(
+                task="specialist_router", model=settings["model"] or None,
+                messages=messages, temperature=0.0, max_tokens=180,
+                timeout=settings["timeout_seconds"], reasoning_config={"enabled": False},
+            )
+            return extract_content_or_reasoning(response)
+
+        return await classify_specialist_request(
+            event.text, _classifier, threshold=settings["confidence_threshold"],
+            timeout=settings["timeout_seconds"],
+        )
+
+    async def _maybe_route_specialist_event(self, event: MessageEvent) -> bool:
+        """Create a guarded specialist card, or return false for normal chat."""
+        settings = self._specialist_routing_settings()
+        if not settings.get("enabled") or event.message_type is not MessageType.TEXT:
+            return False
+        if not (event.text or "").strip() or getattr(event.source, "is_bot", False):
+            return False
+        try:
+            decision = await self._classify_specialist_event(event)
+        except Exception:
+            logger.warning("[Discord] specialist routing classifier failed", exc_info=True)
+            return False
+        if decision.kind.value == "general":
+            logger.info("[Discord] specialist routing fell through: %s", decision.audit_reason)
+            return False
+        if decision.kind.value == "clarify":
+            await self.send(
+                event.source.chat_id,
+                content=("Which specialist task should I start: an audit, a narrow patch, "
+                         "acceptance verification, safety review, research, or performance work?"),
+                reply_to=event.message_id,
+            )
+            return True
+        if not decision.dispatches:
+            return False
+        try:
+            from gateway.specialist_handoff import HandoffSource, create_specialist_handoff
+
+            platform = getattr(event.source.platform, "value", event.source.platform)
+            source = HandoffSource(
+                platform=str(platform), chat_id=str(event.source.chat_id),
+                chat_type=str(event.source.chat_type or "group"),
+                user_id=str(event.source.user_id) if event.source.user_id else None,
+                user_id_alt=str(event.source.user_id_alt) if event.source.user_id_alt else None,
+                guild_id=str(event.source.guild_id) if event.source.guild_id else None,
+                thread_id=str(event.source.thread_id) if event.source.thread_id else None,
+                message_id=str(event.message_id or event.source.message_id or ""),
+                notifier_profile=getattr(event.source, "profile", None) or "default",
+            )
+            result = await asyncio.to_thread(
+                create_specialist_handoff, decision=decision, source=source,
+                request=event.text, router_model=settings["model"] or "configured_auxiliary",
+                board=settings["board"],
+            )
+        except Exception:
+            logger.warning("[Discord] specialist routing handoff failed", exc_info=True)
+            return False
+        if not result.ok or not result.task_id:
+            logger.warning("[Discord] specialist routing handoff rejected: %s", result.reason)
+            return False
+        await self.send(
+            event.source.chat_id,
+            content=(
+                f"Planning `{result.task_id}` with the task orchestrator. "
+                "I’ll post the worker plan and progress here."
+            ),
+            reply_to=event.message_id,
+        )
+        return True
+
     async def _fetch_channel_context(
         self,
         channel: Any,
@@ -8534,6 +8826,14 @@ class DiscordAdapter(BasePlatformAdapter):
             channel_prompt=_channel_prompt,
             channel_context=_channel_context,
         )
+
+        # A high-confidence natural-language task request becomes one durable,
+        # subscribed Kanban card. General, invalid, unavailable, and failed
+        # classifications return false and preserve the existing chat flow.
+        if not recovered and await self._maybe_answer_progress_event(event):
+            return True
+        if not recovered and await self._maybe_route_specialist_event(event):
+            return True
 
         # Track thread participation so the bot won't require @mention for
         # follow-up messages in threads it has already engaged in.

--- a/tests/agent/test_turn_finalizer_kanban_budget.py
+++ b/tests/agent/test_turn_finalizer_kanban_budget.py
@@ -1,0 +1,36 @@
+"""Regression coverage for Kanban workers that exhaust their turn budget."""
+
+from __future__ import annotations
+
+import logging
+
+from agent.turn_finalizer import _record_kanban_budget_exhausted
+from hermes_cli import kanban_db as kb
+
+
+def test_budget_exhaustion_parks_task_for_narrower_input(tmp_path, monkeypatch):
+    """A completed process that ran out of turns must not enter a respawn loop."""
+    db_path = tmp_path / "kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="needs evidence", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (task_id,))
+        assert kb.claim_task(conn, task_id, claimer="worker") is not None
+
+    _record_kanban_budget_exhausted(task_id, 18, 18, logging.getLogger(__name__))
+
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+        events = kb.list_events(conn, task_id)
+
+    assert task is not None
+    assert task.status == "blocked"
+    assert task.consecutive_failures == 0
+    blocked = [event for event in events if event.kind == "blocked"]
+    assert blocked
+    payload = blocked[-1].payload or {}
+    assert payload["kind"] == "needs_input"
+    assert "Iteration budget exhausted (18/18)" in payload["reason"]

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -98,6 +98,30 @@ def _make_adapter(platform_val="telegram"):
 class TestBusySessionAck:
     """User sends a message while agent is running — should get acknowledgment."""
 
+    @pytest.mark.asyncio
+    async def test_voice_fast_lane_queues_followup_instead_of_interrupting(self):
+        """Speech must not discard an in-progress voice reply or task."""
+        from gateway.run import GatewayRunner
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+        event = _make_event(text="And what about tomorrow?", platform_val="discord")
+        event.message_type = MessageType.VOICE
+        event.source._voice_fast_lane = True
+        session_key = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+        agent = MagicMock()
+        runner._running_agents[session_key] = agent
+
+        handled = await GatewayRunner._handle_active_session_busy_message(
+            runner, event, session_key
+        )
+
+        assert handled is True
+        assert adapter._pending_messages[session_key] is event
+        agent.interrupt.assert_not_called()
+
 
     @pytest.mark.asyncio
     async def test_telegram_grace_followups_respect_queue_fifo(self, monkeypatch):
@@ -469,5 +493,4 @@ class TestLongRunningNotificationOwnership:
         assert runner._should_emit_long_running_notification(
             "sess", original_agent, executor_task=None
         ) is False
-
 

--- a/tests/gateway/test_discord_progress_queries.py
+++ b/tests/gateway/test_discord_progress_queries.py
@@ -1,0 +1,102 @@
+"""Discord pre-router contract for read-only project progress recall."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    import plugins.platforms.discord.adapter as discord_platform
+    from plugins.platforms.discord.adapter import DiscordAdapter
+
+    monkeypatch.setattr(discord_platform.discord, "DMChannel", type("DMChannel", (), {}), raising=False)
+    config = PlatformConfig(
+        enabled=True,
+        token="fake-token",
+        extra={
+            "specialist_routing": {
+                "enabled": True,
+                "board": "project-burndown",
+                "model": "fast-router",
+            }
+        },
+    )
+    value = DiscordAdapter(config)
+    value._client = SimpleNamespace(user=SimpleNamespace(id=999))
+    value.send = AsyncMock()
+    return value
+
+
+def _event(text="How did the burndown go and what else do we need to do?"):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        message_id="message-1",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="project-updates",
+            chat_type="group",
+            user_id="operator-1",
+        ),
+    )
+
+
+def test_progress_pre_router_answers_before_model_specialist_classifier(adapter, monkeypatch):
+    from gateway.progress_queries import ProgressQueryResult
+
+    captured = {}
+
+    def fake_resolve(request, *, source, board):
+        captured.update(request=request, source=source, board=board)
+        return ProgressQueryResult(True, "Burndown: 1 completed; next: acceptance.", "resolved")
+
+    monkeypatch.setattr("gateway.progress_queries.resolve_progress_query", fake_resolve)
+    adapter._classify_specialist_event = AsyncMock()
+
+    handled = asyncio.run(adapter._maybe_answer_progress_event(_event()))
+
+    assert handled is True
+    assert captured["request"] == "How did the burndown go and what else do we need to do?"
+    assert captured["source"].platform == "discord"
+    assert captured["source"].chat_id == "project-updates"
+    assert not hasattr(captured["source"], "session_id")
+    assert captured["board"] == "project-burndown"
+    adapter._classify_specialist_event.assert_not_awaited()
+    adapter.send.assert_awaited_once_with(
+        "project-updates", content="Burndown: 1 completed; next: acceptance.", reply_to="message-1"
+    )
+
+
+@pytest.mark.parametrize("reason", ["unavailable", "no_match"])
+def test_unhandled_progress_lookup_falls_through_without_send_or_model(
+    adapter, monkeypatch, reason
+):
+    from gateway.progress_queries import ProgressQueryResult
+
+    monkeypatch.setattr(
+        "gateway.progress_queries.resolve_progress_query",
+        lambda *args, **kwargs: ProgressQueryResult(False, "", reason),
+    )
+
+    handled = asyncio.run(adapter._maybe_answer_progress_event(_event()))
+
+    assert handled is False
+    adapter.send.assert_not_awaited()
+
+
+def test_specialist_routing_configuration_requires_nonempty_explicit_board(adapter):
+    settings = adapter._specialist_routing_settings()
+
+    assert settings["board"] == "project-burndown"
+
+    adapter.config.extra["specialist_routing"]["board"] = ""
+    assert adapter._specialist_routing_settings()["enabled"] is False

--- a/tests/gateway/test_discord_race_polish.py
+++ b/tests/gateway/test_discord_race_polish.py
@@ -2,7 +2,7 @@
 double-invoke channel.connect() on the same guild."""
 
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -55,6 +55,10 @@ async def test_concurrent_joins_do_not_double_connect():
         await release.wait()
         return FakeVC(self)
 
+    def schedule_and_close(coro):
+        coro.close()
+        return asyncio.create_task(asyncio.sleep(0))
+
     channel = MagicMock()
     channel.id = 111
     channel.guild.id = 42
@@ -64,7 +68,7 @@ async def test_concurrent_joins_do_not_double_connect():
     with patch.object(discord_mod, "VoiceReceiver",
                       MagicMock(return_value=MagicMock(start=lambda: None))):
         with patch.object(discord_mod.asyncio, "ensure_future",
-                          lambda _c: asyncio.create_task(asyncio.sleep(0))):
+                          schedule_and_close):
             t1 = asyncio.create_task(adapter.join_voice_channel(channel))
             t2 = asyncio.create_task(adapter.join_voice_channel(channel))
             await asyncio.sleep(0.05)
@@ -77,3 +81,122 @@ async def test_concurrent_joins_do_not_double_connect():
     )
     assert r1 is True and r2 is True
     assert 42 in adapter._voice_clients
+
+
+@pytest.mark.asyncio
+async def test_forced_voice_move_refreshes_packet_receiver():
+    """A Discord transport reconnect must not leave the receiver on its old UDP reader."""
+    adapter = _make_adapter()
+    guild_id = 42
+    voice_client = MagicMock()
+    voice_client.is_connected.return_value = True
+    old_receiver = MagicMock()
+    old_listen_task = MagicMock()
+    replacement_receiver = MagicMock()
+    replacement_listen_task = MagicMock()
+    adapter._voice_clients[guild_id] = voice_client
+    adapter._voice_receivers[guild_id] = old_receiver
+    adapter._voice_listen_tasks[guild_id] = old_listen_task
+
+    def schedule_and_close(coro):
+        coro.close()
+        return replacement_listen_task
+
+    from plugins.platforms.discord import adapter as discord_mod
+    with patch.object(discord_mod, "VoiceReceiver", return_value=replacement_receiver) as receiver_cls, \
+            patch.object(discord_mod.asyncio, "ensure_future", side_effect=schedule_and_close), \
+            patch.object(discord_mod.asyncio, "sleep", return_value=None):
+        await adapter._refresh_voice_receiver_after_forced_move(guild_id)
+
+    old_receiver.stop.assert_called_once_with()
+    old_listen_task.cancel.assert_called_once_with()
+    receiver_cls.assert_called_once_with(voice_client, allowed_user_ids=set())
+    replacement_receiver.start.assert_called_once_with()
+    assert adapter._voice_receivers[guild_id] is replacement_receiver
+    assert adapter._voice_listen_tasks[guild_id] is replacement_listen_task
+
+
+@pytest.mark.asyncio
+async def test_auto_join_requires_configured_user_and_voice_channel():
+    """Only the configured user entering the configured room can auto-join Hermes."""
+    adapter = _make_adapter()
+    adapter._voice_auto_join_channel_id = 111
+    adapter._voice_auto_join_text_channel_id = 222
+    adapter._voice_auto_join_user_ids = {"158441542070173697"}
+    adapter.join_voice_channel = AsyncMock(return_value=True)
+
+    channel = MagicMock()
+    channel.id = 111
+    member = MagicMock()
+    member.id = 158441542070173697
+    member.guild.id = 42
+    before = MagicMock(channel=None)
+    after = MagicMock(channel=channel)
+
+    await adapter._auto_join_voice_for_member(member, before, after)
+
+    adapter.join_voice_channel.assert_awaited_once_with(
+        channel,
+        text_channel_id=222,
+        source={
+            "platform": "discord",
+            "chat_id": "222",
+            "user_id": "158441542070173697",
+            "user_name": "158441542070173697",
+            "chat_type": "channel",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_join_on_ready_joins_when_configured_user_is_present():
+    """A gateway restart rejoins when the configured user is already in the room."""
+    adapter = _make_adapter()
+    adapter._voice_auto_join_channel_id = 111
+    adapter._voice_auto_join_text_channel_id = 222
+    adapter._voice_auto_join_user_ids = {"158441542070173697"}
+    adapter.join_voice_channel = AsyncMock(return_value=True)
+
+    channel = MagicMock()
+    channel.id = 111
+    member = MagicMock()
+    member.id = 158441542070173697
+    channel.members = [member]
+    adapter._client.get_channel.return_value = channel
+
+    await adapter._auto_join_configured_voice_channel_if_user_present()
+
+    adapter.join_voice_channel.assert_awaited_once_with(
+        channel,
+        text_channel_id=222,
+        source={
+            "platform": "discord",
+            "chat_id": "222",
+            "user_id": "158441542070173697",
+            "user_name": "158441542070173697",
+            "chat_type": "channel",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_join_leaves_when_configured_user_leaves_room():
+    """The dedicated auto-join session ends when its configured user leaves."""
+    adapter = _make_adapter()
+    adapter._voice_auto_join_channel_id = 111
+    adapter._voice_auto_join_user_ids = {"158441542070173697"}
+    adapter.leave_voice_channel = AsyncMock()
+
+    configured_channel = MagicMock()
+    configured_channel.id = 111
+    other_channel = MagicMock()
+    other_channel.id = 222
+    member = MagicMock()
+    member.id = 158441542070173697
+    member.guild.id = 42
+    before = MagicMock(channel=configured_channel)
+    after = MagicMock(channel=other_channel)
+
+    await adapter._auto_join_voice_for_member(member, before, after)
+
+    adapter.leave_voice_channel.assert_awaited_once_with(42)

--- a/tests/gateway/test_kanban_budget_notification.py
+++ b/tests/gateway/test_kanban_budget_notification.py
@@ -1,0 +1,22 @@
+"""Regression coverage for truthful Kanban budget-exhaustion notifications."""
+
+from __future__ import annotations
+
+from gateway.kanban_watchers import _format_gave_up_notification
+
+
+def test_budget_exhaustion_is_not_described_as_a_spawn_failure():
+    message = _format_gave_up_notification(
+        board_tag="[board] ",
+        tag="@worker ",
+        task_id="t_budget",
+        payload={
+            "trigger_outcome": "timed_out",
+            "budget_used": 18,
+            "budget_max": 18,
+            "error": "Iteration budget exhausted (18/18) — task could not complete",
+        },
+    )
+
+    assert "iteration budget exhausted (18/18)" in message.lower()
+    assert "spawn failure" not in message.lower()

--- a/tests/gateway/test_plain_english_progress_regression.py
+++ b/tests/gateway/test_plain_english_progress_regression.py
@@ -1,0 +1,64 @@
+"""Regression coverage for natural-language Discord progress questions."""
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+def test_plain_english_burndown_pr_question_is_a_progress_query():
+    try:
+        from gateway.progress_queries import is_progress_query
+    except ModuleNotFoundError:
+        pytest.fail("Discord progress-query routing is missing from the runtime")
+
+    assert is_progress_query(
+        "How’s the burndown patches going how much more do we have to do till we can send a PR"
+    )
+
+
+def test_plain_english_plural_burndown_question_summarizes_all_matching_roots(
+    tmp_path, monkeypatch
+):
+    from gateway.progress_queries import ProgressSource, resolve_progress_query
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    board = "project-burndown"
+    kb.init_db(board=board)
+    with kb.connect(board=board) as conn:
+        first = kb.create_task(
+            conn,
+            title="July exception burndown patches",
+            initial_status="running",
+            created_by="test",
+        )
+        second = kb.create_task(
+            conn,
+            title="August exception burndown patches",
+            initial_status="running",
+            created_by="test",
+        )
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (first,))
+        for task_id in (first, second):
+            kb.add_notify_sub(
+                conn,
+                task_id=task_id,
+                platform="discord",
+                chat_id="project-updates",
+                chat_type="group",
+                delivery_mode="notify",
+            )
+
+    result = resolve_progress_query(
+        "How’s the burndown patches going how much more do we have to do till we can send a PR",
+        source=ProgressSource(platform="discord", chat_id="project-updates"),
+        board=board,
+    )
+
+    assert result.handled is True
+    assert result.reason == "resolved_multiple"
+    assert "July exception burndown patches" in result.response
+    assert "August exception burndown patches" in result.response
+    assert "Please name one" not in result.response

--- a/tests/gateway/test_progress_queries.py
+++ b/tests/gateway/test_progress_queries.py
@@ -1,0 +1,1188 @@
+"""Read-only, source-scoped recall of Kanban project progress."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+BOARD = "project-burndown"
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    with kb.connect(board=BOARD):
+        pass
+    return home
+
+
+def _sub(conn, task_id, *, chat_id="project-updates", thread_id="", delivery_metadata=None):
+    kb.add_notify_sub(
+        conn,
+        task_id=task_id,
+        platform="discord",
+        chat_id=chat_id,
+        thread_id=thread_id,
+        chat_type="thread" if thread_id else "group",
+        user_id="operator-1",
+        delivery_metadata=delivery_metadata,
+    )
+
+
+def _task(
+    conn,
+    title,
+    *,
+    parents=(),
+    status="ready",
+    branch_name=None,
+    created_by=None,
+    idempotency_key=None,
+):
+    task_id = kb.create_task(
+        conn,
+        title=title,
+        body="Untrusted body must never become a filesystem instruction: /Users/not-trusted.",
+        initial_status="running",
+        parents=parents,
+        branch_name=branch_name,
+        created_by=created_by,
+        idempotency_key=idempotency_key,
+    )
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status = ? WHERE id = ?", (status, task_id))
+    return task_id
+
+
+def _run(
+    conn,
+    task_id,
+    *,
+    status,
+    outcome=None,
+    summary=None,
+    metadata=None,
+    error=None,
+    started_at=100,
+    ended_at=None,
+):
+    if ended_at is None and status != "running":
+        ended_at = started_at + 1
+    with kb.write_txn(conn):
+        conn.execute(
+            """
+            INSERT INTO task_runs
+                (task_id, status, started_at, ended_at, outcome, summary, metadata, error)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                task_id,
+                status,
+                started_at,
+                ended_at,
+                outcome,
+                summary,
+                json.dumps(metadata) if metadata is not None else None,
+                error,
+            ),
+        )
+
+
+def _source(
+    *,
+    chat_id="project-updates",
+    thread_id=None,
+    reply_to_message_id=None,
+):
+    from gateway.progress_queries import ProgressSource
+
+    return ProgressSource(
+        platform="discord",
+        chat_id=chat_id,
+        thread_id=thread_id,
+        reply_to_message_id=reply_to_message_id,
+    )
+
+
+def test_burndown_question_summarizes_graph_receipts_and_remaining_work(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "Exception Burndown")
+        done = _task(conn, "Narrow credential exception", parents=[root], status="done")
+        failed = _task(conn, "Repair provider exception", parents=[root], status="blocked")
+        running = _task(conn, "Validate exception evidence", parents=[root], status="running")
+        next_task = _task(conn, "Publish acceptance receipt", parents=[root], status="ready")
+        _sub(conn, root)
+        _run(
+            conn,
+            done,
+            status="done",
+            outcome="completed",
+            summary="Closed with local evidence; prose commit deadbeef must not be trusted.",
+            metadata={"commit": "a1b2c3d4", "branch": "codex/burndown-repair"},
+        )
+        _run(conn, failed, status="failed", outcome="gave_up", error="worker gave up")
+        _run(conn, running, status="running", summary="Worker is validating receipts")
+        kb.add_comment(conn, next_task, "worker", "Need the final acceptance receipt.")
+
+    result = resolve_progress_query(
+        "How did the burndown go and what else do we need to do?",
+        source=_source(),
+        board=BOARD,
+    )
+
+    assert result.handled is True
+    assert result.reason == "resolved"
+    assert "Exception Burndown" in result.response
+    assert "1 completed" in result.response
+    assert "1 failed attempt" in result.response
+    assert "1 blocked" in result.response
+    assert "1 running" in result.response
+    assert "Publish acceptance receipt" in result.response
+    assert "a1b2c3d4" in result.response
+    assert "codex/burndown-repair" in result.response
+    assert "deadbeef" not in result.response
+
+
+def test_progress_query_isolated_to_trusted_source_subscription(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "Exception Burndown", status="done")
+        _sub(conn, root, chat_id="private-audit")
+
+    result = resolve_progress_query(
+        "How did the burndown go?", source=_source(chat_id="project-updates"), board=BOARD
+    )
+
+    assert result.handled is False
+    assert result.reason == "no_match"
+    assert result.response == ""
+    assert "Exception Burndown" not in result.response
+
+
+def test_progress_query_uses_explicit_board_not_current_or_other_board(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    with kb.connect(board="other-board") as conn:
+        root = _task(conn, "Exception Burndown", status="done")
+        _sub(conn, root)
+
+    result = resolve_progress_query(
+        "How did the burndown go?", source=_source(), board=BOARD
+    )
+
+    assert result.handled is False
+    assert result.reason == "no_match"
+    assert result.response == ""
+    assert "Exception Burndown" not in result.response
+
+
+def test_progress_query_summarizes_multiple_matching_roots(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    with kb.connect(board=BOARD) as conn:
+        first = _task(conn, "July Exception Burndown")
+        second = _task(conn, "August Exception Burndown")
+        _sub(conn, first)
+        _sub(conn, second)
+
+    result = resolve_progress_query(
+        "How did the exception burndown go?", source=_source(), board=BOARD
+    )
+
+    assert result.handled is True
+    assert result.reason == "resolved_multiple"
+    assert first in result.response
+    assert second in result.response
+    assert "Please name one" not in result.response
+
+
+def test_single_subscribed_root_does_not_override_zero_topic_score(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "Exception Burndown", status="done")
+        _sub(conn, root)
+
+    result = resolve_progress_query(
+        "How did the release go?", source=_source(), board=BOARD
+    )
+
+    assert result.handled is False
+    assert result.reason == "no_match"
+    assert result.response == ""
+    assert "Exception Burndown" not in result.response
+
+
+def test_generic_how_did_it_go_requires_trusted_linkage(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "Exception Burndown", status="done")
+        _sub(conn, root)
+
+    result = resolve_progress_query("How did it go?", source=_source(), board=BOARD)
+
+    assert result.handled is False
+    assert result.reason == "no_match"
+    assert result.response == ""
+
+
+@pytest.mark.parametrize(
+    "request_text",
+    [
+        "Give me an update on the burndown fix remaining failures",
+        "Give me an update on the burndown frobnicate remaining failures",
+        "Status of ExampleProject deploy production?",
+        "Progress on ExampleProject delete credentials?",
+    ],
+)
+def test_status_topic_requires_every_term_to_be_bound_to_the_subscribed_graph(
+    kanban_home, request_text
+):
+    from gateway.progress_queries import is_progress_query, resolve_progress_query
+
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "ExampleProject Burndown", status="done")
+        _task(conn, "Repair remaining failures", parents=[root], status="done")
+        _sub(conn, root)
+
+    assert is_progress_query(request_text) is True
+    result = resolve_progress_query(request_text, source=_source(), board=BOARD)
+
+    assert result.handled is False
+    assert result.reason == "no_match"
+    assert result.response == ""
+
+
+def test_fully_graph_bound_burndown_topic_is_handled(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "ExampleProject Burndown", status="done")
+        _sub(conn, root)
+
+    result = resolve_progress_query(
+        "How did the burndown go?", source=_source(), board=BOARD
+    )
+
+    assert result.handled is True
+    assert result.reason == "resolved"
+    assert root in result.response
+
+
+def test_generic_how_did_it_go_resolves_one_trusted_reply_linked_root(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    with kb.connect(board=BOARD) as conn:
+        root = _task(
+            conn,
+            "Exception Burndown",
+            status="done",
+            created_by="specialist-routing",
+            idempotency_key="specialist-routing:discord::project-updates::request-42",
+        )
+        _sub(conn, root, delivery_metadata={"origin_message_id": "request-42"})
+
+    result = resolve_progress_query(
+        "How did it go?", source=_source(reply_to_message_id="request-42"), board=BOARD
+    )
+
+    assert result.handled is True
+    assert result.reason == "resolved"
+    assert root in result.response
+
+
+def test_explicit_task_id_selects_one_root_when_topic_is_ambiguous(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    with kb.connect(board=BOARD) as conn:
+        first = _task(conn, "July Exception Burndown")
+        second = _task(conn, "August Exception Burndown", status="done")
+        _sub(conn, first)
+        _sub(conn, second)
+
+    result = resolve_progress_query(
+        f"How did {second} go?", source=_source(), board=BOARD
+    )
+
+    assert result.handled is True
+    assert result.reason == "resolved"
+    assert second in result.response
+    assert first not in result.response
+
+
+def test_non_progress_message_falls_through_without_database_response(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    result = resolve_progress_query("What should I cook for dinner?", source=_source(), board=BOARD)
+
+    assert result.handled is False
+    assert result.reason == "irrelevant"
+    assert result.response == ""
+
+
+def test_ordinary_what_else_chat_falls_through(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    result = resolve_progress_query(
+        "What else can you help with?", source=_source(), board=BOARD
+    )
+
+    assert result.handled is False
+    assert result.reason == "irrelevant"
+
+
+def test_question_shaped_action_request_falls_through_to_specialist_routing(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    result = resolve_progress_query(
+        "Can you start an exception burndown and patch the confirmed failures?",
+        source=_source(),
+        board=BOARD,
+    )
+
+    assert result.handled is False
+    assert result.reason == "irrelevant"
+
+
+def test_mixed_progress_and_action_clause_falls_through_to_specialist_routing(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    result = resolve_progress_query(
+        "How did the burndown go, and patch any remaining failures?",
+        source=_source(),
+        board=BOARD,
+    )
+
+    assert result.handled is False
+    assert result.reason == "irrelevant"
+
+
+def test_mixed_progress_and_direct_delegate_falls_through_to_specialist_routing(
+    kanban_home,
+):
+    from gateway.progress_queries import resolve_progress_query
+
+    result = resolve_progress_query(
+        "How did the burndown go? Delegate the remaining failures.",
+        source=_source(),
+        board=BOARD,
+    )
+
+    assert result.handled is False
+    assert result.reason == "irrelevant"
+
+
+def test_mixed_progress_and_please_resolve_falls_through_to_specialist_routing(
+    kanban_home,
+):
+    from gateway.progress_queries import resolve_progress_query
+
+    result = resolve_progress_query(
+        "How did the burndown go? Please resolve the remaining failures.",
+        source=_source(),
+        board=BOARD,
+    )
+
+    assert result.handled is False
+    assert result.reason == "irrelevant"
+
+
+@pytest.mark.parametrize(
+    "request_text",
+    [
+        "How did the burndown go? I'd like you to remediate the remaining failures.",
+        "How did the burndown go? Could you address the remaining failures?",
+        "How did the burndown go, and please delegate the remaining failures?",
+        "How did the burndown go; resolve the remaining failures.",
+    ],
+)
+def test_mixed_progress_and_engineering_imperative_falls_through_to_specialist_routing(
+    kanban_home, request_text
+):
+    from gateway.progress_queries import resolve_progress_query
+
+    result = resolve_progress_query(request_text, source=_source(), board=BOARD)
+
+    assert result.handled is False
+    assert result.reason == "irrelevant"
+
+
+def test_indirect_mixed_action_falls_through_to_specialist_routing(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    result = resolve_progress_query(
+        "How did the burndown go, and have the bot patch any remaining failures?",
+        source=_source(),
+        board=BOARD,
+    )
+
+    assert result.handled is False
+    assert result.reason == "irrelevant"
+
+
+@pytest.mark.parametrize(
+    "request_text",
+    [
+        "How did the burndown go? I’d like you to fix the remaining failures.",
+        "How did the burndown go? I'd like you to patch the remaining failures.",
+        "How did the burndown go? I would like the bot to fix the remaining failures.",
+    ],
+)
+def test_mixed_progress_and_intent_phrase_falls_through_to_specialist_routing(
+    kanban_home, request_text
+):
+    from gateway.progress_queries import resolve_progress_query
+
+    result = resolve_progress_query(request_text, source=_source(), board=BOARD)
+
+    assert result.handled is False
+    assert result.reason == "irrelevant"
+
+
+def test_patch_completion_question_remains_a_progress_query(kanban_home):
+    from gateway.progress_queries import is_progress_query
+
+    assert is_progress_query("Is the patch complete?") is True
+
+
+@pytest.mark.parametrize(
+    "request_text",
+    [
+        "How did the burndown go?",
+        "How did the burndown go and what else do we need to do?",
+        "Could you update me on the burndown progress?",
+        "Can you update me on the burndown status?",
+        "Would you update me on the exception burndown progress?",
+        "Give me an update on the burndown",
+        "What remains on the exception burndown?",
+        "What's left on the exception burndown?",
+        "Where are we on the exception burndown?",
+        "Status of the exception burndown?",
+        "Progress on the exception burndown?",
+        "Is the patch complete?",
+        "How did it go?",
+    ],
+)
+def test_strict_progress_grammar_accepts_complete_read_only_questions(request_text):
+    from gateway.progress_queries import is_progress_query
+
+    assert is_progress_query(request_text) is True
+
+
+@pytest.mark.parametrize(
+    "action_clause",
+    [
+        "fix the remaining failures",
+        "delegate the remaining failures",
+        "resolve the remaining failures",
+        "continue with the remaining failures",
+        "resume the remaining work",
+        "handle the remaining failures",
+        "proceed with the patches",
+        "keep working on the failures",
+        "frobnicate the remaining failures",
+    ],
+)
+def test_strict_progress_grammar_rejects_any_appended_action_clause(action_clause):
+    from gateway.progress_queries import is_progress_query
+
+    assert is_progress_query(f"How did the burndown go? Please {action_clause}.") is False
+
+
+def test_raw_topic_action_tail_cannot_collapse_to_a_graph_match(kanban_home):
+    from gateway.progress_queries import is_progress_query, resolve_progress_query
+
+    request = "Give me an update on the nebula burndown and do the work"
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "Nebula Burndown", status="done")
+        _sub(conn, root)
+
+    assert is_progress_query(request) is False
+    result = resolve_progress_query(request, source=_source(), board=BOARD)
+
+    assert result.handled is False
+    assert result.reason == "irrelevant"
+    assert result.response == ""
+
+
+@pytest.mark.parametrize(
+    "request_text",
+    [
+        "Give me an update on the burndown while you fix the remaining failures",
+        "Give me an update on the burndown while we continue the remaining work",
+        "Give me an update on the burndown to resolve the remaining failures",
+        "Give me an update on the burndown then proceed with the patches",
+        "Give me an update on the burndown so we can finish",
+        "Give me an update on the burndown I'd like you to fix",
+        "What remains to address?",
+    ],
+)
+def test_status_shaped_structural_topic_tails_are_not_progress_queries(
+    kanban_home, request_text
+):
+    from gateway.progress_queries import is_progress_query, resolve_progress_query
+
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "Exception Burndown", status="done")
+        _sub(conn, root)
+
+    assert is_progress_query(request_text) is False
+    result = resolve_progress_query(request_text, source=_source(), board=BOARD)
+
+    assert result.handled is False
+    assert result.reason == "irrelevant"
+    assert result.response == ""
+
+
+@pytest.mark.parametrize(
+    "request_text",
+    [
+        "Give me an update on the burndown please continue",
+        "Give me an update on the burndown after you review the failures",
+        "Give me an update on the burndown before we continue",
+        "Give me an update on the burndown until I fix the failures",
+        "Give me an update on the burndown also continue",
+        "Give me an update on the burndown you should fix next",
+    ],
+)
+def test_other_unbound_topic_tails_still_defer_to_graph_authority(
+    kanban_home, request_text
+):
+    from gateway.progress_queries import is_progress_query, resolve_progress_query
+
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "Exception Burndown", status="done")
+        _sub(conn, root)
+
+    assert is_progress_query(request_text) is True
+    result = resolve_progress_query(request_text, source=_source(), board=BOARD)
+
+    assert result.handled is False
+    assert result.reason == "no_match"
+    assert result.response == ""
+
+
+@pytest.mark.parametrize(
+    "request_text",
+    [
+        "Give me an update on the ExampleProject Phase 12 burndown",
+        "How did ExampleProject Phase 12 go?",
+        "Status of ExampleProject PATCH-67-7?",
+        "Progress on ExampleProject card t_ab12cd?",
+        "Could you update me on the ExampleProject adaptive-admission card t_ab12cd status?",
+    ],
+)
+def test_strict_progress_grammar_accepts_noun_like_project_topics(request_text):
+    from gateway.progress_queries import is_progress_query
+
+    assert is_progress_query(request_text) is True
+
+
+@pytest.mark.parametrize(
+    "request_text",
+    [
+        "How did the burndown go",
+        "How did the burndown go and what else do I need to do?",
+        "Could you update me about the burndown progress?",
+        "Can you update me on the burndown?",
+        "Give me an update about the burndown",
+        "What is left on the exception burndown?",
+        "How is the delegate migration progressing?",
+        "Is the patch complete",
+    ],
+)
+def test_strict_progress_grammar_rejects_unlisted_near_misses(request_text):
+    from gateway.progress_queries import is_progress_query
+
+    assert is_progress_query(request_text) is False
+
+
+@pytest.mark.parametrize(
+    "request_text",
+    [
+        "Could you update me on the burndown progress?",
+        "Give me an update on the burndown",
+    ],
+)
+def test_status_update_phrasing_remains_a_read_only_progress_query(request_text):
+    from gateway.progress_queries import is_progress_query
+
+    assert is_progress_query(request_text) is True
+
+
+@pytest.mark.parametrize(
+    "request_text",
+    [
+        "Please update the burndown code.",
+        "Please update the burndown implementation.",
+        "How did it go? Please update the code.",
+        "How did it go? Please fix the code.",
+    ],
+)
+def test_update_or_fix_code_requests_remain_actionable(request_text):
+    from gateway.progress_queries import is_progress_query
+
+    assert is_progress_query(request_text) is False
+
+
+@pytest.mark.parametrize(
+    "request_text",
+    [
+        "Is the remediation complete?",
+    ],
+)
+def test_question_shaped_engineering_status_remains_a_progress_query(request_text):
+    from gateway.progress_queries import is_progress_query
+
+    assert is_progress_query(request_text) is True
+
+
+def test_progress_output_is_bounded_and_redacts_secret_and_path_content(kanban_home):
+    from gateway.progress_queries import MAX_PROGRESS_RESPONSE_CHARS, resolve_progress_query
+
+    secret = "ultra-secret-value"
+    path = "/workspace/example-project/.env"
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "Exception Burndown", status="done")
+        _sub(conn, root)
+        _run(
+            conn,
+            root,
+            status="done",
+            outcome="completed",
+            summary=(f"OPENAI_API_KEY={secret}; inspect {path}; " + "detail " * 2_000),
+            metadata={"commit": "f00ba412", "branch": "codex/receipt"},
+        )
+        kb.add_comment(conn, root, "worker", f"TOKEN: {secret} and {path}")
+
+    result = resolve_progress_query("How did the burndown go?", source=_source(), board=BOARD)
+
+    assert result.handled is True
+    assert len(result.response) <= MAX_PROGRESS_RESPONSE_CHARS
+    assert secret not in result.response
+    assert path not in result.response
+    assert "f00ba412" in result.response
+
+
+def test_progress_forces_authoritative_redaction_then_applies_local_egress_defense(
+    kanban_home, monkeypatch
+):
+    import agent.redact as authoritative_redaction
+    from gateway.progress_queries import resolve_progress_query
+
+    monkeypatch.setattr(authoritative_redaction, "_REDACT_ENABLED", False)
+    probes = {
+        "vendor": "ghp_abcdefghijk123456789",
+        "bearer": "bare-bearer-secret",
+        "userinfo": "uri-password-secret",
+        "root_path": "/root/.ssh/id_rsa",
+        "opt_path": "/opt/hermes/credentials.json",
+    }
+    summary = (
+        f"GitHub receipt {probes['vendor']}\n"
+        f"Bearer {probes['bearer']}\n"
+        f"Fetched https://operator:{probes['userinfo']}@example.test/report\n"
+        f"Inspected {probes['root_path']} and {probes['opt_path']}\n"
+        "Acceptance evidence remains visible."
+    )
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "Exception Burndown", status="done")
+        _sub(conn, root)
+        _run(conn, root, status="done", outcome="completed", summary=summary)
+
+    result = resolve_progress_query(
+        "How did the burndown go?", source=_source(), board=BOARD
+    )
+
+    assert result.handled is True
+    for probe in probes.values():
+        assert probe not in result.response
+    assert "Acceptance evidence remains visible." in result.response
+
+
+def test_local_egress_defense_redacts_standalone_github_token(monkeypatch):
+    import agent.redact as authoritative_redaction
+    from gateway.progress_queries import _safe_text
+
+    token = "ghp_abcdefghijk123456789"
+    monkeypatch.setattr(authoritative_redaction, "redact_sensitive_text", lambda text, **_: text)
+
+    result = _safe_text(f"GitHub receipt {token} completed.")
+
+    assert token not in result
+    assert "completed." in result
+
+
+def test_local_egress_defense_redacts_private_key_material(monkeypatch):
+    import agent.redact as authoritative_redaction
+    from gateway.progress_queries import _safe_text
+
+    private_key = (
+        "-----BEGIN PRIVATE KEY-----\n"
+        "cHJpdmF0ZS1rZXktbWF0ZXJpYWw=\n"
+        "-----END PRIVATE KEY-----"
+    )
+    monkeypatch.setattr(authoritative_redaction, "redact_sensitive_text", lambda text, **_: text)
+
+    result = _safe_text(f"Receipt:\n{private_key}\nValidation complete.")
+
+    assert "cHJpdmF0ZS1rZXktbWF0ZXJpYWw" not in result
+    assert "BEGIN PRIVATE KEY" not in result
+    assert "Validation complete." in result
+
+
+def test_structured_branch_rejects_redacted_or_locally_secret_shaped_values(monkeypatch):
+    import agent.redact as authoritative_redaction
+    from gateway.progress_queries import _safe_branch
+
+    token = "ghp_abcdefghijk123456789"
+    assert _safe_branch(f"codex/{token}") is None
+
+    monkeypatch.setattr(
+        authoritative_redaction,
+        "redact_sensitive_text",
+        lambda text, **_: text.replace("safe-branch", "[redacted]"),
+    )
+    assert _safe_branch("codex/safe-branch") is None
+
+    monkeypatch.setattr(authoritative_redaction, "redact_sensitive_text", lambda text, **_: text)
+    assert _safe_branch(token) is None
+
+
+def test_redactor_error_fails_closed_for_text_and_structured_identifiers(monkeypatch):
+    import agent.redact as authoritative_redaction
+    from gateway.progress_queries import _safe_branch, _safe_commit, _safe_text
+
+    def raise_redactor_error(*args, **kwargs):
+        raise RuntimeError("redactor unavailable")
+
+    monkeypatch.setattr(authoritative_redaction, "redact_sensitive_text", raise_redactor_error)
+
+    assert _safe_text("ordinary receipt") == "[redacted]"
+    assert _safe_branch("codex/safe-branch") is None
+    assert _safe_commit("deadbeef") is None
+
+
+def test_progress_redacts_complete_multiline_secret_values_but_keeps_other_prose(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "Exception Burndown", status="done")
+        _sub(conn, root)
+        _run(
+            conn,
+            root,
+            status="done",
+            outcome="completed",
+            summary=(
+                "Authorization: Bearer header-sentinel with trailing secret words\n"
+                "X-API-Key: x-header-sentinel plus another secret word\n"
+                "Proxy-Authorization: proxy-sentinel with another tail\n"
+                "DATABASE_PASSWORD=database-sentinel has an unquoted multiword tail\n"
+                "Unrelated acceptance evidence remains visible."
+            ),
+        )
+
+    result = resolve_progress_query("How did the burndown go?", source=_source(), board=BOARD)
+
+    assert result.handled is True
+    assert "header-sentinel" not in result.response
+    assert "trailing secret words" not in result.response
+    assert "x-header-sentinel" not in result.response
+    assert "another secret word" not in result.response
+    assert "proxy-sentinel" not in result.response
+    assert "another tail" not in result.response
+    assert "database-sentinel" not in result.response
+    assert "unquoted multiword tail" not in result.response
+    assert "Unrelated acceptance evidence remains visible." in result.response
+
+
+def test_progress_redacts_inline_multiword_secret_values_and_preserves_prefix_prose(
+    kanban_home,
+):
+    from gateway.progress_queries import resolve_progress_query
+
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "Exception Burndown", status="done")
+        _sub(conn, root)
+        _run(
+            conn,
+            root,
+            status="done",
+            outcome="completed",
+            summary=(
+                "Worker note: Authorization: Bearer header-sentinel trailing-secret\n"
+                "Deployment note: DATABASE_PASSWORD=database sentinel trailing secret"
+            ),
+        )
+
+    result = resolve_progress_query("How did the burndown go?", source=_source(), board=BOARD)
+
+    assert result.handled is True
+    assert "Worker note:" in result.response
+    assert "Deployment note:" in result.response
+    assert "header-sentinel" not in result.response
+    assert "trailing-secret" not in result.response
+    assert "database sentinel trailing secret" not in result.response
+
+
+def test_progress_redacts_aws_private_key_and_database_url_credentials(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    secret_values = (
+        "aws-secret-sentinel trailing words",
+        "aws-access-sentinel",
+        "private-key-sentinel trailing words",
+        "postgres://operator:db-password-sentinel@localhost/trading",
+        "connection-sentinel trailing words",
+    )
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "Exception Burndown", status="done")
+        _sub(conn, root)
+        _run(
+            conn,
+            root,
+            status="done",
+            outcome="completed",
+            summary=(
+                "AWS_SECRET_ACCESS_KEY=aws-secret-sentinel trailing words\n"
+                "Worker note: AWS_ACCESS_KEY_ID: aws-access-sentinel\n"
+                "Deploy note: PRIVATE_KEY=private-key-sentinel trailing words\n"
+                "DATABASE_URL=postgres://operator:db-password-sentinel@localhost/trading\n"
+                "Worker note: CONNECTION_STRING=connection-sentinel trailing words\n"
+                "Unrelated acceptance evidence remains visible."
+            ),
+        )
+
+    result = resolve_progress_query("How did the burndown go?", source=_source(), board=BOARD)
+
+    assert result.handled is True
+    for secret in secret_values:
+        assert secret not in result.response
+    assert "Unrelated acceptance evidence remains visible." in result.response
+
+
+def test_progress_reads_existing_board_without_using_mutating_connection(kanban_home, monkeypatch):
+    from gateway.progress_queries import resolve_progress_query
+
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "Exception Burndown", status="done")
+        _sub(conn, root)
+
+    def reject_mutating_connect(*args, **kwargs):
+        raise AssertionError("progress lookup must not call kanban_db.connect")
+
+    monkeypatch.setattr(kb, "connect", reject_mutating_connect)
+    result = resolve_progress_query("How did the burndown go?", source=_source(), board=BOARD)
+
+    assert result.handled is True
+    assert result.reason == "resolved"
+    assert root in result.response
+
+
+def test_progress_snapshot_includes_committed_wal_without_touching_source_sidecars(
+    kanban_home,
+):
+    from gateway.progress_queries import resolve_progress_query
+
+    source_path = kb.kanban_db_path(board=BOARD)
+    conn = kb.connect(board=BOARD)
+    try:
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        root = _task(conn, "Exception Burndown", status="done")
+        _sub(conn, root)
+        wal_path = Path(str(source_path) + "-wal")
+        assert wal_path.is_file()
+        assert wal_path.stat().st_size > 0
+
+        tracked_paths = [source_path, wal_path, Path(str(source_path) + "-shm")]
+
+        def signatures():
+            return {
+                path: (
+                    path.exists(),
+                    path.stat().st_ino if path.exists() else None,
+                    path.stat().st_size if path.exists() else None,
+                    path.stat().st_mtime_ns if path.exists() else None,
+                )
+                for path in tracked_paths
+            }
+
+        before = signatures()
+        result = resolve_progress_query(
+            "How did the burndown go?", source=_source(), board=BOARD
+        )
+
+        assert result.handled is True
+        assert result.reason == "resolved"
+        assert root in result.response
+        assert signatures() == before
+    finally:
+        conn.close()
+
+
+def test_progress_snapshot_race_fails_unavailable(kanban_home, monkeypatch):
+    import gateway.progress_queries as progress_queries
+
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "Exception Burndown", status="done")
+        _sub(conn, root)
+
+    real_copy = progress_queries._copy_snapshot_file
+
+    def racing_copy(source, destination, expected):
+        real_copy(source, destination, expected)
+        source_stat = source.stat()
+        os.utime(source, ns=(source_stat.st_atime_ns, source_stat.st_mtime_ns + 1))
+
+    monkeypatch.setattr(progress_queries, "_copy_snapshot_file", racing_copy)
+    result = progress_queries.resolve_progress_query(
+        "How did the burndown go?", source=_source(), board=BOARD
+    )
+
+    assert result.handled is False
+    assert result.reason == "unavailable"
+
+
+def test_snapshot_copy_reads_only_captured_bytes_and_rejects_append(tmp_path, monkeypatch):
+    import gateway.progress_queries as progress_queries
+
+    source = tmp_path / "source.db"
+    destination = tmp_path / "snapshot.db"
+    captured = b"captured-database-bytes"
+    appended = b"-appended-after-read"
+    source.write_bytes(captured)
+    expected = progress_queries._regular_file_signature(source)
+    real_read = os.read
+    requested_sizes = []
+    did_append = False
+
+    def append_after_first_read(descriptor, byte_count):
+        nonlocal did_append
+        requested_sizes.append(byte_count)
+        data = real_read(descriptor, byte_count)
+        if data and not did_append:
+            did_append = True
+            with source.open("ab") as writer:
+                writer.write(appended)
+        return data
+
+    monkeypatch.setattr(os, "read", append_after_first_read)
+
+    with pytest.raises(OSError, match="changed"):
+        progress_queries._copy_snapshot_file(source, destination, expected)
+
+    assert destination.read_bytes() == captured
+    assert sum(requested_sizes) == len(captured) + 1
+
+
+def test_progress_explicit_board_ignores_database_environment_override(
+    kanban_home, monkeypatch, tmp_path
+):
+    from gateway.progress_queries import resolve_progress_query
+
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "Exception Burndown", status="done")
+        _sub(conn, root)
+    override_path = tmp_path / "override" / "kanban.db"
+    with kb.connect(db_path=override_path):
+        pass
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(override_path))
+
+    result = resolve_progress_query(
+        "How did the burndown go?", source=_source(), board=BOARD
+    )
+
+    assert result.handled is True
+    assert result.reason == "resolved"
+    assert root in result.response
+
+
+def test_progress_counts_each_canonical_failed_run_once_and_labels_attempts(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "Exception Burndown", status="done")
+        retrying = _task(conn, "Retry failed patch", parents=[root], status="ready")
+        _task(conn, "Running audit", parents=[root], status="running")
+        _sub(conn, root)
+        for outcome in ("spawn_failed", "failed", "timed_out", "crashed"):
+            assert kb.claim_task(conn, retrying, claimer=f"worker:{outcome}") is not None
+            assert kb._record_task_failure(
+                conn,
+                retrying,
+                f"{outcome} receipt",
+                outcome=outcome,
+                failure_limit=99,
+                release_claim=True,
+                end_run=True,
+            ) is False
+        assert kb.claim_task(conn, retrying, claimer="worker:gave-up") is not None
+        assert kb._record_task_failure(
+            conn,
+            retrying,
+            "gave up receipt",
+            outcome="crashed",
+            failure_limit=99,
+            force_trip=True,
+            release_claim=True,
+            end_run=True,
+        ) is True
+        assert [run.outcome for run in kb.list_runs(conn, retrying)] == [
+            "spawn_failed",
+            "failed",
+            "timed_out",
+            "crashed",
+            "gave_up",
+        ]
+
+    result = resolve_progress_query(
+        "How did the burndown go?", source=_source(), board=BOARD
+    )
+
+    assert "1 completed, 5 failed attempts, 1 blocked, 1 running" in result.response
+
+
+@pytest.mark.parametrize("status", ["triage", "scheduled"])
+def test_progress_includes_root_only_remaining_work_in_next(kanban_home, status):
+    from gateway.progress_queries import resolve_progress_query
+
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "Exception Burndown", status=status)
+        _sub(conn, root)
+
+    result = resolve_progress_query(
+        "How did the burndown go?", source=_source(), board=BOARD
+    )
+
+    assert result.handled is True
+    assert f"`{root}` Exception Burndown ({status})" in result.response
+    assert "Next:" in result.response
+
+
+def test_progress_uses_newest_receipt_across_entire_graph(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "Exception Burndown", status="done")
+        child = _task(conn, "Acceptance follow-up", parents=[root], status="done")
+        _sub(conn, root)
+        _run(conn, root, status="done", summary="Older root receipt.", started_at=100)
+        _run(conn, child, status="done", summary="Newest graph receipt.", started_at=200)
+
+    result = resolve_progress_query(
+        "How did the burndown go?", source=_source(), board=BOARD
+    )
+
+    assert "Newest graph receipt." in result.response
+    assert "Older root receipt." not in result.response
+
+
+def test_progress_discloses_scope_when_graph_exceeds_task_limit(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "Exception Burndown", status="done")
+        _sub(conn, root)
+        _run(conn, root, status="done", summary="Root receipt.", started_at=100)
+        kb.add_comment(conn, root, "worker", "Root note.")
+        for index in range(24):
+            _task(conn, f"Completed child {index}", parents=[root], status="done")
+
+    result = resolve_progress_query(
+        "How did the burndown go?", source=_source(), board=BOARD
+    )
+
+    assert result.handled is True
+    assert "first 24 tasks" in result.response
+    assert "counts and receipt" in result.response.casefold()
+    assert "24 completed" in result.response
+    assert "Newest receipt within first 24 tasks" in result.response
+    assert "Latest receipt" not in result.response
+    assert "Newest note within first 24 tasks" in result.response
+    assert "Latest note" not in result.response
+
+
+def test_truncated_progress_labels_next_list_as_partial(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "Exception Burndown", status="done")
+        _sub(conn, root)
+        _task(conn, "Ready child", parents=[root], status="ready")
+        for index in range(23):
+            _task(conn, f"Completed child {index}", parents=[root], status="done")
+
+    result = resolve_progress_query(
+        "How did the burndown go?", source=_source(), board=BOARD
+    )
+
+    assert result.handled is True
+    assert "Next (partial; first 24 tasks only):" in result.response
+    assert "Ready child" in result.response
+    assert " Next:" not in result.response
+
+
+def test_missing_board_is_unavailable_without_creating_files(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    missing_path = kb.kanban_db_path(board="missing-progress-board")
+    assert not missing_path.exists()
+    assert not missing_path.parent.exists()
+
+    result = resolve_progress_query(
+        "How did the burndown go?", source=_source(), board="missing-progress-board"
+    )
+
+    assert result.handled is False
+    assert result.reason == "unavailable"
+    assert not missing_path.exists()
+    assert not missing_path.parent.exists()
+
+
+def test_symlink_board_database_is_unavailable(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "Exception Burndown", status="done")
+        _sub(conn, root)
+    source_path = kb.kanban_db_path(board=BOARD)
+    alias_path = kb.kanban_db_path(board="linked-progress-board")
+    alias_path.parent.mkdir(parents=True)
+    alias_path.symlink_to(source_path)
+
+    result = resolve_progress_query(
+        "How did the burndown go?", source=_source(), board="linked-progress-board"
+    )
+
+    assert result.handled is False
+    assert result.reason == "unavailable"
+
+
+def test_progress_reply_includes_a_safe_latest_comment_alongside_run_receipt(kanban_home):
+    from gateway.progress_queries import resolve_progress_query
+
+    with kb.connect(board=BOARD) as conn:
+        root = _task(conn, "Exception Burndown", status="running")
+        _sub(conn, root)
+        _run(conn, root, status="running", summary="Worker is checking the failure receipt.")
+        kb.add_comment(conn, root, "operator", "Next, compare the remaining failed gate.")
+
+    result = resolve_progress_query("How did the burndown go?", source=_source(), board=BOARD)
+
+    assert result.handled is True
+    assert "Worker is checking the failure receipt." in result.response
+    assert "Next, compare the remaining failed gate." in result.response

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -579,6 +579,38 @@ class TestSessionStoreLookup:
         assert store.lookup_by_session_key("agent:main:telegram:dm:missing") is None
         assert store.lookup_by_session_key("") is None
 
+    def test_private_voice_lane_never_recovers_peer_transcript(self, store):
+        """A same-chat fallback must not erase an intentional voice boundary."""
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="voice-text-channel",
+            chat_type="channel",
+            user_id="voice-user",
+        )
+        source._session_key_lane = "discord-voice:dedicated-room"
+        store._db = MagicMock()
+        store._db.get_compression_tip.side_effect = lambda session_id: session_id
+
+        def _find(**kwargs):
+            # Model the real DB: the old session is discoverable only through
+            # the platform/chat peer fallback, not by the new lane key.
+            if kwargs["chat_id"] is not None:
+                return {
+                    "id": "legacy-voice-session",
+                    "started_at": datetime.now().timestamp(),
+                    "last_activity_at": datetime.now().timestamp(),
+                }
+            return None
+
+        store._db.find_latest_gateway_session_for_peer.side_effect = _find
+
+        entry = store.get_or_create_session(source)
+
+        assert entry.session_id != "legacy-voice-session"
+        call = store._db.find_latest_gateway_session_for_peer.call_args
+        assert call.kwargs["chat_id"] is None
+        assert call.kwargs["chat_type"] is None
+
 
 class TestSlackWorkspaceSessionIsolation:
     @pytest.fixture()
@@ -1642,5 +1674,4 @@ class TestGatewayRoutingTable:
         recovered = restarted.get_or_create_session(self._source())
         assert recovered.session_id == entry.session_id
         restarted._db.close()
-
 

--- a/tests/gateway/test_specialist_handoff_orchestration.py
+++ b/tests/gateway/test_specialist_handoff_orchestration.py
@@ -1,0 +1,112 @@
+"""Discord specialist work enters the durable orchestration lifecycle."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gateway.specialist_handoff import HandoffSource, create_specialist_handoff
+from gateway.specialist_routing import (
+    RouteKind,
+    SpecialistRouteDecision,
+    parse_specialist_response,
+)
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def test_specialist_handoff_creates_goal_mode_triage_root(kanban_home):
+    decision = SpecialistRouteDecision(
+        kind=RouteKind.SPECIALIST,
+        profile="burndown-patch-steward",
+        confidence=1.0,
+        reason="explicit request",
+        title="Narrow Exception Burndown and Patching",
+    )
+    source = HandoffSource(
+        platform="discord",
+        chat_id="channel-1",
+        chat_type="group",
+        user_id="user-1",
+        message_id="message-1",
+    )
+
+    result = create_specialist_handoff(
+        decision=decision,
+        source=source,
+        request="Audit exception burndown and patch confirmed failures.",
+        board="project-burndown",
+    )
+
+    assert result.ok, result.reason
+    assert result.task_id
+    with kb.connect(board="project-burndown") as conn:
+        task = kb.get_task(conn, result.task_id)
+    assert task is not None
+    assert task.status == "triage"
+    assert task.goal_mode is True
+    assert task.goal_max_turns == 12
+    assert task.skills is None
+
+
+def test_specialist_handoff_explicit_board_ignores_database_environment_override(
+    kanban_home, monkeypatch, tmp_path
+):
+    decision = SpecialistRouteDecision(
+        kind=RouteKind.SPECIALIST,
+        profile="burndown-patch-steward",
+        confidence=1.0,
+        reason="explicit request",
+        title="Patch Exception Burndown",
+    )
+    source = HandoffSource(
+        platform="discord",
+        chat_id="channel-1",
+        chat_type="group",
+        user_id="user-1",
+        message_id="message-env-isolation",
+    )
+    board = "project-burndown"
+    with kb.connect(board=board):
+        pass
+    override_path = tmp_path / "override" / "kanban.db"
+    with kb.connect(db_path=override_path):
+        pass
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(override_path))
+
+    result = create_specialist_handoff(
+        decision=decision,
+        source=source,
+        request="Patch the confirmed exception failures.",
+        board=board,
+    )
+
+    assert result.ok, result.reason
+    monkeypatch.delenv("HERMES_KANBAN_DB")
+    with kb.connect(board=board) as configured_conn:
+        configured_task = kb.get_task(configured_conn, result.task_id)
+    with kb.connect(db_path=override_path) as override_conn:
+        override_task = kb.get_task(override_conn, result.task_id)
+    assert configured_task is not None
+    assert override_task is None
+
+
+def test_router_accepts_task_orchestrator_for_broad_actionable_work():
+    decision = parse_specialist_response(
+        '{"kind":"specialist","profile":"task-orchestrator",'
+        '"confidence":0.91,"reason":"requires planning across roles",'
+        '"title":"Implement the requested workflow"}'
+    )
+
+    assert decision.dispatches is True
+    assert decision.profile == "task-orchestrator"

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -681,6 +681,77 @@ class TestVoiceChannelCommands:
         assert event.source.chat_name == "Hermes Server / #general"
         assert event.source.user_id == "42"
 
+    @pytest.mark.asyncio
+    async def test_input_marks_configured_fast_lane_without_changing_reply_channel(
+        self, runner, monkeypatch
+    ):
+        """Configured voice fast lane gets an isolated session, not a new Discord target."""
+        import gateway.run as _gr
+        from gateway.config import Platform
+
+        monkeypatch.setattr(
+            _gr,
+            "_load_gateway_config",
+            lambda: {
+                "discord": {
+                    "voice_fast_lane": {
+                        "enabled": True,
+                        "channel_id": "456",
+                        "user_ids": ["42"],
+                    }
+                }
+            },
+        )
+        mock_adapter = AsyncMock()
+        mock_adapter._voice_text_channels = {111: 123}
+        mock_adapter._voice_sources = {}
+        mock_adapter._voice_clients = {
+            111: SimpleNamespace(channel=SimpleNamespace(id=456))
+        }
+        mock_adapter._resolve_channel_prompt = None
+        mock_adapter._client = MagicMock()
+        mock_channel = MagicMock()
+        mock_channel.send = AsyncMock()
+        mock_adapter._client.get_channel = MagicMock(return_value=mock_channel)
+        mock_adapter.handle_message = AsyncMock()
+        runner.adapters[Platform.DISCORD] = mock_adapter
+
+        await runner._handle_voice_channel_input(111, 42, "What did you just say?")
+
+        event = mock_adapter.handle_message.call_args.args[0]
+        assert event.source.chat_id == "123"
+        assert event.source._voice_fast_lane is True
+        assert event.source._session_key_lane == "discord-voice:456"
+
+    def test_fast_lane_session_key_isolates_voice_context(self):
+        """The private lane marker must change storage identity, never Discord delivery."""
+        from gateway.config import Platform
+        from gateway.platforms.base import build_session_key
+
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="123",
+            chat_type="channel",
+            user_id="42",
+        )
+        normal_key = build_session_key(source)
+        source._session_key_lane = "discord-voice:456"
+        assert build_session_key(source) != normal_key
+        assert build_session_key(source).endswith(":lane:discord-voice:456")
+
+    def test_fast_lane_work_detection_is_explicit(self):
+        """Conversation stays tool-free; an explicit operation keeps task capability."""
+        from gateway.run import GatewayRunner
+
+        assert not GatewayRunner._voice_fast_lane_requests_work("Can you hear me?")
+        assert not GatewayRunner._voice_fast_lane_requests_work("What did you just say?")
+        assert GatewayRunner._voice_fast_lane_requests_work(
+            "Please inspect the Hermes worktree and fix the voice delay."
+        )
+        assert GatewayRunner._voice_fast_lane_requests_work(
+            "Run the tests and commit the patch."
+        )
+
 
     # -- _get_guild_id --
 
@@ -1700,6 +1771,21 @@ class TestVoiceReception:
 
         assert 100 in receiver._buffers
         assert len(receiver._buffers[100]) > 0
+
+    def test_on_packet_infers_sole_user_before_dave_decrypt(self):
+        """First speech after reconnect must not decode encrypted audio as silence."""
+        dave = MagicMock()
+        receiver = self._make_receiver_with_nacl(dave_session=dave)
+        receiver._infer_user_for_ssrc = MagicMock(return_value=42)
+        self._inject_mock_decoder(receiver, 100)
+
+        with patch("nacl.secret.Aead") as mock_aead:
+            mock_aead.return_value.decrypt.return_value = b"\xf8\xff\xfe"
+            receiver._on_packet(self._build_rtp_packet(ssrc=100))
+
+        receiver._infer_user_for_ssrc.assert_called_once_with(100)
+        assert dave.decrypt.call_args.args[0] == 42
+        assert 100 in receiver._buffers
 
 
 class TestVoiceTTSPlayback:

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -88,5 +88,54 @@ def test_decompose_records_audit_comment_and_event(kanban_home):
     assert any(ev.kind == "decomposed" for ev in events)
 
 
+def test_decompose_inherits_goal_lifecycle_to_children(kanban_home):
+    """A routed goal must not fan out into one-shot child workers."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="durable orchestration root",
+            triage=True,
+            goal_mode=True,
+            goal_max_turns=12,
+        )
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orchestrator",
+            children=[
+                {"title": "first slice", "assignee": "researcher"},
+                {"title": "second slice", "assignee": "engineer"},
+            ],
+            author="decomposer",
+        )
+    assert child_ids is not None
 
+    with kb.connect() as conn:
+        children = [kb.get_task(conn, child_id) for child_id in child_ids]
+
+    assert all(child is not None and child.goal_mode for child in children)
+    assert [child.goal_max_turns for child in children] == [12, 12]
+
+
+def test_decompose_inherits_forced_skills_to_children(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="navigation-bound root",
+            triage=True,
+            skills=["project-worktree-navigation"],
+        )
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orchestrator",
+            children=[{"title": "first slice", "assignee": "researcher"}],
+        )
+    assert child_ids is not None
+
+    with kb.connect() as conn:
+        child = kb.get_task(conn, child_ids[0])
+
+    assert child is not None
+    assert child.skills == ["project-worktree-navigation"]
 


### PR DESCRIPTION
## Summary
- answer bounded plain-English project-progress questions from source-authorized Kanban evidence
- keep ordinary progress questions on the deterministic fast path before specialist model routing
- create idempotent specialist handoffs with explicit board and source identity
- preserve bounded delivery, secret/path redaction, and fail-closed evidence lookup

## Review scope
This PR was reduced from 32 files and 4,465 changed lines to one current-main commit with 25 files and 3,466 changed lines. The vault-report continuation and later follow-ups were removed from this PR and preserved separately for a future self-contained change.

Product-specific board hooks and fixtures were also removed; the published diff uses neutral project examples only.

## Verification
- 338 focused tests passed
- targeted Ruff passed
- git diff --check passed
- full commit branding scan returned no product-specific matches

The focused tests cover progress parsing and graph binding, Discord delivery, specialist handoff identity, Kanban budget notification, session behavior, voice commands, project skills, and skill guards.