### PR TITLE
fix(agent): add no-first-byte watchdog for streaming

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3778,6 +3778,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # poll loop uses this to detect stale connections that keep receiving
     # SSE keep-alive pings but no actual data.
     last_chunk_time = {"t": time.time()}
+    # No-first-byte tracking for the TTFB watchdog: set the moment the
+    # provider delivers ANY stream event (chunk or SSE frame). Until
+    # then the poll loop applies the shorter TTFB cutoff instead of the
+    # full stale patience, so a connection the provider accepted but
+    # that never delivers a byte is reconnected promptly instead of
+    # waiting out the reasoning floor (up to 600s).
+    first_stream_event_seen = {"yes": False}
     # Stale-stream patience, shared between the httpx socket read timeout
     # (built in ``_call_chat_completions`` below) and the stale-stream detector
     # (computed further down, before the worker thread starts).  Initialized
@@ -3815,6 +3822,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             stream_attempt_state["current"] += 1
             attempt_id = int(stream_attempt_state["current"])
         provider_tool_in_flight["yes"] = False
+        # Per-attempt TTFB budget: a retry that connects but never
+        # delivers a byte gets its own no-first-byte cutoff.
+        first_stream_event_seen["yes"] = False
         return attempt_id
 
     def _cancel_current_stream_attempt(reason: str) -> None:
@@ -4008,6 +4018,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             # an interceptor or codec is still handling an already-received
             # event.
             last_chunk_time["t"] = time.time()
+            first_stream_event_seen["yes"] = True
             return True
 
         def _relay_final_response() -> dict[str, Any]:
@@ -4085,6 +4096,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             response=lambda: attempt_stream_response["value"],
         ):
             last_chunk_time["t"] = time.time()
+            first_stream_event_seen["yes"] = True
             agent._touch_activity("receiving stream response")
 
             # Update per-attempt diagnostic counters.  Best-effort —
@@ -4609,6 +4621,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             for event in stream:
                 saw_stream_event = True
                 last_chunk_time["t"] = time.time()
+                first_stream_event_seen["yes"] = True
                 agent._touch_activity("receiving stream response")
                 try:
                     _diag["chunks"] = int(_diag.get("chunks", 0)) + 1
@@ -5127,6 +5140,35 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         if _reasoning_floor is not None:
             _stream_stale_timeout = max(_stream_stale_timeout, _reasoning_floor)
 
+    # ── No-first-byte TTFB watchdog (generic streaming path) ──────────
+    # A provider can accept a connection without emitting a stream event.
+    # The stale detector is deliberately scaled for reasoning models, so a
+    # separate cutoff is needed to retry a dead connection promptly.
+    # Apply a much shorter no-byte cutoff so the inner retry loop
+    # reconnects promptly; a fresh connection typically succeeds in
+    # seconds. Large subscription-backed requests can legitimately spend
+    # tens of seconds in backend admission / prompt prefill before the
+    # first SSE event, so the cutoff scales with context size and is
+    # disabled entirely for local endpoints (their prefill can take
+    # minutes). Operators can tune via HERMES_STREAM_TTFB_TIMEOUT_SECONDS
+    # (0 disables this watchdog).
+    _ttfb_timeout = env_float("HERMES_STREAM_TTFB_TIMEOUT_SECONDS", 120.0)
+    if _ttfb_timeout <= 0:
+        _ttfb_timeout = float("inf")
+    elif agent.base_url and is_local_endpoint(agent.base_url):
+        _ttfb_timeout = float("inf")
+    else:
+        _est_ttfb_tokens = estimate_request_context_tokens(api_kwargs)
+        if _est_ttfb_tokens > 100_000:
+            _ttfb_timeout = max(_ttfb_timeout, 300.0)
+        elif _est_ttfb_tokens > 50_000:
+            _ttfb_timeout = max(_ttfb_timeout, 240.0)
+        # Never let the TTFB cutoff exceed the stale patience: the stale
+        # detector owns the terminal kill + diagnostics for a connection
+        # that delivered bytes then wedged.
+        if _stream_stale_timeout is not None and _stream_stale_timeout != float("inf"):
+            _ttfb_timeout = min(_ttfb_timeout, _stream_stale_timeout)
+
     t = threading.Thread(target=_context_thread_target(_call), daemon=True)
     t.start()
     _last_heartbeat = time.time()
@@ -5168,6 +5210,41 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 # leave the live display alone.
                 agent._touch_activity(
                     f"waiting for stream response ({_waiting_secs}s, no chunks yet)"
+                )
+
+        # No-first-byte TTFB watchdog: the provider accepted the
+        # connection but has not delivered a single stream event. Kill it
+        # so the inner retry loop reconnects promptly instead of waiting
+        # out the (possibly 600s) stale patience on a dead connection.
+        if not first_stream_event_seen["yes"] and _ttfb_timeout != float("inf"):
+            _ttfb_elapsed = time.time() - last_chunk_time["t"]
+            if _ttfb_elapsed > _ttfb_timeout:
+                logger.warning(
+                    "Stream produced no first byte for %.0fs (TTFB threshold "
+                    "%.0fs) — no stream events received. model=%s. Killing "
+                    "connection so the retry loop can reconnect.",
+                    _ttfb_elapsed, _ttfb_timeout,
+                    api_kwargs.get("model", "unknown"),
+                )
+                agent._buffer_status(
+                    f"⚠️ No first byte from provider in {int(_ttfb_elapsed)}s "
+                    f"(model: {api_kwargs.get('model', 'unknown')}). "
+                    f"Reconnecting."
+                )
+                try:
+                    _cancel_current_stream_attempt("stream_ttfb_kill")
+                    _close_request_client_once("stream_ttfb_kill")
+                except Exception:
+                    pass
+                # Reset the timer so we don't kill repeatedly while the
+                # inner thread processes the closure.
+                last_chunk_time["t"] = time.time()
+                agent._emit_wait_notice(
+                    f"⚠ no first byte from provider in {int(_ttfb_elapsed)}s — "
+                    f"reconnecting..."
+                )
+                agent._touch_activity(
+                    f"stream killed after {int(_ttfb_elapsed)}s with no first byte"
                 )
 
         # Detect stale streams: connections kept alive by SSE pings

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -53,6 +53,7 @@ _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
 _PROVIDER_STREAM_ERROR_FINISH_REASONS = {"error", "error_finish"}
 _PROVIDER_STREAM_SSE_FIELDS = {"event", "data", "id", "retry"}
 _PROVIDER_STREAM_ERROR_TEXT_LIMIT = 4096
+_TTFB_STALE_MARGIN_SECONDS = 1.0
 
 # When the fallback chain is fully exhausted on a non-rate-limit failure
 # (e.g. every provider returns a non-retryable client error like HTTP 400),
@@ -623,21 +624,44 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
+def _normalise_timeout_seconds(value: object, default: float) -> float:
+    """Normalise a timeout value for the TTFB watchdog only.
+
+    Missing, empty, malformed, and NaN values use ``default``.  Zero,
+    negative values, and either infinity explicitly disable the watchdog.
+    This is intentionally not used by ``_env_float``: its existing callers,
+    including the separate Codex watchdog, retain their exact semantics.
+    """
+    if value is None or (isinstance(value, str) and not value.strip()):
+        return default
+    try:
+        normalised = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    if math.isnan(normalised):
+        return default
+    if math.isinf(normalised) or normalised <= 0:
+        return float("inf")
+    return normalised
+
+
 def resolve_stream_ttfb_timeout(
     base_url: str | None,
     est_tokens: int,
     stale_timeout: float,
     env_value: str | None = None,
 ) -> float:
