### PR TITLE
fix(desktop): preserve profile overrides on local source picks

### DIFF
--- a/apps/desktop/src/store/profile-select-source.test.ts
+++ b/apps/desktop/src/store/profile-select-source.test.ts
@@ -61,6 +61,15 @@ describe('selectProfile', () => {
     await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('ops'))
     expect(ensureGatewayForAgent).not.toHaveBeenCalled()
   })
+
+  it('keeps the legacy profile-only path when the explicit local source is live', async () => {
+    activeGatewayConnectionId.mockReturnValue('local')
+
+    selectProfile('override-profile')
+
+    await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('override-profile'))
+    expect(ensureGatewayForAgent).not.toHaveBeenCalled()
+  })
 })
 
 describe('newSessionInProfile', () => {
@@ -71,5 +80,14 @@ describe('newSessionInProfile', () => {
 
     await vi.waitFor(() => expect(ensureGatewayForAgent).toHaveBeenCalledWith('mini', 'designer'))
     expect(ensureGatewayForProfile).not.toHaveBeenCalled()
+  })
+
+  it('keeps the legacy profile-only path for a new chat on the explicit local source', async () => {
+    activeGatewayConnectionId.mockReturnValue('local')
+
+    newSessionInProfile('override-profile')
+
+    await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('override-profile'))
+    expect(ensureGatewayForAgent).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -530,17 +530,17 @@ export function selectProfile(name: string): void {
 }
 
 // Route a profile pick at the source the user is LOOKING at. $profiles is the
-// active gateway's list, so a pick made while a registry source is live names
-// one of THAT source's profiles. Sending it through the profile-only path
-// resolves the descriptor with a bare name (getConnection(profile)), which the
-// main process answers against the primary — so picking "researcher" on a
-// remote source opened a local backend of the same name and dropped the user
-// back home, making the pick look like it never took. A null connection id
-// means the primary is live, which is exactly the legacy path.
+// active gateway's list, so a pick made while a remote registry source is live
+// names one of THAT source's profiles and must keep its connection id. The
+// primary and explicit "local" source stay on the legacy profile-only path so
+// the main process can resolve a per-profile remote override before falling
+// back to a local backend.
 function activateOnCurrentSource(target: string): Promise<void> {
   const connectionId = activeGatewayConnectionId()
 
-  return connectionId ? ensureGatewayAgent(connectionId, target) : ensureGatewayProfile(target)
+  return connectionId && connectionId !== 'local'
+    ? ensureGatewayAgent(connectionId, target)
+    : ensureGatewayProfile(target)
 }
 
 // Start a fresh session in `name` WITHOUT collapsing the "All profiles" browse

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -1,3 +1,4 @@
+import { LOCAL_CONNECTION_ID } from '@hermes/shared'
 import { atom, batch, computed } from 'nanostores'
 
 import type { HermesConnection } from '@/global'
@@ -538,7 +539,7 @@ export function selectProfile(name: string): void {
 function activateOnCurrentSource(target: string): Promise<void> {
   const connectionId = activeGatewayConnectionId()
 
-  return connectionId && connectionId !== 'local'
+  return connectionId && connectionId !== LOCAL_CONNECTION_ID
     ? ensureGatewayAgent(connectionId, target)
     : ensureGatewayProfile(target)
 }


### PR DESCRIPTION
## What does this PR do?

Preserves per-profile remote-host overrides when a Desktop profile is selected while the registry's explicit local source is active.

The source-aware activation added in #92194 correctly keeps profile picks on a remote registry connection, but it also treated the explicit `local` connection as connection-scoped. That route intentionally forces the local runtime and therefore bypasses the legacy profile-routing table that resolves per-profile remote overrides.

This change keeps non-local registry sources on `ensureGatewayAgent(connectionId, target)` while routing null and explicit `local` sources through `ensureGatewayProfile(target)`.

## Related Issue

Fixes #94162

Related context:

- #39778 introduced per-profile remote gateway overrides and the profile-only resolution path this PR preserves.
- #87602 intentionally made the registry's explicit `local` connection force the host-local runtime. This PR does not change that connection-scoped contract.
- #92864, closing #91349, added the profile-rail UI that configures the per-profile remote override exercised by this fix.
- #92194 added source-aware profile activation and introduced the narrow compatibility gap fixed here: non-local registry IDs must remain connection-scoped, while null and explicit `"local"` sources must preserve profile override resolution.
- #93888 (canonical; #93937 is marked duplicate) tracks an adjacent remote-session resume/ownership problem. #93451 and #94145 are open fixes for that separate continuation/switch-lifecycle family; neither changes the initial profile-pick branch fixed by this PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `apps/desktop/src/store/profile.ts` so the explicit `local` registry source preserves legacy per-profile backend resolution.
- Keep non-local registry connection IDs on the connection-scoped agent route.
- Add focused regression tests for `selectProfile()` and `newSessionInProfile()` when the active connection ID is `"local"`.

## How to Test

1. Run:

   ```bash
   cd apps/desktop
   npx vitest run src/store/profile-select-source.test.ts
   ```

   Result: 5 tests passed.

2. Run the adjacent profile-routing suites:

   ```bash
   npx vitest run src/store/profile.test.ts src/store/profile-select-source.test.ts src/app/chat/sidebar/profile-rail-connect.test.tsx
   ```

   Result: 24 tests passed.

3. Run Desktop typecheck and lint:

   ```bash
   npm run typecheck --workspace apps/desktop
   eslint apps/desktop/src/store/profile.ts apps/desktop/src/store/profile-select-source.test.ts
   git diff --check
   ```

   Result: all passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing open and closed issues and PRs for this routing regression
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — not applicable to this isolated Desktop TypeScript change; targeted JS suites and full Desktop typecheck were run instead
- [x] I've added tests for my changes
- [x] I've tested the affected logic on macOS; the renderer change is platform-independent

### Documentation & Housekeeping

- [x] Documentation update — N/A; no user-facing configuration or behavior contract changed
- [x] `cli-config.yaml.example` update — N/A; no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update — N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; no platform-specific code was added
- [x] Tool descriptions/schemas update — N/A

## Screenshots / Logs

Not applicable; the deterministic routing tests cover the regression without external artifacts.
