### PR TITLE
fix(desktop): serialize group turns per member room

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -7254,6 +7254,16 @@ async function answerGroupClarify(entry, member, answers) {
   }
 }
 
+// A profile owns one persistent session per room. Different room threads may
+// drive concurrently, but they must never submit into or poll that SAME member
+// session concurrently: both pollers can otherwise claim one completion and
+// append it to different threads (#93127 follow-up). Rooms remain independent.
+const groupMemberTurnFlights = new Map()
+
+function groupMemberTurnFlightKey(group, member) {
+  return `${group}::${groupMemberKey(member)}`
+}
+
 /** One member turn, gateway-native: submit the room delta as a prompt into
  *  the member's per-group session, then poll the session until a NEW
  *  assistant message lands (or timeout → pass). While the session visibly
@@ -7262,16 +7272,32 @@ async function answerGroupClarify(entry, member, answers) {
  *  records a stranded marker so the finished reply can be harvested into
  *  the room at the member's next turn instead of being lost. */
 async function runGroupChatMemberTurn(group, member, prompt, thread, images) {
-  // #93602: hold the member's route socket for the whole turn. Without the
-  // lease, every RPC below rides its own request-scoped socket lease; the
-  // socket that minted `runtime` can close between RPCs, the gateway reaps
-  // the runtime session, and prompt.submit dies 4001 — the bot goes silent.
-  const releaseTurnLease = await retainGroupTurnRoute(member)
+  const key = groupMemberTurnFlightKey(group, member)
+  const prior = groupMemberTurnFlights.get(key)
+  const start = async () => {
+    // #93602: hold the member's route socket for the whole turn. Without the
+    // lease, every RPC below rides its own request-scoped socket lease; the
+    // socket that minted `runtime` can close between RPCs, the gateway reaps
+    // the runtime session, and prompt.submit dies 4001 — the bot goes silent.
+    const releaseTurnLease = await retainGroupTurnRoute(member)
+
+    try {
+      return await runGroupChatMemberTurnLeased(group, member, prompt, thread, images)
+    } finally {
+      releaseTurnLease()
+    }
+  }
+  // A failed earlier turn must release ownership and must not poison the next
+  // thread. Its original caller still observes the failure independently.
+  const flight = prior ? prior.catch(() => undefined).then(start) : start()
+  groupMemberTurnFlights.set(key, flight)
 
   try {
-    return await runGroupChatMemberTurnLeased(group, member, prompt, thread, images)
+    return await flight
   } finally {
-    releaseTurnLease()
+    if (groupMemberTurnFlights.get(key) === flight) {
+      groupMemberTurnFlights.delete(key)
+    }
   }
 }
 
