### PR TITLE
fix(tools): unify callable tool discovery across CLI and TUI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -571,10 +571,7 @@ from rich.text import Text as _RichText
 
 # Agent/tool systems load lazily: bare startup only needs the prompt.
 def get_tool_definitions(*args, **kwargs):
-    from hermes_cli.mcp_startup import wait_for_mcp_discovery
-    from model_tools import get_tool_definitions as _get_tool_definitions
-
-    wait_for_mcp_discovery()
+    from hermes_cli.tool_resolution import get_cli_tool_definitions as _get_tool_definitions
     return _get_tool_definitions(*args, **kwargs)
 
 
@@ -3087,17 +3084,22 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
 
     def _show_tool_availability_warnings(self):
         """Warn about tools disabled by missing API keys (not system deps)."""
+        if self.enabled_toolsets is not None and not self.enabled_toolsets:
+            return
         try:
-            from model_tools import check_tool_availability
+            from model_tools import check_tool_availability, get_toolset_for_tool, _select_tool_names
 
-            available, unavailable = check_tool_availability()
-            api_key_missing = [u for u in unavailable if u["missing_vars"]]
+            selected_tools = _select_tool_names(self.enabled_toolsets, self.disabled_toolsets, quiet_mode=True)
+            selected = {toolset for tool in selected_tools if (toolset := get_toolset_for_tool(tool))}
+            _, unavailable = check_tool_availability(toolsets=selected)
+            api_key_missing = [u for u in unavailable if u.get("missing_vars", u.get("env_vars", []))]
 
             if api_key_missing:
                 self._console_print()
                 self._console_print("[yellow]⚠️  Some tools disabled (missing API keys):[/]")
                 for item in api_key_missing:
-                    self._console_print(f"   [dim]• {item['name']}[/] [dim italic]({', '.join(item['missing_vars'])})[/]")
+                    missing = item.get("missing_vars", item.get("env_vars", []))
+                    self._console_print(f"   [dim]• {item['name']}[/] [dim italic]({', '.join(missing)})[/]")
                 self._console_print("[dim]   Run 'hermes setup' to configure[/]")
         except Exception:
             pass
@@ -4220,24 +4222,8 @@ def _install_single_query_signal_handlers(cli):
 
 def _build_cli_from_args(model, toolsets, provider, reasoning, api_key, base_url, max_turns, run_budget, verbose, compact, resume, checkpoints, pass_session_id, ignore_rules, skills):
     """Resolve the toolset list (explicit / coding posture / platform default), construct HermesCLI, and start the background skills preload."""
-    toolsets_list = None
-    if isinstance(toolsets, str) and toolsets:
-        toolsets_list = [t.strip() for t in toolsets.split(",")]
-    elif isinstance(toolsets, (list, tuple)) and toolsets:
-        # Fire may pass multiple --toolsets as a tuple
-        toolsets_list = []
-        for t in toolsets:
-            toolsets_list.extend([x.strip() for x in t.split(",")] if isinstance(t, str) else [str(t)])
-    elif not toolsets:
-        # Coding posture inside a code workspace, else the shared platform resolver.
-        try:
-            from agent.coding_context import coding_selection
-            toolsets_list = coding_selection(platform="cli", config=CLI_CONFIG)
-        except Exception:
-            toolsets_list = None
-        if toolsets_list is None:
-            from hermes_cli.tools_config import _get_platform_tools
-            toolsets_list = sorted(_get_platform_tools(CLI_CONFIG, "cli"))
+    from hermes_cli.tool_resolution import resolve_cli_toolsets
+    toolsets_list = resolve_cli_toolsets(toolsets, CLI_CONFIG)
 
     parsed_skills = _parse_skills_argument(skills)
 
@@ -4295,23 +4281,13 @@ def _run_legacy_gateway():
 
 
 def _start_worktree_setup(list_tools, list_toolsets, worktree, w):
-    """Start isolated-worktree creation (+ tool prewarm) in the background.
+    """Start isolated-worktree creation in the background.
 
     Returns a join callable that publishes ``_active_worktree``/TERMINAL_CWD and
     schedules stale-worktree GC, or None when no worktree is wanted.
     """
     if list_tools or list_toolsets or not (worktree or w or CLI_CONFIG.get("worktree", False)):
         return None
-    # Overlap tool discovery with the I/O-bound worktree setup so show_banner() hits a warm
-    # cache (~0.4s). Only on the -w path: plain `hermes` has no I/O wait to hide.
-    def _prewarm_tools() -> None:
-        try:
-            import model_tools as _mt
-            _mt.get_tool_definitions(quiet_mode=True)
-        except Exception:
-            logger.debug("tool prewarm failed", exc_info=True)
-
-    threading.Thread(target=_prewarm_tools, name="tool-prewarm", daemon=True).start()
     _sync_base = CLI_CONFIG.get("worktree_sync", True)
     _wt_result: dict = {}
 
@@ -4446,6 +4422,7 @@ def main(
     pass_session_id: bool = False,
     ignore_user_config: bool = False,
     ignore_rules: bool = False,
+    _prefetched_tool_resolution=None,
 ):
     """
     Hermes Agent CLI - Interactive AI Assistant
@@ -4504,6 +4481,11 @@ def main(
     query = query or q
     cli = _build_cli_from_args(model, toolsets, provider, reasoning, api_key, base_url, max_turns, run_budget,
                                verbose, compact, resume, checkpoints, pass_session_id, ignore_rules, skills)
+    # One-shot runs resolve at agent construction; interactive runs consume this at the banner.
+    if not (query or image) or _should_seed_interactive(query, image, quiet, oneshot):
+        from hermes_cli.tool_resolution import start_tool_surface_resolution
+        cli._startup_tool_resolution = _prefetched_tool_resolution or start_tool_surface_resolution(
+            cli.enabled_toolsets, cli.disabled_toolsets)
 
     # Join the background worktree creation before anything consumes TERMINAL_CWD.
     # A requested worktree whose setup failed aborts: never silently run without isolation.

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -563,110 +563,6 @@ def _short_label(name: str) -> str:
     return name[:25] + "..." if len(name) > 28 else name
 
 
-# === Banner snapshot — warm-launch fast path ===
-# The tool panel needs the full tool registry (~0.5-0.9s cold, the largest chunk of time-to-
-# banner). The list is a pure function of (config.yaml, .env, code checkout, enabled toolsets),
-# so the rendered inputs are snapshotted to disk and replayed when the fingerprint matches. The
-# agent's REAL tool list is still computed fresh at first message; the snapshot only feeds the
-# cosmetic panel, and a background refresh (cli.show_banner) re-verifies it right after render.
-
-_BANNER_SNAPSHOT_VERSION = 1
-
-
-def _banner_snapshot_path() -> Path:
-    return get_hermes_home() / "cache" / "banner_snapshot.json"
-
-
-def banner_snapshot_fingerprint() -> Optional[str]:
-    """Fingerprint the inputs the banner tool panel depends on."""
-    import hashlib
-    def _inputs():
-        from hermes_cli.config import get_config_path
-        return (get_config_path(), get_hermes_home() / ".env")
-    paths = _quiet(_inputs)
-    if paths is None:
-        return None
-    parts = [f"v{_BANNER_SNAPSHOT_VERSION}"]
-    for p in paths:
-        st = _quiet(p.stat)
-        parts.append(f"{p.name}:{st.st_mtime_ns}:{st.st_size}" if st else f"{p.name}:absent")
-    # Code checkout: version + git HEAD when available (post-update change).
-    parts.append(str(VERSION))
-    state = get_git_banner_state()
-    if state:
-        parts.append(str(state.get("local", "")))
-    return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
-
-
-def load_banner_snapshot(enabled_toolsets: List[str] = None) -> Optional[Dict[str, Any]]:
-    """Return the stored banner snapshot when its fingerprint is current."""
-    blob = _read_json(_banner_snapshot_path())
-    if blob is None:
-        return None
-    fp = banner_snapshot_fingerprint()
-    if (not fp or blob.get("fingerprint") != fp
-            or blob.get("enabled_toolsets") != sorted(enabled_toolsets or [])
-            or not isinstance(blob.get("tools"), list)
-            or not all(isinstance(blob.get(k), dict)
-                       for k in ("toolset_map", "availability", "skills_by_category"))):
-        return None
-    return blob
-
-
-def save_banner_snapshot(tools: List[dict], enabled_toolsets: List[str], availability: Dict[str, Any],
-                         toolset_map: Dict[str, str]) -> None:
-    """Persist the banner tool panel inputs for next launch (best-effort)."""
-    fp = banner_snapshot_fingerprint()
-    if not fp:
-        return
-    payload = {
-        "fingerprint": fp,
-        "enabled_toolsets": sorted(enabled_toolsets or []),
-        "tools": [{"function": {"name": t["function"]["name"]}}
-                  for t in tools if isinstance(t, dict) and t.get("function", {}).get("name")],
-        "toolset_map": toolset_map,
-        "availability": {
-            "unavailable_toolsets": availability.get("unavailable_toolsets", []),
-            **{k: list(availability.get(k, [])) for k in ("lazy_tools", "disabled_tools")}},
-        "skills_by_category": get_available_skills(),
-    }
-
-    def _write():
-        import tempfile
-        path = _banner_snapshot_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".banner_snap.")
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            json.dump(payload, fh)
-        os.replace(tmp, path)
-    _quiet(_write)
-
-
-def compute_toolset_availability(enabled_toolsets: List[str] = None) -> Dict[str, Any]:
-    """Compute ``{"unavailable_toolsets", "lazy_tools", "disabled_tools"}`` for the banner.
-
-    Split out so the result can be snapshotted and replayed without importing ``model_tools``.
-    """
-    from model_tools import check_tool_availability, TOOLSET_REQUIREMENTS
-    enabled_toolsets = enabled_toolsets or []
-    _, unavailable_toolsets = check_tool_availability(quiet=True)
-    # The availability check walks the GLOBAL registry, so it includes toolsets outside this
-    # agent's platform set (e.g. `discord` on a CLI session) which must never surface in
-    # "Available Tools". Restrict to enabled toolsets; an enabled toolset with unmet deps
-    # legitimately shows as disabled/lazy below.
-    _enabled_ts = {str(t) for t in enabled_toolsets}
-    if _enabled_ts:
-        unavailable_toolsets = [
-            item for item in unavailable_toolsets if str(item.get("id", item.get("name", ""))) in _enabled_ts]
-    # Toolsets with a check_fn are lazy-initialized (e.g. honcho): unavailable at banner time
-    # because the check hasn't run yet, but not misconfigured.
-    lazy_tools, disabled_tools = set(), set()
-    for item in unavailable_toolsets:
-        is_lazy = TOOLSET_REQUIREMENTS.get(item.get("name", ""), {}).get("check_fn")
-        (lazy_tools if is_lazy else disabled_tools).update(item.get("tools", []))
-    return {"unavailable_toolsets": unavailable_toolsets, "lazy_tools": sorted(lazy_tools),
-            "disabled_tools": sorted(disabled_tools)}
-
 
 def _mcp_server_line(srv: dict, *, dim: str, text: str) -> str:
     """One banner line for an MCP server status entry."""
