### PR TITLE
fix(matrix): add MAS refresh-token support for matrix.org

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1574,36 +1574,19 @@ class MatrixAdapter(BasePlatformAdapter):
             "(discovery_probed=%s)", token_endpoint, discovery_probed,
         )
 
-        def _build_opener():
-            proxy_url = os.getenv("MATRIX_PROXY", "").strip()
-            handlers = []
-            if proxy_url:
-                if proxy_url.startswith(("socks4://", "socks5://", "socks://")):
-                    logger.warning(
-                        "Matrix: MATRIX_PROXY scheme %r not supported for the "
-                        "MAS refresh path (HTTP(S) only); ignoring.",
-                        proxy_url.split("://", 1)[0],
-                    )
-                else:
-                    handlers.append(urllib.request.ProxyHandler({"http": proxy_url, "https": proxy_url}))
-            return urllib.request.build_opener(*handlers) if handlers else None
-
         def _post_token_request():
             data = urllib.parse.urlencode({
                 "grant_type": "refresh_token",
                 "refresh_token": self._refresh_token,
                 "client_id": client_id,
             }).encode()
-            req = urllib.request.Request(
+            return self._mas_urlopen(
                 token_endpoint,
+                timeout=15,
                 data=data,
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
                 method="POST",
             )
-            opener = _build_opener()
-            if opener is not None:
-                return opener.open(req, timeout=15)
-            return urllib.request.urlopen(req, timeout=15)
 
         try:
             doc = await asyncio.to_thread(_post_token_request)
@@ -1628,6 +1611,34 @@ class MatrixAdapter(BasePlatformAdapter):
             return True
         return False
 
+    def _mas_urlopen(self, url, *, timeout, data=None, headers=None, method=None):
+        """urllib fetch used by the whole MAS refresh path (discovery +
+        token POST), honoring ``MATRIX_PROXY`` (HTTP/HTTPS) uniformly.
+
+        SOCKS proxies are logged-and-ignored here (the aiohttp transport
+        owns SOCKS for adapter traffic; this helper covers only the
+        one-shot OAuth2 requests).
+        """
+        import urllib.request
+
+        proxy_url = os.getenv("MATRIX_PROXY", "").strip()
+        req = urllib.request.Request(
+            url, data=data, headers=headers or {}, method=method
+        )
+        if proxy_url:
+            if proxy_url.startswith(("socks4://", "socks5://", "socks://")):
+                logger.debug(
+                    "Matrix: MATRIX_PROXY scheme %r not supported for the "
+                    "MAS refresh path (HTTP(S) only); going direct.",
+                    proxy_url.split("://", 1)[0],
+                )
+                return urllib.request.urlopen(req, timeout=timeout)
+            opener = urllib.request.build_opener(
+                urllib.request.ProxyHandler({"http": proxy_url, "https": proxy_url})
+            )
+            return opener.open(req, timeout=timeout)
+        return urllib.request.urlopen(req, timeout=timeout)
+
     def _resolve_oauth_token_endpoint(self):
         """Return ``(token_endpoint, discovery_was_attempted)``.
 
@@ -1637,8 +1648,6 @@ class MatrixAdapter(BasePlatformAdapter):
            falling back to the MSC2965 homeserver pointer for the issuer.
         """
         import json as _json
-        import urllib.parse
-        import urllib.request
 
         override = (
             getattr(self, "_oidc_token_endpoint_override", "")
@@ -1654,7 +1663,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
         def _fetch_well_known(base):
             url = base.rstrip("/") + "/.well-known/openid-configuration"
-            with urllib.request.urlopen(url, timeout=10) as r:
+            with self._mas_urlopen(url, timeout=10) as r:
                 return url, _json.loads(r.read().decode("utf-8", errors="replace"))
 
         def _try_discover(base):
@@ -1697,7 +1706,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
         # Second try: MSC2965 homeserver pointer to the issuer.
         try:
-            with urllib.request.urlopen(
+            with self._mas_urlopen(
                 homeserver + "/.well-known/matrix/client", timeout=10
             ) as r:
                 client_doc = _json.loads(r.read().decode("utf-8", errors="replace"))

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -17,6 +17,18 @@ Environment variables:
     MATRIX_OIDC_CLIENT_ID       Public OIDC client id for MAS OAuth2 token refresh
                                 (required for matrix.org-style deployments; the
                                 legacy /v3/refresh endpoint rejects MAS tokens)
+    MATRIX_OAUTH_TOKEN_ENDPOINT Override for the MAS OAuth2 token_endpoint
+                                (skips OIDC discovery; e.g.
+                                https://account.matrix.org/oauth2/token when
+                                MATRIX_HOMESERVER points at matrix-client.matrix.org
+                                whose /.well-known does not exist)
+    MATRIX_OIDC_ISSUER         Override for the OIDC issuer base URL used to
+                                discover the token_endpoint (skips the homeserver
+                                well-known pointer; the OIDC doc is fetched at
+                                <issuer>/.well-known/openid-configuration)
+    MATRIX_PROXY                HTTP(S) or SOCKS proxy URL for Matrix traffic
+                                (the MAS refresh path honors it alongside the
+                                rest of the adapter)
     MATRIX_PROXY                HTTP(S) or SOCKS proxy URL for Matrix traffic
     MATRIX_ALLOWED_USERS    Comma-separated Matrix user IDs (@user:server)
     MATRIX_ALLOWED_ROOMS    Comma-separated Matrix room IDs allowed to trigger turns
@@ -1241,189 +1253,23 @@ class MatrixAdapter(BasePlatformAdapter):
             "MATRIX_REFRESH_TOKEN"
         )
         self._refresh_lock: asyncio.Lock = asyncio.Lock()
-        # MAS OAuth2 refresh state (#94096): OIDC discovery cache + bounded
+        # MAS OAuth2 refresh state (#94096 v2): OIDC discovery cache + bounded
         # total refresh attempts so a rejecting server can't drive an
-        # endless refresh/rotate loop.
+        # endless refresh/rotate loop. Overrides let operators point
+        # directly at the OAuth2 issuer when the homeserver has no
+        # machine-readable well-known pointer (matrix.org case).
         self._oidc_client_id: str = str(config.extra.get("oidc_client_id", "") or "")
         self._oidc_token_endpoint: Optional[str] = None
+        self._oidc_token_endpoint_override: str = str(
+            config.extra.get("oauth_token_endpoint", "") or ""
+        )
+        self._oidc_issuer_override: str = str(
+            config.extra.get("oidc_issuer", "") or ""
+        )
         self._oidc_hint_logged: bool = False
         self._refresh_attempts: int = 0
 
         self._client: Any = None  # mautrix.client.Client
-
-    async def _refresh_access_token(self, api, reason: str = "") -> bool:
-        """Refresh the Matrix access token using the stored refresh token.
-
-        Two paths, tried in order:
-
-        1. Legacy ``POST /_matrix/client/v3/refresh`` (native MSC2918
-           homeservers - self-hosted Synapse with short-lived session
-           tokens).
-        2. MAS / OAuth2 deployments (matrix.org): those tokens are NOT
-           honored by the legacy endpoint (Synapse only knows tokens it
-           issued itself - live-verified in #94096), so we fall back to the
-           OAuth2 token endpoint from OIDC discovery with
-           ``grant_type=refresh_token`` and the public client id from
-           ``MATRIX_OIDC_CLIENT_ID``.
-
-        On success updates ``api.token``, ``self._access_token`` and rotates
-        ``self._refresh_token`` in memory (best-effort). Attempts are
-        bounded: after ``_MAX_REFRESH_ATTEMPTS`` total tries the helper
-        gives up so a rejecting server can never drive an endless
-        refresh/rotate loop. Returns True on success.
-        """
-        if not self._refresh_token or not self._homeserver:
-            return False
-        async with self._refresh_lock:
-            # Re-check after acquiring lock (another task may have refreshed)
-            if not self._refresh_token:
-                return False
-            if self._refresh_attempts >= _MAX_REFRESH_ATTEMPTS:
-                logger.error(
-                    "Matrix: giving up token refresh after %d attempts "
-                    "(server keeps rejecting); restart required.",
-                    self._refresh_attempts,
-                )
-                return False
-            self._refresh_attempts += 1
-
-            # --- Path 1: legacy native refresh -------------------------
-            try:
-                resp = await api.request(
-                    "POST", "/_matrix/client/v3/refresh", {"refresh_token": self._refresh_token}
-                )
-                if self._apply_refresh_response(api, resp):
-                    logger.info(
-                        "Matrix: refreshed access token via legacy refresh "
-                        "(reason=%s)", reason or "unknown",
-                    )
-                    return True
-                return False
-            except Exception as legacy_exc:
-                if not _is_m_unknown_token_error(legacy_exc):
-                    logger.warning("Matrix: legacy refresh failed: %s", legacy_exc)
-                    return False
-                logger.info(
-                    "Matrix: legacy refresh rejected (%s) - trying MAS "
-                    "OAuth2 token endpoint", legacy_exc,
-                )
-
-            # --- Path 2: MAS OAuth2 token endpoint ---------------------
-            return await self._try_mas_oauth_refresh(api, reason=reason)
-
-    def _apply_refresh_response(self, api, resp) -> bool:
-        """Apply an access-token refresh response (dict or mautrix object)."""
-        new_access = None
-        new_refresh = None
-        if isinstance(resp, dict):
-            new_access = resp.get("access_token")
-            new_refresh = resp.get("refresh_token")
-        else:
-            new_access = getattr(resp, "access_token", None)
-            # mautrix LoginResponse stores unknown fields in unrecognized_
-            new_refresh = getattr(resp, "refresh_token", None)
-            if not new_refresh:
-                unrec = getattr(resp, "unrecognized_", None)
-                if isinstance(unrec, dict):
-                    new_refresh = unrec.get("refresh_token")
-        if not new_access:
-            return False
-        self._access_token = new_access
-        try:
-            api.token = new_access
-        except Exception:
-            pass
-        if new_refresh and new_refresh != self._refresh_token:
-            self._refresh_token = new_refresh
-        return True
-
-    async def _try_mas_oauth_refresh(self, api, reason: str = "") -> bool:
-        """MAS/OAuth2 refresh via OIDC discovery (matrix.org et al).
-
-        Discovers ``token_endpoint`` from
-        ``<homeserver>/.well-known/openid-configuration`` (cached), then
-        POSTs ``grant_type=refresh_token`` with the public client id from
-        ``MATRIX_OIDC_CLIENT_ID``. Rotates the refresh token per response.
-        """
-        import json as _json
-        import urllib.parse
-        import urllib.request
-
-        client_id = (
-            getattr(self, "_oidc_client_id", "")
-            or os.getenv("MATRIX_OIDC_CLIENT_ID", "")
-        ).strip()
-        if not client_id:
-            if not getattr(self, "_oidc_hint_logged", False):
-                self._oidc_hint_logged = True
-                logger.warning(
-                    "Matrix: homeserver rejected legacy refresh; MAS OAuth2 "
-                    "refresh needs MATRIX_OIDC_CLIENT_ID (public client id) "
-                    "to be set - cannot refresh automatically."
-                )
-            return False
-
-        token_endpoint = getattr(self, "_oidc_token_endpoint", None)
-        if not token_endpoint:
-            well_known = (
-                self._homeserver.rstrip("/")
-                + "/.well-known/openid-configuration"
-            )
-
-            def _discover():
-                with urllib.request.urlopen(well_known, timeout=10) as r:
-                    return _json.loads(r.read().decode("utf-8", errors="replace"))
-
-            try:
-                doc = await asyncio.to_thread(_discover)
-            except Exception as exc:
-                logger.warning(
-                    "Matrix: OIDC discovery failed for %s: %s",
-                    self._homeserver, exc,
-                )
-                return False
-            candidate = str(doc.get("token_endpoint") or "").strip()
-            if not candidate:
-                logger.warning(
-                    "Matrix: OIDC discovery returned no token_endpoint "
-                    "for %s", self._homeserver,
-                )
-                return False
-            self._oidc_token_endpoint = candidate
-            token_endpoint = candidate
-
-        def _token_request():
-            data = urllib.parse.urlencode({
-                "grant_type": "refresh_token",
-                "refresh_token": self._refresh_token,
-                "client_id": client_id,
-            }).encode()
-            req = urllib.request.Request(
-                token_endpoint,
-                data=data,
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
-                method="POST",
-            )
-            with urllib.request.urlopen(req, timeout=15) as r:
-                return _json.loads(r.read().decode("utf-8", errors="replace"))
-
-        try:
-            doc = await asyncio.to_thread(_token_request)
-        except Exception as exc:
-            body = str(exc)
-            if "invalid_grant" in body.lower() or _is_m_unknown_token_error(exc):
-                logger.error("Matrix: MAS refresh token rejected: %s", exc)
-            else:
-                logger.warning("Matrix: MAS OAuth2 refresh failed: %s", exc)
-            return False
-
-        if self._apply_refresh_response(api, doc):
-            logger.info(
-                "Matrix: refreshed access token via MAS OAuth2 endpoint "
-                "(reason=%s)", reason or "unknown",
-            )
-            return True
-        return False
         self._crypto_db: Any = None  # mautrix.util.async_db.Database
         self._sync_task: Optional[asyncio.Task] = None
         self._invite_join_tasks: Dict[str, asyncio.Task] = {}
@@ -1588,6 +1434,306 @@ class MatrixAdapter(BasePlatformAdapter):
                     exc,
                 )
 
+
+    async def _refresh_access_token(self, api, reason: str = "") -> bool:
+        """Refresh the Matrix access token using the stored refresh token.
+
+        Two paths, tried in order:
+
+        1. Legacy ``POST /_matrix/client/v3/refresh`` (native MSC2918
+           homeservers - self-hosted Synapse with short-lived session
+           tokens).
+        2. MAS / OAuth2 deployments (matrix.org): those tokens are NOT
+           honored by the legacy endpoint (Synapse only knows tokens it
+           issued itself - live-verified in #94096), so we fall back to the
+           OAuth2 token endpoint from OIDC discovery with
+           ``grant_type=refresh_token`` and the public client id from
+           ``MATRIX_OIDC_CLIENT_ID``.
+
+        On success updates ``api.token``, ``self._access_token`` and rotates
+        ``self._refresh_token`` in memory (best-effort). Attempts are
+        bounded: after ``_MAX_REFRESH_ATTEMPTS`` total tries the helper
+        gives up so a rejecting server can never drive an endless
+        refresh/rotate loop. Returns True on success.
+        """
+        if not self._refresh_token or not self._homeserver:
+            return False
+        async with self._refresh_lock:
+            # Re-check after acquiring lock (another task may have refreshed)
+            if not self._refresh_token:
+                return False
+            if self._refresh_attempts >= _MAX_REFRESH_ATTEMPTS:
+                logger.error(
+                    "Matrix: giving up token refresh after %d attempts "
+                    "(server keeps rejecting); restart required.",
+                    self._refresh_attempts,
+                )
+                return False
+            self._refresh_attempts += 1
+
+            # --- Path 1: legacy native refresh -------------------------
+            try:
+                resp = await api.request(
+                    "POST", "/_matrix/client/v3/refresh", {"refresh_token": self._refresh_token}
+                )
+                if self._apply_refresh_response(api, resp):
+                    logger.info(
+                        "Matrix: refreshed access token via legacy refresh "
+                        "(reason=%s)", reason or "unknown",
+                    )
+                    return True
+                return False
+            except Exception as legacy_exc:
+                if not _is_m_unknown_token_error(legacy_exc):
+                    logger.warning("Matrix: legacy refresh failed: %s", legacy_exc)
+                    return False
+                logger.info(
+                    "Matrix: legacy refresh rejected (%s) - trying MAS "
+                    "OAuth2 token endpoint", legacy_exc,
+                )
+
+            # --- Path 2: MAS OAuth2 token endpoint ---------------------
+            return await self._try_mas_oauth_refresh(api, reason=reason)
+
+    def _apply_refresh_response(self, api, resp) -> bool:
+        """Apply an access-token refresh response (dict or mautrix object)."""
+        new_access = None
+        new_refresh = None
+        if isinstance(resp, dict):
+            new_access = resp.get("access_token")
+            new_refresh = resp.get("refresh_token")
+        else:
+            new_access = getattr(resp, "access_token", None)
+            # mautrix LoginResponse stores unknown fields in unrecognized_
+            new_refresh = getattr(resp, "refresh_token", None)
+            if not new_refresh:
+                unrec = getattr(resp, "unrecognized_", None)
+                if isinstance(unrec, dict):
+                    new_refresh = unrec.get("refresh_token")
+        if not new_access:
+            return False
+        self._access_token = new_access
+        try:
+            api.token = new_access
+        except Exception:
+            pass
+        if new_refresh and new_refresh != self._refresh_token:
+            self._refresh_token = new_refresh
+        return True
+
+    async def _try_mas_oauth_refresh(self, api, reason: str = "") -> bool:
+        """MAS/OAuth2 refresh via OIDC discovery (matrix.org et al).
+
+        Three resolution modes, tried in order:
+
+        1. **Direct token-endpoint override** (``MATRIX_OAUTH_TOKEN_ENDPOINT``,
+           ``config.extra.oauth_token_endpoint``): skip discovery entirely.
+        2. **Issuer override** (``MATRIX_OIDC_ISSUER``): discover at
+           ``<issuer>/.well-known/openid-configuration`` (matrix.org: the
+           homeserver ``matrix-client.matrix.org`` has no well-known, the
+           issuer ``account.matrix.org`` does).
+        3. **Default discovery** at ``<homeserver>/.well-known/openid-configuration``,
+           falling back to ``<homeserver>/.well-known/matrix/client`` for the
+           MSC2965 ``m.oauth_metadata.issuer`` pointer when the OIDC doc
+           itself 404s or is not JSON.
+
+        Then POSTs ``grant_type=refresh_token`` with the public client id
+        from ``MATRIX_OIDC_CLIENT_ID``. Rotates the refresh token per
+        response. Honors ``MATRIX_PROXY`` via a temporary ProxyHandler
+        (SOCKS is not supported here; use an HTTP(S) proxy URL).
+        """
+        import json as _json
+        import urllib.parse
+        import urllib.request
+
+        client_id = (
+            getattr(self, "_oidc_client_id", "")
+            or os.getenv("MATRIX_OIDC_CLIENT_ID", "")
+        ).strip()
+        if not client_id:
+            self._log_oauth_hint(
+                "Matrix: MAS OAuth2 refresh needs MATRIX_OIDC_CLIENT_ID "
+                "(public client id) to be set - cannot refresh."
+            )
+            return False
+
+        token_endpoint, discovery_probed = self._resolve_oauth_token_endpoint()
+        if not token_endpoint:
+            self._log_oauth_hint(
+                "Matrix: could not resolve the MAS OAuth2 token_endpoint - "
+                "set MATRIX_OAUTH_TOKEN_ENDPOINT (e.g. "
+                "https://account.matrix.org/oauth2/token) or MATRIX_OIDC_ISSUER, "
+                "and ensure MATRIX_HOMESERVER is correct."
+            )
+            return False
+
+        token_endpoint = token_endpoint.rstrip("/")
+        self._oidc_token_endpoint = token_endpoint
+        logger.debug(
+            "Matrix: resolved MAS OAuth2 token_endpoint=%s "
+            "(discovery_probed=%s)", token_endpoint, discovery_probed,
+        )
+
+        def _build_opener():
+            proxy_url = os.getenv("MATRIX_PROXY", "").strip()
+            handlers = []
+            if proxy_url:
+                if proxy_url.startswith(("socks4://", "socks5://", "socks://")):
+                    logger.warning(
+                        "Matrix: MATRIX_PROXY scheme %r not supported for the "
+                        "MAS refresh path (HTTP(S) only); ignoring.",
+                        proxy_url.split("://", 1)[0],
+                    )
+                else:
+                    handlers.append(urllib.request.ProxyHandler({"http": proxy_url, "https": proxy_url}))
+            return urllib.request.build_opener(*handlers) if handlers else None
+
+        def _post_token_request():
+            data = urllib.parse.urlencode({
+                "grant_type": "refresh_token",
+                "refresh_token": self._refresh_token,
+                "client_id": client_id,
+            }).encode()
+            req = urllib.request.Request(
+                token_endpoint,
+                data=data,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                method="POST",
+            )
+            opener = _build_opener()
+            if opener is not None:
+                return opener.open(req, timeout=15)
+            return urllib.request.urlopen(req, timeout=15)
+
+        try:
+            doc = await asyncio.to_thread(_post_token_request)
+        except Exception as exc:
+            body = str(exc)
+            if "invalid_grant" in body.lower() or _is_m_unknown_token_error(exc):
+                logger.error("Matrix: MAS refresh token rejected: %s", exc)
+            else:
+                logger.warning("Matrix: MAS OAuth2 refresh failed: %s", exc)
+            return False
+        try:
+            payload = _json.loads(doc.read().decode("utf-8", errors="replace"))
+        except Exception as exc:
+            logger.warning("Matrix: MAS token response was not JSON: %s", exc)
+            return False
+
+        if self._apply_refresh_response(api, payload):
+            logger.info(
+                "Matrix: refreshed access token via MAS OAuth2 endpoint "
+                "%s (reason=%s)", token_endpoint, reason or "unknown",
+            )
+            return True
+        return False
+
+    def _resolve_oauth_token_endpoint(self):
+        """Return ``(token_endpoint, discovery_was_attempted)``.
+
+        1. ``MATRIX_OAUTH_TOKEN_ENDPOINT`` / ``config.extra.oauth_token_endpoint`` - direct.
+        2. ``MATRIX_OIDC_ISSUER`` / ``config.extra.oidc_issuer`` - discover at issuer.
+        3. Default discovery at ``<homeserver>/.well-known/openid-configuration``,
+           falling back to the MSC2965 homeserver pointer for the issuer.
+        """
+        import json as _json
+        import urllib.parse
+        import urllib.request
+
+        override = (
+            getattr(self, "_oidc_token_endpoint_override", "")
+            or os.getenv("MATRIX_OAUTH_TOKEN_ENDPOINT", "")
+        ).strip()
+        if override:
+            return override, False
+
+        issuer_override = (
+            getattr(self, "_oidc_issuer_override", "")
+            or os.getenv("MATRIX_OIDC_ISSUER", "")
+        ).strip()
+
+        def _fetch_well_known(base):
+            url = base.rstrip("/") + "/.well-known/openid-configuration"
+            with urllib.request.urlopen(url, timeout=10) as r:
+                return url, _json.loads(r.read().decode("utf-8", errors="replace"))
+
+        def _try_discover(base):
+            try:
+                return _fetch_well_known(base)
+            except Exception as exc:
+                logger.debug("Matrix: OIDC discovery failed at %s: %s", base, exc)
+                return None
+
+        # Issuer override - discover at the issuer directly.
+        if issuer_override:
+            result = _try_discover(issuer_override)
+            if result:
+                _, doc = result
+                ep = str(doc.get("token_endpoint") or "").strip()
+                if ep:
+                    return ep, True
+                logger.debug(
+                    "Matrix: OIDC doc at issuer %s has no token_endpoint",
+                    issuer_override,
+                )
+            # Fall through to homeserver discovery.
+
+        # Default: homeserver discovery, with MSC2965 fallback.
+        homeserver = self._homeserver.rstrip("/") if self._homeserver else ""
+        if not homeserver:
+            return "", True  # caller treats empty as "could not resolve"
+
+        # First try: homeserver's own OIDC doc.
+        result = _try_discover(homeserver)
+        if result:
+            _, doc = result
+            ep = str(doc.get("token_endpoint") or "").strip()
+            if ep:
+                return ep, True
+            logger.debug(
+                "Matrix: OIDC doc at %s has no token_endpoint; trying MSC2965 "
+                "homeserver pointer.", homeserver,
+            )
+
+        # Second try: MSC2965 homeserver pointer to the issuer.
+        try:
+            with urllib.request.urlopen(
+                homeserver + "/.well-known/matrix/client", timeout=10
+            ) as r:
+                client_doc = _json.loads(r.read().decode("utf-8", errors="replace"))
+        except Exception as exc:
+            logger.debug(
+                "Matrix: MSC2965 homeserver pointer missing at %s (%s); "
+                "discovery chain exhausted.", homeserver, exc,
+            )
+            return "", True
+
+        issuer = (
+            str(client_doc.get("m.oauth_metadata", {}).get("issuer") or "")
+            if isinstance(client_doc, dict)
+            else ""
+        )
+        if not issuer:
+            logger.debug(
+                "Matrix: MSC2965 pointer at %s has no m.oauth_metadata.issuer",
+                homeserver,
+            )
+            return "", True
+
+        result = _try_discover(issuer)
+        if result:
+            _, doc = result
+            ep = str(doc.get("token_endpoint") or "").strip()
+            if ep:
+                return ep, True
+        return "", True
+
+    def _log_oauth_hint(self, message: str) -> None:
+        """Log the OIDC configuration hint once per adapter instance."""
+        if getattr(self, "_oidc_hint_logged", False):
+            return
+        self._oidc_hint_logged = True
+        logger.warning(message)
     def _is_duplicate_event(self, event_id) -> bool:
         """Return True if this event was already processed. Tracks the ID otherwise."""
         if not event_id:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -14,6 +14,9 @@ Environment variables:
                                 when set. Legacy MATRIX_ENCRYPTION=true maps to required.
     MATRIX_DEVICE_ID            Stable device ID for E2EE persistence across restarts
     MATRIX_REFRESH_TOKEN        Refresh token for MAS (matrix.org) — rotated on use
+    MATRIX_OIDC_CLIENT_ID       Public OIDC client id for MAS OAuth2 token refresh
+                                (required for matrix.org-style deployments; the
+                                legacy /v3/refresh endpoint rejects MAS tokens)
     MATRIX_PROXY                HTTP(S) or SOCKS proxy URL for Matrix traffic
     MATRIX_ALLOWED_USERS    Comma-separated Matrix user IDs (@user:server)
     MATRIX_ALLOWED_ROOMS    Comma-separated Matrix room IDs allowed to trigger turns
@@ -1184,6 +1187,12 @@ class _CryptoStateStore:
         return list(self._joined_rooms)
 
 
+# Total access-token refresh attempts per adapter lifetime. MAS refresh
+# tokens are single-use; a server that keeps rejecting freshly-issued
+# tokens must never drive an unbounded refresh/rotate loop (#94096 review).
+_MAX_REFRESH_ATTEMPTS = 8
+
+
 class MatrixAdapter(BasePlatformAdapter):
     """Gateway adapter for Matrix (any homeserver)."""
 
@@ -1232,16 +1241,36 @@ class MatrixAdapter(BasePlatformAdapter):
             "MATRIX_REFRESH_TOKEN"
         )
         self._refresh_lock: asyncio.Lock = asyncio.Lock()
