### PR TITLE
fix(bot-mode): keep remote Bot creation on its selected backend

### DIFF
--- a/apps/desktop/src/lib/profile-route-owner.test.ts
+++ b/apps/desktop/src/lib/profile-route-owner.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { buildProfileRouteOwner, evaluateProfileReadiness, profileNamesForConnection } from './profile-route-owner'
+import type { RuntimeReadinessOptions, RuntimeReadinessRequester, RuntimeReadinessResult } from './runtime-readiness'
+
+describe('remote Bot creation routing', () => {
+  const connections = [
+    { id: 'local', kind: 'local', label: 'This device' },
+    { id: 'mini', kind: 'ssh', label: 'Mac Mini' }
+  ]
+
+  it('captures the selected connection and created profile as one immutable owner', () => {
+    const owner = buildProfileRouteOwner({
+      activeConnectionId: 'local',
+      connections,
+      name: 'omar',
+      targetConnection: 'mini'
+    })
+
+    expect(owner).toMatchObject({
+      connectionId: 'mini',
+      connectionLabel: 'Mac Mini',
+      name: 'omar',
+      remoteSource: true,
+      sourceScoped: true
+    })
+    expect(owner.route).toEqual({
+      connectionId: 'mini',
+      mode: 'remote',
+      profile: 'omar',
+      targetProfile: 'omar'
+    })
+    expect(Object.isFrozen(owner.route)).toBe(true)
+  })
+
+  it('offers fresh/default plus clone profiles from only the selected connection', () => {
+    const roster = [
+      { connectionId: 'local', name: 'default', remoteSource: false },
+      { connectionId: 'local', name: 'writer', remoteSource: false },
+      { connectionId: 'mini', name: 'default', remoteSource: true },
+      { connectionId: 'mini', name: 'omar', remoteSource: true },
+      { connectionId: 'work', name: 'omar', remoteSource: true }
+    ]
+
+    expect(profileNamesForConnection(roster, 'mini', true)).toEqual(['default', 'omar'])
+    expect(profileNamesForConnection(roster, 'local', false)).toEqual(['default', 'writer'])
+  })
+
+  it('checks readiness through the created profile route and preserves a not-ready result', async () => {
+    const owner = buildProfileRouteOwner({
+      activeConnectionId: 'local',
+      connections,
+      name: 'omar',
+      targetConnection: 'mini'
+    })
+
+    const request = vi.fn(async (_owner, method: string, params?: Record<string, unknown>) => ({ method, params }))
+
+    const evaluate = vi.fn(
+      async (
+        requester: RuntimeReadinessRequester,
+        options: RuntimeReadinessOptions = {}
+      ): Promise<RuntimeReadinessResult> => {
+        await requester('setup.status')
+        await requester('setup.runtime_check', { provider: options.requestedProvider })
+
+        return {
+          checksDisagree: false,
+          ready: false,
+          reason: options.defaultReason ?? null,
+          source: 'runtime_check'
+        }
+      }
+    )
+
+    const result = await evaluateProfileReadiness({
+      evaluate,
+      owner,
+      requestedProvider: 'nous',
+      request
+    })
+
+    expect(result).toMatchObject({ ready: false, source: 'runtime_check' })
+    expect(result.reason).toContain('Mac Mini')
+    expect(request).toHaveBeenNthCalledWith(1, owner, 'setup.status', undefined)
+    expect(request).toHaveBeenNthCalledWith(2, owner, 'setup.runtime_check', { provider: 'nous' })
+  })
+})