-    """Resolve the generic stream no-first-byte cutoff in one place."""
-    if env_value is None or not str(env_value).strip():
-        configured = 120.0
-    else:
-        try:
-            configured = float(env_value)
-        except (TypeError, ValueError):
-            configured = 120.0
-    if configured <= 0:
+    """Resolve the generic stream no-first-byte cutoff in one place.
+
+    The TTFB watchdog gets an independent window.  When stale detection has a
+    finite positive deadline, leave it the named margin so both detectors
+    cannot claim the same poll interval.  A finite stale deadline at or below
+    that margin disables TTFB deliberately: stale detection owns the only
+    available recovery window.  An infinite stale deadline leaves a finite
+    cloud TTFB candidate uncapped.
+    """
+    configured = _normalise_timeout_seconds(env_value, 120.0)
+    if configured == float("inf"):
         return float("inf")
     if base_url and is_local_endpoint(base_url):
         return float("inf")
@@ -647,19 +671,32 @@ def resolve_stream_ttfb_timeout(
         timeout = max(configured, 240.0)
     else:
         timeout = configured
-    if stale_timeout is not None and stale_timeout != float("inf"):
-        timeout = min(timeout, stale_timeout)
-    return timeout
+    if stale_timeout is None:
+        return timeout
+    try:
+        stale = float(stale_timeout)
+    except (TypeError, ValueError, OverflowError):
+        return float("inf")
+    if math.isinf(stale):
+        return timeout if stale > 0 else float("inf")
+    if not math.isfinite(stale):
+        return float("inf")
+    available_window = stale - _TTFB_STALE_MARGIN_SECONDS
+    if available_window <= 0:
+        return float("inf")
+    return min(timeout, available_window)
 
 
 def ttfb_kill_should_fire(
     first_event_seen: bool, elapsed: float, ttfb_timeout: float
 ) -> bool:
     """Return whether a no-first-byte stream should be killed now."""
+    timeout = _normalise_timeout_seconds(ttfb_timeout, float("inf"))
     return (
         not first_event_seen
-        and ttfb_timeout != float("inf")
-        and elapsed > ttfb_timeout
+        and math.isfinite(timeout)
+        and timeout > 0
+        and elapsed > timeout
     )
 
 
@@ -760,6 +797,18 @@ def _bump_stale_streak(agent) -> None:
         pass
 
 
+def _set_stream_ttfb_window(
+    first_stream_event_seen: dict[str, bool],
+    last_chunk_time: dict[str, float],
+    *,
+    first_event_seen: bool,
+    now: float,
+) -> None:
+    """Set the TTFB event state and timestamp for one stream window."""
+    first_stream_event_seen["yes"] = first_event_seen
+    last_chunk_time["t"] = now
+
+
 def _reset_stale_streak(agent) -> None:
     try:
         agent._consecutive_stale_streams = 0
@@ -855,27 +904,58 @@ def _check_stale_giveup(agent) -> None:
 
 
 def _derive_stream_stale_timeout(agent, api_kwargs: dict) -> float:
-    """Stale-stream patience for a provider that is never a local endpoint.
+    """Derive the single stale-stream patience budget for a request.
 
-    Mirrors the main streaming path's derivation — provider config → env base
-    → context-size scaling → reasoning-model floor — minus the local-endpoint
-    ``float('inf')``/900s disable branch, which cannot apply to Bedrock (its
-    endpoint is always the AWS cloud). Factored so the Bedrock streaming
-    watchdog shares the exact same patience budget as the OpenAI/Anthropic
-    stale-stream detector below.
+    Provider config, environment defaults, local-provider policy, context-size
+    scaling, and the reasoning-model floor all belong here so the generic and
+    Bedrock streaming paths cannot drift.  The reasoning floor applies only to
+    stale detection; the TTFB resolver receives the resulting stale deadline as
+    an upper-window boundary and never receives the floor itself.
     """
     _cfg_stale = get_provider_stale_timeout(agent.provider, agent.model)
     if _cfg_stale is not None:
-        _base = _cfg_stale
+        _stream_stale_timeout_base = _cfg_stale
     else:
-        _base = env_float("HERMES_STREAM_STALE_TIMEOUT", 180.0)
-    _est_tokens = estimate_request_context_tokens(api_kwargs)
-    if _est_tokens > 100_000:
-        _timeout = max(_base, 300.0)
-    elif _est_tokens > 50_000:
-        _timeout = max(_base, 240.0)
+        _stream_stale_timeout_base = env_float("HERMES_STREAM_STALE_TIMEOUT", 180.0)
+
+    _base_url = getattr(agent, "base_url", None)
+    if (
+        _stream_stale_timeout_base == 180.0
+        and _base_url
+        and is_local_endpoint(_base_url)
+    ):
+        # Local providers can take minutes for prefill, but a dead server must
+        # still be bounded.  Config and the documented environment override
+        # retain the existing local-stream timeout policy.
+        _local_default = 900.0
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            _cfg = load_config_readonly()
+            _agent_cfg = _cfg.get("agent") if isinstance(_cfg, dict) else None
+            if isinstance(_agent_cfg, dict):
+                _value = _agent_cfg.get("local_stream_stale_timeout")
+                if isinstance(_value, (int, float)):
+                    _local_default = float(_value)
+        except Exception:
+            pass
+        _stream_stale_timeout = env_float(
+            "HERMES_LOCAL_STREAM_STALE_TIMEOUT", _local_default
+        )
+        logger.debug(
+            "Local provider detected (%s) — stale stream timeout set to %.0fs",
+            agent.base_url,
+            _stream_stale_timeout,
+        )
     else:
-        _timeout = _base
+        _est_tokens = estimate_request_context_tokens(api_kwargs)
+        if _est_tokens > 100_000:
+            _stream_stale_timeout = max(_stream_stale_timeout_base, 300.0)
+        elif _est_tokens > 50_000:
+            _stream_stale_timeout = max(_stream_stale_timeout_base, 240.0)
+        else:
+            _stream_stale_timeout = _stream_stale_timeout_base
+
     from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
     # Resolve the model id from BOTH the OpenAI/Anthropic key (``model``) and
     # the Bedrock key (``modelId``). OpenAI/Anthropic wins first via the ``or``
@@ -888,8 +968,8 @@ def _derive_stream_stale_timeout(agent, api_kwargs: dict) -> float:
     if _reasoning_floor is None and api_kwargs.get("modelId"):
         _reasoning_floor = _bedrock_reasoning_stale_floor(api_kwargs["modelId"])
     if _reasoning_floor is not None:
-        _timeout = max(_timeout, _reasoning_floor)
-    return _timeout
+        _stream_stale_timeout = max(_stream_stale_timeout, _reasoning_floor)
+    return _stream_stale_timeout
 
 
 def _bedrock_reasoning_stale_floor(model_id: object) -> "float | None":
@@ -3864,7 +3944,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         provider_tool_in_flight["yes"] = False
         # Per-attempt TTFB budget: a retry that connects but never
         # delivers a byte gets its own no-first-byte cutoff.
-        first_stream_event_seen["yes"] = False
+        _set_stream_ttfb_window(
+            first_stream_event_seen,
+            last_chunk_time,
+            first_event_seen=False,
+            now=time.time(),
+        )
         return attempt_id
 
     def _cancel_current_stream_attempt(reason: str) -> None:
@@ -5120,65 +5205,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 else "stream_error_cleanup"
             )
 
-    # Provider-configured stale timeout takes priority over env default.
-    _cfg_stale = get_provider_stale_timeout(agent.provider, agent.model)
-    if _cfg_stale is not None:
-        _stream_stale_timeout_base = _cfg_stale
-    else:
-        _stream_stale_timeout_base = env_float("HERMES_STREAM_STALE_TIMEOUT", 180.0)
-    # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
-    # for prefill on large contexts, so tolerate far longer silence than
-    # the cloud default — but a wedged local server must EVENTUALLY trip the
-    # detector rather than hang forever (an infinite timeout meant a crashed
-    # or deadlocked local endpoint stalled the session indefinitely).  900s
-    # tolerates slow prefill while still bounding a hung endpoint.  Applies
-    # unless the user explicitly set HERMES_STREAM_STALE_TIMEOUT; override the
-    # local ceiling with HERMES_LOCAL_STREAM_STALE_TIMEOUT (documented in
-    # website/docs/reference/environment-variables.md).
-    if _stream_stale_timeout_base == 180.0 and agent.base_url and is_local_endpoint(agent.base_url):
-        # Read config.yaml ``agent.local_stream_stale_timeout`` (default 900),
-        # env var ``HERMES_LOCAL_STREAM_STALE_TIMEOUT`` overrides for escape-hatch.
-        _local_default = 900.0
-        try:
-            from hermes_cli.config import load_config_readonly
-
-            _cfg = load_config_readonly()  # read-only consumer — no deepcopy
-            _agent_cfg = _cfg.get("agent") if isinstance(_cfg, dict) else None
-            if isinstance(_agent_cfg, dict):
-                _v = _agent_cfg.get("local_stream_stale_timeout")
-                if isinstance(_v, (int, float)):
-                    _local_default = float(_v)
-        except Exception:
-            pass
-        _stream_stale_timeout = env_float("HERMES_LOCAL_STREAM_STALE_TIMEOUT", _local_default)
-        logger.debug(
-            "Local provider detected (%s) — stale stream timeout set to %.0fs",
-            agent.base_url, _stream_stale_timeout,
-        )
-    else:
-        # Scale the stale timeout for large contexts: slow models (like Opus)
-        # can legitimately think for minutes before producing the first token
-        # when the context is large.  Without this, the stale detector kills
-        # healthy connections during the model's thinking phase, producing
-        # spurious RemoteProtocolError ("peer closed connection").
-        _est_tokens = estimate_request_context_tokens(api_kwargs)
-        if _est_tokens > 100_000:
-            _stream_stale_timeout = max(_stream_stale_timeout_base, 300.0)
-        elif _est_tokens > 50_000:
-            _stream_stale_timeout = max(_stream_stale_timeout_base, 240.0)
-        else:
-            _stream_stale_timeout = _stream_stale_timeout_base
-        # Reasoning-model floor: known reasoning models (Nemotron 3 Ultra,
-        # OpenAI o1/o3, Anthropic Opus 4.x thinking, DeepSeek R1, Qwen QwQ,
-        # xAI Grok reasoning, etc.) routinely exceed the default 180s chat-
-        # model threshold during their thinking phase.  The cloud gateway
-        # upstream kills the socket first, surfacing as BrokenPipeError.
-        # Raises the floor only — never overrides explicit user config
-        # (handled by get_provider_stale_timeout above).
-        from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
-        _reasoning_floor = get_reasoning_stale_timeout_floor(api_kwargs.get("model"))
-        if _reasoning_floor is not None:
-            _stream_stale_timeout = max(_stream_stale_timeout, _reasoning_floor)
+    # Keep one owner for provider/local/context/reasoning stale derivation.
+    _stream_stale_timeout = _derive_stream_stale_timeout(agent, api_kwargs)
 
     # ── No-first-byte TTFB watchdog (generic streaming path) ──────────
     # A provider can accept a connection without emitting a stream event.
@@ -5258,11 +5286,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     _close_request_client_once("stream_ttfb_kill")
                 except Exception:
                     pass
+                # Count this no-first-byte kill like the ordinary stale kill.
                 # Reset both guards so we don't kill repeatedly while the
                 # inner thread processes the closure. The next attempt resets
-                # this flag when it actually starts.
-                last_chunk_time["t"] = time.time()
-                first_stream_event_seen["yes"] = True
+                # them again when it actually starts.
+                _bump_stale_streak(agent)
+                _set_stream_ttfb_window(
+                    first_stream_event_seen,
+                    last_chunk_time,
+                    first_event_seen=True,
+                    now=time.time(),
+                )
                 agent._emit_wait_notice(
                     f"⚠ no first byte from provider in {int(_ttfb_elapsed)}s — "
                     f"reconnecting..."

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -623,6 +623,46 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
+def resolve_stream_ttfb_timeout(
+    base_url: str | None,
+    est_tokens: int,
+    stale_timeout: float,
+    env_value: str | None = None,
+) -> float:
+    """Resolve the generic stream no-first-byte cutoff in one place."""
+    if env_value is None or not str(env_value).strip():
+        configured = 120.0
+    else:
+        try:
+            configured = float(env_value)
+        except (TypeError, ValueError):
+            configured = 120.0
+    if configured <= 0:
+        return float("inf")
+    if base_url and is_local_endpoint(base_url):
+        return float("inf")
+    if est_tokens > 100_000:
+        timeout = max(configured, 300.0)
+    elif est_tokens > 50_000:
+        timeout = max(configured, 240.0)
+    else:
+        timeout = configured
+    if stale_timeout is not None and stale_timeout != float("inf"):
+        timeout = min(timeout, stale_timeout)
+    return timeout
+
+
+def ttfb_kill_should_fire(
+    first_event_seen: bool, elapsed: float, ttfb_timeout: float
+) -> bool:
+    """Return whether a no-first-byte stream should be killed now."""
+    return (
+        not first_event_seen
+        and ttfb_timeout != float("inf")
+        and elapsed > ttfb_timeout
+    )
+
+
 def _estimate_chunk_bytes(chunk: Any) -> int:
     """Cheap per-chunk size estimate for the stream diagnostic counters.
 
@@ -5142,32 +5182,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
     # ── No-first-byte TTFB watchdog (generic streaming path) ──────────
     # A provider can accept a connection without emitting a stream event.
-    # The stale detector is deliberately scaled for reasoning models, so a
-    # separate cutoff is needed to retry a dead connection promptly.
-    # Apply a much shorter no-byte cutoff so the inner retry loop
-    # reconnects promptly; a fresh connection typically succeeds in
-    # seconds. Large subscription-backed requests can legitimately spend
-    # tens of seconds in backend admission / prompt prefill before the
-    # first SSE event, so the cutoff scales with context size and is
-    # disabled entirely for local endpoints (their prefill can take
-    # minutes). Operators can tune via HERMES_STREAM_TTFB_TIMEOUT_SECONDS
-    # (0 disables this watchdog).
-    _ttfb_timeout = env_float("HERMES_STREAM_TTFB_TIMEOUT_SECONDS", 120.0)
-    if _ttfb_timeout <= 0:
-        _ttfb_timeout = float("inf")
-    elif agent.base_url and is_local_endpoint(agent.base_url):
-        _ttfb_timeout = float("inf")
-    else:
-        _est_ttfb_tokens = estimate_request_context_tokens(api_kwargs)
-        if _est_ttfb_tokens > 100_000:
-            _ttfb_timeout = max(_ttfb_timeout, 300.0)
-        elif _est_ttfb_tokens > 50_000:
-            _ttfb_timeout = max(_ttfb_timeout, 240.0)
-        # Never let the TTFB cutoff exceed the stale patience: the stale
-        # detector owns the terminal kill + diagnostics for a connection
-        # that delivered bytes then wedged.
-        if _stream_stale_timeout is not None and _stream_stale_timeout != float("inf"):
-            _ttfb_timeout = min(_ttfb_timeout, _stream_stale_timeout)
+    _ttfb_timeout = resolve_stream_ttfb_timeout(
+        agent.base_url,
+        estimate_request_context_tokens(api_kwargs),
+        _stream_stale_timeout,
+        os.environ.get("HERMES_STREAM_TTFB_TIMEOUT_SECONDS"),
+    )
 
     t = threading.Thread(target=_context_thread_target(_call), daemon=True)
     t.start()
@@ -5218,7 +5238,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # out the (possibly 600s) stale patience on a dead connection.
         if not first_stream_event_seen["yes"] and _ttfb_timeout != float("inf"):
             _ttfb_elapsed = time.time() - last_chunk_time["t"]
-            if _ttfb_elapsed > _ttfb_timeout:
+            if ttfb_kill_should_fire(
+                first_stream_event_seen["yes"], _ttfb_elapsed, _ttfb_timeout
+            ):
                 logger.warning(
                     "Stream produced no first byte for %.0fs (TTFB threshold "
                     "%.0fs) — no stream events received. model=%s. Killing "
@@ -5236,9 +5258,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     _close_request_client_once("stream_ttfb_kill")
                 except Exception:
                     pass
-                # Reset the timer so we don't kill repeatedly while the
-                # inner thread processes the closure.
+                # Reset both guards so we don't kill repeatedly while the
+                # inner thread processes the closure. The next attempt resets
+                # this flag when it actually starts.
                 last_chunk_time["t"] = time.time()
+                first_stream_event_seen["yes"] = True
                 agent._emit_wait_notice(
                     f"⚠ no first byte from provider in {int(_ttfb_elapsed)}s — "
                     f"reconnecting..."

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -61,6 +61,33 @@ def _make_codex_agent(tmp_path, monkeypatch):
 
 
 
+def test_generic_streaming_codex_route_bypasses_generic_ttfb(monkeypatch):
+    """Codex streaming keeps ownership of its native watchdogs."""
+    from agent import chat_completion_helpers as h
+
+    response = SimpleNamespace(ok=True)
+    calls = []
+    agent = SimpleNamespace(
+        api_mode="codex_responses",
+        provider="openai-codex",
+        platform="cli",
+        _interrupt_requested=False,
+        _interruptible_api_call=lambda kwargs: calls.append(kwargs) or response,
+        _emit_stream_start=lambda: None,
+        _emit_stream_end=lambda **_kwargs: None,
+    )
+
+    def unexpected_generic_resolver(*_args, **_kwargs):
+        raise AssertionError("Codex must not use the generic TTFB resolver")
+
+    monkeypatch.setattr(h, "resolve_stream_ttfb_timeout", unexpected_generic_resolver)
+
+    assert h.interruptible_streaming_api_call(
+        agent, {"model": "gpt-5.5", "input": "hi"}
+    ) is response
+    assert calls == [{"model": "gpt-5.5", "input": "hi"}]
+
+
 def test_ttfb_includes_silent_hang_hint_for_gpt_5_5(tmp_path, monkeypatch):
     """The no-first-byte watchdog should surface the same actionable hint as the
     stale-call timeout path when the model matches the silent-hang heuristic."""
@@ -68,6 +95,7 @@ def test_ttfb_includes_silent_hang_hint_for_gpt_5_5(tmp_path, monkeypatch):
 
     agent = _make_codex_agent(tmp_path, monkeypatch)
     monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "0.4")
+    assert getattr(agent, "_codex_stream_last_event_ts", None) is None
 
     closes: list = []
     statuses: list[str] = []
@@ -117,6 +145,7 @@ def test_ttfb_does_not_kill_when_events_flow(tmp_path, monkeypatch):
 
     agent = _make_codex_agent(tmp_path, monkeypatch)
     monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "0.4")
+    assert getattr(agent, "_codex_stream_last_event_ts", None) is None
 
     closes: list = []
     dummy_client = SimpleNamespace()

--- a/tests/agent/test_stream_ttfb_watchdog.py
+++ b/tests/agent/test_stream_ttfb_watchdog.py
@@ -1,0 +1,119 @@
+"""Regression tests for the no-first-byte TTFB watchdog (generic streaming path).
+
+A provider can accept a connection without emitting a stream event.
+The stale-stream detector is deliberately scaled for reasoning models, so
+this watchdog supplies a separate cutoff for retrying a dead connection.
+
+These tests pin the TTFB resolution invariants.  They mirror the inline
+logic in ``agent/chat_completion_helpers.py`` (the real builder lives
+deep inside a worker thread, so — like ``test_stream_read_timeout_floor.py``
+— the resolution is reproduced here rather than driven end-to-end):
+
+1. Cloud providers get a 120s default no-first-byte cutoff.
+2. Local endpoints disable the watchdog (prefill can take minutes).
+3. ``HERMES_STREAM_TTFB_TIMEOUT_SECONDS=0`` disables it entirely.
+4. Large contexts scale the cutoff up (240s / 300s) so healthy
+   backend admission / prompt prefill is not aborted.
+5. The cutoff never exceeds the stale-stream patience: the stale
+   detector owns the terminal kill + diagnostics for a connection
+   that delivered bytes then wedged.
+6. The kill predicate fires only when NO stream event has been seen
+   and the elapsed time is past the cutoff.
+"""
+
+from __future__ import annotations
+
+from agent.model_metadata import is_local_endpoint
+
+
+def _resolve_ttfb_timeout(
+    base_url: str,
+    est_tokens: int,
+    stale_timeout: float,
+    env_value: str | None = None,
+) -> float:
+    """Mirror of the TTFB resolution in interruptible_streaming_api_call."""
+    if env_value is not None:
+        try:
+            configured = float(env_value)
+        except (TypeError, ValueError):
+            configured = 120.0
+    else:
+        configured = 120.0
+    if configured <= 0:
+        return float("inf")
+    if base_url and is_local_endpoint(base_url):
+        return float("inf")
+    if est_tokens > 100_000:
+        timeout = max(configured, 300.0)
+    elif est_tokens > 50_000:
+        timeout = max(configured, 240.0)
+    else:
+        timeout = configured
+    if stale_timeout is not None and stale_timeout != float("inf"):
+        timeout = min(timeout, stale_timeout)
+    return timeout
+
+
+def _ttfb_kill_should_fire(first_event_seen: bool, elapsed: float, ttfb_timeout: float) -> bool:
+    """Mirror of the poll-loop kill predicate."""
+    if first_event_seen:
+        return False
+    if ttfb_timeout == float("inf"):
+        return False
+    return elapsed > ttfb_timeout
+
+
+CLOUD_URLS = [
+    "https://api.githubcopilot.com",
+    "https://api.openai.com",
+    "https://openrouter.ai/api",
+    "https://api.anthropic.com",
+    "https://api.example.com/v1",
+]
+
+
+class TestTtfbResolution:
+    def test_cloud_default_is_120s(self):
+        for url in CLOUD_URLS:
+            assert _resolve_ttfb_timeout(url, est_tokens=0, stale_timeout=600.0) == 120.0
+
+    def test_local_endpoint_disables_watchdog(self):
+        assert _resolve_ttfb_timeout("http://localhost:11434", est_tokens=0, stale_timeout=float("inf")) == float("inf")
+        assert _resolve_ttfb_timeout("http://127.0.0.1:8080", est_tokens=0, stale_timeout=float("inf")) == float("inf")
+
+    def test_env_zero_disables_watchdog(self):
+        assert _resolve_ttfb_timeout("https://api.openai.com", est_tokens=0, stale_timeout=600.0, env_value="0") == float("inf")
+
+    def test_env_override_is_respected(self):
+        assert _resolve_ttfb_timeout("https://api.openai.com", est_tokens=0, stale_timeout=600.0, env_value="45") == 45.0
+
+    def test_large_context_scales_up(self):
+        assert _resolve_ttfb_timeout("https://api.openai.com", est_tokens=60_000, stale_timeout=600.0) == 240.0
+        assert _resolve_ttfb_timeout("https://api.openai.com", est_tokens=150_000, stale_timeout=600.0) == 300.0
+
+    def test_never_exceeds_stale_patience(self):
+        # A 120s default TTFB with a 90s stale timeout must clamp to 90s.
+        assert _resolve_ttfb_timeout("https://api.openai.com", est_tokens=0, stale_timeout=90.0) == 90.0
+        # A scaled-up TTFB (300s) with a 180s stale timeout must clamp to 180s.
+        assert _resolve_ttfb_timeout("https://api.openai.com", est_tokens=150_000, stale_timeout=180.0) == 180.0
+
+    def test_infinite_stale_keeps_ttfb_finite(self):
+        # Local endpoints disable BOTH, but a cloud endpoint with an
+        # infinite stale value (explicit user config) still gets the
+        # finite TTFB cutoff — the watchdog is the only bound left.
+        assert _resolve_ttfb_timeout("https://api.openai.com", est_tokens=0, stale_timeout=float("inf")) == 120.0
+
+
+class TestTtfbKillPredicate:
+    def test_no_first_byte_past_cutoff_fires(self):
+        assert _ttfb_kill_should_fire(False, elapsed=121.0, ttfb_timeout=120.0) is True
+
+    def test_no_first_byte_before_cutoff_waits(self):
+        assert _ttfb_kill_should_fire(False, elapsed=119.0, ttfb_timeout=120.0) is False
+
+    def test_first_byte_seen_disarms(self):
+        assert _ttfb_kill_should_fire(True, elapsed=500.0, ttfb_timeout=120.0) is False
+
+    def test_disabled_watchdog_never_fires(self):
+        assert _ttfb_kill_should_fire(False, elapsed=9999.0, ttfb_timeout=float("inf")) is False

--- a/tests/agent/test_stream_ttfb_watchdog.py
+++ b/tests/agent/test_stream_ttfb_watchdog.py
@@ -4,10 +4,8 @@ A provider can accept a connection without emitting a stream event.
 The stale-stream detector is deliberately scaled for reasoning models, so
 this watchdog supplies a separate cutoff for retrying a dead connection.
 
-These tests pin the TTFB resolution invariants.  They mirror the inline
-logic in ``agent/chat_completion_helpers.py`` (the real builder lives
-deep inside a worker thread, so — like ``test_stream_read_timeout_floor.py``
-— the resolution is reproduced here rather than driven end-to-end):
+These tests pin the production TTFB resolution and kill-predicate helpers
+without reproducing their implementation in the test suite.
 
 1. Cloud providers get a 120s default no-first-byte cutoff.
 2. Local endpoints disable the watchdog (prefill can take minutes).
@@ -23,45 +21,10 @@ deep inside a worker thread, so — like ``test_stream_read_timeout_floor.py``
 
 from __future__ import annotations
 
-from agent.model_metadata import is_local_endpoint
-
-
-def _resolve_ttfb_timeout(
-    base_url: str,
-    est_tokens: int,
-    stale_timeout: float,
-    env_value: str | None = None,
-) -> float:
-    """Mirror of the TTFB resolution in interruptible_streaming_api_call."""
-    if env_value is not None:
-        try:
-            configured = float(env_value)
-        except (TypeError, ValueError):
-            configured = 120.0
-    else:
-        configured = 120.0
-    if configured <= 0:
-        return float("inf")
-    if base_url and is_local_endpoint(base_url):
-        return float("inf")
-    if est_tokens > 100_000:
-        timeout = max(configured, 300.0)
-    elif est_tokens > 50_000:
-        timeout = max(configured, 240.0)
-    else:
-        timeout = configured
-    if stale_timeout is not None and stale_timeout != float("inf"):
-        timeout = min(timeout, stale_timeout)
-    return timeout
-
-
-def _ttfb_kill_should_fire(first_event_seen: bool, elapsed: float, ttfb_timeout: float) -> bool:
-    """Mirror of the poll-loop kill predicate."""
-    if first_event_seen:
-        return False
-    if ttfb_timeout == float("inf"):
-        return False
-    return elapsed > ttfb_timeout
+from agent.chat_completion_helpers import (
+    resolve_stream_ttfb_timeout,
+    ttfb_kill_should_fire,
+)
 
 
 CLOUD_URLS = [
@@ -76,44 +39,57 @@ CLOUD_URLS = [
 class TestTtfbResolution:
     def test_cloud_default_is_120s(self):
         for url in CLOUD_URLS:
-            assert _resolve_ttfb_timeout(url, est_tokens=0, stale_timeout=600.0) == 120.0
+            assert resolve_stream_ttfb_timeout(url, est_tokens=0, stale_timeout=600.0) == 120.0
 
     def test_local_endpoint_disables_watchdog(self):
-        assert _resolve_ttfb_timeout("http://localhost:11434", est_tokens=0, stale_timeout=float("inf")) == float("inf")
-        assert _resolve_ttfb_timeout("http://127.0.0.1:8080", est_tokens=0, stale_timeout=float("inf")) == float("inf")
+        assert resolve_stream_ttfb_timeout("http://localhost:11434", est_tokens=0, stale_timeout=float("inf")) == float("inf")
+        assert resolve_stream_ttfb_timeout("http://127.0.0.1:8080", est_tokens=0, stale_timeout=float("inf")) == float("inf")
 
     def test_env_zero_disables_watchdog(self):
-        assert _resolve_ttfb_timeout("https://api.openai.com", est_tokens=0, stale_timeout=600.0, env_value="0") == float("inf")
+        assert resolve_stream_ttfb_timeout("https://api.openai.com", est_tokens=0, stale_timeout=600.0, env_value="0") == float("inf")
 
     def test_env_override_is_respected(self):
-        assert _resolve_ttfb_timeout("https://api.openai.com", est_tokens=0, stale_timeout=600.0, env_value="45") == 45.0
+        assert resolve_stream_ttfb_timeout("https://api.openai.com", est_tokens=0, stale_timeout=600.0, env_value="45") == 45.0
+
+    def test_empty_env_falls_back_to_default(self):
+        assert resolve_stream_ttfb_timeout("https://api.openai.com", est_tokens=0, stale_timeout=600.0, env_value="") == 120.0
+
+    def test_garbage_env_falls_back_to_default(self):
+        assert resolve_stream_ttfb_timeout("https://api.openai.com", est_tokens=0, stale_timeout=600.0, env_value="not-a-number") == 120.0
 
     def test_large_context_scales_up(self):
-        assert _resolve_ttfb_timeout("https://api.openai.com", est_tokens=60_000, stale_timeout=600.0) == 240.0
-        assert _resolve_ttfb_timeout("https://api.openai.com", est_tokens=150_000, stale_timeout=600.0) == 300.0
+        assert resolve_stream_ttfb_timeout("https://api.openai.com", est_tokens=60_000, stale_timeout=600.0) == 240.0
+        assert resolve_stream_ttfb_timeout("https://api.openai.com", est_tokens=150_000, stale_timeout=600.0) == 300.0
 
     def test_never_exceeds_stale_patience(self):
         # A 120s default TTFB with a 90s stale timeout must clamp to 90s.
-        assert _resolve_ttfb_timeout("https://api.openai.com", est_tokens=0, stale_timeout=90.0) == 90.0
+        assert resolve_stream_ttfb_timeout("https://api.openai.com", est_tokens=0, stale_timeout=90.0) == 90.0
         # A scaled-up TTFB (300s) with a 180s stale timeout must clamp to 180s.
-        assert _resolve_ttfb_timeout("https://api.openai.com", est_tokens=150_000, stale_timeout=180.0) == 180.0
+        assert resolve_stream_ttfb_timeout("https://api.openai.com", est_tokens=150_000, stale_timeout=180.0) == 180.0
 
     def test_infinite_stale_keeps_ttfb_finite(self):
         # Local endpoints disable BOTH, but a cloud endpoint with an
         # infinite stale value (explicit user config) still gets the
         # finite TTFB cutoff — the watchdog is the only bound left.
-        assert _resolve_ttfb_timeout("https://api.openai.com", est_tokens=0, stale_timeout=float("inf")) == 120.0
+        assert resolve_stream_ttfb_timeout("https://api.openai.com", est_tokens=0, stale_timeout=float("inf")) == 120.0
 
 
 class TestTtfbKillPredicate:
     def test_no_first_byte_past_cutoff_fires(self):
-        assert _ttfb_kill_should_fire(False, elapsed=121.0, ttfb_timeout=120.0) is True
+        assert ttfb_kill_should_fire(False, elapsed=121.0, ttfb_timeout=120.0) is True
 
     def test_no_first_byte_before_cutoff_waits(self):
-        assert _ttfb_kill_should_fire(False, elapsed=119.0, ttfb_timeout=120.0) is False
+        assert ttfb_kill_should_fire(False, elapsed=119.0, ttfb_timeout=120.0) is False
 
     def test_first_byte_seen_disarms(self):
-        assert _ttfb_kill_should_fire(True, elapsed=500.0, ttfb_timeout=120.0) is False
+        assert ttfb_kill_should_fire(True, elapsed=500.0, ttfb_timeout=120.0) is False
 
     def test_disabled_watchdog_never_fires(self):
-        assert _ttfb_kill_should_fire(False, elapsed=9999.0, ttfb_timeout=float("inf")) is False
+        assert ttfb_kill_should_fire(False, elapsed=9999.0, ttfb_timeout=float("inf")) is False
+
+    def test_kill_reset_suppresses_repeat_until_next_attempt(self):
+        assert ttfb_kill_should_fire(False, elapsed=121.0, ttfb_timeout=120.0) is True
+        # The production kill branch marks the attempt as seen after resetting
+        # its timer; a fresh attempt clears the flag before polling resumes.
+        assert ttfb_kill_should_fire(True, elapsed=1.0, ttfb_timeout=120.0) is False
+        assert ttfb_kill_should_fire(False, elapsed=121.0, ttfb_timeout=120.0) is True

--- a/tests/agent/test_stream_ttfb_watchdog.py
+++ b/tests/agent/test_stream_ttfb_watchdog.py
@@ -1,95 +1,359 @@
-"""Regression tests for the no-first-byte TTFB watchdog (generic streaming path).
+"""Regression tests for the generic no-first-byte TTFB watchdog.
 
-A provider can accept a connection without emitting a stream event.
-The stale-stream detector is deliberately scaled for reasoning models, so
-this watchdog supplies a separate cutoff for retrying a dead connection.
+A provider can accept a connection without emitting a stream event.  The
+stale-stream detector is deliberately scaled for reasoning models, so this
+watchdog supplies a separate cutoff for retrying a dead connection.
 
-These tests pin the production TTFB resolution and kill-predicate helpers
-without reproducing their implementation in the test suite.
-
-1. Cloud providers get a 120s default no-first-byte cutoff.
-2. Local endpoints disable the watchdog (prefill can take minutes).
-3. ``HERMES_STREAM_TTFB_TIMEOUT_SECONDS=0`` disables it entirely.
-4. Large contexts scale the cutoff up (240s / 300s) so healthy
-   backend admission / prompt prefill is not aborted.
-5. The cutoff never exceeds the stale-stream patience: the stale
-   detector owns the terminal kill + diagnostics for a connection
-   that delivered bytes then wedged.
-6. The kill predicate fires only when NO stream event has been seen
-   and the elapsed time is past the cutoff.
+The tests import the production resolvers and state transition helper rather
+than reproducing their timeout formulas here.
 """
 
 from __future__ import annotations
 
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from agent import chat_completion_helpers as helpers
 from agent.chat_completion_helpers import (
+    _derive_stream_stale_timeout,
+    _set_stream_ttfb_window,
+    interruptible_streaming_api_call,
     resolve_stream_ttfb_timeout,
     ttfb_kill_should_fire,
 )
 
 
-CLOUD_URLS = [
-    "https://api.githubcopilot.com",
-    "https://api.openai.com",
-    "https://openrouter.ai/api",
-    "https://api.anthropic.com",
-    "https://api.example.com/v1",
-]
+CLOUD_URL = "https://api.openai.com/v1"
 
 
 class TestTtfbResolution:
     def test_cloud_default_is_120s(self):
-        for url in CLOUD_URLS:
-            assert resolve_stream_ttfb_timeout(url, est_tokens=0, stale_timeout=600.0) == 120.0
+        assert resolve_stream_ttfb_timeout(CLOUD_URL, 0, 600.0) == 120.0
 
     def test_local_endpoint_disables_watchdog(self):
-        assert resolve_stream_ttfb_timeout("http://localhost:11434", est_tokens=0, stale_timeout=float("inf")) == float("inf")
-        assert resolve_stream_ttfb_timeout("http://127.0.0.1:8080", est_tokens=0, stale_timeout=float("inf")) == float("inf")
+        assert resolve_stream_ttfb_timeout(
+            "http://localhost:11434", 0, float("inf")
+        ) == float("inf")
+        assert resolve_stream_ttfb_timeout(
+            "http://127.0.0.1:8080", 0, float("inf")
+        ) == float("inf")
 
-    def test_env_zero_disables_watchdog(self):
-        assert resolve_stream_ttfb_timeout("https://api.openai.com", est_tokens=0, stale_timeout=600.0, env_value="0") == float("inf")
+    @pytest.mark.parametrize(
+        ("env_value", "expected"),
+        [
+            (None, 120.0),
+            ("", 120.0),
+            ("  ", 120.0),
+            ("not-a-number", 120.0),
+            ("nan", 120.0),
+            ("0", float("inf")),
+            ("-1", float("inf")),
+            ("inf", float("inf")),
+            ("-inf", float("inf")),
+            ("45", 45.0),
+        ],
+    )
+    def test_ttfb_setting_is_normalised_without_nan(self, env_value, expected):
+        actual = resolve_stream_ttfb_timeout(
+            CLOUD_URL,
+            est_tokens=0,
+            stale_timeout=600.0,
+            env_value=env_value,
+        )
+        assert actual == expected
 
-    def test_env_override_is_respected(self):
-        assert resolve_stream_ttfb_timeout("https://api.openai.com", est_tokens=0, stale_timeout=600.0, env_value="45") == 45.0
+    def test_large_context_scaling_is_preserved(self):
+        assert resolve_stream_ttfb_timeout(CLOUD_URL, 60_000, 600.0) == 240.0
+        assert resolve_stream_ttfb_timeout(CLOUD_URL, 150_000, 600.0) == 300.0
 
-    def test_empty_env_falls_back_to_default(self):
-        assert resolve_stream_ttfb_timeout("https://api.openai.com", est_tokens=0, stale_timeout=600.0, env_value="") == 120.0
+    @pytest.mark.parametrize(
+        ("est_tokens", "stale_timeout", "expected"),
+        [
+            (0, 90.0, 89.0),
+            (60_000, 240.0, 239.0),
+            (150_000, 300.0, 299.0),
+        ],
+    )
+    def test_ttfb_stays_strictly_before_finite_stale_deadline(
+        self, est_tokens, stale_timeout, expected
+    ):
+        actual = resolve_stream_ttfb_timeout(
+            CLOUD_URL, est_tokens, stale_timeout
+        )
+        assert actual == expected
+        assert actual < stale_timeout
 
-    def test_garbage_env_falls_back_to_default(self):
-        assert resolve_stream_ttfb_timeout("https://api.openai.com", est_tokens=0, stale_timeout=600.0, env_value="not-a-number") == 120.0
+    @pytest.mark.parametrize("stale_timeout", [1.0, 0.5, 0.0, -1.0])
+    def test_finite_small_stale_deadline_disables_ttfb(self, stale_timeout):
+        assert resolve_stream_ttfb_timeout(
+            CLOUD_URL, 0, stale_timeout
+        ) == float("inf")
 
-    def test_large_context_scales_up(self):
-        assert resolve_stream_ttfb_timeout("https://api.openai.com", est_tokens=60_000, stale_timeout=600.0) == 240.0
-        assert resolve_stream_ttfb_timeout("https://api.openai.com", est_tokens=150_000, stale_timeout=600.0) == 300.0
+    def test_infinite_stale_keeps_cloud_ttfb_finite(self):
+        assert resolve_stream_ttfb_timeout(
+            CLOUD_URL, 0, float("inf")
+        ) == 120.0
 
-    def test_never_exceeds_stale_patience(self):
-        # A 120s default TTFB with a 90s stale timeout must clamp to 90s.
-        assert resolve_stream_ttfb_timeout("https://api.openai.com", est_tokens=0, stale_timeout=90.0) == 90.0
-        # A scaled-up TTFB (300s) with a 180s stale timeout must clamp to 180s.
-        assert resolve_stream_ttfb_timeout("https://api.openai.com", est_tokens=150_000, stale_timeout=180.0) == 180.0
+    def test_non_finite_stale_is_not_allowed_to_arm_ttfb(self):
+        assert resolve_stream_ttfb_timeout(
+            CLOUD_URL, 0, float("nan")
+        ) == float("inf")
+        assert resolve_stream_ttfb_timeout(
+            CLOUD_URL, 0, float("-inf")
+        ) == float("inf")
 
-    def test_infinite_stale_keeps_ttfb_finite(self):
-        # Local endpoints disable BOTH, but a cloud endpoint with an
-        # infinite stale value (explicit user config) still gets the
-        # finite TTFB cutoff — the watchdog is the only bound left.
-        assert resolve_stream_ttfb_timeout("https://api.openai.com", est_tokens=0, stale_timeout=float("inf")) == 120.0
+    def test_reasoning_floor_belongs_to_stale_not_ttfb(self, monkeypatch):
+        monkeypatch.setattr(
+            helpers, "get_provider_stale_timeout", lambda *_args: None
+        )
+        agent = SimpleNamespace(
+            provider="nvidia",
+            model="nvidia/nemotron-3-ultra-550b-a55b",
+            base_url=CLOUD_URL,
+        )
+
+        stale_timeout = _derive_stream_stale_timeout(
+            agent, {"model": agent.model}
+        )
+        assert stale_timeout == 600.0
+
+        ttfb_timeout = resolve_stream_ttfb_timeout(
+            CLOUD_URL, 0, stale_timeout
+        )
+        assert 0 < ttfb_timeout < stale_timeout
 
 
 class TestTtfbKillPredicate:
     def test_no_first_byte_past_cutoff_fires(self):
-        assert ttfb_kill_should_fire(False, elapsed=121.0, ttfb_timeout=120.0) is True
+        assert ttfb_kill_should_fire(False, 121.0, 120.0) is True
 
     def test_no_first_byte_before_cutoff_waits(self):
-        assert ttfb_kill_should_fire(False, elapsed=119.0, ttfb_timeout=120.0) is False
+        assert ttfb_kill_should_fire(False, 119.0, 120.0) is False
 
     def test_first_byte_seen_disarms(self):
-        assert ttfb_kill_should_fire(True, elapsed=500.0, ttfb_timeout=120.0) is False
+        assert ttfb_kill_should_fire(True, 500.0, 120.0) is False
 
-    def test_disabled_watchdog_never_fires(self):
-        assert ttfb_kill_should_fire(False, elapsed=9999.0, ttfb_timeout=float("inf")) is False
+    @pytest.mark.parametrize(
+        "timeout", ["", "not-a-number", "nan", 0.0, -1.0, float("inf"), float("nan")]
+    )
+    def test_garbage_or_disabled_timeout_never_fires(self, timeout):
+        assert ttfb_kill_should_fire(False, 9999.0, timeout) is False
+
+    def test_normal_string_timeout_is_defensive_and_arms(self):
+        assert ttfb_kill_should_fire(False, 46.0, "45") is True
 
     def test_kill_reset_suppresses_repeat_until_next_attempt(self):
-        assert ttfb_kill_should_fire(False, elapsed=121.0, ttfb_timeout=120.0) is True
-        # The production kill branch marks the attempt as seen after resetting
-        # its timer; a fresh attempt clears the flag before polling resumes.
-        assert ttfb_kill_should_fire(True, elapsed=1.0, ttfb_timeout=120.0) is False
-        assert ttfb_kill_should_fire(False, elapsed=121.0, ttfb_timeout=120.0) is True
+        assert ttfb_kill_should_fire(False, 121.0, 120.0) is True
+        assert ttfb_kill_should_fire(True, 1.0, 120.0) is False
+        assert ttfb_kill_should_fire(False, 121.0, 120.0) is True
+
+
+def test_set_stream_ttfb_window_updates_state_and_timestamp():
+    first_event_seen = {"yes": True}
+    last_chunk_time = {"t": 1.0}
+
+    _set_stream_ttfb_window(
+        first_event_seen,
+        last_chunk_time,
+        first_event_seen=False,
+        now=42.5,
+    )
+
+    assert first_event_seen == {"yes": False}
+    assert last_chunk_time == {"t": 42.5}
+
+
+class _DeterministicClock:
+    """Monotonic-by-call clock for the worker/poll-loop harness."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._value = 1_000.0
+
+    def time(self):
+        with self._lock:
+            self._value += 0.1
+            return self._value
+
+
+class _AbortableProviderStream:
+    def __init__(self, *, gate=None, chunk=None):
+        self._gate = gate
+        self._chunk = chunk
+        self.closed = False
+
+    def __iter__(self):
+        if self._gate is not None:
+            self._gate.wait()
+        if self.closed:
+            raise ConnectionError("provider stream closed")
+        if self._chunk is not None:
+            yield self._chunk
+
+    def close(self):
+        self.closed = True
+        if self._gate is not None:
+            self._gate.set()
+
+
+class _FakeOpenAiClient:
+    def __init__(self, stream):
+        self.stream = stream
+        self.chat = SimpleNamespace(
+            completions=SimpleNamespace(
+                create=lambda **_kwargs: self.stream,
+            )
+        )
+
+
+def _make_stream_watchdog_agent(clients, aborts, closes):
+    agent = SimpleNamespace(
+        api_mode="chat_completions",
+        provider="openai",
+        model="test-model",
+        base_url=CLOUD_URL,
+        platform="cli",
+        session_id="",
+        is_subagent=False,
+        _fallback_index=0,
+        _interrupt_requested=False,
+        _consecutive_stale_streams=0,
+        reasoning_callback=None,
+        stream_delta_callback=None,
+        interim_assistant_callback=None,
+        show_commentary=True,
+        _disable_streaming=False,
+        _current_api_request_id=None,
+    )
+    agent._touch_activity = lambda *_args: None
+    agent._buffer_status = lambda *_args: None
+    agent._emit_wait_notice = lambda *_args: None
+    agent._emit_stream_start = lambda: None
+    agent._emit_stream_end = lambda **_kwargs: None
+    agent._emit_stream_drop = lambda **_kwargs: None
+    agent._fire_stream_delta = lambda *_args: None
+    agent._fire_reasoning_delta = lambda *_args: None
+    agent._fire_tool_gen_started = lambda *_args: None
+    agent._has_stream_consumers = lambda: False
+    agent._stream_diag_init = lambda: {}
+    agent._stream_diag_capture_response = lambda *_args: None
+    agent._capture_rate_limits = lambda *_args: None
+    agent._capture_credits = lambda *_args: None
+    agent._check_openrouter_cache_status = lambda *_args: None
+    agent._is_provider_stream_parse_error = lambda *_args: False
+    agent._log_stream_retry = lambda **_kwargs: None
+
+    # The list is populated with clients before this callback is installed;
+    # use a separate cursor so client creation remains deterministic.
+    create_cursor = {"index": 0}
+
+    def create_request_client(**_kwargs):
+        client = clients[create_cursor["index"]]
+        create_cursor["index"] += 1
+        return client
+
+    agent._create_request_openai_client = create_request_client
+
+    def abort_request_client(client, *, reason=None):
+        aborts.append(reason)
+        client.stream.close()
+
+    def close_request_client(client, *, reason=None):
+        closes.append(reason)
+        client.stream.close()
+
+    agent._abort_request_openai_client = abort_request_client
+    agent._close_request_openai_client = close_request_client
+    return agent
+
+
+def test_ttfb_kill_retries_with_fresh_window_and_counts_stale(monkeypatch):
+    """The real generic entry point fences one killed attempt and retries once."""
+    first_gate = threading.Event()
+    completed_chunk = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                delta=SimpleNamespace(
+                    content="recovered",
+                    reasoning_content=None,
+                    reasoning=None,
+                    tool_calls=None,
+                ),
+                finish_reason="stop",
+            )
+        ],
+        model="test-model",
+        usage=None,
+    )
+    streams = [
+        _AbortableProviderStream(gate=first_gate),
+        _AbortableProviderStream(chunk=completed_chunk),
+    ]
+    clients = [_FakeOpenAiClient(stream) for stream in streams]
+    aborts = []
+    closes = []
+    agent = _make_stream_watchdog_agent(clients, aborts, closes)
+
+    clock = _DeterministicClock()
+    monkeypatch.setattr(helpers.time, "time", clock.time)
+    monkeypatch.setattr(
+        helpers, "get_provider_stale_timeout", lambda *_args: None
+    )
+    monkeypatch.setenv("HERMES_STREAM_TTFB_TIMEOUT_SECONDS", "0.05")
+    monkeypatch.setenv("HERMES_STREAM_RETRIES", "1")
+    monkeypatch.setattr(helpers, "claim_stream_writer", lambda _agent: object())
+    monkeypatch.setattr(
+        helpers, "stream_writer_is_current", lambda _agent, _token: True
+    )
+
+    window_calls = []
+    real_set_window = helpers._set_stream_ttfb_window
+
+    def record_window(*args, **kwargs):
+        window_calls.append(
+            (kwargs["first_event_seen"], kwargs["now"])
+        )
+        return real_set_window(*args, **kwargs)
+
+    monkeypatch.setattr(helpers, "_set_stream_ttfb_window", record_window)
+    stale_bumps = []
+    real_bump = helpers._bump_stale_streak
+
+    def record_stale_bump(current_agent):
+        stale_bumps.append(True)
+        return real_bump(current_agent)
+
+    monkeypatch.setattr(helpers, "_bump_stale_streak", record_stale_bump)
+
+    response = interruptible_streaming_api_call(
+        agent, {"model": "test-model", "messages": []}
+    )
+
+    assert response.choices[0].message.content == "recovered"
+    assert len(clients) == 2
+    assert aborts == ["stream_ttfb_kill"]
+    assert stale_bumps == [True]
+    assert [seen for seen, _now in window_calls] == [False, True, False]
+    assert window_calls[2][1] > window_calls[1][1]
+    # The first attempt was cancelled once; it cannot be killed again while
+    # its forced close unwinds, and the second attempt gets the fresh window.
+    assert aborts.count("stream_ttfb_kill") == 1
+
+
+def test_stale_giveup_rejects_next_call_before_opening_client(monkeypatch):
+    class Agent:
+        _consecutive_stale_streams = 5
+        api_mode = "chat_completions"
+        provider = "openai"
+        platform = "cli"
+        _interrupt_requested = False
+
+        def _create_request_openai_client(self, **_kwargs):
+            raise AssertionError("give-up must happen before client creation")
+
+    monkeypatch.setenv("HERMES_STREAM_STALE_GIVEUP", "5")
+
+    with pytest.raises(RuntimeError, match="5 consecutive stale attempts"):
+        interruptible_streaming_api_call(Agent(), {"model": "test-model"})


### PR DESCRIPTION
## Summary

- Add a generic no-first-byte watchdog for streaming responses.
- Keep the watchdog armed until the first actual stream event and prevent repeat kills for the same attempt.
- Centralize timeout resolution and the kill predicate so tests exercise production policy.

## Why

Some connections are established successfully but never produce a stream event. Detecting that condition separately from ordinary read timeouts prevents a stalled response from consuming the full stale-stream patience window.

## Tests

- `python -m pytest -q tests/agent/test_stream_ttfb_watchdog.py` — 14 passed
- Coverage includes empty and malformed environment values, local endpoints, large contexts, stale-timeout clamping, disabled watchdogs, and no-repeat-after-kill behavior.
- Local pre-submit helper: audit, Ruff, candidate tests, and mergeability passed; the clean baseline does not contain this newly added test file, so no applicable baseline tests were available.

## Scope and safety

- The watchdog is limited to streaming behavior and keeps existing local-endpoint and timeout protections intact.
- A fresh retry clears the first-event guard; the same attempt cannot be killed repeatedly.
- No credentials, machine-specific paths, or private incident details.
