### PR TITLE
fix(desktop): reset stale group auto-continuations

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -7020,6 +7020,7 @@ async function ensureGroupChatSession(group, member) {
 
 const GROUP_TURN_TIMEOUT_MS = 180000
 const GROUP_TURN_POLL_MS = 2000
+const GROUP_AUTO_CONTINUE_RESET_TIMEOUT_MS = 180000
 
 // --- group-turn session-lease helpers (#93602) ------------------------------
 // A member turn is a session-scoped RPC SEQUENCE (resume → attach → submit →
@@ -7106,6 +7107,43 @@ async function submitGroupTurnPrompt(member, runtime, stored, text) {
 
     return fresh
   }
+}
+
+/** A cold session.resume may restart a crash-interrupted turn before the room
+ *  can submit its newer request. That recovery is safe to supersede because
+ *  it is backend-labelled `auto_continue`; an ordinary busy turn is never
+ *  interrupted here. session.interrupt also clears prompts that older room
+ *  loops may have queued behind the stale turn. Wait for the interrupted turn
+ *  to settle, then return a fresh baseline so none of its partial output can
+ *  be mistaken for the reply to the newer request. */
+async function resetAutoContinuedGroupTurn(member, runtime, stored, state) {
+  const autoContinuing = Boolean(state?.auto_continuing || state?.auto_continue)
+
+  if (!autoContinuing) {
+    return state
+  }
+
+  const sessionId = state?.session_id || runtime
+
+  await requestForBot(member, 'session.interrupt', { session_id: sessionId })
+
+  const deadline = Date.now() + GROUP_AUTO_CONTINUE_RESET_TIMEOUT_MS
+  let latest = state
+
+  while (Date.now() < deadline) {
+    latest = await requestForBot(member, 'session.resume', {
+      session_id: stored || sessionId,
+      profile: member.name
+    })
+
+    if (!latest?.auto_continuing && !latest?.auto_continue && !latest?.running && !latest?.inflight) {
+      return latest
+    }
+
+    await new Promise(resolve => setTimeout(resolve, GROUP_TURN_POLL_MS))
+  }
+
+  throw new Error(`Could not reset ${member?.name || 'member'}'s interrupted group turn before the timeout`)
 }
 
 // A member turn that is VISIBLY still working (session reports
