### PR TITLE
docs(dashboard): stop linking the internal Nous Portal OAuth contract

### DIFF
--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -982,7 +982,7 @@ Validation rejects values without `http://` / `https://` scheme, without a host,
 
 ### OAuth flow
 
-The provider implements the [Nous Portal OAuth contract v1](https://github.com/NousResearch/nous-account-service/blob/main/docs/agent-dashboard-oauth-contract.md) — authorization-code grant with PKCE (S256):
+The provider implements the Nous Portal OAuth contract v1 (the contract document lives in the internal `nous-account-service` repository; for public implementation history see [PR #37247](https://github.com/NousResearch/hermes-agent/pull/37247)) — authorization-code grant with PKCE (S256):
 
 1. User hits `/` without a session cookie → gate redirects to `/login`.
 2. Login page shows a "Continue with Nous Research" button → `/auth/login?provider=nous`.


### PR DESCRIPTION
## What does this PR do?

The public Web Dashboard guide linked the label "Nous Portal OAuth contract v1" to `https://github.com/NousResearch/nous-account-service/blob/main/docs/agent-dashboard-oauth-contract.md`, which returns 404 for any reader without NousResearch repository permissions — so a reference presented as public source material in a security-sensitive OAuth section could never be opened. This renders the label as plain text, states where the contract document actually lives, and links the publicly readable implementation history (merged PR #37247) in its place, matching the issue's recommended fix.

## Related Issue

Fixes #94087

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `website/docs/user-guide/features/web-dashboard.md` — the OAuth flow intro line: the markdown link to the inaccessible `nous-account-service` document is replaced by plain text plus a parenthetical noting the contract lives in the internal repository, with a non-normative link to the public implementation history `[PR #37247](https://github.com/NousResearch/hermes-agent/pull/37247)`. The sentence structure (trailing colon introducing the numbered flow) and everything else in the section are unchanged.

## How to Test

- `grep -rn "agent-dashboard-oauth-contract" website/` returns no hits (the 404 URL is gone; the plain-path mention in `plugins/dashboard_auth/nous/__init__.py` docstring is not a link and is out of scope for this issue).
- The replacement link target: `gh pr view 37247 --repo NousResearch/hermes-agent` → `MERGED: feat(dashboard-auth): rotate dashboard sessions via refresh token` (verified via the API; the issue also verified HTTP 200 without repository access).
- Observed result: single-line diff, no other lines touched; the English Docusaurus link-check surface strictly improves (one 404 link removed, one known-200 link added).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of the completed code performed
- [x] New and existing unit tests pass locally
- [x] Changes are backward-compatible (documentation-only change)