+        # MAS OAuth2 refresh state (#94096): OIDC discovery cache + bounded
+        # total refresh attempts so a rejecting server can't drive an
+        # endless refresh/rotate loop.
+        self._oidc_client_id: str = str(config.extra.get("oidc_client_id", "") or "")
+        self._oidc_token_endpoint: Optional[str] = None
+        self._oidc_hint_logged: bool = False
+        self._refresh_attempts: int = 0
 
         self._client: Any = None  # mautrix.client.Client
 
     async def _refresh_access_token(self, api, reason: str = "") -> bool:
         """Refresh the Matrix access token using the stored refresh token.
 
-        Calls ``POST /_matrix/client/v3/refresh`` with the current
-        ``MATRIX_REFRESH_TOKEN``. On success updates ``api.token``,
-        ``self._access_token`` and rotates ``self._refresh_token`` in
-        memory (best-effort). Returns True on success.
+        Two paths, tried in order:
+
+        1. Legacy ``POST /_matrix/client/v3/refresh`` (native MSC2918
+           homeservers - self-hosted Synapse with short-lived session
+           tokens).
+        2. MAS / OAuth2 deployments (matrix.org): those tokens are NOT
+           honored by the legacy endpoint (Synapse only knows tokens it
+           issued itself - live-verified in #94096), so we fall back to the
+           OAuth2 token endpoint from OIDC discovery with
+           ``grant_type=refresh_token`` and the public client id from
+           ``MATRIX_OIDC_CLIENT_ID``.
+
+        On success updates ``api.token``, ``self._access_token`` and rotates
+        ``self._refresh_token`` in memory (best-effort). Attempts are
+        bounded: after ``_MAX_REFRESH_ATTEMPTS`` total tries the helper
+        gives up so a rejecting server can never drive an endless
+        refresh/rotate loop. Returns True on success.
         """
         if not self._refresh_token or not self._homeserver:
             return False
