### PR TITLE
fix(skills): ignore generated Python cache files in drift checks

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -50,6 +50,18 @@ EXCLUDED_SKILL_DIRS = frozenset(
 # archive workflow preserves a complete old skill package under references/.
 SKILL_SUPPORT_DIRS = frozenset(("references", "templates", "assets", "scripts"))
 
+
+def is_generated_skill_path(path) -> bool:
+    """Return whether *path* is generated Python cache data.
+
+    Skill identity and update comparison include intentional package files, but
+    interpreter-generated ``__pycache__`` directories and ``.pyc`` files are
+    not part of the bundled source boundary and must not create drift.
+    """
+    normalized = str(path).replace("\\", "/")
+    return "__pycache__" in normalized.split("/") or normalized.endswith(".pyc")
+
+
 # ── Org-shared skills (sync contract) ───────────────────────────
 # Org mirrors live under ~/.hermes/skills/_org/<org_id>/. Resolution is
 # TOKEN-GATED via a marker file the sync client writes after verifying the

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1124,8 +1124,12 @@ def do_update(name: Optional[str] = None, console: Optional[Console] = None,
     paperclipai/paperclip#10978's explicit-merge-mode rule: destructive
     replacement must be an explicit caller choice, never a rerun default).
     """
-    from tools.skills_hub import SKILLS_DIR, HubLockFile, check_for_skill_updates
-    from tools.skills_guard import content_hash
+    from tools.skills_hub import (
+        SKILLS_DIR,
+        HubLockFile,
+        check_for_skill_updates,
+        resolve_hub_lock_tree_hash,
+    )
 
     c = console or _console
     lock = HubLockFile()
@@ -1143,10 +1147,12 @@ def do_update(name: Optional[str] = None, console: Optional[Console] = None,
             skill_path = SKILLS_DIR / installed.get("install_path", "")
             if recorded_hash and skill_path.is_dir():
                 try:
-                    disk_hash = content_hash(skill_path)
+                    resolved_hash = resolve_hub_lock_tree_hash(
+                        recorded_hash, skill_path
+                    )
                 except OSError:
-                    disk_hash = recorded_hash
-                if disk_hash != recorded_hash:
+                    resolved_hash = recorded_hash
+                if resolved_hash is None:
                     skipped_local.append(entry["name"])
                     c.print(
                         f"[yellow]Skipping:[/] {entry['name']} — you have local edits "

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -1,3 +1,4 @@
+import hashlib
 from io import StringIO
 from unittest.mock import patch
 
@@ -415,7 +416,19 @@ def test_do_search_json_flag_emits_full_identifiers(capsys):
 # ---------------------------------------------------------------------------
 
 
-def _update_env(monkeypatch, tmp_path, *, edit_after_install: bool):
+def _legacy_cache_inclusive_hash(skill_dir):
+    hasher = hashlib.sha256()
+    for path in sorted(skill_dir.rglob("*")):
+        if path.is_file():
+            hasher.update(path.relative_to(skill_dir).as_posix().encode("utf-8"))
+            hasher.update(b"\x00")
+            hasher.update(path.read_bytes())
+    return f"sha256:{hasher.hexdigest()[:16]}"
+
+
+def _update_env(
+    monkeypatch, tmp_path, *, edit_after_install: bool, legacy_cache_hash: bool = False
+):
     """Install a fake hub skill on disk, optionally edit it, and wire mocks.
 
     Returns (console_sink, installs_list).
@@ -429,7 +442,13 @@ def _update_env(monkeypatch, tmp_path, *, edit_after_install: bool):
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text("# hub-skill\noriginal\n")
 
-    recorded = content_hash(skill_dir)
+    if legacy_cache_hash:
+        cache = skill_dir / "scripts" / "__pycache__"
+        cache.mkdir(parents=True)
+        (cache / "helper.cpython-313.pyc").write_bytes(b"generated")
+        recorded = _legacy_cache_inclusive_hash(skill_dir)
+    else:
+        recorded = content_hash(skill_dir)
     if edit_after_install:
         (skill_dir / "SKILL.md").write_text("# hub-skill\nuser edited\n")
 
@@ -489,3 +508,17 @@ def test_do_update_unmodified_skill_updates_normally(monkeypatch, tmp_path):
 
     assert installs == ["someone/hub-skill"]
     assert "Updated 1 skill(s)" in sink.getvalue()
+
+
+def test_do_update_accepts_proven_legacy_cache_inclusive_lock(monkeypatch, tmp_path):
+    console, sink, installs = _update_env(
+        monkeypatch,
+        tmp_path,
+        edit_after_install=False,
+        legacy_cache_hash=True,
+    )
+
+    do_update(console=console)
+
+    assert installs == ["someone/hub-skill"]
+    assert "local edits" not in sink.getvalue()

--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -345,6 +345,16 @@ class TestContentHash:
         h2 = content_hash(tmp_path)
         assert h1 != h2
 
+    def test_ignores_generated_python_cache_files(self, tmp_path):
+        (tmp_path / "SKILL.md").write_text("same content")
+        baseline = content_hash(tmp_path)
+        cache = tmp_path / "scripts" / "__pycache__"
+        cache.mkdir(parents=True)
+        (cache / "helper.cpython-313.pyc").write_bytes(b"generated")
+        (tmp_path / "scripts" / "helper.pyc").write_bytes(b"generated")
+
+        assert content_hash(tmp_path) == baseline
+
 
 # ---------------------------------------------------------------------------
 # _unicode_char_name

--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -27,6 +27,7 @@ from tools.skills_guard import (
     should_allow_install,
     format_scan_report,
     content_hash,
+    full_content_hash,
     _determine_verdict,
     _resolve_trust_level,
     _check_structure,
@@ -354,6 +355,15 @@ class TestContentHash:
         (tmp_path / "scripts" / "helper.pyc").write_bytes(b"generated")
 
         assert content_hash(tmp_path) == baseline
+
+    def test_full_hash_changes_for_generated_python_cache_files(self, tmp_path):
+        (tmp_path / "SKILL.md").write_text("same content")
+        baseline = full_content_hash(tmp_path)
+        cache = tmp_path / "scripts" / "__pycache__"
+        cache.mkdir(parents=True)
+        (cache / "helper.cpython-313.pyc").write_bytes(b"generated")
+
+        assert full_content_hash(tmp_path) != baseline
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1,5 +1,6 @@
 """Tests for tools/skills_hub.py — source adapters, lock file, taps, dedup logic."""
 
+import hashlib
 import json
 import time
 from typing import List, Optional
@@ -561,6 +562,99 @@ class TestCheckForSkillUpdates:
         assert len(results) == 1
         assert results[0]["name"] == "demo-skill"
         assert results[0]["status"] == "update_available"
+
+    @staticmethod
+    def _legacy_cache_inclusive_hash(skill_dir):
+        hasher = hashlib.sha256()
+        for path in sorted(skill_dir.rglob("*")):
+            if path.is_file():
+                hasher.update(path.relative_to(skill_dir).as_posix().encode("utf-8"))
+                hasher.update(b"\x00")
+                hasher.update(path.read_bytes())
+        return f"sha256:{hasher.hexdigest()[:16]}"
+
+    def test_legacy_cache_hash_is_accepted_and_migrated_with_remote_proof(
+        self, tmp_path, monkeypatch
+    ):
+        from tools.skills_guard import content_hash
+        import tools.skills_hub as hub
+
+        skills_dir = tmp_path / "skills"
+        skill_dir = skills_dir / "category" / "demo-skill"
+        cache = skill_dir / "scripts" / "__pycache__"
+        cache.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("same content", encoding="utf-8")
+        cache_file = cache / "helper.cpython-313.pyc"
+        cache_file.write_bytes(b"original-cache")
+        legacy_hash = self._legacy_cache_inclusive_hash(skill_dir)
+        cache_file.write_bytes(b"regenerated-cache")
+
+        lock = HubLockFile(path=tmp_path / "lock.json")
+        lock.record_install(
+            name="demo-skill",
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+            scan_verdict="pass",
+            skill_hash=legacy_hash,
+            install_path="category/demo-skill",
+            files=["SKILL.md", "scripts/__pycache__/helper.cpython-313.pyc"],
+        )
+        source = MagicMock()
+        source.source_id.return_value = "github"
+        source.fetch.return_value = SkillBundle(
+            name="demo-skill",
+            files={
+                "SKILL.md": "same content",
+                "scripts/__pycache__/helper.cpython-313.pyc": b"original-cache",
+            },
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+        monkeypatch.setattr(hub, "SKILLS_DIR", skills_dir)
+
+        results = check_for_skill_updates(lock=lock, sources=[source])
+
+        assert results[0]["status"] == "up_to_date"
+        assert lock.get_installed("demo-skill")["content_hash"] == content_hash(
+            skill_dir
+        )
+
+    def test_corrupt_lock_hash_is_not_accepted_or_migrated(self, tmp_path, monkeypatch):
+        import tools.skills_hub as hub
+
+        skills_dir = tmp_path / "skills"
+        skill_dir = skills_dir / "demo-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("same content", encoding="utf-8")
+        corrupt_hash = "sha256:0000000000000000"
+        lock = HubLockFile(path=tmp_path / "lock.json")
+        lock.record_install(
+            name="demo-skill",
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+            scan_verdict="pass",
+            skill_hash=corrupt_hash,
+            install_path="demo-skill",
+            files=["SKILL.md"],
+        )
+        source = MagicMock()
+        source.source_id.return_value = "github"
+        source.fetch.return_value = SkillBundle(
+            name="demo-skill",
+            files={"SKILL.md": "same content"},
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+        monkeypatch.setattr(hub, "SKILLS_DIR", skills_dir)
+
+        results = check_for_skill_updates(lock=lock, sources=[source])
+
+        assert results[0]["status"] == "update_available"
+        assert lock.get_installed("demo-skill")["content_hash"] == corrupt_hash
 
 class TestCreateSourceRouter:
 

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -573,7 +573,7 @@ class TestCheckForSkillUpdates:
                 hasher.update(path.read_bytes())
         return f"sha256:{hasher.hexdigest()[:16]}"
 
-    def test_legacy_cache_hash_is_accepted_and_migrated_with_remote_proof(
+    def test_legacy_cache_hash_is_accepted_without_migration_with_remote_proof(
         self, tmp_path, monkeypatch
     ):
         from tools.skills_guard import content_hash
@@ -600,6 +600,8 @@ class TestCheckForSkillUpdates:
             install_path="category/demo-skill",
             files=["SKILL.md", "scripts/__pycache__/helper.cpython-313.pyc"],
         )
+        migrate = MagicMock(wraps=lock.migrate_content_hash)
+        monkeypatch.setattr(lock, "migrate_content_hash", migrate)
         source = MagicMock()
         source.source_id.return_value = "github"
         source.fetch.return_value = SkillBundle(
@@ -617,9 +619,80 @@ class TestCheckForSkillUpdates:
         results = check_for_skill_updates(lock=lock, sources=[source])
 
         assert results[0]["status"] == "up_to_date"
-        assert lock.get_installed("demo-skill")["content_hash"] == content_hash(
-            skill_dir
+        assert lock.get_installed("demo-skill")["content_hash"] == legacy_hash
+        assert content_hash(skill_dir) == results[0]["latest_hash"]
+        migrate.assert_not_called()
+
+    @pytest.mark.parametrize("install_path", ["", "../demo-skill", "demo-skill"])
+    def test_legacy_remote_hash_without_resolvable_installed_tree_needs_update(
+        self, tmp_path, monkeypatch, install_path
+    ):
+        import tools.skills_hub as hub
+
+        bundle = SkillBundle(
+            name="demo-skill",
+            files={
+                "SKILL.md": "same content",
+                "scripts/__pycache__/helper.cpython-313.pyc": b"original-cache",
+            },
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
         )
+        lock = MagicMock()
+        lock.list_installed.return_value = [{
+            "name": "demo-skill",
+            "source": "github",
+            "identifier": "owner/repo/demo-skill",
+            "content_hash": hub.legacy_bundle_content_hash(bundle),
+            "install_path": install_path,
+        }]
+        source = MagicMock()
+        source.source_id.return_value = "github"
+        source.fetch.return_value = bundle
+        monkeypatch.setattr(hub, "SKILLS_DIR", tmp_path / "skills")
+
+        results = check_for_skill_updates(lock=lock, sources=[source])
+
+        assert results[0]["status"] == "update_available"
+        lock.migrate_content_hash.assert_not_called()
+
+    def test_legacy_remote_hash_with_local_edits_needs_update(
+        self, tmp_path, monkeypatch
+    ):
+        import tools.skills_hub as hub
+
+        skills_dir = tmp_path / "skills"
+        skill_dir = skills_dir / "demo-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("locally edited", encoding="utf-8")
+        bundle = SkillBundle(
+            name="demo-skill",
+            files={
+                "SKILL.md": "upstream content",
+                "scripts/__pycache__/helper.cpython-313.pyc": b"original-cache",
+            },
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+        lock = MagicMock()
+        lock.list_installed.return_value = [{
+            "name": "demo-skill",
+            "source": "github",
+            "identifier": "owner/repo/demo-skill",
+            "content_hash": hub.legacy_bundle_content_hash(bundle),
+            "install_path": "demo-skill",
+        }]
+        source = MagicMock()
+        source.source_id.return_value = "github"
+        source.fetch.return_value = bundle
+        monkeypatch.setattr(hub, "SKILLS_DIR", skills_dir)
+
+        results = check_for_skill_updates(lock=lock, sources=[source])
+
+        assert results[0]["status"] == "update_available"
+        lock.migrate_content_hash.assert_not_called()
 
     def test_corrupt_lock_hash_is_not_accepted_or_migrated(self, tmp_path, monkeypatch):
         import tools.skills_hub as hub

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -656,6 +656,47 @@ class TestCheckForSkillUpdates:
         assert results[0]["status"] == "update_available"
         assert lock.get_installed("demo-skill")["content_hash"] == corrupt_hash
 
+    def test_current_lock_hash_is_not_rewritten_during_update_check(
+        self, tmp_path, monkeypatch
+    ):
+        from tools.skills_guard import content_hash
+        import tools.skills_hub as hub
+
+        skills_dir = tmp_path / "skills"
+        skill_dir = skills_dir / "demo-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("installed content", encoding="utf-8")
+        canonical_hash = content_hash(skill_dir)
+        lock = HubLockFile(path=tmp_path / "lock.json")
+        lock.record_install(
+            name="demo-skill",
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+            scan_verdict="pass",
+            skill_hash=canonical_hash,
+            install_path="demo-skill",
+            files=["SKILL.md"],
+        )
+        migrate = MagicMock(wraps=lock.migrate_content_hash)
+        monkeypatch.setattr(lock, "migrate_content_hash", migrate)
+        source = MagicMock()
+        source.source_id.return_value = "github"
+        source.fetch.return_value = SkillBundle(
+            name="demo-skill",
+            files={"SKILL.md": "new upstream content"},
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+        monkeypatch.setattr(hub, "SKILLS_DIR", skills_dir)
+
+        results = check_for_skill_updates(lock=lock, sources=[source])
+
+        assert results[0]["status"] == "update_available"
+        migrate.assert_not_called()
+
+
 class TestCreateSourceRouter:
 
     def test_url_source_runs_before_github_source(self):

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -528,6 +528,10 @@ class TestCheckForSkillUpdates:
         (skill_dir / "SKILL.md").write_text("same content")
         (skill_dir / "references").mkdir()
         (skill_dir / "references" / "checklist.md").write_text("- [ ] security\n")
+        cache = skill_dir / "scripts" / "__pycache__"
+        cache.mkdir(parents=True)
+        (cache / "helper.cpython-313.pyc").write_bytes(b"generated")
+        (skill_dir / "scripts" / "helper.pyc").write_bytes(b"generated")
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 

--- a/tests/tools/test_skills_list_modified_diff.py
+++ b/tests/tools/test_skills_list_modified_diff.py
@@ -57,11 +57,20 @@ def _env(tmp_path):
     return bundled, skills_dir, manifest_file
 
 
-def test_pristine_skill_is_not_listed_as_modified(tmp_path):
+def test_pristine_skill_ignores_generated_cache_in_modified_and_diff_checks(tmp_path):
     bundled, skills_dir, manifest_file = _env(tmp_path)
     with _patches(bundled, skills_dir, manifest_file):
         sync_skills(quiet=True)
+        user_skill = skills_dir / "category" / "foo"
+        cache = user_skill / "scripts" / "__pycache__"
+        cache.mkdir(parents=True)
+        (cache / "helper.cpython-313.pyc").write_bytes(b"generated")
+        (user_skill / "scripts" / "helper.pyc").write_bytes(b"generated")
+
         assert list_user_modified_bundled_skills() == []
+        result = diff_bundled_skill("foo")
+        assert result["modified"] is False
+        assert result["diffs"] == []
 
 
 def test_reset_clears_modified_state(tmp_path):

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -1,5 +1,6 @@
 """Tests for tools/skills_sync.py — manifest-based skill seeding and updating."""
 
+import hashlib
 import shutil
 import json
 import os
@@ -21,6 +22,16 @@ from tools.skills_sync import (
     reset_bundled_skill,
     restore_official_optional_skill,
 )
+
+
+def _legacy_cache_inclusive_hash(directory: Path) -> str:
+    """Reproduce the pre-cache-filter bundled manifest hash algorithm."""
+    hasher = hashlib.md5()
+    for fpath in sorted(directory.rglob("*")):
+        if fpath.is_file():
+            hasher.update(str(fpath.relative_to(directory)).encode("utf-8"))
+            hasher.update(fpath.read_bytes())
+    return hasher.hexdigest()
 
 
 class TestReadWriteManifest:
@@ -535,6 +546,178 @@ class TestSyncSkills:
             result2 = sync_skills(quiet=True)
             assert "new-skill" in result2["copied"]
             assert (skills_dir / "category" / "new-skill" / "SKILL.md").exists()
+
+
+class TestLegacyCacheInclusiveManifest:
+    """Compatibility for manifests written before Python caches were ignored."""
+
+    def _skill(self, root, rel="category/demo", body="version one\n"):
+        skill = root / rel
+        cache = skill / "scripts" / "__pycache__"
+        cache.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(
+            f"---\nname: demo\n---\n{body}", encoding="utf-8"
+        )
+        (cache / "helper.cpython-313.pyc").write_bytes(b"original-cache")
+        return skill
+
+    def _patches(self, bundled, skills_dir, manifest_file):
+        from contextlib import ExitStack
+
+        stack = ExitStack()
+        stack.enter_context(
+            patch("tools.skills_sync._get_bundled_dir", return_value=bundled)
+        )
+        stack.enter_context(
+            patch(
+                "tools.skills_sync._get_optional_dir",
+                return_value=bundled.parent / "optional-skills",
+            )
+        )
+        stack.enter_context(patch("tools.skills_sync.SKILLS_DIR", skills_dir))
+        stack.enter_context(
+            patch("tools.skills_sync.MANIFEST_FILE", manifest_file)
+        )
+        return stack
+
+    def _legacy_copy(self, tmp_path):
+        bundled = tmp_path / "bundled"
+        bundled_skill = self._skill(bundled)
+        skills_dir = tmp_path / "user_skills"
+        dest = skills_dir / "category" / "demo"
+        dest.parent.mkdir(parents=True)
+        shutil.copytree(bundled_skill, dest)
+        manifest_file = skills_dir / ".bundled_manifest"
+        manifest_file.write_text(
+            f"demo:{_legacy_cache_inclusive_hash(bundled_skill)}\n",
+            encoding="utf-8",
+        )
+        return bundled, bundled_skill, skills_dir, dest, manifest_file
+
+    def test_cache_only_drift_is_not_listed_or_protected_as_user_edit(self, tmp_path):
+        from tools.skills_sync import list_user_modified_bundled_skills
+
+        bundled, bundled_skill, skills_dir, dest, manifest_file = self._legacy_copy(
+            tmp_path
+        )
+        (dest / "scripts" / "__pycache__" / "helper.cpython-313.pyc").write_bytes(
+            b"regenerated-cache"
+        )
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            assert list_user_modified_bundled_skills() == []
+            result = sync_skills(quiet=True)
+            manifest = _read_manifest()
+
+        assert result["user_modified"] == []
+        assert manifest["demo"] == _dir_hash(bundled_skill)
+        assert (dest / "SKILL.md").exists()
+
+    def test_pristine_legacy_copy_receives_real_upstream_update(self, tmp_path):
+        bundled, bundled_skill, skills_dir, dest, manifest_file = self._legacy_copy(
+            tmp_path
+        )
+        (bundled_skill / "SKILL.md").write_text(
+            "---\nname: demo\n---\nversion two upstream\n", encoding="utf-8"
+        )
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            result = sync_skills(quiet=True)
+            manifest = _read_manifest()
+
+        assert result["updated"] == ["demo"]
+        assert result["user_modified"] == []
+        assert "version two upstream" in (dest / "SKILL.md").read_text()
+        assert manifest["demo"] == _dir_hash(bundled_skill)
+
+    def test_corrupt_origin_does_not_auto_rebaseline(self, tmp_path):
+        from tools.skills_sync import list_user_modified_bundled_skills
+
+        bundled, _bundled_skill, skills_dir, dest, manifest_file = self._legacy_copy(
+            tmp_path
+        )
+        corrupt_origin = "0" * 32
+        manifest_file.write_text(f"demo:{corrupt_origin}\n", encoding="utf-8")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            result = sync_skills(quiet=True)
+            modified = list_user_modified_bundled_skills()
+            manifest = _read_manifest()
+
+        assert result["updated"] == []
+        assert result["user_modified"] == ["demo"]
+        assert [entry["name"] for entry in modified] == ["demo"]
+        assert manifest["demo"] == corrupt_origin
+        assert (dest / "SKILL.md").exists()
+
+    def test_legacy_origin_recovers_an_upstream_rename(self, tmp_path):
+        bundled = tmp_path / "bundled"
+        skills_dir = tmp_path / "user_skills"
+        old = self._skill(skills_dir, rel="old-category/demo")
+        manifest_file = skills_dir / ".bundled_manifest"
+        manifest_file.write_text(
+            f"demo:{_legacy_cache_inclusive_hash(old)}\n", encoding="utf-8"
+        )
+        new_source = self._skill(
+            bundled, rel="new-category/demo", body="version two upstream\n"
+        )
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            result = sync_skills(quiet=True)
+
+        new = skills_dir / "new-category" / "demo"
+        assert result["relocated"] == ["demo"]
+        assert result["updated"] == ["demo"]
+        assert not old.exists()
+        assert "version two upstream" in (new / "SKILL.md").read_text()
+        assert _dir_hash(new) == _dir_hash(new_source)
+
+    def test_legacy_origin_allows_pristine_removal(self, tmp_path):
+        from tools.skills_sync import remove_pristine_bundled_skills
+
+        bundled, _bundled_skill, skills_dir, dest, manifest_file = self._legacy_copy(
+            tmp_path
+        )
+        (dest / "scripts" / "__pycache__" / "helper.cpython-313.pyc").write_bytes(
+            b"regenerated-cache"
+        )
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            result = remove_pristine_bundled_skills()
+
+        assert result["removed"] == ["demo"]
+        assert result["skipped"] == []
+        assert not dest.exists()
+
+    def test_real_content_edit_remains_protected(self, tmp_path):
+        from tools.skills_sync import (
+            list_user_modified_bundled_skills,
+            remove_pristine_bundled_skills,
+        )
+
+        bundled, bundled_skill, skills_dir, dest, manifest_file = self._legacy_copy(
+            tmp_path
+        )
+        (dest / "SKILL.md").write_text(
+            "---\nname: demo\n---\nmy genuine edit\n", encoding="utf-8"
+        )
+        (bundled_skill / "SKILL.md").write_text(
+            "---\nname: demo\n---\nnew upstream content\n", encoding="utf-8"
+        )
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            modified = list_user_modified_bundled_skills()
+            synced = sync_skills(quiet=True)
+            removed = remove_pristine_bundled_skills()
+
+        assert [entry["name"] for entry in modified] == ["demo"]
+        assert synced["user_modified"] == ["demo"]
+        assert synced["updated"] == []
+        assert removed["removed"] == []
+        assert removed["skipped"] == [
+            {"name": "demo", "reason": "user-modified (kept)"}
+        ]
+        assert "my genuine edit" in (dest / "SKILL.md").read_text()
 
 
 class TestGetBundledDir:

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -1015,6 +1015,29 @@ class TestOptOutToggleAndRemove:
             # non-bundled local skill never considered
             assert (skills_dir / "mine" / "SKILL.md").exists()
 
+    def test_remove_keeps_plain_name_v1_manifest_entry(self, tmp_path):
+        """An unbaselined v1 entry is never safe for opt-out deletion."""
+        from tools.skills_sync import remove_pristine_bundled_skills
+
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        dest = skills_dir / "alpha"
+        shutil.copytree(bundled / "alpha", dest)
+        manifest_file = skills_dir / ".bundled_manifest"
+        manifest_file.write_text("alpha\n", encoding="utf-8")
+
+        with patch("tools.skills_sync._get_bundled_dir", return_value=bundled), \
+             patch("tools.skills_sync.SKILLS_DIR", skills_dir), \
+             patch("tools.skills_sync.MANIFEST_FILE", manifest_file):
+            result = remove_pristine_bundled_skills()
+
+        assert result["removed"] == []
+        assert result["skipped"] == [
+            {"name": "alpha", "reason": "user-modified (kept)"}
+        ]
+        assert (dest / "SKILL.md").exists()
+        assert manifest_file.read_text(encoding="utf-8") == "alpha\n"
+
 
 class TestUpdateBackupRecovery:
     """Regression tests for backup handling in the bundled-update path.

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -16,6 +16,7 @@ from tools.skills_sync import (
     _discover_bundled_skills,
     _compute_relative_dest,
     _dir_hash,
+    _skill_file_list,
     sync_skills,
     reset_bundled_skill,
     restore_official_optional_skill,
@@ -82,6 +83,20 @@ class TestDirHash:
         assert isinstance(_dir_hash(empty), str) and len(_dir_hash(empty)) == 32
         # A nonexistent dir hashes as empty content rather than raising.
         assert isinstance(_dir_hash(tmp_path / "nope"), str)
+
+    def test_ignores_generated_python_cache_files(self, tmp_path):
+        skill = tmp_path / "skill"
+        skill.mkdir()
+        (skill / "SKILL.md").write_text("# Test")
+
+        baseline = _dir_hash(skill)
+        cache = skill / "scripts" / "__pycache__"
+        cache.mkdir(parents=True)
+        (cache / "helper.cpython-313.pyc").write_bytes(b"generated")
+        (skill / "scripts" / "helper.pyc").write_bytes(b"generated")
+
+        assert _dir_hash(skill) == baseline
+        assert _skill_file_list(skill) == ["SKILL.md"]
 
 
 class TestDiscoverBundledSkills:

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -883,8 +883,12 @@ def scan_skill(skill_path: Path, source: str = "community") -> ScanResult:
     )
 
 
-def _content_digest(skill_path: Path) -> str:
+def _content_digest(skill_path: Path, *, include_generated: bool = False) -> str:
     """Canonical SHA-256 over relative paths and exact file bytes.
+
+    Generated Python cache data is outside the bundled-skill identity by
+    default, but the scanner attestation can request the full on-disk content
+    so changes to files that the scanner still examines invalidate its cache.
 
     Files are keyed and ORDERED by their POSIX relative path string,
     case-sensitively. Ordering by ``sorted(rglob(...))`` diverged from the
@@ -901,7 +905,10 @@ def _content_digest(skill_path: Path) -> str:
             (file_path.relative_to(skill_path).as_posix(), file_path)
             for file_path in skill_path.rglob("*")
             if file_path.is_file()
-            and not is_generated_skill_path(file_path.relative_to(skill_path))
+            and (
+                include_generated
+                or not is_generated_skill_path(file_path.relative_to(skill_path))
+            )
         )
         for rel, file_path in entries:
             h.update(rel.encode("utf-8") + b"\x00")
@@ -913,7 +920,7 @@ def _content_digest(skill_path: Path) -> str:
 
 def full_content_hash(skill_path: Path) -> str:
     """Full canonical digest used to bind scanner attestations."""
-    return f"sha256:{_content_digest(skill_path)}"
+    return f"sha256:{_content_digest(skill_path, include_generated=True)}"
 
 
 def _finding_dict(finding: Finding) -> dict:

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -45,6 +45,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Tuple
 
+from agent.skill_utils import is_generated_skill_path
+
 
 SCANNER_VERSION = "skills-guard-v2"
 
@@ -899,6 +901,7 @@ def _content_digest(skill_path: Path) -> str:
             (file_path.relative_to(skill_path).as_posix(), file_path)
             for file_path in skill_path.rglob("*")
             if file_path.is_file()
+            and not is_generated_skill_path(file_path.relative_to(skill_path))
         )
         for rel, file_path in entries:
             h.update(rel.encode("utf-8") + b"\x00")

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -923,6 +923,16 @@ def full_content_hash(skill_path: Path) -> str:
     return f"sha256:{_content_digest(skill_path, include_generated=True)}"
 
 
+def legacy_content_hash(skill_path: Path) -> str:
+    """Reproduce the pre-cache-filter Hub lock hash.
+
+    New lock entries use :func:`content_hash`.  This legacy shape exists only
+    to prove that an existing lock hash came from a concrete current tree;
+    callers must not use it as the identity for new installs.
+    """
+    return f"sha256:{_content_digest(skill_path, include_generated=True)[:16]}"
+
+
 def _finding_dict(finding: Finding) -> dict:
     return {key: getattr(finding, key) for key in (
         "pattern_id", "severity", "category", "file", "line", "match", "description"

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -35,7 +35,10 @@ import httpx
 import yaml
 
 from tools.skills_guard import (
-    ScanResult, content_hash, TRUSTED_REPOS,
+    ScanResult,
+    TRUSTED_REPOS,
+    content_hash,
+    legacy_content_hash,
 )
 from tools.url_safety import is_safe_url
 from tools.website_policy import check_website_access
@@ -4071,6 +4074,18 @@ class HubLockFile:
         data["installed"].pop(name, None)
         self.save(data)
 
+    def migrate_content_hash(
+        self, name: str, expected_hash: str, canonical_hash: str
+    ) -> bool:
+        """Replace a proven legacy hash without clobbering concurrent changes."""
+        data = self.load()
+        entry = data.get("installed", {}).get(name)
+        if not entry or entry.get("content_hash", "") != expected_hash:
+            return False
+        entry["content_hash"] = canonical_hash
+        self.save(data)
+        return True
+
     def get_installed(self, name: str) -> Optional[dict]:
         data = self.load()
         return data["installed"].get(name)
@@ -4422,6 +4437,36 @@ def bundle_content_hash(bundle: SkillBundle) -> str:
     return f"sha256:{h.hexdigest()[:16]}"
 
 
+def legacy_bundle_content_hash(bundle: SkillBundle) -> str:
+    """Reproduce the pre-cache-filter hash for an in-memory Hub bundle."""
+    h = hashlib.sha256()
+    normalized = {
+        rel_path.replace("\\", "/"): content
+        for rel_path, content in bundle.files.items()
+    }
+    for rel_path in sorted(normalized):
+        h.update(rel_path.encode("utf-8"))
+        h.update(b"\x00")
+        content = normalized[rel_path]
+        h.update(content if isinstance(content, bytes) else content.encode("utf-8"))
+    return f"sha256:{h.hexdigest()[:16]}"
+
+
+def resolve_hub_lock_tree_hash(recorded_hash: str, skill_path: Path) -> Optional[str]:
+    """Return the canonical tree hash when a Hub lock hash is proven valid.
+
+    Compatibility is deliberately evidence-based: a legacy hash is accepted
+    only when it exactly matches the old cache-inclusive identity of the
+    current installed tree.  Arbitrary stale or corrupt hashes return ``None``.
+    """
+    canonical_hash = content_hash(skill_path)
+    if recorded_hash == canonical_hash:
+        return canonical_hash
+    if recorded_hash == legacy_content_hash(skill_path):
+        return canonical_hash
+    return None
+
+
 def _source_matches(source: SkillSource, source_name: str) -> bool:
     aliases = {
         "skills.sh": "skills-sh",
@@ -4487,7 +4532,50 @@ def check_for_skill_updates(
 
         current_hash = entry.get("content_hash", "")
         latest_hash = bundle_content_hash(bundle)
-        status = "up_to_date" if current_hash == latest_hash else "update_available"
+        resolved_tree_hash = None
+        install_path = None
+        try:
+            install_path = _resolve_lock_install_path(
+                entry.get("install_path", ""), entry.get("name", "")
+            )
+            if install_path.is_dir():
+                resolved_tree_hash = resolve_hub_lock_tree_hash(
+                    current_hash, install_path
+                )
+        except (OSError, ValueError):
+            pass
+
+        if current_hash == latest_hash:
+            status = "up_to_date"
+        elif resolved_tree_hash is not None:
+            # The installed tree proves this was a real old-format lock hash.
+            # Re-baseline to its canonical identity before do_update performs
+            # its independent local-edit check.
+            lock.migrate_content_hash(
+                entry.get("name", ""), current_hash, resolved_tree_hash
+            )
+            status = (
+                "up_to_date"
+                if resolved_tree_hash == latest_hash
+                else "update_available"
+            )
+        elif current_hash == legacy_bundle_content_hash(bundle):
+            # A refreshed generated cache can prevent the local tree from
+            # reproducing the old hash.  The remote bundle still proves the
+            # recorded cache-inclusive identity.  Migrate only when canonical
+            # disk content also matches remote, preserving real-edit guards.
+            status = "up_to_date"
+            if install_path is not None and install_path.is_dir():
+                try:
+                    disk_hash = content_hash(install_path)
+                except OSError:
+                    disk_hash = None
+                if disk_hash == latest_hash:
+                    lock.migrate_content_hash(
+                        entry.get("name", ""), current_hash, latest_hash
+                    )
+        else:
+            status = "update_available"
         results.append({
             "name": entry.get("name", ""),
             "identifier": identifier,

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -27,7 +27,7 @@ from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
-from agent.skill_utils import is_excluded_skill_path
+from agent.skill_utils import is_excluded_skill_path, is_generated_skill_path
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import quote, unquote, urljoin, urlparse, urlsplit, urlunparse
 
@@ -4407,6 +4407,7 @@ def bundle_content_hash(bundle: SkillBundle) -> str:
     normalized = {
         rel_path.replace("\\", "/"): content
         for rel_path, content in bundle.files.items()
+        if not is_generated_skill_path(rel_path)
     }
     for rel_path in sorted(normalized):
         # Include the path so swapping file contents between two paths

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -4551,9 +4551,10 @@ def check_for_skill_updates(
             # The installed tree proves this was a real old-format lock hash.
             # Re-baseline to its canonical identity before do_update performs
             # its independent local-edit check.
-            lock.migrate_content_hash(
-                entry.get("name", ""), current_hash, resolved_tree_hash
-            )
+            if resolved_tree_hash != current_hash:
+                lock.migrate_content_hash(
+                    entry.get("name", ""), current_hash, resolved_tree_hash
+                )
             status = (
                 "up_to_date"
                 if resolved_tree_hash == latest_hash

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -4549,12 +4549,6 @@ def check_for_skill_updates(
             status = "up_to_date"
         elif resolved_tree_hash is not None:
             # The installed tree proves this was a real old-format lock hash.
-            # Re-baseline to its canonical identity before do_update performs
-            # its independent local-edit check.
-            if resolved_tree_hash != current_hash:
-                lock.migrate_content_hash(
-                    entry.get("name", ""), current_hash, resolved_tree_hash
-                )
             status = (
                 "up_to_date"
                 if resolved_tree_hash == latest_hash
@@ -4563,18 +4557,16 @@ def check_for_skill_updates(
         elif current_hash == legacy_bundle_content_hash(bundle):
             # A refreshed generated cache can prevent the local tree from
             # reproducing the old hash.  The remote bundle still proves the
-            # recorded cache-inclusive identity.  Migrate only when canonical
-            # disk content also matches remote, preserving real-edit guards.
-            status = "up_to_date"
+            # recorded cache-inclusive identity.  It is current only when an
+            # existing disk tree also proves its canonical content matches.
+            status = "update_available"
             if install_path is not None and install_path.is_dir():
                 try:
                     disk_hash = content_hash(install_path)
                 except OSError:
                     disk_hash = None
                 if disk_hash == latest_hash:
-                    lock.migrate_content_hash(
-                        entry.get("name", ""), current_hash, latest_hash
-                    )
+                    status = "up_to_date"
         else:
             status = "update_available"
         results.append({

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -951,51 +951,48 @@ def sync_skills(quiet: bool = False) -> dict:
                 skipped += 1
                 continue
 
-            # User copy matches the recorded origin and bundled has a newer
-            # canonical version.
-            if bundled_hash != user_hash:
+            # The equality case returned above, so the proven-pristine user
+            # copy now receives the newer canonical bundled version.
+            try:
+                # Move old copy to a backup so we can restore on failure
+                backup = dest.with_suffix(".bak")
+                # A stale backup left by an earlier failure would make
+                # shutil.move() nest dest *inside* it (or fail outright)
+                # and would poison the restore path below. The current
+                # dest is the authoritative copy — clear the leftover.
+                if backup.exists():
+                    _rmtree_writable(backup)
+                shutil.move(str(dest), str(backup))
                 try:
-                    # Move old copy to a backup so we can restore on failure
-                    backup = dest.with_suffix(".bak")
-                    # A stale backup left by an earlier failure would make
-                    # shutil.move() nest dest *inside* it (or fail outright)
-                    # and would poison the restore path below. The current
-                    # dest is the authoritative copy — clear the leftover.
-                    if backup.exists():
-                        _rmtree_writable(backup)
-                    shutil.move(str(dest), str(backup))
-                    try:
-                        shutil.copytree(skill_src, dest)
-                        manifest[skill_name] = bundled_hash
-                        updated.append(skill_name)
-                        if not quiet:
-                            print(f"  ↑ {skill_name} (updated)")
-                        # Remove backup after successful copy
-                        try:
-                            _rmtree_writable(backup)
-                        except (OSError, IOError):
-                            logger.debug("Could not remove backup %s", backup, exc_info=True)
-                    except (OSError, IOError):
-                        # Restore from backup. A partially-written dest must
-                        # not shadow the user's copy or block the restore —
-                        # clear it first, then move the backup home.
-                        if backup.exists():
-                            if dest.exists():
-                                try:
-                                    _rmtree_writable(dest)
-                                except (OSError, IOError):
-                                    logger.warning(
-                                        "Could not clear partial copy %s during restore",
-                                        dest, exc_info=True,
-                                    )
-                            if not dest.exists():
-                                shutil.move(str(backup), str(dest))
-                        raise
-                except (OSError, IOError) as e:
+                    shutil.copytree(skill_src, dest)
+                    manifest[skill_name] = bundled_hash
+                    updated.append(skill_name)
                     if not quiet:
-                        print(f"  ! Failed to update {skill_name}: {e}")
-            else:
-                skipped += 1  # bundled unchanged, user unchanged
+                        print(f"  ↑ {skill_name} (updated)")
+                    # Remove backup after successful copy
+                    try:
+                        _rmtree_writable(backup)
+                    except (OSError, IOError):
+                        logger.debug("Could not remove backup %s", backup, exc_info=True)
+                except (OSError, IOError):
+                    # Restore from backup. A partially-written dest must
+                    # not shadow the user's copy or block the restore —
+                    # clear it first, then move the backup home.
+                    if backup.exists():
+                        if dest.exists():
+                            try:
+                                _rmtree_writable(dest)
+                            except (OSError, IOError):
+                                logger.warning(
+                                    "Could not clear partial copy %s during restore",
+                                    dest, exc_info=True,
+                                )
+                        if not dest.exists():
+                            shutil.move(str(backup), str(dest))
+                    raise
+            except (OSError, IOError) as e:
+                if not quiet:
+                    print(f"  ! Failed to update {skill_name}: {e}")
 
         else:
             # ── In manifest but not on disk — user deleted it ──
@@ -1496,6 +1493,12 @@ def remove_pristine_bundled_skills(dry_run: bool = False) -> dict:
             # Already gone from disk; just forget the stale manifest entry.
             if not dry_run and name in manifest:
                 del manifest[name]
+            continue
+        if not origin_hash:
+            # A plain-name v1 entry has no provenance hash.  Normal sync may
+            # baseline or migrate it, but destructive opt-out cleanup cannot
+            # prove that the on-disk copy is pristine and must keep it.
+            skipped.append({"name": name, "reason": "user-modified (kept)"})
             continue
         if _is_tracked_user_modification(
             origin_hash,

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -289,11 +289,27 @@ def _compute_relative_dest(skill_dir: Path, bundled_dir: Path) -> Path:
 
 def _dir_hash(directory: Path) -> str:
     """Compute a hash of all file contents in a directory for change detection."""
+    return _dir_hash_impl(directory, include_generated=False)
+
+
+def _legacy_dir_hash(directory: Path) -> str:
+    """Reproduce the pre-cache-filter manifest hash for compatibility.
+
+    This is deliberately not the canonical skill identity.  It exists only to
+    prove that an old manifest origin was produced from a tree that is still
+    available on disk; new manifest entries always use :func:`_dir_hash`.
+    """
+    return _dir_hash_impl(directory, include_generated=True)
+
+
+def _dir_hash_impl(directory: Path, *, include_generated: bool) -> str:
+    """Hash skill files using the bundled-manifest MD5 wire format."""
     hasher = hashlib.md5()
     try:
         for fpath in sorted(directory.rglob("*")):
-            if fpath.is_file() and not is_generated_skill_path(
-                fpath.relative_to(directory)
+            if fpath.is_file() and (
+                include_generated
+                or not is_generated_skill_path(fpath.relative_to(directory))
             ):
                 rel = fpath.relative_to(directory)
                 hasher.update(str(rel).encode("utf-8"))
@@ -653,6 +669,7 @@ def _recover_renamed_skill(
     active_index: Dict[str, List[Path]],
     hub_paths: Set[str],
     quiet: bool,
+    bundled_src: Optional[Path] = None,
 ) -> Optional[str]:
     """Move a bundled skill's stale copy to its new canonical path.
 
@@ -663,9 +680,9 @@ def _recover_renamed_skill(
     *user-deleted*: the old directory is stranded forever and never receives
     another update.
 
-    A stale copy is only moved when it is byte-identical to ``origin_hash`` —
-    the hash recorded the last time sync wrote that skill — which proves the
-    directory is the copy *we* placed there rather than the user's own work.
+    A stale copy is only moved when the manifest origin is proven by the local
+    or bundled tree. This includes an attested legacy cache-inclusive origin,
+    while generated-cache drift alone does not make the copy user-authored.
     Anything else (user-edited, hub-installed) is left untouched.
 
     Returns the relative source path when a move happened, else ``None``.
@@ -683,7 +700,11 @@ def _recover_renamed_skill(
         # Never relocate a hub-installed skill — the hub owns its path.
         if rel in hub_paths:
             continue
-        if _dir_hash(candidate) != origin_hash:
+        if _is_tracked_user_modification(
+            origin_hash,
+            candidate,
+            bundled_src=bundled_src,
+        ):
             # User customized the copy at the old path. Moving it would edit
             # their work; leaving it avoids a duplicate-name collision. Warn
             # so they can migrate deliberately.
@@ -818,6 +839,7 @@ def sync_skills(quiet: bool = False) -> dict:
                 active_index,
                 hub_paths or set(),
                 quiet,
+                bundled_src=skill_src,
             )
             if _moved_from:
                 relocated.append(skill_name)
@@ -908,15 +930,30 @@ def sync_skills(quiet: bool = False) -> dict:
                     skipped += 1
                 continue
 
-            if _is_tracked_user_modification(origin_hash, user_hash):
+            if _is_tracked_user_modification(
+                origin_hash,
+                dest,
+                bundled_src=skill_src,
+                user_hash=user_hash,
+                bundled_hash=bundled_hash,
+            ):
                 # User modified this skill — don't overwrite their changes
                 user_modified.append(skill_name)
                 if not quiet:
                     print(f"  ~ {skill_name} (user-modified, skipping)")
                 continue
 
-            # User copy matches origin — check if bundled has a newer version
-            if bundled_hash != origin_hash:
+            # A legacy cache-inclusive origin is proven but not itself the
+            # canonical identity. If intentional content is already equal,
+            # migrate the manifest without replacing cache files on disk.
+            if user_hash == bundled_hash:
+                manifest[skill_name] = bundled_hash
+                skipped += 1
+                continue
+
+            # User copy matches the recorded origin and bundled has a newer
+            # canonical version.
+            if bundled_hash != user_hash:
                 try:
                     # Move old copy to a backup so we can restore on failure
                     backup = dest.with_suffix(".bak")
@@ -1162,16 +1199,45 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
     return {"ok": True, "action": action, "message": message, "synced": synced}
 
 
-def _is_tracked_user_modification(origin_hash: str, user_hash: str) -> bool:
+def _is_tracked_user_modification(
+    origin_hash: str,
+    user_dir: Path,
+    *,
+    bundled_src: Optional[Path] = None,
+    user_hash: Optional[str] = None,
+    bundled_hash: Optional[str] = None,
+) -> bool:
     """Whether an on-disk skill counts as a user modification ``hermes update`` keeps.
 
-    Shared by the sync loop (which decides what to skip) and
-    ``list_user_modified_bundled_skills`` (which surfaces the names) so the two
-    can never drift. A skill is a tracked modification only when it has a
-    recorded origin hash (an un-baselined / v1 entry with an empty hash is not)
-    and its current content hash differs from that origin.
+    Besides current canonical origins, accept a legacy cache-inclusive origin
+    only with proof from a current tree.  The local tree proves it directly
+    when its old full hash matches.  Alternatively, the bundled tree can prove
+    the legacy origin when its old full hash matches and the user's canonical
+    content still equals bundled.  That second case permits generated cache
+    drift without treating a real content edit as pristine.
+
+    Arbitrary stale hashes match neither tree and remain user modifications.
+    This single decision is shared by sync, modified-skill listing, rename
+    recovery, and pristine removal.
     """
-    return bool(origin_hash) and user_hash != origin_hash
+    if not origin_hash:
+        return False
+
+    current_hash = user_hash if user_hash is not None else _dir_hash(user_dir)
+    if current_hash == origin_hash or _legacy_dir_hash(user_dir) == origin_hash:
+        return False
+
+    if bundled_src is not None:
+        source_hash = (
+            bundled_hash if bundled_hash is not None else _dir_hash(bundled_src)
+        )
+        if (
+            current_hash == source_hash
+            and _legacy_dir_hash(bundled_src) == origin_hash
+        ):
+            return False
+
+    return True
 
 
 def list_user_modified_bundled_skills() -> List[dict]:
@@ -1203,7 +1269,11 @@ def list_user_modified_bundled_skills() -> List[dict]:
         dest = _compute_relative_dest(skill_dir, bundled_dir)
         if not dest.exists():
             continue
-        if _is_tracked_user_modification(origin_hash, _dir_hash(dest)):
+        if _is_tracked_user_modification(
+            origin_hash,
+            dest,
+            bundled_src=skill_dir,
+        ):
             modified.append(
                 {"name": skill_name, "dest": dest, "bundled_src": skill_dir}
             )
@@ -1392,8 +1462,9 @@ def remove_pristine_bundled_skills(dry_run: bool = False) -> dict:
       - it is recorded in the sync manifest (so it is genuinely a bundled
         skill, not a hub-installed or hand-written one), AND
       - it still exists in the bundled source (so we can hash-compare), AND
-      - its on-disk copy is byte-identical to the manifest origin hash
-        (so the user has not edited it).
+      - its on-disk canonical content matches proven manifest provenance
+        (including an attested legacy cache-inclusive origin), so the user has
+        not edited intentional content.
 
     Anything user-modified, hub-installed, or locally authored is left
     untouched and reported under ``skipped``. The manifest entry for each
@@ -1426,8 +1497,11 @@ def remove_pristine_bundled_skills(dry_run: bool = False) -> dict:
             if not dry_run and name in manifest:
                 del manifest[name]
             continue
-        on_disk = _dir_hash(dest)
-        if on_disk != origin_hash:
+        if _is_tracked_user_modification(
+            origin_hash,
+            dest,
+            bundled_src=src,
+        ):
             skipped.append({"name": name, "reason": "user-modified (kept)"})
             continue
         # Pristine bundled copy — safe to remove.

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -46,7 +46,7 @@ for _stream in (sys.stdout, sys.stderr):
         except (ValueError, TypeError):
             pass
 from hermes_constants import get_bundled_skills_dir, get_hermes_home, get_optional_skills_dir
-from agent.skill_utils import is_excluded_skill_path
+from agent.skill_utils import is_excluded_skill_path, is_generated_skill_path
 from typing import Dict, List, Optional, Set, Tuple
 from utils import atomic_replace, atomic_write_text
 
@@ -292,7 +292,9 @@ def _dir_hash(directory: Path) -> str:
     hasher = hashlib.md5()
     try:
         for fpath in sorted(directory.rglob("*")):
-            if fpath.is_file():
+            if fpath.is_file() and not is_generated_skill_path(
+                fpath.relative_to(directory)
+            ):
                 rel = fpath.relative_to(directory)
                 hasher.update(str(rel).encode("utf-8"))
                 hasher.update(fpath.read_bytes())
@@ -317,7 +319,9 @@ def _skill_file_list(skill_dir: Path) -> List[str]:
     files: List[str] = []
     for fpath in sorted(skill_dir.rglob("*")):
         if fpath.is_file():
-            files.append(fpath.relative_to(skill_dir).as_posix())
+            rel = fpath.relative_to(skill_dir).as_posix()
+            if not is_generated_skill_path(rel):
+                files.append(rel)
     return files
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes generated Python cache artifacts (`__pycache__` / `.pyc`) being treated as intentional content in bundled skill and Skills Hub drift checks. These runtime by-products could make `hermes skills diff` show false user edits, block bundled updates, or make Hub updates require `--force` despite no intentional local change.

## Scope

This PR owns bundled/Hubs logical skill identity and its persisted provenance compatibility:

- Exclude generated Python cache artifacts from bundled skill file lists, `hermes skills diff`, and bundled logical hashes.
- Preserve full-content scanner attestations: files the scanner examines still invalidate its cache.
- Migrate only proven cache-inclusive legacy bundled manifest origins across update, modified-list, rename recovery, and pristine opt-out cleanup.
- Keep v1 manifest entries safe during destructive cleanup.
- Migrate only proven legacy Hub lock hashes; keep normal Hub update checks read-only.
- Preserve real user edits and arbitrary/corrupt stale hashes as protected local state.

## Deferred follow-up

Personal/org skill synchronization has a separate content-addressed tree and merge contract. Cache filtering for org fingerprints and tree construction is tracked in #94127, rather than broadening this PR beyond bundled/Hubs behavior.

## Upstream overlap

A narrower older open PR, [#43301](https://github.com/NousResearch/hermes-agent/pull/43301), addressed the same `__pycache__` symptom. This PR supersedes that approach for the current codebase: it preserves full scanner-attestation hashes, covers bundled/Hub logical identity and legacy provenance, and includes the broader regression surface identified during that earlier review.

## How to test

Parent-side verification on exact base `4209d371aa1bb8840ce8447555bdd863a1a96c38` and head `cfc99c75ccab57fe92203fe6322186c757eba34e`:

```text
scripts/run_tests.sh tests/tools/test_skills_sync.py tests/tools/test_skills_guard.py tests/tools/test_skills_hub.py tests/tools/test_skills_list_modified_diff.py tests/hermes_cli/test_skills_hub.py
```

Result: 168 passed.

Also passed:

```text
uv run ruff check <all changed source and test files>
uv run python -m py_compile <changed Python source files>
git diff --check
```

## Exact-head review evidence

- Agy/Gemini immutable-diff review: `READY`, exact base/head matched, no findings or test gaps.
- Codex 0.151.0 exact-base review: one design-dependent P2 observation about hypothetical intentionally shipped bytecode. This PR explicitly defines `.pyc` files and `__pycache__` paths as generated artifacts; the candidate contains no tracked bytecode, and the parent-side source/contract review found no reachable in-scope defect. No speculative scope expansion was made.
- The initial Agy repository-navigation attempt was unavailable because headless command permission was denied; the immutable-diff retry completed with the qualified result above.

## Checklist

- [x] Bug fix with regression coverage
- [x] Conventional commit history
- [x] Open/closed duplicate search completed before the initial PR
- [x] Focused canonical test suite, lint, compile, and diff checks passed
- [x] Current scope excludes personal/org sync tree semantics; see #94127
- [x] No live `~/.hermes/skills` projection, configuration, credentials, sessions, or services changed


