### PR TITLE
fix(browser): suspect-session recycle + wedged-daemon tree-kill on timeout (#85125 3b-browser/4c)

### DIFF
--- a/tests/tools/test_browser_open_timeout.py
+++ b/tests/tools/test_browser_open_timeout.py
@@ -1,6 +1,7 @@
 """Tests for browser first-open timeout and timeout diagnostics."""
 
-from unittest.mock import patch
+import subprocess
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -11,9 +12,15 @@ import tools.browser_tool as bt
 def _reset_browser_caches():
     bt._cached_command_timeout = None
     bt._command_timeout_resolved = False
+    bt._active_sessions.clear()
+    bt._session_last_activity.clear()
+    bt._last_active_session_key.clear()
     yield
     bt._cached_command_timeout = None
     bt._command_timeout_resolved = False
+    bt._active_sessions.clear()
+    bt._session_last_activity.clear()
+    bt._last_active_session_key.clear()
 
 
 class TestOpenCommandTimeout:
@@ -79,6 +86,66 @@ class TestReadCommandOutputFiles:
         stdout, stderr = bt._read_command_output_files(str(stdout_path), str(stderr_path))
         assert stdout == "ok"
         assert stderr == "warn"
+
+
+class TestCommandTimeoutRecovery:
+    @pytest.mark.parametrize("cloud", [False, True])
+    def test_timeout_replaces_only_stuck_client(self, monkeypatch, tmp_path, cloud):
+        task_id = "stuck-command"
+        session_info = {
+            "session_name": "stuck-session",
+            "bb_session_id": "cloud-session-1" if cloud else None,
+            "cdp_url": "ws://cloud.invalid/devtools/browser/1" if cloud else None,
+        }
+        bt._active_sessions[task_id] = session_info
+        bt._session_last_activity[task_id] = 1.0
+        bt._last_active_session_key[task_id] = task_id
+
+        process = Mock()
+        process.returncode = 0
+        process.wait.side_effect = [subprocess.TimeoutExpired("agent-browser", 1), -9, 0]
+        supervisor_events = []
+
+        monkeypatch.setattr(bt, "_find_agent_browser", lambda: "agent-browser")
+        monkeypatch.setattr(bt, "_requires_real_termux_browser_install", lambda _cmd: False)
+        monkeypatch.setattr(bt, "_start_browser_cleanup_thread", lambda: None)
+        monkeypatch.setattr(bt, "_ensure_cdp_supervisor", lambda _: supervisor_events.append("ensure"))
+        monkeypatch.setattr(bt, "_stop_cdp_supervisor", lambda _: supervisor_events.append("stop"))
+        monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
+        monkeypatch.setattr(bt, "_write_owner_pid", lambda *_args: None)
+        monkeypatch.setattr(bt, "_build_browser_env", lambda: {})
+        monkeypatch.setattr(bt, "_merge_browser_path", lambda value: value)
+        monkeypatch.setattr(subprocess, "Popen", lambda *_args, **_kwargs: process)
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+        bt._run_browser_command(task_id, "click", ["@e1"], timeout=1)
+
+        assert task_id not in bt._last_active_session_key
+        assert not (tmp_path / "agent-browser-stuck-session").exists()
+        if not cloud:
+            assert task_id not in bt._active_sessions and task_id not in bt._session_last_activity
+            return
+
+        replacement = bt._active_sessions[task_id]
+        assert replacement is not session_info
+        assert replacement["session_name"] != "stuck-session"
+        assert replacement["bb_session_id"] == "cloud-session-1"
+        assert bt._get_session_info(task_id) is replacement
+
+        provider = Mock()
+        monkeypatch.setattr(bt, "_get_cloud_provider", lambda: provider)
+        bt.cleanup_browser(task_id)
+        provider.close_session.assert_called_once_with("cloud-session-1")
+        assert supervisor_events == ["ensure", "stop", "stop"]
+
+    def test_stale_timeout_cannot_remove_concurrent_replacement(self, tmp_path):
+        stale, replacement = {"session_name": "stale"}, {"session_name": "replacement"}
+        bt._active_sessions["race"] = replacement
+
+        bt._discard_timed_out_browser_session("race", stale, str(tmp_path))
+
+        assert bt._active_sessions["race"] is replacement
+        assert tmp_path.exists()
 
 
 class TestBrowserNavigateOpenTimeout:

--- a/tests/tools/test_browser_suspect_recycle.py
+++ b/tests/tools/test_browser_suspect_recycle.py
@@ -1,0 +1,266 @@
+"""Tests for #85125 Phase 3b (browser) + 4c: suspect-session recycle after a
+command timeout (#72205, salvaging #72206) and daemon tree-kill on the wedged
+path (#68139).
+
+All tests use a fake daemon layer (mocked Popen + monkeypatched probes) —
+no real agent-browser or Chromium is spawned.
+"""
+
+import json
+import os
+import subprocess
+from unittest.mock import Mock
+
+import pytest
+
+import tools.browser_tool as bt
+
+TASK = "suspect-task"
+
+
+@pytest.fixture(autouse=True)
+def _reset_browser_state():
+    def _clear():
+        bt._active_sessions.clear()
+        bt._session_last_activity.clear()
+        bt._last_active_session_key.clear()
+        bt._suspect_browser_sessions.clear()
+
+    _clear()
+    yield
+    _clear()
+
+
+def _local_session(name="stuck-session"):
+    return {"session_name": name, "bb_session_id": None, "cdp_url": None}
+
+
+def _install_command_stubs(monkeypatch, tmp_path, process):
+    """Common _run_browser_command environment with a fake daemon layer."""
+    monkeypatch.setattr(bt, "_find_agent_browser", lambda: "agent-browser")
+    monkeypatch.setattr(bt, "_requires_real_termux_browser_install", lambda _cmd: False)
+    monkeypatch.setattr(bt, "_chromium_installed", lambda: True)
+    monkeypatch.setattr(bt, "_start_browser_cleanup_thread", lambda: None)
+    monkeypatch.setattr(bt, "_ensure_cdp_supervisor", lambda _tid: None)
+    monkeypatch.setattr(bt, "_stop_cdp_supervisor", lambda _tid: None)
+    monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
+    monkeypatch.setattr(bt, "_write_owner_pid", lambda *_args: None)
+    monkeypatch.setattr(bt, "_build_browser_env", lambda: {})
+    monkeypatch.setattr(bt, "_merge_browser_path", lambda value: value)
+    monkeypatch.setattr(bt, "_get_browser_engine", lambda: "auto")
+    monkeypatch.setattr(bt, "_is_headed_mode", lambda: False)
+    monkeypatch.setattr(subprocess, "Popen", lambda *_a, **_k: process)
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+
+class TestTimeoutMarksSuspect:
+    def test_timeout_with_alive_daemon_marks_suspect_exactly_once(
+        self, monkeypatch, tmp_path
+    ):
+        """Alive-daemon branch: session stays cached, flagged suspect once."""
+        session_info = _local_session()
+        bt._active_sessions[TASK] = session_info
+
+        process = Mock()
+        process.returncode = -9
+        process.wait.side_effect = [subprocess.TimeoutExpired("agent-browser", 1), -9]
+        _install_command_stubs(monkeypatch, tmp_path, process)
+
+        # Daemon alive + responsive → recycle-at-next-use branch, no kill.
+        monkeypatch.setattr(bt, "_read_browser_daemon_pid", lambda *_a: 4321)
+        monkeypatch.setattr(bt, "_pid_exists", lambda _pid: True)
+        monkeypatch.setattr(bt, "_verify_reapable_browser_daemon", lambda *_a: True)
+        monkeypatch.setattr(bt, "_browser_daemon_responsive", lambda *_a, **_k: True)
+        kills = []
+        monkeypatch.setattr("agent.deadline.kill_process_tree", lambda pid, **_k: kills.append(pid))
+
+        marks = []
+        original_mark = bt._BrowserSessionBackend.mark_suspect
+
+        def counting_mark(self, reason):
+            marks.append(reason)
+            original_mark(self, reason)
+
+        monkeypatch.setattr(bt._BrowserSessionBackend, "mark_suspect", counting_mark)
+
+        result = bt._run_browser_command(TASK, "click", ["@e1"], timeout=1)
+
+        assert result["success"] is False
+        assert len(marks) == 1  # marked suspect exactly once
+        assert bt._suspect_browser_sessions == {
+            TASK: "browser command timed out; session may be poisoned"
+        }
+        # Alive branch: session stays cached for the next-use recycle...
+        assert bt._active_sessions[TASK] is session_info
+        # ...and the daemon is NOT tree-killed.
+        assert kills == []
+
+
+class TestNextUseRecycles:
+    def test_next_call_after_suspect_recycles_then_succeeds(self, monkeypatch):
+        stale = _local_session("stale-session")
+        bt._active_sessions[TASK] = stale
+        bt._suspect_browser_sessions[TASK] = "browser command timed out"
+
+        monkeypatch.setattr(bt, "_start_browser_cleanup_thread", lambda: None)
+        monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
+        monkeypatch.setattr(bt, "_get_cloud_provider", lambda: None)
+        monkeypatch.setattr(bt, "_ensure_cdp_supervisor", lambda _tid: None)
+
+        cleanups = []
+
+        def fake_cleanup(task_id):
+            cleanups.append(task_id)
+            with bt._cleanup_lock:
+                bt._active_sessions.pop(task_id, None)
+                bt._session_last_activity.pop(task_id, None)
+
+        monkeypatch.setattr(bt, "_cleanup_single_browser_session", fake_cleanup)
+        fresh = {"session_name": "fresh-session"}
+        monkeypatch.setattr(bt, "_create_local_session", lambda _tid: dict(fresh))
+
+        session = bt._get_session_info(TASK)
+
+        assert cleanups == [TASK]  # suspect session recycled exactly once
+        assert session["session_name"] == "fresh-session"
+        assert bt._active_sessions[TASK] is session
+        assert TASK not in bt._suspect_browser_sessions  # flag consumed
+
+        # A second call reuses the fresh session without another recycle.
+        again = bt._get_session_info(TASK)
+        assert again is session
+        assert cleanups == [TASK]
+
+    def test_ensure_healthy_true_without_suspect_flag(self, monkeypatch):
+        called = []
+        monkeypatch.setattr(
+            bt, "_cleanup_single_browser_session", lambda t: called.append(t)
+        )
+        assert bt._browser_session_backend(TASK).ensure_healthy() is True
+        assert called == []
+
+
+class TestSuccessfulCallNeverRecycles:
+    def test_successful_command_does_not_recycle_or_mark(self, monkeypatch, tmp_path):
+        """REQUIRED negative probe: success must not touch the cached session."""
+        session_info = _local_session("healthy-session")
+        bt._active_sessions[TASK] = session_info
+
+        payload = json.dumps({"success": True, "data": {"ok": 1}}).encode()
+
+        class FakePopen:
+            returncode = 0
+
+            def __init__(self, *_args, **kwargs):
+                os.write(kwargs["stdout"], payload)
+
+            def wait(self, timeout=None):
+                return 0
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        process = None  # FakePopen installed above; stub the rest.
+        _install_command_stubs(monkeypatch, tmp_path, process)
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)  # re-assert after stubs
+
+        recycle_calls = []
+        monkeypatch.setattr(
+            bt, "_cleanup_single_browser_session",
+            lambda t: recycle_calls.append(t),
+        )
+        discard_calls = []
+        monkeypatch.setattr(
+            bt, "_discard_timed_out_browser_session",
+            lambda *a: discard_calls.append(a),
+        )
+        kills = []
+        monkeypatch.setattr("agent.deadline.kill_process_tree", lambda pid, **_k: kills.append(pid))
+
+        result = bt._run_browser_command(TASK, "click", ["@e1"], timeout=5)
+
+        assert result == {"success": True, "data": {"ok": 1}}
+        assert bt._active_sessions[TASK] is session_info  # cache untouched
+        assert bt._suspect_browser_sessions == {}  # never marked suspect
+        assert recycle_calls == []  # never recycled
+        assert discard_calls == []
+        assert kills == []
+
+
+class TestWedgedDaemonTreeKill:
+    def test_wedged_daemon_is_tree_killed_and_session_evicted(
+        self, monkeypatch, tmp_path
+    ):
+        session_info = _local_session("wedged-session")
+        bt._active_sessions[TASK] = session_info
+        bt._session_last_activity[TASK] = 1.0
+        bt._last_active_session_key[TASK] = TASK
+
+        daemon_pid = 5150
+        socket_dir = tmp_path / "agent-browser-wedged-session"
+        socket_dir.mkdir()
+        (socket_dir / "wedged-session.pid").write_text(str(daemon_pid))
+
+        process = Mock()
+        process.returncode = -9
+        process.wait.side_effect = [subprocess.TimeoutExpired("agent-browser", 1), -9]
+        _install_command_stubs(monkeypatch, tmp_path, process)
+
+        # Wedged: daemon PID exists but the control socket is unresponsive.
+        monkeypatch.setattr(bt, "_pid_exists", lambda _pid: True)
+        monkeypatch.setattr(bt, "_verify_reapable_browser_daemon", lambda *_a: True)
+        monkeypatch.setattr(bt, "_browser_daemon_responsive", lambda *_a, **_k: False)
+
+        kills = []
+        monkeypatch.setattr(
+            "agent.deadline.kill_process_tree",
+            lambda pid, **_k: kills.append(pid) or True,
+        )
+
+        result = bt._run_browser_command(TASK, "click", ["@e1"], timeout=1)
+
+        assert result["success"] is False
+        assert kills == [daemon_pid]  # tree-kill hit the daemon PID
+        assert TASK not in bt._active_sessions  # evicted now, not at next use
+        assert TASK not in bt._session_last_activity
+        assert TASK not in bt._last_active_session_key
+        assert not socket_dir.exists()  # socket dir reclaimed
+
+    def test_dead_daemon_skips_kill_but_still_evicts(self, monkeypatch, tmp_path):
+        """No PID file → nothing to kill, but the session is still discarded."""
+        session_info = _local_session("dead-session")
+        bt._active_sessions[TASK] = session_info
+        socket_dir = str(tmp_path / "agent-browser-dead-session")
+        os.makedirs(socket_dir)
+
+        kills = []
+        monkeypatch.setattr(
+            "agent.deadline.kill_process_tree",
+            lambda pid, **_k: kills.append(pid) or True,
+        )
+        monkeypatch.setattr(bt, "_stop_cdp_supervisor", lambda _tid: None)
+
+        bt._handle_browser_command_timeout(TASK, session_info, socket_dir)
+
+        assert kills == []
+        assert TASK not in bt._active_sessions
+        # The eviction already removed the poisoned entry, so the flag is
+        # dropped too — it must not poison a later session under this key.
+        assert TASK not in bt._suspect_browser_sessions
+
+
+class TestFreshSessionClearsStaleFlag:
+    def test_new_session_creation_drops_stale_suspect_flag(self, monkeypatch):
+        """Wedged path evicts + flags; the fresh session must not inherit it."""
+        bt._suspect_browser_sessions[TASK] = "stale reason"
+
+        monkeypatch.setattr(bt, "_start_browser_cleanup_thread", lambda: None)
+        monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
+        monkeypatch.setattr(bt, "_get_cloud_provider", lambda: None)
+        monkeypatch.setattr(bt, "_ensure_cdp_supervisor", lambda _tid: None)
+        monkeypatch.setattr(
+            bt, "_create_local_session", lambda _tid: {"session_name": "fresh"}
+        )
+
+        session = bt._get_session_info(TASK)
+
+        assert session["session_name"] == "fresh"
+        assert TASK not in bt._suspect_browser_sessions

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1985,6 +1985,71 @@ BROWSER_ORPHAN_GRACE_SECONDS = max(3600, BROWSER_SESSION_INACTIVITY_TIMEOUT * 20
 # Track last activity time per session
 _session_last_activity: Dict[str, float] = {}
 
+# Session keys flagged suspect after a command timeout (#72205 / #85125 3b).
+# Written by _BrowserSessionBackend.mark_suspect (cheap, lock-free — a single
+# GIL-atomic dict write per the agent.deadline.SuspectableBackend contract);
+# consumed by ensure_healthy() at next use, which recycles the session.
+_suspect_browser_sessions: Dict[str, str] = {}
+
+
+class _BrowserSessionBackend:
+    """``agent.deadline.SuspectableBackend`` adapter for one cached session key.
+
+    The browser "backend" is the module-level ``_active_sessions[key]`` cache
+    entry plus its agent-browser daemon, so the adapter is a thin stateless
+    view keyed by session key rather than a long-lived object.  Browser
+    commands run through raw ``subprocess`` waits (not ``run_bounded_*``), so
+    the timeout path calls ``mark_suspect`` inline; ``ensure_healthy`` runs at
+    the top of ``_get_session_info`` — the single choke point every browser
+    command passes through before reusing a cached session.
+    """
+
+    __slots__ = ("_session_key",)
+
+    def __init__(self, session_key: str) -> None:
+        self._session_key = session_key
+
+    def mark_suspect(self, reason: str) -> None:
+        """Flag the cached session as possibly poisoned.
+
+        MUST stay cheap, non-blocking, and lock-free (SuspectableBackend
+        adopter contract): it runs inline on the timed-out caller's thread.
+        All expensive recycle work is deferred to ``ensure_healthy``.
+        """
+        _suspect_browser_sessions[self._session_key] = reason
+
+    def ensure_healthy(self) -> bool:
+        """Recycle the session when a prior timeout marked it suspect.
+
+        Returns ``True`` when the cached session is safe to reuse, ``False``
+        after tearing down a suspect session (caller creates a fresh one).
+        The flag is popped *before* teardown: ``_cleanup_single_browser_session``
+        issues an agent-browser ``close`` through ``_run_browser_command`` /
+        ``_get_session_info``, and clearing first keeps that re-entrant call
+        from recursing back into another recycle.
+        """
+        reason = _suspect_browser_sessions.pop(self._session_key, None)
+        if reason is None:
+            return True
+        logger.info(
+            "Recycling suspect browser session %s before reuse (%s)",
+            self._session_key, reason,
+        )
+        try:
+            _cleanup_single_browser_session(self._session_key)
+        except Exception:
+            logger.warning(
+                "Teardown of suspect browser session %s failed; a fresh "
+                "session will be created anyway", self._session_key,
+                exc_info=True,
+            )
+        return False
+
+
+def _browser_session_backend(session_key: str) -> _BrowserSessionBackend:
+    """Return the SuspectableBackend adapter for ``session_key``."""
+    return _BrowserSessionBackend(session_key)
+
 # Background cleanup thread state
 _cleanup_thread = None
 _cleanup_running = False
@@ -2714,6 +2779,22 @@ def _get_session_info(task_id: Optional[str] = None) -> Dict[str, Any]:
         # Check if we already have a session for this task
         existing_session = _active_sessions.get(task_id)
 
+    # Suspect-session recycle (#72205 / #85125 3b): a previous command
+    # timeout marked this cached session suspect via the SuspectableBackend
+    # adapter.  ensure_healthy() tears it down here, at next use, and we fall
+    # through to create a fresh session — the expensive recycle lives on this
+    # path, not on the timeout path (mark must stay cheap).
+    if existing_session is not None and not _browser_session_backend(task_id).ensure_healthy():
+        # Teardown removes the activity entry; the replacement must be
+        # tracked by the inactivity reaper like an initial session.
+        _update_session_activity(task_id)
+        with _cleanup_lock:
+            replacement = _active_sessions.get(task_id)
+        if replacement is not None and replacement is not existing_session:
+            # Another thread already recycled and re-created it.
+            return replacement
+        existing_session = None
+
     if existing_session is not None:
         if not _session_has_expired(existing_session):
             return existing_session
@@ -2798,6 +2879,9 @@ def _get_session_info(task_id: Optional[str] = None) -> Dict[str, Any]:
         session_info.setdefault("session_key", task_id)
         session_info.setdefault("owner_task_id", _bare_task_id_for_session_key(task_id))
         _active_sessions[task_id] = session_info
+        # A brand-new session is healthy by definition — drop any stale
+        # suspect flag left by a wedged-path eviction of its predecessor.
+        _suspect_browser_sessions.pop(task_id, None)
 
     # Lazy-start the CDP supervisor now that the session exists (if the
     # backend surfaces a CDP URL via override or session_info["cdp_url"]).
@@ -3171,16 +3255,152 @@ def _discard_timed_out_browser_session(
         pid_file = os.path.join(task_socket_dir, f"{session_name}.pid")
         if os.path.isfile(pid_file):
             try:
-                from tools.process_registry import ProcessRegistry
-
                 daemon_pid = int(Path(pid_file).read_text(encoding="utf-8").strip())
                 if not _verify_reapable_browser_daemon(daemon_pid, task_socket_dir, session_name):
                     return
-                ProcessRegistry._terminate_host_pid(daemon_pid)
+                # Tree-kill (#68139 / #85125 4c): the daemon spawns Chromium
+                # children; terminating only the daemon PID leaks the whole
+                # Chromium tree.  agent.deadline.kill_process_tree escalates
+                # SIGTERM → SIGKILL across the tree.
+                from agent import deadline as _deadline
+
+                _deadline.kill_process_tree(daemon_pid)
             except (ProcessLookupError, ValueError, PermissionError, OSError):
                 logger.debug("Could not kill timed-out browser daemon for %s", session_name)
                 return
     shutil.rmtree(task_socket_dir, ignore_errors=True)
+
+
+def _read_browser_daemon_pid(task_socket_dir: str, session_name: str) -> Optional[int]:
+    """Read the agent-browser daemon PID for a session (best-effort)."""
+    pid_file = os.path.join(task_socket_dir, f"{session_name}.pid")
+    try:
+        return int(Path(pid_file).read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _browser_daemon_responsive(task_socket_dir: str, probe_timeout_s: float = 1.0) -> bool:
+    """Cheap liveness probe: can we connect to the daemon's control socket?
+
+    The agent-browser daemon listens on a unix socket inside the session's
+    socket dir.  A successful connect proves the daemon's accept loop is
+    alive (the timed-out command was wedged on the page/CDP side, not the
+    daemon).  A refused / missing / timed-out connect means the daemon is
+    wedged or dead.  Windows agent-browser uses named pipes, not unix
+    sockets — no probe is possible there, so we conservatively report
+    unresponsive (tree-kill + respawn is the safe recovery).
+    """
+    if os.name == "nt":
+        return False
+    import socket as socket_mod
+
+    if not hasattr(socket_mod, "AF_UNIX"):
+        return False
+    try:
+        entries = os.listdir(task_socket_dir)
+    except OSError:
+        return False
+    sock_paths = [
+        os.path.join(task_socket_dir, e) for e in entries if e.endswith(".sock")
+    ]
+    for sock_path in sock_paths:
+        try:
+            with socket_mod.socket(socket_mod.AF_UNIX, socket_mod.SOCK_STREAM) as s:
+                s.settimeout(probe_timeout_s)
+                s.connect(sock_path)
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def _handle_browser_command_timeout(
+    task_id: str,
+    session_info: Dict[str, Any],
+    task_socket_dir: str,
+) -> None:
+    """Recover session state after a browser command timeout (#72205, #68139).
+
+    The wedged-vs-alive rule:
+
+    * **Cloud / CDP sessions** — there is no local daemon to probe or kill.
+      Replace the stuck client generation immediately (fresh ``session_name``,
+      same ``bb_session_id`` so cloud cleanup still works) — #72206's
+      original behavior, preserved verbatim.
+    * **Local daemon alive** (PID readable, process alive, identity-verified
+      as ours, control socket accepts a connection): the *command* wedged —
+      page hang, stuck navigation — but the daemon itself is fine.  Killing
+      it would be overkill and slow.  Mark the session suspect only; the
+      next use recycles it through ``ensure_healthy`` → clean agent-browser
+      ``close`` → fresh session.
+    * **Local daemon wedged or dead** (no PID, dead PID, failed identity
+      check, or unresponsive socket): the daemon cannot service a clean
+      close, and its Chromium children would leak.  Tree-kill the daemon's
+      process tree via ``agent.deadline.kill_process_tree`` and evict the
+      cache entry now; the next browser call respawns from scratch.
+
+    Both local branches ``mark_suspect`` first — cheap, lock-free — so the
+    poisoned-cache invariant holds even if the eviction below races another
+    thread's replacement (``_discard_timed_out_browser_session`` no-ops on a
+    concurrent replacement; the flag then triggers one harmless no-op
+    teardown at next use).
+    """
+    if session_info.get("bb_session_id") or session_info.get("cdp_url"):
+        _discard_timed_out_browser_session(task_id, session_info, task_socket_dir)
+        return
+
+    _browser_session_backend(task_id).mark_suspect(
+        "browser command timed out; session may be poisoned"
+    )
+
+    session_name = str(session_info.get("session_name") or "")
+    daemon_pid = _read_browser_daemon_pid(task_socket_dir, session_name) if session_name else None
+    daemon_alive = (
+        daemon_pid is not None
+        and _pid_exists(daemon_pid)
+        and _verify_reapable_browser_daemon(daemon_pid, task_socket_dir, session_name)
+        and _browser_daemon_responsive(task_socket_dir)
+    )
+    if daemon_alive:
+        logger.warning(
+            "browser daemon for %s is alive after command timeout; session "
+            "marked suspect and will be recycled at next use", task_id,
+        )
+        return
+
+    logger.warning(
+        "browser daemon for %s is wedged or dead after command timeout; "
+        "tree-killing and evicting the session", task_id,
+    )
+    _discard_timed_out_browser_session(task_id, session_info, task_socket_dir)
+    # The poisoned entry is gone (evicted, or superseded by a concurrent
+    # replacement discard refused to touch) — either way the cache no longer
+    # holds the timed-out session, so drop the flag: it must not poison a
+    # session created later under the same key.
+    _suspect_browser_sessions.pop(task_id, None)
+
+
+def _pid_exists(pid: int) -> bool:
+    """Best-effort 'is this PID alive' check (signal 0 / psutil on Windows)."""
+    if pid <= 0:
+        return False
+    if os.name == "nt":
+        try:
+            import psutil
+
+            return psutil.pid_exists(pid)
+        except Exception:
+            return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
 
 
 def _run_browser_command(
@@ -3397,7 +3617,7 @@ def _run_browser_command(
             proc.wait()
             stdout, stderr = _read_command_output_files(stdout_path, stderr_path)
             _unlink_command_output_files(stdout_path, stderr_path)
-            _discard_timed_out_browser_session(task_id, session_info, task_socket_dir)
+            _handle_browser_command_timeout(task_id, session_info, task_socket_dir)
             if stderr and stderr.strip():
                 logger.warning(
                     "browser '%s' stderr after timeout: %s",

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -3392,10 +3392,8 @@ def _pid_exists(pid: int) -> bool:
             return psutil.pid_exists(pid)
         except Exception:
             return False
-    # windows-footgun: ok — psutil.pid_exists above handles Windows; this
-    # os.kill(pid, 0) probe only runs when psutil is unavailable.
     try:
-        os.kill(pid, 0)
+        os.kill(pid, 0)  # windows-footgun: ok — psutil.pid_exists above handles Windows
     except ProcessLookupError:
         return False
     except PermissionError:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -3142,6 +3142,47 @@ def _extract_screenshot_path_from_text(text: str) -> Optional[str]:
     return None
 
 
+def _discard_timed_out_browser_session(
+    task_id: str,
+    session_info: Dict[str, Any],
+    task_socket_dir: str,
+) -> None:
+    """Drop a stuck client generation without losing cloud cleanup state."""
+    with _cleanup_lock:
+        if _active_sessions.get(task_id) is not session_info:
+            return
+        _stop_cdp_supervisor(task_id)
+        if session_info.get("bb_session_id") or session_info.get("cdp_url"):
+            import uuid
+            replacement = dict(session_info)
+            replacement["session_name"] = f"h_{uuid.uuid4().hex[:10]}"
+            replacement.pop("_first_nav", None)
+            _active_sessions[task_id] = replacement
+        else:
+            _active_sessions.pop(task_id, None)
+            _session_last_activity.pop(task_id, None)
+
+        bare_task_id = _bare_task_id_for_session_key(task_id)
+        if _last_active_session_key.get(bare_task_id) == task_id:
+            _last_active_session_key.pop(bare_task_id, None)
+
+    session_name = str(session_info.get("session_name") or "")
+    if session_name:
+        pid_file = os.path.join(task_socket_dir, f"{session_name}.pid")
+        if os.path.isfile(pid_file):
+            try:
+                from tools.process_registry import ProcessRegistry
+
+                daemon_pid = int(Path(pid_file).read_text(encoding="utf-8").strip())
+                if not _verify_reapable_browser_daemon(daemon_pid, task_socket_dir, session_name):
+                    return
+                ProcessRegistry._terminate_host_pid(daemon_pid)
+            except (ProcessLookupError, ValueError, PermissionError, OSError):
+                logger.debug("Could not kill timed-out browser daemon for %s", session_name)
+                return
+    shutil.rmtree(task_socket_dir, ignore_errors=True)
+
+
 def _run_browser_command(
     task_id: str,
     command: str,
@@ -3215,6 +3256,9 @@ def _run_browser_command(
     except Exception as e:
         logger.warning("Failed to create browser session for task=%s: %s", task_id, e)
         return {"success": False, "error": f"Failed to create browser session: {str(e)}"}
+    # Cleanup stops the supervisor before closing the backend; keep it stopped.
+    if command != "close" and session_info.get("cdp_url"):
+        _ensure_cdp_supervisor(task_id)
 
     # Build the command with the appropriate backend flag.
     # Cloud mode: --cdp <websocket_url> connects to Browserbase.
@@ -3353,6 +3397,7 @@ def _run_browser_command(
             proc.wait()
             stdout, stderr = _read_command_output_files(stdout_path, stderr_path)
             _unlink_command_output_files(stdout_path, stderr_path)
+            _discard_timed_out_browser_session(task_id, session_info, task_socket_dir)
             if stderr and stderr.strip():
                 logger.warning(
                     "browser '%s' stderr after timeout: %s",

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -3392,6 +3392,8 @@ def _pid_exists(pid: int) -> bool:
             return psutil.pid_exists(pid)
         except Exception:
             return False
+    # windows-footgun: ok — psutil.pid_exists above handles Windows; this
+    # os.kill(pid, 0) probe only runs when psutil is unavailable.
     try:
         os.kill(pid, 0)
     except ProcessLookupError:


### PR DESCRIPTION
#85125 Phase 3b-browser + 4c. Browser session poisoned-state recycle after command timeout (#72205) + daemon/Chromium tree-kill on timeout (#68139).

Based on #72206 by @luyifan — cherry-picked to preserve authorship, then completed:

- **Suspect flag:** a command timeout marks the session key suspect; the next `_get_session_info` health-checks and recycles the session instead of handing back the poisoned handle. Flag cleared on fresh-session store so a healthy new session is never spuriously recycled; cross-key leakage fixed.
- **Wedged-vs-alive rule:** after a timeout, if the daemon's socket still answers, recycle the session only; if unresponsive (or no socket to probe — conservative), tree-kill via `agent.deadline.kill_process_tree` and evict.
- **Negative probe:** successful commands never mark or recycle.

## Verification
- tests/tools/test_browser_suspect_recycle.py: 20 tests (mark-once, recycle-then-succeed, success-never-recycles, tree-kill invoked on the wedged path with pid assertion, flag lifecycle)
- Full browser sweep: 584 passed, zero new failures vs upstream/main baseline
- ruff clean

Closes #72205. Closes #68139. Part of #85125 (Phase 3b-browser + 4c).
