### PR TITLE
fix(weixin): stop live replies from silently exhausting iLink contexts

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -113,6 +113,8 @@ BACKOFF_DELAY_SECONDS = 30
 SESSION_EXPIRED_ERRCODE = -14
 RATE_LIMIT_ERRCODE = -2  # iLink frequency limit — backoff and retry
 MESSAGE_DEDUP_TTL_SECONDS = 300
+DEFAULT_CONTEXT_MESSAGE_BUDGET = 8
+MAX_CONTEXT_MESSAGE_BUDGET = 10
 
 
 def _is_stale_session_ret(
@@ -1227,6 +1229,17 @@ class WeixinAdapter(BasePlatformAdapter):
         )
         self._rate_limit_circuit_until = 0.0
         self._rate_limit_events: List[float] = []
+        try:
+            configured_context_budget = int(
+                extra.get("context_message_budget", DEFAULT_CONTEXT_MESSAGE_BUDGET)
+            )
+        except (TypeError, ValueError):
+            configured_context_budget = DEFAULT_CONTEXT_MESSAGE_BUDGET
+        self._context_message_budget = min(
+            MAX_CONTEXT_MESSAGE_BUDGET,
+            max(1, configured_context_budget),
+        )
+        self._context_send_counts: Dict[str, int] = {}
         self._dm_policy = str(extra.get("dm_policy") or _wx_secret("WEIXIN_DM_POLICY", "pairing")).strip().lower()
         self._group_policy = str(extra.get("group_policy") or _wx_secret("WEIXIN_GROUP_POLICY", "disabled")).strip().lower()
         allow_from = extra.get("allow_from")
@@ -1498,6 +1511,7 @@ class WeixinAdapter(BasePlatformAdapter):
 
         context_token = str(message.get("context_token") or "").strip()
         if context_token:
+            self._record_fresh_context(context_token)
             self._token_store.set(self._account_id, sender_id, context_token)
         asyncio.create_task(self._maybe_fetch_typing_ticket(sender_id, context_token or None))
 
@@ -1758,6 +1772,61 @@ class WeixinAdapter(BasePlatformAdapter):
             content, self.MAX_MESSAGE_LENGTH, self._split_multiline_messages,
         )
 
+    def _record_fresh_context(self, context_token: str) -> None:
+        """Reset the local outbound allowance after a fresh inbound turn."""
+        if context_token:
+            self._context_send_counts[context_token] = 0
+
+    def _ensure_context_budget(self, context_token: Optional[str]) -> None:
+        if not context_token:
+            return
+        if self._context_send_counts.get(context_token, 0) < self._context_message_budget:
+            return
+        raise RuntimeError(
+            "Weixin outbound safety budget exhausted for this context; "
+            "wait for a fresh inbound message before sending more bubbles"
+        )
+
+    def _record_context_send(self, context_token: Optional[str]) -> None:
+        if context_token:
+            self._context_send_counts[context_token] = (
+                self._context_send_counts.get(context_token, 0) + 1
+            )
+
+    def _log_send_response(
+        self,
+        response: Dict[str, Any],
+        *,
+        client_id: str,
+        context_token: Optional[str],
+        attempt: int,
+    ) -> None:
+        """Log iLink acceptance fields without claiming downstream delivery."""
+        ret = response.get("ret")
+        errcode = response.get("errcode")
+        accepted = ret in {0, None} and errcode in {0, None}
+        errmsg = re.sub(
+            r"[\x00-\x1f\x7f]+",
+            " ",
+            str(response.get("errmsg") or response.get("msg") or ""),
+        ).strip()[:160]
+        logger.info(
+            "[%s] sendmessage response path=live endpoint=%s ret=%s errcode=%s "
+            "errmsg=%r client=%s context=%s attempt=%d/%d circuit=%s "
+            "acceptance=%s delivery_ack=unavailable",
+            self.name,
+            EP_SEND_MESSAGE,
+            ret,
+            errcode,
+            errmsg,
+            _safe_id(client_id, keep=20),
+            str(bool(context_token)).lower(),
+            attempt + 1,
+            self._send_chunk_retries + 1,
+            "open" if self._rate_limit_cooldown_remaining() > 0 else "closed",
+            "accepted" if accepted else "rejected",
+        )
+
     def _rate_limit_cooldown_remaining(self) -> float:
         return max(0.0, self._rate_limit_circuit_until - time.monotonic())
 
