### PR TITLE
fix(terminal): log singularity backend requirement failures

### DIFF
--- a/tests/tools/test_terminal_requirements.py
+++ b/tests/tools/test_terminal_requirements.py
@@ -85,6 +85,42 @@ def test_modal_backend_managed_mode_without_feature_flag_logs_clear_error(monkey
     )
 
 
+def test_singularity_backend_without_binary_logs_specific_error(monkeypatch, caplog):
+    _clear_terminal_env(monkeypatch)
+    monkeypatch.setenv("TERMINAL_ENV", "singularity")
+    monkeypatch.setattr(terminal_tool_module.shutil, "which", lambda _name: None)
+
+    with caplog.at_level(logging.ERROR):
+        ok = terminal_tool_module.check_terminal_requirements()
+
+    assert ok is False
+    assert any(
+        "neither 'apptainer' nor 'singularity' was found in PATH" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_singularity_backend_version_failure_logs_specific_error(monkeypatch, caplog):
+    _clear_terminal_env(monkeypatch)
+    monkeypatch.setenv("TERMINAL_ENV", "singularity")
+    monkeypatch.setattr(terminal_tool_module.shutil, "which", lambda name: f"C:\\fake\\{name}")
+    monkeypatch.setattr(
+        terminal_tool_module.subprocess,
+        "run",
+        lambda *a, **kw: type("R", (), {"returncode": 1, "stderr": b"version check failed"})(),
+    )
+
+    with caplog.at_level(logging.ERROR):
+        ok = terminal_tool_module.check_terminal_requirements()
+
+    assert ok is False
+    assert any(
+        "--version' exited with 1" in record.getMessage()
+        and "version check failed" in record.getMessage()
+        for record in caplog.records
+    )
+
+
 def test_vercel_backend_without_sdk_logs_specific_error(monkeypatch, caplog):
     _clear_terminal_env(monkeypatch)
     monkeypatch.setenv("TERMINAL_ENV", "vercel_sandbox")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3788,10 +3788,27 @@ def check_terminal_requirements() -> bool:
 
         elif env_type == "singularity":
             executable = shutil.which("apptainer") or shutil.which("singularity")
-            if executable:
-                result = subprocess.run([executable, "--version"], capture_output=True, timeout=5, stdin=subprocess.DEVNULL)
-                return result.returncode == 0
-            return False
+            if not executable:
+                logger.error(
+                    "Singularity backend selected but neither 'apptainer' nor "
+                    "'singularity' was found in PATH. Install Apptainer "
+                    "(https://apptainer.org/docs/admin/main/installation.html) "
+                    "or set TERMINAL_ENV to 'local' or 'docker'."
+                )
+                return False
+            result = subprocess.run([executable, "--version"], capture_output=True, timeout=5, stdin=subprocess.DEVNULL)
+            if result.returncode != 0:
+                stderr_tail = (result.stderr or b"").decode(errors="replace").strip()
+                if len(stderr_tail) > 200:
+                    stderr_tail = stderr_tail[-200:]
+                logger.error(
+                    "Singularity backend selected but '%s --version' exited with %d%s",
+                    executable,
+                    result.returncode,
+                    f": {stderr_tail}" if stderr_tail else "",
+                )
+                return False
+            return True
 
         elif env_type == "ssh":
             if not config.get("ssh_host") or not config.get("ssh_user"):


### PR DESCRIPTION
## Problem

`check_terminal_requirements()` (tools/terminal_tool.py:3771) is the availability gate registered for the terminal tool in `tools/__init__.py`, and the `__main__` self-test tells users to "check the messages above". Every backend branch logs a specific error on failure — except **singularity**, which returned `False` silently in both failure modes:

- neither `apptainer` nor `singularity` found in `PATH` → silent `False` (the docker branch logs "Docker executable not found..." for the equivalent case)
- `<exe> --version` exits nonzero → silent `False`, with stderr discarded

Net effect: a user who sets `TERMINAL_ENV=singularity` sees the terminal tool disappear with zero diagnostics in logs.

## Fix

Mirror the docker branch's error logging:

- missing binary → `logger.error("Singularity backend selected but neither 'apptainer' nor 'singularity' was found in PATH. Install Apptainer (...) or set TERMINAL_ENV to 'local' or 'docker'.")`
- nonzero `--version` exit → log the executable, exit code, and a 200-char tail of stderr.

No behavior change otherwise — same return values, same probe command and timeout.

## Verification

Two new tests in `tests/tools/test_terminal_requirements.py`, following the file's existing caplog-message conventions:
- `test_singularity_backend_without_binary_logs_specific_error`
- `test_singularity_backend_version_failure_logs_specific_error`

Suite passes 16/16.