### PR TITLE
fix(desktop-update): strip interpreter-poisoning env vars in posix hand-off

### DIFF
--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -60,6 +60,21 @@ while [ $# -gt 0 ]; do
 done
 [ "$SELF_TEST_UI" -eq 1 ] || [ -n "$INSTALL_ROOT" ] || { echo "--install-root is required" >&2; exit 64; }
 
+# Interpreter-poison guard: the Desktop app's process chain can carry
+# __PYVENV_LAUNCHER__ / PYTHONHOME / PYTHONPATH (a venv python propagates the
+# first to its children; the others ride inherited shells). Inside this
+# hand-off every interpreter must resolve against INSTALL_ROOT's own venv —
+# the shim server, the venv python helpers below, and `hermes update` itself
+# — and a poisoned var makes them resolve against a foreign prefix instead:
+# "Could not find platform dependent libraries <exec_prefix>" then
+# ModuleNotFoundError from venv/bin/hermes before a single byte is fetched,
+# twice per attempt (2026-08-22..24 macOS fleet: Desktop-initiated updates
+# died exit 1 on the first try AND its retry, while terminal `hermes update`
+# through ~/.local/bin/hermes — which unsets exactly this trio since
+# 2026-08-22 — kept working). Unset BEFORE the setsid re-exec so the detached
+# orchestrator inherits an already-clean environment.
+unset __PYVENV_LAUNCHER__ PYTHONHOME PYTHONPATH
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HERMES_HOME="${INSTALL_ROOT:+$(dirname "$INSTALL_ROOT")}"
 HERMES_HOME="${HERMES_HOME:-${TMPDIR:-/tmp}}"

--- a/tests/test_desktop_update_posix_env_guard.py
+++ b/tests/test_desktop_update_posix_env_guard.py
@@ -1,0 +1,122 @@
+"""The POSIX update hand-off must strip interpreter-poisoning env vars.
+
+The Desktop spawns `scripts/desktop-update/posix.sh` detached, and the script
+re-execs itself through an setsid/nohup chain before running `hermes update`
+from INSTALL_ROOT's venv. Whatever environment the Electron process chain
+carries is copied along the whole way. If that environment contains
+__PYVENV_LAUNCHER__, PYTHONHOME, or PYTHONPATH, every interpreter under the
+hand-off resolves against a foreign prefix: "Could not find platform dependent
+libraries <exec_prefix>" from the shim, then ModuleNotFoundError from
+venv/bin/hermes — twice per attempt, because the retry inherits the same
+poison (observed 2026-08-22..24 on macOS: Desktop-initiated updates died exit
+1 on both tries while terminal `hermes update` kept working).
+
+This drives the REAL posix.sh end-to-end against a stub install root whose
+`venv/bin/hermes` records the environment it received, under a deliberately
+poisoned parent env, and asserts none of the poison reaches it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "desktop-update" / "posix.sh"
+
+requires_posix_handoff = pytest.mark.skipif(
+    not (os.path.exists("/bin/bash") and os.path.exists("/usr/bin/python3")),
+    reason="posix.sh detaches through /bin/bash and /usr/bin/python3",
+)
+
+POISON_VARS = {
+    "__PYVENV_LAUNCHER__": "/poisoned/venv/bin/python",
+    "PYTHONHOME": "/poisoned/python-home",
+    "PYTHONPATH": "/poisoned/site-packages",
+}
+
+
+def _make_stub_install_root(tmp_path: Path) -> tuple[Path, Path]:
+    """A minimal INSTALL_ROOT whose `hermes` dumps the env it was given."""
+    install_root = tmp_path / "hermes-agent"
+    bin_dir = install_root / "venv" / "bin"
+    bin_dir.mkdir(parents=True)
+
+    env_dump = tmp_path / "stub-env.txt"
+    stub = bin_dir / "hermes"
+    stub.write_text(
+        "#!/bin/bash\n"
+        f'env | sort > "{env_dump}"\n'
+        'echo "stub update ran"\n'
+        "exit 0\n"
+    )
+    stub.chmod(0o755)
+    return install_root, env_dump
+
+
+def _wait_for_result(result_path: Path, timeout_s: float = 60.0) -> dict:
+    """posix.sh publishes `.hermes-update-result.json` when the job settles."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if result_path.exists():
+            return json.loads(result_path.read_text())
+        time.sleep(0.25)
+    raise AssertionError(f"update result file never appeared at {result_path}")
+
+
+@requires_posix_handoff
+def test_handoff_strips_interpreter_poison_before_update(tmp_path):
+    assert SCRIPT.exists()
+
+    install_root, env_dump = _make_stub_install_root(tmp_path)
+
+    # A desktop pid already gone: the hand-off waits it out (up to 30s) and
+    # proceeds as soon as `kill -0` stops finding it.
+    victim = subprocess.Popen(["sleep", "0.5"])
+    victim.wait()
+
+    env = dict(os.environ)
+    env.update(POISON_VARS)
+
+    # First invocation daemonizes (re-execs detached) and returns immediately;
+    # the real work happens in the re-parented orchestrator.
+    subprocess.run(
+        [
+            "bash",
+            str(SCRIPT),
+            "--install-root",
+            str(install_root),
+            "--branch",
+            "main",
+            "--desktop-pid",
+            str(victim.pid),
+            "--no-ui",
+        ],
+        env=env,
+        cwd=str(tmp_path),
+        timeout=90,
+        check=False,
+    )
+
+    result = _wait_for_result(tmp_path / ".hermes-update-result.json")
+
+    assert result.get("ok") is True, result
+    assert result.get("exit_code") == 0, result
+
+    received: dict[str, str] = {}
+    for line in env_dump.read_text().splitlines():
+        key, _, value = line.partition("=")
+        received[key] = value
+
+    for key in POISON_VARS:
+        assert key not in received, (
+            f"{key} leaked into the `hermes update` child environment: "
+            "the venv interpreter will resolve against a foreign prefix and "
+            "every Desktop-initiated update dies with ModuleNotFoundError "
+            "before pulling anything"
+        )


### PR DESCRIPTION
## Problem

Desktop-initiated updates have been failing deterministically on macOS: every attempt dies with

```
Could not find platform dependent libraries <exec_prefix>
Traceback (most recent call last):
  File "/Users/<user>/.hermes/hermes-agent/venv/bin/hermes", line 4, in <module>
    from hermes_cli.main import main
ModuleNotFoundError: No module named 'hermes_cli'
```

— on the first try **and** the retry, across multiple days (`desktop-update-handoff.log`, 2026-08-22 → 2026-08-24, 6+ attempts). Terminal `hermes update` kept working throughout.

## Root cause

The hand-off chain is: Electron spawns `scripts/desktop-update/posix.sh` → the script re-execs itself detached via `/usr/bin/python3 -c '...os.execve("/bin/bash", ..., os.environ.copy())'` → the orchestrator runs `$INSTALL_ROOT/venv/bin/hermes update`.

When the Electron process chain carries `__PYVENV_LAUNCHER__` / `PYTHONHOME` / `PYTHONPATH` (a venv python propagates the first to its children; the others ride inherited shells), that copied environment poisons every interpreter under the hand-off:

1. `/usr/bin/python3 -c ...` fails to boot cleanly ("Could not find platform dependent libraries <exec_prefix>") — so the daemonized orchestrator never starts,
2. and even where a venv interpreter does start, it resolves against the wrong prefix → `ModuleNotFoundError: No module named 'hermes_cli'`.

The installed CLI wrapper at `~/.local/bin/hermes` already unsets exactly this trio before exec'ing the venv python — which is why terminal updates work while Desktop-driven ones never did.

## Fix

`posix.sh` now unsets the three variables right after argument parsing, **before** the setsid re-exec, so the detached orchestrator and everything downstream (shim server, venv helpers, `hermes update`) inherits an already-clean environment. One guard at the boundary covers the whole class instead of patching each spawn site.

## Test

`tests/test_desktop_update_posix_env_guard.py` drives the real `posix.sh` end-to-end:

- stub install root whose `venv/bin/hermes` records the environment it receives
- deliberately poisoned parent env (`__PYVENV_LAUNCHER__`, `PYTHONHOME`, `PYTHONPATH`)
- waits for the real `.hermes-update-result.json` contract and asserts `ok/exit_code == 0`
- asserts none of the poison reached the update child

Verified both directions against the unfixed script: the test **fails after a 60s timeout** — faithfully reproducing the production signature where the poisoned re-exec prevents the orchestrator from ever starting — and **passes with the fix**.

## Notes for reviewers

- The unset mirrors the exact trio handled elsewhere in the codebase (managed_uv / sqlite_runtime) and by the installed wrapper; nothing else in this script's process tree needs those vars.
- Windows is untouched (`windows.ps1` path unchanged).