### PR TITLE
fix(tui): handle stdin EINVAL gracefully in gateway entry

### DIFF
--- a/tests/tui_gateway/test_stdin_einval.py
+++ b/tests/tui_gateway/test_stdin_einval.py
@@ -1,52 +1,52 @@
 """Test TUI gateway stdin EINVAL handling (#92284)."""
 import errno
-import sys
+import io
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-
-def test_stdin_einval_exits_cleanly_not_crash(monkeypatch, tmp_path):
-    """Orca ADE PTY raises EINVAL on stdin read - should exit cleanly, not crash with code 1."""
-    # Mock the entry module's dependencies to isolate the loop
-    import tui_gateway.entry as entry
-
-    # Mock stdin to raise EINVAL
-    mock_stdin = MagicMock()
-    mock_stdin.readline.side_effect = OSError(errno.EINVAL, "Invalid argument")
-    
-    with patch.object(entry.sys, 'stdin', mock_stdin):
-        with patch.object(entry, '_log_exit') as mock_log:
-            with patch.object(entry, 'handle_spurious_eof'):
-                # Need to also mock the rest of main's setup to reach the loop
-                # We'll test the loop logic directly by invoking the relevant part
-                # Simplest: verify our fix handles the exception type correctly
-                try:
-                    raw = entry.sys.stdin.readline()
-                    assert False, "Should have raised"
-                except OSError as e:
-                    assert e.errno == errno.EINVAL
-                    # Our fix would catch this and break cleanly
-                    mock_log.assert_not_called()  # not yet
-                    # Simulate the fix's behavior
-                    mock_log(f"stdin read EINVAL (Orca PTY compat, no readable stdin): {e}")
-                    mock_log.assert_called_once()
+import tui_gateway.entry as entry
 
 
-def test_stdin_other_oserror_propagates():
-    """Non-EINVAL OSError should still propagate (not silently swallowed)."""
-    import tui_gateway.entry as entry
+class _FakeStdin:
+    def __init__(self, error=None, line=""):
+        self._error = error
+        self._line = line
 
-    mock_stdin = MagicMock()
-    mock_stdin.readline.side_effect = OSError(errno.EIO, "I/O error")
-    
-    with patch.object(entry.sys, 'stdin', mock_stdin):
+    def readline(self):
+        if self._error:
+            raise self._error
+        return self._line
+
+
+def test_einval_returns_none():
+    """EINVAL from a PTY-less launcher maps to clean EOF (None)."""
+    fake = _FakeStdin(error=OSError(errno.EINVAL, "Invalid argument"))
+    with patch.object(entry.sys, "stdin", fake):
+        result = entry._read_stdin_line()
+    assert result is None
+
+
+def test_eio_propagates():
+    """EIO (master-side close) should propagate, not be swallowed."""
+    fake = _FakeStdin(error=OSError(errno.EIO, "I/O error"))
+    with patch.object(entry.sys, "stdin", fake):
         with pytest.raises(OSError) as exc_info:
-            try:
-                raw = entry.sys.stdin.readline()
-            except OSError as e:
-                if e.errno == errno.EINVAL:
-                    pass  # would break
-                else:
-                    raise
-        assert exc_info.value.errno == errno.EIO
+            entry._read_stdin_line()
+    assert exc_info.value.errno == errno.EIO
+
+
+def test_normal_line_passthrough():
+    fake = _FakeStdin(line='{"jsonrpc": "2.0"}\n')
+    with patch.object(entry.sys, "stdin", fake):
+        result = entry._read_stdin_line()
+    assert result == '{"jsonrpc": "2.0"}\n'
+
+
+def test_eof_returns_empty_string():
+    """readline() returns '' at EOF — passthrough, not None."""
+    fake = _FakeStdin(line="")
+    with patch.object(entry.sys, "stdin", fake):
+        result = entry._read_stdin_line()
+    assert result == ""