@@ -1249,45 +1278,152 @@ class MatrixAdapter(BasePlatformAdapter):
             # Re-check after acquiring lock (another task may have refreshed)
             if not self._refresh_token:
                 return False
+            if self._refresh_attempts >= _MAX_REFRESH_ATTEMPTS:
+                logger.error(
+                    "Matrix: giving up token refresh after %d attempts "
+                    "(server keeps rejecting); restart required.",
+                    self._refresh_attempts,
+                )
+                return False
+            self._refresh_attempts += 1
+
+            # --- Path 1: legacy native refresh -------------------------
             try:
                 resp = await api.request(
                     "POST", "/_matrix/client/v3/refresh", {"refresh_token": self._refresh_token}
                 )
-                # mautrix may return dict or object with access_token attr
-                new_access = None
-                new_refresh = None
-                if isinstance(resp, dict):
-                    new_access = resp.get("access_token")
-                    new_refresh = resp.get("refresh_token")
-                    if not new_refresh:
-                        new_refresh = resp.get("refresh_token")
-                else:
-                    new_access = getattr(resp, "access_token", None)
-                    # mautrix LoginResponse stores unknown fields in unrecognized_
-                    new_refresh = getattr(resp, "refresh_token", None)
-                    if not new_refresh:
-                        unrec = getattr(resp, "unrecognized_", None)
-                        if isinstance(unrec, dict):
-                            new_refresh = unrec.get("refresh_token")
-                if not new_access:
-                    return False
-                self._access_token = new_access
-                try:
-                    api.token = new_access
-                except Exception:
-                    pass
-                if new_refresh and new_refresh != self._refresh_token:
-                    self._refresh_token = new_refresh
-                logger.info(
-                    "Matrix: refreshed access token via MAS (reason=%s)", reason or "unknown"
-                )
-                return True
-            except Exception as exc:
-                if _is_m_unknown_token_error(exc) or "invalid_grant" in str(exc).lower():
-                    logger.error("Matrix: refresh token rejected: %s", exc)
-                else:
-                    logger.warning("Matrix: refresh failed: %s", exc)
+                if self._apply_refresh_response(api, resp):
+                    logger.info(
+                        "Matrix: refreshed access token via legacy refresh "
+                        "(reason=%s)", reason or "unknown",
+                    )
+                    return True
                 return False
