### PR TITLE
fix(desktop): keep a mounted tile's owner socket alive and route its model catalog to the owner (#93892)

### DIFF
--- a/apps/desktop/src/api/models.ts
+++ b/apps/desktop/src/api/models.ts
@@ -31,7 +31,7 @@ export function getGlobalModelOptions(
     includeUnconfigured?: boolean
     explicitOnly?: boolean
   },
-  profile?: null | string
+  profile?: ProfileScope
 ): Promise<ModelOptionsResponse> {
   const params = new URLSearchParams()
 
@@ -47,8 +47,13 @@ export function getGlobalModelOptions(
     params.set('explicit_only', '1')
   }
 
-  return hermesApi<ModelOptionsResponse>({
-    ...profileScoped(profile),
+  // Unlike the global/active model-info read, catalog recovery may belong to
+  // a mounted surface on another (connection, profile) pair. An explicit
+  // ProfileScope must override BOTH ambient dimensions; capabilityScoped is
+  // the shared connection-aware REST routing seam that already enforces that
+  // invariant for skills/toolsets/MCP.
+  return window.hermesDesktop.api<ModelOptionsResponse>({
+    ...capabilityScoped(profile),
     path: params.size > 0 ? `/api/model/options?${params.toString()}` : '/api/model/options',
     timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
   })

--- a/apps/desktop/src/app/chat/composer/model-pill.test.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.test.tsx
@@ -1,12 +1,12 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, render, screen } from '@testing-library/react'
 import { atom } from 'nanostores'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChatBarState } from '@/app/chat/composer/types'
 import { type SessionView, SessionViewProvider } from '@/app/chat/session-view'
 import { $activeSessionId, $currentModel, setCurrentModel, setCurrentModelSource } from '@/store/session'
 
-import { ModelPill } from './model-pill'
+import { MODEL_RESOLVE_GRACE_MS, ModelPill } from './model-pill'
 
 const modelState = (over: Partial<ChatBarState['model']> = {}): ChatBarState['model'] => ({
   canSwitch: true,
@@ -113,5 +113,91 @@ describe('ModelPill per-surface model label', () => {
 
     expect(screen.getByText('Sonnet · High')).toBeTruthy()
     expect(screen.queryByText(/primary/i)).toBeNull()
+  })
+})
+
+// #93892: the pill's loader used to spin for as long as the surface had no
+// model — with no timer, error or retry cap. It is now a bounded grace per
+// surface identity, after which the pill admits "no model" and stays usable.
+describe('ModelPill bounded loader', () => {
+  const tileView = (runtimeId: string, model = ''): SessionView => ({
+    kind: 'tile',
+    $awaitingResponse: atom(false),
+    $busy: atom(false),
+    $cwd: atom(''),
+    $fast: atom(false),
+    $lastVisibleIsUser: atom(false),
+    $messages: atom([]),
+    $messagesEmpty: atom(true),
+    $model: atom(model),
+    $provider: atom(''),
+    $reasoningEffort: atom(''),
+    $runtimeId: atom(runtimeId),
+    $storedId: atom('stored-tile'),
+    $turnStartedAt: atom<number | null>(null)
+  })
+
+  const renderEmptyPill = (view: SessionView) =>
+    render(
+      <SessionViewProvider value={view}>
+        <ModelPill disabled={false} model={modelState({ model: '', provider: '', modelMenuContent: <div /> })} />
+      </SessionViewProvider>
+    )
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('spins only for the grace window, then shows the empty label', () => {
+    vi.useFakeTimers()
+    renderEmptyPill(tileView('rt-1'))
+
+    expect(screen.queryByTestId('model-pill-no-model')).toBeNull()
+
+    act(() => {
+      vi.advanceTimersByTime(MODEL_RESOLVE_GRACE_MS - 1)
+    })
+    expect(screen.queryByTestId('model-pill-no-model')).toBeNull()
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(screen.getByTestId('model-pill-no-model').textContent).toBe('no model')
+  })
+
+  it('does not re-arm the loader when the runtime is rebound (reclaim → resume)', () => {
+    vi.useFakeTimers()
+    const view = tileView('rt-1')
+    renderEmptyPill(view)
+
+    act(() => {
+      vi.advanceTimersByTime(MODEL_RESOLVE_GRACE_MS)
+    })
+    expect(screen.getByTestId('model-pill-no-model')).toBeTruthy()
+
+    // The loop's signature: same stored session, a fresh runtime every cycle.
+    act(() => {
+      ;(view.$runtimeId as ReturnType<typeof atom<null | string>>).set('rt-2')
+    })
+
+    expect(screen.getByTestId('model-pill-no-model')).toBeTruthy()
+  })
+
+  it('paints the model as soon as one lands, before or after the grace', () => {
+    vi.useFakeTimers()
+    const view = tileView('rt-1')
+    renderEmptyPill(view)
+
+    act(() => {
+      vi.advanceTimersByTime(MODEL_RESOLVE_GRACE_MS)
+    })
+    expect(screen.getByTestId('model-pill-no-model')).toBeTruthy()
+
+    act(() => {
+      ;(view.$model as ReturnType<typeof atom<string>>).set('tile/claude-sonnet')
+    })
+
+    expect(screen.queryByTestId('model-pill-no-model')).toBeNull()
+    expect(screen.getByText(/^Sonnet/)).toBeTruthy()
   })
 })

--- a/apps/desktop/src/app/chat/composer/model-pill.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.tsx
@@ -27,6 +27,16 @@ const PILL = cn(
 )
 
 /**
+ * How long the pill shows its loader for a surface with no model before it
+ * admits "no model" (#93892). The loader exists to hide the beat between a
+ * gateway/session coming up and its `session.info` landing — not to spin
+ * for as long as a session's owner socket churns. Past the grace the pill
+ * paints the (translated) empty label and stays a working control: the menu
+ * still opens and a pick still lands.
+ */
+export const MODEL_RESOLVE_GRACE_MS = 8_000
+
+/**
  * Composer model selector — the relocated status-bar pill. Reuses the live
  * `model.options` dropdown (`modelMenuContent`) verbatim; falls back to the
  * full picker when the gateway is closed and no live menu exists.
@@ -56,9 +66,30 @@ export function ModelPill({
   const modelSource = useStore($currentModelSource)
   const defaultEffort = useStore($defaultReasoningEffort)
   const runtimeId = useStore(view.$runtimeId)
+  const storedId = useStore(view.$storedId)
   const [open, setOpen] = useState(false)
   const scope = useComposerScope()
   const hasLiveMenu = Boolean(model.modelMenuContent)
+  const hasModel = Boolean(currentModel.trim())
+
+  // Bounded loader: one grace window per surface identity (the durable stored
+  // id, not the runtime — a reclaimed/re-resumed runtime must not re-arm it).
+  // Once the grace has lapsed for this surface it stays lapsed until a model
+  // lands, so a model that comes and goes never brings the loader back.
+  const graceKey = storedId ?? runtimeId ?? 'draft'
+  const [graceLapsedFor, setGraceLapsedFor] = useState<null | string>(null)
+
+  useEffect(() => {
+    if (hasModel) {
+      return
+    }
+
+    const timer = window.setTimeout(() => setGraceLapsedFor(graceKey), MODEL_RESOLVE_GRACE_MS)
+
+    return () => window.clearTimeout(timer)
+  }, [graceKey, hasModel])
+
+  const showNoModel = !hasModel && graceLapsedFor === graceKey
 
   // The `composer.modelPicker` hotkey, routed to exactly one surface (the pane
   // under the pointer, else the active composer — see requestModelMenuToggle).
@@ -96,9 +127,13 @@ export function ModelPill({
     <ChevronDown className="size-3.5 shrink-0 opacity-70" />
   ) : (
     <>
-      {currentModel.trim() ? (
+      {hasModel ? (
         <span className="truncate">
           {formatModelStatusLabel(currentModel, { defaultEffort, fastMode, reasoningEffort })}
+        </span>
+      ) : showNoModel ? (
+        <span className="truncate" data-testid="model-pill-no-model">
+          {copy.noModel}
         </span>
       ) : (
         <GlyphSpinner className="opacity-50" spinner="braille" />

--- a/apps/desktop/src/app/chat/session-tile.test.ts
+++ b/apps/desktop/src/app/chat/session-tile.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import { sessionTileResumeFailure } from './session-tile'
+import {
+  createTileResumeBudget,
+  recentTileResumes,
+  sessionTileResumeFailure,
+  TILE_RESUME_STORM_LIMIT,
+  TILE_RESUME_STORM_WINDOW_MS,
+  tileResumeStormed
+} from './session-tile'
 
 describe('sessionTileResumeFailure', () => {
   it('keeps a confirmed durable session retryable instead of repeating a stale 404', () => {
@@ -15,5 +22,61 @@ describe('sessionTileResumeFailure', () => {
 
   it('does not overwrite a tile that rebound while the lookup was pending', () => {
     expect(sessionTileResumeFailure('session not found', true, false)).toBeUndefined()
+  })
+})
+
+// #93892: the resume chain had per-step timeouts but no overall budget, so a
+// runtime that resumed and was reclaimed over and over spun the loader
+// forever. These pin the budget helpers and the pane's use of them.
+describe('tile resume storm budget', () => {
+  it('counts only resumes inside the window', () => {
+    const now = 1_000_000
+    const stale = now - TILE_RESUME_STORM_WINDOW_MS
+    const fresh = now - TILE_RESUME_STORM_WINDOW_MS + 1
+
+    expect(recentTileResumes([stale, fresh, now], now)).toEqual([fresh, now])
+  })
+
+  it('trips once the limit of successful resumes lands inside one window', () => {
+    const now = 1_000_000
+    const underLimit = Array.from({ length: TILE_RESUME_STORM_LIMIT - 1 }, (_, i) => now - i * 1_000)
+    const atLimit = Array.from({ length: TILE_RESUME_STORM_LIMIT }, (_, i) => now - i * 1_000)
+
+    expect(tileResumeStormed(underLimit, now)).toBe(false)
+    expect(tileResumeStormed(atLimit, now)).toBe(true)
+  })
+
+  it('lets an old storm age out of the window', () => {
+    const then = 1_000_000
+    const storm = Array.from({ length: TILE_RESUME_STORM_LIMIT }, (_, i) => then - i * 1_000)
+
+    expect(tileResumeStormed(storm, then)).toBe(true)
+    expect(tileResumeStormed(storm, then + TILE_RESUME_STORM_WINDOW_MS)).toBe(false)
+  })
+
+  it('createTileResumeBudget: successes spend it, the next take past the limit latches, Retry starts clean', () => {
+    let now = 1_000_000
+    const budget = createTileResumeBudget(() => now)
+
+    // The reclaim loop: each cycle resumes (take + spend) ~20s apart.
+    for (let cycle = 0; cycle < TILE_RESUME_STORM_LIMIT; cycle += 1) {
+      expect(budget.take()).toBe(true)
+      budget.spend()
+      now += 20_000
+    }
+
+    // One more cycle inside the window: the pane must latch, not dial.
+    expect(budget.take()).toBe(false)
+
+    // The user's Retry (or a gateway reopen) gets a clean budget.
+    expect(budget.take()).toBe(true)
+  })
+
+  it('createTileResumeBudget: failed resumes do not spend it', () => {
+    const budget = createTileResumeBudget(() => 1_000_000)
+
+    for (let attempt = 0; attempt < TILE_RESUME_STORM_LIMIT * 2; attempt += 1) {
+      expect(budget.take()).toBe(true)
+    }
   })
 })

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -76,6 +76,66 @@ import { ChatView } from '.'
 
 const NO_MESSAGES: ChatMessage[] = []
 
+/**
+ * Total resume budget for one tile (#93892). Every dial/RPC/hydration in the
+ * resume chain has its own timeout, but the chain as a whole had none: a
+ * runtime that genuinely resumes and is then reclaimed (`session.reclaimed`
+ * unbinds the tile, which re-arms the resume effect) looped forever behind
+ * the loader. More than TILE_RESUME_STORM_LIMIT successful resumes inside
+ * TILE_RESUME_STORM_WINDOW_MS is not recovery any more — latch the error
+ * card so the user gets a terminal state and a Retry (which re-opens the
+ * budget). A normal sleep/wake or backend restart re-resumes once or twice;
+ * the reclaim loop cycles roughly every orphan-reap grace (~20s).
+ */
+export const TILE_RESUME_STORM_WINDOW_MS = 120_000
+export const TILE_RESUME_STORM_LIMIT = 4
+export const TILE_RESUME_STORM_MESSAGE =
+  'Session keeps losing its backend runtime right after resuming — retry to resume it again.'
+
+/** The resume timestamps still inside the storm window at `now`. */
+export function recentTileResumes(resumedAt: readonly number[], now: number): number[] {
+  return resumedAt.filter(at => now - at < TILE_RESUME_STORM_WINDOW_MS)
+}
+
+/** True once the resume budget is exhausted: the next resume must latch the
+ *  error card instead of dialing again. */
+export function tileResumeStormed(resumedAt: readonly number[], now: number): boolean {
+  return recentTileResumes(resumedAt, now).length >= TILE_RESUME_STORM_LIMIT
+}
+
+export interface TileResumeBudget {
+  /** Ask before dialing. False = the budget is spent: latch the error card
+   *  instead. The budget resets on that answer so a Retry gets a clean cycle. */
+  take: () => boolean
+  /** A resume SUCCEEDED (bound a runtime) — only successes spend budget;
+   *  failures already latch their own error. */
+  spend: () => void
+}
+
+/** One tile's resume budget — the pane keeps one for its lifetime. */
+export function createTileResumeBudget(now: () => number = Date.now): TileResumeBudget {
+  let resumedAt: number[] = []
+
+  return {
+    take: () => {
+      const at = now()
+
+      if (tileResumeStormed(resumedAt, at)) {
+        resumedAt = []
+
+        return false
+      }
+
+      resumedAt = recentTileResumes(resumedAt, at)
+
+      return true
+    },
+    spend: () => {
+      resumedAt = [...resumedAt, now()]
+    }
+  }
+}
+
 export function sessionTileResumeFailure(
   message: string,
   durableSessionFound: boolean | undefined,
@@ -167,6 +227,25 @@ function TileChat({
 
   const { selectModel } = useModelControls({ queryClient, requestGateway: requestTileGateway })
   const activeGatewayProfile = useStore($activeGatewayProfile)
+
+  // Catalog profile for the model menu (#93892): the owner's for a local
+  // (or legacy profile) route, so the REST recovery read is scoped to the
+  // profile that owns this session. A remote route stays UNPINNED: the REST
+  // client scopes by the ACTIVE connection, so pinning the owner's profile
+  // name there would ask a stranger backend for a same-named profile. The
+  // owner-routed gateway read (requestTileGateway) is authoritative for it.
+  const catalogProfile = useMemo(() => {
+    if (!ownerRoute?.connectionId) {
+      return ownerRoute?.profile || activeGatewayProfile
+    }
+
+    if (ownerRoute.mode === 'local' || ownerRoute.connectionId === 'local') {
+      return ownerRoute.targetProfile || ownerRoute.profile
+    }
+
+    return undefined
+  }, [activeGatewayProfile, ownerRoute])
+
   const cwd = useStore(view.$cwd)
   const gatewayOpen = useStore($gatewayState) === 'open'
 
@@ -234,11 +313,11 @@ function TileChat({
         <ModelMenuPanel
           gateway={gateway || undefined}
           onSelectModel={selectModel}
-          profile={ownerRoute?.profile || activeGatewayProfile}
+          profile={catalogProfile}
           requestGateway={requestTileGateway}
         />
       ) : null,
-    [activeGatewayProfile, gateway, gatewayOpen, ownerRoute?.profile, requestTileGateway, selectModel]
+    [catalogProfile, gateway, gatewayOpen, requestTileGateway, selectModel]
   )
 
   return (
@@ -283,6 +362,8 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
   const gatewayOpen = useStore($gatewayState) === 'open'
   const delegateRevision = useStore($sessionTileDelegateRevision)
   const resumingRef = useRef(false)
+  // This tile's overall resume budget (#93892).
+  const resumeBudget = useRef(createTileResumeBudget()).current
   const view = useMemo(() => buildTileView(storedSessionId), [storedSessionId])
 
   const storedSessionStillExists = useCallback(
@@ -353,11 +434,23 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
       return
     }
 
+    // Bounded overall budget (#93892): a runtime that keeps resuming and
+    // getting reclaimed is a loop, not recovery. Latch the error card (and
+    // reset the budget so Retry gets a clean cycle) instead of dialing again.
+    if (!resumeBudget.take()) {
+      patchSessionTile(storedSessionId, { error: TILE_RESUME_STORM_MESSAGE })
+
+      return
+    }
+
     resumingRef.current = true
 
     delegate
       .resumeTile(storedSessionId)
-      .then(id => patchSessionTile(storedSessionId, { error: undefined, runtimeId: id }))
+      .then(id => {
+        resumeBudget.spend()
+        patchSessionTile(storedSessionId, { error: undefined, runtimeId: id })
+      })
       .catch(async (err: unknown) => {
         const message = err instanceof Error ? err.message : String(err)
 
@@ -383,7 +476,7 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
       .finally(() => {
         resumingRef.current = false
       })
-  }, [delegateRevision, gatewayOpen, ownerRoute, runtimeId, storedSessionId, tile?.error])
+  }, [delegateRevision, gatewayOpen, ownerRoute, resumeBudget, runtimeId, storedSessionId, tile?.error])
 
   // The gateway (re)opening invalidates any latched error — it likely came
   // from a not-yet-open gateway or the previous connection. Clearing it

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -228,22 +228,20 @@ function TileChat({
   const { selectModel } = useModelControls({ queryClient, requestGateway: requestTileGateway })
   const activeGatewayProfile = useStore($activeGatewayProfile)
 
-  // Catalog profile for the model menu (#93892): the owner's for a local
-  // (or legacy profile) route, so the REST recovery read is scoped to the
-  // profile that owns this session. A remote route stays UNPINNED: the REST
-  // client scopes by the ACTIVE connection, so pinning the owner's profile
-  // name there would ask a stranger backend for a same-named profile. The
-  // owner-routed gateway read (requestTileGateway) is authoritative for it.
+  // Catalog scope for the model menu (#93892): an owner route pins BOTH the
+  // connection and backend profile. This matters when the owner-routed WS
+  // catalog is temporarily empty: REST recovery must not substitute the
+  // active connection's models. Explicit local is kept too, so an active
+  // remote connection cannot capture a local tile's fallback.
   const catalogProfile = useMemo(() => {
-    if (!ownerRoute?.connectionId) {
-      return ownerRoute?.profile || activeGatewayProfile
+    if (!ownerRoute) {
+      return activeGatewayProfile
     }
 
-    if (ownerRoute.mode === 'local' || ownerRoute.connectionId === 'local') {
-      return ownerRoute.targetProfile || ownerRoute.profile
+    return {
+      connectionId: ownerRoute.connectionId,
+      profile: ownerRoute.targetProfile || ownerRoute.profile
     }
-
-    return undefined
   }, [activeGatewayProfile, ownerRoute])
 
   const cwd = useStore(view.$cwd)

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
@@ -229,6 +229,61 @@ describe('useSessionTileDelegate resumeTile', () => {
   })
 })
 
+describe('useSessionTileDelegate resumeTile runtime info (#93892)', () => {
+  beforeEach(() => {
+    setSessions([])
+  })
+
+  afterEach(() => {
+    setSessions([])
+  })
+
+  const resumeWithInfo = async (info: Record<string, unknown>, cached: Record<string, unknown>) => {
+    setSessions([row({ id: 'stored-info', profile: 'bot' })])
+    vi.mocked(requestGatewayForProfile).mockResolvedValueOnce({ info, session_id: 'runtime-info' } as never)
+    const updateSessionState = vi.fn()
+
+    renderTile(
+      vi.fn(async () => ({}) as never),
+      { updateSessionState }
+    )
+    await sessionTileDelegate()!.resumeTile('stored-info')
+
+    const [runtimeId, updater] = updateSessionState.mock.calls[0] as [string, (state: unknown) => unknown]
+    expect(runtimeId).toBe('runtime-info')
+
+    return updater({ busy: false, messages: [], model: '', provider: '', ...cached }) as Record<string, unknown>
+  }
+
+  it('lands the resume response’s model/provider in tile state so the pill never waits on session.info', async () => {
+    // The owner socket can churn before a `session.info` ever arrives; the
+    // resume response already names the model, so a cold tile paints it now.
+    const next = await resumeWithInfo({ model: 'nous/hermes-4', provider: 'nous', running: false }, {})
+
+    expect(next.model).toBe('nous/hermes-4')
+    expect(next.provider).toBe('nous')
+    expect(next.busy).toBe(false)
+  })
+
+  it('fills gaps only — a model a session.info already published stays authoritative', async () => {
+    const next = await resumeWithInfo(
+      { model: 'profile-default', provider: '', running: true },
+      { model: 'session/picked', provider: 'openai' }
+    )
+
+    expect(next.model).toBe('session/picked')
+    expect(next.provider).toBe('openai')
+    expect(next.busy).toBe(true)
+  })
+
+  it('ignores an empty or missing model in the resume response', async () => {
+    const next = await resumeWithInfo({ model: '   ', running: false }, {})
+
+    expect(next.model).toBe('')
+    expect(next.provider).toBe('')
+  })
+})
+
 describe('useSessionTileDelegate interruptSession', () => {
   beforeEach(() => {
     setSessions([])

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -4,7 +4,12 @@ import { getLatestSessionMessages, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/he
 import { toChatMessages } from '@/lib/chat-messages'
 import { getSessionOwnerHint } from '@/store/session'
 import { requestForSessionProfile, type SessionOwnerScope } from '@/store/session-request-router'
-import { publishSessionState, sessionTileOwnerRoute, setSessionTileDelegate } from '@/store/session-states'
+import {
+  publishSessionState,
+  recordTileOwner,
+  sessionTileOwnerRoute,
+  setSessionTileDelegate
+} from '@/store/session-states'
 import type { SessionResumeResponse } from '@/types/hermes'
 
 import type { usePromptActions } from '../../session/hooks/use-prompt-actions'
@@ -15,6 +20,11 @@ import type { useSessionStateCache } from '../../session/hooks/use-session-state
 import type { GatewayRequester } from '../types'
 
 type SessionStateCache = ReturnType<typeof useSessionStateCache>
+
+/** A non-empty string field off `session.resume`'s `info`, else undefined. */
+function resumedInfoField(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined
+}
 
 interface SessionTileDelegateParams {
   archiveSession: (storedSessionId: string) => Promise<unknown>
@@ -170,6 +180,10 @@ export function useSessionTileDelegate({
         // the same cross-profile bleed the recovery resumes had (#67603).
         const owner = await ownerForStoredSession(storedSessionId)
 
+        // Name the socket this resume is about to mint its runtime on, so the
+        // gateway registry keeps it for as long as the tile is open (#93892).
+        recordTileOwner(storedSessionId, owner)
+
         const restScope =
           owner && typeof owner === 'object'
             ? { connectionId: owner.connectionId, profile: owner.targetProfile || owner.profile }
@@ -193,13 +207,25 @@ export function useSessionTileDelegate({
           throw new Error('resume returned no session id')
         }
 
+        // The resume response already names the session's model/provider.
+        // Land them in tile state now instead of waiting on a `session.info`
+        // event that never arrives when the owner socket churns — a tile with
+        // an empty model rendered the pill's loader with no end (#93892). Fill
+        // only: a value a `session.info` already published stays authoritative.
+        const resumedModel = resumedInfoField(resumed?.info?.model)
+        const resumedProvider = resumedInfoField(resumed?.info?.provider)
+
         updateSessionState(
           runtimeId,
           state => ({
             ...state,
             busy: Boolean(resumed?.info?.running),
             messages:
-              state.messages.length > 0 ? state.messages : toChatMessages(prefetch?.messages ?? resumed?.messages ?? [])
+              state.messages.length > 0
+                ? state.messages
+                : toChatMessages(prefetch?.messages ?? resumed?.messages ?? []),
+            ...(resumedModel && !state.model ? { model: resumedModel } : {}),
+            ...(resumedProvider && !state.provider ? { provider: resumedProvider } : {})
           }),
           storedSessionId
         )

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -43,6 +43,7 @@ import {
   $activeSessionId,
   $connection,
   $currentCwd,
+  $selectedStoredSessionId,
   $sessions,
   ensureDefaultWorkspaceCwd,
   setConnection,
@@ -52,7 +53,9 @@ import {
 } from '@/store/session'
 import {
   $attentionSessionIds,
+  $sessionTiles,
   $workingSessionIds,
+  foregroundSessionScopes,
   liveSessionScopes,
   reconcileBusyStatesOnReconnect,
   recordSessionEventScope,
@@ -600,6 +603,10 @@ export function useGatewayBoot({
     // (connectionId, profile) keep-set so two sources exposing the same
     // profile name (every source has a 'default') can't collide.
     configureGatewayRegistry({
+      // Every dispose path in the registry (live-work pruner AND the
+      // refcount-0 request leases) spares a socket a mounted tile or the
+      // primary thread is bound to (#93892).
+      foregroundScopes: foregroundSessionScopes,
       onActiveConnectionChanged: publish,
       // Keep $activeGatewayProfile in lockstep with the registry's OWN record
       // of which profile the active socket serves. The registry is the only
@@ -727,12 +734,20 @@ export function useGatewayBoot({
         }
       }
 
+      // Foreground-bound owners (a mounted tile, the primary thread) are NOT
+      // added here: the registry reads them itself through its
+      // `foregroundScopes` hook so every dispose path agrees (#93892). This
+      // recompute only has to RUN when they change — see the tile / selected
+      // session subscriptions below, which is how closing a tile releases
+      // its socket.
       pruneSecondaryGateways(keep)
     }
 
     const offWorking = $workingSessionIds.subscribe(() => recomputeKeptGateways())
     const offAttention = $attentionSessionIds.subscribe(() => recomputeKeptGateways())
     const offActiveProfile = $activeGatewayProfile.subscribe(() => recomputeKeptGateways())
+    const offTiles = $sessionTiles.subscribe(() => recomputeKeptGateways())
+    const offSelectedSession = $selectedStoredSessionId.subscribe(() => recomputeKeptGateways())
 
     const offWindowState = desktop.onWindowStateChanged?.(payload => {
       const current = $connection.get()
@@ -924,6 +939,8 @@ export function useGatewayBoot({
       offWorking()
       offAttention()
       offActiveProfile()
+      offTiles()
+      offSelectedSession()
       window.removeEventListener('online', onOnline)
       document.removeEventListener('visibilitychange', onVisible)
       offPowerResume?.()

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
@@ -22,6 +22,7 @@ import {
   setWorkspaceCwdOwner,
   setYoloActive
 } from '@/store/session'
+import { sessionEventOwnerRoute } from '@/store/session-states'
 import { reportInstallMethodWarning } from '@/store/updates'
 
 import { finalizeInterruptedMessages } from '../../use-prompt-actions/rewind'
@@ -346,8 +347,26 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
       // events are untagged and retain the active-profile path.
       const eventProfile = event.profile?.trim() || activeGatewayProfile
 
+      const ownerRoute =
+        event.connectionId && explicitSid && sessionId
+          ? sessionEventOwnerRoute(sessionId, payload?.stored_session_id, {
+              connectionId: event.connectionId,
+              profile: eventProfile
+            })
+          : { kind: 'unknown' as const }
+
+      // Multiple exact owner records mean the alias target is unknowable. Do
+      // not invalidate a guessed socket/ambient catalog; a later authoritative
+      // event or catalog read can reconcile once ownership is unambiguous.
+      if (ownerRoute.kind === 'ambiguous') {
+        return true
+      }
+
+      const catalogProfile =
+        ownerRoute.kind === 'known' ? ownerRoute.route.targetProfile?.trim() || eventProfile : eventProfile
+
       const profileScope = event.connectionId
-        ? { connectionId: event.connectionId, profile: eventProfile }
+        ? { connectionId: event.connectionId, profile: catalogProfile }
         : eventProfile
 
       void queryClient.invalidateQueries({

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
@@ -341,8 +341,17 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
     }
 
     if (modelValueChanged || providerValueChanged) {
+      // Registry events carry their exact owner. Invalidate that composite
+      // catalog, not whichever connection/profile is ambient now; primary
+      // events are untagged and retain the active-profile path.
+      const eventProfile = event.profile?.trim() || activeGatewayProfile
+
+      const profileScope = event.connectionId
+        ? { connectionId: event.connectionId, profile: eventProfile }
+        : eventProfile
+
       void queryClient.invalidateQueries({
-        queryKey: explicitSid && sessionId ? modelOptionsQueryKey(activeGatewayProfile, sessionId) : ['model-options']
+        queryKey: explicitSid && sessionId ? modelOptionsQueryKey(profileScope, sessionId) : ['model-options']
       })
     }
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
@@ -7,8 +7,8 @@ import { isTargetSessionBusy } from '@/app/session/hooks/use-prompt-actions/util
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { modelOptionsQueryKey } from '@/lib/model-options'
-import { setCurrentModel, setCurrentProvider } from '@/store/session'
-import { $sessionTiles } from '@/store/session-states'
+import { setCurrentModel, setCurrentProvider, setSessionOwnerHint } from '@/store/session'
+import { $sessionTiles, sessionEventOwnerRoute } from '@/store/session-states'
 
 import { type MessageStreamHarness, renderMessageStream } from './test-harness'
 import { PRE_TURN_LIVE_SETTLE_GRACE_MS } from './utils'
@@ -241,7 +241,56 @@ describe('session.info model-options invalidation gating', () => {
     expect(invalidate).not.toHaveBeenCalledWith({ queryKey: socketKey })
   })
 
-  it('rejects a stale alias tile when both runtime ids differ despite a matching stored id', () => {
+  it('keeps an unbound tile eligible for durable-id fallback', () => {
+    mountStream()
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const ownerRoute = {
+      connectionId: 'remote-owner',
+      mode: 'remote' as const,
+      profile: 'bot-alias',
+      targetProfile: 'backend-bot'
+    }
+
+    const targetKey = modelOptionsQueryKey(
+      { connectionId: ownerRoute.connectionId, profile: ownerRoute.targetProfile },
+      ACTIVE_SID
+    )
+
+    $sessionTiles.set([{ ownerRoute, storedSessionId: 'stored-unbound-bot' }])
+    sessionInfo(ACTIVE_SID, { model: 'm1', provider: 'p1', running: true })
+    invalidate.mockClear()
+
+    act(() =>
+      stream.handleEvent({
+        connectionId: ownerRoute.connectionId,
+        payload: { model: 'm2', provider: 'p1', running: true, stored_session_id: 'stored-unbound-bot' },
+        profile: ownerRoute.profile,
+        session_id: ACTIVE_SID,
+        type: 'session.info'
+      })
+    )
+
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: targetKey })
+  })
+
+  it('prefers an unambiguous exact runtime route over contradictory durable evidence', () => {
+    const source = { connectionId: 'remote-owner', profile: 'bot-alias' }
+    const exactRoute = { ...source, mode: 'remote' as const, targetProfile: 'backend-exact' }
+    const staleRoute = { ...source, mode: 'remote' as const, targetProfile: 'backend-stale' }
+
+    $sessionTiles.set([
+      { ownerRoute: exactRoute, runtimeId: ACTIVE_SID, storedSessionId: 'stored-lineage-root' },
+      { ownerRoute: staleRoute, runtimeId: 'different-runtime', storedSessionId: 'stored-rotated-tip' }
+    ])
+
+    expect(sessionEventOwnerRoute(ACTIVE_SID, 'stored-rotated-tip', source)).toEqual({
+      kind: 'known',
+      route: exactRoute
+    })
+  })
+
+  it('fails closed when both explicit runtime ids differ despite a matching stored id', () => {
     mountStream()
     const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
 
@@ -251,16 +300,6 @@ describe('session.info model-options invalidation gating', () => {
       profile: 'bot-alias',
       targetProfile: 'stale-backend-bot'
     }
-
-    const socketKey = modelOptionsQueryKey(
-      { connectionId: ownerRoute.connectionId, profile: ownerRoute.profile },
-      ACTIVE_SID
-    )
-
-    const staleTargetKey = modelOptionsQueryKey(
-      { connectionId: ownerRoute.connectionId, profile: ownerRoute.targetProfile },
-      ACTIVE_SID
-    )
 
     $sessionTiles.set([{ ownerRoute, runtimeId: 'stale-runtime', storedSessionId: 'stored-shared' }])
     sessionInfo(ACTIVE_SID, { model: 'm1', provider: 'p1', running: true })
@@ -276,8 +315,41 @@ describe('session.info model-options invalidation gating', () => {
       })
     )
 
-    expect(invalidate).toHaveBeenCalledWith({ queryKey: socketKey })
-    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: staleTargetKey })
+    expect(invalidate).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when a stale stored-id hint contradicts an explicit tile runtime', () => {
+    setApiRequestConnection('ambient-remote')
+    mountStream()
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+    const storedSessionId = 'stored-stale-hint-conflict'
+
+    const ownerRoute = {
+      connectionId: 'remote-owner',
+      mode: 'remote' as const,
+      profile: 'bot-alias',
+      targetProfile: 'stale-backend-bot'
+    }
+
+    $sessionTiles.set([{ ownerRoute, runtimeId: 'different-runtime', storedSessionId }])
+    setSessionOwnerHint(storedSessionId, ownerRoute)
+
+    expect(sessionEventOwnerRoute(ACTIVE_SID, storedSessionId, ownerRoute)).toEqual({ kind: 'ambiguous' })
+
+    sessionInfo(ACTIVE_SID, { model: 'm1', provider: 'p1', running: true })
+    invalidate.mockClear()
+
+    act(() =>
+      stream.handleEvent({
+        connectionId: ownerRoute.connectionId,
+        payload: { model: 'm2', provider: 'p1', running: true, stored_session_id: storedSessionId },
+        profile: ownerRoute.profile,
+        session_id: ACTIVE_SID,
+        type: 'session.info'
+      })
+    )
+
+    expect(invalidate).not.toHaveBeenCalled()
   })
 
   it('fails closed instead of invalidating a guessed catalog when exact owner routes conflict', () => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient } from '@tanstack/react-query'
 import { act, cleanup } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { setApiRequestConnection } from '@/api/client'
 import { isTargetSessionBusy } from '@/app/session/hooks/use-prompt-actions/utils'
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
@@ -55,6 +56,7 @@ afterEach(() => {
   setCurrentProvider('')
   vi.useRealTimers()
   vi.restoreAllMocks()
+  setApiRequestConnection(null)
 })
 
 describe('session.info config refetch gating', () => {
@@ -117,6 +119,31 @@ describe('session.info model-options invalidation gating', () => {
     sessionInfo(ACTIVE_SID, { model: 'm2', provider: 'p1', running: true })
 
     expect(invalidate).toHaveBeenCalledWith({ queryKey: modelOptionsQueryKey(ACTIVE_PROFILE, ACTIVE_SID) })
+  })
+
+  it('invalidates the exact event owner without touching the ambient connection', () => {
+    setApiRequestConnection('ambient-remote')
+    mountStream()
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+    const ownerScope = { connectionId: 'remote-owner', profile: 'bot' }
+    const ownerKey = modelOptionsQueryKey(ownerScope, ACTIVE_SID)
+    const ambientKey = modelOptionsQueryKey(ACTIVE_PROFILE, ACTIVE_SID)
+
+    sessionInfo(ACTIVE_SID, { model: 'm1', provider: 'p1', running: true })
+    invalidate.mockClear()
+
+    act(() =>
+      stream.handleEvent({
+        connectionId: ownerScope.connectionId,
+        payload: { model: 'm2', provider: 'p1', running: true },
+        profile: ownerScope.profile,
+        session_id: ACTIVE_SID,
+        type: 'session.info'
+      })
+    )
+
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ownerKey })
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: ambientKey })
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
@@ -8,6 +8,7 @@ import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { modelOptionsQueryKey } from '@/lib/model-options'
 import { setCurrentModel, setCurrentProvider } from '@/store/session'
+import { $sessionTiles } from '@/store/session-states'
 
 import { type MessageStreamHarness, renderMessageStream } from './test-harness'
 import { PRE_TURN_LIVE_SETTLE_GRACE_MS } from './utils'
@@ -46,12 +47,14 @@ beforeEach(() => {
   refreshSessions = vi.fn<() => Promise<void>>(async () => undefined)
   hydrateFromStoredSession = vi.fn<() => Promise<void>>(async () => undefined)
   queryClient = new QueryClient()
+  $sessionTiles.set([])
   setCurrentModel('')
   setCurrentProvider('')
 })
 
 afterEach(() => {
   cleanup()
+  $sessionTiles.set([])
   setCurrentModel('')
   setCurrentProvider('')
   vi.useRealTimers()
@@ -144,6 +147,91 @@ describe('session.info model-options invalidation gating', () => {
 
     expect(invalidate).toHaveBeenCalledWith({ queryKey: ownerKey })
     expect(invalidate).not.toHaveBeenCalledWith({ queryKey: ambientKey })
+  })
+
+  it('invalidates an alias route’s backend target catalog without touching socket or ambient keys', () => {
+    setApiRequestConnection('ambient-remote')
+    mountStream()
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const ownerRoute = {
+      connectionId: 'remote-owner',
+      mode: 'remote' as const,
+      profile: 'bot-alias',
+      targetProfile: 'backend-bot'
+    }
+
+    const targetKey = modelOptionsQueryKey(
+      { connectionId: ownerRoute.connectionId, profile: ownerRoute.targetProfile },
+      ACTIVE_SID
+    )
+
+    const socketKey = modelOptionsQueryKey(
+      { connectionId: ownerRoute.connectionId, profile: ownerRoute.profile },
+      ACTIVE_SID
+    )
+
+    const ambientKey = modelOptionsQueryKey(ACTIVE_PROFILE, ACTIVE_SID)
+
+    $sessionTiles.set([{ ownerRoute, runtimeId: ACTIVE_SID, storedSessionId: 'stored-bot-chat' }])
+    sessionInfo(ACTIVE_SID, { model: 'm1', provider: 'p1', running: true })
+    invalidate.mockClear()
+
+    act(() =>
+      stream.handleEvent({
+        connectionId: ownerRoute.connectionId,
+        payload: {
+          model: 'm2',
+          provider: 'p1',
+          running: true,
+          stored_session_id: 'stored-bot-chat'
+        },
+        profile: ownerRoute.profile,
+        session_id: ACTIVE_SID,
+        type: 'session.info'
+      })
+    )
+
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: targetKey })
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: socketKey })
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: ambientKey })
+  })
+
+  it('fails closed instead of invalidating a guessed catalog when exact owner routes conflict', () => {
+    mountStream()
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+    const source = { connectionId: 'remote-owner', profile: 'bot-alias' }
+
+    $sessionTiles.set([
+      {
+        ownerRoute: { ...source, mode: 'remote', targetProfile: 'backend-bot-a' },
+        runtimeId: ACTIVE_SID,
+        storedSessionId: 'stored-bot-chat'
+      },
+      {
+        ownerRoute: { ...source, mode: 'remote', targetProfile: 'backend-bot-b' },
+        runtimeId: ACTIVE_SID,
+        storedSessionId: 'stored-bot-chat'
+      }
+    ])
+    sessionInfo(ACTIVE_SID, { model: 'm1', provider: 'p1', running: true })
+    invalidate.mockClear()
+
+    act(() =>
+      stream.handleEvent({
+        ...source,
+        payload: {
+          model: 'm2',
+          provider: 'p1',
+          running: true,
+          stored_session_id: 'stored-bot-chat'
+        },
+        session_id: ACTIVE_SID,
+        type: 'session.info'
+      })
+    )
+
+    expect(invalidate).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx
@@ -197,6 +197,89 @@ describe('session.info model-options invalidation gating', () => {
     expect(invalidate).not.toHaveBeenCalledWith({ queryKey: ambientKey })
   })
 
+  it('keeps the exact runtime-bound alias authoritative after the stored id rotates', () => {
+    mountStream()
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const ownerRoute = {
+      connectionId: 'remote-owner',
+      mode: 'remote' as const,
+      profile: 'bot-alias',
+      targetProfile: 'backend-bot'
+    }
+
+    const targetKey = modelOptionsQueryKey(
+      { connectionId: ownerRoute.connectionId, profile: ownerRoute.targetProfile },
+      ACTIVE_SID
+    )
+
+    const socketKey = modelOptionsQueryKey(
+      { connectionId: ownerRoute.connectionId, profile: ownerRoute.profile },
+      ACTIVE_SID
+    )
+
+    $sessionTiles.set([{ ownerRoute, runtimeId: ACTIVE_SID, storedSessionId: 'stored-lineage-root' }])
+    sessionInfo(ACTIVE_SID, { model: 'm1', provider: 'p1', running: true })
+    invalidate.mockClear()
+
+    act(() =>
+      stream.handleEvent({
+        connectionId: ownerRoute.connectionId,
+        payload: {
+          model: 'm2',
+          provider: 'p1',
+          running: true,
+          stored_session_id: 'stored-rotated-tip'
+        },
+        profile: ownerRoute.profile,
+        session_id: ACTIVE_SID,
+        type: 'session.info'
+      })
+    )
+
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: targetKey })
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: socketKey })
+  })
+
+  it('rejects a stale alias tile when both runtime ids differ despite a matching stored id', () => {
+    mountStream()
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const ownerRoute = {
+      connectionId: 'remote-owner',
+      mode: 'remote' as const,
+      profile: 'bot-alias',
+      targetProfile: 'stale-backend-bot'
+    }
+
+    const socketKey = modelOptionsQueryKey(
+      { connectionId: ownerRoute.connectionId, profile: ownerRoute.profile },
+      ACTIVE_SID
+    )
+
+    const staleTargetKey = modelOptionsQueryKey(
+      { connectionId: ownerRoute.connectionId, profile: ownerRoute.targetProfile },
+      ACTIVE_SID
+    )
+
+    $sessionTiles.set([{ ownerRoute, runtimeId: 'stale-runtime', storedSessionId: 'stored-shared' }])
+    sessionInfo(ACTIVE_SID, { model: 'm1', provider: 'p1', running: true })
+    invalidate.mockClear()
+
+    act(() =>
+      stream.handleEvent({
+        connectionId: ownerRoute.connectionId,
+        payload: { model: 'm2', provider: 'p1', running: true, stored_session_id: 'stored-shared' },
+        profile: ownerRoute.profile,
+        session_id: ACTIVE_SID,
+        type: 'session.info'
+      })
+    )
+
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: socketKey })
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: staleTargetKey })
+  })
+
   it('fails closed instead of invalidating a guessed catalog when exact owner routes conflict', () => {
     mountStream()
     const invalidate = vi.spyOn(queryClient, 'invalidateQueries')

--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -301,6 +301,52 @@ describe('useModelControls', () => {
     expect(invalidate).toHaveBeenCalled()
   })
 
+  it('patches and invalidates only a remote tile owner catalog', async () => {
+    const queryClient = new QueryClient()
+    const ownerScope = { connectionId: 'remote-owner', profile: 'bot' }
+    const ownerKey = modelOptionsQueryKey(ownerScope, 'tile-runtime')
+    const ambientKey = modelOptionsQueryKey('default', 'tile-runtime')
+
+    const ambientCatalog = {
+      model: 'ambient-model',
+      provider: 'ambient-provider',
+      providers: [{ models: ['ambient-model'], name: 'Ambient', slug: 'ambient-provider' }]
+    }
+
+    queryClient.setQueryData(ownerKey, {
+      model: 'old-owner-model',
+      provider: 'owner-provider',
+      providers: [{ models: ['old-owner-model'], name: 'Owner', slug: 'owner-provider' }]
+    })
+    queryClient.setQueryData(ambientKey, ambientCatalog)
+
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        queryClient,
+        requestGateway: vi.fn(async () => ({ key: 'model', scope: 'session' }) as never)
+      })
+    )
+
+    await expect(
+      result.current.selectModel({
+        model: 'new-owner-model',
+        profile: ownerScope,
+        provider: 'owner-provider',
+        sessionId: 'tile-runtime'
+      })
+    ).resolves.toBe(true)
+
+    expect(queryClient.getQueryData(ownerKey)).toMatchObject({
+      model: 'new-owner-model',
+      provider: 'owner-provider'
+    })
+    expect(queryClient.getQueryData(ambientKey)).toEqual(ambientCatalog)
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ownerKey })
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: ambientKey })
+  })
+
   it('keeps the pick when an OLDER gateway refuses a mid-turn switch', async () => {
     // Pre-deferral backends answer 4009 instead of parking the pick. Rolling
     // back would bounce the pill to the old model and toast an error at a user

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -2,7 +2,7 @@ import { type QueryClient } from '@tanstack/react-query'
 import { useCallback, useRef } from 'react'
 
 import type { ModelSelection } from '@/app/shell/model-menu-panel'
-import { getGlobalModelInfo } from '@/hermes'
+import { getGlobalModelInfo, type ProfileScope } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { isBusySessionModelSwitch } from '@/lib/gateway-rpc'
 import { manualPickRemoved, modelOptionsQueryKey } from '@/lib/model-options'
@@ -43,7 +43,7 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
       provider: string,
       model: string,
       includeGlobal: boolean,
-      profile = $activeGatewayProfile.get()
+      profile: ProfileScope = $activeGatewayProfile.get()
     ) => {
       const patch = (prev: ModelOptionsResponse | undefined) => {
         // Selection state can update before the catalog query has resolved.
@@ -188,7 +188,7 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
         : ($sessionStates.get()[liveSessionId!]?.provider ?? '')
 
       const prevSource = getCurrentModelSource()
-      const liveGatewayProfile = $activeGatewayProfile.get()
+      const liveProfileScope = 'profile' in selection ? selection.profile : $activeGatewayProfile.get()
 
       if (touchesPrimary) {
         setCurrentModel(selection.model)
@@ -208,7 +208,7 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
         selection.provider,
         selection.model,
         touchesPrimary && !liveSessionId,
-        liveGatewayProfile
+        liveProfileScope
       )
 
       // No live session yet: the pick is pure UI state. session.create reads
@@ -247,7 +247,7 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
         // the switch publishes session.info when it lands, and that is what
         // re-syncs every surface.
         if (!result?.deferred) {
-          void queryClient.invalidateQueries({ queryKey: modelOptionsQueryKey(liveGatewayProfile, liveSessionId) })
+          void queryClient.invalidateQueries({ queryKey: modelOptionsQueryKey(liveProfileScope, liveSessionId) })
         }
 
         return true
@@ -278,7 +278,7 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
           prevProvider,
           prevModel,
           touchesPrimary && !liveSessionId,
-          liveGatewayProfile
+          liveProfileScope
         )
         notifyError(err, copy.modelSwitchFailed)
 

--- a/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
@@ -106,3 +106,18 @@ describe('the catalog owns model curation', () => {
     expect($modelVisibilityOpen.get()).toBe(true)
   })
 })
+
+// #93892 follow-up: a detached surface (no profile, no gateway — the kanban
+// per-task override) must keep reading the ACTIVE profile's REST catalog.
+// Pinning the read to a literal 'default' listed the wrong profile's models
+// whenever the active profile was not `default`.
+describe('ModelCatalogMenu REST scope', () => {
+  it('leaves the REST read unpinned when no profile is named', async () => {
+    renderMenu()
+
+    await screen.findByText(/Gemini 3\.1 Pro/i)
+
+    expect(getGlobalModelOptions).toHaveBeenCalledTimes(1)
+    expect(getGlobalModelOptions.mock.calls[0]).toEqual([{ explicitOnly: true }])
+  })
+})

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -20,7 +20,7 @@ import { usePointerQuiet } from '@/components/ui/keyboard-first'
 import { Skeleton } from '@/components/ui/skeleton'
 import type { HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
+import { type ModelOptionsDispatch, modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
 import { displayModelName, modelDisplayParts } from '@/lib/model-status-label'
 import { DEFAULT_REASONING_EFFORT, reasoningEffortLabel } from '@/lib/reasoning-effort'
 import { normalize } from '@/lib/text'
@@ -96,7 +96,15 @@ interface ModelCatalogMenuProps {
   /** Render the virtual `moa` provider's presets as a selectable section.
    *  Off for override surfaces, where a MoA preset isn't a worker model. */
   includeMoa?: boolean
+  /** Profile whose catalog this is; keys the query and pins the REST
+   *  recovery read. Omitted → the active API profile scope, never a literal
+   *  'default' (a detached surface must follow the active profile). */
   profile?: string
+  /** Owner-routed dispatcher for the catalog read. A surface bound to a
+   *  session must pass the same dispatcher it writes through, or the read
+   *  lands on the ambient backend, which never held the session (#93892).
+   *  Detached surfaces omit it and read through `gateway` / REST. */
+  requestGateway?: ModelOptionsDispatch
   /** Session whose catalog to fetch. A live session's catalog can differ from
    *  the profile-global one, and the app invalidates the SESSION-scoped query
    *  key on model changes — a surface bound to a session must pass it or its
@@ -121,7 +129,8 @@ export function ModelCatalogMenu({
   footer,
   gateway,
   includeMoa = false,
-  profile = 'default',
+  profile,
+  requestGateway,
   sessionId = null
 }: ModelCatalogMenuProps) {
   const { t } = useI18n()
@@ -141,7 +150,8 @@ export function ModelCatalogMenu({
     // Gateway-first even with no session: a connected (possibly remote)
     // gateway owns the model catalog, including virtual providers the local
     // REST fallback can't know about (#53817).
-    queryFn: (): Promise<ModelOptionsResponse> => requestModelOptions({ gateway, sessionId })
+    queryFn: (): Promise<ModelOptionsResponse> =>
+      requestModelOptions({ gateway, profile, request: requestGateway, sessionId })
   })
 
   const loading = modelOptions.isPending && !modelOptions.data

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -18,7 +18,7 @@ import {
 import { HighlightMatches } from '@/components/ui/highlight-matches'
 import { usePointerQuiet } from '@/components/ui/keyboard-first'
 import { Skeleton } from '@/components/ui/skeleton'
-import type { HermesGateway } from '@/hermes'
+import type { HermesGateway, ProfileScope } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { type ModelOptionsDispatch, modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
 import { displayModelName, modelDisplayParts } from '@/lib/model-status-label'
@@ -99,7 +99,7 @@ interface ModelCatalogMenuProps {
   /** Profile whose catalog this is; keys the query and pins the REST
    *  recovery read. Omitted → the active API profile scope, never a literal
    *  'default' (a detached surface must follow the active profile). */
-  profile?: string
+  profile?: ProfileScope
   /** Owner-routed dispatcher for the catalog read. A surface bound to a
    *  session must pass the same dispatcher it writes through, or the read
    *  lands on the ambient backend, which never held the session (#93892).

--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -402,16 +402,23 @@ describe('ModelMenuPanel provider collapse', () => {
 })
 
 // #93892: a tile's menu is handed an owner-routed `requestGateway`; catalog
-// READS must ride it too (not only writes), or a secondary-profile bot chat
-// lists the ambient profile's models.
+// READS and fallback must remain on that owner (not only writes), or a remote
+// bot tile can list the active connection's models.
 describe('ModelMenuPanel catalog routing', () => {
-  it('reads the catalog through the surface dispatcher, scoped to its session', async () => {
+  it("keeps a remote-owner tile's empty WS catalog pinned while another connection is active", async () => {
+    const ownerScope = { connectionId: 'remote-owner', profile: 'backend-bot' }
+
     const requestGateway = vi.fn(async (method: string) =>
-      method === 'model.options' ? { model: 'gemini-3.1-pro', provider: 'google', providers: [GOOGLE_PROVIDER] } : {}
+      method === 'model.options' ? { model: 'gemini-3.1-pro', provider: 'google', providers: [] } : {}
     )
 
-    // The ambient REST catalog is a different profile's — it must not show.
-    getGlobalModelOptions.mockResolvedValue({ providers: [DEEPSEEK_PROVIDER] })
+    // Deterministic active-connection trap: only the explicit owner scope gets
+    // the owner's REST catalog; an ambient fallback gets the other connection.
+    getGlobalModelOptions.mockImplementation(async (_opts, scope) =>
+      JSON.stringify(scope) === JSON.stringify(ownerScope)
+        ? { providers: [GOOGLE_PROVIDER] }
+        : { providers: [DEEPSEEK_PROVIDER] }
+    )
 
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
@@ -419,7 +426,11 @@ describe('ModelMenuPanel catalog routing', () => {
       <QueryClientProvider client={client}>
         <DropdownMenu open>
           <DropdownMenuContent>
-            <ModelMenuPanel onSelectModel={vi.fn()} profile="bot" requestGateway={requestGateway as never} />
+            <ModelMenuPanel
+              onSelectModel={vi.fn()}
+              profile={ownerScope}
+              requestGateway={requestGateway as never}
+            />
           </DropdownMenuContent>
         </DropdownMenu>
       </QueryClientProvider>
@@ -428,7 +439,7 @@ describe('ModelMenuPanel catalog routing', () => {
     await content.findByText(/Gemini 3\.1 Pro/i)
 
     expect(requestGateway).toHaveBeenCalledWith('model.options', { explicit_only: true, session_id: 'runtime-1' })
-    expect(getGlobalModelOptions).not.toHaveBeenCalled()
+    expect(getGlobalModelOptions).toHaveBeenCalledWith({ explicitOnly: true }, ownerScope)
     expect(content.queryByText('Deepseek Chat')).toBeNull()
   })
 })

--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -400,3 +400,35 @@ describe('ModelMenuPanel provider collapse', () => {
     expect($collapsedProviders.get()).toContain('deepseek')
   })
 })
+
+// #93892: a tile's menu is handed an owner-routed `requestGateway`; catalog
+// READS must ride it too (not only writes), or a secondary-profile bot chat
+// lists the ambient profile's models.
+describe('ModelMenuPanel catalog routing', () => {
+  it('reads the catalog through the surface dispatcher, scoped to its session', async () => {
+    const requestGateway = vi.fn(async (method: string) =>
+      method === 'model.options' ? { model: 'gemini-3.1-pro', provider: 'google', providers: [GOOGLE_PROVIDER] } : {}
+    )
+
+    // The ambient REST catalog is a different profile's — it must not show.
+    getGlobalModelOptions.mockResolvedValue({ providers: [DEEPSEEK_PROVIDER] })
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    const content = render(
+      <QueryClientProvider client={client}>
+        <DropdownMenu open>
+          <DropdownMenuContent>
+            <ModelMenuPanel onSelectModel={vi.fn()} profile="bot" requestGateway={requestGateway as never} />
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </QueryClientProvider>
+    )
+
+    await content.findByText(/Gemini 3\.1 Pro/i)
+
+    expect(requestGateway).toHaveBeenCalledWith('model.options', { explicit_only: true, session_id: 'runtime-1' })
+    expect(getGlobalModelOptions).not.toHaveBeenCalled()
+    expect(content.queryByText('Deepseek Chat')).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { DropdownMenu, DropdownMenuContent } from '@/components/ui/dropdown-menu'
+import type { ProfileScope } from '@/hermes'
 import { $collapsedProviders, toggleCollapsedProvider } from '@/store/provider-collapse'
 import { $activeSessionId, $currentModel, $currentProvider } from '@/store/session'
 
@@ -54,14 +55,14 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
-function renderPanel(onSelectModel = vi.fn()) {
+function renderPanel(onSelectModel = vi.fn(), profile?: ProfileScope) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
   const content = render(
     <QueryClientProvider client={client}>
       <DropdownMenu open>
         <DropdownMenuContent>
-          <ModelMenuPanel onSelectModel={onSelectModel} requestGateway={vi.fn() as never} />
+          <ModelMenuPanel onSelectModel={onSelectModel} profile={profile} requestGateway={vi.fn() as never} />
         </DropdownMenuContent>
       </DropdownMenu>
     </QueryClientProvider>
@@ -125,6 +126,20 @@ describe('ModelMenuPanel MoA presets', () => {
 })
 
 describe('ModelMenuPanel current selection', () => {
+  it('carries the exact catalog owner into the model selection', async () => {
+    const ownerScope = { connectionId: 'remote-owner', profile: 'bot' }
+    const { content, onSelectModel } = renderPanel(vi.fn(), ownerScope)
+
+    fireEvent.click(await content.findByText(/Gemini 3\.1 Pro/i))
+
+    expect(onSelectModel).toHaveBeenCalledWith({
+      model: 'gemini-3.1-pro',
+      profile: ownerScope,
+      provider: 'google',
+      sessionId: 'runtime-1'
+    })
+  })
+
   it('keeps the checkmark on the live SessionView model when a stale options response disagrees', async () => {
     $currentProvider.set('google')
     $currentModel.set('gemini-3.1-pro')

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react'
 import { useSessionView } from '@/app/chat/session-view'
 import { Codicon } from '@/components/ui/codicon'
 import { DropdownMenuItem, dropdownMenuRow } from '@/components/ui/dropdown-menu'
-import type { HermesGateway } from '@/hermes'
+import type { HermesGateway, ProfileScope } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
 import { currentPickerSelection } from '@/lib/model-status-label'
@@ -38,9 +38,8 @@ export interface ModelSelection {
 interface ModelMenuPanelProps {
   gateway?: HermesGateway
   onSelectModel: (selection: ModelSelection) => Promise<boolean> | void
-  /** Profile whose catalog this is. Omitted → the active API profile scope
-   *  (never pinned to a literal 'default'). */
-  profile?: string
+  /** Owner scope whose catalog this is. Omitted → the active API scope. */
+  profile?: ProfileScope
   /** THIS surface's dispatcher — owner-routed for a tile. Catalog reads go
    *  through it too, not only writes: `model.options` resolves the session in
    *  the answering backend's own process, so the ambient socket returns the

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -38,7 +38,13 @@ export interface ModelSelection {
 interface ModelMenuPanelProps {
   gateway?: HermesGateway
   onSelectModel: (selection: ModelSelection) => Promise<boolean> | void
+  /** Profile whose catalog this is. Omitted → the active API profile scope
+   *  (never pinned to a literal 'default'). */
   profile?: string
+  /** THIS surface's dispatcher — owner-routed for a tile. Catalog reads go
+   *  through it too, not only writes: `model.options` resolves the session in
+   *  the answering backend's own process, so the ambient socket returns the
+   *  wrong profile's catalog for a cross-profile tile (#93892). */
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
 }
 
@@ -48,7 +54,7 @@ interface ModelMenuPanelProps {
  * surface's session, remember the pick as a global preset, keep the optimistic
  * stores honest, and roll back on a failed gateway write.
  */
-export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', requestGateway }: ModelMenuPanelProps) {
+export function ModelMenuPanel({ gateway, onSelectModel, profile, requestGateway }: ModelMenuPanelProps) {
   const { t } = useI18n()
   const copy = t.shell.modelMenu
   const [refreshing, setRefreshing] = useState(false)
@@ -73,7 +79,8 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
   // never repaint that fallback once the catalog resolved.
   const modelOptions = useQuery({
     queryKey: modelOptionsQueryKey(profile, activeSessionId),
-    queryFn: (): Promise<ModelOptionsResponse> => requestModelOptions({ gateway, sessionId: activeSessionId })
+    queryFn: (): Promise<ModelOptionsResponse> =>
+      requestModelOptions({ gateway, profile, request: requestGateway, sessionId: activeSessionId })
   })
 
   const { model: optionsModel, provider: optionsProvider } = currentPickerSelection(
@@ -95,7 +102,13 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
     try {
       const queryKey = modelOptionsQueryKey(profile, activeSessionId)
 
-      const next = await requestModelOptions({ gateway, refresh: true, sessionId: activeSessionId })
+      const next = await requestModelOptions({
+        gateway,
+        profile,
+        refresh: true,
+        request: requestGateway,
+        sessionId: activeSessionId
+      })
 
       queryClient.setQueryData<ModelOptionsResponse>(queryKey, next)
     } catch {
@@ -238,6 +251,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile = 'default', re
       gateway={gateway}
       includeMoa
       profile={profile}
+      requestGateway={requestGateway}
       sessionId={activeSessionId}
     />
   )

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -29,6 +29,9 @@ export { ModelMenuCloseContext } from './model-catalog-menu'
 
 export interface ModelSelection {
   model: string
+  /** Catalog owner scope for cache patching/invalidation. A tile carries its
+   * exact connection/profile owner; primary/legacy callers stay ambient. */
+  profile?: ProfileScope
   provider: string
   /** Runtime id of the surface that opened the menu. When set, the switch
    *  targets that session (a tile) instead of the primary `$activeSessionId`. */
@@ -206,7 +209,13 @@ export function ModelMenuPanel({ gateway, onSelectModel, profile, requestGateway
     // scopes the switch to that session; with none it's UI state shipped on the
     // next session.create. Always stamp sessionId from this surface so a tile
     // switch never hits the primary (busy) session by accident.
-    select: (model, provider) => onSelectModel({ model, provider, sessionId: activeSessionId || null }),
+    select: (model, provider) =>
+      onSelectModel({
+        model,
+        ...(profile !== undefined ? { profile } : {}),
+        provider,
+        sessionId: activeSessionId || null
+      }),
 
     setOptions: (patch, row) => {
       // Editing always records the model's global preset (keyed by

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -619,6 +619,21 @@ describe('Hermes REST helpers', () => {
     )
   })
 
+  it('lets an explicit model-catalog owner override the active connection and profile', async () => {
+    setApiRequestConnection('foreground-connection')
+    setApiRequestProfile('foreground-profile')
+
+    await getGlobalModelOptions(undefined, { connectionId: 'remote-owner', profile: 'backend-bot' })
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionId: 'remote-owner',
+        path: '/api/model/options?explicit_only=1',
+        profile: 'backend-bot'
+      })
+    )
+  })
+
   it('can opt into unconfigured providers for onboarding flows', async () => {
     await getGlobalModelOptions({ includeUnconfigured: true, refresh: true, explicitOnly: false })
 

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -167,3 +167,69 @@ describe('manualPickRemoved', () => {
     expect(manualPickRemoved(providers, '', '')).toBe(false)
   })
 })
+
+// #93892: a session-bound surface (a tile) must read its catalog through the
+// same owner-routed dispatcher it writes through. The backend resolves
+// `session_id` in its own process, so the ambient socket answers a
+// cross-profile session with ITS profile's catalog — silently.
+describe('requestModelOptions owner routing', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('prefers the owner-routed dispatcher over the ambient gateway', async () => {
+    const ownerPayload = {
+      model: 'bot-model',
+      provider: 'nous',
+      providers: [{ models: ['bot-model'], name: 'Nous', slug: 'nous' }]
+    }
+
+    const ambient = { request: vi.fn(() => Promise.resolve(globalOptions)) }
+    const request = vi.fn(() => Promise.resolve(ownerPayload))
+
+    await expect(
+      requestModelOptions({ gateway: ambient as never, request: request as never, sessionId: 'tile-runtime' })
+    ).resolves.toBe(ownerPayload)
+
+    expect(request).toHaveBeenCalledWith('model.options', { explicit_only: true, session_id: 'tile-runtime' })
+    expect(ambient.request).not.toHaveBeenCalled()
+    expect(getGlobalModelOptions).not.toHaveBeenCalled()
+  })
+
+  it('pins the REST recovery read to the owner profile', async () => {
+    const restPayload = {
+      model: 'bot-default',
+      provider: 'nous',
+      providers: [{ models: ['bot-default'], name: 'Nous', slug: 'nous' }]
+    }
+
+    const request = vi.fn(() => Promise.reject(new Error('socket closed')))
+
+    vi.mocked(getGlobalModelOptions).mockResolvedValueOnce(restPayload)
+
+    await expect(
+      requestModelOptions({ profile: 'bot', request: request as never, sessionId: 'tile-runtime' })
+    ).resolves.toEqual(restPayload)
+
+    expect(getGlobalModelOptions).toHaveBeenCalledWith({ explicitOnly: true }, 'bot')
+  })
+
+  it('keeps the unpinned REST call shape when no profile is named', async () => {
+    const request = vi.fn(() => Promise.reject(new Error('socket closed')))
+
+    // Neither path has a selectable model, so the dispatcher error surfaces —
+    // this test is only about the REST call shape.
+    await requestModelOptions({ request: request as never, sessionId: null }).catch(() => undefined)
+
+    expect(getGlobalModelOptions).toHaveBeenCalledWith({ explicitOnly: true })
+  })
+
+  it('returns the REST catalog when the dispatcher yields nothing at all', async () => {
+    const emptyRest = { providers: [] }
+    const request = vi.fn(() => Promise.resolve(undefined))
+
+    vi.mocked(getGlobalModelOptions).mockResolvedValueOnce(emptyRest as never)
+
+    await expect(requestModelOptions({ request: request as never, sessionId: null })).resolves.toBe(emptyRest)
+  })
+})

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { setApiRequestConnection, setApiRequestProfile } from '@/api/client'
 import { getGlobalModelOptions } from '@/hermes'
 
 import { manualPickRemoved, modelOptionsQueryKey, requestModelOptions } from './model-options'
@@ -120,6 +121,11 @@ describe('requestModelOptions', () => {
 })
 
 describe('modelOptionsQueryKey', () => {
+  afterEach(() => {
+    setApiRequestConnection(null)
+    setApiRequestProfile(null)
+  })
+
   it('isolates new-chat catalogs by active gateway profile', () => {
     expect(modelOptionsQueryKey('default')).toEqual(['model-options', 'default', 'global'])
     expect(modelOptionsQueryKey('compass')).toEqual(['model-options', 'compass', 'global'])
@@ -128,6 +134,53 @@ describe('modelOptionsQueryKey', () => {
 
   it('keeps session catalogs inside the owning profile namespace', () => {
     expect(modelOptionsQueryKey(' compass ', 'session-1')).toEqual(['model-options', 'compass', 'session-1'])
+  })
+
+  it('does not alias an explicit local catalog with an ambient remote catalog', () => {
+    setApiRequestConnection('remote-active')
+    setApiRequestProfile('bot')
+
+    const explicitLocal = modelOptionsQueryKey({ connectionId: 'local', profile: 'bot' }, 'session-1')
+    const ambientRemote = modelOptionsQueryKey('bot', 'session-1')
+
+    expect(explicitLocal).toEqual(['model-options', 'conn:local::bot', 'session-1'])
+    expect(ambientRemote).toEqual(['model-options', 'conn:remote-active::bot', 'session-1'])
+    expect(explicitLocal).not.toEqual(ambientRemote)
+  })
+
+  it('keeps an explicit local pin distinct from the legacy ambient-local namespace', () => {
+    const explicitLocal = modelOptionsQueryKey({ connectionId: 'local', profile: 'bot' }, 'session-1')
+    const ambientLocal = modelOptionsQueryKey('bot', 'session-1')
+
+    expect(explicitLocal).toEqual(['model-options', 'conn:local::bot', 'session-1'])
+    expect(ambientLocal).toEqual(['model-options', 'bot', 'session-1'])
+    expect(explicitLocal).not.toEqual(ambientLocal)
+  })
+
+  it('includes the effective active connection in ambient catalog keys', () => {
+    setApiRequestProfile('bot')
+    setApiRequestConnection('remote-a')
+    const remoteA = modelOptionsQueryKey(undefined, 'session-1')
+
+    setApiRequestConnection('remote-b')
+    const remoteB = modelOptionsQueryKey(undefined, 'session-1')
+
+    expect(remoteA).toEqual(['model-options', 'conn:remote-a::bot', 'session-1'])
+    expect(remoteB).toEqual(['model-options', 'conn:remote-b::bot', 'session-1'])
+    expect(remoteA).not.toEqual(remoteB)
+  })
+
+  it('keeps explicit remote owners isolated from ambient and same-profile peers', () => {
+    setApiRequestConnection('ambient')
+
+    const ownerA = modelOptionsQueryKey({ connectionId: 'owner-a', profile: 'bot' }, 'session-1')
+    const ownerB = modelOptionsQueryKey({ connectionId: 'owner-b', profile: 'bot' }, 'session-1')
+    const ambient = modelOptionsQueryKey('bot', 'session-1')
+
+    expect(new Set([JSON.stringify(ownerA), JSON.stringify(ownerB), JSON.stringify(ambient)])).toHaveProperty(
+      'size',
+      3
+    )
   })
 })
 

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -214,6 +214,36 @@ describe('requestModelOptions owner routing', () => {
     expect(getGlobalModelOptions).toHaveBeenCalledWith({ explicitOnly: true }, 'bot')
   })
 
+  it("keeps a remote-owner tile's empty WS catalog pinned during REST recovery while another connection is active", async () => {
+    const ambientPayload = {
+      model: 'ambient-model',
+      provider: 'ambient',
+      providers: [{ models: ['ambient-model'], name: 'Ambient', slug: 'ambient' }]
+    }
+
+    const ownerPayload = {
+      model: 'owner-model',
+      provider: 'owner',
+      providers: [{ models: ['owner-model'], name: 'Owner', slug: 'owner' }]
+    }
+
+    const ownerScope = { connectionId: 'remote-owner', profile: 'backend-bot' }
+    const request = vi.fn(() => Promise.resolve({ model: 'owner-model', provider: 'owner', providers: [] }))
+
+    // Deterministically model the active-connection trap: an unpinned REST
+    // read returns the foreground connection's catalog; only the exact tile
+    // owner scope reaches the backend that owns the session.
+    vi.mocked(getGlobalModelOptions).mockImplementationOnce(async (_opts, scope) =>
+      JSON.stringify(scope as unknown) === JSON.stringify(ownerScope) ? ownerPayload : ambientPayload
+    )
+
+    await expect(
+      requestModelOptions({ profile: ownerScope as never, request: request as never, sessionId: 'tile-runtime' })
+    ).resolves.toEqual(ownerPayload)
+
+    expect(getGlobalModelOptions).toHaveBeenCalledWith({ explicitOnly: true }, ownerScope)
+  })
+
   it('keeps the unpinned REST call shape when no profile is named', async () => {
     const request = vi.fn(() => Promise.reject(new Error('socket closed')))
 

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -1,4 +1,6 @@
-import { profileScopeKey } from '@/api/client'
+import { registryBackendScopeKey } from '@hermes/shared'
+
+import { capabilityScoped, getApiRequestConnection } from '@/api/client'
 import { getGlobalModelOptions, type HermesGateway, type ModelOptionsResponse, type ProfileScope } from '@/hermes'
 import type { ModelOptionProvider } from '@/types/hermes'
 
@@ -61,8 +63,19 @@ interface ModelOptionsRequest {
   sessionId?: null | string
 }
 
+/** Canonical model-catalog ownership key. Unlike the general capability key,
+ * model catalogs must distinguish an explicit local pin from ambient routing,
+ * and ambient routing must rotate with the active registry connection. */
+export function modelOptionsScopeKey(profile: ProfileScope): string {
+  const effective = capabilityScoped(profile)
+  const explicit = !!profile && typeof profile === 'object'
+  const connectionId = explicit ? (profile.connectionId ?? '').trim() || 'local' : getApiRequestConnection()
+
+  return registryBackendScopeKey(connectionId, effective.profile)
+}
+
 export function modelOptionsQueryKey(profile: ProfileScope, sessionId?: null | string) {
-  return ['model-options', profileScopeKey(profile), sessionId || 'global'] as const
+  return ['model-options', modelOptionsScopeKey(profile), sessionId || 'global'] as const
 }
 
 function hasSelectableModels(options: ModelOptionsResponse | null | undefined): boolean {

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -34,13 +34,29 @@ export function manualPickRemoved(
   return !models.includes(model)
 }
 
+/** A gateway dispatcher: the ambient `gateway.request`, or a session-owner
+ *  routed one (`requestForSessionProfile`) for surfaces bound to a session. */
+export type ModelOptionsDispatch = <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+
 interface ModelOptionsRequest {
   /** When false, include ambient/unconfigured providers (onboarding/setup
    *  surfaces). Chat pickers default to true so only explicitly configured
    *  providers are listed (#56974). */
   explicitOnly?: boolean
   gateway?: HermesGateway
+  /** Profile whose REST catalog the recovery path reads. Defaults to the
+   *  active API profile — wrong for a tile bound to another profile's
+   *  session, so session-bound surfaces pass their owner's profile. */
+  profile?: null | string
   refresh?: boolean
+  /**
+   * Owner-routed dispatcher for the `model.options` read. Takes precedence
+   * over `gateway`: the backend resolves `session_id` in ITS OWN process, so
+   * a catalog read for a session owned by another profile/connection must go
+   * out on that owner's socket — the ambient one never held the runtime, and
+   * silently answers with its own global config instead (#93892).
+   */
+  request?: ModelOptionsDispatch
   sessionId?: null | string
 }
 
@@ -54,13 +70,30 @@ function hasSelectableModels(options: ModelOptionsResponse | null | undefined): 
   return options?.providers?.some(provider => (provider.models?.length ?? 0) > 0) ?? false
 }
 
+function restModelOptions(
+  opts: { explicitOnly: boolean; refresh?: true },
+  profile: null | string | undefined
+): Promise<ModelOptionsResponse> {
+  const key = (profile ?? '').trim()
+
+  // Only pin the profile when the caller named one — the default keeps the
+  // active API profile scope (and the call shape) every other caller relies on.
+  return key ? getGlobalModelOptions(opts, key) : getGlobalModelOptions(opts)
+}
+
 export async function requestModelOptions({
   explicitOnly = true,
   gateway,
+  profile,
   refresh = false,
+  request,
   sessionId
 }: ModelOptionsRequest): Promise<ModelOptionsResponse> {
-  if (gateway) {
+  const dispatch: ModelOptionsDispatch | undefined =
+    request ??
+    (gateway ? <T>(method: string, params?: Record<string, unknown>) => gateway.request<T>(method, params) : undefined)
+
+  if (dispatch) {
     const params: Record<string, unknown> = {}
 
     if (sessionId) {
@@ -77,9 +110,10 @@ export async function requestModelOptions({
 
     let gatewayError: unknown
     let gatewayOptions: ModelOptionsResponse | undefined
+    let restFallback: ModelOptionsResponse | undefined
 
     try {
-      gatewayOptions = await gateway.request<ModelOptionsResponse>('model.options', params)
+      gatewayOptions = (await dispatch<ModelOptionsResponse | undefined>('model.options', params)) ?? undefined
     } catch (error) {
       gatewayError = error
     }
@@ -93,7 +127,7 @@ export async function requestModelOptions({
     // catalog is already populated. Recover through the same profile-scoped
     // endpoint Settings uses, but keep the live session selection authoritative.
     try {
-      const restOptions = await getGlobalModelOptions({ explicitOnly, ...(refresh ? { refresh: true } : {}) })
+      const restOptions = await restModelOptions({ explicitOnly, ...(refresh ? { refresh: true } : {}) }, profile)
 
       if (hasSelectableModels(restOptions)) {
         return {
@@ -102,6 +136,8 @@ export async function requestModelOptions({
           ...(gatewayOptions?.model ? { model: gatewayOptions.model } : {})
         }
       }
+
+      restFallback = restOptions
     } catch {
       // Preserve the gateway result (or its original error) when the recovery
       // path is unavailable.
@@ -111,8 +147,14 @@ export async function requestModelOptions({
       return gatewayOptions
     }
 
-    throw gatewayError
+    // The dispatcher answered with nothing at all (no catalog, no error): the
+    // REST read is the only catalog we have, selectable models or not.
+    if (restFallback && gatewayError === undefined) {
+      return restFallback
+    }
+
+    throw gatewayError ?? new Error('model.options returned no catalog')
   }
 
-  return getGlobalModelOptions({ explicitOnly, ...(refresh ? { refresh: true } : {}) })
+  return restModelOptions({ explicitOnly, ...(refresh ? { refresh: true } : {}) }, profile)
 }

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -1,4 +1,5 @@
-import { getGlobalModelOptions, type HermesGateway, type ModelOptionsResponse } from '@/hermes'
+import { profileScopeKey } from '@/api/client'
+import { getGlobalModelOptions, type HermesGateway, type ModelOptionsResponse, type ProfileScope } from '@/hermes'
 import type { ModelOptionProvider } from '@/types/hermes'
 
 /**
@@ -47,7 +48,7 @@ interface ModelOptionsRequest {
   /** Profile whose REST catalog the recovery path reads. Defaults to the
    *  active API profile — wrong for a tile bound to another profile's
    *  session, so session-bound surfaces pass their owner's profile. */
-  profile?: null | string
+  profile?: ProfileScope
   refresh?: boolean
   /**
    * Owner-routed dispatcher for the `model.options` read. Takes precedence
@@ -60,10 +61,8 @@ interface ModelOptionsRequest {
   sessionId?: null | string
 }
 
-export function modelOptionsQueryKey(profile: null | string | undefined, sessionId?: null | string) {
-  const profileKey = (profile ?? '').trim() || 'default'
-
-  return ['model-options', profileKey, sessionId || 'global'] as const
+export function modelOptionsQueryKey(profile: ProfileScope, sessionId?: null | string) {
+  return ['model-options', profileScopeKey(profile), sessionId || 'global'] as const
 }
 
 function hasSelectableModels(options: ModelOptionsResponse | null | undefined): boolean {
@@ -72,13 +71,13 @@ function hasSelectableModels(options: ModelOptionsResponse | null | undefined): 
 
 function restModelOptions(
   opts: { explicitOnly: boolean; refresh?: true },
-  profile: null | string | undefined
+  profile: ProfileScope
 ): Promise<ModelOptionsResponse> {
-  const key = (profile ?? '').trim()
-
-  // Only pin the profile when the caller named one — the default keeps the
-  // active API profile scope (and the call shape) every other caller relies on.
-  return key ? getGlobalModelOptions(opts, key) : getGlobalModelOptions(opts)
+  // Only pass a scope when the caller named one — undefined keeps the active
+  // API (connection, profile) scope and the call shape global callers rely on.
+  return profile == null || (typeof profile === 'string' && !profile.trim())
+    ? getGlobalModelOptions(opts)
+    : getGlobalModelOptions(opts, profile)
 }
 
 export async function requestModelOptions({

--- a/apps/desktop/src/store/gateway-foreground-retention.test.ts
+++ b/apps/desktop/src/store/gateway-foreground-retention.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// #93892 regression: the registry disposed the secondary socket an idle Bot
+// Chat tile was bound to — the live-work pruner for a pre-dialed (retained)
+// entry, and the refcount-0 request lease for one the tile's own resume
+// created. openGatewayForAgent marks the entry `retained`, but `retained` is
+// a one-way latch every hover pre-warm and profile switch also sets, so no
+// dispose path can honor it without leaking every socket ever warmed.
+// Instead the registry's `foregroundScopes` hook names the scopes FOREGROUND
+// surfaces are bound to (foregroundSessionScopes): a mounted tile pins its
+// owner socket for exactly as long as it is mounted, on every dispose path.
+
+const gatewayMocks = vi.hoisted(() => ({
+  closed: [] as string[]
+}))
+
+vi.mock('@/hermes', async importActual => ({
+  ...(await importActual<Record<string, unknown>>()),
+  setApiRequestConnection: vi.fn(),
+  HermesGateway: class {
+    connectionState = 'closed'
+    wsUrl = ''
+    connect = async (wsUrl: string): Promise<void> => {
+      this.wsUrl = wsUrl
+      this.connectionState = 'open'
+    }
+    close = (): void => {
+      gatewayMocks.closed.push(this.wsUrl)
+      this.connectionState = 'closed'
+    }
+    request = async (): Promise<unknown> => ({})
+    onEvent = vi.fn(() => () => {})
+    onState = vi.fn(() => () => {})
+  }
+}))
+vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() }))
+
+const {
+  closeSecondaryGateways,
+  configureGatewayRegistry,
+  openGatewayForAgent,
+  pruneSecondaryGateways,
+  requestGatewayForAgent,
+  setPrimaryGateway
+} = await import('./gateway')
+
+const { $sessionTiles, foregroundSessionScopes, liveSessionScopes } = await import('./session-states')
+
+function installDesktop(): void {
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+    getConnection: vi.fn(async () => ({
+      authMode: 'token',
+      profile: 'default',
+      token: 't',
+      wsUrl: 'wss://local.invalid/api/ws?token=t'
+    })),
+    getConnectionFor: vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
+      authMode: 'token',
+      connectionId,
+      profile,
+      token: 't',
+      wsUrl: `wss://${connectionId}.invalid/api/ws?profile=${profile}`
+    })),
+    getGatewayWsUrlFor: vi.fn(
+      async ({ connectionId, profile }: { connectionId: string; profile: string }) =>
+        `wss://${connectionId}.invalid/api/ws?profile=${profile}`
+    ),
+    touchBackend: vi.fn(async () => undefined)
+  }
+}
+
+// What use-gateway-boot's recomputeKeptGateways feeds the pruner for a
+// window with NO busy / needs-input work anywhere — the idle bot chat case.
+// Foreground pins are NOT in here: the registry reads them itself.
+const idleKeepSet = () => liveSessionScopes()
+
+const BOT_TILE = {
+  ownerRoute: { connectionId: 'local', mode: 'local' as const, profile: 'bot' },
+  runtimeId: 'rt-bot',
+  storedSessionId: 'stored-bot'
+}
+
+beforeEach(() => {
+  installDesktop()
+  // Wired exactly as use-gateway-boot wires it.
+  configureGatewayRegistry({ foregroundScopes: foregroundSessionScopes, onEvent: vi.fn() })
+  setPrimaryGateway({ connectionState: 'open' } as never, 'default')
+  gatewayMocks.closed = []
+  $sessionTiles.set([])
+})
+
+afterEach(() => {
+  closeSecondaryGateways()
+  $sessionTiles.set([])
+  vi.clearAllMocks()
+  delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+describe('foreground tile retention vs. the live-work pruner (#93892)', () => {
+  it('keeps an idle Bot Chat tile’s owner socket across prune recomputes', async () => {
+    // The BOTS workspace dials the bot's own backend without activating it
+    // (keepAllProfilesScope) and opens the canonical chat as a tile on that
+    // route. The global active profile stays primary/default.
+    await openGatewayForAgent('local', 'bot')
+    $sessionTiles.set([BOT_TILE])
+
+    // Idle: no working / needs-input session anywhere. Before the fix this
+    // recompute closed the socket → backend reaped the runtime → reclaim →
+    // unbind → resume → … forever.
+    pruneSecondaryGateways(idleKeepSet())
+    pruneSecondaryGateways(idleKeepSet())
+
+    expect(gatewayMocks.closed).toEqual([])
+  })
+
+  it('keeps the socket while the tile is still resuming (no runtime bound yet)', async () => {
+    await openGatewayForAgent('local', 'bot')
+    $sessionTiles.set([{ ...BOT_TILE, runtimeId: undefined }])
+
+    pruneSecondaryGateways(idleKeepSet())
+
+    expect(gatewayMocks.closed).toEqual([])
+  })
+
+  it('releases the socket once the tile is closed — the pin never latches', async () => {
+    await openGatewayForAgent('local', 'bot')
+    $sessionTiles.set([BOT_TILE])
+    pruneSecondaryGateways(idleKeepSet())
+    expect(gatewayMocks.closed).toEqual([])
+
+    $sessionTiles.set([])
+    pruneSecondaryGateways(idleKeepSet())
+
+    expect(gatewayMocks.closed).toEqual(['wss://local.invalid/api/ws?profile=bot'])
+  })
+
+  it('keeps the socket a tile’s OWN resume dialed (no pre-dial, refcount-0 lease path)', async () => {
+    // Relaunch with a persisted Bot Chat tab: nothing pre-dials the bot, so
+    // the tile's session.resume goes out through requestGatewayForAgent's
+    // per-request lease on a fresh, NON-retained entry. Before the fix the
+    // lease's `finally` disposed that socket the instant the resume returned
+    // — the runtime it had just minted was orphaned on the spot.
+    $sessionTiles.set([{ ...BOT_TILE, runtimeId: undefined }])
+
+    await requestGatewayForAgent('local', 'bot', 'session.resume', { session_id: 'stored-bot' })
+
+    expect(gatewayMocks.closed).toEqual([])
+
+    // …and the pruner agrees with the lease.
+    pruneSecondaryGateways(idleKeepSet())
+    expect(gatewayMocks.closed).toEqual([])
+
+    // Tile gone: the next lease release disposes as it always did.
+    $sessionTiles.set([])
+    await requestGatewayForAgent('local', 'bot', 'session.usage', { session_id: 'stored-bot' })
+    expect(gatewayMocks.closed).toEqual(['wss://local.invalid/api/ws?profile=bot'])
+  })
+
+  it('still prunes a merely pre-warmed (retained, no surface) socket — `retained` is not a pin', async () => {
+    // A roster hover warms the bot's socket through the same door and sets
+    // the same `retained` flag; with no tile bound to it, it is idle garbage.
+    await openGatewayForAgent('local', 'bot')
+
+    pruneSecondaryGateways(idleKeepSet())
+
+    expect(gatewayMocks.closed).toEqual(['wss://local.invalid/api/ws?profile=bot'])
+  })
+
+  it('does not let a tile on one source pin another source’s same-named profile', async () => {
+    await openGatewayForAgent('homelab', 'bot')
+    $sessionTiles.set([BOT_TILE])
+
+    pruneSecondaryGateways(idleKeepSet())
+
+    expect(gatewayMocks.closed).toEqual(['wss://homelab.invalid/api/ws?profile=bot'])
+  })
+})

--- a/apps/desktop/src/store/gateway-foreground-retention.test.ts
+++ b/apps/desktop/src/store/gateway-foreground-retention.test.ts
@@ -97,6 +97,18 @@ afterEach(() => {
 })
 
 describe('foreground tile retention vs. the live-work pruner (#93892)', () => {
+  it('computes foreground scopes once for a whole prune pass', async () => {
+    const foregroundScopes = vi.fn(() => new Set<string>())
+
+    configureGatewayRegistry({ foregroundScopes, onEvent: vi.fn() })
+    await openGatewayForAgent('source-a', 'bot')
+    await openGatewayForAgent('source-b', 'bot')
+
+    pruneSecondaryGateways(idleKeepSet())
+
+    expect(foregroundScopes).toHaveBeenCalledTimes(1)
+  })
+
   it('keeps an idle Bot Chat tile’s owner socket across prune recomputes', async () => {
     // The BOTS workspace dials the bot's own backend without activating it
     // (keepAllProfilesScope) and opens the canonical chat as a tile on that

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -36,6 +36,19 @@ interface RegistryConfig {
    * (#89206: the stale-profile split-brain that stranded bot wake-ups).
    */
   onActiveRouteChanged?: (profile: string) => void
+  /**
+   * Scopes a FOREGROUND surface is bound to right now — every mounted
+   * session tile's owner and the primary thread's (foregroundSessionScopes in
+   * store/session-states; a config hook because that store imports this
+   * one). Consulted by EVERY dispose path — the live-work pruner and the
+   * dispose-at-refcount-0 request/relay leases alike (#93892): a tile's
+   * resume mints its runtime on its owner's socket, and any path that closes
+   * that socket makes the backend orphan-reap the runtime, whose
+   * `session.reclaimed` unbinds the tile and re-arms its resume — a spinner
+   * loop with no terminal state. Read at decision time, never cached: it
+   * follows the tile set, so closing the tile releases the socket.
+   */
+  foregroundScopes?: () => ReadonlySet<string>
 }
 
 // ── Secondary (pool) backends ──────────────────────────────────────────────
@@ -54,7 +67,16 @@ interface Secondary {
   reconnectTimer: ReturnType<typeof setTimeout> | null
   reconnectAttempt: number
   reconnecting: boolean
-  /** True when a foreground/prewarmed consumer owns this entry beyond one RPC. */
+  /**
+   * True when a foreground/prewarmed consumer owns this entry beyond one RPC.
+   * Guards ONLY the dispose-at-refcount-0 paths (request/relay leases), never
+   * the live-work pruner: it is a one-way latch that every hover pre-warm and
+   * profile switch sets and nothing ever clears, so honoring it in
+   * pruneSecondaryGateways would pin every socket ever warmed. A foreground
+   * surface that must keep its owner socket (a mounted session tile, the
+   * primary thread) is represented in the pruner's keep-set instead — see
+   * foregroundSessionScopes in store/session-states (#93892).
+   */
   retained: boolean
   /**
    * Bot-relay retainers pinning this socket open across drain ticks (#93594).
@@ -593,7 +615,13 @@ async function gatewayForProfile(
       released = true
       entry.activeRequests = Math.max(0, entry.activeRequests - 1)
 
-      if (entry.activeRequests === 0 && !entry.retained && !relayRetained(entry) && g.activeKey !== entry.scope) {
+      if (
+        entry.activeRequests === 0 &&
+        !entry.retained &&
+        !relayRetained(entry) &&
+        !foregroundPinned(entry) &&
+        g.activeKey !== entry.scope
+      ) {
         disposeSecondary(entry)
 
         if (g.secondaries.get(entry.scope) === entry) {
@@ -697,7 +725,13 @@ export async function requestGatewayForAgent<T>(
   } finally {
     entry.activeRequests = Math.max(0, entry.activeRequests - 1)
 
-    if (entry.activeRequests === 0 && !entry.retained && !relayRetained(entry) && g.activeKey !== entry.scope) {
+    if (
+      entry.activeRequests === 0 &&
+      !entry.retained &&
+      !relayRetained(entry) &&
+      !foregroundPinned(entry) &&
+      g.activeKey !== entry.scope
+    ) {
       disposeSecondary(entry)
 
       if (g.secondaries.get(entry.scope) === entry) {
@@ -716,6 +750,22 @@ export async function requestGatewayForAgent<T>(
 // counted retention that keeps the pooled socket (and its existing
 // scheduleReconnect/backoff machinery) alive across ticks; stopBotRelay (and
 // plugin dispose) releases it, restoring the dispose-at-refcount-0 behavior.
+
+/**
+ * True when a foreground surface (mounted tile / primary thread) is bound to
+ * this entry's scope (#93892). Registry-scoped entries match on their
+ * composite key only; local/legacy entries also match on the bare profile —
+ * the same key language pruneSecondaryGateways' keep-set speaks.
+ */
+function foregroundPinned(entry: Secondary): boolean {
+  const scopes = g.config?.foregroundScopes?.()
+
+  if (!scopes) {
+    return false
+  }
+
+  return scopes.has(entry.scope) || (!entry.connectionId && scopes.has(entry.profile))
+}
 
 /** True when the bot relay currently pins this entry open. Number guard:
  *  dev-HMR entries predate the field. */
@@ -765,6 +815,7 @@ export function retainGatewayForRelay(connectionId: null | string, profile: stri
       entry.relayRetainCount === 0 &&
       entry.activeRequests === 0 &&
       !entry.retained &&
+      !foregroundPinned(entry) &&
       g.activeKey !== entry.scope &&
       g.secondaries.get(entry.scope) === entry
     ) {
@@ -827,7 +878,13 @@ export async function retainGatewayForAgent(connectionId: null | string, profile
     released = true
     entry.activeRequests = Math.max(0, entry.activeRequests - 1)
 
-    if (entry.activeRequests === 0 && !entry.retained && !relayRetained(entry) && g.activeKey !== entry.scope) {
+    if (
+      entry.activeRequests === 0 &&
+      !entry.retained &&
+      !relayRetained(entry) &&
+      !foregroundPinned(entry) &&
+      g.activeKey !== entry.scope
+    ) {
       disposeSecondary(entry)
 
       if (g.secondaries.get(entry.scope) === entry) {
@@ -1102,6 +1159,16 @@ function restoreActiveToPrimaryIfEvicted(): void {
 // source exposes a 'default' profile, so matching a non-local entry on the
 // bare profile name kept gateway B's 'default' socket alive off gateway A's
 // 'default' activity (and vice versa) — cross-connection attribution.
+//
+// Live work is not the only thing worth a socket: an idle tile still holds a
+// resumed runtime on its owner's socket, and closing that socket makes the
+// backend detach and orphan-reap the runtime, whose `session.reclaimed`
+// unbinds the tile and re-resumes it on a fresh socket that the next
+// recompute closes again — a spinner loop with no terminal state (#93892).
+// Foreground-bound scopes come from the registry's `foregroundScopes` hook
+// (foregroundPinned), not from `keep`, so every dispose path sees the same
+// pin. `entry.retained` is deliberately NOT consulted here (see the field's
+// doc).
 export function pruneSecondaryGateways(keep: Set<string>): void {
   const now = Date.now()
 
@@ -1115,6 +1182,9 @@ export function pruneSecondaryGateways(keep: Set<string>): void {
       // its whole active lifetime; the live-work pruner must not undo that
       // pin between drain ticks or the socket churn returns.
       relayRetained(entry) ||
+      // A mounted tile / the primary thread is bound to a runtime on this
+      // socket (#93892) — pinned for as long as that surface is mounted.
+      foregroundPinned(entry) ||
       // Mid-dial activation target: the profile being switched TO is not yet
       // active and has no live work, so without this lease any recompute
       // during its cold spawn disposed the entry and the click died silently

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -757,9 +757,7 @@ export async function requestGatewayForAgent<T>(
  * composite key only; local/legacy entries also match on the bare profile —
  * the same key language pruneSecondaryGateways' keep-set speaks.
  */
-function foregroundPinned(entry: Secondary): boolean {
-  const scopes = g.config?.foregroundScopes?.()
-
+function foregroundPinned(entry: Secondary, scopes = g.config?.foregroundScopes?.()): boolean {
   if (!scopes) {
     return false
   }
@@ -1171,6 +1169,9 @@ function restoreActiveToPrimaryIfEvicted(): void {
 // doc).
 export function pruneSecondaryGateways(keep: Set<string>): void {
   const now = Date.now()
+  // foregroundSessionScopes walks mounted surfaces and owner maps. Snapshot
+  // it once for this decision pass rather than rebuilding it per secondary.
+  const foregroundScopes = g.config?.foregroundScopes?.()
 
   for (const [key, entry] of [...g.secondaries]) {
     if (
@@ -1184,7 +1185,7 @@ export function pruneSecondaryGateways(keep: Set<string>): void {
       relayRetained(entry) ||
       // A mounted tile / the primary thread is bound to a runtime on this
       // socket (#93892) — pinned for as long as that surface is mounted.
-      foregroundPinned(entry) ||
+      foregroundPinned(entry, foregroundScopes) ||
       // Mid-dial activation target: the profile being switched TO is not yet
       // active and has no live work, so without this lease any recompute
       // during its cold spawn disposed the entry and the click died silently

--- a/apps/desktop/src/store/session-states-foreground-scopes.test.ts
+++ b/apps/desktop/src/store/session-states-foreground-scopes.test.ts
@@ -103,6 +103,36 @@ describe('foregroundSessionScopes', () => {
     expect(foregroundSessionScopes()).toEqual(new Set(['bot']))
   })
 
+  it('pins only the persisted tile route when owner candidates disagree', () => {
+    setSessionOwnerHint('stored-disagree', {
+      connectionId: 'stale-hint',
+      mode: 'remote',
+      profile: 'bot'
+    })
+    recordTileOwner('stored-disagree', { connectionId: 'stale-resolved', profile: 'bot' })
+    $sessionTiles.set([
+      {
+        ownerRoute: { connectionId: 'authoritative-route', mode: 'remote', profile: 'bot' },
+        storedSessionId: 'stored-disagree'
+      }
+    ])
+
+    expect(foregroundSessionScopes()).toEqual(new Set(['conn:authoritative-route::bot']))
+  })
+
+  it('pins only the first valid recovery owner when route data is unavailable', () => {
+    setSessionOwnerHint('stored-fallback-disagree', {
+      connectionId: 'authoritative-hint',
+      mode: 'remote',
+      profile: 'bot'
+    })
+    recordTileOwner('stored-fallback-disagree', { connectionId: 'stale-resolved', profile: 'bot' })
+    setSessions([row({ id: 'stored-fallback-disagree', profile: 'stale-row' })])
+    $sessionTiles.set([{ storedSessionId: 'stored-fallback-disagree' }])
+
+    expect(foregroundSessionScopes()).toEqual(new Set(['conn:authoritative-hint::bot']))
+  })
+
   it('follows the tile set: closing the tile releases its scope', () => {
     $sessionTiles.set([
       { ownerRoute: { connectionId: 'local', mode: 'local', profile: 'bot' }, storedSessionId: 'stored-bot' }

--- a/apps/desktop/src/store/session-states-foreground-scopes.test.ts
+++ b/apps/desktop/src/store/session-states-foreground-scopes.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { $selectedStoredSessionId, setSessionOwnerHint, setSessions } from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
+
+import { $sessionTiles, foregroundSessionScopes, recordTileOwner } from './session-states'
+
+// #93892: the gateway keep-set only carried busy / needs-input work, so an
+// idle tile's owner socket was pruned out from under its resumed runtime —
+// backend reap → `session.reclaimed` → tile unbound → resume → prune → … a
+// spinner loop with no terminal state. foregroundSessionScopes() is the
+// foreground half of the keep-set: every mounted tile's owner plus the
+// primary thread's owner, expressed in the pruner's own key language.
+
+const row = (over: Partial<SessionInfo>): SessionInfo =>
+  ({
+    ended_at: null,
+    id: 'stored',
+    input_tokens: 0,
+    is_active: false,
+    last_active: 0,
+    message_count: 1,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    profile: 'default',
+    source: null,
+    started_at: 0,
+    title: null,
+    ...over
+  }) as SessionInfo
+
+afterEach(() => {
+  $sessionTiles.set([])
+  $selectedStoredSessionId.set(null)
+  setSessions([])
+})
+
+describe('foregroundSessionScopes', () => {
+  it('is empty with nothing mounted', () => {
+    expect(foregroundSessionScopes()).toEqual(new Set())
+  })
+
+  it('pins a route-owned tile by its composite (connectionId, profile) scope — bound or still resuming', () => {
+    $sessionTiles.set([
+      {
+        ownerRoute: { connectionId: 'local', mode: 'local', profile: 'bot' },
+        runtimeId: 'rt-bot',
+        storedSessionId: 'stored-bot'
+      },
+      {
+        ownerRoute: { connectionId: 'homelab', mode: 'remote', profile: 'research' },
+        storedSessionId: 'stored-remote'
+      }
+    ])
+
+    expect(foregroundSessionScopes()).toEqual(new Set(['conn:local::bot', 'conn:homelab::research']))
+  })
+
+  it('pins a profile-owned tile (no route) by the bare profile key the local pool matches on', () => {
+    setSessions([row({ id: 'stored-legacy', profile: ' Research ' })])
+    $sessionTiles.set([{ storedSessionId: 'stored-legacy' }])
+
+    expect(foregroundSessionScopes()).toEqual(new Set(['Research']))
+  })
+
+  it('contributes nothing for a tile whose owner is unknown, and ignores a blank connection id', () => {
+    $sessionTiles.set([
+      { storedSessionId: 'stored-unknown' },
+      { ownerRoute: { connectionId: '   ', profile: 'bot' }, storedSessionId: 'stored-blank' }
+    ])
+
+    expect(foregroundSessionScopes()).toEqual(new Set())
+  })
+
+  it('pins the primary thread’s owner too (all-profiles mode dials it without activating)', () => {
+    // Keyed by the SELECTED STORED id: the runtime id is re-minted on every
+    // resume and never resolves to an owner.
+    setSessions([row({ id: 'stored-primary', profile: 'ai-engineer' })])
+    $selectedStoredSessionId.set('stored-primary')
+
+    expect(foregroundSessionScopes()).toEqual(new Set(['ai-engineer']))
+  })
+
+  it('names a route-less tile through its open-time owner hint', () => {
+    // A hidden Bot Chat has no sidebar row and (here) no persisted route —
+    // the hint host.openSession recorded is the only owner record.
+    setSessionOwnerHint('stored-hinted', { connectionId: 'local', mode: 'local', profile: 'bot' })
+    $sessionTiles.set([{ storedSessionId: 'stored-hinted' }])
+
+    expect(foregroundSessionScopes()).toEqual(new Set(['conn:local::bot']))
+  })
+
+  it('names a route-less, hint-less tile through the owner its resume resolved', () => {
+    // Legacy roster row opened while the primary is active: no route, no
+    // hint, hidden session. resumeTile resolves the owning profile and
+    // records it — that profile's bare socket is the one carrying the runtime.
+    $sessionTiles.set([{ storedSessionId: 'stored-resolved' }])
+    expect(foregroundSessionScopes()).toEqual(new Set())
+
+    recordTileOwner('stored-resolved', 'bot')
+
+    expect(foregroundSessionScopes()).toEqual(new Set(['bot']))
+  })
+
+  it('follows the tile set: closing the tile releases its scope', () => {
+    $sessionTiles.set([
+      { ownerRoute: { connectionId: 'local', mode: 'local', profile: 'bot' }, storedSessionId: 'stored-bot' }
+    ])
+    expect(foregroundSessionScopes().has('conn:local::bot')).toBe(true)
+
+    $sessionTiles.set([])
+    expect(foregroundSessionScopes().has('conn:local::bot')).toBe(false)
+  })
+})

--- a/apps/desktop/src/store/session-states-foreground-scopes.test.ts
+++ b/apps/desktop/src/store/session-states-foreground-scopes.test.ts
@@ -112,4 +112,15 @@ describe('foregroundSessionScopes', () => {
     $sessionTiles.set([])
     expect(foregroundSessionScopes().has('conn:local::bot')).toBe(false)
   })
+
+  it('forgets a resolved owner when its tile closes instead of reviving stale ownership', () => {
+    $sessionTiles.set([{ storedSessionId: 'stored-resolved' }])
+    recordTileOwner('stored-resolved', 'bot')
+    expect(foregroundSessionScopes()).toEqual(new Set(['bot']))
+
+    $sessionTiles.set([])
+    $sessionTiles.set([{ storedSessionId: 'stored-resolved' }])
+
+    expect(foregroundSessionScopes()).toEqual(new Set())
+  })
 })

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -124,8 +124,8 @@ export function recordTileOwner(storedSessionId: string, owner: SessionOwnerScop
  * socket, which the next dispose decision closes again — a spinner loop with
  * no terminal state.
  *
- * Owners are named the way the resume itself resolves them (owner hint, tile
- * route, the owner the delegate recorded), falling back to the session row's
+ * Owners are named by authoritative precedence (persisted tile route, owner
+ * hint, the owner the delegate recorded), falling back to the session row's
  * profile. Route-owned surfaces map to their composite (connectionId,
  * profile) scope; profile-owned ones to the bare profile key the local/legacy
  * pool entries match on. The set follows `$sessionTiles` /
@@ -138,33 +138,41 @@ export function foregroundSessionScopes(): Set<string> {
   const scopes = new Set<string>()
   const sessions = $sessions.get()
 
-  const addOwner = (owner: SessionOwnerScope): boolean => {
+  const ownerScopeKey = (owner: SessionOwnerScope): string | undefined => {
     if (!owner) {
-      return false
+      return undefined
     }
 
     if (typeof owner === 'string') {
-      scopes.add(normalizeProfileKey(owner))
-
-      return true
+      return normalizeProfileKey(owner)
     }
 
     if (!owner.connectionId.trim()) {
-      return false
+      return undefined
     }
 
-    scopes.add(registryBackendScopeKey(owner.connectionId, normalizeProfileKey(owner.profile)))
-
-    return true
+    return registryBackendScopeKey(owner.connectionId, normalizeProfileKey(owner.profile))
   }
 
   const addStoredSession = (storedSessionId: string, route: SessionProfileRoute | undefined) => {
-    const known = [getSessionOwnerHint(storedSessionId), route, resolvedTileOwners.get(storedSessionId)]
-      .map(addOwner)
-      .some(Boolean)
+    // One surface has one owner. Persisted tile routing is authoritative;
+    // hints and the last resolved owner are recovery fallbacks only. Resolve
+    // the precedence first so stale candidates never pin extra sockets.
+    const candidates: SessionOwnerScope[] = [
+      route,
+      getSessionOwnerHint(storedSessionId),
+      resolvedTileOwners.get(storedSessionId),
+      knownSessionProfile(sessions, storedSessionId)
+    ]
 
-    if (!known) {
-      addOwner(knownSessionProfile(sessions, storedSessionId))
+    for (const candidate of candidates) {
+      const key = ownerScopeKey(candidate)
+
+      if (key) {
+        scopes.add(key)
+
+        return
+      }
     }
   }
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -773,6 +773,21 @@ export const $sessionTiles = atom<SessionTile[]>(
   isSecondaryWindow() ? [] : [...(tilesByProfile[profileKey()] ?? []), ...(tilesByProfile[BOTS_TILE_BUCKET] ?? [])]
 )
 
+// A resume-resolved owner is useful only while that tile is mounted. Prune at
+// the atom boundary so close, profile switch, restore, and direct test/store
+// replacement all release the record; otherwise repeatedly opened one-off
+// tiles grow resolvedTileOwners forever and can revive stale ownership if a
+// stored id is reused later.
+$sessionTiles.subscribe(tiles => {
+  const mounted = new Set(tiles.map(tile => tile.storedSessionId))
+
+  for (const storedSessionId of resolvedTileOwners.keys()) {
+    if (!mounted.has(storedSessionId)) {
+      resolvedTileOwners.delete(storedSessionId)
+    }
+  }
+})
+
 function persistTiles() {
   // Shares the origin's storage; a secondary window holds no tiles, so a write
   // back would only wipe the primary's set.

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -861,6 +861,75 @@ export function knownOwnerForSession(sessionId: null | string | undefined): Sess
   return sessionTileOwnerRoute(storedSessionId) ?? knownSessionProfile($sessions.get(), storedSessionId)
 }
 
+export type SessionEventOwnerRouteResolution =
+  | { kind: 'ambiguous' }
+  | { kind: 'known'; route: SessionProfileRoute }
+  | { kind: 'unknown' }
+
+/**
+ * Resolve the authoritative owner route for one registry event. The registry
+ * tags events with the socket route (`profile`), while a persisted tile/hint
+ * may additionally name the backend `targetProfile` that owns its catalog.
+ * Match both the event source and session identity; never borrow an alias from
+ * another connection that happens to reuse the same runtime/stored id.
+ */
+export function sessionEventOwnerRoute(
+  runtimeSessionId: null | string | undefined,
+  storedSessionId: null | string | undefined,
+  source: Pick<SessionProfileRoute, 'connectionId' | 'profile'>
+): SessionEventOwnerRouteResolution {
+  const runtimeId = runtimeSessionId?.trim() || ''
+  const storedId = storedSessionId?.trim() || ''
+  const connectionId = source.connectionId.trim()
+  const profile = source.profile.trim() || 'default'
+
+  if (!connectionId || (!runtimeId && !storedId)) {
+    return { kind: 'unknown' }
+  }
+
+  const sourceMatches = (route: SessionProfileRoute | undefined) =>
+    route?.connectionId.trim() === connectionId && (route.profile.trim() || 'default') === profile
+
+  const tileRoutes = $sessionTiles
+    .get()
+    .filter(tile =>
+      storedId
+        ? tile.storedSessionId === storedId && (!runtimeId || !tile.runtimeId || tile.runtimeId === runtimeId)
+        : tile.runtimeId === runtimeId || tile.storedSessionId === runtimeId
+    )
+    .map(tile => tile.ownerRoute)
+    .filter((route): route is SessionProfileRoute => sourceMatches(route))
+
+  if (tileRoutes.length > 1) {
+    return { kind: 'ambiguous' }
+  }
+
+  if (tileRoutes.length === 1) {
+    return { kind: 'known', route: tileRoutes[0] }
+  }
+
+  const hintRoutes = [...new Set([storedId, runtimeId].filter(Boolean))]
+    .map(id => getSessionOwnerHint(id, { connectionId, profile }))
+    .filter((route): route is SessionProfileRoute => Boolean(route))
+
+  if (hintRoutes.length > 1) {
+    const first = hintRoutes[0]
+
+    const sameRoute = hintRoutes.every(
+      route =>
+        route.connectionId === first.connectionId &&
+        route.profile === first.profile &&
+        route.targetProfile === first.targetProfile
+    )
+
+    if (!sameRoute) {
+      return { kind: 'ambiguous' }
+    }
+  }
+
+  return hintRoutes[0] ? { kind: 'known', route: hintRoutes[0] } : { kind: 'unknown' }
+}
+
 /**
  * Dispatch a session-scoped RPC through the OWNER of `sessionId` (tile route →
  * known profile), falling back to the ambient dispatcher only when no owner is

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -892,11 +892,21 @@ export function sessionEventOwnerRoute(
 
   const tileRoutes = $sessionTiles
     .get()
-    .filter(tile =>
-      storedId
-        ? tile.storedSessionId === storedId && (!runtimeId || !tile.runtimeId || tile.runtimeId === runtimeId)
-        : tile.runtimeId === runtimeId || tile.storedSessionId === runtimeId
-    )
+    .filter(tile => {
+      // A live runtime binding is the strongest identity. Compression can
+      // rotate the backend's stored id while the mounted tile intentionally
+      // retains the durable lineage id.
+      if (runtimeId && tile.runtimeId) {
+        return tile.runtimeId === runtimeId
+      }
+
+      // Fall back to durable identity only when the event has no runtime id or
+      // the tile has not acquired one. Never let a matching stored id override
+      // two explicit, differing runtime bindings.
+      const durableId = storedId || runtimeId
+
+      return Boolean(durableId && tile.storedSessionId === durableId)
+    })
     .map(tile => tile.ownerRoute)
     .filter((route): route is SessionProfileRoute => sourceMatches(route))
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -42,6 +42,7 @@ import {
   $selectedStoredSessionId,
   $sessions,
   clearReadBaseline,
+  getSessionOwnerHint,
   knownSessionProfile,
   lineageAliases,
   markSessionRead,
@@ -93,6 +94,88 @@ export function liveSessionScopes(): Set<string> {
     if (scope) {
       scopes.add(scope)
     }
+  }
+
+  return scopes
+}
+
+// Owner a tile's resume actually resolved (use-session-tile-delegate), keyed
+// by stored id. A route-less local Bot Chat — legacy roster row, primary
+// active — has no ownerRoute, no owner hint and no sidebar row, so without
+// this record foregroundSessionScopes could not name its socket (#93892).
+const resolvedTileOwners = new Map<string, SessionOwnerScope>()
+
+export function recordTileOwner(storedSessionId: string, owner: SessionOwnerScope): void {
+  if (!storedSessionId || !owner) {
+    return
+  }
+
+  resolvedTileOwners.set(storedSessionId, owner)
+}
+
+/**
+ * Scopes a FOREGROUND surface is bound to right now — every mounted session
+ * tile's owner plus the primary thread's — the foreground half of the
+ * gateway registry's dispose guard (its `foregroundScopes` hook, #93892).
+ * Live work alone (liveSessionScopes) is not enough: an idle tile still
+ * holds a resumed runtime on its owner's socket. Closing that socket makes
+ * the backend detach and orphan-reap the runtime, whose `session.reclaimed`
+ * unbinds the tile, whose resume effect binds a fresh runtime on a fresh
+ * socket, which the next dispose decision closes again — a spinner loop with
+ * no terminal state.
+ *
+ * Owners are named the way the resume itself resolves them (owner hint, tile
+ * route, the owner the delegate recorded), falling back to the session row's
+ * profile. Route-owned surfaces map to their composite (connectionId,
+ * profile) scope; profile-owned ones to the bare profile key the local/legacy
+ * pool entries match on. The set follows `$sessionTiles` /
+ * `$selectedStoredSessionId`, so closing the tile (or navigating away)
+ * releases the socket — nothing latches. Cost, deliberately: every open
+ * tile (including a background Bot Chat tab) keeps its owner's socket and
+ * backend alive for as long as it is open.
+ */
+export function foregroundSessionScopes(): Set<string> {
+  const scopes = new Set<string>()
+  const sessions = $sessions.get()
+
+  const addOwner = (owner: SessionOwnerScope): boolean => {
+    if (!owner) {
+      return false
+    }
+
+    if (typeof owner === 'string') {
+      scopes.add(normalizeProfileKey(owner))
+
+      return true
+    }
+
+    if (!owner.connectionId.trim()) {
+      return false
+    }
+
+    scopes.add(registryBackendScopeKey(owner.connectionId, normalizeProfileKey(owner.profile)))
+
+    return true
+  }
+
+  const addStoredSession = (storedSessionId: string, route: SessionProfileRoute | undefined) => {
+    const known = [getSessionOwnerHint(storedSessionId), route, resolvedTileOwners.get(storedSessionId)]
+      .map(addOwner)
+      .some(Boolean)
+
+    if (!known) {
+      addOwner(knownSessionProfile(sessions, storedSessionId))
+    }
+  }
+
+  for (const tile of $sessionTiles.get()) {
+    addStoredSession(tile.storedSessionId, tile.ownerRoute)
+  }
+
+  const selected = $selectedStoredSessionId.get()
+
+  if (selected) {
+    addStoredSession(selected, sessionTileOwnerRoute(selected))
   }
 
   return scopes

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -862,9 +862,7 @@ export function knownOwnerForSession(sessionId: null | string | undefined): Sess
 }
 
 export type SessionEventOwnerRouteResolution =
-  | { kind: 'ambiguous' }
-  | { kind: 'known'; route: SessionProfileRoute }
-  | { kind: 'unknown' }
+  { kind: 'ambiguous' } | { kind: 'known'; route: SessionProfileRoute } | { kind: 'unknown' }
 
 /**
  * Resolve the authoritative owner route for one registry event. The registry
@@ -890,54 +888,77 @@ export function sessionEventOwnerRoute(
   const sourceMatches = (route: SessionProfileRoute | undefined) =>
     route?.connectionId.trim() === connectionId && (route.profile.trim() || 'default') === profile
 
-  const tileRoutes = $sessionTiles
+  const distinctRouteResolution = (routes: SessionProfileRoute[]): SessionEventOwnerRouteResolution => {
+    const distinctRoutes = new Map<string, SessionProfileRoute>()
+
+    for (const route of routes) {
+      const routeProfile = route.profile.trim() || 'default'
+      const targetProfile = route.targetProfile?.trim() || routeProfile
+      distinctRoutes.set(JSON.stringify([route.connectionId.trim(), routeProfile, targetProfile]), route)
+    }
+
+    if (distinctRoutes.size > 1) {
+      return { kind: 'ambiguous' }
+    }
+
+    const route = distinctRoutes.values().next().value
+
+    return route ? { kind: 'known', route } : { kind: 'unknown' }
+  }
+
+  const sourceTiles = $sessionTiles
     .get()
-    .filter(tile => {
-      // A live runtime binding is the strongest identity. Compression can
-      // rotate the backend's stored id while the mounted tile intentionally
-      // retains the durable lineage id.
-      if (runtimeId && tile.runtimeId) {
-        return tile.runtimeId === runtimeId
-      }
+    .filter((tile): tile is SessionTile & { ownerRoute: SessionProfileRoute } =>
+      Boolean(tile.ownerRoute && sourceMatches(tile.ownerRoute))
+    )
 
-      // Fall back to durable identity only when the event has no runtime id or
-      // the tile has not acquired one. Never let a matching stored id override
-      // two explicit, differing runtime bindings.
-      const durableId = storedId || runtimeId
+  // Ownership confidence, strongest first:
+  // 1. An exact live runtime binding is authoritative even if compression has
+  //    rotated the stored id retained by the mounted tile.
+  const exactRuntimeResolution = distinctRouteResolution(
+    sourceTiles.filter(tile => Boolean(runtimeId && tile.runtimeId === runtimeId)).map(tile => tile.ownerRoute)
+  )
 
-      return Boolean(durableId && tile.storedSessionId === durableId)
-    })
-    .map(tile => tile.ownerRoute)
-    .filter((route): route is SessionProfileRoute => sourceMatches(route))
+  if (exactRuntimeResolution.kind !== 'unknown') {
+    return exactRuntimeResolution
+  }
 
-  if (tileRoutes.length > 1) {
+  const durableId = storedId || runtimeId
+
+  // 2. A durable-id match with a different explicit runtime is negative
+  //    ownership evidence. It globally blocks every lower-confidence candidate
+  //    (including stale hints) unless the exact-runtime rung above resolved.
+  const hasConflictingRuntime = Boolean(
+    runtimeId &&
+    durableId &&
+    sourceTiles.some(
+      tile => tile.storedSessionId === durableId && Boolean(tile.runtimeId && tile.runtimeId !== runtimeId)
+    )
+  )
+
+  if (hasConflictingRuntime) {
     return { kind: 'ambiguous' }
   }
 
-  if (tileRoutes.length === 1) {
-    return { kind: 'known', route: tileRoutes[0] }
+  // 3. Durable tile identity is eligible only when the event has no runtime or
+  //    the tile has not bound one yet.
+  const durableTileResolution = distinctRouteResolution(
+    sourceTiles
+      .filter(tile => Boolean(durableId && tile.storedSessionId === durableId && (!runtimeId || !tile.runtimeId)))
+      .map(tile => tile.ownerRoute)
+  )
+
+  if (durableTileResolution.kind !== 'unknown') {
+    return durableTileResolution
   }
 
+  // 4. Hints are the final rung and are considered only after stronger tile
+  //    evidence has produced neither an owner nor a contradiction.
   const hintRoutes = [...new Set([storedId, runtimeId].filter(Boolean))]
     .map(id => getSessionOwnerHint(id, { connectionId, profile }))
     .filter((route): route is SessionProfileRoute => Boolean(route))
 
-  if (hintRoutes.length > 1) {
-    const first = hintRoutes[0]
-
-    const sameRoute = hintRoutes.every(
-      route =>
-        route.connectionId === first.connectionId &&
-        route.profile === first.profile &&
-        route.targetProfile === first.targetProfile
-    )
-
-    if (!sameRoute) {
-      return { kind: 'ambiguous' }
-    }
-  }
-
-  return hintRoutes[0] ? { kind: 'known', route: hintRoutes[0] } : { kind: 'unknown' }
+  return distinctRouteResolution(hintRoutes)
 }
 
 /**


### PR DESCRIPTION
## Summary

Keeps a mounted session tile tied to its exact gateway/profile owner for socket retention and model-catalog operations.

- Retains the tile's owner socket while the tile remains mounted and releases bounded owner state when it closes.
- Routes `model.options` and REST fallback through the exact owner connection and backend target profile.
- Uses canonical model-option cache keys that distinguish explicit local, ambient local/remote and explicit remote owners.
- Propagates tile `ProfileScope` through model selection, optimistic cache updates, rollback and invalidation.
- Resolves `session.info` invalidation through the authoritative session/tile route, including non-identity aliases where `targetProfile !== profile`; ambiguous ownership fails closed.
- Prunes against one authoritative foreground owner rather than retaining every stale candidate.

Fixes #93892.

## Why

A secondary tile could remain visible after its owner connection was pruned, and model-catalog fallback could silently query or cache data from the active connection instead. Same-named profiles and non-identity aliases made ambient keys especially unsafe.

## Correctness properties

- Model catalogs never mix across effective connection owners.
- Explicit local and ambient remote scopes cannot alias.
- Alias routes key and invalidate by `targetProfile || profile`.
- Event-source/session-route disagreement or ambiguity does not invalidate a guessed ambient catalog.
- Foreground pruning retains exactly one authoritative owner and bounded maps are cleaned when tiles close.

## Verification on current head

- Owner/model routing matrix: **11 files / 168 tests passed**
- Full Desktop UI suite: **594 files / 5,723 tests passed**
- Desktop renderer, Electron and E2E TypeScript checks: passed
- Targeted and full Desktop ESLint: passed
- Contributor attribution audit: passed
- `git diff --check`: passed
- Independent final blocking review: **APPROVE**
