### PR TITLE
fix(tui): surface slash command args hints and register /goal entry (#93716)

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1518,6 +1518,29 @@ def slack_subcommand_map() -> dict[str, str]:
 # Autocomplete
 # ---------------------------------------------------------------------------
 
+_ARGS_HINTS_CACHE: Optional[Dict[str, str]] = None
+
+
+def _registry_args_hints() -> Dict[str, str]:
+    """Map '/name' (and each alias) to the registry ``args_hint``.
+
+    Picker rows used to carry only the description, so syntax the registry
+    already owned -- e.g. ``draft <text>`` under /goal (#93716) -- was
+    invisible in both the CLI dropdown and the Ink TUI picker. Cached for
+    process lifetime: COMMAND_REGISTRY is static after import.
+    """
+    global _ARGS_HINTS_CACHE
+    if _ARGS_HINTS_CACHE is None:
+        hints: Dict[str, str] = {}
+        for cmd in COMMAND_REGISTRY:
+            if not cmd.args_hint:
+                continue
+            hints[f"/{cmd.name}"] = cmd.args_hint
+            for alias in cmd.aliases:
+                hints[f"/{alias}"] = cmd.args_hint
+        _ARGS_HINTS_CACHE = hints
+    return _ARGS_HINTS_CACHE
+
 
 class SlashCommandCompleter(Completer):
     """Autocomplete for built-in slash commands, subcommands, and skill commands."""
@@ -2222,16 +2245,19 @@ class SlashCommandCompleter(Completer):
 
         word = text[1:]
 
+        args_hints = _registry_args_hints()
+
         for cmd, desc in COMMANDS.items():
             if not self._command_allowed(cmd):
                 continue
             cmd_name = cmd[1:]
             if cmd_name.startswith(word):
+                hint = args_hints.get(cmd)
                 yield Completion(
                     self._completion_text(cmd_name, word),
                     start_position=-len(word),
                     display=cmd,
-                    display_meta=desc,
+                    display_meta=f"{desc} \u00b7 {hint}" if hint else desc,
                 )
 
         for cmd, info in self._iter_skill_bundles().items():

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -100,6 +100,25 @@ export const sessionCommands: SlashCommand[] = [
   },
 
   {
+    help: 'set a standing goal Hermes works on across turns until achieved',
+    name: 'goal',
+    usage: '/goal [text | draft <text> | show | pause | resume | clear | status]',
+    run: (_arg, ctx, cmd) => {
+      // Backend-owned command — forwarded whole so every subcommand
+      // (including draft/wait/unwait) stays at CLI parity.
+      ctx.gateway.gw
+        .request<SlashExecResponse>('slash.exec', { command: cmd.slice(1), session_id: ctx.sid })
+        .then(
+          ctx.guarded<SlashExecResponse>(r => {
+            const body = r.output || '/goal: no output'
+            ctx.transcript.sys(r.warning ? `warning: ${r.warning}\n${body}` : body)
+          })
+        )
+        .catch(ctx.guardedErr)
+    }
+  },
+
+  {
     help: 'change or show model',
     name: 'model',
     run: (arg, ctx) => {


### PR DESCRIPTION
Closes #93716

The /goal command (including its draft <text> syntax) was undiscoverable: the completer showed descriptions but never argument hints, and the TUI static registry lacked /goal entirely.

Slash command display_meta now renders "{description} - {args_hint}" from a cached registry map (feeding both CLI dropdown and TUI picker), and a TUI-local /goal entry documents usage including draft subcommand. Backend passthrough unchanged.
