### PR TITLE
fix(desktop): remote New Bot keeps profile origin, routes to owner, preflights provider before first turn

### DIFF
--- a/apps/desktop/src/api/client.ts
+++ b/apps/desktop/src/api/client.ts
@@ -138,15 +138,21 @@ export function capabilityScoped(scope?: ProfileScope): { connectionId?: string;
   return { ...profileScoped(scope), ...connectionScoped() }
 }
 
-/** Stable cache-key for a capability scope: `profile` for the local/legacy
- *  path, `connectionId::profile` for an explicit remote pin. Mirrors
- *  normalizeProfileKey for plain strings so existing keys stay byte-identical. */
+/** Stable cache-key for a capability scope: `profile` for the legacy path
+ *  (string scope / empty connection id), `connectionId::profile` for ANY
+ *  explicit pin — `'local'` included. capabilityScoped routes an explicit
+ *  `'local'` pin to THIS machine while the legacy path follows the active
+ *  gateway, so the two must never share a cache row: with a remote gateway
+ *  active, a "This device" bot's editor would otherwise read (and write) the
+ *  remote same-named profile's skills/toolsets/config from the query cache
+ *  (#94071). Mirrors normalizeProfileKey for plain strings so existing keys
+ *  stay byte-identical. */
 export function profileScopeKey(scope?: ProfileScope): string {
   if (scope && typeof scope === 'object') {
     const profile = (scope.profile ?? '').trim() || 'default'
     const connectionId = (scope.connectionId ?? '').trim()
 
-    return connectionId && connectionId !== 'local' ? `${connectionId}::${profile}` : profile
+    return connectionId ? `${connectionId}::${profile}` : profile
   }
 
   return (scope ?? '').trim() || 'default'

--- a/apps/desktop/src/api/client.ts
+++ b/apps/desktop/src/api/client.ts
@@ -113,10 +113,15 @@ export function hermesApi<T>(request: HermesApiRequest): Promise<T> {
 //     connection tag (connectionScoped, same contract the cron helpers adopted
 //     in #87882). Without the tag, a window activated onto a registered remote
 //     gateway read the LOCAL pool's skills/tools/MCP — the wrong machine.
-//   - `{ connectionId, profile }` → explicit pin. `''`/`'local'` connection
-//     ids mean the local pool and deliberately DROP the ambient connection
-//     tag, so a local-profile pick made while a remote gateway is active still
-//     routes to the local machine.
+//   - `{ connectionId, profile }` → explicit pin. A `'local'` connection id
+//     means THIS machine and is emitted verbatim: the main process keeps an
+//     explicit `local` registry-pinned (hermes:api's registry branch spawns a
+//     forced-local child when the v1 route is remote), which is the only way
+//     a local-profile pick made while a remote gateway is active reaches the
+//     local machine. Dropping it left the request on the legacy profile
+//     route, which follows the ACTIVE remote — so a "This device" bot's
+//     skills/tools/MCP 404'd there with "Profile 'x' does not exist" (#94071).
+//     An empty id keeps the ambient-free legacy route (no pin at all).
 export type ProfileScope = undefined | null | string | { connectionId?: null | string; profile?: null | string }
 
 export function capabilityScoped(scope?: ProfileScope): { connectionId?: string; profile?: string } {
@@ -126,7 +131,7 @@ export function capabilityScoped(scope?: ProfileScope): { connectionId?: string;
 
     return {
       ...(profile ? { profile } : {}),
-      ...(connectionId && connectionId !== 'local' ? { connectionId } : {})
+      ...(connectionId ? { connectionId } : {})
     }
   }
 

--- a/apps/desktop/src/api/profiles.ts
+++ b/apps/desktop/src/api/profiles.ts
@@ -44,8 +44,9 @@ export function deleteProfile(name: string, scope?: ProfileScope): Promise<{ ok:
   }
 
   return hermesApi<{ ok: boolean; path: string }>({
+    // capabilityScoped emits an explicit 'local' pin itself, which wins over
+    // hermesApi's ambient connection tag spread underneath it.
     ...capabilityScoped(scope),
-    ...(scope && typeof scope === 'object' && scope.connectionId?.trim() === 'local' ? { connectionId: 'local' } : {}),
     path: `/api/profiles/${encodeURIComponent(normalized)}`,
     method: 'DELETE'
   })

--- a/apps/desktop/src/hermes-capability-scope.test.ts
+++ b/apps/desktop/src/hermes-capability-scope.test.ts
@@ -22,8 +22,9 @@ import {
 // machine's backend. Three shapes:
 //   - no scope         → ambient profile + ambient registry connection tag
 //   - string scope     → explicit profile, ambient connection tag
-//   - object scope     → explicit (connection, profile) pin; 'local' pins the
-//                        local pool and DROPS the ambient connection tag
+//   - object scope     → explicit (connection, profile) pin; 'local' pins THIS
+//                        machine explicitly (overriding the ambient connection
+//                        tag AND the legacy remote route in the main process)
 describe('capability helpers are connection-scoped', () => {
   const api = vi.fn(async (_req: { connectionId?: string; path: string; profile?: string }) => ({}) as never)
 
@@ -89,11 +90,25 @@ describe('capability helpers are connection-scoped', () => {
     }
   })
 
-  it("a 'local' pin routes to the local pool even while a remote gateway is active", () => {
+  it("a 'local' pin routes to THIS machine even while a remote gateway is active (#94071)", () => {
     setApiRequestProfile('research')
     setApiRequestConnection('gw-tailscale')
 
     void getSkills({ connectionId: 'local', profile: 'coder' })
+
+    // Emitted verbatim: the main process keeps an explicit `local` registry-
+    // pinned so it cannot inherit the active/legacy remote route. Dropping it
+    // sent a "This device" bot's capability reads to the remote gateway,
+    // which answered 404 "Profile 'coder' does not exist".
+    expect(last().profile).toBe('coder')
+    expect(last().connectionId).toBe('local')
+  })
+
+  it('an empty connection id in an object scope stays unpinned (legacy route, no ambient tag)', () => {
+    setApiRequestProfile('research')
+    setApiRequestConnection('gw-tailscale')
+
+    void getSkills({ connectionId: '', profile: 'coder' })
 
     expect(last().profile).toBe('coder')
     expect(last()).not.toHaveProperty('connectionId')

--- a/apps/desktop/src/hermes-capability-scope.test.ts
+++ b/apps/desktop/src/hermes-capability-scope.test.ts
@@ -114,12 +114,23 @@ describe('capability helpers are connection-scoped', () => {
     expect(last()).not.toHaveProperty('connectionId')
   })
 
-  it('profileScopeKey keeps legacy keys byte-identical and namespaces remote pins', () => {
+  it('profileScopeKey keeps legacy keys byte-identical and namespaces every explicit pin', () => {
     expect(profileScopeKey()).toBe('default')
     expect(profileScopeKey(null)).toBe('default')
     expect(profileScopeKey('coder')).toBe('coder')
-    expect(profileScopeKey({ connectionId: 'local', profile: 'coder' })).toBe('coder')
+    expect(profileScopeKey({ connectionId: '', profile: 'coder' })).toBe('coder')
     expect(profileScopeKey({ connectionId: 'homelab', profile: 'coder' })).toBe('homelab::coder')
     expect(profileScopeKey({ connectionId: 'homelab' })).toBe('homelab::default')
+  })
+
+  it("a 'local' pin is namespaced apart from the legacy key it no longer routes with (#94071)", () => {
+    // capabilityScoped sends an explicit 'local' pin to THIS machine while a
+    // legacy string scope follows the active gateway. Sharing the bare key
+    // would let the query cache serve a remote same-named profile's
+    // skills/toolsets/config to a "This device" bot's editor — and let that
+    // editor's toggles write into the remote row.
+    expect(profileScopeKey({ connectionId: 'local', profile: 'coder' })).toBe('local::coder')
+    expect(profileScopeKey({ connectionId: 'local', profile: 'coder' })).not.toBe(profileScopeKey('coder'))
+    expect(profileScopeKey({ connectionId: 'local' })).toBe('local::default')
   })
 })

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -3761,18 +3761,23 @@ async function mcpRpc(method, params, request = null) {
   }
 }
 
-// Probe whether the new lifecycle RPCs exist on this gateway (cached per session).
-let _mcpRpcSupported = null
-async function mcpSetupSupported() {
-  if (_mcpRpcSupported !== null) {
-    return _mcpRpcSupported
+// Probe lifecycle support on the owning gateway. Capability is connection
+// state, so cache it by the stable owner/connection key supplied by callers;
+// never let whichever gateway happened to be active answer for every bot.
+const _mcpRpcSupportedByOwner = new Map()
+async function mcpSetupSupported(request, ownerKey) {
+  const key = String(ownerKey || '').trim()
+  if (key && _mcpRpcSupportedByOwner.has(key)) {
+    return _mcpRpcSupportedByOwner.get(key)
   }
-  const r = await mcpRpc('mcp.servers.list', {})
-  _mcpRpcSupported = !(r.ok === false && r.unsupported)
-  return _mcpRpcSupported
+  const probe = mcpRpc('mcp.servers.list', {}, request).then(r => !(r.ok === false && r.unsupported))
+  if (key) {
+    _mcpRpcSupportedByOwner.set(key, probe)
+  }
+  return probe
 }
 
-function McpSetupButton({ profile, entry, onDone, ensureProfile, request }) {
+function McpSetupButton({ profile, entry, onDone, ensureProfile, request, supportScope }) {
   // entry: { name, requires:[env keys], auth?, fromCatalog, installed }
   // profile may be null at first (New Bot: the profile isn't created yet).
   // ensureProfile() lazily creates it on the first setup action and returns the
@@ -3809,7 +3814,7 @@ function McpSetupButton({ profile, entry, onDone, ensureProfile, request }) {
 
   useEffect(() => {
     let alive = true
-    mcpSetupSupported().then(ok => {
+    mcpSetupSupported(request, supportScope).then(ok => {
       if (alive) setSupported(ok)
     })
     return () => {
@@ -9080,6 +9085,9 @@ function AdvancedProfileConfig({ bot, state, setState }) {
   const botRoute = resolveBotConnectionRoute(bot).route
   const backendProfile = botRoute?.targetProfile || botRoute?.profile || bot.name
   const backendScope = botBackendProfileScope(botRoute, bot.name)
+  const mcpSupportScope = botRoute
+    ? `owner:${botOwner(bot).key}`
+    : `connection:${String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'active')}`
   const inheritLabel = botInheritLabel(bot)
   // Every mutation from this editor rides the bot's OWN (connection, profile)
   // route; requestForBot rewrites `profile` to the backend name.
@@ -9362,6 +9370,7 @@ function AdvancedProfileConfig({ bot, state, setState }) {
                                       profile: bot.name,
                                       entry: m,
                                       request: requestForThisBot,
+                                      supportScope: mcpSupportScope,
                                       onDone: () => toggleMcp(m.name, true)
                                     })
                                   : null,
@@ -10774,6 +10783,9 @@ function CreateAgentDialog({ open, onClose, roster }) {
                                                             entry: m,
                                                             ensureProfile: ensureAgentCreated,
                                                             request: requestForTarget,
+                                                            supportScope: remoteTarget
+                                                              ? `connection:${targetConnection}`
+                                                              : `connection:${activeConnectionId || 'active'}`,
                                                             onDone: () => {
                                                               // Setup done: mark installed so the row's
                                                               // checkbox un-disables, and enable it.

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -327,6 +327,20 @@ async function preflightProviderReadiness(request, profile) {
   }
 }
 
+/** Preflight and surface the one creation-side effect that belongs to an
+ *  unready backend. Keeping this orchestration outside the dialog makes the
+ *  ordering contract executable: readiness is checked before any first-chat
+ *  decision, and the bot is badged on its owning target. */
+async function prepareBotFirstChat({ request, profile, ownerKey, hostLabel }) {
+  const readiness = await preflightProviderReadiness(request, profile)
+
+  if (!readiness.ready) {
+    noteProviderSetupNeeded(ownerKey, hostLabel, readiness.reason)
+  }
+
+  return readiness
+}
+
 // Bot Mode sessions are ALWAYS hidden from the global Sessions sidebar:
 // canonical Bot Chats are plugin-owned forever-chats and group-chat member
 // sessions are room plumbing — neither is a scratch conversation, and a
@@ -8848,6 +8862,20 @@ function resolveCloneSource(cloneFrom, { remoteTarget = false, targetProfiles = 
   return Array.isArray(targetProfiles) && targetProfiles.includes(cloneFrom) ? cloneFrom : 'default'
 }
 
+/** Route every New Bot backend request through the selected create target.
+ *  The default/active target preserves the ambient request path. */
+function requestForCreateTarget(hostApi, { remoteTarget, targetConnection }, method, params = {}) {
+  if (!remoteTarget) {
+    return hostApi.request(method, params)
+  }
+
+  return hostApi.requestProfile(
+    { connectionId: targetConnection, mode: 'remote', profile: 'default', targetProfile: 'default' },
+    method,
+    params
+  )
+}
+
 function ModelPicker({
   bot = null,
   value,
@@ -9959,13 +9987,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
   /** Gateway RPC on the create target: the picked connection's default
    *  backend for remote targets, the active gateway otherwise. */
   const requestForTarget = (method, params = {}) =>
-    remoteTarget
-      ? host.requestProfile(
-          { connectionId: targetConnection, mode: 'remote', profile: 'default', targetProfile: 'default' },
-          method,
-          params
-        )
-      : host.request(method, params)
+    requestForCreateTarget(host, { remoteTarget, targetConnection }, method, params)
 
   // Clone sources belong to the TARGET backend. For a remote target, list
   // that machine's profiles over the routed RPC (null while loading, [] when
@@ -9980,12 +10002,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
 
     let cancelled = false
 
-    host
-      .requestProfile(
-        { connectionId: targetConnection, mode: 'remote', profile: 'default', targetProfile: 'default' },
-        'profiles.list',
-        { include_sessions: false }
-      )
+    requestForTarget('profiles.list', { include_sessions: false })
       .then(res => {
         if (!cancelled) {
           setTargetProfiles(cloneSourcesFromProfileList(res))
@@ -10271,13 +10288,14 @@ function CreateAgentDialog({ open, onClose, roster }) {
       // init failed" and reads as a failed creation (#94071). Credentials are
       // never copied across machines — the target must be able to serve a
       // model itself.
-      const readiness = await preflightProviderReadiness(requestForTarget, slug)
+      const readiness = await prepareBotFirstChat({
+        request: requestForTarget,
+        profile: slug,
+        ownerKey,
+        hostLabel
+      })
       reset()
       onClose()
-
-      if (!readiness.ready) {
-        noteProviderSetupNeeded(ownerKey, hostLabel, readiness.reason)
-      }
 
       if (wasRemote) {
         // The bot lives on another machine: it appears in the roster via the

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -231,7 +231,11 @@ function attentionReasonFromError(errorTextOrReason) {
     return null
   }
 
-  if (/no llm provider|no access token|not configured|no api key|missing api key/.test(text)) {
+  if (
+    /no (?:llm|hermes|inference) provider|no usable credentials|no access token|not configured|no api key|missing api key/.test(
+      text
+    )
+  ) {
     return 'missing_config'
   }
 
@@ -284,6 +288,44 @@ function clearBotAttention(key) {
 
 /** Last good cron list, same idea as the roster snapshot. */
 const $lastJobs = atom([])
+
+/** A bot was created on a backend that cannot serve a model yet (#94071):
+ *  badge it as missing_config and tell the user WHERE to fix it — the bot's
+ *  own machine, never the window's active gateway. The creation itself is
+ *  kept; only the automatic first turn is withheld. */
+function noteProviderSetupNeeded(key, hostLabel, reason) {
+  const detail = String(reason || 'No inference provider is configured.').trim()
+
+  noteBotAttention(key, 'missing_config')
+  host.notify({
+    kind: 'info',
+    message: `Configure a model on ${hostLabel} before this bot's first chat — ${detail} Use the bot's editor (Model) or run \`hermes model\` on ${hostLabel}.`
+  })
+}
+
+/** Provider readiness for a profile on a backend WITHOUT starting a turn:
+ *  setup.runtime_check runs the same resolve_runtime_provider() the agent
+ *  uses at session build. `profile` scopes the check to that profile's home
+ *  on the backend (newer gateways; older ones answer for their launch
+ *  profile, whose credentials a new bot mirrors). Fail-open: a gateway that
+ *  predates the RPC, or a transport blip, reads as ready so the intro turn
+ *  still runs there and reports its own error. */
+async function preflightProviderReadiness(request, profile) {
+  try {
+    const result = await request('setup.runtime_check', { profile })
+
+    if (result && result.ok === false) {
+      return {
+        ready: false,
+        reason: String(result.error || 'No inference provider is configured.').trim()
+      }
+    }
+
+    return { ready: true, reason: null }
+  } catch {
+    return { ready: true, reason: null }
+  }
+}
 
 // Bot Mode sessions are ALWAYS hidden from the global Sessions sidebar:
 // canonical Bot Chats are plugin-owned forever-chats and group-chat member
@@ -3685,11 +3727,16 @@ function BotFace({ shape, color, image, size = 36, name = 'agent', mood = 'idle'
 // and the row falls back to the "run hermes mcp / Settings" hint. profile is
 // the target bot's profile name (its config is what we write).
 
-async function mcpRpc(method, params) {
+async function mcpRpc(method, params, request = null) {
   // Returns { ok, result } or { ok:false, unsupported:true } when the gateway
-  // doesn't know the method (older backend) vs a real error.
+  // doesn't know the method (older backend) vs a real error. `request` routes
+  // the call to the bot's OWNING backend (requestForBot / the create target);
+  // without it the active gateway answers — wrong for a bot that lives on
+  // another connection (its profile does not exist here → 404, #94071).
+  const send = typeof request === 'function' ? request : (m, p) => host.request(m, p)
+
   try {
-    const res = await host.request(method, params)
+    const res = await send(method, params)
     return { ok: true, result: res }
   } catch (err) {
     const msg = String((err && err.message) || err || '')
@@ -3711,7 +3758,7 @@ async function mcpSetupSupported() {
   return _mcpRpcSupported
 }
 
-function McpSetupButton({ profile, entry, onDone, ensureProfile }) {
+function McpSetupButton({ profile, entry, onDone, ensureProfile, request }) {
   // entry: { name, requires:[env keys], auth?, fromCatalog, installed }
   // profile may be null at first (New Bot: the profile isn't created yet).
   // ensureProfile() lazily creates it on the first setup action and returns the
@@ -3722,6 +3769,8 @@ function McpSetupButton({ profile, entry, onDone, ensureProfile }) {
   const [message, setMessage] = useState('')
   const pollRef = useRef(null)
   const profileRef = useRef(profile || null)
+  // Every lifecycle RPC rides the owning backend's route (see mcpRpc).
+  const rpc = (method, params) => mcpRpc(method, params, request)
 
   useEffect(() => {
     if (profile) {
@@ -3771,7 +3820,7 @@ function McpSetupButton({ profile, entry, onDone, ensureProfile }) {
       return
     }
     if (entry.fromCatalog && !entry.installed) {
-      const add = await mcpRpc('mcp.servers.add', { profile, name: entry.name, preset: entry.name })
+      const add = await rpc('mcp.servers.add', { profile, name: entry.name, preset: entry.name })
       if (!add.ok) {
         setPhase('error')
         setMessage(add.error || 'Could not add server')
@@ -3794,7 +3843,7 @@ function McpSetupButton({ profile, entry, onDone, ensureProfile }) {
       if (!val) {
         continue
       }
-      const r = await mcpRpc('mcp.servers.set_api_key', { profile, name: entry.name, env_var: k, value: val })
+      const r = await rpc('mcp.servers.set_api_key', { profile, name: entry.name, env_var: k, value: val })
       if (!r.ok) {
         setPhase('error')
         setMessage(r.error || ('Failed to set ' + k))
@@ -3802,7 +3851,7 @@ function McpSetupButton({ profile, entry, onDone, ensureProfile }) {
       }
     }
     // Verify via test.
-    const t = await mcpRpc('mcp.servers.test', { profile, name: entry.name })
+    const t = await rpc('mcp.servers.test', { profile, name: entry.name })
     if (t.ok && t.result && (t.result.ok || (t.result.result && t.result.result.ok))) {
       setPhase('done')
       host.notify({ kind: 'success', message: entry.name + ' configured' })
@@ -3829,14 +3878,14 @@ function McpSetupButton({ profile, entry, onDone, ensureProfile }) {
       return
     }
     if (entry.fromCatalog && !entry.installed) {
-      const add = await mcpRpc('mcp.servers.add', { profile, name: entry.name, preset: entry.name })
+      const add = await rpc('mcp.servers.add', { profile, name: entry.name, preset: entry.name })
       if (!add.ok) {
         setPhase('error')
         setMessage(add.error || 'Could not add server')
         return
       }
     }
-    const start = await mcpRpc('mcp.servers.oauth.start', { profile, name: entry.name })
+    const start = await rpc('mcp.servers.oauth.start', { profile, name: entry.name })
     const payload = start.result && (start.result.result || start.result)
     const authUrl = payload && (payload.auth_url || payload.verification_url)
     const sessionId = payload && payload.session_id
@@ -3860,7 +3909,7 @@ function McpSetupButton({ profile, entry, onDone, ensureProfile }) {
     setPhase('oauth')
     setMessage('Complete sign-in in your browser...')
     pollRef.current = setInterval(async () => {
-      const poll = await mcpRpc('mcp.servers.oauth.poll', { profile, name: entry.name, session_id: sessionId })
+      const poll = await rpc('mcp.servers.oauth.poll', { profile, name: entry.name, session_id: sessionId })
       const pd = poll.result && (poll.result.result || poll.result)
       const status = pd && pd.status
       if (status === 'approved') {
@@ -5748,8 +5797,14 @@ async function findExistingCanonicalChat(owner) {
  *  persistence job is done by the eager session.title write below on modern
  *  gateways; older gateways that reject the eager write keep a narrow
  *  compat kickoff, else the pruner reaps the empty lazy session and the
- *  chat never survives its own creation. */
-function createCanonicalChat(owner, { kickoff = false } = {}) {
+ *  chat never survives its own creation.
+ *
+ *  `ready` (default true): the target's provider preflight (#94071,
+ *  `setup.runtime_check`). When false the intro turn is suppressed in BOTH
+ *  cases above — a prompt against a target that cannot serve a model only
+ *  produces a misleading failed-chat error — and the user is still landed in
+ *  the pinned chat; the provider-setup notice is shown by the caller. */
+function createCanonicalChat(owner, { kickoff = false, ready = true } = {}) {
   const { bot, name, key, route } = botOwner(owner)
   const inflight = canonicalCreations.get(key)
 
@@ -5827,8 +5882,10 @@ function createCanonicalChat(owner, { kickoff = false } = {}) {
       // COMPAT persistence write when the eager title failed — an old gateway
       // prunes the zero-message lazy session, so without some first prompt
       // the chat never survives its own creation. A titled row needs neither:
-      // the user speaks first.
-      const submitIntro = kickoff || !titled
+      // the user speaks first. Either way, never against a target whose
+      // provider preflight failed (`ready === false`, #94071): the turn
+      // cannot be served and would only surface as a failed-chat error.
+      const submitIntro = ready && (kickoff || !titled)
 
       if (submitIntro) {
         await new Promise(resolve => window.setTimeout(resolve, 400))
@@ -5849,8 +5906,8 @@ function createCanonicalChat(owner, { kickoff = false } = {}) {
           // finds it by name instead of making a second Bot Chat.
         }
       } else if (!opened && sid && typeof host.openSession === 'function') {
-        // No intro turn: still finish mounting the chat when the first open
-        // raced the (now titled) row.
+        // No intro turn (titled row, or provider not ready): still finish
+        // mounting the chat when the first open raced the (now titled) row.
         try {
           await host.openSession(sid, {
             ...(route ? { route } : {}),
@@ -5859,7 +5916,8 @@ function createCanonicalChat(owner, { kickoff = false } = {}) {
             keepAllProfilesScope: route ? true : false
           })
         } catch {
-          /* row is titled and persistent — the next click opens it by name */
+          // Titled row, or a lazy row on an older gateway with the intro
+          // suppressed — the next click finds it by name.
         }
       }
     }
@@ -8755,7 +8813,48 @@ function useModelOptions(bot = null) {
  * same data the core model picker shows. `value = {provider, model}`;
  * onChange receives the merged patch.
  */
-function ModelPicker({ bot = null, value, onChange, placeholderModel = 'gateway default' }) {
+/** "Inherit" means the launch/default profile of the bot's OWNING backend —
+ *  name that machine so a multi-connection roster never reads as inheriting
+ *  from whatever gateway the window is on. */
+function botInheritLabel(bot) {
+  const label = String(bot?.connectionLabel || '').trim()
+
+  return label ? `Inherit from default on ${label}` : 'Inherit (launch profile)'
+}
+
+/** Clone-source names from a profiles.list reply (either the {profiles}
+ *  envelope or a bare array). `default` always leads: every backend has it,
+ *  and it is the picker's fallback when a pick does not exist there. */
+function cloneSourcesFromProfileList(res) {
+  const rows = Array.isArray(res?.profiles) ? res.profiles : Array.isArray(res) ? res : []
+  const names = rows.map(row => String(row?.name || '').trim()).filter(Boolean)
+
+  return ['default', ...names.filter(name => name !== 'default')]
+}
+
+/** clone_from for profiles.create: null = fresh profile. A remote pick must
+ *  name a profile of the TARGET backend — the picker's roster is the local
+ *  one — so anything not in that machine's list (or an unloaded list) falls
+ *  back to its default rather than a name the remote box doesn't have. */
+function resolveCloneSource(cloneFrom, { remoteTarget = false, targetProfiles = null } = {}) {
+  if (cloneFrom === '__none__') {
+    return null
+  }
+
+  if (!remoteTarget) {
+    return cloneFrom
+  }
+
+  return Array.isArray(targetProfiles) && targetProfiles.includes(cloneFrom) ? cloneFrom : 'default'
+}
+
+function ModelPicker({
+  bot = null,
+  value,
+  onChange,
+  placeholderModel = 'gateway default',
+  inheritLabel = 'Inherit (launch profile)'
+}) {
   const { data, isLoading, error } = useModelOptions(bot)
 
   // Hooks are ALWAYS declared up front, before any conditional return.
@@ -8868,7 +8967,7 @@ function ModelPicker({ bot = null, value, onChange, placeholderModel = 'gateway 
             jsx(SelectTrigger, { className: 'h-8 rounded-md', children: jsx(SelectValue, {}) }),
             jsxs(SelectContent, {
               children: [
-                jsx(SelectItem, { value: NONE, children: 'Inherit (launch profile)' }),
+                jsx(SelectItem, { value: NONE, children: inheritLabel }),
                 ...providers.map(p =>
                   jsx(
                     SelectItem,
@@ -8953,6 +9052,10 @@ function AdvancedProfileConfig({ bot, state, setState }) {
   const botRoute = resolveBotConnectionRoute(bot).route
   const backendProfile = botRoute?.targetProfile || botRoute?.profile || bot.name
   const backendScope = botBackendProfileScope(botRoute, bot.name)
+  const inheritLabel = botInheritLabel(bot)
+  // Every mutation from this editor rides the bot's OWN (connection, profile)
+  // route; requestForBot rewrites `profile` to the backend name.
+  const requestForThisBot = (method, params) => requestForBot(bot, method, params)
 
   if (!loaded) {
     setLoaded(true)
@@ -9046,6 +9149,7 @@ function AdvancedProfileConfig({ bot, state, setState }) {
       children: [
         jsx(ModelPicker, {
           bot,
+          inheritLabel,
           value: { provider: state.provider, model: state.model },
           onChange: patch => setState(prev => ({ ...prev, dirtyModel: true, ...patch }))
         }),
@@ -9079,6 +9183,7 @@ function AdvancedProfileConfig({ bot, state, setState }) {
       children: [
         jsx(ModelPicker, {
           bot,
+          inheritLabel,
           value: { provider: state.provider, model: state.model },
           onChange: patch => setState(prev => ({ ...prev, dirtyModel: true, ...patch }))
         }),
@@ -9103,6 +9208,7 @@ function AdvancedProfileConfig({ bot, state, setState }) {
     children: [
       jsx(ModelPicker, {
         bot,
+        inheritLabel,
         value: { provider: state.provider, model: state.model },
         onChange: patch => setState(prev => ({ ...prev, dirtyModel: true, ...patch }))
       }),
@@ -9123,7 +9229,8 @@ function AdvancedProfileConfig({ bot, state, setState }) {
               children: jsx(CheckList, { items: visibleSkills, onToggle: toggleSkill, columns: 2 })
             }),
             jsx(HubSkillsSection, {
-              forProfile: backendScope,
+              forProfile: bot.name,
+              request: requestForThisBot,
               onInstalled: name =>
                 setState(prev =>
                   prev.skills.some(s => s.name === name)
@@ -9224,8 +9331,9 @@ function AdvancedProfileConfig({ bot, state, setState }) {
                                   : null,
                                 needsSetup
                                   ? jsx(McpSetupButton, {
-                                      profile: backendScope,
+                                      profile: bot.name,
                                       entry: m,
+                                      request: requestForThisBot,
                                       onDone: () => toggleMcp(m.name, true)
                                     })
                                   : null,
@@ -9268,7 +9376,7 @@ function AdvancedProfileConfig({ bot, state, setState }) {
 const HUB_ORIGIN = 'https://hermes-agent.nousresearch.com'
 const HUB_PICKER_URL = HUB_ORIGIN + '/docs/skills?embed=picker'
 
-function HubSkillsSection({ forProfile, onInstalled }) {
+function HubSkillsSection({ forProfile, onInstalled, request }) {
   const [query, setQuery] = useState('')
   const [results, setResults] = useState(null)
   const [searching, setSearching] = useState(false)
@@ -9277,6 +9385,10 @@ function HubSkillsSection({ forProfile, onInstalled }) {
   const [browseHub, setBrowseHub] = useState(false)
   const installRef = useRef(null)
   const frameRef = useRef(null)
+  // Search + install ride the OWNING backend (an edited bot's connection, or
+  // the create target) via `request`; without it the active gateway answers,
+  // which is the wrong machine for a bot that lives elsewhere (#94071).
+  const send = typeof request === 'function' ? request : (method, params) => host.request(method, params)
 
   // Picker messages from the embedded hub page. Origin- AND source-checked —
   // only OUR frame may ask for an install (the hub origin alone would let any
@@ -9331,7 +9443,7 @@ function HubSkillsSection({ forProfile, onInstalled }) {
     setResults(null)
 
     try {
-      const res = await host.request('skills.manage', { action: 'search', query: q })
+      const res = await send('skills.manage', { action: 'search', query: q })
       setResults(res.results || [])
     } catch {
       setResults([])
@@ -9353,7 +9465,7 @@ function HubSkillsSection({ forProfile, onInstalled }) {
       // With forProfile the install lands in that bot's skills dir
       // (gateway skills.manage profile scoping); null = launch profile,
       // which is right at create time — the new bot clones/copies from it.
-      await host.request('skills.manage', {
+      await send('skills.manage', {
         action: 'install',
         query: name,
         ...(forProfile ? { profile: forProfile } : {})
@@ -9855,6 +9967,54 @@ function CreateAgentDialog({ open, onClose, roster }) {
         )
       : host.request(method, params)
 
+  // Clone sources belong to the TARGET backend. For a remote target, list
+  // that machine's profiles over the routed RPC (null while loading, [] when
+  // the listing failed) so the picker offers the same origin choices as a
+  // local create — fresh, or a clone of any profile that exists THERE.
+  const [targetProfiles, setTargetProfiles] = useState(null)
+
+  useEffect(() => {
+    if (!open || !remoteTarget) {
+      return undefined
+    }
+
+    let cancelled = false
+
+    host
+      .requestProfile(
+        { connectionId: targetConnection, mode: 'remote', profile: 'default', targetProfile: 'default' },
+        'profiles.list',
+        { include_sessions: false }
+      )
+      .then(res => {
+        if (!cancelled) {
+          setTargetProfiles(cloneSourcesFromProfileList(res))
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setTargetProfiles([])
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [open, remoteTarget, targetConnection])
+
+  const cloneChoices = remoteTarget
+    ? Array.isArray(targetProfiles) && targetProfiles.length
+      ? targetProfiles
+      : ['default']
+    : roster.map(b => b.name)
+  const cloneSource = resolveCloneSource(cloneFrom, { remoteTarget, targetProfiles })
+  // The machine whose default profile the new bot shares credentials with
+  // and inherits its model from — always the CREATE TARGET, never the
+  // window's active gateway.
+  const credentialHostLabel = remoteTarget
+    ? targetLabel
+    : (connections || []).find(c => c.id === (activeConnectionId || 'local'))?.label || 'this device'
+
   // Set once ensureAgentCreated() materializes the profile for the live
   // Capabilities tab (SkillsView needs a real backend to point at). State —
   // not just createdRef — because the render must flip when it lands.
@@ -9924,6 +10084,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
     setDirtyCaps({ skills: false, toolsets: false, mcp: false })
     setCapFilter('')
     setTargetConnection('')
+    setTargetProfiles(null)
     setBusy(false)
     setError(null)
     createdRef.current = null
@@ -9932,14 +10093,14 @@ function CreateAgentDialog({ open, onClose, roster }) {
 
   // Capability catalog for the tabs: the profile doesn't exist yet, so show
   // what it WILL have — the clone source's catalog, else the main profile's.
-  const capSource = cloneFrom === '__none__' ? 'default' : cloneFrom
+  const capSource = cloneSource || 'default'
   const ensureCaps = () => {
     if ((caps && caps.source === capSource) || capsFailed) {
       return
     }
 
     Promise.all([
-      requestForTarget('profiles.describe', { name: remoteTarget ? 'default' : capSource }),
+      requestForTarget('profiles.describe', { name: capSource }),
       requestForTarget('mcp.catalog', {}).catch(() => null)
     ])
       .then(([res, cat]) => {
@@ -10007,11 +10168,11 @@ function CreateAgentDialog({ open, onClose, roster }) {
       await requestForTarget('profiles.create', {
         name: slug,
         description: descriptionText,
-        // Clone sources are profiles of the TARGET backend. The picker's
-        // roster is the local one, so a remote create always starts from the
-        // remote machine's default (or fresh) — never a local profile name
-        // the remote box doesn't have.
-        clone_from: cloneFrom === '__none__' ? null : remoteTarget ? 'default' : cloneFrom,
+        // Clone sources are profiles of the TARGET backend: a remote pick is
+        // validated against that machine's own list (resolveCloneSource) —
+        // never a local profile name the remote box doesn't have. null =
+        // fresh profile, exactly as for a local create.
+        clone_from: cloneSource,
         no_skills: noSkills,
         // Shared (not copied) auth keeps ONE OAuth/token pool with the main
         // profile, so refreshes can't invalidate each other. Older gateways
@@ -10103,8 +10264,20 @@ function CreateAgentDialog({ open, onClose, roster }) {
           : `Bot "${displayName({ name: slug, title })}" created`
       })
       const wasRemote = remoteTarget
+      const ownerKey = botRosterKey({ name: slug, connectionId: wasRemote ? targetConnection : activeConnectionId })
+      const hostLabel = credentialHostLabel
+      // Provider readiness on the CREATE TARGET before any automatic turn:
+      // the bot exists either way, but a doomed intro surfaces as "agent
+      // init failed" and reads as a failed creation (#94071). Credentials are
+      // never copied across machines — the target must be able to serve a
+      // model itself.
+      const readiness = await preflightProviderReadiness(requestForTarget, slug)
       reset()
       onClose()
+
+      if (!readiness.ready) {
+        noteProviderSetupNeeded(ownerKey, hostLabel, readiness.reason)
+      }
 
       if (wasRemote) {
         // The bot lives on another machine: it appears in the roster via the
@@ -10122,8 +10295,10 @@ function CreateAgentDialog({ open, onClose, roster }) {
         // Creates, pins, opens, and kicks off the intro in one flow. This is
         // the ONE caller allowed to request the intro turn — genuine New
         // Agent creation. Click-path resolution (openBotCanonicalChat) mints
-        // silently so a resolution miss never burns a turn (ScottFive).
-        const sid = await createCanonicalChat(slug, { kickoff: true })
+        // silently so a resolution miss never burns a turn (ScottFive). The
+        // intro is still withheld when the target cannot serve a model yet
+        // (`ready`, #94071 provider preflight).
+        const sid = await createCanonicalChat(slug, { kickoff: true, ready: readiness.ready })
 
         if (!sid && typeof host.newChat === 'function') {
           host.newChat(slug)
@@ -10210,6 +10385,10 @@ function CreateAgentDialog({ open, onClose, roster }) {
                     value: targetConnection || activeConnectionId || 'local',
                     onValueChange: value => {
                       setTargetConnection(value === (activeConnectionId || 'local') ? '' : value)
+                      // A clone pick names a profile of the OLD target; start the
+                      // new one from its default until its list arrives.
+                      setCloneFrom('default')
+                      setTargetProfiles(null)
                       // The capability catalog and clone list belong to the
                       // target backend — refetch for the new home. The live
                       // Capabilities tab re-pins to it via fixedConnection on
@@ -10346,8 +10525,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
                             labeled(
                               remoteTarget ? `Clone from profile (on ${targetLabel})` : 'Clone from profile',
                               jsxs(Select, {
-                                disabled: remoteTarget,
-                                value: remoteTarget ? 'default' : cloneFrom,
+                                value: remoteTarget ? cloneSource || '__none__' : cloneFrom,
                                 onValueChange: value => {
                                   setCloneFrom(value)
                                   setCaps(null)
@@ -10364,13 +10542,20 @@ function CreateAgentDialog({ open, onClose, roster }) {
                                         value: '__none__',
                                         children: 'Fresh profile (bundled skills)'
                                       }),
-                                      ...roster.map(b => jsx(SelectItem, { value: b.name, children: b.name }, b.name))
+                                      ...cloneChoices.map(name => jsx(SelectItem, { value: name, children: name }, name))
                                     ]
                                   })
                                 ]
                               })
                             ),
+                            remoteTarget && Array.isArray(targetProfiles) && !targetProfiles.length
+                              ? jsx('div', {
+                                  className: 'text-[0.7rem] leading-5 text-(--ui-text-tertiary)',
+                                  children: `Could not list profiles on ${targetLabel} — clone sources fall back to its default profile.`
+                                })
+                              : null,
                             jsx(ModelPicker, {
+                              inheritLabel: `Inherit from default on ${credentialHostLabel}`,
                               value: { provider, model },
                               onChange: patch => {
                                 if ('provider' in patch) {
@@ -10380,7 +10565,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
                                   setModel(patch.model)
                                 }
                               },
-                              placeholderModel: 'inherited from launch profile'
+                              placeholderModel: `inherited from default on ${credentialHostLabel}`
                             }),
                             labeled(
                               'SOUL.md (optional — replaces the generated persona)',
@@ -10399,13 +10584,12 @@ function CreateAgentDialog({ open, onClose, roster }) {
                                   checked: shareAuth,
                                   onCheckedChange: value => setShareAuth(Boolean(value))
                                 }),
-                                'Share keys & accounts with the main profile'
+                                `Share keys & accounts with the default profile on ${credentialHostLabel}`
                               ]
                             }),
                             jsx('div', {
                               className: 'pl-6 pt-0.5 text-[0.7rem] leading-5 text-(--ui-text-tertiary)',
-                              children:
-                                'Subscriptions, OAuth logins, and API keys stay shared (not copied), so token refreshes never invalidate each other. Uncheck for an isolated snapshot copy.'
+                              children: `Scoped to ${credentialHostLabel}: subscriptions, OAuth logins, and API keys stay shared (not copied) with that machine's default profile, so token refreshes never invalidate each other. Credentials are never copied between machines. Uncheck for an isolated snapshot copy there.`
                             }),
                             jsxs('label', {
                               className: 'flex items-center gap-2 text-xs text-(--ui-text-secondary)',
@@ -10498,6 +10682,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
                                     }),
                                     jsx(HubSkillsSection, {
                                       forProfile: null,
+                                      request: requestForTarget,
                                       onInstalled: name =>
                                         setCaps(prev =>
                                           !prev || prev.skills.some(s => s.name === name)
@@ -10570,6 +10755,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
                                                             profile: createdRef.current,
                                                             entry: m,
                                                             ensureProfile: ensureAgentCreated,
+                                                            request: requestForTarget,
                                                             onDone: () => {
                                                               // Setup done: mark installed so the row's
                                                               // checkbox un-disables, and enable it.

--- a/apps/desktop/src/plugins/hermes-bots/tests/create-agent-mcp-setup.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/create-agent-mcp-setup.test.mjs
@@ -15,7 +15,7 @@ test('McpSetupButton accepts an ensureProfile callback and resolves the profile 
     source.indexOf('function botAppearance(')
   )
   // Signature carries ensureProfile.
-  assert.match(fn, /function McpSetupButton\(\{ profile, entry, onDone, ensureProfile, request \}\)/)
+  assert.match(fn, /function McpSetupButton\(\{ profile, entry, onDone, ensureProfile, request, supportScope \}\)/)
   // resolveProfile falls back to ensureProfile() when no profile is set yet.
   assert.match(fn, /const resolveProfile = async \(\) =>/)
   assert.match(fn, /const created = await ensureProfile\(\)/)

--- a/apps/desktop/src/plugins/hermes-bots/tests/create-agent-mcp-setup.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/create-agent-mcp-setup.test.mjs
@@ -15,7 +15,7 @@ test('McpSetupButton accepts an ensureProfile callback and resolves the profile 
     source.indexOf('function botAppearance(')
   )
   // Signature carries ensureProfile.
-  assert.match(fn, /function McpSetupButton\(\{ profile, entry, onDone, ensureProfile \}\)/)
+  assert.match(fn, /function McpSetupButton\(\{ profile, entry, onDone, ensureProfile, request \}\)/)
   // resolveProfile falls back to ensureProfile() when no profile is set yet.
   assert.match(fn, /const resolveProfile = async \(\) =>/)
   assert.match(fn, /const created = await ensureProfile\(\)/)

--- a/apps/desktop/src/plugins/hermes-bots/tests/remote-target-profile-origin.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/remote-target-profile-origin.test.mjs
@@ -67,8 +67,8 @@ function loadMcpRpc(hostRequest) {
   const context = { host: { request: hostRequest } }
   vm.createContext(context)
   return vm.runInContext(
-    `${slice('async function mcpRpc(', '// Probe whether the new lifecycle RPCs exist')}
-;({ mcpRpc })`,
+    `${slice('async function mcpRpc(', 'function McpSetupButton(')}
+;({ mcpRpc, mcpSetupSupported })`,
     context
   )
 }
@@ -410,6 +410,30 @@ test('mcpRpc rides the supplied request fn (owning backend) and falls back to ho
     throw new Error('unknown method: mcp.servers.list')
   })
   assert.deepEqual(plain(unsupported), { ok: false, unsupported: true })
+})
+
+test('mcpSetupSupported probes and caches each owning backend independently', async () => {
+  const ambientCalls = []
+  const oldCalls = []
+  const newCalls = []
+  const { mcpSetupSupported } = loadMcpRpc(async (...args) => ambientCalls.push(args))
+  const oldBackend = async (method, params) => {
+    oldCalls.push({ method, params })
+    throw new Error(`unknown method: ${method}`)
+  }
+  const newBackend = async (method, params) => {
+    newCalls.push({ method, params })
+    return { servers: [] }
+  }
+
+  assert.equal(await mcpSetupSupported(oldBackend, 'connection:old'), false)
+  assert.equal(await mcpSetupSupported(newBackend, 'connection:new'), true)
+  assert.equal(await mcpSetupSupported(oldBackend, 'connection:old'), false)
+  assert.equal(await mcpSetupSupported(newBackend, 'connection:new'), true)
+
+  assert.deepEqual(plain(oldCalls), [{ method: 'mcp.servers.list', params: {} }])
+  assert.deepEqual(plain(newCalls), [{ method: 'mcp.servers.list', params: {} }])
+  assert.deepEqual(ambientCalls, [])
 })
 
 test('regression: MCP setup + hub installs carry the owning route (editor) or the create target (New Bot)', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/remote-target-profile-origin.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/remote-target-profile-origin.test.mjs
@@ -1,0 +1,389 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// #94071 — New Bot on a non-active connection:
+//   1. the profile-origin picker offers the SAME choices for every target
+//      (fresh, or a clone of any profile that exists on THAT machine), sourced
+//      from a routed profiles.list — never forced to `default`;
+//   2. the credential/inherit wording names the create target, not the
+//      window's active gateway;
+//   3. provider readiness on the target is preflighted before the automatic
+//      intro turn — an unready target keeps the bot, badges it, and withholds
+//      the doomed first turn instead of surfacing "agent init failed";
+//   4. editor/create surfaces (MCP setup, hub installs) ride the owning
+//      backend's route instead of the active gateway.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+/** Values built inside a vm context belong to another realm; strict deepEqual
+ *  rejects their prototypes even when the shapes match. Compare plain data. */
+const plain = value => JSON.parse(JSON.stringify(value))
+
+function slice(startMarker, endMarker) {
+  const start = source.indexOf(startMarker)
+  assert.notEqual(start, -1, `missing: ${startMarker}`)
+  const end = source.indexOf(endMarker, start)
+  assert.ok(end > start, `missing delimiter: ${endMarker}`)
+  return source.slice(start, end)
+}
+
+function loadOriginHelpers() {
+  const context = {}
+  vm.createContext(context)
+  return vm.runInContext(
+    `${slice('/** "Inherit" means the launch/default profile', 'function ModelPicker(')}
+;({ botInheritLabel, cloneSourcesFromProfileList, resolveCloneSource })`,
+    context
+  )
+}
+
+function loadReadinessHelpers({ notify, noteBotAttention }) {
+  const context = { host: { notify }, noteBotAttention }
+  vm.createContext(context)
+  return vm.runInContext(
+    `${slice('/** A bot was created on a backend that cannot serve a model yet', '// Bot Mode sessions are ALWAYS hidden')}
+;({ noteProviderSetupNeeded, preflightProviderReadiness })`,
+    context
+  )
+}
+
+function loadClassifier() {
+  const atom = initial => {
+    let value = initial
+    return { get: () => value, set: next => (value = next) }
+  }
+  const context = { atom }
+  vm.createContext(context)
+  return vm.runInContext(
+    `${slice('const BOT_ATTENTION_CLASSES', '/** Last good cron list')}
+;({ attentionReasonFromError })`,
+    context
+  )
+}
+
+function loadMcpRpc(hostRequest) {
+  const context = { host: { request: hostRequest } }
+  vm.createContext(context)
+  return vm.runInContext(
+    `${slice('async function mcpRpc(', '// Probe whether the new lifecycle RPCs exist')}
+;({ mcpRpc })`,
+    context
+  )
+}
+
+function loadCanonicalCreation({ openSession, request }) {
+  const start = source.indexOf('const canonicalCreations = new Map()')
+  const end = source.indexOf('function displayName(', start)
+  const context = {
+    host: { openSession, request },
+    backendTargetProfile: (route, name) => route?.targetProfile || name,
+    botOwner: name => ({ bot: { name }, key: name, name, route: null }),
+    requestForBot: (_bot, method, params) => context.host.request(method, params),
+    window: { setTimeout: callback => callback() }
+  }
+  assert.ok(start > -1 && end > start, 'canonical creation section exists')
+  vm.runInNewContext(`${source.slice(start, end)}\nglobalThis.__c = { createCanonicalChat };`, context)
+  return context.__c
+}
+
+// ── 1. profile origin on a remote target ────────────────────────────────────
+
+test('cloneSourcesFromProfileList: target list → default first, envelope or bare array', () => {
+  const { cloneSourcesFromProfileList } = loadOriginHelpers()
+
+  assert.deepEqual(
+    plain(cloneSourcesFromProfileList({ profiles: [{ name: 'omar' }, { name: 'default' }, { name: '' }, {}] })),
+    ['default', 'omar']
+  )
+  assert.deepEqual(plain(cloneSourcesFromProfileList([{ name: 'a' }, { name: 'b' }])), ['default', 'a', 'b'])
+  assert.deepEqual(plain(cloneSourcesFromProfileList(null)), ['default'])
+  assert.deepEqual(plain(cloneSourcesFromProfileList({ profiles: 'nope' })), ['default'])
+})
+
+test('resolveCloneSource: fresh stays fresh on every target; remote picks are validated against the target', () => {
+  const { resolveCloneSource } = loadOriginHelpers()
+
+  // Fresh profile is a first-class remote choice — the issue's headline gap.
+  assert.equal(resolveCloneSource('__none__', { remoteTarget: true, targetProfiles: ['default', 'omar'] }), null)
+  assert.equal(resolveCloneSource('__none__', { remoteTarget: false }), null)
+  // Local creates are untouched.
+  assert.equal(resolveCloneSource('researcher', { remoteTarget: false }), 'researcher')
+  // A remote pick that exists THERE is honored.
+  assert.equal(resolveCloneSource('omar', { remoteTarget: true, targetProfiles: ['default', 'omar'] }), 'omar')
+  // A name the remote box doesn't have (stale local pick) falls back to its default.
+  assert.equal(resolveCloneSource('local-only', { remoteTarget: true, targetProfiles: ['default', 'omar'] }), 'default')
+  // List not loaded yet / failed → default, never a guess.
+  assert.equal(resolveCloneSource('omar', { remoteTarget: true, targetProfiles: null }), 'default')
+  assert.equal(resolveCloneSource('omar', { remoteTarget: true, targetProfiles: [] }), 'default')
+})
+
+test('regression: the clone picker is never disabled or pinned to default for a remote target', () => {
+  assert.doesNotMatch(source, /disabled: remoteTarget/)
+  assert.doesNotMatch(source, /remoteTarget \? 'default' : cloneFrom/)
+  assert.doesNotMatch(source, /clone_from: cloneFrom === '__none__' \? null : remoteTarget \? 'default' : cloneFrom/)
+  assert.match(source, /clone_from: cloneSource,/)
+  assert.match(source, /value: remoteTarget \? cloneSource \|\| '__none__' : cloneFrom,/)
+  assert.match(source, /\.\.\.cloneChoices\.map\(name => jsx\(SelectItem, \{ value: name, children: name \}, name\)\)/)
+  // The capability catalog preview follows the same resolved source.
+  assert.match(source, /const capSource = cloneSource \|\| 'default'/)
+  assert.match(source, /requestForTarget\('profiles\.describe', \{ name: capSource \}\)/)
+})
+
+test('regression: the clone list for a remote target is the TARGET backend\'s profiles.list (routed RPC)', () => {
+  const dialog = slice('function CreateAgentDialog(', 'function routineBot(')
+
+  assert.match(
+    dialog,
+    /host\s*\.requestProfile\(\s*\{ connectionId: targetConnection, mode: 'remote', profile: 'default', targetProfile: 'default' \},\s*'profiles\.list',\s*\{ include_sessions: false \}\s*\)/
+  )
+  assert.match(dialog, /setTargetProfiles\(cloneSourcesFromProfileList\(res\)\)/)
+  // Switching "Create on" resets the pick to the new target's default and refetches.
+  assert.match(
+    dialog,
+    /setTargetConnection\(value === \(activeConnectionId \|\| 'local'\) \? '' : value\)[\s\S]{0,300}setCloneFrom\('default'\)\s*setTargetProfiles\(null\)/
+  )
+})
+
+// ── 2. target-explicit wording ──────────────────────────────────────────────
+
+test('botInheritLabel names the owning connection; legacy rows keep the old label', () => {
+  const { botInheritLabel } = loadOriginHelpers()
+
+  assert.equal(botInheritLabel({ name: 'omar', connectionLabel: 'This device' }), 'Inherit from default on This device')
+  assert.equal(botInheritLabel({ name: 'omar', connectionLabel: '  ' }), 'Inherit (launch profile)')
+  assert.equal(botInheritLabel(null), 'Inherit (launch profile)')
+})
+
+test('regression: share-keys and inherit copy are scoped to the create target', () => {
+  const dialog = slice('function CreateAgentDialog(', 'function routineBot(')
+
+  assert.doesNotMatch(dialog, /'Share keys & accounts with the main profile'/)
+  assert.match(dialog, /`Share keys & accounts with the default profile on \$\{credentialHostLabel\}`/)
+  assert.match(dialog, /Credentials are never copied between machines\./)
+  assert.match(dialog, /inheritLabel: `Inherit from default on \$\{credentialHostLabel\}`/)
+  assert.match(dialog, /placeholderModel: `inherited from default on \$\{credentialHostLabel\}`/)
+  // The host label is the TARGET's (remote) or the active connection's own row.
+  assert.match(dialog, /const credentialHostLabel = remoteTarget\s*\? targetLabel\s*: \(connections \|\| \[\]\)\.find\(c => c\.id === \(activeConnectionId \|\| 'local'\)\)\?\.label \|\| 'this device'/)
+  // Editor: every ModelPicker in AdvancedProfileConfig carries the bot-qualified label.
+  const editor = slice('function AdvancedProfileConfig(', 'function HubSkillsSection(')
+  assert.equal((editor.match(/jsx\(ModelPicker, \{\s*bot,\s*inheritLabel,/g) || []).length, 3)
+  assert.match(source, /jsx\(SelectItem, \{ value: NONE, children: inheritLabel \}\)/)
+})
+
+// ── 3. provider readiness before the intro turn ─────────────────────────────
+
+test('preflightProviderReadiness: ok=false → not ready with the backend reason; ok/unsupported/errors fail open', async () => {
+  const { preflightProviderReadiness } = loadReadinessHelpers({ notify() {}, noteBotAttention() {} })
+  const calls = []
+  const request = answer => async (method, params) => {
+    calls.push({ method, params })
+    if (typeof answer === 'function') return answer()
+    return answer
+  }
+
+  assert.deepEqual(
+    plain(await preflightProviderReadiness(request({ ok: false, error: 'No usable credentials found for anthropic.' }), 'omar')),
+    { ready: false, reason: 'No usable credentials found for anthropic.' }
+  )
+  assert.deepEqual(plain(calls.at(-1)), { method: 'setup.runtime_check', params: { profile: 'omar' } })
+  assert.deepEqual(plain(await preflightProviderReadiness(request({ ok: false }), 'omar')), {
+    ready: false,
+    reason: 'No inference provider is configured.'
+  })
+  assert.deepEqual(plain(await preflightProviderReadiness(request({ ok: true, provider: 'nous' }), 'omar')), {
+    ready: true,
+    reason: null
+  })
+  // Older gateway without the RPC / transport blip → ready (the intro turn reports itself).
+  assert.deepEqual(
+    plain(
+      await preflightProviderReadiness(
+        request(() => {
+          throw new Error('unknown method: setup.runtime_check')
+        }),
+        'omar'
+      )
+    ),
+    { ready: true, reason: null }
+  )
+  assert.deepEqual(plain(await preflightProviderReadiness(request(undefined), 'omar')), { ready: true, reason: null })
+})
+
+test('noteProviderSetupNeeded badges the bot as missing_config and points at the TARGET machine', () => {
+  const badges = []
+  const toasts = []
+  const { noteProviderSetupNeeded } = loadReadinessHelpers({
+    notify: toast => toasts.push(toast),
+    noteBotAttention: (key, reason) => badges.push({ key, reason })
+  })
+
+  noteProviderSetupNeeded('local::omar', 'This device', 'No usable credentials found for anthropic.')
+
+  assert.deepEqual(badges, [{ key: 'local::omar', reason: 'missing_config' }])
+  assert.equal(toasts.length, 1)
+  assert.equal(toasts[0].kind, 'info')
+  assert.match(toasts[0].message, /^Configure a model on This device before this bot's first chat/)
+  assert.match(toasts[0].message, /No usable credentials found for anthropic\./)
+  assert.match(toasts[0].message, /run `hermes model` on This device/)
+})
+
+test('classifier: readiness-check phrasings classify as missing_config', () => {
+  const { attentionReasonFromError } = loadClassifier()
+
+  assert.equal(attentionReasonFromError('No usable credentials found for openrouter.'), 'missing_config')
+  assert.equal(attentionReasonFromError('No Hermes provider is configured.'), 'missing_config')
+  assert.equal(attentionReasonFromError('No inference provider is configured.'), 'missing_config')
+  assert.equal(
+    attentionReasonFromError('agent init failed: No LLM provider configured. Run `hermes model` to select a provider'),
+    'missing_config'
+  )
+  // Transient classes still never badge.
+  assert.equal(attentionReasonFromError('502 server error'), null)
+})
+
+test('regression: submit preflights the create target BEFORE the intro and withholds the turn when unready', () => {
+  const dialog = slice('function CreateAgentDialog(', 'function routineBot(')
+  const preflight = dialog.indexOf('const readiness = await preflightProviderReadiness(requestForTarget, slug)')
+  const resetAt = dialog.indexOf('reset()\n      onClose()', preflight)
+  const intro = dialog.indexOf('createCanonicalChat(slug, { kickoff: true, ready: readiness.ready })')
+
+  assert.ok(preflight > -1, 'preflight runs on the create target')
+  assert.ok(resetAt > preflight, 'preflight closes over this render\'s target before reset()')
+  assert.ok(intro > resetAt, 'intro is gated on readiness')
+  assert.match(dialog, /if \(!readiness\.ready\) \{\s*noteProviderSetupNeeded\(ownerKey, hostLabel, readiness\.reason\)\s*\}/)
+  // Remote creates get the same badge + notice (they never had an intro turn).
+  assert.ok(dialog.indexOf('noteProviderSetupNeeded(ownerKey') < dialog.indexOf('if (wasRemote) {', preflight))
+  assert.match(
+    dialog,
+    /const ownerKey = botRosterKey\(\{ name: slug, connectionId: wasRemote \? targetConnection : activeConnectionId \}\)/
+  )
+})
+
+test('createCanonicalChat({ kickoff: true, ready: false }) creates, titles, pins and opens — and sends NO prompt', async () => {
+  const events = []
+  const { createCanonicalChat } = loadCanonicalCreation({
+    openSession: async id => events.push(`open:${id}`),
+    request: async method => {
+      events.push(method)
+      if (method === 'session.create') return { stored_session_id: 'stored-1', session_id: 'runtime-1' }
+      return {}
+    }
+  })
+
+  assert.equal(await createCanonicalChat('omar', { kickoff: true, ready: false }), 'stored-1')
+  assert.deepEqual(events, ['session.list', 'session.create', 'session.title', 'open:stored-1'])
+})
+
+test('createCanonicalChat({ kickoff: true, ready: false }) still lands in the chat when the first open raced the lazy row', async () => {
+  const events = []
+  let attempts = 0
+  const { createCanonicalChat } = loadCanonicalCreation({
+    openSession: async id => {
+      attempts += 1
+      events.push(`open:${id}`)
+      if (attempts === 1) throw new Error('not yet')
+    },
+    request: async method => {
+      events.push(method)
+      if (method === 'session.create') return { stored_session_id: 'stored-1', session_id: 'runtime-1' }
+      return {}
+    }
+  })
+
+  assert.equal(await createCanonicalChat('omar', { kickoff: true, ready: false }), 'stored-1')
+  assert.deepEqual(events, ['session.list', 'session.create', 'session.title', 'open:stored-1', 'open:stored-1'])
+  assert.equal(events.includes('prompt.submit'), false)
+})
+
+test('createCanonicalChat({ ready: false }) also withholds the old-gateway compat kickoff', async () => {
+  // Eager session.title is rejected (older gateway) — on a ready target that
+  // is the one case a non-kickoff mint still sends a persistence prompt. An
+  // unready target must not: the lazy row is left to the next click instead.
+  const events = []
+  const { createCanonicalChat } = loadCanonicalCreation({
+    openSession: async id => {
+      events.push(`open:${id}`)
+      throw new Error('Session not found')
+    },
+    request: async method => {
+      events.push(method)
+      if (method === 'session.create') return { stored_session_id: 'stored-1', session_id: 'runtime-1' }
+      if (method === 'session.title') throw new Error('unknown method: session.title')
+      return {}
+    }
+  })
+
+  assert.equal(await createCanonicalChat('omar', { kickoff: true, ready: false }), 'stored-1')
+  assert.deepEqual(events, ['session.list', 'session.create', 'session.title', 'open:stored-1', 'open:stored-1'])
+})
+
+test('createCanonicalChat({ kickoff: true }) on a ready target still introduces the bot (unchanged behavior)', async () => {
+  const events = []
+  const { createCanonicalChat } = loadCanonicalCreation({
+    openSession: async () => undefined,
+    request: async method => {
+      events.push(method)
+      if (method === 'session.create') return { stored_session_id: 'stored-1', session_id: 'runtime-1' }
+      return {}
+    }
+  })
+
+  await createCanonicalChat('omar', { kickoff: true })
+  assert.equal(events.includes('prompt.submit'), true)
+})
+
+// ── 4. owner-routed editor / create surfaces ────────────────────────────────
+
+test('mcpRpc rides the supplied request fn (owning backend) and falls back to host.request', async () => {
+  const hostCalls = []
+  const routed = []
+  const { mcpRpc } = loadMcpRpc(async (method, params) => {
+    hostCalls.push({ method, params })
+    return 'ambient'
+  })
+
+  const viaRoute = await mcpRpc('mcp.servers.list', { profile: 'omar' }, async (method, params) => {
+    routed.push({ method, params })
+    return 'owner'
+  })
+  assert.deepEqual(plain(viaRoute), { ok: true, result: 'owner' })
+  assert.deepEqual(routed, [{ method: 'mcp.servers.list', params: { profile: 'omar' } }])
+  assert.deepEqual(hostCalls, [])
+
+  const ambient = await mcpRpc('mcp.servers.list', {})
+  assert.deepEqual(plain(ambient), { ok: true, result: 'ambient' })
+  assert.equal(hostCalls.length, 1)
+
+  const unsupported = await mcpRpc('mcp.servers.list', {}, async () => {
+    throw new Error('unknown method: mcp.servers.list')
+  })
+  assert.deepEqual(plain(unsupported), { ok: false, unsupported: true })
+})
+
+test('regression: MCP setup + hub installs carry the owning route (editor) or the create target (New Bot)', () => {
+  const button = slice('function McpSetupButton(', 'function botAppearance(')
+  assert.match(button, /const rpc = \(method, params\) => mcpRpc\(method, params, request\)/)
+  assert.doesNotMatch(button, /await mcpRpc\(/)
+  assert.equal((button.match(/await rpc\(/g) || []).length, 6)
+
+  const editor = slice('function AdvancedProfileConfig(', 'function HubSkillsSection(')
+  assert.match(editor, /const requestForThisBot = \(method, params\) => requestForBot\(bot, method, params\)/)
+  // The editor passes the bot's logical NAME (requestForBot rewrites it to
+  // the backend profile) — never the {connectionId, profile} scope object.
+  assert.match(editor, /jsx\(McpSetupButton, \{\s*profile: bot\.name,\s*entry: m,\s*request: requestForThisBot,/)
+  assert.match(editor, /jsx\(HubSkillsSection, \{\s*forProfile: bot\.name,\s*request: requestForThisBot,/)
+  assert.doesNotMatch(editor, /profile: backendScope,\s*entry: m/)
+  assert.doesNotMatch(editor, /forProfile: backendScope/)
+
+  const hub = slice('function HubSkillsSection(', 'function emptyAdvancedState(')
+  assert.match(hub, /function HubSkillsSection\(\{ forProfile, onInstalled, request \}\)/)
+  assert.doesNotMatch(hub, /host\.request\('skills\.manage'/)
+  assert.match(hub, /await send\('skills\.manage', \{ action: 'search', query: q \}\)/)
+  assert.match(hub, /await send\('skills\.manage', \{\s*action: 'install',/)
+
+  const dialog = slice('function CreateAgentDialog(', 'function routineBot(')
+  assert.match(dialog, /ensureProfile: ensureAgentCreated,\s*request: requestForTarget,/)
+  assert.match(dialog, /jsx\(HubSkillsSection, \{\s*forProfile: null,\s*request: requestForTarget,/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/remote-target-profile-origin.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/remote-target-profile-origin.test.mjs
@@ -34,7 +34,7 @@ function loadOriginHelpers() {
   vm.createContext(context)
   return vm.runInContext(
     `${slice('/** "Inherit" means the launch/default profile', 'function ModelPicker(')}
-;({ botInheritLabel, cloneSourcesFromProfileList, resolveCloneSource })`,
+;({ botInheritLabel, cloneSourcesFromProfileList, resolveCloneSource, requestForCreateTarget })`,
     context
   )
 }
@@ -44,7 +44,7 @@ function loadReadinessHelpers({ notify, noteBotAttention }) {
   vm.createContext(context)
   return vm.runInContext(
     `${slice('/** A bot was created on a backend that cannot serve a model yet', '// Bot Mode sessions are ALWAYS hidden')}
-;({ noteProviderSetupNeeded, preflightProviderReadiness })`,
+;({ noteProviderSetupNeeded, preflightProviderReadiness, prepareBotFirstChat })`,
     context
   )
 }
@@ -131,19 +131,31 @@ test('regression: the clone picker is never disabled or pinned to default for a 
   assert.match(source, /requestForTarget\('profiles\.describe', \{ name: capSource \}\)/)
 })
 
-test('regression: the clone list for a remote target is the TARGET backend\'s profiles.list (routed RPC)', () => {
-  const dialog = slice('function CreateAgentDialog(', 'function routineBot(')
+test('requestForCreateTarget routes profile discovery and writes to the selected backend', async () => {
+  const { requestForCreateTarget } = loadOriginHelpers()
+  const calls = []
+  const hostApi = {
+    request: async (method, params) => calls.push({ via: 'ambient', method, params }),
+    requestProfile: async (route, method, params) => calls.push({ via: 'profile', route, method, params })
+  }
 
-  assert.match(
-    dialog,
-    /host\s*\.requestProfile\(\s*\{ connectionId: targetConnection, mode: 'remote', profile: 'default', targetProfile: 'default' \},\s*'profiles\.list',\s*\{ include_sessions: false \}\s*\)/
-  )
-  assert.match(dialog, /setTargetProfiles\(cloneSourcesFromProfileList\(res\)\)/)
-  // Switching "Create on" resets the pick to the new target's default and refetches.
-  assert.match(
-    dialog,
-    /setTargetConnection\(value === \(activeConnectionId \|\| 'local'\) \? '' : value\)[\s\S]{0,300}setCloneFrom\('default'\)\s*setTargetProfiles\(null\)/
-  )
+  await requestForCreateTarget(hostApi, { remoteTarget: false, targetConnection: 'ignored' }, 'profiles.list', {
+    include_sessions: false
+  })
+  await requestForCreateTarget(hostApi, { remoteTarget: true, targetConnection: 'homelab' }, 'profiles.create', {
+    name: 'omar',
+    clone_from: null
+  })
+
+  assert.deepEqual(plain(calls), [
+    { via: 'ambient', method: 'profiles.list', params: { include_sessions: false } },
+    {
+      via: 'profile',
+      route: { connectionId: 'homelab', mode: 'remote', profile: 'default', targetProfile: 'default' },
+      method: 'profiles.create',
+      params: { name: 'omar', clone_from: null }
+    }
+  ])
 })
 
 // ── 2. target-explicit wording ──────────────────────────────────────────────
@@ -165,7 +177,10 @@ test('regression: share-keys and inherit copy are scoped to the create target', 
   assert.match(dialog, /inheritLabel: `Inherit from default on \$\{credentialHostLabel\}`/)
   assert.match(dialog, /placeholderModel: `inherited from default on \$\{credentialHostLabel\}`/)
   // The host label is the TARGET's (remote) or the active connection's own row.
-  assert.match(dialog, /const credentialHostLabel = remoteTarget\s*\? targetLabel\s*: \(connections \|\| \[\]\)\.find\(c => c\.id === \(activeConnectionId \|\| 'local'\)\)\?\.label \|\| 'this device'/)
+  assert.match(
+    dialog,
+    /const credentialHostLabel = remoteTarget\s*\? targetLabel\s*: \(connections \|\| \[\]\)\.find\(c => c\.id === \(activeConnectionId \|\| 'local'\)\)\?\.label \|\| 'this device'/
+  )
   // Editor: every ModelPicker in AdvancedProfileConfig carries the bot-qualified label.
   const editor = slice('function AdvancedProfileConfig(', 'function HubSkillsSection(')
   assert.equal((editor.match(/jsx\(ModelPicker, \{\s*bot,\s*inheritLabel,/g) || []).length, 3)
@@ -184,7 +199,12 @@ test('preflightProviderReadiness: ok=false → not ready with the backend reason
   }
 
   assert.deepEqual(
-    plain(await preflightProviderReadiness(request({ ok: false, error: 'No usable credentials found for anthropic.' }), 'omar')),
+    plain(
+      await preflightProviderReadiness(
+        request({ ok: false, error: 'No usable credentials found for anthropic.' }),
+        'omar'
+      )
+    ),
     { ready: false, reason: 'No usable credentials found for anthropic.' }
   )
   assert.deepEqual(plain(calls.at(-1)), { method: 'setup.runtime_check', params: { profile: 'omar' } })
@@ -229,6 +249,40 @@ test('noteProviderSetupNeeded badges the bot as missing_config and points at the
   assert.match(toasts[0].message, /run `hermes model` on This device/)
 })
 
+test('prepareBotFirstChat preflights before badging the owning target', async () => {
+  const events = []
+  const { prepareBotFirstChat } = loadReadinessHelpers({
+    notify: toast => events.push({ type: 'notify', message: toast.message }),
+    noteBotAttention: (key, reason) => events.push({ type: 'badge', key, reason })
+  })
+
+  const readiness = await prepareBotFirstChat({
+    request: async (method, params) => {
+      events.push({ type: 'request', method, params })
+      return { ok: false, error: "Profile 'omar' does not exist on this backend." }
+    },
+    profile: 'omar',
+    ownerKey: 'homelab::omar',
+    hostLabel: 'Home Lab'
+  })
+
+  assert.deepEqual(plain(readiness), {
+    ready: false,
+    reason: "Profile 'omar' does not exist on this backend."
+  })
+  assert.deepEqual(
+    events.map(event => event.type),
+    ['request', 'badge', 'notify']
+  )
+  assert.deepEqual(plain(events[0]), {
+    type: 'request',
+    method: 'setup.runtime_check',
+    params: { profile: 'omar' }
+  })
+  assert.deepEqual(events[1], { type: 'badge', key: 'homelab::omar', reason: 'missing_config' })
+  assert.match(events[2].message, /^Configure a model on Home Lab/)
+})
+
 test('classifier: readiness-check phrasings classify as missing_config', () => {
   const { attentionReasonFromError } = loadClassifier()
 
@@ -243,22 +297,18 @@ test('classifier: readiness-check phrasings classify as missing_config', () => {
   assert.equal(attentionReasonFromError('502 server error'), null)
 })
 
-test('regression: submit preflights the create target BEFORE the intro and withholds the turn when unready', () => {
+test('regression: submit uses the preflight result to withhold the intro turn when unready', () => {
   const dialog = slice('function CreateAgentDialog(', 'function routineBot(')
-  const preflight = dialog.indexOf('const readiness = await preflightProviderReadiness(requestForTarget, slug)')
+  const preflight = dialog.indexOf('const readiness = await prepareBotFirstChat({')
   const resetAt = dialog.indexOf('reset()\n      onClose()', preflight)
   const intro = dialog.indexOf('createCanonicalChat(slug, { kickoff: true, ready: readiness.ready })')
 
   assert.ok(preflight > -1, 'preflight runs on the create target')
-  assert.ok(resetAt > preflight, 'preflight closes over this render\'s target before reset()')
+  assert.ok(resetAt > preflight, "preflight closes over this render's target before reset()")
   assert.ok(intro > resetAt, 'intro is gated on readiness')
-  assert.match(dialog, /if \(!readiness\.ready\) \{\s*noteProviderSetupNeeded\(ownerKey, hostLabel, readiness\.reason\)\s*\}/)
-  // Remote creates get the same badge + notice (they never had an intro turn).
-  assert.ok(dialog.indexOf('noteProviderSetupNeeded(ownerKey') < dialog.indexOf('if (wasRemote) {', preflight))
-  assert.match(
-    dialog,
-    /const ownerKey = botRosterKey\(\{ name: slug, connectionId: wasRemote \? targetConnection : activeConnectionId \}\)/
-  )
+  // Remote creates are preflighted and badged by the same helper before their
+  // early return (they never create a local canonical chat).
+  assert.ok(preflight < dialog.indexOf('if (wasRemote) {', preflight))
 })
 
 test('createCanonicalChat({ kickoff: true, ready: false }) creates, titles, pins and opens — and sends NO prompt', async () => {

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -987,10 +987,15 @@ def _relative_time(ts) -> str:
     return relative_time(ts)
 
 
-def _has_any_provider_configured() -> bool:
+def _has_any_provider_configured(*, strict_profile_scope: bool = False) -> bool:
     """Check if at least one inference provider is usable."""
+    from agent.secret_scope import current_secret_scope
     from hermes_cli.config import get_env_path, get_hermes_home, load_config
     from hermes_cli.auth import get_auth_status
+
+    # A named profile scope is an isolation boundary: launch-process provider
+    # env belongs to the launch profile and must not make this target appear
+    # ready. Unscoped callers retain the legacy os.getenv behavior.
 
     # Determine whether Hermes itself has been explicitly configured (model
     # in config that isn't the hardcoded default). Used below to gate external
@@ -1031,7 +1036,9 @@ def _has_any_provider_configured() -> bool:
     for pconfig in PROVIDER_REGISTRY.values():
         if pconfig.auth_type == "api_key":
             provider_env_vars.update(pconfig.api_key_env_vars)
-    if any(os.getenv(v) for v in provider_env_vars):
+    scope = current_secret_scope() or {}
+    read_provider_env = scope.get if strict_profile_scope else os.getenv
+    if any(read_provider_env(v) for v in provider_env_vars):
         return True
 
     # Check .env file for keys
@@ -1063,7 +1070,10 @@ def _has_any_provider_configured() -> bool:
 
             auth = json.loads(auth_file.read_text(encoding="utf-8-sig"))
             active = auth.get("active_provider")
-            if active:
+            active_config = PROVIDER_REGISTRY.get(str(active).strip().lower())
+            if active and not (
+                strict_profile_scope and active_config and active_config.auth_type == "api_key"
+            ):
                 status = get_auth_status(active)
                 if status.get("logged_in"):
                     return True
@@ -1082,20 +1092,21 @@ def _has_any_provider_configured() -> bool:
             return True
 
     # Check provider-specific auth fallbacks (for example, Copilot via gh auth).
-    try:
-        for provider_id, pconfig in PROVIDER_REGISTRY.items():
-            if pconfig.auth_type != "api_key":
-                continue
-            status = get_auth_status(provider_id)
-            if status.get("logged_in"):
-                return True
-    except Exception:
-        pass
+    if not strict_profile_scope:
+        try:
+            for provider_id, pconfig in PROVIDER_REGISTRY.items():
+                if pconfig.auth_type != "api_key":
+                    continue
+                status = get_auth_status(provider_id)
+                if status.get("logged_in"):
+                    return True
+        except Exception:
+            pass
 
     # Check for Claude Code OAuth credentials (~/.claude/.credentials.json)
     # Only count these if Hermes has been explicitly configured — Claude Code
     # being installed doesn't mean the user wants Hermes to use their tokens.
-    if _has_hermes_config:
+    if _has_hermes_config and not strict_profile_scope:
         try:
             from agent.anthropic_adapter import (
                 read_claude_code_credentials,

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8590,11 +8590,84 @@ def test_enable_gateway_prompts_sets_gateway_env(monkeypatch):
 
 
 def test_setup_status_reports_provider_config(monkeypatch):
-    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: False)
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda **_kwargs: False)
 
     resp = server.handle_request({"id": "1", "method": "setup.status", "params": {}})
 
     assert resp["result"]["provider_configured"] is False
+
+
+def test_setup_status_without_profile_still_uses_launch_process_credentials(monkeypatch):
+    """Strict named-profile isolation must not change legacy unscoped readiness."""
+    monkeypatch.setenv("OPENAI_API_KEY", "launch-profile-secret")
+
+    response = server.handle_request({"id": "1", "method": "setup.status", "params": {}})
+
+    assert response["result"]["provider_configured"] is True
+
+
+@pytest.mark.parametrize("failure", ["builder", "setter"])
+def test_readiness_profile_bind_failure_restores_prior_context(monkeypatch, tmp_path, failure):
+    """A half-installed readiness scope must never escape into its caller."""
+    from agent import secret_scope
+    from hermes_constants import get_hermes_home, reset_hermes_home_override, set_hermes_home_override
+    from tui_gateway import methods_config
+
+    prior_home = tmp_path / "prior"
+    target_home = tmp_path / "target"
+    prior_home.mkdir()
+    target_home.mkdir()
+    home_token = set_hermes_home_override(prior_home)
+    secret_token = secret_scope.set_secret_scope({"OPENAI_API_KEY": "prior-secret"})
+    try:
+        if failure == "builder":
+            monkeypatch.setattr(
+                methods_config,
+                "build_profile_secret_scope",
+                lambda _home: (_ for _ in ()).throw(RuntimeError("builder failed")),
+            )
+        else:
+            monkeypatch.setattr(
+                methods_config,
+                "set_secret_scope",
+                lambda _scope: (_ for _ in ()).throw(RuntimeError("setter failed")),
+            )
+
+        with pytest.raises(RuntimeError, match=f"{failure} failed"):
+            methods_config._bind_readiness_profile(target_home)
+
+        assert Path(get_hermes_home()).resolve() == prior_home.resolve()
+        assert secret_scope.current_secret_scope() == {"OPENAI_API_KEY": "prior-secret"}
+    finally:
+        secret_scope.reset_secret_scope(secret_token)
+        reset_hermes_home_override(home_token)
+
+
+def test_readiness_profile_unbind_restores_home_when_secret_reset_fails(monkeypatch, tmp_path):
+    from agent import secret_scope
+    from hermes_constants import get_hermes_home, reset_hermes_home_override, set_hermes_home_override
+    from tui_gateway import methods_config
+
+    prior_home = tmp_path / "prior"
+    target_home = tmp_path / "target"
+    prior_home.mkdir()
+    target_home.mkdir()
+    prior_token = set_hermes_home_override(prior_home)
+    home_token = set_hermes_home_override(target_home)
+    try:
+        monkeypatch.setattr(
+            methods_config,
+            "reset_secret_scope",
+            lambda _token: (_ for _ in ()).throw(RuntimeError("reset failed")),
+        )
+
+        with pytest.raises(RuntimeError, match="reset failed"):
+            methods_config._unbind_readiness_profile(home_token, object())
+
+        assert Path(get_hermes_home()).resolve() == prior_home.resolve()
+        assert secret_scope.current_secret_scope() is None
+    finally:
+        reset_hermes_home_override(prior_token)
 
 
 def test_probe_credentials_emits_exact_empty_key_warning():
@@ -8612,7 +8685,7 @@ def test_probe_credentials_allows_keyless_custom_runtime():
 
 
 def test_setup_runtime_check_rejects_empty_runtime_key(monkeypatch):
-    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: True)
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda **_kwargs: True)
     monkeypatch.setattr(
         "hermes_cli.runtime_provider.resolve_runtime_provider",
         lambda requested=None: {
@@ -8634,7 +8707,7 @@ def test_setup_runtime_check_rejects_empty_runtime_key(monkeypatch):
 
 
 def test_setup_runtime_check_allows_no_key_custom_runtime(monkeypatch):
-    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: True)
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda **_kwargs: True)
     monkeypatch.setattr(
         "hermes_cli.runtime_provider.resolve_runtime_provider",
         lambda requested=None: {
@@ -8651,7 +8724,7 @@ def test_setup_runtime_check_allows_no_key_custom_runtime(monkeypatch):
 
 
 def test_setup_runtime_check_rejects_implicit_bedrock_when_unconfigured(monkeypatch):
-    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: False)
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda **_kwargs: False)
     monkeypatch.setattr(
         "hermes_cli.runtime_provider.resolve_runtime_provider",
         lambda requested=None: {
@@ -8667,9 +8740,86 @@ def test_setup_runtime_check_rejects_implicit_bedrock_when_unconfigured(monkeypa
     assert resp["result"]["provider"] == "bedrock"
 
 
+def test_profile_scoped_status_ignores_launch_credentials_in_multiplex(monkeypatch, tmp_path):
+    from agent import secret_scope
+
+    bot_home = tmp_path / "profiles" / "bot"
+    bot_home.mkdir(parents=True)
+    monkeypatch.setenv("OPENAI_API_KEY", "launch-profile-secret")
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name == "bot")
+    monkeypatch.setattr(server, "_profile_home", lambda profile: bot_home)
+
+    secret_scope.set_multiplex_active(True)
+    try:
+        response = server.handle_request(
+            {"id": "1", "method": "setup.status", "params": {"profile": "bot"}}
+        )
+    finally:
+        secret_scope.set_multiplex_active(False)
+
+    assert response["result"] == {"provider_configured": False, "profile": "bot"}
+
+
+def test_profile_scoped_status_uses_target_credentials_not_launch_credentials(monkeypatch, tmp_path):
+    from agent import secret_scope
+
+    bot_home = tmp_path / "profiles" / "bot"
+    bot_home.mkdir(parents=True)
+    (bot_home / ".env").write_text("ANTHROPIC_API_KEY=target-profile-secret\n", encoding="utf-8")
+    monkeypatch.setenv("OPENAI_API_KEY", "launch-profile-secret")
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name == "bot")
+    monkeypatch.setattr(server, "_profile_home", lambda profile: bot_home)
+
+    secret_scope.set_multiplex_active(True)
+    try:
+        response = server.handle_request(
+            {"id": "1", "method": "setup.status", "params": {"profile": "bot"}}
+        )
+    finally:
+        secret_scope.set_multiplex_active(False)
+
+    assert response["result"] == {"provider_configured": True, "profile": "bot"}
+
+
+def test_profile_scoped_runtime_rejects_implicit_bedrock_despite_launch_key(monkeypatch, tmp_path):
+    from agent import secret_scope
+
+    bot_home = tmp_path / "profiles" / "bot"
+    bot_home.mkdir(parents=True)
+    monkeypatch.setenv("OPENAI_API_KEY", "launch-profile-secret")
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name == "bot")
+    monkeypatch.setattr(server, "_profile_home", lambda profile: bot_home)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested=None: {
+            "provider": "bedrock",
+            "model": "bedrock-model",
+            "api_key": "aws-sdk",
+            "source": "iam-role",
+        },
+    )
+
+    secret_scope.set_multiplex_active(True)
+    try:
+        response = server.handle_request(
+            {"id": "1", "method": "setup.runtime_check", "params": {"profile": "bot"}}
+        )
+    finally:
+        secret_scope.set_multiplex_active(False)
+
+    assert response["result"] == {
+        "ok": False,
+        "provider": "bedrock",
+        "model": "bedrock-model",
+        "source": "iam-role",
+        "error": "No Hermes provider is configured.",
+        "profile": "bot",
+    }
+
+
 def test_setup_runtime_check_honors_requested_provider(monkeypatch):
     """Onboarding must be able to validate the provider the user just connected."""
-    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: True)
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda **_kwargs: True)
 
     def fake_resolve(requested=None, **kwargs):
         if requested == "nous":
@@ -8719,7 +8869,7 @@ def test_setup_runtime_check_scopes_to_requested_profile(monkeypatch, tmp_path):
         seen["secret"] = get_secret("OPENROUTER_API_KEY")
         return {"provider": "openrouter", "api_key": "sk-or-scoped-secret-1234", "source": "env"}
 
-    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: True)
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda **_kwargs: True)
     monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", fake_resolve)
     monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name == "bot")
     monkeypatch.setattr(server, "_profile_home", lambda profile: bot_home if profile == "bot" else None)
@@ -8761,7 +8911,7 @@ def test_setup_runtime_check_profile_scope_is_concurrency_safe(monkeypatch, tmp_
         }
         return {"provider": "openrouter", "api_key": "no-key-required", "source": "env"}
 
-    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: True)
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda **_kwargs: True)
     monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", fake_resolve)
     monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name in homes)
     monkeypatch.setattr(server, "_profile_home", lambda profile: homes[profile])
@@ -8791,7 +8941,7 @@ def test_setup_runtime_check_unknown_profile_never_answers_for_launch_profile(mo
         calls.append(requested)
         return {"provider": "openrouter", "api_key": "sk-or-real-1234", "source": "env"}
 
-    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: True)
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda **_kwargs: True)
     monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", fake_resolve)
     monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: False)
 
@@ -8825,7 +8975,7 @@ def test_setup_readiness_unknown_profile_errors_are_identical(monkeypatch):
 
 def test_setup_runtime_check_without_profile_is_byte_identical(monkeypatch):
     """No ``profile`` param → the pre-#94071 payload shape (no extra keys)."""
-    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: True)
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda **_kwargs: True)
     monkeypatch.setattr(
         "hermes_cli.runtime_provider.resolve_runtime_provider",
         lambda requested=None: {"provider": "nous", "api_key": "invoke-jwt", "source": "portal"},
@@ -8843,7 +8993,7 @@ def test_setup_runtime_check_scoped_profile_reports_missing_credentials(monkeypa
     bot_home = tmp_path / "profiles" / "bot"
     bot_home.mkdir(parents=True)
 
-    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: True)
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda **_kwargs: True)
     monkeypatch.setattr(
         "hermes_cli.runtime_provider.resolve_runtime_provider",
         lambda requested=None: {"provider": "anthropic", "api_key": "", "source": "config"},
@@ -8872,7 +9022,7 @@ def test_setup_status_scopes_to_requested_profile(monkeypatch, tmp_path):
     bot_home.mkdir(parents=True)
     seen = {}
 
-    def fake_configured():
+    def fake_configured(**_kwargs):
         seen["home"] = str(get_hermes_home())
         return False
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6,6 +6,7 @@ import sys
 import threading
 import time
 import types
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -8735,6 +8736,52 @@ def test_setup_runtime_check_scopes_to_requested_profile(monkeypatch, tmp_path):
     assert Path(str(get_hermes_home())).resolve() != bot_home.resolve()
 
 
+def test_setup_runtime_check_profile_scope_is_concurrency_safe(monkeypatch, tmp_path):
+    """Hermes home and secret scope are ContextVars, so overlapping checks for
+    different profiles must never observe one another's home or credentials."""
+    from agent.secret_scope import get_secret
+    from hermes_constants import get_hermes_home
+
+    homes = {}
+    for profile in ("alpha", "beta"):
+        home = tmp_path / "profiles" / profile
+        home.mkdir(parents=True)
+        (home / ".env").write_text(f"OPENROUTER_API_KEY={profile}-secret\n", encoding="utf-8")
+        homes[profile] = home
+
+    rendezvous = threading.Barrier(2)
+    seen = {}
+
+    def fake_resolve(requested=None, **kwargs):
+        rendezvous.wait(timeout=5)
+        profile = Path(get_hermes_home()).name
+        seen[profile] = {
+            "home": str(get_hermes_home()),
+            "secret": get_secret("OPENROUTER_API_KEY"),
+        }
+        return {"provider": "openrouter", "api_key": "no-key-required", "source": "env"}
+
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: True)
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", fake_resolve)
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name in homes)
+    monkeypatch.setattr(server, "_profile_home", lambda profile: homes[profile])
+
+    def check(profile):
+        return server.handle_request(
+            {"id": profile, "method": "setup.runtime_check", "params": {"profile": profile}}
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        responses = list(pool.map(check, ("alpha", "beta")))
+
+    assert [response["result"]["profile"] for response in responses] == ["alpha", "beta"]
+    assert all(response["result"]["ok"] is True for response in responses)
+    assert Path(seen["alpha"]["home"]).resolve() == homes["alpha"].resolve()
+    assert Path(seen["beta"]["home"]).resolve() == homes["beta"].resolve()
+    assert seen["alpha"]["secret"] == "alpha-secret"
+    assert seen["beta"]["secret"] == "beta-secret"
+
+
 def test_setup_runtime_check_unknown_profile_never_answers_for_launch_profile(monkeypatch):
     """A profile this backend does not have must NOT silently report the
     launch profile's readiness (that is the wrong-backend class of #94071)."""
@@ -8756,6 +8803,24 @@ def test_setup_runtime_check_unknown_profile_never_answers_for_launch_profile(mo
     assert resp["result"]["profile"] == "ghost"
     assert "does not exist on this backend" in resp["result"]["error"]
     assert calls == []
+
+
+def test_setup_readiness_unknown_profile_errors_are_identical(monkeypatch):
+    """Both profile-aware readiness methods reject an invalid target with the
+    same semantic result instead of disagreeing on JSON-RPC error shape."""
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: False)
+
+    params = {"profile": " ghost "}
+    status = server.handle_request({"id": "1", "method": "setup.status", "params": params})
+    runtime = server.handle_request({"id": "2", "method": "setup.runtime_check", "params": params})
+
+    expected = {
+        "ok": False,
+        "profile": "ghost",
+        "error": "Profile 'ghost' does not exist on this backend.",
+    }
+    assert status["result"] == expected
+    assert runtime["result"] == expected
 
 
 def test_setup_runtime_check_without_profile_is_byte_identical(monkeypatch):
@@ -8821,8 +8886,11 @@ def test_setup_status_scopes_to_requested_profile(monkeypatch, tmp_path):
     assert Path(seen["home"]).resolve() == bot_home.resolve()
 
     unknown = server.handle_request({"id": "2", "method": "setup.status", "params": {"profile": "ghost"}})
-    assert "error" in unknown
-    assert "does not exist on this backend" in unknown["error"]["message"]
+    assert unknown["result"] == {
+        "ok": False,
+        "profile": "ghost",
+        "error": "Profile 'ghost' does not exist on this backend.",
+    }
 
 
 def test_complete_slash_drops_removed_provider_alias():

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8699,6 +8699,132 @@ def test_setup_runtime_check_honors_requested_provider(monkeypatch):
     assert default["result"]["provider"] == "anthropic"
 
 
+def test_setup_runtime_check_scopes_to_requested_profile(monkeypatch, tmp_path):
+    """#94071: the Desktop preflights a freshly created bot's provider on its
+    target backend BEFORE the automatic first turn. The check must resolve
+    against THAT profile's home + .env, not the launch profile's."""
+    from hermes_constants import get_hermes_home
+
+    bot_home = tmp_path / "profiles" / "bot"
+    bot_home.mkdir(parents=True)
+    (bot_home / ".env").write_text("OPENROUTER_API_KEY=sk-or-scoped-secret-1234\n", encoding="utf-8")
+
+    seen = {}
+
+    def fake_resolve(requested=None, **kwargs):
+        from agent.secret_scope import get_secret
+
+        seen["home"] = str(get_hermes_home())
+        seen["secret"] = get_secret("OPENROUTER_API_KEY")
+        return {"provider": "openrouter", "api_key": "sk-or-scoped-secret-1234", "source": "env"}
+
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: True)
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", fake_resolve)
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name == "bot")
+    monkeypatch.setattr(server, "_profile_home", lambda profile: bot_home if profile == "bot" else None)
+
+    resp = server.handle_request(
+        {"id": "1", "method": "setup.runtime_check", "params": {"profile": "bot"}}
+    )
+
+    assert resp["result"]["ok"] is True
+    assert resp["result"]["profile"] == "bot"
+    assert Path(seen["home"]).resolve() == bot_home.resolve()
+    assert seen["secret"] == "sk-or-scoped-secret-1234"
+    # Bindings are restored after the call.
+    assert Path(str(get_hermes_home())).resolve() != bot_home.resolve()
+
+
+def test_setup_runtime_check_unknown_profile_never_answers_for_launch_profile(monkeypatch):
+    """A profile this backend does not have must NOT silently report the
+    launch profile's readiness (that is the wrong-backend class of #94071)."""
+    calls = []
+
+    def fake_resolve(requested=None, **kwargs):
+        calls.append(requested)
+        return {"provider": "openrouter", "api_key": "sk-or-real-1234", "source": "env"}
+
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: True)
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", fake_resolve)
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: False)
+
+    resp = server.handle_request(
+        {"id": "1", "method": "setup.runtime_check", "params": {"profile": "ghost"}}
+    )
+
+    assert resp["result"]["ok"] is False
+    assert resp["result"]["profile"] == "ghost"
+    assert "does not exist on this backend" in resp["result"]["error"]
+    assert calls == []
+
+
+def test_setup_runtime_check_without_profile_is_byte_identical(monkeypatch):
+    """No ``profile`` param → the pre-#94071 payload shape (no extra keys)."""
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: True)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested=None: {"provider": "nous", "api_key": "invoke-jwt", "source": "portal"},
+    )
+
+    resp = server.handle_request({"id": "1", "method": "setup.runtime_check", "params": {}})
+
+    assert resp["result"] == {"ok": True, "provider": "nous", "model": None, "source": "portal"}
+
+
+def test_setup_runtime_check_scoped_profile_reports_missing_credentials(monkeypatch, tmp_path):
+    """The reproduced #94071 case: the target's profile has a model pin but no
+    usable credential → ok=False with the profile named, so the Desktop keeps
+    the bot and withholds the doomed intro turn."""
+    bot_home = tmp_path / "profiles" / "bot"
+    bot_home.mkdir(parents=True)
+
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: True)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested=None: {"provider": "anthropic", "api_key": "", "source": "config"},
+    )
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name == "bot")
+    monkeypatch.setattr(server, "_profile_home", lambda profile: bot_home if profile == "bot" else None)
+
+    resp = server.handle_request(
+        {"id": "1", "method": "setup.runtime_check", "params": {"profile": "bot"}}
+    )
+
+    assert resp["result"] == {
+        "ok": False,
+        "provider": "anthropic",
+        "model": None,
+        "source": "config",
+        "error": "No usable credentials found for anthropic.",
+        "profile": "bot",
+    }
+
+
+def test_setup_status_scopes_to_requested_profile(monkeypatch, tmp_path):
+    from hermes_constants import get_hermes_home
+
+    bot_home = tmp_path / "profiles" / "bot"
+    bot_home.mkdir(parents=True)
+    seen = {}
+
+    def fake_configured():
+        seen["home"] = str(get_hermes_home())
+        return False
+
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", fake_configured)
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: name == "bot")
+    monkeypatch.setattr(server, "_profile_home", lambda profile: bot_home if profile == "bot" else None)
+
+    resp = server.handle_request({"id": "1", "method": "setup.status", "params": {"profile": "bot"}})
+
+    assert resp["result"] == {"provider_configured": False, "profile": "bot"}
+    assert Path(seen["home"]).resolve() == bot_home.resolve()
+
+    unknown = server.handle_request({"id": "2", "method": "setup.status", "params": {"profile": "ghost"}})
+    assert "error" in unknown
+    assert "does not exist on this backend" in unknown["error"]["message"]
+
+
 def test_complete_slash_drops_removed_provider_alias():
     # `/provider` was folded into a single `/model` command, so autocomplete
     # must no longer offer the dead alias...

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -7,9 +7,17 @@ Handler bodies are byte-identical to their pre-split server.py form; they
 are rebound onto server.py's globals at install time — see method_ctx.py.
 """
 
+from pathlib import Path
+
 from .method_ctx import HandlerRegistry
 
-from hermes_constants import DEFAULT_INDICATOR_STYLE, INDICATOR_STYLES
+from agent.secret_scope import build_profile_secret_scope, reset_secret_scope, set_secret_scope
+from hermes_constants import (
+    DEFAULT_INDICATOR_STYLE,
+    INDICATOR_STYLES,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
 
 _registry = HandlerRegistry()
 method = _registry.method
@@ -376,12 +384,73 @@ def _(rid, params: dict) -> dict:
     return _err(rid, 4002, f"unknown config key: {key}")
 
 
+def _readiness_profile_home(params: dict):
+    """Resolve the optional ``profile`` param of the setup readiness RPCs.
+
+    Returns ``(profile, home)``: ``home`` is the named profile's directory on
+    THIS host (None for the launch profile / no param). A profile that does
+    not exist here raises ``FileNotFoundError`` instead of silently answering
+    for the launch profile — a readiness check that quietly reports the wrong
+    profile (or the wrong machine) is exactly the failure #94071 describes.
+    """
+    profile = str(params.get("profile") or "").strip() if isinstance(params, dict) else ""
+    if not profile:
+        return "", None
+    from hermes_cli import profiles as profiles_mod
+
+    if not profiles_mod.profile_exists(profile):
+        raise FileNotFoundError(f"Profile '{profile}' does not exist on this backend.")
+    # Looked up on the server module at call time: these helpers keep THIS
+    # module's globals (only handlers are rebound onto server.py's), and tests
+    # monkeypatch ``server._profile_home``.
+    from tui_gateway import server as _server
+
+    return profile, _server._profile_home(profile)
+
+
+def _bind_readiness_profile(home):
+    """Bind a profile's HERMES_HOME *and* its ``.env`` secret scope.
+
+    ``_profile_scoped`` only overrides the home; provider resolution also reads
+    credentials through the secret scope, so a scoped check must see the same
+    ``.env`` the agent would at session build (server.py's turn thread does the
+    identical pair). Returns the two reset tokens (None, None) for no-op.
+    """
+    if home is None:
+        return None, None
+    home_token = set_hermes_home_override(home)
+    secret_token = set_secret_scope(build_profile_secret_scope(Path(home)))
+    return home_token, secret_token
+
+
+def _unbind_readiness_profile(home_token, secret_token) -> None:
+    if secret_token is not None:
+        reset_secret_scope(secret_token)
+    if home_token is not None:
+        reset_hermes_home_override(home_token)
+
+
 @method("setup.status")
 def _(rid, params: dict) -> dict:
+    """Loose provider check; ``profile`` (optional) scopes it to that profile's home."""
     try:
         from hermes_cli.main import _has_any_provider_configured
+        from tui_gateway.methods_config import (
+            _bind_readiness_profile,
+            _readiness_profile_home,
+            _unbind_readiness_profile,
+        )
 
-        return _ok(rid, {"provider_configured": bool(_has_any_provider_configured())})
+        profile, home = _readiness_profile_home(params)
+        home_token, secret_token = _bind_readiness_profile(home)
+        try:
+            configured = bool(_has_any_provider_configured())
+        finally:
+            _unbind_readiness_profile(home_token, secret_token)
+        payload = {"provider_configured": configured}
+        if profile:
+            payload["profile"] = profile
+        return _ok(rid, payload)
     except Exception as e:
         return _err(rid, 5016, str(e))
 
@@ -396,15 +465,39 @@ def _(rid, params: dict) -> dict:
     uses on session creation. It returns ok=False with the auth error message
     when the user's configured model cannot actually be served, so UIs can
     surface onboarding before the user submits a doomed prompt.
+
+    ``profile`` (optional): answer for THAT profile's home on this host —
+    its config.yaml model pin and its ``.env`` — instead of the launch
+    profile's. The Desktop uses this right after creating a bot on a target
+    connection, before starting the bot's automatic first turn (#94071). A
+    profile unknown to this backend answers ``ok=False`` with an explicit
+    error rather than reporting the launch profile's readiness.
     """
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
         from hermes_cli.auth import has_usable_secret
         from hermes_cli.main import _has_any_provider_configured
+        from tui_gateway.methods_config import (
+            _bind_readiness_profile,
+            _readiness_profile_home,
+            _unbind_readiness_profile,
+        )
 
         requested = str(params.get("provider") or "").strip() or None
-        runtime = resolve_runtime_provider(requested=requested)
-        provider_configured = bool(_has_any_provider_configured())
+        try:
+            profile, home = _readiness_profile_home(params)
+        except FileNotFoundError as e:
+            return _ok(
+                rid,
+                {"ok": False, "profile": str(params.get("profile") or "").strip(), "error": str(e)},
+            )
+        home_token, secret_token = _bind_readiness_profile(home)
+        try:
+            runtime = resolve_runtime_provider(requested=requested)
+            provider_configured = bool(_has_any_provider_configured())
+        finally:
+            _unbind_readiness_profile(home_token, secret_token)
+        scoped = {"profile": profile} if profile else {}
         provider = runtime.get("provider") or "provider"
         source = str(runtime.get("source") or "")
         if (
@@ -424,6 +517,7 @@ def _(rid, params: dict) -> dict:
                     "model": runtime.get("model"),
                     "source": source,
                     "error": "No Hermes provider is configured.",
+                    **scoped,
                 },
             )
 
@@ -445,6 +539,7 @@ def _(rid, params: dict) -> dict:
                     "model": runtime.get("model"),
                     "source": runtime.get("source"),
                     "error": f"No usable credentials found for {provider}.",
+                    **scoped,
                 },
             )
 
@@ -455,6 +550,7 @@ def _(rid, params: dict) -> dict:
                 "provider": runtime.get("provider"),
                 "model": runtime.get("model"),
                 "source": runtime.get("source"),
+                **scoped,
             },
         )
     except Exception as e:

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -420,15 +420,21 @@ def _bind_readiness_profile(home):
     if home is None:
         return None, None
     home_token = set_hermes_home_override(home)
-    secret_token = set_secret_scope(build_profile_secret_scope(Path(home)))
+    try:
+        secret_token = set_secret_scope(build_profile_secret_scope(Path(home)))
+    except Exception:
+        reset_hermes_home_override(home_token)
+        raise
     return home_token, secret_token
 
 
 def _unbind_readiness_profile(home_token, secret_token) -> None:
-    if secret_token is not None:
-        reset_secret_scope(secret_token)
-    if home_token is not None:
-        reset_hermes_home_override(home_token)
+    try:
+        if secret_token is not None:
+            reset_secret_scope(secret_token)
+    finally:
+        if home_token is not None:
+            reset_hermes_home_override(home_token)
 
 
 def _unknown_readiness_profile(ok, rid, params: dict, error: FileNotFoundError) -> dict:
@@ -461,7 +467,7 @@ def _(rid, params: dict) -> dict:
             return _unknown_readiness_profile(_ok, rid, params, e)
         home_token, secret_token = _bind_readiness_profile(home)
         try:
-            configured = bool(_has_any_provider_configured())
+            configured = bool(_has_any_provider_configured(strict_profile_scope=bool(profile)))
         finally:
             _unbind_readiness_profile(home_token, secret_token)
         payload = {"provider_configured": configured}
@@ -509,7 +515,7 @@ def _(rid, params: dict) -> dict:
         home_token, secret_token = _bind_readiness_profile(home)
         try:
             runtime = resolve_runtime_provider(requested=requested)
-            provider_configured = bool(_has_any_provider_configured())
+            provider_configured = bool(_has_any_provider_configured(strict_profile_scope=bool(profile)))
         finally:
             _unbind_readiness_profile(home_token, secret_token)
         scoped = {"profile": profile} if profile else {}

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -409,12 +409,13 @@ def _readiness_profile_home(params: dict):
 
 
 def _bind_readiness_profile(home):
-    """Bind a profile's HERMES_HOME *and* its ``.env`` secret scope.
+    """Bind context-local HERMES_HOME and ``.env`` secret scope.
 
-    ``_profile_scoped`` only overrides the home; provider resolution also reads
-    credentials through the secret scope, so a scoped check must see the same
-    ``.env`` the agent would at session build (server.py's turn thread does the
-    identical pair). Returns the two reset tokens (None, None) for no-op.
+    Both setters use ContextVars (not process globals), matching the turn
+    thread's pair while allowing concurrent checks for different profiles to
+    remain isolated. ``_profile_scoped`` only overrides the home; provider
+    resolution also reads credentials through the secret scope. Returns the
+    two reset tokens (None, None) for no-op.
     """
     if home is None:
         return None, None
@@ -430,6 +431,18 @@ def _unbind_readiness_profile(home_token, secret_token) -> None:
         reset_hermes_home_override(home_token)
 
 
+def _unknown_readiness_profile(ok, rid, params: dict, error: FileNotFoundError) -> dict:
+    """Return the same semantic failure for both profile-aware readiness RPCs."""
+    return ok(
+        rid,
+        {
+            "ok": False,
+            "profile": str(params.get("profile") or "").strip(),
+            "error": str(error),
+        },
+    )
+
+
 @method("setup.status")
 def _(rid, params: dict) -> dict:
     """Loose provider check; ``profile`` (optional) scopes it to that profile's home."""
@@ -439,9 +452,13 @@ def _(rid, params: dict) -> dict:
             _bind_readiness_profile,
             _readiness_profile_home,
             _unbind_readiness_profile,
+            _unknown_readiness_profile,
         )
 
-        profile, home = _readiness_profile_home(params)
+        try:
+            profile, home = _readiness_profile_home(params)
+        except FileNotFoundError as e:
+            return _unknown_readiness_profile(_ok, rid, params, e)
         home_token, secret_token = _bind_readiness_profile(home)
         try:
             configured = bool(_has_any_provider_configured())
@@ -481,16 +498,14 @@ def _(rid, params: dict) -> dict:
             _bind_readiness_profile,
             _readiness_profile_home,
             _unbind_readiness_profile,
+            _unknown_readiness_profile,
         )
 
         requested = str(params.get("provider") or "").strip() or None
         try:
             profile, home = _readiness_profile_home(params)
         except FileNotFoundError as e:
-            return _ok(
-                rid,
-                {"ok": False, "profile": str(params.get("profile") or "").strip(), "error": str(e)},
-            )
+            return _unknown_readiness_profile(_ok, rid, params, e)
         home_token, secret_token = _bind_readiness_profile(home)
         try:
             runtime = resolve_runtime_provider(requested=requested)


### PR DESCRIPTION
## Summary

Fixes remote **Bots → New Bot** creation when the selected target is not the Desktop's active gateway.

- Discovers clone sources from the selected target and preserves the chosen fresh/empty/clone origin.
- Makes credential-sharing and inherited-model copy name the target machine explicitly.
- Runs provider readiness against the newly created target profile before the intro turn; unready profiles remain created and receive an actionable configuration notice instead of a misleading failed-chat error.
- Routes MCP support/setup and Hub search/install through the bot/create target's owning request path, with capability support cached per owner rather than globally.
- Keeps explicit `local` capability scope distinct from the ambient active connection.
- Adds profile-scoped `setup.status` / `setup.runtime_check` handling in the gateway.

Fixes #94071.

## Correctness details

- Named-profile readiness binds both that profile's home and secret scope and restores both ContextVars on every normal and exceptional path.
- Named-profile provider detection ignores launch-profile process credentials; unscoped RPC behavior remains unchanged.
- Unknown target profiles fail explicitly instead of silently reporting readiness for the launch profile.
- MCP capability probing is routed and cached per stable owner/connection; two backends with opposite capability support remain isolated.

## Scope

The cleaned branch contains 4 linear commits and changes 9 files. Superseded broad session-owner routing commits were removed; exact fresh-chat owner continuity remains in dependent PR #94656.

## Verification on current head

- Gateway readiness regressions: **15 passed**
- Focused Hermes Bots plugin tests: **19 passed**
- Capability-scope Vitest: **8 passed**
- Full Desktop plugin suite: **573 passed**
- Desktop renderer, Electron and E2E TypeScript checks: passed
- Full Desktop ESLint: passed
- Python Ruff checks: passed
- Contributor attribution audit: passed
- `git diff --check`: passed
- Independent post-fix review: **APPROVE**

## Manual test outline

1. Register two connections and keep connection A active.
2. Create a bot on connection B using Fresh, Empty, and Clone origins; verify profile discovery and writes occur on B.
3. Create on B without a usable provider; verify the bot remains created, the intro turn is withheld, and the notice names B.
4. Open that bot's editor while A remains active; verify Skills/MCP/Hub operations go to B.
5. Configure B and verify the first chat succeeds without switching the whole Desktop to B.
