### PR TITLE
fix(state): reap stale state-owned sessions safely

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2062,6 +2062,65 @@ def _cross_process_repair_lock(db_path: Path):
             handle.close()
 
 
+def _try_acquire_auto_maintenance_lock(db_path: Path) -> Optional[Any]:
+    """Non-blocking cross-process lock for one auto-maintenance pass.
+
+    The kernel releases this advisory lock if the holder exits, unlike a
+    durable pid/meta marker. A caller that cannot acquire it must skip the
+    pass: otherwise two startups can both pass the interval check and the
+    second can prune a row the first has only just closed recoverably.
+    """
+    lock_path = db_path.with_name(db_path.name + ".auto-maintenance.lock")
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        handle = lock_path.open("a+b")
+    except OSError as exc:
+        logger.warning(
+            "Could not open state.db auto-maintenance lock %s (%s) — skipping "
+            "automatic maintenance.",
+            lock_path,
+            exc,
+        )
+        return None
+
+    try:
+        if _IS_WINDOWS:
+            import msvcrt
+
+            handle.seek(0)
+            msvcrt.locking(  # type: ignore[attr-defined]
+                handle.fileno(), msvcrt.LK_NBLCK, 1  # type: ignore[attr-defined]
+            )
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (BlockingIOError, OSError):
+        handle.close()
+        return None
+    return handle
+
+
+def _release_auto_maintenance_lock(handle: Any) -> None:
+    """Release a handle returned by :func:`_try_acquire_auto_maintenance_lock`."""
+    try:
+        if _IS_WINDOWS:
+            import msvcrt
+
+            handle.seek(0)
+            msvcrt.locking(  # type: ignore[attr-defined]
+                handle.fileno(), msvcrt.LK_UNLCK, 1  # type: ignore[attr-defined]
+            )
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except OSError:  # pragma: no cover - best effort release
+        pass
+    finally:
+        handle.close()
+
+
 def _bump_schema_cookie(conn: sqlite3.Connection) -> None:
     """Increment the schema cookie after direct ``sqlite_master`` surgery.
 
@@ -4389,6 +4448,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     Thread-safe for the common gateway pattern (multiple reader threads,
     single writer via WAL mode). Each method opens its own cursor.
     """
+
+    # Only these state-owned producers participate in automatic stale-open
+    # reconciliation. Messaging-platform and UI/desktop sources have separate
+    # lifecycle owners; unknown/future sources fail closed (#60609).
+    _AUTO_PRUNE_STALE_OPEN_SOURCES: Tuple[str, ...] = (
+        "cli",
+        "cron",
+        "kanban",
+        "acp",
+        "api_server",
+        "subagent",
+        "tool",
+    )
 
     # ── Write-contention tuning ──
     # With multiple hermes processes (gateway + CLI sessions + worktree agents)
@@ -9290,57 +9362,54 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         max_idle_seconds: float,
         sources: Tuple[str, ...] = ("tui", "desktop", "subagent"),
         exclude_ids: Tuple[str, ...] = (),
+        exclude_pinned: bool = False,
         heartbeat_staleness_seconds: Optional[float] = None,
         heartbeat_ownership_grace_seconds: Optional[float] = None,
