### PR TITLE
test(kanban): regression tests for judge transport_failed completion gate

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2228,8 +2228,9 @@ def _goal_mode_handoff_rejection(task: Optional[kb.Task], evidence: str) -> Opti
 
     verdict = "done"
     reason = ""
+    transport_failed = False
     try:
-        verdict, reason, _, _, _ = judge_goal(
+        verdict, reason, _parse_failed, _, transport_failed = judge_goal(
             goal=f"{task.title}\n\n{task.body or ''}".strip(),
             last_response=evidence.strip(),
         )
@@ -2241,6 +2242,20 @@ def _goal_mode_handoff_rejection(task: Optional[kb.Task], evidence: str) -> Opti
             judge_exc,
             exc_info=True,
         )
+        return None
+    if transport_failed:
+        # A judge transport failure is transient — judge_goal already fails
+        # open (returns a "continue" verdict). Log a warning and proceed on
+        # the completion path rather than wedging the goal_mode worker. Only
+        # transport_failed=True is allowed to fail open; a parse failure or
+        # any other reliable non-"done" verdict still rejects below.
+        import logging as _logging
+
+        _logging.getLogger(__name__).warning(
+            "goal judge transport failed (unreachable), allowing completion: %s",
+            reason,
+        )
+        return None
     return reason if verdict != "done" else None
 
 

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -145,7 +145,8 @@ class TestCLIJudgeGate:
     """
 
     def _run(self, monkeypatch, *, goal_mode=True, judge_available=True,
-             verdict="done", reason="", complete_ok=True, summary="done"):
+             verdict="done", reason="", complete_ok=True, summary="done",
+             parse_failed=False, transport_failed=False):
         import argparse
         import types
         from unittest.mock import MagicMock
@@ -184,7 +185,7 @@ class TestCLIJudgeGate:
         # (verdict, reason, parse_failed, wait_directive, transport_failed)
         monkeypatch.setattr(
             "hermes_cli.goals.judge_goal",
-            lambda **kw: (verdict, reason, False, None, False),
+            lambda **kw: (verdict, reason, parse_failed, None, transport_failed),
         )
 
         args = argparse.Namespace(task_ids=["t1"], summary=summary, result=None, metadata=None)
@@ -205,3 +206,32 @@ class TestCLIJudgeGate:
         rc, complete_calls = self._run(monkeypatch, goal_mode=False)
         assert rc == 0
         assert complete_calls == ["t1"]
+
+    def test_transport_failure_fails_open(self, monkeypatch, caplog):
+        """A judge transport failure (transport_failed=True) must NOT reject
+        completion — the gate fails open with a warning instead of wedging the
+        worker (regression for PermissionDeniedError / HTTP 403)."""
+        import logging
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.kanban"):
+            rc, complete_calls = self._run(
+                monkeypatch, verdict="continue", reason="judge error: PermissionDeniedError",
+                transport_failed=True,
+            )
+        assert rc == 0
+        assert complete_calls == ["t1"]
+        assert any(
+            "transport failed" in rec.message for rec in caplog.records
+        ), f"expected a transport-failure warning, got: {[r.message for r in caplog.records]}"
+
+    def test_parse_failure_still_rejected(self, monkeypatch):
+        """parse_failed=True with transport_failed=False is not a transport
+        failure: the non-done verdict must still reject completion. Only
+        transport_failed=True is allowed to fail open."""
+        rc, complete_calls = self._run(
+            monkeypatch, verdict="continue", reason="judge error: mock",
+            parse_failed=True, transport_failed=False,
+        )
+        assert rc != 0, "parse failure must not fail open"
+        assert complete_calls == [], (
+            "complete_task must NOT be invoked on a parse-failure rejection"
+        )

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -215,6 +215,66 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
         conn2.close()
 
 
+def test_complete_goal_mode_transport_failure_fails_open(monkeypatch, tmp_path, caplog):
+    """A judge transport failure (transport_failed=True) must not wedge the
+    worker: kanban_complete fails OPEN and logs a warning. Regression for the
+    quota-exhausted Kimi endpoint (PermissionDeniedError / HTTP 403)."""
+    import logging
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    goal_task_id = _make_goal_mode_worker_env(monkeypatch, tmp_path)
+
+    def mock_judge_goal(goal, last_response, *, timeout=30.0, subgoals=None):
+        # (verdict, reason, parse_failed, wait_directive, transport_failed)
+        return "continue", "judge error: PermissionDeniedError", False, None, True
+
+    monkeypatch.setattr("tools.kanban_tools.judge_goal", mock_judge_goal)
+    monkeypatch.setattr("tools.kanban_tools._goal_judge_available", lambda: True)
+
+    with caplog.at_level(logging.WARNING, logger="tools.kanban_tools"):
+        out = kt._handle_complete({"summary": "done with evidence"})
+    d = json.loads(out)
+    assert d.get("ok") is True, d
+    assert any(
+        "transport failed" in rec.message for rec in caplog.records
+    ), f"expected a transport-failure warning, got: {[r.message for r in caplog.records]}"
+
+    conn2 = kb.connect()
+    try:
+        assert kb.get_task(conn2, goal_task_id).status == "done"
+    finally:
+        conn2.close()
+
+
+def test_complete_goal_mode_parse_failure_rejected(monkeypatch, tmp_path):
+    """A judge parse failure (parse_failed=True, transport_failed=False) is NOT
+    a transport failure: the non-done verdict must still reject completion.
+    Only transport_failed=True is allowed to fail open."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    goal_task_id = _make_goal_mode_worker_env(monkeypatch, tmp_path)
+
+    def mock_judge_goal(goal, last_response, *, timeout=30.0, subgoals=None):
+        # (verdict, reason, parse_failed, wait_directive, transport_failed)
+        return "continue", "judge error: mock", True, None, False
+
+    monkeypatch.setattr("tools.kanban_tools.judge_goal", mock_judge_goal)
+    monkeypatch.setattr("tools.kanban_tools._goal_judge_available", lambda: True)
+
+    out = kt._handle_complete({"summary": "partial work, judge could not parse"})
+    d = json.loads(out)
+    assert "error" in d
+    assert "Goal completion rejected by judge" in d["error"]
+
+    conn2 = kb.connect()
+    try:
+        assert kb.get_task(conn2, goal_task_id).status == "running"
+    finally:
+        conn2.close()
+
+
 def test_block_happy_path(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_block({"reason": "need clarification"})

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -257,8 +257,9 @@ def _goal_mode_handoff_rejection(task, evidence: str) -> Optional[str]:
         return None
     verdict = "done"
     reason = ""
+    transport_failed = False
     try:
-        verdict, reason, _, _, _ = judge_goal(
+        verdict, reason, _parse_failed, _, transport_failed = judge_goal(
             goal=f"{task.title}\n\n{task.body or ''}".strip(),
             last_response=evidence.strip(),
         )
@@ -270,6 +271,18 @@ def _goal_mode_handoff_rejection(task, evidence: str) -> Optional[str]:
             judge_exc,
             exc_info=True,
         )
+        return None
+    if transport_failed:
+        # A judge transport failure is transient — judge_goal already fails
+        # open (returns a "continue" verdict). Log a warning and proceed on
+        # the completion path rather than wedging the goal_mode worker. Only
+        # transport_failed=True is allowed to fail open; a parse failure or
+        # any other reliable non-"done" verdict still rejects below.
+        logger.warning(
+            "goal judge transport failed (unreachable), allowing completion: %s",
+            reason,
+        )
+        return None
     return reason if verdict != "done" else None
 
 


### PR DESCRIPTION
## Summary

Adds regression coverage for the goal-mode completion judge gate's `transport_failed` fail-open contract at **both** call sites:

- `tools/kanban_tools._handle_complete`
- `hermes_cli.kanban._cmd_complete`

Both gates now unpack `judge_goal`'s full 5-tuple `(verdict, reason, parse_failed, wait_directive, transport_failed)` and:

- **fail open only when `transport_failed=True`** — log a warning and allow completion (a degraded/unreachable judge must not wedge a `goal_mode` worker).
- **reject on a reliable non-\`done\` verdict** — including a parse failure (`parse_failed=True, transport_failed=False`), which is *not* a transport failure.

## Motivation

`judge_goal` documents that transport errors return `("continue", ..., None, True)`. The completion gates previously discarded `transport_failed` and treated the resulting fail-open `"continue"` verdict as a rejection, failing **closed** and wedging every goal_mode worker when the judge was unreachable (e.g. quota-exhausted Kimi endpoint raising `PermissionDeniedError` / HTTP 403).

## Changes

- `tools/kanban_tools.py` — `_goal_mode_handoff_rejection` captures `transport_failed`, warns + returns `None` (allow) on `transport_failed=True`.
- `hermes_cli/kanban.py` — same fix in the CLI gate.
- `tests/tools/test_kanban_tools.py` — `test_complete_goal_mode_transport_failure_fails_open`, `test_complete_goal_mode_parse_failure_rejected`.
- `tests/hermes_cli/test_kanban_goal_mode.py` — `TestCLIJudgeGate.test_transport_failure_fails_open`, `TestCLIJudgeGate.test_parse_failure_still_rejected`.

## Test plan

- Focused canonical suite: `pytest tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_goal_mode.py tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_goals.py` — **80 passed**.
- Full suite run in progress on the isolated worktree.