### PR TITLE
fix(web): use native-compatible Vite dirname

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
 
+const dirname = import.meta.dirname;
 const BACKEND = process.env.HERMES_DASHBOARD_URL ?? "http://127.0.0.1:9119";
 
 /**
@@ -61,8 +62,8 @@ export default defineConfig({
   plugins: [react(), tailwindcss(), hermesDevToken()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
-      "@hermes/shared": path.resolve(__dirname, "../apps/shared/src"),
+      "@": path.resolve(dirname, "./src"),
+      "@hermes/shared": path.resolve(dirname, "../apps/shared/src"),
     },
     // When @nous-research/ui is symlinked via `file:../../design-language`,
     // Node's module resolution would pick up shared deps from


### PR DESCRIPTION
## Summary
- Replace web Vite config alias usage of __dirname with import.meta.dirname.
- Keeps path resolution equivalent while avoiding the Vite native config-loader warning.

## Verification
- npm run build --workspace web
