### PR TITLE
fix(desktop): keep the session-rename input focused so Space reaches the caret

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -682,12 +682,33 @@ function RenameSessionDialog({ open, onOpenChange, sessionId, currentTitle, prof
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogContent className="max-w-md">
+      <DialogContent
+        className="max-w-md"
+        // Radix focuses the first focusable element on open, but a sidebar
+        // row's focus-restore can land after that autofocus and pull focus
+        // out of the input — the user then types into the void (Space
+        // activates the row instead of typing a character, arrows scroll the
+        // list). Owning the open-autofocus here and re-claiming focus on blur
+        // (below) keeps the caret in the input for the dialog's whole life.
+        onOpenAutoFocus={event => {
+          event.preventDefault()
+          inputRef.current?.focus()
+          inputRef.current?.select()
+        }}
+      >
         <DialogHeader>
           <DialogTitle>{r.renameTitle}</DialogTitle>
         </DialogHeader>
         <Input
           autoFocus
+          onBlur={event => {
+            // Re-claim focus while the dialog is open and not submitting —
+            // the belt-and-suspenders half of the onOpenAutoFocus fix above.
+            if (open && !submitting) {
+              event.preventDefault()
+              window.setTimeout(() => inputRef.current?.focus(), 0)
+            }
+          }}
           disabled={submitting}
           onChange={event => setValue(event.target.value)}
           onKeyDown={event => {


### PR DESCRIPTION
Hi Hermes team! 👋

Hope you're doing well. I'm an individual user (personal finding, no affiliation) — while renaming a session from the sidebar **context menu**, I noticed that pressing **Space** in the rename dialog's input does nothing: `OD Hyperframes` comes out as `ODHyperframes`, with no error and no visible feedback. Arrow keys scroll the session list instead of moving the caret. I dug into the source and I think I found the cause — this PR is a small, defensive fix. I'd be grateful if you'd take a look. 🙏

## Repro

1. Right-click a session in the sidebar → **Rename**
2. With the caret inside the dialog input, press **Space**
3. Expected: a space is typed. Actual: nothing happens (the keystroke activates the sidebar row behind the dialog instead)

The same dialog opened from the row's ⋯ menu is affected intermittently as well.

## Root cause

`session-actions-menu.tsx` already knows about this class of bug — the `suppressCloseFocusRef` comment says it plainly:

> "When a menu closes, Radix restores focus to its trigger — for a sidebar row that trigger is the row's own `<button>`, so focus lands there instead of the dialog's input: **Space then activates the row** (selecting the session) and the arrow keys move the list rather than the caret."

That guard covers the moment the *menu* closes, but the row's focus-restore can still land **after** the dialog's autofocus (they race across the menu-teardown and dialog-mount tasks), so focus ends up on the row `<button>` while the dialog is visually open. Every keystroke then goes to the sidebar, not the input — Space is the most visible casualty because it *activates* the row.

## The fix (one file, +22/−1)

`RenameSessionDialog` now owns its focus for the dialog's whole life:

1. `onOpenAutoFocus` → `preventDefault()` + focus/select the input explicitly (the Radix-recommended pattern for "the dialog decides where focus goes");
2. the input re-claims focus `onBlur` while the dialog is open and not submitting (belt-and-suspenders against any late focus-restore, whichever path opens the dialog).

No behavior change for other dialogs; the guard only lives inside the rename dialog.

## Testing

- Manual: rename via both the ⋯ menu and the context menu — Space, arrows, and IME composition all land in the input; Escape/Enter still close/submit.
- No existing test asserts the old focus behavior; happy to add a jsdom regression test if you'd like one (I saw `session-actions-menu.test.tsx` nearby and would follow its patterns).

Thanks for considering this small fix — and thanks for a great desktop app! Happy to iterate on anything (approach, naming, tests) per your conventions. 🙏
