### PR TITLE
fix(desktop): keep venv symlink interpreter in .desktop Exec

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -77,12 +77,15 @@ def resolve_exec_command() -> str:
             # shebang resolves to the SYSTEM python and dies on the first
             # third-party import (#90292) — silently, since Terminal=false.
             # sys.executable is the interpreter actually running Hermes (the
-            # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            # venv one), so prefix it explicitly. Keep it UNRESOLVED: a venv
+            # `bin/python` is commonly a symlink into a shared toolchain (uv,
+            # pyenv, conda) and resolving it loses the venv, so the spawned
+            # interpreter would not see Hermes' site-packages.
+            argv = [str(sys.executable), str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        argv = [str(sys.executable), "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
 
 
@@ -106,8 +109,21 @@ def _needs_interpreter(bin_path: Path) -> bool:
     # A python shebang pointing INSIDE the running interpreter's environment
     # already resolves correctly; anything else (``/usr/bin/env python3``,
     # a system path) would escape the venv when spawned by the DE.
-    exe_dir = str(Path(sys.executable).resolve().parent)
-    return exe_dir not in shebang
+    # Compare by resolving both sides: a venv's ``bin/python`` is often a
+    # symlink into a shared toolchain (uv, pyenv, conda), so a shebang that
+    # points at the venv symlink and the running interpreter both resolve to
+    # the same real binary — and must NOT be prefixed (prefixing with the
+    # toolchain's real binary would lose Hermes' site-packages and die with
+    # ``ModuleNotFoundError``). String-compare the raw paths instead and this
+    # venv-symlink shebang is wrongly treated as "outside" the interpreter.
+    real_exe = str(Path(sys.executable).resolve())
+    if not shebang[2:].strip():
+        return False
+    try:
+        real_shebang = str(Path(shebang[2:].split()[0].strip()).resolve())
+    except (OSError, IndexError):
+        real_shebang = ""
+    return real_shebang != real_exe
 
 
 def _quote_exec_arg(arg: str) -> str:

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -107,8 +107,10 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    interpreter = str(Path(sys.executable).resolve())
-    assert exec_line.split(" ")[0].strip('"') == interpreter
+    # Prefix with the UNRESOLVED interpreter: a venv `bin/python` may be a
+    # symlink into a shared toolchain, and resolving it would drop the venv's
+    # site-packages (#venv-symlink-exec).
+    assert exec_line.split(" ")[0].strip('"') == str(sys.executable)
     assert str(hermes_bin) in exec_line
     assert exec_line.endswith("desktop")
 
@@ -146,6 +148,46 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
 
     # Console-script with the venv's own interpreter in the shebang: correct
     # as-is, prefixing would only add noise.
+    assert exec_line == f"{hermes_bin} desktop"
+
+
+def test_exec_leaves_venv_symlink_shebang_alone(tmp_path, xdg_home, monkeypatch):
+    """Regression: a venv whose ``bin/python`` is a symlink into a shared
+    toolchain (uv, pyenv, conda).
+
+    The shebang points at the venv symlink; the running interpreter is the
+    same binary reached through that symlink. Resolving either side yields the
+    toolchain's real binary, so the script's own shebang already loads the
+    venv — the Exec must NOT be prefixed with the resolved toolchain python
+    (which lacks Hermes' site-packages → ModuleNotFoundError on launch).
+    """
+    import sys
+
+    root = _make_project(tmp_path)
+
+    # Fake a shared toolchain binary + a venv symlink pointing at it.
+    toolchain = tmp_path / "toolchain" / "bin" / "python3"
+    toolchain.parent.mkdir(parents=True)
+    toolchain.write_text("", encoding="utf-8")
+    toolchain.chmod(0o755)
+    venv = tmp_path / "venv"
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin" / "python").symlink_to(toolchain)
+
+    hermes_bin = venv / "bin" / "hermes"
+    hermes_bin.write_text(f"#!{venv / 'bin' / 'python'}\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    # The running interpreter must resolve to the same real binary as the
+    # shebang (both reach the toolchain python).
+    monkeypatch.setattr(lde.sys, "executable", str(venv / "bin" / "python"))
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    # No interpreter prefix: the venv symlink shebang is self-sufficient.
     assert exec_line == f"{hermes_bin} desktop"
 
 


### PR DESCRIPTION
## Bug Description

Launching **Hermes Desktop from the app menu** fails silently (`Terminal=false`) right after an update with:

```
ModuleNotFoundError: No module named 'hermes_cli'
```

The app still opens from the terminal (`~/.local/bin/hermes desktop`), which made the failure look environment-specific. This is the "Hermes won't open from the launcher" class that follows #90292.

## Root Cause

`hermes_cli/linux_desktop_entry.py::resolve_exec_command()` resolves `sys.executable` before writing the `Exec=` line into the XDG desktop entry:

```python
argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
```

With a **uv-managed install** (the default for `install.sh`), the venv's `bin/python` is a **symlink** into a shared toolchain:

```
~/.hermes/hermes-agent/venv/bin/python -> ~/.local/share/uv/python/cpython-3.11.15-.../bin/python3.11
```

`.resolve()` follows that symlink and substitutes the toolchain's real binary — which has **no Hermes site-packages**. The generated `Exec=` then runs the script with an interpreter that cannot import `hermes_cli`, and the backend dies before the window ever appears.

The same resolve is applied in `_needs_interpreter()`, which string-matches the *resolved* interpreter's parent directory against the *raw* shebang — so a shebang pointing at the venv symlink is wrongly classified as "outside the environment" and gets the bad prefix.

## Fix

- **`resolve_exec_command()`**: use the **unresolved** `sys.executable` in the interpreter prefix and in the `python -m hermes_cli.main` fallback. The venv symlink (and its site-packages) then survives into the spawned process.
- **`_needs_interpreter()`**: compare the shebang interpreter and `sys.executable` by **resolving both sides** rather than string-matching the resolved dir against the raw shebang. A shebang pointing at the venv symlink resolves to the same real binary as the running interpreter and is now correctly left unprefixed.
- **Regression test**: simulates the uv layout (`venv/bin/python` → toolchain binary) and asserts the `Exec=` stays unprefixed.

## How to Verify

1. Install Hermes via the uv-managed `install.sh` path (venv `bin/python` is a symlink).
2. `grep '^Exec=' ~/.local/share/applications/hermes.desktop`
   - **Before:** `Exec=/home/.../uv/python/.../python3.11 /home/.../venv/bin/hermes desktop` ❌
   - **After:** `Exec=/home/.../venv/bin/hermes desktop` ✅
3. Launch from the app menu — the window opens.

## Test Plan

- [x] Added regression test for this bug (`test_exec_leaves_venv_symlink_shebang_alone`)
- [x] Existing tests still pass (`16 passed, 2 skipped` in `tests/hermes_cli/test_linux_desktop_entry.py`)
- [x] Manual verification of the fix on the affected machine (Fedora/cachyOS, uv-managed venv)

## Risk Assessment

**Low.** The change only affects how the desktop-entry `Exec=` line is rendered:

- Non-symlinked venvs: `sys.executable` and `Path(sys.executable).resolve()` are identical, so behavior is unchanged.
- `_needs_interpreter()` now resolves the shebang interpreter instead of comparing raw paths; all previously-working cases (env shebangs, system python paths, shell wrappers, native binaries) still classify the same way, now with the symlink case fixed.
- Blast radius is confined to Linux desktop-entry generation; CLI/gateway paths are untouched.
