### PR TITLE
feat(feishu): isolate thread-scoped conversations

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -122,6 +122,16 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
         anchor = reply_to_message_id or getattr(source, "message_id", None)
         if anchor is not None:
             metadata["telegram_reply_to_message_id"] = str(anchor)
+    elif (
+        _platform_name(getattr(source, "platform", None)) == "feishu"
+        and thread_id is not None
+    ):
+        # Feishu rich posts and attachments need a concrete message anchor to
+        # stay in the originating topic. A bare thread_id create can be rejected
+        # by the API or open a sibling topic instead.
+        anchor = reply_to_message_id or getattr(source, "message_id", None)
+        if anchor is not None:
+            metadata["reply_to_message_id"] = str(anchor)
     return metadata
 
 
@@ -2494,6 +2504,10 @@ class SendResult:
     # ``None`` (unset / not classified).  Producers should set this via
     # :func:`classify_send_error`.
     error_kind: Optional[str] = None
+    # Native conversation identifier returned by platforms that create a
+    # thread/topic as part of a send. Kept last for positional compatibility
+    # with third-party adapters constructing older SendResult shapes.
+    thread_id: Optional[str] = None
 
 
 # Machine-readable send-failure categories.  Kept platform-neutral so every
@@ -5820,6 +5834,30 @@ class BasePlatformAdapter(ABC):
             return
         del self._active_sessions[session_key]
 
+    def release_retargeted_session_guard(self, session_key: str) -> bool:
+        """Release a guard after its handler moves work to another session.
+
+        Feishu ``/thread`` starts under the parent-chat guard, creates a stable
+        thread id, then continues under that thread's session key. Releasing the
+        parent only after the thread exists keeps concurrent launches linear
+        without blocking unrelated parent-chat turns for the full agent run.
+        """
+        current_task = asyncio.current_task()
+        if (
+            current_task is None
+            or self._session_tasks.get(session_key) is not current_task
+        ):
+            return False
+
+        self._session_tasks.pop(session_key, None)
+        self._release_session_guard(session_key)
+        self._discard_text_debounce(session_key)
+
+        pending_event = self._pending_messages.pop(session_key, None)
+        if pending_event is not None:
+            self._start_session_processing(pending_event, session_key)
+        return True
+
     def _session_task_is_stale(self, session_key: str) -> bool:
         """Return True if the owner task for ``session_key`` is done/cancelled.
 
@@ -6135,8 +6173,12 @@ class BasePlatformAdapter(ABC):
                     self.name, cmd, session_key,
                 )
                 try:
-                    _thread_meta = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
                     response = await self._message_handler(event)
+                    # The handler may retarget a command (for example Feishu
+                    # /thread) to a new conversation before returning.
+                    _thread_meta = _thread_metadata_for_source(
+                        event.source, _reply_anchor_for_event(event)
+                    )
                     _text, _eph_ttl = self._unwrap_ephemeral(response)
                     if _text:
                         _r = await self._send_with_retry(
@@ -6354,6 +6396,13 @@ class BasePlatformAdapter(ABC):
             # streaming already delivered the text (already_sent=True) or
             # when the message was queued behind an active agent.  Log at
             # DEBUG to avoid noisy warnings for expected behavior.
+            # A command handler may retarget the event to a newly created
+            # conversation (Feishu /thread). Recompute after the handler so
+            # final/progress delivery follows the new source, not the parent.
+            _thread_metadata = _thread_metadata_for_source(
+                event.source,
+                _reply_anchor_for_event(event),
+            )
             #
             # Suppress stale response when the session was interrupted by a
             # new message that hasn't been consumed yet.  The pending message
@@ -6455,6 +6504,52 @@ class BasePlatformAdapter(ABC):
                 # metadata stays unmarked and progress bubbles remain
                 # thread-strict.
                 _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
+
+                # Feishu can deliver the common ``text + MEDIA:image`` response
+                # as one rich post. Keep the concrete reply anchor on that post
+                # so both text and image remain in the same conversation.
+                if (
+                    self.platform == Platform.FEISHU
+                    and len(media_files) == 1
+                    and not images
+                    and not local_files
+                    and not force_document_attachments
+                ):
+                    _inline_path, _inline_is_voice = media_files[0]
+                    if (
+                        Path(_inline_path).suffix.lower()
+                        in {".jpg", ".jpeg", ".png", ".webp", ".gif"}
+                        and not _inline_is_voice
+                    ):
+                        try:
+                            inline_result = await self.send_image_file(
+                                chat_id=event.source.chat_id,
+                                image_path=_inline_path,
+                                caption=text_content or None,
+                                reply_to=_reply_anchor_for_event(event),
+                                metadata=_final_thread_metadata,
+                            )
+                            _record_delivery(inline_result)
+                            if getattr(inline_result, "success", False):
+                                text_content = ""
+                                media_files = []
+                            else:
+                                logger.warning(
+                                    "[%s] Feishu inline image delivery failed: %s",
+                                    self.name,
+                                    getattr(
+                                        inline_result,
+                                        "error",
+                                        "send returned success=False",
+                                    ),
+                                )
+                        except Exception as inline_err:
+                            logger.warning(
+                                "[%s] Error sending Feishu inline image post: %s",
+                                self.name,
+                                inline_err,
+                                exc_info=True,
+                            )
 
                 # Auto-TTS: if voice message, generate audio FIRST (before sending text)
                 # Gated via ``_should_auto_tts_for_chat``: fires when the chat has

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16461,6 +16461,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             plain = {
                 "status": self._handle_status_command,
                 "context": self._handle_context_command,
+                "thread": self._handle_thread_command,
                 "restart": self._handle_restart_command,
                 "approve": self._handle_approve_command,
                 "deny": self._handle_deny_command,
@@ -17603,6 +17604,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "topic":
             return await self._handle_topic_command(event)
+
+        if canonical == "thread":
+            return await self._handle_thread_command(event)
         
         if canonical == "help":
             return await self._handle_help_command(event)
@@ -18176,6 +18180,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return self._telegram_topic_root_lobby_message()
             return None
 
+        return await self._dispatch_event_to_agent(
+            event,
+            source,
+            _quick_key,
+            is_internal=is_internal,
+        )
+
+    async def _dispatch_event_to_agent(
+        self,
+        event: MessageEvent,
+        source: SessionSource,
+        session_key: str,
+        *,
+        is_internal: bool = False,
+    ) -> Any:
+        """Run one resolved event through the normal agent-turn pipeline."""
         # ── External-drain new-turn gate (Phase 2) ────────────────────
         # When NAS has engaged an external drain (.drain_request.json present,
         # observed by _drain_control_watcher), refuse to START a new turn so
@@ -18189,7 +18209,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if self._external_drain_active and not is_internal:
             logger.info(
                 "Refusing new turn for session %s — external drain active.",
-                _quick_key,
+                session_key,
             )
             return (
                 "⏳ This agent is draining for a maintenance action and isn't "
@@ -18205,27 +18225,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # "already running" guard and spin up a duplicate agent for the
         # same session — corrupting the transcript.
         _active_session_lease, _limit_message = self._claim_active_session_slot(
-            _quick_key,
+            session_key,
             source,
         )
         if _limit_message is not None:
             logger.info(
                 "Rejecting new active session %s: max_concurrent_sessions reached",
-                _quick_key,
+                session_key,
             )
             return _limit_message
-        _claim_state = self._session_state(_quick_key)
+        _claim_state = self._session_state(session_key)
         if _active_session_lease is not None:
             _claim_state.turn.lease = _active_session_lease
         _claim_state.turn.agent = _AGENT_PENDING_SENTINEL
         _claim_state.turn.started_ts = time.time()
         self._persist_active_agents()
-        _run_generation = self._begin_session_run_generation(_quick_key)
+        _run_generation = self._begin_session_run_generation(session_key)
 
         try:
             try:
                 _agent_result = await self._handle_message_with_agent(
-                    event, source, _quick_key, _run_generation
+                    event, source, session_key, _run_generation
                 )
             except TurnLeaseTimeoutError as exc:
                 # This is a rejected message, not a completed agent turn. Return
@@ -18235,7 +18255,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "Rejecting turn for routing key %s on session %s after "
                     "turn-lease timeout; transcript load was not started and "
                     "the user must resend",
-                    _quick_key,
+                    session_key,
                     exc.session_id,
                 )
                 return (
@@ -18262,8 +18282,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # permanently (every later message silently fans out through MoA).
             # Putting it in finally guarantees the revert on success, exception,
             # and interrupt alike.
-            self._restore_moa_one_shot(event, _quick_key)
-            self._restore_pending_one_turn_model_override(_quick_key)
+            self._restore_moa_one_shot(event, session_key)
+            self._restore_pending_one_turn_model_override(session_key)
             # Normal completion/exception/interrupt owns and clears this exact
             # durable marker.  SIGKILL/OOM skips finally, leaving the marker for
             # the next unclean startup's recovery pass.
@@ -18275,11 +18295,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # bumps the generation (N -> N+1) mid-flight: gen-N's guarded release
             # inside _run_agent returns False, and the old sentinel-only check here
             # missed the leftover real agent — locking the session out forever (#28686).
-            self._release_running_agent_state(_quick_key)
+            self._release_running_agent_state(session_key)
             # Turn lease (#64934): release THIS turn's lease token — keyed by
             # (routing key, run generation) so this unwind can only ever free
             # the lease its own turn acquired, never a newer turn's.
-            self._release_turn_lease(_quick_key, _run_generation)
+            self._release_turn_lease(session_key, _run_generation)
 
     def _restore_moa_one_shot(self, event: "MessageEvent", quick_key: str) -> None:
         """Revert a ``/moa <prompt>`` one-shot model override after its turn.
