### PR TITLE
fix(desktop-update): repair stale editable install before hand-off

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -26,7 +26,7 @@
 #     [-NoUi]               headless (tests); default shows a progress window
 #     [-NoMarkerCleanup]    leave .hermes-update-in-progress in place (tests)
 #
-# SAFETY POSTURE: both preflight gates FAIL CLOSED. A Desktop that never
+# SAFETY POSTURE: all preflight gates FAIL CLOSED. A Desktop that never
 # exits, or a venv shim that never unlocks, aborts the hand-off without
 # mutating the install -- a skipped update is recoverable, a half-updated
 # venv is not. Every exit path (success, abort, crash) writes
@@ -1110,6 +1110,116 @@ try {
         exit $finalCode
     }
     $updateArgs = @("-m", "hermes_cli.main", "update", "--yes", "--gateway", "--force", "--branch", $Branch)
+
+    # -- 3a. Editable-install preflight (FAIL CLOSED on stale finder/origin) --
+    # The editable install can still point at a deleted worktree, and a bare
+    # `import hermes_cli` is not proof that the canonical checkout is healthy:
+    # PYTHONPATH or the inherited cwd can supply a shadow copy. The probe below
+    # therefore returns a durable origin receipt and accepts the import only
+    # when hermes_cli.__file__ resolves beneath this exact $InstallRoot.
+    #
+    # The repair ladder first performs the narrow finder rewrite used by the
+    # update itself (`pip install -e . --no-deps`). If that command fails, or
+    # succeeds without restoring the canonical origin, a second dependency-
+    # aware editable reinstall repairs missing/mismatched dependencies before
+    # we require manual intervention. Both rungs run from $InstallRoot and
+    # through python.exe, never the hermes.exe shim that uv must replace.
+    function Test-HermesCliImportFromInstallRoot {
+        $probeOutput = ""
+        $probeExit = 1
+        try {
+            $probeOutput = (& $pythonExe -c "import base64, pathlib, sys, hermes_cli; root = pathlib.Path(sys.argv[1]).resolve(); module = pathlib.Path(hermes_cli.__file__).resolve(); print('__HERMES_CLI_ORIGIN_B64__=' + base64.b64encode(str(module).encode('utf-8')).decode('ascii')); raise SystemExit(0 if root in module.parents else 13)" $InstallRoot 2>$null | Out-String).Trim()
+            $probeExit = $LASTEXITCODE
+        } catch {
+            Write-HandoffLog "editable install probe threw: $($_.Exception.Message)"
+            return $false
+        }
+
+        [string]$originLine = $probeOutput -split "\r?\n" |
+            Where-Object { $_.StartsWith("__HERMES_CLI_ORIGIN_B64__=") } |
+            Select-Object -Last 1
+        if (-not $originLine) {
+            Write-HandoffLog "editable install probe returned no package-origin receipt (exit $probeExit)"
+            return $false
+        }
+
+        try {
+            $encodedOrigin = $originLine.Substring("__HERMES_CLI_ORIGIN_B64__=".Length).Trim()
+            $modulePath = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($encodedOrigin))
+        } catch {
+            Write-HandoffLog "editable install probe returned an invalid package-origin receipt"
+            return $false
+        }
+
+        if ($probeExit -eq 0) {
+            Write-HandoffLog "editable install probe resolved canonical module: $modulePath"
+            return $true
+        }
+        if ($probeExit -eq 13) {
+            Write-HandoffLog "editable install probe resolved outside install root: $modulePath"
+            return $false
+        }
+        Write-HandoffLog "editable install probe failed (exit $probeExit; origin $modulePath)"
+        return $false
+    }
+
+    function Invoke-EditableInstallRepair([switch]$WithDependencies) {
+        $pipArgs = @("-m", "pip", "install", "-e", ".")
+        $tag = "repair-dependencies"
+        if (-not $WithDependencies) {
+            $pipArgs += "--no-deps"
+            $tag = "repair-finder"
+        }
+
+        $repair = $null
+        Push-Location -LiteralPath $InstallRoot
+        try {
+            $repair = Invoke-HermesStep $pythonExe $pipArgs $tag
+        } catch {
+            Write-HandoffLog "$tag threw: $($_.Exception.Message)"
+        } finally {
+            Pop-Location
+        }
+        return $repair
+    }
+
+    $probeOk = Test-HermesCliImportFromInstallRoot
+    if (-not $probeOk) {
+        Write-HandoffLog "editable install probe failed; repairing editable finder (pip install -e . --no-deps)"
+        Publish-UiProgress "Repairing Hermes install"
+        $finderRepair = Invoke-EditableInstallRepair
+        $finderRepairOk = ($null -ne $finderRepair -and $finderRepair.Code -eq 0)
+        if ($finderRepairOk) {
+            $probeOk = Test-HermesCliImportFromInstallRoot
+        } else {
+            $probeOk = $false
+        }
+
+        if (-not $finderRepairOk -or -not $probeOk) {
+            Write-HandoffLog "finder-only repair did not restore a canonical import; retrying with dependencies"
+            Publish-UiProgress "Repairing Hermes dependencies"
+            $dependencyRepair = Invoke-EditableInstallRepair -WithDependencies
+            $dependencyRepairOk = ($null -ne $dependencyRepair -and $dependencyRepair.Code -eq 0)
+            if ($dependencyRepairOk) {
+                $probeOk = Test-HermesCliImportFromInstallRoot
+            } else {
+                $probeOk = $false
+            }
+
+            if (-not $dependencyRepairOk -or -not $probeOk) {
+                # Exit 7 is terminal at the Desktop boundary: finally writes
+                # ok:false and main.ts surfaces every non-ok hand-off result
+                # in a one-shot error dialog. The update retry below is never
+                # reached after this preflight exit.
+                $finalCode = 7
+                $finalMsg = "Update aborted: the Hermes install's Python environment could not be restored after finder-only and dependency-aware editable reinstalls. Run `hermes doctor` or reinstall Hermes."
+                Write-HandoffLog $finalMsg
+                exit $finalCode
+            }
+        }
+        Write-HandoffLog "editable install repaired; update proceeding"
+    }
+
     # --keep-stash: never re-apply local source edits after the update (they
     # stay parked in git stash). Probe --help first: the flag ships with newer
     # backends and an unknown flag would abort argparse with exit 2, which

