### PR TITLE
feat(desktop): add ElevenLabs realtime voice transcription

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -92,6 +92,7 @@
     "@dnd-kit/core": "6.3.1",
     "@dnd-kit/sortable": "10.0.0",
     "@dnd-kit/utilities": "3.2.2",
+    "@elevenlabs/client": "1.21.0",
     "@hermes/shared": "file:../shared",
     "@icons-pack/react-simple-icons": "13.11.1",
     "@lezer/highlight": "1.2.3",

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
@@ -45,6 +45,25 @@ const micHandle = {
   stop: vi.fn<() => Promise<MicRecording | null>>(async () => null)
 }
 
+let realtimeCommitted: ((text: string) => void) | null = null
+
+const realtimeSession = {
+  close: vi.fn(),
+  commit: vi.fn(() => realtimeCommitted?.('kick off the task')),
+  mute: vi.fn(),
+  unmute: vi.fn()
+}
+
+const startRealtimeScribe = vi.fn<
+  (options: { onCommitted: (text: string) => void }) => Promise<typeof realtimeSession | null>
+>(async ({ onCommitted }) => {
+  realtimeCommitted = onCommitted
+
+  return realtimeSession
+})
+
+vi.mock('@/lib/realtime-scribe', () => ({ startRealtimeScribe: (options: { onCommitted: (text: string) => void }) => startRealtimeScribe(options) }))
+
 vi.mock('./use-mic-recorder', () => ({
   useMicRecorder: () => ({ handle: micHandle, level: 0, recording: false })
 }))