+        respect_gateway_heartbeats: bool = True,
     ) -> List[str]:
         """Close session rows orphaned by a dead gateway process (#65194, #94895).
 
         The TUI/desktop gateway reaps disconnected websocket sessions with an
         in-process ``threading.Timer`` grace timer; a gateway restart destroys
-        the timer and leaves the row ``ended_at IS NULL`` forever.  This is
-        the startup-time complement: it closes rows for the given ``sources``
-        whose ``started_at`` AND newest ``messages.timestamp`` are both older
-        than ``max_idle_seconds``, with a distinct
+        the timer and leaves the row ``ended_at IS NULL`` forever. This is the
+        startup-time complement: it closes rows for the given ``sources`` whose
+        ``started_at`` and canonical last-activity time are both older than
+        ``max_idle_seconds``, with a distinct
         ``end_reason='startup_orphan_reap'`` for traceability.
 
-        Both timestamps must be stale on purpose: message recency alone would
-        sweep a freshly created compression/branch child carrying old copied
-        message timestamps, while ``started_at`` alone would sweep a
-        long-lived session that is still actively producing messages.
-        Message-less rows fall back to ``started_at`` via COALESCE.
+        Canonical activity is the newest of ``last_activity_at`` (the in-turn
+        heartbeat) and the newest durable message timestamp, falling back to
+        ``started_at``. The separate ``started_at`` predicate protects freshly
+        created compression/branch children whose copied activity is old.
 
-        Only pass sources owned by the local UI stack (never messaging-gateway
+        Only pass sources whose lifecycle the caller owns (never messaging-gateway
         platforms like ``telegram`` — ending those triggers the #60609 routing
-        loop).  ``exclude_ids`` spares rows this process still holds in
-        memory (a ``session.resume`` that landed during the startup grace
-        window).  Non-destructive: messages are preserved and the row remains
-        resumable.  First-reason-wins is preserved via ``ended_at IS NULL``.
+        loop). ``exclude_ids`` spares rows this process still holds in memory
+        (a ``session.resume`` that landed during the startup grace window).
+        ``exclude_pinned`` is intended for broad automatic sweeps; pinned rows
+        remain explicitly recoverable. Non-destructive: messages are preserved
+        and the row remains resumable. First-reason-wins is preserved via
+        ``ended_at IS NULL``.
 
-        Cross-backend liveness (#94895): when one ``state.db`` is shared by
-        N serve / gateway processes (isolated backends, fixed-port launchd
-        ``hermes serve``, desktop WS sidecar), each backend registers a row
-        in ``gateway_heartbeats`` refreshed every few seconds.  A row is
-        only reaped when ``started_at``/message staleness hold AND no live
-        backend (heartbeat refreshed within ``heartbeat_staleness_seconds``,
-        default ``2 * max_idle_seconds``) could plausibly own it.
+        Cross-backend liveness (#94895): when one ``state.db`` is shared by N
+        serve / gateway processes, each backend refreshes a row in
+        ``gateway_heartbeats``. With ``respect_gateway_heartbeats`` enabled, a
+        row is only reaped when activity staleness holds AND no live backend
+        (heartbeat refreshed within ``heartbeat_staleness_seconds``, default
+        ``2 * max_idle_seconds``) could plausibly own it. Disable that gate only
+        for sources whose lifecycle is explicitly owned by state.db itself.
 
         Ownership inference: a live backend B ``owns`` a session S if
         ``B.started_at <= S.started_at + heartbeat_ownership_grace_seconds``
-        (default ``heartbeat_staleness_seconds``).  The grace window
-        accommodates the deploy-time migration case where a backend just
-        wrote its first heartbeat row while its existing open sessions
-        predate the schema.  The grace is bounded by the staleness window
-        so a fresh PID-reuse respawn cannot indefinitely protect sessions
-        inherited from a dead predecessor.
+        (default ``heartbeat_staleness_seconds``). The grace window covers a
+        migrating backend whose existing sessions predate its first heartbeat,
+        but is bounded so a fresh PID-reuse respawn cannot protect rows forever.
+        With no fresh heartbeat the predicate falls back to the legacy sweep.
 
-        When NO backend has ever written a heartbeat (legacy deployment
-        mid-upgrade before any process has registered) the predicate falls
-        back to the original behavior so we never silently strand a row
-        that pre-dates the schema.
-
-        The SELECT + UPDATE run in one ``BEGIN IMMEDIATE`` write, so a sibling
-        process cannot sneak a new message or end-reason between the
-        staleness check and the close.  Returns the swept session ids.
+        The SELECT, live-lease validation, and UPDATE run in one
+        ``BEGIN IMMEDIATE`` transaction. Active turn leases or compression
+        locks spare the row; expired/reclaimed guards are removed so their
+        former owner is fenced. Returns the swept session ids.
         """
         srcs = tuple(s for s in sources if s)
         if max_idle_seconds <= 0 or not srcs:
@@ -9352,56 +9421,76 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         )
         hb_grace = (
             heartbeat_ownership_grace_seconds
-            if heartbeat_ownership_grace_seconds and heartbeat_ownership_grace_seconds >= 0
+            if heartbeat_ownership_grace_seconds is not None
+            and heartbeat_ownership_grace_seconds >= 0
             else hb_staleness
         )
-        cutoff = time.time() - max_idle_seconds
-        hb_cutoff = time.time() - hb_staleness
+        now = time.time()
+        cutoff = now - max_idle_seconds
+        hb_cutoff = now - hb_staleness
         placeholders = ",".join("?" for _ in srcs)
         staleness = (
-            "started_at < ? AND COALESCE((SELECT MAX(m.timestamp) FROM messages m"
-            " WHERE m.session_id = sessions.id), started_at) < ?"
+            f"started_at < ? AND {_sql_session_last_active('sessions')} < ?"
         )