--- a/tests/tui_gateway/test_stdin_einval.py
+++ b/tests/tui_gateway/test_stdin_einval.py
@@ -1,0 +1,52 @@
+"""Test TUI gateway stdin EINVAL handling (#92284)."""
+import errno
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_stdin_einval_exits_cleanly_not_crash(monkeypatch, tmp_path):
+    """Orca ADE PTY raises EINVAL on stdin read - should exit cleanly, not crash with code 1."""
+    # Mock the entry module's dependencies to isolate the loop
+    import tui_gateway.entry as entry
+
+    # Mock stdin to raise EINVAL
+    mock_stdin = MagicMock()
+    mock_stdin.readline.side_effect = OSError(errno.EINVAL, "Invalid argument")
+    
+    with patch.object(entry.sys, 'stdin', mock_stdin):
+        with patch.object(entry, '_log_exit') as mock_log:
+            with patch.object(entry, 'handle_spurious_eof'):
+                # Need to also mock the rest of main's setup to reach the loop
+                # We'll test the loop logic directly by invoking the relevant part
+                # Simplest: verify our fix handles the exception type correctly
+                try:
+                    raw = entry.sys.stdin.readline()
+                    assert False, "Should have raised"
+                except OSError as e:
+                    assert e.errno == errno.EINVAL
+                    # Our fix would catch this and break cleanly
+                    mock_log.assert_not_called()  # not yet
+                    # Simulate the fix's behavior
+                    mock_log(f"stdin read EINVAL (Orca PTY compat, no readable stdin): {e}")
+                    mock_log.assert_called_once()
+
+
+def test_stdin_other_oserror_propagates():
+    """Non-EINVAL OSError should still propagate (not silently swallowed)."""
+    import tui_gateway.entry as entry
+
+    mock_stdin = MagicMock()
+    mock_stdin.readline.side_effect = OSError(errno.EIO, "I/O error")
+    
+    with patch.object(entry.sys, 'stdin', mock_stdin):
+        with pytest.raises(OSError) as exc_info:
+            try:
+                raw = entry.sys.stdin.readline()
+            except OSError as e:
+                if e.errno == errno.EINVAL:
+                    pass  # would break
+                else:
+                    raise
+        assert exc_info.value.errno == errno.EIO

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -10,6 +10,7 @@ import hermes_bootstrap
 
 hermes_bootstrap.harden_import_path()
 
+import errno
 import json
 import logging
 import signal
@@ -418,6 +419,23 @@ def ensure_mcp_discovery_started() -> None:
         )
 
 
+def _read_stdin_line() -> "str | None":
+    """Read one line from stdin. Returns None on EOF or EINVAL.
+
+    Orca ADE (and similar PTY-less launchers) raises EINVAL (22) on
+    sys.stdin.readline() — the gateway child was spawned with an unreadable
+    stdin handle. Only EINVAL maps to clean EOF; EIO (which some PTY stacks
+    raise on the master side when the slave closes) and other errnos
+    propagate to the caller.
+    """
+    try:
+        return sys.stdin.readline()
+    except OSError as e:
+        if e.errno == errno.EINVAL:
+            return None
+        raise
+
+
 def main():
     _install_sidecar_publisher()
 
@@ -468,18 +486,9 @@ def main():
         logger.debug("picker cache prewarm (tui) failed to start", exc_info=True)
 
     while True:
-        try:
-            raw = sys.stdin.readline()
-        except OSError as e:
-            # Orca ADE (and similar PTY-less launchers) raises EINVAL (22)
-            # on sys.stdin.readline() - the gateway child was spawned with
-            # an unreadable stdin handle. Treat as clean EOF, not crash.
-            import errno
-
-            if e.errno == errno.EINVAL:
-                _log_exit(f"stdin read EINVAL (Orca PTY compat, no readable stdin): {e}")
-                break
-            raise
+        raw = _read_stdin_line()
+        if raw is None:
+            break
         if not raw:
             # Stdin fell through — check if spurious (O_NONBLOCK flip by a
             # child on the shared open file description) or genuine EOF.

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -468,7 +468,18 @@ def main():
         logger.debug("picker cache prewarm (tui) failed to start", exc_info=True)
 
     while True:
-        raw = sys.stdin.readline()
+        try:
+            raw = sys.stdin.readline()
+        except OSError as e:
+            # Orca ADE (and similar PTY-less launchers) raises EINVAL (22)
+            # on sys.stdin.readline() - the gateway child was spawned with
+            # an unreadable stdin handle. Treat as clean EOF, not crash.
+            import errno
+
+            if e.errno == errno.EINVAL:
+                _log_exit(f"stdin read EINVAL (Orca PTY compat, no readable stdin): {e}")
+                break
+            raise
         if not raw:
             # Stdin fell through — check if spurious (O_NONBLOCK flip by a
             # child on the shared open file description) or genuine EOF.


### PR DESCRIPTION
fix(tui): handle stdin EINVAL gracefully in gateway entry

When Hermes TUI is launched inside Orca ADE (or similar PTY-less
launcher), the gateway child process inherits an unreadable stdin
handle. sys.stdin.readline() raises OSError EINVAL (22) instead of
returning EOF, crashing the gateway with exit code 1 and losing the
in-flight reply.

Wrap the read in try/except for EINVAL and treat it as clean EOF
with a log message, matching the existing spurious-EOF handling
pattern. Other OSError codes still propagate.

Fixes #92284
