### PR TITLE
feat(desktop): add mobile Sessions swipe navigation

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.test.tsx
@@ -21,6 +21,7 @@ beforeAll(() => {
 })
 
 const disposers: (() => void)[] = []
+const originalInnerWidth = globalThis.innerWidth
 
 const registerPane = (id: string, title: string, data: Record<string, unknown>, body: string) => {
   disposers.push(
@@ -35,6 +36,7 @@ const registerPane = (id: string, title: string, data: Record<string, unknown>, 
 }
 
 beforeEach(() => {
+  Object.defineProperty(globalThis, 'innerWidth', { configurable: true, value: 400 })
   window.localStorage.clear()
   $hiddenTreePanes.set(new Set())
 
@@ -48,6 +50,8 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup()
+  globalThis.document.body.style.touchAction = ''
+  Object.defineProperty(globalThis, 'innerWidth', { configurable: true, value: originalInnerWidth })
   $narrowViewport.set(false)
   $layoutTree.set(null)
   disposers.splice(0).forEach(dispose => dispose())
@@ -59,7 +63,38 @@ const revealPane = (id: string) => {
   })
 }
 
-const overlayTab = (paneId: string) => document.querySelector<HTMLElement>(`[data-narrow-overlay-tab="${paneId}"]`)
+const overlayTab = (paneId: string) =>
+  globalThis.document.querySelector<HTMLElement>(`[data-narrow-overlay-tab="${paneId}"]`)
+
+const swipe = (
+  target: Window | Document | Node | Element,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  pointerId = 7,
+  pointerType = 'touch'
+) => {
+  fireEvent.pointerDown(target, {
+    button: 0,
+    clientX: from.x,
+    clientY: from.y,
+    pointerId,
+    pointerType
+  })
+  fireEvent.pointerMove(target, {
+    button: 0,
+    clientX: to.x,
+    clientY: to.y,
+    pointerId,
+    pointerType
+  })
+  fireEvent.pointerUp(target, {
+    button: 0,
+    clientX: to.x,
+    clientY: to.y,
+    pointerId,
+    pointerType
+  })
+}
 
 describe('narrow overlay of a stacked zone', () => {
   it('mirrors the zone tab strip so every stacked collapsible stays reachable', () => {
@@ -77,6 +112,179 @@ describe('narrow overlay of a stacked zone', () => {
     fireEvent.pointerDown(overlayTab('bots')!, { button: 0 })
     expect(getByTestId('bots-body')).toBeTruthy()
     expect(queryByTestId('sessions-body')).toBeNull()
+  })
+
+  it('opens Sessions with an inward swipe from anywhere in the left half', () => {
+    const { getByTestId, queryByTestId } = render(<NarrowOverlays />)
+
+    expect(queryByTestId('sessions-body')).toBeNull()
+    expect(globalThis.document.body.style.touchAction).toBe('pan-y')
+
+    // Starts well away from the edge, inside the left half of the viewport.
+    swipe(globalThis.document.body, { x: 180, y: 240 }, { x: 236, y: 240 })
+
+    expect(getByTestId('sessions-body')).toBeTruthy()
+    expect(globalThis.document.querySelector('[data-sessions-swipe-close="left"]')).toBeTruthy()
+  })
+
+  it('opens Sessions for a pen swipe from the left half as well as touch', () => {
+    const { getByTestId } = render(<NarrowOverlays />)
+
+    swipe(globalThis.document.body, { x: 120, y: 240 }, { x: 188, y: 240 }, 8, 'pen')
+
+    expect(getByTestId('sessions-body')).toBeTruthy()
+  })
+
+  it('ignores right-half, short, vertical, cancelled, mouse and unknown gestures', () => {
+    const { queryByTestId } = render(<NarrowOverlays />)
+    const screen = globalThis.document.body
+
+    swipe(screen, { x: 220, y: 240 }, { x: 290, y: 240 }, 7)
+    expect(queryByTestId('sessions-body')).toBeNull()
+
+    swipe(screen, { x: 120, y: 240 }, { x: 164, y: 243 }, 8)
+    expect(queryByTestId('sessions-body')).toBeNull()
+
+    swipe(screen, { x: 120, y: 240 }, { x: 184, y: 340 }, 9)
+    expect(queryByTestId('sessions-body')).toBeNull()
+
+    fireEvent.pointerDown(screen, { button: 0, clientX: 120, clientY: 240, pointerId: 10, pointerType: 'touch' })
+    fireEvent.pointerCancel(screen, { pointerId: 10, pointerType: 'touch' })
+    fireEvent.pointerMove(screen, { button: 0, clientX: 196, clientY: 240, pointerId: 10, pointerType: 'touch' })
+    expect(queryByTestId('sessions-body')).toBeNull()
+
+    swipe(screen, { x: 120, y: 240 }, { x: 196, y: 240 }, 11, 'mouse')
+    expect(queryByTestId('sessions-body')).toBeNull()
+
+    swipe(screen, { x: 120, y: 240 }, { x: 196, y: 240 }, 12, '')
+    expect(queryByTestId('sessions-body')).toBeNull()
+
+    swipe(screen, { x: 120, y: 240 }, { x: 196, y: 240 }, 13, 'unknown')
+    expect(queryByTestId('sessions-body')).toBeNull()
+  })
+
+  it('keeps the left-half gesture narrow-only and restores the page touch policy on unmount', () => {
+    globalThis.document.body.style.touchAction = 'manipulation'
+    const { unmount } = render(<NarrowOverlays />)
+
+    expect(globalThis.document.body.style.touchAction).toBe('pan-y')
+    unmount()
+    expect(globalThis.document.body.style.touchAction).toBe('manipulation')
+
+    $narrowViewport.set(false)
+    render(<NarrowOverlays />)
+    swipe(globalThis.document.body, { x: 120, y: 240 }, { x: 196, y: 240 }, 14)
+
+    expect(globalThis.document.querySelector('[data-testid="sessions-body"]')).toBeNull()
+    expect(globalThis.document.body.style.touchAction).toBe('manipulation')
+    globalThis.document.body.style.touchAction = ''
+  })
+
+  it('closes Sessions with a swipe back toward the left edge', () => {
+    const { getByTestId, queryByTestId } = render(<NarrowOverlays />)
+
+    revealPane('sessions')
+
+    const pane = globalThis.document.querySelector<HTMLElement>('[data-sessions-swipe-close="left"]')
+    expect(pane).toBeTruthy()
+    expect(getByTestId('sessions-body')).toBeTruthy()
+
+    swipe(pane!, { x: 190, y: 240 }, { x: 118, y: 245 })
+
+    expect(queryByTestId('sessions-body')).toBeNull()
+  })
+
+  it('does not close Sessions for the wrong or vertical swipe direction', () => {
+    const { getByTestId } = render(<NarrowOverlays />)
+
+    revealPane('sessions')
+
+    const pane = globalThis.document.querySelector<HTMLElement>('[data-sessions-swipe-close="left"]')!
+
+    swipe(pane, { x: 120, y: 240 }, { x: 198, y: 242 }, 11)
+    expect(getByTestId('sessions-body')).toBeTruthy()
+
+    swipe(pane, { x: 190, y: 240 }, { x: 120, y: 340 }, 12)
+    expect(getByTestId('sessions-body')).toBeTruthy()
+  })
+
+  it('closes a pinned sessions overlay when the visible chat pane is tapped', () => {
+    const { getByTestId, queryByTestId } = render(<NarrowOverlays />)
+
+    revealPane('sessions')
+
+    expect(getByTestId('sessions-body')).toBeTruthy()
+
+    const dismissTarget = globalThis.document.querySelector<HTMLElement>('[data-narrow-overlay-dismiss]')
+    const pane = globalThis.document.querySelector<HTMLElement>('[data-sessions-swipe-close]')
+    expect(dismissTarget).toBeTruthy()
+    expect(dismissTarget!.tagName).toBe('DIV')
+    expect(dismissTarget!.getAttribute('aria-hidden')).toBe('true')
+    expect(dismissTarget!.tabIndex).toBe(-1)
+    expect(dismissTarget!.classList.contains('z-[var(--z-narrow-overlay-backdrop)]')).toBe(true)
+    expect(pane!.classList.contains('z-[var(--z-narrow-overlay)]')).toBe(true)
+    expect(pane!.getAttribute('role')).toBe('dialog')
+    expect(pane!.getAttribute('aria-modal')).toBe('true')
+    expect(pane!.getAttribute('aria-label')).toBe('sessions')
+    expect(globalThis.document.activeElement).toBe(pane)
+
+    fireEvent.click(dismissTarget!)
+
+    expect(queryByTestId('sessions-body')).toBeNull()
+    expect(globalThis.document.querySelector('[data-narrow-overlay-dismiss]')).toBeNull()
+  })
+
+  it('makes background controls inert and restores their focus when the overlay closes', () => {
+    const { getByTestId } = render(
+      <>
+        <button data-testid="background-action" type="button">
+          Chat action
+        </button>
+        <NarrowOverlays />
+      </>
+    )
+
+    const backgroundAction = getByTestId('background-action') as HTMLButtonElement
+    const previousInert = backgroundAction.inert
+
+    backgroundAction.focus()
+
+    revealPane('sessions')
+
+    const pane = globalThis.document.querySelector<HTMLElement>('[data-narrow-overlay-pane]')
+    const dismissTarget = globalThis.document.querySelector<HTMLElement>('[data-narrow-overlay-dismiss]')
+    expect(backgroundAction.inert).toBe(true)
+    expect(globalThis.document.activeElement).toBe(pane)
+
+    fireEvent.click(dismissTarget!)
+
+    expect(backgroundAction.inert).toBe(previousInert)
+    expect(globalThis.document.activeElement).toBe(backgroundAction)
+  })
+
+  it('keeps desktop hover previews nonmodal without stealing focus', () => {
+    const { getByTestId } = render(
+      <>
+        <button data-testid="background-action" type="button">
+          Chat action
+        </button>
+        <NarrowOverlays />
+      </>
+    )
+
+    const backgroundAction = getByTestId('background-action') as HTMLButtonElement
+    const previousInert = backgroundAction.inert
+
+    backgroundAction.focus()
+    fireEvent.mouseEnter(globalThis.document.querySelector<HTMLElement>('[data-narrow-overlay-edge="left"]')!)
+
+    const pane = globalThis.document.querySelector<HTMLElement>('[data-narrow-overlay-pane]')
+    expect(pane).toBeTruthy()
+    expect(pane!.getAttribute('role')).toBeNull()
+    expect(pane!.getAttribute('aria-modal')).toBeNull()
+    expect(globalThis.document.querySelector('[data-narrow-overlay-dismiss]')).toBeNull()
+    expect(backgroundAction.inert).toBe(previousInert)
+    expect(globalThis.document.activeElement).toBe(backgroundAction)
   })
 
   it('keeps the stripless form for a zone with a single collapsible', () => {

--- a/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useStore } from '@nanostores/react'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { type PointerEvent as ReactPointerEvent, useEffect, useMemo, useRef, useState } from 'react'
 
 import { PaneTab, PaneTabLabel, PaneTabStrip } from '@/components/ui/pane-tab'
 import { ContribBoundary, ContribRender } from '@/contrib/react/boundary'
@@ -22,12 +22,33 @@ import { $hiddenTreePanes, $layoutTree, $narrowViewport } from '../store'
 
 import { paneChrome } from './track-model'
 
+const SWIPE_THRESHOLD_PX = 56
+const SWIPE_AXIS_RATIO = 1.25
+
+type SwipeSide = 'left' | 'right'
+type SwipeMode = 'close' | 'open'
+type SwipeState = { mode: SwipeMode; pointerId: number; side: SwipeSide; startX: number; startY: number }
+
+const isSessionsPane = (pane: Contribution | undefined) =>
+  Boolean(pane && (pane.id === 'sessions' || paneChrome(pane).revealAliases?.includes('sessions')))
+
+const completedHorizontalSwipe = (swipe: SwipeState, x: number, y: number): boolean => {
+  const dx = x - swipe.startX
+  const dy = y - swipe.startY
+  const inward = swipe.side === 'left' ? dx : -dx
+  const distance = swipe.mode === 'open' ? inward : -inward
+
+  return distance >= SWIPE_THRESHOLD_PX && Math.abs(dx) >= Math.abs(dy) * SWIPE_AXIS_RATIO
+}
+
 export function NarrowOverlays() {
   const narrow = useStore($narrowViewport)
   const tree = useStore($layoutTree)
   const panes = useContributions('panes')
   const hiddenPanes = useStore($hiddenTreePanes)
   const [reveal, setReveal] = useState<{ id: string; pinned: boolean } | null>(null)
+  const overlayLayerRef = useRef<HTMLDivElement>(null)
+  const swipeRef = useRef<SwipeState | null>(null)
 
   // Own an Escape layer only while something is revealed, so Escape closes the
   // overlay only when it's the top layer (never under a dialog / edit mode).
@@ -43,6 +64,142 @@ export function NarrowOverlays() {
 
   const collapsiblesRef = useRef(collapsibles)
   collapsiblesRef.current = collapsibles
+
+  // Phone navigation owns horizontal swipes while preserving ordinary vertical
+  // scroll. Restore the prior page policy exactly when narrow mode unmounts.
+  useEffect(() => {
+    if (!narrow) {
+      return
+    }
+
+    const previousTouchAction = globalThis.document.body.style.touchAction
+    globalThis.document.body.style.touchAction = 'pan-y'
+
+    return () => {
+      globalThis.document.body.style.touchAction = previousTouchAction
+    }
+  }, [narrow])
+
+  // A revealed drawer is modal to the layout beneath it: pointer input lands
+  // on the dismiss surface and keyboard focus stays inside the drawer. Preserve
+  // every sibling's prior inert state and the user's prior focus exactly.
+  useEffect(() => {
+    if (!reveal?.pinned) {
+      return
+    }
+
+    const layer = overlayLayerRef.current
+    const parent = layer?.parentElement
+
+    if (!layer || !parent) {
+      return
+    }
+
+    const background = [...parent.children].filter(
+      (element): element is HTMLElement => element !== layer && element instanceof HTMLElement
+    )
+
+    const previousInert = background.map(element => ({ element, inert: element.inert }))
+
+    const previousFocus =
+      globalThis.document.activeElement instanceof HTMLElement ? globalThis.document.activeElement : null
+
+    previousInert.forEach(({ element }) => {
+      element.inert = true
+    })
+
+    layer.querySelector<HTMLElement>('[data-narrow-overlay-pane]')?.focus({ preventScroll: true })
+
+    return () => {
+      previousInert.forEach(({ element, inert }) => {
+        element.inert = inert
+      })
+
+      if (previousFocus?.isConnected) {
+        previousFocus.focus({ preventScroll: true })
+      }
+    }
+  }, [reveal])
+
+  // On narrow screens, an inward horizontal gesture may start anywhere in the
+  // left half of the app. Listen at window scope so chat content, blank space,
+  // and titlebar chrome all share one route without a transparent hit layer
+  // stealing taps.
+  useEffect(() => {
+    if (!narrow) {
+      return
+    }
+
+    let openingSwipe: SwipeState | null = null
+
+    const clearSwipe = (event: globalThis.PointerEvent) => {
+      if (openingSwipe?.pointerId === event.pointerId) {
+        openingSwipe = null
+      }
+    }
+
+    const onPointerDown = (event: globalThis.PointerEvent) => {
+      openingSwipe = null
+
+      if (
+        reveal ||
+        (event.pointerType !== 'touch' && event.pointerType !== 'pen') ||
+        event.button !== 0 ||
+        event.clientX > globalThis.innerWidth / 2
+      ) {
+        return
+      }
+
+      const sessionsPane = collapsiblesRef.current.find(isSessionsPane)
+
+      if (!sessionsPane) {
+        return
+      }
+
+      const side: SwipeSide = paneChrome(sessionsPane).placement === 'left' ? 'left' : 'right'
+      openingSwipe = {
+        mode: 'open',
+        pointerId: event.pointerId,
+        side,
+        startX: event.clientX,
+        startY: event.clientY
+      }
+    }
+
+    const onPointerMove = (event: globalThis.PointerEvent) => {
+      const swipe = openingSwipe
+
+      if (
+        !swipe ||
+        swipe.mode !== 'open' ||
+        swipe.pointerId !== event.pointerId ||
+        !completedHorizontalSwipe(swipe, event.clientX, event.clientY)
+      ) {
+        return
+      }
+
+      const sessionsPane = collapsiblesRef.current.find(isSessionsPane)
+      openingSwipe = null
+
+      if (sessionsPane) {
+        event.preventDefault()
+        setReveal({ id: sessionsPane.id, pinned: true })
+      }
+    }
+
+    globalThis.addEventListener('pointerdown', onPointerDown, true)
+    globalThis.addEventListener('pointermove', onPointerMove, true)
+    globalThis.addEventListener('pointerup', clearSwipe, true)
+    globalThis.addEventListener('pointercancel', clearSwipe, true)
+
+    return () => {
+      openingSwipe = null
+      globalThis.removeEventListener('pointerdown', onPointerDown, true)
+      globalThis.removeEventListener('pointermove', onPointerMove, true)
+      globalThis.removeEventListener('pointerup', clearSwipe, true)
+      globalThis.removeEventListener('pointercancel', clearSwipe, true)
+    }
+  }, [narrow, reveal])
 
   // ⌘B / ⌘G's narrow branch dispatches the app's toggle-reveal event with the
   // REAL pane id — accept those via each contribution's revealAliases.
@@ -105,9 +262,51 @@ export function NarrowOverlays() {
     return null
   }
 
-  const sideOf = (c: Contribution) => (paneChrome(c).placement === 'left' ? 'left' : 'right')
+  const sideOf = (c: Contribution): SwipeSide => (paneChrome(c).placement === 'left' ? 'left' : 'right')
   const revealed = reveal ? collapsibles.find(p => p.id === reveal.id) : undefined
+  const sessionsRevealed = isSessionsPane(revealed)
   const sides = [...new Set(collapsibles.map(sideOf))]
+
+  const beginSwipe = (event: ReactPointerEvent<HTMLElement>, mode: SwipeMode, side: SwipeSide) => {
+    if ((event.pointerType !== 'touch' && event.pointerType !== 'pen') || event.button !== 0) {
+      return
+    }
+
+    swipeRef.current = {
+      mode,
+      pointerId: event.pointerId,
+      side,
+      startX: event.clientX,
+      startY: event.clientY
+    }
+
+    if (mode === 'open') {
+      event.currentTarget.setPointerCapture?.(event.pointerId)
+    }
+  }
+
+  const advanceSwipe = (event: ReactPointerEvent<HTMLElement>, sessionsPane?: Contribution) => {
+    const swipe = swipeRef.current
+
+    if (!swipe || swipe.pointerId !== event.pointerId || !completedHorizontalSwipe(swipe, event.clientX, event.clientY)) {
+      return
+    }
+
+    swipeRef.current = null
+    event.preventDefault()
+
+    if (swipe.mode === 'open' && sessionsPane) {
+      setReveal({ id: sessionsPane.id, pinned: true })
+    } else if (swipe.mode === 'close') {
+      setReveal(null)
+    }
+  }
+
+  const endSwipe = (event: ReactPointerEvent<HTMLElement>) => {
+    if (swipeRef.current?.pointerId === event.pointerId) {
+      swipeRef.current = null
+    }
+  }
 
   // The revealed pane's ZONE-mates that also left the grid (the sessions zone
   // stacks SESSIONS | BOTS): the overlay mirrors the zone's tab strip so a
@@ -126,11 +325,13 @@ export function NarrowOverlays() {
   })()
 
   return (
-    <>
-      {/* Hover-intent strips on each edge that has a collapsed pane. */}
+    <div className="contents" data-narrow-overlay-layer="" ref={overlayLayerRef}>
+      {/* Desktop hover intent remains a narrow edge strip. Phone opening
+          gestures are captured across the entire left half above. */}
       {sides.map(side => (
         <div
           className={cn('absolute inset-y-0 z-30 w-1.5', side === 'left' ? 'left-0' : 'right-0')}
+          data-narrow-overlay-edge={side}
           key={side}
           onMouseEnter={() => {
             const first = collapsibles.find(p => sideOf(p) === side)
@@ -143,49 +344,79 @@ export function NarrowOverlays() {
       ))}
 
       {revealed && (
-        <div
-          className={cn(
-            'absolute inset-y-0 z-40 flex flex-col overflow-hidden bg-(--ui-sidebar-surface-background) shadow-2xl',
-            sideOf(revealed) === 'left'
-              ? 'left-0 border-r border-(--ui-stroke-secondary)'
-              : 'right-0 border-l border-(--ui-stroke-secondary)'
+        <>
+          {reveal?.pinned && (
+            <div
+              aria-hidden="true"
+              className="absolute inset-0 z-[var(--z-narrow-overlay-backdrop)] cursor-default bg-transparent"
+              data-narrow-overlay-dismiss=""
+              onClick={event => {
+                event.preventDefault()
+                event.stopPropagation()
+                setReveal(null)
+              }}
+              onPointerDown={event => event.stopPropagation()}
+            />
           )}
-          // Floats OVER the layout, so under glass its surface must mask the
-          // panes beneath it — a see-through overlay reads as text bleeding
-          // through text. Contract: `[data-glass-opaque]` in styles.css.
-          data-glass-opaque=""
-          onMouseLeave={() => setReveal(current => (current?.pinned ? current : null))}
-          // Match the pane's docked width (sessions ~237px, files its rail
-          // width) instead of a fat fixed 20rem — capped for tiny screens.
-          style={{ width: `min(${(revealed.data as { width?: string } | undefined)?.width ?? '18rem'}, 85vw)` }}
-        >
-          {/* Zone-mates share the overlay through the zone's own tab strip
-              (SESSIONS | BOTS) — a lone pane keeps the stripless form. */}
-          {zonePanes.length > 1 && (
-            <PaneTabStrip>
-              {zonePanes.map(pane => (
-                <PaneTab
-                  active={pane.id === revealed.id}
-                  aria-selected={pane.id === revealed.id}
-                  data-narrow-overlay-tab={pane.id}
-                  key={pane.id}
-                  onPointerDown={event => {
-                    if (event.button === 0) {
-                      event.preventDefault()
-                      setReveal(current => ({ id: pane.id, pinned: current?.pinned ?? false }))
-                    }
-                  }}
-                >
-                  <PaneTabLabel>{pane.title ?? pane.id}</PaneTabLabel>
-                </PaneTab>
-              ))}
-            </PaneTabStrip>
-          )}
-          <ContribBoundary id={revealed.id}>
-            {revealed.render && <ContribRender render={revealed.render} />}
-          </ContribBoundary>
-        </div>
+          <div
+            aria-label={revealed.title ?? revealed.id}
+            aria-modal={reveal?.pinned ? 'true' : undefined}
+            className={cn(
+              'absolute inset-y-0 z-[var(--z-narrow-overlay)] flex flex-col overflow-hidden bg-(--ui-sidebar-surface-background) shadow-2xl',
+              sessionsRevealed && 'touch-pan-y',
+              sideOf(revealed) === 'left'
+                ? 'left-0 border-r border-(--ui-stroke-secondary)'
+                : 'right-0 border-l border-(--ui-stroke-secondary)'
+            )}
+            // Floats OVER the layout, so under glass its surface must mask the
+            // panes beneath it — a see-through overlay reads as text bleeding
+            // through text. Contract: `[data-glass-opaque]` in styles.css.
+            data-glass-opaque=""
+            data-narrow-overlay-pane=""
+            data-sessions-swipe-close={sessionsRevealed ? sideOf(revealed) : undefined}
+            onMouseLeave={() => setReveal(current => (current?.pinned ? current : null))}
+            onPointerCancel={endSwipe}
+            onPointerDown={event => {
+              if (sessionsRevealed) {
+                beginSwipe(event, 'close', sideOf(revealed))
+              }
+            }}
+            onPointerMove={advanceSwipe}
+            onPointerUp={endSwipe}
+            role={reveal?.pinned ? 'dialog' : undefined}
+            // Match the pane's docked width (sessions ~237px, files its rail
+            // width) instead of a fat fixed 20rem — capped for tiny screens.
+            style={{ width: `min(${(revealed.data as { width?: string } | undefined)?.width ?? '18rem'}, 85vw)` }}
+            tabIndex={reveal?.pinned ? -1 : undefined}
+          >
+            {/* Zone-mates share the overlay through the zone's own tab strip
+                (SESSIONS | BOTS) — a lone pane keeps the stripless form. */}
+            {zonePanes.length > 1 && (
+              <PaneTabStrip>
+                {zonePanes.map(pane => (
+                  <PaneTab
+                    active={pane.id === revealed.id}
+                    aria-selected={pane.id === revealed.id}
+                    data-narrow-overlay-tab={pane.id}
+                    key={pane.id}
+                    onPointerDown={event => {
+                      if (event.button === 0) {
+                        event.preventDefault()
+                        setReveal(current => ({ id: pane.id, pinned: current?.pinned ?? false }))
+                      }
+                    }}
+                  >
+                    <PaneTabLabel>{pane.title ?? pane.id}</PaneTabLabel>
+                  </PaneTab>
+                ))}
+              </PaneTabStrip>
+            )}
+            <ContribBoundary id={revealed.id}>
+              {revealed.render && <ContribRender render={revealed.render} />}
+            </ContribBoundary>
+          </div>
+        </>
       )}
-    </>
+    </div>
   )
 }

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -242,6 +242,8 @@
        without a renumber. Local stacking inside a component (a sticky header
        over its own scroll area) stays on plain `z-10`/`z-20`; these rungs are
        only for surfaces that float over the app. */
+    --z-narrow-overlay-backdrop: 80;
+    --z-narrow-overlay: 90;
     --z-modal-backdrop: 120;
     --z-modal: 130;
     /* A select/dropdown/popover opened from inside a modal, portaled to body. */


### PR DESCRIPTION
## What does this PR do?

Adds touch first Sessions navigation for narrow desktop layouts. On phones and similarly narrow touch screens, users can swipe inward from anywhere in the left half of the viewport to reveal Sessions, swipe the revealed Sessions pane back toward its edge to close it, or tap the visible chat area to dismiss it.

The gesture accepts touch and pen input only. It requires 56 pixels of horizontal travel with 1.25 times horizontal dominance, so ordinary taps and primarily vertical scrolling remain native. The window listeners and temporary `touch-action` policy exist only while narrow mode is active and clean up exactly on exit. Existing desktop hover behavior is unchanged.

The drawer and its dismiss surface use dedicated application overlay ladder tokens. This keeps the dismiss surface above pane local sticky chat chrome, the Sessions drawer above the dismiss surface, and both below true modal dialogs. Pinned drawers use modal dialog semantics, move focus into the drawer, make background surfaces inert, and restore prior focus and inert state on close. The pointer dismissal surface is hidden from assistive technology and does not allow mouse or touch input to activate background controls. Desktop hover previews remain nonmodal and do not steal focus.

## Related Issue

N/A

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Updated `apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.tsx` with narrow-only touch and pen swipe navigation, chat-area dismissal, reverse swipe closing, and exact listener and style cleanup.
- Expanded `apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.test.tsx` to cover left-half starts, touch and pen input, reverse closing, right-half rejection, short and vertical rejection, cancellation, unsupported pointer types, tap dismissal, narrow-only behavior, cleanup, overlay ordering tokens, touch click through prevention, modal focus and inert restoration, and nonmodal desktop hover behavior.
- Added dedicated narrow overlay backdrop and content rungs to the existing application overlay ladder in `apps/desktop/src/styles.css`.

## How to Test

1. Use a narrow viewport and swipe right from anywhere in the left half with touch or pen. Sessions should open.
2. Swipe the open Sessions pane left or tap any visible chat content. Sessions should close.
3. Confirm right-half starts, short movement, primarily vertical movement, mouse input, cancelled gestures, and wide layouts do not trigger Sessions.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing issues and pull requests for duplicate mobile Sessions swipe work
- [x] My PR contains only changes related to this feature
- [x] I've added tests for the change
- [x] I've tested on Linux with browser renderer and Electron production build paths

### Documentation & Housekeeping

- [x] Documentation update is not applicable
- [x] Configuration example update is not applicable
- [x] Architecture documentation update is not applicable
- [x] Cross-platform impact was considered. Mouse and wide desktop behavior remain unchanged
- [x] Tool schema updates are not applicable

## Verification

- Focused narrow overlay suite: 11 of 11 passed
- Complete desktop UI suite on the exact final commit: 5,694 of 5,694 passed across 592 files using four workers
- Desktop TypeScript checks: passed for renderer, Electron, and end to end configurations
- ESLint on both changed TypeScript files with zero allowed warnings: passed
- Complete desktop lint: passed with the existing repository warnings and no warnings in the changed files
- Production desktop build: passed, including renderer assets, Electron main, preload, and native dependency staging
- Chromium mouse and mobile touchscreen tests: drawer receives pane taps, dismiss receives visible chat taps, background controls receive zero clicks, modal focus is contained, and prior focus is restored
- Public diff scan: exactly three interface files, with no credentials, private URLs, owner configuration, or infrastructure data

## Screenshots / Logs

Not included. The behavior is covered by deterministic pointer event tests, a real Chromium stacking hit test, and the production build.