--- a/apps/desktop/src/lib/profile-route-owner.ts
+++ b/apps/desktop/src/lib/profile-route-owner.ts
@@ -1,0 +1,104 @@
+import {
+  evaluateRuntimeReadiness,
+  type RuntimeReadinessRequester,
+  type RuntimeReadinessResult
+} from './runtime-readiness'
+
+export interface ProfileConnectionRow {
+  id: string
+  kind?: string
+  label?: string
+}
+
+export interface ProfileRouteOwner {
+  connectionId: string
+  connectionKind: 'local' | 'remote'
+  connectionLabel: string
+  name: string
+  remoteSource: boolean
+  route: Readonly<{
+    connectionId: string
+    mode: 'local' | 'remote'
+    profile: string
+    targetProfile: string
+  }>
+  sourceScoped: true
+}
+
+export interface ProfileRosterRow {
+  connectionId?: string
+  name?: string
+  remoteSource?: boolean
+  targetProfile?: string
+}
+
+export function buildProfileRouteOwner({
+  activeConnectionId,
+  connections,
+  name,
+  targetConnection
+}: {
+  activeConnectionId?: string
+  connections?: ProfileConnectionRow[] | null
+  name: string
+  targetConnection?: string
+}): ProfileRouteOwner {
+  const connectionId = String(targetConnection || activeConnectionId || 'local').trim() || 'local'
+  const row = (Array.isArray(connections) ? connections : []).find(connection => connection.id === connectionId)
+  const mode = row?.kind === 'local' || connectionId === 'local' ? 'local' : 'remote'
+
+  return {
+    name,
+    connectionId,
+    connectionKind: mode,
+    connectionLabel: row?.label || (connectionId === 'local' ? 'This device' : connectionId),
+    sourceScoped: true,
+    remoteSource: mode === 'remote',
+    route: Object.freeze({ connectionId, mode, profile: name, targetProfile: name })
+  }
+}
+
+/** Return clone sources owned by one connection. The default profile is always
+ * available even before that connection's roster finishes hydrating. */
+export function profileNamesForConnection(
+  roster: ProfileRosterRow[] | null | undefined,
+  connectionId: string,
+  remoteTarget: boolean
+): string[] {
+  const names = (Array.isArray(roster) ? roster : [])
+    .filter(bot =>
+      remoteTarget
+        ? bot.connectionId === connectionId
+        : !bot.remoteSource && (!connectionId || !bot.connectionId || bot.connectionId === connectionId)
+    )
+    .map(bot => String(bot.targetProfile || bot.name || '').trim())
+    .filter(Boolean)
+
+  return [...new Set(['default', ...names])]
+}
+
+export async function evaluateProfileReadiness({
+  evaluate = evaluateRuntimeReadiness,
+  label,
+  owner,
+  requestedProvider,
+  request
+}: {
+  evaluate?: typeof evaluateRuntimeReadiness
+  label?: string
+  owner: ProfileRouteOwner
+  requestedProvider?: string
+  request: (owner: ProfileRouteOwner, method: string, params?: Record<string, unknown>) => Promise<unknown>
+}): Promise<RuntimeReadinessResult> {
+  if (typeof evaluate !== 'function') {
+    return { checksDisagree: false, ready: true, reason: null, source: 'fallback' }
+  }
+
+  const requester: RuntimeReadinessRequester = <T = unknown>(method: string, params?: Record<string, unknown>) =>
+    request(owner, method, params) as Promise<T>
+
+  return evaluate(requester, {
+    requestedProvider: requestedProvider?.trim() || undefined,
+    defaultReason: `Configure a provider on ${label || owner.connectionLabel} before starting this Bot's chat.`
+  })
+}

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -67,6 +67,9 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { jsx, jsxs } from 'react/jsx-runtime'
 
 const { McpTab, ToolsetConfigPanel } = sdk
+const createAgentOwner = typeof sdk === 'undefined' ? undefined : sdk.buildProfileRouteOwner
+const createAgentCloneProfiles = typeof sdk === 'undefined' ? undefined : sdk.profileNamesForConnection
+const evaluateCreatedAgentReadiness = typeof sdk === 'undefined' ? undefined : sdk.evaluateProfileReadiness
 // Keep optional exports feature-detected; test harnesses may strip the SDK namespace.
 const SkillsView = typeof sdk === 'undefined' ? undefined : sdk.SkillsView
 // TRUE only on builds whose SkillsView routes `fixedConnection` to the pinned
