### PR TITLE
Multi-tab in-app browser

### DIFF
--- a/apps/desktop/src/app/chat/pane-mirror.ts
+++ b/apps/desktop/src/app/chat/pane-mirror.ts
@@ -48,6 +48,9 @@ export interface PaneMirror<T> {
    *  as `tabLead` — a name that moves faster than re-registration (see
    *  PaneChrome.tabTitle). Falls back to `title`. */
   tabTitle?: (key: string) => ReactNode
+  /** Mint another tile of this kind — the strip's "+" (see PaneChrome.newTab).
+   *  Per tile so a mirror can offer it for some of its tabs and not others. */
+  newTab?: (key: string) => (() => void) | undefined
   render: (key: string) => ReactNode
   /** Wrap the tile's TAB (domain context menu — session verbs). */
   tabWrap?: (key: string, tab: ReactElement) => ReactNode
@@ -102,6 +105,7 @@ export function paneMirror<T>(cfg: PaneMirror<T>): () => void {
             pos: cfg.dir?.(tile) ?? 'right'
           },
           minWidth: cfg.minWidth,
+          newTab: cfg.newTab?.(key),
           // Every mirrored tile is a full workspace surface docked beside main —
           // and closeable, which is what keeps its tab when it lands in a zone of
           // its own (see strip-visibility.ts).

--- a/apps/desktop/src/app/chat/preview-tile.test.ts
+++ b/apps/desktop/src/app/chat/preview-tile.test.ts
@@ -12,7 +12,7 @@ import { contributesToWorkspace } from '@/components/pane-shell/workspace-scope'
 import { registry } from '@/contrib/registry'
 import { closeRightRail, openPreview } from '@/store/preview'
 
-import { watchPreviewTiles } from './preview-tile'
+import { browserTabLabel, watchPreviewTiles } from './preview-tile'
 
 beforeAll(() => {
   watchPreviewTiles()
@@ -22,8 +22,10 @@ afterEach(() => {
   closeRightRail()
 })
 
+// By prefix, not by a literal id: a Browser tab's id is minted per tab now
+// that there can be more than one of them.
 function browserPane() {
-  return registry.getArea('panes').find(entry => entry.id === 'preview-tile:url:browser')
+  return registry.getArea('panes').find(entry => entry.id.startsWith('preview-tile:url:'))
 }
 
 describe('preview tiles in Bot Mode', () => {
@@ -39,6 +41,34 @@ describe('preview tiles in Bot Mode', () => {
     expect(pane?.workspaceMode).toBeUndefined()
     expect(contributesToWorkspace(pane, 'sessions')).toBe(true)
     expect(contributesToWorkspace(pane, 'bots', 'bot:connection-a::default')).toBe(true)
+  })
+})
+
+describe('browserTabLabel', () => {
+  const target = { kind: 'url', label: 'Browser', source: 'about:blank', url: 'about:blank' } as const
+
+  it('names the tab after the page', () => {
+    expect(browserTabLabel(target, { title: 'Hacker News', url: 'https://news.ycombinator.com/' })).toBe('Hacker News')
+  })
+
+  // Chromium hands back the address as the title when the page never set one,
+  // which is a worse tab label than the host it came from.
+  it('falls back to the host when the page has no title of its own', () => {
+    expect(browserTabLabel(target, { title: '', url: 'https://www.example.com/a/b' })).toBe('example.com')
+    expect(browserTabLabel(target, { title: 'https://example.com/a', url: 'https://example.com/a' })).toBe(
+      'example.com'
+    )
+  })
+
+  it('falls back to the surface when there is no page and no host', () => {
+    expect(browserTabLabel(target)).toBe('Browser')
+    expect(browserTabLabel(target, { title: '', url: 'about:blank' })).toBe('Browser')
+  })
+
+  // A tab restored from storage has reported nothing yet, so its target is all
+  // there is to name it by.
+  it('names an unreported tab from its target', () => {
+    expect(browserTabLabel({ ...target, url: 'https://github.com/nous' })).toBe('github.com')
   })
 })
 

--- a/apps/desktop/src/app/chat/preview-tile.tsx
+++ b/apps/desktop/src/app/chat/preview-tile.tsx
@@ -10,12 +10,22 @@
  * one bar instead of two.
  */
 
+import { useStore } from '@nanostores/react'
+
 import { findGroup } from '@/components/pane-shell/tree/model'
 import { $activeTreeGroup, $layoutTree, revealTreePane, treePanesWithPrefix } from '@/components/pane-shell/tree/store'
 import { FileTypeIcon } from '@/components/ui/file-type-icon'
 import { ToolIcon } from '@/components/ui/tool-icon'
 import { $rightRailActiveTabId, type RightRailTabId, selectRightRailTab } from '@/store/layout'
-import { $previewTabs, closeRightRailTab, type PreviewTarget } from '@/store/preview'
+import {
+  $browserPages,
+  $previewTabs,
+  type BrowserPage,
+  closeRightRailTab,
+  forgetBrowserPage,
+  newBrowserTab,
+  type PreviewTarget
+} from '@/store/preview'
 
 import { paneMirror } from './pane-mirror'
 import { PreviewTilePane } from './right-rail/preview'
@@ -26,9 +36,11 @@ function targetFor(tabId: string): PreviewTarget | null {
   return $previewTabs.get().find(tab => tab.id === tabId)?.target ?? null
 }
 
-/** Tab title. A URL is a BROWSER — the tab names the surface, not the page, so
- *  it doesn't rename itself on every navigation. A file names the file; an
- *  artifact is titled rather than located, so its label is the whole name. */
+/** Tab title. A URL tab is titled by the CONTRIBUTION as the surface — see
+ *  `BrowserTabLabel` for the live page name the strip actually renders — so
+ *  navigating doesn't re-register the pane on every hop. A file names the
+ *  file; an artifact is titled rather than located, so its label is the whole
+ *  name. */
 function previewTitle(tabId: string): string {
   const target = targetFor(tabId)
 
@@ -48,6 +60,40 @@ function previewTitle(tabId: string): string {
   const tail = value.split(/[\\/]/).filter(Boolean).at(-1)
 
   return tail || value || 'Preview'
+}
+
+/**
+ * What to call a Browser tab. Its page title, else the host it is on, else
+ * the surface — the ladder every browser walks, and the reason more than one
+ * Browser is usable at all: three tabs reading "Browser" name nothing.
+ *
+ * A page that never set a title reports its own address as one, which is a
+ * worse label than the host it came from, so an address-shaped title falls
+ * through.
+ */
+export function browserTabLabel(target: PreviewTarget, page?: BrowserPage): string {
+  const url = page?.url || target.url
+  const title = page?.title.trim()
+
+  if (title && title !== url) {
+    return title
+  }
+
+  try {
+    return new URL(url).hostname.replace(/^www\./, '') || 'Browser'
+  } catch {
+    // `about:blank` and half-typed addresses have no host to fall back to.
+    return 'Browser'
+  }
+}
+
+/** Live tab label for a Browser: it renames itself as the page navigates,
+ *  without the contribution re-registering (see PaneChrome.tabTitle). */
+function BrowserTabLabel({ tabId }: { tabId: string }) {
+  const pages = useStore($browserPages)
+  const target = targetFor(tabId)
+
+  return target ? browserTabLabel(target, pages[tabId]) : null
 }
 
 /** The tab's lead glyph — the same file/tool icon family the file tree and code
@@ -157,8 +203,13 @@ const watchPreviewTileMirror = paneMirror<{ id: string }>({
   minWidth: '22rem',
   title: previewTitle,
   tabLead: tabId => <PreviewTabLead tabId={tabId} />,
+  tabTitle: tabId => (targetFor(tabId)?.kind === 'url' ? <BrowserTabLabel tabId={tabId} /> : undefined),
+  // A Browser is a vessel, so there can be more of it — a file peek is one of
+  // a kind and leaves the strip's "+" to whatever else the zone holds.
+  newTab: tabId => (targetFor(tabId)?.kind === 'url' ? newBrowserTab : undefined),
   render: tabId => <PreviewTilePane tabId={tabId} />,
   close: tabId => {
+    forgetBrowserPage(tabId)
     forgetPreviewConsole(tabId)
     closeRightRailTab(tabId)
   }

--- a/apps/desktop/src/app/chat/right-rail/preview-browser-bar.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-browser-bar.test.tsx
@@ -163,7 +163,10 @@ describe('PreviewBrowserBar', () => {
     expect(address(rendered).value).toBe('example.org/docs')
   })
 
-  it('normalizes and navigates on Enter, then releases the field back to the page', () => {
+  // Committing used to drop the field back to `url` — the page you were
+  // LEAVING — so the address you typed flashed away and came back once the
+  // load landed. What you asked for stays put until the page actually moves.
+  it('normalizes and navigates on Enter, and holds the address it asked for', () => {
     const onNavigate = vi.fn()
     const rendered = render(<PreviewBrowserBar {...baseProps} onNavigate={onNavigate} />)
     const input = address(rendered)
@@ -173,7 +176,35 @@ describe('PreviewBrowserBar', () => {
     fireEvent.keyDown(input, { key: 'Enter' })
 
     expect(onNavigate).toHaveBeenCalledWith('http://localhost:5173')
-    expect(address(rendered).value).toBe('https://example.com')
+    expect(address(rendered).value).toBe('http://localhost:5173')
+  })
+
+  // A redirect means the address you asked for is no longer the truth.
+  it('releases the asked-for address once the page lands somewhere', () => {
+    const rendered = render(<PreviewBrowserBar {...baseProps} />)
+    const input = address(rendered)
+
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: 'example.org' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    rendered.rerender(<PreviewBrowserBar {...baseProps} url="https://www.example.org/home" />)
+
+    expect(address(rendered).value).toBe('https://www.example.org/home')
+  })
+
+  // Re-focusing mid-flight must offer what is on screen to edit, not resurrect
+  // the address of the page being left behind.
+  it('hands the in-flight address to the field on re-focus', () => {
+    const rendered = render(<PreviewBrowserBar {...baseProps} />)
+    const input = address(rendered)
+
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: 'example.org' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    fireEvent.blur(input)
+    fireEvent.focus(input)
+
+    expect(address(rendered).value).toBe('https://example.org')
   })
 
   it('refuses to navigate to a script-bearing scheme and marks the field invalid', () => {
@@ -227,6 +258,19 @@ describe('PreviewBrowserBar', () => {
 
     expect(onNavigate).not.toHaveBeenCalled()
     expect(address(rendered).value).toBe('https://example.com')
+  })
+
+  // Progress belongs beside the address it describes; the reload glyph sits in
+  // a row of four and reads as chrome rather than as this page's state.
+  it('shows progress inside the address field only while loading', () => {
+    const { container, rerender } = render(<PreviewBrowserBar {...baseProps} loading />)
+    const field = screen.getByRole('textbox', { name: 'Address' }).parentElement
+
+    expect(field?.querySelector('.codicon-loading')).toBeTruthy()
+
+    rerender(<PreviewBrowserBar {...baseProps} />)
+
+    expect(container.querySelector('.codicon-loading')).toBeNull()
   })
 
   it('spins the reload glyph only while loading', () => {

--- a/apps/desktop/src/app/chat/right-rail/preview-browser-bar.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-browser-bar.tsx
@@ -14,13 +14,14 @@
  * buttons, so a glyph here and a glyph on the strip are still the same button.
  */
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { Codicon } from '@/components/ui/codicon'
 import { CopyButton } from '@/components/ui/copy-button'
 import { Input } from '@/components/ui/input'
 import { PaneStripGlyph } from '@/components/ui/pane-tab'
 import { useI18n } from '@/i18n'
+import { cn } from '@/lib/utils'
 
 interface PreviewBrowserBarProps {
   canGoBack: boolean
@@ -105,9 +106,18 @@ export function PreviewBrowserBar({
   // Null while the field is idle, so the address tracks navigation on its own;
   // a string once the user takes it over, so typing survives a page load.
   const [draft, setDraft] = useState<null | string>(null)
+  // The address we asked for and are still waiting on. Without it, committing
+  // dropped the field straight back to `url` — the page you were LEAVING —
+  // so every navigation flashed the old address before the new one arrived.
+  const [pending, setPending] = useState<null | string>(null)
   // Only while the user is typing: a page that navigates itself is never the
   // user's mistake to flag.
   const invalid = draft !== null && draft.trim().length > 0 && !normalizePreviewAddress(draft)
+  const shown = draft ?? pending ?? url
+
+  // The page moved (or a redirect landed somewhere else entirely), so the real
+  // address supersedes what we asked for.
+  useEffect(() => setPending(null), [url])
 
   const commit = (value: string) => {
     const address = normalizePreviewAddress(value)
@@ -117,6 +127,7 @@ export function PreviewBrowserBar({
     }
 
     setDraft(null)
+    setPending(address)
     onNavigate(address)
   }
 
@@ -144,15 +155,26 @@ export function PreviewBrowserBar({
           It copies what the field shows: on a remote gateway, that is the
           reach-resolved address. */}
       <div className="relative min-w-0 flex-1">
+        {/* Progress lives IN the field, where the address it belongs to is —
+            the reload glyph also spins, but it sits in a row of four and
+            reads as chrome rather than as this page's state. */}
+        {loading && (
+          <Codicon
+            className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+            name="loading"
+            size="0.75rem"
+            spinning
+          />
+        )}
         <Input
           aria-invalid={invalid || undefined}
           aria-label={copy.address}
-          className="pr-7"
+          className={cn('pr-7', loading && 'pl-6')}
           inputMode="url"
           onBlur={() => setDraft(null)}
           onChange={event => setDraft(event.target.value)}
           onFocus={event => {
-            setDraft(url)
+            setDraft(shown)
             event.currentTarget.select()
           }}
           onKeyDown={event => {
@@ -169,7 +191,7 @@ export function PreviewBrowserBar({
           placeholder={copy.addressPlaceholder}
           size="xs"
           spellCheck={false}
-          value={draft ?? url}
+          value={shown}
         />
         <CopyButton
           appearance="inline"

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -390,6 +390,10 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
   const navigateTo = useCallback(
     (url: string) => {
       setLoadError(null)
+      // The reach probe below is a round-trip of its own, and `did-start-loading`
+      // can't fire until it resolves — so own the loading state from the moment
+      // we accept the address, or the bar sits idle over a request in flight.
+      setLoading(true)
       // Typed addresses get the same loopback reach as agent-opened ones — on a
       // remote gateway `localhost:5173` is usually the dev server the user is
       // there to look at, not something on their own laptop.

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -18,7 +18,12 @@ import { reachablePreviewUrl } from '@/lib/preview-reach'
 import { rafCoalesce } from '@/lib/raf-coalesce'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
-import { $previewServerRestart, failPreviewServerRestart, type PreviewTarget } from '@/store/preview'
+import {
+  $previewServerRestart,
+  failPreviewServerRestart,
+  noteBrowserPage,
+  type PreviewTarget
+} from '@/store/preview'
 
 import { ArtifactPreview } from './preview-artifact'
 import { PreviewBrowserBar } from './preview-browser-bar'
@@ -746,6 +751,18 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
     const syncHistory = () =>
       setHistory({ back: webview.canGoBack?.() ?? false, forward: webview.canGoForward?.() ?? false })
 
+    // Tell the strip what this Browser is showing, so its tab renames itself
+    // like a tab anywhere else. Deliberately NOT written back into the tab's
+    // target: the guest is built from `target.url`, so that would rebuild the
+    // webview mid-navigation and throw away the history.
+    const notePage = () => {
+      if (target.kind !== 'url' || !tabId) {
+        return
+      }
+
+      noteBrowserPage(tabId, { title: webview.getTitle?.() ?? '', url: webview.getURL?.() || target.url })
+    }
+
     const onNavigate = (event: Event) => {
       const detail = event as Event & { url?: string }
 
@@ -753,6 +770,8 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
         setLoadError(null)
         setCurrentUrl(detail.url)
       }
+
+      notePage()
 
       // Ask the webview rather than counting navigations: the guest page can
       // move itself (redirects, history.pushState, a link into a new document),
@@ -794,6 +813,7 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
       // cancelled navigation) still settles the history — resync so the
       // buttons can't be left stale.
       syncHistory()
+      notePage()
     }
 
     // The WEBVIEW is the source of truth for DevTools, not our click handler:
@@ -885,6 +905,9 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
     webview.addEventListener('did-navigate-in-page', onNavigate)
     webview.addEventListener('did-start-loading', onStart)
     webview.addEventListener('did-stop-loading', onStop)
+    // SPAs title themselves long after the load settles, and a route change
+    // renames the page without navigating at all.
+    webview.addEventListener('page-title-updated', notePage)
     host.appendChild(webview)
     webviewRef.current = webview
 
@@ -898,9 +921,10 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
       webview.removeEventListener('did-navigate-in-page', onNavigate)
       webview.removeEventListener('did-start-loading', onStart)
       webview.removeEventListener('did-stop-loading', onStop)
+      webview.removeEventListener('page-title-updated', notePage)
       webview.remove()
     }
-  }, [appendConsoleEntry, consoleState, copy, isRemoteHtml, isWebPreview, target.url])
+  }, [appendConsoleEntry, consoleState, copy, isRemoteHtml, isWebPreview, tabId, target.kind, target.url])
 
   return (
     <aside

--- a/apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts
@@ -90,6 +90,11 @@ interface PaneChrome extends PaneSizing {
    *  the tab and the sidebar row render status/color from the ONE primitive
    *  (self-subscribing — it updates without the strip re-registering). */
   tabLead?: () => React.ReactNode
+  /** Mint another tab of THIS pane's kind — the strip's "+" while this pane is
+   *  active. A Browser tab makes another Browser tab; a pane that is one of a
+   *  kind (a file peek) leaves it absent and the strip falls back to the chat
+   *  "+" if the zone holds session tabs. */
+  newTab?: () => void
   /** This pane's TAB LABEL, when it changes faster than the contribution
    *  should. A session pane whose draft is being typed renames on every
    *  debounce beat; re-registering `title` that often would re-render the

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -270,6 +270,25 @@ export function TreeGroup({
   const active = paneFor(activeId)
   const isEmpty = shown.length === 0
 
+  // What the strip's "+" makes. The pane you are LOOKING AT answers first (a
+  // Browser tab makes another Browser, even stacked into the chat strip), then
+  // the chat "+" for any zone holding session tabs, then any other tenant that
+  // can mint its own kind — that last rung is what keeps the button from
+  // blinking out when you click a file tab sitting beside a Browser.
+  const ownNewTab = (id: string) => {
+    const mint = paneChrome(paneFor(id)).newTab
+
+    return mint ? { label: t.zones.newTab, onSelect: mint } : null
+  }
+
+  const newTab =
+    ownNewTab(activeId) ??
+    (shown.some(isSessionStripPane) && newSessionTabAction
+      ? { label: t.zones.newSessionTab, onSelect: newSessionTabAction }
+      : null) ??
+    shown.map(ownNewTab).find(Boolean) ??
+    null
+
   useEffect(() => {
     if (activeId) {
       rememberActivePane(memoryKey, activeId)
@@ -594,12 +613,13 @@ export function TreeGroup({
               return <Fragment key={paneId}>{chrome.tabWrap ? chrome.tabWrap(tab) : tab}</Fragment>
             })}
 
-            {/* Plain "+" after the last tab of a CHAT strip (the workspace
-                zone, or any zone holding session tabs) — always shown. Creates
-                a new session tab (mirrors ⌘T) via the app-registered action;
-                the pointerdown focuses this zone first, so the tab lands in
-                THIS strip. Hidden when unwired or the zone is minimized. */}
-            {shown.some(isSessionStripPane) && newSessionTabAction && !node.minimized && (
+            {/* Plain "+" after the last tab — it mints another tab of the kind
+                you are LOOKING AT, so a Browser strip makes another Browser
+                and a chat strip makes another session (mirrors ⌘T, via the
+                app-registered action). The pointerdown focuses this zone
+                first, so the tab lands in THIS strip. Hidden when the active
+                pane is one of a kind and the zone holds no session tabs. */}
+            {newTab && !node.minimized && (
               <span
                 // The action docks into the FOCUSED chat zone; clicking a
                 // background strip's "+" must make THAT zone the focused one
@@ -610,8 +630,8 @@ export function TreeGroup({
               >
                 <PaneStripGlyph
                   icon={<Codicon name="add" size="0.8125rem" />}
-                  label={t.zones.newSessionTab}
-                  onSelect={() => newSessionTabAction()}
+                  label={newTab.label}
+                  onSelect={newTab.onSelect}
                 />
               </span>
             )}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3072,6 +3072,7 @@ export const en: Translations = {
     closeToRight: 'Close to the right',
     closeAll: 'Close all',
     newSessionTab: 'New session tab',
+    newTab: 'New tab',
     pluginDisabled: pluginId => `Plugin "${pluginId}" disabled`,
     pluginDisabledBody: 'Re-enable it in Settings → Plugins to bring the pane back.',
     missingPane: paneId => `missing pane: ${paneId}`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2724,6 +2724,7 @@ export const ja = defineLocale({
     closeToRight: '右側を閉じる',
     closeAll: 'すべて閉じる',
     newSessionTab: '新しいセッションタブ',
+    newTab: '新しいタブ',
     pluginDisabled: pluginId => `プラグイン「${pluginId}」を無効化しました`,
     pluginDisabledBody: '設定 → プラグイン で再有効化するとペインが戻ります。',
     missingPane: paneId => `ペインが見つかりません: ${paneId}`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2633,6 +2633,7 @@ export interface Translations {
     closeToRight: string
     closeAll: string
     newSessionTab: string
+    newTab: string
     pluginDisabled: (pluginId: string) => string
     pluginDisabledBody: string
     missingPane: (paneId: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2632,6 +2632,7 @@ export const zhHant = defineLocale({
     closeToRight: '關閉右側',
     closeAll: '全部關閉',
     newSessionTab: '新增工作階段分頁',
+    newTab: '新增分頁',
     pluginDisabled: pluginId => `外掛「${pluginId}」已停用`,
     pluginDisabledBody: '在 設定 → 外掛 中重新啟用即可恢復面板。',
     missingPane: paneId => `缺少面板：${paneId}`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3234,6 +3234,7 @@ export const zh: Translations = {
     closeToRight: '关闭右侧',
     closeAll: '全部关闭',
     newSessionTab: '新建会话标签',
+    newTab: '新建标签页',
     pluginDisabled: pluginId => `插件“${pluginId}”已禁用`,
     pluginDisabledBody: '在 设置 → 插件 中重新启用即可恢复面板。',
     missingPane: paneId => `缺少面板：${paneId}`,

--- a/apps/desktop/src/store/preview-open-browser.test.ts
+++ b/apps/desktop/src/store/preview-open-browser.test.ts
@@ -30,7 +30,8 @@ describe('openBrowserTab', () => {
     expect(tabs[0]?.target.url).toBe('https://example.com')
   })
 
-  it('reuses the one Browser tab rather than stacking duplicates', () => {
+  // "Show me the browser" is idempotent — the "+" is how you ask for another.
+  it('shows the browser it already has rather than stacking duplicates', () => {
     openBrowserTab()
     openBrowserTab()
     openBrowserTab()
@@ -38,7 +39,6 @@ describe('openBrowserTab', () => {
     expect($previewTabs.get()).toHaveLength(1)
   })
 
-  // A file tab is keyed by identity; only the web surface is a singleton.
   it('leaves other preview tabs alone', () => {
     openPreview({ kind: 'file', label: 'notes.md', source: '/work/notes.md', url: 'file:///work/notes.md' })
     openBrowserTab()

--- a/apps/desktop/src/store/preview.test.ts
+++ b/apps/desktop/src/store/preview.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { $rightRailActiveTabId } from './layout'
+import { $rightRailActiveTabId, selectRightRailTab } from './layout'
 import {
   $previewServerRestart,
   $previewServerRestartStatus,
@@ -11,6 +11,7 @@ import {
   closePreviewMatching,
   closeRightRail,
   closeRightRailTab,
+  newBrowserTab,
   openPreview,
   previewTabId,
   type PreviewTarget,
@@ -69,10 +70,10 @@ describe('preview store', () => {
     expect($previewTabs.get().map(tab => tab.target.kind)).toEqual(['file', 'url', 'artifact'])
   })
 
-  // The Browser is a SINGLETON: the tab names the surface, not the page, so a
-  // second URL navigates the browser it already has instead of stacking a
-  // second Browser tab beside the first.
-  it('keeps one Browser tab — a second url swaps its target instead of adding a tab', () => {
+  // A Browser tab is a VESSEL, so a link hands its page to the browser you are
+  // already looking at. New tabs are something you ask for (`newBrowserTab`) —
+  // otherwise an agent opening five pages leaves five Browsers behind.
+  it('navigates the open Browser rather than stacking a second one', () => {
     openPreview(urlTarget('https://news.ycombinator.com'), 'tool-result')
     openPreview(urlTarget('https://www.reddit.com'), 'tool-result')
 
@@ -81,6 +82,42 @@ describe('preview store', () => {
     expect(urlTabs).toHaveLength(1)
     expect(urlTabs[0].target.url).toBe('https://www.reddit.com')
     expect($rightRailActiveTabId.get()).toBe(urlTabs[0].id)
+  })
+
+  it('opens more than one Browser on request, each holding its own page', () => {
+    openPreview(urlTarget('https://news.ycombinator.com'), 'tool-result')
+    newBrowserTab()
+    openPreview(urlTarget('https://www.reddit.com'), 'tool-result')
+
+    const urlTabs = $previewTabs.get().filter(tab => tab.target.kind === 'url')
+
+    expect(urlTabs.map(tab => tab.target.url)).toEqual(['https://news.ycombinator.com', 'https://www.reddit.com'])
+    expect(new Set(urlTabs.map(tab => tab.id)).size).toBe(2)
+  })
+
+  // Which Browser a link lands in: the one on screen. Selecting the older tab
+  // must send the next page there, not to whichever was opened most recently.
+  it('navigates the Browser you are looking at', () => {
+    openPreview(urlTarget('https://news.ycombinator.com'), 'tool-result')
+    const first = $previewTabs.get()[0].id
+
+    newBrowserTab()
+    selectRightRailTab(first)
+    openPreview(urlTarget('https://www.reddit.com'), 'tool-result')
+
+    expect($previewTabs.get().find(tab => tab.id === first)?.target.url).toBe('https://www.reddit.com')
+    expect($previewTabs.get()).toHaveLength(2)
+  })
+
+  it('reuses a closed slot instead of counting Browser ids up forever', () => {
+    newBrowserTab()
+    const first = $previewTabs.get()[0].id
+
+    newBrowserTab()
+    closeRightRailTab(first)
+    newBrowserTab()
+
+    expect($previewTabs.get().map(tab => tab.id)).toContain(first)
   })
 
   it('re-fronts an existing tab instead of duplicating it, refreshing its target', () => {

--- a/apps/desktop/src/store/preview.test.ts
+++ b/apps/desktop/src/store/preview.test.ts
@@ -109,7 +109,9 @@ describe('preview store', () => {
     expect($previewTabs.get()).toHaveLength(2)
   })
 
-  it('reuses a closed slot instead of counting Browser ids up forever', () => {
+  // A Browser id is minted rather than derived, so it must never be handed out
+  // twice: per-tab state keyed by it would resurface under an unrelated tab.
+  it('never reuses a Browser id, even after one is closed', () => {
     newBrowserTab()
     const first = $previewTabs.get()[0].id
 
@@ -117,7 +119,10 @@ describe('preview store', () => {
     closeRightRailTab(first)
     newBrowserTab()
 
-    expect($previewTabs.get().map(tab => tab.id)).toContain(first)
+    const ids = $previewTabs.get().map(tab => tab.id)
+
+    expect(ids).not.toContain(first)
+    expect(new Set(ids).size).toBe(ids.length)
   })
 
   it('re-fronts an existing tab instead of duplicating it, refreshing its target', () => {

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -220,18 +220,15 @@ export function previewTabId(target: PreviewTarget): RightRailTabId {
 
 const isBrowserTab = (tab: PreviewTab): boolean => tab.target.kind === 'url'
 
-/** The lowest free Browser slot, so ids stay short and readable across a
- *  restore instead of accreting one per page ever opened. */
-function mintBrowserTabId(tabs: PreviewTab[]): RightRailTabId {
-  const used = new Set(tabs.map(tab => tab.id))
+/** A Browser tab's id, minted the way a terminal's is — there is no identity to
+ *  derive one from. Random rather than the lowest free slot: an id is never
+ *  handed out twice, so per-tab state keyed by it (`$browserPages`, the console
+ *  buffer) cannot resurface under a later tab if a close ever fails to wipe it. */
+function mintBrowserTabId(): RightRailTabId {
+  const unique =
+    globalThis.crypto?.randomUUID?.() ?? `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
 
-  for (let n = 1; ; n += 1) {
-    const id: RightRailTabId = `url:browser-${n}`
-
-    if (!used.has(id)) {
-      return id
-    }
-  }
+  return `url:browser-${unique}`
 }
 
 /** The Browser a URL should open in: the one you're looking at, else the one
@@ -245,7 +242,7 @@ function browserTabId(tabs: PreviewTab[]): RightRailTabId {
     return active.id
   }
 
-  return tabs.findLast(isBrowserTab)?.id ?? mintBrowserTabId(tabs)
+  return tabs.findLast(isBrowserTab)?.id ?? mintBrowserTabId()
 }
 
 // Browsing files is "peek at the source"; a tool or an explicit link handing
@@ -291,10 +288,9 @@ export function openBrowserTab() {
 
 /** Another Browser, always — the strip's "+". */
 export function newBrowserTab() {
-  const tabs = $previewTabs.get()
-  const id = mintBrowserTabId(tabs)
+  const id = mintBrowserTabId()
 
-  $previewTabs.set([...tabs, { id, target: blankPage() }])
+  $previewTabs.set([...$previewTabs.get(), { id, target: blankPage() }])
   selectRightRailTab(id)
 }
 

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -118,20 +118,11 @@ function isPdfFileTarget(target: PreviewTarget): boolean {
 export function decodePreviewTabs(raw: string): PreviewTab[] {
   const parsed = JSON.parse(raw) as unknown
 
-  const tabs = (Array.isArray(parsed) ? parsed.filter(isPreviewTab) : []).map(tab =>
+  return (Array.isArray(parsed) ? parsed.filter(isPreviewTab) : []).map(tab =>
     isPdfFileTarget(tab.target) && tab.target.previewKind === 'binary'
       ? { ...tab, target: { ...tab.target, previewKind: 'pdf' as const } }
       : tab
   )
-
-  // One Browser: rekey restored URL tabs onto the singleton id (rows written
-  // before the id existed carried one id per address) and keep only the
-  // LAST — the most recently opened page is the one the browser shows.
-  const lastUrl = tabs.findLast(tab => tab.target.kind === 'url')
-
-  return tabs
-    .filter(tab => tab.target.kind !== 'url' || tab === lastUrl)
-    .map(tab => (tab.target.kind === 'url' ? { ...tab, id: previewTabId(tab.target) } : tab))
 }
 
 export const $previewTabs = persistentAtom<PreviewTab[]>(TABS_STORAGE_KEY, [], {
@@ -183,19 +174,78 @@ export const $previewTarget = computed(
  *  preview open and closed by the target they were handed. */
 export const $previewTabSources = computed($previewTabs, tabs => tabs.map(tab => tab.target.source))
 
+export interface BrowserPage {
+  title: string
+  url: string
+}
+
+/**
+ * What each Browser tab is SHOWING right now, as opposed to the target it was
+ * opened with. Kept out of the target on purpose: the pane builds its guest
+ * from `target.url`, so folding navigation back in would tear the webview down
+ * and lose the history behind it. Memory-only — a restored tab reports again
+ * on its first load.
+ */
+export const $browserPages = atom<Record<string, BrowserPage>>({})
+
+export function noteBrowserPage(tabId: string, page: BrowserPage) {
+  const current = $browserPages.get()[tabId]
+
+  if (current?.title === page.title && current.url === page.url) {
+    return
+  }
+
+  $browserPages.set({ ...$browserPages.get(), [tabId]: page })
+}
+
+export function forgetBrowserPage(tabId: string) {
+  const { [tabId]: gone, ...rest } = $browserPages.get()
+
+  if (gone) {
+    $browserPages.set(rest)
+  }
+}
+
 export const $previewReloadRequest = atom(0)
 export const $previewServerRestart = atom<PreviewServerRestart | null>(null)
 export const $previewServerRestartStatus = computed($previewServerRestart, restart => restart?.status ?? 'idle')
 
-/** The one Browser tab's id. URL targets all share it: the tab names the
- *  SURFACE (Browser), not the page, so opening a second URL navigates the
- *  browser it already has — re-front the tab, swap its target, and the pane
- *  rebuilds its webview against the new url. Files and artifacts stay keyed
- *  by identity; only the web surface is a singleton. */
-const BROWSER_TAB_ID: RightRailTabId = 'url:browser'
-
+/** The tab that owns `target`. Files and artifacts are keyed by IDENTITY —
+ *  the same file is always the same tab, reopening it re-fronts the one it
+ *  already has. A URL has no identity here: a Browser tab is a vessel you
+ *  navigate, so it is picked (`browserTabId`) rather than derived. */
 export function previewTabId(target: PreviewTarget): RightRailTabId {
-  return target.kind === 'url' ? BROWSER_TAB_ID : `${target.kind}:${target.url}`
+  return `${target.kind}:${target.url}`
+}
+
+const isBrowserTab = (tab: PreviewTab): boolean => tab.target.kind === 'url'
+
+/** The lowest free Browser slot, so ids stay short and readable across a
+ *  restore instead of accreting one per page ever opened. */
+function mintBrowserTabId(tabs: PreviewTab[]): RightRailTabId {
+  const used = new Set(tabs.map(tab => tab.id))
+
+  for (let n = 1; ; n += 1) {
+    const id: RightRailTabId = `url:browser-${n}`
+
+    if (!used.has(id)) {
+      return id
+    }
+  }
+}
+
+/** The Browser a URL should open in: the one you're looking at, else the one
+ *  you used last. A link from chat navigates the browser you already have
+ *  rather than stacking another identical tab — new tabs are something you
+ *  ask for (the strip's "+"), the way they are in a real browser. */
+function browserTabId(tabs: PreviewTab[]): RightRailTabId {
+  const active = tabs.find(tab => tab.id === $rightRailActiveTabId.get())
+
+  if (active && isBrowserTab(active)) {
+    return active.id
+  }
+
+  return tabs.findLast(isBrowserTab)?.id ?? mintBrowserTabId(tabs)
 }
 
 // Browsing files is "peek at the source"; a tool or an explicit link handing
@@ -217,8 +267,8 @@ function previewTargetForSource(target: PreviewTarget, source: PreviewRecordSour
  *  only way anything reaches a preview. */
 export function openPreview(target: PreviewTarget, source: PreviewRecordSource = 'manual') {
   const resolved = previewTargetForSource(target, source)
-  const id = previewTabId(resolved)
   const current = $previewTabs.get()
+  const id = resolved.kind === 'url' ? browserTabId(current) : previewTabId(resolved)
   const index = current.findIndex(tab => tab.id === id)
   const tab: PreviewTab = { id, target: resolved }
 
@@ -226,13 +276,26 @@ export function openPreview(target: PreviewTarget, source: PreviewRecordSource =
   selectRightRailTab(id)
 }
 
-/** Open the Browser tab — the surface, not a page. Keeps whatever it was last
- *  showing so the hotkey re-fronts your page instead of wiping it; a fresh tab
- *  lands on `about:blank`, where the pane's empty state invites an address. */
-export function openBrowserTab() {
-  const existing = $previewTabs.get().find(tab => tab.id === BROWSER_TAB_ID)
+const blankPage = (): PreviewTarget => ({ kind: 'url', label: 'Browser', source: 'about:blank', url: 'about:blank' })
 
-  openPreview(existing?.target ?? { kind: 'url', label: 'Browser', source: 'about:blank', url: 'about:blank' })
+/** Show the Browser — the surface, not a page. Keeps whatever it was last
+ *  showing so the hotkey re-fronts your page instead of wiping it; with no
+ *  browser open it lands on `about:blank`, where the pane's empty state
+ *  invites an address. */
+export function openBrowserTab() {
+  const tabs = $previewTabs.get()
+  const current = tabs.find(tab => tab.id === browserTabId(tabs))
+
+  openPreview(current?.target ?? blankPage())
+}
+
+/** Another Browser, always — the strip's "+". */
+export function newBrowserTab() {
+  const tabs = $previewTabs.get()
+  const id = mintBrowserTabId(tabs)
+
+  $previewTabs.set([...tabs, { id, target: blankPage() }])
+  selectRightRailTab(id)
 }
 
 export function closeRightRailTab(tabId: string) {


### PR DESCRIPTION
The in-app browser was a singleton. Every link navigated the one Browser tab, so you could never keep a page open beside another, and the tab strip's "+" never appeared next to it — only session tabs could mint anything.

A Browser tab is now a vessel with its own id. Links still land in the browser you are looking at, because an agent opening five pages must not leave five tabs behind; the "+" is how you ask for another one, the way it works in a real browser. Tabs name themselves after the page they are showing — three tabs reading "Browser" name nothing.

It follows the conventions the session tabs set. Slow-changing names go through the registered `title`; the live page name goes through `tabTitle` as a self-subscribing node, so navigating renames the tab without re-registering the contribution and tearing down the webview (the same split `SessionDraftTitle` uses for unsent drafts). Live page state stays out of the persisted target, as `runtimeId` does for session tiles. Where it departs: a Browser has no durable identity to key on, so its id is minted at random like a terminal's rather than derived like `session-tile:<stored_session_id>` or `file:<path>`.

The "+" became a pane capability (`PaneChrome.newTab`) rather than a session-only button, so the active pane answers for what it makes and any pane kind that can make more of itself contributes one. Sessions keep their global action atom; the strip asks the active pane first and falls back to it.

Riding along is an unrelated but adjacent fix to the address bar. Committing an address dropped the field back to the url of the page you were leaving, so typing `baby.com` over `google.com` flashed `google.com` back before `baby.com` arrived, and nothing indicated a load was underway. The address you asked for now sticks until the page actually lands somewhere (a redirect supersedes it, as it should), with progress spinning inside the field. It is a separate commit if you would rather read them apart.

## Test plan

- [x] `npm run test:ui` — full suite green
- [x] `npm run typecheck`, `npm run lint` (0 errors)
- [x] Driven live over CDP: opened a Browser, navigated it, hit "+", navigated the second tab, confirmed two tabs with independent pages and their own labels
- [x] Sampled the address field mid-navigation — holds the typed address, spinner up, releases to the redirect target on landing

One test had encoded the old behavior as correct (`then releases the field back to the page`); it now asserts the new contract, alongside coverage for the redirect handoff and for re-focusing mid-flight.