### PR TITLE
docs(dashboard): replace inaccessible Nous Portal OAuth contract link

### DIFF
--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -982,7 +982,7 @@ Validation rejects values without `http://` / `https://` scheme, without a host,
 
 ### OAuth flow
 
-The provider implements the [Nous Portal OAuth contract v1](https://github.com/NousResearch/nous-account-service/blob/main/docs/agent-dashboard-oauth-contract.md) — authorization-code grant with PKCE (S256):
+The provider implements the Nous Portal OAuth contract v1 — authorization-code grant with PKCE (S256):
 
 1. User hits `/` without a session cookie → gate redirects to `/login`.
 2. Login page shows a "Continue with Nous Research" button → `/auth/login?provider=nous`.


### PR DESCRIPTION
The link to NousResearch/nous-account-service/blob/main/docs/agent-dashboard-oauth-contract.md returns 404 for unauthenticated readers. Replace with plain text so the doc doesn't reference an inaccessible resource. Fixes #94087