@@ -87,13 +106,9 @@ function renderConversation(overrides: { onInterrupt?: () => void; transcript?: 
 
   const onStopWord = vi.fn()
 
-  // First transcription is the turn that starts the conversation; subsequent
-  // ones are barge captures (the overridable transcript).
-  let transcriptions = 0
-
-  const onTranscribeAudio = vi.fn(async () =>
-    transcriptions++ === 0 ? 'kick off the task' : (overrides.transcript ?? 'and another thing')
-  )
+  // Realtime supplies the kickoff transcript directly; record/upload is used
+  // either as the compatibility path or for a captured barge utterance.
+  const onTranscribeAudio = vi.fn(async () => overrides.transcript ?? 'kick off the task')
 
   const hook = renderHook(
     ({ busy }: HookProps) =>
@@ -137,12 +152,97 @@ async function enterThinking(hook: ReturnType<typeof renderConversation>['hook']
 describe('useVoiceConversation full-duplex barge-in', () => {
   beforeEach(() => {
     monitorCalls.length = 0
+    realtimeCommitted = null
     vi.clearAllMocks()
+    startRealtimeScribe.mockImplementation(async ({ onCommitted }: { onCommitted: (text: string) => void }) => {
+      realtimeCommitted = onCommitted
+
+      return realtimeSession
+    })
     micHandle.start.mockResolvedValue(undefined)
     micHandle.stop.mockResolvedValue(null)
   })
 
   afterEach(cleanup)
+
+  it('uses a persistent realtime transcript instead of record-upload when available', async () => {
+    const { hook, onSubmit, onTranscribeAudio } = renderConversation()
+
+    await act(async () => {
+      await hook.result.current.start()
+    })
+    await waitFor(() => expect(startRealtimeScribe).toHaveBeenCalledTimes(1))
+    expect(realtimeSession.unmute).toHaveBeenCalled()
+
+    await act(async () => {
+      realtimeCommitted?.('hello in realtime')
+    })
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('hello in realtime'))
+    expect(onTranscribeAudio).not.toHaveBeenCalled()
+    expect(realtimeSession.mute).toHaveBeenCalled()
+
+    await act(async () => {
+      await hook.result.current.end()
+    })
+    expect(realtimeSession.close).toHaveBeenCalled()
+  })
+
+  it('closes a realtime session that resolves after the user mutes', async () => {
+    let resolveRealtime: ((session: typeof realtimeSession) => void) | null = null
+    startRealtimeScribe.mockImplementationOnce(
+      ({ onCommitted }: { onCommitted: (text: string) => void }) => {
+        realtimeCommitted = onCommitted
+
+        return new Promise(resolve => {
+          resolveRealtime = resolve
+        })
+      }
+    )
+    const { hook } = renderConversation()
+
+    let starting: Promise<void>
+    act(() => {
+      starting = hook.result.current.start()
+    })
+    await waitFor(() => expect(startRealtimeScribe).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      hook.result.current.toggleMute()
+    })
+    expect(hook.result.current.muted).toBe(true)
+
+    await act(async () => {
+      resolveRealtime?.(realtimeSession)
+      await starting
+    })
+
+    expect(realtimeSession.close).toHaveBeenCalled()
+    expect(realtimeSession.unmute).not.toHaveBeenCalled()
+    expect(hook.result.current.status).toBe('idle')
+  })
+
+  it('falls back to record-upload when realtime Scribe is unavailable', async () => {
+    startRealtimeScribe.mockResolvedValueOnce(null)
+    const { hook, onSubmit, onTranscribeAudio } = renderConversation()
+
+    await act(async () => {
+      await hook.result.current.start()
+    })
+    await waitFor(() => expect(hook.result.current.status).toBe('listening'))
+    micHandle.stop.mockResolvedValueOnce({
+      audio: new Blob(['q'], { type: 'audio/webm' }),
+      durationMs: 900,
+      heardSpeech: true
+    })
+
+    await act(async () => {
+      hook.result.current.stopTurn()
+    })
+
+    await waitFor(() => expect(onTranscribeAudio).toHaveBeenCalled())
+    expect(onSubmit).toHaveBeenCalledWith('kick off the task')
+  })
 
   it('arms the barge monitor during generation (before any reply audio exists)', async () => {
     const { hook } = renderConversation()

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { useI18n } from '@/i18n'
+import { type RealtimeScribeSession, startRealtimeScribe } from '@/lib/realtime-scribe'
 import { startThinkingSound, stopThinkingSound } from '@/lib/thinking-sound'
 import { monitorSpeechDuringPlayback } from '@/lib/voice-barge-in'
 import {
@@ -69,6 +70,13 @@ export function useVoiceConversation({
   const responseIdRef = useRef<string | null>(null)
   const spokenSourceLengthRef = useRef(0)
   const speechSessionRef = useRef<null | SpeechStreamSession>(null)
+  const realtimeScribeRef = useRef<null | RealtimeScribeSession>(null)
+  const realtimeStartingRef = useRef<null | Promise<RealtimeScribeSession | null>>(null)
+  const realtimeTurnPendingRef = useRef(false)
+  const realtimeGenerationRef = useRef(0)
+  // Once realtime setup fails, stay on the proven record/upload path for this
+  // conversation instead of minting a new token on every listen cycle.
+  const realtimeUnavailableRef = useRef(false)
   const stopBargeMonitorRef = useRef<(() => void) | null>(null)
   const bargeCapturePendingRef = useRef(false)
   const bargedRef = useRef(false)
@@ -203,10 +211,129 @@ export function useVoiceConversation({
     [handle, onSubmit, onTranscribeAudio, voiceCopy.transcriptionFailed]
   )
 
+  const submitRealtimeTranscript = useCallback(
+    async (rawText: string) => {
+      const transcript = rawText.trim()
+
+      if (
+        !transcript ||
+        realtimeTurnPendingRef.current ||
+        !enabledRef.current ||
+        mutedRef.current ||
+        busyRef.current
+      ) {
+        return
+      }
+
+      realtimeTurnPendingRef.current = true
+      clearTurnTimeout()
+      realtimeScribeRef.current?.mute()
+
+      if (isVoiceStopCommand(transcript)) {
+        realtimeTurnPendingRef.current = false
+        setStatus('idle')
+        onStopWordRef.current?.()
+
+        return
+      }
+
+      try {
+        awaitingSpokenResponseRef.current = true
+        dropSpeechSession()
+        setStatus('thinking')
+        await onSubmit(transcript)
+      } catch (error) {
+        awaitingSpokenResponseRef.current = false
+        notifyError(error, voiceCopy.transcriptionFailed)
+        pendingStartRef.current = true
+        setStatus('idle')
+      } finally {
+        realtimeTurnPendingRef.current = false
+      }
+    },
+    [onSubmit, voiceCopy.transcriptionFailed]
+  )
+
+  const failRealtimeSession = useCallback(() => {
+    const session = realtimeScribeRef.current
+
+    realtimeGenerationRef.current += 1
+    realtimeScribeRef.current = null
+    realtimeStartingRef.current = null
+    realtimeUnavailableRef.current = true
+    session?.close()
+
+    if (
+      enabledRef.current &&
+      !mutedRef.current &&
+      !busyRef.current &&
+      statusRef.current === 'listening'
+    ) {
+      setStatus('idle')
+      pendingStartRef.current = true
+    }
+  }, [])
+
   const startListening = useCallback(async () => {
     pendingStartRef.current = false
 
     if (!enabledRef.current || mutedRef.current || busyRef.current) {
+      return
+    }
+
+    // Let wake-word capture release the microphone before either realtime
+    // Scribe or the batch recorder opens it.
+    try {
+      await beforeMicOpenRef.current?.()
+    } catch {
+      // A pause failure shouldn't block the user's explicit start.
+    }
+
+    if (!enabledRef.current || mutedRef.current || busyRef.current) {
+      return
+    }
+
+    // ElevenLabs Scribe Realtime owns a persistent microphone stream for the
+    // whole voice conversation. Keep the batch recorder as an automatic
+    // fallback for other providers, older backends, or connection failures.
+    if (
+      !realtimeUnavailableRef.current &&
+      !realtimeScribeRef.current &&
+      !realtimeStartingRef.current
+    ) {
+      realtimeStartingRef.current = startRealtimeScribe({
+        onCommitted: text => void submitRealtimeTranscript(text),
+        onError: failRealtimeSession,
+        silenceSeconds: 1
+      })
+    }
+
+    if (realtimeStartingRef.current) {
+      const generation = realtimeGenerationRef.current
+      const starting = realtimeStartingRef.current
+      const session = await starting
+
+      if (
+        generation !== realtimeGenerationRef.current ||
+        starting !== realtimeStartingRef.current ||
+        !enabledRef.current ||
+        mutedRef.current ||
+        busyRef.current
+      ) {
+        session?.close()
+
+        return
+      }
+
+      realtimeScribeRef.current = session
+      realtimeStartingRef.current = null
+      realtimeUnavailableRef.current = session === null
+    }
+
+    if (realtimeScribeRef.current) {
+      realtimeScribeRef.current.unmute()
+      setStatus('listening')
+
       return
     }
 
@@ -218,16 +345,8 @@ export function useVoiceConversation({
       return
     }
 
-    // Let the wake-word listener fully release the capture device before we
-    // open ours — opening the mic while wake still holds it makes getUserMedia
-    // fail (the "clicked voice but it never starts listening" bug).
-    try {
-      await beforeMicOpenRef.current?.()
-    } catch {
-      // A pause failure shouldn't block the user's explicit start.
-    }
-
-    // enabled/muted/busy or an interleaved turn may have changed while we waited.
+    // enabled/muted/busy or an interleaved turn may have changed while realtime
+    // discovery/fallback selection ran.
     if (!enabledRef.current || mutedRef.current || busyRef.current || statusRef.current !== 'idle') {
       return
     }
@@ -259,7 +378,15 @@ export function useVoiceConversation({
       setStatus('idle')
       onFatalError?.()
     }
-  }, [handle, handleTurn, onFatalError, voiceCopy.couldNotStartSession, voiceCopy.microphoneFailed])
+  }, [
+    failRealtimeSession,
+    handle,
+    handleTurn,
+    onFatalError,
+    submitRealtimeTranscript,
+    voiceCopy.couldNotStartSession,
+    voiceCopy.microphoneFailed
+  ])
 
   const settleAfterSpeech = useCallback(
     (barged: boolean, stoppedDuringSetup = false) => {
@@ -604,6 +731,12 @@ export function useVoiceConversation({
     clearTurnTimeout()
     stopVoicePlayback()
     handle.cancel()
+    realtimeGenerationRef.current += 1
+    realtimeScribeRef.current?.close()
+    realtimeScribeRef.current = null
+    realtimeStartingRef.current = null
+    realtimeTurnPendingRef.current = false
+    realtimeUnavailableRef.current = false
     turnClosingRef.current = false
     awaitingSpokenResponseRef.current = false
     dropSpeechSession()
@@ -614,7 +747,11 @@ export function useVoiceConversation({
 
   const stopTurn = useCallback(() => {
     if (statusRef.current === 'listening') {
-      void handleTurn(true)
+      if (realtimeScribeRef.current) {
+        realtimeScribeRef.current.commit()
+      } else {
+        void handleTurn(true)
+      }
     }
   }, [handleTurn])
 
@@ -625,6 +762,7 @@ export function useVoiceConversation({
       if (next) {
         clearTurnTimeout()
         handle.cancel()
+        realtimeScribeRef.current?.mute()
         setStatus('idle')
       } else if (enabledRef.current && !busyRef.current && statusRef.current === 'idle') {
         pendingStartRef.current = true

--- a/apps/desktop/src/lib/realtime-scribe.test.ts
+++ b/apps/desktop/src/lib/realtime-scribe.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { setApiRequestConnection, setApiRequestProfile } from '@/hermes'
+
+const { connect } = vi.hoisted(() => ({ connect: vi.fn() }))
+
+vi.mock('@elevenlabs/client', () => ({
+  AudioFormat: { PCM_16000: 'pcm_16000' },
+  CommitStrategy: { VAD: 'vad' },
+  RealtimeEvents: {
+    CLOSE: 'close',
+    COMMITTED_TRANSCRIPT: 'committed_transcript',
+    ERROR: 'error',
+    OPEN: 'open',
+    PARTIAL_TRANSCRIPT: 'partial_transcript'
+  },
+  Scribe: { connect }
+}))
+
+import { startRealtimeScribe } from './realtime-scribe'
+
+function mockDesktopApi(response: unknown) {
+  const api = vi.fn(async () => response)
+  Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: { api } })
+
+  return api
+}
+
+describe('startRealtimeScribe', () => {
+  afterEach(() => {
+    connect.mockReset()
+    setApiRequestConnection(null)
+    setApiRequestProfile(null)
+    Reflect.deleteProperty(window, 'hermesDesktop')
+  })
+
+  it('mints a scoped token and opens a VAD microphone connection', async () => {
+    const listeners = new Map<string, (data?: unknown) => void>()
+    let muted = false
+
+    const connection = {
+      close: vi.fn(),
+      commit: vi.fn(),
+      get isMuted() {
+        return muted
+      },
+      mute: vi.fn(() => {
+        muted = true
+      }),
+      on: vi.fn((event: string, listener: (data?: unknown) => void) => listeners.set(event, listener)),
+      unmute: vi.fn(() => {
+        muted = false
+      })
+    }
+
+    connect.mockReturnValue(connection)
+
+    const api = mockDesktopApi({
+      ok: true,
+      token: 'sutkn_one_use',
+      websocket_url: 'wss://api.elevenlabs.io',
+      model: 'scribe_v2_realtime',
+      language: 'en'
+    })
+
+    setApiRequestConnection('remote')
+    setApiRequestProfile('default')
+    const committed = vi.fn()
+
+    const pending = startRealtimeScribe({ onCommitted: committed })
+    await vi.waitFor(() => expect(listeners.has('open')).toBe(true))
+    listeners.get('open')?.()
+    const session = await pending
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: 'remote', path: '/api/audio/scribe-token', profile: 'default' })
+    )
+    expect(connect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: 'sutkn_one_use',
+        modelId: 'scribe_v2_realtime',
+        baseUri: 'wss://api.elevenlabs.io',
+        commitStrategy: 'vad',
+        vadSilenceThresholdSecs: 1,
+        microphone: expect.objectContaining({ echoCancellation: true, noiseSuppression: true })
+      })
+    )
+
+    listeners.get('committed_transcript')?.({ text: '  hello there  ' })
+    expect(committed).toHaveBeenCalledWith('hello there')
+    session?.mute()
+    session?.unmute()
+    session?.commit()
+    session?.close()
+    expect(connection.mute).toHaveBeenCalled()
+    expect(connection.unmute).toHaveBeenCalled()
+    expect(connection.commit).toHaveBeenCalled()
+    expect(connection.close).toHaveBeenCalled()
+  })
+
+  it('returns null when the backend cannot mint a token', async () => {
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { api: vi.fn(async () => Promise.reject(new Error('409'))) }
+    })
+
+    await expect(startRealtimeScribe({ onCommitted: vi.fn() })).resolves.toBeNull()
+    expect(connect).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/lib/realtime-scribe.ts
+++ b/apps/desktop/src/lib/realtime-scribe.ts
@@ -1,0 +1,147 @@
+import { CommitStrategy, RealtimeEvents, Scribe } from '@elevenlabs/client'
+
+import { profileScoped } from '@/api/client'
+import { hermesApi } from '@/hermes'
+
+interface TokenResponse {
+  ok: boolean
+  language?: null | string
+  model: string
+  token: string
+  websocket_url: string
+}
+
+export interface RealtimeScribeSession {
+  close: () => void
+  commit: () => void
+  mute: () => void
+  unmute: () => void
+}
+
+export interface RealtimeScribeOptions {
+  onCommitted: (text: string) => void
+  onError?: (error: Error) => void
+  onPartial?: (text: string) => void
+  silenceSeconds?: number
+}
+
+/**
+ * Open one persistent ElevenLabs Scribe connection for a voice conversation.
+ * Returns null when realtime isn't available so callers retain the existing
+ * record/upload transcription path as a compatibility fallback.
+ */
+export async function startRealtimeScribe({
+  onCommitted,
+  onError,
+  onPartial,
+  silenceSeconds = 1
+}: RealtimeScribeOptions): Promise<RealtimeScribeSession | null> {
+  let token: TokenResponse
+
+  try {
+    token = await hermesApi<TokenResponse>({
+      ...profileScoped(),
+      method: 'POST',
+      path: '/api/audio/scribe-token'
+    })
+  } catch {
+    return null
+  }
+
+  if (!token?.ok || !token.token || !token.websocket_url) {
+    return null
+  }
+
+  let connection: ReturnType<typeof Scribe.connect>
+
+  try {
+    connection = Scribe.connect({
+      token: token.token,
+      modelId: token.model || 'scribe_v2_realtime',
+      baseUri: token.websocket_url,
+      languageCode: token.language || undefined,
+      commitStrategy: CommitStrategy.VAD,
+      vadSilenceThresholdSecs: silenceSeconds,
+      vadThreshold: 0.4,
+      minSpeechDurationMs: 100,
+      minSilenceDurationMs: 100,
+      noVerbatim: true,
+      microphone: {
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+        channelCount: 1
+      }
+    })
+  } catch {
+    return null
+  }
+
+  let openedSuccessfully = false
+  let closing = false
+  let terminalNotified = false
+
+  const notifyTerminal = (error: Error) => {
+    if (openedSuccessfully && !closing && !terminalNotified) {
+      terminalNotified = true
+      onError?.(error)
+    }
+  }
+
+  connection.on(RealtimeEvents.PARTIAL_TRANSCRIPT, data => onPartial?.(data.text.trim()))
+  connection.on(RealtimeEvents.COMMITTED_TRANSCRIPT, data => {
+    const text = data.text.trim()
+
+    if (text) {
+      onCommitted(text)
+    }
+  })
+  connection.on(RealtimeEvents.ERROR, data => {
+    notifyTerminal(new Error(data.error || 'Realtime transcription failed'))
+  })
+  connection.on(RealtimeEvents.CLOSE, () => notifyTerminal(new Error('Realtime transcription closed')))
+
+  // A single-use token is consumed while the WebSocket opens. Do not report a
+  // ready session until that succeeds; callers may safely fall back on failure.
+  const opened = new Promise<boolean>(resolve => {
+    let settled = false
+
+    const finish = (value: boolean) => {
+      if (!settled) {
+        settled = true
+        resolve(value)
+      }
+    }
+
+    connection.on(RealtimeEvents.OPEN, () => finish(true))
+    connection.on(RealtimeEvents.CLOSE, () => finish(false))
+    connection.on(RealtimeEvents.ERROR, () => finish(false))
+    window.setTimeout(() => finish(false), 10_000)
+  })
+
+  if (!(await opened)) {
+    connection.close()
+
+    return null
+  }
+
+  openedSuccessfully = true
+
+  return {
+    close: () => {
+      closing = true
+      connection.close()
+    },
+    commit: () => connection.commit(),
+    mute: () => {
+      if (!connection.isMuted) {
+        connection.mute()
+      }
+    },
+    unmute: () => {
+      if (connection.isMuted) {
+        connection.unmute()
+      }
+    }
+  }
+}

--- a/apps/desktop/src/lib/speech-text.test.ts
+++ b/apps/desktop/src/lib/speech-text.test.ts
@@ -3,6 +3,15 @@ import { describe, expect, it } from 'vitest'
 import { sanitizeTextForSpeech } from './speech-text'
 
 describe('sanitizeTextForSpeech', () => {
+  it('omits native media attachment directives instead of reading file paths aloud', () => {
+    expect(
+      sanitizeTextForSpeech(
+        'Here you go.\nMEDIA:/Users/example/.hermes/cache/audio/tts_20260824_182426_116072.mp3'
+      )
+    ).toBe('Here you go.')
+    expect(sanitizeTextForSpeech('MEDIA:/Users/example/voice memo.mp3')).toBe('')
+  })
+
   it('summarizes fenced code blocks instead of reading them literally', () => {
     expect(sanitizeTextForSpeech('Here is code:\n```ts\nconst x = 1\n```\nDone.')).toBe(
       'Here is code: code block omitted Done.'

--- a/apps/desktop/src/lib/speech-text.ts
+++ b/apps/desktop/src/lib/speech-text.ts
@@ -12,6 +12,10 @@ const THINKING_PREFIX_RE =
   /^\s*(?:\([^)\n]{1,48}\)\s*)?(?:processing|thinking|reasoning|analyzing|pondering|contemplating|musing|cogitating|ruminating|deliberating|mulling|reflecting|computing|synthesizing|formulating|brainstorming)\.\.\.\s*/i
 
 const URL_RE = /\bhttps?:\/\/\S+/gi
+// MEDIA lines are native attachment directives, not prose. Strip the whole
+// line before newline normalization so voice playback never spells a local
+// filename while the UI separately renders/plays the attachment.
+const MEDIA_DIRECTIVE_LINE_RE = /^\s*(?:\[\[audio_as_voice\]\]\s*)?MEDIA:.*$/gim
 
 const MARKDOWN_TABLE_DELIMITER_CELL_RE = /^:?-{3,}:?$/
 
@@ -152,7 +156,7 @@ function normalizeLineBreaks(text: string): string {
 }
 
 export function sanitizeTextForSpeech(text: string): string {
-  return normalizeLineBreaks(stripMarkdownTables(text))
+  return normalizeLineBreaks(stripMarkdownTables(text.replace(MEDIA_DIRECTIVE_LINE_RE, '')))
     .replace(FENCED_CODE_RE, CODE_BLOCK_SUMMARY)
     .replace(THINKING_PREFIX_RE, ' ')
     .replace(MARKDOWN_LINK_RE, '$1')

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5302,6 +5302,70 @@ async def get_client_voice_config(profile: Optional[str] = None):
     return {"ok": True, **result}
 
 
+@app.post("/api/audio/scribe-token")
+async def create_realtime_scribe_token(profile: Optional[str] = None):
+    """Mint a short-lived ElevenLabs token for client-side realtime STT.
+
+    The desktop must never put the profile's long-lived ElevenLabs API key in a
+    WebSocket URL.  This authenticated route resolves that key server-side and
+    exchanges it for a single-use ``realtime_scribe`` token (15 minute expiry).
+    """
+    from tools.voice_client_config import resolve_client_voice_config
+
+    def _mint_scoped():
+        with _config_profile_scope(profile):
+            voice_config = resolve_client_voice_config()
+        stt = voice_config.get("stt") or {}
+        if (
+            stt.get("mode") != "direct"
+            or stt.get("provider") != "elevenlabs"
+            or not stt.get("api_key")
+        ):
+            raise HTTPException(
+                status_code=409,
+                detail="ElevenLabs client-direct STT is not configured",
+            )
+
+        import requests
+
+        base_url = str(stt.get("base_url") or "https://api.elevenlabs.io/v1").rstrip("/")
+        response = requests.post(
+            f"{base_url}/single-use-token/realtime_scribe",
+            headers={"xi-api-key": stt["api_key"]},
+            timeout=15,
+        )
+        response.raise_for_status()
+        token = str((response.json() or {}).get("token") or "").strip()
+        if not token:
+            raise ValueError("ElevenLabs returned an empty realtime token")
+
+        origin = base_url[:-3] if base_url.endswith("/v1") else base_url
+        websocket_origin = (
+            origin.replace("https://", "wss://", 1)
+            .replace("http://", "ws://", 1)
+        )
+        language = stt.get("language") or None
+        return {
+            "ok": True,
+            "token": token,
+            # The ElevenLabs browser SDK appends the realtime path itself.
+            "websocket_url": websocket_origin,
+            "model": "scribe_v2_realtime",
+            "language": language,
+        }
+
+    try:
+        return await asyncio.get_running_loop().run_in_executor(None, _mint_scoped)
+    except HTTPException:
+        raise
+    except Exception:
+        # Do not include the upstream exception: provider errors can echo URLs
+        # or credentials, and this route exists specifically to keep the
+        # long-lived key out of the renderer and logs.
+        _log.warning("Could not mint ElevenLabs realtime Scribe token")
+        raise HTTPException(status_code=502, detail="Could not start realtime transcription")
+
+
 def _elevenlabs_voice_label(voice: Dict[str, Any]) -> str:
     name = str(voice.get("name") or voice.get("voice_id") or "Voice").strip()
     category = str(voice.get("category") or "").strip()

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
         "@dnd-kit/core": "6.3.1",
         "@dnd-kit/sortable": "10.0.0",
         "@dnd-kit/utilities": "3.2.2",
+        "@elevenlabs/client": "1.21.0",
         "@hermes/shared": "file:../shared",
         "@icons-pack/react-simple-icons": "13.11.1",
         "@lezer/highlight": "1.2.3",
@@ -758,6 +759,7 @@
       "resolved": "https://registry.npmjs.org/@assistant-ui/store/-/store-0.2.22.tgz",
       "integrity": "sha512-RdUFLOFJ3ZwIoOZYrRvps3OAODwnWoUAuNfqbROKrj5qtlQsIJRqxUNdLTjcf4AimhkjCwOaFacGHHm9lE4qBw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "use-effect-event": "^2.0.3"
       },
@@ -777,6 +779,7 @@
       "resolved": "https://registry.npmjs.org/@assistant-ui/tap/-/tap-0.9.8.tgz",
       "integrity": "sha512-pajYWHwvsApAyEtK/TDSr2J2O6/fV1M+ZOmmkKM8apoE6JrC6F8IVKCU1b9rMkB0RidM2lrQxFpN9Ujw3mKEGQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "*",
         "react": "^18 || ^19"
@@ -837,6 +840,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1073,6 +1077,12 @@
       "bin": {
         "specificity": "bin/cli.js"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@chenglou/pretext": {
       "version": "0.0.6",
@@ -1564,6 +1574,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1612,6 +1623,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1633,6 +1645,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -2028,7 +2041,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -2050,7 +2062,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2067,7 +2078,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -2082,10 +2092,25 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/@elevenlabs/client": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/client/-/client-1.21.0.tgz",
+      "integrity": "sha512-K/xMfsHSPYHK6xM3RISP6RME4nTGeEGONXHGa6VfiUuOUUiqZKXEyr491iZkCugWicNlTXkmR5haV8J0fyfUaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@elevenlabs/types": "0.21.1",
+        "livekit-client": "^2.21.0"
+      }
+    },
+    "node_modules/@elevenlabs/types": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/types/-/types-0.21.1.tgz",
+      "integrity": "sha512-g5kRS00t+u8oHiyt27naWEMkKGmel9MH49ElNesOPKH2bPDBJvivzw9rOS3rh8g/cci2dK087HP/0JcNGY4xiw==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "2.0.0-alpha.3",
@@ -2137,7 +2162,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2154,7 +2178,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2171,7 +2194,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2188,7 +2210,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2205,7 +2226,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2222,7 +2242,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2239,7 +2258,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2256,7 +2274,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2273,7 +2290,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2290,7 +2306,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2307,7 +2322,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2324,7 +2338,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2341,7 +2354,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2358,7 +2370,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2375,7 +2386,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2392,7 +2402,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2409,7 +2418,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2426,7 +2434,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2443,7 +2450,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2460,7 +2466,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2477,7 +2482,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2494,7 +2498,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2511,7 +2514,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2528,7 +2530,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2545,7 +2546,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2562,7 +2562,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2615,7 +2614,6 @@
       "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
@@ -2631,7 +2629,6 @@
       "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/core": "^1.2.1"
       },
@@ -2645,7 +2642,6 @@
       "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -2672,7 +2668,6 @@
       "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
@@ -2683,7 +2678,6 @@
       "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
@@ -2824,7 +2818,6 @@
       "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@humanfs/types": "^0.15.0"
       },
@@ -2838,7 +2831,6 @@
       "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@humanfs/core": "^0.19.2",
         "@humanfs/types": "^0.15.0",
@@ -2854,7 +2846,6 @@
       "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18.0"
       }
@@ -2865,7 +2856,6 @@
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -2880,7 +2870,6 @@
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -3226,6 +3215,21 @@
         "@lezer/lr": "^1.4.0"
       }
     },
+    "node_modules/@livekit/mutex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz",
+      "integrity": "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.50.4",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.50.4.tgz",
+      "integrity": "sha512-L1uggNQAqyY21smQY8AllyOYbcv9Me9TaxwuLytL1R8ck9nbYPmQLNwEDi3pOFGAMa5F8I2nUi2Jc59W5awxlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
@@ -3551,6 +3555,7 @@
       "resolved": "https://registry.npmjs.org/@observablehq/plot/-/plot-0.6.17.tgz",
       "integrity": "sha512-/qaXP/7mc4MUS0s4cPPFASDRjtsWp85/TbfsciqDgU1HwYixbSbbytNuInD8AcTYC3xaxACgVX06agdfQy9W+g==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d3": "^7.9.0",
         "interval-tree-1d": "^1.0.0",
@@ -5166,6 +5171,7 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
       "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -5602,6 +5608,7 @@
       "resolved": "https://registry.npmjs.org/@streamdown/code/-/code-1.1.1.tgz",
       "integrity": "sha512-i7HTNuDgZWb+VdrNVOam9gQhIc5MSSDXKWXgbUrn/4vSRaSMM+Rtl10MQj4wLWPNpF7p80waJsAqFP8HZfb0Jg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "shiki": "^3.19.0"
       },
@@ -5691,6 +5698,7 @@
       "resolved": "https://registry.npmjs.org/@streamdown/math/-/math-1.0.2.tgz",
       "integrity": "sha512-r8Ur9/lBuFnzZAFdEWrLUF2s/gRwRRRwruqltdZibyjbCBnuW7SJbFm26nXqvpJPW/gzpBUMrBVBzd88z05D5g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "katex": "^0.16.27",
         "rehype-katex": "^7.0.1",
@@ -6330,6 +6338,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -6717,13 +6726,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/dom-mediacapture-record": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
+      "integrity": "sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
       "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -6791,8 +6806,7 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/katex": {
       "version": "0.16.8",
@@ -6831,6 +6845,7 @@
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -6969,6 +6984,7 @@
       "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.64.0",
         "@typescript-eslint/types": "8.64.0",
@@ -7425,7 +7441,6 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -7470,7 +7485,6 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -7487,7 +7501,6 @@
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
       "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "environment": "^1.0.0"
       },
@@ -7845,6 +7858,7 @@
       "resolved": "https://registry.npmjs.org/assistant-cloud/-/assistant-cloud-0.1.37.tgz",
       "integrity": "sha512-cofr0dM/mRyHZKwIDhMxX8xvZNWd078PM77eBdxbuuzxTa6aXYm5E+rq6q92RZF10CAMn+Ruir3vhjsVg7kZ0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assistant-stream": "^0.3.28"
       }
@@ -8111,6 +8125,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001803",
@@ -8589,7 +8604,6 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
       "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "restore-cursor": "^4.0.0"
       },
@@ -8605,7 +8619,6 @@
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-6.1.1.tgz",
       "integrity": "sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "slice-ansi": "^9.0.0",
         "string-width": "^8.2.0"
@@ -8859,8 +8872,7 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
@@ -8980,6 +8992,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -9389,6 +9402,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9583,8 +9597,7 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -9750,6 +9763,7 @@
       "integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.15.3",
         "builder-util": "26.15.3",
@@ -10330,7 +10344,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -10351,7 +10364,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -10404,16 +10416,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -10464,7 +10466,6 @@
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
       "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -10746,7 +10747,6 @@
       "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@types/esrecurse": "^4.3.1",
         "@types/estree": "^1.0.8",
@@ -10779,7 +10779,6 @@
       "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
@@ -10798,7 +10797,6 @@
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -10812,7 +10810,6 @@
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -10826,7 +10823,6 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -10857,9 +10853,17 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/expect-type": {
@@ -10938,16 +10942,14 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.5",
@@ -10995,7 +10997,6 @@
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flat-cache": "^4.0.0"
       },
@@ -11044,7 +11045,6 @@
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -11062,7 +11062,6 @@
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.4"
@@ -11076,8 +11075,7 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -11617,7 +11615,6 @@
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -11751,7 +11748,8 @@
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.15.0.tgz",
       "integrity": "sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==",
-      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license.",
+      "peer": true
     },
     "node_modules/hachure-fill": {
       "version": "0.5.2",
@@ -12308,7 +12306,6 @@
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -12369,7 +12366,6 @@
       "resolved": "https://registry.npmjs.org/ink/-/ink-7.1.1.tgz",
       "integrity": "sha512-Y43xxa1ZSPvpmfLHcN5o+OdP8Rf8ykkNJEuKYOUNZKT8wXVNLFTtEm1nSDMQkfBH+YANF4Xuu0hhZ4ejqAtN2w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.3.0",
         "ansi-escapes": "^7.3.0",
@@ -12419,6 +12415,7 @@
       "resolved": "https://registry.npmjs.org/ink-text-input/-/ink-text-input-6.0.0.tgz",
       "integrity": "sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^5.3.0",
         "type-fest": "^4.18.2"
@@ -12436,7 +12433,6 @@
       "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.3.0.tgz",
       "integrity": "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^6.2.1",
         "is-fullwidth-code-point": "^5.0.0"
@@ -12450,7 +12446,6 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-4.0.1.tgz",
       "integrity": "sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.20 <19 || >=20.10"
       },
@@ -12463,7 +12458,6 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
       "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "get-east-asian-width": "^1.3.1"
       },
@@ -12478,15 +12472,13 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/ink/node_modules/type-fest": {
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
       "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "dependencies": {
         "tagged-tag": "^1.0.0"
       },
@@ -12502,7 +12494,6 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
       "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^6.2.3",
         "string-width": "^8.2.0",
@@ -12629,7 +12620,6 @@
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12652,7 +12642,6 @@
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -12675,7 +12664,6 @@
       "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-2.0.0.tgz",
       "integrity": "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "is-in-ci": "cli.js"
       },
@@ -12850,6 +12838,15 @@
         "node": ">= 20"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+      "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -12981,16 +12978,14 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -13090,6 +13085,7 @@
       "resolved": "https://registry.npmjs.org/leva/-/leva-0.10.1.tgz",
       "integrity": "sha512-BcjnfUX8jpmwZUz2L7AfBtF9vn4ggTH33hmeufDULbP3YgNZ/C+ss/oO3stbrqRQyaOmRwy70y7BGTGO81S3rA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@radix-ui/react-portal": "^1.1.4",
         "@radix-ui/react-tooltip": "^1.1.8",
@@ -13131,7 +13127,6 @@
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -13389,13 +13384,32 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/livekit-client": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.22.0.tgz",
+      "integrity": "sha512-GLtYQfRh/RsvXaOX1x609bFZ17yyKmKWDqu9JmkMKn9vIFLi2GsapRv9gT8OJO/1R2dsitrkbGmloyUfxWQsaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/mutex": "1.1.1",
+        "@livekit/protocol": "1.50.4",
+        "events": "^3.3.0",
+        "jose": "^6.1.0",
+        "loglevel": "^1.9.2",
+        "sdp-transform": "^2.15.0",
+        "tslib": "2.8.1",
+        "typed-emitter": "^2.1.0",
+        "webrtc-adapter": "9.0.6"
+      },
+      "peerDependencies": {
+        "@types/dom-mediacapture-record": "^1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -13424,6 +13438,19 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -14572,7 +14599,6 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -14819,7 +14845,6 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -14832,6 +14857,7 @@
       "resolved": "https://registry.npmjs.org/motion/-/motion-12.42.2.tgz",
       "integrity": "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "framer-motion": "^12.42.2",
         "tslib": "^2.4.0"
@@ -14903,6 +14929,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -15228,7 +15255,6 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -15262,7 +15288,6 @@
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -15307,7 +15332,6 @@
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -15404,7 +15428,6 @@
       "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
       "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -15638,7 +15661,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -15656,7 +15678,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -15667,7 +15688,6 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -16154,6 +16174,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16235,6 +16256,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -16721,7 +16743,6 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
       "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -16737,8 +16758,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/retry": {
       "version": "0.12.0",
@@ -16757,7 +16777,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -16795,6 +16814,7 @@
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.1.tgz",
       "integrity": "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.142.0",
         "@rolldown/pluginutils": "^1.0.0"
@@ -16845,7 +16865,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -16972,6 +16992,21 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/sdp": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz",
+      "integrity": "sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==",
+      "license": "MIT"
+    },
+    "node_modules/sdp-transform": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz",
+      "integrity": "sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==",
+      "license": "MIT",
+      "bin": {
+        "sdp-verify": "checker.js"
+      }
     },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",
@@ -17202,7 +17237,6 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-9.0.0.tgz",
       "integrity": "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^6.2.3",
         "is-fullwidth-code-point": "^5.1.0"
@@ -17219,7 +17253,6 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
       "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "get-east-asian-width": "^1.3.1"
       },
@@ -17457,7 +17490,6 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
       "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "get-east-asian-width": "^1.5.0",
         "strip-ansi": "^7.1.2"
@@ -17675,7 +17707,6 @@
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
       "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -17697,7 +17728,8 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
       "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.3",
@@ -17745,7 +17777,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -17808,7 +17839,6 @@
       "resolved": "https://registry.npmjs.org/terminal-size/-/terminal-size-4.0.1.tgz",
       "integrity": "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -17820,7 +17850,8 @@
       "version": "0.180.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
       "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tiny-async-pool": {
       "version": "1.3.0",
@@ -18047,7 +18078,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -18076,7 +18106,6 @@
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -18096,12 +18125,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "rxjs": "*"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18404,7 +18443,6 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -18624,6 +18662,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
       "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
@@ -18978,6 +19017,19 @@
         "node": ">=20"
       }
     },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.6.tgz",
+      "integrity": "sha512-CHbl2ZQbxx164IgWRgzJno4hWtM4tFbRam1QfI3Yxhs3w/DvqluVxVWeXs3oL5/fbGkSNLKo0Ty5MgUWceNhog==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
+      }
+    },
     "node_modules/whatwg-mimetype": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
