### PR TITLE
fix(tools): mark non-security hashlib.md5 calls usedforsecurity=False

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3829,7 +3829,7 @@ class ContextCompressor(ContextEngine):
                 continue
             if len(content) < _PRUNE_MIN_CHARS:
                 continue
-            h = hashlib.md5(content.encode("utf-8", errors="replace")).hexdigest()[:12]
+            h = hashlib.md5(content.encode("utf-8", errors="replace"), usedforsecurity=False).hexdigest()[:12]
             if h in content_hashes:
                 # This is an older duplicate — replace with back-reference
                 result[i] = {**msg, "content": "[Duplicate tool output — same content as a more recent call]"}

--- a/gateway/platforms/qqbot/chunked_upload.py
+++ b/gateway/platforms/qqbot/chunked_upload.py
@@ -366,7 +366,7 @@ class ChunkedUploader:
         data = await asyncio.get_running_loop().run_in_executor(
             None, _read_file_chunk, file_path, offset, length
         )
-        md5_hex = hashlib.md5(data).hexdigest()
+        md5_hex = hashlib.md5(data, usedforsecurity=False).hexdigest()
 
         logger.debug(
             "[%s] Part %d/%d: uploading %s (offset=%d md5=%s)",
@@ -558,9 +558,9 @@ def _read_file_chunk(file_path: str, offset: int, length: int) -> bytes:
 
 def _compute_file_hashes(file_path: str, file_size: int) -> Dict[str, str]:
     """Compute md5, sha1, and md5_10m in a single pass."""
-    md5 = hashlib.md5()
+    md5 = hashlib.md5(usedforsecurity=False)
     sha1 = hashlib.sha1()
-    md5_10m = hashlib.md5()
+    md5_10m = hashlib.md5(usedforsecurity=False)
 
     need_10m = file_size > _MD5_10M_SIZE
     bytes_read = 0

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1480,7 +1480,7 @@ class WeixinAdapter(BasePlatformAdapter):
         item_list = message.get("item_list") or []
         text = _extract_text(item_list)
         if text:
-            content_key = f"content:{sender_id}:{hashlib.md5(text.encode()).hexdigest()}"
+            content_key = f"content:{sender_id}:{hashlib.md5(text.encode(), usedforsecurity=False).hexdigest()}"
             if self._dedup.is_duplicate(content_key):
                 logger.debug("[%s] Content-dedup: skipping duplicate message from %s", self.name, sender_id)
                 return
@@ -2186,7 +2186,7 @@ class WeixinAdapter(BasePlatformAdapter):
         filekey = secrets.token_hex(16)
         aes_key = secrets.token_bytes(16)
         rawsize = len(plaintext)
-        rawfilemd5 = hashlib.md5(plaintext).hexdigest()
+        rawfilemd5 = hashlib.md5(plaintext, usedforsecurity=False).hexdigest()
         upload_response = await _get_upload_url(
             self._send_session,
             base_url=self._base_url,

--- a/gateway/platforms/yuanbao_media.py
+++ b/gateway/platforms/yuanbao_media.py
@@ -107,7 +107,7 @@ def get_image_format(mime_type: str) -> int:
 
 def md5_hex(data: bytes) -> str:
     """计算 MD5 十六进制摘要。"""
-    return hashlib.md5(data).hexdigest()
+    return hashlib.md5(data, usedforsecurity=False).hexdigest()
 
 
 def generate_file_id() -> str:

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -1246,7 +1246,7 @@ class WeComAdapter(BasePlatformAdapter):
                 "filename": filename,
                 "total_size": total_size,
                 "total_chunks": total_chunks,
-                "md5": hashlib.md5(data).hexdigest(),
+                "md5": hashlib.md5(data, usedforsecurity=False).hexdigest(),
             },
         )
         self._raise_for_wecom_error(init_response, "media upload init")

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -1378,7 +1378,7 @@ class WellKnownSkillSource(SkillSource):
         }
 
     def _parse_index(self, index_url: str) -> Optional[dict]:
-        cache_key = f"well_known_index_{hashlib.md5(index_url.encode()).hexdigest()}"
+        cache_key = f"well_known_index_{hashlib.md5(index_url.encode(), usedforsecurity=False).hexdigest()}"
         cached = _read_index_cache(cache_key)
         if isinstance(cached, dict) and isinstance(cached.get("skills"), list):
             return cached
@@ -1663,7 +1663,7 @@ class SkillsShSource(SkillSource):
             # entries; the sitemap walks the full ~20k+ catalog.
             return self._sitemap_catalog(limit)
 
-        cache_key = f"skills_sh_search_{hashlib.md5(f'{query}|{limit}'.encode()).hexdigest()}"
+        cache_key = f"skills_sh_search_{hashlib.md5(f'{query}|{limit}'.encode(), usedforsecurity=False).hexdigest()}"
         cached = _read_index_cache(cache_key)
         if cached is not None:
             return [SkillMeta(**item) for item in cached][:limit]
@@ -1890,7 +1890,7 @@ class SkillsShSource(SkillSource):
         )
 
     def _fetch_detail_page(self, identifier: str) -> Optional[dict]:
-        cache_key = f"skills_sh_detail_{hashlib.md5(identifier.encode()).hexdigest()}"
+        cache_key = f"skills_sh_detail_{hashlib.md5(identifier.encode(), usedforsecurity=False).hexdigest()}"
         cached = _read_index_cache(cache_key)
         if isinstance(cached, dict):
             return cached
@@ -2391,7 +2391,7 @@ class ClawHubSource(SkillSource):
 
         # Non-empty query catalog miss, or catalog walker failure: fall back to
         # the lightweight listing API for a best-effort response.
-        cache_key = f"clawhub_search_listing_v1_{hashlib.md5(query.encode()).hexdigest()}_{limit}"
+        cache_key = f"clawhub_search_listing_v1_{hashlib.md5(query.encode(), usedforsecurity=False).hexdigest()}_{limit}"
         cached = _read_index_cache(cache_key)
         if cached is not None:
             return self._finalize_search_results(
@@ -2580,7 +2580,7 @@ class ClawHubSource(SkillSource):
         )
 
     def _search_catalog(self, query: str, limit: int = 10) -> List[SkillMeta]:
-        cache_key = f"clawhub_search_catalog_v1_{hashlib.md5(f'{query}|{limit}'.encode()).hexdigest()}"
+        cache_key = f"clawhub_search_catalog_v1_{hashlib.md5(f'{query}|{limit}'.encode(), usedforsecurity=False).hexdigest()}"
         cached = _read_index_cache(cache_key)
         if cached is not None:
             return [SkillMeta(**s) for s in cached][:limit]

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -280,7 +280,7 @@ def _compute_relative_dest(skill_dir: Path, bundled_dir: Path) -> Path:
 
 def _dir_hash(directory: Path) -> str:
     """Compute a hash of all file contents in a directory for change detection."""
-    hasher = hashlib.md5()
+    hasher = hashlib.md5(usedforsecurity=False)
     try:
         for fpath in sorted(directory.rglob("*")):
             if fpath.is_file():


### PR DESCRIPTION
fix(tools): mark non-security hashlib.md5 calls usedforsecurity=False

On FIPS-mode Windows (and any OpenSSL build with FIPS provider enabled),
hashlib.md5() raises ValueError unless the call declares
usedforsecurity=False. Every md5 call site in the runtime is a
non-security checksum or dedup key - QQ/WeChat/WeCom/Yuanbao API
integrity fields mandated by those platform protocols, skill-content
hashes in the Skills Hub, and tool-output dedup in the context
compressor - so the declaration is semantically honest as well as the
only way these paths run on FIPS-configured hosts.

14 call sites across 7 files:
- agent/context_compressor.py (tool-output dedup)
- gateway/platforms/qqbot/chunked_upload.py (API md5/md5_10m checksums)
- gateway/platforms/weixin.py (content key + file checksum)
- gateway/platforms/yuanbao_media.py (API checksum)
- plugins/platforms/wecom/adapter.py (API md5 field)
- tools/skills_hub.py (skill content hashing x5)
- tools/skills_sync.py (bundle hash)

Digest values are unchanged (verified: identical hex with and without
the flag); the kwarg only unlocks FIPS-restricted builds.