@@ -1823,6 +1892,7 @@ class WeixinAdapter(BasePlatformAdapter):
         """Send a text chunk while holding the adapter-wide outbound text gate."""
         last_error: Optional[Exception] = None
         retried_without_token = False
+        self._ensure_context_budget(context_token)
         for attempt in range(self._send_chunk_retries + 1):
             if self._rate_limit_cooldown_remaining() > 0:
                 raise self._rate_limit_error()
@@ -1836,6 +1906,13 @@ class WeixinAdapter(BasePlatformAdapter):
                     context_token=context_token,
                     client_id=client_id,
                 )
+                if isinstance(resp, dict):
+                    self._log_send_response(
+                        resp,
+                        client_id=client_id,
+                        context_token=context_token,
+                        attempt=attempt,
+                    )
                 # Check iLink response for session-expired error
                 if resp and isinstance(resp, dict):
                     ret = resp.get("ret")
@@ -1887,6 +1964,7 @@ class WeixinAdapter(BasePlatformAdapter):
                         raise RuntimeError(
                             f"iLink sendmessage error: ret={ret} errcode={errcode} errmsg={errmsg}"
                         )
+                self._record_context_send(context_token)
                 self._reset_rate_limit_circuit()
                 return
             except Exception as exc:

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -3,6 +3,7 @@
 import asyncio
 import base64
 import json
+import logging
 import os
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -269,6 +270,72 @@ class TestWeixinChunkDelivery:
         # rest of the current chunk and follow-up sends fail fast.
         assert send_message_mock.await_count == 2
         assert sleep_mock.await_count == 1
+
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_send_logs_api_acceptance_without_claiming_delivery(
+        self, send_message_mock, caplog,
+    ):
+        adapter = self._connected_adapter()
+        send_message_mock.return_value = {
+            "ret": 0,
+            "errcode": 0,
+            "errmsg": "ok\nignored-control-line",
+        }
+
+        with caplog.at_level(logging.INFO, logger="gateway.platforms.weixin"):
+            result = asyncio.run(adapter.send("wxid_test123", "hello"))
+
+        assert result.success is True
+        [record] = [
+            record for record in caplog.records
+            if "sendmessage response" in record.getMessage()
+        ]
+        message = record.getMessage()
+        assert "path=live" in message
+        assert "ret=0" in message
+        assert "errcode=0" in message
+        assert "context=true" in message
+        assert "acceptance=accepted" in message
+        assert "delivery_ack=unavailable" in message
+        assert "ignored-control-line" in message
+        assert "\n" not in message
+        assert "wxid_test123" not in message
+        assert "ctx-token" not in message
+
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_context_budget_blocks_excess_bubbles_until_fresh_inbound(
+        self, send_message_mock,
+    ):
+        adapter = WeixinAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="test-token",
+                extra={
+                    "account_id": "test-account",
+                    "context_message_budget": 2,
+                },
+            )
+        )
+        adapter._session = object()
+        adapter._send_session = adapter._session
+        adapter._token_store.get = lambda account_id, chat_id: "ctx-token"
+        send_message_mock.return_value = {"ret": 0, "errcode": 0}
+
+        first = asyncio.run(adapter.send("wxid_test123", "first"))
+        second = asyncio.run(adapter.send("wxid_test123", "second"))
+        blocked = asyncio.run(adapter.send("wxid_test123", "third"))
+
+        assert first.success is True
+        assert second.success is True
+        assert blocked.success is False
+        assert "fresh inbound message" in (blocked.error or "")
+        assert send_message_mock.await_count == 2
+
+        adapter._record_fresh_context("ctx-token")
+        recovered = asyncio.run(adapter.send("wxid_test123", "after inbound"))
+
+        assert recovered.success is True
+        assert send_message_mock.await_count == 3
 
 
 class TestWeixinOutboundMedia:


