### PR TITLE
fix(kanban): forward HERMES_KANBAN_* env to codex MCP subprocess

### DIFF
--- a/hermes_cli/codex_runtime_plugin_migration.py
+++ b/hermes_cli/codex_runtime_plugin_migration.py
@@ -599,6 +599,19 @@ def _build_hermes_tools_mcp_entry() -> dict:
     }
     if env:
         out["env"] = env
+    # Forward dynamic Kanban env vars so Codex-spawned workers expose
+    # kanban lifecycle tools (kanban_show, kanban_complete, etc.).
+    # Without this, the hermes-tools MCP server starts without
+    # HERMES_KANBAN_* vars and hides those tools (#92282).
+    out["env_vars"] = [
+        "HERMES_KANBAN_TASK",
+        "HERMES_KANBAN_BOARD",
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_ROOT",
+        "HERMES_KANBAN_WORKSPACE",
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+        "HERMES_KANBAN_BRANCH",
+    ]
     # Generous timeouts — browser_navigate or delegate_task can take a
     # while; we don't want codex's MCP client to give up too early.
     out["startup_timeout_sec"] = 30.0

--- a/tests/hermes_cli/test_kanban_codex_env.py
+++ b/tests/hermes_cli/test_kanban_codex_env.py
@@ -1,0 +1,19 @@
+"""Test kanban env_vars forwarding in codex MCP entry (#92282)."""
+
+from hermes_cli.codex_runtime_plugin_migration import _build_hermes_tools_mcp_entry
+
+
+def test_hermes_tools_mcp_entry_forwards_kanban_env_vars():
+    entry = _build_hermes_tools_mcp_entry()
+    env_vars = entry.get("env_vars", [])
+    expected = [
+        "HERMES_KANBAN_TASK",
+        "HERMES_KANBAN_BOARD",
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_ROOT",
+        "HERMES_KANBAN_WORKSPACE",
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+        "HERMES_KANBAN_BRANCH",
+    ]
+    for var in expected:
+        assert var in env_vars, f"{var} should be forwarded to codex MCP subprocess"


### PR DESCRIPTION
fix(kanban): forward HERMES_KANBAN_* env to codex MCP subprocess

Codex-spawned kanban workers (model.openai_runtime: codex_app_server)
could not access kanban lifecycle tools (kanban_show, kanban_complete,
etc.) because the hermes-tools MCP server was launched without the
dynamic Kanban env vars. The dispatcher sets HERMES_KANBAN_TASK/BOARD/DB
etc., but they were not in the MCP entry's env_vars forwarding list.

Add the seven HERMES_KANBAN_* vars to _build_hermes_tools_mcp_entry's
env_vars so Codex forwards them to the hermes-tools subprocess.

Fixes #92282
