### PR TITLE
fix(cron): stop the cronjob tool probing its own gateway as dead

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -6,6 +6,7 @@ pause/resume/run/remove, status, and tick.
 """
 
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Iterable, List, Optional
@@ -77,6 +78,14 @@ def _builtin_gateway_liveness() -> Optional[bool]:
     try:
         if _active_cron_provider_name() != "builtin":
             return True  # external provider fires jobs without the gateway
+        from gateway.status import get_running_pid
+
+        if get_running_pid() == os.getpid():
+            # This process IS the gateway (the cronjob tool runs inside it):
+            # find_gateway_pids() excludes the current PID by design (#13242),
+            # so a single-process gateway would otherwise probe as dead while
+            # its own ticker is firing (#94143).
+            return True
         from hermes_cli.gateway import find_gateway_pids
 
         return bool(find_gateway_pids())

--- a/tests/cron/test_87033_cronjob_gateway_liveness.py
+++ b/tests/cron/test_87033_cronjob_gateway_liveness.py
@@ -161,6 +161,91 @@ class TestListSurfacesGatewayLiveness:
 from contextlib import ExitStack
 
 
+class TestInGatewayProcessLiveness:
+    """The cronjob tool is often invoked from inside the gateway process
+    itself (#94143): find_gateway_pids() excludes the current PID by design
+    (#13242), so a single-process gateway probed as dead while its own
+    ticker was firing. When the verified running gateway PID is the current
+    process, liveness must report alive."""
+
+    def test_gateway_process_itself_probes_alive(self, hermes_env):
+        """pid file resolves to *this* process + pid scan self-excluded →
+        still gateway_running: true, no warning."""
+        import os as _os
+        from unittest.mock import patch
+
+        _create_job()
+        with (
+            patch_liveness(provider="builtin", pids=[]),
+            patch("gateway.status.get_running_pid", return_value=_os.getpid()),
+        ):
+            from tools.cronjob_tools import cronjob
+
+            result = json.loads(cronjob(action="list"))
+
+        assert result["success"] is True
+        assert result["gateway_running"] is True
+        assert "warning" not in result
+
+    def test_other_process_gateway_still_probes_via_pid_scan(self, hermes_env):
+        """Out-of-process caller: pid file points at another PID, the pid
+        scan is authoritative as before."""
+        from unittest.mock import patch
+
+        _create_job()
+        with (
+            patch_liveness(provider="builtin", pids=[424242]),
+            patch("gateway.status.get_running_pid", return_value=424242),
+        ):
+            from tools.cronjob_tools import cronjob
+
+            result = json.loads(cronjob(action="list"))
+
+        assert result["success"] is True
+        assert result["gateway_running"] is True
+
+
+class TestBuiltinLivenessUnit:
+    """Direct unit pins for the tri-state helper."""
+
+    def test_self_pid_short_circuits_true(self):
+        import os as _os
+        from unittest.mock import patch
+
+        import hermes_cli.cron as cron_cli
+
+        with (
+            patch("hermes_cli.cron._active_cron_provider_name", return_value="builtin"),
+            patch("gateway.status.get_running_pid", return_value=_os.getpid()),
+            patch("hermes_cli.gateway.find_gateway_pids", return_value=[]),
+        ):
+            assert cron_cli._builtin_gateway_liveness() is True
+
+    def test_no_gateway_anywhere_is_false(self):
+        from unittest.mock import patch
+
+        import hermes_cli.cron as cron_cli
+
+        with (
+            patch("hermes_cli.cron._active_cron_provider_name", return_value="builtin"),
+            patch("gateway.status.get_running_pid", return_value=None),
+            patch("hermes_cli.gateway.find_gateway_pids", return_value=[]),
+        ):
+            assert cron_cli._builtin_gateway_liveness() is False
+
+    def test_external_gateway_pid_is_true(self):
+        from unittest.mock import patch
+
+        import hermes_cli.cron as cron_cli
+
+        with (
+            patch("hermes_cli.cron._active_cron_provider_name", return_value="builtin"),
+            patch("gateway.status.get_running_pid", return_value=424242),
+            patch("hermes_cli.gateway.find_gateway_pids", return_value=[424242]),
+        ):
+            assert cron_cli._builtin_gateway_liveness() is True
+
+
 class _LivenessPatches:
     """Context manager patching the provider/gateway-pid probes."""
 


### PR DESCRIPTION
## What does this PR do?

`find_gateway_pids()` excludes the current PID by design (#13242 — a `hermes gateway status` CLI invocation must never count itself as a running gateway). But the `cronjob` model tool also runs **inside** the gateway process, and there that exclusion removes the only gateway PID there is: `_builtin_gateway_liveness()` returned `False` for a live single-process gateway, so every `list`/`create` result carried `gateway_running: false` plus the warning "The Hermes gateway is not running — these jobs are saved but will NOT fire" while the builtin ticker was demonstrably firing (the reporter's every-3m job ran 75 s after gateway start, next run already scheduled, out-of-process probe of the identical code path returns `True`).

This short-circuits the probe when the verified running gateway PID is the current process: `get_running_pid()` already validates the runtime lock and the PID record, so `get_running_pid() == os.getpid()` means this process IS the gateway the ticker runs in. Out-of-process callers (the CLI warning path, external tools) keep the pid-scan path unchanged.

## Related Issue

Fixes #94143

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `hermes_cli/cron.py` (`_builtin_gateway_liveness`) — after the provider check, compare `get_running_pid()` (from `gateway.status`) to `os.getpid()` and return `True` on a match, with a comment naming the self-exclusion interaction (#94143 / #13242). `os` added to the module imports.
- `tests/cron/test_87033_cronjob_gateway_liveness.py` — two new test groups on the existing fixtures:
  - `TestInGatewayProcessLiveness` — the reported scenario end-to-end through the `cronjob` tool: pid file resolves to the current process + pid scan empty (exactly what `find_gateway_pids` yields in-process) → `gateway_running: true`, no warning; and the out-of-process caller still probes via the pid scan.
  - `TestBuiltinLivenessUnit` — direct tri-state pins: self-pid short-circuits true; no gateway anywhere is false; an external gateway PID is true.

## How to Test

- Run: `.venv/bin/python -m pytest tests/cron/test_87033_cronjob_gateway_liveness.py -q`
- Observed result: `13 passed` (8 pre-existing #87033 tests plus the 5 new ones — the pre-existing tests are unaffected because an out-of-process test runner's `get_running_pid()` resolves to another PID/None and falls through to the pid scan). Fail-on-main check (`git stash` of the source change): the two self-pid tests fail against unpatched `main` (the tool reports `gateway_running: false` + the wrong warning); the out-of-process test passes both ways.
- Regression sweep (`tests/cron/` + `tests/hermes_cli/test_cron.py`): `962 passed, 1 skipped, 3 failed` — all three failures (`test_script_claim_heartbeat` ×2, `test_scheduler_provider::test_desktop_ticker_calls_tick_then_stops`) are the known pre-existing local-environment failures (process-tree kill probing), previously stash-compared as failing on unpatched `main` during the #94010 work; zero overlap with the liveness path.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of the completed code performed
- [x] New and existing unit tests pass locally
- [x] Changes are backward-compatible (out-of-process liveness semantics unchanged and pinned)
