### PR TITLE
fix(agent): include skills manifest in prompt cache key

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1902,6 +1902,35 @@ def _build_skills_system_prompt_inner(
     _platform_hint = _current_session_platform_hint()
     disabled = get_disabled_skill_names(_platform_hint or None)
     project_dirs = project_dirs or []
+    # Include skills-dir manifest fingerprint so a newly installed skill
+    # invalidates the in-process LRU even though the install runs in a
+    # different process from the long-running gateway (#92313).
+    try:
+        manifest = _build_skills_manifest(skills_dir)
+        manifest_fp = tuple(sorted((k, tuple(v)) for k, v in manifest.items()))
+    except Exception:
+        manifest_fp = ()
+    # Also fingerprint external/project dirs (best-effort, ignore errors).
+    try:
+        ext_manifest = tuple(
+            sorted(
+                (k, tuple(v))
+                for d in external_dirs
+                for k, v in _build_skills_manifest(d).items()
+            )
+        )
+    except Exception:
+        ext_manifest = ()
+    try:
+        proj_manifest = tuple(
+            sorted(
+                (k, tuple(v))
+                for d in project_dirs
+                for k, v in _build_skills_manifest(d).items()
+            )
+        )
+    except Exception:
+        proj_manifest = ()
     cache_key = (
         str(skills_dir),
         tuple(str(d) for d in external_dirs),
@@ -1911,6 +1940,9 @@ def _build_skills_system_prompt_inner(
         _platform_hint,
         tuple(sorted(disabled)),
         tuple(sorted(compact_categories or ())),
+        manifest_fp,
+        ext_manifest,
+        proj_manifest,
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)

--- a/tests/agent/test_skills_cache_mtime.py
+++ b/tests/agent/test_skills_cache_mtime.py
@@ -1,0 +1,35 @@
+"""Test that skills cache invalidates when a new skill is installed (#92313)."""
+import sys
+from pathlib import Path
+
+import pytest
+
+from agent.prompt_builder import build_skills_system_prompt, clear_skills_system_prompt_cache
+
+
+def test_new_skill_visible_without_manual_cache_clear(tmp_path, monkeypatch):
+    # Setup isolated HERMES_HOME
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    skills_dir = hermes_home / "skills"
+    skills_dir.mkdir()
+    
+    # Create an initial skill
+    skill_a = skills_dir / "skill-a"
+    skill_a.mkdir()
+    (skill_a / "SKILL.md").write_text("---\nname: skill-a\ndescription: Test skill A.\n---\n# Skill A\n", encoding="utf-8")
+    
+    clear_skills_system_prompt_cache()
+    first = build_skills_system_prompt(skills_dir_override=skills_dir)
+    assert "skill-a" in first
+    
+    # Install a new skill (simulating `hermes skills install`)
+    skill_b = skills_dir / "skill-b"
+    skill_b.mkdir()
+    (skill_b / "SKILL.md").write_text("---\nname: skill-b\ndescription: Test skill B.\n---\n# Skill B\n", encoding="utf-8")
+    
+    # Without clearing cache, new skill should still be visible due to manifest fingerprint
+    second = build_skills_system_prompt(skills_dir_override=skills_dir)
+    assert "skill-b" in second, "Newly installed skill should be visible without manual cache clear"
+    assert "skill-a" in second


### PR DESCRIPTION
fix(agent): include skills manifest in prompt cache key

build_skills_system_prompt cached the rendered skill index in a
process-global LRU keyed by dirs/tools/platform/disabled, but not by
skills-dir contents. Installing a skill (SKILL.md written to
~/.hermes/skills/) in the CLI process did not invalidate the
gateway's in-process cache, so newly installed skills were invisible
to the agent until gateway restart.

Include mtime/size manifest fingerprint for local, external, and
project skills dirs in the cache key so the LRU auto-invalidates
when any SKILL.md appears, changes, or is removed.

Fixes #92313
