### PR TITLE
fix(desktop): restore pending clarify cards after session switch (supersedes #90053)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
@@ -1,6 +1,8 @@
 import { act, cleanup } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { ChatMessage } from '@/lib/chat-messages'
+import { createClientSessionState } from '@/lib/chat-runtime'
 import { $clarifyRequests, clearClarifyRequest } from '@/store/clarify'
 import { onScrollToBottomRequest } from '@/store/thread-scroll'
 
@@ -28,10 +30,23 @@ const clarifyRequest = (payload: Record<string, unknown>) =>
 const toolStart = (payload: Record<string, unknown>) =>
   act(() => stream.handleEvent({ payload, session_id: SID, type: 'tool.start' }))
 
+const toolComplete = (payload: Record<string, unknown>) =>
+  act(() => stream.handleEvent({ payload, session_id: SID, type: 'tool.complete' }))
+
+const clarifyExpire = (requestId: string) =>
+  act(() => stream.handleEvent({ payload: { request_id: requestId }, session_id: SID, type: 'clarify.expire' }))
+
 function clarifyParts() {
   const messages = stream.state().messages ?? []
 
   return messages.flatMap(m => m.parts).filter(p => p.type === 'tool-call' && p.toolName === 'clarify')
+}
+
+function seedHydratedMessages(messages: ChatMessage[]) {
+  const state = createClientSessionState()
+  state.messages = messages
+  state.streamId = null
+  stream.states.set(SID, state)
 }
 
 describe('clarify.request stream hydration', () => {
@@ -130,6 +145,131 @@ describe('clarify.request stream hydration', () => {
     toolStart({ args: { choices: ['a'], question: 'Pick' }, name: 'clarify', tool_id: 'call-xyz' })
 
     expect(clarifyParts()).toHaveLength(1)
+  })
+
+  it('re-arms a hydrated Codex tool-only clarify in place instead of appending a second card', () => {
+    mountStream()
+
+    seedHydratedMessages([
+      { id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'help me choose' }] },
+      {
+        id: 'assistant-codex',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-codex',
+            toolName: 'clarify',
+            args: { choices: ['a', 'b'], question: 'Pick' },
+            argsText: '{"question":"Pick","choices":["a","b"]}'
+          }
+        ]
+      }
+    ])
+
+    clarifyRequest({ choices: ['a', 'b'], question: 'Pick', request_id: 'req-codex' })
+
+    const messages = stream.state().messages
+    expect(messages).toHaveLength(2)
+    expect(clarifyParts()).toHaveLength(1)
+    expect(messages[1]).toMatchObject({ id: 'assistant-codex', pending: true })
+    expect(stream.state().streamId).toBe('assistant-codex')
+  })
+
+  it('keeps a hydrated DeepSeek text-plus-clarify row in its original position', () => {
+    mountStream()
+
+    seedHydratedMessages([
+      { id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'inspect this' }] },
+      {
+        id: 'assistant-deepseek',
+        role: 'assistant',
+        parts: [
+          { type: 'text', text: 'I found two paths; choose one.' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-deepseek',
+            toolName: 'clarify',
+            args: { choices: ['safe', 'fast'], question: 'Which path?' },
+            argsText: '{"question":"Which path?","choices":["safe","fast"]}'
+          }
+        ]
+      }
+    ])
+
+    clarifyRequest({ choices: ['safe', 'fast'], question: 'Which path?', request_id: 'req-deepseek' })
+
+    const messages = stream.state().messages
+    expect(messages).toHaveLength(2)
+    expect(messages[1].id).toBe('assistant-deepseek')
+    expect(messages[1].parts.map(part => part.type)).toEqual(['text', 'tool-call'])
+    expect(messages[1].pending).toBe(true)
+    expect(stream.state().streamId).toBe('assistant-deepseek')
+  })
+
+  it('settles the re-armed provider tool id in place when tool.complete arrives', () => {
+    mountStream()
+
+    seedHydratedMessages([
+      { id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'inspect this' }] },
+      {
+        id: 'assistant-deepseek',
+        role: 'assistant',
+        parts: [
+          { type: 'text', text: 'I found two paths; choose one.' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-provider',
+            toolName: 'clarify',
+            args: { choices: ['safe', 'fast'], question: 'Which path?' },
+            argsText: '{"question":"Which path?","choices":["safe","fast"]}'
+          }
+        ]
+      }
+    ])
+
+    clarifyRequest({ choices: ['safe', 'fast'], question: 'Which path?', request_id: 'req-ui' })
+    toolComplete({
+      args: { choices: ['safe', 'fast'], question: 'Which path?' },
+      name: 'clarify',
+      result: { question: 'Which path?', user_response: 'safe' },
+      tool_id: 'call-provider'
+    })
+
+    const parts = clarifyParts()
+    expect(parts).toHaveLength(1)
+    expect(parts[0]).toMatchObject({ toolCallId: 'call-provider', result: { user_response: 'safe' } })
+  })
+
+  it('ignores a late clarify.request after the turn was interrupted', () => {
+    mountStream()
+    seedHydratedMessages([{ id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'stop this' }] }])
+
+    const state = stream.states.get(SID)!
+    state.interrupted = true
+
+    clarifyRequest({ choices: ['a', 'b'], question: 'Pick', request_id: 'req-late' })
+
+    expect($clarifyRequests.get()[SID]).toBeUndefined()
+    expect(stream.state().messages).toHaveLength(1)
+  })
+
+  it('expires only the matching clarify request and deactivates its card', () => {
+    mountStream()
+
+    toolStart({ args: { choices: ['a'], question: 'Pick' }, name: 'clarify', tool_id: 'call-provider' })
+    clarifyRequest({ choices: ['a'], question: 'Pick', request_id: 'req-expire' })
+    clarifyExpire('req-other')
+
+    expect($clarifyRequests.get()[SID]?.requestId).toBe('req-expire')
+    expect(clarifyParts()[0]).not.toHaveProperty('result')
+
+    clarifyExpire('req-expire')
+
+    expect($clarifyRequests.get()[SID]).toBeUndefined()
+    expect(clarifyParts()).toHaveLength(1)
+    expect(clarifyParts()[0]).toHaveProperty('result')
+    expect(stream.state().needsInput).toBe(false)
   })
 
   it('merges a BATCH tool.start row with its clarify.request (no top-level question)', () => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
@@ -1,5 +1,14 @@
+import { pendingClarifyToolPayload } from '@/app/session/hooks/use-session-actions/restore-pending-clarify'
 import { translateNow } from '@/i18n'
-import { normalizeChoices, normalizeQuestions, setClarifyRequest, warnDroppedChoices } from '@/store/clarify'
+import { restorePendingClarifyToolCall, settlePendingClarifyToolCall } from '@/lib/chat-messages'
+import {
+  $clarifyRequests,
+  clearClarifyRequest,
+  normalizeChoices,
+  normalizeQuestions,
+  setClarifyRequest,
+  warnDroppedChoices
+} from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
 import { setMcpSetupRequest } from '@/store/mcp-setup'
 import { dispatchNativeNotification } from '@/store/native-notifications'
@@ -13,7 +22,7 @@ import type { GatewayEventContext } from './types'
  *  each of these must be parked per-session and surfaced. */
 export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
   const { deps, event, payload, sessionId, occurredAt } = ctx
-  const { activeSessionIdRef, updateSessionState, upsertToolCall } = deps
+  const { activeSessionIdRef, sessionInterrupted, updateSessionState, upsertToolCall } = deps
 
   if (event.type === 'clarify.request') {
     // Surface the clarify tool's overlay. The Python side is blocked on
@@ -26,6 +35,10 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
     // indefinitely and re-focusing it could never recover (the event is
     // gone). Parking it per-session lets the user answer once they switch
     // over; the inline ClarifyTool reads the active session's entry.
+    if (sessionId && sessionInterrupted(sessionId)) {
+      return true
+    }
+
     const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
     const question = typeof payload?.question === 'string' ? payload.question : ''
     const rawChoices = payload?.choices
@@ -46,38 +59,39 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         : undefined
 
     if (requestId && questions.length > 0) {
-      setClarifyRequest({
+      const request = {
         choices: null,
         lockedAnswers,
         multiSelect: false,
         question: '',
         questions,
+        receivedAt: Date.now() / 1000,
         requestId,
         sessionId: sessionId ?? null
-      })
+      }
+
+      setClarifyRequest(request)
 
       if (sessionId) {
-        // Same hydration-race guard as the single-question path below: the
-        // form mounts from the tool row, so upsert a stable one keyed by
-        // the request id in case tool.start was missed.
-        upsertToolCall(
-          sessionId,
-          {
-            args: {
-              questions: questions.map(q => ({
-                choices: q.choices ?? undefined,
-                multi_select: q.multiSelect || undefined,
-                question: q.question
-              }))
-            },
-            name: 'clarify',
-            tool_id: requestId
-          },
-          'running',
-          event.type,
-          occurredAt
-        )
-        updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
+        // A resumed/hydrated transcript may already contain this provider's
+        // clarify call while carrying no live streamId. Re-arm that exact row
+        // instead of letting the generic stream mutator append a second card.
+        updateSessionState(sessionId, state => {
+          const projection = restorePendingClarifyToolCall(
+            state.messages,
+            pendingClarifyToolPayload(request),
+            occurredAt
+          )
+
+          return {
+            ...state,
+            messages: projection.messages,
+            streamId: projection.streamId,
+            sawAssistantPayload: true,
+            awaitingResponse: false,
+            needsInput: true
+          }
+        })
 
         if (sessionId === activeSessionIdRef.current) {
           requestScrollToBottom()
@@ -95,40 +109,37 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         warnDroppedChoices('gateway', question, rawChoices)
       }
 
-      setClarifyRequest({
+      const request = {
         requestId,
         question,
         choices: choices.length > 0 ? choices : null,
         multiSelect,
+        receivedAt: Date.now() / 1000,
         sessionId: sessionId ?? null
-      })
+      }
+
+      setClarifyRequest(request)
 
       if (sessionId) {
-        // `clarify.request` is the blocking event the Python side waits on,
-        // while the inline UI normally mounts from the earlier `tool.start`
-        // row. If that row was missed (stream reconnect / hydration race) the
-        // sidebar still says "needs input" but there is nowhere to render the
-        // choices. Upsert a stable pending clarify tool row from the request
-        // itself so the prompt stays answerable; a real tool.start/complete
-        // with the same request id merges rather than duplicates.
-        upsertToolCall(
-          sessionId,
-          {
-            args: { choices, ...(multiSelect ? { multi_select: true } : {}), question },
-            name: 'clarify',
-            tool_id: requestId
-          },
-          'running',
-          event.type,
-          occurredAt
-        )
+        // Same provider-shape-aware repair as the batch path above. This keeps
+        // the original hydrated row and provider tool id, while still seeding
+        // a row when tool.start was genuinely missed.
+        updateSessionState(sessionId, state => {
+          const projection = restorePendingClarifyToolCall(
+            state.messages,
+            pendingClarifyToolPayload(request),
+            occurredAt
+          )
 
-        // The transcript only renders the active session, so a background
-        // clarify is otherwise invisible (the row just keeps spinning like
-        // it's working). Flag the session so the sidebar shows a persistent
-        // "needs input" indicator on its row — works for the active session
-        // too, and survives alt-tab / window blur (unlike a toast).
-        updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
+          return {
+            ...state,
+            messages: projection.messages,
+            streamId: projection.streamId,
+            sawAssistantPayload: true,
+            awaitingResponse: false,
+            needsInput: true
+          }
+        })
 
         if (sessionId === activeSessionIdRef.current) {
           requestScrollToBottom()
@@ -142,6 +153,40 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         title: translateNow('notifications.native.inputTitle')
       })
     }
+
+    return true
+  }
+
+  if (event.type === 'clarify.expire') {
+    if (!sessionId) {
+      return true
+    }
+
+    const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
+    const request = $clarifyRequests.get()[sessionId]
+
+    // Expiry is request-correlated: a delayed event from an older prompt must
+    // not erase a newer clarify raised by the same session.
+    if (!requestId || !request || request.requestId !== requestId) {
+      return true
+    }
+
+    clearClarifyRequest(requestId, sessionId)
+    updateSessionState(sessionId, state => {
+      const projection = settlePendingClarifyToolCall(
+        state.messages,
+        pendingClarifyToolPayload(request),
+        state.busy,
+        occurredAt
+      )
+
+      return {
+        ...state,
+        messages: projection.messages,
+        needsInput: false,
+        streamId: state.busy ? (projection.streamId ?? state.streamId) : null
+      }
+    })
 
     return true
   }

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -15,6 +15,7 @@ import {
   type SessionResumeResponse
 } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { $clarifyRequests, clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
 import { requestGatewayForAgent } from '@/store/gateway'
 import { $activeGatewayProfile, $newChatProfile, $newChatRoute, ensureGatewayProfile } from '@/store/profile'
@@ -806,6 +807,7 @@ describe('resumeSession failure recovery', () => {
     setResumeFailedSessionId(null)
     setMessages([])
     setSessions([])
+    clearClarifyRequest()
     vi.restoreAllMocks()
   })
 
@@ -821,6 +823,130 @@ describe('resumeSession failure recovery', () => {
     await waitFor(() => expect(resume).not.toBeNull())
     await resume!('stored-1', true)
   }
+
+  it.each([
+    ['Codex tool-only', ''],
+    ['DeepSeek text-plus-tool', 'I found two paths; choose one.']
+  ])('restores a pending clarify as a running inline card for a %s transcript', async (_shape, content) => {
+    const stateMapRef: MutableRefObject<Map<string, ClientSessionState>> = { current: new Map() }
+
+    const toolCall = {
+      function: { arguments: '{"question":"Which path?","choices":["safe","fast"]}', name: 'clarify' },
+      id: 'call-provider'
+    }
+
+    setSessions([storedSession({ id: 'stored-1', message_count: 2 })])
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({
+      messages: [
+        { content: 'help me choose', role: 'user', timestamp: 1 },
+        { content, role: 'assistant', timestamp: 2, tool_calls: [toolCall] }
+      ],
+      session_id: 'stored-1'
+    } as never)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.resume') {
+        return {
+          info: {},
+          message_count: 2,
+          messages: [],
+          messages_omitted: true,
+          pending_clarify: {
+            choices: ['safe', 'fast'],
+            question: 'Which path?',
+            request_id: 'req-resumed'
+          },
+          resumed: 'stored-1',
+          running: true,
+          session_id: 'runtime-1',
+          session_key: 'stored-1'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    await runResume(requestGateway, { sessionStateByRuntimeIdRef: stateMapRef })
+
+    const state = stateMapRef.current.get('runtime-1')
+
+    const clarifyMessages =
+      state?.messages.filter(message =>
+        message.parts.some(part => part.type === 'tool-call' && part.toolName === 'clarify')
+      ) ?? []
+
+    expect(clarifyMessages).toHaveLength(1)
+    expect(clarifyMessages[0].pending).toBe(true)
+    expect(state?.streamId).toBe(clarifyMessages[0].id)
+    expect($clarifyRequests.get()['runtime-1']).toMatchObject({ requestId: 'req-resumed', question: 'Which path?' })
+  })
+
+  it('restores a pending batch clarify whose resume snapshot has no top-level question', async () => {
+    const stateMapRef: MutableRefObject<Map<string, ClientSessionState>> = { current: new Map() }
+
+    setSessions([storedSession({ id: 'stored-1', message_count: 2 })])
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({
+      messages: [
+        { content: 'help me choose', role: 'user', timestamp: 1 },
+        {
+          content: '',
+          role: 'assistant',
+          timestamp: 2,
+          tool_calls: [
+            {
+              function: {
+                arguments: '{"questions":[{"question":"Color?"},{"question":"Size?"}]}',
+                name: 'clarify'
+              },
+              id: 'call-batch-provider'
+            }
+          ]
+        }
+      ],
+      session_id: 'stored-1'
+    } as never)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.resume') {
+        return {
+          info: {},
+          message_count: 2,
+          messages: [],
+          messages_omitted: true,
+          pending_clarify: {
+            answers: { q0: 'Blue' },
+            questions: [
+              { choices: ['Blue', 'Red'], qid: 'q0', question: 'Color?' },
+              { choices: ['Small', 'Large'], qid: 'q1', question: 'Size?' }
+            ],
+            request_id: 'req-batch-resumed'
+          },
+          resumed: 'stored-1',
+          running: true,
+          session_id: 'runtime-1',
+          session_key: 'stored-1'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    await runResume(requestGateway, { sessionStateByRuntimeIdRef: stateMapRef })
+
+    const state = stateMapRef.current.get('runtime-1')
+    const request = $clarifyRequests.get()['runtime-1']
+    expect(request).toMatchObject({
+      lockedAnswers: { q0: 'Blue' },
+      question: '',
+      requestId: 'req-batch-resumed'
+    })
+    expect(request.questions).toHaveLength(2)
+    expect(
+      state?.messages.flatMap(message => message.parts).filter(part => part.type === 'tool-call' && part.toolName === 'clarify')
+    ).toHaveLength(1)
+    expect(state?.messages.filter(message => message.pending)).toHaveLength(1)
+    expect(state?.streamId).toBe(state?.messages.find(message => message.pending)?.id)
+  })
 
   it('arms $resumeFailedSessionId when resume RPC and REST fallback both fail', async () => {
     // session.resume rejects (e.g. timeout against a wedged backend)...
@@ -1858,6 +1984,7 @@ describe('resumeSession warm-cache mapping integrity', () => {
       .mockReset()
       .mockResolvedValue({ messages: [] } as never)
     vi.mocked(requestGatewayForAgent).mockReset()
+    clearClarifyRequest()
     vi.restoreAllMocks()
   })
 
@@ -2119,6 +2246,265 @@ describe('resumeSession warm-cache mapping integrity', () => {
       expect.objectContaining({ omit_messages: true, session_id: 'rt-A' })
     )
     expect(runtimeIdByStoredSessionIdRef.current.get('stored-A')).toBe('rt-A')
+  })
+
+  it('re-arms a pending clarify in place on the warm session.activate path', async () => {
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-A']])
+    }
+
+    const state = clientState('stored-A')
+    state.messages = [
+      { id: 'cached-user', role: 'user', parts: [{ type: 'text', text: 'help me choose' }] },
+      {
+        id: 'cached-assistant',
+        role: 'assistant',
+        parts: [
+          { type: 'text', text: 'I found two paths.' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-provider',
+            toolName: 'clarify',
+            args: { choices: ['safe', 'fast'], question: 'Which path?' },
+            argsText: '{"question":"Which path?","choices":["safe","fast"]}'
+          }
+        ]
+      }
+    ]
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-A', state]])
+    }
+
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({
+      messages: [
+        { content: 'help me choose', role: 'user', timestamp: 1 },
+        {
+          content: 'I found two paths.',
+          role: 'assistant',
+          timestamp: 2,
+          tool_calls: [
+            {
+              function: {
+                arguments: '{"question":"Which path?","choices":["safe","fast"]}',
+                name: 'clarify'
+              },
+              id: 'call-provider'
+            }
+          ]
+        }
+      ],
+      session_id: 'stored-A'
+    } as never)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        return {
+          info: {},
+          message_count: 2,
+          messages: [],
+          messages_omitted: true,
+          pending_clarify: {
+            choices: ['safe', 'fast'],
+            question: 'Which path?',
+            request_id: 'req-warm'
+          },
+          resumed: 'stored-A',
+          running: true,
+          session_id: 'rt-A',
+          session_key: 'stored-A'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!('stored-A', true)
+
+    const resumedState = sessionStateByRuntimeIdRef.current.get('rt-A')
+
+    const clarifyMessages =
+      resumedState?.messages.filter(message =>
+        message.parts.some(part => part.type === 'tool-call' && part.toolName === 'clarify')
+      ) ?? []
+
+    expect(requestGateway.mock.calls.map(([method]) => method)).toContain('session.activate')
+    expect(clarifyMessages).toHaveLength(1)
+    expect(clarifyMessages[0].pending).toBe(true)
+    expect(
+      clarifyMessages[0].parts.find(part => part.type === 'tool-call' && part.toolName === 'clarify')
+    ).toMatchObject({ toolCallId: 'call-provider' })
+    expect(resumedState?.streamId).toBe(clarifyMessages[0].id)
+    expect($clarifyRequests.get()['rt-A']).toMatchObject({ requestId: 'req-warm' })
+  })
+
+  it.each([
+    ['with a stale request-store entry', true],
+    ['after the request store was already cleared', false]
+  ])('de-arms stale clarify state %s when session.activate reports no pending request', async (_case, keepStore) => {
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-A']])
+    }
+
+    const state = clientState('stored-A')
+    state.busy = true
+    state.needsInput = true
+    state.streamId = 'cached-assistant'
+    state.messages = [
+      { id: 'cached-user', role: 'user', parts: [{ type: 'text', text: 'help me choose' }] },
+      {
+        id: 'cached-assistant',
+        role: 'assistant',
+        pending: true,
+        parts: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-provider',
+            toolName: 'clarify',
+            args: { choices: ['safe', 'fast'], question: 'Which path?' },
+            argsText: '{"question":"Which path?","choices":["safe","fast"]}'
+          }
+        ]
+      }
+    ]
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-A', state]])
+    }
+
+    if (keepStore) {
+      setClarifyRequest({
+        choices: ['safe', 'fast'],
+        multiSelect: false,
+        question: 'Which path?',
+        requestId: 'req-stale',
+        sessionId: 'rt-A'
+      })
+    }
+
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({
+      messages: [
+        { content: 'help me choose', role: 'user', timestamp: 1 },
+        {
+          content: '',
+          role: 'assistant',
+          timestamp: 2,
+          tool_calls: [
+            {
+              function: {
+                arguments: '{"question":"Which path?","choices":["safe","fast"]}',
+                name: 'clarify'
+              },
+              id: 'call-provider'
+            }
+          ]
+        }
+      ],
+      session_id: 'stored-A'
+    } as never)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        return {
+          info: {},
+          message_count: 2,
+          messages: [],
+          messages_omitted: true,
+          resumed: 'stored-A',
+          running: false,
+          session_id: 'rt-A',
+          session_key: 'stored-A'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!('stored-A', true)
+
+    const resumedState = sessionStateByRuntimeIdRef.current.get('rt-A')
+
+    const clarifyPart = resumedState?.messages
+      .flatMap(message => message.parts)
+      .find(part => part.type === 'tool-call' && part.toolName === 'clarify')
+
+    expect($clarifyRequests.get()['rt-A']).toBeUndefined()
+    expect(resumedState).toMatchObject({ needsInput: false, streamId: null })
+    expect(resumedState?.messages.find(message => message.id === resumedState.streamId)).toBeUndefined()
+    expect(clarifyPart).toHaveProperty('result')
+  })
+
+  it('does not let an older activate response clear a newer clarify request', async () => {
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-A']])
+    }
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-A', clientState('stored-A')]])
+    }
+
+    const activated = deferred<SessionResumeResponse>()
+
+    const requestGateway = vi.fn((method: string) =>
+      method === 'session.activate' ? activated.promise : Promise.resolve({})
+    )
+
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: [], session_id: 'stored-A' } as never)
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        requestGateway={requestGateway as never}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+    const resumePromise = resume!('stored-A', true)
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('session.activate', expect.anything()))
+
+    setClarifyRequest({
+      choices: ['new'],
+      multiSelect: false,
+      question: 'New question?',
+      receivedAt: Date.now() / 1000 + 60,
+      requestId: 'req-newer',
+      sessionId: 'rt-A'
+    })
+    activated.resolve({
+      info: {},
+      message_count: 0,
+      messages: [],
+      messages_omitted: true,
+      resumed: 'stored-A',
+      running: false,
+      session_id: 'rt-A',
+      session_key: 'stored-A'
+    })
+    await resumePromise
+
+    expect($clarifyRequests.get()['rt-A']).toMatchObject({ requestId: 'req-newer' })
   })
 
   it('preserves cached image attachments through an idle persisted transcript refresh', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -107,6 +107,7 @@ import { navigateToWorkspacePage, NEW_CHAT_ROUTE, sessionRoute, SETTINGS_ROUTE }
 import type { ClientSessionState, SidebarNavItem } from '../../../types'
 import { sessionContextDrift } from '../session-context-drift'
 import { singleFlightSessionResume } from '../use-prompt-actions/single-flight-resume'
+
 import { pendingClarifyToolPayload, restorePendingClarifyFromSnapshot } from './restore-pending-clarify'
 import {
   appendLiveSessionProjection,

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -7,11 +7,18 @@ import { revealTreePane } from '@/components/pane-shell/tree/store'
 import { setWorkspaceScope } from '@/components/pane-shell/workspace-scope'
 import { deleteSession, getAllSessionMessages, getLatestSessionMessages, setSessionArchived } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { type ChatMessage, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
+import {
+  type ChatMessage,
+  preserveLocalAssistantErrors,
+  restorePendingClarifyToolCall,
+  settlePendingClarifyToolCall,
+  stripPendingClarifyProjectionForCache,
+  toChatMessages
+} from '@/lib/chat-messages'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { recoverInFlightTurnJournal } from '@/lib/inflight-turn-journal'
 import { setSessionYolo } from '@/lib/yolo-session'
-import { normalizeChoices, setClarifyRequest } from '@/store/clarify'
+import { $clarifyRequests } from '@/store/clarify'
 import { migrateSessionDraft } from '@/store/composer'
 import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue'
 import { openGatewayForAgent, openGatewayForProfile, requestGatewayForAgent } from '@/store/gateway'
@@ -100,7 +107,7 @@ import { navigateToWorkspacePage, NEW_CHAT_ROUTE, sessionRoute, SETTINGS_ROUTE }
 import type { ClientSessionState, SidebarNavItem } from '../../../types'
 import { sessionContextDrift } from '../session-context-drift'
 import { singleFlightSessionResume } from '../use-prompt-actions/single-flight-resume'
-
+import { pendingClarifyToolPayload, restorePendingClarifyFromSnapshot } from './restore-pending-clarify'
 import {
   appendLiveSessionProjection,
   applyRuntimeInfo,
@@ -258,29 +265,6 @@ function restorePendingApproval(response: SessionResumeResponse, sessionId: stri
     requestId: typeof pending.request_id === 'string' ? pending.request_id : undefined,
     sessionId,
     smartDenied: pending.smart_denied === true
-  })
-
-  return true
-}
-
-function restorePendingClarify(response: SessionResumeResponse, sessionId: string): boolean {
-  // Same replay class as pending_approval: the clarify.request event was
-  // emitted while this client's transport was detached, so without the resume
-  // snapshot the question stays invisible until it times out server-side.
-  const pending = response.pending_clarify
-
-  if (!pending || typeof pending.request_id !== 'string' || typeof pending.question !== 'string') {
-    return false
-  }
-
-  const choices = normalizeChoices(pending.choices)
-
-  setClarifyRequest({
-    choices: choices.length > 0 ? choices : null,
-    multiSelect: pending.multi_select === true,
-    question: pending.question,
-    requestId: pending.request_id,
-    sessionId
   })
 
   return true
@@ -921,6 +905,9 @@ export function useSessionActions({
 
           try {
             let activated: SessionResumeResponse | null = null
+            const activateStartedAt = Date.now() / 1000
+            const activateBaselineState = sessionStateByRuntimeIdRef.current.get(cachedRuntimeId) ?? cachedViewState
+            const clarifyRequestIdAtActivateStart = $clarifyRequests.get()[cachedRuntimeId]?.requestId
 
             try {
               activated = await requestForSession<SessionResumeResponse>('session.activate', {
@@ -959,7 +946,23 @@ export function useSessionActions({
               dropSessionState(cachedRuntimeId)
             } else {
               const pendingApproval = restorePendingApproval(activated, cachedRuntimeId)
-              const pendingClarify = restorePendingClarify(activated, cachedRuntimeId)
+
+              const pendingClarifyState = restorePendingClarifyFromSnapshot(
+                activated,
+                cachedRuntimeId,
+                activateStartedAt,
+                clarifyRequestIdAtActivateStart
+              )
+
+              const pendingClarify = pendingClarifyState.request
+
+              const clarifyAuthoritativelyAbsent =
+                pendingClarifyState.authoritativeAbsent && !$clarifyRequests.get()[cachedRuntimeId]
+
+              const staleClarifyAtActivateStart = clarifyAuthoritativelyAbsent
+                ? Boolean(settlePendingClarifyToolCall(cachedViewState.messages, {}, false).streamId)
+                : false
+
               const runtimeInfo = applyRuntimeInfo(activated.info)
 
               // `omit_messages` means the response carries NO transcript, not
@@ -979,10 +982,20 @@ export function useSessionActions({
               // #70449: never let the activate snapshot's stale running:false
               // rewind a turn that started while the RPC was in flight — read
               // the freshest cache entry, not the pre-await cachedViewState.
-              const running = resolveResumedBusy(
-                activated.running ?? cachedViewState.busy,
-                Boolean(sessionStateByRuntimeIdRef.current.get(cachedRuntimeId)?.busy)
+              const latestCachedState = sessionStateByRuntimeIdRef.current.get(cachedRuntimeId)
+
+              const busyChangedWhileActivating = Boolean(
+                latestCachedState?.busy &&
+                (latestCachedState.turnStartedAt !== activateBaselineState.turnStartedAt ||
+                  (latestCachedState.turnLive && !activateBaselineState.turnLive))
               )
+
+              const running =
+                (pendingClarifyState.cleared || staleClarifyAtActivateStart) &&
+                activated.running === false &&
+                !busyChangedWhileActivating
+                  ? false
+                  : resolveResumedBusy(activated.running ?? cachedViewState.busy, Boolean(latestCachedState?.busy))
 
               const activatedTurnStartedAt =
                 typeof activated.turn_started_at === 'number' && activated.turn_started_at > 0
@@ -1054,34 +1067,73 @@ export function useSessionActions({
                 )
               }
 
+              const pendingClarifyProjection = pendingClarify
+                ? restorePendingClarifyToolCall(activatedMessages, pendingClarifyToolPayload(pendingClarify))
+                : null
+
+              const clearedClarifyProjection = clarifyAuthoritativelyAbsent
+                ? settlePendingClarifyToolCall(
+                    activatedMessages,
+                    pendingClarifyState.cleared ? pendingClarifyToolPayload(pendingClarifyState.cleared) : {},
+                    running
+                  )
+                : null
+
+              const visibleActivatedMessages =
+                pendingClarifyProjection?.messages ?? clearedClarifyProjection?.messages ?? activatedMessages
+
               const activatedState = updateSessionState(
                 cachedRuntimeId,
                 state => ({
                   ...state,
                   ...(runtimeInfo ?? {}),
-                  messages: activatedMessages,
+                  messages: visibleActivatedMessages,
                   busy: running,
                   awaitingResponse: running,
                   // Resumed onto an already-running turn — that IS backend
                   // proof the turn is live (no message.start will replay).
                   turnLive: state.turnLive || running,
-                  needsInput: pendingApproval || pendingClarify || state.needsInput,
+                  needsInput:
+                    pendingApproval ||
+                    Boolean(pendingClarify) ||
+                    (clarifyAuthoritativelyAbsent ? false : state.needsInput),
                   // Adopting someone else's turn: we'll stream its reply
                   // without ever having received its prompt, so the settle
                   // path must not take the "I saw it all" shortcut.
                   adoptedRunningTurn: state.adoptedRunningTurn || running,
-                  turnStartedAt: running ? (activatedTurnStartedAt ?? state.turnStartedAt ?? Date.now()) : null
+                  turnStartedAt: running ? (activatedTurnStartedAt ?? state.turnStartedAt ?? Date.now()) : null,
+                  ...(pendingClarifyProjection
+                    ? {
+                        awaitingResponse: false,
+                        sawAssistantPayload: true,
+                        streamId: pendingClarifyProjection.streamId
+                      }
+                    : {}),
+                  ...(clearedClarifyProjection
+                    ? {
+                        streamId: running ? (clearedClarifyProjection.streamId ?? state.streamId) : null
+                      }
+                    : {})
                 }),
                 storedSessionId
               )
 
               busyRef.current = running
               setBusy(running)
-              setAwaitingResponse(running)
+              setAwaitingResponse(running && !pendingClarify)
               syncSessionStateToView(cachedRuntimeId, activatedState)
-              // Durable tail refresh — same post-reconcile contract as the
-              // cold path's save below.
-              saveTranscriptTail(storedSessionId, activatedState.messages)
+              // Cache backend transcript truth only. The pending/running bit and
+              // any synthetic clarify row are a live resume projection and must
+              // not survive after the server-side request expires.
+              saveTranscriptTail(
+                storedSessionId,
+                stripPendingClarifyProjectionForCache(
+                  activatedMessages,
+                  pendingClarify?.requestId ??
+                    pendingClarifyState.cleared?.requestId ??
+                    $clarifyRequests.get()[cachedRuntimeId]?.requestId
+                )
+              )
 
               return
             }
@@ -1196,6 +1248,7 @@ export function useSessionActions({
         const prefetchPromise = watchWindow ? null : getLatestSessionMessages(storedSessionId, sessionRestScope)
 
         let resumeRuntimeBaselineMessages: ChatMessage[] = []
+        const resumeStartedAt = Date.now() / 1000
 
         const resumePromise = singleFlightSessionResume(storedSessionId, () =>
           requestForSession<SessionResumeResponse>('session.resume', {
@@ -1385,7 +1438,12 @@ export function useSessionActions({
         setActiveSessionId(resumed.session_id)
         activeSessionIdRef.current = resumed.session_id
         const pendingApproval = restorePendingApproval(resumed, resumed.session_id)
-        const pendingClarify = restorePendingClarify(resumed, resumed.session_id)
+        const pendingClarifyState = restorePendingClarifyFromSnapshot(resumed, resumed.session_id, resumeStartedAt)
+        const pendingClarify = pendingClarifyState.request
+
+        const clarifyAuthoritativelyAbsent =
+          pendingClarifyState.authoritativeAbsent && !$clarifyRequests.get()[resumed.session_id]
+
         const runtimeInfo = applyRuntimeInfo(resumed.info)
 
         patchSessionWorkspace(storedSessionId, runtimeInfo?.cwd)
@@ -1398,17 +1456,33 @@ export function useSessionActions({
             ? resumed.turn_started_at * 1000
             : null
 
+        const pendingClarifyProjection = pendingClarify
+          ? restorePendingClarifyToolCall(messagesForView, pendingClarifyToolPayload(pendingClarify))
+          : null
+
+        const clearedClarifyProjection = clarifyAuthoritativelyAbsent
+          ? settlePendingClarifyToolCall(
+              messagesForView,
+              pendingClarifyState.cleared ? pendingClarifyToolPayload(pendingClarifyState.cleared) : {},
+              resumedRunning
+            )
+          : null
+
+        const visibleMessagesForView =
+          pendingClarifyProjection?.messages ?? clearedClarifyProjection?.messages ?? messagesForView
+
         updateSessionState(
           resumed.session_id,
           state => ({
             ...state,
             ...(runtimeInfo ?? {}),
-            messages: messagesForView,
+            messages: visibleMessagesForView,
             busy: resumedRunning,
             awaitingResponse: resumedRunning && !recoveredInFlightTail,
             // Backend reported this turn running at resume time — live proof.
             turnLive: state.turnLive || resumedRunning,
-            needsInput: pendingApproval || pendingClarify || state.needsInput,
+            needsInput:
+              pendingApproval || Boolean(pendingClarify) || (clarifyAuthoritativelyAbsent ? false : state.needsInput),
             adoptedRunningTurn: state.adoptedRunningTurn || resumedRunning,
             ...(inFlightRecovery.applied
               ? {
@@ -1420,7 +1494,19 @@ export function useSessionActions({
                 }
               : {
                   turnStartedAt: resumedRunning && resumedTurnStartedAt !== null ? resumedTurnStartedAt : null
-                })
+                }),
+            ...(pendingClarifyProjection
+              ? {
+                  awaitingResponse: false,
+                  sawAssistantPayload: true,
+                  streamId: pendingClarifyProjection.streamId
+                }
+              : {}),
+            ...(clearedClarifyProjection
+              ? {
+                  streamId: resumedRunning ? (clearedClarifyProjection.streamId ?? state.streamId) : null
+                }
+              : {})
           }),
           storedSessionId
         )
@@ -1429,15 +1515,21 @@ export function useSessionActions({
         // Commit the final, already-reconciled transcript now so resume has one
         // additive DOM build instead of an eager prefetch build plus a later
         // runtime projection build.
-        if (!chatMessageArraysEquivalent($messages.get(), messagesForView)) {
-          setMessages(messagesForView)
+        if (!chatMessageArraysEquivalent($messages.get(), visibleMessagesForView)) {
+          setMessages(visibleMessagesForView)
         }
 
-        // Refresh the durable tail cache with the authoritative transcript so
-        // the NEXT wake of this session paints instantly (fresh launch,
-        // reaped backend). Post-reconcile only — never persist an optimistic
-        // or in-flight-recovered projection ahead of backend truth.
-        saveTranscriptTail(storedSessionId, messagesForView)
+        // Refresh the durable tail cache with backend transcript truth only;
+        // the live pending clarify projection expires with the server request.
+        saveTranscriptTail(
+          storedSessionId,
+          stripPendingClarifyProjectionForCache(
+            messagesForView,
+            pendingClarify?.requestId ??
+              pendingClarifyState.cleared?.requestId ??
+              $clarifyRequests.get()[resumed.session_id]?.requestId
+          )
+        )
       } catch (err) {
         if (!isCurrentResume()) {
           return

--- a/apps/desktop/src/app/session/hooks/use-session-actions/restore-pending-clarify.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/restore-pending-clarify.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type * as clarifyStore from '@/store/clarify'
+
+const { setClarifyRequestMock, clearClarifyRequestMock } = vi.hoisted(() => ({
+  clearClarifyRequestMock: vi.fn(),
+  setClarifyRequestMock: vi.fn()
+}))
+
+vi.mock('@/store/clarify', async importOriginal => {
+  const actual = await importOriginal<typeof clarifyStore>()
+
+  return {
+    ...actual,
+    clearClarifyRequest: clearClarifyRequestMock,
+    setClarifyRequest: setClarifyRequestMock
+  }
+})
+
+import { $clarifyRequests } from '@/store/clarify'
+
+import { pendingClarifyToolPayload, restorePendingClarifyFromSnapshot } from './restore-pending-clarify'
+
+const resumeStartedAt = 1_700_000_000
+
+describe('restorePendingClarifyFromSnapshot', () => {
+  beforeEach(() => {
+    clearClarifyRequestMock.mockClear()
+    setClarifyRequestMock.mockClear()
+    $clarifyRequests.set({})
+  })
+
+  it('restores a batch clarify snapshot (questions, no top-level question)', () => {
+    const state = restorePendingClarifyFromSnapshot(
+      {
+        pending_clarify: {
+          request_id: 'rid1',
+          questions: [
+            { choices: ['Yes', 'No'], multi_select: false, qid: 'q0', question: 'Proceed?' },
+            { qid: 'q1', question: 'Which region?' }
+          ]
+        }
+      },
+      'sess-1',
+      resumeStartedAt
+    )
+
+    expect(state.request).not.toBeNull()
+    expect(setClarifyRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        multiSelect: false,
+        question: '',
+        requestId: 'rid1',
+        sessionId: 'sess-1',
+        questions: [
+          { choices: ['Yes', 'No'], multiSelect: false, qid: 'q0', question: 'Proceed?' },
+          { multiSelect: false, qid: 'q1', question: 'Which region?', choices: null }
+        ]
+      })
+    )
+  })
+
+  it('carries server-locked answers into the replayed batch card', () => {
+    restorePendingClarifyFromSnapshot(
+      {
+        pending_clarify: {
+          answers: { q0: 'Yes', junk: 42 },
+          request_id: 'rid2',
+          questions: [{ qid: 'q0', question: 'Proceed?' }]
+        }
+      },
+      'sess-2',
+      resumeStartedAt
+    )
+
+    expect(setClarifyRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({ lockedAnswers: { q0: 'Yes' }, requestId: 'rid2' })
+    )
+  })
+
+  it('still restores the single-question form', () => {
+    const state = restorePendingClarifyFromSnapshot(
+      {
+        pending_clarify: {
+          choices: ['A', 'B'],
+          multi_select: true,
+          question: 'Pick one',
+          request_id: 'rid3'
+        }
+      },
+      'sess-3',
+      resumeStartedAt
+    )
+
+    expect(state.request).not.toBeNull()
+    expect(setClarifyRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        choices: ['A', 'B'],
+        multiSelect: true,
+        question: 'Pick one',
+        requestId: 'rid3'
+      })
+    )
+  })
+
+  it('rejects a payload with neither form (no request restored)', () => {
+    const state = restorePendingClarifyFromSnapshot(
+      { pending_clarify: { request_id: 'rid4' } },
+      'sess-4',
+      resumeStartedAt
+    )
+
+    expect(state.request).toBeNull()
+    expect(setClarifyRequestMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a payload with no request id', () => {
+    const state = restorePendingClarifyFromSnapshot(
+      { pending_clarify: { question: 'Orphaned prompt' } },
+      'sess-5',
+      resumeStartedAt
+    )
+
+    expect(state.request).toBeNull()
+    expect(state.authoritativeAbsent).toBe(true)
+    expect(setClarifyRequestMock).not.toHaveBeenCalled()
+  })
+
+  it('clears a stale local request when the snapshot has none, and leaves a newer in-flight one', () => {
+    $clarifyRequests.set({
+      'sess-6': {
+        choices: null,
+        multiSelect: false,
+        question: 'Old',
+        receivedAt: resumeStartedAt - 10,
+        requestId: 'old-rid',
+        sessionId: 'sess-6'
+      }
+    })
+
+    const cleared = restorePendingClarifyFromSnapshot({}, 'sess-6', resumeStartedAt, 'old-rid')
+
+    expect(cleared.authoritativeAbsent).toBe(true)
+    expect(cleared.cleared?.requestId).toBe('old-rid')
+    expect(clearClarifyRequestMock).toHaveBeenCalledWith('old-rid', 'sess-6')
+
+    $clarifyRequests.set({
+      'sess-6': {
+        choices: null,
+        multiSelect: false,
+        question: 'Newer',
+        receivedAt: resumeStartedAt + 1,
+        requestId: 'new-rid',
+        sessionId: 'sess-6'
+      }
+    })
+
+    const kept = restorePendingClarifyFromSnapshot({}, 'sess-6', resumeStartedAt, 'old-rid')
+
+    expect(kept.cleared).toBeNull()
+    expect(kept.request).toBeNull()
+    expect(clearClarifyRequestMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('pendingClarifyToolPayload', () => {
+  it('mirrors the batch wire shape for in-place re-arm', () => {
+    expect(
+      pendingClarifyToolPayload({
+        choices: null,
+        multiSelect: false,
+        question: '',
+        questions: [{ choices: ['Yes', 'No'], multiSelect: false, qid: 'q0', question: 'Proceed?' }],
+        requestId: 'rid',
+        sessionId: 'sess'
+      })
+    ).toEqual({
+      args: {
+        questions: [{ choices: ['Yes', 'No'], question: 'Proceed?' }]
+      },
+      tool_id: 'rid'
+    })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-actions/restore-pending-clarify.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/restore-pending-clarify.ts
@@ -1,0 +1,105 @@
+import type { GatewayEventPayload } from '@/lib/chat-messages'
+import {
+  $clarifyRequests,
+  type ClarifyRequest,
+  clearClarifyRequest,
+  normalizeChoices,
+  normalizeQuestions,
+  setClarifyRequest
+} from '@/store/clarify'
+import type { SessionResumeResponse } from '@/types/hermes'
+
+export interface PendingClarifyResumeState {
+  authoritativeAbsent: boolean
+  cleared: ClarifyRequest | null
+  request: ClarifyRequest | null
+}
+
+/**
+ * Restore a pending clarify from a resume/activate snapshot onto `sessionId`.
+ *
+ * The snapshot mirrors the live clarify.request wire shape: single-question
+ * payloads carry `question`/`choices`/`multi_select`; batch (multi-question)
+ * ones carry `questions` (+ any answers already locked server-side) and no
+ * top-level `question`. Multi-select locks arrive as JSON-encoded arrays
+ * inside a string — never a bare array — so `lockedAnswers` keeps string
+ * values only.
+ *
+ * A missing snapshot is authoritative only for requests that already existed
+ * when the RPC began. A newer clarify.request that arrives while the response
+ * is in flight is left alone.
+ */
+export function restorePendingClarifyFromSnapshot(
+  response: Pick<SessionResumeResponse, 'pending_clarify'>,
+  sessionId: string,
+  resumeStartedAt: number,
+  requestIdAtStart?: string
+): PendingClarifyResumeState {
+  const pending = response.pending_clarify
+
+  if (!pending || typeof pending.request_id !== 'string') {
+    const current = $clarifyRequests.get()[sessionId]
+
+    const existedAtStart = Boolean(current && requestIdAtStart && current.requestId === requestIdAtStart)
+    const definitelyOlder = Boolean(current?.receivedAt !== undefined && current.receivedAt < resumeStartedAt)
+    const legacyWithoutTime = Boolean(current && current.receivedAt === undefined && !requestIdAtStart)
+
+    if (current && (existedAtStart || definitelyOlder || legacyWithoutTime)) {
+      clearClarifyRequest(current.requestId, sessionId)
+
+      return { authoritativeAbsent: true, cleared: current, request: null }
+    }
+
+    return { authoritativeAbsent: true, cleared: null, request: null }
+  }
+
+  const questions = normalizeQuestions(pending.questions)
+  const question = typeof pending.question === 'string' ? pending.question : ''
+
+  if (!question && questions.length === 0) {
+    return { authoritativeAbsent: false, cleared: null, request: null }
+  }
+
+  const choices = normalizeChoices(pending.choices)
+
+  const lockedAnswers =
+    typeof pending.answers === 'object' && pending.answers !== null
+      ? Object.fromEntries(
+          Object.entries(pending.answers).filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+        )
+      : undefined
+
+  const request: ClarifyRequest = {
+    choices: choices.length > 0 ? choices : null,
+    lockedAnswers,
+    multiSelect: pending.multi_select === true,
+    question,
+    receivedAt: Date.now() / 1000,
+    requestId: pending.request_id,
+    sessionId,
+    ...(questions.length > 0 ? { questions } : {})
+  }
+
+  setClarifyRequest(request)
+
+  return { authoritativeAbsent: false, cleared: null, request }
+}
+
+export function pendingClarifyToolPayload(request: ClarifyRequest): GatewayEventPayload {
+  return {
+    args: request.questions?.length
+      ? {
+          questions: request.questions.map(question => ({
+            choices: question.choices ?? undefined,
+            multi_select: question.multiSelect || undefined,
+            question: question.question
+          }))
+        }
+      : {
+          choices: request.choices ?? [],
+          ...(request.multiSelect ? { multi_select: true } : {}),
+          question: request.question
+        },
+    tool_id: request.requestId
+  }
+}

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -475,7 +475,7 @@ function liveBatchProps(): ToolCallMessagePartProps {
   }
 }
 
-function renderLiveBatch(lockedAnswers?: Record<string, string>) {
+function renderLiveBatch(lockedAnswers?: Record<string, string>, multiSelect = false) {
   const request = vi.fn().mockResolvedValue({ ok: true, remaining: [] })
 
   $activeSessionId.set('session-1')
@@ -486,7 +486,7 @@ function renderLiveBatch(lockedAnswers?: Record<string, string>) {
     multiSelect: false,
     question: '',
     questions: [
-      { choices: ['red', 'blue'], multiSelect: false, qid: 'q0', question: 'Color?' },
+      { choices: ['red', 'blue'], multiSelect, qid: 'q0', question: 'Color?' },
       { choices: null, multiSelect: false, qid: 'q1', question: 'Name?' }
     ],
     requestId: 'request-batch',
@@ -593,6 +593,14 @@ describe('ClarifyTool batch card', () => {
     renderLiveBatch({ q0: 'red' })
 
     // The replayed answer counts as staged: one question left to answer.
+    expect(screen.getByText('1 of 2 answered')).toBeTruthy()
+  })
+
+  it('reselects every choice from a replayed multi-select JSON answer', () => {
+    renderLiveBatch({ q0: '["red","blue"]' }, true)
+
+    expect(screen.getByRole('button', { name: /red/ }).getAttribute('aria-pressed')).toBe('true')
+    expect(screen.getByRole('button', { name: /blue/ }).getAttribute('aria-pressed')).toBe('true')
     expect(screen.getByText('1 of 2 answered')).toBeTruthy()
   })
 

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -940,8 +940,24 @@ function ClarifyToolBatchPending({ request }: { request: ClarifyRequest | null }
           continue
         }
 
-        const asChoice = (question.choices ?? []).find(choice => bareChoice(choice) === answer)
-        next[question.qid] = asChoice ? { choices: [asChoice], draft: '' } : { choices: [], draft: answer }
+        const options = question.choices ?? []
+        let replayedAnswers = [answer]
+
+        if (question.multiSelect) {
+          try {
+            const parsed = JSON.parse(answer)
+
+            if (Array.isArray(parsed) && parsed.every(value => typeof value === 'string')) {
+              replayedAnswers = parsed
+            }
+          } catch {
+            // Older/non-JSON replies remain a one-value replay below.
+          }
+        }
+
+        const matchedChoices = options.filter(choice => replayedAnswers.includes(bareChoice(choice)))
+        next[question.qid] =
+          matchedChoices.length > 0 ? { choices: matchedChoices, draft: '' } : { choices: [], draft: answer }
       }
 
       return next

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -14,6 +14,7 @@ import {
   reasoningPart,
   renderMediaTags,
   sealOpenToolParts,
+  stripPendingClarifyProjectionForCache,
   toChatMessages,
   upsertToolPart,
   withUniqueToolCallIdsWithinMessage
@@ -1330,6 +1331,40 @@ describe('collectUnspokenTurnSpeech', () => {
     expect(collectUnspokenTurnSpeech([], null)).toBeNull()
     expect(collectUnspokenTurnSpeech([assistant('a1', 'Done.')], 'a1')).toBeNull()
     expect(collectUnspokenTurnSpeech([user('u1', 'hello'), assistant('a1', '')], null)).toBeNull()
+  })
+})
+
+describe('stripPendingClarifyProjectionForCache', () => {
+  const clarifyPart = (toolCallId: string): ChatMessagePart => ({
+    type: 'tool-call',
+    toolCallId,
+    toolName: 'clarify',
+    args: { choices: ['a'], question: 'Pick' },
+    argsText: '{"question":"Pick","choices":["a"]}'
+  })
+
+  it('drops a synthetic request-id-only clarify row from the durable cache', () => {
+    const messages: ChatMessage[] = [
+      { id: 'user', role: 'user', parts: [{ type: 'text', text: 'choose' }] },
+      { id: 'synthetic', role: 'assistant', parts: [clarifyPart('req-1')], pending: true }
+    ]
+
+    expect(stripPendingClarifyProjectionForCache(messages, 'req-1')).toEqual([messages[0]])
+  })
+
+  it('keeps a provider-authored clarify in position but strips its local running bit', () => {
+    const messages: ChatMessage[] = [
+      {
+        id: 'provider',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Choose.' }, clarifyPart('call-provider')],
+        pending: true
+      }
+    ]
+
+    const [cached] = stripPendingClarifyProjectionForCache(messages, 'req-1')
+    expect(cached.pending).toBe(false)
+    expect(cached.parts.map(part => part.type)).toEqual(['text', 'tool-call'])
   })
 })
 

--- a/apps/desktop/src/lib/chat-messages/index.ts
+++ b/apps/desktop/src/lib/chat-messages/index.ts
@@ -14,5 +14,13 @@ export {
 } from './parts'
 export type { UnspokenTurnSpeech } from './parts'
 export { branchGroupForUser, preserveLocalAssistantErrors } from './reconciliation'
-export { sealOpenToolParts, upsertToolPart, withUniqueToolCallIdsWithinMessage } from './tool-parts'
+export {
+  restorePendingClarifyToolCall,
+  sealOpenToolParts,
+  settlePendingClarifyToolCall,
+  stripPendingClarifyProjectionForCache,
+  upsertToolPart,
+  withUniqueToolCallIdsWithinMessage
+} from './tool-parts'
+export type { PendingClarifyProjection, SettledClarifyProjection } from './tool-parts'
 export type { ChatMessage, ChatMessagePart, GatewayEventPayload, TimelinePartMetadata } from './types'

--- a/apps/desktop/src/lib/chat-messages/tool-parts.ts
+++ b/apps/desktop/src/lib/chat-messages/tool-parts.ts
@@ -333,6 +333,221 @@ export function upsertToolPart(
   return next
 }
 
+export interface PendingClarifyProjection {
+  messages: ChatMessage[]
+  streamId: string
+}
+
+export interface SettledClarifyProjection {
+  messages: ChatMessage[]
+  streamId: string | null
+}
+
+interface PendingClarifyLocation {
+  messageIndex: number
+  partIndex: number
+}
+
+function findPendingClarifyLocation(
+  messages: ChatMessage[],
+  payload: GatewayEventPayload
+): PendingClarifyLocation | null {
+  const stableId = toolId(payload)
+  const matchValues = toolPayloadMatchValues(payload)
+  let solePending: PendingClarifyLocation | null = null
+  let pendingCount = 0
+
+  for (let messageIndex = messages.length - 1; messageIndex >= 0; messageIndex -= 1) {
+    const message = messages[messageIndex]
+
+    for (let partIndex = message.parts.length - 1; partIndex >= 0; partIndex -= 1) {
+      const part = message.parts[partIndex]
+
+      if (part.type !== 'tool-call' || part.toolName !== 'clarify' || part.result !== undefined) {
+        continue
+      }
+
+      pendingCount += 1
+      solePending = { messageIndex, partIndex }
+
+      const exactId = Boolean(stableId && part.toolCallId === stableId)
+      const contextual = hasToolMatchOverlap(matchValues, toolPartMatchValues(part))
+
+      if (exactId || contextual) {
+        return { messageIndex, partIndex }
+      }
+    }
+  }
+
+  // Older/sparse projections can lose the identifying args. One session can
+  // only block on one clarify at a time, so a sole open clarify is still the
+  // authoritative row even without a usable correlation value.
+  return pendingCount === 1 ? solePending : null
+}
+
+function skippedClarifyResult(part: Extract<ChatMessagePart, { type: 'tool-call' }>): Record<string, unknown> {
+  const args = recordFromUnknown(part.args) ?? {}
+  const questions = Array.isArray(args.questions) ? args.questions : []
+
+  if (questions.length > 0) {
+    return {
+      responses: questions.map(entry => ({
+        question: firstStringField(recordFromUnknown(entry) ?? {}, ['question']),
+        user_response: ''
+      })),
+      timed_out: true
+    }
+  }
+
+  return {
+    question: firstStringField(args, ['question']),
+    user_response: ''
+  }
+}
+
+/** Mark one pending clarify as timed out/settled without ending a later phase
+ * of the same assistant turn. `keepMessageRunning` keeps the containing message
+ * open for subsequent deltas while the clarify part itself becomes settled. */
+export function settlePendingClarifyToolCall(
+  messages: ChatMessage[],
+  payload: GatewayEventPayload,
+  keepMessageRunning: boolean,
+  occurredAt = Date.now() / 1000
+): SettledClarifyProjection {
+  const clarifyPayload = { ...payload, name: 'clarify' }
+  const location = findPendingClarifyLocation(messages, clarifyPayload)
+
+  if (!location) {
+    return { messages, streamId: null }
+  }
+
+  const message = messages[location.messageIndex]
+  const part = message.parts[location.partIndex]
+
+  if (part.type !== 'tool-call') {
+    return { messages, streamId: null }
+  }
+
+  const parts = [...message.parts]
+  parts[location.partIndex] = {
+    ...part,
+    completedAt: occurredAt,
+    result: skippedClarifyResult(part)
+  }
+
+  const next = [...messages]
+  next[location.messageIndex] = { ...message, parts, pending: keepMessageRunning }
+
+  return { messages: next, streamId: message.id }
+}
+
+/** Remove ephemeral clarify liveness before writing the durable transcript-tail
+ * cache. A synthetic request-id part is dropped; a provider-authored call stays
+ * visible but loses its local `pending` bit until an authoritative resume
+ * snapshot re-arms it. */
+export function stripPendingClarifyProjectionForCache(messages: ChatMessage[], requestId?: string): ChatMessage[] {
+  let changed = false
+  const next: ChatMessage[] = []
+
+  for (const message of messages) {
+    const hasOpenClarify = message.parts.some(
+      part => part.type === 'tool-call' && part.toolName === 'clarify' && part.result === undefined
+    )
+
+    if (!hasOpenClarify) {
+      next.push(message)
+
+      continue
+    }
+
+    const parts = message.parts.filter(
+      part =>
+        !(
+          requestId &&
+          part.type === 'tool-call' &&
+          part.toolName === 'clarify' &&
+          part.result === undefined &&
+          part.toolCallId === requestId
+        )
+    )
+
+    changed = true
+
+    if (parts.length > 0) {
+      next.push({ ...message, parts, pending: false })
+    }
+  }
+
+  return changed ? next : messages
+}
+
+/**
+ * Re-arm a clarify request against a transcript that may already have been
+ * hydrated from REST/session.resume.
+ *
+ * Provider transcript shapes differ: Codex commonly persists a tool-only
+ * assistant row, while DeepSeek can persist visible assistant text and the
+ * clarify call on the same row. The clarify request id is distinct from the
+ * provider's tool-call id and can arrive when `state.streamId` is null, so the
+ * generic live-stream mutator would append a second assistant row at the tail.
+ * Match the existing open clarify by its question(s), keep that row's provider
+ * tool id/position, and mark it running. If the backend projection omitted the
+ * tool call, attach it to trailing assistant commentary or seed one tail row as
+ * a last resort.
+ */
+export function restorePendingClarifyToolCall(
+  messages: ChatMessage[],
+  payload: GatewayEventPayload,
+  occurredAt = Date.now() / 1000
+): PendingClarifyProjection {
+  const clarifyPayload = { ...payload, name: 'clarify' }
+  const location = findPendingClarifyLocation(messages, clarifyPayload)
+
+  if (location) {
+    const message = messages[location.messageIndex]
+
+    if (message.pending) {
+      return { messages, streamId: message.id }
+    }
+
+    const next = [...messages]
+    next[location.messageIndex] = { ...message, pending: true }
+
+    return { messages: next, streamId: message.id }
+  }
+
+  const parts = upsertToolPart([], clarifyPayload, 'running', occurredAt)
+  const tailIndex = messages.findLastIndex(message => !message.hidden)
+  const tail = messages[tailIndex]
+
+  if (tail?.role === 'assistant') {
+    const next = [...messages]
+    next[tailIndex] = {
+      ...tail,
+      parts: [...completeOpenStreamParts(tail.parts, occurredAt), ...parts],
+      pending: true
+    }
+
+    return { messages: next, streamId: tail.id }
+  }
+
+  const streamId = nextLiveToolId('clarify-message')
+
+  return {
+    messages: [
+      ...messages,
+      {
+        id: streamId,
+        role: 'assistant',
+        parts,
+        pending: true,
+        timestamp: occurredAt
+      }
+    ],
+    streamId
+  }
+}
+
 /**
  * Turn-settle reconciliation: close every tool-call part that never received
  * its completion event. A `tool.complete` lost to a degraded websocket

--- a/apps/desktop/src/store/clarify.ts
+++ b/apps/desktop/src/store/clarify.ts
@@ -16,6 +16,8 @@ export interface ClarifyRequest {
   question: string
   choices: string[] | null
   multiSelect: boolean
+  /** Local receipt time (Unix seconds), used to reject stale resume cleanup. */
+  receivedAt?: number
   sessionId: string | null
   /** Batch (multi-question) clarify: present instead of question/choices. */
   questions?: ClarifyQuestion[]

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -666,9 +666,11 @@ export interface SessionResumeResponse {
   // class as pending_approval: emitted-while-detached prompts are restored
   // from the resume snapshot instead of being lost until server-side timeout.
   pending_clarify?: {
+    answers?: Record<string, unknown>
     choices?: null | string[]
     multi_select?: boolean
     question?: string
+    questions?: unknown
     request_id?: string
   }
   info?: SessionRuntimeInfo


### PR DESCRIPTION
## What does this PR do?

Supersedes #90053 and consolidates #93178.

Switching bots or sessions in Hermes Desktop can leave a live Ask/clarify prompt invisible. The backend still has `pending_clarify` and is blocked, but the transcript row is already hydrated as complete, so `ClarifyToolLive` never mounts. Sending another message then skips the original question.

#90053 had the right fix (re-arm the existing row in place, keep the provider tool id) and tests for Codex tool-only vs DeepSeek text+tool rows. It was conflicting with `main`. #93178 restored batch `questions[]` snapshots but only wrote the store, so the card still stayed hidden.

This rebases the in-place re-arm onto current `main` and extracts `restorePendingClarifyFromSnapshot` so both single-question and batch snapshots (plus locked answers) replay on `session.activate` / `session.resume`.

### What this PR does
- Re-arm a hydrated clarify row in place instead of appending a duplicate card
- Restore single and batch `pending_clarify` snapshots on warm activate and cold resume
- Settle/expire only the matching request, and leave a newer in-flight prompt alone
- Replay multi-select answers as the original choices

### What was dropped from #90053 / #93178
- Nothing load-bearing. The restore helper lives in its own module (`restorePendingClarifyFromSnapshot`) instead of the session-actions god-file.

## Related Issue

Fixes #53666

Related: #67265 (dashboard/TUI overlay, different surface), #53728 (already on `main`)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## How to Test

1. Start Hermes Desktop, trigger a multiple-choice Ask/clarify, switch to another bot or session and back. The question and choices should render immediately and stay answerable without sending another message.
2. Repeat with a batch (multi-question) clarify. Locked answers should stay locked.
3. Automated:

   ```bash
   cd apps/desktop
   npm run test:ui -- src/lib/chat-messages.test.ts src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx src/app/session/hooks/use-session-actions.test.tsx src/app/session/hooks/use-session-actions/restore-pending-clarify.test.ts src/components/assistant-ui/clarify-tool.test.tsx
   ```

   Result: 5 files / 185 tests passed (plus a later 85-test re-run after the payload DRY).

## Checklist

### Code

- [x] Conventional Commits
- [x] Only this fix
- [x] Desktop vitest for the bug class
- [ ] `pytest tests/ -q` — N/A, Desktop TypeScript only

Credit: @FrendoWu (primary). Related: @ClintonEmok on the snapshot extract. Discord report: bot-switch hides the Ask box until another message is sent.