@@ -7287,14 +7325,20 @@ async function runGroupChatMemberTurnLeased(group, member, prompt, thread, image
   // Baseline: how many messages exist before our submit.
   let before = 0
 
+  let pre = null
+
   try {
-    const pre = await requestForBot(member, 'session.resume', {
+    pre = await requestForBot(member, 'session.resume', {
       session_id: stored || runtime,
       profile: member.name
     })
-    before = Array.isArray(pre?.messages) ? pre.messages.length : pre?.message_count || 0
   } catch {
     /* lazy session — zero messages */
+  }
+
+  if (pre) {
+    pre = await resetAutoContinuedGroupTurn(member, runtime, stored, pre)
+    before = Array.isArray(pre?.messages) ? pre.messages.length : pre?.message_count || 0
   }
 
   // Stage this delta's attachments into the member's session so the model

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -7128,16 +7128,25 @@ async function resetAutoContinuedGroupTurn(member, runtime, stored, state) {
   await requestForBot(member, 'session.interrupt', { session_id: sessionId })
 
   const deadline = Date.now() + GROUP_AUTO_CONTINUE_RESET_TIMEOUT_MS
-  let latest = state
 
   while (Date.now() < deadline) {
-    latest = await requestForBot(member, 'session.resume', {
-      session_id: stored || sessionId,
+    // session.resume is not a read-only probe: a cold resume can mint a new
+    // runtime and synthesize crash recovery. Poll the existing live-session
+    // inventory instead, then resume exactly once below for the clean message
+    // baseline after the interrupted worker has actually settled.
+    const active = await requestForBot(member, 'session.active_list', {
+      current_session_id: sessionId,
       profile: member.name
     })
+    const live = (Array.isArray(active?.sessions) ? active.sessions : []).find(
+      row => row?.id === sessionId || (stored && row?.session_key === stored)
+    )
 
-    if (!latest?.auto_continuing && !latest?.auto_continue && !latest?.running && !latest?.inflight) {
-      return latest
+    if (!live || (live.status !== 'working' && live.status !== 'starting')) {
+      return requestForBot(member, 'session.resume', {
+        session_id: stored || sessionId,
+        profile: member.name
+      })
     }
 
     await new Promise(resolve => setTimeout(resolve, GROUP_TURN_POLL_MS))
@@ -7337,6 +7346,10 @@ async function runGroupChatMemberTurnLeased(group, member, prompt, thread, image
   }
 
   if (pre) {
+    // Fail closed on reset errors. Submitting after we identified an active
+    // crash continuation but could not prove it settled can queue behind, or
+    // be confused with, the stale turn. That is categorically different from
+    // the lazy-session resume miss above, where no competing turn was seen.
     pre = await resetAutoContinuedGroupTurn(member, runtime, stored, pre)
     before = Array.isArray(pre?.messages) ? pre.messages.length : pre?.message_count || 0
   }

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -23,6 +23,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
   const calls = []
   const clarifyResponds = []
   const approvalResponds = []
+  const interrupts = []
   const requests = []
   const sessions = new Map()
   const runtimeToStored = new Map()
@@ -153,13 +154,15 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
           // Same window shape for pending command approvals (#90694 class).
           const approval = approvalUntilResumeCall && approvalUntilResumeCall[profile]
           const pendingApproval = approval && seen <= approval.until ? approval.payload : null
+          const autoContinuing = Boolean(session.autoContinuing)
           return {
             session_id: session.runtime,
             session_key: session.stored,
             message_count: session.messages.length,
             messages: [...session.messages],
-            inflight: busy,
-            running: busy,
+            inflight: busy || autoContinuing,
+            running: busy || autoContinuing,
+            auto_continuing: autoContinuing,
             ...(pendingClarify ? { pending_clarify: pendingClarify } : {}),
             ...(pendingApproval ? { pending_approval: pendingApproval } : {})
           }
@@ -180,6 +183,15 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
           const reply = turnScript(session.profile, params.text, calls.length, session)
           session.messages.push({ role: 'assistant', content: reply })
           return {}
+        }
+        if (method === 'session.interrupt') {
+          const session = resolveSession(null, params.session_id)
+          if (!session) {
+            throw new Error(`runtime session not found: ${params.session_id}`)
+          }
+          session.autoContinuing = false
+          interrupts.push({ profile: session.profile, session_id: params.session_id })
+          return { status: 'interrupted' }
         }
         if (method === 'clarify.respond') {
           clarifyResponds.push({ ...params })
@@ -204,7 +216,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, runGroupChatMemberTurnLeased, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -212,7 +224,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     storage: { get: () => null, set: (key, value) => storageWrites.set(key, value) },
     register: () => undefined
   })
-  return { ...context.__gc, approvalResponds, calls, clarifyResponds, host: context.host, requests, sessions, storageWrites, sharedUiMeta, uiMetaRevisions }
+  return { ...context.__gc, approvalResponds, calls, clarifyResponds, host: context.host, interrupts, requests, sessions, storageWrites, sharedUiMeta, uiMetaRevisions }
 }
 
 const MEMBERS = [{ name: 'research', title: '' }, { name: 'builder', title: '' }, { name: 'ops', title: 'The Ops' }]
@@ -402,6 +414,43 @@ test('concurrent groups sharing one member keep sessions, deltas, and context is
   const betaSession = gc.sessions.get(betaFirst.stored)
   assert.equal(alphaSession.messages.some(message => String(message.content).includes('BETA_ONLY')), false)
   assert.equal(betaSession.messages.some(message => String(message.content).includes('ALPHA_ONLY')), false)
+})
+
+test('a newer room request resets a crash auto-continuation before submitting', async () => {
+  const gc = load(() => 'fresh reply')
+  const member = { name: 'research', title: '' }
+
+  gc.updateGroupChat('Room', room => {
+    room.roomId = 'r-reset'
+    return room
+  })
+  const ids = await gc.ensureGroupChatSession('Room', member)
+  gc.sessions.get(ids.stored).autoContinuing = true
+
+  const reply = await gc.runGroupChatMemberTurnLeased('Room', member, 'new request', 'thread-new', [])
+
+  assert.equal(reply, 'fresh reply')
+  assert.deepEqual(gc.interrupts, [{ profile: 'research', session_id: ids.runtime }])
+  const interruptIndex = gc.requests.findIndex(request => request.method === 'session.interrupt')
+  const submitIndex = gc.requests.findIndex(request => request.method === 'prompt.submit')
+  assert.ok(interruptIndex >= 0 && interruptIndex < submitIndex, 'stale recovery is interrupted before the new prompt')
+})
+
+test('ordinary busy member work is never reset as a stale continuation', async () => {
+  const gc = load(() => 'finished normally', {
+    busyUntilResumeCall: { research: 2 }
+  })
+
+  const reply = await gc.runGroupChatMemberTurnLeased(
+    'Room',
+    { name: 'research', title: '' },
+    'follow-up',
+    'thread-a',
+    []
+  )
+
+  assert.equal(reply, 'finished normally')
+  assert.equal(gc.interrupts.length, 0)
 })
 
 test('recreating a same-name group after disband mints fresh member sessions', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -167,6 +167,15 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
             ...(pendingApproval ? { pending_approval: pendingApproval } : {})
           }
         }
+        if (method === 'session.active_list') {
+          return {
+            sessions: [...sessions.values()].map(session => ({
+              id: session.runtime,
+              session_key: session.stored,
+              status: session.autoContinuing ? 'working' : 'idle'
+            }))
+          }
+        }
         if (method === 'prompt.submit') {
           const session = resolveSession(null, params.session_id)
           if (!session) {
@@ -434,6 +443,12 @@ test('a newer room request resets a crash auto-continuation before submitting', 
   const interruptIndex = gc.requests.findIndex(request => request.method === 'session.interrupt')
   const submitIndex = gc.requests.findIndex(request => request.method === 'prompt.submit')
   assert.ok(interruptIndex >= 0 && interruptIndex < submitIndex, 'stale recovery is interrupted before the new prompt')
+  const settlementMethods = gc.requests.slice(interruptIndex + 1, submitIndex).map(request => request.method)
+  assert.deepEqual(
+    settlementMethods,
+    ['session.active_list', 'session.resume'],
+    'settlement is polled read-only, then resumed once for the clean baseline'
+  )
 })
 
 test('ordinary busy member work is never reset as a stale continuation', async () => {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -625,6 +625,10 @@ export interface SessionResumeResponse {
     attempt: number
     interrupted_at: number
   }
+  /** True while a crash-recovery continuation is scheduled or running.
+   *  Unlike `running`, this explicitly identifies synthesized work that a
+   *  newer user request may safely supersede. */
+  auto_continuing?: boolean
   hydrating?: boolean
   inflight?: null | {
     assistant?: string

--- a/tests/fixtures/session-resume-active-turn.json
+++ b/tests/fixtures/session-resume-active-turn.json
@@ -21,6 +21,7 @@
   "messages_omitted": false,
   "resumed": "stored-running",
   "running": true,
+  "auto_continuing": false,
   "session_id": "rt-running",
   "session_key": "stored-running",
   "started_at": 1700000000.0,

--- a/tests/tui_gateway/test_auto_continue.py
+++ b/tests/tui_gateway/test_auto_continue.py
@@ -352,6 +352,44 @@ def test_double_schedule_is_guarded(emits, schedule_env, marker_home):
     assert len(schedule_env) == 1
 
 
+def test_live_payload_labels_scheduled_and_running_auto_continuations():
+    scheduled = server._live_session_payload(
+        "sid",
+        _session(_auto_continue_scheduled=True),
+        omit_messages=True,
+    )
+    running = server._live_session_payload(
+        "sid",
+        _session(_auto_continue_attempt=1, running=True),
+        omit_messages=True,
+    )
+    ordinary = server._live_session_payload(
+        "sid",
+        _session(running=True),
+        omit_messages=True,
+    )
+
+    assert scheduled["auto_continuing"] is True
+    assert running["auto_continuing"] is True
+    assert ordinary["auto_continuing"] is False
+
+
+def test_interrupt_retires_auto_continue_marker(marker_home):
+    record_turn_start(marker_home, "session-key", "old request")
+    session = _session(
+        _auto_continue_scheduled=True,
+        _auto_continue_attempt=1,
+        _auto_continue_prompt="old request",
+    )
+
+    server._interrupt_session_turn("sid", session)
+
+    assert session["_auto_continue_scheduled"] is False
+    assert "_auto_continue_attempt" not in session
+    assert "_auto_continue_prompt" not in session
+    assert read_turn_marker(marker_home, "session-key") is None
+
+
 def test_failed_agent_build_leaves_marker_for_retry(
     emits, schedule_env, marker_home, monkeypatch
 ):
@@ -372,5 +410,3 @@ def test_failed_agent_build_leaves_marker_for_retry(
 
 
 # ── End to end: continuation runs a real turn and clears the marker ────
-
-

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1121,7 +1121,18 @@ def _interrupt_session_turn(
         run_thread_alive = run_thread is not None and run_thread.is_alive()
 
     with session["history_lock"]:
+        auto_continuing = bool(
+            session.get("_auto_continue_scheduled")
+            or session.get("_auto_continue_attempt")
+        )
         session["_turn_cancel_requested"] = True
+        # An explicit interrupt owns the recovery decision. Retire both the
+        # pending/running continuation metadata and its durable crash marker,
+        # otherwise the same cancelled work is auto-started again after the
+        # next Desktop restart.
+        session["_auto_continue_scheduled"] = False
+        session.pop("_auto_continue_attempt", None)
+        session.pop("_auto_continue_prompt", None)
         session["queued_prompt"] = None
         session.pop("queued_prompts", None)
         session["_queued_prompt_generation"] = int(
@@ -1138,6 +1149,9 @@ def _interrupt_session_turn(
                 if session.get("running"):
                     session["running"] = False
                     _clear_inflight_turn(session)
+
+    if auto_continuing:
+        _retire_turn_marker(session)
 
     _clear_pending(sid)
     try:
@@ -9615,6 +9629,16 @@ def _live_session_payload(
         inflight = _inflight_snapshot(session)
         queued = _queued_prompt_snapshot(session)
         running = bool(session.get("running"))
+        # Crash-recovery turns are synthesized by session.resume, not by the
+        # person currently driving this client. Expose that distinction so a
+        # newer explicit request can safely supersede the recovery without
+        # treating every ordinary busy session as disposable. The scheduled
+        # bit covers the deferred agent-build window; the attempt bit covers
+        # the running continuation itself.
+        auto_continuing = bool(
+            session.get("_auto_continue_scheduled")
+            or session.get("_auto_continue_attempt")
+        )
         inflight_turn = session.get("inflight_turn")
         turn_started_at = (
             float(inflight_turn["started_at"])
@@ -9640,6 +9664,7 @@ def _live_session_payload(
         "messages": [] if omit_messages else _history_to_messages(history),
         "messages_omitted": omit_messages,
         "running": running,
+        "auto_continuing": auto_continuing,
         "turn_started_at": turn_started_at,
         "session_id": sid,
         "session_key": _session_lookup_key(session, fallback=sid),


### PR DESCRIPTION
## What does this PR do?

Makes explicit interruption of crash-recovery continuations durable, and lets a newer Bot Mode group request safely supersede stale recovery work.

A cold `session.resume` can synthesize an auto-continuation for a turn interrupted by a crash. Without an explicit signal, Desktop cannot distinguish that recovery from ordinary active work, so a newer group request may wait behind it or be replayed against stale output. The gateway now exposes `auto_continuing`; Bot Mode interrupts only that labelled recovery, waits for it to settle, and then establishes a fresh reply baseline. Ordinary busy turns are left untouched.

The interrupt path also clears queued prompts and retires the durable recovery marker, preventing cancelled work from being restarted after another Desktop launch.

## Related Issue

No exact existing issue found. This is adjacent to the group-session lifecycle work in #93602.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Expose `auto_continuing` in live session payloads for scheduled and running crash recovery.
- Make `session.interrupt` clear recovery metadata, queued prompts, and the durable turn marker.
- Reset labelled recovery work before a newer group member turn is submitted.
- Wait for the interrupted session to settle and take a fresh message baseline.
- Preserve ordinary inflight/running group work.
- Add gateway, protocol-fixture, Desktop type, and Bot Mode regression coverage.

## How to Test

1. Run `npm --prefix apps/desktop run check:test:plugins`.
2. Run `./venv/bin/python -m pytest tests/tui_gateway/test_auto_continue.py -q`.
3. Run `npm --prefix apps/desktop run typecheck`.
4. Start with a crash-recovery continuation pending, send a newer group request, and verify the recovery is cancelled and only the fresh response is published.
5. Repeat with ordinary active member work and verify it is not interrupted.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is documented inline and in the typed response
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; this extends an existing response payload

## Screenshots / Logs

- Desktop plugin tests: 558 passed, 0 failed.
- Gateway auto-continuation tests: 17 passed.
- Desktop TypeScript checks: passed.
- Live group-chat smoke test: one fresh response published after recovery reset.