-
-        def _do(conn):
-            # Cross-process liveness gate (#94895). A session is "owned by
-            # a live backend" if any row in gateway_heartbeats is fresh
-            # (last_heartbeat >= hb_cutoff) AND was alive no later than
-            # ``sessions.started_at + hb_grace`` (heartbeats.started_at <=
-            # sessions.started_at + hb_grace). If at least one live backend
-            # matches, the row is not orphaned.
-            #
-            # ``hb_cutoff`` and ``hb_grace`` are computed above so all
-            # backends running concurrent sweep queries agree on the same
-            # boundaries. We do NOT clear heartbeats here — that's each
-            # backend's atexit responsibility via ``clear_backend_heartbeat``.
-            orphan_predicate = (
-                f"{staleness} AND NOT EXISTS ("
+        pin_scope = " AND COALESCE(pinned, 0) = 0" if exclude_pinned else ""
+        heartbeat_params: Tuple[float, ...] = ()
+        orphan_predicate = staleness
+        if respect_gateway_heartbeats:
+            orphan_predicate += (
+                " AND NOT EXISTS ("
                 "SELECT 1 FROM gateway_heartbeats h"
                 " WHERE h.last_heartbeat >= ?"
-                f" AND h.started_at <= sessions.started_at + ?"
+                " AND h.started_at <= sessions.started_at + ?"
                 ")"
             )
+            heartbeat_params = (hb_cutoff, hb_grace)
+
+        def _do(conn):
             rows = conn.execute(
                 f"SELECT id FROM sessions WHERE ended_at IS NULL"
-                f" AND source IN ({placeholders}) AND {orphan_predicate}",
-                (*srcs, cutoff, cutoff, hb_cutoff, hb_grace),
+                f" AND source IN ({placeholders}){pin_scope}"
+                f" AND {orphan_predicate}",
+                (*srcs, cutoff, cutoff, *heartbeat_params),
             ).fetchall()
             excluded = {str(x) for x in exclude_ids if x}
-            victims = [str(r["id"]) for r in rows if str(r["id"]) not in excluded]
+            victims = []
+            for row in rows:
+                sid = str(row["id"])
+                if sid in excluded:
+                    continue
+                try:
+                    self._check_transcript_write_guards(
+                        conn,
+                        sid,
+                        compression_lock_holder=None,
+                        turn_lease_holder=None,
+                        reject_active_turn_lease=True,
+                        reject_active_compression_lock=True,
+                    )
+                except (
+                    SessionCompressionInProgressError,
+                    SessionTurnLeaseLostError,
+                ):
+                    continue
+                victims.append(sid)
             if not victims:
                 return []
-            now = time.time()
+            closed_at = time.time()
             marks = ",".join("?" for _ in victims)
-            # Re-apply the same predicates under the write lock so a
-            # row that raced to activity between SELECT and UPDATE is
-            # spared (and so a freshly registered heartbeat from a sibling
-            # that started during this transaction can still save the row).
+            # Re-apply every scope/liveness predicate under the write lock.
             conn.execute(
                 f"UPDATE sessions SET ended_at = ?, end_reason = 'startup_orphan_reap'"
                 f" WHERE id IN ({marks}) AND ended_at IS NULL"
+                f" AND source IN ({placeholders}){pin_scope}"
                 f" AND {orphan_predicate}",
-                (now, *victims, cutoff, cutoff, hb_cutoff, hb_grace),
+                (
+                    closed_at,
+                    *victims,
+                    *srcs,
+                    cutoff,
+                    cutoff,
+                    *heartbeat_params,
+                ),
             )
             return victims
 
@@ -10911,6 +11000,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         turn_lease_ttl_seconds: float = 300.0,
         reject_active_turn_lease: bool = False,
         reject_active_compression_lock: bool = False,
+        allow_closed_compression_parent: bool = False,
     ) -> None:
         """Transcript-write admission checks, run INSIDE the write txn.
 
@@ -11010,6 +11100,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             session is not None
             and session["ended_at"] is not None
             and session["end_reason"] == "compression"
+            and not allow_closed_compression_parent
         ):
             raise CompressionSessionClosedError(session_id)
 
@@ -13838,6 +13929,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                    ) < ?"""
             )
             params.append(last_active_before)
