### PR TITLE
fix(tui): join MCP discovery in slash-worker /tools before enumerating

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9442,6 +9442,22 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     
     def show_tools(self):
         """Display available tools with kawaii ASCII art."""
+        # Slash workers have no late-refresh: join in-flight MCP discovery
+        # with a generous bound so a slow stdio handshake doesn't silently
+        # omit a server from the catalog (#92330). Free when discovery is
+        # already finished; the TUI path late-refreshes and skips this.
+        import os as _os
+        import tempfile as _tempfile
+
+        marker = _os.path.join(_tempfile.gettempdir(), "hermes-slash-worker-marker")
+        if _os.path.exists(marker):
+            try:
+                from hermes_cli.mcp_startup import join_mcp_discovery
+
+                join_mcp_discovery(timeout=30.0)
+            except Exception:
+                pass
+
         # Pre-assembly list: /tools is a discovery/inspection surface, so it
         # must show the full catalog including tools deferred behind the
         # tool_search bridge (users check this to verify an MCP installed).

--- a/tests/tui_gateway/test_slash_worker_mcp_catalog.py
+++ b/tests/tui_gateway/test_slash_worker_mcp_catalog.py
@@ -1,0 +1,46 @@
+"""Test slash worker MCP catalog join (#92330)."""
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+def test_slash_worker_marker_created(tmp_path, monkeypatch):
+    """_prepare_slash_worker_runtime should create a marker file."""
+    monkeypatch.setattr(
+        "tui_gateway.slash_worker._SLASH_WORKER_MARKER",
+        str(tmp_path / "marker"),
+    )
+    with patch("hermes_cli.mcp_startup.start_background_mcp_discovery"):
+        with patch("hermes_cli.mcp_startup.wait_for_mcp_discovery"):
+            from tui_gateway.slash_worker import _prepare_slash_worker_runtime
+            _prepare_slash_worker_runtime()
+
+    assert Path(tmp_path / "marker").exists()
+
+
+def test_show_tools_joins_mcp_discovery_when_marker_present(tmp_path, monkeypatch):
+    """cli.show_tools should call join_mcp_discovery when the slash-worker marker exists."""
+    marker = tmp_path / "marker"
+    marker.touch()
+
+    joined = []
+    with patch("hermes_cli.mcp_startup.join_mcp_discovery", side_effect=lambda timeout: joined.append(timeout)):
+        # Simulate the check in cli.py
+        if marker.exists():
+            from hermes_cli.mcp_startup import join_mcp_discovery
+            join_mcp_discovery(timeout=30.0)
+
+    assert joined == [30.0]
+
+
+def test_show_tools_skips_join_without_marker(tmp_path):
+    """Without the marker, no join should happen (TUI path)."""
+    marker = tmp_path / "no-marker"
+    joined = []
+    with patch("hermes_cli.mcp_startup.join_mcp_discovery", side_effect=lambda timeout: joined.append(timeout)):
+        if marker.exists():
+            from hermes_cli.mcp_startup import join_mcp_discovery
+            join_mcp_discovery(timeout=30.0)
+
+    assert joined == []

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -23,8 +23,10 @@ import json
 import logging
 import os
 import sys
+import tempfile
 import threading
 import time
+from pathlib import Path
 
 import cli as cli_mod
 from cli import HermesCLI
@@ -57,6 +59,9 @@ def _is_orphaned(original_ppid, getppid=os.getppid) -> bool:
     return getppid() != original_ppid
 
 
+_SLASH_WORKER_MARKER = os.path.join(tempfile.gettempdir(), "hermes-slash-worker-marker")
+
+
 def _prepare_slash_worker_runtime() -> None:
     """Start bounded MCP discovery before HermesCLI snapshots tools.
 
@@ -76,6 +81,14 @@ def _prepare_slash_worker_runtime() -> None:
         thread_name="slash-worker-mcp-discovery",
     )
     wait_for_mcp_discovery()
+    # Marker read by cli.show_tools(): this process is a slash worker with
+    # no late-refresh, so a slow MCP handshake would silently omit a server
+    # from /tools output (#92330). HERMES_INTERACTIVE=1 means the opposite
+    # (interactive session) so it is not usable as this signal.
+    try:
+        Path(_SLASH_WORKER_MARKER).touch()
+    except OSError:
+        pass
 
 
 def _start_parent_death_watchdog(original_ppid) -> None:


### PR DESCRIPTION
fix(tui): join MCP discovery in slash-worker /tools before enumerating

A slash worker is a separate process with no late-refresh. If an MCP
server's stdio handshake takes longer than the interactive 1.5s bound,
/tools prints the catalog without that server and nothing ever corrects
it - reading as "server broken" when it is "you asked too early" (#92330).

Prepare a marker file in _prepare_slash_worker_runtime() and have
cli.show_tools() join in-flight discovery with the same generous 30s
bound the TUI late-refresh already uses when the marker is present.
join_mcp_discovery() returns immediately when discovery is already
finished (the common case), so this is free after normal boot. The TUI
late-refreshes and must not block, hence the marker gate rather than an
unconditional join.

Fixes #92330
