### PR TITLE
fix(desktop): preserve transcript directive provenance

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -35,6 +35,12 @@ import {
 } from '@/lib/media'
 import { previewTargetFromMarkdownHref } from '@/lib/preview-targets'
 import { sessionRefFromMarkdownHref } from '@/lib/session-refs'
+import {
+  createTranscriptDirectiveCodec,
+  finalizeTranscriptDirectiveBlocks,
+  protectTranscriptDirectiveBlocks,
+  type TranscriptDirectiveCodec
+} from '@/lib/transcript-directives'
 import { cn } from '@/lib/utils'
 
 import { ArtifactCard } from './artifact-card'
@@ -503,22 +509,25 @@ function HugeTextFallback({ containerClassName, text }: { containerClassName?: s
 function MarkdownParagraph({
   children,
   className,
+  directiveCodec,
   streaming,
   ...props
-}: ComponentProps<'p'> & { streaming?: boolean }) {
+}: ComponentProps<'p'> & { streaming?: boolean; directiveCodec: TranscriptDirectiveCodec }) {
   const plain = paragraphPlainText(children)
-  const claimed = useIsClaimedDirective(plain)
+  const directiveText = plain === null ? null : directiveCodec.decode(plain)
+  const claimed = useIsClaimedDirective(directiveText)
 
-  if (claimed && plain !== null) {
-    return <TranscriptDirectiveLeaf streaming={streaming} text={plain} />
+  if (claimed && directiveText !== null) {
+    return <TranscriptDirectiveLeaf streaming={streaming} text={directiveText} />
   }
 
+  const fallbackChildren = directiveText ?? children
+
   return (
-    // Vertical rhythm is owned by styles.css (`--paragraph-gap`), which
-    // must out-specify Tailwind Typography's `prose` margins — so no
-    // `my-*` here on purpose.
+    // Vertical rhythm is owned by styles.css (paragraph gap), which
+    // must out-specify Tailwind Typography margins, so no margin class here.
     <p className={cn('wrap-anywhere leading-(--dt-line-height)', className)} {...props}>
-      {children}
+      {fallbackChildren}
     </p>
   )
 }
@@ -531,6 +540,24 @@ function MarkdownTextSurface({
 }: MarkdownTextSurfaceProps) {
   const { status, text } = useMessagePartText()
   const isStreaming = status.type === 'running'
+
+  const protectionCodec = useMemo(() => createTranscriptDirectiveCodec(), [])
+  const directiveCodec = useMemo(() => createTranscriptDirectiveCodec(), [])
+
+  const preprocess = useMemo(
+    () => (value: string) => {
+      const protectedValue = protectTranscriptDirectiveBlocks(value, parseMarkdownIntoBlocksCached, protectionCodec)
+      const preprocessedValue = preprocessWithTailRepair(protectedValue)
+
+      return finalizeTranscriptDirectiveBlocks(
+        preprocessedValue,
+        parseMarkdownIntoBlocksCached,
+        protectionCodec,
+        directiveCodec
+      )
+    },
+    [directiveCodec, protectionCodec]
+  )
 
   // Keep code parsing enabled while streaming so incomplete fenced blocks still
   // render as code cards. The expensive Shiki pass is deferred by
@@ -554,7 +581,9 @@ function MarkdownTextSurface({
         h4: ({ className, ...props }: ComponentProps<'h4'>) => (
           <h4 className={cn('my-1 font-semibold', HEADING_SIZES.h4, className)} {...props} />
         ),
-        p: (props: ComponentProps<'p'>) => <MarkdownParagraph {...props} streaming={isStreaming} />,
+        p: (props: ComponentProps<'p'>) => (
+          <MarkdownParagraph {...props} directiveCodec={directiveCodec} streaming={isStreaming} />
+        ),
         a: MarkdownLink,
         // Inline code must not vote when an ancestor resolves `dir="auto"`
         // (HTML's algorithm skips descendants that carry their own dir),
@@ -636,7 +665,7 @@ function MarkdownTextSurface({
           )
         }
       }) as StreamdownTextComponents,
-    [disableArtifacts, isStreaming]
+    [disableArtifacts, directiveCodec, isStreaming]
   )
 
   if (text.length > MAX_MARKDOWN_CHARS) {
@@ -681,7 +710,7 @@ function MarkdownTextSurface({
         parseIncompleteMarkdown={false}
         parseMarkdownIntoBlocksFn={parseMarkdownIntoBlocksCached}
         plugins={plugins}
-        preprocess={preprocessWithTailRepair}
+        preprocess={preprocess}
       />
     </ErrorBoundary>
   )

--- a/apps/desktop/src/components/assistant-ui/transcript-directive.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/transcript-directive.test.tsx
@@ -1,10 +1,19 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { registry } from '@/contrib/registry'
-import { TRANSCRIPT_DIRECTIVE_AREA, type TranscriptDirectiveContribution } from '@/lib/transcript-directives'
+import { parseMarkdownIntoBlocksCached } from '@/lib/markdown-blocks'
+import { preprocessMarkdown } from '@/lib/markdown-preprocess'
+import {
+  createTranscriptDirectiveCodec,
+  finalizeTranscriptDirectiveBlocks,
+  protectTranscriptDirectiveBlocks,
+  TRANSCRIPT_DIRECTIVE_AREA,
+  type TranscriptDirectiveContribution
+} from '@/lib/transcript-directives'
 
+import { MarkdownTextContent } from './markdown-text'
 import { paragraphPlainText, TranscriptDirectiveLeaf } from './transcript-directive'
 
 describe('paragraphPlainText', () => {
@@ -72,6 +81,441 @@ describe('TranscriptDirectiveLeaf', () => {
       render(<TranscriptDirectiveLeaf text="::demo" />)
       // The chip fallback renders the contribution id, not a dead subtree.
       expect(screen.getByRole('button')).toBeTruthy()
+    } finally {
+      dispose()
+    }
+  })
+})
+
+describe('TranscriptDirectiveCodec', () => {
+  it('uses fixed-length Markdown-inert tokens and round-trips Unicode sources', () => {
+    const codec = createTranscriptDirectiveCodec()
+    const sources = ['::link', '::link{title="naïve ☃ ~~ __ [x]"}']
+    const tokens = sources.map(source => codec.encode(source))
+
+    for (const token of tokens) {
+      expect(token).toMatch(/^hermestranscriptdirectivev1[A-F0-9]{40}$/u)
+    }
+
+    expect(tokens[0]?.length).toBe(tokens[1]?.length)
+    expect(codec.encode(sources[0])).toBe(tokens[0])
+    expect(codec.decode(tokens[0] ?? '')).toBe(sources[0])
+    expect(codec.decode(tokens[1] ?? '')).toBe(sources[1])
+  })
+
+  it('caps each surface codec at 256 distinct directive sources', () => {
+    const codec = createTranscriptDirectiveCodec()
+
+    for (let index = 0; index < 256; index += 1) {
+      expect(codec.encode(`::link{key="${index}"}`)).not.toBeNull()
+    }
+
+    expect(codec.encode('::link{key="overflow"}')).toBeNull()
+  })
+
+  it('fails closed when secure random values are unavailable', () => {
+    const cryptoSource = globalThis.crypto
+    vi.stubGlobal('crypto', undefined)
+
+    try {
+      expect(createTranscriptDirectiveCodec().encode('::link{key="x"}')).toBeNull()
+    } finally {
+      vi.stubGlobal('crypto', cryptoSource)
+    }
+  })
+
+  it('fails closed when secure random generation throws', () => {
+    const cryptoSource = globalThis.crypto
+    vi.stubGlobal('crypto', {
+      getRandomValues() {
+        throw new Error('synthetic rng failure')
+      }
+    })
+
+    try {
+      expect(createTranscriptDirectiveCodec().encode('::link{key="x"}')).toBeNull()
+    } finally {
+      vi.stubGlobal('crypto', cryptoSource)
+    }
+  })
+
+  it('remints a finalized raw token into a separate claim codec', () => {
+    const protectionCodec = createTranscriptDirectiveCodec()
+    const claimCodec = createTranscriptDirectiveCodec()
+    const source = '::link{key="x"}'
+    const protectedToken = protectionCodec.encode(source)
+
+    if (!protectedToken) {
+      throw new Error('Expected the protection codec to encode a valid directive')
+    }
+
+    const finalized = finalizeTranscriptDirectiveBlocks(
+      protectedToken,
+      parseMarkdownIntoBlocksCached,
+      protectionCodec,
+      claimCodec
+    )
+
+    expect(finalized).not.toBe(protectedToken)
+    expect(protectionCodec.decode(finalized)).toBeNull()
+    expect(claimCodec.decode(finalized)).toBe(source)
+  })
+})
+
+describe('protectTranscriptDirectiveBlocks', () => {
+  it('returns markdown without directive candidates without invoking the block parser', () => {
+    const source = 'plain CRLF prose\r\nwith no directive candidate'
+    const codec = createTranscriptDirectiveCodec()
+
+    expect(
+      protectTranscriptDirectiveBlocks(
+        source,
+        () => {
+          throw new Error('block parser should not run')
+        },
+        codec
+      )
+    ).toBe(source)
+  })
+
+  it('returns the original Markdown when the block parser throws', () => {
+    const source = '::link{key="x"}'
+
+    expect(
+      protectTranscriptDirectiveBlocks(
+        source,
+        () => {
+          throw new Error('synthetic parser failure')
+        },
+        createTranscriptDirectiveCodec()
+      )
+    ).toBe(source)
+  })
+
+  it.each([
+    ['CDATA-like markup', '<div><![CDATA[ ><script>foo]]></div>\n\n::link{key="after-cdata"}'],
+    ['a malformed closing tag', '<div></div "><script>foo ">\n\n::link{key="after-malformed-close"}'],
+    ['a bogus declaration', '<div><!foo "><script>foo" > </div>\n\n::link{key="after-bogus-declaration"}']
+  ])('does not mint a directive after %s', (_label, source) => {
+    expect(protectTranscriptDirectiveBlocks(source, parseMarkdownIntoBlocksCached, createTranscriptDirectiveCodec())).toBe(
+      source
+    )
+  })
+
+  it('preserves original CRLF bytes when directive-looking prose is not protected', () => {
+    const source = 'alpha\r\n::link[1]\r\nomega'
+
+    expect(protectTranscriptDirectiveBlocks(source, parseMarkdownIntoBlocksCached, createTranscriptDirectiveCodec())).toBe(
+      source
+    )
+  })
+
+  it('preserves CRLF around a protected standalone directive', () => {
+    const source = '::link{key="x"}\r\n\r\nomega'
+
+    const protectedValue = protectTranscriptDirectiveBlocks(
+      source,
+      parseMarkdownIntoBlocksCached,
+      createTranscriptDirectiveCodec()
+    )
+
+    expect(protectedValue).toMatch(/^hermestranscriptdirectivev1[A-F0-9]{40}\r\n\r\nomega$/u)
+  })
+})
+
+describe('MarkdownTextContent transcript directives', () => {
+  afterEach(cleanup)
+
+  it('preserves a URL attribute through markdown preprocessing', async () => {
+    const dispose = registry.register({
+      id: 'test:link',
+      area: TRANSCRIPT_DIRECTIVE_AREA,
+      source: 'plugin:test',
+      data: {
+        name: 'link',
+        render: ({ attrs }) => <div data-testid="link-card">{attrs.url}</div>
+      } satisfies TranscriptDirectiveContribution
+    })
+
+    try {
+      render(
+        <MarkdownTextContent
+          isRunning={false}
+          text='::link{title="Hermes Desktop Plugin SDK" url="https://hermes-agent.nousresearch.com/docs/developer-guide/desktop-plugin-sdk" desc="Die offizielle Primärquelle für native Erweiterungen und Host-Schnittstellen."}'
+        />
+      )
+
+      expect((await screen.findByTestId('link-card')).textContent).toBe(
+        'https://hermes-agent.nousresearch.com/docs/developer-guide/desktop-plugin-sdk'
+      )
+    } finally {
+      dispose()
+    }
+  })
+})
+
+describe('Link-fix blocker regressions', () => {
+  afterEach(cleanup)
+
+  const registerLink = () =>
+    registry.register({
+      id: 'test:link-regression',
+      area: TRANSCRIPT_DIRECTIVE_AREA,
+      source: 'plugin:test',
+      data: {
+        name: 'link',
+        render: ({ attrs }) => <div data-testid="link-card">{JSON.stringify(attrs)}</div>
+      } satisfies TranscriptDirectiveContribution
+    })
+
+  const renderLink = (text: string, isRunning = false) =>
+    render(<MarkdownTextContent isRunning={isRunning} text={text} />)
+
+  const mintForeignToken = () => {
+    const token = createTranscriptDirectiveCodec().encode('::link{url="https://x.test"}')
+
+    if (!token) {
+      throw new Error('Expected the foreign codec to encode a valid directive')
+    }
+
+    return token
+  }
+
+  it('keeps a minted but unclaimed directive as its original source text', async () => {
+    const source = '::not-registered{key="x"}'
+
+    renderLink(source)
+    await waitFor(() => expect(globalThis.document.body.textContent).toContain(source))
+    expect(screen.queryByTestId('link-card')).toBeNull()
+  })
+
+  it('does not claim an authentic token minted by another surface codec', async () => {
+    const rawLookalike = mintForeignToken()
+
+    const dispose = registerLink()
+
+    try {
+      renderLink(rawLookalike)
+      await waitFor(() => expect(globalThis.document.body.textContent).toContain(rawLookalike))
+      expect(screen.queryByTestId('link-card')).toBeNull()
+    } finally {
+      dispose()
+    }
+  })
+
+  it('leaves directive-looking lines to the markdown boundary instead of encoding them generically', () => {
+    const source = '::link{label="plain"}'
+
+    expect(preprocessMarkdown(source)).toBe(source)
+  })
+
+  it('keeps a directive followed by another line as ordinary prose', async () => {
+    const dispose = registerLink()
+    const source = '::link\ncontinued'
+
+    try {
+      renderLink(source)
+      await waitFor(() => expect(globalThis.document.body.textContent).toContain('::link'))
+      expect(globalThis.document.body.textContent).toContain('continued')
+      expect(globalThis.document.body.textContent).not.toContain('hermestranscriptdirectivev1')
+      expect(screen.queryByTestId('link-card')).toBeNull()
+    } finally {
+      dispose()
+    }
+  })
+
+  it.each([
+    ['four-space indented code', '    ::link{url="https://x.test"}'],
+    ['tab-indented code', '\t::link{url="https://x.test"}'],
+    ['closed fenced code', '```\n::link{url="https://x.test"}\n```'],
+    ['incomplete fenced code', '```\n::link{url="https://x.test"}'],
+    ['list item', '- ::link{url="https://x.test"}'],
+    ['blockquote', '> ::link{url="https://x.test"}'],
+    ['HTML block', '<div>\n::link{url="https://x.test"}\n</div>']
+  ])('keeps %s ordinary and never claims a directive', async (_label, text) => {
+    const dispose = registerLink()
+
+    try {
+      renderLink(text)
+      await waitFor(() => expect(globalThis.document.body.textContent).toContain('::link'))
+      expect(globalThis.document.body.textContent).not.toContain('hermestranscriptdirectivev1')
+      expect(screen.queryByTestId('link-card')).toBeNull()
+    } finally {
+      dispose()
+    }
+  })
+
+  it.each([
+    ['loose list continuation', '- item\n\n  ::link{key="x"}', 'item'],
+    ['loose blockquote continuation', '> item\n>\n> ::link{key="x"}', 'item'],
+    ['citation normalization', '::link[1]', '::link'],
+    [
+      'closed prose-like fence',
+      '```text\nalpha prose sentence\nbeta prose sentence\n::link{key="x"}\ngamma prose sentence\n```',
+      'alpha prose sentence'
+    ],
+    [
+      'incomplete prose-like fence',
+      '```text\nalpha prose sentence\nbeta prose sentence\n::link{key="x"}\ngamma prose sentence',
+      'alpha prose sentence'
+    ],
+    ['triple-backtick noise', '```::link{key="x"}```', '::link']
+  ])('does not claim a directive produced by preprocessing from %s', async (_label, text, visibleText) => {
+    const dispose = registerLink()
+
+    try {
+      renderLink(text)
+      await waitFor(() => expect(globalThis.document.body.textContent).toContain(visibleText))
+      expect(screen.queryByTestId('link-card')).toBeNull()
+    } finally {
+      dispose()
+    }
+  })
+
+  it.each([
+    ['backtick scrubbing', '<```div>\n\n::link{key="post-backtick-html"}', 'post-backtick-html'],
+    [
+      'preview-marker stripping',
+      '<[Preview:x](#preview/foo)div>\n\n::link{key="post-preview-html"}',
+      'post-preview-html'
+    ]
+  ])('does not claim a raw directive after %s synthesizes HTML', async (_label, text, visibleText) => {
+    const dispose = registerLink()
+
+    try {
+      renderLink(text)
+      await waitFor(() => expect(globalThis.document.body.textContent).toContain(visibleText))
+      expect(screen.queryByTestId('link-card')).toBeNull()
+      expect(globalThis.document.body.textContent).not.toContain('hermestranscriptdirectivev1')
+    } finally {
+      dispose()
+    }
+  })
+
+  it.each([
+    ['tab', '<div\tclass="directive-html-context">\n\n::link{key="inside-tab-html"}\n\n</div>', 'inside-tab-html'],
+    [
+      'form feed',
+      '<div\fclass="directive-html-context">\n\n::link{key="inside-form-feed-html"}\n\n</div>',
+      'inside-form-feed-html'
+    ]
+  ])('does not claim a directive inside raw HTML with %s attribute whitespace', async (_label, text, visibleText) => {
+    const dispose = registerLink()
+
+    try {
+      renderLink(text)
+      await waitFor(() => expect(globalThis.document.body.textContent).toContain(visibleText))
+      expect(screen.queryByTestId('link-card')).toBeNull()
+      expect(globalThis.document.body.textContent).not.toContain('hermestranscriptdirectivev1')
+    } finally {
+      dispose()
+    }
+  })
+
+  it.each([
+    [
+      'a closing tag embedded in an HTML comment',
+      '<div><!-- </div> -->\n\n::link{key="inside-commented-close"}\n\n</div>',
+      'inside-commented-close'
+    ],
+    [
+      'a closing tag embedded in script raw text',
+      '<div><script>const fake = "</div>"</script>\n\n::link{key="inside-script-fake-close"}\n\n</div>',
+      'inside-script-fake-close'
+    ]
+  ])('keeps HTML context closed against %s', async (_label, text, visibleText) => {
+    const dispose = registerLink()
+
+    try {
+      renderLink(text)
+      await waitFor(() => expect(globalThis.document.body.textContent).toContain(visibleText))
+      expect(screen.queryByTestId('link-card')).toBeNull()
+    } finally {
+      dispose()
+    }
+  })
+
+  it.each([
+    ['a closed element', '<div>ordinary HTML</div>\n\n::link{key="after-closed-html"}', 'after-closed-html'],
+    ['a void element', '<br>\n\n::link{key="after-void-html"}', 'after-void-html'],
+    ['a closed comment', '<!-- ordinary comment -->\n\n::link{key="after-comment"}', 'after-comment']
+  ])('keeps a later directive ordinary after %s', async (_label, text, expectedKey) => {
+    const dispose = registerLink()
+
+    try {
+      renderLink(text)
+      await waitFor(() => expect(globalThis.document.body.textContent).toContain(expectedKey))
+      expect(screen.queryByTestId('link-card')).toBeNull()
+      expect(globalThis.document.body.textContent).not.toContain('hermestranscriptdirectivev1')
+    } finally {
+      dispose()
+    }
+  })
+
+  it('round-trips markdown markers, links, punctuation, percent escapes, and Unicode attributes', async () => {
+    const dispose = registerLink()
+
+    const source =
+      '::link{title="~~del __strong__ [label](https://example.test/a?x=1%2520)" url="https://example.test/a_(b)?x=1%2F2%25&y=[z]" unicode="naïve ☃"}'
+
+    const expected = {
+      title: '~~del __strong__ [label](https://example.test/a?x=1%2520)',
+      url: 'https://example.test/a_(b)?x=1%2F2%25&y=[z]',
+      unicode: 'naïve ☃'
+    }
+
+    try {
+      renderLink(source)
+      expect((await screen.findByTestId('link-card')).textContent).toBe(JSON.stringify(expected))
+    } finally {
+      dispose()
+    }
+  })
+
+  it('does not treat HTML-looking attributes in a protected directive as raw HTML context', async () => {
+    const dispose = registerLink()
+    const source = '::link{key="<b>"}\n\n::link{key="second"}'
+
+    try {
+      renderLink(source)
+      const cards = await screen.findAllByTestId('link-card')
+
+      expect(cards.map(card => card.textContent)).toEqual([
+        JSON.stringify({ key: '<b>' }),
+        JSON.stringify({ key: 'second' })
+      ])
+    } finally {
+      dispose()
+    }
+  })
+
+  it.each([
+    ['noncanonical lowercase hex', (token: string) => token.replace(/[A-F]/u, value => value.toLowerCase())],
+    ['malformed non-hex suffix', (token: string) => `${token}G`],
+    ['oversized payload', (token: string) => `${token}${'A'.repeat(5000)}`]
+  ])('passes an actual-format %s token through unchanged', async (_label, mutateToken) => {
+    const rawToken = mutateToken(mintForeignToken())
+    const dispose = registerLink()
+
+    try {
+      renderLink(rawToken)
+      await waitFor(() => expect(globalThis.document.body.textContent).toContain(rawToken))
+      expect(screen.queryByTestId('link-card')).toBeNull()
+    } finally {
+      dispose()
+    }
+  })
+
+  it('transitions from a partial directive to the card when streaming completes', async () => {
+    const dispose = registerLink()
+    const partial = '::link{url="https://x.test/path'
+    const complete = '::link{url="https://x.test/path"}'
+
+    try {
+      const view = renderLink(partial, true)
+      expect(screen.queryByTestId('link-card')).toBeNull()
+      view.rerender(<MarkdownTextContent isRunning={false} text={complete} />)
+      expect((await screen.findByTestId('link-card')).textContent).toBe(JSON.stringify({ url: 'https://x.test/path' }))
     } finally {
       dispose()
     }

--- a/apps/desktop/src/lib/transcript-directives.ts
+++ b/apps/desktop/src/lib/transcript-directives.ts
@@ -44,6 +44,7 @@ export interface ParsedTranscriptDirective {
   source: string
 }
 
+const TRANSCRIPT_DIRECTIVE_PLACEHOLDER_PREFIX = 'hermestranscriptdirectivev1'
 // The whole paragraph, nothing else on the line: `::name` or `::name{...}`.
 // Length caps bound the attr scan on adversarial input.
 const DIRECTIVE_RE = /^::([a-z][a-z0-9-]{0,63})(?:\{([^{}]{0,1024})\})?$/
@@ -79,4 +80,290 @@ export function parseTranscriptDirective(text: string): ParsedTranscriptDirectiv
   }
 
   return { name: match[1], attrs, source: trimmed }
+}
+
+export interface TranscriptDirectiveCodec {
+  encode(text: string): string | null
+  decode(text: string): string | null
+  restoreOwnedTokens(text: string): string
+}
+
+const MAX_TRANSCRIPT_DIRECTIVE_CODEC_ENTRIES = 256
+
+function createCodecNonce(): string | null {
+  const values = new Uint32Array(4)
+  const cryptoSource = globalThis.crypto
+
+  if (!cryptoSource?.getRandomValues) {
+    return null
+  }
+
+  try {
+    cryptoSource.getRandomValues(values)
+  } catch {
+    return null
+  }
+
+  return Array.from(values, value => value.toString(16).padStart(8, '0'))
+    .join('')
+    .toUpperCase()
+}
+
+/**
+ * Create a per-Markdown-surface codec. The token map is private to the
+ * surface, and decoding is an exact map lookup rather than a parser round
+ * trip, so model-authored lookalikes cannot claim a contribution.
+ */
+export function createTranscriptDirectiveCodec(): TranscriptDirectiveCodec {
+  const tokenToSource = new Map<string, string>()
+  const sourceToToken = new Map<string, string>()
+  const nonce = createCodecNonce()
+  const ownedTokenPrefix = nonce ? TRANSCRIPT_DIRECTIVE_PLACEHOLDER_PREFIX + nonce : null
+  const ownedTokenPattern = ownedTokenPrefix ? new RegExp(`${ownedTokenPrefix}[A-F0-9]{8}`, 'gu') : null
+
+  return {
+    encode(text) {
+      if (!nonce) {
+        return null
+      }
+
+      const parsed = parseTranscriptDirective(text)
+
+      if (!parsed) {
+        return null
+      }
+
+      const existing = sourceToToken.get(parsed.source)
+
+      if (existing) {
+        return existing
+      }
+
+      if (sourceToToken.size >= MAX_TRANSCRIPT_DIRECTIVE_CODEC_ENTRIES) {
+        return null
+      }
+
+      const index = sourceToToken.size.toString(16).padStart(8, '0').toUpperCase()
+      const token = TRANSCRIPT_DIRECTIVE_PLACEHOLDER_PREFIX + nonce + index
+      sourceToToken.set(parsed.source, token)
+      tokenToSource.set(token, parsed.source)
+
+      return token
+    },
+    decode(text) {
+      return tokenToSource.get(text) ?? null
+    },
+    restoreOwnedTokens(text) {
+      if (!ownedTokenPrefix || !ownedTokenPattern || !text.includes(ownedTokenPrefix)) {
+        return text
+      }
+
+      return text.replace(ownedTokenPattern, token => tokenToSource.get(token) ?? token)
+    }
+  }
+}
+
+interface StandaloneDirectiveBlock {
+  leading: string
+  source: string
+  trailing: string
+}
+
+interface StandaloneOwnedTokenBlock {
+  leading: string
+  token: string
+  trailing: string
+}
+
+// Do not attempt to duplicate the downstream HTML parser. Once an unprotected
+// block contains HTML-like markup, later directive-looking blocks in the same
+// message stay ordinary Markdown. Protected directives are inert tokens here,
+// so HTML-looking attribute text cannot taint a following directive.
+const HTML_LIKE_MARKUP_RE = /<(?:[a-z!/]|\?)/iu
+
+function standaloneDirectiveBlock(block: string): StandaloneDirectiveBlock | null {
+  const leading = block.match(/^[ \t]*/u)?.[0] ?? ''
+
+  // Four-space indentation is an indented code block; tabs are structural
+  // indentation too. Neither context is a directive paragraph.
+  if (leading.includes('\t') || leading.length >= 4) {
+    return null
+  }
+
+  const remaining = block.slice(leading.length)
+  const trailing = remaining.match(/[ \t\r\n]*$/u)?.[0] ?? ''
+  const source = remaining.slice(0, remaining.length - trailing.length)
+
+  if (!source || source.includes('\n') || source.includes('\r')) {
+    return null
+  }
+
+  const parsed = parseTranscriptDirective(source)
+
+  return parsed?.source === source ? { leading, source, trailing } : null
+}
+
+function standaloneOwnedTokenBlock(
+  block: string,
+  codec: TranscriptDirectiveCodec
+): StandaloneOwnedTokenBlock | null {
+  const leading = block.match(/^[ \t]*/u)?.[0] ?? ''
+
+  if (leading.includes('\t') || leading.length >= 4) {
+    return null
+  }
+
+  const remaining = block.slice(leading.length)
+  const trailing = remaining.match(/[ \t\r\n]*$/u)?.[0] ?? ''
+  const token = remaining.slice(0, remaining.length - trailing.length)
+
+  if (!token || token.includes('\n') || token.includes('\r') || codec.decode(token) === null) {
+    return null
+  }
+
+  return { leading, token, trailing }
+}
+
+function normalizeBlockLineEndings(value: string): string {
+  return value.replace(/\r\n?/g, '\n')
+}
+
+function rawEndForNormalizedLength(markdown: string, start: number, normalizedLength: number): number | null {
+  let normalizedOffset = 0
+  let rawOffset = start
+
+  while (normalizedOffset < normalizedLength) {
+    if (rawOffset >= markdown.length) {
+      return null
+    }
+
+    if (markdown[rawOffset] === '\r' && markdown[rawOffset + 1] === '\n') {
+      rawOffset += 2
+    } else {
+      rawOffset += 1
+    }
+
+    normalizedOffset += 1
+  }
+
+  return rawOffset
+}
+
+/**
+ * Protect only Markdown blocks that are truly standalone directive
+ * paragraphs. Structural whitespace is copied around the inert token, while
+ * lists, quotes, HTML, fences, indented code, and multi-line prose remain
+ * untouched for the normal Markdown parser.
+ */
+export function protectTranscriptDirectiveBlocks(
+  markdown: string,
+  parseBlocks: (value: string) => readonly string[],
+  codec: TranscriptDirectiveCodec
+): string {
+  if (!markdown.includes('::')) {
+    return markdown
+  }
+
+  let blocks: readonly string[]
+
+  try {
+    blocks = parseBlocks(markdown)
+  } catch {
+    return markdown
+  }
+
+  if (blocks.join('') !== normalizeBlockLineEndings(markdown)) {
+    return markdown
+  }
+
+  const protectedBlocks: string[] = []
+  let htmlLikeMarkupSeen = false
+  let rawOffset = 0
+
+  for (const block of blocks) {
+    const rawEnd = rawEndForNormalizedLength(markdown, rawOffset, block.length)
+
+    if (rawEnd === null) {
+      return markdown
+    }
+
+    const rawBlock = markdown.slice(rawOffset, rawEnd)
+
+    if (normalizeBlockLineEndings(rawBlock) !== block) {
+      return markdown
+    }
+
+    const directive = htmlLikeMarkupSeen ? null : standaloneDirectiveBlock(rawBlock)
+    const token = directive ? codec.encode(directive.source) : null
+    const protectedBlock = token && directive ? directive.leading + token + directive.trailing : rawBlock
+
+    protectedBlocks.push(protectedBlock)
+    htmlLikeMarkupSeen ||= HTML_LIKE_MARKUP_RE.test(protectedBlock)
+    rawOffset = rawEnd
+  }
+
+  return rawOffset === markdown.length ? protectedBlocks.join('') : markdown
+}
+
+/**
+ * Re-check owned directive tokens after generic Markdown preprocessing. Only
+ * tokens that remain complete standalone blocks in the final Markdown may
+ * reach Streamdown. Structural changes, synthesized HTML, or parser ambiguity
+ * restore the token's original source, which is visible but cannot be claimed.
+ */
+export function finalizeTranscriptDirectiveBlocks(
+  markdown: string,
+  parseBlocks: (value: string) => readonly string[],
+  protectionCodec: TranscriptDirectiveCodec,
+  claimCodec: TranscriptDirectiveCodec
+): string {
+  if (!markdown.includes(TRANSCRIPT_DIRECTIVE_PLACEHOLDER_PREFIX)) {
+    return markdown
+  }
+
+  const restoreAll = () => protectionCodec.restoreOwnedTokens(markdown)
+  let blocks: readonly string[]
+
+  try {
+    blocks = parseBlocks(markdown)
+  } catch {
+    return restoreAll()
+  }
+
+  if (blocks.join('') !== normalizeBlockLineEndings(markdown)) {
+    return restoreAll()
+  }
+
+  const finalizedBlocks: string[] = []
+  let htmlLikeMarkupSeen = false
+  let rawOffset = 0
+
+  for (const block of blocks) {
+    const rawEnd = rawEndForNormalizedLength(markdown, rawOffset, block.length)
+
+    if (rawEnd === null) {
+      return restoreAll()
+    }
+
+    const rawBlock = markdown.slice(rawOffset, rawEnd)
+
+    if (normalizeBlockLineEndings(rawBlock) !== block) {
+      return restoreAll()
+    }
+
+    const ownedToken = htmlLikeMarkupSeen ? null : standaloneOwnedTokenBlock(rawBlock, protectionCodec)
+    const source = ownedToken ? protectionCodec.decode(ownedToken.token) : null
+    const claimToken = source ? claimCodec.encode(source) : null
+
+    const finalizedBlock =
+      ownedToken && claimToken
+        ? ownedToken.leading + claimToken + ownedToken.trailing
+        : protectionCodec.restoreOwnedTokens(rawBlock)
+
+    finalizedBlocks.push(finalizedBlock)
+    htmlLikeMarkupSeen ||= HTML_LIKE_MARKUP_RE.test(finalizedBlock)
+    rawOffset = rawEnd
+  }
+
+  return rawOffset === markdown.length ? finalizedBlocks.join('') : restoreAll()
 }


### PR DESCRIPTION
## What does this PR do?

Transcript contribution directives can be modified by Markdown preprocessing and Streamdown before `parseTranscriptDirective()` gets a chance to claim them. A valid `::link{...}` paragraph containing an absolute HTTPS URL or Markdown-significant attribute text can therefore render as broken prose or disappear instead of reaching the registered plugin renderer.

### Root Cause

Directive detection happened after transformations intended for ordinary prose and URLs. Protecting line fragments is insufficient: Markdown block context determines whether directive-looking text is a paragraph, code, a list, a quote, HTML, or part of an incomplete stream, and Streamdown can tokenize the directive syntax before contribution claiming. Protecting a valid raw block before preprocessing is also insufficient on its own because generic cleanup can synthesize new structural or HTML context around the protected token. The claim therefore needs separate provenance checks before and after every generic transformation.

## Related Issue

N/A — found while dogfooding transcript contributions in the Desktop client.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- split the raw accumulated message with the same cached Markdown block parser used by Streamdown
- map those parser boundaries back to exact raw slices, preserving CRLF and mixed line endings; any reconstruction mismatch fails closed to the original Markdown
- protect only complete, standalone blocks already accepted by `parseTranscriptDirective()`; code, lists, quotes, fences, and multiline prose stay on the ordinary Markdown path
- once any earlier unprotected block contains HTML-like markup, conservatively leave every later directive-looking block in that message on the ordinary Markdown path instead of duplicating the downstream HTML parser
- mint first-stage protection tokens with a private exact map only for valid raw directive blocks, then run the existing generic preprocessing and tail repair
- reparse the fully transformed output and remint only still-standalone, structurally safe first-stage tokens through a separate per-surface claim codec; every other first-stage token is restored to visible, unclaimable source text
- decode only the second-stage claim codec at the paragraph contribution boundary, so a leaked first-stage, model-authored, foreign, stale, or transformed token cannot claim
- use fixed-length alphanumeric `128-bit nonce + counter` tokens, exact private maps, and secure Web Crypto randomness; if secure randomness is unavailable or throws, encoding fails closed instead of falling back to `Math.random()`
- preserve the existing unclaimed-directive fallback to original visible source text
- skip block parsing entirely when the message contains no directive introducer
- cover the real `MarkdownTextContent`/Streamdown pipeline, including URL and Markdown-significant attributes, foreign tokens, malformed tokens, structural Markdown contexts, and partial-to-complete streaming

The existing parser limits, whole-paragraph requirement, and `MAX_MARKDOWN_CHARS` fallback remain authoritative. Codec growth is capped at 256 distinct directive sources per surface.

## How to Test

1. Register a transcript `link` contribution.
2. Render a Markdown paragraph containing `::link{title="Hermes Desktop Plugin SDK" url="https://hermes-agent.nousresearch.com/docs/developer-guide/desktop-plugin-sdk" desc="..."}`.
3. Confirm the contribution receives the original HTTPS URL and renders a native link card instead of raw or transformed Markdown.
4. Confirm the same directive syntax inside code, lists, quotes, raw HTML (including malformed declarations and tab/form-feed-separated attributes), fences, or multiline prose remains ordinary Markdown and that a token minted by another codec is not claimed.
5. Confirm preprocessing that turns `<```div>` or `<[Preview:x](#preview/foo)div>` into `<div>` cannot make a following raw directive claim.
6. Confirm a later directive remains ordinary after any earlier unprotected HTML-like block, while HTML-looking attribute text inside a protected directive does not suppress a following standalone directive.
7. Confirm first-stage protection tokens are reminted through a different claim codec, missing or throwing Web Crypto disables encoding, unprotected CRLF input is returned byte-for-byte, and a block-parser failure returns visible original source.

### Automated verification

- [x] Focused directive suite — 52 tests passed
- [x] Focused and adjacent UI suites — 6 files / 140 tests passed
- [x] Full desktop UI suite under deterministic locale — 591 files / 5,712 tests passed
- [x] Full desktop TypeScript checks
- [x] Focused ESLint on all three changed files
- [x] Production renderer, Electron main/preload, native dependency staging, and dist assertion
- [x] Canonical Desktop `npm run check`, including 1,700 Electron tests and 556 plugin tests
- [x] `git diff --check` and focused added-line danger scan

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits (`fix(desktop): ...`)
- [x] I searched existing open PRs for transcript-directive/Streamdown duplicates
- [x] This PR contains only the three files required for this fix
- [x] N/A for the Python suite — this is Desktop-only; the full Desktop UI suite passed
- [x] I've added regression tests for the full Streamdown pipeline and protection helpers
- [x] Tested on Linux x86_64 with the full UI suite and production Desktop build

### Documentation & Housekeeping

- [x] Documentation N/A — no public API or configuration changes
- [x] `cli-config.yaml.example` N/A — no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A — no contributor workflow changes
- [x] Cross-platform impact considered — browser-neutral TypeScript and Markdown behavior
- [x] Tool descriptions/schemas N/A — no tool behavior changed

## Risk Assessment

Low to medium — the change is limited to standalone blocks already accepted by the transcript-directive parser. Rather than duplicating HTML parsing, any prior unprotected HTML-like block conservatively disables later directive claims in that message. A second check runs after generic preprocessing and tail repair: only a still-standalone first-stage token is reminted into the distinct codec accepted by the paragraph decoder. Any parser, raw-slice, structural, or secure-randomness ambiguity—including missing or throwing Web Crypto—leaves visible ordinary Markdown instead. Both fixed-length codec maps are private and bounded to 256 directive sources; after that cap, additional directives intentionally remain ordinary Markdown.

## Screenshots / Logs

The original failure and happy path were reproduced in a live Linux Desktop transcript. The final hardened source candidate was not activated over the running client; it is verified by the full UI suite and production build above.
