### PR TITLE
fix(photon): suppress the plain-text resend on sidecar_internal 500s

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -259,6 +259,14 @@ _PHOTON_RETRYABLE_PATTERNS = (
     "upstream_unavailable",
 )
 
+# Sidecar error classes for which neither the retry loop nor the plain-text
+# fallback resend may fire: retrying can only double-send (permanent classes,
+# #50971) or double-deliver (ambiguous post-handoff failures, #94117). Keep
+# the docstring of _should_suppress_resend_and_retry in sync with this set.
+_RESEND_SUPPRESSED_CLASSES = frozenset(
+    {"auth_or_config", "target_not_allowed", "sidecar_internal"}
+)
+
 # iMessage may emit the Open Graph preview art for a rich link as one or more
 # image attachments immediately after the URL/richlink message. Suppress those
 # artifacts so Hermes sees the link once, not a follow-up "(attachment)" prompt.
@@ -2398,7 +2406,7 @@ class PhotonAdapter(BasePlatformAdapter):
         return any(pat in lowered for pat in _PHOTON_RETRYABLE_PATTERNS)
 
     @staticmethod
-    def _is_permanent_sidecar_failure(result: SendResult) -> bool:
+    def _should_suppress_resend_and_retry(result: SendResult) -> bool:
         """True when the sidecar failure must not be retried or re-sent.
 
         ``auth_or_config`` and ``target_not_allowed`` cannot be fixed by
@@ -2412,13 +2420,19 @@ class PhotonAdapter(BasePlatformAdapter):
         the plain-text resend then duplicated the reply (issue #94117).
         For a personal channel one silent failure beats one duplicate per
         message, so the ambiguous class suppresses the resend too.
+
+        The ``retryable is False`` precondition means the guard can only
+        fire on classes the sidecar itself declared un-retryable — the
+        in-repo sidecar classifies ``sidecar_internal`` exactly that way
+        (``classifySidecarError`` in ``sidecar/index.mjs``), while the
+        genuinely transient upstream classes come back ``retryable=true``
+        and keep their retry loop.
         """
         raw = result.raw_response
         return (
             isinstance(raw, dict)
             and raw.get("retryable") is False
-            and raw.get("error_class")
-            in ("auth_or_config", "target_not_allowed", "sidecar_internal")
+            and raw.get("error_class") in _RESEND_SUPPRESSED_CLASSES
         )
 
     async def _send_with_retry(
@@ -2446,7 +2460,7 @@ class PhotonAdapter(BasePlatformAdapter):
         if result.success:
             return result
 
-        if self._is_permanent_sidecar_failure(result):
+        if self._should_suppress_resend_and_retry(result):
             # Permanent failure classes: retrying cannot succeed and the
             # unconditional plain-text fallback below would double-send the
             # same doomed request. For ``sidecar_internal`` the send may
@@ -2478,7 +2492,7 @@ class PhotonAdapter(BasePlatformAdapter):
                 if result.success:
                     return result
                 error_str = result.error or ""
-                if self._is_permanent_sidecar_failure(result):
+                if self._should_suppress_resend_and_retry(result):
                     # A retry surfaced a permanent class — don't fall through
                     # to the plain-text resend either.
                     return result

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -2399,17 +2399,26 @@ class PhotonAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _is_permanent_sidecar_failure(result: SendResult) -> bool:
-        """True when the sidecar classified the failure as permanent.
+        """True when the sidecar failure must not be retried or re-sent.
 
         ``auth_or_config`` and ``target_not_allowed`` cannot be fixed by
         retrying or by the plain-text fallback resend — attempting either
         just double-sends a doomed request (issue #50971).
+
+        ``sidecar_internal`` is included fail-closed: the sidecar hit an
+        internal error *after* handing the send to the upstream, so the
+        message may already have been delivered. Spectrum's "Unknown server
+        error occurred" surfaces this class on sends that completed, and
+        the plain-text resend then duplicated the reply (issue #94117).
+        For a personal channel one silent failure beats one duplicate per
+        message, so the ambiguous class suppresses the resend too.
         """
         raw = result.raw_response
         return (
             isinstance(raw, dict)
             and raw.get("retryable") is False
-            and raw.get("error_class") in ("auth_or_config", "target_not_allowed")
+            and raw.get("error_class")
+            in ("auth_or_config", "target_not_allowed", "sidecar_internal")
         )
 
     async def _send_with_retry(
@@ -2440,7 +2449,9 @@ class PhotonAdapter(BasePlatformAdapter):
         if self._is_permanent_sidecar_failure(result):
             # Permanent failure classes: retrying cannot succeed and the
             # unconditional plain-text fallback below would double-send the
-            # same doomed request. Return the structured failure as-is
+            # same doomed request. For ``sidecar_internal`` the send may
+            # already have delivered, so the resend is suppressed too
+            # (fail-closed, #94117). Return the structured failure as-is
             # (with the user-facing explanation already attached for
             # target_not_allowed in _sidecar_send).
             return result

--- a/tests/plugins/platforms/photon/test_overflow_recovery.py
+++ b/tests/plugins/platforms/photon/test_overflow_recovery.py
@@ -166,7 +166,7 @@ def test_sidecar_internal_in_permanent_failure_tuple() -> None:
             "retryable": False,
         },
     )
-    assert PhotonAdapter._is_permanent_sidecar_failure(suppressed) is True
+    assert PhotonAdapter._should_suppress_resend_and_retry(suppressed) is True
 
     transient = SendResult(
         success=False,
@@ -176,10 +176,10 @@ def test_sidecar_internal_in_permanent_failure_tuple() -> None:
             "retryable": True,
         },
     )
-    assert PhotonAdapter._is_permanent_sidecar_failure(transient) is False
+    assert PhotonAdapter._should_suppress_resend_and_retry(transient) is False
 
     unstructured = SendResult(success=False, error="boom", raw_response=None)
-    assert PhotonAdapter._is_permanent_sidecar_failure(unstructured) is False
+    assert PhotonAdapter._should_suppress_resend_and_retry(unstructured) is False
 
 
 async def _noop_sleep(delay: float) -> None:

--- a/tests/plugins/platforms/photon/test_overflow_recovery.py
+++ b/tests/plugins/platforms/photon/test_overflow_recovery.py
@@ -116,6 +116,76 @@ async def test_send_with_retry_uses_structured_retryable_flag(
     assert sleeps == [0.25]
 
 
+# -- sidecar_internal: ambiguous class must suppress the plain-text resend --
+
+@pytest.mark.asyncio
+async def test_sidecar_internal_suppresses_retry_and_plaintext_resend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 500 ``sidecar_internal`` may have delivered upstream already; the
+    adapter must fail closed instead of double-sending (issue #94117)."""
+    adapter = _make_adapter(monkeypatch)
+    calls = 0
+
+    async def _fake_sidecar_call(path: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        raise photon_adapter.PhotonSidecarError(
+            path=path,
+            status_code=500,
+            error="internal sidecar error",
+            error_class="sidecar_internal",
+            retryable=False,
+        )
+
+    monkeypatch.setattr(photon_adapter.asyncio, "sleep", _noop_sleep)
+    monkeypatch.setattr(adapter, "_sidecar_call", _fake_sidecar_call)
+
+    result = await adapter._send_with_retry(
+        "space-1", "hello", max_retries=1, base_delay=0.25
+    )
+
+    # One send attempt only: no backoff retry, no plain-text fallback resend.
+    assert calls == 1
+    assert result.success is False
+    # _sidecar_send's PhotonSidecarError branch carries the structured
+    # classification the suppression guard reads.
+    assert result.raw_response == {
+        "error_class": "sidecar_internal",
+        "retryable": False,
+    }
+
+
+def test_sidecar_internal_in_permanent_failure_tuple() -> None:
+    """Direct pin for the suppression set (first direct coverage of the guard)."""
+    suppressed = SendResult(
+        success=False,
+        error="internal sidecar error",
+        raw_response={
+            "error_class": "sidecar_internal",
+            "retryable": False,
+        },
+    )
+    assert PhotonAdapter._is_permanent_sidecar_failure(suppressed) is True
+
+    transient = SendResult(
+        success=False,
+        error="temporary upstream failure",
+        raw_response={
+            "error_class": "upstream_transient",
+            "retryable": True,
+        },
+    )
+    assert PhotonAdapter._is_permanent_sidecar_failure(transient) is False
+
+    unstructured = SendResult(success=False, error="boom", raw_response=None)
+    assert PhotonAdapter._is_permanent_sidecar_failure(unstructured) is False
+
+
+async def _noop_sleep(delay: float) -> None:
+    return None
+
+
 # -- Gap 2: typing-indicator cooldown ---------------------------------------
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

When the Photon sidecar returns HTTP 500 with `error_class=sidecar_internal` (the catch-all internal class), the upstream iMessage send may already have completed — Spectrum's `@spectrum-ts/imessage` raises "Unknown server error occurred" on some sends that delivered. The adapter's `_is_permanent_sidecar_failure()` guard only suppressed the resend for `auth_or_config` and `target_not_allowed`, so the ambiguous internal class fell through to the unconditional plain-text fallback and the recipient got the same reply twice (styled bubble + plain-text duplicate — the reporter observed two occurrences in one session).

This adds `sidecar_internal` to the fail-closed suppression set: a class that cannot be proven to have *not* delivered must not trigger a resend. For a personal channel one silent failure beats one duplicate per message. This completes the structured error-class routing landed in #73563 (which made the ambiguity visible but left the adapter guard incomplete), and follows the direction teknium1 set when closing #49718 ("the fix landed via the error-classification route") without reintroducing that PR's env-var toggle.

## Related Issue

Fixes #94117

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `plugins/platforms/photon/adapter.py`:
  - `_is_permanent_sidecar_failure()` — `sidecar_internal` added to the suppression tuple; docstring now explains the ambiguous fail-closed rationale (the send may have delivered; a resend would duplicate).
  - `_send_with_retry()` — comment at the suppression branch notes the `sidecar_internal` case alongside the permanent classes.
- `tests/plugins/platforms/photon/test_overflow_recovery.py` — first direct coverage of the suppression guard:
  - `test_sidecar_internal_suppresses_retry_and_plaintext_resend` — the reported scenario end-to-end: a 500 `sidecar_internal` from `/send` results in exactly one sidecar call (no backoff retry, no plain-text fallback resend) and the structured failure is returned as-is.
  - `test_sidecar_internal_in_permanent_failure_tuple` — direct pin: `sidecar_internal`+`retryable=false` is suppressed; `upstream_transient`+`retryable=true` and unstructured failures are not.

## How to Test

- Run: `.venv/bin/python -m pytest tests/plugins/platforms/photon/ -q`
- Observed result: `130 passed, 1 failed` — the single failure (`test_spectrum_patch.py::test_sidecar_patch_failure_still_reaches_health_endpoint`) reproduces identically on unpatched `main` (stash-compared), i.e. pre-existing and unrelated. Within `test_overflow_recovery.py`: `19 passed`. Fail-on-main check (`git stash` of the source change): both new tests fail against unpatched `main` (the resend fires and the tuple pin fails); all green with the fix.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of the completed code performed
- [x] New and existing unit tests pass locally
- [x] Changes are backward-compatible (permanent classes keep their behavior; only the ambiguous internal class now fails closed)