@@ -21211,6 +21231,129 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
 
 
+
+    async def _handle_thread_command(self, event: MessageEvent) -> Any:
+        """Start a Feishu thread-scoped turn or reset the current thread.
+
+        A command typed in a parent chat creates a native Feishu topic rooted
+        at that command and retargets the agent turn to the new deterministic
+        session key. Inside an existing topic, it resets only that topic's
+        Hermes session before running the supplied prompt.
+        """
+        source = event.source
+        if source.platform != Platform.FEISHU:
+            return "/thread is currently supported only on Feishu."
+
+        prompt = event.get_command_args().strip()
+        if not prompt:
+            return "Usage: /thread <prompt>"
+
+        adapter = self._adapter_for_source(source)
+        original_session_key = self._session_key_for_source(source)
+        original_message_id = getattr(event, "message_id", None)
+        thread_source = source
+        seed_message_id: Optional[str] = None
+
+        if source.thread_id:
+            thread_key = self._session_key_for_source(source)
+            if self._is_session_running(thread_key):
+                await self._interrupt_and_clear_session(
+                    thread_key,
+                    source,
+                    interrupt_reason=_INTERRUPT_REASON_RESET,
+                    invalidation_reason="thread_command",
+                )
+            # Reset only this topic. The /new notice is intentionally hidden;
+            # the next visible final should answer the supplied prompt.
+            await self._handle_reset_command(dataclasses.replace(event, text="/new"))
+        else:
+            create_thread = getattr(adapter, "create_thread", None) if adapter else None
+            if create_thread is None:
+                return (
+                    "Feishu /thread is unavailable: adapter does not support "
+                    "thread creation."
+                )
+            if not original_message_id:
+                return "Feishu /thread requires a message id to create a thread."
+
+            result = await create_thread(
+                source.chat_id,
+                "⏳",
+                reply_to=str(original_message_id),
+            )
+            if not getattr(result, "success", False):
+                return (
+                    "Failed to create Feishu thread: "
+                    f"{getattr(result, 'error', 'unknown error')}"
+                )
+            thread_id = getattr(result, "thread_id", None) or getattr(
+                result, "message_id", None
+            )
+            if not thread_id:
+                return (
+                    "Failed to create Feishu thread: response did not include "
+                    "a thread id."
+                )
+
+            created_message_id = getattr(result, "message_id", None)
+            seed_message_id = (
+                str(created_message_id) if created_message_id is not None else None
+            )
+            thread_source = dataclasses.replace(
+                source,
+                thread_id=str(thread_id),
+                parent_chat_id=source.chat_id,
+                # Preserve the user command as the durable reply anchor. The
+                # temporary bot seed is deleted after the turn.
+                message_id=str(original_message_id),
+            )
+            release_retargeted = getattr(
+                adapter, "release_retargeted_session_guard", None
+            )
+            if release_retargeted is not None:
+                release_retargeted(original_session_key)
+
+        event.text = prompt
+        event.message_type = MessageType.TEXT
+        event.source = thread_source
+        # Keep routing anchored to the user command without injecting the
+        # prompt a second time as synthetic reply context for the model.
+        event.reply_to_message_id = (
+            str(original_message_id) if original_message_id else None
+        )
+        event.reply_to_text = None
+        event.reply_to_author_id = None
+        event.reply_to_author_name = None
+        event.reply_to_is_own_message = False
+
+        thread_key = self._session_key_for_source(thread_source)
+        try:
+            return await self._dispatch_event_to_agent(
+                event,
+                thread_source,
+                thread_key,
+            )
+        finally:
+            # The seed exists only to ask Feishu for a native topic id. Cleanup
+            # is best-effort and must never suppress or replace final delivery.
+            if seed_message_id and adapter is not None:
+                delete_message = getattr(adapter, "delete_message", None)
+                if delete_message is not None:
+                    try:
+                        deleted = await delete_message(source.chat_id, seed_message_id)
+                    except Exception as exc:
+                        deleted = False
+                        logger.warning(
+                            "Feishu /thread seed delete failed for %s: %s",
+                            seed_message_id,
+                            exc,
+                            exc_info=True,
+                        )
+                    if not deleted:
+                        logger.warning(
+                            "Feishu /thread seed delete failed for %s",
+                            seed_message_id,
+                        )
 
     def _check_slash_access(
         self, source: SessionSource, canonical_cmd: str

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -2436,14 +2436,36 @@ class GatewayStreamConsumer:
         try:
             if self._message_id is not None:
                 if self._edit_supported:
+                    _needs_fresh_final = False
+                    if finalize:
+                        # Resolve adapter preference before the identical-text
+                        # fast path. Fresh-final adapters must still replace a
+                        # fully flushed preview with a new bottom message.
+                        _has_prefers_hook = (
+                            hasattr(
+                                type(self.adapter),
+                                "prefers_fresh_final_streaming",
+                            )
+                            or "prefers_fresh_final_streaming"
+                            in getattr(self.adapter, "__dict__", {})
+                        )
+                        _prefers_fresh = self._adapter_prefers_fresh_final(text)
+                        _needs_fresh_final = (
+                            _prefers_fresh
+                            or (
+                                not _has_prefers_hook
+                                and self._should_send_fresh_final()
+                            )
+                        )
                     # Skip if text is identical to what we last sent.
-                    # Exception: adapters that require an explicit finalize
-                    # call (REQUIRES_EDIT_FINALIZE) must still receive the
-                    # finalize=True edit even when content is unchanged, so
-                    # their streaming UI can transition out of the in-
-                    # progress state.  Everyone else short-circuits.
+                    # Explicit-finalize and fresh-final adapters still need the
+                    # final tick even when the complete preview is on screen.
                     if text == self._last_sent_text and not (
-                        finalize and self._adapter_requires_finalize
+                        finalize
+                        and (
+                            self._adapter_requires_finalize
+                            or _needs_fresh_final
+                        )
                     ):
                         return True
                     # Fresh-final for long-lived previews: when finalizing
@@ -2479,22 +2501,9 @@ class GatewayStreamConsumer:
                     # __dict__ for test doubles that explicitly assign the
                     # attribute (e.g. adapter.prefers_fresh_final_streaming
                     # = MagicMock(return_value=False)).
-                    _has_prefers_hook = (
-                        hasattr(type(self.adapter),
-                                "prefers_fresh_final_streaming")
-                        or "prefers_fresh_final_streaming"
-                            in getattr(self.adapter, "__dict__", {})
-                    )
-                    _prefers_fresh = self._adapter_prefers_fresh_final(text)
                     if (
                         finalize
-                        and (
-                            _prefers_fresh
-                            or (
-                                not _has_prefers_hook
-                                and self._should_send_fresh_final()
-                            )
-                        )
+                        and _needs_fresh_final
                         and await self._try_fresh_final(
                             text, is_turn_final=is_turn_final,
                         )

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -148,6 +148,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
                busy_policy="interrupt_then_dispatch", busy_handler="new"),
     CommandDef("topic", "Enable or inspect Telegram DM topic sessions", "Session",
                gateway_only=True, args_hint="[off|help|session-id]"),
+    CommandDef("thread", "Start or reset a Feishu thread session", "Session",
+               gateway_only=True, args_hint="<prompt>",
+               busy_policy="dispatch"),
     CommandDef("clear", "Clear screen and start a new session", "Session",
                cli_only=True),
     CommandDef("redraw", "Force a full UI repaint (recovers from terminal drift)", "Session",
@@ -1368,7 +1371,9 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #     (session export is an interactive surface; platform is a rare
 #     informational lookup) — without this entry /save tips the registry
 #     past the 50-cap and silently clamps /platform, breaking parity.
-_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat", "refine", "review", "pause", "whoami", "platform"})
+#   - thread: Feishu-only conversation launcher; reachable as
+#     /hermes thread on Slack without consuming a native Slack slot.
+_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat", "refine", "review", "pause", "whoami", "platform", "thread"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -95,6 +95,7 @@ CreateImageRequest = None  # type: ignore[assignment]
 CreateImageRequestBody = None  # type: ignore[assignment]
 CreateMessageRequest = None  # type: ignore[assignment]
 CreateMessageRequestBody = None  # type: ignore[assignment]
+DeleteMessageRequest = None  # type: ignore[assignment]
 GetChatRequest = None  # type: ignore[assignment]
 GetMessageRequest = None  # type: ignore[assignment]
 GetMessageResourceRequest = None  # type: ignore[assignment]
@@ -1400,6 +1401,7 @@ def _load_lark_oapi() -> bool:
                 CreateFileRequest, CreateFileRequestBody,
                 CreateImageRequest, CreateImageRequestBody,
                 CreateMessageRequest, CreateMessageRequestBody,
+                DeleteMessageRequest,
                 GetChatRequest, GetMessageRequest, GetMessageResourceRequest,
                 P2ImMessageMessageReadV1,
                 ReplyMessageRequest, ReplyMessageRequestBody,
@@ -1425,6 +1427,7 @@ def _load_lark_oapi() -> bool:
             "CreateImageRequestBody": CreateImageRequestBody,
             "CreateMessageRequest": CreateMessageRequest,
             "CreateMessageRequestBody": CreateMessageRequestBody,
+            "DeleteMessageRequest": DeleteMessageRequest,
             "GetChatRequest": GetChatRequest,
             "GetMessageRequest": GetMessageRequest,
             "GetMessageResourceRequest": GetMessageResourceRequest,
@@ -1487,6 +1490,14 @@ class FeishuAdapter(BasePlatformAdapter):
     supports_code_blocks = True  # Feishu renders fenced code blocks
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
 
+    def prefers_fresh_final_streaming(
+        self,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Keep completed Feishu replies below their progress messages."""
+        return True
+
     MAX_MESSAGE_LENGTH = 8000
     # Max distinct chat IDs retained in _chat_locks before LRU eviction kicks in.
     CHAT_LOCK_MAX_SIZE: int = 1000
@@ -1538,6 +1549,10 @@ class FeishuAdapter(BasePlatformAdapter):
         self._pending_drain_scheduled = False
         self._pending_inbound_max_depth = 1000  # cap queue; drop oldest beyond
         self._chat_locks: "collections.OrderedDict[str, asyncio.Lock]" = collections.OrderedDict()  # chat_id → lock (per-chat serial processing, LRU-bounded)
+        # Thread creation gets a dedicated per-chat lock because handle_message()
+        # releases _chat_locks after scheduling ordinary work. Without this
+        # narrower lock, two fast /thread launches can overlap at the API seam.
+        self._thread_creation_locks: "collections.OrderedDict[str, asyncio.Lock]" = collections.OrderedDict()
         self._sent_message_ids_to_chat: Dict[str, str] = {}  # message_id → chat_id (for reaction routing)
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
@@ -2012,6 +2027,48 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.error("[Feishu] Send error: %s", exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
 
+    async def create_thread(
+        self,
+        chat_id: str,
+        content: str,
+        *,
+        reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Create a Feishu topic by replying with ``reply_in_thread``."""
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+        if not reply_to:
+            return SendResult(
+                success=False,
+                error="Feishu /thread requires a source message id",
+            )
+
+        # Keep the platform call linear per visible parent conversation. Each
+        # result remains paired with its own command message even when users
+        # launch multiple isolated threads in quick succession.
+        creation_lock = self._get_thread_creation_lock(chat_id)
+        async with creation_lock:
+            formatted = self.format_message(content)
+            chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            seed_chunk = chunks[0] if chunks else formatted
+            msg_type, payload = self._build_outbound_payload(seed_chunk)
+            try:
+                response = await self._feishu_send_with_retry(
+                    chat_id=chat_id,
+                    msg_type=msg_type,
+                    payload=payload,
+                    reply_to=reply_to,
+                    metadata={**(metadata or {}), "thread_id": "__create__"},
+                )
+                result = self._finalize_send_result(response, "create_thread failed")
+                if result.success and not result.thread_id:
+                    result.thread_id = result.message_id
+                return result
+            except Exception as exc:
+                logger.error("[Feishu] create_thread error: %s", exc, exc_info=True)
+                return SendResult(success=False, error=str(exc))
+
     async def edit_message(
         self,
         chat_id: str,
@@ -2046,6 +2103,32 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.error("[Feishu] Failed to edit message %s: %s", message_id, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
+
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        """Delete a temporary seed or stale streaming preview."""
+        if not self._client or not message_id:
+            return False
+        try:
+            request = self._build_delete_message_request(message_id)
+            response = await self._run_blocking(
+                self._client.im.v1.message.delete,
+                request,
+            )
+            if self._response_succeeded(response):
+                return True
+            logger.warning(
+                "[Feishu] Failed to delete message %s: %s",
+                message_id,
+                getattr(response, "msg", None) or "delete failed",
+            )
+        except Exception as exc:
+            logger.warning(
+                "[Feishu] Failed to delete message %s: %s",
+                message_id,
+                exc,
+                exc_info=True,
+            )
+        return False
 
     # Template attrs for the shared _format_exec_approval core. The card
     # header carries the title, so the text core starts at the code fence.
@@ -3114,6 +3197,21 @@ class FeishuAdapter(BasePlatformAdapter):
     # Per-chat serialization and typing indicator
     # =========================================================================
 
+    def _get_thread_creation_lock(self, chat_id: str) -> asyncio.Lock:
+        """Return the bounded per-chat lock for Feishu topic creation."""
+        lock = self._thread_creation_locks.get(chat_id)
+        if lock is not None:
+            self._thread_creation_locks.move_to_end(chat_id)
+            return lock
+        if len(self._thread_creation_locks) >= self.CHAT_LOCK_MAX_SIZE:
+            for key in list(self._thread_creation_locks):
+                if not self._thread_creation_locks[key].locked():
+                    self._thread_creation_locks.pop(key)
+                    break
+        lock = asyncio.Lock()
+        self._thread_creation_locks[chat_id] = lock
+        return lock
+
     def _get_chat_lock(self, chat_id: str) -> asyncio.Lock:
         """Return (creating if needed) the per-chat asyncio.Lock for serial message processing.
 
@@ -3385,6 +3483,7 @@ class FeishuAdapter(BasePlatformAdapter):
             thread_id=thread_id,
             user_id_alt=sender_profile["user_id_alt"],
             is_bot=is_bot,
+            message_id=message_id,
         )
         normalized = MessageEvent(
             text=text,
@@ -4895,6 +4994,10 @@ class FeishuAdapter(BasePlatformAdapter):
         return SendResult(
             success=True,
             message_id=self._extract_response_field(response, "message_id"),
+            thread_id=(
+                self._extract_response_field(response, "thread_id")
+                or self._extract_response_field(response, "root_id")
+            ),
             raw_response=response,
         )
 
@@ -5155,6 +5258,12 @@ class FeishuAdapter(BasePlatformAdapter):
                 .build()
             )
         return SimpleNamespace(message_id=message_id, request_body=request_body)
+
+    @staticmethod
+    def _build_delete_message_request(message_id: str) -> Any:
+        if DeleteMessageRequest is not None:
+            return DeleteMessageRequest.builder().message_id(message_id).build()
+        return SimpleNamespace(message_id=message_id)
 
     @staticmethod
     def _build_create_message_body(*, receive_id: str, msg_type: str, content: str, uuid_value: str) -> Any:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -949,6 +949,7 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.source.user_name, "张三")
         self.assertEqual(event.source.user_id_alt, "on_union")
         self.assertEqual(event.source.chat_name, "Feishu DM")
+        self.assertEqual(event.source.message_id, "om_text")
 
 
     @patch.dict(

--- a/tests/gateway/test_feishu_conversation_isolation.py
+++ b/tests/gateway/test_feishu_conversation_isolation.py
@@ -1,0 +1,631 @@
+"""Behavior contracts for Feishu conversation-isolated thread turns."""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+    _thread_metadata_for_source,
+)
+from gateway.session import SessionSource, build_session_key
+
+
+def _source(*, thread_id: str | None = None, message_id: str | None = None):
+    return SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        chat_name="Feishu Chat",
+        chat_type="group",
+        user_id="ou_user",
+        user_name="Tester",
+        thread_id=thread_id,
+        message_id=message_id,
+    )
+
+
+def _event(
+    text: str = "/thread summarize this",
+    *,
+    thread_id: str | None = None,
+    message_id: str | None = "om_command",
+):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=_source(thread_id=thread_id, message_id=message_id),
+        message_id=message_id,
+    )
+
+
+def _runner(adapter, *, agent_result="assistant answer"):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._adapter_for_source = MagicMock(return_value=adapter)
+    runner._session_key_for_source = MagicMock(
+        side_effect=lambda source: build_session_key(source)
+    )
+    runner._is_session_running = MagicMock(return_value=False)
+    runner._interrupt_and_clear_session = AsyncMock()
+    runner._handle_reset_command = AsyncMock()
+    runner._dispatch_event_to_agent = AsyncMock(return_value=agent_result)
+    return runner
+
+
+def test_thread_command_is_gateway_dispatchable():
+    from hermes_cli.commands import (
+        ACTIVE_SESSION_BYPASS_COMMANDS,
+        resolve_command,
+        should_bypass_active_session,
+    )
+
+    command = resolve_command("thread")
+    assert command is not None
+    assert command.gateway_only is True
+    assert command.busy_policy == "dispatch"
+    assert "thread" in ACTIVE_SESSION_BYPASS_COMMANDS
+    assert should_bypass_active_session("thread") is True
+
+
+def test_feishu_thread_source_has_deterministic_shared_session_identity():
+    alice = _source(thread_id="omt_topic")
+    bob = dataclasses.replace(alice, user_id="ou_bob")
+    other_topic = dataclasses.replace(alice, thread_id="omt_other")
+
+    assert build_session_key(alice) == build_session_key(bob)
+    assert build_session_key(alice) != build_session_key(other_topic)
+
+
+def test_feishu_thread_metadata_carries_durable_reply_anchor():
+    source = _source(thread_id="omt_topic", message_id="om_origin")
+
+    assert _thread_metadata_for_source(source) == {
+        "thread_id": "omt_topic",
+        "reply_to_message_id": "om_origin",
+    }
+    assert _thread_metadata_for_source(source, "om_latest") == {
+        "thread_id": "omt_topic",
+        "reply_to_message_id": "om_latest",
+    }
+
+
+@pytest.mark.asyncio
+async def test_parent_thread_launch_retargets_agent_and_retracts_seed():
+    adapter = MagicMock()
+    adapter.create_thread = AsyncMock(
+        return_value=SendResult(
+            success=True,
+            message_id="om_seed",
+            thread_id="omt_created",
+        )
+    )
+    adapter.delete_message = AsyncMock(return_value=True)
+    adapter.release_retargeted_session_guard = MagicMock(return_value=True)
+    runner = _runner(adapter)
+    event = _event()
+    parent_key = build_session_key(event.source)
+
+    result = await runner._handle_thread_command(event)
+
+    assert result == "assistant answer"
+    adapter.create_thread.assert_awaited_once_with(
+        "oc_chat",
+        "⏳",
+        reply_to="om_command",
+    )
+    adapter.release_retargeted_session_guard.assert_called_once_with(parent_key)
+    adapter.delete_message.assert_awaited_once_with("oc_chat", "om_seed")
+    assert event.text == "summarize this"
+    assert event.message_type == MessageType.TEXT
+    assert event.source.thread_id == "omt_created"
+    assert event.source.parent_chat_id == "oc_chat"
+    assert event.source.message_id == "om_command"
+    assert event.reply_to_message_id == "om_command"
+    assert event.reply_to_text is None
+    dispatched_event, dispatched_source, dispatched_key = (
+        runner._dispatch_event_to_agent.await_args.args
+    )
+    assert dispatched_event is event
+    assert dispatched_source is event.source
+    assert dispatched_key == build_session_key(event.source)
+
+
+@pytest.mark.asyncio
+async def test_seed_cleanup_runs_when_agent_dispatch_raises():
+    adapter = MagicMock()
+    adapter.create_thread = AsyncMock(
+        return_value=SendResult(
+            success=True,
+            message_id="om_seed",
+            thread_id="omt_created",
+        )
+    )
+    adapter.delete_message = AsyncMock(return_value=True)
+    adapter.release_retargeted_session_guard = MagicMock(return_value=True)
+    runner = _runner(adapter)
+    runner._dispatch_event_to_agent.side_effect = RuntimeError("agent failed")
+
+    with pytest.raises(RuntimeError, match="agent failed"):
+        await runner._handle_thread_command(_event())
+
+    adapter.delete_message.assert_awaited_once_with("oc_chat", "om_seed")
+
+
+@pytest.mark.asyncio
+async def test_missing_seed_id_never_deletes_the_user_command():
+    adapter = MagicMock()
+    adapter.create_thread = AsyncMock(
+        return_value=SendResult(
+            success=True,
+            message_id=None,
+            thread_id="omt_created",
+        )
+    )
+    adapter.delete_message = AsyncMock(return_value=True)
+    adapter.release_retargeted_session_guard = MagicMock(return_value=True)
+    runner = _runner(adapter)
+
+    result = await runner._handle_thread_command(_event())
+
+    assert result == "assistant answer"
+    adapter.delete_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_existing_thread_resets_only_that_session_before_dispatch():
+    adapter = MagicMock()
+    runner = _runner(adapter)
+    runner._is_session_running.return_value = True
+    event = _event(
+        "/thread start over",
+        thread_id="omt_existing",
+        message_id="om_restart",
+    )
+    thread_key = build_session_key(event.source)
+
+    result = await runner._handle_thread_command(event)
+
+    assert result == "assistant answer"
+    runner._interrupt_and_clear_session.assert_awaited_once()
+    assert runner._interrupt_and_clear_session.await_args.args[:2] == (
+        thread_key,
+        event.source,
+    )
+    runner._handle_reset_command.assert_awaited_once()
+    reset_event = runner._handle_reset_command.await_args.args[0]
+    assert reset_event.text == "/new"
+    assert reset_event.source.thread_id == "omt_existing"
+    adapter.create_thread.assert_not_called()
+    runner._dispatch_event_to_agent.assert_awaited_once_with(
+        event,
+        event.source,
+        thread_key,
+    )
+
+
+@pytest.mark.asyncio
+async def test_thread_command_fails_closed_without_safe_target():
+    adapter = MagicMock()
+    runner = _runner(adapter)
+
+    assert await runner._handle_thread_command(_event("/thread")) == (
+        "Usage: /thread <prompt>"
+    )
+    assert "requires a message id" in await runner._handle_thread_command(
+        _event(message_id=None)
+    )
+
+    adapter.create_thread = AsyncMock(
+        return_value=SendResult(success=False, error="permission denied")
+    )
+    assert await runner._handle_thread_command(_event()) == (
+        "Failed to create Feishu thread: permission denied"
+    )
+
+    telegram_event = MessageEvent(
+        text="/thread prompt",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="123",
+            chat_type="dm",
+        ),
+        message_id="1",
+    )
+    assert "only on Feishu" in await runner._handle_thread_command(telegram_event)
+
+
+class _RecordingFeishuAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(
+            PlatformConfig(enabled=True, token="fake"),
+            Platform.FEISHU,
+        )
+        self.config.typing_indicator = False
+        self.sent = []
+        self.inline_images = []
+
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id="om_final")
+
+    async def send_image_file(
+        self,
+        chat_id,
+        image_path,
+        caption=None,
+        reply_to=None,
+        metadata=None,
+        **kwargs,
+    ):
+        self.inline_images.append(
+            {
+                "chat_id": chat_id,
+                "image_path": image_path,
+                "caption": caption,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id="om_image")
+
+    async def send_typing(self, chat_id, metadata=None):
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+@pytest.mark.asyncio
+async def test_final_delivery_recomputes_metadata_after_thread_retarget():
+    adapter = _RecordingFeishuAdapter()
+    event = _event()
+    parent_key = build_session_key(event.source)
+
+    async def handler(mutated_event):
+        mutated_event.source = dataclasses.replace(
+            mutated_event.source,
+            thread_id="omt_created",
+            message_id="om_command",
+        )
+        mutated_event.reply_to_message_id = "om_command"
+        return "final answer"
+
+    adapter.set_message_handler(handler)
+    await adapter._process_message_background(event, parent_key)
+
+    assert adapter.sent == [
+        {
+            "chat_id": "oc_chat",
+            "content": "final answer",
+            "reply_to": "om_command",
+            "metadata": {
+                "thread_id": "omt_created",
+                "reply_to_message_id": "om_command",
+                "notify": True,
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_inline_media_uses_same_retargeted_conversation(tmp_path):
+    image = tmp_path / "chart.png"
+    image.write_bytes(b"image")
+    adapter = _RecordingFeishuAdapter()
+    event = _event()
+    parent_key = build_session_key(event.source)
+
+    async def handler(mutated_event):
+        mutated_event.source = dataclasses.replace(
+            mutated_event.source,
+            thread_id="omt_created",
+            message_id="om_command",
+        )
+        mutated_event.reply_to_message_id = "om_command"
+        return f"Chart summary\nMEDIA:{image}"
+
+    adapter.set_message_handler(handler)
+    await adapter._process_message_background(event, parent_key)
+
+    assert adapter.sent == []
+    assert adapter.inline_images == [
+        {
+            "chat_id": "oc_chat",
+            "image_path": str(image),
+            "caption": "Chart summary",
+            "reply_to": "om_command",
+            "metadata": {
+                "thread_id": "omt_created",
+                "reply_to_message_id": "om_command",
+                "notify": True,
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_busy_bypass_recomputes_metadata_after_thread_retarget():
+    adapter = _RecordingFeishuAdapter()
+    event = _event()
+    parent_key = build_session_key(event.source)
+    adapter._active_sessions[parent_key] = asyncio.Event()
+
+    async def handler(mutated_event):
+        mutated_event.source = dataclasses.replace(
+            mutated_event.source,
+            thread_id="omt_created",
+            message_id="om_command",
+        )
+        mutated_event.reply_to_message_id = "om_command"
+        return "busy-path final"
+
+    adapter.set_message_handler(handler)
+    await adapter.handle_message(event)
+
+    assert adapter.sent == [
+        {
+            "chat_id": "oc_chat",
+            "content": "busy-path final",
+            "reply_to": "om_command",
+            "metadata": {
+                "thread_id": "omt_created",
+                "reply_to_message_id": "om_command",
+                "notify": True,
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_retarget_release_unblocks_queued_parent_turn():
+    adapter = _RecordingFeishuAdapter()
+    parent_event = _event()
+    parent_key = build_session_key(parent_event.source)
+    owner_task = asyncio.current_task()
+    assert owner_task is not None
+
+    adapter._active_sessions[parent_key] = asyncio.Event()
+    adapter._session_tasks[parent_key] = owner_task
+    adapter._pending_messages[parent_key] = _event(
+        "queued parent follow-up",
+        message_id="om_followup",
+    )
+    started = []
+
+    def start_processing(event, session_key, *, interrupt_event=None):
+        started.append((event, session_key, interrupt_event))
+        return True
+
+    adapter._start_session_processing = start_processing
+
+    assert adapter.release_retargeted_session_guard(parent_key) is True
+    assert parent_key not in adapter._active_sessions
+    assert parent_key not in adapter._session_tasks
+    assert parent_key not in adapter._pending_messages
+    assert [(event.text, key) for event, key, _guard in started] == [
+        ("queued parent follow-up", parent_key)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_adapter_serializes_thread_creation_per_parent_chat():
+    from plugins.platforms.feishu.adapter import FeishuAdapter
+
+    adapter = FeishuAdapter(PlatformConfig())
+    adapter._client = SimpleNamespace()
+    active_sends = 0
+    max_active_sends = 0
+
+    async def fake_send(*, reply_to, **kwargs):
+        nonlocal active_sends, max_active_sends
+        active_sends += 1
+        max_active_sends = max(max_active_sends, active_sends)
+        try:
+            await asyncio.sleep(0)
+            return SimpleNamespace(
+                success=lambda: True,
+                data=SimpleNamespace(
+                    message_id=f"seed-{reply_to}",
+                    thread_id=f"thread-{reply_to}",
+                    root_id=None,
+                ),
+            )
+        finally:
+            active_sends -= 1
+
+    adapter._feishu_send_with_retry = fake_send
+    first_result, second_result = await asyncio.gather(
+        adapter.create_thread("oc_chat", "one", reply_to="om_one"),
+        adapter.create_thread("oc_chat", "two", reply_to="om_two"),
+    )
+
+    assert max_active_sends == 1
+    assert first_result.thread_id == "thread-om_one"
+    assert second_result.thread_id == "thread-om_two"
+
+
+@pytest.mark.asyncio
+async def test_adapter_creates_thread_reply_and_uses_message_id_fallback():
+    from plugins.platforms.feishu.adapter import FeishuAdapter
+
+    captured = {}
+
+    def reply(request):
+        captured["request"] = request
+        return SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(
+                message_id="om_seed",
+                thread_id=None,
+                root_id=None,
+            ),
+        )
+
+    async def run_direct(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    adapter = FeishuAdapter(PlatformConfig())
+    adapter._client = SimpleNamespace(
+        im=SimpleNamespace(v1=SimpleNamespace(message=SimpleNamespace(reply=reply)))
+    )
+    adapter._run_blocking = AsyncMock(side_effect=run_direct)
+
+    result = await adapter.create_thread(
+        "oc_chat",
+        "Creating isolated conversation",
+        reply_to="om_command",
+    )
+
+    request = captured["request"]
+    assert request.message_id == "om_command"
+    assert request.request_body.reply_in_thread is True
+    assert result.success is True
+    assert result.message_id == "om_seed"
+    assert result.thread_id == "om_seed"
+
+
+@pytest.mark.asyncio
+async def test_adapter_deletes_seed_through_sdk_executor():
+    from plugins.platforms.feishu.adapter import FeishuAdapter
+
+    adapter = FeishuAdapter(PlatformConfig())
+    delete_call = MagicMock()
+    adapter._client = SimpleNamespace(
+        im=SimpleNamespace(
+            v1=SimpleNamespace(
+                message=SimpleNamespace(delete=delete_call),
+            )
+        )
+    )
+    response = SimpleNamespace(success=lambda: True)
+    adapter._run_blocking = AsyncMock(return_value=response)
+
+    assert await adapter.delete_message("oc_chat", "om_seed") is True
+    function, request = adapter._run_blocking.await_args.args
+    assert function is delete_call
+    assert request.message_id == "om_seed"
+
+
+@pytest.mark.asyncio
+async def test_card_callback_resolves_only_its_recorded_thread_session(monkeypatch):
+    from plugins.platforms.feishu.adapter import FeishuAdapter
+    from tools import approval as approval_module
+
+    adapter = FeishuAdapter(PlatformConfig())
+    first_key = build_session_key(_source(thread_id="omt_first"))
+    second_key = build_session_key(_source(thread_id="omt_second"))
+    adapter._approval_state = {
+        1: {
+            "session_key": first_key,
+            "message_id": "om_first_card",
+            "chat_id": "oc_chat",
+        },
+        2: {
+            "session_key": second_key,
+            "message_id": "om_second_card",
+            "chat_id": "oc_chat",
+        },
+    }
+    resolved = []
+    monkeypatch.setattr(
+        approval_module,
+        "resolve_gateway_approval",
+        lambda session_key, choice: resolved.append((session_key, choice)) or 1,
+    )
+
+    await adapter._resolve_approval(
+        2,
+        "once",
+        "Tester",
+        open_id="ou_user",
+        chat_id="oc_chat",
+    )
+
+    assert resolved == [(second_key, "once")]
+    assert 1 in adapter._approval_state
+    assert 2 not in adapter._approval_state
+
+
+@pytest.mark.asyncio
+async def test_identical_streamed_final_is_resent_below_progress():
+    from gateway.stream_consumer import (
+        GatewayStreamConsumer,
+        StreamConsumerConfig,
+    )
+    from plugins.platforms.feishu.adapter import FeishuAdapter
+
+    adapter = FeishuAdapter(PlatformConfig())
+    preview_sent = asyncio.Event()
+
+    async def send(*args, **kwargs):
+        if not preview_sent.is_set():
+            preview_sent.set()
+            return SendResult(success=True, message_id="om_preview")
+        return SendResult(success=True, message_id="om_final")
+
+    adapter.send = AsyncMock(side_effect=send)
+    adapter.edit_message = AsyncMock(return_value=SendResult(success=True))
+    adapter.delete_message = AsyncMock(return_value=True)
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "oc_chat",
+        StreamConsumerConfig(
+            transport="auto",
+            chat_type="group",
+            edit_interval=0.01,
+            buffer_threshold=5,
+            cursor="",
+            fresh_final_after_seconds=0.0,
+        ),
+        metadata={
+            "thread_id": "omt_created",
+            "reply_to_message_id": "om_command",
+        },
+    )
+
+    consumer.on_delta("Full answer")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.wait_for(preview_sent.wait(), timeout=1.0)
+    consumer.finish()
+    await task
+
+    assert adapter.send.await_count == 2
+    assert [
+        call.kwargs["content"] for call in adapter.send.await_args_list
+    ] == ["Full answer", "Full answer"]
+    adapter.edit_message.assert_not_awaited()
+    adapter.delete_message.assert_awaited_once_with("oc_chat", "om_preview")
+    assert consumer.final_response_sent is True
+
+
+def test_feishu_finals_use_fresh_message_below_progress():
+    from plugins.platforms.feishu.adapter import FeishuAdapter
+
+    adapter = FeishuAdapter(PlatformConfig())
+    assert adapter.prefers_fresh_final_streaming(
+        "answer",
+        {"thread_id": "omt_created"},
+    ) is True


### PR DESCRIPTION
## Summary
- route each launched Feishu topic through its own deterministic Hermes session, serializing concurrent launch handoffs and failing closed when no safe message anchor exists
- keep streaming progress, final text, generated images, and temporary-seed cleanup on the same native conversation
- add behavior coverage for thread identity, launch races, reply anchoring, delayed card callbacks, media placement, and cleanup safety

This intentionally excludes template launcher/listing behavior.

Refs #93953

## Test plan
- [x] `scripts/run_tests.sh tests/gateway/test_feishu.py tests/gateway/test_feishu_conversation_isolation.py -q` (94 passed)
- [x] `git diff official/main...HEAD --check`

Made with [Cursor](https://cursor.com)