### PR TITLE
fix(gateway): retry failed deliveries while owner is alive

### DIFF
--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -322,6 +322,93 @@ def sweep_recoverable(
     return claimed
 
 
+def sweep_live_owner_failed(
+    now: Optional[float] = None,
+    *,
+    deliverable_platforms: Optional[set] = None,
+    min_age_seconds: float = 60.0,
+) -> List[Dict[str, Any]]:
+    """Claim failed rows owned by THIS live process for periodic redelivery.
+
+    #91653: ``sweep_recoverable`` only claims rows whose owner is dead, and
+    the gateway only runs that sweep at startup. A platform rejection
+    (transient 5xx storm) leaves the row ``state='failed'`` with a live
+    owner forever — the turn completed, the answer exists in the ledger,
+    and nothing ever retries delivery. This sweep claims rows in
+    ``failed`` state owned by this process (the gateway that marked them
+    failed) once they are older than ``min_age_seconds``, so the periodic
+    delivery-retry watcher can redeliver them with the recovered-reply
+    marker.
+
+    Only ``failed`` rows qualify: ``pending``/``attempting`` rows owned by
+    a live process are mid-flight and must not be touched. Only rows owned
+    by THIS process qualify: another live gateway owns its own rows, and
+    dead-owner rows are ``sweep_recoverable``'s job.
+
+    Claiming atomically re-stamps the owner and increments ``attempts``
+    (same CAS guard as ``sweep_recoverable``), so a racing sweep cannot
+    double-claim. Rows over the attempts cap or older than the stale cutoff
+    transition to 'abandoned' instead of being returned.
+    """
+    now = now if now is not None else time.time()
+    pid, started = _owner_stamp()
+    claimed: List[Dict[str, Any]] = []
+    with _DB_LOCK, _transaction() as conn:
+        rows = conn.execute(
+            """SELECT obligation_id, session_key, platform, chat_id, thread_id,
+                      content, state, attempts, created_at, updated_at,
+                      owner_pid, owner_started_at
+               FROM delivery_obligations
+               WHERE state = 'failed'"""
+        ).fetchall()
+        for (oid, session_key, platform, chat_id, thread_id, content, state,
+             attempts, created_at, updated_at, owner_pid,
+             owner_started_at) in rows:
+            if owner_pid != pid:
+                # Another live process owns this row (or the owner is dead —
+                # sweep_recoverable handles that class). Never steal.
+                continue
+            if (now - updated_at) < min_age_seconds:
+                # Too fresh — a rejection that just happened may be retried
+                # by the caller's own error path; avoid a tight retry loop.
+                continue
+            if attempts >= MAX_ATTEMPTS or (now - created_at) > STALE_AFTER_SECONDS:
+                conn.execute(
+                    """UPDATE delivery_obligations
+                       SET state='abandoned', updated_at=? WHERE obligation_id=?""",
+                    (now, oid),
+                )
+                continue
+            if (
+                deliverable_platforms is not None
+                and platform not in deliverable_platforms
+            ):
+                # No adapter for this platform this boot — claiming would
+                # spend an attempt on a no-op.
+                continue
+            cursor = conn.execute(
+                """UPDATE delivery_obligations
+                   SET owner_pid=?, owner_started_at=?, attempts=attempts+1,
+                       updated_at=?
+                   WHERE obligation_id=? AND (owner_pid IS ? OR owner_pid=?)""",
+                (pid, started, now, oid, owner_pid, owner_pid),
+            )
+            if cursor.rowcount:
+                claimed.append({
+                    "obligation_id": oid,
+                    "session_key": session_key,
+                    "platform": platform,
+                    "chat_id": chat_id,
+                    "thread_id": thread_id,
+                    "content": content,
+                    # failed = definitively rejected once; redelivery carries
+                    # the recovered-reply marker (honest at-least-once).
+                    "needs_marker": True,
+                    "attempts": attempts + 1,
+                })
+    return claimed
+
+
 def _prune(now: Optional[float] = None) -> None:
     now = now if now is not None else time.time()
     cutoff = now - _RETENTION_SECONDS

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13351,6 +13351,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Start background session expiry watcher to finalize expired sessions
         self._spawn_supervised(self._session_expiry_watcher, "session_expiry_watcher")
 
+        # Start background delivery-retry watcher: retries failed
+        # delivery-ledger rows owned by this live gateway (#91653) so a
+        # transient platform rejection no longer strands a completed
+        # answer until the next restart.
+        self._spawn_supervised(self._delivery_retry_watcher, "delivery_retry_watcher")
+
         # Stall watchdog: pending inbound + stale agent activity → warn user
         # to /new (does not kill the turn; see agent.session_stall_timeout).
         self._spawn_supervised(self._session_stall_watcher, "session_stall_watcher")
@@ -13861,6 +13867,47 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not getattr(result, "success", True):
             err = getattr(result, "error", "send returned success=False")
             raise RuntimeError(f"adapter.send failed: {err}")
+
+    async def _delivery_retry_watcher(self, interval: int = 300):
+        """Background task that retries failed delivery-ledger rows owned by
+        this live gateway (#91653).
+
+        ``sweep_recoverable`` only claims rows whose owner is dead, and the
+        startup sweep is the only redelivery pass. A platform rejection
+        (transient 5xx storm) leaves a row ``state='failed'`` with a live
+        owner forever — the turn completed, the answer sits in the ledger,
+        and nothing ever retries it. This watcher periodically claims
+        failed rows owned by THIS process (older than the freshness floor)
+        and redelivers them with the recovered-reply marker, so a
+        transient platform outage no longer strands a completed answer.
+
+        Runs every ``interval`` seconds (default 5 min). Best-effort: a
+        ledger or send failure is logged and retried on the next tick.
+        """
+        await asyncio.sleep(90)  # initial delay — let the gateway fully start
+        while self._running:
+            try:
+                from gateway.delivery_ledger import (
+                    ledger_enabled,
+                    sweep_live_owner_failed,
+                )
+
+                if not await asyncio.to_thread(ledger_enabled):
+                    await asyncio.sleep(interval)
+                    continue
+                _deliverable = {
+                    getattr(p, "value", str(p)) for p in self.adapters
+                }
+                claimed = await asyncio.to_thread(
+                    sweep_live_owner_failed,
+                    None,
+                    deliverable_platforms=_deliverable,
+                )
+                if claimed:
+                    await self._redeliver_claimed_obligations(claimed)
+            except Exception:
+                logger.debug("delivery retry watcher tick failed", exc_info=True)
+            await asyncio.sleep(interval)
 
     async def _session_expiry_watcher(self, interval: int = 300):
         """Background task that finalizes expired sessions.

--- a/tests/gateway/test_delivery_ledger.py
+++ b/tests/gateway/test_delivery_ledger.py
@@ -123,6 +123,75 @@ class TestSweep:
         assert dl.sweep_recoverable() == []
 
 
+class TestLiveOwnerSweep:
+    """#91653: failed rows owned by a LIVE process must be claimable for
+    periodic redelivery — the startup-only dead-owner sweep strands them."""
+
+    def test_failed_live_owner_row_claimed_after_freshness_floor(self):
+        _record()
+        dl.mark_failed("ob-1", "503 Service Unavailable")
+        # Too fresh: the freshness floor protects the caller's own retry path.
+        assert dl.sweep_live_owner_failed() == []
+        # Age the row past the floor.
+        with dl._connect() as conn:
+            conn.execute(
+                "UPDATE delivery_obligations SET updated_at=? WHERE obligation_id=?",
+                (time.time() - 120, "ob-1"),
+            )
+        claimed = dl.sweep_live_owner_failed()
+        assert len(claimed) == 1
+        assert claimed[0]["obligation_id"] == "ob-1"
+        assert claimed[0]["needs_marker"] is True  # failed = honest at-least-once
+        assert claimed[0]["attempts"] == 1
+        # Claim re-stamps ownership: a second sweep must not double-claim.
+        assert dl.sweep_live_owner_failed() == []
+
+    def test_pending_or_attempting_live_rows_never_claimed(self):
+        _record("ob-pending")
+        _record("ob-attempting")
+        dl.mark_attempting("ob-attempting")
+        with dl._connect() as conn:
+            conn.execute(
+                "UPDATE delivery_obligations SET updated_at=? WHERE obligation_id IN (?,?)",
+                (time.time() - 120, "ob-pending", "ob-attempting"),
+            )
+        assert dl.sweep_live_owner_failed() == []
+
+    def test_other_process_rows_never_claimed(self):
+        _record()
+        dl.mark_failed("ob-1", "nope")
+        with dl._connect() as conn:
+            conn.execute(
+                "UPDATE delivery_obligations SET owner_pid=999999999, "
+                "owner_started_at=1, updated_at=? WHERE obligation_id=?",
+                (time.time() - 120, "ob-1"),
+            )
+        assert dl.sweep_live_owner_failed() == []
+
+    def test_attempts_cap_abandons(self):
+        _record()
+        dl.mark_failed("ob-1", "nope")
+        with dl._connect() as conn:
+            conn.execute(
+                "UPDATE delivery_obligations SET attempts=?, updated_at=? "
+                "WHERE obligation_id=?",
+                (dl.MAX_ATTEMPTS, time.time() - 120, "ob-1"),
+            )
+        assert dl.sweep_live_owner_failed() == []
+        assert _row("ob-1")["state"] == "abandoned"
+
+    def test_absent_platform_does_not_burn_attempts(self):
+        _record()
+        dl.mark_failed("ob-1", "nope")
+        with dl._connect() as conn:
+            conn.execute(
+                "UPDATE delivery_obligations SET updated_at=? WHERE obligation_id=?",
+                (time.time() - 120, "ob-1"),
+            )
+        assert dl.sweep_live_owner_failed(deliverable_platforms={"discord"}) == []
+        assert _row("ob-1")["attempts"] == 0
+
+
 class TestPrune:
     def test_old_delivered_rows_pruned(self):
         _record()


### PR DESCRIPTION
## Summary

- Retry failed gateway deliveries while the owning session is still live.
- Add bounded retry sweeping while preserving delivery-ledger state and avoiding duplicate delivery.

## Why

A transient delivery failure should not permanently lose a response when the session that owns it is still active. This keeps retries tied to live ownership and avoids treating an active session as abandoned.

## Tests

- `python -m pytest tests/gateway/test_delivery_ledger.py` — 23 passed

The branch was rebased onto the current upstream `main` before submission.

## Scope and safety

- Retries are bounded by the existing delivery state and live-owner checks.
- No credentials, machine-specific paths, or private incident details.
- No unrelated configuration, startup, or destructive behavior changes.
