### PR TITLE
fix(webhook): resolve bare-path requests to the serving profile, not "default"

### DIFF
--- a/contributors/emails/dennis@devenv.com
+++ b/contributors/emails/dennis@devenv.com
@@ -1,2 +1,1 @@
 martwals
-# First upstream contribution: webhook bare-path serving-profile fix

--- a/contributors/emails/dennis@devenv.com
+++ b/contributors/emails/dennis@devenv.com
@@ -1,0 +1,2 @@
+martwals
+# First upstream contribution: webhook bare-path serving-profile fix

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -610,6 +610,28 @@ class WebhookAdapter(BasePlatformAdapter):
         return profile
 
     @staticmethod
+    def _serving_profile_name() -> str:
+        """Return this gateway's serving profile name.
+
+        Mirrors ``hermes_cli.profiles.profiles_to_serve(multiplex=False)``,
+        which resolves ``get_active_profile_name() or "default"``. A bare-path
+        webhook request resolves to this name rather than the literal
+        ``"default"``. Resolution failures fall back to ``"default"`` so a
+        bare-path request degrades to the pre-fix behavior instead of 500ing.
+        """
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+
+            return get_active_profile_name() or "default"
+        except Exception:
+            logger.debug(
+                "webhook: serving-profile resolution failed; "
+                "falling back to 'default'",
+                exc_info=True,
+            )
+            return "default"
+
+    @staticmethod
     def _route_allows_profile(
         route_config: dict,
         request_profile: Optional[str],
@@ -618,6 +640,13 @@ class WebhookAdapter(BasePlatformAdapter):
 
         Omitting ``profile`` keeps a route on the default profile. An explicit
         null, blank, or non-string value is malformed and fails closed.
+
+        A bare-path request (``request_profile`` is ``None``) resolves to the
+        gateway's *serving* profile — ``get_active_profile_name() or
+        "default"`` — not the literal ``"default"``. This is what makes a
+        single-profile gateway (``boole``/``quoins``) match a route bound to
+        its own name on the bare path, matching
+        :func:`hermes_cli.profiles.profiles_to_serve(multiplex=False)`.
         """
         if "profile" not in route_config:
             configured_profile = "default"
@@ -628,7 +657,10 @@ class WebhookAdapter(BasePlatformAdapter):
         configured_profile = configured_profile.strip()
         if not configured_profile:
             return False
-        effective_profile = request_profile or "default"
+        if request_profile is None:
+            effective_profile = WebhookAdapter._serving_profile_name()
+        else:
+            effective_profile = request_profile
         return configured_profile == effective_profile
 
     async def _handle_webhook(self, request: "web.Request") -> "web.Response":
@@ -652,7 +684,9 @@ class WebhookAdapter(BasePlatformAdapter):
             )
 
         if not self._route_allows_profile(route_config, profile):
-            effective_profile = profile or "default"
+            effective_profile = (
+                profile if profile is not None else self._serving_profile_name()
+            )
             logger.warning(
                 "[webhook] Route %s is not authorized for profile %r",
                 route_name,

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -42,7 +42,7 @@ import subprocess
 import sys
 import time
 from collections import deque
-from typing import Any, Deque, Dict, List, Optional
+from typing import Any, Deque, Dict, List, Optional, cast
 
 try:
     from aiohttp import web
@@ -631,6 +631,20 @@ class WebhookAdapter(BasePlatformAdapter):
             )
             return "default"
 
+    def _resolve_bare_path_profile(self) -> str:
+        """Resolve a bare-path request (no ``/p/<profile>/`` prefix) to a concrete profile.
+
+        A single-profile gateway resolves to its serving profile
+        (``get_active_profile_name() or "default"``). A multiplexed gateway has
+        no single serving identity, so a bare path is ambiguous and keeps the
+        pre-fix ``"default"`` resolution rather than guessing an arbitrary
+        active profile.
+        """
+        cfg = getattr(self.gateway_runner, "config", None)
+        if getattr(cfg, "multiplex_profiles", False):
+            return "default"
+        return self._serving_profile_name()
+
     @staticmethod
     def _route_allows_profile(
         route_config: dict,
@@ -677,6 +691,12 @@ class WebhookAdapter(BasePlatformAdapter):
             return web.json_response(
                 {"error": "Unknown or unconfigured profile"}, status=404
             )
+        if profile is None:
+            # Bare path: resolve to a concrete profile once — the serving profile
+            # on a single-profile gateway, "default" on a multiplexed one.
+            profile = self._resolve_bare_path_profile()
+        # _PROFILE_REJECTED returned above and None was resolved, so profile is str.
+        profile = cast(str, profile)
 
         if not route_config:
             return web.json_response(
@@ -684,13 +704,10 @@ class WebhookAdapter(BasePlatformAdapter):
             )
 
         if not self._route_allows_profile(route_config, profile):
-            effective_profile = (
-                profile if profile is not None else self._serving_profile_name()
-            )
             logger.warning(
                 "[webhook] Route %s is not authorized for profile %r",
                 route_name,
-                effective_profile,
+                profile,
             )
             # Match the unknown-route response so callers cannot use profile
             # mismatches to enumerate route bindings.

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -1080,3 +1080,24 @@ def test_serving_profile_name_resolution(monkeypatch):
         "hermes_cli.profiles.get_active_profile_name", _boom
     )
     assert WebhookAdapter._serving_profile_name() == "default"
+
+
+def test_bare_path_profile_resolution_is_multiplex_aware(monkeypatch):
+    # A bare-path request resolves to the serving profile on a single-profile
+    # gateway, but to "default" on a multiplexed gateway — a multiplexed gateway
+    # has no single serving identity, and guessing the active profile would
+    # route a bare path to an arbitrary profile.
+    adapter = _make_adapter()
+
+    # Single-profile: resolves to the serving profile.
+    runner = MagicMock()
+    runner.config.multiplex_profiles = False
+    adapter.gateway_runner = runner
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "boole"
+    )
+    assert adapter._resolve_bare_path_profile() == "boole"
+
+    # Multiplexed: a bare path is ambiguous, so keep the pre-fix "default".
+    runner.config.multiplex_profiles = True
+    assert adapter._resolve_bare_path_profile() == "default"

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -1012,7 +1012,12 @@ class TestMultiplexProfileWebhookAuthentication:
             assert default_profile.status == 404
 
 
-def test_route_profile_validation_fails_closed():
+def test_route_profile_validation_fails_closed(monkeypatch):
+    # A bare-path request resolves to the gateway's serving profile. Pin the
+    # serving profile to "default" so the test is independent of HERMES_HOME.
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+    )
     assert WebhookAdapter._route_allows_profile({}, None) is True
     assert WebhookAdapter._route_allows_profile(
         {"profile": "worker"}, "worker"
@@ -1024,3 +1029,54 @@ def test_route_profile_validation_fails_closed():
         assert WebhookAdapter._route_allows_profile(
             {"profile": malformed}, "worker"
         ) is False
+
+
+def test_route_profile_bare_path_resolves_serving_profile(monkeypatch):
+    # Regression for the single-profile gateway 404: a bare-path request
+    # (request_profile=None) must resolve to the gateway's serving profile
+    # (get_active_profile_name()), not the literal "default" — otherwise a
+    # route bound to a named profile (e.g. "boole") never matches its own
+    # gateway's bare path.
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "boole"
+    )
+    # Route bound to the serving profile accepts the bare path.
+    assert WebhookAdapter._route_allows_profile(
+        {"profile": "boole"}, None
+    ) is True
+    # A profile-less route (=> "default") does not match a named-profile
+    # gateway's bare path.
+    assert WebhookAdapter._route_allows_profile({}, None) is False
+    assert WebhookAdapter._route_allows_profile(
+        {"profile": "default"}, None
+    ) is False
+
+    # On the default gateway, the profile-less route does match its bare path.
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+    )
+    assert WebhookAdapter._route_allows_profile({}, None) is True
+    assert WebhookAdapter._route_allows_profile(
+        {"profile": "default"}, None
+    ) is True
+    assert WebhookAdapter._route_allows_profile(
+        {"profile": "boole"}, None
+    ) is False
+
+
+def test_serving_profile_name_resolution(monkeypatch):
+    # Resolves the active profile name when available.
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "boole"
+    )
+    assert WebhookAdapter._serving_profile_name() == "boole"
+
+    # Degrades to "default" if resolution raises, so a bare-path request
+    # never 500s on a profile-resolution failure.
+    def _boom():
+        raise RuntimeError("symlink loop")
+
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", _boom
+    )
+    assert WebhookAdapter._serving_profile_name() == "default"


### PR DESCRIPTION
## What does this PR do?

Fixes a 404 on single-profile gateways: a webhook route bound to the gateway's own serving profile (e.g. `profile: "boole"`) never matched a bare-path request (`/webhooks/<route>` with no `/p/<profile>/` prefix), because the bare path resolved its effective profile to the literal `"default"` rather than the profile the gateway is actually serving.

The fix resolves a bare-path request on a single-profile gateway to the gateway's serving profile — `hermes_cli.profiles.get_active_profile_name() or "default"` — mirroring `profiles_to_serve(multiplex=False)`. Multiplexed gateways are unchanged: a bare path is ambiguous there (no single serving identity), so it keeps resolving to `"default"`.

## Breaking change

On a single-profile gateway (e.g. `HERMES_PROFILE=boole`, multiplexing off), a bare-path request now resolves to the gateway's serving profile (`boole`) instead of `"default"`. A profile-less route (no `profile` key, implying `"default"`) that previously matched the bare path on such a gateway no longer does — it now 404s. To keep the old behavior, either bind the route to the gateway's own profile name (`profile: "boole"`) or drop the explicit name so it matches the `"default"` route. This is the intended routing fix, but flagging it for release notes / migration docs.

## Related Issue

Follow-up to #92871, which made a *foreign* `/p/<profile>/` prefix fail closed on a non-multiplex gateway. This PR fixes the complementary *bare-path* case. Rooted in #91583 (profile-routing defects).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/webhook.py`
  - Add `_serving_profile_name()` — resolves `get_active_profile_name() or "default"`, falling back to `"default"` with a `logger.debug` if resolution raises.
  - Add `_resolve_bare_path_profile()` — multiplex-aware: `"default"` when `multiplex_profiles` is on, else the serving profile.
  - `_handle_webhook`: resolve a bare path once and pass a concrete profile to `_route_allows_profile`; the rejection log reuses it (single source of truth).
- `tests/gateway/test_webhook_adapter.py`
  - Pin the serving profile in the existing fail-closed test.
  - Add `test_route_profile_bare_path_resolves_serving_profile` (regression for the 404).
  - Add `test_serving_profile_name_resolution` (fallback behavior).
  - Add `test_bare_path_profile_resolution_is_multiplex_aware`.
- `contributors/emails/dennis@devenv.com` — one-line username mapping.

## How to Test

1. Configure a single-profile gateway (multiplexing off) with a route bound to `profile: "<the gateway's own profile name>"`.
2. POST to the bare path `/webhooks/<route>`.
3. Before: 404. After: handled. On a multiplexed gateway, a bare path still resolves to `"default"`.

Regression: `scripts/run_tests.sh tests/gateway/test_webhook_adapter.py` — 39 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (follow-up to #92871)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite for the changed area and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian 12 (Linux)

### Documentation & Housekeeping

- [x] Documentation — N/A (docstrings updated in-place)
- [x] `cli-config.yaml.example` — N/A (no config keys changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact — none (pure Python reusing existing cross-platform `hermes_cli.profiles` helpers; no file I/O / process / terminal handling)
- [x] Tool descriptions/schemas — N/A