@@ -7516,7 +7542,8 @@ async function harvestStrandedGroupReply(group, member) {
  *
  *  The re-drive premise is only true for a send in the SAME thread (delta
  *  filters are thread-scoped): a cross-thread epoch bump must NOT discard
- *  finished work no fresh loop will regenerate. Callers pass whether a newer
+ *  finished work that belongs to the old thread. Per-member turn ownership
+ *  serializes the newer thread behind this one. Callers pass whether a newer
  *  USER entry landed in this thread since dispatch; the default (true)
  *  preserves the conservative drop when the caller can't tell. */
 function shouldCommitMemberTurn(epochAtDispatch, currentEpoch, newerUserEntryInThread = true) {

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -7222,6 +7222,10 @@ function clearGroupClarify(group) {
  *    keyed by session + request_id — the same wire the 1:1 approval card
  *    and native notifications use. */
 async function answerGroupClarify(entry, member, answers) {
+  // Intentionally do NOT join groupMemberTurnFlights here. These RPCs
+  // unblock the member turn that currently owns that flight; queueing the
+  // response behind the blocked turn would deadlock until its timeout.
+  // They also do not submit prompts or inspect the session transcript.
   if (entry.kind === 'approval') {
     await requestForBot(member, 'approval.respond', {
       session_id: entry.sessionId || undefined,
@@ -7264,6 +7268,50 @@ function groupMemberTurnFlightKey(group, member) {
   return `${group}::${groupMemberKey(member)}`
 }
 
+/** Serialize every transcript-reading/submitting operation for one member's
+ *  room session. Clarify/approval responses deliberately bypass this helper:
+ *  they unblock the operation that currently owns the flight. */
+async function runGroupMemberSessionFlight(group, member, start) {
+  const key = groupMemberTurnFlightKey(group, member)
+  const prior = groupMemberTurnFlights.get(key)
+  // A failed earlier operation must release ownership and must not poison the
+  // next one. Its original caller still observes the failure independently.
+  const flight = prior ? prior.catch(() => undefined).then(start) : start()
+  groupMemberTurnFlights.set(key, flight)
+
+  try {
+    return await flight
+  } finally {
+    if (groupMemberTurnFlights.get(key) === flight) {
+      groupMemberTurnFlights.delete(key)
+    }
+  }
+}
+
+/** A queued turn can become obsolete before it ever starts. Re-check the
+ *  room at flight acquisition so a newer send in the SAME thread cancels it
+ *  without spending an inference. Cross-thread sends must not cancel it:
+ *  their thread-scoped loop will never regenerate this turn. */
+function queuedGroupTurnIsCurrent(group, thread, epochAtEnqueue, anchorId) {
+  const room = $groupChats.get()[group] || { log: [] }
+
+  if (room.tombstone) {
+    return false
+  }
+
+  if ((room.epoch || 0) === epochAtEnqueue) {
+    return true
+  }
+
+  const log = Array.isArray(room.log) ? room.log : []
+  const anchorIdx = anchorId === null ? -1 : log.findIndex(entry => entry.id === anchorId)
+  // If history trimming removed the anchor, every surviving entry may be
+  // newer, so scanning the retained log is the conservative exact choice.
+  const queuedTail = anchorIdx >= 0 ? log.slice(anchorIdx + 1) : log
+
+  return !queuedTail.some(entry => entry.from?.kind === 'user' && groupThreadOf(entry) === thread)
+}
+
 /** One member turn, gateway-native: submit the room delta as a prompt into
  *  the member's per-group session, then poll the session until a NEW
  *  assistant message lands (or timeout → pass). While the session visibly
@@ -7272,9 +7320,14 @@ function groupMemberTurnFlightKey(group, member) {
  *  records a stranded marker so the finished reply can be harvested into
  *  the room at the member's next turn instead of being lost. */
 async function runGroupChatMemberTurn(group, member, prompt, thread, images) {
-  const key = groupMemberTurnFlightKey(group, member)
-  const prior = groupMemberTurnFlights.get(key)
+  const roomAtEnqueue = $groupChats.get()[group] || { log: [] }
+  const epochAtEnqueue = roomAtEnqueue.epoch || 0
+  const anchorId = roomAtEnqueue.log?.length ? roomAtEnqueue.log[roomAtEnqueue.log.length - 1].id : null
   const start = async () => {
+    if (!queuedGroupTurnIsCurrent(group, thread, epochAtEnqueue, anchorId)) {
+      return null
+    }
+
     // #93602: hold the member's route socket for the whole turn. Without the
     // lease, every RPC below rides its own request-scoped socket lease; the
     // socket that minted `runtime` can close between RPCs, the gateway reaps
@@ -7287,18 +7340,8 @@ async function runGroupChatMemberTurn(group, member, prompt, thread, images) {
       releaseTurnLease()
     }
   }
-  // A failed earlier turn must release ownership and must not poison the next
-  // thread. Its original caller still observes the failure independently.
-  const flight = prior ? prior.catch(() => undefined).then(start) : start()
-  groupMemberTurnFlights.set(key, flight)
 
-  try {
-    return await flight
-  } finally {
-    if (groupMemberTurnFlights.get(key) === flight) {
-      groupMemberTurnFlights.delete(key)
-    }
-  }
+  return runGroupMemberSessionFlight(group, member, start)
 }
 
 async function runGroupChatMemberTurnLeased(group, member, prompt, thread, images) {
@@ -7455,6 +7498,10 @@ async function runGroupChatMemberTurnLeased(group, member, prompt, thread, image
  *  after we stopped waiting. Called at the member's next turn boundary and
  *  on user sends, so long-running work is delivered late rather than lost. */
 async function harvestStrandedGroupReply(group, member) {
+  return runGroupMemberSessionFlight(group, member, () => harvestStrandedGroupReplyOwned(group, member))
+}
+
+async function harvestStrandedGroupReplyOwned(group, member) {
   const memberKey = groupMemberKey(member)
   const room = $groupChats.get()[group] || {}
   const marker = room.stranded?.[memberKey]

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs
@@ -183,15 +183,18 @@ test('a newer send interrupts the previous run and records cancelled in the CURR
     await new Promise(resolve => setImmediate(resolve))
   }
   gc.sendToGroupChat('Busy', member, 'second ask, supersede')
+  for (let i = 0; i < 10; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+  assert.equal(gc.calls.length, 1, 'the superseding turn waits for the member already in flight')
+
+  gates[1].resolve('late from the old run')
   for (let i = 0; i < 50 && gc.calls.length < 2; i++) {
     await new Promise(resolve => setImmediate(resolve))
   }
-
+  assert.equal(gc.calls.length, 2, 'the superseding turn starts after ownership is released')
   gates[2].resolve('from the new run')
   await drain(gc, 'Busy')
-  gates[1].resolve('late from the old run')
-  await new Promise(resolve => setImmediate(resolve))
-  await new Promise(resolve => setImmediate(resolve))
 
   const epoch = (gc.$groupChats.get().Busy || {}).epoch || 0
   const events = feed(gc, 'Busy')

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -177,7 +177,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
             stored: session.stored,
             title: session.title
           })
-          const reply = turnScript(session.profile, params.text, calls.length, session)
+          const reply = await turnScript(session.profile, params.text, calls.length, session)
           session.messages.push({ role: 'assistant', content: reply })
           return {}
         }
@@ -204,7 +204,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, runGroupChatMemberTurn, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -402,6 +402,35 @@ test('concurrent groups sharing one member keep sessions, deltas, and context is
   const betaSession = gc.sessions.get(betaFirst.stored)
   assert.equal(alphaSession.messages.some(message => String(message.content).includes('BETA_ONLY')), false)
   assert.equal(betaSession.messages.some(message => String(message.content).includes('ALPHA_ONLY')), false)
+})
+
+test('one member cannot run two turns concurrently across threads in the same room', async () => {
+  let releaseFirst
+  let markFirstStarted
+  const firstGate = new Promise(resolve => { releaseFirst = resolve })
+  const firstStarted = new Promise(resolve => { markFirstStarted = resolve })
+  const gc = load(async (_profile, prompt) => {
+    if (prompt === 'first thread') {
+      markFirstStarted()
+      await firstGate
+      return 'first reply'
+    }
+    return 'second reply'
+  })
+  const member = { name: 'research', title: '' }
+
+  const first = gc.runGroupChatMemberTurn('Room', member, 'first thread', 'thread-a', [])
+  await firstStarted
+  const second = gc.runGroupChatMemberTurn('Room', member, 'second thread', 'thread-b', [])
+  await new Promise(resolve => setImmediate(resolve))
+
+  assert.equal(gc.calls.length, 1, 'the second thread must not submit into a busy member session')
+
+  releaseFirst()
+  assert.deepEqual(await Promise.all([first, second]), ['first reply', 'second reply'])
+  assert.equal(gc.calls.length, 2)
+  assert.equal(gc.calls[0].prompt, 'first thread')
+  assert.equal(gc.calls[1].prompt, 'second thread')
 })
 
 test('recreating a same-name group after disband mints fresh member sessions', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -433,6 +433,110 @@ test('one member cannot run two turns concurrently across threads in the same ro
   assert.equal(gc.calls[1].prompt, 'second thread')
 })
 
+test('a queued member turn is dropped before inference when its thread is superseded', async () => {
+  let releaseFirst
+  let markFirstStarted
+  const firstGate = new Promise(resolve => { releaseFirst = resolve })
+  const firstStarted = new Promise(resolve => { markFirstStarted = resolve })
+  const gc = load(async (_profile, prompt) => {
+    if (prompt === 'blocking turn') {
+      markFirstStarted()
+      await firstGate
+    }
+    return `${prompt} reply`
+  })
+  const member = { name: 'research', title: '' }
+
+  gc.updateGroupChat('Room', room => {
+    room.epoch = 1
+    room.log.push({ id: 'user:1', from: { kind: 'user', name: 'You' }, text: 'old', at: 1, thread: 'thread-a' })
+    return room
+  })
+
+  const first = gc.runGroupChatMemberTurn('Room', member, 'blocking turn', 'thread-b', [])
+  await firstStarted
+  const queued = gc.runGroupChatMemberTurn('Room', member, 'obsolete turn', 'thread-a', [])
+
+  gc.updateGroupChat('Room', room => {
+    room.epoch += 1
+    room.log.push({ id: 'user:2', from: { kind: 'user', name: 'You' }, text: 'newer', at: 2, thread: 'thread-a' })
+    return room
+  })
+
+  releaseFirst()
+  assert.deepEqual(await Promise.all([first, queued]), ['blocking turn reply', null])
+  assert.equal(gc.calls.length, 1, 'the superseded queued turn must spend no inference')
+})
+
+test('a cross-thread epoch bump preserves queued work for the original thread', async () => {
+  let releaseFirst
+  let markFirstStarted
+  const firstGate = new Promise(resolve => { releaseFirst = resolve })
+  const firstStarted = new Promise(resolve => { markFirstStarted = resolve })
+  const gc = load(async (_profile, prompt) => {
+    if (prompt === 'blocking turn') {
+      markFirstStarted()
+      await firstGate
+    }
+    return `${prompt} reply`
+  })
+  const member = { name: 'research', title: '' }
+
+  gc.updateGroupChat('Room', room => {
+    room.epoch = 1
+    room.log.push({ id: 'user:1', from: { kind: 'user', name: 'You' }, text: 'old', at: 1, thread: 'thread-a' })
+    return room
+  })
+
+  const first = gc.runGroupChatMemberTurn('Room', member, 'blocking turn', 'thread-b', [])
+  await firstStarted
+  const queued = gc.runGroupChatMemberTurn('Room', member, 'still current', 'thread-a', [])
+
+  gc.updateGroupChat('Room', room => {
+    room.epoch += 1
+    room.log.push({ id: 'user:2', from: { kind: 'user', name: 'You' }, text: 'other thread', at: 2, thread: 'thread-c' })
+    return room
+  })
+
+  releaseFirst()
+  assert.deepEqual(await Promise.all([first, queued]), ['blocking turn reply', 'still current reply'])
+  assert.equal(gc.calls.length, 2)
+})
+
+test('stranded harvesting waits for the member session flight', async () => {
+  let releaseTurn
+  let markTurnStarted
+  const turnGate = new Promise(resolve => { releaseTurn = resolve })
+  const turnStarted = new Promise(resolve => { markTurnStarted = resolve })
+  const gc = load(async () => {
+    markTurnStarted()
+    await turnGate
+    return 'finished'
+  })
+  const member = { name: 'research', title: '' }
+
+  const turn = gc.runGroupChatMemberTurn('Room', member, 'work', 'thread-a', [])
+  await turnStarted
+  gc.updateGroupChat('Room', room => {
+    room.stranded = { research: { before: 999, thread: 'thread-a' } }
+    return room
+  })
+
+  const resumesBeforeHarvest = gc.requests.filter(request => request.method === 'session.resume').length
+  const harvest = gc.harvestStrandedGroupReply('Room', member)
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(
+    gc.requests.filter(request => request.method === 'session.resume').length,
+    resumesBeforeHarvest,
+    'harvest must not inspect the transcript while a member turn owns it'
+  )
+
+  releaseTurn()
+  await turn
+  await harvest
+  assert.equal(gc.$groupChats.get().Room.stranded.research, undefined)
+})
+
 test('recreating a same-name group after disband mints fresh member sessions', async () => {
   const gc = load(() => '(pass)')
   const member = { name: 'research', title: '' }

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-turn-races.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-turn-races.test.mjs
@@ -50,11 +50,11 @@ test('a current turn commits — epoch unchanged since dispatch', () => {
   assert.equal(shouldCommitMemberTurn(0, 0), true)
 })
 
-test('a cross-thread epoch bump does NOT discard finished work (no fresh loop re-drives it)', () => {
+test('a cross-thread epoch bump preserves the old thread reply', () => {
   const { shouldCommitMemberTurn } = loadHelpers()
   // Epoch moved, but no newer user entry landed in THIS thread: the
-  // superseding send lives in another thread whose loop filters this one
-  // out — dropping the reply would lose completed work forever.
+  // superseding send lives in another thread. Member-turn ownership keeps
+  // its later prompt from consuming this completion.
   assert.equal(shouldCommitMemberTurn(3, 4, false), true)
 })
 


### PR DESCRIPTION
## What does this PR do?

Serializes group-chat turns that share the same room/member session.

Hermes keeps one persistent gateway session per member in a group room. Separate threads in that room could previously submit into and poll that session concurrently, allowing one completion to be claimed and published by the wrong thread. The new single-flight queue is keyed by room and member, so unrelated rooms and members remain concurrent. A rejected turn releases the queue and does not poison later work.

## Related Issue

Follow-up to #93127. Complements the epoch and adjacent-deduplication work in #93207 by preventing concurrent RPC sequences from sharing one member session in the first place.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a per-room/member single-flight queue around group member turns.
- Preserve parallelism between different rooms and different members.
- Ensure failed turns release ownership without blocking later requests.
- Add regression coverage for cross-thread ordering and update race expectations.

## How to Test

1. Run `npm --prefix apps/desktop run check:test:plugins`.
2. Confirm all 557 plugin tests pass, including `one member cannot run two turns concurrently across threads in the same room`.
3. Send two concurrent messages in separate threads of one group and verify each reply is published only to its originating thread.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

`npm --prefix apps/desktop run check:test:plugins`: 557 passed, 0 failed.
