### PR TITLE
fix(acp): isolate shell probes from protocol stdin

### DIFF
--- a/tests/tools/test_find_shell.py
+++ b/tests/tools/test_find_shell.py
@@ -153,6 +153,23 @@ class TestGitBashExternalProgramProbe:
 
         assert local_mod._bash_starts(r"C:\Git\bin\bash.exe") is True
         assert calls[0][0][-1] == "/usr/bin/true; /usr/bin/cat --version >/dev/null"
+        assert calls[0][1]["stdin"] is subprocess.DEVNULL
+
+    def test_aslr_probe_does_not_inherit_protocol_stdin(self, monkeypatch):
+        import tools.environments.local as local_mod
+
+        calls = []
+
+        def fake_run(argv, **kwargs):
+            calls.append((argv, kwargs))
+            return subprocess.CompletedProcess(argv, 0, stdout="OFF", stderr="")
+
+        monkeypatch.setattr(local_mod, "_mandatory_aslr_enabled_cache", None)
+        monkeypatch.setattr(local_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(local_mod.shutil, "which", lambda _name: "powershell.exe")
+
+        assert local_mod._mandatory_aslr_enabled() is False
+        assert calls[0][1]["stdin"] is subprocess.DEVNULL
 
     @pytest.mark.windows_only
     def test_aslr_failure_surfaces_targeted_windows_command(

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -867,6 +867,7 @@ def _mandatory_aslr_enabled() -> "bool | None":
                 "-Command",
                 "(Get-ProcessMitigation -System).Aslr.ForceRelocateImages.ToString()",
             ],
+            stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
             timeout=10,
@@ -933,6 +934,7 @@ def _bash_starts(bash: str) -> bool:
     try:
         result = subprocess.run(
             [bash, "--noprofile", "--norc", "-c", _BASH_EXTERNAL_PROGRAM_PROBE],
+            stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
             timeout=15,


### PR DESCRIPTION
## What does this PR do?

Hermes can use stdin/stdout as its ACP transport. During Windows local-shell discovery, the Git Bash health check and Mandatory-ASLR PowerShell check launched child processes without overriding stdin, so those noninteractive probes inherited the protocol input pipe.

Both probes now receive `subprocess.DEVNULL` as stdin. They never require interactive input, and isolating them prevents child processes from retaining or consuming ACP protocol input.

## Related Issue

No existing issue or pull request found after searching open and closed results.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Pass `stdin=subprocess.DEVNULL` to the PowerShell Mandatory-ASLR probe in `tools/environments/local.py`.
- Pass `stdin=subprocess.DEVNULL` to the Git Bash external-program probe in `tools/environments/local.py`.
- Add regression coverage that executes both probe paths with a mocked subprocess and verifies that protocol stdin cannot be inherited.

## How to Test

1. On Windows, run:
   `scripts/run_tests.sh tests/tools/test_find_shell.py -k "probe_runs_external_msys_programs or aslr_probe_does_not_inherit_protocol_stdin"`
2. Confirm both selected tests pass.
3. Remove either `stdin=subprocess.DEVNULL` argument and confirm its corresponding regression fails.

Local result on Windows 11 / Python 3.13.15: **2 passed, 0 failed**.

The complete `tests/tools/test_find_shell.py` run reports two unrelated existing Windows failures in `test_returns_shell_env_when_set_and_exists` and `test_honours_allowlisted_bash_and_dash`. I reproduced the same failures on the untouched upstream base commit `cd297653fa4fac85f45f7d3ad8e361db0f14e9be`; this PR does not modify those paths.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing PRs and issues to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the complete test suite and all tests pass — targeted regressions pass; the pre-existing Windows failures are documented above
- [x] I've added tests for the fix
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation update — N/A; no user-facing behavior or configuration changed
- [x] `cli-config.yaml.example` update — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A
- [x] Cross-platform impact considered; the changed probes are Windows-specific and tests mock their subprocess boundary
- [x] Tool descriptions/schemas update — N/A