### PR TITLE
fix(desktop): clear code controls from native scrollbar

### DIFF
--- a/apps/desktop/e2e/code-block-scrollbar-controls.spec.ts
+++ b/apps/desktop/e2e/code-block-scrollbar-controls.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression coverage for native Linux/Windows code-block scrollbars covering
+ * the copy and expand controls. This boots a fully isolated Electron instance
+ * and exercises the real markdown renderer with vertical overflow.
+ */
+
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+import { expect, test } from './test'
+
+const PROMPT = 'Render the scrollbar-control regression fixture.'
+
+const CODE_REPLY = ['```bash', ...Array.from({ length: 18 }, (_, index) => `echo line-${index + 1}`), '```'].join(
+  '\n',
+)
+
+let fixture: MockBackendFixture | null = null
+
+test.setTimeout(180_000)
+
+test.beforeAll(async () => {
+  fixture = await setupMockBackend({ mockServer: { reply: CODE_REPLY } })
+  await waitForAppReady(fixture, 120_000)
+})
+
+test.afterAll(async () => {
+  await fixture?.cleanup()
+  fixture = null
+})
+
+// Playwright requires an object destructuring pattern even when this spec owns its Electron fixture.
+// eslint-disable-next-line no-empty-pattern
+test('keeps code-block controls clear of a native vertical scrollbar', async ({}, testInfo) => {
+  const { page } = fixture!
+  const composer = page.locator('[contenteditable="true"]').first()
+
+  await composer.click()
+  await composer.fill(PROMPT)
+  await page.keyboard.press('Enter')
+
+  const card = page.locator('[data-slot="code-card"]').last()
+  await expect(card).toBeVisible({ timeout: 60_000 })
+  await expect(card).toContainText('echo line-18', { timeout: 60_000 })
+  await card.hover()
+  await expect(card.getByRole('button', { name: 'Copy code' })).toBeVisible()
+  await expect(card.getByRole('button', { name: 'Expand' })).toBeVisible()
+
+  const geometry = await card.evaluate(element => {
+    const scroller = element.querySelector<HTMLElement>('.overflow-y-auto')
+    const toggle = element.querySelector<HTMLElement>('button[aria-label="Expand"]')
+    const copy = element.querySelector<HTMLElement>('button[aria-label="Copy code"]')
+
+    if (!scroller || !toggle || !copy) {
+      throw new Error('Code-card scrollbar controls were not rendered')
+    }
+
+    const scrollRect = scroller.getBoundingClientRect()
+    const toggleRect = toggle.getBoundingClientRect()
+    const copyRect = copy.getBoundingClientRect()
+    const rootFontSize = Number.parseFloat(getComputedStyle(document.documentElement).fontSize)
+
+    return {
+      verticalOverflow: scroller.scrollHeight > scroller.clientHeight,
+      preservesNativeOverlayClass: scroller.classList.contains('scrollbar-overlay'),
+      verticalGutter: scroller.offsetWidth - scroller.clientWidth,
+      copyBaseInset: rootFontSize * 0.375,
+      copyRightGap: scrollRect.right - copyRect.right,
+      toggleRightGap: scrollRect.right - toggleRect.right,
+    }
+  })
+
+  expect(geometry.verticalOverflow).toBe(true)
+  expect(geometry.preservesNativeOverlayClass).toBe(true)
+  expect(geometry.verticalGutter).toBeGreaterThan(0)
+  expect(Math.abs(geometry.copyRightGap - (geometry.copyBaseInset + geometry.verticalGutter))).toBeLessThanOrEqual(0.5)
+  expect(Math.abs(geometry.toggleRightGap - geometry.verticalGutter)).toBeLessThanOrEqual(0.5)
+
+  await page.screenshot({ path: testInfo.outputPath('code-block-scrollbar-controls.png') })
+})