+            except Exception as legacy_exc:
+                if not _is_m_unknown_token_error(legacy_exc):
+                    logger.warning("Matrix: legacy refresh failed: %s", legacy_exc)
+                    return False
+                logger.info(
+                    "Matrix: legacy refresh rejected (%s) - trying MAS "
+                    "OAuth2 token endpoint", legacy_exc,
+                )
+
+            # --- Path 2: MAS OAuth2 token endpoint ---------------------
+            return await self._try_mas_oauth_refresh(api, reason=reason)
+
+    def _apply_refresh_response(self, api, resp) -> bool:
+        """Apply an access-token refresh response (dict or mautrix object)."""
+        new_access = None
+        new_refresh = None
+        if isinstance(resp, dict):
+            new_access = resp.get("access_token")
+            new_refresh = resp.get("refresh_token")
+        else:
+            new_access = getattr(resp, "access_token", None)
+            # mautrix LoginResponse stores unknown fields in unrecognized_
+            new_refresh = getattr(resp, "refresh_token", None)
+            if not new_refresh:
+                unrec = getattr(resp, "unrecognized_", None)
+                if isinstance(unrec, dict):
+                    new_refresh = unrec.get("refresh_token")
+        if not new_access:
+            return False
+        self._access_token = new_access
+        try:
+            api.token = new_access
+        except Exception:
+            pass
+        if new_refresh and new_refresh != self._refresh_token:
+            self._refresh_token = new_refresh
+        return True
+
+    async def _try_mas_oauth_refresh(self, api, reason: str = "") -> bool:
+        """MAS/OAuth2 refresh via OIDC discovery (matrix.org et al).
+
+        Discovers ``token_endpoint`` from
+        ``<homeserver>/.well-known/openid-configuration`` (cached), then
+        POSTs ``grant_type=refresh_token`` with the public client id from
+        ``MATRIX_OIDC_CLIENT_ID``. Rotates the refresh token per response.
+        """
+        import json as _json
+        import urllib.parse
+        import urllib.request
+
+        client_id = (
+            getattr(self, "_oidc_client_id", "")
+            or os.getenv("MATRIX_OIDC_CLIENT_ID", "")
+        ).strip()
+        if not client_id:
+            if not getattr(self, "_oidc_hint_logged", False):
+                self._oidc_hint_logged = True
+                logger.warning(
+                    "Matrix: homeserver rejected legacy refresh; MAS OAuth2 "
+                    "refresh needs MATRIX_OIDC_CLIENT_ID (public client id) "
+                    "to be set - cannot refresh automatically."
+                )
+            return False
+
+        token_endpoint = getattr(self, "_oidc_token_endpoint", None)
+        if not token_endpoint:
+            well_known = (
+                self._homeserver.rstrip("/")
+                + "/.well-known/openid-configuration"
+            )
+
+            def _discover():
+                with urllib.request.urlopen(well_known, timeout=10) as r:
+                    return _json.loads(r.read().decode("utf-8", errors="replace"))
+
+            try:
+                doc = await asyncio.to_thread(_discover)
+            except Exception as exc:
+                logger.warning(
+                    "Matrix: OIDC discovery failed for %s: %s",
+                    self._homeserver, exc,
+                )
+                return False
+            candidate = str(doc.get("token_endpoint") or "").strip()
+            if not candidate:
+                logger.warning(
+                    "Matrix: OIDC discovery returned no token_endpoint "
+                    "for %s", self._homeserver,
+                )
+                return False
+            self._oidc_token_endpoint = candidate
+            token_endpoint = candidate
+
+        def _token_request():
+            data = urllib.parse.urlencode({
+                "grant_type": "refresh_token",
+                "refresh_token": self._refresh_token,
+                "client_id": client_id,
+            }).encode()
+            req = urllib.request.Request(
+                token_endpoint,
+                data=data,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=15) as r:
+                return _json.loads(r.read().decode("utf-8", errors="replace"))
+
+        try:
+            doc = await asyncio.to_thread(_token_request)
+        except Exception as exc:
+            body = str(exc)
+            if "invalid_grant" in body.lower() or _is_m_unknown_token_error(exc):
+                logger.error("Matrix: MAS refresh token rejected: %s", exc)
+            else:
+                logger.warning("Matrix: MAS OAuth2 refresh failed: %s", exc)
+            return False
+
+        if self._apply_refresh_response(api, doc):
+            logger.info(
+                "Matrix: refreshed access token via MAS OAuth2 endpoint "
+                "(reason=%s)", reason or "unknown",
+            )
+            return True
+        return False
         self._crypto_db: Any = None  # mautrix.util.async_db.Database
         self._sync_task: Optional[asyncio.Task] = None
         self._invite_join_tasks: Dict[str, asyncio.Task] = {}

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1199,9 +1199,12 @@ class _CryptoStateStore:
         return list(self._joined_rooms)
 
 
