### PR TITLE
feat(kanban): native Review and Scheduled handoffs

### DIFF
--- a/docs/kanban-native-review-scheduling.md
+++ b/docs/kanban-native-review-scheduling.md
@@ -1,0 +1,77 @@
+# Native Kanban review and scheduled handoffs
+
+Status: review-only implementation; production activation is not authorized.
+Base commit: `2eaa863112d2980bbe6f15ea409a6a29e50964fe`.
+
+## Architecture decision
+
+The same card retains `assignee` as the implementation owner. Native review routing uses `review_assignee`; the dispatcher resolves that independent profile only while the card is in Review. The writer must present its active run id and authenticated profile to request review. The transition atomically closes the writer run, stores canonical frozen commit/tree/artifact digests, clears the claim, parks the card in Review, and emits `review_requested`.
+
+A reviewer claim creates a separately attributable run whose `profile` is the effective reviewer and whose claim event records `source_status=review`. PASS and REQUEST_CHANGES require the bound reviewer profile and active run id. PASS emits `review_passed` and moves to Done. REQUEST_CHANGES emits `changes_requested`, clears the current frozen artifact set, and returns to Ready/Todo for the preserved writer. Generic completion cannot approve a native review run.
+
+Review and writer lanes share the existing global and per-profile concurrency accounting. Queue order remains priority descending, then creation time ascending. Existing crash, timeout, stale-claim, restart, spawn-failure, and orphan reconciliation use claim provenance to restore interrupted reviewer runs to Review rather than Ready.
+
+The existing `kanban_notify_subs` cursor protocol remains the single notification mechanism. It already provides ordered event ids, transactional cursor claim, CAS rewind, deduplication, per-subscription failure isolation, retry, and dead-route removal. Native review verdict and scheduling event kinds are added to the notifier allowlist; no second outbox or dispatcher is introduced.
+
+Native schedules use UTC Unix epochs. `scheduled_for` controls promotion; `due_at` is a visible deadline. A single dispatcher tick atomically emits at most one `scheduled_pre_notice` inside T-15 and at most one `scheduled_promoted` at/after the scheduled epoch. Open parents land in Todo; otherwise cards land in Ready. Durable markers and status-CAS make restart, missed tick, and duplicate tick safe.
+
+## Compatibility and migration
+
+The migration is additive and idempotent:
+
+- `tasks.review_assignee TEXT`
+- `tasks.review_artifacts TEXT`
+- `tasks.scheduled_for INTEGER`
+- `tasks.due_at INTEGER`
+- `tasks.pre_notice_sent_at INTEGER`
+- `idx_tasks_schedule(status, scheduled_for, created_at)`
+
+Existing rows receive NULL values and retain prior behavior. Legacy Review cards without frozen artifact metadata keep the compatibility lifecycle. New authenticated work does not depend on `review-required` comment text.
+
+SQLite ignores additional columns when an older binary reads named legacy fields. Historical review/schedule fields and events therefore remain preserved if code is rolled back. Cards already in Review remain in the pre-existing Review status. Cards in Scheduled remain parked and can be manually unblocked by the legacy control surface.
+
+## Activation plan
+
+1. Freeze the reviewed commit/tree and capture a production-shaped database backup plus SQLite integrity result.
+2. Stage the image without changing the running digest.
+3. Provision a distinct reviewer profile and verify the sole dispatcher resolves it; do not share BB8, R2D2, human, or admin credentials.
+4. On a production-shaped copy, run migration twice, validate all row counts/links/comments/runs/events/subscriptions, and run the full Kanban regression suite.
+5. Deploy with `kanban.review_dispatch=false` and `kanban.native_scheduling=false`; restart only in the approved maintenance step.
+6. Exercise one non-production board through writer -> reviewer -> changes -> writer -> reviewer -> pass, including controller wake delivery.
+7. Enable `review_dispatch` for the staged board only. Observe ordering, global/per-profile caps, reviewer attribution, cursor advancement, and abnormal-run return to Review.
+8. Enable `native_scheduling` only after T-15 and due-time route proof.
+9. Migrate legacy review-required cards through the authenticated API in a separately reviewed operation; never infer reviewer authority from free text.
+10. Expand board scope only after R2D2 accepts the staged evidence.
+
+## Rollback
+
+1. Set `kanban.review_dispatch=false` and `kanban.native_scheduling=false`; verify no new review/schedule claims occur.
+2. Stop only the approved dispatcher/gateway unit in the maintenance window.
+3. Restore the previously pinned image/runtime atomically; do not downgrade or rewrite the database.
+4. Restart the prior runtime and verify card/comment/link/run/event/subscription counts and SQLite integrity.
+5. Leave native columns/events intact as historical evidence. Do not delete them.
+6. For any active reviewer run, first allow the approved reclaim path to restore it to Review; do not directly edit SQLite.
+7. Scheduled cards remain parked until manually unblocked or until the reviewed runtime is restored.
+
+Rollback proof is a feature-disable plus prior-runtime restoration, not a destructive down migration. This avoids loss or misassignment of in-flight cards.
+
+## Threat model
+
+- Self-approval: reviewer canonical identity must differ from the stable writer identity.
+- Identity spoofing: worker tools derive profile and run id from dispatcher-owned environment; DB transitions compare them with the active run.
+- Stale/replayed verdict: verdicts require current_run_id, an open matching run, and a review-origin claim event.
+- Generic completion bypass: native frozen reviews reject generic completion.
+- Artifact substitution: canonical commit/tree ids and relative artifact paths with SHA-256 digests are frozen in the request transaction; reassignment is refused during Review.
+- Queue starvation: review lane reserves an opportunity within the shared bounded budget.
+- Crash/restart: review-origin provenance restores the Review phase.
+- Notification replay/loss: event-id ordering, atomic cursor claim, CAS rewind, retry, and dead-route handling are reused.
+- Schedule replay: durable pre-notice marker and status-CAS make ticks idempotent.
+- Shared credentials: prohibited; reviewer and writer profiles remain separately attributable.
+
+## Residual risk and approval gates
+
+- Real controller-session wake and external route delivery must be proven in the staged deployment. This branch does not activate notification fan-out, by work-order exclusion.
+- Reviewer profile provisioning and authority are platform-state changes requiring exact-tree review.
+- No live database migration, dispatcher replacement, gateway restart, or production activation was performed.
+- The deployment’s accepted approximately-one-month-behind source target still needs R2D2 to compare this backport base with the managed image ancestry before rollout.
+- Legacy compatibility paths remain intentionally available; removal requires a later deprecation cycle after every board is migrated.

--- a/docs/kanban-native-review-scheduling.md
+++ b/docs/kanban-native-review-scheduling.md
@@ -9,6 +9,8 @@ The same card retains `assignee` as the implementation owner. Native review rout
 
 A reviewer claim creates a separately attributable run whose `profile` is the effective reviewer and whose claim event records `source_status=review`. PASS and REQUEST_CHANGES require the bound reviewer profile and active run id. PASS emits `review_passed` and moves to Done. REQUEST_CHANGES emits `changes_requested`, clears the current frozen artifact set, and returns to Ready/Todo for the preserved writer. Generic completion cannot approve a native review run.
 
+Native reviewer claims require a nonempty authenticated actor exactly matching `review_assignee`; argument omission is not authority. Autonomous review dispatch is fail closed: the default is false and only the exact managed Boolean `kanban.review_dispatch=true` activates it. Missing keys, nulls, integers, strings, malformed containers, and configuration-loader failures all leave Review parked. Gateway stuck detection calls the same gate as the dispatcher.
+
 Review and writer lanes share the existing global and per-profile concurrency accounting. Queue order remains priority descending, then creation time ascending. Existing crash, timeout, stale-claim, restart, spawn-failure, and orphan reconciliation use claim provenance to restore interrupted reviewer runs to Review rather than Ready.
 
 The existing `kanban_notify_subs` cursor protocol remains the single notification mechanism. It already provides ordered event ids, transactional cursor claim, CAS rewind, deduplication, per-subscription failure isolation, retry, and dead-route removal. Native review verdict and scheduling event kinds are added to the notifier allowlist; no second outbox or dispatcher is introduced.

--- a/docs/kanban-native-review-scheduling.md
+++ b/docs/kanban-native-review-scheduling.md
@@ -21,12 +21,14 @@ The migration is additive and idempotent:
 
 - `tasks.review_assignee TEXT`
 - `tasks.review_artifacts TEXT`
+- `tasks.review_protocol TEXT NOT NULL DEFAULT 'native_v2'` with an allow-list
+  constraint for `native_v2|legacy`
 - `tasks.scheduled_for INTEGER`
 - `tasks.due_at INTEGER`
 - `tasks.pre_notice_sent_at INTEGER`
 - `idx_tasks_schedule(status, scheduled_for, created_at)`
 
-Existing rows receive NULL values and retain prior behavior. Legacy Review cards without frozen artifact metadata keep the compatibility lifecycle. New authenticated work does not depend on `review-required` comment text.
+When `review_protocol` is first added, rows already present in that transaction are explicitly marked `legacy`; tasks created after the migration inherit `native_v2`. Reopen/reapply does not relabel either class. Legacy compatibility is selected only by that durable one-time marker, never by omitted function arguments or nullable artifact metadata. Missing, malformed, or future protocol values fail closed as native. New authenticated work does not depend on `review-required` comment text.
 
 SQLite ignores additional columns when an older binary reads named legacy fields. Historical review/schedule fields and events therefore remain preserved if code is rolled back. Cards already in Review remain in the pre-existing Review status. Cards in Scheduled remain parked and can be manually unblocked by the legacy control surface.
 
@@ -47,7 +49,7 @@ SQLite ignores additional columns when an older binary reads named legacy fields
 
 1. Set `kanban.review_dispatch=false` and `kanban.native_scheduling=false`; verify no new review/schedule claims occur.
 2. Stop only the approved dispatcher/gateway unit in the maintenance window.
-3. Restore the previously pinned image/runtime atomically; do not downgrade or rewrite the database.
+3. Verify there are no active or parked `native_v2` Review cycles before restoring the previously pinned image/runtime atomically; the old runtime does not enforce the native verdict gate. Do not downgrade or rewrite the database.
 4. Restart the prior runtime and verify card/comment/link/run/event/subscription counts and SQLite integrity.
 5. Leave native columns/events intact as historical evidence. Do not delete them.
 6. For any active reviewer run, first allow the approved reclaim path to restore it to Review; do not directly edit SQLite.
@@ -60,7 +62,8 @@ Rollback proof is a feature-disable plus prior-runtime restoration, not a destru
 - Self-approval: reviewer canonical identity must differ from the stable writer identity.
 - Identity spoofing: worker tools derive profile and run id from dispatcher-owned environment; DB transitions compare them with the active run.
 - Stale/replayed verdict: verdicts require current_run_id, an open matching run, and a review-origin claim event.
-- Generic completion bypass: native frozen reviews reject generic completion.
+- Authority downgrade: review authority is bound to `review_protocol`; omitted actor/run/artifact arguments cannot select legacy behavior for new tasks.
+- Generic completion bypass: every `native_v2` review rejects generic completion, including malformed rows with missing frozen metadata.
 - Artifact substitution: canonical commit/tree ids and relative artifact paths with SHA-256 digests are frozen in the request transaction; reassignment is refused during Review.
 - Queue starvation: review lane reserves an opportunity within the shared bounded budget.
 - Crash/restart: review-origin provenance restores the Review phase.

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -239,7 +239,12 @@ class GatewayKanbanWatchersMixin:
         # but is not a block (see kanban_db.request_review); the task is not
         # archived, so the subscription stays alive and later review
         # cycles keep notifying.