--- a/apps/desktop/e2e/mock-server.ts
+++ b/apps/desktop/e2e/mock-server.ts
@@ -24,6 +24,8 @@ import nodePath from 'node:path'
 export const MOCK_REPLY = 'Hello from the mock inference server! The full boot chain is working.'
 
 export interface MockServerOptions {
+  /** Override the default assistant text for focused renderer scenarios. */
+  reply?: string
   /** Pause the matching stream after its first token for session-switch E2E coverage. */
   holdFirstStreamForPrompt?: string
 /** Pause the first completion whose request JSON contains this text. */
@@ -615,12 +617,14 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
             return
           }
 
+          const reply = options.reply ?? MOCK_REPLY
+
           if (stream) {
             const holdThisStream = Boolean(
               options.holdFirstStreamForPrompt && typeof lastUserMessage?.content === 'string' &&
                 lastUserMessage.content.includes(options.holdFirstStreamForPrompt),
             )
-            streamTextResponse(res, model, MOCK_REPLY, holdThisStream || holdThisCompletion ? () => {
+            streamTextResponse(res, model, reply, holdThisStream || holdThisCompletion ? () => {
               if (holdThisCompletion) {
                 heldCompletionCount++
               }
@@ -631,9 +635,9 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
             if (holdThisCompletion) {
               heldCompletionCount++
               resolveHeldStreamStarted?.()
-              void heldStreamReleased.then(() => nonStreamingTextResponse(res, model, MOCK_REPLY))
+              void heldStreamReleased.then(() => nonStreamingTextResponse(res, model, reply))
             } else {
-              nonStreamingTextResponse(res, model, MOCK_REPLY)
+              nonStreamingTextResponse(res, model, reply)
             }
           }
         })

--- a/apps/desktop/src/components/chat/expandable-block.test.tsx
+++ b/apps/desktop/src/components/chat/expandable-block.test.tsx
@@ -11,6 +11,9 @@ class TestResizeObserver {
 
   observe(target: Element) {
     Object.defineProperty(target, 'scrollHeight', { configurable: true, value: 400 })
+    Object.defineProperty(target, 'offsetWidth', { configurable: true, value: 200 })
+    Object.defineProperty(target, 'clientWidth', { configurable: true, value: 185 })
+
     this.callback([{ target } as ResizeObserverEntry], this as unknown as ResizeObserver)
   }
 
@@ -24,11 +27,12 @@ afterEach(() => {
 })
 
 describe('ExpandableBlock', () => {
-  it('lets horizontal scroll through and keeps the last line selectable', () => {
+  it('keeps scroll interactions free and offsets controls by the vertical gutter', () => {
     vi.stubGlobal('ResizeObserver', TestResizeObserver)
+    const onScrollbarSizeChange = vi.fn()
 
     const { container } = render(
-      <ExpandableBlock>
+      <ExpandableBlock onScrollbarSizeChange={onScrollbarSizeChange}>
         <pre data-testid="content">{'const x = 1\n'.repeat(20)}</pre>
       </ExpandableBlock>
     )
@@ -37,8 +41,8 @@ describe('ExpandableBlock', () => {
     const toggle = screen.getByRole('button', { name: /expand|collapse/i })
     const fade = toggle.parentElement!
 
-    // Inner container allows horizontal scroll so wide code gets a scrollbar:
-    // platform overlay (`scrollbar-overlay`), not the always-on classic gutter.
+    // Preserve the native overlay treatment. On platforms where Chromium uses
+    // a classic gutter instead, measurement—not restyling—moves the controls.
     expect(inner.className).toContain('overflow-x-auto')
     expect(inner.className).toContain('scrollbar-overlay')
 
@@ -49,9 +53,13 @@ describe('ExpandableBlock', () => {
     expect(fade.className).toContain('inset-x-0')
 
     // Only the compact toggle is clickable, and it is pinned to the right edge
-    // rather than spanning the full width (the old bug).
+    // rather than spanning the full width (the old bug). Its measured margins
+    // match the native scrollbar gutters, so overlay bars stay unchanged while
+    // classic Linux/Windows bars get their exact hit area back.
     expect(toggle.className).toContain('pointer-events-auto')
     expect(toggle.className).toContain('w-9')
+    expect(toggle.style.marginRight).toBe('15px')
+    expect(onScrollbarSizeChange).toHaveBeenLastCalledWith({ inline: 15 })
     expect(toggle.className).not.toContain('inset-x-0')
   })
 

--- a/apps/desktop/src/components/chat/expandable-block.tsx
+++ b/apps/desktop/src/components/chat/expandable-block.tsx
@@ -9,12 +9,21 @@ import { cn } from '@/lib/utils'
 interface ExpandableBlockProps {
   children: ReactNode
   className?: string
+  onScrollbarSizeChange?: (size: ScrollbarSize) => void
 }
 
-export function ExpandableBlock({ children, className }: ExpandableBlockProps) {
+export interface ScrollbarSize {
+  inline: number
+}
+
+const NO_SCROLLBAR = { inline: 0 } satisfies ScrollbarSize
+
+export function ExpandableBlock({ children, className, onScrollbarSizeChange }: ExpandableBlockProps) {
   const innerRef = useRef<HTMLDivElement>(null)
+  const scrollbarSizeRef = useRef<ScrollbarSize>(NO_SCROLLBAR)
   const [expanded, setExpanded] = useState(false)
   const [overflowing, setOverflowing] = useState(false)
+  const [scrollbarSize, setScrollbarSize] = useState<ScrollbarSize>(NO_SCROLLBAR)
 
   // Measure inside ResizeObserver timing only (layout is clean there). A
   // synchronous mount-time scrollHeight read forces a reflow per instance,
@@ -24,8 +33,23 @@ export function ExpandableBlock({ children, className }: ExpandableBlockProps) {
 
     if (el) {
       setOverflowing(el.scrollHeight > 121)
+
+      // Overlay scrollbars consume no layout space (0); classic Linux/Windows
+      // bars do. Preserve the platform scrollbar exactly as rendered and move
+      // controls only by the gutter it actually occupies.
+      const next = {
+        inline: Math.max(0, el.offsetWidth - el.clientWidth)
+      }
+
+      const previous = scrollbarSizeRef.current
+
+      if (next.inline !== previous.inline) {
+        scrollbarSizeRef.current = next
+        setScrollbarSize(next)
+        onScrollbarSizeChange?.(next)
+      }
     }
-  }, [])
+  }, [onScrollbarSizeChange])
 
   useResizeObserver(measure, innerRef)
 
@@ -33,8 +57,9 @@ export function ExpandableBlock({ children, className }: ExpandableBlockProps) {
     <div className="relative">
       <div
         className={cn(
-          // `scrollbar-overlay` opts out of the app-wide classic thin gutters so
-          // this scroller keeps platform overlay bars (no always-on track).
+          // Keep platform overlay bars (no always-on authored track). The
+          // measured gutter below handles platforms that render these as
+          // classic scrollbars instead.
           'scrollbar-overlay overflow-y-auto overflow-x-auto',
           expanded ? 'max-h-[40dvh]' : 'max-h-[7.5rem]',
           className
@@ -56,6 +81,7 @@ export function ExpandableBlock({ children, className }: ExpandableBlockProps) {
             aria-label={expanded ? 'Collapse' : 'Expand'}
             className="pointer-events-auto flex h-7 w-9 cursor-pointer items-end justify-center pb-1 text-muted-foreground/70 transition-colors hover:text-foreground"
             onClick={() => setExpanded(v => !v)}
+            style={{ marginRight: scrollbarSize.inline }}
             type="button"
           >
             <ChevronDown className={cn('size-3.5 transition-transform', expanded && 'rotate-180')} />

--- a/apps/desktop/src/components/chat/shiki-highlighter.tsx
+++ b/apps/desktop/src/components/chat/shiki-highlighter.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import type { SyntaxHighlighterProps } from '@assistant-ui/react-streamdown'
-import { type ComponentProps, type FC, lazy, Suspense, useMemo } from 'react'
+import { type ComponentProps, type FC, lazy, Suspense, useMemo, useState } from 'react'
 import type ShikiHighlighter from 'react-shiki'
 
 import { CodeCard, CodeCardBody } from '@/components/chat/code-card'
-import { ExpandableBlock } from '@/components/chat/expandable-block'
+import { ExpandableBlock, type ScrollbarSize } from '@/components/chat/expandable-block'
 import { CopyButton } from '@/components/ui/copy-button'
 import { useI18n } from '@/i18n'
 import { isLikelyProseCodeBlock } from '@/lib/markdown-code'
@@ -130,6 +130,7 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
   defer = false
 }) => {
   const { t } = useI18n()
+  const [scrollbarSize, setScrollbarSize] = useState<ScrollbarSize>({ inline: 0 })
   const trimmed = (code ?? '').replace(/^\n+/, '').trimEnd()
 
   // Streaming may hand us empty/incomplete fences — render nothing rather
@@ -146,16 +147,18 @@ export const SyntaxHighlighter: FC<HermesSyntaxHighlighterProps> = ({
 
   return (
     <CodeCard data-streaming={defer ? 'true' : undefined}>
-      <CopyButton
-        appearance="inline"
-        className="absolute right-1.5 top-1.5 z-10 h-5 gap-0 rounded-md px-1 opacity-0 transition-opacity group-hover/code:opacity-100 focus-visible:opacity-100"
-        iconClassName="size-2.5"
-        label={t.assistant.tool.copyCode}
-        showLabel={false}
-        text={trimmed}
-      />
+      <div className="absolute top-1.5 z-10" style={{ right: `calc(0.375rem + ${scrollbarSize.inline}px)` }}>
+        <CopyButton
+          appearance="inline"
+          className="h-5 gap-0 rounded-md px-1 opacity-0 transition-opacity group-hover/code:opacity-100 focus-visible:opacity-100"
+          iconClassName="size-2.5"
+          label={t.assistant.tool.copyCode}
+          showLabel={false}
+          text={trimmed}
+        />
+      </div>
       <CodeCardBody className="[&_pre]:px-3 [&_pre]:py-2.5">
-        <ExpandableBlock>
+        <ExpandableBlock onScrollbarSizeChange={setScrollbarSize}>
           <Pre className="aui-shiki m-0 overflow-hidden bg-transparent p-0">
             {plain ? (
               <PlainCode code={trimmed} />


### PR DESCRIPTION
## Summary

- preserve the existing native/overlay scrollbar appearance for conversation code blocks
- measure the actual vertical scrollbar gutter reported by the rendered scroller
- offset the copy and expand controls only when that scrollbar occupies layout space
- add unit and isolated Electron regression coverage for the native vertical-scrollbar case

## Root cause

`scrollbar-overlay` intentionally opts code cards out of Hermes' authored scrollbar styling. On macOS this normally yields a zero-width overlay bar, but Chromium on Linux and Windows can render a classic native vertical scrollbar that consumes layout space. The copy button and compact expand toggle remained pinned to the code card's right edge, so they occupied the same hit area as that native scrollbar.

This follows up on #69841 and #73670: it keeps their scrollbar behavior and appearance unchanged while handling the non-overlay platform fallback. Existing horizontal-scroll behavior is unchanged.

## Approach

`ExpandableBlock` already measures overflow inside `ResizeObserver`. It now also records the real vertical scrollbar gutter as `offsetWidth - clientWidth`:

- overlay scrollbar: measured gutter is `0`, so controls do not move
- classic native scrollbar: controls move left by exactly the occupied gutter

No scrollbar CSS, color, width, or platform detection changes are introduced.

## Validation

- `npm run build`
- `npm run typecheck`
- changed-file ESLint
- `npm run test:ui` — 591 files / 5,667 tests passed
- `npx playwright test e2e/code-block-scrollbar-controls.spec.ts --reporter=list` — passed in an isolated Electron instance
- sabotage check: disabling the offsets makes the E2E regression fail (`15px` native gutter vs `6px` copy-control gap)

## Risk

Low and presentation-only. The existing scrollbar remains authoritative; controls only consume its measured vertical gutter. Platforms with true overlay scrollbars retain the current zero-offset layout.
