### PR TITLE
fix(gateway): register show_cost in display config resolver

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -33,6 +33,7 @@ from typing import Any
 _GLOBAL_DEFAULTS: dict[str, Any] = {
     "tool_progress": "all",
     "tool_progress_grouping": "accumulate",  # "accumulate" = edit one bubble; "separate" = one msg per tool
+    "show_cost": False,
     "show_reasoning": False,
     # How a reasoning/thinking summary is rendered when show_reasoning is on.
     #   "code"      -> 💭 **Reasoning:** + fenced code block (legacy default)


### PR DESCRIPTION
Related to #93951

## Problem

`display.show_cost` is defined in `hermes_cli/config_defaults.py:1413` (`False` by default) and documented in `website/docs/user-guide/configuration.md:1822`, but never registered in `gateway/display_config.py:_GLOBAL_DEFAULTS`. `resolve_display_setting(..., "show_cost")` therefore always falls back to `None`, so gateway `/usage` and any per-platform `display.platforms.<platform>.show_cost` override cannot gate cost display.

## Fix

Add `"show_cost": False` to `_GLOBAL_DEFAULTS`. No migration needed — default matches the documented `false` and preserves current behavior (cost hidden) until a user opts in via `config.yaml` or per-platform override.

This is the minimal wiring step for #93951; CLI/TUI/desktop rendering of `estimated_cost_usd` can follow in a follow-up once the resolver is correct.