-# Total access-token refresh attempts per adapter lifetime. MAS refresh
-# tokens are single-use; a server that keeps rejecting freshly-issued
+# Consecutive access-token refresh failures before the adapter gives up. MAS
+# refresh tokens are single-use; a server that keeps rejecting freshly-issued
 # tokens must never drive an unbounded refresh/rotate loop (#94096 review).
+# A SUCCESSFUL refresh resets the counter, so a healthy chain rotating every
+# ~4h never trips the cap (32h live repro showed a lifetime cap exhausting
+# a valid chain).
 _MAX_REFRESH_ATTEMPTS = 8
 
 
@@ -1452,9 +1455,10 @@ class MatrixAdapter(BasePlatformAdapter):
 
         On success updates ``api.token``, ``self._access_token`` and rotates
         ``self._refresh_token`` in memory (best-effort). Attempts are
-        bounded: after ``_MAX_REFRESH_ATTEMPTS`` total tries the helper
-        gives up so a rejecting server can never drive an endless
-        refresh/rotate loop. Returns True on success.
+        bounded: after ``_MAX_REFRESH_ATTEMPTS`` consecutive failures the
+        helper gives up so a rejecting server can never drive an endless
+        refresh/rotate loop; a successful refresh resets the counter, so a
+        healthy chain rotating every few hours never trips the cap.
         """
         if not self._refresh_token or not self._homeserver:
             return False
@@ -1464,8 +1468,8 @@ class MatrixAdapter(BasePlatformAdapter):
                 return False
             if self._refresh_attempts >= _MAX_REFRESH_ATTEMPTS:
                 logger.error(
-                    "Matrix: giving up token refresh after %d attempts "
-                    "(server keeps rejecting); restart required.",
+                    "Matrix: giving up token refresh after %d consecutive "
+                    "failures (server keeps rejecting); restart required.",
                     self._refresh_attempts,
                 )
                 return False
@@ -1513,6 +1517,12 @@ class MatrixAdapter(BasePlatformAdapter):
         if not new_access:
             return False
         self._access_token = new_access
+        # A successful refresh proves the chain is valid: reset the
+        # consecutive-failure counter so the cap measures a BROKEN chain,
+        # not the process lifetime. MAS rotates tokens every ~4h — a
+        # lifetime cap would exhaust in ~32h and permanently kill a
+        # healthy refresh chain (live 32h repro in #94096 review).
+        self._refresh_attempts = 0
         try:
             api.token = new_access
         except Exception:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -13,6 +13,7 @@ Environment variables:
     MATRIX_E2EE_MODE            off | optional | required. Overrides MATRIX_ENCRYPTION
                                 when set. Legacy MATRIX_ENCRYPTION=true maps to required.
     MATRIX_DEVICE_ID            Stable device ID for E2EE persistence across restarts
+    MATRIX_REFRESH_TOKEN        Refresh token for MAS (matrix.org) — rotated on use
     MATRIX_PROXY                HTTP(S) or SOCKS proxy URL for Matrix traffic
     MATRIX_ALLOWED_USERS    Comma-separated Matrix user IDs (@user:server)
     MATRIX_ALLOWED_ROOMS    Comma-separated Matrix room IDs allowed to trigger turns
@@ -829,6 +830,19 @@ def _resolve_e2ee_mode(extra: Optional[Dict[str, Any]] = None) -> str:
     return "required" if legacy_enabled else "off"
 
 
+def _is_m_unknown_token_error(exc: Exception) -> bool:
+    """Return True if *exc* is a Matrix M_UNKNOWN_TOKEN / MUnknownToken error."""
+    try:
+        from mautrix.errors import MatrixInvalidToken  # type: ignore
+
+        if isinstance(exc, MatrixInvalidToken):
+            return True
+    except ImportError:
+        pass
+    text = str(exc).lower()
+    return "m_unknown_token" in text or "unknown_token" in text or getattr(exc, "errcode", "") == "M_UNKNOWN_TOKEN"
+
+
 def _redact_matrix_value(value: Any) -> str:
     """Return a safe, non-reversible preview for Matrix diagnostics."""
     text = str(value or "").strip()
@@ -1214,8 +1228,66 @@ class MatrixAdapter(BasePlatformAdapter):
             "MATRIX_DEVICE_ID", ""
         )
         self._device_id_unverified: bool = False
+        self._refresh_token: str = config.extra.get("refresh_token", "") or _startup_env_secret(
+            "MATRIX_REFRESH_TOKEN"
+        )
+        self._refresh_lock: asyncio.Lock = asyncio.Lock()
 
         self._client: Any = None  # mautrix.client.Client
+
+    async def _refresh_access_token(self, api, reason: str = "") -> bool:
+        """Refresh the Matrix access token using the stored refresh token.
+
+        Calls ``POST /_matrix/client/v3/refresh`` with the current
+        ``MATRIX_REFRESH_TOKEN``. On success updates ``api.token``,
+        ``self._access_token`` and rotates ``self._refresh_token`` in
+        memory (best-effort). Returns True on success.
+        """
+        if not self._refresh_token or not self._homeserver:
+            return False
+        async with self._refresh_lock:
+            # Re-check after acquiring lock (another task may have refreshed)
+            if not self._refresh_token:
+                return False
+            try:
+                resp = await api.request(
+                    "POST", "/_matrix/client/v3/refresh", {"refresh_token": self._refresh_token}
+                )
+                # mautrix may return dict or object with access_token attr
+                new_access = None
+                new_refresh = None
+                if isinstance(resp, dict):
+                    new_access = resp.get("access_token")
+                    new_refresh = resp.get("refresh_token")
+                    if not new_refresh:
+                        new_refresh = resp.get("refresh_token")
+                else:
+                    new_access = getattr(resp, "access_token", None)
+                    # mautrix LoginResponse stores unknown fields in unrecognized_
+                    new_refresh = getattr(resp, "refresh_token", None)
+                    if not new_refresh:
+                        unrec = getattr(resp, "unrecognized_", None)
+                        if isinstance(unrec, dict):
+                            new_refresh = unrec.get("refresh_token")
+                if not new_access:
+                    return False
+                self._access_token = new_access
+                try:
+                    api.token = new_access
+                except Exception:
+                    pass
+                if new_refresh and new_refresh != self._refresh_token:
+                    self._refresh_token = new_refresh
+                logger.info(
+                    "Matrix: refreshed access token via MAS (reason=%s)", reason or "unknown"
+                )
+                return True
+            except Exception as exc:
+                if _is_m_unknown_token_error(exc) or "invalid_grant" in str(exc).lower():
+                    logger.error("Matrix: refresh token rejected: %s", exc)
+                else:
+                    logger.warning("Matrix: refresh failed: %s", exc)
+                return False
         self._crypto_db: Any = None  # mautrix.util.async_db.Database
         self._sync_task: Optional[asyncio.Task] = None
         self._invite_join_tasks: Dict[str, asyncio.Task] = {}
@@ -1831,13 +1903,63 @@ class MatrixAdapter(BasePlatformAdapter):
                     f" (device {effective_device_id})" if effective_device_id else "",
                 )
             except Exception as exc:
-                logger.error(
-                    "Matrix: whoami failed — check MATRIX_ACCESS_TOKEN and MATRIX_HOMESERVER: %s",
-                    exc,
-                    exc_info=True,
-                )
-                await api.session.close()
-                return False
+                if _is_m_unknown_token_error(exc):
+                    logger.warning(
+                        "Matrix: whoami failed with M_UNKNOWN_TOKEN, attempting refresh: %s", exc
+                    )
+                    if await self._refresh_access_token(api, reason="whoami M_UNKNOWN_TOKEN"):
+                        try:
+                            resp = await client.whoami()
+                            resolved_user_id = getattr(resp, "user_id", "") or self._user_id
+                            resolved_device_id = str(getattr(resp, "device_id", "") or "")
+                            if resolved_user_id:
+                                self._user_id = str(resolved_user_id)
+                                client.mxid = UserID(self._user_id)
+                            if (
+                                resolved_device_id
+                                and self._device_id
+                                and resolved_device_id != self._device_id
+                            ):
+                                logger.error(
+                                    "Matrix: MATRIX_DEVICE_ID=%s does not match the device "
+                                    "this access token belongs to (%s).",
+                                    self._device_id,
+                                    resolved_device_id,
+                                )
+                                effective_device_id = resolved_device_id
+                            else:
+                                effective_device_id = self._device_id or resolved_device_id
+                            if effective_device_id:
+                                client.device_id = effective_device_id
+                            logger.info(
+                                "Matrix: using access token for %s%s (refreshed)",
+                                self._user_id or "(unknown user)",
+                                f" (device {effective_device_id})" if effective_device_id else "",
+                            )
+                        except Exception as exc2:
+                            logger.error(
+                                "Matrix: whoami failed after refresh — check MATRIX_ACCESS_TOKEN and MATRIX_HOMESERVER: %s",
+                                exc2,
+                                exc_info=True,
+                            )
+                            await api.session.close()
+                            return False
+                    else:
+                        logger.error(
+                            "Matrix: whoami failed — check MATRIX_ACCESS_TOKEN and MATRIX_HOMESERVER: %s",
+                            exc,
+                            exc_info=True,
+                        )
+                        await api.session.close()
+                        return False
+                else:
+                    logger.error(
+                        "Matrix: whoami failed — check MATRIX_ACCESS_TOKEN and MATRIX_HOMESERVER: %s",
+                        exc,
+                        exc_info=True,
+                    )
+                    await api.session.close()
+                    return False
         elif self._password and self._user_id:
             try:
                 resp = await client.login(
@@ -1848,6 +1970,22 @@ class MatrixAdapter(BasePlatformAdapter):
                 )
                 if resp and hasattr(resp, "device_id"):
                     client.device_id = resp.device_id
+                # Capture refresh token if homeserver returned one (MAS, matrix.org)
+                try:
+                    raw_refresh = None
+                    if isinstance(resp, dict):
+                        raw_refresh = resp.get("refresh_token")
+                    else:
+                        raw_refresh = getattr(resp, "refresh_token", None)
+                        if not raw_refresh:
+                            unrec = getattr(resp, "unrecognized_", None)
+                            if isinstance(unrec, dict):
+                                raw_refresh = unrec.get("refresh_token")
+                    if raw_refresh:
+                        self._refresh_token = str(raw_refresh)
+                        logger.debug("Matrix: captured refresh token from login")
+                except Exception:
+                    pass
                 logger.info("Matrix: logged in as %s", self._user_id)
             except Exception as exc:
                 logger.error("Matrix: login failed — %s", exc)
@@ -3043,6 +3181,13 @@ class MatrixAdapter(BasePlatformAdapter):
                 if _sync_msg and isinstance(_sync_msg, str):
                     _lower = _sync_msg.lower()
                     if "m_unknown_token" in _lower or "unknown_token" in _lower:
+                        if await self._refresh_access_token(
+                            client.api, reason="sync M_UNKNOWN_TOKEN"
+                        ):
+                            logger.info(
+                                "Matrix: refreshed token after sync M_UNKNOWN_TOKEN, retrying"
+                            )
+                            continue
                         logger.error(
                             "Matrix: permanent auth error from sync: %s — stopping",
                             _sync_msg,
@@ -3083,12 +3228,20 @@ class MatrixAdapter(BasePlatformAdapter):
                     return
                 # Detect permanent auth/permission failures.
                 err_str = str(exc).lower()
-                if (
+                if _is_m_unknown_token_error(exc) or (
                     "401" in err_str
                     or "403" in err_str
                     or "unauthorized" in err_str
                     or "forbidden" in err_str
                 ):
+                    if _is_m_unknown_token_error(exc):
+                        if await self._refresh_access_token(
+                            client.api, reason=f"sync exception {exc}"
+                        ):
+                            logger.info(
+                                "Matrix: refreshed token after sync exception, retrying"
+                            )
+                            continue
                     logger.error(
                         "Matrix: permanent auth error: %s — stopping sync", exc
                     )

--- a/tests/plugins/platforms/matrix/test_mas_refresh.py
+++ b/tests/plugins/platforms/matrix/test_mas_refresh.py
@@ -259,6 +259,43 @@ async def test_refresh_attempts_bounded(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_success_resets_attempt_counter_chain_survives(monkeypatch):
+    """32h live repro (#94096 review): MAS rotates tokens every ~4h, so a
+    LIFETIME cap of 8 attempts exhausts a perfectly valid refresh chain
+    after ~32h and the adapter gives up forever. The counter must reset
+    on every successful refresh — only consecutive failures trip it."""
+    a = _make_adapter()
+    api = _FakeApi()
+
+    async def ok_req(method, path, body):
+        return {"access_token": "acc-1", "refresh_token": "rt-1"}
+
+    api.request = ok_req
+
+    # Simulate many success/fail cycles spanning days of runtime: each
+    # success must reset the counter so the next failure sequence starts
+    # from zero.
+    async def fail_req(method, path, body):
+        raise RuntimeError("M_UNKNOWN_TOKEN Invalid refresh token")
+
+    for cycle in range(matrix_adapter._MAX_REFRESH_ATTEMPTS + 2):
+        # Successful refresh (rotation happens every ~4h in production).
+        assert await a._refresh_access_token(api, reason="cycle") is True
+        assert a._refresh_attempts == 0, (
+            "success must reset the consecutive-failure counter"
+        )
+        # One transient failure (network blip) before the next success.
+        api.request = fail_req
+        assert await a._refresh_access_token(api, reason="blip") is False
+        assert a._refresh_attempts == 1
+        api.request = ok_req
+
+    # After all cycles the chain is still alive — a lifetime cap would
+    # have given up around cycle 8.
+    assert await a._refresh_access_token(api, reason="still-alive") is True
+
+
+@pytest.mark.asyncio
 async def test_mas_path_requires_client_id(monkeypatch):
     import urllib.request as _ureq
 

--- a/tests/plugins/platforms/matrix/test_mas_refresh.py
+++ b/tests/plugins/platforms/matrix/test_mas_refresh.py
@@ -1,9 +1,12 @@
-"""MAS OAuth2 + legacy refresh tests for the Matrix adapter (#94096).
+"""MAS OAuth2 + legacy refresh tests for the Matrix adapter (#94096 v2).
 
 matrix.org runs MAS: the legacy ``/_matrix/client/v3/refresh`` endpoint
-rejects MAS-issued tokens (live-verified), so the adapter must fall back to
-the OAuth2 token endpoint from OIDC discovery. Also pins the bounded
-attempt count so a rejecting server can't drive an endless rotate loop.
+rejects MAS-issued tokens, so the adapter must fall back to the OAuth2
+token endpoint. Live verification (vlify, 2026-08-27) showed the
+homeserver-side OIDC well-known 404s on matrix.org and the issuer host
+differs from the homeserver, so v2 adds ``MATRIX_OAUTH_TOKEN_ENDPOINT``
+and ``MATRIX_OIDC_ISSUER`` overrides, an MSC2965 homeserver-pointer
+fallback, and proxy support.
 """
 import asyncio
 import json
@@ -24,34 +27,6 @@ class _FakeApi:
         raise RuntimeError("M_UNKNOWN_TOKEN Invalid refresh token")
 
 
-def _make_adapter(client_id="my-client"):
-    a = object.__new__(matrix_adapter.MatrixAdapter)
-    a._refresh_token = "rt-1"
-    a._homeserver = "https://matrix.org"
-    a._access_token = "old-access"
-    a._refresh_lock = asyncio.Lock()
-    a._oidc_client_id = client_id
-    a._oidc_token_endpoint = None
-    a._oidc_hint_logged = False
-    a._refresh_attempts = 0
-    return a
-
-
-@pytest.mark.asyncio
-async def test_legacy_refresh_success_applies_tokens():
-    a = _make_adapter()
-    api = _FakeApi()
-
-    async def req(method, path, body):
-        return {"access_token": "acc-2", "refresh_token": "rt-2"}
-
-    api.request = req
-    assert await a._refresh_access_token(api, reason="test") is True
-    assert a._access_token == "acc-2"
-    assert api.token == "acc-2"
-    assert a._refresh_token == "rt-2"
-
-
 class _Ctx:
     """Context-manager wrapper for stubbed urlopen responses."""
 
@@ -68,55 +43,197 @@ class _Ctx:
         return False
 
 
+def _make_adapter(
+    client_id="my-client",
+    token_endpoint_override="",
+    issuer_override="",
+    homeserver="https://matrix-client.matrix.org",
+):
+    a = object.__new__(matrix_adapter.MatrixAdapter)
+    a._refresh_token = "rt-1"
+    a._homeserver = homeserver
+    a._access_token = "old-access"
+    a._refresh_lock = asyncio.Lock()
+    a._oidc_client_id = client_id
+    a._oidc_token_endpoint = None
+    a._oidc_token_endpoint_override = token_endpoint_override
+    a._oidc_issuer_override = issuer_override
+    a._oidc_hint_logged = False
+    a._refresh_attempts = 0
+    return a
+
+
+# ---------------------------------------------------------------- legacy ok
+
 @pytest.mark.asyncio
-async def test_legacy_rejection_falls_back_to_mas_oauth(monkeypatch):
+async def test_legacy_refresh_success_applies_tokens():
+    a = _make_adapter()
+    api = _FakeApi()
+
+    async def req(method, path, body):
+        return {"access_token": "acc-2", "refresh_token": "rt-2"}
+
+    api.request = req
+    assert await a._refresh_access_token(api, reason="test") is True
+    assert a._access_token == "acc-2"
+    assert api.token == "acc-2"
+    assert a._refresh_token == "rt-2"
+
+
+# --------------------------------------------- legacy rejected -> MAS oauth
+
+@pytest.mark.asyncio
+async def test_legacy_rejection_probes_homeserver_oidc_then_msc2965(monkeypatch):
+    """vlify live verification (Aug 27): the homeserver
+    matrix-client.matrix.org has no /.well-known/openid-configuration
+    (404) and no /.well-known/matrix/client either, so both probes
+    return empty and we fall through to the clear hint log. This locks
+    in the exact-URL discovery behavior the mock test was previously
+    silently passing.
+    """
     import urllib.request as _ureq
 
     a = _make_adapter(client_id="pub-client")
     api = _FakeApi()
-    captured = {}
+    probed = []
 
-    def routed(req, timeout=10):
+    def fail_404(req, timeout=10):
         url = req if isinstance(req, str) else req.full_url
-        captured["urls"] = captured.get("urls", []) + [url]
-        if "openid-configuration" in url:
-            return _Ctx(
-                {"token_endpoint": "https://account.matrix.org/oauth2/token"}
-            )
-        captured["token_url"] = url
-        captured["body"] = req.data.decode()
+        probed.append(url)
+        raise FileNotFoundError("404")
+
+    monkeypatch.setattr(_ureq, "urlopen", fail_404, raising=True)
+    monkeypatch.delenv("MATRIX_OAUTH_TOKEN_ENDPOINT", raising=False)
+    monkeypatch.delenv("MATRIX_OIDC_ISSUER", raising=False)
+
+    assert await a._refresh_access_token(api, reason="test") is False
+    # Both homeserver probes attempted in order.
+    assert any(".well-known/openid-configuration" in u for u in probed)
+    assert any(".well-known/matrix/client" in u for u in probed)
+    # The exact homeserver base must be the one we constructed.
+    assert any(u.startswith("https://matrix-client.matrix.org/") for u in probed)
+
+
+# ----------------------------------------------------- direct token override
+
+@pytest.mark.asyncio
+async def test_oauth_token_endpoint_override_skips_discovery(monkeypatch):
+    """``MATRIX_OAUTH_TOKEN_ENDPOINT`` bypasses discovery entirely: the
+    config override is the documented matrix.org escape hatch when the
+    homeserver has no machine-readable well-known pointer. The LEGACY
+    ``/v3/refresh`` attempt still runs first (it must reject to fall
+    through); only the OIDC discovery step is skipped."""
+    import urllib.request as _ureq
+
+    a = _make_adapter(
+        client_id="pub",
+        token_endpoint_override="https://account.matrix.org/oauth2/token",
+    )
+    api = _FakeApi()  # legacy request raises M_UNKNOWN_TOKEN -> fall through
+    probed = []
+
+    def routed(req, timeout=15):
+        url = req if isinstance(req, str) else req.full_url
+        probed.append(url)
+        if "openid-configuration" in url or "well-known" in url:
+            raise AssertionError("discovery must be skipped when override set")
         return _Ctx({
-            "access_token": "mas-acc",
-            "refresh_token": "mas-rt",
-            "expires_in": 14400,
+            "access_token": "ov-acc",
+            "refresh_token": "ov-rt",
         })
 
     monkeypatch.setattr(_ureq, "urlopen", routed, raising=True)
 
     assert await a._refresh_access_token(api, reason="test") is True
-    assert any("openid-configuration" in u for u in captured["urls"])
-    assert captured["token_url"] == "https://account.matrix.org/oauth2/token"
-    assert "grant_type=refresh_token" in captured["body"]
-    assert "client_id=pub-client" in captured["body"]
-    assert a._access_token == "mas-acc"
-    assert a._refresh_token == "mas-rt"
-    assert api.token == "mas-acc"
+    # No discovery/well-known URL was probed.
+    assert not any("well-known" in u for u in probed)
+    # The token POST went straight to the override endpoint.
+    assert "https://account.matrix.org/oauth2/token" in probed
+    assert a._access_token == "ov-acc"
+    assert a._refresh_token == "ov-rt"
 
+
+# -------------------------------------------------------- issuer override
 
 @pytest.mark.asyncio
-async def test_mas_path_requires_client_id(monkeypatch):
+async def test_oidc_issuer_override_discovers_at_issuer(monkeypatch):
+    """``MATRIX_OIDC_ISSUER`` (e.g. ``https://account.matrix.org``) makes
+    the discover probe hit the issuer directly, skipping the homeserver
+    well-known entirely."""
     import urllib.request as _ureq
 
-    a = _make_adapter(client_id="")
-    api = _FakeApi()
-    monkeypatch.delenv("MATRIX_OIDC_CLIENT_ID", raising=False)
-    monkeypatch.setattr(
-        _ureq, "urlopen",
-        lambda *a, **k: (_ for _ in ()).throw(AssertionError("no network")),
-        raising=True,
+    a = _make_adapter(
+        client_id="pub",
+        issuer_override="https://account.matrix.org",
     )
-    assert await a._refresh_access_token(api, reason="test") is False
+    api = _FakeApi()
+    captured = {"probed": []}
 
+    def routed(req, timeout=10):
+        url = req if isinstance(req, str) else req.full_url
+        captured["probed"].append(url)
+        if "openid-configuration" in url:
+            return _Ctx(
+                {"token_endpoint": "https://account.matrix.org/oauth2/token"}
+            )
+        # Token POST.
+        captured["token_url"] = url
+        return _Ctx({
+            "access_token": "iss-acc",
+            "refresh_token": "iss-rt",
+        })
+
+    monkeypatch.setattr(_ureq, "urlopen", routed, raising=True)
+    monkeypatch.delenv("MATRIX_OAUTH_TOKEN_ENDPOINT", raising=False)
+
+    assert await a._refresh_access_token(api, reason="test") is True
+    # No homeserver probe was attempted.
+    assert all("matrix-client.matrix.org" not in u for u in captured["probed"])
+    # The discovery probe hit the issuer.
+    assert any("account.matrix.org" in u for u in captured["probed"])
+    assert captured["token_url"] == "https://account.matrix.org/oauth2/token"
+
+
+# -------------------------------------------------------------- proxy
+
+@pytest.mark.asyncio
+async def test_http_proxy_honored_for_mas_refresh(monkeypatch):
+    """The MAS refresh path must honor ``MATRIX_PROXY`` so deployments
+    behind an outbound proxy work (the legacy aiohttp path does)."""
+    import urllib.request as _ureq
+
+    a = _make_adapter(
+        client_id="pub",
+        token_endpoint_override="https://account.matrix.org/oauth2/token",
+    )
+    api = _FakeApi()
+    captured = {"proxies": None}
+
+    def record_proxy_handler(proxies=None):
+        captured["proxies"] = proxies
+        return object()  # unused; build_opener is stubbed
+
+    class _Opener:
+        def open(self, req, timeout=15):
+            return _Ctx({
+                "access_token": "px-acc",
+                "refresh_token": "px-rt",
+            })
+
+    monkeypatch.setattr(_ureq, "ProxyHandler", record_proxy_handler)
+    monkeypatch.setattr(_ureq, "build_opener", lambda *handlers: _Opener())
+    monkeypatch.setenv("MATRIX_PROXY", "http://proxy.local:7897")
+    monkeypatch.delenv("MATRIX_OAUTH_TOKEN_ENDPOINT", raising=False)
+
+    assert await a._refresh_access_token(api, reason="test") is True
+    assert captured["proxies"] == {
+        "http": "http://proxy.local:7897",
+        "https": "http://proxy.local:7897",
+    }
+    assert a._access_token == "px-acc"
+
+
+# --------------------------------------------------------- bound / hint
 
 @pytest.mark.asyncio
 async def test_refresh_attempts_bounded(monkeypatch):
@@ -135,8 +252,22 @@ async def test_refresh_attempts_bounded(monkeypatch):
         ok = await a._refresh_access_token(api, reason="test")
         assert ok is False
 
-    # Cap reached: further calls fail fast without touching the network.
     calls_after_cap = api.legacy_calls
     assert await a._refresh_access_token(api, reason="test") is False
     assert api.legacy_calls == calls_after_cap
     assert a._refresh_attempts >= matrix_adapter._MAX_REFRESH_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_mas_path_requires_client_id(monkeypatch):
+    import urllib.request as _ureq
+
+    a = _make_adapter(client_id="")
+    api = _FakeApi()
+    monkeypatch.delenv("MATRIX_OIDC_CLIENT_ID", raising=False)
+    monkeypatch.setattr(
+        _ureq, "urlopen",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("no network")),
+        raising=True,
+    )
+    assert await a._refresh_access_token(api, reason="test") is False

--- a/tests/plugins/platforms/matrix/test_mas_refresh.py
+++ b/tests/plugins/platforms/matrix/test_mas_refresh.py
@@ -1,0 +1,142 @@
+"""MAS OAuth2 + legacy refresh tests for the Matrix adapter (#94096).
+
+matrix.org runs MAS: the legacy ``/_matrix/client/v3/refresh`` endpoint
+rejects MAS-issued tokens (live-verified), so the adapter must fall back to
+the OAuth2 token endpoint from OIDC discovery. Also pins the bounded
+attempt count so a rejecting server can't drive an endless rotate loop.
+"""
+import asyncio
+import json
+import types
+
+import pytest
+
+from plugins.platforms.matrix import adapter as matrix_adapter
+
+
+class _FakeApi:
+    def __init__(self):
+        self.token = "old-access"
+        self.legacy_calls = 0
+
+    async def request(self, method, path, body):
+        self.legacy_calls += 1
+        raise RuntimeError("M_UNKNOWN_TOKEN Invalid refresh token")
+
+
+def _make_adapter(client_id="my-client"):
+    a = object.__new__(matrix_adapter.MatrixAdapter)
+    a._refresh_token = "rt-1"
+    a._homeserver = "https://matrix.org"
+    a._access_token = "old-access"
+    a._refresh_lock = asyncio.Lock()
+    a._oidc_client_id = client_id
+    a._oidc_token_endpoint = None
+    a._oidc_hint_logged = False
+    a._refresh_attempts = 0
+    return a
+
+
+@pytest.mark.asyncio
+async def test_legacy_refresh_success_applies_tokens():
+    a = _make_adapter()
+    api = _FakeApi()
+
+    async def req(method, path, body):
+        return {"access_token": "acc-2", "refresh_token": "rt-2"}
+
+    api.request = req
+    assert await a._refresh_access_token(api, reason="test") is True
+    assert a._access_token == "acc-2"
+    assert api.token == "acc-2"
+    assert a._refresh_token == "rt-2"
+
+
+class _Ctx:
+    """Context-manager wrapper for stubbed urlopen responses."""
+
+    def __init__(self, payload: dict):
+        self._payload = json.dumps(payload).encode()
+
+    def read(self):
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_legacy_rejection_falls_back_to_mas_oauth(monkeypatch):
+    import urllib.request as _ureq
+
+    a = _make_adapter(client_id="pub-client")
+    api = _FakeApi()
+    captured = {}
+
+    def routed(req, timeout=10):
+        url = req if isinstance(req, str) else req.full_url
+        captured["urls"] = captured.get("urls", []) + [url]
+        if "openid-configuration" in url:
+            return _Ctx(
+                {"token_endpoint": "https://account.matrix.org/oauth2/token"}
+            )
+        captured["token_url"] = url
+        captured["body"] = req.data.decode()
+        return _Ctx({
+            "access_token": "mas-acc",
+            "refresh_token": "mas-rt",
+            "expires_in": 14400,
+        })
+
+    monkeypatch.setattr(_ureq, "urlopen", routed, raising=True)
+
+    assert await a._refresh_access_token(api, reason="test") is True
+    assert any("openid-configuration" in u for u in captured["urls"])
+    assert captured["token_url"] == "https://account.matrix.org/oauth2/token"
+    assert "grant_type=refresh_token" in captured["body"]
+    assert "client_id=pub-client" in captured["body"]
+    assert a._access_token == "mas-acc"
+    assert a._refresh_token == "mas-rt"
+    assert api.token == "mas-acc"
+
+
+@pytest.mark.asyncio
+async def test_mas_path_requires_client_id(monkeypatch):
+    import urllib.request as _ureq
+
+    a = _make_adapter(client_id="")
+    api = _FakeApi()
+    monkeypatch.delenv("MATRIX_OIDC_CLIENT_ID", raising=False)
+    monkeypatch.setattr(
+        _ureq, "urlopen",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("no network")),
+        raising=True,
+    )
+    assert await a._refresh_access_token(api, reason="test") is False
+
+
+@pytest.mark.asyncio
+async def test_refresh_attempts_bounded(monkeypatch):
+    import urllib.request as _ureq
+
+    a = _make_adapter(client_id="pub")
+    api = _FakeApi()
+    monkeypatch.setenv("MATRIX_OIDC_CLIENT_ID", "pub")
+
+    def always_fail(req, timeout=10):
+        raise RuntimeError("M_UNKNOWN_TOKEN Invalid refresh token")
+
+    monkeypatch.setattr(_ureq, "urlopen", always_fail, raising=True)
+
+    for _ in range(matrix_adapter._MAX_REFRESH_ATTEMPTS + 3):
+        ok = await a._refresh_access_token(api, reason="test")
+        assert ok is False
+
+    # Cap reached: further calls fail fast without touching the network.
+    calls_after_cap = api.legacy_calls
+    assert await a._refresh_access_token(api, reason="test") is False
+    assert api.legacy_calls == calls_after_cap
+    assert a._refresh_attempts >= matrix_adapter._MAX_REFRESH_ATTEMPTS


### PR DESCRIPTION
Fixes #93929

## Problem

matrix.org migrated to MAS (Matrix Authentication Service, OAuth 2.0) on 2025-04-07. Access tokens now rotate every ~3-4h and the old token is revoked on refresh. The Hermes Matrix adapter only supported `MATRIX_ACCESS_TOKEN` / `MATRIX_PASSWORD` with no refresh handling, so a gateway with a matrix.org bot died every few hours with `MUnknownToken: *** is not active` and required manual token rotation.

`mautrix` 0.21.x has no refresh API, and `LoginResponse` stashes `refresh_token` in `unrecognized_`.

## Fix

- Add `MATRIX_REFRESH_TOKEN` (documented in the module docstring, read via `config.extra.refresh_token` or env, scope-aware). In-memory rotation with `asyncio.Lock` to avoid thundering herd.
- Helper `_refresh_access_token(api, reason)`: `POST /_matrix/client/v3/refresh` with the stored refresh token, updates `api.token` / `self._access_token` and rotates `self._refresh_token` on `refresh_token` rotation.
- `connect()` token path: on `whoami` `M_UNKNOWN_TOKEN`, refresh once and retry `whoami`.
- `connect()` password path: capture `refresh_token` from `LoginResponse.unrecognized_` after `client.login`.
- `_sync_loop`: on `SyncError` `M_UNKNOWN_TOKEN` message and on exception-path `401`/`MUnknownToken`, attempt refresh and `continue` instead of `return`.

Helper `_is_m_unknown_token_error` covers `mautrix.errors.MatrixInvalidToken` and string variants.

## Verification

Mocked `api.request` for `/_matrix/client/v3/refresh` returning `{"access_token":"new","refresh_token":"rotated"}` — `whoami` retry succeeds, `api.token` updated, sync loop continues instead of stopping. `mautrix` 0.21.1 `LoginResponse` `unrecognized_` capture verified.