### PR TITLE
fix(desktop): serialize mutable build preflight

### DIFF
--- a/hermes_cli/desktop_build_lock.py
+++ b/hermes_cli/desktop_build_lock.py
@@ -1,0 +1,71 @@
+"""Cross-process serialization for the mutable Desktop build preflight."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+from typing import IO
+
+
+class DesktopBuildLock:
+    """Advisory lock held while npm installs and packages Hermes Desktop.
+
+    ``node_modules`` and ``apps/desktop/release`` are checkout-scoped even
+    when two commands use different Hermes profiles.  The lock therefore
+    lives under the profile-common Hermes root and is keyed by the resolved
+    checkout path.  Keeping it out of the checkout preserves ``--skip-build``
+    launches from read-only/prebuilt source trees.  The open handle owns the
+    lock, so the OS releases it automatically if a builder crashes.
+    """
+
+    def __init__(self, project_root: Path) -> None:
+        from hermes_constants import get_default_hermes_root
+
+        resolved = os.path.normcase(str(project_root.resolve(strict=False)))
+        checkout_key = hashlib.sha256(resolved.encode("utf-8")).hexdigest()[:24]
+        self.path = get_default_hermes_root() / "locks" / f"desktop-build-{checkout_key}.lock"
+        self._handle: IO[str] | None = None
+
+    def acquire(self) -> bool:
+        """Try to acquire the lock without waiting.
+
+        Returns ``False`` only when another process owns the lock.  Filesystem
+        errors propagate so callers fail explicitly instead of silently
+        falling back to the corrupting concurrent behavior.
+        """
+        if self._handle is not None:
+            return True
+
+        from gateway.status import _try_acquire_file_lock
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        handle = self.path.open("a+", encoding="utf-8")
+        if not _try_acquire_file_lock(handle):
+            handle.close()
+            return False
+
+        self._handle = handle
+        return True
+
+    def release(self) -> None:
+        """Release the lock when held.  Safe to call more than once."""
+        handle = self._handle
+        if handle is None:
+            return
+        self._handle = None
+
+        try:
+            from gateway.status import _release_file_lock
+
+            _release_file_lock(handle)
+        finally:
+            handle.close()
+
+    def __enter__(self) -> "DesktopBuildLock":
+        if not self.acquire():
+            raise RuntimeError("desktop build lock is already held")
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.release()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7842,8 +7842,21 @@ def _register_linux_desktop_entry() -> None:
         print(f"⚠ Could not install the desktop launcher entry: {exc}")
 
 
+def _desktop_source_dir_or_exit() -> Path:
+    """Return the Desktop source directory or fail with an actionable error."""
+    desktop_dir = PROJECT_ROOT / "apps" / "desktop"
+    if not (desktop_dir / "package.json").exists():
+        print(f"Desktop GUI source not found at: {desktop_dir}")
+        sys.exit(1)
+    return desktop_dir
+
+
 def cmd_gui(args: argparse.Namespace):
     """Serialize the mutable Desktop preflight, then build and launch it."""
+    # Validate before constructing the external lock so a broken checkout does
+    # not create lock state or obscure the source-specific diagnostic.
+    _desktop_source_dir_or_exit()
+
     from hermes_cli.desktop_build_lock import DesktopBuildLock
 
     build_lock = DesktopBuildLock(PROJECT_ROOT)
@@ -7867,10 +7880,7 @@ def cmd_gui(args: argparse.Namespace):
 
 def _cmd_gui_impl(args: argparse.Namespace, *, build_lock=None):
     """Build and launch Desktop under ``build_lock`` when a build is allowed."""
-    desktop_dir = PROJECT_ROOT / "apps" / "desktop"
-    if not (desktop_dir / "package.json").exists():
-        print(f"Desktop GUI source not found at: {desktop_dir}")
-        sys.exit(1)
+    desktop_dir = _desktop_source_dir_or_exit()
 
     try:
         from hermes_logging import setup_logging as _setup_logging_gui

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7843,7 +7843,30 @@ def _register_linux_desktop_entry() -> None:
 
 
 def cmd_gui(args: argparse.Namespace):
-    """Build and launch the native Electron desktop GUI."""
+    """Serialize the mutable Desktop preflight, then build and launch it."""
+    from hermes_cli.desktop_build_lock import DesktopBuildLock
+
+    build_lock = DesktopBuildLock(PROJECT_ROOT)
+    try:
+        acquired = build_lock.acquire()
+    except OSError as exc:
+        print(f"✗ Could not create the Desktop build lock: {exc}")
+        print("  Refusing to run npm without serialization; check the checkout permissions and retry.")
+        sys.exit(1)
+
+    if not acquired:
+        print("✗ Another Hermes Desktop dependency install or package build is already running.")
+        print("  Wait for that launch/build to finish, then retry.")
+        sys.exit(2)
+
+    try:
+        return _cmd_gui_impl(args, build_lock=build_lock)
+    finally:
+        build_lock.release()
+
+
+def _cmd_gui_impl(args: argparse.Namespace, *, build_lock=None):
+    """Build and launch Desktop under ``build_lock`` when a build is allowed."""
     desktop_dir = PROJECT_ROOT / "apps" / "desktop"
     if not (desktop_dir / "package.json").exists():
         print(f"Desktop GUI source not found at: {desktop_dir}")
@@ -8096,6 +8119,10 @@ def cmd_gui(args: argparse.Namespace):
 
     if source_mode:
         print("→ Launching Hermes Desktop from source build...")
+        # Electron is the long-lived handoff.  Release immediately before it
+        # starts so an open Desktop window never blocks a future rebuild.
+        if build_lock is not None:
+            build_lock.release()
         launch_result = subprocess.run([npm, "exec", "--", "electron", "."], cwd=desktop_dir, env=env, check=False)
         sys.exit(launch_result.returncode)
 
@@ -8114,6 +8141,11 @@ def cmd_gui(args: argparse.Namespace):
 
     launch_command.extend(config_electron_flags)
     print(f"→ Launching packaged Hermes Desktop: {' '.join(launch_command)}")
+    # Keep serialization through the Linux sandbox permission fixup above;
+    # that still mutates the packaged tree.  Only the Electron handoff is
+    # outside the build lock.
+    if build_lock is not None:
+        build_lock.release()
     launch_result = subprocess.run(launch_command, cwd=desktop_dir, env=env, check=False)
     sys.exit(launch_result.returncode)
 

--- a/tests/hermes_cli/test_desktop_build_lock.py
+++ b/tests/hermes_cli/test_desktop_build_lock.py
@@ -61,12 +61,30 @@ def test_desktop_build_lock_releases_after_exception(tmp_path):
     successor.release()
 
 
+def test_gui_reports_missing_source_before_constructing_build_lock(tmp_path, monkeypatch, capsys):
+    root = tmp_path / "broken-hermes-agent"
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    args = argparse.Namespace()
+
+    with patch(
+        "hermes_cli.desktop_build_lock.DesktopBuildLock",
+        side_effect=AssertionError("build lock constructed before source validation"),
+    ), pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(args)
+
+    assert exc.value.code == 1
+    assert capsys.readouterr().out.strip() == (
+        f"Desktop GUI source not found at: {root / 'apps' / 'desktop'}"
+    )
+
+
 def test_gui_refuses_contended_build_before_checking_freshness(tmp_path, monkeypatch):
     root = tmp_path / "hermes-agent"
     desktop_dir = root / "apps" / "desktop"
     desktop_dir.mkdir(parents=True)
     (desktop_dir / "package.json").write_text("{}", encoding="utf-8")
     monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    # Keep this lock-order test out of the unrelated Linux keyring bootstrap.
     monkeypatch.setenv("GNOME_KEYRING_CONTROL", "/run/user/1000/keyring")
 
     holder = DesktopBuildLock(root)

--- a/tests/hermes_cli/test_desktop_build_lock.py
+++ b/tests/hermes_cli/test_desktop_build_lock.py
@@ -1,0 +1,138 @@
+"""Behavior tests for the Desktop build's cross-process lock."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import main as cli_main
+from hermes_cli.desktop_build_lock import DesktopBuildLock
+
+
+def test_desktop_build_lock_is_exclusive_and_reacquirable(tmp_path):
+    first = DesktopBuildLock(tmp_path)
+    contender = DesktopBuildLock(tmp_path)
+
+    assert first.acquire() is True
+    try:
+        assert contender.acquire() is False
+    finally:
+        first.release()
+
+    assert contender.acquire() is True
+    contender.release()
+
+
+def test_desktop_build_lock_excludes_another_process(tmp_path):
+    holder = DesktopBuildLock(tmp_path)
+    assert holder.acquire() is True
+
+    probe = (
+        "import sys\n"
+        "from pathlib import Path\n"
+        "from hermes_cli.desktop_build_lock import DesktopBuildLock\n"
+        "lock = DesktopBuildLock(Path(sys.argv[1]))\n"
+        "raise SystemExit(0 if lock.acquire() else 23)\n"
+    )
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", probe, str(tmp_path)],
+            check=False,
+        )
+    finally:
+        holder.release()
+
+    assert result.returncode == 23
+
+
+def test_desktop_build_lock_releases_after_exception(tmp_path):
+    try:
+        with DesktopBuildLock(tmp_path):
+            raise ValueError("build failed")
+    except ValueError:
+        pass
+
+    successor = DesktopBuildLock(tmp_path)
+    assert successor.acquire() is True
+    successor.release()
+
+
+def test_gui_refuses_contended_build_before_checking_freshness(tmp_path, monkeypatch):
+    root = tmp_path / "hermes-agent"
+    desktop_dir = root / "apps" / "desktop"
+    desktop_dir.mkdir(parents=True)
+    (desktop_dir / "package.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    monkeypatch.setenv("GNOME_KEYRING_CONTROL", "/run/user/1000/keyring")
+
+    holder = DesktopBuildLock(root)
+    assert holder.acquire() is True
+    args = argparse.Namespace(
+        build_only=True,
+        cwd=None,
+        fake_boot=False,
+        force_build=False,
+        hermes_root=None,
+        ignore_existing=False,
+        skip_build=False,
+        source=False,
+    )
+
+    try:
+        with patch(
+            "hermes_cli.main._desktop_build_needed",
+            side_effect=AssertionError("freshness check ran without the build lock"),
+        ), pytest.raises(SystemExit) as exc:
+            cli_main.cmd_gui(args)
+    finally:
+        holder.release()
+
+    assert exc.value.code == 2
+
+
+def test_gui_releases_lock_before_packaged_electron_handoff(tmp_path, monkeypatch):
+    root = tmp_path / "hermes-agent"
+    desktop_dir = root / "apps" / "desktop"
+    desktop_dir.mkdir(parents=True)
+    (desktop_dir / "package.json").write_text("{}", encoding="utf-8")
+
+    if sys.platform == "darwin":
+        executable = desktop_dir / "release" / "mac-arm64" / "Hermes.app" / "Contents" / "MacOS" / "Hermes"
+    elif sys.platform == "win32":
+        executable = desktop_dir / "release" / "win-unpacked" / "Hermes.exe"
+    else:
+        executable = desktop_dir / "release" / "linux-unpacked" / "hermes"
+    executable.parent.mkdir(parents=True)
+    executable.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    monkeypatch.setenv("GNOME_KEYRING_CONTROL", "/run/user/1000/keyring")
+    args = argparse.Namespace(
+        build_only=False,
+        cwd=None,
+        fake_boot=False,
+        force_build=False,
+        hermes_root=None,
+        ignore_existing=False,
+        skip_build=True,
+        source=False,
+    )
+
+    def launch_after_lock_release(*_args, **_kwargs):
+        handoff_probe = DesktopBuildLock(root)
+        assert handoff_probe.acquire() is True
+        handoff_probe.release()
+        return subprocess.CompletedProcess([], 0)
+
+    with patch("hermes_cli.main._desktop_launch_options", return_value=([], "auto", "auto", "auto")), \
+         patch("hermes_cli.main._register_linux_desktop_entry"), \
+         patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
+         patch("hermes_cli.main.subprocess.run", side_effect=launch_after_lock_release), \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(args)
+
+    assert exc.value.code == 0


### PR DESCRIPTION
## Summary

Serializes the mutable `hermes desktop` preflight so concurrent launches cannot both install dependencies or package over the same checkout. Fixes #93940.

## Changes

- add a checkout-keyed advisory lock under the profile-common Hermes `locks/` root
- acquire it before freshness checks and hold it through npm install, packaging, artifact verification, and packaged-tree fixups
- reject a contending launch before it can touch `node_modules` or `apps/desktop/release`
- release the lock immediately before the long-lived Electron handoff; crashed builders are released by the OS
- keep read-only/prebuilt checkouts working by storing lock state outside the source tree

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_desktop_build_lock.py tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_desktop_exe_integrity.py -q`
- 39 passed, 9 platform-specific tests skipped for their macOS/Windows CI lanes
- real second-process contention, exception cleanup, pre-freshness exclusion, and pre-Electron release covered
- `git diff --check`