--- a/tests/test_desktop_update_windows_editable_preflight.py
+++ b/tests/test_desktop_update_windows_editable_preflight.py
@@ -1,0 +1,176 @@
+"""Regression: the Windows Desktop update hand-off must repair a stale editable install.
+
+`scripts/desktop-update/windows.ps1` drives `hermes update` as
+`python.exe -m hermes_cli.main update`. The venv's editable install maps
+top-level packages through a finder file that pins the checkout path it was
+installed from. When that checkout was a worktree that has since been deleted
+(a campaign lane, a PR branch), the finder still points at the dead path and
+every `python -m hermes_cli.main ...` dies before argparse with
+``ModuleNotFoundError: No module named 'hermes_cli'``. A shadow copy supplied
+by ``PYTHONPATH`` or the inherited cwd can also make a bare import succeed
+while the canonical editable install remains broken.
+
+The hand-off now proves that ``hermes_cli.__file__`` resolves beneath the
+canonical install root before the update step. When the proof fails, it first
+rewrites only the editable finder (``pip install -e . --no-deps``), then
+escalates to a dependency-aware editable reinstall when the narrow repair
+fails or does not restore the canonical origin. It re-probes after each
+successful repair and fails closed with dedicated exit code 7 only after both
+repair rungs are exhausted.
+
+This test is source-level because Linux CI cannot execute the PowerShell
+hand-off. The invariants it guards are structural: the probe binds import
+origin to ``$InstallRoot``; repair drives ``$pythonExe`` rather than the
+``hermes.exe`` shim; repair runs from the install root; the dependency-aware
+fallback exists; and exit 7 flows through the Desktop's generic, terminal
+handoff-failure surface instead of the update retry.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path, PureWindowsPath
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WINDOWS_PS1 = REPO_ROOT / "scripts" / "desktop-update" / "windows.ps1"
+DESKTOP_MAIN = REPO_ROOT / "apps" / "desktop" / "electron" / "main.ts"
+
+
+def _read() -> str:
+    return WINDOWS_PS1.read_text(encoding="utf-8")
+
+
+def _preflight_block() -> str:
+    """The editable-install preflight, from its banner to the --keep-stash probe."""
+    source = _read()
+    match = re.search(
+        r"# -- 3a\. Editable-install preflight.*?# --keep-stash: never re-apply",
+        source,
+        re.DOTALL,
+    )
+    assert match, (
+        "Expected the editable-install preflight block in "
+        "scripts/desktop-update/windows.ps1; the hand-off structure changed -- "
+        "update this guard."
+    )
+    return match.group(0)
+
+
+def test_preflight_binds_import_to_the_canonical_install_root() -> None:
+    block = _preflight_block()
+
+    assert "function Test-HermesCliImportFromInstallRoot" in block
+    assert "hermes_cli.__file__" in block
+    assert "pathlib.Path(sys.argv[1]).resolve()" in block
+    assert "root in module.parents" in block, (
+        "The probe must use path-component ancestry, not a string-prefix check "
+        "that would accept an install-root sibling such as Hermes-agent-old."
+    )
+    assert "__HERMES_CLI_ORIGIN_B64__=" in block, (
+        "The probe must return a loggable origin receipt. Base64 keeps Unicode "
+        "Windows paths intact across PowerShell 5.1 native-output decoding."
+    )
+    assert "editable install probe resolved outside install root" in block
+    assert "editable install probe resolved canonical module" in block
+
+
+def test_windows_component_ancestry_rejects_prefix_named_sibling() -> None:
+    """WindowsPath ancestry is case-insensitive but component-boundary exact."""
+    root = PureWindowsPath(r"C:\Hermes-agent")
+    canonical_module = PureWindowsPath(
+        r"c:\HERMES-AGENT\hermes_cli\__init__.py"
+    )
+    prefix_sibling_module = PureWindowsPath(
+        r"C:\Hermes-agent-old\hermes_cli\__init__.py"
+    )
+
+    assert root in canonical_module.parents
+    assert root not in prefix_sibling_module.parents
+
+
+def test_repair_drives_python_not_the_shim() -> None:
+    block = _preflight_block()
+
+    assert "function Invoke-EditableInstallRepair" in block
+    assert "Invoke-HermesStep $pythonExe $pipArgs $tag" in block, (
+        "Editable repair must drive $pythonExe, not the hermes.exe shim. "
+        "Driving the update through the shim keeps hermes.exe mapped as a "
+        "running image, so uv's final shim rewrite fails with os error 32 "
+        "(see test_desktop_update_windows_python_handoff.py)."
+    )
+    assert "Invoke-HermesStep $hermesExe" not in block
+
+
+def test_repair_runs_from_the_install_root() -> None:
+    block = _preflight_block()
+
+    assert "Push-Location -LiteralPath $InstallRoot" in block, (
+        "`pip install -e .` resolves the tree it installs from the working "
+        "directory, and the hand-off inherits the Desktop's cwd (HERMES_HOME, "
+        "not the install root). The repair must Push-Location to $InstallRoot "
+        "first -- the same class posix.sh guards against."
+    )
+    assert "Pop-Location" in block, (
+        "The repair must restore the original location so the update step "
+        "runs from the same cwd the hand-off inherited."
+    )
+
+
+def test_repair_escalates_to_a_dependency_aware_second_rung() -> None:
+    block = _preflight_block()
+
+    assert '$pipArgs += "--no-deps"' in block, (
+        "The first repair rung must remain the narrow finder rewrite."
+    )
+    assert "Invoke-EditableInstallRepair -WithDependencies" in block, (
+        "A missing or mismatched dependency can leave the canonical import "
+        "broken after --no-deps; the hand-off must try a full editable reinstall "
+        "before requiring manual repair."
+    )
+    assert "finder-only repair did not restore a canonical import" in block
+    assert 'Publish-UiProgress "Repairing Hermes dependencies"' in block
+
+
+def test_each_successful_repair_is_reprobed_before_proceeding() -> None:
+    block = _preflight_block()
+
+    assert block.count("$probeOk = Test-HermesCliImportFromInstallRoot") == 3, (
+        "The preflight needs one initial canonical-origin probe and one re-probe "
+        "after each repair rung."
+    )
+    assert "editable install repaired; update proceeding" in block, (
+        "The success path must log that a canonical import was restored before "
+        "the update step runs."
+    )
+
+
+def test_exhausted_repairs_fail_closed_with_terminal_exit_7() -> None:
+    block = _preflight_block()
+
+    assert block.count("$finalCode = 7") == 1, (
+        "The two repair rungs should converge on one dedicated terminal state."
+    )
+    assert "exit $finalCode" in block, (
+        "An exhausted preflight must exit before the update step; falling "
+        "through runs the update into the same import wall."
+    )
+    assert "finder-only and dependency-aware editable reinstalls" in block
+    assert "hermes doctor" in block, (
+        "The terminal message must point at a real repair path."
+    )
+
+
+def test_exit_7_flows_to_the_desktops_terminal_failure_surface() -> None:
+    windows = _read()
+    desktop = DESKTOP_MAIN.read_text(encoding="utf-8")
+
+    assert "Write-Result ($finalCode -eq 0) $finalCode $finalMsg" in windows, (
+        "Every preflight exit must be persisted for the relaunched Desktop."
+    )
+    assert "else if (result)" in desktop
+    assert "detached update FAILED (exit ${result.exitCode})" in desktop
+    assert "'Hermes update did not finish'" in desktop, (
+        "Desktop consumes every non-ok result through one terminal error dialog; "
+        "it does not classify unknown codes as retryable."
+    )


### PR DESCRIPTION
## Summary

The Windows Desktop update hand-off invokes the updater as:

```text
venv\Scripts\python.exe -m hermes_cli.main update ...
```

That still fails before argparse when the venv's editable finder points at a checkout or worktree that no longer exists. Because `hermes_cli` cannot repair an import path that prevents `hermes_cli` from importing, the external repo-owned hand-off must repair this class before it enters the updater.

A live incident on 2026-08-24 had the editable finder pinned to a deleted PR worktree (`C:\temp\pr92545-r1-fix\hermes_cli`). Re-running the editable install from the canonical checkout repaired it.

## Fix

Before probing `update --help` or starting the updater, `scripts/desktop-update/windows.ps1` now:

1. Executes a provenance probe through the installed `$pythonExe`.
2. Emits `hermes_cli.__file__` as an ASCII-safe Base64 receipt.
3. Canonicalizes the module path and `$InstallRoot`, then accepts the import only when the module is a path-component descendant of the canonical install root.
4. Treats a missing import and a wrong-tree/shadow import identically.
5. Runs a narrow `python -m pip install -e . --no-deps` repair from `$InstallRoot`, through `python.exe` rather than the replaceable `hermes.exe` shim.
6. Re-probes the canonical origin after that repair.
7. If the narrow repair fails or still resolves outside `$InstallRoot`, escalates once to dependency-aware `python -m pip install -e .`, then re-probes again.
8. Fails closed with dedicated exit code 7 only after both repair rungs are exhausted, with `hermes doctor` / reinstall guidance.

The normal update is not allowed to run through an unresolved import wall.

## Exit-7 consumer contract

Exit 7 is terminal, not retryable:

- the PowerShell `finally` block persists every preflight result through `Write-Result`;
- the Desktop consumer's generic `else if (result)` branch logs the exact exit code and displays `Hermes update did not finish` for every non-OK hand-off result;
- the updater retry loop is below this preflight and is therefore unreachable after exit 7.

No Desktop code change is needed for the new code.

## Regression coverage

`tests/test_desktop_update_windows_editable_preflight.py` locks down:

- canonical `hermes_cli.__file__` provenance rather than bare importability;
- Windows case-insensitive, component-boundary containment, including rejection of `C:\Hermes-agent-old` for root `C:\Hermes-agent`;
- repair through `$pythonExe`, never the `hermes.exe` shim;
- repair cwd fixed to `$InstallRoot`;
- narrow finder repair followed by the dependency-aware fallback;
- a re-probe after each successful repair rung;
- one terminal exit-7 convergence point and actionable recovery text;
- the existing Desktop generic failure surface for arbitrary non-OK exit codes.

## Exact object and green receipts

- base: `d736f5d53f1d33fabad5a17cb070eb138b618fb8`
- head: `d5bd9185fd629c177c93c56d4c0e64e12e2c995c`
- shape: one commit, two changed files, no temporary workflow or materializer
- [CI #9189](https://github.com/NousResearch/hermes-agent/actions/runs/32840966722): **success** — full Python, E2E, Windows-only, macOS-only, Ruff, type-diff, OSV, supply-chain, attribution, and aggregate required-check gate
- [Docker #23267](https://github.com/NousResearch/hermes-agent/actions/runs/32840966365): **success** — amd64 and arm64 builds plus Docker integration tests
- [Nix #67188](https://github.com/NousResearch/hermes-agent/actions/runs/32840966183): **success** — `nix flake check`

All receipts are attached to the exact final head above. Upstream `main` remained at the exact base through completion.

## Scope / ownership

- `scripts/desktop-update/windows.ps1`
- `tests/test_desktop_update_windows_editable_preflight.py`

This PR remains the single owner for the pre-interpreter Windows editable-install provenance and repair class.