@@ -782,8 +678,7 @@ def _banner_left_lines(model: str, cwd: str, session_id, context_length, provide
 
 
 def _banner_tool_lines(
-    tools: list, unavailable_toolsets: list, get_toolset_for_tool, *,
-    lazy_tools: set, disabled_tools: set, accent: str, dim: str, text: str) -> list:
+    tools: list, get_toolset_for_tool, *, accent: str, dim: str, text: str) -> list:
     """"Available Tools" section: up to 8 toolsets, each truncated to ~42 columns."""
     lines = [f"[bold {accent}]Available Tools[/]"]
     toolsets_dict: Dict[str, list] = {}
@@ -791,17 +686,11 @@ def _banner_tool_lines(
         tool_name = tool["function"]["name"]
         toolset = _display_toolset_name(get_toolset_for_tool(tool_name) or "other")
         toolsets_dict.setdefault(toolset, []).append(tool_name)
-    for item in unavailable_toolsets:
-        names = toolsets_dict.setdefault(_display_toolset_name(item.get("id", item.get("name", "unknown"))), [])
-        for tool_name in item.get("tools", []):
-            if tool_name not in names:
-                names.append(tool_name)
 
     def _color_tool(name: Optional[str]) -> str:
         if name is None:  # truncation marker
             return "[dim]...[/]"
-        color = "red" if name in disabled_tools else "yellow" if name in lazy_tools else text
-        return f"[{color}]{name}[/]"
+        return f"[{text}]{name}[/]"
     sorted_toolsets = sorted(toolsets_dict.keys())
     for toolset in sorted_toolsets[:8]:
         tool_names = _truncate_tool_names(sorted(toolsets_dict[toolset]))
@@ -834,18 +723,14 @@ def build_welcome_banner(
     """Build and print a welcome banner with caduceus on left and info on right.
 
     When ``provider == "moa"``, ``model`` is a MoA preset name and the aggregator is rendered.
-    Passing a precomputed ``availability`` together with ``get_toolset_for_tool`` avoids any
-    ``model_tools`` import (banner snapshot replay).
+    Tools are the resolved callable surface, never widened from the global catalog.
+    ``enabled_toolsets`` and ``availability`` are retained for caller compatibility only.
     """
     from rich.panel import Panel
     from rich.table import Table
-    if get_toolset_for_tool is None:
+    if tools and get_toolset_for_tool is None:
         from model_tools import get_toolset_for_tool
     tools = tools or []
-    enabled_toolsets = enabled_toolsets or []
-    if availability is None:
-        availability = compute_toolset_availability(enabled_toolsets)
-    _enabled_ts = {str(t) for t in enabled_toolsets}
     # Resolve skin colors once for the entire banner
     accent = _skin_color("banner_accent", "#FFBF00")
     dim = _skin_color("banner_dim", "#B8860B")
@@ -855,11 +740,10 @@ def build_welcome_banner(
     left_lines = ["", getattr(_bskin, "banner_hero", None) or HERMES_CADUCEUS, ""]
     left_lines += _banner_left_lines(model, cwd, session_id, context_length, provider, accent=accent, dim=dim)
     right_lines = _banner_tool_lines(
-        tools, availability.get("unavailable_toolsets", []), get_toolset_for_tool,
-        lazy_tools=set(availability.get("lazy_tools", [])), disabled_tools=set(availability.get("disabled_tools", [])),
+        tools, get_toolset_for_tool,
         accent=accent, dim=dim, text=text)
     # MCP Servers section (only if configured) — see ``_mcp_configured`` for why the cheap probe.
-    mcp_status = _quiet(_probe_mcp_status, []) if _mcp_configured() else []
+    mcp_status = _quiet(_probe_mcp_status, []) if tools and _mcp_configured() else []
     if mcp_status:
         right_lines += ["", f"[bold {accent}]MCP Servers[/]"]
         right_lines.extend(_mcp_server_line(srv, dim=dim, text=text) for srv in mcp_status)
@@ -867,7 +751,7 @@ def build_welcome_banner(
     # The skills catalog is only reachable when the `skills` toolset is enabled (skill_view /
     # skill_manage). When disabled (Blank Slate) the agent cannot load any skill, so advertising
     # the on-disk catalog would be misleading — reflect the real state.
-    _skills_enabled = (not _enabled_ts) or ("skills" in _enabled_ts)
+    _skills_enabled = any(t["function"]["name"] == "skill_view" for t in tools)
     if not _skills_enabled:
         skills_by_category = {}
     elif skills_by_category is None:

--- a/hermes_cli/cli_info_mixin.py
+++ b/hermes_cli/cli_info_mixin.py
@@ -55,14 +55,6 @@ def _ascii_box(title: str, width: int) -> None:
     print("+" + "-" * width + "+")
 
 
-def _toolset_map(tools, availability, get_toolset_for_tool) -> dict:
-    """tool name → toolset id, including tools of unavailable toolsets (banner snapshot)."""
-    tmap = {t["function"]["name"]: get_toolset_for_tool(t["function"]["name"]) for t in tools}
-    for item in availability.get("unavailable_toolsets", []):
-        for name in item.get("tools", []):
-            tmap.setdefault(name, item.get("id", item.get("name", "")))
-    return tmap
-
 
 def _skill_line(item: dict) -> str:
     nm = item.get("name", "")
@@ -91,83 +83,46 @@ class CLIInfoMixin:
 
     def show_banner(self):
         """Display the welcome banner in Claude Code style."""
-        from cli import _build_compact_banner, get_tool_definitions, logger
+        from cli import _build_compact_banner, logger
         from hermes_cli.banner import build_welcome_banner
+        from hermes_cli.tool_resolution import ToolResolutionRequest, resolve_startup_tools
+
+        pending = getattr(self, "_startup_tool_resolution", None)
+        self._startup_tool_resolution = None
+        tools = getattr(getattr(self, "agent", None), "tools", None)
+        request = ToolResolutionRequest.from_lists(self.enabled_toolsets, self.disabled_toolsets)
+        deferred = (
+            tools is None and os.environ.get("HERMES_DEFER_AGENT_STARTUP") == "1"
+            and request.enabled_toolsets != frozenset()
+        )
+        if tools is None and not deferred:
+            tools = resolve_startup_tools(request, pending)
         self.console.clear()
         ctx_len = None
         if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
             ctx_len = self.agent.context_compressor.context_length
 
         # Auto-compact for narrow terminals — the full banner needs ~80 columns to avoid wrapping.
-        if self.compact or shutil.get_terminal_size().columns < 80:
+        if deferred:
             self._console_print(_build_compact_banner())
             self._show_status()
+        elif tools is None:
+            self._console_print(_build_compact_banner())
+            self._console_print(
+                "[yellow]⚠ Tool discovery unavailable; tools will be resolved on the first message.[/]")
+        elif self.compact or shutil.get_terminal_size().columns < 80:
+            self._console_print(_build_compact_banner())
+            self._show_status(resolved_tools=tools)
         else:
-            # Warm-launch fast path: replay last launch's tool panel when the snapshot fingerprint
-            # (config.yaml + .env + checkout rev + toolsets) is unchanged, skipping the ~0.5-0.9s
-            # cold get_tool_definitions walk. The agent's REAL tool list is still computed fresh at
-            # first message; a background refresh re-verifies the snapshot so drift self-heals.
-            from hermes_cli.banner import (
-                compute_toolset_availability, load_banner_snapshot, save_banner_snapshot)
-            try:
-                snapshot = load_banner_snapshot(self.enabled_toolsets)
-            except Exception:
-                snapshot = None
             cwd = os.getenv("TERMINAL_CWD", os.getcwd())  # where commands will execute
-            banner_kw = dict(
+            build_welcome_banner(
                 console=self.console, model=self.model, cwd=cwd,
-                enabled_toolsets=self.enabled_toolsets, session_id=self.session_id,
+                tools=tools, session_id=self.session_id,
                 context_length=ctx_len, provider=self.provider)
 
-            if snapshot is not None:
-                self._defer_tool_warnings = True
-                toolset_map = snapshot["toolset_map"]
-                build_welcome_banner(
-                    tools=snapshot["tools"],
-                    get_toolset_for_tool=lambda name: toolset_map.get(name),
-                    availability=snapshot["availability"],
-                    skills_by_category=snapshot.get("skills_by_category"),
-                    **banner_kw)
-
-                def _refresh_banner_snapshot() -> None:
-                    try:
-                        from model_tools import get_toolset_for_tool
-                        tools = get_tool_definitions(
-                            enabled_toolsets=self.enabled_toolsets,
-                            disabled_toolsets=self.disabled_toolsets, quiet_mode=True)
-                        availability = compute_toolset_availability(self.enabled_toolsets)
-                        tmap = _toolset_map(tools, availability, get_toolset_for_tool)
-                        save_banner_snapshot(tools, self.enabled_toolsets, availability, tmap)
-                    except Exception:
-                        logger.debug("banner snapshot refresh failed", exc_info=True)
-
-                threading.Thread(
-                    target=_refresh_banner_snapshot, name="banner-snapshot-refresh", daemon=True,
-                ).start()
-            else:
-                # Cold path: compute live, then persist the snapshot for the next launch.
-                from model_tools import get_toolset_for_tool
-                tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets,
-                                             disabled_toolsets=self.disabled_toolsets, quiet_mode=True)
-                availability = compute_toolset_availability(self.enabled_toolsets)
-                build_welcome_banner(tools=tools, availability=availability, **banner_kw)
-                try:
-                    tmap = _toolset_map(tools, availability, get_toolset_for_tool)
-                    save_banner_snapshot(tools, self.enabled_toolsets, availability, tmap)
-                except Exception:
-                    logger.debug("banner snapshot save failed", exc_info=True)
-
-        # Tool discovery is deferred on the Termux bare prompt path (warnings show once tools
-        # init). On the snapshot fast path the check walks every check_fn (~180ms) — run it in
-        # the background and let its output land above the prompt (patch_stdout-safe).
-        if os.environ.get("HERMES_DEFER_AGENT_STARTUP") != "1":
-            if getattr(self, "_defer_tool_warnings", False):
-                threading.Thread(
-                    target=self._show_tool_availability_warnings,
-                    name="tool-availability-warnings",
-                    daemon=True).start()
-            else:
-                self._show_tool_availability_warnings()
+        # Complete diagnostics before prompt_toolkit takes terminal ownership.
+        if tools is not None:
+            self._show_tool_availability_warnings()
 
         # Low context warning — tied to the runtime guard so guidance cannot drift.
         from agent.model_metadata import MINIMUM_CONTEXT_LENGTH

--- a/hermes_cli/cli_session_mixin.py
+++ b/hermes_cli/cli_session_mixin.py
@@ -209,11 +209,13 @@ class CLISessionMixin:
         print(f"  Invalid checkpoint number. Use 1-{len(checkpoints)}.")
         return None
 
-    def _show_status(self):
+    def _show_status(self, resolved_tools=None):
         """Show compact startup status line."""
         from cli import get_tool_definitions
         # Avoid pulling the full tool registry into the bare Termux prompt path.
-        if os.environ.get("HERMES_DEFER_AGENT_STARTUP") == "1":
+        if resolved_tools is not None:
+            tool_status = f"{len(resolved_tools)} tools"
+        elif os.environ.get("HERMES_DEFER_AGENT_STARTUP") == "1":
             tool_status = "tools deferred"
         else:
             tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1912,6 +1912,13 @@ def _read_raw_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
         return data if want_deepcopy else cached_copy
 
 
+def platform_toolsets_explicitly_empty(config: dict, platform: str) -> bool:
+    """Whether a platform is explicitly configured with no toolsets."""
+    platforms = config.get("platform_toolsets") if isinstance(config, dict) else None
+    toolsets = platforms.get(platform) if isinstance(platforms, dict) else None
+    return isinstance(toolsets, list) and not toolsets
+
+
 def read_raw_config() -> Dict[str, Any]:
     """Read config.yaml as-is (no defaults merged, no migration); ``{}`` if missing/unparseable.
     Cached on (mtime_ns, size); returns a deepcopy since callers mutate before ``save_config()``."""

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1714,6 +1714,11 @@ def cmd_chat(args):
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
     try:
+        # One canonical resolution shared with the banner, overlapping the remaining imports.
+        # One-shot mode resolves at agent construction and needs no cosmetic prefetch.
+        if not (args.query or getattr(args, "image", None) or getattr(args, "worktree", False)):
+            from hermes_cli.tool_resolution import start_cli_tool_resolution
+            kwargs["_prefetched_tool_resolution"] = start_cli_tool_resolution(args.toolsets)
         from cli import main as cli_main
 
         cli_main(**kwargs)

--- a/hermes_cli/tool_resolution.py
+++ b/hermes_cli/tool_resolution.py
@@ -1,0 +1,177 @@
+"""Classic CLI startup orchestration for canonical tool definitions."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from concurrent.futures import Future
+from dataclasses import dataclass
+from typing import Callable, Iterable, Optional, TypeVar
+
+T = TypeVar("T")
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ToolResolutionRequest:
+    """Immutable inputs to the canonical model-tool resolver."""
+
+    enabled_toolsets: Optional[frozenset[str]]
+    disabled_toolsets: frozenset[str]
+
+    @classmethod
+    def from_lists(
+        cls,
+        enabled_toolsets: Optional[Iterable[str]],
+        disabled_toolsets: Optional[Iterable[str]],
+    ) -> "ToolResolutionRequest":
+        return cls(
+            None if enabled_toolsets is None else frozenset(enabled_toolsets),
+            frozenset(disabled_toolsets or ()),
+        )
+
+
+def _submit_daemon(work: Callable[[], T]) -> Future[T]:
+    future: Future[T] = Future()
+
+    def run() -> None:
+        if not future.set_running_or_notify_cancel():
+            return
+        try:
+            future.set_result(work())
+        except BaseException as exc:
+            future.set_exception(exc)
+
+    threading.Thread(target=run, name="tool-surface-resolution", daemon=True).start()
+    return future
+
+
+def start_tool_surface_resolution(
+    enabled_toolsets: Optional[Iterable[str]],
+    disabled_toolsets: Optional[Iterable[str]],
+) -> Optional[tuple[ToolResolutionRequest, Future[list[dict]]]]:
+    """Start classic-CLI definition resolution for a known policy."""
+    request = ToolResolutionRequest.from_lists(enabled_toolsets, disabled_toolsets)
+    if not request.enabled_toolsets and request.enabled_toolsets is not None:
+        completed: Future[list[dict]] = Future()
+        completed.set_result([])
+        return request, completed
+    if os.environ.get("HERMES_DEFER_AGENT_STARTUP") == "1":
+        return None
+    future = _submit_daemon(
+        lambda: get_cli_tool_definitions(
+            enabled_toolsets=request.enabled_toolsets,
+            disabled_toolsets=request.disabled_toolsets,
+            quiet_mode=True,
+        )
+    )
+    return request, future
+
+
+def resolve_cli_toolsets(toolsets, config: dict) -> list[str]:
+    """Resolve command input and configured defaults into one CLI policy."""
+    if toolsets is not None:
+        values = (toolsets,) if isinstance(toolsets, str) else toolsets
+        return [
+            part.strip()
+            for value in values
+            for part in (
+                value.split(",") if isinstance(value, str) else (str(value),)
+            )
+            if part.strip()
+        ]
+
+    from hermes_cli.config import platform_toolsets_explicitly_empty
+
+    if platform_toolsets_explicitly_empty(config, "cli"):
+        return []
+
+    try:
+        from agent.coding_context import coding_selection
+
+        coding = coding_selection(platform="cli", config=config)
+    except Exception:
+        coding = None
+    if coding is not None:
+        return coding
+
+    from hermes_cli.tools_config import _get_platform_tools
+
+    return sorted(_get_platform_tools(config, "cli"))
+
+
+def get_cli_tool_definitions(
+    enabled_toolsets: Optional[Iterable[str]] = None,
+    disabled_toolsets: Optional[Iterable[str]] = None,
+    quiet_mode: bool = False,
+    skip_tool_search_assembly: bool = False,
+) -> list[dict]:
+    """Resolve classic-CLI definitions after the bounded MCP startup wait."""
+    if enabled_toolsets is not None:
+        enabled_toolsets = list(enabled_toolsets)
+        if not enabled_toolsets:
+            return []
+    if disabled_toolsets is not None:
+        disabled_toolsets = list(disabled_toolsets)
+
+    from hermes_cli.mcp_startup import wait_for_mcp_discovery
+    from model_tools import get_tool_definitions
+
+    wait_for_mcp_discovery()
+    return get_tool_definitions(
+        enabled_toolsets=enabled_toolsets,
+        disabled_toolsets=disabled_toolsets,
+        quiet_mode=quiet_mode,
+        skip_tool_search_assembly=skip_tool_search_assembly,
+    )
+
+
+def start_cli_tool_resolution(
+    toolsets, config: Optional[dict] = None
+) -> Optional[tuple[ToolResolutionRequest, Future[list[dict]]]]:
+    """Resolve CLI policy and start definition resolution."""
+    if toolsets is not None and not toolsets:
+        return start_tool_surface_resolution([], [])
+    if config is None:
+        from hermes_cli.config import load_config
+
+        resolved_config = load_config()
+    else:
+        resolved_config = config
+    selection = resolve_cli_toolsets(toolsets, resolved_config)
+    if not selection:
+        return start_tool_surface_resolution([], [])
+
+    from agent.skill_utils import parse_config_string_list
+
+    return start_tool_surface_resolution(
+        selection,
+        parse_config_string_list(
+            (resolved_config.get("agent") or {}).get("disabled_toolsets")
+        ),
+    )
+
+
+def resolve_startup_tools(
+    request: ToolResolutionRequest,
+    pending: Optional[tuple[ToolResolutionRequest, Future[list[dict]]]] = None,
+) -> Optional[list[dict]]:
+    """Resolve a request using a matching prefetch; None means no result, never deny-all."""
+    if pending is None or pending[0] != request:
+        pending = start_tool_surface_resolution(request.enabled_toolsets, request.disabled_toolsets)
+    if pending is None:
+        return None
+    for attempt in range(2):
+        try:
+            return pending[1].result(timeout=30.0)
+        except TimeoutError:
+            break  # Do not start a competing worker while this one is still running.
+        except Exception:
+            logger.debug("tool resolution failed", exc_info=True)
+            if attempt == 0:
+                pending = start_tool_surface_resolution(request.enabled_toolsets, request.disabled_toolsets)
+                if pending is None:
+                    break
+    logger.warning("startup tool discovery unavailable; leaving session tool policy unchanged")
+    return None

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -556,6 +556,8 @@ def _get_platform_tools(config: dict, platform: str, *, include_default_mcp_serv
     # Track whether the user explicitly saved a toolset list for this platform (vs. falling back to the
     # platform default). See #35527.
     explicitly_configured = isinstance(toolset_names, list)
+    if explicitly_configured and not toolset_names:
+        return set()
     if not explicitly_configured:
         toolset_names = [_platform_default_toolset(platform)]
     # YAML may parse bare numeric names (``12306:``) as int; normalise so sorted() never mixes types.

--- a/model_tools.py
+++ b/model_tools.py
@@ -218,6 +218,12 @@ def get_tool_definitions(enabled_toolsets: Optional[List[str]] = None, disabled_
     skip_tool_search_assembly returns raw schemas for every enabled tool — only
     the tool_search bridge should use it (it reads the real, uncollapsed catalog).
     """
+    global _last_resolved_tool_names
+    if enabled_toolsets is not None and not enabled_toolsets:
+        # Deny-all precedes caching and dispatcher-worker tool injection.
+        _last_resolved_tool_names = []
+        return []
+
     def compute():
         return _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
                                          skip_tool_search_assembly=skip_tool_search_assembly)
@@ -244,7 +250,6 @@ def get_tool_definitions(enabled_toolsets: Optional[List[str]] = None, disabled_
                     _tool_defs_cache.pop(next(iter(_tool_defs_cache)))
                 _tool_defs_cache[cache_key] = cached = result
     else:
-        global _last_resolved_tool_names
         _last_resolved_tool_names = [t["function"]["name"] for t in cached]
     # Always a shallow copy: run_agent appends memory/LCM schemas to its list; a
     # shared list would accumulate duplicate names (HTTP 400 from DeepSeek/Kimi/MiMo).
@@ -901,6 +906,6 @@ def check_toolset_requirements() -> Dict[str, bool]:
     return registry.check_toolset_requirements()
 
 
-def check_tool_availability(quiet: bool = False) -> Tuple[List[str], List[dict]]:
+def check_tool_availability(quiet: bool = False, toolsets: Optional[set[str]] = None) -> Tuple[List[str], List[dict]]:
     """(available_toolsets, unavailable_info)."""
-    return registry.check_tool_availability(quiet=quiet)
+    return registry.check_tool_availability(quiet=quiet, toolsets=toolsets)

--- a/tests/cli/test_cli_preloaded_skills.py
+++ b/tests/cli/test_cli_preloaded_skills.py
@@ -54,6 +54,8 @@ class _DummyCLI:
         self.session_id = "session-123"
         self.system_prompt = "base prompt"
         self.preloaded_skills = []
+        self.enabled_toolsets = []
+        self.disabled_toolsets = []
 
     def show_banner(self):
         return None

--- a/tests/cli/test_cli_tool_surface.py
+++ b/tests/cli/test_cli_tool_surface.py
@@ -1,0 +1,234 @@
+"""The welcome banner projects callable tools without changing session policy."""
+
+import os
+import threading
+from concurrent.futures import Future
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_cli.tool_resolution import ToolResolutionRequest
+
+
+@pytest.fixture
+def cli_obj(monkeypatch):
+    from cli import HermesCLI
+
+    monkeypatch.setattr("shutil.get_terminal_size", lambda: os.terminal_size((160, 40)))
+    obj = HermesCLI.__new__(HermesCLI)
+    obj.model = "test-model"
+    obj.enabled_toolsets = ["file"]
+    obj.disabled_toolsets = []
+    obj.compact = False
+    obj.console = MagicMock()
+    obj.session_id = None
+    obj.api_key = "test"
+    obj.base_url = ""
+    obj.provider = "test"
+    obj._provider_source = None
+    obj.agent = None
+    obj._show_tool_availability_warnings = MagicMock()
+    return obj
+
+
+def prefetch(cli_obj, future):
+    cli_obj._startup_tool_resolution = (
+        ToolResolutionRequest.from_lists(cli_obj.enabled_toolsets, cli_obj.disabled_toolsets),
+        future,
+    )
+
+
+def test_banner_waits_then_consumes_exact_surface(cli_obj):
+    entered, release = threading.Event(), threading.Event()
+    expected = [{"function": {"name": "read_file"}}]
+    errors = []
+
+    def resolve(**_kwargs):
+        entered.set()
+        assert release.wait(timeout=5)
+        return expected
+
+    def show():
+        try:
+            cli_obj.show_banner()
+        except Exception as exc:
+            errors.append(exc)
+
+    with (
+        patch("hermes_cli.tool_resolution.get_cli_tool_definitions", side_effect=resolve),
+        patch("hermes_cli.banner.build_welcome_banner") as banner,
+    ):
+        render = threading.Thread(target=show)
+        render.start()
+        try:
+            assert entered.wait(timeout=5)
+            banner.assert_not_called()
+        finally:
+            release.set()
+            render.join(timeout=5)
+    assert not render.is_alive()
+    assert errors == []
+    assert banner.call_args.kwargs["tools"] == expected
+    assert cli_obj._startup_tool_resolution is None
+    cli_obj._show_tool_availability_warnings.assert_called_once_with()
+
+
+def test_failed_prefetch_retried_once(cli_obj):
+    failed = Future()
+    failed.set_exception(RuntimeError("transient"))
+    prefetch(cli_obj, failed)
+    expected = [{"function": {"name": "read_file"}}]
+    with (
+        patch("hermes_cli.tool_resolution.get_cli_tool_definitions", return_value=expected) as resolve,
+        patch("hermes_cli.banner.build_welcome_banner") as banner,
+    ):
+        cli_obj.show_banner()
+    resolve.assert_called_once()
+    assert banner.call_args.kwargs["tools"] == expected
+    assert cli_obj._startup_tool_resolution is None
+
+
+@pytest.mark.parametrize("error", [TimeoutError(), RuntimeError("persistent")])
+def test_discovery_failure_is_not_deny_all(cli_obj, error):
+    failed = Future()
+    failed.set_exception(error)
+    prefetch(cli_obj, failed)
+    with (
+        patch("hermes_cli.tool_resolution.get_cli_tool_definitions", side_effect=error) as resolve,
+        patch("hermes_cli.banner.build_welcome_banner") as banner,
+    ):
+        cli_obj.show_banner()
+    assert resolve.call_count == (0 if isinstance(error, TimeoutError) else 1)
+    assert cli_obj.enabled_toolsets == ["file"]
+    banner.assert_not_called()  # unknown must not be presented as a zero count
+    assert any("Tool discovery unavailable" in str(call) for call in cli_obj.console.print.call_args_list)
+    cli_obj._show_tool_availability_warnings.assert_not_called()
+
+
+@pytest.mark.parametrize("selection", [[], (), set()])
+def test_explicit_empty_banner_never_discovers(cli_obj, selection):
+    cli_obj.enabled_toolsets = selection
+    with (
+        patch("hermes_cli.tool_resolution.get_cli_tool_definitions") as resolve,
+        patch("hermes_cli.banner.build_welcome_banner") as banner,
+    ):
+        cli_obj.show_banner()
+    assert banner.call_args.kwargs["tools"] == []
+    resolve.assert_not_called()
+
+
+def test_live_agent_surface_wins_over_prefetch(cli_obj):
+    cli_obj.agent = SimpleNamespace(tools=[])
+    future = Future()
+    future.set_result([{"function": {"name": "read_file"}}])
+    prefetch(cli_obj, future)
+    with (
+        patch("hermes_cli.tool_resolution.get_cli_tool_definitions") as resolve,
+        patch("hermes_cli.banner.build_welcome_banner") as banner,
+    ):
+        cli_obj.show_banner()
+    assert banner.call_args.kwargs["tools"] == []
+    assert cli_obj._startup_tool_resolution is None
+    resolve.assert_not_called()
+
+
+def test_later_banner_uses_fresh_canonical_resolution(cli_obj):
+    first, second = [], [{"function": {"name": "read_file"}}]
+    future = Future()
+    future.set_result(first)
+    prefetch(cli_obj, future)
+    with (
+        patch("hermes_cli.tool_resolution.get_cli_tool_definitions", return_value=second) as resolve,
+        patch("hermes_cli.banner.build_welcome_banner") as banner,
+    ):
+        cli_obj.show_banner()
+        cli_obj.show_banner()
+    resolve.assert_called_once()
+    assert [call.kwargs["tools"] for call in banner.call_args_list] == [first, second]
+
+
+@pytest.mark.parametrize("selection", [[], (), set()])
+def test_empty_diagnostics_do_not_import_registry(cli_obj, selection):
+    from cli import HermesCLI
+
+    cli_obj.enabled_toolsets = selection
+    with patch("builtins.__import__", wraps=__import__) as imports:
+        HermesCLI._show_tool_availability_warnings(cli_obj)
+    assert not any(call.args[0] == "model_tools" for call in imports.call_args_list)
+
+
+@pytest.mark.parametrize("enabled,disabled", [(["web", "tts"], ["tts"]), (["hermes-cli"], ["hermes-cli"]), (None, ["tts"])])
+def test_diagnostics_use_canonical_bundle_semantics(cli_obj, enabled, disabled):
+    from cli import HermesCLI
+    from model_tools import _select_tool_names, get_toolset_for_tool
+
+    cli_obj.enabled_toolsets, cli_obj.disabled_toolsets = enabled, disabled
+    expected = {owner for name in _select_tool_names(enabled, disabled, True) if (owner := get_toolset_for_tool(name))}
+    with patch("model_tools.check_tool_availability", return_value=([], [])) as check:
+        HermesCLI._show_tool_availability_warnings(cli_obj)
+    check.assert_called_once_with(toolsets=expected)
+
+
+@pytest.mark.parametrize("selection", ["", [], (), set()])
+def test_main_preserves_explicit_empty(cli_obj, selection):
+    from cli import main
+
+    with patch("cli.HermesCLI", return_value=cli_obj) as constructor, patch.object(cli_obj, "run"):
+        main(toolsets=selection)
+    assert constructor.call_args.kwargs["toolsets"] == []
+
+
+def test_one_shot_does_not_consume_banner_prefetch(cli_obj):
+    from cli import main
+
+    pending = Future()
+    with (
+        patch("cli.HermesCLI", return_value=cli_obj),
+        patch("cli._run_single_query_mode"),
+        patch.object(pending, "result", side_effect=AssertionError("banner-only work")),
+        patch("hermes_cli.tool_resolution.start_tool_surface_resolution", side_effect=AssertionError("banner-only work")),
+    ):
+        main(query="test", oneshot=True, toolsets=["file"], _prefetched_tool_resolution=(ToolResolutionRequest.from_lists(["file"], []), pending))
+    assert cli_obj.enabled_toolsets == ["file"]
+
+
+@pytest.mark.parametrize("compact", [False, True])
+def test_deferred_banner_never_claims_zero_tools(cli_obj, monkeypatch, compact):
+    monkeypatch.setenv("HERMES_DEFER_AGENT_STARTUP", "1")
+    cli_obj.compact = compact
+    with (
+        patch("hermes_cli.tool_resolution._submit_daemon") as resolve,
+        patch("hermes_cli.banner.build_welcome_banner") as banner,
+    ):
+        cli_obj.show_banner()
+    resolve.assert_not_called()
+    banner.assert_not_called()
+    printed = str(cli_obj.console.print.call_args_list)
+    assert "tools deferred" in printed
+    assert "0 tools" not in printed
+    assert "Tool discovery unavailable" not in printed
+    cli_obj._show_tool_availability_warnings.assert_not_called()
+
+
+@pytest.mark.parametrize("compact", [False, True])
+@pytest.mark.parametrize("live", [False, True])
+def test_known_surface_wins_over_deferral(cli_obj, monkeypatch, compact, live):
+    monkeypatch.setenv("HERMES_DEFER_AGENT_STARTUP", "1")
+    cli_obj.compact = compact
+    tools = [{"function": {"name": "read_file"}}] if live else []
+    if live:
+        cli_obj.agent = SimpleNamespace(tools=tools)
+    else:
+        cli_obj.enabled_toolsets = []
+    with (
+        patch("hermes_cli.tool_resolution._submit_daemon") as start,
+        patch("hermes_cli.banner.build_welcome_banner") as banner,
+    ):
+        cli_obj.show_banner()
+    start.assert_not_called()
+    if compact:
+        assert f"{len(tools)} tools" in str(cli_obj.console.print.call_args_list)
+    else:
+        assert banner.call_args.kwargs["tools"] == tools
+    assert "tools deferred" not in str(cli_obj.console.print.call_args_list)

--- a/tests/hermes_cli/test_argparse_flag_propagation.py
+++ b/tests/hermes_cli/test_argparse_flag_propagation.py
@@ -73,6 +73,7 @@ class TestChatVerboseArg:
         import sys
 
         import hermes_cli.main as main_mod
+        import hermes_cli.tool_resolution as tool_resolution
         from hermes_cli._parser import build_top_level_parser
 
         parser, _subparsers, chat_parser = build_top_level_parser()
@@ -95,11 +96,18 @@ class TestChatVerboseArg:
         monkeypatch.setitem(sys.modules, "tools.skills_sync", fake_skills_sync)
         monkeypatch.setattr(main_mod, "_has_any_provider_configured", lambda: True)
         monkeypatch.setattr(main_mod, "_pin_kanban_board_env", lambda: None)
+        prefetched = object()
+        monkeypatch.setattr(
+            tool_resolution,
+            "start_cli_tool_resolution",
+            lambda *_args, **_kwargs: prefetched,
+        )
 
         main_mod.cmd_chat(args)
 
         assert captured["quiet"] is False
         assert "verbose" not in captured
+        assert captured["_prefetched_tool_resolution"] is prefetched
 
 
 class TestYoloEnvVar:

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -84,3 +84,33 @@ def test_build_welcome_banner_non_moa_unchanged(tmp_path, monkeypatch):
     out = console.export_text()
     assert "claude-opus-4.8" in out
     assert "MoA:" not in out
+
+
+def test_banner_uses_only_the_canonical_callable_surface(tmp_path, monkeypatch):
+    """An empty callable surface renders no tools or skills."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    (tmp_path / ".hermes").mkdir()
+
+    with (
+        patch.object(
+            model_tools,
+            "check_tool_availability",
+            side_effect=AssertionError("banner must not rediscover tools"),
+        ),
+        patch.object(banner, "get_available_skills", return_value={"dev": ["demo"]}),
+        patch.object(banner, "get_update_result", return_value=None),
+        patch.object(tools.mcp_tool_discovery, "get_mcp_status", return_value=[]),
+    ):
+        console = Console(record=True, force_terminal=False, color_system=None, width=160)
+        banner.build_welcome_banner(
+            console=console,
+            model="test-model",
+            cwd="/tmp/project",
+            tools=[],
+            get_toolset_for_tool=lambda _name: None,
+        )
+
+    out = console.export_text()
+    assert "0 tools" in out
+    assert "Skills toolset disabled" in out
+    assert "demo" not in out

--- a/tests/hermes_cli/test_banner_skills_width.py
+++ b/tests/hermes_cli/test_banner_skills_width.py
@@ -30,7 +30,8 @@ def _build_banner_with_skills(skills_by_category, term_width=160):
             console=console,
             model="anthropic/test-model",
             cwd="/tmp/project",
-            tools=[],
+            tools=[{"function": {"name": "skill_view"}}],
+            get_toolset_for_tool=lambda _name: "skills",
         )
         return console.export_text()
 

--- a/tests/hermes_cli/test_cli_startup_model_cost_guard.py
+++ b/tests/hermes_cli/test_cli_startup_model_cost_guard.py
@@ -52,6 +52,10 @@ def main_mod(monkeypatch):
     monkeypatch.setattr(mod, "_pin_kanban_board_env", lambda: None)
     monkeypatch.setattr(mod, "_resolve_session_by_name_or_id", lambda val: val)
     monkeypatch.setattr(mod, "_oneshot_cleanup_done", False)
+    monkeypatch.setattr(
+        "hermes_cli.tool_resolution.start_cli_tool_resolution",
+        lambda *_args, **_kwargs: object(),
+    )
     return mod
 
 

--- a/tests/hermes_cli/test_safe_mode.py
+++ b/tests/hermes_cli/test_safe_mode.py
@@ -44,6 +44,10 @@ def test_cmd_chat_safe_mode_sets_env_before_startup(monkeypatch):
     monkeypatch.setattr(main_mod, "_pin_kanban_board_env", lambda: None)
     monkeypatch.setattr(main_mod, "_sync_bundled_skills_for_startup", lambda: None)
     monkeypatch.setattr(main_mod, "_termux_should_prefetch_update_check", lambda: False)
+    monkeypatch.setattr(
+        "hermes_cli.tool_resolution.start_cli_tool_resolution",
+        lambda *_args, **_kwargs: object(),
+    )
     setattr(fake_cli, "main", fake_main)
     monkeypatch.setitem(sys.modules, "cli", fake_cli)
 

--- a/tests/hermes_cli/test_tool_resolution.py
+++ b/tests/hermes_cli/test_tool_resolution.py
@@ -1,0 +1,204 @@
+import json
+import os
+import subprocess
+import sys
+import threading
+from unittest.mock import patch
+
+from hermes_cli.tool_resolution import (
+    ToolResolutionRequest,
+    get_cli_tool_definitions,
+    resolve_cli_toolsets,
+    resolve_startup_tools,
+    start_cli_tool_resolution,
+    start_tool_surface_resolution,
+)
+
+
+def test_cli_policy_preserves_explicit_empty_and_normalizes_values():
+    assert resolve_cli_toolsets([], {}) == []
+    assert resolve_cli_toolsets("", {}) == []
+    assert resolve_cli_toolsets("web, terminal", {}) == ["web", "terminal"]
+    assert resolve_cli_toolsets(("web,file", "skills"), {}) == [
+        "web",
+        "file",
+        "skills",
+    ]
+
+
+def test_configured_empty_policy_precedes_coding_focus():
+    with patch(
+        "agent.coding_context.coding_selection",
+        side_effect=AssertionError("empty policy must return before coding focus"),
+    ) as coding:
+        assert resolve_cli_toolsets(
+            None, {"platform_toolsets": {"cli": []}}
+        ) == []
+    coding.assert_not_called()
+
+
+def test_request_preserves_default_and_explicit_empty():
+    assert ToolResolutionRequest.from_lists(None, []).enabled_toolsets is None
+    assert ToolResolutionRequest.from_lists([], []).enabled_toolsets == frozenset()
+
+
+def test_background_resolution_uses_immutable_request():
+    enabled = ["web"]
+    disabled = ["tts"]
+
+    seen = []
+
+    def resolver(**kwargs):
+        seen.append((kwargs, threading.current_thread().daemon))
+        return [{"function": {"name": "web_search"}}]
+
+    with patch(
+        "hermes_cli.tool_resolution.get_cli_tool_definitions", side_effect=resolver
+    ):
+        pending = start_tool_surface_resolution(enabled, disabled)
+        assert pending is not None
+        resolved_request, future = pending
+        enabled.append("file")
+        disabled.clear()
+        result = future.result(timeout=2)
+
+    assert resolved_request == ToolResolutionRequest.from_lists(["web"], ["tts"])
+    assert result == [{"function": {"name": "web_search"}}]
+    assert seen == [
+        (
+            {
+                "enabled_toolsets": frozenset({"web"}),
+                "disabled_toolsets": frozenset({"tts"}),
+                "quiet_mode": True,
+            },
+            True,
+        )
+    ]
+
+
+def test_cli_policy_is_available_while_definitions_resolve():
+    entered = threading.Event()
+    release = threading.Event()
+
+    def resolver(**_kwargs):
+        entered.set()
+        assert release.wait(timeout=2)
+        return [{"function": {"name": "web_search"}}]
+
+    with patch(
+        "hermes_cli.tool_resolution.get_cli_tool_definitions", side_effect=resolver
+    ):
+        pending = start_cli_tool_resolution(["web"], config={})
+        assert pending is not None
+        request, future = pending
+        try:
+            assert request.enabled_toolsets == {"web"}
+            assert entered.wait(timeout=2)
+            assert not future.done()
+        finally:
+            release.set()
+        assert future.result(timeout=2) == [
+            {"function": {"name": "web_search"}}
+        ]
+
+
+def test_early_cli_resolution_knows_explicit_empty_without_worker_imports():
+    pending = start_cli_tool_resolution([])
+
+    assert pending is not None
+    request, future = pending
+    assert request.enabled_toolsets == frozenset()
+    assert future.result(timeout=0) == []
+
+
+def test_configured_empty_resolution_uses_the_supplied_config():
+    with patch(
+        "hermes_cli.tool_resolution._submit_daemon",
+        side_effect=AssertionError("known-empty policy must not start a worker"),
+    ):
+        pending = start_cli_tool_resolution(
+            None, config={"platform_toolsets": {"cli": []}}
+        )
+
+    assert pending is not None
+    request, future = pending
+    assert request.enabled_toolsets == frozenset()
+    assert future.result(timeout=0) == []
+
+
+def test_explicit_empty_resolution_imports_no_tool_runtime(tmp_path):
+    script = """
+import json
+import sys
+import threading
+from hermes_cli.tool_resolution import start_cli_tool_resolution
+
+request, future = start_cli_tool_resolution(())
+print(json.dumps({
+    "enabled": sorted(request.enabled_toolsets),
+    "tools": future.result(timeout=0),
+    "model_tools": "model_tools" in sys.modules,
+    "registry": "tools.registry" in sys.modules,
+    "worker": any(
+        thread.name == "tool-surface-resolution"
+        for thread in threading.enumerate()
+    ),
+}))
+"""
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(tmp_path)
+    env.pop("HERMES_DEFER_AGENT_STARTUP", None)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert json.loads(result.stdout) == {
+        "enabled": [],
+        "tools": [],
+        "model_tools": False,
+        "registry": False,
+        "worker": False,
+    }
+
+
+def test_cli_definition_wrapper_short_circuits_positional_empty_policy():
+    with patch(
+        "hermes_cli.mcp_startup.wait_for_mcp_discovery",
+        side_effect=AssertionError("empty policy must not wait for MCP"),
+    ):
+        assert get_cli_tool_definitions([]) == []
+
+
+def test_equivalent_policy_reuses_prefetch():
+    from concurrent.futures import Future
+
+    original = ToolResolutionRequest.from_lists(["file", "web", "file"], ["tts", "vision"])
+    reordered = ToolResolutionRequest.from_lists(["web", "file"], ["vision", "tts", "tts"])
+    future = Future()
+    expected = [{"function": {"name": "read_file"}}]
+    future.set_result(expected)
+    with patch("hermes_cli.tool_resolution.start_tool_surface_resolution") as start:
+        assert resolve_startup_tools(reordered, (original, future)) == expected
+    start.assert_not_called()
+
+
+def test_changed_policy_does_not_reuse_prefetch():
+    from concurrent.futures import Future
+
+    original = ToolResolutionRequest.from_lists(["file"], [])
+    future = Future()
+    future.set_result([{"function": {"name": "read_file"}}])
+    empty = ToolResolutionRequest.from_lists([], [])
+    assert resolve_startup_tools(empty, (original, future)) == []
+
+
+def test_deferred_resolution_is_unknown_not_empty(monkeypatch):
+    monkeypatch.setenv("HERMES_DEFER_AGENT_STARTUP", "1")
+    with patch("hermes_cli.tool_resolution._submit_daemon") as start:
+        assert resolve_startup_tools(ToolResolutionRequest.from_lists(["file"], [])) is None
+        assert resolve_startup_tools(ToolResolutionRequest.from_lists([], [])) == []
+    start.assert_not_called()

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -289,6 +289,18 @@ def test_first_install_nous_auto_configures_video_gen(monkeypatch):
 # ── Platform / toolset consistency ────────────────────────────────────────────
 
 
+def test_explicit_empty_platform_toolsets_disable_every_recovery_path():
+    """An empty platform policy yields no toolsets."""
+    assert _get_platform_tools(
+        {
+            "platform_toolsets": {"cli": []},
+            "mcp_servers": {"example": {"enabled": True}},
+        },
+        "cli",
+        include_default_mcp_servers=True,
+    ) == set()
+
+
 class TestPlatformToolsetConsistency:
     """Every platform in tools_config.PLATFORMS must have a matching toolset."""
 

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -7,10 +7,20 @@ from unittest.mock import patch
 from model_tools import (
     handle_function_call,
     get_all_tool_names,
+    get_tool_definitions,
     get_toolset_for_tool,
     _AGENT_LOOP_TOOLS,
     _LEGACY_TOOLSET_MAP,
 )
+
+
+def test_explicit_empty_toolsets_cannot_be_widened_by_worker_context(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-1")
+    with (
+        patch("model_tools._is_delegated_child_context", return_value=False),
+        patch("model_tools._is_dispatcher_owned_worker", return_value=True),
+    ):
+        assert get_tool_definitions(enabled_toolsets=[], quiet_mode=True) == []
 
 
 # =========================================================================

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -329,6 +329,32 @@ class TestCheckFnExceptionHandling:
         assert "works" in available
         assert any(u["name"] == "crashes" for u in unavailable)
 
+    def test_check_tool_availability_only_probes_requested_toolsets(self):
+        reg = ToolRegistry()
+        unselected_checks = []
+        reg.register(
+            name="selected",
+            toolset="selected",
+            schema=_make_schema(),
+            handler=_dummy_handler,
+            check_fn=lambda: True,
+        )
+        reg.register(
+            name="unselected",
+            toolset="unselected",
+            schema=_make_schema(),
+            handler=_dummy_handler,
+            check_fn=lambda: unselected_checks.append(True) or True,
+        )
+
+        available, unavailable = reg.check_tool_availability(
+            toolsets={"selected"}
+        )
+
+        assert available == ["selected"]
+        assert unavailable == []
+        assert unselected_checks == []
+
 
 class TestBuiltinDiscovery:
     def test_discovers_all_real_self_registering_builtin_tool_modules(self):

--- a/tests/tui_gateway/test_empty_tool_policy_integration.py
+++ b/tests/tui_gateway/test_empty_tool_policy_integration.py
@@ -1,0 +1,129 @@
+"""Persisted deny-all policy composes across the real GUI gateway boundaries.
+
+Only the model-runtime/agent-constructor boundary is replaced: the constructor
+records gateway inputs and builds its tool snapshot with the real resolver.
+No policy, config loader, inspector, or MCP refresh function is mocked.
+"""
+
+import socket
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+import hermes_cli.banner as banner
+import hermes_cli.config as config
+import run_agent
+import tui_gateway.server as server
+from model_tools import get_tool_definitions
+from tools.mcp_tool_agent import refresh_agent_mcp_tools
+from tools.registry import registry
+
+
+class _OfflineAgent(SimpleNamespace):
+    """Constructor sink, not a simulated model or a hardcoded empty snapshot."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.disabled_toolsets = kwargs.get("disabled_toolsets")
+        self.tools = get_tool_definitions(
+            enabled_toolsets=self.enabled_toolsets,
+            disabled_toolsets=self.disabled_toolsets,
+            quiet_mode=True,
+        )
+        self.valid_tool_names = {tool["function"]["name"] for tool in self.tools}
+
+
+@pytest.fixture(params=["tui", "desktop"])
+def empty_session(request, tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    for name in ("HERMES_TUI_TOOLSETS", "HERMES_DESKTOP", "HERMES_DESKTOP_TERMINAL",
+                 "HERMES_TUI_SKILLS"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.chdir(tmp_path)
+    # A genuine code workspace with opt-in focus competes with the empty policy.
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'empty-policy'\n", encoding="utf-8")
+    (tmp_path / "config.yaml").write_text(
+        "platform_toolsets:\n  cli: []\nagent:\n  coding_context: focus\n",
+        encoding="utf-8",
+    )
+    connect = Mock(side_effect=AssertionError("integration test attempted network access"))
+    monkeypatch.setattr(socket.socket, "connect", connect)
+    monkeypatch.setattr(socket.socket, "connect_ex", connect)
+    # Cosmetic update checks and provider auth are outside the tool-policy path.
+    monkeypatch.setattr(banner, "get_update_result", lambda **kwargs: None)
+    monkeypatch.setattr(server, "_probe_credentials", lambda agent: "")
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(
+        server, "_resolve_agent_model_runtime",
+        lambda *args: ("offline-policy-test", {"provider": "openai"}),
+    )
+    constructor = Mock(side_effect=_OfflineAgent)
+    monkeypatch.setattr(run_agent, "AIAgent", constructor)
+
+    cfg = config.load_config()
+    assert cfg["platform_toolsets"]["cli"] == []
+    assert cfg["agent"]["coding_context"] == "focus"
+    sid = f"empty-policy-{request.param}"
+    agent = server._make_agent(sid, sid, platform_override=request.param)
+    constructor.assert_called_once()
+    assert constructor.call_args.kwargs["enabled_toolsets"] == []
+    assert constructor.call_args.kwargs["platform"] == request.param
+    session = {"agent": agent, "session_key": sid, "source": request.param, "cwd": str(tmp_path)}
+    monkeypatch.setitem(server._sessions, sid, session)
+    yield sid, agent, monkeypatch
+    connect.assert_not_called()
+
+
+def _assert_empty_inspection(sid, agent):
+    assert agent.enabled_toolsets == []
+    assert agent.tools == []
+    assert agent.valid_tool_names == set()
+    shown = server._methods["tools.show"]("show-empty", {"session_id": sid})
+    assert shown["result"] == {"sections": [], "total": len(agent.tools)}
+    for method in ("tools.list", "toolsets.list"):
+        listed = server._methods[method]("list-empty", {"session_id": sid})
+        rows = listed["result"]["toolsets"]
+        assert rows  # A real catalog, not a vacuously empty inspector response.
+        assert not any(row["enabled"] for row in rows)
+    # session.info is an event payload, not a registered request method.
+    assert server._session_info(agent, server._sessions[sid])["tools"] == {}
+
+
+def test_persisted_empty_policy_reaches_gateway_and_detached_inspectors(empty_session):
+    sid, agent, monkeypatch = empty_session
+    _assert_empty_inspection(sid, agent)
+    for kind, build_kwargs in (
+        ("background", server._background_agent_kwargs),
+        ("preview", server._ephemeral_preview_agent_kwargs),
+    ):
+        child_sid = f"{sid}-{kind}"
+        kwargs = build_kwargs(agent, child_sid)
+        assert kwargs["enabled_toolsets"] == []
+        child = _OfflineAgent(**kwargs)
+        monkeypatch.setitem(server._sessions, child_sid, {
+            "agent": child, "session_key": child_sid, "source": kwargs["platform"],
+        })
+        _assert_empty_inspection(child_sid, child)
+
+
+def test_late_mcp_registry_refresh_cannot_widen_persisted_empty_policy(empty_session):
+    sid, agent, _ = empty_session
+    name = "mcp_empty_policy_late_probe"
+    toolset = "mcp-empty-policy"
+    _assert_empty_inspection(sid, agent)
+    # Simulate completed discovery at its registry boundary, never launch an MCP
+    # process. Refresh and its policy/tool-definition resolvers remain real.
+    registry.register(
+        name=name, toolset=toolset,
+        schema={"name": name, "description": "Offline late-discovery probe",
+                "parameters": {"type": "object", "properties": {}}},
+        handler=lambda args, **kwargs: "unused",
+    )
+    try:
+        assert registry.get_entry(name) is not None
+        for enabled in (None, server._load_enabled_toolsets(agent.platform)):
+            assert refresh_agent_mcp_tools(agent, enabled_override=enabled) == set()
+            _assert_empty_inspection(sid, agent)
+    finally:
+        registry.deregister(name)

--- a/tests/tui_gateway/test_gui_surface_toolsets.py
+++ b/tests/tui_gateway/test_gui_surface_toolsets.py
@@ -12,6 +12,8 @@ session's own ``source`` (``session.create``'s ``source: 'desktop'``), so the
 answer is identical on every connection topology.
 """
 
+from types import SimpleNamespace
+
 import pytest
 
 import tui_gateway.server as server
@@ -90,9 +92,16 @@ class TestSurfaceResolution:
 class TestResolverPlumbing:
     def test_posture_path_folds_in_the_session_surface(self, no_desktop_env):
         """Focus-mode returns early — the surface toolsets must survive it."""
-        import agent.coding_context as cc
+        from unittest.mock import Mock, call
 
-        no_desktop_env.setattr(cc, "coding_selection", lambda **_: ["coding"])
+        import agent.coding_context as cc
+        import hermes_cli.config as config_mod
+
+        cfg = {"platform_toolsets": {"cli": ["file"]}}
+        load = Mock(return_value=cfg)
+        select = Mock(return_value=["coding"])
+        no_desktop_env.setattr(config_mod, "load_config", load)
+        no_desktop_env.setattr(cc, "coding_selection", select)
 
         assert server._load_enabled_toolsets("desktop") == [
             "coding",
@@ -100,6 +109,10 @@ class TestResolverPlumbing:
             "project",
         ]
         assert server._load_enabled_toolsets("tui") == ["coding", "project"]
+        assert load.call_count == 2
+        assert select.call_args_list == [
+            call(platform="desktop", config=cfg), call(platform="tui", config=cfg),
+        ]
 
     def test_config_path_folds_in_the_session_surface(self, no_desktop_env):
         import agent.coding_context as cc
@@ -117,8 +130,100 @@ class TestResolverPlumbing:
         assert "desktop_ui" in desktop
         assert "desktop_ui" not in tui
 
+    def test_explicit_empty_config_beats_focus_and_gui_surfaces(self, no_desktop_env):
+        import agent.coding_context as cc
+        import hermes_cli.config as config_mod
+
+        no_desktop_env.setattr(cc, "coding_selection", lambda **_: ["coding"])
+        no_desktop_env.setattr(
+            config_mod, "load_config", lambda: {"platform_toolsets": {"cli": []}}
+        )
+
+        assert server._load_enabled_toolsets("desktop") == []
+        assert server._load_enabled_toolsets("tui") == []
+
     def test_explicit_env_pin_still_wins(self, no_desktop_env):
         """HERMES_TUI_TOOLSETS is an operator override; surface can't re-add."""
         no_desktop_env.setenv("HERMES_TUI_TOOLSETS", "web,memory")
 
         assert server._load_enabled_toolsets("desktop") == ["web", "memory"]
+
+
+def test_zero_tool_inspectors_agree_with_the_live_agent(monkeypatch):
+    agent = SimpleNamespace(enabled_toolsets=[], tools=[], model="test-model")
+    session = {"agent": agent, "session_key": "empty-tools", "source": "desktop"}
+    monkeypatch.setitem(server._sessions, "empty-tools", session)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+
+    try:
+        shown = server._methods["tools.show"](
+            "show-empty", {"session_id": "empty-tools"}
+        )
+        listed = server._methods["tools.list"](
+            "list-empty", {"session_id": "empty-tools"}
+        )
+        info = server._session_info(agent, session)
+    finally:
+        server._sessions.pop("empty-tools", None)
+
+    assert shown["result"] == {"sections": [], "total": 0}
+    assert not any(row["enabled"] for row in listed["result"]["toolsets"])
+    assert info["tools"] == {}
+
+
+@pytest.mark.parametrize("selection", [[], (), set()])
+def test_preview_agent_preserves_any_explicit_empty_selection(monkeypatch, selection):
+    agent = SimpleNamespace(
+        enabled_toolsets=selection, disabled_toolsets=["file"],
+        model="test-model", provider="test-provider"
+    )
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    kwargs = server._ephemeral_preview_agent_kwargs(agent, "empty-preview")
+
+    assert kwargs["enabled_toolsets"] == []
+    assert kwargs["disabled_toolsets"] == ["file"]
+
+
+@pytest.mark.parametrize("selection", [None, [], ["memory"]])
+def test_background_agent_preserves_selection_and_disabled_policy(monkeypatch, selection):
+    agent = SimpleNamespace(enabled_toolsets=selection, disabled_toolsets=["file"], model="test")
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda platform: ["terminal"])
+    kwargs = server._background_agent_kwargs(agent, "background")
+    assert kwargs["enabled_toolsets"] == (["terminal"] if selection is None else selection)
+    assert kwargs["disabled_toolsets"] == ["file"]
+
+
+@pytest.mark.parametrize("selection", [None, [], ["terminal", "file", "memory"]])
+def test_toolset_rows_apply_composite_disabled_policy(monkeypatch, selection):
+    agent = SimpleNamespace(enabled_toolsets=selection, disabled_toolsets=["debugging"])
+    monkeypatch.setitem(server._sessions, "disabled-tools", {"agent": agent})
+    for method in ("tools.list", "toolsets.list"):
+        result = server._methods[method]("list", {"session_id": "disabled-tools"})
+        rows = {row["name"]: row for row in result["result"]["toolsets"]}
+        assert not rows["terminal"]["enabled"]
+        assert not rows["file"]["enabled"]
+        assert rows["memory"]["enabled"] is (selection != [])
+
+
+def test_tools_show_forwards_disabled_policy(monkeypatch):
+    import model_tools
+
+    agent = SimpleNamespace(enabled_toolsets=["terminal"], disabled_toolsets=["debugging"])
+    monkeypatch.setitem(server._sessions, "disabled-tools", {"agent": agent})
+    expected = model_tools.get_tool_definitions(
+        enabled_toolsets=agent.enabled_toolsets, disabled_toolsets=agent.disabled_toolsets,
+        quiet_mode=True, skip_tool_search_assembly=True,
+    )
+    result = server._methods["tools.show"]("show", {"session_id": "disabled-tools"})
+    assert result["result"]["total"] == len(expected) == 0
+
+
+def test_real_empty_config_survives_gui_resolution(tmp_path, monkeypatch, no_desktop_env):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("platform_toolsets:\n  cli: []\n", encoding="utf-8")
+    assert server._load_enabled_toolsets("desktop") == []
+    assert server._load_enabled_toolsets("tui") == []

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -901,12 +901,12 @@ class ToolRegistry:
                 "tools": [entry.name for entry in members]}
         return result
 
-    def check_tool_availability(self, quiet: bool = False):
+    def check_tool_availability(self, quiet: bool = False, toolsets: Optional[Set[str]] = None):
         """Return (available_toolsets, unavailable_info) like the old function."""
         available, unavailable = [], []
         entries = self._snapshot_entries()
         groups = self._grouped(entries)
-        for ts in sorted(groups):
+        for ts in sorted(groups.keys() if toolsets is None else groups.keys() & toolsets):
             if self._toolset_has_exposable_tools(ts, entries):
                 available.append(ts)
             else:

--- a/tui_gateway/agent_callbacks.py
+++ b/tui_gateway/agent_callbacks.py
@@ -270,7 +270,9 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         **{k: g(k) for k in ("providers_allowed", "providers_ignored", "providers_order", "provider_sort",
                              "provider_data_collection", "openrouter_min_coding_score")},
         "model": g("model") or _resolve_model(), "max_iterations": _cfg_max_turns(cfg, 25),
-        "enabled_toolsets": g("enabled_toolsets") or _load_enabled_toolsets("tui"),
+        "enabled_toolsets": (g("enabled_toolsets") if g("enabled_toolsets") is not None
+                             else _load_enabled_toolsets("tui")),
+        "disabled_toolsets": g("disabled_toolsets"),
         "quiet_mode": True, "verbose_logging": False,
         "provider_require_parameters": g("provider_require_parameters", False), "session_id": task_id,
         "reasoning_config": g("reasoning_config") or _load_reasoning_config(str(g("model", "") or "")),
@@ -280,8 +282,11 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
 
 
 def _ephemeral_preview_agent_kwargs(agent, task_id: str) -> dict:
-    return {**_background_agent_kwargs(agent, task_id),
-            "enabled_toolsets": ["terminal", "file"], "session_db": None, "skip_memory": True}
+    kwargs = _background_agent_kwargs(agent, task_id)
+    enabled = kwargs["enabled_toolsets"]
+    return {**kwargs,
+            "enabled_toolsets": [] if enabled is not None and not enabled else ["terminal", "file"],
+            "session_db": None, "skip_memory": True}
 
 
 def _preview_restart_history(session: dict, max_messages: int = 24, max_tool_chars: int = 1200) -> list[dict]:

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -183,13 +183,18 @@ def _joined_output(r) -> str:
 def _toolset_rows(params: dict, *, with_tools: bool) -> list[dict]:
     toolsets = _tools_mod("toolsets")
     session = _sessions.get(params.get("session_id", ""))
-    enabled = set((getattr(session["agent"], "enabled_toolsets", []) if session else _load_enabled_toolsets()) or [])
+    selection = getattr(session["agent"], "enabled_toolsets", None) if session else _load_enabled_toolsets()
+    enabled = set(toolsets.get_all_toolsets() if selection is None else selection)
+    disabled = getattr(session["agent"], "disabled_toolsets", None) if session else None
+    if disabled:
+        from hermes_cli.tools_config import _prune_toolsets_stripped_by_disabled
+        enabled = _prune_toolsets_stripped_by_disabled(enabled, disabled)
     items = []
     for name in sorted(toolsets.get_all_toolsets().keys()):
         if info := toolsets.get_toolset_info(name):
             row = {
                 "name": name, "description": info["description"], "tool_count": info["tool_count"],
-                "enabled": name in enabled if enabled else True}
+                "enabled": name in enabled}
             if with_tools:
                 row["tools"] = info["resolved_tools"]
             items.append(row)
@@ -965,8 +970,10 @@ def _(rid, params: dict) -> dict:
     mt = _tools_mod("model_tools")
     session = _sessions.get(params.get("session_id", ""))
     enabled = getattr(session["agent"], "enabled_toolsets", None) if session else _load_enabled_toolsets()
+    disabled = getattr(session["agent"], "disabled_toolsets", None) if session else None
     # Pre-assembly list: /tools must also show tools deferred behind the tool_search bridge (as the CLI).
-    tools = mt.get_tool_definitions(enabled_toolsets=enabled, quiet_mode=True, skip_tool_search_assembly=True)
+    tools = mt.get_tool_definitions(enabled_toolsets=enabled, disabled_toolsets=disabled,
+                                    quiet_mode=True, skip_tool_search_assembly=True)
     sections = {}
     for tool in sorted(tools, key=lambda t: t["function"]["name"]):
         name = tool["function"]["name"]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1821,10 +1821,16 @@ def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
     session_platform = platform or _resolve_session_platform()
     explicit = [item.strip() for item in os.environ.get("HERMES_TUI_TOOLSETS", "").split(",") if item.strip()]
     fallback_notice = None
+    cfg = None
     if not explicit:
         with contextlib.suppress(Exception):
+            from hermes_cli.config import load_config, platform_toolsets_explicitly_empty
+            cfg = load_config()
+            if platform_toolsets_explicitly_empty(cfg, "cli"):
+                return []
+        with contextlib.suppress(Exception):
             from agent.coding_context import coding_selection
-            selection = coding_selection(platform=session_platform)
+            selection = coding_selection(platform=session_platform, config=cfg)
             if selection is not None:
                 return sorted({*selection, *_gui_surface_toolsets(session_platform)})
     try:
@@ -1839,7 +1845,8 @@ def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
     try:
         from hermes_cli.config import load_config
         from hermes_cli.tools_config import _get_platform_tools
-        cfg = load_config()
+        if cfg is None:
+            cfg = load_config()
         # include_default_mcp_servers=True is the runtime variant (the agent must be able to call
         # default MCP servers); the config-editing variant would silently drop MCP tools from the TUI.
         # Passing ``False`` here is the config-editing variant — used when we need to persist a toolset list
@@ -1848,7 +1855,7 @@ def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
         enabled = _get_platform_tools(cfg, "cli", include_default_mcp_servers=True)
         if fallback_notice is not None:
             _tui_notice(fallback_notice)
-        return sorted(enabled | _gui_surface_toolsets(session_platform)) if enabled else None
+        return sorted(enabled | _gui_surface_toolsets(session_platform)) if enabled else []
     except Exception:
         if fallback_notice is not None:
             _tui_notice("[tui] no valid HERMES_TUI_TOOLSETS entries and configured CLI toolsets could not be loaded; enabling all toolsets")


### PR DESCRIPTION
## Summary

Fixes #94090 and #82010 by making tool discovery and presentation follow one canonical callable-surface resolution path.

- Use shared CLI policy resolution for explicit arguments, configured platform defaults, and coding posture; forward disabled toolsets to canonical discovery.
- Preserve the semantic distinction between `None` (use the default policy) and an explicit empty selection (deny all model-callable tools). Empty selections short-circuit discovery, coding-focus inference, MCP waiting, registry imports, and worker startup.
- Use the live agent tool definitions as the authority when an agent exists. Otherwise, consume the matching startup `Future` once and render exactly the definitions it produced; do not reconstruct a cosmetic banner snapshot or widen it from the global catalog.
- Match immutable requests by semantic selection: ordering and duplicate names do not trigger redundant discovery; changed enabled/disabled selections reject the old prefetch. The consumed Future is not a persistent cache.
- Keep discovery failures separate from policy. A timeout or exception leaves the requested policy unchanged and reports discovery as unknown; it never turns an unknown/deferred result into zero tools. Deferred startup likewise displays “tools deferred,” not `0 tools`.
- One-shot runs do not start cosmetic banner prefetch work.
- An empty callable surface does not suppress independent launcher MCP processes. The launcher may still perform its existing MCP discovery, but those definitions cannot widen the explicit empty agent policy or appear as callable tools.
- Keep CLI/TUI/Desktop inspectors aligned with the live agent surface and disabled-toolset policy, including background and preview agents.

## Validation evidence

- Final post-rebase suite: 2,700 passed, 24 skipped across 265 files (all CLI/TUI tests plus other changed test files), with no retry flakes in this run. Earlier runs exposed compute-host and hosted-room retry flakes; those were not fixed by this PR.
- Targeted refinement coverage: 65 passed. Independent Luna review found no actionable issues and ran its own focused suite: 69 passed.
- Real MCP integration used the actual stdio server and actual `AIAgent` construction. Raw server schemas matched canonical resolver output and actual-agent MCP schemas; a late real refresh did not widen an explicit empty policy. No MCP tool calls or model requests were made.
- Full real PTY launcher with the default discovery wait: two normal launches and two explicit-empty launches. Normal sessions rendered 30 tools, including 11 MCP definitions; empty sessions rendered 0. Prompts rendered, `/exit` was accepted, all four exits were clean, and owned MCP server processes were gone.
- Prefetch A/B used the same working tree, seven measured pairs per policy, isolated offline homes, and no MCP configuration. With launcher prefetch versus without it, median prompt time was 3.207s vs 4.439s for defaults and 3.094s vs 3.939s for the configured file surface. This is not a comparison with latest `main`.

## Final revision

- Commit: `1f0d6adcc0d0e6f7573c157801d31190e93824b7` (metadata-only amendment of tested `bea46f8c5e`; identical source tree).
- Rebased on `c8aa5608c24e3636e77c267650c0f1f52e44adb0`, verified as upstream main at finalisation.
- Real MCP/actual-agent parity and the default-wait PTY checks above were repeated successfully after this rebase.
- Ruff and `git diff --check origin/main...HEAD` passed.
- Production diff: +286/-248 (net +38); tests: +771/-2. No new core tool or configuration flag.

Local reproducible evidence is retained outside the checkout under `/Users/jskillen/src/hermes-agent/review-artifacts/pr-94180/`. Prefetch timing evidence predates the final rebase; it is not being presented as a remeasurement on the final commit. No model requests or Quantrix model changes were made during integration checks.
