### PR TITLE
fix(desktop): commit gateway switches before publishing the new source (#93937)

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -1,11 +1,27 @@
 import { act, cleanup, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { DesktopConnectionsRegistry } from '@/global'
 import { $desktopBoot } from '@/store/boot'
+import {
+  $connectionsRegistry,
+  _resetConnectionsForTests,
+  selectConnection,
+  setConnectionsRegistry
+} from '@/store/connections'
 import { closeSecondaryGateways, isActivePrimary } from '@/store/gateway'
 import { reconnectGateway } from '@/store/gateway-reconnect'
+import { $gatewaySwitching, beginGatewaySwitch, endGatewaySwitch } from '@/store/gateway-switch'
 import { $activeGatewayProfile, $profiles, ensureGatewayProfile } from '@/store/profile'
-import { $connection, $currentCwd, $gatewayState } from '@/store/session'
+import {
+  $activeSessionId,
+  $connection,
+  $currentCwd,
+  $gatewayState,
+  $selectedStoredSessionId,
+  setActiveSessionId,
+  setSelectedStoredSessionId
+} from '@/store/session'
 import { $sessionTiles } from '@/store/session-states'
 
 import { takeGatewaySurvivor } from './gateway-hmr-survivor'
@@ -277,6 +293,11 @@ afterEach(() => {
   $connection.set(null)
   $profiles.set([])
   $sessionTiles.set([])
+  _resetConnectionsForTests()
+  $connectionsRegistry.set(null)
+  setActiveSessionId(null)
+  setSelectedStoredSessionId(null)
+  endGatewaySwitch()
   vi.useRealTimers()
   ;(globalThis as { WebSocket: unknown }).WebSocket = originalWebSocket
   delete (window as { hermesDesktop?: unknown }).hermesDesktop
@@ -348,6 +369,107 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect(beforeConnectionSwitch).toHaveBeenCalledTimes(1)
     await flushAsync()
     expect($gatewayState.get()).toBe('open')
+  })
+
+  it('a store-driven switch (Sessions switcher) runs the same machine-context reset as a Settings apply (#93937)', async () => {
+    const beforeConnectionSwitch = vi.fn()
+    const { unmount } = render(<Harness beforeConnectionSwitch={beforeConnectionSwitch} />)
+    await flushAsync()
+
+    act(() => beginGatewaySwitch())
+    expect(beforeConnectionSwitch).toHaveBeenCalledTimes(1)
+    expect($gatewaySwitching.get()).toBe(true)
+    act(() => endGatewaySwitch())
+    expect($gatewaySwitching.get()).toBe(false)
+
+    // Teardown unregisters: a switch after unmount must not call a dead host.
+    unmount()
+    beginGatewaySwitch()
+    endGatewaySwitch()
+    expect(beforeConnectionSwitch).toHaveBeenCalledTimes(1)
+  })
+
+  it("#93937: the Sessions switcher never publishes the new source while the previous backend's runtime id is still bound", async () => {
+    // Real stores end to end: real useGatewayBoot, real gateway registry, real
+    // selectConnection, fake sockets. Boot on the primary VPS with a transcript
+    // open (its runtime id was minted by THAT backend), then switch sources
+    // through the sidebar door. Before the fix that door activated the new
+    // socket first and wiped the bindings after an IPC round-trip, so the
+    // renderer sat on "gateway B + runtime id from A" and B answered every
+    // session RPC with "session not found".
+    const registryConnections: DesktopConnectionsRegistry = {
+      connections: [
+        { id: 'primary-vps', kind: 'remote', label: 'VPS', tokenPreview: '...t', tokenSet: true },
+        { id: 'coder-remote', kind: 'remote', label: 'Coder', tokenPreview: '...c', tokenSet: true }
+      ],
+      primary: 'primary-vps',
+      secureTokenStorage: true,
+      version: 2
+    }
+
+    const desktop = fakeDesktop() as ReturnType<typeof fakeDesktop> & Record<string, unknown>
+    const setLastUsed = vi.fn(async (id: string) => ({ ok: true, registry: { ...registryConnections, lastUsed: id } }))
+    let bindingAtDial: null | string = null
+
+    desktop.api = vi.fn(async ({ path }: { path: string }) =>
+      path === '/api/profiles/active' ? { active: 'default', current: 'default' } : { profiles: [] }
+    )
+    desktop.getConnectionFor = vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
+      ...coderConn,
+      connectionId,
+      profile,
+      registryScoped: true
+    }))
+    desktop.getGatewayWsUrlFor = vi.fn(async () => {
+      // Phase 1 (the dial) runs with the previous source still fully bound.
+      bindingAtDial = $activeSessionId.get()
+
+      return coderConn.wsUrl
+    })
+    desktop.connections = { list: vi.fn(async () => registryConnections), setLastUsed }
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    const beforeConnectionSwitch = vi.fn()
+    render(<Harness beforeConnectionSwitch={beforeConnectionSwitch} />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+    expect($connection.get()?.connectionId).toBe('primary-vps')
+
+    setConnectionsRegistry(registryConnections)
+    setSelectedStoredSessionId('stored-on-vps')
+    setActiveSessionId('a93bb39d')
+
+    // Every instant the new source is visible, with what a session-scoped
+    // effect would read right then.
+    const published: Array<{ activeSessionId: null | string; switching: boolean }> = []
+
+    const off = $connection.listen(next => {
+      if (next?.connectionId === 'coder-remote') {
+        published.push({ activeSessionId: $activeSessionId.get(), switching: $gatewaySwitching.get() })
+      }
+    })
+
+    const switching = selectConnection('coder-remote')
+    await flushAsync()
+    await flushAsync()
+    await flushAsync()
+    await switching
+    off()
+
+    // The previous backend's runtime id was already gone — and the barrier up —
+    // at every publication of the new source. (Pre-fix: the first publication
+    // carried activeSessionId 'a93bb39d' with the barrier down.)
+    expect(published.length).toBeGreaterThan(0)
+    expect(published).toEqual(published.map(() => ({ activeSessionId: null, switching: true })))
+    expect(bindingAtDial).toBe('a93bb39d')
+    expect(beforeConnectionSwitch).toHaveBeenCalledTimes(1)
+    expect($connection.get()?.connectionId).toBe('coder-remote')
+    expect(isActivePrimary()).toBe(false)
+    expect($activeSessionId.get()).toBeNull()
+    expect($selectedStoredSessionId.get()).toBeNull()
+    expect($gatewaySwitching.get()).toBe(false)
+    // The switch committed: the registry remembers the new source as last-used.
+    expect(setLastUsed).toHaveBeenCalledWith('coder-remote')
   })
 
   it('re-fetches the profile rail from the NEW backend after a connection apply (#85731)', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -11,7 +11,12 @@ import {
 } from '@/store/connections'
 import { closeSecondaryGateways, isActivePrimary } from '@/store/gateway'
 import { reconnectGateway } from '@/store/gateway-reconnect'
-import { $gatewaySwitching, beginGatewaySwitch, endGatewaySwitch } from '@/store/gateway-switch'
+import {
+  $gatewaySwitching,
+  beginGatewaySwitch,
+  endGatewaySwitch,
+  recoverActiveSourceAfterFailedGatewaySwitch
+} from '@/store/gateway-switch'
 import { notifyError } from '@/store/notifications'
 import { $activeGatewayProfile, $profiles, ensureGatewayProfile } from '@/store/profile'
 import {
@@ -763,6 +768,29 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
 
     expect(publications).toEqual(['settings-b'])
     expect($gatewaySwitching.get()).toBe(false)
+  })
+
+  it('forwards failed-switch recovery ownership through its registered lifecycle', async () => {
+    const refreshSessions = vi.fn(async (_shouldPublish?: () => boolean) => undefined)
+
+    render(<Harness refreshSessions={refreshSessions} />)
+    await flushAsync()
+
+    const failed = beginGatewaySwitch()
+
+    recoverActiveSourceAfterFailedGatewaySwitch(failed)
+    endGatewaySwitch(failed)
+    await vi.waitFor(() => expect(refreshSessions).toHaveBeenCalledTimes(2))
+
+    const shouldPublish = refreshSessions.mock.calls[1][0]
+
+    expect(shouldPublish).toBeTypeOf('function')
+    expect(shouldPublish?.()).toBe(true)
+
+    const newer = beginGatewaySwitch()
+
+    expect(shouldPublish?.()).toBe(false)
+    endGatewaySwitch(newer)
   })
 
   it('a superseded Settings switch cannot publish delayed cwd or config work after the winner', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -234,7 +234,7 @@ function Harness({
 }: {
   beforeConnectionSwitch?: () => void
   refreshHermesConfig?: (force?: boolean, shouldPublish?: () => boolean) => Promise<void>
-  refreshSessions?: () => Promise<void>
+  refreshSessions?: (shouldPublish?: () => boolean) => Promise<void>
 } = {}) {
   useGatewayBoot({
     beforeConnectionSwitch,
@@ -719,6 +719,50 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect(desktop.profile.get).toHaveBeenCalledTimes(profileReads)
     expect(desktop.api).toHaveBeenCalledTimes(profileRefreshes)
     expect(FakeWebSocket.instances).toHaveLength(socketCount)
+  })
+
+  it('passes switch ownership through a session refresh held across a newer switch', async () => {
+    const staleRefresh = deferred<void>()
+    const publications: string[] = []
+    let switchRefresh = 0
+
+    const refreshSessions = vi.fn(async (shouldPublish?: () => boolean) => {
+      // Initial boot remains a compatible zero-argument caller.
+      if (!shouldPublish) {
+        return
+      }
+
+      switchRefresh += 1
+      const label = switchRefresh === 1 ? 'settings-a' : 'settings-b'
+
+      if (switchRefresh === 1) {
+        await staleRefresh.promise
+      }
+
+      if (shouldPublish()) {
+        publications.push(label)
+      }
+    })
+
+    render(<Harness refreshSessions={refreshSessions} />)
+    await flushAsync()
+
+    act(() => connectionApplied?.())
+    await vi.waitFor(() => expect(switchRefresh).toBe(1))
+
+    act(() => connectionApplied?.())
+    await vi.waitFor(() => expect(switchRefresh).toBe(2))
+    await flushAsync()
+
+    expect(publications).toEqual(['settings-b'])
+
+    await act(async () => {
+      staleRefresh.resolve()
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(publications).toEqual(['settings-b'])
+    expect($gatewaySwitching.get()).toBe(false)
   })
 
   it('a superseded Settings switch cannot publish delayed cwd or config work after the winner', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -12,6 +12,7 @@ import {
 import { closeSecondaryGateways, isActivePrimary } from '@/store/gateway'
 import { reconnectGateway } from '@/store/gateway-reconnect'
 import { $gatewaySwitching, beginGatewaySwitch, endGatewaySwitch } from '@/store/gateway-switch'
+import { notifyError } from '@/store/notifications'
 import { $activeGatewayProfile, $profiles, ensureGatewayProfile } from '@/store/profile'
 import {
   $activeSessionId,
@@ -19,6 +20,7 @@ import {
   $currentCwd,
   $gatewayState,
   $selectedStoredSessionId,
+  $sessionsLoading,
   setActiveSessionId,
   setSelectedStoredSessionId
 } from '@/store/session'
@@ -26,6 +28,11 @@ import { $sessionTiles } from '@/store/session-states'
 
 import { takeGatewaySurvivor } from './gateway-hmr-survivor'
 import { primaryRuntimeConnectionId, useGatewayBoot } from './use-gateway-boot'
+
+vi.mock(import('@/store/notifications'), async importOriginal => ({
+  ...(await importOriginal()),
+  notifyError: vi.fn()
+}))
 
 // End-to-end-ish repro of the "remote VPS → stuck on CONNECTING, no Settings"
 // bug that drives the REAL useGatewayBoot hook + REAL HermesGateway through a
@@ -258,6 +265,7 @@ beforeEach(() => {
   FakeWebSocket.pingMode = 'pong'
   connectionApplied = null
   powerResume = null
+  vi.mocked(notifyError).mockReset()
   ;(globalThis as { WebSocket: unknown }).WebSocket = FakeWebSocket
   ;(window as { hermesDesktop?: unknown }).hermesDesktop = fakeDesktop()
   $gatewayState.set('idle')
@@ -369,6 +377,39 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect(beforeConnectionSwitch).toHaveBeenCalledTimes(1)
     await flushAsync()
     expect($gatewayState.get()).toBe('open')
+  })
+
+  it('reports a Settings switch setup failure and does not disarm a newer switch started by recovery UI', async () => {
+    const failure = new Error('machine-context reset failed')
+    const beforeConnectionSwitch = vi.fn()
+    let newerToken: null | ReturnType<typeof beginGatewaySwitch> = null
+
+    beforeConnectionSwitch.mockImplementationOnce(() => {
+      throw failure
+    })
+    vi.mocked(notifyError).mockImplementationOnce((_error, fallback) => {
+      // A notification/recovery callback may synchronously start another
+      // switch. The failed Settings attempt never received a token and must
+      // not force this newer owner's barrier down from its finally block.
+      newerToken = beginGatewaySwitch()
+
+      return fallback
+    })
+
+    render(<Harness beforeConnectionSwitch={beforeConnectionSwitch} />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+
+    act(() => connectionApplied?.())
+    await flushAsync()
+
+    expect($desktopBoot.get().error).toBe(failure.message)
+    expect(notifyError).toHaveBeenCalledWith(failure, expect.any(String))
+    expect(newerToken).not.toBeNull()
+    expect($gatewaySwitching.get()).toBe(true)
+    expect($sessionsLoading.get()).toBe(true)
+
+    endGatewaySwitch(newerToken ?? undefined)
   })
 
   it('a store-driven switch (Sessions switcher) runs the same machine-context reset as a Settings apply (#93937)', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -379,6 +379,63 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect($gatewayState.get()).toBe('open')
   })
 
+  it('a stale failed Settings switch cannot disarm the newer switch loading owner', async () => {
+    const desktop = fakeDesktop()
+
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+
+    const failureA = new Error('switch A failed')
+    const failureB = new Error('switch B failed')
+    let rejectA: (error: Error) => void = () => undefined
+    let rejectB: (error: Error) => void = () => undefined
+
+    desktop.getConnection
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectA = reject
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectB = reject
+          })
+      )
+
+    act(() => connectionApplied?.())
+    expect($gatewaySwitching.get()).toBe(true)
+    expect($sessionsLoading.get()).toBe(true)
+
+    act(() => connectionApplied?.())
+    expect($gatewaySwitching.get()).toBe(true)
+    expect($sessionsLoading.get()).toBe(true)
+
+    await act(async () => {
+      rejectA(failureA)
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(notifyError).toHaveBeenCalledWith(failureA, expect.any(String))
+    expect($desktopBoot.get().error).toBe(failureA.message)
+    expect($gatewaySwitching.get()).toBe(true)
+    expect($sessionsLoading.get()).toBe(true)
+
+    await act(async () => {
+      rejectB(failureB)
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(notifyError).toHaveBeenCalledWith(failureB, expect.any(String))
+    expect($desktopBoot.get().error).toBe(failureB.message)
+    expect($gatewaySwitching.get()).toBe(false)
+    expect($sessionsLoading.get()).toBe(false)
+  })
+
   it('reports a Settings switch setup failure and does not disarm a newer switch started by recovery UI', async () => {
     const failure = new Error('machine-context reset failed')
     const beforeConnectionSwitch = vi.fn()

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -21,10 +21,13 @@ import {
   $gatewayState,
   $selectedStoredSessionId,
   $sessionsLoading,
+  getConfiguredDefaultProjectDir,
   setActiveSessionId,
   setSelectedStoredSessionId
 } from '@/store/session'
 import { $sessionTiles } from '@/store/session-states'
+
+import { deferred } from '../../../test/deferred'
 
 import { takeGatewaySurvivor } from './gateway-hmr-survivor'
 import { primaryRuntimeConnectionId, useGatewayBoot } from './use-gateway-boot'
@@ -226,14 +229,19 @@ function fakeDesktop() {
 
 function Harness({
   beforeConnectionSwitch = () => undefined,
+  refreshHermesConfig = async () => undefined,
   refreshSessions
-}: { beforeConnectionSwitch?: () => void; refreshSessions?: () => Promise<void> } = {}) {
+}: {
+  beforeConnectionSwitch?: () => void
+  refreshHermesConfig?: (force?: boolean, shouldPublish?: () => boolean) => Promise<void>
+  refreshSessions?: () => Promise<void>
+} = {}) {
   useGatewayBoot({
     beforeConnectionSwitch,
     handleGatewayEvent: () => undefined,
     onConnectionReady: () => undefined,
     onGatewayReady: () => undefined,
-    refreshHermesConfig: async () => undefined,
+    refreshHermesConfig,
     refreshSessions: refreshSessions ?? (async () => undefined)
   })
 
@@ -379,7 +387,7 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect($gatewayState.get()).toBe('open')
   })
 
-  it('a stale failed Settings switch cannot disarm the newer switch loading owner', async () => {
+  it('a stale failed Settings switch cannot publish failure or disarm the newer switch owner', async () => {
     const desktop = fakeDesktop()
 
     ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
@@ -420,8 +428,8 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
       await vi.advanceTimersByTimeAsync(0)
     })
 
-    expect(notifyError).toHaveBeenCalledWith(failureA, expect.any(String))
-    expect($desktopBoot.get().error).toBe(failureA.message)
+    expect(notifyError).not.toHaveBeenCalled()
+    expect($desktopBoot.get().error).toBeNull()
     expect($gatewaySwitching.get()).toBe(true)
     expect($sessionsLoading.get()).toBe(true)
 
@@ -430,10 +438,45 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
       await vi.advanceTimersByTimeAsync(0)
     })
 
+    expect(notifyError).toHaveBeenCalledTimes(1)
     expect(notifyError).toHaveBeenCalledWith(failureB, expect.any(String))
     expect($desktopBoot.get().error).toBe(failureB.message)
     expect($gatewaySwitching.get()).toBe(false)
     expect($sessionsLoading.get()).toBe(false)
+  })
+
+  it('does not publish a late Settings failure after a newer switch wins', async () => {
+    const desktop = fakeDesktop()
+
+    let rejectStale: (error: Error) => void = () => undefined
+
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+    render(<Harness />)
+    await flushAsync()
+
+    desktop.getConnection.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectStale = reject
+        })
+    )
+
+    act(() => connectionApplied?.())
+    await vi.waitFor(() => expect(desktop.getConnection).toHaveBeenCalledTimes(2))
+    act(() => connectionApplied?.())
+    await flushAsync()
+    await flushAsync()
+
+    expect($gatewaySwitching.get()).toBe(false)
+    expect($desktopBoot.get().error).toBeNull()
+
+    await act(async () => {
+      rejectStale(new Error('late stale failure'))
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect($desktopBoot.get().error).toBeNull()
+    expect(notifyError).not.toHaveBeenCalled()
   })
 
   it('reports a Settings switch setup failure and does not disarm a newer switch started by recovery UI', async () => {
@@ -465,6 +508,30 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect(newerToken).not.toBeNull()
     expect($gatewaySwitching.get()).toBe(true)
     expect($sessionsLoading.get()).toBe(true)
+
+    endGatewaySwitch(newerToken ?? undefined)
+  })
+
+  it('a token-less setup failure cannot publish after a nested switch raised a newer barrier', async () => {
+    const failure = new Error('outer setup failed')
+    const beforeConnectionSwitch = vi.fn()
+    let newerToken: null | ReturnType<typeof beginGatewaySwitch> = null
+
+    beforeConnectionSwitch.mockImplementationOnce(() => {
+      newerToken = beginGatewaySwitch()
+      throw failure
+    })
+
+    render(<Harness beforeConnectionSwitch={beforeConnectionSwitch} />)
+    await flushAsync()
+
+    act(() => connectionApplied?.())
+    await flushAsync()
+
+    expect(newerToken).not.toBeNull()
+    expect($gatewaySwitching.get()).toBe(true)
+    expect($desktopBoot.get().error).toBeNull()
+    expect(notifyError).not.toHaveBeenCalled()
 
     endGatewaySwitch(newerToken ?? undefined)
   })
@@ -652,6 +719,82 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect(desktop.profile.get).toHaveBeenCalledTimes(profileReads)
     expect(desktop.api).toHaveBeenCalledTimes(profileRefreshes)
     expect(FakeWebSocket.instances).toHaveLength(socketCount)
+  })
+
+  it('a superseded Settings switch cannot publish delayed cwd or config work after the winner', async () => {
+    const desktop = fakeDesktop() as ReturnType<typeof fakeDesktop> & Record<string, unknown>
+    const staleSanitize = deferred<{ cwd: string }>()
+    const staleConfig = deferred<void>()
+    const configPublications: string[] = []
+    let settingsRead = 0
+    let sanitizeRead = 0
+    let switchConfigRead = 0
+
+    const settings = {
+      getDefaultProjectDir: vi.fn(async () => {
+        settingsRead += 1
+
+        return {
+          defaultLabel: settingsRead === 1 ? '/settings-a' : '/settings-b',
+          dir: settingsRead === 1 ? '/settings-a' : '/settings-b',
+          resolvedCwd: settingsRead === 1 ? '/settings-a' : '/settings-b'
+        }
+      })
+    }
+
+    const sanitizeWorkspaceCwd = vi.fn((cwd: string) => {
+      sanitizeRead += 1
+
+      return sanitizeRead === 1 ? staleSanitize.promise : Promise.resolve({ cwd })
+    })
+
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    const refreshHermesConfig = async (_force = false, shouldPublish?: () => boolean) => {
+      if (!shouldPublish) {
+        return
+      }
+
+      switchConfigRead += 1
+      const label = switchConfigRead === 1 ? 'settings-a' : 'settings-b'
+
+      if (switchConfigRead === 1) {
+        await staleConfig.promise
+      }
+
+      if (shouldPublish()) {
+        configPublications.push(label)
+      }
+    }
+
+    render(<Harness refreshHermesConfig={refreshHermesConfig} />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+
+    desktop.settings = settings
+    desktop.sanitizeWorkspaceCwd = sanitizeWorkspaceCwd
+
+    act(() => connectionApplied?.())
+    await vi.waitFor(() => expect(sanitizeWorkspaceCwd).toHaveBeenCalledTimes(1))
+
+    act(() => connectionApplied?.())
+    await flushAsync()
+    await flushAsync()
+
+    expect($gatewaySwitching.get()).toBe(false)
+    expect(getConfiguredDefaultProjectDir()).toBe('/settings-b')
+    expect($currentCwd.get()).toBe('/settings-b')
+    expect(configPublications).toEqual(['settings-b'])
+
+    await act(async () => {
+      staleSanitize.resolve({ cwd: '/settings-a/stale' })
+      staleConfig.resolve()
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(getConfiguredDefaultProjectDir()).toBe('/settings-b')
+    expect($currentCwd.get()).toBe('/settings-b')
+    expect(configPublications).toEqual(['settings-b'])
   })
 
   it('re-fetches the profile rail from the NEW backend after a connection apply (#85731)', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -570,6 +570,90 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect(setLastUsed).toHaveBeenCalledWith('coder-remote')
   })
 
+  it('a Settings switch superseded while reading its descriptor cannot publish over a newer Sessions switch', async () => {
+    const registryConnections: DesktopConnectionsRegistry = {
+      connections: [
+        { id: 'primary-vps', kind: 'remote', label: 'VPS', tokenPreview: '...t', tokenSet: true },
+        { id: 'coder-remote', kind: 'remote', label: 'Coder', tokenPreview: '...c', tokenSet: true }
+      ],
+      primary: 'primary-vps',
+      secureTokenStorage: true,
+      version: 2
+    }
+
+    const desktop = fakeDesktop() as ReturnType<typeof fakeDesktop> & Record<string, unknown>
+
+    const settingsConn = {
+      ...primaryConn,
+      connectionId: 'settings-a',
+      profile: 'settings-profile',
+      wsUrl: 'wss://settings-a.example.com/api/ws?token=a'
+    }
+
+    let releaseSettings: (connection: typeof settingsConn) => void = () => undefined
+
+    desktop.api = vi.fn(async ({ path }: { path: string }) =>
+      path === '/api/profiles/active' ? { active: 'coder', current: 'coder' } : { profiles: [] }
+    )
+    desktop.getConnectionFor = vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
+      ...coderConn,
+      connectionId,
+      profile,
+      registryScoped: true
+    }))
+    desktop.getGatewayWsUrlFor = vi.fn(async () => coderConn.wsUrl)
+    desktop.connections = {
+      list: vi.fn(async () => registryConnections),
+      setLastUsed: vi.fn(async (id: string) => ({ ok: true, registry: { ...registryConnections, lastUsed: id } }))
+    }
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+
+    setConnectionsRegistry(registryConnections)
+    desktop.getConnection.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          releaseSettings = resolve
+        })
+    )
+
+    act(() => connectionApplied?.())
+    await vi.waitFor(() => expect(desktop.getConnection).toHaveBeenCalledTimes(2))
+
+    const sessionsSwitch = selectConnection('coder-remote')
+    await flushAsync()
+    await flushAsync()
+    await flushAsync()
+    await sessionsSwitch
+
+    expect(isActivePrimary()).toBe(false)
+    expect($activeGatewayProfile.get()).toBe('default')
+    expect($connection.get()?.connectionId).toBe('coder-remote')
+
+    const wsUrlReads = desktop.getGatewayWsUrl.mock.calls.length
+    const profileReads = desktop.profile.get.mock.calls.length
+    const profileRefreshes = vi.mocked(desktop.api as ReturnType<typeof vi.fn>).mock.calls.length
+    const socketCount = FakeWebSocket.instances.length
+
+    await act(async () => {
+      releaseSettings(settingsConn)
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    // Switch-token ownership governs every later publication, not just loading
+    // teardown: stale Settings work cannot publish/connect/refresh after B won.
+    expect(isActivePrimary()).toBe(false)
+    expect($activeGatewayProfile.get()).toBe('default')
+    expect($connection.get()?.connectionId).toBe('coder-remote')
+    expect(desktop.getGatewayWsUrl).toHaveBeenCalledTimes(wsUrlReads)
+    expect(desktop.profile.get).toHaveBeenCalledTimes(profileReads)
+    expect(desktop.api).toHaveBeenCalledTimes(profileRefreshes)
+    expect(FakeWebSocket.instances).toHaveLength(socketCount)
+  })
+
   it('re-fetches the profile rail from the NEW backend after a connection apply (#85731)', async () => {
     // The reported repro: connected to backend A, the rail shows A's named
     // profiles; the user applies a different remote/Cloud connection (soft

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -475,18 +475,22 @@ export function useGatewayBoot({
         return
       }
 
-      // Barrier up + machine-context reset + session wipe, in one synchronous
-      // step — the shared commit point of every connection switch.
-      const switchToken = beginGatewaySwitch()
-      clearReconnectTimer()
-      clearBootRetryTimer()
-      bootRetryAttempt = 0
-      reconnectAttempt = 0
-      reconnectFailingSince = null
-      escalated = false
-      reauthNotified = false
+      let switchToken: null | ReturnType<typeof beginGatewaySwitch> = null
 
       try {
+        // Barrier up + machine-context reset + session wipe, in one synchronous
+        // step — the shared commit point of every connection switch. Keep this
+        // inside the error boundary: lifecycle/wipe setup can throw before a
+        // token is returned and must follow the normal boot-failure path.
+        switchToken = beginGatewaySwitch()
+        clearReconnectTimer()
+        clearBootRetryTimer()
+        bootRetryAttempt = 0
+        reconnectAttempt = 0
+        reconnectFailingSince = null
+        escalated = false
+        reauthNotified = false
+
         gateway.close()
         closeSecondaryGateways()
 
@@ -535,11 +539,19 @@ export function useGatewayBoot({
         if (!cancelled) {
           const message = err instanceof Error ? err.message : String(err)
           failDesktopBoot(message)
-          notifyError(err, translateNow('boot.errors.desktopBootFailed'))
+          // Disarm this failed attempt before notifying: recovery UI may
+          // synchronously begin a newer switch and re-arm loading under its own
+          // token, which this older catch must not lower afterwards.
           setSessionsLoading(false)
+          notifyError(err, translateNow('boot.errors.desktopBootFailed'))
         }
       } finally {
-        endGatewaySwitch(switchToken)
+        // beginGatewaySwitch cleans up internally when setup throws before
+        // returning. Never use token-less teardown here: it would force down a
+        // newer switch started synchronously by error recovery/notification UI.
+        if (switchToken !== null) {
+          endGatewaySwitch(switchToken)
+        }
       }
     }
 

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -36,6 +36,7 @@ import {
   $gatewaySwitching,
   beginGatewaySwitch,
   endGatewaySwitch,
+  isCurrentGatewaySwitch,
   registerGatewaySwitchLifecycle
 } from '@/store/gateway-switch'
 import { notify, notifyError } from '@/store/notifications'
@@ -539,10 +540,14 @@ export function useGatewayBoot({
         if (!cancelled) {
           const message = err instanceof Error ? err.message : String(err)
           failDesktopBoot(message)
-          // Disarm this failed attempt before notifying: recovery UI may
-          // synchronously begin a newer switch and re-arm loading under its own
-          // token, which this older catch must not lower afterwards.
-          setSessionsLoading(false)
+
+          // Only the current owner may lower loading. A failed begin returns no
+          // token and cleans its own barrier internally; lower loading only when
+          // that cleanup did not preserve a recursively-started newer switch.
+          if (switchToken === null ? !$gatewaySwitching.get() : isCurrentGatewaySwitch(switchToken)) {
+            setSessionsLoading(false)
+          }
+
           notifyError(err, translateNow('boot.errors.desktopBootFailed'))
         }
       } finally {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -134,7 +134,7 @@ interface GatewayBootOptions {
     connection: Awaited<ReturnType<NonNullable<typeof window.hermesDesktop>['getConnection']>> | null
   ) => void
   onGatewayReady: (gateway: HermesGateway | null) => void
-  refreshHermesConfig: () => Promise<void>
+  refreshHermesConfig: (force?: boolean, shouldPublish?: () => boolean) => Promise<void>
   refreshSessions: () => Promise<void>
 }
 
@@ -471,7 +471,7 @@ export function useGatewayBoot({
     // Seed the working dir from the backend default on a fresh view (nothing
     // open yet). Shared by boot + soft switch.
     async function seedDefaultCwd(shouldPublish: () => boolean = () => true) {
-      await ensureDefaultWorkspaceCwd()
+      await ensureDefaultWorkspaceCwd(shouldPublish)
 
       if (!shouldPublish()) {
         return
@@ -555,7 +555,7 @@ export function useGatewayBoot({
         await Promise.all([
           seedDefaultCwd(ownsSwitch),
           refreshActiveProfile().catch(() => undefined),
-          callbacksRef.current.refreshHermesConfig().catch(() => undefined),
+          callbacksRef.current.refreshHermesConfig(false, ownsSwitch).catch(() => undefined),
           callbacksRef.current.refreshSessions().catch(() => undefined)
         ])
 
@@ -566,16 +566,18 @@ export function useGatewayBoot({
         completeDesktopBoot()
         bootCompleted = true
       } catch (err) {
-        if (!cancelled) {
+        const mayPublishFailure =
+          !cancelled &&
+          (switchToken === null ? !$gatewaySwitching.get() : isCurrentGatewaySwitch(switchToken))
+
+        if (mayPublishFailure) {
           const message = err instanceof Error ? err.message : String(err)
           failDesktopBoot(message)
 
           // Only the current owner may lower loading. A failed begin returns no
           // token and cleans its own barrier internally; lower loading only when
           // that cleanup did not preserve a recursively-started newer switch.
-          if (switchToken === null ? !$gatewaySwitching.get() : isCurrentGatewaySwitch(switchToken)) {
-            setSessionsLoading(false)
-          }
+          setSessionsLoading(false)
 
           notifyError(err, translateNow('boot.errors.desktopBootFailed'))
         }

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -443,27 +443,43 @@ export function useGatewayBoot({
     // session id against the wrong backend — the HUD then falls back to the
     // default profile's last session (#82285). The override wins over the
     // stored preference; absent, behavior is unchanged.
-    async function adoptPrimaryProfile() {
+    async function adoptPrimaryProfile(shouldPublish: () => boolean = () => true): Promise<boolean> {
       const override = windowProfileOverride()
 
       try {
         const profileKey = override ?? (await desktop.profile?.get?.())?.profile ?? ''
+
+        if (!shouldPublish()) {
+          return false
+        }
+
         const key = normalizeProfileKey(profileKey)
         $activeGatewayProfile.set(key)
         setPrimaryGateway(gateway, key)
         void ensureGatewayForProfile(key)
       } catch {
+        if (!shouldPublish()) {
+          return false
+        }
+
         $activeGatewayProfile.set(normalizeProfileKey(override))
       }
+
+      return true
     }
 
     // Seed the working dir from the backend default on a fresh view (nothing
     // open yet). Shared by boot + soft switch.
-    async function seedDefaultCwd() {
+    async function seedDefaultCwd(shouldPublish: () => boolean = () => true) {
       await ensureDefaultWorkspaceCwd()
+
+      if (!shouldPublish()) {
+        return
+      }
+
       const remoteDefault = await desktopDefaultCwd().catch(() => null)
 
-      if (remoteDefault?.cwd && !$activeSessionId.get() && !$currentCwd.get()) {
+      if (shouldPublish() && remoteDefault?.cwd && !$activeSessionId.get() && !$currentCwd.get()) {
         setCurrentCwd(remoteDefault.cwd)
         setCurrentBranch(remoteDefault.branch || '')
       }
@@ -484,6 +500,7 @@ export function useGatewayBoot({
         // inside the error boundary: lifecycle/wipe setup can throw before a
         // token is returned and must follow the normal boot-failure path.
         switchToken = beginGatewaySwitch()
+        const ownsSwitch = () => !cancelled && switchToken !== null && isCurrentGatewaySwitch(switchToken)
         clearReconnectTimer()
         clearBootRetryTimer()
         bootRetryAttempt = 0
@@ -499,7 +516,7 @@ export function useGatewayBoot({
         // on its pinned profile's backend across a soft switch.
         const conn = await desktop.getConnection(windowProfileOverride() ?? undefined)
 
-        if (cancelled) {
+        if (!ownsSwitch()) {
           return
         }
 
@@ -513,9 +530,13 @@ export function useGatewayBoot({
           'Timed out re-minting the gateway WebSocket URL'
         )
 
+        if (!ownsSwitch()) {
+          return
+        }
+
         await gateway.connect(wsUrl)
 
-        if (cancelled) {
+        if (!ownsSwitch()) {
           return
         }
 
@@ -527,13 +548,21 @@ export function useGatewayBoot({
         // rail stale or (if a stale in-flight response landed) collapsed
         // (#85731). Best-effort like the rest: a failure keeps the cached
         // list rather than blanking the rail.
-        await adoptPrimaryProfile()
+        if (!(await adoptPrimaryProfile(ownsSwitch)) || !ownsSwitch()) {
+          return
+        }
+
         await Promise.all([
-          seedDefaultCwd(),
+          seedDefaultCwd(ownsSwitch),
           refreshActiveProfile().catch(() => undefined),
           callbacksRef.current.refreshHermesConfig().catch(() => undefined),
           callbacksRef.current.refreshSessions().catch(() => undefined)
         ])
+
+        if (!ownsSwitch()) {
+          return
+        }
+
         completeDesktopBoot()
         bootCompleted = true
       } catch (err) {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -186,7 +186,7 @@ export function useGatewayBoot({
     // one reset, so the two doors can't drift apart again (#93937).
     const offSwitchLifecycle = registerGatewaySwitchLifecycle({
       beforeConnectionSwitch: () => callbacksRef.current.beforeConnectionSwitch(),
-      refreshSessions: () => callbacksRef.current.refreshSessions()
+      refreshSessions: shouldPublish => callbacksRef.current.refreshSessions(shouldPublish)
     })
 
     // --- Reconnect-after-sleep machinery -------------------------------------

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -135,7 +135,7 @@ interface GatewayBootOptions {
   ) => void
   onGatewayReady: (gateway: HermesGateway | null) => void
   refreshHermesConfig: (force?: boolean, shouldPublish?: () => boolean) => Promise<void>
-  refreshSessions: () => Promise<void>
+  refreshSessions: (shouldPublish?: () => boolean) => Promise<void>
 }
 
 export function useGatewayBoot({
@@ -556,7 +556,7 @@ export function useGatewayBoot({
           seedDefaultCwd(ownsSwitch),
           refreshActiveProfile().catch(() => undefined),
           callbacksRef.current.refreshHermesConfig(false, ownsSwitch).catch(() => undefined),
-          callbacksRef.current.refreshSessions().catch(() => undefined)
+          callbacksRef.current.refreshSessions(ownsSwitch).catch(() => undefined)
         ])
 
         if (!ownsSwitch()) {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -7,6 +7,7 @@ import { HermesGateway } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { desktopDefaultCwd } from '@/lib/desktop-fs'
 import { reconnectBackoffDelayMs } from '@/lib/reconnect-backoff'
+import { withTimeout } from '@/lib/with-timeout'
 import {
   $desktopBoot,
   applyDesktopBootProgress,
@@ -113,23 +114,6 @@ const BOOT_RETRY_BASE_DELAY_MS = 2_000
 // existing catch/finally clear the guard and resume backoff. gateway.connect()
 // already has its own connect timeout.
 const RECONNECT_ATTEMPT_TIMEOUT_MS = 20_000
-
-function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(message)), ms)
-
-    promise.then(
-      value => {
-        clearTimeout(timer)
-        resolve(value)
-      },
-      err => {
-        clearTimeout(timer)
-        reject(err)
-      }
-    )
-  })
-}
 
 /** Registry identity whose runtimes died with the primary connection. */
 export function primaryRuntimeConnectionId(connection: Pick<HermesConnection, 'connectionId' | 'mode'>): null | string {
@@ -493,7 +477,7 @@ export function useGatewayBoot({
 
       // Barrier up + machine-context reset + session wipe, in one synchronous
       // step — the shared commit point of every connection switch.
-      beginGatewaySwitch()
+      const switchToken = beginGatewaySwitch()
       clearReconnectTimer()
       clearBootRetryTimer()
       bootRetryAttempt = 0
@@ -555,7 +539,7 @@ export function useGatewayBoot({
           setSessionsLoading(false)
         }
       } finally {
-        endGatewaySwitch()
+        endGatewaySwitch(switchToken)
       }
     }
 

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -31,7 +31,12 @@ import {
   touchSecondaryGateways
 } from '@/store/gateway'
 import { registerGatewayReconnect } from '@/store/gateway-reconnect'
-import { $gatewaySwitching, wipeSessionListsForGatewaySwitch } from '@/store/gateway-switch'
+import {
+  $gatewaySwitching,
+  beginGatewaySwitch,
+  endGatewaySwitch,
+  registerGatewaySwitchLifecycle
+} from '@/store/gateway-switch'
 import { notify, notifyError } from '@/store/notifications'
 import {
   $activeGatewayProfile,
@@ -189,6 +194,15 @@ export function useGatewayBoot({
 
       return () => void (cancelled = true)
     }
+
+    // Store-driven switches (Sessions switcher → selectConnection) commit
+    // through beginGatewaySwitch(), which runs this window's machine-context
+    // reset — the same one a Settings apply (softSwitch below) runs. One owner,
+    // one reset, so the two doors can't drift apart again (#93937).
+    const offSwitchLifecycle = registerGatewaySwitchLifecycle({
+      beforeConnectionSwitch: () => callbacksRef.current.beforeConnectionSwitch(),
+      refreshSessions: () => callbacksRef.current.refreshSessions()
+    })
 
     // --- Reconnect-after-sleep machinery -------------------------------------
     // macOS sleep silently drops the renderer's WebSocket. The backend Python
@@ -477,7 +491,9 @@ export function useGatewayBoot({
         return
       }
 
-      $gatewaySwitching.set(true)
+      // Barrier up + machine-context reset + session wipe, in one synchronous
+      // step — the shared commit point of every connection switch.
+      beginGatewaySwitch()
       clearReconnectTimer()
       clearBootRetryTimer()
       bootRetryAttempt = 0
@@ -485,8 +501,6 @@ export function useGatewayBoot({
       reconnectFailingSince = null
       escalated = false
       reauthNotified = false
-      callbacksRef.current.beforeConnectionSwitch()
-      wipeSessionListsForGatewaySwitch()
 
       try {
         gateway.close()
@@ -541,7 +555,7 @@ export function useGatewayBoot({
           setSessionsLoading(false)
         }
       } finally {
-        $gatewaySwitching.set(false)
+        endGatewaySwitch()
       }
     }
 
@@ -917,7 +931,8 @@ export function useGatewayBoot({
 
     return () => {
       cancelled = true
-      $gatewaySwitching.set(false)
+      offSwitchLifecycle()
+      endGatewaySwitch()
       clearReconnectTimer()
       clearBootRetryTimer()
       clearInterval(keepaliveTimer)

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
@@ -120,6 +120,33 @@ describe('useHermesConfig refreshHermesConfig', () => {
     expect($currentFastMode.get()).toBe(false)
   })
 
+  it('does not publish config after its switch loses ownership', async () => {
+    const staleConfig = deferred<Awaited<ReturnType<typeof getHermesConfig>>>()
+    vi.mocked(getHermesConfig).mockReturnValueOnce(staleConfig.promise)
+    const { result } = renderHook(() => useHermesConfig({ activeSessionIdRef: { current: null } }))
+    let ownsSwitch = true
+
+    let refresh!: Promise<void>
+    act(() => {
+      refresh = result.current.refreshHermesConfig(false, () => ownsSwitch)
+    })
+
+    ownsSwitch = false
+    staleConfig.resolve({
+      agent: { reasoning_effort: 'high', service_tier: 'priority' },
+      terminal: { font_family: 'MesloLGS NF' }
+    } as Awaited<ReturnType<typeof getHermesConfig>>)
+
+    await act(async () => {
+      await refresh
+    })
+
+    expect($defaultReasoningEffort.get()).toBe('')
+    expect($currentReasoningEffort.get()).toBe('')
+    expect($currentFastMode.get()).toBe(false)
+    expect($terminalFontFamily.get()).toBe('')
+  })
+
   it('does not let an older profile config overwrite a newer profile', async () => {
     const profileB = deferred<Awaited<ReturnType<typeof getHermesConfig>>>()
     const profileC = deferred<Awaited<ReturnType<typeof getHermesConfig>>>()

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -56,7 +56,7 @@ export function useHermesConfig({ activeSessionIdRef }: HermesConfigOptions) {
   const profileRefreshEpochRef = useRef(0)
 
   const refreshHermesConfig = useCallback(
-    async (force = false) => {
+    async (force = false, shouldPublish: () => boolean = () => true) => {
       if (force) {
         profileRefreshEpochRef.current += 1
       }
@@ -67,13 +67,19 @@ export function useHermesConfig({ activeSessionIdRef }: HermesConfigOptions) {
       try {
         const [config, defaults] = await Promise.all([getHermesConfig(), getHermesConfigDefaults().catch(() => ({}))])
 
-        if (profileRefreshEpochRef.current !== profileRefreshEpoch) {
+        const canPublish = () => profileRefreshEpochRef.current === profileRefreshEpoch && shouldPublish()
+
+        if (!canPublish()) {
           return
         }
 
         const personality = normalizePersonalityValue(
           typeof config.display?.personality === 'string' ? config.display.personality : ''
         )
+
+        if (!canPublish()) {
+          return
+        }
 
         setIntroPersonality(personality)
         // Active sessions keep their per-session value; standalone falls back to config.
@@ -94,6 +100,10 @@ export function useHermesConfig({ activeSessionIdRef }: HermesConfigOptions) {
         // reseeded below: picker rows and preset application resolve "the
         // default" from here, so a manual model pick must not leave them
         // rendering/applying Hermes' built-in medium over the user's config.
+        if (!canPublish()) {
+          return
+        }
+
         setDefaultReasoningEffort(reasoning)
 
         const shouldSeedComposer =
@@ -102,16 +112,38 @@ export function useHermesConfig({ activeSessionIdRef }: HermesConfigOptions) {
           (force || getCurrentModelSource() !== 'manual')
 
         if (shouldSeedComposer) {
+          if (!canPublish()) {
+            return
+          }
+
           setCurrentReasoningEffort(reasoning)
           setCurrentFastMode(FAST_TIERS.has(tier.toLowerCase()))
         }
 
+        if (!canPublish()) {
+          return
+        }
+
         setCurrentServiceTier(prev => (activeSessionIdRef.current ? prev : tier))
+
+        if (!canPublish()) {
+          return
+        }
 
         setVoiceMaxRecordingSeconds(recordingLimit(config.voice?.max_recording_seconds))
         setSttEnabled(config.stt?.enabled !== false)
+
+        if (!canPublish()) {
+          return
+        }
+
         setDisplayTimestampsFromConfig(config.display?.timestamps)
         setTerminalFontFamilyFromConfig(config.terminal?.font_family)
+
+        if (!canPublish()) {
+          return
+        }
+
         applyAutoSpeakFromConfig(config)
         applyVoiceStopPhraseFromConfig(config)
         applyThinkingSoundFromConfig(config)

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -5,6 +5,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { SessionInfo, SidebarSessionsResponse } from '@/hermes'
 import { $cronJobs, setCronJobs } from '@/store/cron'
 import {
+  beginGatewaySwitch,
+  endGatewaySwitch,
+  recoverActiveSourceAfterFailedGatewaySwitch,
+  registerGatewaySwitchLifecycle
+} from '@/store/gateway-switch'
+import {
   $cronSessions,
   $messagingPlatformTotals,
   $messagingSessions,
@@ -300,6 +306,59 @@ describe('refreshSessions identity + loading hygiene', () => {
     expect($sessionProfilesUsage.get()).toEqual({ winner: { cost_usd: 2, tokens: 20 } })
     expect($sessionsLoading.get()).toBe(true)
     expect(getCronJobs).not.toHaveBeenCalled()
+  })
+
+  it('keeps failed-switch recovery from publishing through a newer switch', async () => {
+    const pending = deferred<SidebarSessionsResponse>()
+
+    listSidebarSessions.mockReturnValue(pending.promise)
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'default' }))
+
+    const off = registerGatewaySwitchLifecycle({
+      beforeConnectionSwitch: () => undefined,
+      refreshSessions: result.current.refreshSessions
+    })
+
+    let newer: number | undefined
+
+    try {
+      const failed = beginGatewaySwitch()
+
+      recoverActiveSourceAfterFailedGatewaySwitch(failed)
+      endGatewaySwitch(failed)
+      await vi.waitFor(() => expect(listSidebarSessions).toHaveBeenCalledTimes(1))
+
+      // A newer switch owns the freshly wiped lists and loading barrier while
+      // the failed switch's real sidebar publisher is still in flight.
+      newer = beginGatewaySwitch()
+
+      await act(async () => {
+        pending.resolve({
+          recents: {
+            profiles_truncated: { stale: true },
+            profiles_usage: { stale: { cost_usd: 1, tokens: 10 } },
+            sessions: [row('stale')]
+          },
+          cron: { sessions: [row('stale-cron', { source: 'cron' })] },
+          messaging: { sessions: [row('stale-message', { source: 'telegram' })] }
+        })
+        await pending.promise
+      })
+
+      expect($sessions.get()).toEqual([])
+      expect($cronSessions.get()).toEqual([])
+      expect($messagingSessions.get()).toEqual([])
+      expect($messagingTruncated.get()).toBe(false)
+      expect($sessionProfilesTruncated.get()).toEqual({})
+      expect($sessionProfilesUsage.get()).toEqual({})
+      expect($sessionsLoading.get()).toBe(true)
+      expect($cronJobs.get()).toEqual([])
+      expect(getCronJobs).not.toHaveBeenCalled()
+    } finally {
+      endGatewaySwitch(newer)
+      off()
+    }
   })
 
   it('clears initial loading after a failed source activation advances the gateway epoch', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -8,12 +8,17 @@ import {
   $cronSessions,
   $messagingPlatformTotals,
   $messagingSessions,
+  $messagingTruncated,
+  $sessionProfilesTruncated,
+  $sessionProfilesUsage,
   $sessions,
   $sessionsLoading,
   setCronSessions,
   setMessagingPlatformTotals,
   setMessagingSessions,
   setMessagingTruncated,
+  setSessionProfilesTruncated,
+  setSessionProfilesUsage,
   setSessions,
   setSessionsLoading
 } from '@/store/session'
@@ -104,6 +109,8 @@ beforeEach(() => {
   setMessagingSessions([])
   setMessagingPlatformTotals({})
   setMessagingTruncated(false)
+  setSessionProfilesTruncated({})
+  setSessionProfilesUsage({})
   setSessionsLoading(false)
 })
 
@@ -114,6 +121,8 @@ afterEach(() => {
   setMessagingSessions([])
   setMessagingPlatformTotals({})
   setMessagingTruncated(false)
+  setSessionProfilesTruncated({})
+  setSessionProfilesUsage({})
   setSessionsLoading(false)
 })
 
@@ -248,6 +257,49 @@ describe('refreshSessions identity + loading hygiene', () => {
 
     off()
     expect(loadingStates).toEqual([false, true, false])
+  })
+
+  it('does not let a superseded owner publish or release a newer switch loading barrier', async () => {
+    const pending = deferred<SidebarSessionsResponse>()
+    let ownsRefresh = true
+
+    listSidebarSessions.mockReturnValue(pending.promise)
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'default' }))
+    const refresh = result.current.refreshSessions(() => ownsRefresh)
+
+    expect($sessionsLoading.get()).toBe(true)
+
+    ownsRefresh = false
+    setSessions([row('winner')])
+    setCronSessions([row('winner-cron', { source: 'cron' })])
+    setMessagingSessions([row('winner-message', { source: 'signal' })])
+    setMessagingTruncated(true)
+    setSessionProfilesTruncated({ winner: true })
+    setSessionProfilesUsage({ winner: { cost_usd: 2, tokens: 20 } })
+    setSessionsLoading(true)
+
+    await act(async () => {
+      pending.resolve({
+        recents: {
+          profiles_truncated: { stale: true },
+          profiles_usage: { stale: { cost_usd: 1, tokens: 10 } },
+          sessions: [row('stale')]
+        },
+        cron: { sessions: [row('stale-cron', { source: 'cron' })] },
+        messaging: { sessions: [row('stale-message', { source: 'telegram' })] }
+      })
+      await refresh
+    })
+
+    expect($sessions.get().map(session => session.id)).toEqual(['winner'])
+    expect($cronSessions.get().map(session => session.id)).toEqual(['winner-cron'])
+    expect($messagingSessions.get().map(session => session.id)).toEqual(['winner-message'])
+    expect($messagingTruncated.get()).toBe(true)
+    expect($sessionProfilesTruncated.get()).toEqual({ winner: true })
+    expect($sessionProfilesUsage.get()).toEqual({ winner: { cost_usd: 2, tokens: 20 } })
+    expect($sessionsLoading.get()).toBe(true)
+    expect(getCronJobs).not.toHaveBeenCalled()
   })
 
   it('clears initial loading after a failed source activation advances the gateway epoch', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -224,11 +224,11 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   }, [profileScope])
 
   /** Refresh every sidebar session slice without committing an obsolete profile response. */
-  const refreshSessions = useCallback(async () => {
+  const refreshSessions = useCallback(async (shouldPublish: () => boolean = () => true) => {
     const sessionProfile = sidebarProfileForScope(profileScope)
     const activationEpoch = gatewayActivationEpoch()
 
-    if (sidebarProfileForScope(profileScopeRef.current) !== sessionProfile) {
+    if (!shouldPublish() || sidebarProfileForScope(profileScopeRef.current) !== sessionProfile) {
       return
     }
 
@@ -240,7 +240,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     // $sessionsLoading subscriber twice per turn for no visible change.
     const showLoading = $sessions.get().length === 0
 
-    if (showLoading) {
+    if (showLoading && shouldPublish()) {
       setSessionsLoading(true)
     }
 
@@ -270,6 +270,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       })
 
       if (
+        shouldPublish() &&
         refreshSessionsRequestRef.current === requestId &&
         sidebarProfileForScope(profileScopeRef.current) === sessionProfile &&
         gatewayActivationEpoch() === activationEpoch
@@ -332,16 +333,16 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         setMessagingTruncated(result.messaging.sessions.length >= MESSAGING_SECTION_LIMIT)
       }
     } finally {
-      // The request id is enough here: a newer refresh owns its own loading
-      // state, while a failed source activation still needs the old request to
-      // clear the spinner even though it advanced the gateway epoch.
-      if (showLoading && refreshSessionsRequestRef.current === requestId) {
+      // Request identity preserves the zero-argument refresh contract across a
+      // failed activation epoch; an explicit owner predicate is stronger and
+      // must never release a newer switch's loading barrier.
+      if (showLoading && shouldPublish() && refreshSessionsRequestRef.current === requestId) {
         setSessionsLoading(false)
       }
     }
 
     // Cron *jobs* are a distinct API (getCronJobs), not a session slice.
-    if (sidebarProfileForScope(profileScopeRef.current) === sessionProfile) {
+    if (shouldPublish() && sidebarProfileForScope(profileScopeRef.current) === sessionProfile) {
       void refreshCronJobs()
     }
   }, [profileScope, refreshCronJobs])

--- a/apps/desktop/src/lib/json-rpc-gateway-recovery.test.ts
+++ b/apps/desktop/src/lib/json-rpc-gateway-recovery.test.ts
@@ -132,6 +132,48 @@ describe('hermes-ws-recovery-v1 silent blackhole', () => {
     vi.useRealTimers()
   })
 
+  it('keeps a replacement socket open when a superseded connect times out', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('WebSocket', { OPEN: LoopbackSocket.OPEN })
+    const backend = new RecoveryBackend()
+    const sockets: LoopbackSocket[] = []
+    const states: string[] = []
+
+    const client = new JsonRpcGatewayClient({
+      connectTimeoutMs: 50,
+      heartbeatIntervalMs: 0,
+      socketFactory: () => {
+        const socket = new LoopbackSocket(sockets.length + 1, backend)
+
+        sockets.push(socket)
+
+        return socket as unknown as WebSocket
+      }
+    })
+
+    client.onState(state => states.push(state))
+
+    const staleConnect = client.connect('ws://gateway.test/a')
+    const staleRejection = expect(staleConnect).rejects.toThrow('WebSocket connection failed')
+
+    client.close()
+
+    const currentConnect = client.connect('ws://gateway.test/b')
+
+    sockets[1].open()
+    await currentConnect
+    expect(client.connectionState).toBe('open')
+
+    await vi.advanceTimersByTimeAsync(50)
+
+    await staleRejection
+    expect(client.connectionState).toBe('open')
+    expect(sockets[1].readyState).toBe(LoopbackSocket.OPEN)
+    expect(states.slice(states.lastIndexOf('open'))).toEqual(['open'])
+
+    client.close()
+  })
+
   it('recovers the persisted final on a replacement socket without duplicating the prompt', async () => {
     vi.useFakeTimers()
     vi.stubGlobal('WebSocket', { OPEN: LoopbackSocket.OPEN })

--- a/apps/desktop/src/lib/with-timeout.test.ts
+++ b/apps/desktop/src/lib/with-timeout.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { withTimeout } from './with-timeout'
+
+describe('withTimeout', () => {
+  it('rejects with an onTimeout exception instead of letting it escape the timer callback', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const callbackFailure = new Error('abort callback failed')
+
+      const result = withTimeout(new Promise<never>(() => undefined), 10, 'work timed out', () => {
+        throw callbackFailure
+      })
+
+      const rejection = expect(result).rejects.toBe(callbackFailure)
+
+      await vi.advanceTimersByTimeAsync(10)
+      await rejection
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/apps/desktop/src/lib/with-timeout.ts
+++ b/apps/desktop/src/lib/with-timeout.ts
@@ -11,10 +11,22 @@ export function isTimeoutError(error: unknown): error is TimeoutError {
   return error instanceof TimeoutError
 }
 
-/** Settle with `promise`, or reject with a TimeoutError after `ms`. */
-export function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+/** Settle with `promise`, or reject with a TimeoutError after `ms`.
+ * `onTimeout` runs synchronously before the rejection is published so callers
+ * can revoke ownership of work that would otherwise keep running unowned. */
+export function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  message: string,
+  onTimeout?: (error: TimeoutError) => void
+): Promise<T> {
   return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new TimeoutError(message)), ms)
+    const timer = setTimeout(() => {
+      const error = new TimeoutError(message)
+
+      onTimeout?.(error)
+      reject(error)
+    }, ms)
 
     Promise.resolve(promise).then(
       value => {

--- a/apps/desktop/src/lib/with-timeout.ts
+++ b/apps/desktop/src/lib/with-timeout.ts
@@ -13,7 +13,8 @@ export function isTimeoutError(error: unknown): error is TimeoutError {
 
 /** Settle with `promise`, or reject with a TimeoutError after `ms`.
  * `onTimeout` runs synchronously before the rejection is published so callers
- * can revoke ownership of work that would otherwise keep running unowned. */
+ * can revoke ownership of work that would otherwise keep running unowned. If
+ * that callback throws, its error becomes this promise's rejection. */
 export function withTimeout<T>(
   promise: Promise<T>,
   ms: number,
@@ -24,7 +25,14 @@ export function withTimeout<T>(
     const timer = setTimeout(() => {
       const error = new TimeoutError(message)
 
-      onTimeout?.(error)
+      try {
+        onTimeout?.(error)
+      } catch (onTimeoutError) {
+        reject(onTimeoutError)
+
+        return
+      }
+
       reject(error)
     }, ms)
 

--- a/apps/desktop/src/lib/with-timeout.ts
+++ b/apps/desktop/src/lib/with-timeout.ts
@@ -1,0 +1,30 @@
+/** Rejection raised by withTimeout. The bounded work is NOT cancelled — the
+ * caller decides what a straggler that settles later means. */
+export class TimeoutError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'TimeoutError'
+  }
+}
+
+export function isTimeoutError(error: unknown): error is TimeoutError {
+  return error instanceof TimeoutError
+}
+
+/** Settle with `promise`, or reject with a TimeoutError after `ms`. */
+export function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new TimeoutError(message)), ms)
+
+    Promise.resolve(promise).then(
+      value => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      err => {
+        clearTimeout(timer)
+        reject(err)
+      }
+    )
+  })
+}

--- a/apps/desktop/src/store/connections.test.ts
+++ b/apps/desktop/src/store/connections.test.ts
@@ -14,19 +14,45 @@ const $connection = atom<null | {
   registryScoped?: boolean
 }>(null)
 
+// The runtime session id minted by the CURRENT backend — the binding a switch
+// must sever before the next source is published (#93937).
+const $activeSessionId = atom<null | string>(null)
+const $gatewaySwitching = atom(false)
+
 const ensureGatewayAgent = vi.fn(async (_connectionId: null | string, _profile: string): Promise<void> => undefined)
+const openGatewayAgent = vi.fn(async (_connectionId: string, _profile: string): Promise<void> => undefined)
 const refreshActiveProfile = vi.fn(async () => undefined)
 const requestFreshSession = vi.fn()
-const wipeSessionListsForGatewaySwitch = vi.fn()
+const beforeConnectionSwitch = vi.fn()
+const wipeSessionListsForGatewaySwitch = vi.fn(() => $activeSessionId.set(null))
+
+// Test double for the store's commit point with the real one's contract
+// (barrier → machine-context reset → wipe, synchronously); the real
+// implementation is covered by gateway-switch.test.ts.
+const beginGatewaySwitch = vi.fn(() => {
+  $gatewaySwitching.set(true)
+  beforeConnectionSwitch()
+  wipeSessionListsForGatewaySwitch()
+})
+
+const endGatewaySwitch = vi.fn(() => $gatewaySwitching.set(false))
+const recoverActiveSourceAfterFailedGatewaySwitch = vi.fn()
 
 vi.mock('@/store/session', () => ({ $connection }))
-vi.mock('@/store/gateway-switch', () => ({ wipeSessionListsForGatewaySwitch }))
+vi.mock('@/store/gateway-switch', () => ({
+  $gatewaySwitching,
+  beginGatewaySwitch,
+  endGatewaySwitch,
+  recoverActiveSourceAfterFailedGatewaySwitch,
+  wipeSessionListsForGatewaySwitch
+}))
 vi.mock('@/store/profile', () => ({
   $activeGatewayProfile,
   $newChatProfile,
   $showAllProfiles,
   ensureGatewayAgent,
   normalizeProfileKey: (name: null | string | undefined) => (name ?? '').trim() || 'default',
+  openGatewayAgent,
   refreshActiveProfile,
   requestFreshSession
 }))
@@ -73,9 +99,17 @@ beforeEach(() => {
       registryScoped: true
     })
   })
+  openGatewayAgent.mockReset()
+  openGatewayAgent.mockResolvedValue(undefined)
   refreshActiveProfile.mockClear()
   requestFreshSession.mockClear()
+  beforeConnectionSwitch.mockClear()
+  beginGatewaySwitch.mockClear()
+  endGatewaySwitch.mockClear()
+  recoverActiveSourceAfterFailedGatewaySwitch.mockClear()
   wipeSessionListsForGatewaySwitch.mockClear()
+  $activeSessionId.set(null)
+  $gatewaySwitching.set(false)
   list.mockClear()
   setLastUsed.mockClear()
   vi.stubGlobal('window', { hermesDesktop: { connections: { list, setLastUsed } }, localStorage })
@@ -144,7 +178,9 @@ describe('selectConnection', () => {
 
     await selectConnection('homelab')
 
+    expect(openGatewayAgent).toHaveBeenCalledWith('homelab', 'default')
     expect(ensureGatewayAgent).toHaveBeenCalledWith('homelab', 'default')
+    expect(beforeConnectionSwitch).toHaveBeenCalledTimes(1)
     expect(requestFreshSession).toHaveBeenCalledTimes(1)
     expect(wipeSessionListsForGatewaySwitch).toHaveBeenCalledTimes(1)
     expect($newChatProfile.get()).toBe('default')
@@ -172,37 +208,38 @@ describe('selectConnection', () => {
   })
 
   it('lets a later source choice win while an earlier dial is still pending', async () => {
-    let releaseHomelab!: () => void
+    let releaseDials!: () => void
 
-    const homelabGate = new Promise<void>(resolve => {
-      releaseHomelab = resolve
+    const dialGate = new Promise<void>(resolve => {
+      releaseDials = resolve
     })
 
     setConnectionsRegistry(registry)
     $connection.set({ connectionId: 'local', mode: 'local' })
-    ensureGatewayAgent.mockImplementationOnce(async () => {
-      await homelabGate
-      $connection.set({ connectionId: 'homelab', mode: 'remote' })
-    })
-    ensureGatewayAgent.mockImplementationOnce(async () => {
-      await homelabGate
-      $connection.set({ connectionId: 'local', mode: 'local' })
+    openGatewayAgent.mockImplementation(async () => {
+      await dialGate
     })
 
     const openHomelab = selectConnection('homelab')
     await Promise.resolve()
     const stayLocal = selectConnection('local')
 
-    releaseHomelab()
+    releaseDials()
     await Promise.all([openHomelab, stayLocal])
 
-    expect(ensureGatewayAgent.mock.calls).toEqual([
+    expect(openGatewayAgent.mock.calls).toEqual([
       ['homelab', 'default'],
       ['local', 'default']
     ])
+    // The superseded dial never activates: the user doesn't flip through
+    // homelab on the way back to local, and only the winner commits.
+    expect(ensureGatewayAgent.mock.calls).toEqual([['local', 'default']])
+    expect(beginGatewaySwitch).toHaveBeenCalledTimes(1)
+    expect(wipeSessionListsForGatewaySwitch).toHaveBeenCalledTimes(1)
     // Only the latest intent repaints the profile list.
     expect(refreshActiveProfile).toHaveBeenCalledTimes(1)
-    expect(wipeSessionListsForGatewaySwitch).toHaveBeenCalledTimes(1)
+    expect($connection.get()?.connectionId).toBe('local')
+    expect($gatewaySwitching.get()).toBe(false)
   })
 
   it('restores the last profile used on each source', async () => {
@@ -240,18 +277,90 @@ describe('selectConnection', () => {
     expect(ensureGatewayAgent).toHaveBeenCalledWith('local', 'default')
   })
 
-  it('keeps the current source usable when a dial fails', async () => {
+  it('keeps the current source usable when a dial fails: nothing is severed before the target is reachable', async () => {
     setConnectionsRegistry(registry)
     $connection.set({ connectionId: 'local', mode: 'local' })
-    ensureGatewayAgent.mockRejectedValueOnce(new Error('offline'))
+    $activeSessionId.set('a93bb39d')
+    openGatewayAgent.mockRejectedValueOnce(new Error('offline'))
 
     await expect(selectConnection('homelab')).rejects.toThrow('offline')
 
-    expect(requestFreshSession).not.toHaveBeenCalled()
+    // The dial failed in phase 1 — the switch never committed, so the open
+    // transcript, its runtime binding and the session lists are all intact.
+    expect(ensureGatewayAgent).not.toHaveBeenCalled()
+    expect(beginGatewaySwitch).not.toHaveBeenCalled()
+    expect(beforeConnectionSwitch).not.toHaveBeenCalled()
     expect(wipeSessionListsForGatewaySwitch).not.toHaveBeenCalled()
+    expect($activeSessionId.get()).toBe('a93bb39d')
+    expect($gatewaySwitching.get()).toBe(false)
+    expect(requestFreshSession).not.toHaveBeenCalled()
     expect($newChatProfile.get()).toBeNull()
     expect($pendingConnectionId.get()).toBeNull()
     expect(setLastUsed).not.toHaveBeenCalled()
+    expect($connection.get()?.connectionId).toBe('local')
+  })
+
+  it('an activation that does not land after the wipe lowers the barrier and repaints the still-active source', async () => {
+    setConnectionsRegistry(registry)
+    $connection.set({ connectionId: 'local', mode: 'local' })
+    // The dial opened the socket but the activation was declined (source
+    // edited/removed mid-switch): $connection never moves to homelab.
+    ensureGatewayAgent.mockImplementationOnce(async () => undefined)
+
+    await expect(selectConnection('homelab')).rejects.toThrow('did not become active')
+
+    expect(beginGatewaySwitch).toHaveBeenCalledTimes(1)
+    expect(endGatewaySwitch).toHaveBeenCalledTimes(1)
+    expect($gatewaySwitching.get()).toBe(false)
+    // The lists were wiped for a commit that never happened; the source that
+    // is still active gets repainted and the user lands on a fresh draft there.
+    expect(recoverActiveSourceAfterFailedGatewaySwitch).toHaveBeenCalledTimes(1)
+    expect(requestFreshSession).toHaveBeenCalledTimes(1)
+    expect(setLastUsed).not.toHaveBeenCalled()
+    expect($newChatProfile.get()).toBeNull()
+    expect($pendingConnectionId.get()).toBeNull()
+    expect($connection.get()?.connectionId).toBe('local')
+  })
+
+  it("#93937: severs the previous source's runtime session binding BEFORE the new source is published, behind the barrier", async () => {
+    setConnectionsRegistry(registry)
+    $connection.set({ connectionId: 'local', mode: 'local' })
+    // Runtime id minted by the local backend; only local has ever heard of it.
+    $activeSessionId.set('a93bb39d')
+
+    // Phase 1 (the dial) must not touch the current workspace at all.
+    openGatewayAgent.mockImplementationOnce(async () => {
+      expect($activeSessionId.get()).toBe('a93bb39d')
+      expect($gatewaySwitching.get()).toBe(false)
+      expect(wipeSessionListsForGatewaySwitch).not.toHaveBeenCalled()
+    })
+
+    // Every publication of the new source, with what a session-scoped effect
+    // would read at that instant.
+    const published: Array<{ activeSessionId: null | string; connectionId?: string; switching: boolean }> = []
+
+    const off = $connection.listen(next => {
+      published.push({
+        activeSessionId: $activeSessionId.get(),
+        connectionId: next?.connectionId,
+        switching: $gatewaySwitching.get()
+      })
+    })
+
+    await selectConnection('homelab')
+    off()
+
+    // The old runtime id was already gone when homelab became visible, and
+    // the barrier was up — nothing could pair 'a93bb39d' with the new backend.
+    expect(published).toEqual([{ activeSessionId: null, connectionId: 'homelab', switching: true }])
+    // dial → commit (barrier + reset + wipe) → activate, in that order.
+    expect(openGatewayAgent).toHaveBeenCalledWith('homelab', 'default')
+    expect(openGatewayAgent.mock.invocationCallOrder[0]).toBeLessThan(beginGatewaySwitch.mock.invocationCallOrder[0])
+    expect(beginGatewaySwitch.mock.invocationCallOrder[0]).toBeLessThan(ensureGatewayAgent.mock.invocationCallOrder[0])
+    expect(beforeConnectionSwitch).toHaveBeenCalledTimes(1)
+    expect(endGatewaySwitch).toHaveBeenCalledTimes(1)
+    expect($gatewaySwitching.get()).toBe(false)
+    expect($activeSessionId.get()).toBeNull()
   })
 
   it('boot-time restore leaves "All profiles" browse mode on (#93197)', async () => {

--- a/apps/desktop/src/store/connections.test.ts
+++ b/apps/desktop/src/store/connections.test.ts
@@ -557,6 +557,89 @@ describe('selectConnection', () => {
     }
   })
 
+  it('a timed-out activation that already published cannot republish after a newer source wins', async () => {
+    vi.useFakeTimers()
+
+    try {
+      let releaseDescriptor: () => void = () => undefined
+
+      setConnectionsRegistry(registry)
+      // Seed A's remembered profile through the real source/profile observer,
+      // then restore the currently active local source.
+      $activeGatewayProfile.set('research')
+      $connection.set({ connectionId: 'homelab', mode: 'remote', profile: 'research', registryScoped: true })
+      $activeGatewayProfile.set('default')
+      $connection.set({ connectionId: 'local', mode: 'local', profile: 'default', registryScoped: true })
+
+      ensureGatewayAgent
+        .mockImplementationOnce((connectionId, profile, options) => {
+          options?.beforeActivate?.()
+
+          // Low-level activation publishes synchronously. The trailing descriptor
+          // promise remains alive beyond selectConnection's commit timeout.
+          $activeGatewayProfile.set(profile)
+          $connection.set({
+            connectionId: connectionId ?? undefined,
+            mode: 'remote',
+            profile,
+            registryScoped: true
+          })
+
+          return new Promise<void>(resolve => {
+            releaseDescriptor = () => {
+              // Mirrors ensureGatewayAgent's publication seam: a revoked owner
+              // observes its signal and must not publish its late descriptor.
+              if (!options?.signal?.aborted) {
+                $activeGatewayProfile.set(profile)
+                $connection.set({
+                  connectionId: connectionId ?? undefined,
+                  mode: 'remote',
+                  profile,
+                  registryScoped: true
+                })
+              }
+
+              resolve()
+            }
+          })
+        })
+        .mockImplementationOnce(async (connectionId, profile, options) => {
+          if (options?.beforeActivate && !options.beforeActivate()) {
+            return
+          }
+
+          $activeGatewayProfile.set(profile)
+          $connection.set({
+            connectionId: connectionId ?? undefined,
+            mode: 'remote',
+            profile,
+            registryScoped: true
+          })
+        })
+
+      const timedOutOwner = selectConnection('homelab')
+      await vi.advanceTimersByTimeAsync(20_000)
+      await timedOutOwner
+
+      // Fail open: A really did become active before its trailing descriptor
+      // work timed out, so the commit remains successful.
+      expect($activeGatewayProfile.get()).toBe('research')
+      expect($connection.get()?.connectionId).toBe('homelab')
+
+      await selectConnection('work-vps')
+      expect($activeGatewayProfile.get()).toBe('default')
+      expect($connection.get()?.connectionId).toBe('work-vps')
+
+      releaseDescriptor()
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect($activeGatewayProfile.get()).toBe('default')
+      expect($connection.get()?.connectionId).toBe('work-vps')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('an activation that stalls AFTER the wipe times out: barrier down, still-active source repainted', async () => {
     vi.useFakeTimers()
 

--- a/apps/desktop/src/store/connections.test.ts
+++ b/apps/desktop/src/store/connections.test.ts
@@ -23,6 +23,7 @@ const $gatewaySwitching = atom(false)
 
 interface ActivationOptions {
   beforeActivate?: () => boolean
+  signal?: AbortSignal
 }
 
 const ensureGatewayAgent = vi.fn(
@@ -112,7 +113,7 @@ beforeEach(() => {
   ensureGatewayAgent.mockReset()
   // Mirrors the real door: the commit hook runs right before the activation
   // publishes, and a declined hook publishes nothing.
-  ensureGatewayAgent.mockImplementation(async (connectionId, _profile, options) => {
+  ensureGatewayAgent.mockImplementation(async (connectionId, profile, options) => {
     if (options?.beforeActivate && !options.beforeActivate()) {
       return
     }
@@ -120,7 +121,7 @@ beforeEach(() => {
     $connection.set({
       connectionId: connectionId ?? undefined,
       mode: connectionId === 'local' ? 'local' : 'remote',
-      profile: 'default',
+      profile,
       registryScoped: true
     })
   })
@@ -445,6 +446,48 @@ describe('selectConnection', () => {
     expect($pendingConnectionId.get()).toBeNull()
   })
 
+  it('does not spend the activation timeout while waiting for the serialized commit turn', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const mutex = deferred()
+
+      setConnectionsRegistry(registry)
+      $connection.set({ connectionId: 'local', mode: 'local' })
+      ensureGatewayAgent.mockImplementationOnce(async (connectionId, _profile, options) => {
+        await mutex.promise
+
+        if (options?.beforeActivate && !options.beforeActivate()) {
+          return
+        }
+
+        $connection.set({
+          connectionId: connectionId ?? undefined,
+          mode: 'remote',
+          profile: 'default',
+          registryScoped: true
+        })
+      })
+
+      const attempt = selectConnection('homelab')
+      await vi.waitFor(() => expect(ensureGatewayAgent).toHaveBeenCalledTimes(1))
+
+      // Queue ownership belongs to the shared mutex, not the actual activation
+      // attempt, so waiting here must not consume its 20-second commit budget.
+      await vi.advanceTimersByTimeAsync(20_000)
+      expect(beginGatewaySwitch).not.toHaveBeenCalled()
+
+      mutex.resolve()
+      await attempt
+
+      expect($connection.get()?.connectionId).toBe('homelab')
+      expect(beginGatewaySwitch).toHaveBeenCalledTimes(1)
+      expect($gatewaySwitching.get()).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('a dial that never answers times out: nothing severed, the click fails visibly, and the source can be retried', async () => {
     vi.useFakeTimers()
 
@@ -540,6 +583,56 @@ describe('selectConnection', () => {
       expect(requestFreshSession).toHaveBeenCalledTimes(1)
       expect(setLastUsed).not.toHaveBeenCalled()
       expect($connection.get()?.connectionId).toBe('local')
+      expect($pendingConnectionId.get()).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('a timed-out activation cannot publish the target after it eventually settles', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const activation = deferred()
+
+      setConnectionsRegistry(registry)
+      $connection.set({ connectionId: 'local', mode: 'local' })
+      ensureGatewayAgent.mockImplementationOnce(async (connectionId, _profile, options) => {
+        options?.beforeActivate?.()
+        await activation.promise
+
+        // Mirrors the real activation door: cancellation ownership is checked
+        // immediately before publishing after the async activation work.
+        if (options?.signal?.aborted) {
+          return
+        }
+
+        $connection.set({
+          connectionId: connectionId ?? undefined,
+          mode: 'remote',
+          profile: 'default',
+          registryScoped: true
+        })
+      })
+
+      const outcome = selectConnection('homelab').then(
+        () => 'resolved',
+        (error: Error) => error.message
+      )
+
+      await vi.advanceTimersByTimeAsync(20_000)
+
+      expect(await outcome).toMatch(/Timed out activating "Homelab"/)
+      expect($connection.get()?.connectionId).toBe('local')
+      expect($gatewaySwitching.get()).toBe(false)
+
+      activation.resolve()
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect($connection.get()?.connectionId).toBe('local')
+      expect(beginGatewaySwitch).toHaveBeenCalledTimes(1)
+      expect(endGatewaySwitch).toHaveBeenCalledTimes(1)
+      expect($gatewaySwitching.get()).toBe(false)
       expect($pendingConnectionId.get()).toBeNull()
     } finally {
       vi.useRealTimers()

--- a/apps/desktop/src/store/connections.test.ts
+++ b/apps/desktop/src/store/connections.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { DesktopConnectionsRegistry } from '@/global'
 
+import { deferred } from '../test/deferred'
+
 const $activeGatewayProfile = atom('default')
 const $newChatProfile = atom<null | string>(null)
 const $showAllProfiles = atom(false)
@@ -19,7 +21,14 @@ const $connection = atom<null | {
 const $activeSessionId = atom<null | string>(null)
 const $gatewaySwitching = atom(false)
 
-const ensureGatewayAgent = vi.fn(async (_connectionId: null | string, _profile: string): Promise<void> => undefined)
+interface ActivationOptions {
+  beforeActivate?: () => boolean
+}
+
+const ensureGatewayAgent = vi.fn(
+  async (_connectionId: null | string, _profile: string, _options?: ActivationOptions): Promise<void> => undefined
+)
+
 const openGatewayAgent = vi.fn(async (_connectionId: string, _profile: string): Promise<void> => undefined)
 const refreshActiveProfile = vi.fn(async () => undefined)
 const requestFreshSession = vi.fn()
@@ -27,15 +36,25 @@ const beforeConnectionSwitch = vi.fn()
 const wipeSessionListsForGatewaySwitch = vi.fn(() => $activeSessionId.set(null))
 
 // Test double for the store's commit point with the real one's contract
-// (barrier → machine-context reset → wipe, synchronously); the real
-// implementation is covered by gateway-switch.test.ts.
+// (barrier → machine-context reset → wipe, synchronously; the barrier is
+// owned by the latest token); the real implementation is covered by
+// gateway-switch.test.ts.
+let latestSwitchToken = 0
+
 const beginGatewaySwitch = vi.fn(() => {
   $gatewaySwitching.set(true)
   beforeConnectionSwitch()
   wipeSessionListsForGatewaySwitch()
+
+  return ++latestSwitchToken
 })
 
-const endGatewaySwitch = vi.fn(() => $gatewaySwitching.set(false))
+const endGatewaySwitch = vi.fn((token?: number) => {
+  if (token === undefined || token === latestSwitchToken) {
+    $gatewaySwitching.set(false)
+  }
+})
+
 const recoverActiveSourceAfterFailedGatewaySwitch = vi.fn()
 
 vi.mock('@/store/session', () => ({ $connection }))
@@ -91,7 +110,13 @@ beforeEach(() => {
   $newChatProfile.set(null)
   $showAllProfiles.set(false)
   ensureGatewayAgent.mockReset()
-  ensureGatewayAgent.mockImplementation(async connectionId => {
+  // Mirrors the real door: the commit hook runs right before the activation
+  // publishes, and a declined hook publishes nothing.
+  ensureGatewayAgent.mockImplementation(async (connectionId, _profile, options) => {
+    if (options?.beforeActivate && !options.beforeActivate()) {
+      return
+    }
+
     $connection.set({
       connectionId: connectionId ?? undefined,
       mode: connectionId === 'local' ? 'local' : 'remote',
@@ -134,7 +159,7 @@ describe('connection registry cache', () => {
     await initializeConnectionsRegistry()
 
     expect(ensureGatewayAgent).toHaveBeenCalledTimes(1)
-    expect(ensureGatewayAgent).toHaveBeenCalledWith('homelab', 'default')
+    expect(ensureGatewayAgent).toHaveBeenCalledWith('homelab', 'default', expect.anything())
     expect(setLastUsed).toHaveBeenCalledWith('homelab')
   })
 
@@ -154,7 +179,7 @@ describe('connection registry cache', () => {
     await initializeConnectionsRegistry()
 
     expect(ensureGatewayAgent).toHaveBeenCalledTimes(1)
-    expect(ensureGatewayAgent).toHaveBeenCalledWith('homelab', 'default')
+    expect(ensureGatewayAgent).toHaveBeenCalledWith('homelab', 'default', expect.anything())
     expect(setLastUsed).toHaveBeenCalledWith('homelab')
   })
 
@@ -179,7 +204,7 @@ describe('selectConnection', () => {
     await selectConnection('homelab')
 
     expect(openGatewayAgent).toHaveBeenCalledWith('homelab', 'default')
-    expect(ensureGatewayAgent).toHaveBeenCalledWith('homelab', 'default')
+    expect(ensureGatewayAgent).toHaveBeenCalledWith('homelab', 'default', expect.anything())
     expect(beforeConnectionSwitch).toHaveBeenCalledTimes(1)
     expect(requestFreshSession).toHaveBeenCalledTimes(1)
     expect(wipeSessionListsForGatewaySwitch).toHaveBeenCalledTimes(1)
@@ -204,7 +229,7 @@ describe('selectConnection', () => {
 
     await selectConnection('local')
 
-    expect(ensureGatewayAgent).toHaveBeenCalledWith('local', 'default')
+    expect(ensureGatewayAgent).toHaveBeenCalledWith('local', 'default', expect.anything())
   })
 
   it('lets a later source choice win while an earlier dial is still pending', async () => {
@@ -233,7 +258,7 @@ describe('selectConnection', () => {
     ])
     // The superseded dial never activates: the user doesn't flip through
     // homelab on the way back to local, and only the winner commits.
-    expect(ensureGatewayAgent.mock.calls).toEqual([['local', 'default']])
+    expect(ensureGatewayAgent.mock.calls.map(call => [call[0], call[1]])).toEqual([['local', 'default']])
     expect(beginGatewaySwitch).toHaveBeenCalledTimes(1)
     expect(wipeSessionListsForGatewaySwitch).toHaveBeenCalledTimes(1)
     // Only the latest intent repaints the profile list.
@@ -251,7 +276,7 @@ describe('selectConnection', () => {
 
     await selectConnection('local')
 
-    expect(ensureGatewayAgent).toHaveBeenCalledWith('local', 'research')
+    expect(ensureGatewayAgent).toHaveBeenCalledWith('local', 'research', expect.anything())
   })
 
   it('does not remember a migrated v1 routing alias as a backend profile', async () => {
@@ -262,7 +287,7 @@ describe('selectConnection', () => {
 
     await selectConnection('homelab')
 
-    expect(ensureGatewayAgent).toHaveBeenCalledWith('homelab', 'default')
+    expect(ensureGatewayAgent).toHaveBeenCalledWith('homelab', 'default', expect.anything())
   })
 
   it('does not remember a stale startup profile under the resolved source', async () => {
@@ -274,7 +299,7 @@ describe('selectConnection', () => {
 
     await selectConnection('local')
 
-    expect(ensureGatewayAgent).toHaveBeenCalledWith('local', 'default')
+    expect(ensureGatewayAgent).toHaveBeenCalledWith('local', 'default', expect.anything())
   })
 
   it('keeps the current source usable when a dial fails: nothing is severed before the target is reachable', async () => {
@@ -304,8 +329,11 @@ describe('selectConnection', () => {
     setConnectionsRegistry(registry)
     $connection.set({ connectionId: 'local', mode: 'local' })
     // The dial opened the socket but the activation was declined (source
-    // edited/removed mid-switch): $connection never moves to homelab.
-    ensureGatewayAgent.mockImplementationOnce(async () => undefined)
+    // edited/removed mid-switch): the commit hook ran (wipe done), yet
+    // $connection never moves to homelab.
+    ensureGatewayAgent.mockImplementationOnce(async (_connectionId, _profile, options) => {
+      options?.beforeActivate?.()
+    })
 
     await expect(selectConnection('homelab')).rejects.toThrow('did not become active')
 
@@ -353,14 +381,169 @@ describe('selectConnection', () => {
     // The old runtime id was already gone when homelab became visible, and
     // the barrier was up — nothing could pair 'a93bb39d' with the new backend.
     expect(published).toEqual([{ activeSessionId: null, connectionId: 'homelab', switching: true }])
-    // dial → commit (barrier + reset + wipe) → activate, in that order.
+    // dial → commit (barrier + reset + wipe, inside the activation's commit
+    // hook) → publish, in that order.
     expect(openGatewayAgent).toHaveBeenCalledWith('homelab', 'default')
-    expect(openGatewayAgent.mock.invocationCallOrder[0]).toBeLessThan(beginGatewaySwitch.mock.invocationCallOrder[0])
-    expect(beginGatewaySwitch.mock.invocationCallOrder[0]).toBeLessThan(ensureGatewayAgent.mock.invocationCallOrder[0])
+    expect(openGatewayAgent.mock.invocationCallOrder[0]).toBeLessThan(ensureGatewayAgent.mock.invocationCallOrder[0])
+    expect(beginGatewaySwitch).toHaveBeenCalledTimes(1)
     expect(beforeConnectionSwitch).toHaveBeenCalledTimes(1)
     expect(endGatewaySwitch).toHaveBeenCalledTimes(1)
     expect($gatewaySwitching.get()).toBe(false)
     expect($activeSessionId.get()).toBeNull()
+  })
+
+  it('a click that supersedes a QUEUED commit wins: the superseded switch neither wipes nor activates', async () => {
+    // Both activations sit behind an in-flight profile/agent switch (the
+    // profile store's mutex); their commit hooks only run once it settles.
+    const mutex = deferred()
+
+    setConnectionsRegistry(registry)
+    $connection.set({ connectionId: 'local', mode: 'local' })
+    $activeSessionId.set('a93bb39d')
+    ensureGatewayAgent.mockImplementation(async (connectionId, _profile, options) => {
+      await mutex.promise
+
+      if (options?.beforeActivate && !options.beforeActivate()) {
+        return
+      }
+
+      $connection.set({
+        connectionId: connectionId ?? undefined,
+        mode: 'remote',
+        profile: 'default',
+        registryScoped: true
+      })
+    })
+
+    const published: string[] = []
+    const off = $connection.listen(next => published.push(`${next?.connectionId}:active=${$activeSessionId.get()}`))
+
+    const first = selectConnection('homelab')
+    await vi.waitFor(() => expect(ensureGatewayAgent).toHaveBeenCalledTimes(1))
+    const second = selectConnection('work-vps')
+    await vi.waitFor(() => expect(ensureGatewayAgent).toHaveBeenCalledTimes(2))
+
+    // Nothing is severed while both are still queued.
+    expect(beginGatewaySwitch).not.toHaveBeenCalled()
+    expect($activeSessionId.get()).toBe('a93bb39d')
+
+    mutex.resolve()
+    await Promise.all([first, second])
+    off()
+
+    // homelab stepped aside at its turn: no wipe, no publication, no error
+    // UI; work-vps wiped once and is the only source ever published.
+    expect(ensureGatewayAgent.mock.calls.map(call => call[0])).toEqual(['homelab', 'work-vps'])
+    expect(beginGatewaySwitch).toHaveBeenCalledTimes(1)
+    expect(published).toEqual(['work-vps:active=null'])
+    expect($connection.get()?.connectionId).toBe('work-vps')
+    expect(recoverActiveSourceAfterFailedGatewaySwitch).not.toHaveBeenCalled()
+    expect(requestFreshSession).toHaveBeenCalledTimes(1)
+    expect(setLastUsed).toHaveBeenCalledTimes(1)
+    expect(setLastUsed).toHaveBeenCalledWith('work-vps')
+    expect($gatewaySwitching.get()).toBe(false)
+    expect($pendingConnectionId.get()).toBeNull()
+  })
+
+  it('a dial that never answers times out: nothing severed, the click fails visibly, and the source can be retried', async () => {
+    vi.useFakeTimers()
+
+    try {
+      setConnectionsRegistry(registry)
+      $connection.set({ connectionId: 'local', mode: 'local' })
+      $activeSessionId.set('a93bb39d')
+      openGatewayAgent.mockImplementationOnce(() => new Promise<void>(() => undefined))
+
+      const outcome = selectConnection('homelab').then(
+        () => 'resolved',
+        (error: Error) => error.message
+      )
+
+      await vi.advanceTimersByTimeAsync(20_000)
+
+      expect(await outcome).toMatch(/Timed out connecting to "Homelab"/)
+      expect(ensureGatewayAgent).not.toHaveBeenCalled()
+      expect(beginGatewaySwitch).not.toHaveBeenCalled()
+      expect($activeSessionId.get()).toBe('a93bb39d')
+      expect($gatewaySwitching.get()).toBe(false)
+      expect($pendingConnectionId.get()).toBeNull()
+
+      // The stalled click does not poison the source: a retry is a real switch,
+      // not a duplicate of the pending one.
+      await selectConnection('homelab')
+
+      expect(ensureGatewayAgent).toHaveBeenCalledWith('homelab', 'default', expect.anything())
+      expect($connection.get()?.connectionId).toBe('homelab')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('an activation that published the new source but never settled counts as committed', async () => {
+    vi.useFakeTimers()
+
+    try {
+      setConnectionsRegistry(registry)
+      $connection.set({ connectionId: 'local', mode: 'local' })
+      // The socket activates and publishes synchronously; only the trailing
+      // descriptor resync (an IPC) stalls.
+      ensureGatewayAgent.mockImplementationOnce((connectionId, _profile, options) => {
+        options?.beforeActivate?.()
+        $connection.set({
+          connectionId: connectionId ?? undefined,
+          mode: 'remote',
+          profile: 'default',
+          registryScoped: true
+        })
+
+        return new Promise<void>(() => undefined)
+      })
+
+      const attempt = selectConnection('homelab')
+      await vi.advanceTimersByTimeAsync(20_000)
+      await attempt
+
+      expect($connection.get()?.connectionId).toBe('homelab')
+      expect($gatewaySwitching.get()).toBe(false)
+      expect(setLastUsed).toHaveBeenCalledWith('homelab')
+      expect(requestFreshSession).toHaveBeenCalledTimes(1)
+      expect(recoverActiveSourceAfterFailedGatewaySwitch).not.toHaveBeenCalled()
+      expect($pendingConnectionId.get()).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('an activation that stalls AFTER the wipe times out: barrier down, still-active source repainted', async () => {
+    vi.useFakeTimers()
+
+    try {
+      setConnectionsRegistry(registry)
+      $connection.set({ connectionId: 'local', mode: 'local' })
+      ensureGatewayAgent.mockImplementationOnce((_connectionId, _profile, options) => {
+        options?.beforeActivate?.()
+
+        return new Promise<void>(() => undefined)
+      })
+
+      const outcome = selectConnection('homelab').then(
+        () => 'resolved',
+        (error: Error) => error.message
+      )
+
+      await vi.advanceTimersByTimeAsync(20_000)
+
+      expect(await outcome).toMatch(/Timed out activating "Homelab"/)
+      expect(beginGatewaySwitch).toHaveBeenCalledTimes(1)
+      expect($gatewaySwitching.get()).toBe(false)
+      expect(recoverActiveSourceAfterFailedGatewaySwitch).toHaveBeenCalledTimes(1)
+      expect(requestFreshSession).toHaveBeenCalledTimes(1)
+      expect(setLastUsed).not.toHaveBeenCalled()
+      expect($connection.get()?.connectionId).toBe('local')
+      expect($pendingConnectionId.get()).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('boot-time restore leaves "All profiles" browse mode on (#93197)', async () => {
@@ -371,7 +554,7 @@ describe('selectConnection', () => {
 
     await initializeConnectionsRegistry()
 
-    expect(ensureGatewayAgent).toHaveBeenCalledWith('homelab', 'default')
+    expect(ensureGatewayAgent).toHaveBeenCalledWith('homelab', 'default', expect.anything())
     expect($showAllProfiles.get()).toBe(true)
   })
 
@@ -382,7 +565,7 @@ describe('selectConnection', () => {
 
     await selectConnection('homelab')
 
-    expect(ensureGatewayAgent).toHaveBeenCalledWith('homelab', 'default')
+    expect(ensureGatewayAgent).toHaveBeenCalledWith('homelab', 'default', expect.anything())
     expect($showAllProfiles.get()).toBe(false)
   })
 

--- a/apps/desktop/src/store/connections.ts
+++ b/apps/desktop/src/store/connections.ts
@@ -2,13 +2,18 @@ import { atom, computed } from 'nanostores'
 
 import type { DesktopConnectionsRegistry } from '@/global'
 import { persistStringRecord, storedStringRecord } from '@/lib/storage'
-import { wipeSessionListsForGatewaySwitch } from '@/store/gateway-switch'
+import {
+  beginGatewaySwitch,
+  endGatewaySwitch,
+  recoverActiveSourceAfterFailedGatewaySwitch
+} from '@/store/gateway-switch'
 import {
   $activeGatewayProfile,
   $newChatProfile,
   $showAllProfiles,
   ensureGatewayAgent,
   normalizeProfileKey,
+  openGatewayAgent,
   refreshActiveProfile,
   requestFreshSession
 } from '@/store/profile'
@@ -160,6 +165,17 @@ export async function initializeConnectionsRegistry(): Promise<DesktopConnection
  * Re-home Sessions to one registered source, restoring that source's last
  * profile. Only the selected source is dialed; merely rendering the switcher
  * never probes or opens remote gateways.
+ *
+ * Two phases, same commit contract as a Settings → Gateway apply (softSwitch):
+ *  1. Dial the target WITHOUT activating it. The previous source stays fully
+ *     bound and painted, so a dead target fails with nothing lost.
+ *  2. beginGatewaySwitch() — barrier up, machine-context reset, session
+ *     bindings wiped — then activate the already-open socket. Nothing awaits
+ *     between the wipe and the publication, so no route/session effect can
+ *     observe the new source while $activeSessionId still names the previous
+ *     backend's runtime. Activating first and wiping after (across an IPC
+ *     round-trip) is exactly how that id leaked to the new backend and came
+ *     back as "session not found" (#93937).
  */
 export async function selectConnection(connectionId: string): Promise<void> {
   const registry = $connectionsRegistry.get()
@@ -210,12 +226,39 @@ export async function selectConnection(connectionId: string): Promise<void> {
   $pendingConnectionId.set(connectionId)
 
   try {
+    // Phase 1 — open the target's socket; the active route is untouched.
     // Always use the explicit registry route. `local` must mean This device,
     // and a registry primary can differ from a legacy per-profile override.
-    await ensureGatewayAgent(connectionId, targetProfile)
+    await openGatewayAgent(connectionId, targetProfile)
 
-    if ($connection.get()?.connectionId !== connectionId) {
-      throw new Error(`Connection "${targetConnection.label}" did not become active.`)
+    // A newer click owns the switch from here on. The superseded dial never
+    // activates, so the user doesn't flip through it on the way to the source
+    // they picked last; its socket stays warm for that click or idles out.
+    if (revision !== switchRevision) {
+      return
+    }
+
+    // Phase 2 — commit: sever the previous backend's bindings FIRST, then
+    // activate. Synchronous from the wipe to the publication (the socket is
+    // already open), and behind the barrier until the descriptor lands.
+    beginGatewaySwitch()
+
+    try {
+      await ensureGatewayAgent(connectionId, targetProfile)
+
+      if ($connection.get()?.connectionId !== connectionId) {
+        throw new Error(`Connection "${targetConnection.label}" did not become active.`)
+      }
+    } catch (error) {
+      // The wipe already happened but the previous source is still the active
+      // one, and nothing reactive re-pulls its lists (no scope moved). Repaint
+      // it and land on a fresh draft there, matching what a failed Settings
+      // apply leaves behind.
+      recoverActiveSourceAfterFailedGatewaySwitch()
+      requestFreshSession()
+      throw error
+    } finally {
+      endGatewaySwitch()
     }
 
     // A newer click owns the final refresh. Serialized gateway activation
@@ -223,7 +266,6 @@ export async function selectConnection(connectionId: string): Promise<void> {
     // request from repainting its profile list after that newer activation.
     if (revision === switchRevision) {
       await rememberConnection(connectionId)
-      wipeSessionListsForGatewaySwitch()
 
       if (!restoreOnBoot) {
         $showAllProfiles.set(false)

--- a/apps/desktop/src/store/connections.ts
+++ b/apps/desktop/src/store/connections.ts
@@ -310,14 +310,12 @@ export async function selectConnection(connectionId: string): Promise<void> {
             SWITCH_COMMIT_TIMEOUT_MS,
             `Timed out activating "${targetConnection.label}".`,
             error => {
-              // withTimeout does not cancel its input. Revoke this activation's
-              // ownership before publishing the timeout so a queued/stalled
-              // ensure cannot wake later and commit without a caller. If the
-              // gateway already published the target, the commit landed and its
-              // trailing descriptor resync remains a harmless fail-open straggler.
-              if (!targetIsActive()) {
-                activationController.abort(error)
-              }
+              // withTimeout does not cancel its input. Every timed-out owner
+              // loses future activation/publication rights, even when low-level
+              // activation already published the target and the commit remains
+              // fail-open. The shared activation signal suppresses any trailing
+              // descriptor/profile publication when stale work later settles.
+              activationController.abort(error)
             }
           )
         )
@@ -327,9 +325,9 @@ export async function selectConnection(connectionId: string): Promise<void> {
         await Promise.race([activation, timedActivation])
       } catch (error) {
         // The socket is activated and its descriptor published synchronously;
-        // only the best-effort descriptor resync trails it. A commit that timed
-        // out AFTER the new source became active has landed — the straggler is
-        // fail-open and cannot undo it.
+        // only best-effort descriptor resync trails it. A commit that timed out
+        // AFTER the new source became active has landed, so keep it fail-open;
+        // the timeout signal still revokes all trailing publication rights.
         if (!isTimeoutError(error) || !targetIsActive()) {
           throw error
         }

--- a/apps/desktop/src/store/connections.ts
+++ b/apps/desktop/src/store/connections.ts
@@ -2,9 +2,11 @@ import { atom, computed } from 'nanostores'
 
 import type { DesktopConnectionsRegistry } from '@/global'
 import { persistStringRecord, storedStringRecord } from '@/lib/storage'
+import { isTimeoutError, withTimeout } from '@/lib/with-timeout'
 import {
   beginGatewaySwitch,
   endGatewaySwitch,
+  type GatewaySwitchToken,
   recoverActiveSourceAfterFailedGatewaySwitch
 } from '@/store/gateway-switch'
 import {
@@ -20,6 +22,14 @@ import {
 import { $connection } from '@/store/session'
 
 const LAST_PROFILE_STORAGE_KEY = 'hermes.desktop.lastProfileByConnection'
+
+// Every await of a source switch is bounded. A wedged spawn, ticket mint,
+// handshake or IPC (the #93454 class) must surface as a failed click — not a
+// spinner that also swallows every later click on the same source, and never
+// a barrier left up or a wipe left unpainted.
+const SWITCH_DIAL_TIMEOUT_MS = 20_000
+const SWITCH_COMMIT_TIMEOUT_MS = 20_000
+const SWITCH_REMEMBER_TIMEOUT_MS = 5_000
 
 export const $connectionsRegistry = atom<DesktopConnectionsRegistry | null>(null)
 
@@ -109,11 +119,17 @@ async function rememberConnection(connectionId: string): Promise<void> {
   }
 
   try {
-    const result = await setLastUsed(connectionId)
+    const result = await withTimeout(
+      setLastUsed(connectionId),
+      SWITCH_REMEMBER_TIMEOUT_MS,
+      'Timed out remembering the last-used connection'
+    )
+
     setConnectionsRegistry(result.registry)
   } catch {
-    // The source is already usable. A read-only/full userData directory must
-    // not turn a successful backend switch into a false connection failure.
+    // The source is already usable. A read-only/full userData directory (or
+    // a stalled IPC) must not turn a successful backend switch into a false
+    // connection failure.
   }
 }
 
@@ -169,13 +185,21 @@ export async function initializeConnectionsRegistry(): Promise<DesktopConnection
  * Two phases, same commit contract as a Settings → Gateway apply (softSwitch):
  *  1. Dial the target WITHOUT activating it. The previous source stays fully
  *     bound and painted, so a dead target fails with nothing lost.
- *  2. beginGatewaySwitch() — barrier up, machine-context reset, session
- *     bindings wiped — then activate the already-open socket. Nothing awaits
- *     between the wipe and the publication, so no route/session effect can
- *     observe the new source while $activeSessionId still names the previous
- *     backend's runtime. Activating first and wiping after (across an IPC
- *     round-trip) is exactly how that id leaked to the new backend and came
- *     back as "session not found" (#93937).
+ *  2. Commit: beginGatewaySwitch() — barrier up, machine-context reset,
+ *     session bindings wiped — then activate the already-open socket. The
+ *     wipe runs inside the activation's serialized section, synchronously
+ *     before the publication, so no route/session effect can observe the new
+ *     source while $activeSessionId still names the previous backend's
+ *     runtime. Activating first and wiping after (across an IPC round-trip)
+ *     is exactly how that id leaked to the new backend and came back as
+ *     "session not found" (#93937).
+ *
+ * Overlap and stalls: clicks can supersede a switch at any point. A switch
+ * superseded while queued behind another activation declines its commit —
+ * no wipe, no activation — so the winner's wipe is always the one that
+ * precedes the final publication, and the barrier is owned by the latest
+ * switch. Every await is bounded; a commit that stalls after the wipe lowers
+ * the barrier and repaints the source that is still active.
  */
 export async function selectConnection(connectionId: string): Promise<void> {
   const registry = $connectionsRegistry.get()
@@ -224,12 +248,20 @@ export async function selectConnection(connectionId: string): Promise<void> {
   const revision = ++switchRevision
   pendingTarget = targetKey
   $pendingConnectionId.set(connectionId)
+  // Set by the commit hook once THIS switch has wiped — i.e. it owns the
+  // barrier and, if the commit then fails, owes the still-active source a
+  // repaint. Null while queued, or if it stepped aside before its turn.
+  let token = null as GatewaySwitchToken | null
 
   try {
     // Phase 1 — open the target's socket; the active route is untouched.
     // Always use the explicit registry route. `local` must mean This device,
     // and a registry primary can differ from a legacy per-profile override.
-    await openGatewayAgent(connectionId, targetProfile)
+    await withTimeout(
+      openGatewayAgent(connectionId, targetProfile),
+      SWITCH_DIAL_TIMEOUT_MS,
+      `Timed out connecting to "${targetConnection.label}".`
+    )
 
     // A newer click owns the switch from here on. The superseded dial never
     // activates, so the user doesn't flip through it on the way to the source
@@ -238,27 +270,51 @@ export async function selectConnection(connectionId: string): Promise<void> {
       return
     }
 
-    // Phase 2 — commit: sever the previous backend's bindings FIRST, then
-    // activate. Synchronous from the wipe to the publication (the socket is
-    // already open), and behind the barrier until the descriptor lands.
-    beginGatewaySwitch()
-
+    // Phase 2 — commit. The hook runs inside the activation's serialized
+    // section, right before the socket is activated: sever the previous
+    // backend's bindings, then publish, with nothing in between. A click that
+    // superseded this switch while it was queued makes the hook decline —
+    // neither wipe nor activation — so the user never flips through it.
     try {
-      await ensureGatewayAgent(connectionId, targetProfile)
+      try {
+        await withTimeout(
+          ensureGatewayAgent(connectionId, targetProfile, {
+            beforeActivate: () => {
+              if (revision !== switchRevision) {
+                return false
+              }
+
+              token = beginGatewaySwitch()
+
+              return true
+            }
+          }),
+          SWITCH_COMMIT_TIMEOUT_MS,
+          `Timed out activating "${targetConnection.label}".`
+        )
+      } catch (error) {
+        // The socket is activated and its descriptor published synchronously;
+        // only the best-effort descriptor resync trails it. A commit that timed
+        // out AFTER the new source became active has landed — the straggler is
+        // fail-open and cannot undo it.
+        if (!isTimeoutError(error) || $connection.get()?.connectionId !== connectionId) {
+          throw error
+        }
+      }
+
+      if (revision !== switchRevision) {
+        return
+      }
 
       if ($connection.get()?.connectionId !== connectionId) {
         throw new Error(`Connection "${targetConnection.label}" did not become active.`)
       }
-    } catch (error) {
-      // The wipe already happened but the previous source is still the active
-      // one, and nothing reactive re-pulls its lists (no scope moved). Repaint
-      // it and land on a fresh draft there, matching what a failed Settings
-      // apply leaves behind.
-      recoverActiveSourceAfterFailedGatewaySwitch()
-      requestFreshSession()
-      throw error
     } finally {
-      endGatewaySwitch()
+      // Lower the barrier the moment the commit settles — before the
+      // bookkeeping awaits below — but only if this switch still owns it.
+      if (token !== null) {
+        endGatewaySwitch(token)
+      }
     }
 
     // A newer click owns the final refresh. Serialized gateway activation
@@ -277,6 +333,15 @@ export async function selectConnection(connectionId: string): Promise<void> {
     }
   } catch (error) {
     if (revision === switchRevision) {
+      if (token !== null) {
+        // This switch wiped for a commit that never landed. The previous
+        // source is still the active one, and nothing reactive re-pulls its
+        // lists (no scope moved): repaint it and land on a fresh draft there,
+        // matching what a failed Settings apply leaves behind.
+        recoverActiveSourceAfterFailedGatewaySwitch()
+        requestFreshSession()
+      }
+
       throw error
     }
   } finally {

--- a/apps/desktop/src/store/connections.ts
+++ b/apps/desktop/src/store/connections.ts
@@ -371,7 +371,7 @@ export async function selectConnection(connectionId: string): Promise<void> {
         // source is still the active one, and nothing reactive re-pulls its
         // lists (no scope moved): repaint it and land on a fresh draft there,
         // matching what a failed Settings apply leaves behind.
-        recoverActiveSourceAfterFailedGatewaySwitch()
+        recoverActiveSourceAfterFailedGatewaySwitch(token)
         requestFreshSession()
       }
 

--- a/apps/desktop/src/store/connections.ts
+++ b/apps/desktop/src/store/connections.ts
@@ -220,6 +220,12 @@ export async function selectConnection(connectionId: string): Promise<void> {
   const targetProfile = normalizeProfileKey($lastProfileByConnection.get()[connectionId] ?? 'default')
   const targetKey = `${connectionId}::${targetProfile}`
 
+  const targetIsActive = () => {
+    const active = $connection.get()
+
+    return active?.connectionId === connectionId && normalizeProfileKey(active.profile) === targetProfile
+  }
+
   if (pendingTarget === targetKey) {
     return
   }
@@ -275,29 +281,56 @@ export async function selectConnection(connectionId: string): Promise<void> {
     // backend's bindings, then publish, with nothing in between. A click that
     // superseded this switch while it was queued makes the hook decline —
     // neither wipe nor activation — so the user never flips through it.
+    const activationController = new AbortController()
+    let markActivationStarted: () => void = () => undefined
+
+    const activationStarted = new Promise<void>(resolve => {
+      markActivationStarted = resolve
+    })
+
     try {
       try {
-        await withTimeout(
-          ensureGatewayAgent(connectionId, targetProfile, {
-            beforeActivate: () => {
-              if (revision !== switchRevision) {
-                return false
-              }
-
-              token = beginGatewaySwitch()
-
-              return true
+        const activation = ensureGatewayAgent(connectionId, targetProfile, {
+          signal: activationController.signal,
+          beforeActivate: () => {
+            if (revision !== switchRevision) {
+              return false
             }
-          }),
-          SWITCH_COMMIT_TIMEOUT_MS,
-          `Timed out activating "${targetConnection.label}".`
+
+            token = beginGatewaySwitch()
+            markActivationStarted()
+
+            return true
+          }
+        })
+
+        const timedActivation = activationStarted.then(() =>
+          withTimeout(
+            activation,
+            SWITCH_COMMIT_TIMEOUT_MS,
+            `Timed out activating "${targetConnection.label}".`,
+            error => {
+              // withTimeout does not cancel its input. Revoke this activation's
+              // ownership before publishing the timeout so a queued/stalled
+              // ensure cannot wake later and commit without a caller. If the
+              // gateway already published the target, the commit landed and its
+              // trailing descriptor resync remains a harmless fail-open straggler.
+              if (!targetIsActive()) {
+                activationController.abort(error)
+              }
+            }
+          )
         )
+
+        // Queue time belongs to the profile-store mutex. Start the bounded
+        // commit window only once beforeActivate grants this request its turn.
+        await Promise.race([activation, timedActivation])
       } catch (error) {
         // The socket is activated and its descriptor published synchronously;
         // only the best-effort descriptor resync trails it. A commit that timed
         // out AFTER the new source became active has landed — the straggler is
         // fail-open and cannot undo it.
-        if (!isTimeoutError(error) || $connection.get()?.connectionId !== connectionId) {
+        if (!isTimeoutError(error) || !targetIsActive()) {
           throw error
         }
       }
@@ -306,7 +339,7 @@ export async function selectConnection(connectionId: string): Promise<void> {
         return
       }
 
-      if ($connection.get()?.connectionId !== connectionId) {
+      if (!targetIsActive()) {
         throw new Error(`Connection "${targetConnection.label}" did not become active.`)
       }
     } finally {

--- a/apps/desktop/src/store/gateway-connection-scope.test.ts
+++ b/apps/desktop/src/store/gateway-connection-scope.test.ts
@@ -105,6 +105,18 @@ describe('pruneSecondaryGateways with registry-scoped entries', () => {
     expect(gatewayMocks.closed).toEqual(['wss://homelab.invalid/api/ws?profile=default'])
   })
 
+  it('a switch-phase dial (activationLease) survives a live-work recompute until its activation lands', async () => {
+    // Phase one of the Sessions-switcher source switch: the target is opened
+    // but not yet active and has no live work of its own. Another source's
+    // streaming turn recomputes the keep-set mid-dial — that must not dispose
+    // the socket the switch is about to activate (#89622 via #93937).
+    await openGatewayForAgent('homelab', 'default', { activationLease: true })
+
+    pruneSecondaryGateways(new Set(['default']))
+
+    expect(gatewayMocks.closed).toEqual([])
+  })
+
   it('keeps a registry socket whose composite scope has live work', async () => {
     await openGatewayForAgent('homelab', 'default')
 

--- a/apps/desktop/src/store/gateway-profile-request.test.ts
+++ b/apps/desktop/src/store/gateway-profile-request.test.ts
@@ -370,6 +370,39 @@ describe('requestGatewayForAgent', () => {
     expect(onActiveConnectionChanged).not.toHaveBeenCalled()
     expect($gateway.get()).toBe(primary)
   })
+
+  it('does not activate or publish a source whose activation owner aborted while dialing', async () => {
+    const primary = makePrimary()
+    const onActiveConnectionChanged = vi.fn()
+    const controller = new AbortController()
+
+    setPrimaryGateway(primary as never, 'default')
+    configureGatewayRegistry({ onActiveConnectionChanged, onEvent: vi.fn() })
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+      getConnection: vi.fn(async profile => ({ port: 4242, profile })),
+      getConnectionFor: vi.fn(async ({ connectionId, profile }) => ({ connectionId, port: 5151, profile })),
+      getGatewayWsUrlFor: vi.fn(async ({ connectionId, profile }) => ({
+        ok: true as const,
+        wsUrl: `ws://${connectionId}/${profile}`
+      })),
+      touchBackend: vi.fn(async () => undefined)
+    }
+    await ensureGatewayForProfile('default')
+
+    let releaseConnect: () => void = () => undefined
+    connectGate = new Promise<void>(resolve => {
+      releaseConnect = resolve
+    })
+    const abandoned = ensureGatewayForAgent('source-b', 'default', { signal: controller.signal })
+    await vi.waitFor(() => expect(secondaryGateways[0]?.connect).toHaveBeenCalledOnce())
+
+    controller.abort()
+    releaseConnect()
+
+    expect(await abandoned).toBe(false)
+    expect(onActiveConnectionChanged).not.toHaveBeenCalled()
+    expect($gateway.get()).toBe(primary)
+  })
 })
 
 describe('retainGatewayForAgent (#93602)', () => {

--- a/apps/desktop/src/store/gateway-switch.test.ts
+++ b/apps/desktop/src/store/gateway-switch.test.ts
@@ -132,6 +132,22 @@ describe('beginGatewaySwitch / endGatewaySwitch — the shared switch commit poi
     off()
   })
 
+  it('the barrier belongs to the LATEST switch: an older switch ending mid-commit of a newer one is a no-op', () => {
+    const older = beginGatewaySwitch()
+    const newer = beginGatewaySwitch()
+
+    endGatewaySwitch(older)
+    expect($gatewaySwitching.get()).toBe(true)
+
+    endGatewaySwitch(newer)
+    expect($gatewaySwitching.get()).toBe(false)
+
+    // Host teardown forces it down regardless of ownership.
+    beginGatewaySwitch()
+    endGatewaySwitch()
+    expect($gatewaySwitching.get()).toBe(false)
+  })
+
   it('still severs the bindings when no lifecycle is registered (windows that never mount the boot hook)', () => {
     beginGatewaySwitch()
 

--- a/apps/desktop/src/store/gateway-switch.test.ts
+++ b/apps/desktop/src/store/gateway-switch.test.ts
@@ -148,6 +148,31 @@ describe('beginGatewaySwitch / endGatewaySwitch — the shared switch commit poi
     expect($gatewaySwitching.get()).toBe(false)
   })
 
+  it('repeated overlapping commits safely re-run the lifecycle and wipe without losing barrier ownership', () => {
+    const beforeConnectionSwitch = vi.fn()
+
+    const off = registerGatewaySwitchLifecycle({
+      beforeConnectionSwitch,
+      refreshSessions: async () => undefined
+    })
+
+    const older = beginGatewaySwitch()
+    // Simulate stale gateway-bound state racing back before the newer commit.
+    setSessions([{ id: 'late', title: 'late old-source row', profile: 'default' } as never])
+    setActiveSessionId('late-runtime')
+    const newer = beginGatewaySwitch()
+
+    expect(beforeConnectionSwitch).toHaveBeenCalledTimes(2)
+    expect($sessions.get()).toEqual([])
+    expect($activeSessionId.get()).toBeNull()
+
+    endGatewaySwitch(older)
+    expect($gatewaySwitching.get()).toBe(true)
+    endGatewaySwitch(newer)
+    expect($gatewaySwitching.get()).toBe(false)
+    off()
+  })
+
   it('still severs the bindings when no lifecycle is registered (windows that never mount the boot hook)', () => {
     beginGatewaySwitch()
 
@@ -217,7 +242,14 @@ describe('beginGatewaySwitch / endGatewaySwitch — the shared switch commit poi
     off()
 
     setSessionsLoading(true)
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => undefined)
+
     recoverActiveSourceAfterFailedGatewaySwitch()
     await vi.waitFor(() => expect($sessionsLoading.get()).toBe(false))
+
+    expect(debug).toHaveBeenCalledWith(
+      '[gateway-switch] cannot repaint the active source because no switch lifecycle is registered'
+    )
+    debug.mockRestore()
   })
 })

--- a/apps/desktop/src/store/gateway-switch.test.ts
+++ b/apps/desktop/src/store/gateway-switch.test.ts
@@ -156,9 +156,20 @@ describe('beginGatewaySwitch / endGatewaySwitch — the shared switch commit poi
     expect($gatewaySwitching.get()).toBe(false)
   })
 
-  it('recovers the active source and tears down its barrier when the wipe throws partway through', async () => {
+  it('does not disarm a newer switch while a partial-wipe recovery refresh is pending', async () => {
     const failure = new Error('profile fetch invalidation failed')
-    const refreshSessions = vi.fn(async () => undefined)
+    let finishRefresh: () => void = () => undefined
+    let refreshCompleted = false
+
+    const refreshPending = new Promise<void>(resolve => {
+      finishRefresh = resolve
+    })
+
+    const refreshSessions = vi.fn(async () => {
+      await refreshPending
+      refreshCompleted = true
+    })
+
     const off = registerGatewaySwitchLifecycle({ beforeConnectionSwitch: () => undefined, refreshSessions })
 
     vi.mocked(invalidateProfileListFetches).mockImplementationOnce(() => {
@@ -168,13 +179,46 @@ describe('beginGatewaySwitch / endGatewaySwitch — the shared switch commit poi
     expect(() => beginGatewaySwitch()).toThrow(failure)
     expect($gatewaySwitching.get()).toBe(false)
     await vi.waitFor(() => expect(refreshSessions).toHaveBeenCalledTimes(1))
-    expect($sessionsLoading.get()).toBe(false)
 
-    // The failed token cannot strand or lower ownership acquired afterwards.
+    // A newer switch takes ownership while the old source repaint is still in
+    // flight. Completing the old repaint must not lower the newer skeleton.
     const next = beginGatewaySwitch()
     expect($gatewaySwitching.get()).toBe(true)
+    expect($sessionsLoading.get()).toBe(true)
+
+    finishRefresh()
+    await vi.waitFor(() => expect(refreshCompleted).toBe(true))
+    await Promise.resolve()
+
+    expect($sessionsLoading.get()).toBe(true)
+    expect($gatewaySwitching.get()).toBe(true)
+
     endGatewaySwitch(next)
     expect($gatewaySwitching.get()).toBe(false)
+    off()
+  })
+
+  it('does not refresh through a newer route when recovery is superseded before it starts', async () => {
+    const failure = new Error('profile fetch invalidation failed')
+    const refreshSessions = vi.fn(async () => undefined)
+    const off = registerGatewaySwitchLifecycle({ beforeConnectionSwitch: () => undefined, refreshSessions })
+
+    vi.mocked(invalidateProfileListFetches).mockImplementationOnce(() => {
+      throw failure
+    })
+
+    expect(() => beginGatewaySwitch()).toThrow(failure)
+
+    // Recovery is queued on a microtask. A newer switch that starts first owns
+    // the active route, so the stale recovery must not issue a request through it.
+    const next = beginGatewaySwitch()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(refreshSessions).not.toHaveBeenCalled()
+    expect($sessionsLoading.get()).toBe(true)
+
+    endGatewaySwitch(next)
     off()
   })
 
@@ -263,11 +307,11 @@ describe('beginGatewaySwitch / endGatewaySwitch — the shared switch commit poi
     const refreshSessions = vi.fn(async () => undefined)
     const off = registerGatewaySwitchLifecycle({ beforeConnectionSwitch: () => undefined, refreshSessions })
 
-    beginGatewaySwitch()
+    const token = beginGatewaySwitch()
     expect($sessionsLoading.get()).toBe(true)
 
-    recoverActiveSourceAfterFailedGatewaySwitch()
-    endGatewaySwitch()
+    recoverActiveSourceAfterFailedGatewaySwitch(token)
+    endGatewaySwitch(token)
     await vi.waitFor(() => expect($sessionsLoading.get()).toBe(false))
 
     expect(refreshSessions).toHaveBeenCalledTimes(1)
@@ -283,14 +327,18 @@ describe('beginGatewaySwitch / endGatewaySwitch — the shared switch commit poi
     })
 
     setSessionsLoading(true)
-    recoverActiveSourceAfterFailedGatewaySwitch()
+    const failingToken = beginGatewaySwitch()
+    recoverActiveSourceAfterFailedGatewaySwitch(failingToken)
+    endGatewaySwitch(failingToken)
     await vi.waitFor(() => expect($sessionsLoading.get()).toBe(false))
     off()
 
     setSessionsLoading(true)
     const debug = vi.spyOn(console, 'debug').mockImplementation(() => undefined)
+    const missingLifecycleToken = beginGatewaySwitch()
 
-    recoverActiveSourceAfterFailedGatewaySwitch()
+    recoverActiveSourceAfterFailedGatewaySwitch(missingLifecycleToken)
+    endGatewaySwitch(missingLifecycleToken)
     await vi.waitFor(() => expect($sessionsLoading.get()).toBe(false))
 
     expect(debug).toHaveBeenCalledWith(

--- a/apps/desktop/src/store/gateway-switch.test.ts
+++ b/apps/desktop/src/store/gateway-switch.test.ts
@@ -132,6 +132,52 @@ describe('beginGatewaySwitch / endGatewaySwitch — the shared switch commit poi
     off()
   })
 
+  it('tears down its barrier when the registered lifecycle throws before the wipe', () => {
+    const failure = new Error('machine-context reset failed')
+
+    const off = registerGatewaySwitchLifecycle({
+      beforeConnectionSwitch: () => {
+        throw failure
+      },
+      refreshSessions: vi.fn(async () => undefined)
+    })
+
+    expect(() => beginGatewaySwitch()).toThrow(failure)
+    expect($gatewaySwitching.get()).toBe(false)
+    // No wipe started, so the still-active source remains intact and needs no
+    // repaint. A later switch can acquire and release barrier ownership.
+    expect($activeSessionId.get()).toBe('a93bb39d')
+    expect($sessions.get()).toHaveLength(1)
+
+    off()
+    const next = beginGatewaySwitch()
+    expect($gatewaySwitching.get()).toBe(true)
+    endGatewaySwitch(next)
+    expect($gatewaySwitching.get()).toBe(false)
+  })
+
+  it('recovers the active source and tears down its barrier when the wipe throws partway through', async () => {
+    const failure = new Error('profile fetch invalidation failed')
+    const refreshSessions = vi.fn(async () => undefined)
+    const off = registerGatewaySwitchLifecycle({ beforeConnectionSwitch: () => undefined, refreshSessions })
+
+    vi.mocked(invalidateProfileListFetches).mockImplementationOnce(() => {
+      throw failure
+    })
+
+    expect(() => beginGatewaySwitch()).toThrow(failure)
+    expect($gatewaySwitching.get()).toBe(false)
+    await vi.waitFor(() => expect(refreshSessions).toHaveBeenCalledTimes(1))
+    expect($sessionsLoading.get()).toBe(false)
+
+    // The failed token cannot strand or lower ownership acquired afterwards.
+    const next = beginGatewaySwitch()
+    expect($gatewaySwitching.get()).toBe(true)
+    endGatewaySwitch(next)
+    expect($gatewaySwitching.get()).toBe(false)
+    off()
+  })
+
   it('the barrier belongs to the LATEST switch: an older switch ending mid-commit of a newer one is a no-op', () => {
     const older = beginGatewaySwitch()
     const newer = beginGatewaySwitch()

--- a/apps/desktop/src/store/gateway-switch.test.ts
+++ b/apps/desktop/src/store/gateway-switch.test.ts
@@ -2,12 +2,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $sessionsLimit, resetSessionsLimit, SIDEBAR_SESSIONS_PAGE_SIZE } from '@/store/layout'
 import {
+  $activeSessionId,
   $cronSessions,
   $freshDraftReady,
   $messagingSessions,
   $sessionProfilesTruncated,
   $sessions,
   $sessionsLoading,
+  setActiveSessionId,
   setCronSessions,
   setFreshDraftReady,
   setMessagingSessions,
@@ -17,7 +19,14 @@ import {
 } from '@/store/session'
 import { $stalledSessionIds } from '@/store/session-states'
 
-import { $gatewaySwitching, wipeSessionListsForGatewaySwitch } from './gateway-switch'
+import {
+  $gatewaySwitching,
+  beginGatewaySwitch,
+  endGatewaySwitch,
+  recoverActiveSourceAfterFailedGatewaySwitch,
+  registerGatewaySwitchLifecycle,
+  wipeSessionListsForGatewaySwitch
+} from './gateway-switch'
 
 vi.mock('@/lib/query-client', () => ({
   invalidateProfileScopedQueries: vi.fn()
@@ -77,5 +86,122 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     wipeSessionListsForGatewaySwitch()
 
     expect(invalidateProfileListFetches).toHaveBeenCalled()
+  })
+})
+
+describe('beginGatewaySwitch / endGatewaySwitch — the shared switch commit point (#93937)', () => {
+  beforeEach(() => {
+    $gatewaySwitching.set(false)
+    setSessions([{ id: 's1', title: 'old', profile: 'default' } as never])
+    setActiveSessionId('a93bb39d')
+    setSessionsLoading(false)
+  })
+
+  afterEach(() => {
+    setSessions([])
+    setActiveSessionId(null)
+    setSessionsLoading(true)
+    $gatewaySwitching.set(false)
+  })
+
+  it('raises the barrier, runs the registered machine-context reset, then wipes — synchronously, in that order', () => {
+    const seen: string[] = []
+
+    const off = registerGatewaySwitchLifecycle({
+      beforeConnectionSwitch: () => {
+        // The reset runs behind the barrier and BEFORE the wipe: it may still
+        // read the outgoing session (to fresh-draft it), never a half-wiped one.
+        seen.push(
+          `switching=${$gatewaySwitching.get()} active=${$activeSessionId.get()} rows=${$sessions.get().length}`
+        )
+      },
+      refreshSessions: async () => undefined
+    })
+
+    beginGatewaySwitch()
+
+    expect(seen).toEqual(['switching=true active=a93bb39d rows=1'])
+    expect($gatewaySwitching.get()).toBe(true)
+    // The previous backend's runtime binding is gone before anything can dial.
+    expect($activeSessionId.get()).toBeNull()
+    expect($sessions.get()).toEqual([])
+    expect($sessionsLoading.get()).toBe(true)
+
+    endGatewaySwitch()
+    expect($gatewaySwitching.get()).toBe(false)
+    off()
+  })
+
+  it('still severs the bindings when no lifecycle is registered (windows that never mount the boot hook)', () => {
+    beginGatewaySwitch()
+
+    expect($gatewaySwitching.get()).toBe(true)
+    expect($activeSessionId.get()).toBeNull()
+    expect($sessions.get()).toEqual([])
+
+    endGatewaySwitch()
+    expect($gatewaySwitching.get()).toBe(false)
+  })
+
+  it('an unregistered lifecycle no longer runs, and a stale unregister cannot evict a newer one', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+
+    const offFirst = registerGatewaySwitchLifecycle({
+      beforeConnectionSwitch: first,
+      refreshSessions: async () => undefined
+    })
+
+    const offSecond = registerGatewaySwitchLifecycle({
+      beforeConnectionSwitch: second,
+      refreshSessions: async () => undefined
+    })
+
+    // Stale unregister from the older host: the newer registration stays.
+    offFirst()
+    beginGatewaySwitch()
+    endGatewaySwitch()
+
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledTimes(1)
+
+    offSecond()
+    beginGatewaySwitch()
+    endGatewaySwitch()
+
+    expect(second).toHaveBeenCalledTimes(1)
+  })
+
+  it('recoverActiveSourceAfterFailedGatewaySwitch re-pulls the still-active source and disarms the skeleton', async () => {
+    const refreshSessions = vi.fn(async () => undefined)
+    const off = registerGatewaySwitchLifecycle({ beforeConnectionSwitch: () => undefined, refreshSessions })
+
+    beginGatewaySwitch()
+    expect($sessionsLoading.get()).toBe(true)
+
+    recoverActiveSourceAfterFailedGatewaySwitch()
+    endGatewaySwitch()
+    await vi.waitFor(() => expect($sessionsLoading.get()).toBe(false))
+
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+    off()
+  })
+
+  it('a failing repaint (or none registered) still disarms the skeleton', async () => {
+    const off = registerGatewaySwitchLifecycle({
+      beforeConnectionSwitch: () => undefined,
+      refreshSessions: async () => {
+        throw new Error('backend busy')
+      }
+    })
+
+    setSessionsLoading(true)
+    recoverActiveSourceAfterFailedGatewaySwitch()
+    await vi.waitFor(() => expect($sessionsLoading.get()).toBe(false))
+    off()
+
+    setSessionsLoading(true)
+    recoverActiveSourceAfterFailedGatewaySwitch()
+    await vi.waitFor(() => expect($sessionsLoading.get()).toBe(false))
   })
 })

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -101,7 +101,7 @@ export function beginGatewaySwitch(): GatewaySwitchToken {
     // If a nested switch superseded this one, its owner is responsible instead.
     if (wipeStarted && stillOwnsSwitch) {
       try {
-        recoverActiveSourceAfterFailedGatewaySwitch()
+        recoverActiveSourceAfterFailedGatewaySwitch(token)
       } catch {
         // Recovery must never replace the original commit failure.
       }
@@ -129,23 +129,31 @@ export function endGatewaySwitch(token?: GatewaySwitchToken): void {
  * A commit that fails AFTER beginGatewaySwitch leaves the still-active source
  * with its lists wiped and the sidebar skeleton armed, and nothing reactive
  * re-pulls them (no source/profile scope moved). Repaint it explicitly so the
- * sidebar doesn't sit on the skeleton; the fetch is best-effort, the skeleton
- * always disarms.
+ * sidebar doesn't sit on the skeleton; the fetch is best-effort. Recovery
+ * retains the failed switch's token across the async refresh so it cannot
+ * request through, or disarm loading for, a newer route.
  */
-export function recoverActiveSourceAfterFailedGatewaySwitch(): void {
+export function recoverActiveSourceAfterFailedGatewaySwitch(token: GatewaySwitchToken): void {
   const lifecycle = switchLifecycle
 
   if (!lifecycle) {
     console.debug('[gateway-switch] cannot repaint the active source because no switch lifecycle is registered')
-    setSessionsLoading(false)
+
+    if (token === latestSwitchToken) {
+      setSessionsLoading(false)
+    }
 
     return
   }
 
   void Promise.resolve()
-    .then(() => lifecycle.refreshSessions())
+    .then(() => (token === latestSwitchToken ? lifecycle.refreshSessions() : undefined))
     .catch(() => undefined)
-    .finally(() => setSessionsLoading(false))
+    .finally(() => {
+      if (token === latestSwitchToken) {
+        setSessionsLoading(false)
+      }
+    })
 }
 
 /**

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -51,6 +51,11 @@ export interface GatewaySwitchLifecycle {
 
 let switchLifecycle: GatewaySwitchLifecycle | null = null
 
+/** Ownership handle returned by beginGatewaySwitch; see endGatewaySwitch. */
+export type GatewaySwitchToken = number
+
+let latestSwitchToken = 0
+
 export function registerGatewaySwitchLifecycle(lifecycle: GatewaySwitchLifecycle): () => void {
   switchLifecycle = lifecycle
 
@@ -71,14 +76,26 @@ export function registerGatewaySwitchLifecycle(lifecycle: GatewaySwitchLifecycle
  * $activeSessionId still named the previous backend's runtime and sent that id
  * to a backend that had never minted it — "session not found" (#93937).
  */
-export function beginGatewaySwitch(): void {
+export function beginGatewaySwitch(): GatewaySwitchToken {
+  const token = ++latestSwitchToken
   $gatewaySwitching.set(true)
   switchLifecycle?.beforeConnectionSwitch()
   wipeSessionListsForGatewaySwitch()
+
+  return token
 }
 
-/** Lower the barrier once the switch has committed (or failed). */
-export function endGatewaySwitch(): void {
+/**
+ * Lower the barrier once the switch that owns it has committed (or failed).
+ * Switches overlap — a click can supersede one that is mid-commit — and the
+ * barrier belongs to the LATEST one: an older switch ending is a no-op while a
+ * newer one is still in flight. No token = force down (host teardown).
+ */
+export function endGatewaySwitch(token?: GatewaySwitchToken): void {
+  if (token !== undefined && token !== latestSwitchToken) {
+    return
+  }
+
   $gatewaySwitching.set(false)
 }
 

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -78,11 +78,37 @@ export function registerGatewaySwitchLifecycle(lifecycle: GatewaySwitchLifecycle
  */
 export function beginGatewaySwitch(): GatewaySwitchToken {
   const token = ++latestSwitchToken
-  $gatewaySwitching.set(true)
-  switchLifecycle?.beforeConnectionSwitch()
-  wipeSessionListsForGatewaySwitch()
+  let wipeStarted = false
 
-  return token
+  $gatewaySwitching.set(true)
+
+  try {
+    switchLifecycle?.beforeConnectionSwitch()
+    wipeStarted = true
+    wipeSessionListsForGatewaySwitch()
+
+    return token
+  } catch (error) {
+    // No caller received this token, so begin owns cleanup. Token-aware teardown
+    // preserves a newer recursively-started switch, if lifecycle code began one.
+    const stillOwnsSwitch = token === latestSwitchToken
+
+    endGatewaySwitch(token)
+
+    // A synchronous wipe has no rollback: once it starts, some outgoing-source
+    // stores may already be empty. Repaint the still-active source best-effort.
+    // A lifecycle failure happens before the wipe and leaves lists untouched.
+    // If a nested switch superseded this one, its owner is responsible instead.
+    if (wipeStarted && stillOwnsSwitch) {
+      try {
+        recoverActiveSourceAfterFailedGatewaySwitch()
+      } catch {
+        // Recovery must never replace the original commit failure.
+      }
+    }
+
+    throw error
+  }
 }
 
 /**

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -27,10 +27,74 @@ import { resetSessionPinMirror } from '@/store/session-pin-sync'
 import { clearAllSessionStates } from '@/store/session-states'
 import { clearTranscriptTails } from '@/store/transcript-tail-cache'
 
-// True while a soft gateway-mode apply is mid-flight (wipe → re-dial). Lets the
-// boot hook suppress the backend-exit toast and keeps the cold-boot CONNECTING
-// overlay from resurrecting when startHermes re-emits boot progress.
+// True while a connection switch is mid-flight — a Settings → Gateway apply
+// (wipe → re-dial, use-gateway-boot softSwitch) or a Sessions-switcher source
+// change (store/connections selectConnection). Lets the boot hook suppress the
+// backend-exit toast, keeps the cold-boot CONNECTING overlay from resurrecting
+// when startHermes re-emits boot progress, and tells the resume path that a
+// "session not found" mid-switch means "retry once things settle", not "gone".
 export const $gatewaySwitching = atom(false)
+
+/**
+ * Renderer-side cleanup a connection switch must run before the next gateway
+ * is activated or published: fresh-draft the open transcript, drop the overlay
+ * return route, reset the project tree, close terminals — everything bound to
+ * the OUTGOING backend that lives outside the session store. Registered by
+ * useGatewayBoot (whose host owns those React callbacks) so store-driven
+ * switches run the exact same reset as a Settings → Gateway apply.
+ */
+export interface GatewaySwitchLifecycle {
+  beforeConnectionSwitch: () => void
+  /** Re-pull the session lists from whichever backend is active NOW. */
+  refreshSessions: () => Promise<void>
+}
+
+let switchLifecycle: GatewaySwitchLifecycle | null = null
+
+export function registerGatewaySwitchLifecycle(lifecycle: GatewaySwitchLifecycle): () => void {
+  switchLifecycle = lifecycle
+
+  return () => {
+    if (switchLifecycle === lifecycle) {
+      switchLifecycle = null
+    }
+  }
+}
+
+/**
+ * Commit point of every connection switch: raise the barrier and sever every
+ * binding to the outgoing backend in ONE synchronous step. Both switch doors —
+ * Settings apply (softSwitch) and the Sessions switcher (selectConnection) —
+ * must call this BEFORE the next gateway is activated or its descriptor
+ * published. The sidebar door used to activate first and wipe afterwards
+ * (across an IPC round-trip), so route/session effects saw the new source while
+ * $activeSessionId still named the previous backend's runtime and sent that id
+ * to a backend that had never minted it — "session not found" (#93937).
+ */
+export function beginGatewaySwitch(): void {
+  $gatewaySwitching.set(true)
+  switchLifecycle?.beforeConnectionSwitch()
+  wipeSessionListsForGatewaySwitch()
+}
+
+/** Lower the barrier once the switch has committed (or failed). */
+export function endGatewaySwitch(): void {
+  $gatewaySwitching.set(false)
+}
+
+/**
+ * A commit that fails AFTER beginGatewaySwitch leaves the still-active source
+ * with its lists wiped and the sidebar skeleton armed, and nothing reactive
+ * re-pulls them (no source/profile scope moved). Repaint it explicitly so the
+ * sidebar doesn't sit on the skeleton; the fetch is best-effort, the skeleton
+ * always disarms.
+ */
+export function recoverActiveSourceAfterFailedGatewaySwitch(): void {
+  void Promise.resolve()
+    .then(() => switchLifecycle?.refreshSessions())
+    .catch(() => undefined)
+    .finally(() => setSessionsLoading(false))
+}
 
 /**
  * Clear gateway-bound session UI so sidebar skeletons retrigger.

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -46,7 +46,7 @@ export const $gatewaySwitching = atom(false)
 export interface GatewaySwitchLifecycle {
   beforeConnectionSwitch: () => void
   /** Re-pull the session lists from whichever backend is active NOW. */
-  refreshSessions: () => Promise<void>
+  refreshSessions: (shouldPublish?: () => boolean) => Promise<void>
 }
 
 let switchLifecycle: GatewaySwitchLifecycle | null = null
@@ -152,7 +152,9 @@ export function recoverActiveSourceAfterFailedGatewaySwitch(token: GatewaySwitch
   }
 
   void Promise.resolve()
-    .then(() => (isCurrentGatewaySwitch(token) ? lifecycle.refreshSessions() : undefined))
+    .then(() =>
+      isCurrentGatewaySwitch(token) ? lifecycle.refreshSessions(() => isCurrentGatewaySwitch(token)) : undefined
+    )
     .catch(() => undefined)
     .finally(() => {
       if (isCurrentGatewaySwitch(token)) {

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -56,6 +56,11 @@ export type GatewaySwitchToken = number
 
 let latestSwitchToken = 0
 
+/** True only while token owns the latest connection-switch lifecycle. */
+export function isCurrentGatewaySwitch(token: GatewaySwitchToken): boolean {
+  return token === latestSwitchToken
+}
+
 export function registerGatewaySwitchLifecycle(lifecycle: GatewaySwitchLifecycle): () => void {
   switchLifecycle = lifecycle
 
@@ -91,7 +96,7 @@ export function beginGatewaySwitch(): GatewaySwitchToken {
   } catch (error) {
     // No caller received this token, so begin owns cleanup. Token-aware teardown
     // preserves a newer recursively-started switch, if lifecycle code began one.
-    const stillOwnsSwitch = token === latestSwitchToken
+    const stillOwnsSwitch = isCurrentGatewaySwitch(token)
 
     endGatewaySwitch(token)
 
@@ -118,7 +123,7 @@ export function beginGatewaySwitch(): GatewaySwitchToken {
  * newer one is still in flight. No token = force down (host teardown).
  */
 export function endGatewaySwitch(token?: GatewaySwitchToken): void {
-  if (token !== undefined && token !== latestSwitchToken) {
+  if (token !== undefined && !isCurrentGatewaySwitch(token)) {
     return
   }
 
@@ -139,7 +144,7 @@ export function recoverActiveSourceAfterFailedGatewaySwitch(token: GatewaySwitch
   if (!lifecycle) {
     console.debug('[gateway-switch] cannot repaint the active source because no switch lifecycle is registered')
 
-    if (token === latestSwitchToken) {
+    if (isCurrentGatewaySwitch(token)) {
       setSessionsLoading(false)
     }
 
@@ -147,10 +152,10 @@ export function recoverActiveSourceAfterFailedGatewaySwitch(token: GatewaySwitch
   }
 
   void Promise.resolve()
-    .then(() => (token === latestSwitchToken ? lifecycle.refreshSessions() : undefined))
+    .then(() => (isCurrentGatewaySwitch(token) ? lifecycle.refreshSessions() : undefined))
     .catch(() => undefined)
     .finally(() => {
-      if (token === latestSwitchToken) {
+      if (isCurrentGatewaySwitch(token)) {
         setSessionsLoading(false)
       }
     })

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -107,8 +107,17 @@ export function endGatewaySwitch(token?: GatewaySwitchToken): void {
  * always disarms.
  */
 export function recoverActiveSourceAfterFailedGatewaySwitch(): void {
+  const lifecycle = switchLifecycle
+
+  if (!lifecycle) {
+    console.debug('[gateway-switch] cannot repaint the active source because no switch lifecycle is registered')
+    setSessionsLoading(false)
+
+    return
+  }
+
   void Promise.resolve()
-    .then(() => switchLifecycle?.refreshSessions())
+    .then(() => lifecycle.refreshSessions())
     .catch(() => undefined)
     .finally(() => setSessionsLoading(false))
 }

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -865,7 +865,18 @@ export async function openGatewayForProfile(profile: string): Promise<void> {
 // routing. Feature-detected: without the Electron getConnectionFor door these
 // throw, and roster surfaces disable non-local rows instead.
 
-export async function openGatewayForAgent(connectionId: null | string, profile: string): Promise<void> {
+// `activationLease`: hold the same prune lease ensureGatewayForAgent holds for
+// the whole dial. Phase one of the two-phase source switch (store/connections
+// selectConnection) opens the target here and activates it right after; without
+// the lease a live-work recompute during the cold spawn would dispose the entry
+// mid-dial and the click would die (#89622). Plain pre-warms stay prunable —
+// a hovered-but-never-activated socket must not be pinned off another source's
+// live work.
+export async function openGatewayForAgent(
+  connectionId: null | string,
+  profile: string,
+  { activationLease = false }: { activationLease?: boolean } = {}
+): Promise<void> {
   const scope = registryBackendScopeKey(connectionId, profile)
 
   if (scope === normKey(profile)) {
@@ -880,8 +891,24 @@ export async function openGatewayForAgent(connectionId: null | string, profile: 
   entry.retained = true
   entry.wantOpen = true
 
-  if (!isOpen(entry.gateway)) {
+  if (activationLease) {
+    // Stays held after a successful open: the activation that follows releases
+    // it (applyActive path), and one that never comes lets it expire.
+    entry.activationLeaseUntil = Date.now() + ACTIVATION_LEASE_MS
+  }
+
+  if (isOpen(entry.gateway)) {
+    return
+  }
+
+  try {
     await openSecondary(entry)
+  } catch (error) {
+    if (activationLease) {
+      entry.activationLeaseUntil = 0
+    }
+
+    throw error
   }
 }
 

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -912,13 +912,21 @@ export async function openGatewayForAgent(
   }
 }
 
-export async function ensureGatewayForAgent(connectionId: null | string, profile: string): Promise<boolean> {
+export async function ensureGatewayForAgent(
+  connectionId: null | string,
+  profile: string,
+  { signal }: { signal?: AbortSignal } = {}
+): Promise<boolean> {
   const scope = registryBackendScopeKey(connectionId, profile)
 
   if (scope === normKey(profile)) {
+    if (signal?.aborted) {
+      return false
+    }
+
     await ensureGatewayForProfile(profile)
 
-    return true
+    return !signal?.aborted
   }
 
   if (!window.hermesDesktop?.getConnectionFor) {
@@ -954,6 +962,12 @@ export async function ensureGatewayForAgent(connectionId: null | string, profile
 
   // The activation is settling either way — release the prune lease.
   entry.activationLeaseUntil = 0
+
+  // A timed-out owner may leave the dial running, but it no longer has the
+  // right to move the foreground route when that work eventually settles.
+  if (signal?.aborted) {
+    return false
+  }
 
   // A source edit/remove may dispose this entry while its dial is still in
   // flight. Only the still-registered, still-owned activation may publish.

--- a/apps/desktop/src/store/profile-agent-activation.test.ts
+++ b/apps/desktop/src/store/profile-agent-activation.test.ts
@@ -274,4 +274,38 @@ describe('ensureGatewayAgent commit hook (beforeActivate) — the Sessions switc
       vi.useRealTimers()
     }
   })
+
+  it('an aborted activation releases the mutex and cannot publish when its work settles later', async () => {
+    const activationGate = deferred()
+    const controller = new AbortController()
+
+    ensureGatewayForAgent.mockImplementationOnce(async () => {
+      await activationGate.promise
+
+      return true
+    })
+    getConnectionFor.mockImplementation(async ({ profile }) => agentConn({ profile: profile ?? 'default' }))
+
+    const abandoned = ensureGatewayAgent('homelab', 'research', { signal: controller.signal })
+    await vi.waitFor(() => expect(ensureGatewayForAgent).toHaveBeenCalledTimes(1))
+
+    controller.abort()
+
+    try {
+      const winner = ensureGatewayAgent('homelab', 'writer')
+      await vi.waitFor(() => expect(ensureGatewayForAgent).toHaveBeenCalledTimes(2))
+      await winner
+
+      expect($activeGatewayProfile.get()).toBe('writer')
+      expect($connection.get()?.profile).toBe('writer')
+    } finally {
+      activationGate.resolve()
+      await abandoned
+    }
+
+    // The detached activation completed after cancellation but did not regain
+    // ownership and overwrite the newer source/profile publication.
+    expect($activeGatewayProfile.get()).toBe('writer')
+    expect($connection.get()?.profile).toBe('writer')
+  })
 })

--- a/apps/desktop/src/store/profile-agent-activation.test.ts
+++ b/apps/desktop/src/store/profile-agent-activation.test.ts
@@ -193,3 +193,85 @@ describe('ensureGatewayAgent shares the gatewaySwitch mutex with profile switche
     expect($activeGatewayProfile.get()).toBe('worker')
   })
 })
+
+describe('ensureGatewayAgent commit hook (beforeActivate) — the Sessions switcher door (#93937)', () => {
+  it('runs the hook inside the serialized section, right before the activation; a declined hook activates nothing', async () => {
+    const profileGate = deferred()
+    const order: string[] = []
+
+    ensureGatewayForProfile.mockImplementation(async (profile: string) => {
+      order.push(`profile:${profile}`)
+      await profileGate.promise
+    })
+    ensureGatewayForAgent.mockImplementation(async (_connectionId, profile) => {
+      order.push(`agent:${profile}`)
+
+      return true
+    })
+    getConnection.mockResolvedValue(localConn({ profile: 'worker' }))
+    getConnectionFor.mockResolvedValue(agentConn())
+
+    const profileSwitch = ensureGatewayProfile('worker')
+    await Promise.resolve()
+
+    const declined = ensureGatewayAgent('homelab', 'research', {
+      beforeActivate: () => {
+        order.push('hook:declined')
+
+        return false
+      }
+    })
+
+    await Promise.resolve()
+    // The hook waits for its turn — it must see the world AFTER the earlier
+    // switch published, never before.
+    expect(order).toEqual(['profile:worker'])
+
+    profileGate.resolve()
+    await profileSwitch
+    await declined
+
+    expect(order).toEqual(['profile:worker', 'hook:declined'])
+    expect(ensureGatewayForAgent).not.toHaveBeenCalled()
+    expect(getConnectionFor).not.toHaveBeenCalled()
+    expect($activeGatewayProfile.get()).toBe('worker')
+
+    // An accepted hook runs synchronously before the activation starts.
+    await ensureGatewayAgent('homelab', 'research', {
+      beforeActivate: () => {
+        order.push('hook:accepted')
+
+        return true
+      }
+    })
+
+    expect(order).toEqual(['profile:worker', 'hook:declined', 'hook:accepted', 'agent:research'])
+    expect($activeGatewayProfile.get()).toBe('research')
+    expect($connection.get()?.profile).toBe('research')
+  })
+
+  it('a descriptor lookup that never answers is bounded, fails open, and releases the mutex', async () => {
+    vi.useFakeTimers()
+
+    try {
+      getConnectionFor.mockImplementationOnce(() => new Promise<HermesConnection>(() => undefined))
+
+      const activation = ensureGatewayAgent('homelab', 'research')
+      await vi.advanceTimersByTimeAsync(20_000)
+      await activation
+
+      // Activated; the previous descriptor is kept (fail open), not nulled.
+      expect($activeGatewayProfile.get()).toBe('research')
+      expect($connection.get()?.mode).toBe('local')
+
+      // The next switch is not stuck behind the stalled lookup.
+      getConnectionFor.mockResolvedValue(agentConn({ profile: 'writer' }))
+      await ensureGatewayAgent('homelab', 'writer')
+
+      expect($activeGatewayProfile.get()).toBe('writer')
+      expect($connection.get()?.profile).toBe('writer')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -12,6 +12,7 @@ import {
   storedStringArray,
   storedStringRecord
 } from '@/lib/storage'
+import { withTimeout } from '@/lib/with-timeout'
 import { invalidateCronModelImpactScopeState } from '@/store/cron-model-impact-scope'
 import {
   $gateway,
@@ -288,6 +289,13 @@ export function prewarmProfileBackend(name: string): void {
 
 let gatewaySwitch: Promise<void> | null = null
 
+// Descriptor lookups are IPC round-trips into Electron main. A wedged main
+// (the #93454 class: a ticket mint that never answers) must not latch the
+// gatewaySwitch mutex — and, through it, every later profile/source switch
+// and the switch barrier — so they are bounded and fail open like any other
+// lookup failure.
+const DESCRIPTOR_LOOKUP_TIMEOUT_MS = 20_000
+
 // The target profile's connection descriptor (mode / baseUrl / …), resolved
 // CONCURRENTLY with the socket work so the switch can publish the profile
 // pointer and $connection in one frame. Without this, $connection seeds from
@@ -311,7 +319,11 @@ async function resolveConnectionForProfile(profile: string): Promise<HermesConne
   }
 
   try {
-    return await getConnection(profile)
+    return await withTimeout(
+      getConnection(profile),
+      DESCRIPTOR_LOOKUP_TIMEOUT_MS,
+      `Timed out resolving the connection descriptor for profile "${profile}"`
+    )
   } catch (err) {
     console.warn(`[profile] descriptor lookup for "${profile}" failed; keeping the previous connection`, err)
 
@@ -398,7 +410,11 @@ async function resolveConnectionForAgent(connectionId: string, profile: string):
   }
 
   try {
-    return await getConnectionFor({ connectionId, profile })
+    return await withTimeout(
+      getConnectionFor({ connectionId, profile }),
+      DESCRIPTOR_LOOKUP_TIMEOUT_MS,
+      `Timed out resolving the connection descriptor for agent "${connectionId}:${profile}"`
+    )
   } catch (err) {
     console.warn(
       `[profile] descriptor lookup for agent "${connectionId}:${profile}" failed; keeping the previous connection`,
@@ -442,7 +458,25 @@ export async function openGatewayAgent(connectionId: string, profile: string): P
 //    order and leave the EARLIER setActive() as the last write.
 // Only a null connectionId falls through to the legacy profile path. Explicit
 // `local` is a registry identity and must use the genuinely-local route.
-export async function ensureGatewayAgent(connectionId: null | string, profile: string): Promise<void> {
+//
+// `beforeActivate` is the commit hook of the two-phase source switch
+// (store/connections selectConnection). It runs INSIDE the serialized
+// section, synchronously right before the socket is activated — i.e. after
+// every earlier switch has published and before this one does — so the caller
+// can sever the previous backend's session bindings at exactly that point
+// (#93937). Returning false declines: nothing is activated or published, the
+// mutex is released. That is how a switch superseded while queued behind
+// another one steps aside without a destructive wipe. Not consulted on the
+// null-connectionId profile fallthrough.
+export interface EnsureGatewayAgentOptions {
+  beforeActivate?: () => boolean
+}
+
+export async function ensureGatewayAgent(
+  connectionId: null | string,
+  profile: string,
+  { beforeActivate }: EnsureGatewayAgentOptions = {}
+): Promise<void> {
   const target = normalizeProfileKey(profile)
   const connection = (connectionId ?? '').trim() || null
 
@@ -450,13 +484,20 @@ export async function ensureGatewayAgent(connectionId: null | string, profile: s
     return ensureGatewayProfile(target)
   }
 
-  // Serialize against any in-flight profile/agent switch (shared mutex).
-  if (gatewaySwitch) {
+  // Serialize against any in-flight profile/agent switch (shared mutex). A
+  // loop, not a single await: several waiters wake from the same settled
+  // switch, and the first to re-acquire starts a new one the rest must also
+  // wait out — otherwise two overlapping activations run interleaved.
+  while (gatewaySwitch) {
     await gatewaySwitch.catch(() => undefined)
   }
 
   $gatewaySwapTarget.set(target)
   gatewaySwitch = (async () => {
+    if (beforeActivate && !beforeActivate()) {
+      return
+    }
+
     // Descriptor resolves concurrently with the dial, same as the profile
     // path, so no await sits between the activation and the publication.
     const [descriptor, activated] = await Promise.all([

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -470,12 +470,42 @@ export async function openGatewayAgent(connectionId: string, profile: string): P
 // null-connectionId profile fallthrough.
 export interface EnsureGatewayAgentOptions {
   beforeActivate?: () => boolean
+  /** Revokes this caller's right to activate or publish after async work. */
+  signal?: AbortSignal
+}
+
+function releaseWhenAborted(promise: Promise<void>, signal?: AbortSignal): Promise<void> {
+  if (!signal) {
+    return promise
+  }
+
+  if (signal.aborted) {
+    return Promise.resolve()
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener('abort', onAbort)
+      resolve()
+    }
+
+    const settle = (callback: () => void) => {
+      signal.removeEventListener('abort', onAbort)
+      callback()
+    }
+
+    signal.addEventListener('abort', onAbort, { once: true })
+    promise.then(
+      () => settle(resolve),
+      error => settle(() => reject(error))
+    )
+  })
 }
 
 export async function ensureGatewayAgent(
   connectionId: null | string,
   profile: string,
-  { beforeActivate }: EnsureGatewayAgentOptions = {}
+  { beforeActivate, signal }: EnsureGatewayAgentOptions = {}
 ): Promise<void> {
   const target = normalizeProfileKey(profile)
   const connection = (connectionId ?? '').trim() || null
@@ -492,18 +522,32 @@ export async function ensureGatewayAgent(
     await gatewaySwitch.catch(() => undefined)
   }
 
+  if (signal?.aborted) {
+    return
+  }
+
   $gatewaySwapTarget.set(target)
-  gatewaySwitch = (async () => {
+
+  const activationWork = (async () => {
+    if (signal?.aborted) {
+      return
+    }
+
     if (beforeActivate && !beforeActivate()) {
       return
     }
 
     // Descriptor resolves concurrently with the dial, same as the profile
     // path, so no await sits between the activation and the publication.
-    const [descriptor, activated] = await Promise.all([
-      resolveConnectionForAgent(connection, target),
-      ensureGatewayForAgent(connection, target)
-    ])
+    const activation = signal
+      ? ensureGatewayForAgent(connection, target, { signal })
+      : ensureGatewayForAgent(connection, target)
+
+    const [descriptor, activated] = await Promise.all([resolveConnectionForAgent(connection, target), activation])
+
+    if (signal?.aborted) {
+      return
+    }
 
     if (!activated) {
       // The target stopped existing mid-dial (source edited/removed). Keep
@@ -526,6 +570,10 @@ export async function ensureGatewayAgent(
       }
     })
   })()
+
+  // Cancellation releases the mutex immediately; activationWork remains
+  // observed and is ownership-guarded at both gateway and publication seams.
+  gatewaySwitch = releaseWhenAborted(activationWork, signal)
 
   try {
     await gatewaySwitch

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -18,6 +18,7 @@ import {
   activeGatewayConnectionId,
   ensureGatewayForAgent,
   ensureGatewayForProfile,
+  openGatewayForAgent,
   openGatewayForProfile
 } from '@/store/gateway'
 import { notifyRemoteOverrideAuthFailure } from '@/store/profile-remote-override'
@@ -406,6 +407,25 @@ async function resolveConnectionForAgent(connectionId: string, profile: string):
 
     return null
   }
+}
+
+// Phase one of the two-phase source switch (store/connections
+// selectConnection): dial the (connectionId, profile) socket WITHOUT activating
+// it. The active route, $activeGatewayProfile and $connection are untouched, so
+// the previous backend stays fully bound and painted while the target
+// spawns/connects — a dead target fails HERE and the current source loses
+// nothing. The follow-up ensureGatewayAgent then finds the socket open and
+// activates it synchronously, which lets the caller sever the previous
+// backend's session bindings and publish the new source in the same tick
+// (#93937). An already-open target is a no-op.
+export async function openGatewayAgent(connectionId: string, profile: string): Promise<void> {
+  const connection = connectionId.trim()
+
+  if (!connection) {
+    return
+  }
+
+  await openGatewayForAgent(connection, normalizeProfileKey(profile), { activationLease: true })
 }
 
 // Activate a connection-scoped agent's gateway — the (connectionId, profile)

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -15,6 +15,7 @@ vi.mock('@/hermes', () => ({
   setSessionUnreadRemote: (id: string, unread: boolean, profile?: null | string) => setUnreadRemote(id, unread, profile)
 }))
 
+import { deferred } from '../test/deferred'
 import { makeSessionInfo } from '../test/session-info'
 
 import {
@@ -27,6 +28,8 @@ import {
   _resetLegacyDiscardForTests,
   applyConfiguredDefaultProjectDir,
   commitWorkspaceCwdForSelectedSession,
+  ensureDefaultWorkspaceCwd,
+  getConfiguredDefaultProjectDir,
   getRememberedRoute,
   getRememberedSessionId,
   getSessionOwnerHint,
@@ -421,6 +424,57 @@ describe('workspaceCwdForNewSession', () => {
     window.localStorage.removeItem('hermes.desktop.workspace-cwd')
     window.localStorage.removeItem('hermes.desktop.workspace-cwd.remote.http%3A%2F%2Fbackend-a.default')
     window.localStorage.removeItem('hermes.desktop.workspace-cwd.remote.http%3A%2F%2Fbackend-b.default')
+    delete (window as { hermesDesktop?: unknown }).hermesDesktop
+  })
+
+  it('does not publish a delayed configured default after ownership is lost', async () => {
+    const settingsResult = deferred<{
+      defaultLabel: string
+      dir: string
+      resolvedCwd: string
+    }>()
+
+    const sanitizeWorkspaceCwd = vi.fn(async (cwd: string) => ({ cwd }))
+
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = {
+      sanitizeWorkspaceCwd,
+      settings: { getDefaultProjectDir: vi.fn(() => settingsResult.promise) }
+    }
+    applyConfiguredDefaultProjectDir('/newer/default')
+    let ownsSwitch = true
+
+    const seeding = ensureDefaultWorkspaceCwd(() => ownsSwitch)
+    ownsSwitch = false
+    settingsResult.resolve({ defaultLabel: '/stale', dir: '/stale/default', resolvedCwd: '/stale/default' })
+    await seeding
+
+    expect(getConfiguredDefaultProjectDir()).toBe('/newer/default')
+    expect($currentCwd.get()).toBe('')
+    expect(sanitizeWorkspaceCwd).not.toHaveBeenCalled()
+  })
+
+  it('does not publish a delayed sanitized cwd after ownership is lost', async () => {
+    const sanitized = deferred<{ cwd: string }>()
+
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = {
+      sanitizeWorkspaceCwd: vi.fn(() => sanitized.promise),
+      settings: {
+        getDefaultProjectDir: vi.fn(async () => ({
+          defaultLabel: '/configured',
+          dir: '/configured',
+          resolvedCwd: '/configured'
+        }))
+      }
+    }
+    let ownsSwitch = true
+
+    const seeding = ensureDefaultWorkspaceCwd(() => ownsSwitch)
+    await vi.waitFor(() => expect(getConfiguredDefaultProjectDir()).toBe('/configured'))
+    ownsSwitch = false
+    sanitized.resolve({ cwd: '/stale/sanitized' })
+    await seeding
+
+    expect($currentCwd.get()).toBe('')
   })
 
   it('prefers the configured default over the sticky remembered workspace', () => {

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -199,17 +199,24 @@ export type NewChatWorkspaceTarget = null | string | undefined
 
 export const getConfiguredDefaultProjectDir = (): string => configuredDefaultProjectDir
 
-export async function syncConfiguredDefaultProjectDir(): Promise<string> {
+export async function syncConfiguredDefaultProjectDir(
+  shouldPublish: () => boolean = () => true
+): Promise<string> {
   const settings = window.hermesDesktop?.settings?.getDefaultProjectDir
 
   if (!settings) {
-    configuredDefaultProjectDir = ''
+    if (shouldPublish()) {
+      configuredDefaultProjectDir = ''
+    }
 
-    return ''
+    return configuredDefaultProjectDir
   }
 
   const { dir } = await settings()
-  configuredDefaultProjectDir = dir?.trim() || ''
+
+  if (shouldPublish()) {
+    configuredDefaultProjectDir = dir?.trim() || ''
+  }
 
   return configuredDefaultProjectDir
 }
@@ -217,21 +224,26 @@ export async function syncConfiguredDefaultProjectDir(): Promise<string> {
 /** Align the renderer workspace with the main-process default (home dir when
  *  packaged, optional Settings override). Clears stale install-dir paths that
  *  PR #37586's localStorage stickiness can preserve across the #37536 fix. */
-export async function ensureDefaultWorkspaceCwd(): Promise<void> {
+export async function ensureDefaultWorkspaceCwd(shouldPublish: () => boolean = () => true): Promise<void> {
   const sanitize = window.hermesDesktop?.sanitizeWorkspaceCwd
 
-  if (!sanitize) {
+  if (!sanitize || !shouldPublish()) {
     return
   }
 
-  await syncConfiguredDefaultProjectDir()
+  await syncConfiguredDefaultProjectDir(shouldPublish)
+
+  if (!shouldPublish()) {
+    return
+  }
+
   const configured = getConfiguredDefaultProjectDir()
 
   // Transient: each source below is already remembered or comes from config, so
   // persisting would only promote a configured default into the per-backend
   // memory of what the user picked.
   const seedLiveCwd = (cwd: string) => {
-    if (cwd && !$activeSessionId.get()) {
+    if (shouldPublish() && cwd && !$activeSessionId.get()) {
       setCurrentCwdTransient(cwd)
     }
   }

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -245,9 +245,9 @@ export class JsonRpcGatewayClient {
             }
 
             this.socket = null
+            this.setState('error')
           }
 
-          this.setState('error')
           reject(new Error(this.options.connectErrorMessage))
         }, this.options.connectTimeoutMs)
       }


### PR DESCRIPTION
## Summary

Makes Desktop gateway changes commit atomically before a new gateway/profile is published.

- Raises a token-owned switch barrier and clears outgoing session/UI bindings before activation.
- Serializes overlapping profile-agent activations and starts the commit timeout only after queue ownership is acquired.
- Propagates cancellation so a timed-out activation cannot publish its descriptor/profile later.
- Makes switch setup exception-safe: lifecycle or wipe failures cannot strand the barrier.
- Repaints a partially wiped active source only while the failed switch still owns recovery; stale recovery cannot refresh through or disarm a newer switch.
- Routes current Settings soft-switch setup failures through the existing boot-failure notification path while suppressing stale failures after a newer switch wins.
- Carries switch ownership into asynchronous CWD, Hermes-config, and session-list helpers so delayed work cannot publish after supersession.
- Keeps WebSocket connect-timeout state transitions socket-generation-owned, so a stale handshake cannot mark a newer open gateway as errored.

Fixes #93937.

## Why

Previously, one switch path could activate/publish a new source before clearing the old runtime/session identity. Overlapping or stalled switches could then expose a new gateway while UI state still named a runtime created by the previous gateway, producing `session not found` and permanently raised switching/loading state on error paths.

## Correctness properties

- Only the latest switch token may lower the barrier.
- Timeout begins after activation queue acquisition, not while waiting behind unrelated work.
- Abort/switch ownership is checked before activation and at every later publication seam, including delayed descriptors, CWD seeding, config refresh, boot finalization, and failure notifications.
- Partial-wipe recovery checks token ownership before refreshing and again before lowering loading state.
- Lifecycle, wipe, timeout-callback and Settings soft-switch exceptions preserve the original error and cannot poison future switches.

## Verification on current head

- Focused gateway/switch regressions: **11 files / 241 tests passed**
- Full Desktop UI suite: **592 files / 5,708 tests passed**
- Desktop renderer, Electron and E2E TypeScript checks: passed
- Targeted ESLint: passed
- Contributor attribution audit: passed
- `git diff --check`: passed
- Independent final blocking review: **APPROVE**
