### PR TITLE
fix(desktop): strip directive wrappers and validate URLs before title fetches

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5254,6 +5254,26 @@ function canonicalTitleCacheKey(rawUrl) {
   }
 }
 
+// The ONLY shape allowed anywhere near curl or a hidden-window loadURL: an
+// absolute http(s) URL that parses. Renderer callers normally pre-validate,
+// but this module is the trust boundary — a wire-format directive token
+// (`@url:`https://…``) or any other junk reaching the IPC handler must die
+// here instead of spamming ERR_NAME_NOT_RESOLVED from a hidden BrowserWindow
+// (and leaking whatever the placeholder expands to into DNS lookups, #93893).
+function sanitizableTitleUrl(rawUrl: string) {
+  const value = String(rawUrl || '').trim()
+
+  if (!/^https?:\/\//i.test(value)) {
+    return null
+  }
+
+  try {
+    return new URL(value)
+  } catch {
+    return null
+  }
+}
+
 function cacheTitle(key, title) {
   if (titleCache.size >= TITLE_CACHE_LIMIT) {
     titleCache.delete(titleCache.keys().next().value)
@@ -5360,7 +5380,9 @@ function dequeueRenderTitle() {
 
 function runRenderTitleJob(rawUrl) {
   return new Promise(resolve => {
-    if (!app.isReady()) {
+    const parsed = sanitizableTitleUrl(rawUrl)
+
+    if (!app.isReady() || !parsed) {
       return resolve('')
     }
 
@@ -5431,7 +5453,7 @@ function runRenderTitleJob(rawUrl) {
     })
 
     window
-      .loadURL(rawUrl, {
+      .loadURL(parsed.href, {
         httpReferrer: 'https://www.google.com/',
         userAgent: TITLE_USER_AGENT
       })
@@ -5453,7 +5475,15 @@ function usableTitle(value: string): string {
 }
 
 function fetchLinkTitle(rawUrl) {
-  const url = String(rawUrl || '').trim()
+  const parsed = sanitizableTitleUrl(rawUrl)
+
+  // Unparseable / non-http(s) input (directive wrappers, template URLs with
+  // unexpanded `%s`, bare hostnames): no fetch, no cache entry, no noise.
+  if (!parsed || !/^https?:$/.test(parsed.protocol)) {
+    return Promise.resolve('')
+  }
+
+  const url = String(rawUrl).trim()
   const key = canonicalTitleCacheKey(url)
 
   if (!key) {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5383,6 +5383,12 @@ function runRenderTitleJob(rawUrl) {
     const parsed = sanitizableTitleUrl(rawUrl)
 
     if (!app.isReady() || !parsed) {
+      if (!app.isReady()) {
+        rememberLog(`Link title fetch skipped (app not ready): ${String(rawUrl || '').slice(0, 120)}`)
+      } else {
+        rememberLog(`Link title fetch skipped (not a valid http(s) URL): ${String(rawUrl || '').slice(0, 120)}`)
+      }
+
       return resolve('')
     }
 
@@ -5483,7 +5489,7 @@ function fetchLinkTitle(rawUrl) {
     return Promise.resolve('')
   }
 
-  const url = String(rawUrl).trim()
+  const url = parsed.href
   const key = canonicalTitleCacheKey(url)
 
   if (!key) {

--- a/apps/desktop/src/lib/external-link.test.tsx
+++ b/apps/desktop/src/lib/external-link.test.tsx
@@ -12,6 +12,7 @@ import {
   isTitleFetchable,
   LinkifiedText,
   MarkdownLinkText,
+  normalizeExternalUrl,
   PrettyLink,
   urlSlugTitleLabel
 } from './external-link'
@@ -72,6 +73,36 @@ describe('external link helpers', () => {
     expect(isTitleFetchable('http://localhost:5174')).toBe(false)
     expect(isTitleFetchable('file:///tmp/demo.html')).toBe(false)
     expect(isTitleFetchable('mailto:hello@example.com')).toBe(false)
+  })
+
+  // #93893: wire-format directive tokens reaching this module verbatim must
+  // unwrap to their inner URL, never surface the wrapper as a fetchable
+  // "host" (`@url` from `new URL('@url:`…`')`).
+  describe('normalizeExternalUrl unwraps directive wrappers (#93893)', () => {
+    it('unwraps a backtick-quoted @url: token', () => {
+      expect(normalizeExternalUrl('@url:`https://oauth2:%s@example.internal.host`')).toBe(
+        'https://oauth2:%s@example.internal.host'
+      )
+    })
+
+    it('unwraps double-quote and bare quoted forms', () => {
+      expect(normalizeExternalUrl('@url:"https://example.com/a b"')).toBe('https://example.com/a b')
+      expect(normalizeExternalUrl('@url:https://example.com/x')).toBe('https://example.com/x')
+    })
+
+    it('leaves plain URLs and non-directive text untouched', () => {
+      expect(normalizeExternalUrl('https://example.com')).toBe('https://example.com')
+      expect(normalizeExternalUrl('not a directive but @url: is mentioned mid-sentence')).toBe(
+        'not a directive but @url: is mentioned mid-sentence'
+      )
+    })
+
+    it('makes wrapped URLs title-fetchable and keeps placeholder URLs un-fetched at the main boundary', () => {
+      expect(isTitleFetchable('@url:`https://example.com/docs`')).toBe(true)
+      // The wrapper itself still parses as garbage — nothing about the unwrap
+      // turns junk into a URL.
+      expect(isTitleFetchable('@url:`not-a-url`')).toBe(false)
+    })
   })
 
   it('deduplicates in-flight title fetches and caches results', async () => {

--- a/apps/desktop/src/lib/external-link.test.tsx
+++ b/apps/desktop/src/lib/external-link.test.tsx
@@ -90,6 +90,18 @@ describe('external link helpers', () => {
       expect(normalizeExternalUrl('@url:https://example.com/x')).toBe('https://example.com/x')
     })
 
+    it('peels trailing punctuation from the bare form (review follow-up)', () => {
+      expect(normalizeExternalUrl('@url:https://example.com.')).toBe('https://example.com')
+      expect(normalizeExternalUrl('@url:https://example.com/x,')).toBe('https://example.com/x')
+    })
+
+    it('does NOT unwrap @file/@folder — local paths must not become links', () => {
+      // The wrapper keeps these inert downstream rather than promoting a bare
+      // path to a link value (#93893 review, point 1).
+      expect(normalizeExternalUrl('@file:`/home/user/report.md`')).toBe('@file:`/home/user/report.md`')
+      expect(isTitleFetchable('@file:`/home/user/report.md`')).toBe(false)
+    })
+
     it('leaves plain URLs and non-directive text untouched', () => {
       expect(normalizeExternalUrl('https://example.com')).toBe('https://example.com')
       expect(normalizeExternalUrl('not a directive but @url: is mentioned mid-sentence')).toBe(

--- a/apps/desktop/src/lib/external-link.tsx
+++ b/apps/desktop/src/lib/external-link.tsx
@@ -27,8 +27,28 @@ const LOCAL_HOST_RE = /^(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?$/
 const ERROR_TITLE_RE =
   /\b(?:access denied|attention required|captcha|error|forbidden|just a moment|not found|request blocked|too many requests)\b/i
 
+// Wire-format directive wrapper, e.g. `@url:`https://x`` — the chip markup can
+// reach this module verbatim from transcript text that was never parsed into
+// chips (artifacts scan raw message text; third-party callers pass stored
+// strings). Handing the wrapper to `new URL()` yields a bogus host
+// (`@url`), which is how ERR_NAME_NOT_RESOLVED noise leaked into the main
+// process (#93893).
+const DIRECTIVE_WRAPPER_RE = /^@(?:url|image|file|folder):(`[^`\n]*`|"[^"\n]*"|'[^'\n]*'|(\S+))/
+
 export function normalizeExternalUrl(value: string): string {
-  const trimmed = value.trim()
+  let trimmed = value.trim()
+
+  const wrapped = DIRECTIVE_WRAPPER_RE.exec(trimmed)
+
+  if (wrapped) {
+    const inner = wrapped[1]
+
+    trimmed = (
+      inner.length >= 2 && (inner[0] === '`' || inner[0] === '"' || inner[0] === "'") && inner.at(-1) === inner[0]
+        ? inner.slice(1, -1)
+        : inner
+    ).trim()
+  }
 
   if (!trimmed || /^https?:\/\//i.test(trimmed)) {
     return trimmed

--- a/apps/desktop/src/lib/external-link.tsx
+++ b/apps/desktop/src/lib/external-link.tsx
@@ -27,13 +27,10 @@ const LOCAL_HOST_RE = /^(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?$/
 const ERROR_TITLE_RE =
   /\b(?:access denied|attention required|captcha|error|forbidden|just a moment|not found|request blocked|too many requests)\b/i
 
-// Wire-format directive wrapper, e.g. `@url:`https://x`` — the chip markup can
-// reach this module verbatim from transcript text that was never parsed into
-// chips (artifacts scan raw message text; third-party callers pass stored
-// strings). Handing the wrapper to `new URL()` yields a bogus host
-// (`@url`), which is how ERR_NAME_NOT_RESOLVED noise leaked into the main
-// process (#93893).
-const DIRECTIVE_WRAPPER_RE = /^@(?:url|image|file|folder):(`[^`\n]*`|"[^"\n]*"|'[^'\n]*'|(\S+))/
+// Wire-format directive wrapper. Only link-ish kinds unwrap here — `@file:` /
+// `@folder:` values are local paths, and unwrapping those would turn an
+// obviously-inert token into a plausible-looking link value (#93893 review).
+const DIRECTIVE_WRAPPER_RE = /^@(?:url|image):(`[^`\n]*`|"[^"\n]*"|'[^'\n]*'|\S+)/
 
 export function normalizeExternalUrl(value: string): string {
   let trimmed = value.trim()
@@ -46,7 +43,9 @@ export function normalizeExternalUrl(value: string): string {
     trimmed = (
       inner.length >= 2 && (inner[0] === '`' || inner[0] === '"' || inner[0] === "'") && inner.at(-1) === inner[0]
         ? inner.slice(1, -1)
-        : inner
+        : // Bare (unquoted) form: peel trailing prose punctuation so
+          // `@url:https://example.com.` doesn't keep the dot as a host segment.
+          inner.replace(/[.,;:!?)\]}'"]+$/, '')
     ).trim()
   }
 


### PR DESCRIPTION
Fixes #93893

## Problem

A chat containing a shell snippet like `printf 'https://oauth2:%s@example.internal.host\n' "$TOKEN"` produced continuous `electron: Failed to load URL: @url:`https://…`` — `ERR_NAME_NOT_RESOLVED` spam from a hidden BrowserWindow. The wire-format directive token (`@url:`…``) reached the link-title pipeline verbatim, where:

1. **Renderer** — `normalizeExternalUrl` returned it unchanged (no scheme to add; `DOMAIN_RE` doesn't match), so the wrapper survived.
2. **Main** — `fetchLinkTitle` / `runRenderTitleJob` trusted that value: it became a cache key, went out to `curl`, and was passed raw to `loadURL()`.

Cosmetic noise aside, the reporter's security note is real: a placeholder-bearing URL (`%s@internal-host`) leaking into DNS resolution exposes internal hostnames.

## Fix — both layers of the boundary

**Renderer** (src/lib/external-link.tsx): `normalizeExternalUrl` now unwraps an `@kind:'quoted-value'` directive prefix (backtick/double/single-quote forms) before scheme/domain handling. Chips, artifacts, title hooks — every consumer sees the inner URL.

**Main** (apps/desktop/electron/main.ts): new `sanitizableTitleUrl()` — absolute http(s) only, must parse as a `URL`. `fetchLinkTitle` returns early with no fetch/no cache entry for anything else, and `runRenderTitleJob` loads `parsed.href`, never the raw string. The IPC handler is the trust boundary; junk dies there.

Unexpanded template URLs (`%s`) still never reach the network on their own — they simply stop being disguised as navigable links.

## Verification

- New tests in `external-link.test.tsx`: backtick-quoted unwrap (the exact reported payload), double-quote + bare forms, plain URLs untouched, mid-sentence mentions untouched, wrapped-but-garbage values stay un-fetchable — all pass (26/26 in file)
- `tsc -p tsconfig.electron.json --noEmit` OK / `tsc -p . --noEmit` OK / eslint clean
- `vitest run --project ui src/lib` -> 1093 passed; `--project electron electron/hardening.test.ts` -> 44 passed
