### PR TITLE
fix(cli): preserve explicit empty toolsets

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -21222,15 +21222,15 @@ def main(
     # Parse toolsets - handle both string and tuple/list inputs
     # Default to hermes-cli toolset which includes cronjob management tools
     toolsets_list = None
-    if toolsets:
+    if toolsets is not None:
         if isinstance(toolsets, str):
-            toolsets_list = [t.strip() for t in toolsets.split(",")]
+            toolsets_list = [t.strip() for t in toolsets.split(",") if t.strip()]
         elif isinstance(toolsets, (list, tuple)):
             # Fire may pass multiple --toolsets as a tuple
             toolsets_list = []
             for t in toolsets:
                 if isinstance(t, str):
-                    toolsets_list.extend([x.strip() for x in t.split(",")])
+                    toolsets_list.extend(x.strip() for x in t.split(",") if x.strip())
                 else:
                     toolsets_list.append(str(t))
     else:

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -962,10 +962,9 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
 
     tools = tools or []
     unrestricted_toolsets = enabled_toolsets is None
-    enabled_toolsets = enabled_toolsets or []
-
     if availability is None:
         availability = compute_toolset_availability(enabled_toolsets)
+    enabled_toolsets = enabled_toolsets or []
     unavailable_toolsets = availability.get("unavailable_toolsets", [])
     lazy_tools = set(availability.get("lazy_tools", []))
     disabled_tools = set(availability.get("disabled_tools", []))

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -786,7 +786,7 @@ def _display_toolset_name(toolset_name: str) -> str:
 # refresh re-verifies it right after the banner renders (see
 # cli.show_banner), so a stale panel self-heals within one launch.
 
-_BANNER_SNAPSHOT_VERSION = 1
+_BANNER_SNAPSHOT_VERSION = 2
 
 
 def _banner_snapshot_path() -> Path:
@@ -826,7 +826,8 @@ def load_banner_snapshot(enabled_toolsets: List[str] = None) -> Optional[Dict[st
     fp = banner_snapshot_fingerprint()
     if not fp or blob.get("fingerprint") != fp:
         return None
-    if blob.get("enabled_toolsets") != sorted(enabled_toolsets or []):
+    snapshot_toolsets = None if enabled_toolsets is None else sorted(enabled_toolsets)
+    if blob.get("enabled_toolsets") != snapshot_toolsets:
         return None
     tools = blob.get("tools")
     toolset_map = blob.get("toolset_map")
@@ -841,7 +842,7 @@ def load_banner_snapshot(enabled_toolsets: List[str] = None) -> Optional[Dict[st
 
 def save_banner_snapshot(
     tools: List[dict],
-    enabled_toolsets: List[str],
+    enabled_toolsets: Optional[List[str]],
     availability: Dict[str, Any],
     toolset_map: Dict[str, str],
 ) -> None:
@@ -851,7 +852,9 @@ def save_banner_snapshot(
         return
     payload = {
         "fingerprint": fp,
-        "enabled_toolsets": sorted(enabled_toolsets or []),
+        "enabled_toolsets": (
+            None if enabled_toolsets is None else sorted(enabled_toolsets)
+        ),
         "tools": [
             {"function": {"name": t["function"]["name"]}}
             for t in tools
@@ -889,6 +892,7 @@ def compute_toolset_availability(enabled_toolsets: List[str] = None) -> Dict[str
     """
     from model_tools import check_tool_availability, TOOLSET_REQUIREMENTS
 
+    restrict_to_enabled = enabled_toolsets is not None
     enabled_toolsets = enabled_toolsets or []
     _, unavailable_toolsets = check_tool_availability(quiet=True)
     # The availability check walks the GLOBAL toolset registry, so it includes
@@ -898,7 +902,7 @@ def compute_toolset_availability(enabled_toolsets: List[str] = None) -> Dict[str
     # toolsets actually enabled for this agent; a toolset that's enabled but
     # currently has unmet deps legitimately shows as disabled/lazy below.
     _enabled_ts = {str(t) for t in enabled_toolsets}
-    if _enabled_ts:
+    if restrict_to_enabled:
         unavailable_toolsets = [
             item for item in unavailable_toolsets
             if str(item.get("id", item.get("name", ""))) in _enabled_ts
@@ -957,6 +961,7 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
         from model_tools import get_toolset_for_tool
 
     tools = tools or []
+    unrestricted_toolsets = enabled_toolsets is None
     enabled_toolsets = enabled_toolsets or []
 
     if availability is None:
@@ -1153,7 +1158,7 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
     # (it exposes skill_view / skill_manage). When it's disabled — e.g. a Blank
     # Slate install — the agent literally cannot load any skill, so advertising
     # the on-disk catalog here is misleading. Reflect the real state instead.
-    _skills_enabled = (not _enabled_ts) or ("skills" in _enabled_ts)
+    _skills_enabled = unrestricted_toolsets or ("skills" in _enabled_ts)
     if _skills_enabled:
         if skills_by_category is None:
             skills_by_category = get_available_skills()

--- a/tests/cli/test_cli_empty_toolsets_banner.py
+++ b/tests/cli/test_cli_empty_toolsets_banner.py
@@ -1,0 +1,35 @@
+"""Regression tests for explicit classic-CLI toolset selections."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import cli
+
+
+def test_main_preserves_explicit_empty_toolsets_for_banner():
+    """An explicit empty selection must not fall back to configured tools."""
+    cli_instance = MagicMock()
+
+    with patch.object(cli, "HermesCLI", return_value=cli_instance) as cli_class:
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main(toolsets="", list_tools=True)
+
+    assert exc_info.value.code == 0
+    assert cli_class.call_args.kwargs["toolsets"] == []
+    cli_instance.show_banner.assert_called_once_with()
+
+
+def test_main_omitted_toolsets_still_uses_default_resolution():
+    """Omitting the option must retain configured/coding default resolution."""
+    cli_instance = MagicMock()
+
+    with (
+        patch.object(cli, "HermesCLI", return_value=cli_instance) as cli_class,
+        patch("agent.coding_context.coding_selection", return_value=["coding"]),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main(list_tools=True)
+
+    assert exc_info.value.code == 0
+    assert cli_class.call_args.kwargs["toolsets"] == ["coding"]

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -122,6 +122,34 @@ def test_explicit_empty_toolsets_do_not_advertise_tools_or_skills(
     assert "Skills toolset disabled" in out
 
 
+def test_unrestricted_toolsets_keep_global_unavailable_tools(tmp_path, monkeypatch):
+    """Omitting the selector keeps the unrestricted availability display."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    (tmp_path / ".hermes").mkdir()
+    unavailable = [{"id": "web", "name": "web", "tools": ["web_search"]}]
+
+    with (
+        patch.object(
+            model_tools,
+            "check_tool_availability",
+            return_value=([], unavailable),
+        ),
+        patch.object(banner, "get_available_skills", return_value={}),
+        patch.object(banner, "get_update_result", return_value=None),
+        patch.object(tools.mcp_tool, "get_mcp_status", return_value=[]),
+    ):
+        console = Console(record=True, force_terminal=False, color_system=None, width=160)
+        banner.build_welcome_banner(
+            console=console,
+            model="test-model",
+            cwd="/tmp/project",
+            tools=[],
+            enabled_toolsets=None,
+        )
+
+    assert "web_search" in console.export_text()
+
+
 def test_banner_snapshot_distinguishes_unrestricted_from_explicit_empty(
     tmp_path, monkeypatch
 ):

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -83,3 +83,60 @@ def test_build_welcome_banner_non_moa_unchanged(tmp_path, monkeypatch):
     out = console.export_text()
     assert "claude-opus-4.8" in out
     assert "MoA:" not in out
+
+
+def test_explicit_empty_toolsets_do_not_advertise_tools_or_skills(
+    tmp_path, monkeypatch
+):
+    """An explicit empty capability surface must render as empty."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    (tmp_path / ".hermes").mkdir()
+    unavailable = [{"id": "web", "name": "web", "tools": ["web_search"]}]
+
+    with (
+        patch.object(
+            model_tools,
+            "check_tool_availability",
+            return_value=([], unavailable),
+        ),
+        patch.object(
+            banner,
+            "get_available_skills",
+            return_value={"research": ["grounded-citations"]},
+        ),
+        patch.object(banner, "get_update_result", return_value=None),
+        patch.object(tools.mcp_tool, "get_mcp_status", return_value=[]),
+    ):
+        console = Console(record=True, force_terminal=False, color_system=None, width=160)
+        banner.build_welcome_banner(
+            console=console,
+            model="test-model",
+            cwd="/tmp/project",
+            tools=[],
+            enabled_toolsets=[],
+        )
+
+    out = console.export_text()
+    assert "web_search" not in out
+    assert "grounded-citations" not in out
+    assert "Skills toolset disabled" in out
+
+
+def test_banner_snapshot_distinguishes_unrestricted_from_explicit_empty(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    (tmp_path / ".hermes").mkdir()
+    availability = {
+        "unavailable_toolsets": [],
+        "lazy_tools": [],
+        "disabled_tools": [],
+    }
+
+    with (
+        patch.object(banner, "banner_snapshot_fingerprint", return_value="current"),
+        patch.object(banner, "get_available_skills", return_value={}),
+    ):
+        banner.save_banner_snapshot([], None, availability, {})
+        assert banner.load_banner_snapshot(None) is not None
+        assert banner.load_banner_snapshot([]) is None


### PR DESCRIPTION
## Summary

- preserve an explicitly empty classic CLI `--toolsets` selection instead of resolving configured defaults
- ignore empty comma-separated entries while retaining the existing omitted-option default path
- add regression coverage for explicit-empty and omitted startup selections

## Testing

- `scripts/run_tests.sh tests/cli/test_cli_empty_toolsets_banner.py tests/hermes_cli/test_banner.py tests/cli/test_cli_context_warning.py -q`

Closes #94090
