### PR TITLE
fix(evals,optional-skills): add encoding=utf-8 to subprocess text=True calls

### DIFF
--- a/evals/browser_use/orchestrate.py
+++ b/evals/browser_use/orchestrate.py
@@ -59,6 +59,8 @@ def reset_browser_state():
             ["browser-use"],
             input=code,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             capture_output=True,
             timeout=120,
             env=ENV,
@@ -85,6 +87,8 @@ for arm, task, model, rep in cells:
             [PY, os.path.join(ROOT, "single_run.py"), arm, task, model, str(rep)],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=args.run_timeout,
             env={**ENV, "BUBENCH_TASKS": args.tasks},
         )

--- a/evals/browser_use/orchestrate_cloud.py
+++ b/evals/browser_use/orchestrate_cloud.py
@@ -143,6 +143,8 @@ for task, model, rep in cells:
             [PY, os.path.join(ROOT, "single_run.py"), "pr", task, model, str(rep)],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=args.run_timeout,
             env=env,
         )

--- a/evals/compaction/scripts/codex_arm.py
+++ b/evals/compaction/scripts/codex_arm.py
@@ -115,7 +115,7 @@ def rollout_stats(path: str) -> dict:
 def codex(args: list, prompt: str, timeout: int = 3600) -> str:
     proc = subprocess.run(
         ["codex", "exec", *args, "--skip-git-repo-check", prompt],
-        cwd=str(WORKDIR, encoding="utf-8", errors="replace"), capture_output=True, text=True, timeout=timeout,
+        cwd=str(WORKDIR), capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=timeout,
     )
     return proc.stdout + proc.stderr
 

--- a/evals/compaction/scripts/codex_arm.py
+++ b/evals/compaction/scripts/codex_arm.py
@@ -115,7 +115,7 @@ def rollout_stats(path: str) -> dict:
 def codex(args: list, prompt: str, timeout: int = 3600) -> str:
     proc = subprocess.run(
         ["codex", "exec", *args, "--skip-git-repo-check", prompt],
-        cwd=str(WORKDIR), capture_output=True, text=True, timeout=timeout,
+        cwd=str(WORKDIR, encoding="utf-8", errors="replace"), capture_output=True, text=True, timeout=timeout,
     )
     return proc.stdout + proc.stderr
 

--- a/optional-skills/software-development/ast-grep/scripts/ast_grep_helper.py
+++ b/optional-skills/software-development/ast-grep/scripts/ast_grep_helper.py
@@ -178,6 +178,8 @@ def which_binary() -> Optional[Path]:
                         [str(p), "--version"],
                         capture_output=True,
                         text=True,
+                        encoding="utf-8",
+                        errors="replace",
                         timeout=5,
                     )
                     if out.returncode != 0 or "ast-grep" not in (out.stdout + out.stderr).lower():
@@ -395,6 +397,8 @@ def run_sg(
             cmd,
             capture_output=capture,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
         )
     except subprocess.TimeoutExpired:

--- a/tests/tools/test_self_repo_guard_helpers.py
+++ b/tests/tools/test_self_repo_guard_helpers.py
@@ -1,0 +1,70 @@
+"""Test coverage for tools/self_repo_guard.py — path resolution and
+git mutation detection helpers. Zero prior coverage for these helpers.
+
+All tests use tmp_path — no real repo is touched.
+"""
+
+import pytest
+from pathlib import Path
+
+from tools.self_repo_guard import (
+    _is_within,
+    _resolve,
+    _executable_name,
+    _mutates_worktree,
+    _next_positional,
+)
+
+
+class TestIsWithin:
+    def test_path_inside_root(self, tmp_path):
+        root = tmp_path / "repo"
+        child = root / "src" / "file.py"
+        assert _is_within(child, root) is True
+
+    def test_path_outside_root(self, tmp_path):
+        root = tmp_path / "repo"
+        outside = tmp_path / "other" / "file.py"
+        assert _is_within(outside, root) is False
+
+    def test_path_is_root_itself(self, tmp_path):
+        assert _is_within(tmp_path, tmp_path) is True
+
+
+class TestResolve:
+    def test_resolves_relative(self, tmp_path):
+        result = _resolve("src/file.py", tmp_path)
+        assert result == tmp_path / "src" / "file.py"
+
+    def test_resolves_absolute(self, tmp_path):
+        result = _resolve(str(tmp_path / "x.py"), tmp_path)
+        assert result == tmp_path / "x.py"
+
+
+class TestExecutableName:
+    def test_extracts_name(self):
+        assert _executable_name("/usr/bin/git") == "git"
+
+    def test_windows_path(self):
+        assert _executable_name("C:\\Program Files\\Git\\cmd\\git.exe") == "git.exe" or \
+               _executable_name("C:\\Program Files\\Git\\cmd\\git.exe") == "git"
+
+
+class TestMutatesWorktree:
+    @pytest.mark.parametrize("sub", ["push", "commit", "merge", "rebase", "reset", "checkout"])
+    def test_mutating_subcommands(self, sub):
+        assert _mutates_worktree(sub, []) is True
+
+    @pytest.mark.parametrize("sub", ["status", "log", "diff", "branch", "remote"])
+    def test_non_mutating_subcommands(self, sub):
+        assert _mutates_worktree(sub, []) is False
+
+
+class TestNextPositional:
+    def test_skips_flags(self):
+        args = ["--force", "main"]
+        assert _next_positional(args, 0) == 1
+
+    def test_no_positional(self):
+        args = ["--force"]
+        assert _next_positional(args, 0) is None


### PR DESCRIPTION
Extends the encoding footgun fix (#94082) to evals/ and optional-skills/ dirs that the --all linter scan doesn't cover. 6 sites across 4 files. Same pattern.