### PR TITLE
fix(desktop): prefer CIMD for local MCP OAuth

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -14066,6 +14066,10 @@ async function handleHermesApiRequest(request) {
     const timeoutMs = resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
 
     const url = `${connection.baseUrl}${apiRoute.requestPath}`
+    const host = new URL(connection.baseUrl).hostname
+    const loopbackOAuth = request?.desktopLoopbackOAuth && (
+      host === '127.0.0.1' || host === '::1' || host === 'localhost'
+    )
 
     // OAuth gateways authenticate REST via EITHER a native bearer token
     // (cookieless RFC 8252 flow) OR the HttpOnly session cookie held in the OAuth
@@ -14093,13 +14097,15 @@ async function handleHermesApiRequest(request) {
           method: request?.method,
           body: request?.body,
           timeoutMs,
-          bearer: restAuth.token
+          bearer: restAuth.token,
+          headers: loopbackOAuth ? { 'X-Hermes-Desktop-Loopback-OAuth': '1' } : undefined
         })
       } else {
         response = await fetchJsonViaOauthSession(url, {
           method: request?.method,
           body: request?.body,
-          timeoutMs
+          timeoutMs,
+          headers: loopbackOAuth ? { 'X-Hermes-Desktop-Loopback-OAuth': '1' } : undefined
         })
       }
     } else {
@@ -14107,7 +14113,8 @@ async function handleHermesApiRequest(request) {
         method: request?.method,
         body: request?.body,
         upload: request?.upload,
-        timeoutMs
+        timeoutMs,
+        headers: loopbackOAuth ? { 'X-Hermes-Desktop-Loopback-OAuth': '1' } : undefined
       })
     }
   } catch (error) {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -14068,7 +14068,7 @@ async function handleHermesApiRequest(request) {
     const url = `${connection.baseUrl}${apiRoute.requestPath}`
     const host = new URL(connection.baseUrl).hostname
     const loopbackOAuth = request?.desktopLoopbackOAuth && (
-      host === '127.0.0.1' || host === '::1' || host === 'localhost'
+      host === '127.0.0.1' || host === '[::1]' || host === 'localhost'
     )
 
     // OAuth gateways authenticate REST via EITHER a native bearer token

--- a/apps/desktop/src/api/mcp.ts
+++ b/apps/desktop/src/api/mcp.ts
@@ -54,6 +54,7 @@ export function authMcpServer(name: string, profile?: ProfileScope): Promise<Mcp
     ...capabilityScoped(profile),
     path: `/api/mcp/servers/${encodeURIComponent(name)}/auth`,
     method: 'POST',
+    desktopLoopbackOAuth: true,
     timeoutMs: 60_000
   })
 }

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -1114,6 +1114,7 @@ export interface HermesApiRequest {
   // ArrayBuffer. Token-mode backends only.
   upload?: { filename: string; contentType?: string; bytes: ArrayBuffer }
   timeoutMs?: number
+  desktopLoopbackOAuth?: boolean
   // Route this REST call to a specific profile's backend. Omit for the primary
   // (window) backend. Read-only cross-profile data is served by the primary, so
   // this is only needed for profile-scoped live/settings calls.

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -267,6 +267,9 @@ async def auth_mcp_server(name: str, request: Request, profile: Optional[str] = 
         hermes_home=flow_home,
         redirect_uri=(cfg.get("oauth") or {}).get("redirect_uri")
         or _mcp_oauth_callback_url(request, name),
+        use_loopback_callback=(
+            request.headers.get("X-Hermes-Desktop-Loopback-OAuth") == "1"
+        ),
         reconnect_live=flow_home == process_home,
     )
     with _mcp_oauth_flows_lock:

--- a/tests/tools/test_mcp_cimd.py
+++ b/tests/tools/test_mcp_cimd.py
@@ -345,6 +345,28 @@ def test_dashboard_flow_falls_back_to_dcr(tmp_path, monkeypatch, private_ports):
     assert cfg["redirect_uri"] == flow.redirect_uri
 
 
+def test_desktop_dashboard_flow_uses_cimd(tmp_path, monkeypatch, private_ports):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools.mcp_dashboard_oauth import DashboardOAuthFlow, dashboard_oauth_flow
+
+    flow = DashboardOAuthFlow(
+        flow_id="flow-1",
+        server_name="srv",
+        profile=None,
+        hermes_home=str(tmp_path),
+        redirect_uri="https://agent.example/api/mcp/oauth/callback/srv",
+        use_loopback_callback=True,
+    )
+
+    cfg: dict = {}
+    with dashboard_oauth_flow(flow):
+        port = _configure_callback_port(cfg, HermesTokenStorage("srv"))
+
+    assert cfg["_cimd_url"] == _CIMD_CLIENT_METADATA_URL
+    assert port in private_ports
+    assert "redirect_uri" not in cfg
+
+
 def test_existing_registration_falls_back_to_dcr(tmp_path, monkeypatch, private_ports):
     """A stored client_id is bound to the redirect URI it registered with;
     switching to CIMD now would invalidate it."""

--- a/tests/tools/test_mcp_dashboard_oauth.py
+++ b/tests/tools/test_mcp_dashboard_oauth.py
@@ -100,6 +100,31 @@ def test_mcp_oauth_helpers_use_dashboard_flow_without_loopback_port():
     assert flow.authorization_url == "https://idp.example/authorize?state=state-4"
 
 
+def test_loopback_dashboard_flow_stops_when_cancelled(monkeypatch):
+    from tools.mcp_dashboard_oauth import DashboardOAuthFlow, dashboard_oauth_flow
+    from tools.mcp_oauth import _find_free_port, _make_callback_waiter
+
+    flow = DashboardOAuthFlow(
+        flow_id="flow-cancel",
+        server_name="reports",
+        profile=None,
+        hermes_home="/tmp/hermes-test",
+        redirect_uri="https://agent.example/mcp/oauth/callback/flow-cancel",
+        use_loopback_callback=True,
+    )
+    monkeypatch.setattr("tools.mcp_oauth._raise_if_non_interactive", lambda _: None)
+
+    async def wait_then_cancel():
+        with dashboard_oauth_flow(flow):
+            task = asyncio.create_task(_make_callback_waiter(_find_free_port(), timeout=10)())
+            await asyncio.sleep(0)
+            flow.mark_error("Cancelled by user")
+            with pytest.raises(RuntimeError, match="Cancelled by user"):
+                await asyncio.wait_for(task, timeout=1)
+
+    asyncio.run(wait_then_cancel())
+
+
 def test_failed_reauth_rollback_preserves_newer_oauth_state(tmp_path, monkeypatch):
     from tools.mcp_oauth import HermesTokenStorage
 

--- a/tools/mcp_dashboard_oauth.py
+++ b/tools/mcp_dashboard_oauth.py
@@ -25,6 +25,7 @@ class DashboardOAuthFlow:
     profile: str | None
     hermes_home: str
     redirect_uri: str
+    use_loopback_callback: bool = False
     reconnect_live: bool = False
     created_at: float = field(default_factory=time.time)
     status: str = "starting"

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -950,7 +950,7 @@ def _make_callback_waiter(
         from tools.mcp_dashboard_oauth import get_dashboard_oauth_flow
 
         dashboard_flow = get_dashboard_oauth_flow()
-        if dashboard_flow is not None:
+        if dashboard_flow is not None and not dashboard_flow.use_loopback_callback:
             # The dashboard flow still speaks the legacy tuple; normalize it
             # here so both callback sources hand the SDK one shape.
             dash_code, dash_state = await dashboard_flow.wait_for_callback()
@@ -1472,12 +1472,10 @@ def _maybe_use_cimd(
     if (cfg.get("token_endpoint_auth_method") or "none") != "none":
         return None
 
-    # Dashboard/desktop flows redirect to the server's own externally
-    # reachable URL (``/api/mcp/oauth/callback/<name>``), which is
-    # deployment-specific and can never appear in a static document.
     from tools.mcp_dashboard_oauth import get_dashboard_oauth_flow
 
-    if get_dashboard_oauth_flow() is not None:
+    dashboard_flow = get_dashboard_oauth_flow()
+    if dashboard_flow is not None and not dashboard_flow.use_loopback_callback:
         return None
 
     if cfg.get("redirect_uri") or cfg.get("redirect_port"):
@@ -1563,7 +1561,7 @@ def _configure_callback_port(
     from tools.mcp_dashboard_oauth import get_dashboard_oauth_flow
 
     dashboard_flow = get_dashboard_oauth_flow()
-    if dashboard_flow is not None:
+    if dashboard_flow is not None and not dashboard_flow.use_loopback_callback:
         cfg["_resolved_port"] = 0
         cfg["redirect_uri"] = cfg.get("redirect_uri") or dashboard_flow.redirect_uri
         return 0

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -1037,6 +1037,10 @@ def _make_callback_waiter(
             while elapsed < timeout:
                 if result["auth_code"] is not None or result["error"] is not None:
                     break
+                if dashboard_flow is not None:
+                    flow = dashboard_flow.snapshot()
+                    if flow["status"] == "error":
+                        raise RuntimeError(flow["error"] or "OAuth flow cancelled")
                 await asyncio.sleep(poll_interval)
                 elapsed += poll_interval
         finally:


### PR DESCRIPTION
## What does this PR do?

Uses the local loopback callback for Desktop MCP OAuth so CIMD is attempted before DCR. Remote gateways retain the existing DCR callback flow. This makes the Desktop MCP OAuth flow match the CLI's.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Route local Desktop MCP OAuth through the published CIMD client metadata.
- Preserve dashboard URL publishing and remote gateway behavior.
- Cover the Desktop dashboard CIMD path.

## Security Impact

- Affects OAuth callback selection. The Desktop loopback marker is sent only to local loopback backends; remote gateway behavior remains unchanged.
- No credentials, tokens, or authorization scope handling changes.

## How to Test

1. Add an OAuth MCP server in local Hermes Desktop.
2. Complete browser authorization.
3. Confirm the server connects without a DCR registration.

## Validation

- `scripts/run_tests.sh tests/tools/test_mcp_cimd.py tests/tools/test_mcp_dashboard_oauth.py` — targeted OAuth tests passing.

## Platforms Tested

- macOS (Darwin 25.6.0)