### PR TITLE
fix(gateway): return sanitized title from session.title RPC

### DIFF
--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1332,10 +1332,15 @@ def _(rid, params: dict) -> dict:
         if not title:
             return _err(rid, 4021, "title required")
         try:
-            if db.set_session_title(key, title):
+            from hermes_state import SessionDB
+
+            sanitized = SessionDB.sanitize_title(title)
+            if not sanitized:
+                return _err(rid, 4021, "title required")
+            if db.set_session_title(key, sanitized):
                 session["pending_title"] = None
                 _emit_session_info_for_session(params.get("session_id", ""), session)
-                return _ok(rid, {"pending": False, "title": title})
+                return _ok(rid, {"pending": False, "title": sanitized})
             # rowcount == 0 can mean "same value" as well as "missing row".
             existing_row = db.get_session(key)
             if existing_row:
@@ -1345,7 +1350,7 @@ def _(rid, params: dict) -> dict:
                     rid,
                     {
                         "pending": False,
-                        "title": (existing_row.get("title") or title),
+                        "title": (existing_row.get("title") or sanitized),
                     },
                 )
             # No row yet (the DB write is deferred to the first prompt so empty
@@ -1360,15 +1365,15 @@ def _(rid, params: dict) -> dict:
             # a /title'd-but-never-used draft still doesn't clutter the list.
             _ensure_session_db_row(session)
             with _session_db(session) as scoped_db:
-                if scoped_db is not None and scoped_db.set_session_title(key, title):
+                if scoped_db is not None and scoped_db.set_session_title(key, sanitized):
                     session["pending_title"] = None
                     _emit_session_info_for_session(params.get("session_id", ""), session)
-                    return _ok(rid, {"pending": False, "title": title})
+                    return _ok(rid, {"pending": False, "title": sanitized})
             # Row creation didn't take (DB unavailable, or a concurrent writer) —
             # fall back to queuing so the post-turn apply block can still recover.
-            session["pending_title"] = title
+            session["pending_title"] = sanitized
             _emit_session_info_for_session(params.get("session_id", ""), session)
-            return _ok(rid, {"pending": True, "title": title})
+            return _ok(rid, {"pending": True, "title": sanitized})
         except ValueError as e:
             return _err(rid, 4022, str(e))
         except Exception as e:


### PR DESCRIPTION
Related to #93968

## Problem

`session.title` (`tui_gateway/methods_session.py:1338`) echoed the raw `title` param back to the caller, while `SessionDB.set_session_title` stored the sanitized version. A title containing control characters (e.g. `U+200B` pasted from a chat app) was stored as `AlphaBeta` but the RPC returned `Alpha\u200bBeta`, so the desktop UI showed the unsanitized value until reload/restart. The pending-title queue had the same mismatch.

## Fix

Compute `sanitized = SessionDB.sanitize_title(title)` once, reject empty sanitized values, and use `sanitized` for all `set_session_title` calls and all `_ok` responses. The existing-row fallback now also prefers `existing_row.title or sanitized`.

This is the companion to #94075: with that state fix `U+200B` becomes a real space; with this gateway fix the caller sees exactly what is persisted.