-        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked", "block_loop_detected", "review_requested")
+        TERMINAL_KINDS = (
+            "completed", "blocked", "gave_up", "crashed", "timed_out",
+            "status", "archived", "unblocked", "block_loop_detected",
+            "review_requested", "review_passed", "changes_requested",
+            "scheduled_pre_notice", "scheduled_promoted",
+        )
         # Subscriptions are removed only when the task reaches the irreversible
         # archived status. ``done`` is reversible in review/controller flows,
         # so removing its subscription would silence a later reopen. We used

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2628,9 +2628,10 @@ DEFAULT_CONFIG = {
         # don't want the gateway to spawn workers.
         "dispatch_in_gateway": True,
         # Automatically claim tasks in the first-class review column and spawn
-        # the assigned profile with the bundled sdlc-review skill. Disable for
-        # boards where every review is performed manually from the dashboard.
-        "review_dispatch": True,
+        # the assigned profile with the bundled sdlc-review skill. Fail closed:
+        # an operator must explicitly set the exact Boolean true only after an
+        # independent reviewer profile and staged routing proof exist.
+        "review_dispatch": False,
         # Seconds between dispatcher ticks (idle or not). Lower = snappier
         # pickup of newly-ready tasks; higher = less SQL pressure.
         "dispatch_interval_seconds": 60,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4909,6 +4909,44 @@ def claim_task(
     return claimed
 
 
+def _review_routing_reviewer(
+    routing: sqlite3.Row,
+    actor_profile: Optional[str],
+) -> Optional[str]:
+    """Return the authenticated reviewer iff routing is claimable.
+
+    Shared by admission and capacity planning so malformed Review rows cannot
+    reserve dispatcher slots.
+    """
+    native_v2 = routing["review_protocol"] != "legacy"
+    try:
+        effective_reviewer = _canonical_assignee(
+            routing["review_assignee"] if native_v2
+            else (routing["review_assignee"] or routing["assignee"])
+        )
+        writer = _canonical_assignee(routing["assignee"])
+        actor = (
+            _canonical_assignee(actor_profile)
+            if isinstance(actor_profile, str) and actor_profile.strip()
+            else None
+        )
+    except (TypeError, ValueError):
+        return None
+    if native_v2:
+        if actor is None or actor != effective_reviewer or actor == writer:
+            return None
+        try:
+            frozen = json.loads(routing["review_artifacts"])
+        except (json.JSONDecodeError, TypeError):
+            return None
+        canonical_frozen, artifact_error = _validate_frozen_review_artifacts(frozen)
+        if artifact_error or canonical_frozen != frozen:
+            return None
+    elif actor is not None and actor != effective_reviewer:
+        return None
+    return effective_reviewer
+
+
 def claim_review_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4940,33 +4978,8 @@ def claim_review_task(
         ).fetchone()
         if routing is None:
             return None
-        native_v2 = routing["review_protocol"] != "legacy"
-        try:
-            effective_reviewer = _canonical_assignee(
-                routing["review_assignee"] if native_v2
-                else (routing["review_assignee"] or routing["assignee"])
-            )
-            writer = _canonical_assignee(routing["assignee"])
-            actor = (
-                _canonical_assignee(actor_profile)
-                if isinstance(actor_profile, str) and actor_profile.strip()
-                else None
-            )
-        except (TypeError, ValueError):
-            return None
-        if native_v2:
-            # Native reviewer authority is never inferred from an omitted
-            # argument, the writer identity, or legacy assignee routing.
-            if actor is None or actor != effective_reviewer or actor == writer:
-                return None
-            try:
-                frozen = json.loads(routing["review_artifacts"])
-            except (json.JSONDecodeError, TypeError):
-                return None
-            canonical_frozen, artifact_error = _validate_frozen_review_artifacts(frozen)
-            if artifact_error or canonical_frozen != frozen:
-                return None
-        elif actor is not None and actor != effective_reviewer:
+        effective_reviewer = _review_routing_reviewer(routing, actor_profile)
+        if effective_reviewer is None:
             return None
         if not _parents_satisfied(conn, task_id):
             demoted = conn.execute(
@@ -5055,21 +5068,44 @@ def _retry_status_for_run(
             (task_id,),
         ).fetchone()
         run_id = row["current_run_id"] if row else None
-    if run_id is None:
-        return "ready"
-    event = conn.execute(
-        "SELECT payload FROM task_events "
-        "WHERE task_id = ? AND run_id = ? AND kind = 'claimed' "
-        "ORDER BY id DESC LIMIT 1",
-        (task_id, int(run_id)),
+    if run_id is not None:
+        event = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND run_id = ? AND kind = 'claimed' "
+            "ORDER BY id DESC LIMIT 1",
+            (task_id, int(run_id)),
+        ).fetchone()
+        try:
+            payload = json.loads(event["payload"]) if event and event["payload"] else {}
+        except (json.JSONDecodeError, TypeError):
+            payload = {}
+        if isinstance(payload, dict) and payload.get("source_status") == "review":
+            return "review"
+
+    # A missing/stale current_run_id must not erase durable review provenance.
+    # The latest lifecycle marker still distinguishes an interrupted reviewer
+    # from an ordinary writer retry after changes were requested.
+    latest = conn.execute(
+        "SELECT kind, payload FROM task_events WHERE task_id = ? "
+        "AND kind IN ('claimed', 'review_requested', 'changes_requested', "
+        "             'review_passed') ORDER BY id DESC LIMIT 1",
+        (task_id,),
     ).fetchone()
-    try:
-        payload = json.loads(event["payload"]) if event and event["payload"] else {}
-    except (json.JSONDecodeError, TypeError):
-        payload = {}
-    if not isinstance(payload, dict):
-        payload = {}
-    return "review" if payload.get("source_status") == "review" else "ready"
+    if latest is None:
+        return "ready"
+    if latest["kind"] == "review_requested":
+        return "review"
+    if latest["kind"] == "claimed":
+        try:
+            latest_payload = json.loads(latest["payload"] or "{}")
+        except (json.JSONDecodeError, TypeError):
+            latest_payload = {}
+        if (
+            isinstance(latest_payload, dict)
+            and latest_payload.get("source_status") == "review"
+        ):
+            return "review"
+    return "ready"
 
 
 def goal_run_status(
@@ -9111,8 +9147,8 @@ def reconcile_orphaned_running(
     ``detect_stale_running`` is disabled by default — so the card shows
     Running forever (a zombie).
 
-    This pass finds those orphans, requeues them to ``ready`` with an
-    explanatory comment, closes any leaked run, and appends a
+    This pass finds those orphans, restores them to their durable source phase
+    with an explanatory comment, closes any leaked run, and appends a
     ``reconciled`` event. If the orphan row still records a live PID on
     this host, requeueing is deferred to a later tick so we never spawn a
     duplicate beside a possibly-alive worker.
@@ -9140,13 +9176,14 @@ def reconcile_orphaned_running(
             )
             continue
         with write_txn(conn):
+            retry_status = _retry_status_for_run(conn, tid)
             cur = conn.execute(
-                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running' "
                 "  AND claim_lock IS ? AND claim_expires IS ?",
-                (tid, row["claim_lock"], row["claim_expires"]),
+                (retry_status, tid, row["claim_lock"], row["claim_expires"]),
             )
             if cur.rowcount != 1:
                 continue
@@ -9159,6 +9196,7 @@ def reconcile_orphaned_running(
                 ),
                 "worker_pid": int(pid) if pid else None,
                 "now": now,
+                "retry_status": retry_status,
             }
             run_id = _end_run(
                 conn, tid,
@@ -9174,15 +9212,16 @@ def reconcile_orphaned_running(
                 (
                     tid, "dispatcher",
                     "reconciliation: card was 'running' with no valid claim "
-                    "(dead/gone worker) — requeued to ready",
+                    "(dead/gone worker) — requeued to " + retry_status,
                     now,
                 ),
             )
             _append_event(conn, tid, "reconciled", payload, run_id=run_id)
             reconciled.append(tid)
         _log.info(
-            "kanban reconcile: requeued orphaned running task %s "
-            "(claim_lock=%r, worker_pid=%r)", tid, row["claim_lock"], pid,
+            "kanban reconcile: restored orphaned running task %s to %s "
+            "(claim_lock=%r, worker_pid=%r)",
+            tid, retry_status, row["claim_lock"], pid,
         )
     return reconciled
 
@@ -10035,9 +10074,13 @@ def native_scheduling_enabled() -> bool:
     """Fail closed until an operator explicitly activates native scheduling."""
     try:
         from hermes_cli.config import load_config
-        return bool(
-            (load_config() or {}).get("kanban", {}).get("native_scheduling", False)
-        )
+        config = load_config()
+        if not isinstance(config, dict):
+            return False
+        kanban_config = config.get("kanban")
+        if not isinstance(kanban_config, dict):
+            return False
+        return kanban_config.get("native_scheduling") is True
     except Exception:
         return False
 
@@ -10479,11 +10522,21 @@ def _dispatch_once_locked(
     # budget split below can see whether review work exists at all.
     review_rows = []
     if review_dispatch_enabled():
-        review_rows = conn.execute(
-            "SELECT id, COALESCE(review_assignee, assignee) AS assignee "
+        routing_rows = conn.execute(
+            "SELECT id, assignee, review_assignee, review_protocol, review_artifacts "
             "FROM tasks WHERE status = 'review' AND claim_lock IS NULL "
             "ORDER BY priority DESC, created_at ASC"
         ).fetchall()
+        review_rows = []
+        for routing in routing_rows:
+            actor = (
+                routing["review_assignee"]
+                if routing["review_protocol"] != "legacy"
+                else (routing["review_assignee"] or routing["assignee"])
+            )
+            reviewer = _review_routing_reviewer(routing, actor)
+            if reviewer is not None and _parents_satisfied(conn, routing["id"]):
+                review_rows.append({"id": routing["id"], "assignee": reviewer})
     # Review-lane reservation (OOF-30 review finding): the ready loop runs
     # first and used to consume the ENTIRE shared budget, so a sustained
     # ready backlog permanently starved autonomous reviews — completed work

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1049,6 +1049,16 @@ def remove_board(slug: str, *, archive: bool = True) -> dict:
 # Data classes
 # ---------------------------------------------------------------------------
 
+def _decode_review_artifacts(raw: Any) -> Optional[dict]:
+    if not raw:
+        return None
+    try:
+        value = json.loads(raw) if isinstance(raw, str) else raw
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
 @dataclass
 class Task:
     """In-memory view of a row from the ``tasks`` table."""
@@ -1057,6 +1067,8 @@ class Task:
     title: str
     body: Optional[str]
     assignee: Optional[str]
+    # Implementation ownership is stable across review. The independently
+    # attributable reviewer is routed through a separate column.
     status: str
     priority: int
     created_by: Optional[str]
@@ -1068,6 +1080,13 @@ class Task:
     claim_lock: Optional[str]
     claim_expires: Optional[int]
     tenant: Optional[str]
+    # Optional additive fields stay defaulted so integrations constructing Task
+    # directly remain source-compatible with pre-review releases.
+    review_assignee: Optional[str] = None
+    review_artifacts: Optional[dict] = None
+    scheduled_for: Optional[int] = None
+    due_at: Optional[int] = None
+    pre_notice_sent_at: Optional[int] = None
     branch_name: Optional[str] = None
     project_id: Optional[str] = None
     result: Optional[str] = None
@@ -1159,6 +1178,18 @@ class Task:
             title=row["title"],
             body=row["body"],
             assignee=row["assignee"],
+            review_assignee=(
+                row["review_assignee"] if "review_assignee" in keys else None
+            ),
+            review_artifacts=(
+                _decode_review_artifacts(row["review_artifacts"])
+                if "review_artifacts" in keys else None
+            ),
+            scheduled_for=(row["scheduled_for"] if "scheduled_for" in keys else None),
+            due_at=(row["due_at"] if "due_at" in keys else None),
+            pre_notice_sent_at=(
+                row["pre_notice_sent_at"] if "pre_notice_sent_at" in keys else None
+            ),
             status=row["status"],
             priority=row["priority"],
             created_by=row["created_by"],
@@ -1335,6 +1366,15 @@ CREATE TABLE IF NOT EXISTS tasks (
     title                TEXT NOT NULL,
     body                 TEXT,
     assignee             TEXT,
+    -- Stable, independently attributable review routing. ``assignee`` remains
+    -- the implementation owner; the frozen artifact identity is immutable for
+    -- a review cycle and survives reviewer retries/restarts.
+    review_assignee      TEXT,
+    review_artifacts     TEXT,
+    -- UTC Unix epochs avoid worker-local timezone/DST disagreement.
+    scheduled_for        INTEGER,
+    due_at               INTEGER,
+    pre_notice_sent_at   INTEGER,
     status               TEXT NOT NULL,
     priority             INTEGER DEFAULT 0,
     created_by           TEXT,
@@ -2679,6 +2719,22 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
         )
 
+    # Additive review-v2 migration. Legacy cards remain readable with NULL
+    # values; new native review requests populate both columns atomically.
+    if "review_assignee" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "review_assignee", "review_assignee TEXT"
+        )
+    if "review_artifacts" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "review_artifacts", "review_artifacts TEXT"
+        )
+
+    # Additive native scheduling migration. NULL means legacy/immediate work.
+    for column in ("scheduled_for", "due_at", "pre_notice_sent_at"):
+        if column not in cols:
+            _add_column_if_missing(conn, "tasks", column, f"{column} INTEGER")
+
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a
@@ -2693,6 +2749,14 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)"
     )
+    schedule_index_cols = {
+        row["name"] for row in conn.execute("PRAGMA table_info(tasks)")
+    }
+    if {"status", "scheduled_for", "created_at"} <= schedule_index_cols:
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_tasks_schedule "
+            "ON tasks(status, scheduled_for, created_at)"
+        )
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
@@ -3183,6 +3247,8 @@ def create_task(
     board: Optional[str] = None,
     project_id: Optional[str] = None,
     project_source_task_id: Optional[str] = None,
+    scheduled_for: Optional[int] = None,
+    due_at: Optional[int] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -3228,6 +3294,12 @@ def create_task(
     reasoning_effort = normalize_reasoning_effort(reasoning_effort)
     if provider_override and not model_override:
         raise ValueError("provider_override requires a model_override")
+    scheduled_for = int(scheduled_for) if scheduled_for is not None else None
+    due_at = int(due_at) if due_at is not None else None
+    if scheduled_for is not None and scheduled_for < 0:
+        raise ValueError("scheduled_for must be a non-negative UTC Unix epoch")
+    if due_at is not None and due_at < 0:
+        raise ValueError("due_at must be a non-negative UTC Unix epoch")
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
         raise ValueError("title is required")
@@ -3449,6 +3521,12 @@ def create_task(
                             raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
                 elif triage:
                     task_status = "triage"
+                elif scheduled_for is not None and scheduled_for > now:
+                    task_status = "scheduled"
+                    if parents:
+                        missing = _find_missing_parents(conn, parents)
+                        if missing:
+                            raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
                 else:
                     task_status = "ready"
                     if parents:
@@ -3497,8 +3575,9 @@ def create_task(
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
-                        goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, session_id,
+                        scheduled_for, due_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3524,6 +3603,8 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        scheduled_for,
+                        due_at,
                     ),
                 )
                 for pid in parents:
@@ -3552,6 +3633,8 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                         "model_override": model_override,
                         "provider_override": provider_override,
+                        "scheduled_for": scheduled_for,
+                        "due_at": due_at,
                     },
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
@@ -3575,6 +3658,68 @@ def _find_missing_parents(conn: sqlite3.Connection, parents: Iterable[str]) -> l
     ).fetchall()
     present = {r["id"] for r in rows}
     return [p for p in parents if p not in present]
+
+
+def process_scheduled_tasks(
+    conn: sqlite3.Connection,
+    *,
+    now: Optional[int] = None,
+    pre_notice_seconds: int = 15 * 60,
+) -> dict[str, list[str]]:
+    """Emit idempotent T-15 notices and promote due scheduled cards.
+
+    Values are UTC Unix epochs. The durable marker and event append share one
+    transaction, so duplicate ticks and restarts cannot duplicate a notice or
+    promotion. Cards with open parents land in ``todo``; others in ``ready``.
+    """
+    current = int(time.time()) if now is None else int(now)
+    lead = max(0, int(pre_notice_seconds))
+    noticed: list[str] = []
+    promoted: list[str] = []
+    with write_txn(conn):
+        notice_rows = conn.execute(
+            "SELECT id, scheduled_for FROM tasks WHERE status = 'scheduled' "
+            "AND scheduled_for IS NOT NULL AND pre_notice_sent_at IS NULL "
+            "AND scheduled_for > ? AND scheduled_for - ? <= ? "
+            "ORDER BY priority DESC, created_at ASC",
+            (current, lead, current),
+        ).fetchall()
+        for row in notice_rows:
+            changed = conn.execute(
+                "UPDATE tasks SET pre_notice_sent_at = ? WHERE id = ? "
+                "AND status = 'scheduled' AND pre_notice_sent_at IS NULL",
+                (current, row["id"]),
+            )
+            if changed.rowcount == 1:
+                _append_event(
+                    conn,
+                    row["id"],
+                    "scheduled_pre_notice",
+                    {"scheduled_for": int(row["scheduled_for"]), "lead_seconds": lead},
+                )
+                noticed.append(row["id"])
+
+        due_rows = conn.execute(
+            "SELECT id, scheduled_for FROM tasks WHERE status = 'scheduled' "
+            "AND scheduled_for IS NOT NULL AND scheduled_for <= ? "
+            "ORDER BY priority DESC, created_at ASC",
+            (current,),
+        ).fetchall()
+        for row in due_rows:
+            landing = _landing_status_after_parents(conn, row["id"])
+            changed = conn.execute(
+                "UPDATE tasks SET status = ? WHERE id = ? AND status = 'scheduled'",
+                (landing, row["id"]),
+            )
+            if changed.rowcount == 1:
+                _append_event(
+                    conn,
+                    row["id"],
+                    "scheduled_promoted",
+                    {"scheduled_for": int(row["scheduled_for"]), "status": landing},
+                )
+                promoted.append(row["id"])
+    return {"noticed": noticed, "promoted": promoted}
 
 
 def _inherit_notify_subs(
@@ -3712,6 +3857,11 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
         ).fetchone()
         if not row:
             return False
+        if row["status"] == "review":
+            raise RuntimeError(
+                f"cannot reassign {task_id}: review artifact identity is frozen; "
+                "request changes or reopen review first"
+            )
         if row["claim_lock"] is not None and row["status"] == "running":
             raise RuntimeError(
                 f"cannot reassign {task_id}: currently running (claimed). "
@@ -4742,6 +4892,7 @@ def claim_review_task(
     *,
     ttl_seconds: Optional[int] = None,
     claimer: Optional[str] = None,
+    actor_profile: Optional[str] = None,
 ) -> Optional[Task]:
     """Atomically transition ``review -> running``.
 
@@ -4758,6 +4909,20 @@ def claim_review_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        routing = conn.execute(
+            "SELECT assignee, review_assignee FROM tasks "
+            "WHERE id = ? AND status = 'review' AND claim_lock IS NULL",
+            (task_id,),
+        ).fetchone()
+        if routing is None:
+            return None
+        effective_reviewer = _canonical_assignee(
+            routing["review_assignee"] or routing["assignee"]
+        )
+        if actor_profile is not None and (
+            _canonical_assignee(actor_profile) != effective_reviewer
+        ):
+            return None
         if not _parents_satisfied(conn, task_id):
             demoted = conn.execute(
                 "UPDATE tasks SET status = 'todo' "
@@ -4805,7 +4970,7 @@ def claim_review_task(
             """,
             (
                 task_id,
-                trow["assignee"] if trow else None,
+                effective_reviewer,
                 trow["current_step_key"] if trow else None,
                 lock,
                 expires,
@@ -4821,7 +4986,7 @@ def claim_review_task(
         _append_event(
             conn, task_id, "claimed",
             {"lock": lock, "expires": expires, "run_id": run_id,
-             "source_status": "review"},
+             "source_status": "review", "profile": effective_reviewer},
             run_id=run_id,
         )
         return get_task(conn, task_id)
@@ -5393,6 +5558,44 @@ def complete_task(
     and never blocks.
     """
     now = int(time.time())
+    # Review verdicts are security-sensitive lifecycle transitions. Generic
+    # completion must never approve a parked review or an active reviewer run;
+    # callers use pass_review(), which authenticates profile + run token and
+    # emits review_passed rather than the ambiguous completed event.
+    review_gate = conn.execute(
+        "SELECT status, current_run_id FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    if review_gate is not None:
+        # Native v2 reviews carry a frozen artifact identity and require the
+        # authenticated pass_review() verdict.  Legacy review rows predate
+        # that field and retain their operator-driven complete behavior during
+        # the additive migration window.
+        native_review = conn.execute(
+            "SELECT review_artifacts FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if (
+            review_gate["status"] == "review"
+            and native_review is not None
+            and native_review["review_artifacts"] is not None
+        ):
+            return False
+        if review_gate["status"] == "running" and review_gate["current_run_id"]:
+            source = conn.execute(
+                "SELECT payload FROM task_events WHERE task_id = ? AND run_id = ? "
+                "AND kind = 'claimed' ORDER BY id DESC LIMIT 1",
+                (task_id, int(review_gate["current_run_id"])),
+            ).fetchone()
+            try:
+                source_payload = json.loads(source["payload"]) if source and source["payload"] else {}
+            except (json.JSONDecodeError, TypeError):
+                source_payload = {}
+            if (
+                isinstance(source_payload, dict)
+                and source_payload.get("source_status") == "review"
+                and native_review is not None
+                and native_review["review_artifacts"] is not None
+            ):
+                return False
     # Fail before validating cards or staging artifacts; re-check inside the
     # final write transaction below to close the parent-reopen race.
     if not _parents_satisfied(conn, task_id):
@@ -5453,6 +5656,7 @@ def complete_task(
                        block_recurrences = 0
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked', 'review')
+                   AND review_artifacts IS NULL
                 """,
                 (result, now, task_id),
             )
@@ -5470,6 +5674,7 @@ def complete_task(
                        block_recurrences = 0
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked', 'review')
+                   AND review_artifacts IS NULL
                    AND current_run_id = ?
                 """,
                 (result, now, task_id, int(expected_run_id)),
@@ -6487,6 +6692,48 @@ def redact_review_value(value: Any) -> Any:
     return value
 
 
+def _validate_frozen_review_artifacts(value: Any) -> tuple[Optional[dict], Optional[str]]:
+    """Return canonical frozen artifact metadata or a fail-closed reason."""
+    if not isinstance(value, dict):
+        return None, "frozen artifacts object is required"
+    commit = value.get("commit")
+    tree = value.get("tree")
+    artifacts = value.get("artifacts")
+    oid = re.compile(r"^[0-9a-fA-F]{40}(?:[0-9a-fA-F]{24})?$")
+    if not isinstance(commit, str) or not oid.fullmatch(commit):
+        return None, "frozen artifacts.commit must be a 40- or 64-hex object id"
+    if not isinstance(tree, str) or not oid.fullmatch(tree):
+        return None, "frozen artifacts.tree must be a 40- or 64-hex object id"
+    if not isinstance(artifacts, list):
+        return None, "frozen artifacts.artifacts must be a list"
+    normalized: list[dict] = []
+    for item in artifacts:
+        if not isinstance(item, dict):
+            return None, "each frozen artifact must be an object"
+        path = item.get("path")
+        digest = item.get("sha256")
+        if (
+            not isinstance(path, str)
+            or not path.strip()
+            or path.startswith("/")
+            or "\\" in path
+            or "\x00" in path
+            or any(part in {"", ".", ".."} for part in path.strip().split("/"))
+        ):
+            return None, (
+                "each frozen artifact path must be canonical, relative, and "
+                "must not contain dot segments"
+            )
+        if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-fA-F]{64}", digest):
+            return None, "each frozen artifact sha256 must be 64 hex characters"
+        normalized.append({"path": path.strip(), "sha256": digest.lower()})
+    return {
+        "commit": commit.lower(),
+        "tree": tree.lower(),
+        "artifacts": normalized,
+    }, None
+
+
 def request_review(
     conn: sqlite3.Connection,
     task_id: str,
@@ -6494,159 +6741,230 @@ def request_review(
     summary: Optional[str] = None,
     metadata: Optional[dict] = None,
     reviewer: Optional[str] = None,
+    artifacts: Optional[dict] = None,
+    actor_profile: Optional[str] = None,
     expected_run_id: Optional[int] = None,
     force: bool = False,
     with_reason: bool = False,
 ):
-    """Transition implementation work into the first-class review phase.
+    """Atomically close a writer run and route a frozen tree to review.
 
-    Unlike :func:`block_task`, this transition never touches block recurrence
-    accounting.  The current implementer and resolved reviewer are recorded on
-    the event so an autonomous reviewer can route requested changes back to the
-    right profile.  Supplying ``reviewer`` reassigns the task before it is
-    exposed to the review dispatcher.  On re-review, omitting it reuses the
-    reviewer provenance persisted by the latest ``changes_requested`` event.
-
-    When the task is ``running`` under a live claim, a caller that supplies no
-    ``expected_run_id`` must pass ``force=True`` (explicit human/CLI override)
-    — otherwise the request is refused instead of silently clearing the live
-    worker's ``claim_lock``/``worker_pid``. Workers prove ownership by passing
-    their own run id as ``expected_run_id`` (unchanged).
-
-    Returns ``bool`` by default. With ``with_reason=True`` returns
-    ``(ok, reason)`` mirroring :func:`request_changes` — ``reason`` is a
-    diagnostic string on failure, ``None`` on success.
+    Authenticated v2 callers pass ``actor_profile`` and must also provide the
+    active run token, an independent reviewer, and a valid frozen artifact
+    identity. Legacy operator/CLI callers remain readable during migration,
+    but are explicitly compatibility-only and do not get v2 authorization
+    claims unless they provide those arguments.
     """
-
     def _ret(ok: bool, reason: Optional[str] = None):
         return (ok, reason) if with_reason else ok
 
     summary = redact_review_value(summary)
     metadata = redact_review_value(metadata)
+    native_v2 = actor_profile is not None or artifacts is not None
+    canonical_artifacts: Optional[dict] = None
+    if native_v2:
+        canonical_artifacts, artifact_error = _validate_frozen_review_artifacts(
+            redact_review_value(artifacts)
+        )
+        if artifact_error:
+            return _ret(False, artifact_error)
+    actor = _canonical_assignee(actor_profile) if actor_profile is not None else None
+
     with write_txn(conn):
         if not _parents_satisfied(conn, task_id):
             return _ret(False, "parent dependencies are not satisfied")
         trow = conn.execute(
-            "SELECT assignee, status, claim_lock, current_run_id "
+            "SELECT assignee, review_assignee, status, claim_lock, current_run_id "
             "FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if trow is None:
             return _ret(False, "task not found")
-        # Refuse to clear a live worker's claim without proof of ownership
-        # (expected_run_id) or an explicit human override (force=True).
-        if (
-            expected_run_id is None
-            and not force
-            and trow["status"] == "running"
+        implementer = _canonical_assignee(trow["assignee"])
+        if native_v2:
+            if expected_run_id is None:
+                return _ret(False, "active writer run token is required")
+            run = conn.execute(
+                "SELECT profile, ended_at FROM task_runs WHERE id = ? AND task_id = ?",
+                (int(expected_run_id), task_id),
+            ).fetchone()
+            if (
+                run is None or run["ended_at"] is not None
+                or trow["current_run_id"] != int(expected_run_id)
+            ):
+                return _ret(False, "stale or missing writer run token")
+            run_profile = _canonical_assignee(run["profile"])
+            if actor != implementer or run_profile != actor:
+                return _ret(False, "writer profile does not own the active run")
+        elif (
+            expected_run_id is None and not force and trow["status"] == "running"
             and trow["claim_lock"] is not None
         ):
-            return _ret(
-                False,
-                "task is running under a live claim; pass expected_run_id "
-                "(worker ownership) or force=True (explicit operator "
-                "override) instead of clearing the live run's claim",
-            )
-        implementer = trow["assignee"]
+            return _ret(False, "task is running under a live claim; pass expected_run_id or force=True")
+
         if reviewer is None:
-            changes_run = conn.execute(
-                "SELECT id FROM task_runs "
-                "WHERE task_id = ? AND outcome = 'changes_requested' "
-                "ORDER BY id DESC LIMIT 1",
-                (task_id,),
-            ).fetchone()
-            changes_event = None
-            if changes_run is not None:
+            # Native v2 persists routing independently from assignee. Legacy
+            # re-review intentionally continues to prove reviewer provenance
+            # from the latest changes_requested event so malformed historical
+            # data fails closed exactly as it did before this migration.
+            reviewer = trow["review_assignee"] if native_v2 else None
+            if reviewer is None:
                 changes_event = conn.execute(
-                    "SELECT payload FROM task_events "
-                    "WHERE task_id = ? AND run_id = ? "
-                    "AND kind = 'changes_requested' "
-                    "ORDER BY id DESC LIMIT 1",
-                    (task_id, int(changes_run["id"])),
+                    "SELECT payload FROM task_events WHERE task_id = ? "
+                    "AND kind = 'changes_requested' ORDER BY id DESC LIMIT 1",
+                    (task_id,),
                 ).fetchone()
-            try:
-                changes_payload = (
-                    json.loads(changes_event["payload"])
-                    if changes_event and changes_event["payload"]
-                    else {}
-                )
-            except (json.JSONDecodeError, TypeError):
-                changes_payload = {}
-            prior_reviewer = (
-                changes_payload.get("reviewer")
-                if isinstance(changes_payload, dict)
-                else None
-            )
-            if changes_run is not None:
-                if not isinstance(prior_reviewer, str) or not prior_reviewer.strip():
-                    return _ret(
-                        False,
-                        "re-review has no durable reviewer provenance (the "
-                        "latest changes_requested event is missing or "
-                        "malformed); pass reviewer= explicitly",
-                    )
-                reviewer = prior_reviewer
+                try:
+                    payload = json.loads(changes_event["payload"]) if changes_event and changes_event["payload"] else {}
+                except (json.JSONDecodeError, TypeError):
+                    payload = {}
+                reviewer = payload.get("reviewer") if isinstance(payload, dict) else None
+                if not native_v2:
+                    changes_run = conn.execute(
+                        "SELECT id FROM task_runs WHERE task_id = ? "
+                        "AND outcome = 'changes_requested' ORDER BY id DESC LIMIT 1",
+                        (task_id,),
+                    ).fetchone()
+                    if changes_run is not None and (
+                        not isinstance(reviewer, str) or not reviewer.strip()
+                    ):
+                        return _ret(
+                            False,
+                            "re-review has no durable reviewer provenance; "
+                            "pass reviewer= explicitly",
+                        )
         reviewer = _canonical_assignee(reviewer) if reviewer is not None else None
-        assignee_sql = ", assignee = ?" if reviewer is not None else ""
-        params: tuple[Any, ...]
-        if expected_run_id is None:
-            params = (reviewer, task_id) if reviewer is not None else (task_id,)
-            run_guard = ""
-        else:
-            params = (
-                (reviewer, task_id, int(expected_run_id))
-                if reviewer is not None
-                else (task_id, int(expected_run_id))
-            )
+        if native_v2 and not reviewer:
+            return _ret(False, "independent reviewer is required")
+        if reviewer and reviewer == implementer:
+            return _ret(False, "reviewer must be independent from the writer")
+
+        params: list[Any] = [reviewer]
+        assignment_sql = ""
+        # Compatibility-only legacy rows used assignee as the routing field.
+        if not native_v2 and reviewer is not None:
+            assignment_sql = ", assignee = ?"
+            params.append(reviewer)
+        params.extend([
+            json.dumps(canonical_artifacts, sort_keys=True) if canonical_artifacts else None,
+            task_id,
+        ])
+        run_guard = ""
+        if expected_run_id is not None:
             run_guard = " AND current_run_id = ?"
+            params.append(int(expected_run_id))
         cur = conn.execute(
-            """
-            UPDATE tasks
-               SET status        = 'review',
-                   claim_lock    = NULL,
-                   claim_expires = NULL,
-                   worker_pid    = NULL
-            """ + assignee_sql + """
-             WHERE id = ?
-               AND status IN ('running', 'ready')
-            """ + run_guard,
-            params,
+            "UPDATE tasks SET status = 'review', claim_lock = NULL, "
+            "claim_expires = NULL, worker_pid = NULL, review_assignee = ?"
+            + assignment_sql
+            + ", review_artifacts = ? WHERE id = ? "
+            "AND status IN ('running', 'ready')" + run_guard,
+            tuple(params),
         )
         if cur.rowcount != 1:
-            return _ret(
-                False,
-                "task is not in running/ready (or expected_run_id did not "
-                "match the current run)",
-            )
+            return _ret(False, "task is not in running/ready or run token is stale")
         run_id = _end_run(
-            conn,
-            task_id,
-            outcome="review_requested",
-            status="review",
-            summary=summary,
-            metadata=metadata,
+            conn, task_id, outcome="review_requested", status="review",
+            summary=summary, metadata=metadata,
         )
         if run_id is None and (summary or metadata):
             run_id = _synthesize_ended_run(
-                conn,
-                task_id,
-                outcome="review_requested",
-                summary=summary,
-                metadata=metadata,
+                conn, task_id, outcome="review_requested",
+                summary=summary, metadata=metadata,
             )
         lines = (summary or "").strip().splitlines()
         event_summary = lines[0][:400] if lines else ""
         _append_event(
-            conn,
-            task_id,
-            "review_requested",
+            conn, task_id, "review_requested",
             {
                 "summary": event_summary or None,
                 "implementer": implementer,
                 "reviewer": reviewer,
+                "artifacts": canonical_artifacts,
             },
             run_id=run_id,
         )
     return _ret(True)
+
+
+def pass_review(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    summary: str,
+    actor_profile: str,
+    expected_run_id: int,
+) -> tuple[bool, Optional[str]]:
+    """Authenticated PASS verdict for an active independently routed review."""
+    summary = str(redact_review_value(summary or "")).strip()
+    if not summary:
+        return False, "review evidence summary is required"
+    actor = _canonical_assignee(actor_profile)
+    now = int(time.time())
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status, assignee, review_assignee, review_artifacts, "
+            "current_run_id FROM tasks WHERE id = ?", (task_id,),
+        ).fetchone()
+        if row is None:
+            return False, "task not found"
+        if row["status"] != "running" or row["current_run_id"] is None:
+            return False, "task is not in an active review run"
+        if int(row["current_run_id"]) != int(expected_run_id):
+            return False, "stale reviewer run token"
+        reviewer = _canonical_assignee(row["review_assignee"] or row["assignee"])
+        if actor != reviewer:
+            return False, "actor is not the bound reviewer"
+        if actor == _canonical_assignee(row["assignee"]):
+            return False, "self-approval is forbidden"
+        run = conn.execute(
+            "SELECT profile, ended_at FROM task_runs WHERE id = ? AND task_id = ?",
+            (int(expected_run_id), task_id),
+        ).fetchone()
+        claimed = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? AND run_id = ? "
+            "AND kind = 'claimed' ORDER BY id DESC LIMIT 1",
+            (task_id, int(expected_run_id)),
+        ).fetchone()
+        try:
+            claim_payload = json.loads(claimed["payload"]) if claimed and claimed["payload"] else {}
+        except (json.JSONDecodeError, TypeError):
+            claim_payload = {}
+        if (
+            run is None or run["ended_at"] is not None
+            or _canonical_assignee(run["profile"]) != actor
+            or not isinstance(claim_payload, dict)
+            or claim_payload.get("source_status") != "review"
+        ):
+            return False, "run is not an authenticated review claim"
+        if _decode_review_artifacts(row["review_artifacts"]) is None:
+            return False, "frozen review artifact identity is missing or malformed"
+        if not _parents_satisfied(conn, task_id):
+            return False, "parent dependencies are not satisfied"
+        cur = conn.execute(
+            "UPDATE tasks SET status = 'done', completed_at = ?, claim_lock = NULL, "
+            "claim_expires = NULL, worker_pid = NULL, block_kind = NULL, "
+            "block_recurrences = 0 WHERE id = ? AND status = 'running' "
+            "AND current_run_id = ?",
+            (now, task_id, int(expected_run_id)),
+        )
+        if cur.rowcount != 1:
+            return False, "task changed during review verdict"
+        run_id = _end_run(
+            conn, task_id, outcome="review_passed", status="done", summary=summary,
+        )
+        _append_event(
+            conn, task_id, "review_passed",
+            {"reviewer": actor, "implementer": row["assignee"], "summary": summary[:400]},
+            run_id=run_id,
+        )
+    _clear_failure_counter(conn, task_id)
+    recompute_ready(conn)
+    _cleanup_workspace(conn, task_id)
+    _fire_kanban_lifecycle_hook(
+        "kanban_task_completed", task_id, board=get_current_board(),
+        assignee=row["assignee"], run_id=run_id,
+    )
+    return True, None
 
 
 def request_changes(
@@ -6654,6 +6972,7 @@ def request_changes(
     task_id: str,
     *,
     reason: str,
+    actor_profile: Optional[str] = None,
     expected_run_id: Optional[int] = None,
 ) -> tuple[bool, Optional[str]]:
     """Finish an active review run and route the task back for rework.
@@ -6670,7 +6989,8 @@ def request_changes(
 
     with write_txn(conn):
         task_row = conn.execute(
-            "SELECT status, assignee, current_run_id FROM tasks WHERE id = ?",
+            "SELECT status, assignee, review_assignee, current_run_id "
+            "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         if task_row is None:
@@ -6680,6 +7000,24 @@ def request_changes(
             return False, "task is not in an active review run"
         if expected_run_id is not None and int(current_run_id) != int(expected_run_id):
             return False, "run_id mismatch"
+        effective_reviewer = _canonical_assignee(
+            task_row["review_assignee"] or task_row["assignee"]
+        )
+        if actor_profile is not None:
+            if expected_run_id is None:
+                return False, "active reviewer run token is required"
+            actor = _canonical_assignee(actor_profile)
+            run_profile = conn.execute(
+                "SELECT profile, ended_at FROM task_runs WHERE id = ? AND task_id = ?",
+                (int(current_run_id), task_id),
+            ).fetchone()
+            if (
+                actor != effective_reviewer
+                or run_profile is None
+                or run_profile["ended_at"] is not None
+                or _canonical_assignee(run_profile["profile"]) != actor
+            ):
+                return False, "actor is not the bound reviewer for the active run"
 
         claimed_event = conn.execute(
             "SELECT payload FROM task_events "
@@ -6721,11 +7059,7 @@ def request_changes(
         implementer = requested_payload.get("implementer")
         if not isinstance(implementer, str) or not implementer.strip():
             return False, "review handoff has no valid implementer provenance"
-        reviewer = task_row["assignee"]
-        if isinstance(reviewer, str) and reviewer.strip():
-            reviewer = _canonical_assignee(reviewer)
-        else:
-            reviewer = None
+        reviewer = effective_reviewer
 
         new_status = _landing_status_after_parents(conn, task_id)
         # NOTE: consecutive_failures is deliberately PRESERVED (neither
@@ -6737,6 +7071,7 @@ def request_changes(
             UPDATE tasks
                SET status = ?,
                    assignee = COALESCE(?, assignee),
+                   review_artifacts = NULL,
                    claim_lock = NULL,
                    claim_expires = NULL,
                    worker_pid = NULL
@@ -9578,9 +9913,10 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     should have spawned a review agent.
     """
     rows = conn.execute(
-        "SELECT DISTINCT assignee FROM tasks "
-        "WHERE status = 'review' AND assignee IS NOT NULL "
-        "    AND claim_lock IS NULL"
+        "SELECT DISTINCT COALESCE(review_assignee, assignee) AS assignee "
+        "FROM tasks WHERE status = 'review' "
+        "AND COALESCE(review_assignee, assignee) IS NOT NULL "
+        "AND claim_lock IS NULL"
     ).fetchall()
     if not rows:
         return False
@@ -9608,6 +9944,17 @@ def review_dispatch_enabled() -> bool:
         )
     except Exception:
         return True
+
+
+def native_scheduling_enabled() -> bool:
+    """Fail closed until an operator explicitly activates native scheduling."""
+    try:
+        from hermes_cli.config import load_config
+        return bool(
+            (load_config() or {}).get("kanban", {}).get("native_scheduling", False)
+        )
+    except Exception:
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -9942,6 +10289,11 @@ def _dispatch_once_locked(
     reap_worker_zombies()
 
     result = DispatchResult()
+    # Scheduling runs under the singleton dispatcher before queue enumeration.
+    # It is fail-closed behind an explicit activation knob; a restart or missed
+    # tick catches up exactly once and can spawn the newly-ready card this tick.
+    if native_scheduling_enabled():
+        process_scheduled_tasks(conn)
     result.reclaimed = release_stale_claims(conn)
     if reconcile_orphans:
         # Orphaned-card reconciliation: requeue 'running' cards whose claim
@@ -10043,8 +10395,8 @@ def _dispatch_once_locked(
     review_rows = []
     if review_dispatch_enabled():
         review_rows = conn.execute(
-            "SELECT id, assignee FROM tasks "
-            "WHERE status = 'review' AND claim_lock IS NULL "
+            "SELECT id, COALESCE(review_assignee, assignee) AS assignee "
+            "FROM tasks WHERE status = 'review' AND claim_lock IS NULL "
             "ORDER BY priority DESC, created_at ASC"
         ).fetchall()
     # Review-lane reservation (OOF-30 review finding): the ready loop runs
@@ -10090,9 +10442,10 @@ def _dispatch_once_locked(
     _per_profile_running: dict[str, int] = {}
     if _per_profile_cap is not None:
         for prow in conn.execute(
-            "SELECT assignee, COUNT(*) AS n FROM tasks "
-            "WHERE status = 'running' AND assignee IS NOT NULL "
-            "GROUP BY assignee"
+            "SELECT r.profile AS assignee, COUNT(*) AS n FROM tasks t "
+            "JOIN task_runs r ON r.id = t.current_run_id "
+            "WHERE t.status = 'running' AND r.profile IS NOT NULL "
+            "GROUP BY r.profile"
         ):
             _per_profile_running[prow["assignee"]] = int(prow["n"])
     # Normalize default_assignee once: empty/whitespace string → None so the
@@ -10354,9 +10707,15 @@ def _dispatch_once_locked(
                     _per_profile_running.get(row["assignee"], 0) + 1
                 )
             continue
-        claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
+        claimed = claim_review_task(
+            conn, row["id"], ttl_seconds=ttl_seconds,
+            actor_profile=row["assignee"],
+        )
         if claimed is None:
             continue
+        # Spawn routing is the effective reviewer while durable task.assignee
+        # remains the writer. This mutation is in-memory only.
+        claimed.assignee = row["assignee"]
         try:
             resolved_branch_name = None
             if claimed.workspace_kind == "worktree":

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1084,6 +1084,7 @@ class Task:
     # directly remain source-compatible with pre-review releases.
     review_assignee: Optional[str] = None
     review_artifacts: Optional[dict] = None
+    review_protocol: str = "native_v2"
     scheduled_for: Optional[int] = None
     due_at: Optional[int] = None
     pre_notice_sent_at: Optional[int] = None
@@ -1184,6 +1185,11 @@ class Task:
             review_artifacts=(
                 _decode_review_artifacts(row["review_artifacts"])
                 if "review_artifacts" in keys else None
+            ),
+            review_protocol=(
+                row["review_protocol"]
+                if "review_protocol" in keys and row["review_protocol"]
+                else "legacy"
             ),
             scheduled_for=(row["scheduled_for"] if "scheduled_for" in keys else None),
             due_at=(row["due_at"] if "due_at" in keys else None),
@@ -1371,6 +1377,11 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- a review cycle and survives reviewer retries/restarts.
     review_assignee      TEXT,
     review_artifacts     TEXT,
+    -- Authority mode is durable row state, never inferred from nullable call
+    -- arguments. Fresh work is fail-closed; migration marks existing rows as
+    -- legacy before they can use the compatibility lifecycle.
+    review_protocol      TEXT NOT NULL DEFAULT 'native_v2'
+                         CHECK (review_protocol IN ('native_v2', 'legacy')),
     -- UTC Unix epochs avoid worker-local timezone/DST disagreement.
     scheduled_for        INTEGER,
     due_at               INTEGER,
@@ -2729,6 +2740,18 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         _add_column_if_missing(
             conn, "tasks", "review_artifacts", "review_artifacts TEXT"
         )
+    if "review_protocol" not in cols:
+        _add_column_if_missing(
+            conn,
+            "tasks",
+            "review_protocol",
+            "review_protocol TEXT NOT NULL DEFAULT 'native_v2' "
+            "CHECK (review_protocol IN ('native_v2', 'legacy'))",
+        )
+        # This branch only runs for a board created by a pre-v2 runtime. Mark
+        # exactly those already-existing rows as compatibility-only. Tasks
+        # created after this migration inherit the fail-closed native default.
+        conn.execute("UPDATE tasks SET review_protocol = 'legacy'")
 
     # Additive native scheduling migration. NULL means legacy/immediate work.
     for column in ("scheduled_for", "due_at", "pre_notice_sent_at"):
@@ -5566,17 +5589,17 @@ def complete_task(
         "SELECT status, current_run_id FROM tasks WHERE id = ?", (task_id,)
     ).fetchone()
     if review_gate is not None:
-        # Native v2 reviews carry a frozen artifact identity and require the
-        # authenticated pass_review() verdict.  Legacy review rows predate
-        # that field and retain their operator-driven complete behavior during
-        # the additive migration window.
+        # Native v2 authority is a durable row property, not inferred from a
+        # nullable artifact. Legacy review rows predate the protocol marker and
+        # retain operator-driven completion during the additive migration.
         native_review = conn.execute(
-            "SELECT review_artifacts FROM tasks WHERE id = ?", (task_id,)
+            "SELECT review_artifacts, review_protocol FROM tasks WHERE id = ?",
+            (task_id,),
         ).fetchone()
         if (
             review_gate["status"] == "review"
             and native_review is not None
-            and native_review["review_artifacts"] is not None
+            and native_review["review_protocol"] != "legacy"
         ):
             return False
         if review_gate["status"] == "running" and review_gate["current_run_id"]:
@@ -5593,7 +5616,7 @@ def complete_task(
                 isinstance(source_payload, dict)
                 and source_payload.get("source_status") == "review"
                 and native_review is not None
-                and native_review["review_artifacts"] is not None
+                and native_review["review_protocol"] != "legacy"
             ):
                 return False
     # Fail before validating cards or staging artifacts; re-check inside the
@@ -5638,10 +5661,36 @@ def complete_task(
         if not _parents_satisfied(conn, task_id):
             return False
         prior = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?",
+            "SELECT status, current_run_id, review_protocol FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         prior_status = prior["status"] if prior else None
+        # Re-evaluate the security-sensitive review gate under the same
+        # BEGIN IMMEDIATE transaction as the completion update. The optimistic
+        # check above gives callers an early failure, but cannot be the trust
+        # boundary because another connection may route the task to native
+        # review before this transaction acquires the write lock.
+        if prior is not None and prior["review_protocol"] != "legacy":
+            if prior_status == "review":
+                return False
+            if prior_status == "running" and prior["current_run_id"] is not None:
+                claimed = conn.execute(
+                    "SELECT payload FROM task_events WHERE task_id = ? AND run_id = ? "
+                    "AND kind = 'claimed' ORDER BY id DESC LIMIT 1",
+                    (task_id, int(prior["current_run_id"])),
+                ).fetchone()
+                try:
+                    claimed_payload = (
+                        json.loads(claimed["payload"])
+                        if claimed and claimed["payload"] else {}
+                    )
+                except (json.JSONDecodeError, TypeError):
+                    claimed_payload = {}
+                if (
+                    isinstance(claimed_payload, dict)
+                    and claimed_payload.get("source_status") == "review"
+                ):
+                    return False
         if expected_run_id is None:
             cur = conn.execute(
                 """
@@ -6749,36 +6798,41 @@ def request_review(
 ):
     """Atomically close a writer run and route a frozen tree to review.
 
-    Authenticated v2 callers pass ``actor_profile`` and must also provide the
-    active run token, an independent reviewer, and a valid frozen artifact
-    identity. Legacy operator/CLI callers remain readable during migration,
-    but are explicitly compatibility-only and do not get v2 authorization
-    claims unless they provide those arguments.
+    Authority mode is selected only by the task's durable ``review_protocol``
+    marker. New tasks are native v2 and must provide the active run token, an
+    authenticated writer, an independent reviewer, and frozen artifact
+    identity. Only rows proven to predate the additive migration are marked
+    legacy and retain the compatibility lifecycle.
     """
     def _ret(ok: bool, reason: Optional[str] = None):
         return (ok, reason) if with_reason else ok
 
     summary = redact_review_value(summary)
     metadata = redact_review_value(metadata)
-    native_v2 = actor_profile is not None or artifacts is not None
-    canonical_artifacts: Optional[dict] = None
-    if native_v2:
-        canonical_artifacts, artifact_error = _validate_frozen_review_artifacts(
-            redact_review_value(artifacts)
-        )
-        if artifact_error:
-            return _ret(False, artifact_error)
     actor = _canonical_assignee(actor_profile) if actor_profile is not None else None
+    canonical_artifacts: Optional[dict] = None
 
     with write_txn(conn):
         if not _parents_satisfied(conn, task_id):
             return _ret(False, "parent dependencies are not satisfied")
         trow = conn.execute(
-            "SELECT assignee, review_assignee, status, claim_lock, current_run_id "
-            "FROM tasks WHERE id = ?", (task_id,),
+            "SELECT assignee, review_assignee, status, claim_lock, current_run_id, "
+            "review_protocol FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if trow is None:
             return _ret(False, "task not found")
+        # Compatibility is an explicit allow-list. Any missing/corrupt/future
+        # marker fails closed as native rather than becoming an authorization
+        # downgrade merely because it is not the current native literal.
+        native_v2 = trow["review_protocol"] != "legacy"
+        if native_v2:
+            if actor_profile is None:
+                return _ret(False, "authenticated writer profile is required")
+            canonical_artifacts, artifact_error = _validate_frozen_review_artifacts(
+                redact_review_value(artifacts)
+            )
+            if artifact_error:
+                return _ret(False, artifact_error)
         implementer = _canonical_assignee(trow["assignee"])
         if native_v2:
             if expected_run_id is None:
@@ -6903,10 +6957,12 @@ def pass_review(
     with write_txn(conn):
         row = conn.execute(
             "SELECT status, assignee, review_assignee, review_artifacts, "
-            "current_run_id FROM tasks WHERE id = ?", (task_id,),
+            "review_protocol, current_run_id FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if row is None:
             return False, "task not found"
+        if row["review_protocol"] != "native_v2":
+            return False, "authenticated PASS is available only for native review cycles"
         if row["status"] != "running" or row["current_run_id"] is None:
             return False, "task is not in an active review run"
         if int(row["current_run_id"]) != int(expected_run_id):
@@ -6989,8 +7045,8 @@ def request_changes(
 
     with write_txn(conn):
         task_row = conn.execute(
-            "SELECT status, assignee, review_assignee, current_run_id "
-            "FROM tasks WHERE id = ?",
+            "SELECT status, assignee, review_assignee, review_artifacts, "
+            "review_protocol, current_run_id FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         if task_row is None:
@@ -6998,6 +7054,13 @@ def request_changes(
         current_run_id = task_row["current_run_id"]
         if task_row["status"] != "running" or current_run_id is None:
             return False, "task is not in an active review run"
+        native_v2 = task_row["review_protocol"] != "legacy"
+        if native_v2 and actor_profile is None:
+            return False, "authenticated reviewer profile is required"
+        if native_v2 and expected_run_id is None:
+            return False, "active reviewer run token is required"
+        if native_v2 and _decode_review_artifacts(task_row["review_artifacts"]) is None:
+            return False, "frozen review artifact identity is missing or malformed"
         if expected_run_id is not None and int(current_run_id) != int(expected_run_id):
             return False, "run_id mismatch"
         effective_reviewer = _canonical_assignee(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4933,18 +4933,40 @@ def claim_review_task(
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
         routing = conn.execute(
-            "SELECT assignee, review_assignee FROM tasks "
+            "SELECT assignee, review_assignee, review_protocol, review_artifacts "
+            "FROM tasks "
             "WHERE id = ? AND status = 'review' AND claim_lock IS NULL",
             (task_id,),
         ).fetchone()
         if routing is None:
             return None
-        effective_reviewer = _canonical_assignee(
-            routing["review_assignee"] or routing["assignee"]
-        )
-        if actor_profile is not None and (
-            _canonical_assignee(actor_profile) != effective_reviewer
-        ):
+        native_v2 = routing["review_protocol"] != "legacy"
+        try:
+            effective_reviewer = _canonical_assignee(
+                routing["review_assignee"] if native_v2
+                else (routing["review_assignee"] or routing["assignee"])
+            )
+            writer = _canonical_assignee(routing["assignee"])
+            actor = (
+                _canonical_assignee(actor_profile)
+                if isinstance(actor_profile, str) and actor_profile.strip()
+                else None
+            )
+        except (TypeError, ValueError):
+            return None
+        if native_v2:
+            # Native reviewer authority is never inferred from an omitted
+            # argument, the writer identity, or legacy assignee routing.
+            if actor is None or actor != effective_reviewer or actor == writer:
+                return None
+            try:
+                frozen = json.loads(routing["review_artifacts"])
+            except (json.JSONDecodeError, TypeError):
+                return None
+            canonical_frozen, artifact_error = _validate_frozen_review_artifacts(frozen)
+            if artifact_error or canonical_frozen != frozen:
+                return None
+        elif actor is not None and actor != effective_reviewer:
             return None
         if not _parents_satisfied(conn, task_id):
             demoted = conn.execute(
@@ -9994,19 +10016,19 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
 
 
 def review_dispatch_enabled() -> bool:
-    """Return whether first-class review tasks should dispatch automatically.
-
-    The default is true because Hermes ships the ``sdlc-review`` skill and the
-    review lifecycle includes a supported reviewer-owned changes-requested
-    transition. Operators can disable it for human-only review boards.
-    """
+    """Return True only for an explicit, exact managed Boolean activation."""
     try:
         from hermes_cli.config import load_config
-        return bool(
-            (load_config() or {}).get("kanban", {}).get("review_dispatch", True)
-        )
+
+        config = load_config()
+        if not isinstance(config, dict):
+            return False
+        kanban_config = config.get("kanban")
+        if not isinstance(kanban_config, dict):
+            return False
+        return kanban_config.get("review_dispatch") is True
     except Exception:
-        return True
+        return False
 
 
 def native_scheduling_enabled() -> bool:
@@ -10721,10 +10743,9 @@ def _dispatch_once_locked(
     # Same concurrency model as ready dispatch: review spawns count
     # against max_spawn alongside ready tasks, so the total number of
     # running workers stays bounded.
-    # Auto-dispatch is enabled by default because Hermes bundles the
-    # ``sdlc-review`` skill and reviewer workers can now approve, request
-    # changes without block-loop accounting, or escalate a genuine blocker.
-    # Human-only boards can disable it with ``kanban.review_dispatch``.
+    # Auto-dispatch is fail closed. It activates only when the managed
+    # ``kanban.review_dispatch`` value is the exact Boolean true; missing,
+    # malformed, or unreadable configuration leaves Review parked.
     #
     # ``review_rows`` was enumerated before the ready loop; when it is
     # non-empty the ready loop ran against ``ready_budget`` (one slot held

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -161,6 +161,19 @@ def _task_dict(
     latest_summary: Optional[str] = None,
 ) -> dict[str, Any]:
     d = asdict(task)
+    # Native review routing keeps implementation ownership stable while exposing
+    # the effective reviewer and next authorization gate explicitly to clients.
+    d["effective_reviewer"] = task.review_assignee or (
+        task.assignee if task.status == "review" else None
+    )
+    if task.status == "review":
+        d["next_gate"] = "reviewer_claim"
+    elif task.status == "running" and task.review_artifacts is not None:
+        d["next_gate"] = "review_verdict"
+    elif task.status == "done":
+        d["next_gate"] = None
+    else:
+        d["next_gate"] = "writer_execution"
     # Add derived age metrics so the UI can colour stale cards without
     # computing deltas client-side.
     try:
@@ -618,6 +631,9 @@ class CreateTaskBody(BaseModel):
     # Explicit project link; when omitted, create_task inherits the board's
     # scoped project (if any) so a project-scoped board anchors every task.
     project_id: Optional[str] = None
+    # UTC Unix epochs; scheduled_for parks the card until dispatcher promotion.
+    scheduled_for: Optional[int] = None
+    due_at: Optional[int] = None
 
 
 @router.post("/tasks")
@@ -646,6 +662,8 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             provider_override=payload.provider_override,
             reasoning_effort=payload.reasoning_effort,
             project_id=payload.project_id,
+            scheduled_for=payload.scheduled_for,
+            due_at=payload.due_at,
             board=board,
         )
         task = kanban_db.get_task(conn, task_id)

--- a/tests/gateway/test_kanban_reconcile_orphans.py
+++ b/tests/gateway/test_kanban_reconcile_orphans.py
@@ -139,6 +139,23 @@ class TestReconcileOrphanedRunning:
 
         assert kb.reconcile_orphaned_running(conn) == [tid]
 
+    def test_review_orphan_with_intact_provenance_returns_to_review(self, conn):
+        tid = kb.create_task(conn, title="orphaned reviewer", assignee="writer")
+        writer = kb.claim_task(conn, tid)
+        assert writer is not None
+        frozen = {"commit": "a" * 40, "tree": "b" * 40, "artifacts": []}
+        assert kb.request_review(
+            conn, tid, reviewer="reviewer", artifacts=frozen,
+            actor_profile="writer", expected_run_id=writer.current_run_id,
+        )
+        assert kb.claim_review_task(conn, tid, actor_profile="reviewer") is not None
+        _orphan_running(conn, tid)
+
+        assert kb.reconcile_orphaned_running(conn) == [tid]
+        assert conn.execute(
+            "SELECT status FROM tasks WHERE id=?", (tid,)
+        ).fetchone()["status"] == "review"
+
     def test_non_running_statuses_ignored(self, conn):
         for status in ("todo", "ready", "blocked", "done"):
             tid = kb.create_task(conn, title=f"s-{status}", assignee="w")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -158,11 +158,17 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
     assert "session_id" in task_columns
     assert "tenant" in task_columns
     assert "idempotency_key" in task_columns
+    assert "review_assignee" in task_columns
+    assert "review_artifacts" in task_columns
+    assert "scheduled_for" in task_columns
+    assert "due_at" in task_columns
+    assert "pre_notice_sent_at" in task_columns
     assert "run_id" in event_columns
     # And their indexes — the regression scope of this test:
     assert "idx_tasks_session_id" in indexes
     assert "idx_tasks_tenant" in indexes
     assert "idx_tasks_idempotency" in indexes
+    assert "idx_tasks_schedule" in indexes
     assert "idx_events_run" in indexes
 
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -153,6 +153,25 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
                 "SELECT name FROM sqlite_master WHERE type = 'index'"
             )
         }
+        assert migrated.execute(
+            "SELECT review_protocol FROM tasks WHERE id = 'legacy'"
+        ).fetchone()[0] == "legacy"
+        fresh_id = kb.create_task(
+            migrated, title="created after migration", assignee="writer"
+        )
+        assert migrated.execute(
+            "SELECT review_protocol FROM tasks WHERE id = ?", (fresh_id,)
+        ).fetchone()[0] == "native_v2"
+
+    # Reopen proves the additive migration is idempotent and does not relabel
+    # work created after the one-time legacy-row boundary.
+    with kb.connect(db_path) as reopened:
+        assert reopened.execute(
+            "SELECT review_protocol FROM tasks WHERE id = 'legacy'"
+        ).fetchone()[0] == "legacy"
+        assert reopened.execute(
+            "SELECT review_protocol FROM tasks WHERE id = ?", (fresh_id,)
+        ).fetchone()[0] == "native_v2"
 
     # Additive columns added by migration:
     assert "session_id" in task_columns

--- a/tests/hermes_cli/test_kanban_host_cap.py
+++ b/tests/hermes_cli/test_kanban_host_cap.py
@@ -211,8 +211,16 @@ def test_max_spawn_stays_per_board(kanban_home, all_assignees_spawnable):
 
 
 def _park_in_review(conn: sqlite3.Connection, title: str, assignee: str) -> str:
+    """Create an explicit pre-native fixture for queue-budget tests.
+
+    These tests exercise dispatcher fairness rather than native claim authority;
+    native rows must enter Review through request_review with frozen artifacts.
+    """
     tid = kb.create_task(conn, title=title, assignee=assignee)
-    _set_task_status(conn, tid, "review")
+    conn.execute(
+        "UPDATE tasks SET status = 'review', review_protocol = 'legacy' WHERE id = ?",
+        (tid,),
+    )
     return tid
 
 

--- a/tests/hermes_cli/test_kanban_native_review_v2.py
+++ b/tests/hermes_cli/test_kanban_native_review_v2.py
@@ -207,6 +207,110 @@ def test_request_changes_requires_bound_reviewer_and_restores_writer(conn) -> No
     assert task.review_artifacts is None
 
 
+def test_native_request_review_argument_omission_fails_closed(conn) -> None:
+    """Direct module callers cannot select legacy authority by omitting args."""
+    task_id = kb.create_task(conn, title="no downgrade", assignee="writer")
+    writer_run = kb.claim_task(conn, task_id)
+    assert writer_run is not None
+    before = _event_count(conn, task_id)
+
+    ok, reason = kb.request_review(
+        conn,
+        task_id,
+        reviewer="reviewer",
+        artifacts=_frozen(),
+        expected_run_id=writer_run.current_run_id,
+        with_reason=True,
+    )
+
+    assert ok is False
+    assert "authenticated writer" in (reason or "")
+    assert _event_count(conn, task_id) == before
+
+    ok, reason = kb.request_review(
+        conn,
+        task_id,
+        reviewer="reviewer",
+        artifacts=_frozen(),
+        actor_profile="writer",
+        with_reason=True,
+    )
+
+    assert ok is False
+    assert "run token" in (reason or "")
+    unchanged = kb.get_task(conn, task_id)
+    assert unchanged is not None
+    assert unchanged.status == "running"
+    assert unchanged.current_run_id == writer_run.current_run_id
+    assert unchanged.assignee == "writer"
+    assert unchanged.review_assignee is None
+    assert unchanged.review_artifacts is None
+    assert _event_count(conn, task_id) == before
+
+
+def test_native_request_changes_argument_omission_fails_closed(conn) -> None:
+    task_id = kb.create_task(conn, title="no verdict downgrade", assignee="writer")
+    writer_run = kb.claim_task(conn, task_id)
+    assert writer_run is not None
+    assert kb.request_review(
+        conn,
+        task_id,
+        reviewer="reviewer",
+        artifacts=_frozen(),
+        actor_profile="writer",
+        expected_run_id=writer_run.current_run_id,
+    )
+    review_run = kb.claim_review_task(conn, task_id, actor_profile="reviewer")
+    assert review_run is not None
+    before = _event_count(conn, task_id)
+
+    ok, reason = kb.request_changes(
+        conn,
+        task_id,
+        reason="unauthenticated",
+        expected_run_id=review_run.current_run_id,
+    )
+
+    assert ok is False
+    assert "authenticated reviewer" in (reason or "")
+    assert _event_count(conn, task_id) == before
+
+    ok, reason = kb.request_changes(
+        conn,
+        task_id,
+        reason="missing token",
+        actor_profile="reviewer",
+    )
+
+    assert ok is False
+    assert "run token" in (reason or "")
+    unchanged = kb.get_task(conn, task_id)
+    assert unchanged is not None
+    assert unchanged.status == "running"
+    assert unchanged.current_run_id == review_run.current_run_id
+    assert unchanged.assignee == "writer"
+    assert unchanged.review_assignee == "reviewer"
+    assert unchanged.review_artifacts == _frozen()
+    assert _event_count(conn, task_id) == before
+
+
+def test_generic_complete_cannot_approve_malformed_native_review(conn) -> None:
+    """The generic-complete gate keys off protocol, not nullable artifacts."""
+    task_id = kb.create_task(conn, title="malformed native review", assignee="writer")
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status = 'review', review_assignee = 'reviewer', "
+            "review_artifacts = NULL WHERE id = ?",
+            (task_id,),
+        )
+
+    assert kb.complete_task(conn, task_id) is False
+    task = kb.get_task(conn, task_id)
+    assert task is not None
+    assert task.status == "review"
+    assert not any(event.kind == "completed" for event in kb.list_events(conn, task_id))
+
+
 def test_native_schedule_t15_due_restart_and_duplicate_ticks(tmp_path: Path) -> None:
     db_path = tmp_path / "scheduled.db"
     base = 2_000_000_000

--- a/tests/hermes_cli/test_kanban_native_review_v2.py
+++ b/tests/hermes_cli/test_kanban_native_review_v2.py
@@ -294,6 +294,198 @@ def test_native_request_changes_argument_omission_fails_closed(conn) -> None:
     assert _event_count(conn, task_id) == before
 
 
+@pytest.mark.parametrize("actor", [None, "", "intruder", "writer"])
+def test_native_review_claim_requires_bound_independent_actor(conn, actor) -> None:
+    task_id = kb.create_task(conn, title="claim authority", assignee="writer")
+    writer_run = kb.claim_task(conn, task_id)
+    assert writer_run is not None
+    assert kb.request_review(
+        conn,
+        task_id,
+        reviewer="reviewer",
+        artifacts=_frozen(),
+        actor_profile="writer",
+        expected_run_id=writer_run.current_run_id,
+    )
+    before = _event_count(conn, task_id)
+
+    assert kb.claim_review_task(conn, task_id, actor_profile=actor) is None
+    unchanged = kb.get_task(conn, task_id)
+    assert unchanged is not None
+    assert unchanged.status == "review"
+    assert unchanged.current_run_id is None
+    assert _event_count(conn, task_id) == before
+
+
+def test_native_review_claim_accepts_exact_actor_and_legacy_is_explicit(conn) -> None:
+    native_id = kb.create_task(conn, title="native claim", assignee="writer")
+    writer_run = kb.claim_task(conn, native_id)
+    assert writer_run is not None
+    assert kb.request_review(
+        conn,
+        native_id,
+        reviewer="reviewer",
+        artifacts=_frozen(),
+        actor_profile="writer",
+        expected_run_id=writer_run.current_run_id,
+    )
+    claimed = kb.claim_review_task(conn, native_id, actor_profile=" reviewer ")
+    assert claimed is not None
+    assert kb.latest_run(conn, native_id).profile == "reviewer"
+
+    legacy_id = kb.create_task(conn, title="pre-migration review", assignee="writer")
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status = 'review', assignee = 'reviewer', "
+            "review_protocol = 'legacy' WHERE id = ?",
+            (legacy_id,),
+        )
+    legacy_claim = kb.claim_review_task(conn, legacy_id)
+    assert legacy_claim is not None
+    assert kb.latest_run(conn, legacy_id).profile == "reviewer"
+
+
+def test_native_review_claim_rejects_stale_or_malformed_routing(conn) -> None:
+    for mutation in (
+        "review_assignee = NULL",
+        "review_assignee = 'writer'",
+        "review_artifacts = NULL",
+        "review_artifacts = '{\"commit\":\"bad\"}'",
+    ):
+        task_id = kb.create_task(conn, title="stale routing", assignee="writer")
+        writer_run = kb.claim_task(conn, task_id)
+        assert writer_run is not None
+        assert kb.request_review(
+            conn,
+            task_id,
+            reviewer="reviewer",
+            artifacts=_frozen(),
+            actor_profile="writer",
+            expected_run_id=writer_run.current_run_id,
+        )
+        with kb.write_txn(conn):
+            conn.execute(f"UPDATE tasks SET {mutation} WHERE id = ?", (task_id,))
+        before = _event_count(conn, task_id)
+
+        assert kb.claim_review_task(
+            conn, task_id, actor_profile="reviewer"
+        ) is None
+        assert kb.get_task(conn, task_id).status == "review"
+        assert _event_count(conn, task_id) == before
+
+
+def test_gateway_stuck_probe_uses_dispatchers_exact_review_gate() -> None:
+    source = (
+        Path(__file__).resolve().parents[2] / "gateway" / "kanban_watchers.py"
+    ).read_text(encoding="utf-8")
+    assert "_review_probe = _kb.review_dispatch_enabled()" in source
+    assert "if _review_probe and _kb.has_spawnable_review(conn):" in source
+
+
+@pytest.mark.parametrize(
+    ("config_value", "expected"),
+    [
+        ({}, False),
+        ({"kanban": {}}, False),
+        ({"kanban": {"review_dispatch": False}}, False),
+        ({"kanban": {"review_dispatch": True}}, True),
+        ({"kanban": {"review_dispatch": None}}, False),
+        ({"kanban": {"review_dispatch": 0}}, False),
+        ({"kanban": {"review_dispatch": 1}}, False),
+        ({"kanban": {"review_dispatch": "true"}}, False),
+        ({"kanban": []}, False),
+        ([], False),
+    ],
+)
+def test_review_dispatch_gate_requires_explicit_boolean_true(
+    monkeypatch: pytest.MonkeyPatch,
+    config_value,
+    expected: bool,
+) -> None:
+    from hermes_cli import config as cfgmod
+
+    monkeypatch.setattr(cfgmod, "load_config", lambda: config_value)
+    assert kb.review_dispatch_enabled() is expected
+
+
+def test_review_dispatch_gate_fails_closed_on_loader_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hermes_cli import config as cfgmod
+
+    def broken_loader():
+        raise RuntimeError("unreadable managed config")
+
+    monkeypatch.setattr(cfgmod, "load_config", broken_loader)
+    assert kb.review_dispatch_enabled() is False
+
+
+def test_dispatcher_does_not_claim_review_until_explicitly_enabled(
+    conn,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hermes_cli import config as cfgmod
+    from hermes_cli import profiles
+
+    task_id = kb.create_task(conn, title="staged dispatch", assignee="writer")
+    writer_run = kb.claim_task(conn, task_id)
+    assert writer_run is not None
+    assert kb.request_review(
+        conn,
+        task_id,
+        reviewer="reviewer",
+        artifacts=_frozen(),
+        actor_profile="writer",
+        expected_run_id=writer_run.current_run_id,
+    )
+    claimed_before = len([
+        event for event in kb.list_events(conn, task_id) if event.kind == "claimed"
+    ])
+    spawned = []
+    monkeypatch.setattr(profiles, "profile_exists", lambda profile: profile == "reviewer")
+
+    monkeypatch.setattr(cfgmod, "load_config", lambda: {})
+    disabled = kb.dispatch_once(
+        conn,
+        spawn_fn=lambda task, workspace: spawned.append(task.assignee) or 123,
+    )
+    assert disabled.spawned == []
+    assert spawned == []
+    assert kb.get_task(conn, task_id).status == "review"
+    assert len([
+        event for event in kb.list_events(conn, task_id) if event.kind == "claimed"
+    ]) == claimed_before
+
+    def broken_loader():
+        raise RuntimeError("config unavailable")
+
+    monkeypatch.setattr(cfgmod, "load_config", broken_loader)
+    failed_closed = kb.dispatch_once(
+        conn,
+        spawn_fn=lambda task, workspace: spawned.append(task.assignee) or 124,
+    )
+    assert failed_closed.spawned == []
+    assert spawned == []
+    assert kb.get_task(conn, task_id).status == "review"
+
+    monkeypatch.setattr(
+        cfgmod,
+        "load_config",
+        lambda: {"kanban": {"review_dispatch": True}},
+    )
+    enabled = kb.dispatch_once(
+        conn,
+        spawn_fn=lambda task, workspace: spawned.append(task.assignee) or 125,
+    )
+    assert [item[0] for item in enabled.spawned] == [task_id]
+    assert spawned == ["reviewer"]
+    running = kb.get_task(conn, task_id)
+    assert running is not None
+    assert running.status == "running"
+    assert running.assignee == "writer"
+    assert kb.latest_run(conn, task_id).profile == "reviewer"
+
+
 def test_generic_complete_cannot_approve_malformed_native_review(conn) -> None:
     """The generic-complete gate keys off protocol, not nullable artifacts."""
     task_id = kb.create_task(conn, title="malformed native review", assignee="writer")

--- a/tests/hermes_cli/test_kanban_native_review_v2.py
+++ b/tests/hermes_cli/test_kanban_native_review_v2.py
@@ -1,0 +1,368 @@
+"""Security and routing contracts for native same-card review v2."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def conn(tmp_path: Path):
+    db = kb.connect(tmp_path / "kanban.db")
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _frozen() -> dict:
+    return {
+        "commit": "a" * 40,
+        "tree": "b" * 40,
+        "artifacts": [{"path": "dist/release.tar", "sha256": "c" * 64}],
+    }
+
+
+def _event_count(conn, task_id: str) -> int:
+    return int(conn.execute(
+        "SELECT COUNT(*) FROM task_events WHERE task_id = ?", (task_id,)
+    ).fetchone()[0])
+
+
+def test_same_writer_review_rejected_without_mutation(conn) -> None:
+    task_id = kb.create_task(conn, title="independent review", assignee="writer")
+    run = kb.claim_task(conn, task_id)
+    assert run is not None
+    before = _event_count(conn, task_id)
+
+    ok, reason = kb.request_review(
+        conn,
+        task_id,
+        reviewer="writer",
+        artifacts=_frozen(),
+        actor_profile="writer",
+        expected_run_id=run.current_run_id,
+        with_reason=True,
+    )
+
+    assert ok is False
+    assert "independent" in (reason or "")
+    task = kb.get_task(conn, task_id)
+    assert task is not None
+    assert task.status == "running"
+    assert task.current_run_id == run.current_run_id
+    assert task.review_assignee is None
+    assert _event_count(conn, task_id) == before
+
+
+def test_request_review_preserves_writer_and_freezes_artifacts(conn) -> None:
+    task_id = kb.create_task(conn, title="freeze me", assignee="writer")
+    run = kb.claim_task(conn, task_id)
+    assert run is not None
+    frozen = _frozen()
+
+    assert kb.request_review(
+        conn,
+        task_id,
+        reviewer="reviewer",
+        artifacts=frozen,
+        actor_profile="writer",
+        expected_run_id=run.current_run_id,
+    )
+    task = kb.get_task(conn, task_id)
+    assert task is not None
+    assert task.status == "review"
+    assert task.assignee == "writer"
+    assert task.review_assignee == "reviewer"
+    assert task.review_artifacts == frozen
+    event = [e for e in kb.list_events(conn, task_id) if e.kind == "review_requested"][-1]
+    assert event.payload["implementer"] == "writer"
+    assert event.payload["reviewer"] == "reviewer"
+    assert event.payload["artifacts"] == frozen
+
+    # The frozen identity is immutable for the current review cycle.
+    with pytest.raises(RuntimeError, match="frozen"):
+        kb.assign_task(conn, task_id, "other-writer")
+
+
+@pytest.mark.parametrize(
+    "artifacts",
+    [
+        None,
+        {},
+        {"commit": "nope", "tree": "b" * 40, "artifacts": []},
+        {"commit": "a" * 40, "tree": "b" * 40, "artifacts": [{"path": "x"}]},
+        {
+            "commit": "a" * 40,
+            "tree": "b" * 40,
+            "artifacts": [{"path": "../escape", "sha256": "c" * 64}],
+        },
+    ],
+)
+def test_frozen_artifact_validation_is_fail_closed(conn, artifacts) -> None:
+    task_id = kb.create_task(conn, title="bad identity", assignee="writer")
+    run = kb.claim_task(conn, task_id)
+    assert run is not None
+    before = _event_count(conn, task_id)
+    ok, _reason = kb.request_review(
+        conn,
+        task_id,
+        reviewer="reviewer",
+        artifacts=artifacts,
+        actor_profile="writer",
+        expected_run_id=run.current_run_id,
+        with_reason=True,
+    )
+    assert ok is False
+    assert kb.get_task(conn, task_id).status == "running"
+    assert _event_count(conn, task_id) == before
+
+
+def test_authenticated_reviewer_verdicts_and_generic_complete_bypass(conn) -> None:
+    task_id = kb.create_task(conn, title="verdict", assignee="writer")
+    writer_run = kb.claim_task(conn, task_id)
+    assert writer_run is not None
+    assert kb.request_review(
+        conn,
+        task_id,
+        reviewer="reviewer",
+        artifacts=_frozen(),
+        actor_profile="writer",
+        expected_run_id=writer_run.current_run_id,
+    )
+    review_run = kb.claim_review_task(conn, task_id, actor_profile="reviewer")
+    assert review_run is not None
+
+    assert not kb.complete_task(
+        conn, task_id, expected_run_id=review_run.current_run_id
+    )
+    assert not kb.pass_review(
+        conn,
+        task_id,
+        summary="wrong identity",
+        actor_profile="intruder",
+        expected_run_id=review_run.current_run_id,
+    )[0]
+    assert not kb.pass_review(
+        conn,
+        task_id,
+        summary="stale token",
+        actor_profile="reviewer",
+        expected_run_id=review_run.current_run_id + 1,
+    )[0]
+
+    ok, reason = kb.pass_review(
+        conn,
+        task_id,
+        summary="independently verified",
+        actor_profile="reviewer",
+        expected_run_id=review_run.current_run_id,
+    )
+    assert ok is True, reason
+    done = kb.get_task(conn, task_id)
+    assert done.status == "done"
+    assert done.assignee == "writer"
+    assert [e.kind for e in kb.list_events(conn, task_id)][-1] == "review_passed"
+
+
+def test_request_changes_requires_bound_reviewer_and_restores_writer(conn) -> None:
+    task_id = kb.create_task(conn, title="changes", assignee="writer")
+    writer_run = kb.claim_task(conn, task_id)
+    assert writer_run is not None
+    assert kb.request_review(
+        conn,
+        task_id,
+        reviewer="reviewer",
+        artifacts=_frozen(),
+        actor_profile="writer",
+        expected_run_id=writer_run.current_run_id,
+    )
+    review_run = kb.claim_review_task(conn, task_id, actor_profile="reviewer")
+    assert review_run is not None
+
+    ok, reason = kb.request_changes(
+        conn,
+        task_id,
+        reason="fix boundary",
+        actor_profile="intruder",
+        expected_run_id=review_run.current_run_id,
+    )
+    assert ok is False
+    assert "reviewer" in (reason or "")
+
+    assert kb.request_changes(
+        conn,
+        task_id,
+        reason="fix boundary",
+        actor_profile="reviewer",
+        expected_run_id=review_run.current_run_id,
+    ) == (True, "writer")
+    task = kb.get_task(conn, task_id)
+    assert task.status == "ready"
+    assert task.assignee == "writer"
+    assert task.review_assignee == "reviewer"
+    assert task.review_artifacts is None
+
+
+def test_native_schedule_t15_due_restart_and_duplicate_ticks(tmp_path: Path) -> None:
+    db_path = tmp_path / "scheduled.db"
+    base = 2_000_000_000
+    db = kb.connect(db_path)
+    task_id = kb.create_task(
+        db,
+        title="future work",
+        assignee="writer",
+        scheduled_for=base,
+        due_at=base + 3600,
+    )
+    task = kb.get_task(db, task_id)
+    assert task.status == "scheduled"
+    assert task.scheduled_for == base
+    assert task.due_at == base + 3600
+
+    assert kb.process_scheduled_tasks(db, now=base - 901) == {
+        "noticed": [], "promoted": []
+    }
+    first = kb.process_scheduled_tasks(db, now=base - 900)
+    assert first == {"noticed": [task_id], "promoted": []}
+    assert kb.process_scheduled_tasks(db, now=base - 899) == {
+        "noticed": [], "promoted": []
+    }
+    db.close()
+
+    # Restart recovery: the durable marker suppresses duplicate notice and a
+    # missed due tick promotes exactly once on the next open.
+    db = kb.connect(db_path)
+    try:
+        due = kb.process_scheduled_tasks(db, now=base + 60)
+        assert due == {"noticed": [], "promoted": [task_id]}
+        assert kb.get_task(db, task_id).status == "ready"
+        assert kb.process_scheduled_tasks(db, now=base + 60) == {
+            "noticed": [], "promoted": []
+        }
+        kinds = [e.kind for e in kb.list_events(db, task_id)]
+        assert kinds.count("scheduled_pre_notice") == 1
+        assert kinds.count("scheduled_promoted") == 1
+    finally:
+        db.close()
+
+
+def test_review_and_schedule_events_are_ordered_and_deduplicated_for_sub(conn) -> None:
+    task_id = kb.create_task(conn, title="notify lifecycle", assignee="writer")
+    kb.add_notify_sub(
+        conn, task_id=task_id, platform="api_server", chat_id="controller"
+    )
+    writer_run = kb.claim_task(conn, task_id)
+    assert writer_run is not None
+    assert kb.request_review(
+        conn,
+        task_id,
+        reviewer="reviewer",
+        artifacts=_frozen(),
+        actor_profile="writer",
+        expected_run_id=writer_run.current_run_id,
+    )
+    review_run = kb.claim_review_task(conn, task_id, actor_profile="reviewer")
+    assert review_run is not None
+    assert kb.request_changes(
+        conn,
+        task_id,
+        reason="structured correction",
+        actor_profile="reviewer",
+        expected_run_id=review_run.current_run_id,
+    )[0]
+
+    kinds = ("review_requested", "review_passed", "changes_requested")
+    old, new, events = kb.claim_unseen_events_for_sub(
+        conn,
+        task_id=task_id,
+        platform="api_server",
+        chat_id="controller",
+        kinds=kinds,
+    )
+    assert old < new
+    assert [e.kind for e in events] == ["review_requested", "changes_requested"]
+    ids = [e.id for e in events]
+    assert ids == sorted(ids)
+    # Atomic cursor claim prevents a second notifier from seeing the range.
+    _old2, _new2, duplicate = kb.claim_unseen_events_for_sub(
+        conn,
+        task_id=task_id,
+        platform="api_server",
+        chat_id="controller",
+        kinds=kinds,
+    )
+    assert duplicate == []
+    # Rewind provides bounded retry without event loss.
+    assert kb.rewind_notify_cursor(
+        conn,
+        task_id=task_id,
+        platform="api_server",
+        chat_id="controller",
+        claimed_cursor=new,
+        old_cursor=old,
+    )
+    _old3, _new3, retried = kb.claim_unseen_events_for_sub(
+        conn,
+        task_id=task_id,
+        platform="api_server",
+        chat_id="controller",
+        kinds=kinds,
+    )
+    assert [e.id for e in retried] == ids
+
+
+def test_end_to_end_distinct_writer_reviewer_changes_rereview_pass(conn) -> None:
+    task_id = kb.create_task(conn, title="full cycle", assignee="writer")
+    writer_run = kb.claim_task(conn, task_id)
+    assert writer_run is not None
+    assert kb.request_review(
+        conn,
+        task_id,
+        reviewer="reviewer",
+        artifacts=_frozen(),
+        actor_profile="writer",
+        expected_run_id=writer_run.current_run_id,
+    )
+    first_review = kb.claim_review_task(conn, task_id, actor_profile="reviewer")
+    assert first_review is not None
+    assert kb.request_changes(
+        conn,
+        task_id,
+        reason="correct the boundary",
+        actor_profile="reviewer",
+        expected_run_id=first_review.current_run_id,
+    ) == (True, "writer")
+
+    second_writer = kb.claim_task(conn, task_id)
+    assert second_writer is not None
+    assert second_writer.assignee == "writer"
+    assert kb.request_review(
+        conn,
+        task_id,
+        reviewer=None,  # durable routing reuses the independently bound reviewer
+        artifacts=_frozen(),
+        actor_profile="writer",
+        expected_run_id=second_writer.current_run_id,
+    )
+    second_review = kb.claim_review_task(conn, task_id, actor_profile="reviewer")
+    assert second_review is not None
+    assert kb.pass_review(
+        conn,
+        task_id,
+        summary="verified corrected frozen tree",
+        actor_profile="reviewer",
+        expected_run_id=second_review.current_run_id,
+    ) == (True, None)
+
+    task = kb.get_task(conn, task_id)
+    assert task.status == "done"
+    assert task.assignee == "writer"
+    assert task.review_assignee == "reviewer"
+    kinds = [e.kind for e in kb.list_events(conn, task_id)]
+    assert kinds.count("review_requested") == 2
+    assert kinds.count("changes_requested") == 1
+    assert kinds.count("review_passed") == 1

--- a/tests/hermes_cli/test_kanban_native_review_v2.py
+++ b/tests/hermes_cli/test_kanban_native_review_v2.py
@@ -486,6 +486,108 @@ def test_dispatcher_does_not_claim_review_until_explicitly_enabled(
     assert kb.latest_run(conn, task_id).profile == "reviewer"
 
 
+@pytest.mark.parametrize("provenance", ["missing", "stale"])
+def test_review_reclaim_without_current_run_fails_closed_to_review(
+    conn, provenance: str,
+) -> None:
+    task_id = kb.create_task(conn, title="lost review bookkeeping", assignee="writer")
+    writer_run = kb.claim_task(conn, task_id)
+    assert writer_run is not None
+    assert kb.request_review(
+        conn, task_id, reviewer="reviewer", artifacts=_frozen(),
+        actor_profile="writer", expected_run_id=writer_run.current_run_id,
+    )
+    assert kb.claim_review_task(conn, task_id, actor_profile="reviewer") is not None
+    with kb.write_txn(conn):
+        current_run_id = None if provenance == "missing" else writer_run.current_run_id
+        conn.execute(
+            "UPDATE tasks SET current_run_id = ? WHERE id = ?",
+            (current_run_id, task_id),
+        )
+
+    assert kb.reclaim_task(conn, task_id, reason="repair missing run")
+    recovered = kb.get_task(conn, task_id)
+    assert recovered is not None
+    assert recovered.status == "review"
+    assert recovered.assignee == "writer"
+    assert recovered.review_assignee == "reviewer"
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "review_assignee = NULL",
+        "review_assignee = 'writer'",
+        "review_artifacts = NULL",
+        "review_artifacts = '{\"commit\":\"bad\"}'",
+    ],
+)
+def test_malformed_review_cannot_reserve_capacity_ahead_of_valid_ready(
+    conn, monkeypatch: pytest.MonkeyPatch, mutation: str,
+) -> None:
+    from hermes_cli import config as cfgmod
+    from hermes_cli import profiles
+
+    malformed = kb.create_task(
+        conn, title="malformed review", assignee="writer", priority=100
+    )
+    writer_run = kb.claim_task(conn, malformed)
+    assert writer_run is not None
+    assert kb.request_review(
+        conn, malformed, reviewer="reviewer", artifacts=_frozen(),
+        actor_profile="writer", expected_run_id=writer_run.current_run_id,
+    )
+    with kb.write_txn(conn):
+        conn.execute(f"UPDATE tasks SET {mutation} WHERE id = ?", (malformed,))
+    valid = kb.create_task(conn, title="valid work", assignee="worker", priority=1)
+    malformed_events = _event_count(conn, malformed)
+    spawned = []
+    monkeypatch.setattr(
+        cfgmod, "load_config", lambda: {"kanban": {"review_dispatch": True}}
+    )
+    monkeypatch.setattr(
+        profiles, "profile_exists", lambda profile: profile in {"reviewer", "worker"}
+    )
+
+    result = kb.dispatch_once(
+        conn,
+        spawn_fn=lambda task, workspace: spawned.append(task.id) or 123,
+        max_spawn=1,
+    )
+
+    assert [item[0] for item in result.spawned] == [valid]
+    assert spawned == [valid]
+    assert kb.get_task(conn, malformed).status == "review"
+    assert _event_count(conn, malformed) == malformed_events
+
+
+@pytest.mark.parametrize(
+    ("config_value", "expected"),
+    [
+        ({}, False),
+        ({"kanban": {}}, False),
+        ({"kanban": {"native_scheduling": None}}, False),
+        ({"kanban": {"native_scheduling": False}}, False),
+        ({"kanban": {"native_scheduling": 0}}, False),
+        ({"kanban": {"native_scheduling": 1}}, False),
+        ({"kanban": {"native_scheduling": "false"}}, False),
+        ({"kanban": {"native_scheduling": "true"}}, False),
+        ({"kanban": {"native_scheduling": []}}, False),
+        ({"kanban": {"native_scheduling": {}}}, False),
+        ({"kanban": {"native_scheduling": True}}, True),
+        ({"kanban": []}, False),
+        ([], False),
+    ],
+)
+def test_native_scheduling_gate_requires_explicit_boolean_true(
+    monkeypatch: pytest.MonkeyPatch, config_value, expected: bool,
+) -> None:
+    from hermes_cli import config as cfgmod
+
+    monkeypatch.setattr(cfgmod, "load_config", lambda: config_value)
+    assert kb.native_scheduling_enabled() is expected
+
+
 def test_generic_complete_cannot_approve_malformed_native_review(conn) -> None:
     """The generic-complete gate keys off protocol, not nullable artifacts."""
     task_id = kb.create_task(conn, title="malformed native review", assignee="writer")

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -594,6 +594,13 @@ async def test_notifier_wakes_origin_for_review_and_keeps_subscription(kanban_ho
 
     with kb.connect() as conn:
         task_id = kb.create_task(conn, title="review handoff", assignee="builder")
+        # This test exercises notification compatibility for a pre-v2 handoff;
+        # native authenticated wake behavior is covered by the v2 suite.
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET review_protocol = 'legacy' WHERE id = ?",
+                (task_id,),
+            )
         kb.add_notify_sub(
             conn,
             task_id=task_id,

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -28,6 +28,29 @@ import pytest
 from hermes_cli import kanban_db as kb
 
 
+@pytest.fixture(autouse=True)
+def legacy_review_protocol(monkeypatch: pytest.MonkeyPatch):
+    """Keep this pre-v2 compatibility suite on proven legacy rows.
+
+    Native authenticated lifecycle behavior is covered separately in
+    ``test_kanban_native_review_v2.py``. Ordinary production creation remains
+    native; only this historical compatibility fixture writes the durable
+    migration marker explicitly.
+    """
+    create_task = kb.create_task
+
+    def create_legacy_task(conn, *args, **kwargs):
+        task_id = create_task(conn, *args, **kwargs)
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET review_protocol = 'legacy' WHERE id = ?",
+                (task_id,),
+            )
+        return task_id
+
+    monkeypatch.setattr(kb, "create_task", create_legacy_task)
+
+
 @pytest.fixture
 def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Isolated HERMES_HOME with an empty kanban DB."""

--- a/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
@@ -29,6 +29,20 @@ def conn(tmp_path: Path):
         db.close()
 
 
+def _create_legacy_task(conn, **kwargs) -> str:
+    """Create a row representing a task proven to predate native review v2.
+
+    This file is the compatibility lifecycle suite. Native authority and
+    writer-preserving routing are covered in test_kanban_native_review_v2.py.
+    """
+    task_id = kb.create_task(conn, **kwargs)
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET review_protocol = 'legacy' WHERE id = ?", (task_id,)
+        )
+    return task_id
+
+
 def _event(events, kind: str):
     return [event for event in events if event.kind == kind][-1]
 
@@ -44,7 +58,7 @@ def _claimed_review(
     ttl_seconds: int | None = None,
     max_runtime_seconds: int | None = None,
 ):
-    task_id = kb.create_task(
+    task_id = _create_legacy_task(
         conn,
         title=title,
         assignee="builder",
@@ -69,7 +83,7 @@ def _claimed_review(
 
 
 def test_same_card_review_supports_changes_and_approval_without_block_loop(conn):
-    task_id = kb.create_task(conn, title="Implement guarded export", assignee="builder")
+    task_id = _create_legacy_task(conn, title="Implement guarded export", assignee="builder")
     implementation = kb.claim_task(conn, task_id, claimer="builder:1")
     assert implementation is not None
 
@@ -204,8 +218,8 @@ def test_rereview_requires_explicit_reviewer_when_provenance_is_invalid(
 
 
 def test_review_changes_reapply_parent_gate(conn):
-    parent_id = kb.create_task(conn, title="Upstream prerequisite", assignee="planner")
-    task_id = kb.create_task(
+    parent_id = _create_legacy_task(conn, title="Upstream prerequisite", assignee="planner")
+    task_id = _create_legacy_task(
         conn,
         title="Dependent implementation",
         assignee="builder",
@@ -241,9 +255,9 @@ def test_review_changes_reapply_parent_gate(conn):
 
 
 def test_parent_reopen_blocks_request_review_until_parent_is_done(conn) -> None:
-    parent_id = kb.create_task(conn, title="Parent", assignee="planner")
+    parent_id = _create_legacy_task(conn, title="Parent", assignee="planner")
     assert kb.complete_task(conn, parent_id)
-    task_id = kb.create_task(
+    task_id = _create_legacy_task(
         conn,
         title="Implementation with reopened parent",
         assignee="builder",
@@ -276,7 +290,7 @@ def test_request_changes_fails_closed_on_malformed_review_provenance(
     conn,
     bad_payload: str,
 ):
-    task_id = kb.create_task(conn, title="Malformed handoff", assignee="builder")
+    task_id = _create_legacy_task(conn, title="Malformed handoff", assignee="builder")
     implementation = kb.claim_task(conn, task_id, claimer="builder:1")
     assert implementation is not None
     assert kb.request_review(
@@ -417,9 +431,9 @@ def test_review_escalation_unblocks_back_to_review(conn) -> None:
 
 
 def test_review_dependency_wait_reenters_review_after_parent_finishes(conn) -> None:
-    parent_id = kb.create_task(conn, title="Parent", assignee="planner")
+    parent_id = _create_legacy_task(conn, title="Parent", assignee="planner")
     assert kb.complete_task(conn, parent_id)
-    task_id = kb.create_task(
+    task_id = _create_legacy_task(
         conn,
         title="Review after dependency refresh",
         assignee="builder",
@@ -498,7 +512,7 @@ def test_crashed_and_timed_out_review_runs_retry_in_review_phase(
 
 
 def test_goal_run_status_is_bound_to_original_run(conn) -> None:
-    task_id = kb.create_task(conn, title="Goal handoff race", assignee="builder")
+    task_id = _create_legacy_task(conn, title="Goal handoff race", assignee="builder")
     implementation = kb.claim_task(conn, task_id)
     assert implementation is not None
     assert kb.request_review(
@@ -541,7 +555,7 @@ def test_goal_run_status_is_bound_to_original_run(conn) -> None:
 
 
 def test_parked_review_approval_without_evidence_still_creates_audit_run(conn) -> None:
-    task_id = kb.create_task(conn, title="Manual approval", assignee="reviewer")
+    task_id = _create_legacy_task(conn, title="Manual approval", assignee="reviewer")
     assert kb.request_review(conn, task_id, summary="implementation handoff")
     assert kb.complete_task(conn, task_id)
     completed_event = _event(kb.list_events(conn, task_id), "completed")
@@ -559,12 +573,12 @@ def test_parked_review_approval_without_evidence_still_creates_audit_run(conn) -
 
 
 def test_legacy_review_child_deadlock_is_reported_immediately(conn):
-    implementation_id = kb.create_task(
+    implementation_id = _create_legacy_task(
         conn,
         title="Implement export",
         assignee="builder",
     )
-    reviewer_id = kb.create_task(
+    reviewer_id = _create_legacy_task(
         conn,
         title="Review export",
         assignee="reviewer",
@@ -609,10 +623,10 @@ def test_legacy_review_child_deadlock_is_reported_immediately(conn):
 
 
 def test_hard_block_with_waiting_child_is_not_mislabeled_as_review_deadlock(conn):
-    implementation_id = kb.create_task(
+    implementation_id = _create_legacy_task(
         conn, title="Implement export", assignee="builder"
     )
-    child_id = kb.create_task(
+    child_id = _create_legacy_task(
         conn,
         title="Publish export",
         assignee="release",
@@ -653,7 +667,7 @@ def test_review_transitions_preserve_consecutive_failures(conn) -> None:
     a crash after request_changes increments it to 2 and trips a
     failure_limit=2 breaker. Only complete_task's success path resets it.
     """
-    task_id = kb.create_task(conn, title="flaky feature", assignee="builder")
+    task_id = _create_legacy_task(conn, title="flaky feature", assignee="builder")
     with kb.write_txn(conn):
         conn.execute(
             "UPDATE tasks SET consecutive_failures = 1 WHERE id = ?",
@@ -699,7 +713,7 @@ def test_review_transitions_preserve_consecutive_failures(conn) -> None:
     assert kb.get_task(conn, task_id).status == "blocked"
 
     # Sanity: complete_task's success path still clears the counter.
-    ok_id = kb.create_task(conn, title="healthy", assignee="builder")
+    ok_id = _create_legacy_task(conn, title="healthy", assignee="builder")
     with kb.write_txn(conn):
         conn.execute(
             "UPDATE tasks SET consecutive_failures = 1 WHERE id = ?",

--- a/tests/hermes_cli/test_kanban_review_surfaces.py
+++ b/tests/hermes_cli/test_kanban_review_surfaces.py
@@ -292,7 +292,7 @@ def test_worker_guidance_distinguishes_same_card_and_downstream_review() -> None
     assert "metadata=..." in KANBAN_GUIDANCE
     kanban_defaults = DEFAULT_CONFIG["kanban"]
     assert isinstance(kanban_defaults, dict)
-    assert kanban_defaults["review_dispatch"] is True
+    assert kanban_defaults["review_dispatch"] is False
 
     repo_root = Path(__file__).resolve().parents[2]
     review_skill = repo_root / "skills" / "devops" / "sdlc-review" / "SKILL.md"

--- a/tests/hermes_cli/test_kanban_review_surfaces.py
+++ b/tests/hermes_cli/test_kanban_review_surfaces.py
@@ -42,6 +42,11 @@ def test_review_tools_redact_handoff_and_route_changes(
             "summary": f"Ready; temporary token was {secret}",
             "metadata": {"token": secret, "tests_run": 7},
             "reviewer": "reviewer",
+            "artifacts": {
+                "commit": "a" * 40,
+                "tree": "b" * 40,
+                "artifacts": [{"path": "dist/x", "sha256": "c" * 64}],
+            },
         })
     )
     assert requested["ok"] is True
@@ -50,12 +55,15 @@ def test_review_tools_redact_handoff_and_route_changes(
         task = kb.get_task(conn, review_worker)
         assert task is not None
         assert task.status == "review"
-        assert task.assignee == "reviewer"
+        assert task.assignee == "builder"
+        assert task.review_assignee == "reviewer"
         handoff = kb.latest_run(conn, review_worker)
         assert handoff is not None
         assert secret not in (handoff.summary or "")
         assert secret not in json.dumps(handoff.metadata)
-        review = kb.claim_review_task(conn, review_worker, claimer="reviewer:1")
+        review = kb.claim_review_task(
+            conn, review_worker, claimer="reviewer:1", actor_profile="reviewer"
+        )
         assert review is not None
 
     monkeypatch.setenv("HERMES_PROFILE", "reviewer")
@@ -319,7 +327,14 @@ def test_goal_mode_review_handoff_cannot_bypass_judge(
             False,
         ),
     )
-    rejected = json.loads(tools._handle_request_review({"summary": "Looks ready."}))
+    rejected = json.loads(tools._handle_request_review({
+        "summary": "Looks ready.",
+        "artifacts": {
+            "commit": "a" * 40,
+            "tree": "b" * 40,
+            "artifacts": [{"path": "dist/x", "sha256": "c" * 64}],
+        },
+    }))
     assert "error" in rejected
     assert "rejected by judge" in rejected["error"]
     with kb.connect() as conn:

--- a/tests/hermes_cli/test_kanban_review_surfaces.py
+++ b/tests/hermes_cli/test_kanban_review_surfaces.py
@@ -11,6 +11,14 @@ from hermes_cli import kanban as kc
 from hermes_cli import kanban_db as kb
 
 
+def _mark_legacy_fixture(conn, task_id: str) -> None:
+    """Model a row proven to exist before the native-v2 migration."""
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET review_protocol = 'legacy' WHERE id = ?", (task_id,)
+        )
+
+
 @pytest.fixture
 def review_worker(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> str:
     home = tmp_path / ".hermes"
@@ -134,6 +142,7 @@ def test_review_cli_round_trip_preserves_handoff(
 
     with kb.connect() as conn:
         task_id = kb.create_task(conn, title="CLI review", assignee="builder")
+        _mark_legacy_fixture(conn, task_id)
         implementation = kb.claim_task(conn, task_id, claimer="builder:1")
         assert implementation is not None
     monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
@@ -167,6 +176,41 @@ def test_review_cli_round_trip_preserves_handoff(
         assert task.assignee == "builder"
 
 
+def test_cli_cannot_downgrade_new_native_task_by_omitting_authority(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="native CLI mutant", assignee="builder")
+        implementation = kb.claim_task(conn, task_id, claimer="builder:1")
+        assert implementation is not None
+        before = len(kb.list_events(conn, task_id))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(implementation.current_run_id))
+
+    output = kc.run_slash(
+        f"request-review {task_id} --summary 'attempted downgrade' "
+        "--reviewer reviewer"
+    )
+
+    assert "authenticated writer profile is required" in output
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "running"
+        assert task.current_run_id == implementation.current_run_id
+        assert task.review_assignee is None
+        assert task.review_artifacts is None
+        assert len(kb.list_events(conn, task_id)) == before
+
+
 def test_domain_and_cli_review_handoffs_redact_before_persistence(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -178,6 +222,7 @@ def test_domain_and_cli_review_handoffs_redact_before_persistence(
 
     with kb.connect() as conn:
         direct_id = kb.create_task(conn, title="direct redaction", assignee="builder")
+        _mark_legacy_fixture(conn, direct_id)
         direct_run = kb.claim_task(conn, direct_id)
         assert direct_run is not None
         assert kb.request_review(
@@ -215,6 +260,7 @@ def test_domain_and_cli_review_handoffs_redact_before_persistence(
         assert secret not in json.dumps(event.payload)
 
         cli_id = kb.create_task(conn, title="CLI redaction", assignee="builder")
+        _mark_legacy_fixture(conn, cli_id)
     cli_output = kc.run_slash(
         f'request-review {cli_id} --summary "cli {secret}" '
         f"--metadata '{{\"token\":\"{secret}\"}}'"
@@ -267,6 +313,7 @@ def test_cli_reopen_review_is_transition_first_and_redacts_reason(
     with kb.connect() as conn:
         invalid_id = kb.create_task(conn, title="not review", assignee="builder")
         review_id = kb.create_task(conn, title="review", assignee="builder")
+        _mark_legacy_fixture(conn, review_id)
         assert kb.request_review(conn, review_id, summary="ready")
 
     invalid_output = kc.run_slash(

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -932,6 +932,16 @@ def _handle_request_review(args: dict, **kw) -> str:
         # Model-supplied free text stored durably on the event payload —
         # redact like summary / kanban_block's reason.
         reviewer = redact_sensitive_text(str(reviewer), force=True)
+    artifacts = args.get("artifacts")
+    if artifacts is None:
+        return tool_error(
+            "artifacts is required for worker review handoff; freeze commit, "
+            "tree, and artifact SHA-256 identities"
+        )
+    if not isinstance(artifacts, dict):
+        return tool_error(
+            f"artifacts must be an object/dict, got {type(artifacts).__name__}"
+        )
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
@@ -949,6 +959,11 @@ def _handle_request_review(args: dict, **kw) -> str:
                 summary=summary,
                 metadata=metadata,
                 reviewer=reviewer,
+                artifacts=artifacts,
+                # Worker handoffs always use the authenticated v2 contract.
+                # Compatibility-only legacy transitions remain on operator/CLI
+                # surfaces and cannot be selected by a dispatched worker.
+                actor_profile=os.environ.get("HERMES_PROFILE"),
                 expected_run_id=_worker_run_id(tid),
                 with_reason=True,
             )
@@ -994,10 +1009,16 @@ def _handle_request_changes(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
+            task = kb.get_task(conn, tid)
             ok, detail = kb.request_changes(
                 conn,
                 tid,
                 reason=reason,
+                actor_profile=(
+                    os.environ.get("HERMES_PROFILE")
+                    if task is not None and task.review_artifacts is not None
+                    else None
+                ),
                 expected_run_id=_worker_run_id(tid),
             )
             if not ok:
@@ -1019,6 +1040,54 @@ def _handle_request_changes(args: dict, **kw) -> str:
     except Exception as e:
         logger.exception("kanban_request_changes failed")
         return tool_error(f"kanban_request_changes: {e}")
+
+
+def _handle_review_pass(args: dict, **kw) -> str:
+    """Submit an authenticated PASS verdict for a native review run."""
+    delegated_err = _reject_delegated_child_mutation("kanban_review_pass")
+    if delegated_err:
+        return delegated_err
+    tid = _default_task_id(args.get("task_id"))
+    if not tid:
+        return tool_error(
+            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
+        )
+    ownership_err = _enforce_worker_task_ownership(tid)
+    if ownership_err:
+        return ownership_err
+    summary = args.get("summary")
+    if not summary or not str(summary).strip():
+        return tool_error("summary is required — cite independent review evidence")
+    actor = os.environ.get("HERMES_PROFILE")
+    run_id = _worker_run_id(tid)
+    if not actor or run_id is None:
+        return tool_error(
+            "authenticated dispatcher profile and active reviewer run token are required"
+        )
+    board = args.get("board")
+    try:
+        kb, conn = _connect(board=board)
+        try:
+            ok, detail = kb.pass_review(
+                conn,
+                tid,
+                summary=redact_sensitive_text(str(summary), force=True),
+                actor_profile=actor,
+                expected_run_id=run_id,
+            )
+            if not ok:
+                return tool_error(
+                    f"could not pass review for {tid}: "
+                    f"{detail or 'invalid review state'}"
+                )
+            return _ok(task_id=tid, run_id=run_id, status="done")
+        finally:
+            conn.close()
+    except ValueError as e:
+        return tool_error(f"kanban_review_pass: {e}")
+    except Exception as e:
+        logger.exception("kanban_review_pass failed")
+        return tool_error(f"kanban_review_pass: {e}")
 
 
 def _handle_heartbeat(args: dict, **kw) -> str:
@@ -1397,6 +1466,8 @@ def _handle_create(args: dict, **kw) -> str:
     idempotency_key = args.get("idempotency_key")
     max_runtime_seconds = args.get("max_runtime_seconds")
     initial_status = args.get("initial_status") or "running"
+    scheduled_for = args.get("scheduled_for")
+    due_at = args.get("due_at")
     skills = args.get("skills")
     if isinstance(skills, str):
         # Accept a single skill name as a string for convenience.
@@ -1459,6 +1530,10 @@ def _handle_create(args: dict, **kw) -> str:
                     int(goal_max_turns) if goal_max_turns is not None else None
                 ),
                 initial_status=str(initial_status),
+                scheduled_for=(
+                    int(scheduled_for) if scheduled_for is not None else None
+                ),
+                due_at=(int(due_at) if due_at is not None else None),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
             )
@@ -1942,9 +2017,33 @@ KANBAN_REQUEST_REVIEW_SCHEMA = {
                 ),
                 "additionalProperties": True,
             },
+            "artifacts": {
+                "type": "object",
+                "description": (
+                    "Required frozen native-review identity: commit, tree, and "
+                    "artifact path/SHA-256 entries. Worker handoffs always use "
+                    "the authenticated review contract."
+                ),
+                "properties": {
+                    "commit": {"type": "string"},
+                    "tree": {"type": "string"},
+                    "artifacts": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "path": {"type": "string"},
+                                "sha256": {"type": "string"},
+                            },
+                            "required": ["path", "sha256"],
+                        },
+                    },
+                },
+                "required": ["commit", "tree", "artifacts"],
+            },
             "board": _board_schema_prop(),
         },
-        "required": ["summary"],
+        "required": ["summary", "artifacts"],
     },
 }
 
@@ -1976,6 +2075,31 @@ KANBAN_REQUEST_CHANGES_SCHEMA = {
         "required": ["reason"],
     },
 }
+
+KANBAN_REVIEW_PASS_SCHEMA = {
+    "name": "kanban_review_pass",
+    "description": (
+        "Authenticated reviewer PASS verdict for a native frozen-artifact "
+        "review. Only the bound independent reviewer holding the active "
+        "dispatcher run token can move Review to Done."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": _DESC_TASK_ID_DEFAULT,
+            },
+            "summary": {
+                "type": "string",
+                "description": "Independent verification performed and evidence observed.",
+            },
+            "board": _board_schema_prop(),
+        },
+        "required": ["summary"],
+    },
+}
+
 
 KANBAN_HEARTBEAT_SCHEMA = {
     "name": "kanban_heartbeat",
@@ -2247,6 +2371,18 @@ KANBAN_CREATE_SCHEMA = {
                     "'running', which preserves the usual dispatch path."
                 ),
             },
+            "scheduled_for": {
+                "type": "integer",
+                "description": (
+                    "UTC Unix epoch when the sole dispatcher atomically promotes "
+                    "this card from scheduled to ready (or todo while parents "
+                    "remain open). Emits one T-15 pre-notice event."
+                ),
+            },
+            "due_at": {
+                "type": "integer",
+                "description": "Optional visible deadline as a UTC Unix epoch.",
+            },
             "skills": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -2405,6 +2541,15 @@ registry.register(
     handler=_handle_request_changes,
     check_fn=_check_kanban_mode,
     emoji="↩",
+)
+
+registry.register(
+    name="kanban_review_pass",
+    toolset="kanban",
+    schema=KANBAN_REVIEW_PASS_SCHEMA,
+    handler=_handle_review_pass,
+    check_fn=_check_kanban_mode,
+    emoji="✅",
 )
 
 registry.register(


### PR DESCRIPTION
Integrates the independently accepted native Kanban Review/Scheduled stack, including the fail-closed recovery/admission correction from exact commit `4dcd49b2fca3ffd0218245bf6f843052e3dab467` (tree `108fc2a8f1023f3041836d9733c2e6ca758d56be`).

The integration merge is based on upstream `a0795acc831210970586a99f2263de5486eab245`. Its first-parent diff has the same stable patch-id as the accepted four-commit stack from merge base `2eaa863112d2980bbe6f15ea409a6a29e50964fe`, so the accepted delta is applied exactly once while preserving authorship.

Verification:
- Focused Review/Scheduled/notifier/watcher/recovery suite: 153 passed
- Broad Kanban suite: 373 passed, 1 skipped, 15 known process-global order-pollution failures; all 15 passed in isolated fresh-process reruns
- Python compilation and `git diff --check`: passed

No install, service restart, scheduler activation, profile change, or live board/database mutation was performed.