### PR TITLE
fix: stabilize Desktop auth and MCP OAuth routing

### DIFF
--- a/apps/desktop/src/api/mcp.ts
+++ b/apps/desktop/src/api/mcp.ts
@@ -67,9 +67,9 @@ export function getMcpOAuthFlow(flowId: string, profile?: ProfileScope): Promise
 
 /** Cancel an in-flight MCP OAuth flow server-side, freeing the per-server
  *  "already in progress" slot so a retry doesn't 409. */
-export function cancelMcpOAuthFlow(flowId: string, profile?: null | string): Promise<{ ok: boolean; status: string }> {
-  return hermesApi<{ ok: boolean; status: string }>({
-    ...profileScoped(profile),
+export function cancelMcpOAuthFlow(flowId: string, profile?: ProfileScope): Promise<{ ok: boolean; status: string }> {
+  return window.hermesDesktop.api<{ ok: boolean; status: string }>({
+    ...capabilityScoped(profile),
     path: `/api/mcp/oauth/flows/${encodeURIComponent(flowId)}`,
     method: 'DELETE'
   })

--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -17,11 +17,9 @@ import { TextTab } from '@/components/ui/text-tab'
 import { Textarea } from '@/components/ui/textarea'
 import { Tip } from '@/components/ui/tooltip'
 import {
-  authMcpServer,
   getActionStatus,
   getLogs,
   getMcpCatalog,
-  getMcpOAuthFlow,
   getUsageAnalytics,
   type HermesGateway,
   installMcpCatalogEntry,
@@ -36,8 +34,8 @@ import { type Translations, useI18n } from '@/i18n'
 import { compactNumber } from '@/lib/format'
 import { brandFor } from '@/lib/mcp-brands'
 import { estimateServerTokens, serverUsageCount } from '@/lib/mcp-cost'
-import { completeMcpDesktopOAuth } from '@/lib/mcp-dashboard-oauth'
 import { type McpImportEntry, parseMcpImport } from '@/lib/mcp-import'
+import { completeRoutedMcpDesktopOAuth } from '@/lib/mcp-oauth-routing'
 import { NEEDS_AUTH_RE, PROBE_TTL_MS, probeCache, probeKey, serverFingerprint } from '@/lib/mcp-probe-cache'
 import { getServers, isServerShape, type McpServers, normalizeEntry } from '@/lib/mcp-servers'
 import { countEnabledTools, isToolEnabled, toggleToolInServer } from '@/lib/mcp-tool-filter'
@@ -609,10 +607,9 @@ export function McpTab({ gateway, profile }: { gateway: HermesGateway | null; pr
     setProbes(current => ({ ...current, [serverName]: 'probing' }))
 
     try {
-      const flow = await completeMcpDesktopOAuth({
+      const flow = await completeRoutedMcpDesktopOAuth({
         serverName,
-        start: name => authMcpServer(name, profile ?? undefined),
-        status: flowId => getMcpOAuthFlow(flowId, profile ?? undefined),
+        scope: profile ?? undefined,
         openExternal: url => window.hermesDesktop.openExternal(url)
       })
 

--- a/apps/desktop/src/components/assistant-ui/mcp-setup-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/mcp-setup-tool.tsx
@@ -12,11 +12,8 @@ import { Codicon } from '@/components/ui/codicon'
 import { Input } from '@/components/ui/input'
 import {
   addMcpServer,
-  authMcpServer,
-  cancelMcpOAuthFlow,
   getActionStatus,
   getMcpCatalog,
-  getMcpOAuthFlow,
   installMcpCatalogEntry,
   type McpCatalogEntry,
   removeMcpServer,
@@ -26,8 +23,9 @@ import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { AlertCircle, CheckCircle2, Loader2 } from '@/lib/icons'
 import { brandFor, brandGlyphStyle } from '@/lib/mcp-brands'
-import { completeMcpDesktopOAuth, McpOAuthCancelled } from '@/lib/mcp-dashboard-oauth'
+import { McpOAuthCancelled } from '@/lib/mcp-dashboard-oauth'
 import { directoryEntry } from '@/lib/mcp-directory'
+import { completeRoutedMcpDesktopOAuth } from '@/lib/mcp-oauth-routing'
 import { prettyName } from '@/lib/text'
 import { cn } from '@/lib/utils'
 import { $gateway } from '@/store/gateway'
@@ -272,12 +270,9 @@ function McpSetupPending({ args }: ToolCallMessagePartProps) {
       }
 
       if (action === 'authorize') {
-        const flow = await completeMcpDesktopOAuth({
+        const flow = await completeRoutedMcpDesktopOAuth({
           serverName: server,
-          start: authMcpServer,
-          status: getMcpOAuthFlow,
           cancelled: () => cancelRef.current,
-          cancel: cancelMcpOAuthFlow,
           openExternal: url => window.hermesDesktop.openExternal(url)
         })
 
@@ -319,12 +314,9 @@ function McpSetupPending({ args }: ToolCallMessagePartProps) {
         let flow
 
         try {
-          flow = await completeMcpDesktopOAuth({
+          flow = await completeRoutedMcpDesktopOAuth({
             serverName: known.name,
-            start: authMcpServer,
-            status: getMcpOAuthFlow,
             cancelled: () => cancelRef.current,
-            cancel: cancelMcpOAuthFlow,
             openExternal: url => window.hermesDesktop.openExternal(url)
           })
         } catch (error) {

--- a/apps/desktop/src/lib/mcp-dashboard-oauth.test.ts
+++ b/apps/desktop/src/lib/mcp-dashboard-oauth.test.ts
@@ -69,4 +69,55 @@ describe('completeMcpDesktopOAuth', () => {
     expect(result.status).toBe('approved')
     expect(status).toHaveBeenCalledTimes(2)
   })
+
+  it('cancels the server flow when opening the authorization URL fails', async () => {
+    const cancel = vi.fn().mockResolvedValue(undefined)
+
+    await expect(
+      completeMcpDesktopOAuth({
+        serverName: 'reports',
+        start: vi.fn().mockResolvedValue({
+          flow_id: 'flow-open-failure',
+          server_name: 'reports',
+          status: 'authorization_required',
+          authorization_url: 'https://idp.example/authorize',
+          error: null
+        }),
+        status: vi.fn(),
+        openExternal: vi.fn().mockRejectedValue(new Error('browser unavailable')),
+        cancel,
+        sleep: async () => {}
+      })
+    ).rejects.toThrow('browser unavailable')
+
+    expect(cancel).toHaveBeenCalledOnce()
+    expect(cancel).toHaveBeenCalledWith('flow-open-failure')
+  })
+
+  it('cancels the server flow after terminal polling failure', async () => {
+    const cancel = vi.fn().mockResolvedValue(undefined)
+    const status = vi.fn().mockRejectedValue(new Error('gateway unavailable'))
+
+    await expect(
+      completeMcpDesktopOAuth({
+        serverName: 'reports',
+        start: vi.fn().mockResolvedValue({
+          flow_id: 'flow-poll-failure',
+          server_name: 'reports',
+          status: 'authorization_required',
+          authorization_url: 'https://idp.example/authorize',
+          error: null
+        }),
+        status,
+        openExternal: vi.fn().mockResolvedValue(undefined),
+        cancel,
+        sleep: async () => {},
+        maxPollFailures: 2
+      })
+    ).rejects.toThrow('gateway unavailable')
+
+    expect(status).toHaveBeenCalledTimes(2)
+    expect(cancel).toHaveBeenCalledOnce()
+    expect(cancel).toHaveBeenCalledWith('flow-poll-failure')
+  })
 })

--- a/apps/desktop/src/lib/mcp-dashboard-oauth.ts
+++ b/apps/desktop/src/lib/mcp-dashboard-oauth.ts
@@ -45,52 +45,63 @@ export async function completeMcpDesktopOAuth({
   maxPollFailures = 3
 }: CompleteOptions): Promise<McpOAuthFlow> {
   const started = await start(serverName)
+  let cleanedUp = false
 
-  if (started.status === 'error') {
-    throw new Error(started.error || 'OAuth failed to start')
+  const cleanup = async () => {
+    if (cleanedUp) {return}
+    cleanedUp = true
+    await cancel?.(started.flow_id).catch(() => {})
   }
 
-  if (!started.authorization_url) {
-    throw new Error('OAuth server did not provide an authorization URL')
-  }
-
-  await openExternal(started.authorization_url)
-
-  let pollFailures = 0
-
-  for (;;) {
-    if (cancelled?.()) {
-      // Free the backend slot before rejecting; best-effort — the flow also
-      // dies on its own timeout if this request is lost.
-      await cancel?.(started.flow_id).catch(() => {})
-      throw new McpOAuthCancelled()
+  try {
+    if (started.status === 'error') {
+      throw new Error(started.error || 'OAuth failed to start')
     }
 
-    let current: McpOAuthFlow
+    if (!started.authorization_url) {
+      throw new Error('OAuth server did not provide an authorization URL')
+    }
 
-    try {
-      current = await status(started.flow_id)
-      pollFailures = 0
-    } catch (error) {
-      pollFailures += 1
+    await openExternal(started.authorization_url)
+    let pollFailures = 0
 
-      if (pollFailures >= maxPollFailures) {
-        throw error
+    for (;;) {
+      if (cancelled?.()) {
+        await cleanup()
+        throw new McpOAuthCancelled()
+      }
+
+      let current: McpOAuthFlow
+
+      try {
+        current = await status(started.flow_id)
+        pollFailures = 0
+      } catch (error) {
+        pollFailures += 1
+
+        if (pollFailures >= maxPollFailures) {
+          throw error
+        }
+
+        await sleep(1000)
+
+        continue
+      }
+
+      if (current.status === 'approved') {
+        cleanedUp = true
+
+        return current
+      }
+
+      if (current.status === 'error') {
+        throw new Error(current.error || 'OAuth authorization failed')
       }
 
       await sleep(1000)
-
-      continue
     }
-
-    if (current.status === 'approved') {
-      return current
-    }
-
-    if (current.status === 'error') {
-      throw new Error(current.error || 'OAuth authorization failed')
-    }
-
-    await sleep(1000)
+  } catch (error) {
+    await cleanup()
+    throw error
   }
 }

--- a/apps/desktop/src/lib/mcp-oauth-routing.test.ts
+++ b/apps/desktop/src/lib/mcp-oauth-routing.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { setApiRequestConnection } from '@/hermes'
+
+import { completeRoutedMcpDesktopOAuth, resolveMcpOAuthScope } from './mcp-oauth-routing'
+
+const approved = {
+  flow_id: 'flow-1',
+  server_name: 'linear',
+  status: 'approved' as const,
+  authorization_url: null,
+  error: null,
+  tools: [{ name: 'list_issues', description: 'List issues' }]
+}
+
+describe('completeRoutedMcpDesktopOAuth', () => {
+  it('preserves the ambient registry connection for legacy scopes', () => {
+    expect(resolveMcpOAuthScope(undefined, 'studio')).toEqual({ connectionId: 'studio', profile: 'default' })
+    expect(resolveMcpOAuthScope('work', 'studio')).toEqual({ connectionId: 'studio', profile: 'work' })
+  })
+
+  it('pins explicit object scopes without a remote connection to the local pool', () => {
+    expect(resolveMcpOAuthScope({ profile: 'work' }, 'studio')).toEqual({ connectionId: 'local', profile: 'work' })
+    expect(resolveMcpOAuthScope({ connectionId: 'local', profile: 'work' }, 'studio')).toEqual({
+      connectionId: 'local',
+      profile: 'work'
+    })
+  })
+
+  it('uses the loopback gateway flow for a local backend', async () => {
+    const openExternal = vi.fn().mockResolvedValue(undefined)
+
+    const requestRpc = vi
+      .fn()
+      .mockResolvedValueOnce({ session_id: 'flow-1', auth_url: 'https://linear.example/authorize' })
+      .mockResolvedValueOnce({ status: 'approved', tools: approved.tools })
+
+    const restStart = vi.fn()
+    const restStatus = vi.fn()
+
+    const result = await completeRoutedMcpDesktopOAuth(
+      {
+        serverName: 'linear',
+        scope: { connectionId: 'local', profile: 'default' },
+        openExternal,
+        sleep: async () => {}
+      },
+      {
+        connectionMode: async () => 'local',
+        requestRpc,
+        restStart,
+        restStatus,
+        restCancel: vi.fn()
+      }
+    )
+
+    expect(requestRpc).toHaveBeenNthCalledWith(1, { connectionId: 'local', profile: 'default' }, 'mcp.servers.oauth.start', {
+      name: 'linear'
+    })
+    expect(requestRpc).toHaveBeenNthCalledWith(2, { connectionId: 'local', profile: 'default' }, 'mcp.servers.oauth.poll', {
+      name: 'linear',
+      session_id: 'flow-1'
+    })
+    expect(restStart).not.toHaveBeenCalled()
+    expect(restStatus).not.toHaveBeenCalled()
+    expect(openExternal).toHaveBeenCalledWith('https://linear.example/authorize')
+    expect(result).toEqual(approved)
+  })
+
+  it('keeps the dashboard callback flow for a remote backend', async () => {
+    const restStart = vi.fn().mockResolvedValue({
+      flow_id: 'flow-remote',
+      server_name: 'linear',
+      status: 'authorization_required',
+      authorization_url: 'https://linear.example/authorize',
+      error: null
+    })
+
+    const restStatus = vi.fn().mockResolvedValue({ ...approved, flow_id: 'flow-remote' })
+    const requestRpc = vi.fn()
+
+    const result = await completeRoutedMcpDesktopOAuth(
+      {
+        serverName: 'linear',
+        scope: { connectionId: 'studio', profile: 'default' },
+        openExternal: vi.fn().mockResolvedValue(undefined),
+        sleep: async () => {}
+      },
+      {
+        connectionMode: async () => 'remote',
+        requestRpc,
+        restStart,
+        restStatus,
+        restCancel: vi.fn()
+      }
+    )
+
+    expect(requestRpc).not.toHaveBeenCalled()
+    expect(restStart).toHaveBeenCalledWith('linear', { connectionId: 'studio', profile: 'default' })
+    expect(restStatus).toHaveBeenCalledWith('flow-remote', { connectionId: 'studio', profile: 'default' })
+    expect(result.flow_id).toBe('flow-remote')
+  })
+
+  it('cancels a local loopback flow through the gateway', async () => {
+    const requestRpc = vi
+      .fn()
+      .mockResolvedValueOnce({ session_id: 'flow-cancel', auth_url: 'https://linear.example/authorize' })
+      .mockResolvedValueOnce({ status: 'error' })
+
+    await expect(
+      completeRoutedMcpDesktopOAuth(
+        {
+          serverName: 'linear',
+          cancelled: () => true,
+          openExternal: vi.fn().mockResolvedValue(undefined)
+        },
+        {
+          connectionMode: async () => 'local',
+          requestRpc,
+          restStart: vi.fn(),
+          restStatus: vi.fn(),
+          restCancel: vi.fn()
+        }
+      )
+    ).rejects.toMatchObject({ name: 'McpOAuthCancelled' })
+
+    expect(requestRpc).toHaveBeenNthCalledWith(
+      2,
+      { connectionId: 'local', profile: 'default' },
+      'mcp.servers.oauth.cancel',
+      { name: 'linear', session_id: 'flow-cancel' }
+    )
+  })
+
+  it('freezes an ambient route before the connection changes', async () => {
+    const restStart = vi.fn().mockImplementation(async (_name, scope) => {
+      setApiRequestConnection('other')
+
+      return {
+        flow_id: 'flow-frozen',
+        server_name: 'linear',
+        status: 'authorization_required',
+        authorization_url: 'https://linear.example/authorize',
+        error: null,
+        scope
+      }
+    })
+
+    const restStatus = vi.fn().mockResolvedValue({ ...approved, flow_id: 'flow-frozen' })
+
+    setApiRequestConnection('studio')
+
+    try {
+      await completeRoutedMcpDesktopOAuth(
+        {
+          serverName: 'linear',
+          openExternal: vi.fn().mockResolvedValue(undefined),
+          sleep: async () => {}
+        },
+        {
+          connectionMode: async () => 'remote',
+          requestRpc: vi.fn(),
+          restStart,
+          restStatus,
+          restCancel: vi.fn()
+        }
+      )
+    } finally {
+      setApiRequestConnection(null)
+    }
+
+    const frozen = { connectionId: 'studio', profile: 'default' }
+    expect(restStart).toHaveBeenCalledWith('linear', frozen)
+    expect(restStatus).toHaveBeenCalledWith('flow-frozen', frozen)
+  })
+
+  it('preserves the exact remote scope when cancelling', async () => {
+    const scope = { connectionId: 'studio', profile: 'work' }
+    const restCancel = vi.fn().mockResolvedValue(undefined)
+
+    await expect(
+      completeRoutedMcpDesktopOAuth(
+        {
+          serverName: 'linear',
+          scope,
+          cancelled: () => true,
+          openExternal: vi.fn().mockResolvedValue(undefined)
+        },
+        {
+          connectionMode: async () => 'remote',
+          requestRpc: vi.fn(),
+          restStart: vi.fn().mockResolvedValue({
+            flow_id: 'flow-remote-cancel',
+            server_name: 'linear',
+            status: 'authorization_required',
+            authorization_url: 'https://linear.example/authorize',
+            error: null
+          }),
+          restStatus: vi.fn(),
+          restCancel
+        }
+      )
+    ).rejects.toMatchObject({ name: 'McpOAuthCancelled' })
+
+    expect(restCancel).toHaveBeenCalledWith('flow-remote-cancel', scope)
+  })
+})

--- a/apps/desktop/src/lib/mcp-oauth-routing.ts
+++ b/apps/desktop/src/lib/mcp-oauth-routing.ts
@@ -1,0 +1,188 @@
+import {
+  authMcpServer,
+  cancelMcpOAuthFlow,
+  getApiRequestConnection,
+  getMcpOAuthFlow,
+  type ProfileScope
+} from '@/hermes'
+import { requestGatewayForAgent, requestGatewayForProfile } from '@/store/gateway'
+
+import { completeMcpDesktopOAuth, type McpOAuthFlow } from './mcp-dashboard-oauth'
+
+interface RoutedOptions {
+  serverName: string
+  scope?: ProfileScope
+  openExternal: (url: string) => Promise<void>
+  cancelled?: () => boolean
+  sleep?: (milliseconds: number) => Promise<void>
+  maxPollFailures?: number
+}
+
+interface LocalStartResult {
+  session_id: string
+  auth_url: string
+}
+
+interface LocalPollResult {
+  status: 'pending' | 'approved' | 'error'
+  error_message?: string | null
+  auth_url?: string | null
+  tools?: McpOAuthFlow['tools']
+}
+
+interface RoutingDependencies {
+  connectionMode: (scope?: ProfileScope) => Promise<'local' | 'remote'>
+  requestRpc: <T>(scope: ProfileScope | undefined, method: string, params: Record<string, unknown>) => Promise<T>
+  restStart: (name: string, scope?: ProfileScope) => Promise<McpOAuthFlow>
+  restStatus: (flowId: string, scope?: ProfileScope) => Promise<McpOAuthFlow>
+  restCancel: (flowId: string, scope?: ProfileScope) => Promise<unknown>
+}
+
+function profileFromScope(scope?: ProfileScope): string {
+  if (scope && typeof scope === 'object') {
+    return (scope.profile ?? '').trim() || 'default'
+  }
+
+  return (scope ?? '').trim() || 'default'
+}
+
+interface ResolvedMcpOAuthScope {
+  connectionId: null | string
+  profile: string
+}
+
+export function resolveMcpOAuthScope(
+  scope: ProfileScope | undefined,
+  ambientConnectionId: null | string
+): ResolvedMcpOAuthScope {
+  const profile = profileFromScope(scope)
+
+  if (scope && typeof scope === 'object') {
+    const requested = (scope.connectionId ?? '').trim()
+
+    return {
+      connectionId: requested && requested !== 'local' ? requested : 'local',
+      profile
+    }
+  }
+
+  return {
+    connectionId: (ambientConnectionId ?? '').trim() || null,
+    profile
+  }
+}
+
+function inferredConnectionMode(connection: { baseUrl: string; mode?: 'local' | 'remote' }): 'local' | 'remote' {
+  if (connection.mode) {
+    return connection.mode
+  }
+
+  try {
+    const host = new URL(connection.baseUrl).hostname
+
+    return host === '127.0.0.1' || host === 'localhost' || host === '::1' ? 'local' : 'remote'
+  } catch {
+    return 'remote'
+  }
+}
+
+async function connectionMode(scope?: ProfileScope): Promise<'local' | 'remote'> {
+  const resolved = resolveMcpOAuthScope(scope, getApiRequestConnection())
+
+  const connection =
+    resolved.connectionId && window.hermesDesktop.getConnectionFor
+      ? await window.hermesDesktop.getConnectionFor(resolved)
+      : await window.hermesDesktop.getConnection(resolved.profile)
+
+  return inferredConnectionMode(connection)
+}
+
+async function requestRpc<T>(
+  scope: ProfileScope | undefined,
+  method: string,
+  params: Record<string, unknown>
+): Promise<T> {
+  const resolved = resolveMcpOAuthScope(scope, getApiRequestConnection())
+
+  if (resolved.connectionId) {
+    return requestGatewayForAgent<T>(resolved.connectionId, resolved.profile, method, params)
+  }
+
+  return requestGatewayForProfile<T>(resolved.profile, method, params)
+}
+
+const defaultDependencies: RoutingDependencies = {
+  connectionMode,
+  requestRpc,
+  restStart: (name, scope) => authMcpServer(name, scope),
+  restStatus: (flowId, scope) => getMcpOAuthFlow(flowId, scope),
+  restCancel: (flowId, scope) => cancelMcpOAuthFlow(flowId, scope)
+}
+
+function localFlow(serverName: string, started: LocalStartResult): McpOAuthFlow {
+  return {
+    flow_id: started.session_id,
+    server_name: serverName,
+    status: 'authorization_required',
+    authorization_url: started.auth_url,
+    error: null
+  }
+}
+
+function localPoll(serverName: string, flowId: string, current: LocalPollResult): McpOAuthFlow {
+  return {
+    flow_id: flowId,
+    server_name: serverName,
+    status: current.status === 'pending' ? 'authorization_required' : current.status,
+    authorization_url: current.auth_url ?? null,
+    error: current.error_message ?? null,
+    tools: current.tools
+  }
+}
+
+export async function completeRoutedMcpDesktopOAuth(
+  options: RoutedOptions,
+  dependencies: RoutingDependencies = defaultDependencies
+): Promise<McpOAuthFlow> {
+  const { serverName, scope } = options
+  const resolved = resolveMcpOAuthScope(scope, getApiRequestConnection())
+
+  const frozenScope: ProfileScope = {
+    connectionId: resolved.connectionId ?? 'local',
+    profile: resolved.profile
+  }
+
+  const mode = await dependencies.connectionMode(frozenScope)
+
+  if (mode === 'remote') {
+    return completeMcpDesktopOAuth({
+      ...options,
+      start: name => dependencies.restStart(name, frozenScope),
+      status: flowId => dependencies.restStatus(flowId, frozenScope),
+      cancel: flowId => dependencies.restCancel(flowId, frozenScope)
+    })
+  }
+
+  return completeMcpDesktopOAuth({
+    ...options,
+    start: async name =>
+      localFlow(
+        name,
+        await dependencies.requestRpc<LocalStartResult>(frozenScope, 'mcp.servers.oauth.start', { name })
+      ),
+    status: async flowId =>
+      localPoll(
+        serverName,
+        flowId,
+        await dependencies.requestRpc<LocalPollResult>(frozenScope, 'mcp.servers.oauth.poll', {
+          name: serverName,
+          session_id: flowId
+        })
+      ),
+    cancel: flowId =>
+      dependencies.requestRpc(frozenScope, 'mcp.servers.oauth.cancel', {
+        name: serverName,
+        session_id: flowId
+      })
+  })
+}

--- a/apps/desktop/src/store/suggestion-providers/mcp.ts
+++ b/apps/desktop/src/store/suggestion-providers/mcp.ts
@@ -1,15 +1,13 @@
 import {
   addMcpServer,
-  authMcpServer,
-  cancelMcpOAuthFlow,
   getMcpCatalog,
-  getMcpOAuthFlow,
   listMcpServers,
   removeMcpServer
 } from '@/hermes'
 import { translateNow } from '@/i18n'
-import { completeMcpDesktopOAuth, McpOAuthCancelled } from '@/lib/mcp-dashboard-oauth'
+import { McpOAuthCancelled } from '@/lib/mcp-dashboard-oauth'
 import { MCP_DIRECTORY } from '@/lib/mcp-directory'
+import { completeRoutedMcpDesktopOAuth } from '@/lib/mcp-oauth-routing'
 import { prettyName } from '@/lib/text'
 import { type ComposerSuggestion, registerDraftProvider } from '@/store/composer-suggestions'
 import { $gateway } from '@/store/gateway'
@@ -194,12 +192,9 @@ async function connect(known: SuggestibleServer, sessionId: string | null, cance
     await addMcpServer({ name: known.server, url: known.url })
 
     try {
-      await completeMcpDesktopOAuth({
+      await completeRoutedMcpDesktopOAuth({
         serverName: known.server,
-        start: authMcpServer,
-        status: getMcpOAuthFlow,
         cancelled,
-        cancel: cancelMcpOAuthFlow,
         openExternal: url => window.hermesDesktop.openExternal(url)
       })
     } catch (error) {

--- a/apps/desktop/src/store/suggestion-providers/repair.ts
+++ b/apps/desktop/src/store/suggestion-providers/repair.ts
@@ -1,6 +1,7 @@
-import { authMcpServer, cancelMcpOAuthFlow, getMcpOAuthFlow, listMcpServers } from '@/hermes'
+import { listMcpServers } from '@/hermes'
 import { translateNow } from '@/i18n'
-import { completeMcpDesktopOAuth, McpOAuthCancelled } from '@/lib/mcp-dashboard-oauth'
+import { McpOAuthCancelled } from '@/lib/mcp-dashboard-oauth'
+import { completeRoutedMcpDesktopOAuth } from '@/lib/mcp-oauth-routing'
 import { prettyName } from '@/lib/text'
 import { type ComposerSuggestion, offerSuggestions } from '@/store/composer-suggestions'
 import { $gateway } from '@/store/gateway'
@@ -38,12 +39,9 @@ const keyFor = (sessionId: string | null | undefined): string => sessionId ?? ''
 
 async function reconnect(server: string, sessionId: string | null, cancelled: () => boolean): Promise<void> {
   try {
-    await completeMcpDesktopOAuth({
+    await completeRoutedMcpDesktopOAuth({
       serverName: server,
-      start: authMcpServer,
-      status: getMcpOAuthFlow,
       cancelled,
-      cancel: cancelMcpOAuthFlow,
       openExternal: url => window.hermesDesktop.openExternal(url)
     })
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11277,7 +11277,10 @@ def _maybe_setup_dashboard_auth_interactively(args) -> None:
 
     try:
         from hermes_cli.web_server import should_require_dashboard_auth
-        if not should_require_dashboard_auth(host):
+        if not should_require_dashboard_auth(
+            host,
+            headless=bool(getattr(args, "headless_backend", False)),
+        ):
             return  # local-only bind and URL — gate does not engage
     except Exception:
         return  # if we can't tell, defer to start_server's own gate

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -725,6 +725,8 @@ def should_require_auth(host: str, allow_public: bool = False) -> bool:
 def should_require_dashboard_auth(
     host: str,
     trusted_public_hosts: Optional[frozenset[str]] = None,
+    *,
+    headless: bool = False,
 ) -> bool:
     """Return whether the dashboard auth gate must be active.
 
@@ -732,7 +734,16 @@ def should_require_dashboard_auth(
     ``dashboard.public_url`` requires authentication even when a reverse proxy
     reaches a backend bound to loopback. Callers may pass the already-resolved
     host set so startup and request validation use the same snapshot.
+
+    A loopback-only ``hermes serve`` process is not that browser-facing
+    dashboard. It is Desktop's private control plane: no SPA is mounted and
+    Electron mints a process-lifetime token for its REST/WebSocket traffic.
+    Applying the public dashboard gate there rejects that token in favour of a
+    browser OAuth ticket. Headless mode therefore ignores ``public_url`` only
+    for an actual loopback bind; non-loopback binds remain gated.
     """
+    if headless and not should_require_auth(host):
+        return False
     if trusted_public_hosts is None:
         trusted_public_hosts = _dashboard_public_hosts()
     return should_require_auth(host) or any(
@@ -19308,7 +19319,9 @@ def start_server(
     # WS-auth paths can branch on it consistently. It also decides whether to
     # refuse startup, log the gate-on banner, and enable uvicorn proxy_headers.
     app.state.auth_required = should_require_dashboard_auth(
-        host, app.state.trusted_public_hosts
+        host,
+        app.state.trusted_public_hosts,
+        headless=headless,
     )
 
     # ``--insecure`` no longer disables the auth gate (June 2026 hardening:

--- a/run_agent.py
+++ b/run_agent.py
@@ -7284,6 +7284,10 @@ class AIAgent:
         try:
             from providers import get_provider_profile
             provider = (getattr(self, "provider", "") or "").strip()
+            # The ChatGPT-account Codex endpoint supports images on user turns
+            # but rejects base64 input_image parts nested in function output.
+            if provider.lower() == "openai-codex":
+                return False
             profile = get_provider_profile(provider)
             if profile is not None:
                 return getattr(profile, "supports_vision_tool_messages", True)

--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -255,6 +255,34 @@ def test_public_url_aware_gate_preserves_local_only_mode(monkeypatch):
     assert should_require_dashboard_auth("127.0.0.1") is False
 
 
+def test_headless_loopback_ignores_external_dashboard_public_url(monkeypatch):
+    """Desktop's private serve child must keep ephemeral-token auth.
+
+    ``dashboard.public_url`` describes a browser-facing reverse-proxy
+    deployment.  It must not turn a loopback-only, headless control plane into
+    gated browser mode, where the Desktop's freshly minted WebSocket token is
+    rejected in favour of an OAuth ticket.
+    """
+    from hermes_cli.web_server import should_require_dashboard_auth
+
+    monkeypatch.setenv(
+        "HERMES_DASHBOARD_PUBLIC_URL",
+        "https://dashboard.example.test:9443",
+    )
+    assert should_require_dashboard_auth("127.0.0.1", headless=True) is False
+
+
+def test_headless_non_loopback_bind_still_requires_auth(monkeypatch):
+    """Headless mode never weakens the non-loopback security boundary."""
+    from hermes_cli.web_server import should_require_dashboard_auth
+
+    monkeypatch.setenv(
+        "HERMES_DASHBOARD_PUBLIC_URL",
+        "https://dashboard.example.test:9443",
+    )
+    assert should_require_dashboard_auth("100.64.0.1", headless=True) is True
+
+
 def test_start_server_loopback_public_url_enables_gate(monkeypatch):
     """A declared external URL turns a loopback reverse proxy into gated mode."""
     from hermes_cli.dashboard_auth import clear_providers, register_provider
@@ -287,6 +315,39 @@ def test_start_server_loopback_public_url_enables_gate(monkeypatch):
         assert captured["kwargs"].get("proxy_headers") is True
     finally:
         clear_providers()
+
+
+def test_start_server_headless_loopback_public_url_keeps_token_mode(monkeypatch):
+    """The real start path must preserve Desktop token auth on loopback."""
+    from hermes_cli.dashboard_auth import clear_providers
+
+    monkeypatch.setenv(
+        "HERMES_DASHBOARD_PUBLIC_URL",
+        "https://dashboard.example.test:9443",
+    )
+    clear_providers()
+    captured = _stub_uvicorn_run(monkeypatch)
+    _restore_app_state_after_test(
+        monkeypatch,
+        "auth_required",
+        "bound_host",
+        "bound_port",
+        "trusted_public_hosts",
+    )
+
+    web_server.start_server(
+        host="127.0.0.1",
+        port=9119,
+        open_browser=False,
+        allow_public=False,
+        headless=True,
+    )
+
+    assert web_server.app.state.auth_required is False
+    assert web_server.app.state.trusted_public_hosts == frozenset(
+        {"dashboard.example.test"}
+    )
+    assert captured["kwargs"].get("proxy_headers") is False
 
 
 def test_start_server_loopback_public_url_without_provider_fails_closed(monkeypatch):

--- a/tests/hermes_cli/test_dashboard_unified_launch.py
+++ b/tests/hermes_cli/test_dashboard_unified_launch.py
@@ -87,6 +87,28 @@ class TestUnifiedDashboardRouting:
 
 class TestInteractiveDashboardAuthSetup:
 
+    def test_headless_loopback_public_url_skips_auth_setup(
+        self, main_mod, monkeypatch
+    ):
+        """A private Desktop serve child does not prompt for dashboard auth."""
+        from hermes_cli.dashboard_auth import clear_providers
+
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_PUBLIC_URL",
+            "https://dashboard.example.test:9443",
+        )
+        clear_providers()
+        monkeypatch.setattr(main_mod.sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(main_mod.sys.stdout, "isatty", lambda: True)
+        monkeypatch.setattr(
+            "builtins.input",
+            lambda _prompt: pytest.fail("headless serve must not prompt"),
+        )
+
+        main_mod._maybe_setup_dashboard_auth_interactively(
+            _args(headless_backend=True)
+        )
+
     def test_loopback_proxy_public_url_offers_auth_setup(
         self, main_mod, monkeypatch, capsys
     ):
@@ -108,7 +130,6 @@ class TestInteractiveDashboardAuthSetup:
         assert exc.value.code == 1
         output = capsys.readouterr().out
         assert "configured external dashboard.public_url" in output
-
 
 
 

--- a/tests/run_agent/test_multimodal_tool_content_recovery.py
+++ b/tests/run_agent/test_multimodal_tool_content_recovery.py
@@ -151,6 +151,20 @@ class TestToolResultContentShortCircuit:
         assert "data:image" not in out
         assert "image_url" not in out
 
+    def test_codex_account_backend_downgrades_tool_images(self, monkeypatch):
+        """ChatGPT Codex accepts user images but not images in tool output."""
+        agent = _make_agent(provider="openai-codex", model="gpt-5.6-sol")
+        agent._no_list_tool_content_models = set()
+        monkeypatch.setattr(agent, "_model_supports_vision", lambda: True)
+
+        out = agent._tool_result_content_for_active_model(
+            "computer_use", self._multimodal_result()
+        )
+
+        assert isinstance(out, str)
+        assert "data:image" not in out
+        assert "image_url" not in out
+
 
 
     def test_missing_cache_attribute_falls_through(self, monkeypatch):

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -200,6 +200,33 @@ class TestHandleVisionAnalyzeFastPath:
         assert not (isinstance(result, dict) and result.get("_multimodal") is True), \
             "Fast path fired for unknown provider; should have fallen through"
 
+    def test_codex_account_backend_uses_aux_vision_for_tool_images(self, tmp_path):
+        """ChatGPT Codex rejects data-URL images inside function outputs."""
+        img = tmp_path / "x.png"
+        img.write_bytes(_TINY_PNG)
+
+        async def _aux_sentinel(*args, **kwargs):
+            return '{"sentinel": "aux-path"}'
+
+        from agent.auxiliary_client import set_runtime_main, clear_runtime_main
+        set_runtime_main("openai-codex", "gpt-5.6-sol")
+        try:
+            with patch(
+                "agent.image_routing.decide_image_input_mode",
+                return_value="native",
+            ), patch(
+                "tools.vision_tools.vision_analyze_tool",
+                side_effect=_aux_sentinel,
+            ) as mock_aux:
+                result = asyncio.get_event_loop().run_until_complete(
+                    _handle_vision_analyze({"image_url": str(img), "question": "?"})
+                )
+        finally:
+            clear_runtime_main()
+
+        assert result == '{"sentinel": "aux-path"}'
+        mock_aux.assert_awaited_once()
+
     def test_supports_vision_override_bypasses_provider_allowlist(self, tmp_path):
         """supports_vision=true enables the fast path on an unlisted provider."""
         img = tmp_path / "x.png"

--- a/tests/tui_gateway/test_mcp_oauth_sessions.py
+++ b/tests/tui_gateway/test_mcp_oauth_sessions.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+
+class _Flow:
+    def __init__(self):
+        self.error = None
+
+    def mark_error(self, error: str) -> None:
+        self.error = error
+
+
+class _Listener:
+    def __init__(self):
+        self.shutdown_called = False
+        self.close_called = False
+
+    def shutdown(self) -> None:
+        self.shutdown_called = True
+
+    def server_close(self) -> None:
+        self.close_called = True
+
+
+def test_cancel_flow_marks_error_closes_listener_and_removes_session():
+    from tui_gateway import mcp_oauth_sessions
+
+    flow = _Flow()
+    listener = _Listener()
+    session_id = "session-cancel"
+    mcp_oauth_sessions._sessions[session_id] = {
+        "session_id": session_id,
+        "server_name": "linear",
+        "hermes_home": "/tmp/hermes-test",
+        "flow": flow,
+        "httpd": listener,
+        "created_at": 0,
+    }
+
+    try:
+        result = mcp_oauth_sessions.cancel_flow(session_id, "linear")
+    finally:
+        mcp_oauth_sessions._sessions.pop(session_id, None)
+
+    assert result == {
+        "status": "error",
+        "error_message": "OAuth cancelled by user",
+    }
+    assert flow.error == "OAuth cancelled by user"
+    assert listener.shutdown_called is True
+    assert listener.close_called is True
+    assert session_id not in mcp_oauth_sessions._sessions
+
+
+def test_cancel_flow_rejects_a_server_name_mismatch():
+    from tui_gateway import mcp_oauth_sessions
+
+    flow = _Flow()
+    session_id = "session-mismatch"
+    mcp_oauth_sessions._sessions[session_id] = {
+        "session_id": session_id,
+        "server_name": "linear",
+        "hermes_home": "/tmp/hermes-test",
+        "flow": flow,
+        "httpd": None,
+        "created_at": 0,
+    }
+
+    try:
+        result = mcp_oauth_sessions.cancel_flow(session_id, "notion")
+        assert session_id in mcp_oauth_sessions._sessions
+    finally:
+        mcp_oauth_sessions._sessions.pop(session_id, None)
+
+    assert result == {
+        "status": "error",
+        "error_message": "server name mismatch for session",
+    }
+    assert flow.error is None

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -988,8 +988,9 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
         ``tool_result`` blocks accept ``image`` content blocks.
       * OpenAI Chat Completions: tool messages accept array content with
         ``image_url`` parts.
-      * OpenAI Responses (``openai-codex``): ``function_call_output.output``
-        accepts an array of ``input_text``/``input_image`` items.
+      * The public OpenAI APIs accept multimodal content. The ChatGPT-account
+        Codex backend does not accept base64 ``input_image`` values inside
+        ``function_call_output``; it must use the auxiliary vision path.
       * Gemini 3 (and proxied via aggregators): supports multimodal tool
         results. Older Gemini does NOT.
 
@@ -1018,8 +1019,10 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
     if p in {"anthropic", "claude", "anthropic-direct"}:
         return True
 
-    # OpenAI Chat Completions and Responses
-    if p in {"openai", "openai-chat", "openai-codex", "azure-openai"}:
+    # OpenAI Chat Completions. Keep the ChatGPT-account Codex backend out of
+    # this allowlist: it rejects data:image/... values inside function output
+    # with HTTP 400 even though it supports image input on user messages.
+    if p in {"openai", "openai-chat", "azure-openai"}:
         return True
 
     # Gemini — gate on model name; older Gemini variants did not support
@@ -1069,6 +1072,11 @@ def _should_use_native_vision_fast_path() -> bool:
         model = _read_main_model()
         cfg = load_config()
         if decide_image_input_mode(provider, model, cfg) != "native":
+            return False
+        # The ChatGPT-account Codex endpoint supports images on user turns but
+        # rejects base64 images nested in function-call outputs. A generic
+        # supports_vision model override must not bypass that wire constraint.
+        if (provider or "").strip().lower() == "openai-codex":
             return False
         return (
             _supports_media_in_tool_results(provider, model)

--- a/tui_gateway/mcp_oauth_sessions.py
+++ b/tui_gateway/mcp_oauth_sessions.py
@@ -337,3 +337,24 @@ def poll_flow(session_id: str, server_name: str) -> Dict[str, Any]:
     if status == "approved":
         out["tools"] = list(getattr(flow, "tools", []) or [])
     return out
+
+
+def cancel_flow(session_id: str, server_name: str) -> Dict[str, Any]:
+    """Cancel one loopback OAuth flow and release its listener immediately."""
+    with _sessions_lock:
+        rec = _sessions.get(session_id)
+        if rec is None:
+            return {
+                "status": "error",
+                "error_message": "OAuth session not found or expired",
+            }
+        if rec["server_name"] != server_name:
+            return {
+                "status": "error",
+                "error_message": "server name mismatch for session",
+            }
+        _sessions.pop(session_id, None)
+
+    rec["flow"].mark_error("OAuth cancelled by user")
+    _shutdown_listener(rec)
+    return {"status": "error", "error_message": "OAuth cancelled by user"}

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -2367,6 +2367,29 @@ def _(rid, params: dict) -> dict:
         _mcp_reset_profile(token)
 
 
+@method("mcp.servers.oauth.cancel")
+def _(rid, params: dict) -> dict:
+    """Cancel a session-backed MCP OAuth flow and release its listener."""
+    name = str(params.get("name") or "").strip()
+    if not name:
+        return _err(rid, 4063, "name required")
+    session_id = str(params.get("session_id") or "").strip()
+    if not session_id:
+        return _err(rid, 4063, "session_id required")
+    token, err = _mcp_resolve_profile(rid, params)
+    if err:
+        return err
+    try:
+        from tui_gateway import mcp_oauth_sessions
+
+        result = mcp_oauth_sessions.cancel_flow(session_id, name)
+        return _ok(rid, {"ok": True, **result})
+    except Exception as e:
+        return _err(rid, 5024, str(e))
+    finally:
+        _mcp_reset_profile(token)
+
+
 @method("skills.reload")
 def _(rid, params: dict) -> dict:
     try:


### PR DESCRIPTION
## Context

A configured public dashboard URL caused the private Desktop loopback backend to engage browser-dashboard auth and reject Electron session tokens. MCP OAuth also selected its route from ambient connection state, so a flow could start locally and later poll or cancel through a different connection. Separately, the ChatGPT-account Codex backend rejects image parts nested inside function outputs.

## What changed

- Keep headless loopback `hermes serve` on Desktop session-token auth while preserving the dashboard auth gate for non-loopback binds.
- Freeze MCP OAuth `{connectionId, profile}` at flow start; use gateway loopback RPC for local flows and the dashboard callback flow for remote connections.
- Add explicit local OAuth cancellation and best-effort cleanup after browser/poll failures.
- Route Codex tool-result images through the auxiliary vision/text path while preserving native user-image input.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_gate.py tests/hermes_cli/test_dashboard_unified_launch.py tests/tui_gateway/test_mcp_oauth_sessions.py tests/run_agent/test_multimodal_tool_content_recovery.py tests/tools/test_vision_native_fast_path.py -q`
- `npx vitest run src/lib/mcp-dashboard-oauth.test.ts src/lib/mcp-oauth-routing.test.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing repository warnings)
- Focused Python Ruff check on changed files
- Packaged macOS app and verified a loopback `/api/ws` session-token handshake end to end

## Risk / rollout

The auth exception is limited to headless processes actually bound to loopback. Public and non-loopback dashboard binds remain gated. Remote OAuth retains the REST callback path and is pinned to the initiating connection.