@@ -19102,7 +19154,6 @@
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-6.0.0.tgz",
       "integrity": "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "string-width": "^8.1.0"
       },
@@ -19119,7 +19170,6 @@
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19250,7 +19300,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
       "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -19387,14 +19436,14 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -19417,6 +19466,7 @@
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
       "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.20.0"
       },
@@ -19637,6 +19687,7 @@
       "integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^8.0.0",
         "@babel/generator": "^8.0.0",

--- a/tests/hermes_cli/test_web_server_scribe_token.py
+++ b/tests/hermes_cli/test_web_server_scribe_token.py
@@ -1,0 +1,118 @@
+"""/api/audio/scribe-token — scoped ElevenLabs realtime credentials."""
+
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+
+from hermes_cli import web_server
+
+
+@pytest.fixture
+def client(monkeypatch, _isolate_hermes_home):
+    previous_auth_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.auth_required = False
+    test_client = TestClient(web_server.app)
+    test_client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    try:
+        yield test_client
+    finally:
+        test_client.close()
+        if previous_auth_required is None:
+            if hasattr(web_server.app.state, "auth_required"):
+                delattr(web_server.app.state, "auth_required")
+        else:
+            web_server.app.state.auth_required = previous_auth_required
+
+
+class _Response:
+    status_code = 200
+    text = '{"token":"sutkn_secret"}'
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return {"token": "sutkn_secret"}
+
+
+def test_mints_realtime_token_without_returning_long_lived_key(client, monkeypatch):
+    monkeypatch.setattr(
+        "tools.voice_client_config.resolve_client_voice_config",
+        lambda: {
+            "stt": {
+                "mode": "direct",
+                "wire": "elevenlabs-stt",
+                "provider": "elevenlabs",
+                "base_url": "https://api.elevenlabs.io/v1",
+                "api_key": "el_long_lived",
+                "model": "scribe_v2",
+                "language": "en",
+            },
+            "tts": {"mode": "relay"},
+        },
+    )
+    calls = []
+
+    def fake_post(url, *, headers, timeout):
+        calls.append((url, headers, timeout))
+        return _Response()
+
+    monkeypatch.setattr("requests.post", fake_post)
+
+    response = client.post("/api/audio/scribe-token")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload == {
+        "ok": True,
+        "token": "sutkn_secret",
+        "websocket_url": "wss://api.elevenlabs.io",
+        "model": "scribe_v2_realtime",
+        "language": "en",
+    }
+    assert "el_long_lived" not in response.text
+    assert calls == [
+        (
+            "https://api.elevenlabs.io/v1/single-use-token/realtime_scribe",
+            {"xi-api-key": "el_long_lived"},
+            15,
+        )
+    ]
+
+
+def test_non_elevenlabs_provider_returns_409(client, monkeypatch):
+    monkeypatch.setattr(
+        "tools.voice_client_config.resolve_client_voice_config",
+        lambda: {"stt": {"mode": "direct", "provider": "groq"}, "tts": {"mode": "relay"}},
+    )
+
+    response = client.post("/api/audio/scribe-token")
+
+    assert response.status_code == 409
+    assert "ElevenLabs" in response.json()["detail"]
+
+
+def test_upstream_failure_does_not_leak_api_key(client, monkeypatch):
+    monkeypatch.setattr(
+        "tools.voice_client_config.resolve_client_voice_config",
+        lambda: {
+            "stt": {
+                "mode": "direct",
+                "provider": "elevenlabs",
+                "base_url": "https://api.elevenlabs.io/v1",
+                "api_key": "el_do_not_leak",
+            },
+            "tts": {"mode": "relay"},
+        },
+    )
+
+    def fail(*args, **kwargs):
+        raise RuntimeError("upstream failed for el_do_not_leak")
+
+    monkeypatch.setattr("requests.post", fail)
+
+    response = client.post("/api/audio/scribe-token")
+
+    assert response.status_code == 502
+    assert "el_do_not_leak" not in response.text


### PR DESCRIPTION
## Summary
- add persistent ElevenLabs Scribe Realtime microphone transcription to Desktop voice conversations
- mint single-use Scribe tokens server-side so the long-lived API key never enters the renderer
- retain record/upload STT as a compatibility and runtime-failure fallback
- handle commit, mute, close, connection loss, async startup cancellation, and spoken stop commands
- prevent native MEDIA attachment directives from being spoken aloud

## Security and lifecycle
- upstream failures return a sanitized 502 and omit provider exception text from responses and logs
- pending realtime sessions are closed if voice mode ends, becomes muted, becomes busy, or is superseded
- post-open ERROR/CLOSE events switch the conversation to the batch fallback

## Test plan
- [x] Desktop focused tests: 29 passed
- [x] Backend token endpoint tests: 3 passed
- [x] Desktop TypeScript typecheck
- [x] Focused ESLint
- [x] Full Desktop production build
- [x] Manual microphone conversation, transcript commit, and spoken interruption trial

## Notes
Hermes Cloud currently deploys the upstream product rather than advertising custom-source deployments. Upstreaming this is therefore the clean path for using the same low-latency voice loop with a Nous-hosted cloud agent.