### PR TITLE
fix(cli): use ancestry check for launchd fallback pid dedupe

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5507,12 +5507,20 @@ def wait_for_launchd_gateway_supervision(
 
 
 def _pid_is_descendant(pid: int | None, ancestor_pid: int | None, max_depth: int = 32) -> bool:
-    """Return True if *pid* is *ancestor_pid* or a descendant of it.
+    """Return True if *pid* is *ancestor_pid* OR a descendant of it.
+
+    Equality-inclusive: callers depend on a direct PID match counting as
+    "related" without a separate check (the name says descendant; the
+    contract is ancestor-or-self).
 
     launchd supervises ``hermes_cli.stderr_timestamp`` which in turn spawns
     the gateway (``hermes_cli.main gateway run``). The PID in the launchd
     plist therefore differs from the gateway PID, so an equality check never
     fires. Walking the parent chain covers the wrapper case (#94050).
+
+    Without psutil the walk is impossible and the helper degrades to
+    equality-only — observable via a one-time debug log so
+    ``launchd_status --deep`` output can explain the weaker dedupe.
     """
     if pid is None or ancestor_pid is None:
         return False
@@ -5521,15 +5529,22 @@ def _pid_is_descendant(pid: int | None, ancestor_pid: int | None, max_depth: int
     try:
         import psutil
     except ImportError:
+        logger.debug(
+            "psutil unavailable; launchd fallback dedupe limited to PID "
+            "equality (ancestry walk impossible)",
+        )
         return False
     try:
         proc = psutil.Process(pid)
-    except Exception:
+    except psutil.Error:
+        # Race: the process can exit between read and Process() (includes
+        # psutil.NoSuchProcess). Callers treat False as "not related" —
+        # the same answer as before the walk began.
         return False
     for _ in range(max_depth):
         try:
             parent = proc.parent()
-        except Exception:
+        except psutil.Error:
             return False
         if parent is None:
             return False

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5506,6 +5506,41 @@ def wait_for_launchd_gateway_supervision(
         time.sleep(max(poll_interval, 0.01))
 
 
+def _pid_is_descendant(pid: int | None, ancestor_pid: int | None, max_depth: int = 32) -> bool:
+    """Return True if *pid* is *ancestor_pid* or a descendant of it.
+
+    launchd supervises ``hermes_cli.stderr_timestamp`` which in turn spawns
+    the gateway (``hermes_cli.main gateway run``). The PID in the launchd
+    plist therefore differs from the gateway PID, so an equality check never
+    fires. Walking the parent chain covers the wrapper case (#94050).
+    """
+    if pid is None or ancestor_pid is None:
+        return False
+    if pid == ancestor_pid:
+        return True
+    try:
+        import psutil
+    except ImportError:
+        return False
+    try:
+        proc = psutil.Process(pid)
+    except Exception:
+        return False
+    for _ in range(max_depth):
+        try:
+            parent = proc.parent()
+        except Exception:
+            return False
+        if parent is None:
+            return False
+        if parent.pid == ancestor_pid:
+            return True
+        if parent.pid == 1:
+            return False
+        proc = parent
+    return False
+
+
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
@@ -5533,10 +5568,11 @@ def launchd_status(deep: bool = False):
     from gateway.status import get_running_pid
     fallback_pid = get_running_pid(cleanup_stale=False)
 
-    # Avoid double-counting: when launchd IS supervising, fallback_pid and
-    # launchd_pid point at the same process (the gateway writes both the
-    # launchd PID and the Hermes PID file).
-    if launchd_pid is not None and fallback_pid == launchd_pid:
+    # Avoid double-counting: when launchd IS supervising, fallback_pid is
+    # either the same process or a child of it (stderr_timestamp wrapper
+    # spawns the gateway, so PIDs differ). Check ancestry, not just equality
+    # (#94050).
+    if launchd_pid is not None and _pid_is_descendant(fallback_pid, launchd_pid):
         fallback_pid = None
 
     # Persistent marker written when launchd bootstrap/kickstart fails with

--- a/tests/hermes_cli/test_pid_is_descendant.py
+++ b/tests/hermes_cli/test_pid_is_descendant.py
@@ -1,0 +1,123 @@
+"""Contract tests for _pid_is_descendant (#94084).
+
+A second consumer (the update-path manual-gateway sweep) depends on this
+primitive, so the semantics are locked with a fake psutil chain: direct
+match, wrapper-descendant match, unrelated tree, PID-1 stop, depth
+exhaustion, and the psutil-unavailable degradation to equality-only.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import gateway as gw
+
+
+class _FakeProcess:
+    def __init__(self, pid, parent=None):
+        self.pid = pid
+        self._parent = parent
+
+    def parent(self):
+        return self._parent
+
+
+def _chain(*pids):
+    """Build a fake psutil.Process chain child->...->root from PID list."""
+    proc = None
+    for pid in reversed(pids):
+        proc = _FakeProcess(pid, parent=proc)
+    return proc
+
+
+def _patch_psutil(monkeypatch, *, available=True):
+    """Install a fake psutil module capturing Process() lookups."""
+    calls = {"pids": []}
+
+    if available:
+        import psutil as real_psutil
+
+        class _FakePsutil:
+            Error = real_psutil.Error
+            NoSuchProcess = real_psutil.NoSuchProcess
+
+            @staticmethod
+            def Process(pid):
+                calls["pids"].append(pid)
+                if pid in calls.get("chain", {}):
+                    return calls["chain"][pid]
+                raise real_psutil.NoSuchProcess(pid)
+
+        fake = _FakePsutil
+        import sys
+
+        monkeypatch.setitem(sys.modules, "psutil", fake)
+    else:
+        # Make `import psutil` genuinely fail: remove the cached module and
+        # point the loader at a path where it does not exist.
+        import builtins
+        import sys
+
+        monkeypatch.delitem(sys.modules, "psutil", raising=False)
+        real_import = builtins.__import__
+
+        def _blocked_import(name, *args, **kwargs):
+            if name == "psutil" or name.startswith("psutil."):
+                raise ImportError("psutil blocked for test")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _blocked_import)
+    return calls
+
+
+def test_direct_pid_match_is_true(monkeypatch):
+    """Equality is inclusive: ancestor-or-self, not strict descendant."""
+    assert gw._pid_is_descendant(100, 100) is True
+
+
+def test_child_of_wrapper_matches(monkeypatch):
+    """The #94050 shape: gateway is a descendant of the launchd wrapper."""
+    calls = _patch_psutil(monkeypatch)
+    # gateway 200 -> wrapper 100
+    calls["chain"] = {200: _chain(200, 100)}
+    assert gw._pid_is_descendant(200, 100) is True
+
+
+def test_unrelated_tree_is_false(monkeypatch):
+    calls = _patch_psutil(monkeypatch)
+    # gateway 300 -> some other parent 999 -> init 1
+    calls["chain"] = {300: _chain(300, 999, 1)}
+    assert gw._pid_is_descendant(300, 100) is False
+
+
+def test_walk_stops_at_pid_1(monkeypatch):
+    """Reaching init without seeing the ancestor ends the walk (not related)."""
+    calls = _patch_psutil(monkeypatch)
+    calls["chain"] = {300: _chain(300, 200, 1)}
+    assert gw._pid_is_descendant(300, 100) is False
+
+
+def test_depth_exhaustion_is_false(monkeypatch):
+    """A chain deeper than max_depth is treated as unrelated (bounded walk)."""
+    calls = _patch_psutil(monkeypatch)
+    deep_chain = list(range(1000, 1000 + 40))  # 40-deep, ancestor never hit
+    calls["chain"] = {deep_chain[0]: _chain(*deep_chain)}
+    assert gw._pid_is_descendant(deep_chain[0], 1, max_depth=4) is False
+
+
+def test_missing_psutil_degrades_to_equality(monkeypatch):
+    """Without psutil the walk is impossible: only a direct PID match counts."""
+    _patch_psutil(monkeypatch, available=False)
+    assert gw._pid_is_descendant(200, 100) is False
+    assert gw._pid_is_descendant(100, 100) is True
+
+
+def test_dead_process_race_is_false(monkeypatch):
+    """Process vanishing between read and walk start answers False (race)."""
+    calls = _patch_psutil(monkeypatch)
+    calls["chain"] = {}  # Process() raises NoSuchProcess for any pid
+    assert gw._pid_is_descendant(200, 100) is False
+
+
+def test_none_inputs_are_false():
+    assert gw._pid_is_descendant(None, 100) is False
+    assert gw._pid_is_descendant(200, None) is False


### PR DESCRIPTION
Fixes #94050

## Problem

`launchd_status()` dedupes `fallback_pid` against `launchd_pid` by equality (`hermes_cli/gateway.py:5539`). Since `stderr_timestamp` wraps the gateway, launchd supervises the wrapper (PID 60628 in the report) while `get_running_pid()` returns its child (60634). Equality never holds, so a healthy supervised gateway can also report `Note: a detached gateway process is running (PID 60634)` on hosts where `launchctl` domain is degraded (exit 5/125).

## Fix

Add `_pid_is_descendant(pid, ancestor)` that walks the parent chain via `psutil` (depth-capped at 32, `ImportError` fallback to equality). Replace the equality test with the ancestry check. Equality is still the fast path.

Verified: same-PID, None, real parent/grandparent chain, unrelated PID, and ImportError fallback all behave as expected (local test script with real `psutil` PIDs).