### PR TITLE
fix(desktop): remove redundant cron statusbar entry (#93835)

### DIFF
--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -13,7 +13,7 @@ import { Codicon } from '@/components/ui/codicon'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { useI18n } from '@/i18n'
 import { displayPath, pathLeaf } from '@/lib/display-path'
-import { Activity, AlertCircle, Clock, Command, FolderOpen, Globe, Hash, Loader2, Terminal } from '@/lib/icons'
+import { Activity, AlertCircle, Command, FolderOpen, Globe, Hash, Loader2, Terminal } from '@/lib/icons'
 import { runtimeReadinessDisplay, type RuntimeReadinessResult } from '@/lib/runtime-readiness'
 import { contextBarLabel, LiveDuration, usageContextLabel } from '@/lib/statusbar'
 import { useStoreSelector } from '@/lib/use-session-slice'
@@ -50,7 +50,7 @@ import {
 } from '@/store/updates'
 import type { StatusResponse, UsageStats } from '@/types/hermes'
 
-import { CRON_ROUTE, SETTINGS_ROUTE, WEBHOOKS_ROUTE } from '../../routes'
+import { SETTINGS_ROUTE, WEBHOOKS_ROUTE } from '../../routes'
 import type { StatusbarItem } from '../statusbar-controls'
 
 const EMPTY_USAGE: UsageStats = { calls: 0, input: 0, output: 0, total: 0 }
@@ -490,14 +490,6 @@ export function useStatusbarItems({
         onSelect: openAgents,
         title: agentsOpen ? copy.closeAgents : copy.openAgents,
         toggleLabel: copy.agents,
-        variant: 'action'
-      },
-      {
-        icon: <Clock className="size-3" />,
-        id: 'cron',
-        label: copy.cron,
-        to: CRON_ROUTE,
-        toggleLabel: copy.cron,
         variant: 'action'
       },
       {

--- a/apps/desktop/src/store/statusbar-prefs.ts
+++ b/apps/desktop/src/store/statusbar-prefs.ts
@@ -14,7 +14,7 @@ export function toggleStatusbarVisible() {
 
 // Items the bar hides until the user turns them on from its context menu. The
 // bar's job is to answer "is the backend healthy, where am I, what's it doing" —
-// route shortcuts (cron/webhooks/agents), the terminal toggle, and the approval
+// route shortcuts (webhooks/agents), the terminal toggle, and the approval
 // pill are navigation, not status, so they start out of the way. The per-turn
 // session readouts (running/session timers, context meter) are diagnostics most
 // users don't watch, so they start hidden too and the bar stays quiet mid-turn.


### PR DESCRIPTION
Closes #93835

The statusbar duplicated the cron entry already reachable from sidebar navigation and the command palette. Removed the statusbar item and its unused imports; cron stays in STATUSBAR_HIDDEN_BY_DEFAULT so existing users' persisted layouts still compare equal to defaults.