### PR DESCRIPTION
## What does this PR do?

Weixin live replies can emit many progress, interim, and final bubbles under one inbound context token. Once iLink starts suppressing delivery, Hermes currently discards the send response and reports success as though API acceptance proved user-visible delivery. This change caps each inbound context to a conservative outbound budget and records sanitized API acceptance fields while explicitly stating that iLink exposes no delivery acknowledgement.

### Symptom

The gateway logs that it is sending a live reply and returns a successful `SendResult`, but the WeChat client may receive nothing after rate-limit incidents. Operators cannot tell whether iLink rejected the request, accepted it without confirming delivery, or whether the local rate-limit circuit was active.

### Impact

Affected Weixin channels can become effectively inbound-only while Hermes continues to report successful outbound sends. The blast radius beyond reported affected accounts is unknown.

### Bug Cause

**Trigger:** `gateway/platforms/weixin.py` in `WeixinAdapter._send_text_chunk_locked`, when several outbound bubbles share one inbound `context_token`.

**Causal chain:**
1. Global progress/interim settings can produce multiple live `sendmessage` calls under the same inbound context.
2. Hermes has no per-context outbound budget, and after each call it discards the raw iLink response once `ret` and `errcode` appear successful.
3. iLink can accept a request without exposing downstream delivery acknowledgement, so Hermes returns `SendResult(success=True)` with no evidence distinguishing API acceptance from client delivery.

**Why it is wrong:** An upstream acceptance response is not a delivery receipt. Unbounded bubbles also let local notification traffic repeatedly consume the same context and trigger upstream suppression.

**Working sibling / contrast:** Explicit nonzero `ret` or `errcode` responses already fail the send and surface an error. The silent path is limited to accepted responses for which iLink provides no delivery signal.

**Ruled out:** The live-adapter reproduction excludes the standalone `send_weixin_direct` session conflict. The reporter also tested the protocol 2.4.3 lifecycle handshake from closed PR #25004 without restoring delivery, so this change does not repeat that unrelated approach.

### Fix

- Track accepted text bubbles per inbound context token and fail closed after eight sends until a fresh inbound message resets the allowance.
- Log every live `sendmessage` response with sanitized endpoint, `ret`, `errcode`, `errmsg`, client ID prefix, context use, retry/circuit state, and explicit `delivery_ack=unavailable` semantics.
- Add regression tests proving both the accepted-but-unconfirmed observability contract and local budget recovery after fresh inbound context.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/weixin.py` - bound live text sends per inbound context and expose sanitized acceptance diagnostics.
- `tests/gateway/test_weixin.py` - cover unconfirmed acceptance logs and budget reset behavior.

## How to Test

1. Configure a Weixin adapter with `context_message_budget: 2` in its platform extras and reuse one context token.
2. Send three live text bubbles; verify the third fails before another iLink request and asks for a fresh inbound message.
3. Record a fresh inbound context, send again, and verify the allowance recovers.
4. Verify an accepted response logs `acceptance=accepted delivery_ack=unavailable` without peer IDs or context tokens.
5. Automated test run: 32 passed.

```bash
scripts/run_tests.sh tests/gateway/test_weixin.py -q
uv run ruff check gateway/platforms/weixin.py tests/gateway/test_weixin.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; the behavior is internal safety and observability
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; this is a dynamic platform extra
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Not included. Regression tests assert the sanitized log contract without exposing account data.