+            # An automatic orphan sweep closes a stale open row so the user can
+            # still recover it. Age those rows from the sweep, not from their old
+            # activity, or the next prune pass can delete them immediately.
+            clauses.append(
+                "(COALESCE(s.end_reason, '') != 'startup_orphan_reap' "
+                "OR s.ended_at < ?)"
+            )
+            params.append(last_active_before)
         if last_active_after is not None:
             clauses.append(
                 """COALESCE(
@@ -14099,6 +14198,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         older_than_days: Optional[float] = 90,
         source: str = None,
         sessions_dir: Optional[Path] = None,
+        exclude_active_write_guards: bool = False,
         **filters,
     ) -> int:
         """Delete sessions matching the filters. Returns count deleted.
@@ -14136,6 +14236,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         on-disk transcript files (``.json`` / ``.jsonl`` /
         ``request_dump_*``) for every pruned session, outside the DB
         transaction.
+
+        ``exclude_active_write_guards`` is for destructive automatic
+        maintenance: rows protected by a live turn lease or compression lock
+        are skipped, while expired or provably dead holders are reclaimed and
+        fenced in the same write transaction.
         """
         self._apply_prune_age_filter(older_than_days, filters)
         where, where_params = self._prune_filter_where(source=source, **filters)
@@ -14146,6 +14251,26 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 f"SELECT s.id FROM sessions s WHERE {where}", where_params
             )
             session_ids = {row["id"] for row in cursor.fetchall()}
+
+            if exclude_active_write_guards:
+                protected = set()
+                for sid in session_ids:
+                    try:
+                        self._check_transcript_write_guards(
+                            conn,
+                            sid,
+                            compression_lock_holder=None,
+                            turn_lease_holder=None,
+                            reject_active_turn_lease=True,
+                            reject_active_compression_lock=True,
+                            allow_closed_compression_parent=True,
+                        )
+                    except (
+                        SessionCompressionInProgressError,
+                        SessionTurnLeaseLostError,
+                    ):
+                        protected.add(sid)
+                session_ids.difference_update(protected)
 
             if not session_ids:
                 return 0
@@ -14998,6 +15123,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
           - ``"error"`` (str, optional) — present only on failure
         """
         result: Dict[str, Any] = {"skipped": False, "pruned": 0, "vacuumed": False}
+        maintenance_lock = _try_acquire_auto_maintenance_lock(self.db_path)
+        if maintenance_lock is None:
+            result["skipped"] = True
+            return result
         try:
             # Skip if another process/call did maintenance recently.
             last_raw = self.get_meta("last_auto_prune")
@@ -15011,11 +15140,26 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 except (TypeError, ValueError):
                     pass  # corrupt meta; treat as no prior run
 
+            # Delete only sessions that were already explicitly closed. A
+            # startup orphan discovered by this pass is closed *after* pruning,
+            # preserving a full retention window in which it can be resumed.
             pruned = self.prune_sessions(
                 older_than_days=retention_days,
                 sessions_dir=sessions_dir,
+                exclude_active_write_guards=True,
             )
             result["pruned"] = pruned
+
+            # Reap stale state-owned rows only. Runtime-owned messaging sources
+            # are intentionally outside this automatic destructive scope.
+            closed = self.sweep_orphaned_sessions(
+                max_idle_seconds=float(retention_days) * 86400.0,
+                sources=self._AUTO_PRUNE_STALE_OPEN_SOURCES,
+                exclude_pinned=True,
+                # These sources are owned by state.db lifecycles, not by the
+                # dashboard/TUI gateway heartbeats used by startup recovery.
+                respect_gateway_heartbeats=False,
+            )
 
             # Only VACUUM if we actually freed rows, and no more often than
             # once every min_vacuum_interval_days -- a large prune (e.g. the
@@ -15043,9 +15187,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # every startup within the min_interval_hours window.
             self.set_meta("last_auto_prune", str(now))
 
-            if pruned > 0:
+            if closed or pruned > 0:
                 logger.info(
-                    "state.db auto-maintenance: pruned %d session(s) inactive for %d days%s",
+                    "state.db auto-maintenance: closed %d stale open session(s), "
+                    "pruned %d session(s) inactive for %d days%s",
+                    len(closed),
                     pruned,
                     retention_days,
                     " + VACUUM" if result["vacuumed"] else "",
@@ -15054,6 +15200,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # Maintenance must never block startup. Log and return error marker.
             logger.warning("state.db auto-maintenance failed: %s", exc)
             result["error"] = str(exc)
+        finally:
+            _release_auto_maintenance_lock(maintenance_lock)
 
         return result
 

--- a/tests/hermes_state/test_sweep_orphaned_sessions.py
+++ b/tests/hermes_state/test_sweep_orphaned_sessions.py
@@ -16,6 +16,7 @@ to be older than the cutoff:
   actively producing messages.
 """
 
+import threading
 import time
 
 import pytest
@@ -42,6 +43,15 @@ def _set_message_timestamps(db: SessionDB, session_id: str, ts: float) -> None:
         "UPDATE messages SET timestamp = ? WHERE session_id = ?", (ts, session_id)
     )
     db._conn.commit()
+
+
+def _set_last_activity(db: SessionDB, session_id: str, ts: float) -> None:
+    conn = db._conn
+    assert conn is not None
+    conn.execute(
+        "UPDATE sessions SET last_activity_at = ? WHERE id = ?", (ts, session_id)
+    )
+    conn.commit()
 
 
 def _make_session(
@@ -98,6 +108,17 @@ class TestSweepOrphanedSessions:
 
         assert db.sweep_orphaned_sessions(max_idle_seconds=IDLE_S) == []
         assert db.get_session("active")["ended_at"] is None
+
+    def test_recent_heartbeat_spares_old_session(self, db):
+        """A turn heartbeat is activity even before its next message lands."""
+        stale = time.time() - 48 * 3600
+        _make_session(
+            db, "active-heartbeat", source="tui", started_at=stale, message_at=stale
+        )
+        _set_last_activity(db, "active-heartbeat", time.time())
+
+        assert db.sweep_orphaned_sessions(max_idle_seconds=IDLE_S) == []
+        assert db.get_session("active-heartbeat")["ended_at"] is None
 
     def test_fresh_session_with_old_copied_messages_spared(self, db):
         """Compression/branch children copy history — old message timestamps
@@ -162,6 +183,355 @@ class TestSweepOrphanedSessions:
         ) == ["stale-cli"]
         assert db.get_session("stale-cli")["end_reason"] == "startup_orphan_reap"
         assert db.get_session("stale-tui")["ended_at"] is None
+
+    def test_explicit_source_scope_spares_gateway_sessions(self, db):
+        stale = time.time() - 8 * 3600
+        _make_session(
+            db, "stale-cron", source="cron", started_at=stale, message_at=stale
+        )
+        for sid, session_key in (
+            ("keyed-telegram", "telegram:chat:1"),
+            ("unkeyed-telegram", None),
+        ):
+            db.create_session(sid, source="telegram", session_key=session_key)
+            db.append_message(sid, role="user", content="hello")
+            _set_message_timestamps(db, sid, stale)
+            _backdate_session(db, sid, stale)
+
+        assert db.sweep_orphaned_sessions(
+            max_idle_seconds=IDLE_S, sources=("cron",)
+        ) == ["stale-cron"]
+        assert db.get_session("stale-cron")["end_reason"] == "startup_orphan_reap"
+        assert db.get_session("keyed-telegram")["ended_at"] is None
+        assert db.get_session("unkeyed-telegram")["ended_at"] is None
+
+    def test_automatic_source_scope_spares_pinned_session(self, db):
+        stale = time.time() - 8 * 3600
+        _make_session(
+            db, "pinned", source="cli", started_at=stale, message_at=stale
+        )
+        db.set_session_pinned("pinned", True)
+
+        assert db.sweep_orphaned_sessions(
+            max_idle_seconds=IDLE_S,
+            sources=("cli",),
+            exclude_pinned=True,
+        ) == []
+        assert db.get_session("pinned")["ended_at"] is None
+
+    def test_live_turn_lease_on_compression_lineage_spares_session(self, db):
+        stale = time.time() - 8 * 3600
+        _make_session(db, "root", source="cli", started_at=stale, message_at=stale)
+        db.end_session("root", "compression")
+        db.create_session("tip", source="cli", parent_session_id="root")
+        db.append_message("tip", role="user", content="continued")
+        _set_message_timestamps(db, "tip", stale)
+        _backdate_session(db, "tip", stale)
+        assert db.try_acquire_session_turn_lease(
+            "tip", "external-turn", ttl_seconds=300
+        )
+
+        assert db.sweep_orphaned_sessions(
+            max_idle_seconds=IDLE_S, sources=("cli",)
+        ) == []
+        assert db.get_session("tip")["ended_at"] is None
+
+    def test_active_compression_lock_spares_and_expiry_fences_owner(self, db):
+        stale = time.time() - 8 * 3600
+        _make_session(
+            db, "compressing", source="cli", started_at=stale, message_at=stale
+        )
+        assert db.try_acquire_compression_lock(
+            "compressing", "compressor", ttl_seconds=300
+        )
+
+        assert db.sweep_orphaned_sessions(
+            max_idle_seconds=IDLE_S, sources=("cli",)
+        ) == []
+
+        conn = db._conn
+        assert conn is not None
+        conn.execute(
+            "UPDATE compression_locks SET expires_at = ? WHERE session_id = ?",
+            (time.time() - 1, "compressing"),
+        )
+        conn.commit()
+
+        assert db.sweep_orphaned_sessions(
+            max_idle_seconds=IDLE_S, sources=("cli",)
+        ) == ["compressing"]
+        assert db.get_compression_lock_holder("compressing") is None
+        assert db.refresh_compression_lock("compressing", "compressor") is False
+
+    def test_expired_turn_lease_does_not_block_sweep(self, db):
+        stale = time.time() - 8 * 3600
+        _make_session(
+            db, "expired", source="cli", started_at=stale, message_at=stale
+        )
+        assert db.try_acquire_session_turn_lease(
+            "expired", "expired-turn", ttl_seconds=300
+        )
+        db._conn.execute(
+            "UPDATE session_turn_leases SET expires_at = ? WHERE conversation_id = ?",
+            (time.time() - 1, "expired"),
+        )
+        db._conn.commit()
+
+        assert db.sweep_orphaned_sessions(
+            max_idle_seconds=IDLE_S, sources=("cli",)
+        ) == ["expired"]
+        assert db.get_session("expired")["end_reason"] == "startup_orphan_reap"
+        assert db.refresh_session_turn_lease("expired", "expired-turn") is False
+
+    def test_auto_prune_closes_stale_state_owned_rows_but_spares_live_turns(self, db):
+        stale = time.time() - 100 * 86400
+        recent = time.time() - 86400
+        for sid, source in (
+            ("orphan", "cli"),
+            ("live-turn", "cli"),
+            ("stale-cron", "cron"),
+            ("runtime-owned-ui", "tui"),
+        ):
+            _make_session(db, sid, source=source, started_at=stale, message_at=stale)
+            _set_last_activity(db, sid, stale)
+        _make_session(
+            db,
+            "recent-orphan",
+            source="cli",
+            started_at=recent,
+            message_at=recent,
+        )
+        _set_last_activity(db, "recent-orphan", recent)
+        db.create_session(
+            "keyed", source="telegram", session_key="telegram:chat:1"
+        )
+        _backdate_session(db, "keyed", stale)
+        db.create_session("unkeyed-gateway", source="telegram")
+        _backdate_session(db, "unkeyed-gateway", stale)
+        _set_last_activity(db, "unkeyed-gateway", stale)
+        assert db.try_acquire_session_turn_lease(
+            "live-turn", "external-turn", ttl_seconds=300
+        )
+        db.register_backend_heartbeat(
+            backend_id="unrelated-dashboard",
+            pid=12345,
+            started_at=time.time(),
+            last_heartbeat=time.time(),
+        )
+
+        first = db.maybe_auto_prune_and_vacuum(
+            retention_days=90,
+            min_interval_hours=0,
+            vacuum=False,
+        )
+
+        assert first["pruned"] == 0
+        assert db.get_session("orphan")["end_reason"] == "startup_orphan_reap"
+        assert db.get_session("stale-cron")["end_reason"] == "startup_orphan_reap"
+        assert db.get_session("live-turn")["ended_at"] is None
+        assert db.get_session("recent-orphan")["ended_at"] is None
+        assert db.get_session("runtime-owned-ui")["ended_at"] is None
+        assert db.get_session("keyed")["ended_at"] is None
+        assert db.get_session("unkeyed-gateway")["ended_at"] is None
+
+        second = db.maybe_auto_prune_and_vacuum(
+            retention_days=90,
+            min_interval_hours=0,
+            vacuum=False,
+        )
+
+        assert second["pruned"] == 0
+        assert db.get_session("orphan") is not None
+        assert db.get_session("stale-cron") is not None
+
+        db._conn.execute(
+            "UPDATE sessions SET ended_at = ? WHERE id IN (?, ?)",
+            (stale, "orphan", "stale-cron"),
+        )
+        db._conn.commit()
+        third = db.maybe_auto_prune_and_vacuum(
+            retention_days=90,
+            min_interval_hours=0,
+            vacuum=False,
+        )
+
+        assert third["pruned"] == 2
+        assert db.get_session("orphan") is None
+        assert db.get_session("stale-cron") is None
+
+    def test_failed_maintenance_marker_keeps_newly_swept_row_recoverable(
+        self, db, monkeypatch
+    ):
+        stale = time.time() - 100 * 86400
+        _make_session(
+            db,
+            "recoverable",
+            source="cli",
+            started_at=stale,
+            message_at=stale,
+        )
+        _set_last_activity(db, "recoverable", stale)
+        set_meta = db.set_meta
+        fail_once = True
+
+        def flaky_set_meta(key, value):
+            nonlocal fail_once
+            if key == "last_auto_prune" and fail_once:
+                fail_once = False
+                raise RuntimeError("injected marker failure")
+            return set_meta(key, value)
+
+        monkeypatch.setattr(db, "set_meta", flaky_set_meta)
+
+        first = db.maybe_auto_prune_and_vacuum(
+            retention_days=90,
+            min_interval_hours=0,
+            vacuum=False,
+        )
+        retry = db.maybe_auto_prune_and_vacuum(
+            retention_days=90,
+            min_interval_hours=0,
+            vacuum=False,
+        )
+
+        assert first["error"] == "injected marker failure"
+        assert retry["pruned"] == 0
+        assert db.get_session("recoverable")["end_reason"] == "startup_orphan_reap"
+
+    def test_concurrent_auto_maintenance_preserves_the_recovery_window(
+        self, db, monkeypatch
+    ):
+        stale = time.time() - 100 * 86400
+        _make_session(db, "concurrent", source="cli", started_at=stale, message_at=stale)
+        _set_last_activity(db, "concurrent", stale)
+        peer = SessionDB(db.db_path)
+        read_barrier = threading.Barrier(2)
+        second_done = threading.Event()
+        release_first_prune = threading.Event()
+        errors = []
+        results = {}
+
+        for instance in (db, peer):
+            get_meta = instance.get_meta
+
+            def synchronized_get_meta(key, *, _get_meta=get_meta):
+                value = _get_meta(key)
+                if key == "last_auto_prune":
+                    try:
+                        read_barrier.wait(timeout=1)
+                    except threading.BrokenBarrierError:
+                        pass
+                return value
+
+            monkeypatch.setattr(instance, "get_meta", synchronized_get_meta)
+
+        prune_sessions = db.prune_sessions
+
+        def delayed_prune(*args, **kwargs):
+            assert release_first_prune.wait(timeout=5)
+            return prune_sessions(*args, **kwargs)
+
+        monkeypatch.setattr(db, "prune_sessions", delayed_prune)
+
+        def run(name, instance, *, done=None):
+            try:
+                results[name] = instance.maybe_auto_prune_and_vacuum(
+                    retention_days=90,
+                    min_interval_hours=24,
+                    vacuum=False,
+                )
+            except BaseException as exc:  # pragma: no cover - asserted below
+                errors.append(exc)
+            finally:
+                if done is not None:
+                    done.set()
+
+        first = threading.Thread(target=run, args=("first", db))
+        second = threading.Thread(
+            target=run, args=("second", peer), kwargs={"done": second_done}
+        )
+        try:
+            first.start()
+            second.start()
+            assert second_done.wait(timeout=5)
+            release_first_prune.set()
+        finally:
+            release_first_prune.set()
+            first.join(timeout=5)
+            second.join(timeout=5)
+            peer.close()
+
+        assert not first.is_alive()
+        assert not second.is_alive()
+        assert errors == []
+        assert sum(bool(result["skipped"]) for result in results.values()) == 1
+        assert sum(int(result["pruned"]) for result in results.values()) == 0
+        assert db.get_session("concurrent")["end_reason"] == "startup_orphan_reap"
+
+    def test_auto_prune_spares_compression_root_of_live_turn(self, db):
+        stale = time.time() - 100 * 86400
+        _make_session(db, "root", source="cli", started_at=stale, message_at=stale)
+        db.end_session("root", "compression")
+        db.create_session("tip", source="cli", parent_session_id="root")
+        db.append_message("tip", role="user", content="continued")
+        _set_message_timestamps(db, "tip", stale)
+        _backdate_session(db, "tip", stale)
+        _set_last_activity(db, "tip", stale)
+        assert db.try_acquire_session_turn_lease(
+            "tip", "external-turn", ttl_seconds=300
+        )
+
+        result = db.maybe_auto_prune_and_vacuum(
+            retention_days=90,
+            min_interval_hours=0,
+            vacuum=False,
+        )
+
+        assert result["pruned"] == 0
+        assert db.get_session("root") is not None
+        assert db.get_session("tip")["ended_at"] is None
+
+    def test_auto_prune_spares_prior_sweep_row_with_new_turn_lease(self, db):
+        stale = time.time() - 100 * 86400
+        _make_session(db, "racy", source="cli", started_at=stale, message_at=stale)
+        _set_last_activity(db, "racy", stale)
+        db.end_session("racy", "startup_orphan_reap")
+        assert db.try_acquire_session_turn_lease(
+            "racy", "arriving-turn", ttl_seconds=300
+        )
+
+        result = db.maybe_auto_prune_and_vacuum(
+            retention_days=90,
+            min_interval_hours=0,
+            vacuum=False,
+        )
+
+        assert result["pruned"] == 0
+        assert db.get_session("racy") is not None
+
+    def test_auto_prune_spares_prior_sweep_row_with_new_compression_lock(self, db):
+        stale = time.time() - 100 * 86400
+        _make_session(
+            db,
+            "racy-compression",
+            source="cli",
+            started_at=stale,
+            message_at=stale,
+        )
+        _set_last_activity(db, "racy-compression", stale)
+        db.end_session("racy-compression", "startup_orphan_reap")
+        assert db.try_acquire_compression_lock(
+            "racy-compression", "arriving-compressor", ttl_seconds=300
+        )
+
+        result = db.maybe_auto_prune_and_vacuum(
+            retention_days=90,
+            min_interval_hours=0,
+            vacuum=False,
+        )
+
+        assert result["pruned"] == 0
+        assert db.get_session("racy-compression") is not None
 
     def test_returns_empty_on_empty_db(self, db):
         assert db.sweep_orphaned_sessions(max_idle_seconds=IDLE_S) == []


### PR DESCRIPTION
## Summary

Rebuilt on `main` at `e078b2fe7` after the cross-backend orphan-sweep changes in #94895; the final candidate also merges cleanly with latest `main` at `48d252806`.

- Preserve current main's cross-backend gateway heartbeat ownership gate for UI/startup sweeps while preventing unrelated UI heartbeats from suppressing state-owned automatic cleanup.
- During automatic maintenance, close only stale open sessions from explicitly state-owned producers (`cli`, `cron`, `kanban`, `acp`, `api_server`, `subagent`, `tool`) after the configured retention window.
- Spare messaging/UI/desktop and unknown sources, pinned sessions, live turn leases, active compression locks, compression lineage with live work, and rows protected by transcript write guards.
- Revalidate the full stale/orphan predicate inside the same write transaction before closing rows.
- Serialize automatic maintenance across processes with a sidecar lock. Prune previously ended rows before closing newly stale rows, and age `startup_orphan_reap` rows from their closure time so marker-write failures cannot collapse the recovery window.
- Keep the public maintenance result contract unchanged; closed-row counts are logged operationally.

This addresses the stale-open portion of #54189. The separate CLI surface proposed in #92744 remains complementary.

## Verification

- Regression proof on unmodified current main: the two adversarial recovery-window/heartbeat selectors fail.
- Focused current-main candidate: **50 passed** across orphan sweep, #94895 cross-backend ownership, archived-transcript safety, and startup sweep tests.
- Broader state package: **212 passed**.
- Existing prune/filter classes: **15 passed**.
- `ruff check` and `git diff --check`: pass.
- `git merge-tree --write-tree origin/main HEAD`: clean.

A repository-wide `tests/test_hermes_state.py` run also exposed a pre-existing, unrelated FTS trace assertion failure and exceeded the per-file timeout; the same assertion fails on unmodified current main. The directly affected prune/filter classes pass as reported above.

## Scope

No messaging gateway ownership changes, public CLI command, schema migration, or public maintenance-result field is added.