@@ -8592,7 +8595,7 @@ function useModelOptions(bot = null) {
  * same data the core model picker shows. `value = {provider, model}`;
  * onChange receives the merged patch.
  */
-function ModelPicker({ bot = null, value, onChange, placeholderModel = 'gateway default' }) {
+function ModelPicker({ bot = null, value, onChange, placeholderModel = 'gateway default', inheritLabel = 'Inherit (launch profile)' }) {
   const { data, isLoading, error } = useModelOptions(bot)
 
   // Hooks are ALWAYS declared up front, before any conditional return.
@@ -8705,7 +8708,7 @@ function ModelPicker({ bot = null, value, onChange, placeholderModel = 'gateway 
             jsx(SelectTrigger, { className: 'h-8 rounded-md', children: jsx(SelectValue, {}) }),
             jsxs(SelectContent, {
               children: [
-                jsx(SelectItem, { value: NONE, children: 'Inherit (launch profile)' }),
+                jsx(SelectItem, { value: NONE, children: inheritLabel }),
                 ...providers.map(p =>
                   jsx(
                     SelectItem,
@@ -9680,6 +9683,14 @@ function CreateAgentDialog({ open, onClose, roster }) {
   const targetLabel = remoteTarget
     ? (connections || []).find(c => c.id === targetConnection)?.label || targetConnection
     : ''
+  const createConnectionId = targetConnection || activeConnectionId || 'local'
+  const targetOwner = createAgentOwner({
+    activeConnectionId,
+    connections,
+    name: remoteTarget ? 'default' : String(host.state?.profile?.get?.() || 'default'),
+    targetConnection
+  })
+  const cloneProfiles = createAgentCloneProfiles(roster, createConnectionId, remoteTarget)
 
   /** Gateway RPC on the create target: the picked connection's default
    *  backend for remote targets, the active gateway otherwise. */
@@ -9690,6 +9701,14 @@ function CreateAgentDialog({ open, onClose, roster }) {
           method,
           params
         )
+      : host.request(method, params)
+
+  /** Profile-scoped RPC after creation. Unlike requestForTarget, this opens the
+   * created profile's socket, so readiness and first-turn checks cannot borrow
+   * the active/default profile's provider state. */
+  const requestForCreatedAgent = (owner, method, params = {}) =>
+    typeof host.requestProfile === 'function'
+      ? host.requestProfile(owner.route, method, params)
       : host.request(method, params)
 
   // Set once ensureAgentCreated() materializes the profile for the live
@@ -9776,7 +9795,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
     }
 
     Promise.all([
-      requestForTarget('profiles.describe', { name: remoteTarget ? 'default' : capSource }),
+      requestForTarget('profiles.describe', { name: capSource }),
       requestForTarget('mcp.catalog', {}).catch(() => null)
     ])
       .then(([res, cat]) => {
@@ -9844,11 +9863,9 @@ function CreateAgentDialog({ open, onClose, roster }) {
       await requestForTarget('profiles.create', {
         name: slug,
         description: descriptionText,
-        // Clone sources are profiles of the TARGET backend. The picker's
-        // roster is the local one, so a remote create always starts from the
-        // remote machine's default (or fresh) — never a local profile name
-        // the remote box doesn't have.
-        clone_from: cloneFrom === '__none__' ? null : remoteTarget ? 'default' : cloneFrom,
+        // Clone choices are already filtered to the target connection, so the
+        // selected name is safe to send unchanged for local and remote homes.
+        clone_from: cloneFrom === '__none__' ? null : cloneFrom,
         no_skills: noSkills,
         // Shared (not copied) auth keeps ONE OAuth/token pool with the main
         // profile, so refreshes can't invalidate each other. Older gateways
@@ -9940,31 +9957,52 @@ function CreateAgentDialog({ open, onClose, roster }) {
           : `Bot "${displayName({ name: slug, title })}" created`
       })
       const wasRemote = remoteTarget
+      const createdOwner = createAgentOwner({
+        activeConnectionId,
+        connections,
+        name: slugCreated,
+        targetConnection: wasRemote ? targetConnection : ''
+      })
+      const readiness = await evaluateCreatedAgentReadiness({
+        owner: createdOwner,
+        requestedProvider: provider,
+        request: requestForCreatedAgent
+      })
       reset()
       onClose()
 
-      if (wasRemote) {
-        // The bot lives on another machine: it appears in the roster via the
-        // union enumeration; chat routes through its own source. No local
-        // canonical chat to birth here.
+      if (!readiness.ready) {
+        noteBotAttention(botRosterKey(createdOwner), readiness.reason || 'missing_config')
+        host.notify({
+          kind: 'warning',
+          message: `Bot created on ${createdOwner.connectionLabel}, but its model is not ready. ${readiness.reason || `Switch to ${createdOwner.connectionLabel} and open Settings → Providers.`}`
+        })
         queryClient.invalidateQueries({ queryKey: ROSTER_KEY })
         return
       }
 
-      $selectedBot.set(slug)
+      $selectedBot.set(slugCreated)
+      $selectedRosterKey.set(botRosterKey(createdOwner))
 
       // Birth the bot's forever chat right away: it introduces itself as
       // the first thing the user sees, and the pin exists from minute one.
       try {
         // Creates, pins, opens, and kicks off the intro in one flow.
-        const sid = await createCanonicalChat(slug)
+        const sid = await createCanonicalChat(createdOwner)
 
-        if (!sid && typeof host.newChat === 'function') {
-          host.newChat(slug)
+        if (!sid && !wasRemote && typeof host.newChat === 'function') {
+          host.newChat(slugCreated)
+        } else if (!sid && wasRemote) {
+          host.notify({
+            kind: 'warning',
+            message: `Bot created on ${createdOwner.connectionLabel}, but its first chat could not be started. Open the Bot from the roster to retry.`
+          })
         }
-      } catch {
-        if (typeof host.newChat === 'function') {
-          host.newChat(slug)
+      } catch (err) {
+        if (!wasRemote && typeof host.newChat === 'function') {
+          host.newChat(slugCreated)
+        } else {
+          host.notifyError(err, `Bot created on ${createdOwner.connectionLabel}, but its first chat could not be started`)
         }
       }
     } catch (err) {
@@ -10044,6 +10082,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
                     value: targetConnection || activeConnectionId || 'local',
                     onValueChange: value => {
                       setTargetConnection(value === (activeConnectionId || 'local') ? '' : value)
+                      setCloneFrom('default')
                       // The capability catalog and clone list belong to the
                       // target backend — refetch for the new home. The live
                       // Capabilities tab re-pins to it via fixedConnection on
@@ -10180,8 +10219,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
                             labeled(
                               remoteTarget ? `Clone from profile (on ${targetLabel})` : 'Clone from profile',
                               jsxs(Select, {
-                                disabled: remoteTarget,
-                                value: remoteTarget ? 'default' : cloneFrom,
+                                value: cloneFrom,
                                 onValueChange: value => {
                                   setCloneFrom(value)
                                   setCaps(null)
@@ -10198,13 +10236,16 @@ function CreateAgentDialog({ open, onClose, roster }) {
                                         value: '__none__',
                                         children: 'Fresh profile (bundled skills)'
                                       }),
-                                      ...roster.map(b => jsx(SelectItem, { value: b.name, children: b.name }, b.name))
+                                      ...cloneProfiles.map(profile =>
+                                        jsx(SelectItem, { value: profile, children: profile }, profile)
+                                      )
                                     ]
                                   })
                                 ]
                               })
                             ),
                             jsx(ModelPicker, {
+                              bot: remoteTarget ? targetOwner : null,
                               value: { provider, model },
                               onChange: patch => {
                                 if ('provider' in patch) {
@@ -10214,7 +10255,12 @@ function CreateAgentDialog({ open, onClose, roster }) {
                                   setModel(patch.model)
                                 }
                               },
-                              placeholderModel: 'inherited from launch profile'
+                              placeholderModel: remoteTarget
+                                ? `inherited from default on ${targetLabel}`
+                                : 'inherited from launch profile',
+                              inheritLabel: remoteTarget
+                                ? `Inherit from default on ${targetLabel}`
+                                : 'Inherit (launch profile)'
                             }),
                             labeled(
                               'SOUL.md (optional — replaces the generated persona)',
@@ -10233,7 +10279,9 @@ function CreateAgentDialog({ open, onClose, roster }) {
                                   checked: shareAuth,
                                   onCheckedChange: value => setShareAuth(Boolean(value))
                                 }),
-                                'Share keys & accounts with the main profile'
+                                remoteTarget
+                                  ? `Share keys & accounts with default on ${targetLabel}`
+                                  : 'Share keys & accounts with the main profile'
                               ]
                             }),
                             jsx('div', {
@@ -10330,15 +10378,17 @@ function CreateAgentDialog({ open, onClose, roster }) {
                                       className: 'text-[0.65rem] leading-4 text-(--ui-text-quaternary)',
                                       children: `Catalog from ${caps.source} — unchecked skills are disabled after creation.`
                                     }),
-                                    jsx(HubSkillsSection, {
-                                      forProfile: null,
-                                      onInstalled: name =>
-                                        setCaps(prev =>
-                                          !prev || prev.skills.some(s => s.name === name)
-                                            ? prev
-                                            : { ...prev, skills: [...prev.skills, { name, enabled: true }] }
-                                        )
-                                    })
+                                    remoteTarget
+                                      ? null
+                                      : jsx(HubSkillsSection, {
+                                          forProfile: null,
+                                          onInstalled: name =>
+                                            setCaps(prev =>
+                                              !prev || prev.skills.some(s => s.name === name)
+                                                ? prev
+                                                : { ...prev, skills: [...prev.skills, { name, enabled: true }] }
+                                            )
+                                        })
                                   ]
                                 })
                             : advTab === 'toolsets'

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -1355,6 +1355,13 @@ export { formatModifierToken } from '@/lib/keybinds/combo'
  *  authors) + its translucent tag fill — so plugin-rendered identities read
  *  the same hue as everywhere else. */
 export { profileColor, profileColorSoft } from '@/lib/profile-color'
+/** Stable connection/profile ownership helpers for routed plugin surfaces. */
+export {
+  buildProfileRouteOwner,
+  evaluateProfileReadiness,
+  profileNamesForConnection,
+  type ProfileRouteOwner
+} from '@/lib/profile-route-owner'
 /** The shared client itself, for invalidation OUTSIDE React (e.g. a
  *  `ctx.socket` frame invalidating a query). Inside components keep using
  *  `useQueryClient`. */


### PR DESCRIPTION
## What does this PR do?

Remote Bot creation now keeps one connection/profile owner from the target picker through clone selection, model and capability reads, provider readiness checks, and the first canonical chat. A Bot whose target profile cannot resolve a usable provider remains created, receives an actionable target-qualified warning, and does not start a failing intro turn.

### Symptom

In a multi-connection Desktop, selecting another connection disabled the clone picker and forced the target's default profile. The model picker and some capability reads could still use the active gateway. After creation, the automatic intro could fail with `agent init failed: No LLM provider configured` even though the profile and bundled skills had already been created.

### Impact

Users could not create a fresh remote Bot or clone another profile on the selected backend. Editor state could describe or mutate the wrong backend, and an unready target produced a failed first turn instead of preserving the Bot with setup guidance.

### Bug Cause

**Trigger:** `apps/desktop/src/plugins/hermes-bots/plugin.js` / `CreateAgentDialog` when `targetConnection` differs from the active connection.

**Causal chain:**
1. The create dialog selected a remote connection.
2. The UI disabled clone selection, rewrote every non-fresh clone to `default`, and left model/readiness work on ambient or default-profile request paths.
3. The created profile could inherit the wrong assumptions about models and capabilities, then start an intro without proving that its own runtime could resolve a provider.

**Why it is wrong:** Connection selection is authoritative state. Re-reading the active gateway or forcing the remote default after that selection breaks the `(connection, profile)` ownership contract.

**Working sibling / contrast:** Existing Bot edit and canonical-chat paths already route source-scoped Bots through immutable owner descriptors. The create path did not retain an equivalent owner across its stages.

**Ruled out:** The failure is not a general inability to run the target backend. The reported target profile succeeds after provider setup, while the editor's capability request can still return a profile-not-found response from another backend.

### Fix

- Added tested SDK helpers that build immutable profile-route owners, filter clone sources by connection, and evaluate runtime readiness through an owner-scoped request door.
- Enabled fresh and target-owned clone choices for remote creation and qualified inherited model/auth copy by target connection.
- Pinned model options, capability catalogs, configuration, readiness checks, and canonical-chat creation to the selected owner.
- Kept successfully created Bots when readiness fails, skipped the intro turn, and surfaced target-qualified provider setup guidance.
- Prevented remote failures from falling back to a local `newChat` path.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js` - route every remote create/editor stage through the selected owner and gate the intro on target runtime readiness.
- `apps/desktop/src/lib/profile-route-owner.ts` - add reusable connection/profile ownership and readiness helpers.
- `apps/desktop/src/lib/profile-route-owner.test.ts` - cover route capture, per-connection clone lists, and owner-scoped not-ready results.
- `apps/desktop/src/sdk/index.ts` - expose the ownership helpers to bundled plugins.

## How to Test

1. In a multi-connection Desktop, open New Bot and select a non-active connection.
2. Verify the clone picker offers Fresh profile and profiles from only that target, and that model/auth copy identifies the target connection.
3. Create once with a ready target and verify its canonical Bot Chat starts on that connection. Create once without target credentials and verify the Bot remains in the roster without a failed intro turn.
4. Run:

```bash
cd apps/desktop
npx vitest run --project ui src/lib/profile-route-owner.test.ts src/lib/runtime-readiness.test.ts
npm run typecheck
npm run lint
npm run check:test:plugins
```

Local results: 11 focused Vitest tests passed, 556 bundled plugin tests passed, typecheck passed, and lint completed with no errors.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests listed above and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior and SDK contracts are documented in code
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A. Automated route-contract tests cover the affected multi-connection behavior.