### PR TITLE
fix(desktop): preserve remote profile ownership across SSH switches

### DIFF
--- a/apps/desktop/src/app/chat/profile-tag.test.tsx
+++ b/apps/desktop/src/app/chat/profile-tag.test.tsx
@@ -6,6 +6,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 // REST client) — same seam as store/profile.test.ts.
 vi.mock('@/store/gateway', () => ({
   $gateway: atom<unknown>(null),
+  activeGatewayConnectionId: vi.fn(() => null),
+  openGatewayForAgent: vi.fn(async () => undefined),
   ensureGatewayForProfile: vi.fn(async () => undefined)
 }))
 vi.mock('@/hermes', () => ({

--- a/apps/desktop/src/app/chat/session-tile-actions.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.test.ts
@@ -6,9 +6,9 @@ import { MAIN_COMPOSER_SCOPE } from './composer/scope'
 
 const requestGatewayMock = vi.hoisted(() => vi.fn())
 
-const { $activeSessionId } = await import('@/store/session')
+const { $activeSessionId, $sessions, setSessions } = await import('@/store/session')
 const { $sessionTiles, setSessionTileDelegate } = await import('@/store/session-states')
-const { useSessionTileActions } = await import('./session-tile-actions')
+const { listTileSessionRow, useSessionTileActions } = await import('./session-tile-actions')
 
 const RUNTIME_SESSION_ID = 'rt-tile-current'
 const STORED_SESSION_ID = 'stored-tile-db'
@@ -25,6 +25,36 @@ function renderTileActions() {
   )
 }
 
+describe('session tile optimistic owner metadata', () => {
+  afterEach(() => {
+    $sessions.set([])
+    $sessionTiles.set([])
+  })
+
+  it('keeps the tile source on its first optimistic sidebar row', () => {
+    const storedSessionId = 'stored-tile-owner-metadata'
+    const ownerRoute = { connectionId: 'source-a', profile: 'default' }
+    $sessionTiles.set([{ ownerRoute, storedSessionId }])
+
+    expect(
+      listTileSessionRow({
+        cwd: '/remote/worktree',
+        model: 'model-a',
+        preview: 'hello from the tile',
+        runtimeId: 'rt-tile-owner-metadata',
+        sessions: [],
+        storedSessionId
+      })
+    ).toBe(true)
+
+    expect($sessions.get()[0]).toMatchObject({
+      connection_id: 'source-a',
+      id: storedSessionId,
+      profile: 'default'
+    })
+  })
+})
+
 // A tile's cancelRun/steerPrompt/reloadFromMessage each build their own
 // requestGateway call directly instead of going through the shared
 // submitPromptText pipeline (which already wraps its call in
@@ -34,6 +64,7 @@ function renderTileActions() {
 describe('useSessionTileActions sleep/wake session recovery', () => {
   beforeEach(() => {
     $activeSessionId.set('foreground-runtime')
+    setSessions([])
     $sessionTiles.set([{ runtimeId: RUNTIME_SESSION_ID, storedSessionId: STORED_SESSION_ID }])
     setSessionTileDelegate({
       archiveSession: vi.fn(async () => undefined),
@@ -59,6 +90,7 @@ describe('useSessionTileActions sleep/wake session recovery', () => {
 
   afterEach(() => {
     $activeSessionId.set(null)
+    setSessions([])
     $sessionTiles.set([])
     requestGatewayMock.mockReset()
     vi.restoreAllMocks()

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -22,8 +22,13 @@ import { resetSessionBackground } from '@/store/composer-status'
 import { notifyError } from '@/store/notifications'
 import { clearPreviewArtifacts } from '@/store/preview-status'
 import { clearAllPrompts } from '@/store/prompts'
-import { $connection, $sessions, sessionMatchesStoredId } from '@/store/session'
-import { $sessionStates, patchSessionTile, sessionTileDelegate } from '@/store/session-states'
+import { $connection, $sessions, knownSessionOwner, sessionMatchesStoredId } from '@/store/session'
+import {
+  requestForSessionProfile,
+  type SessionOwnerScope,
+  type SessionProfileRoute
+} from '@/store/session-request-router'
+import { $sessionStates, patchSessionTile, sessionTileDelegate, sessionTileOwnerRoute } from '@/store/session-states'
 import { broadcastSessionsChanged } from '@/store/session-sync'
 import { clearSessionSubagents } from '@/store/subagents'
 import { clearSessionTodos } from '@/store/todos'
@@ -85,11 +90,19 @@ export function listTileSessionRow(deps: {
     return false
   }
 
+  const knownOwner =
+    sessionTileOwnerRoute(deps.storedSessionId) ?? knownSessionOwner(deps.sessions, deps.storedSessionId)
+  const ownerRoute: SessionProfileRoute | undefined =
+    knownOwner && typeof knownOwner === 'object' ? knownOwner : undefined
+
   upsertOptimisticSession(
     { info: { cwd: deps.cwd, model: deps.model }, session_id: deps.runtimeId, stored_session_id: deps.storedSessionId },
     deps.storedSessionId,
     null,
-    preview
+    preview,
+    null,
+    undefined,
+    ownerRoute
   )
   broadcastSessionsChanged()
 
@@ -153,6 +166,22 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
   const readState = useCallback(() => $sessionStates.get()[runtimeIdRef.current], [])
   const readMessages = useCallback(() => readState()?.messages ?? [], [readState])
 
+  // Tile session RPCs must follow the tile's composite owner even when the
+  // active gateway has moved to a same-named profile on another source.
+  const requestSessionGateway = useCallback(
+    <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal) => {
+      const knownOwner: SessionOwnerScope =
+        sessionTileOwnerRoute(storedIdRef.current) ?? knownSessionOwner($sessions.get(), storedIdRef.current)
+      // A bare profile is the legacy/unknown tile shape. Preserve its ambient
+      // behavior; only a composite route is strong enough to retarget a tile
+      // across same-named sources.
+      const owner: SessionOwnerScope = knownOwner && typeof knownOwner === 'object' ? knownOwner : undefined
+
+      return requestForSessionProfile<T>(owner, requestGateway, method, params ?? {}, timeoutMs, signal)
+    },
+    [requestGateway]
+  )
+
   // A ⌘T tab's session is unlisted until its first turn persists — seed the
   // row from the user's first message so the tab and sidebar name it right
   // away (see listTileSessionRow).
@@ -200,7 +229,7 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
           const next = await uploadComposerAttachment(attachment, {
             backendCwd: readState()?.cwd,
             remote,
-            requestGateway,
+            requestGateway: requestSessionGateway,
             sessionId: liveSessionId,
             storedSessionId: storedIdRef.current,
             onSessionRecovered
@@ -233,7 +262,7 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
 
       return { attachments: synced, sessionId: liveSessionId }
     },
-    [bindRecoveredRuntime, readState, requestGateway, scope.attachments]
+    [bindRecoveredRuntime, readState, requestSessionGateway, scope.attachments]
   )
 
   // The REAL submit pipeline with tile seams: session always exists, and the
@@ -249,7 +278,7 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
     // token is a stable constant (the guard never trips for a tile).
     getRouteToken: () => runtimeId,
     onRuntimeRecovered: bindRecoveredRuntime,
-    requestGateway,
+    requestGateway: requestSessionGateway,
     runtimeIdByStoredSessionIdRef,
     // Tile ids are always bound before this hook mounts, so routed recovery is
     // unreachable here; keep the shared submit contract explicit.
@@ -315,16 +344,16 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
       await withSessionNotFoundResume(
         sessionId,
         storedIdRef.current,
-        liveId => requestGateway('session.interrupt', { session_id: liveId }),
+        liveId => requestSessionGateway('session.interrupt', { session_id: liveId }),
         {
-          requestGateway,
+          requestGateway: requestSessionGateway,
           onRecovered: bindRecoveredRuntime
         }
       )
     } catch (err) {
       notifyError(err, copy.stopFailed)
     }
-  }, [bindRecoveredRuntime, copy.stopFailed, requestGateway, update])
+  }, [bindRecoveredRuntime, copy.stopFailed, requestSessionGateway, update])
 
   const steerPrompt = useCallback(
     async (rawText: string): Promise<boolean> => {
@@ -374,9 +403,9 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
         const { result } = await withSessionNotFoundResume(
           sessionId,
           storedIdRef.current,
-          liveId => requestGateway<{ status?: string }>('session.redirect', { session_id: liveId, text }),
+          liveId => requestSessionGateway<{ status?: string }>('session.redirect', { session_id: liveId, text }),
           {
-            requestGateway,
+            requestGateway: requestSessionGateway,
             onRecovered: bindRecoveredRuntime
           }
         )
@@ -404,7 +433,7 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
 
       return false
     },
-    [bindRecoveredRuntime, requestGateway]
+    [bindRecoveredRuntime, requestSessionGateway]
   )
 
   // Rewind primitive (interrupt-first for live turns, busy-retry) — shared with
@@ -420,7 +449,7 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
       rebindRowIds?: readonly number[]
     ) =>
       runRewindSubmit(
-        requestGateway,
+        requestSessionGateway,
         runtimeIdRef.current,
         text,
         truncateOrdinal,
@@ -434,7 +463,7 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
         sourceText,
         rebindRowIds
       ),
-    [bindRecoveredRuntime, requestGateway]
+    [bindRecoveredRuntime, requestSessionGateway]
   )
 
   // After a durable rewind the surviving bubbles' cached rowIds are stale (the

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
@@ -132,6 +132,25 @@ describe('useSessionTileDelegate resumeTile', () => {
     expect(requestGateway).not.toHaveBeenCalled()
   })
 
+  it('carries a session row connection owner into a same-named tile resume', async () => {
+    setSessions([row({ connection_id: 'source-b', id: 'stored-shared', profile: 'default' })])
+
+    const ambientRequest = vi.fn(async () => ({}) as never)
+    vi.mocked(requestGatewayForAgent).mockResolvedValueOnce({ session_id: 'runtime-shared' } as never)
+
+    renderTile(ambientRequest)
+    const runtimeId = await sessionTileDelegate()!.resumeTile('stored-shared')
+
+    expect(runtimeId).toBe('runtime-shared')
+    expect(requestGatewayForAgent).toHaveBeenCalledWith('source-b', 'default', 'session.resume', {
+      session_id: 'stored-shared',
+      cols: 96,
+      omit_messages: true,
+      profile: 'default'
+    })
+    expect(ambientRequest).not.toHaveBeenCalled()
+  })
+
   it('routes a Bot tile prefetch and resume through its exact connection owner', async () => {
     const route = {
       connectionId: 'barry',

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 
 import { getLatestSessionMessages, PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
 import { toChatMessages } from '@/lib/chat-messages'
-import { getSessionOwnerHint } from '@/store/session'
+import { $sessions, knownSessionOwner } from '@/store/session'
 import { requestForSessionProfile, type SessionOwnerScope } from '@/store/session-request-router'
 import { publishSessionState, sessionTileOwnerRoute, setSessionTileDelegate } from '@/store/session-states'
 import type { SessionResumeResponse } from '@/types/hermes'
@@ -76,8 +76,8 @@ export function useSessionTileDelegate({
 
     const ownerForStoredSession = async (storedSessionId: string): Promise<SessionOwnerScope> => {
       const owner =
-        getSessionOwnerHint(storedSessionId) ??
         sessionTileOwnerRoute(storedSessionId) ??
+        knownSessionOwner($sessions.get(), storedSessionId) ??
         (await resolveSessionProfile(storedSessionId))
 
       return owner

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -72,7 +72,7 @@ import {
   $selectedStoredSessionId,
   $sessionResumeRequest,
   $sessions,
-  knownSessionProfile,
+  knownSessionOwner,
   sessionMatchesStoredId,
   sessionPinId,
   setAwaitingResponse,
@@ -320,7 +320,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // profile's own local gateway — never to whatever is "active" (active is
   // presentation only). Resolve the owner from, in order: the tile's persisted
   // route (bot chats carry an exact connectionId+profile), the known session
-  // profile (row or open-time hint), then a cross-profile REST probe that
+  // owner (row or open-time hint), then a cross-profile REST probe that
   // stamps ownership for a hidden/unlisted session. Only a request with NO
   // session at all (a fresh draft, global chrome) falls to the ambient socket.
   // The probe result is cached as an owner hint so the next call is sync.
@@ -358,7 +358,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
       let owner: SessionOwnerScope =
         (routingSessionId ? sessionTileOwnerRoute(routingSessionId) : undefined) ??
-        knownSessionProfile($sessions.get(), routingSessionId)
+        knownSessionOwner($sessions.get(), routingSessionId)
 
       if (!owner && routingSessionId) {
         // Unknown owner for a REAL session: probe across profiles (REST, not the

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-request.test.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-request.test.ts
@@ -1,24 +1,230 @@
+import type { GatewayWsUrlResult } from '@hermes/shared'
 import { act, renderHook } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const gatewayMocks = vi.hoisted(() => ({
+  instances: [] as Array<{
+    connect: ReturnType<typeof vi.fn>
+    connectionState: string
+    request: ReturnType<typeof vi.fn>
+    wsUrl: string
+  }>
+}))
+
+vi.mock('@/hermes', async importOriginal => {
+  const actual = await importOriginal<typeof HermesModule>()
+
+  class FakeHermesGateway {
+    connectionState = 'closed'
+    wsUrl = ''
+    request = vi.fn()
+    connect = vi.fn(async (wsUrl: string) => {
+      this.wsUrl = wsUrl
+      this.connectionState = 'open'
+
+      for (const handler of this.stateHandlers) {
+        handler('open')
+      }
+    })
+    close = vi.fn(() => {
+      this.connectionState = 'closed'
+
+      for (const handler of this.stateHandlers) {
+        handler('closed')
+      }
+    })
+    onEvent = vi.fn(() => () => undefined)
+    onState = vi.fn((handler: (state: string) => void) => {
+      this.stateHandlers.add(handler)
+      handler(this.connectionState)
+
+      return () => this.stateHandlers.delete(handler)
+    })
+    private stateHandlers = new Set<(state: string) => void>()
+
+    constructor() {
+      gatewayMocks.instances.push(this)
+    }
+  }
+
+  return { ...actual, HermesGateway: FakeHermesGateway }
+})
+
+import type * as HermesModule from '@/hermes'
 import type { HermesGateway } from '@/hermes'
-import { $gateway } from '@/store/gateway'
+import {
+  $gateway,
+  closeSecondaryGateways,
+  configureGatewayRegistry,
+  ensureGatewayForAgent,
+  setPrimaryGateway
+} from '@/store/gateway'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $connection, $gatewayState } from '@/store/session'
 
 import { useGatewayRequest } from './use-gateway-request'
 
+interface TestGateway {
+  connect: ReturnType<typeof vi.fn>
+  connectionState: string
+  request: ReturnType<typeof vi.fn>
+  wsUrl?: string
+}
+
 const fakeGateway = { connectionState: 'open' } as unknown as HermesGateway
 
-afterEach(() => {
+const remoteConnection = {
+  authMode: 'oauth' as const,
+  baseUrl: 'https://ssh.example.test',
+  connectionId: 'ssh-source',
+  mode: 'remote' as const,
+  profile: 'research',
+  remoteIdentity: 'ssh.example.test',
+  remoteKind: 'ssh' as const,
+  token: 'remote-token',
+  wsUrl: 'wss://ssh.example.test/api/ws?ticket=stale'
+}
+
+function installRemoteDesktop() {
+  let mintCount = 0
+  const getConnection = vi.fn(async (profile?: null | string) => ({
+    authMode: 'token' as const,
+    baseUrl: 'http://127.0.0.1:5151',
+    mode: 'local' as const,
+    profile: profile ?? 'default',
+    token: 'local-token',
+    wsUrl: 'ws://127.0.0.1:5151/api/ws?token=local'
+  }))
+  const getConnectionFor = vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
+    ...remoteConnection,
+    connectionId,
+    profile
+  }))
+  const getGatewayWsUrl = vi.fn(async () => ({
+    ok: true as const,
+    wsUrl: 'ws://127.0.0.1:5151/api/ws?token=fresh-local'
+  }))
+  const getGatewayWsUrlFor = vi.fn(
+    async ({ connectionId, profile }: { connectionId: string; profile: string }): Promise<GatewayWsUrlResult> => {
+      mintCount += 1
+
+      return {
+        ok: true as const,
+        wsUrl: `wss://${connectionId}.example.test/api/ws?profile=${profile}&ticket=fresh-${mintCount}`
+      }
+    }
+  )
+
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: { getConnection, getConnectionFor, getGatewayWsUrl, getGatewayWsUrlFor }
+  })
+
+  return { getConnection, getConnectionFor, getGatewayWsUrl, getGatewayWsUrlFor }
+}
+
+function installPrimaryDesktop(authMode: 'oauth' | 'token') {
+  const getConnection = vi.fn(async (profile?: null | string) => ({
+    authMode,
+    baseUrl: authMode === 'oauth' ? 'https://gateway.example.test' : 'http://127.0.0.1:5151',
+    mode: authMode === 'oauth' ? ('remote' as const) : ('local' as const),
+    profile: profile ?? 'default',
+    token: 'primary-token',
+    wsUrl: authMode === 'oauth' ? 'wss://gateway.example.test/api/ws?ticket=stale' : 'ws://127.0.0.1:5151/api/ws'
+  }))
+  const getGatewayWsUrl = vi.fn(async (profile?: null | string) => ({
+    ok: true as const,
+    wsUrl:
+      authMode === 'oauth'
+        ? `wss://gateway.example.test/api/ws?profile=${profile ?? 'default'}&ticket=fresh`
+        : 'ws://127.0.0.1:5151/api/ws?token=fresh'
+  }))
+  const getConnectionFor = vi.fn()
+  const getGatewayWsUrlFor = vi.fn()
+
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: { getConnection, getConnectionFor, getGatewayWsUrl, getGatewayWsUrlFor }
+  })
+
+  return { getConnection, getConnectionFor, getGatewayWsUrl, getGatewayWsUrlFor }
+}
+
+function makePrimaryGateway(): TestGateway {
+  return {
+    connect: vi.fn(async () => undefined),
+    connectionState: 'open',
+    request: vi.fn()
+  }
+}
+
+async function activateRemoteGateway() {
+  const desktop = installRemoteDesktop()
+  const primary = makePrimaryGateway()
+
+  setPrimaryGateway(primary as unknown as HermesGateway, 'default')
+  $gateway.set(primary as unknown as HermesGateway)
+  await ensureGatewayForAgent('ssh-source', 'research')
+
+  const gateway = $gateway.get() as unknown as TestGateway
+
+  expect(gateway).not.toBe(primary)
+  expect($activeGatewayProfile.get()).toBe('research')
+
+  return { desktop, gateway }
+}
+
+async function expectSecondaryRecoveryFailure(
+  gateway: TestGateway,
+  request: ReturnType<typeof useGatewayRequest>['requestGateway']
+) {
+  const transportError = new Error('connection closed')
+  gateway.request.mockRejectedValueOnce(transportError)
+  gateway.connectionState = 'closed'
+
+  vi.useFakeTimers()
+  const retry = request('session.resume').then(
+    () => undefined,
+    error => error
+  )
+
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(8_000)
+  })
+
+  await expect(retry).resolves.toBe(transportError)
+  expect(gateway.request).toHaveBeenCalledTimes(1)
+  expect(gateway.connect).toHaveBeenCalledTimes(1)
+}
+
+beforeEach(() => {
+  gatewayMocks.instances.length = 0
+  closeSecondaryGateways()
+  setPrimaryGateway(null)
   $gateway.set(null)
+  $connection.set(null)
+  $gatewayState.set('idle')
+  $activeGatewayProfile.set('default')
+  configureGatewayRegistry({
+    onActiveRouteChanged: profile => $activeGatewayProfile.set(profile),
+    onEvent: vi.fn()
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  closeSecondaryGateways()
+  setPrimaryGateway(null)
+  $gateway.set(null)
+  $connection.set(null)
+  $gatewayState.set('idle')
+  $activeGatewayProfile.set('default')
+  Reflect.deleteProperty(window, 'hermesDesktop')
 })
 
 describe('useGatewayRequest', () => {
-  // The composer's `/` completions only exist when ChatBar receives a non-null
-  // gateway PROP. `gatewayRef` is populated by a subscription effect, so it is
-  // still null on the first render — a surface that read the ref while
-  // rendering (session tiles / ⌘T tabs) shipped `gateway={null}` and silently
-  // lost slash completions. The returned `gateway` value must be live
-  // immediately so that never happens again.
   it('exposes the live gateway on the first render, before effects run', () => {
     $gateway.set(fakeGateway)
 
@@ -35,5 +241,114 @@ describe('useGatewayRequest', () => {
     act(() => $gateway.set(fakeGateway))
 
     expect(result.current.gateway).toBe(fakeGateway)
+  })
+
+  it.each([
+    { error: new Error('connection closed'), label: 'closed message' },
+    { error: new Error('ECONNRESET'), label: 'reset message' },
+    { error: Object.assign(new Error('socket failed'), { code: 'ECONNRESET' }), label: 'error code' },
+    { error: Object.assign(new Error('socket failed'), { cause: { code: 'ECONNRESET' } }), label: 'cause code' }
+  ])('recovers the registered remote source after a $label failure', async ({ error }) => {
+    const { desktop, gateway } = await activateRemoteGateway()
+    gateway.request.mockResolvedValueOnce({ turn: 1 }).mockRejectedValueOnce(error).mockResolvedValueOnce({ turn: 2 })
+
+    const { result } = renderHook(() => useGatewayRequest())
+
+    await act(async () => {
+      await expect(result.current.requestGateway('prompt.submit', { text: 'first' })).resolves.toEqual({ turn: 1 })
+    })
+    gateway.connectionState = 'closed'
+    await act(async () => {
+      await expect(result.current.requestGateway('prompt.submit', { text: 'second' })).resolves.toEqual({ turn: 2 })
+    })
+
+    expect(desktop.getConnectionFor).toHaveBeenCalledTimes(2)
+    expect(desktop.getConnectionFor).toHaveBeenCalledWith({ connectionId: 'ssh-source', profile: 'research' })
+    expect(desktop.getGatewayWsUrlFor).toHaveBeenCalledTimes(2)
+    expect(desktop.getGatewayWsUrlFor).toHaveBeenCalledWith({ connectionId: 'ssh-source', profile: 'research' })
+    expect(desktop.getConnection).not.toHaveBeenCalled()
+    expect(desktop.getGatewayWsUrl).not.toHaveBeenCalled()
+    expect(gateway.connect).toHaveBeenLastCalledWith(expect.stringContaining('ticket=fresh-2'))
+  })
+
+  it('does not reconnect for a non-transport request failure', async () => {
+    const { desktop, gateway } = await activateRemoteGateway()
+    const failure = Object.assign(new Error('request rejected'), { code: 'EVALIDATION' })
+    gateway.request.mockRejectedValueOnce(failure)
+
+    const { result } = renderHook(() => useGatewayRequest())
+
+    await expect(result.current.requestGateway('session.resume')).rejects.toBe(failure)
+    expect(desktop.getConnectionFor).toHaveBeenCalledTimes(1)
+    expect(desktop.getGatewayWsUrlFor).toHaveBeenCalledTimes(1)
+    expect(gateway.connect).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces a real secondary OAuth reauth rejection as the original transport failure', async () => {
+    const { desktop, gateway } = await activateRemoteGateway()
+    desktop.getGatewayWsUrlFor.mockImplementation(async () => ({
+      error: '401 cookie expired',
+      needsOauthLogin: true,
+      ok: false as const
+    }))
+
+    const { result } = renderHook(() => useGatewayRequest())
+
+    await expectSecondaryRecoveryFailure(gateway, result.current.requestGateway)
+
+    expect(desktop.getConnectionFor).toHaveBeenCalledWith({ connectionId: 'ssh-source', profile: 'research' })
+    expect(desktop.getGatewayWsUrlFor).toHaveBeenCalled()
+    expect(desktop.getConnection).not.toHaveBeenCalled()
+    expect(desktop.getGatewayWsUrl).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a failed secondary OAuth ticket mint without using the stale ticket or local bridges', async () => {
+    const { desktop, gateway } = await activateRemoteGateway()
+    desktop.getGatewayWsUrlFor.mockRejectedValue(new Error('ticket mint failed'))
+
+    const { result } = renderHook(() => useGatewayRequest())
+
+    await expectSecondaryRecoveryFailure(gateway, result.current.requestGateway)
+
+    expect(desktop.getConnectionFor).toHaveBeenCalledWith({ connectionId: 'ssh-source', profile: 'research' })
+    expect(desktop.getConnection).not.toHaveBeenCalled()
+    expect(desktop.getGatewayWsUrl).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a missing optional scoped mint bridge without falling back to a stale ticket or local lookup', async () => {
+    const { desktop, gateway } = await activateRemoteGateway()
+    Reflect.deleteProperty(window.hermesDesktop, 'getGatewayWsUrlFor')
+
+    const { result } = renderHook(() => useGatewayRequest())
+
+    await expectSecondaryRecoveryFailure(gateway, result.current.requestGateway)
+
+    expect(desktop.getConnectionFor).toHaveBeenCalledWith({ connectionId: 'ssh-source', profile: 'research' })
+    expect(desktop.getConnection).not.toHaveBeenCalled()
+    expect(desktop.getGatewayWsUrl).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    { authMode: 'oauth' as const, label: 'primary OAuth' },
+    { authMode: 'token' as const, label: 'local primary' }
+  ])('preserves $label recovery', async ({ authMode }) => {
+    const desktop = installPrimaryDesktop(authMode)
+    const primary = makePrimaryGateway()
+    primary.request.mockRejectedValueOnce(new Error('connection closed')).mockResolvedValueOnce({ recovered: true })
+
+    setPrimaryGateway(primary as unknown as HermesGateway, 'default')
+    $gateway.set(primary as unknown as HermesGateway)
+    $gatewayState.set('closed')
+
+    const { result } = renderHook(() => useGatewayRequest())
+
+    await act(async () => {
+      await expect(result.current.requestGateway('session.resume')).resolves.toEqual({ recovered: true })
+    })
+
+    expect(desktop.getConnection).toHaveBeenCalledWith('default')
+    expect(desktop.getGatewayWsUrl).toHaveBeenCalledWith('default')
+    expect(desktop.getConnectionFor).not.toHaveBeenCalled()
+    expect(desktop.getGatewayWsUrlFor).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-request.ts
@@ -114,15 +114,14 @@ export function useGatewayRequest() {
       try {
         return await gateway.request<T>(method, params, timeoutMs, signal)
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
-
-        if (!/not connected|connection closed/i.test(message)) {
+        if (!isGatewayTransportError(error)) {
           throw error
         }
 
         // Primary keeps the OAuth-aware reconnect (remote gateways re-mint a
-        // single-use ticket); background profiles are always local pool
-        // backends, so the registry handles their reconnect with no reauth.
+        // single-use ticket). Background profiles stay on the registry's
+        // connection-owned reconnect path, including composite remote/SSH
+        // sources.
         const recovered = isActivePrimary() ? await ensureGatewayOpen() : await ensureActiveGatewayOpen()
 
         if (!recovered) {
@@ -145,4 +144,43 @@ export function useGatewayRequest() {
   )
 
   return { connectionRef, gateway, gatewayRef, requestGateway }
+}
+
+const GATEWAY_TRANSPORT_ERROR_CODES = new Set([
+  'ECONNABORTED',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ENOTFOUND',
+  'EPIPE',
+  'ETIMEDOUT',
+  'ERR_NETWORK',
+  'ERR_SOCKET_CLOSED'
+])
+
+function errorCode(value: unknown): string | null {
+  if (typeof value !== 'object' || value === null) {
+    return null
+  }
+
+  const code = (value as { code?: unknown }).code
+
+  return typeof code === 'string' ? code.toUpperCase() : null
+}
+
+function isGatewayTransportError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+
+  if (/not connected|connection closed|connection reset|ECONNRESET/i.test(message)) {
+    return true
+  }
+
+  const cause = typeof error === 'object' && error !== null ? (error as { cause?: unknown }).cause : undefined
+
+  return [error, cause].some(value => {
+    const code = errorCode(value)
+
+    return code !== null && GATEWAY_TRANSPORT_ERROR_CODES.has(code)
+  })
 }

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -19,7 +19,14 @@ import { createClientSessionState } from '@/lib/chat-runtime'
 import { $clarifyRequests, clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
 import { requestGatewayForAgent } from '@/store/gateway'
-import { $activeGatewayProfile, $newChatProfile, $newChatRoute, ensureGatewayProfile } from '@/store/profile'
+import {
+  $activeGatewayProfile,
+  $newChatProfile,
+  $newChatRoute,
+  ensureGatewayAgent,
+  ensureGatewayProfile,
+  selectProfile
+} from '@/store/profile'
 import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
 import {
   $activeSessionId,
@@ -33,7 +40,9 @@ import {
   $newChatWorkspaceTarget,
   $resumeFailedSessionId,
   $selectedStoredSessionId,
+  $sessions,
   $turnStartedAt,
+  $yoloActive,
   setActiveSessionId,
   setActiveSessionStoredIdRotation,
   setAwaitingResponse,
@@ -96,6 +105,7 @@ type HarnessHandle = Pick<
   | 'createBackendSessionForSend'
   | 'openNewSessionTile'
   | 'removeSession'
+  | 'resumeSession'
   | 'selectSidebarItem'
   | 'startFreshSessionDraft'
 >
@@ -124,13 +134,15 @@ function Harness({
   navigate = vi.fn(),
   onReady,
   requestGateway,
-  selectedStoredSessionId = null
+  selectedStoredSessionId = null,
+  getRouteToken = () => 'token'
 }: {
   activeSessionId?: null | string
   navigate?: ReturnType<typeof vi.fn>
   onReady: (handle: HarnessHandle) => void
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
   selectedStoredSessionId?: null | string
+  getRouteToken?: () => string
 }) {
   const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
 
@@ -140,7 +152,7 @@ function Harness({
     busyRef: ref(false),
     creatingSessionRef: ref(false),
     ensureSessionState: () => ({}) as ClientSessionState,
-    getRouteToken: () => 'token',
+    getRouteToken,
     getRoutedStoredSessionId: () => null,
     navigate: navigate as never,
     requestGateway,
@@ -545,6 +557,8 @@ describe('createBackendSessionForSend profile routing', () => {
     $currentProvider.set('')
     $currentReasoningEffort.set('')
     setNewChatWorkspaceTarget(undefined)
+    $sessions.set([])
+    $yoloActive.set(false)
     vi.restoreAllMocks()
   })
 
@@ -626,6 +640,151 @@ describe('createBackendSessionForSend profile routing', () => {
       expect.objectContaining({ profile: 'backend-default', source: 'desktop' })
     )
     expect(ambientRequest).not.toHaveBeenCalledWith('session.create', expect.anything())
+  })
+
+  it('recaptures the resumed session owner for the next fresh draft', async () => {
+    const oldRoute = { connectionId: 'source-a', profile: 'default' }
+    const ownerRoute = { connectionId: 'source-b', profile: 'default' }
+    const ambientRequest = vi.fn(async () => ({}) as never)
+
+    $sessions.set([{ connection_id: 'source-b', id: 'stored-resumed', profile: 'default' } as SessionInfo])
+    $newChatRoute.set(oldRoute)
+    vi.mocked(getLatestSessionMessages).mockResolvedValueOnce({ messages: [] } as never)
+    vi.mocked(requestGatewayForAgent).mockResolvedValueOnce({ session_id: 'runtime-resumed' } as never)
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={value => (handle = value)} requestGateway={ambientRequest} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.resumeSession('stored-resumed')
+    })
+
+    expect($newChatRoute.get()).toEqual(ownerRoute)
+
+    act(() => handle!.startFreshSessionDraft())
+
+    expect($newChatRoute.get()).toEqual(ownerRoute)
+  })
+
+  it('does not let a slow resume overwrite a newer profile route intent', async () => {
+    const activation = deferred<void>()
+    const oldRoute = { connectionId: 'source-a', profile: 'default' }
+    const ambientRequest = vi.fn(async () => ({}) as never)
+
+    $sessions.set([{ connection_id: 'source-b', id: 'stored-slow-resume', profile: 'default' } as SessionInfo])
+    $newChatRoute.set(oldRoute)
+    vi.mocked(getLatestSessionMessages).mockResolvedValueOnce({ messages: [] } as never)
+    vi.mocked(requestGatewayForAgent).mockResolvedValueOnce({ session_id: 'runtime-slow-resume' } as never)
+    vi.mocked(ensureGatewayAgent).mockReturnValueOnce(activation.promise)
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={value => (handle = value)} requestGateway={ambientRequest} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    let resumePromise!: Promise<void>
+    await act(async () => {
+      resumePromise = handle!.resumeSession('stored-slow-resume')
+      await vi.waitFor(() => expect(ensureGatewayAgent).toHaveBeenCalledWith('source-b', 'default'))
+    })
+
+    act(() => selectProfile('newer-profile'))
+    activation.resolve()
+
+    await act(async () => {
+      await resumePromise
+    })
+
+    expect($newChatRoute.get()).not.toEqual({ connectionId: 'source-b', profile: 'default' })
+    expect($newChatProfile.get()).toBe('newer-profile')
+  })
+
+  it('keeps optimistic session ownership composite for later same-name RPC routing', async () => {
+    const route = { connectionId: 'source-a', profile: 'default' }
+    const ambientRequest = vi.fn(async () => ({}) as never)
+    vi.mocked(requestGatewayForAgent).mockResolvedValueOnce({
+      session_id: RUNTIME_SESSION_ID,
+      stored_session_id: 'stored-remote'
+    } as never)
+
+    $newChatProfile.set(route.profile)
+    $newChatRoute.set(route)
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={value => (handle = value)} requestGateway={ambientRequest} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.createBackendSessionForSend('hello')
+    })
+
+    expect($sessions.get()[0]).toMatchObject({
+      connection_id: 'source-a',
+      id: 'stored-remote',
+      profile: 'default'
+    })
+    expect(ambientRequest).not.toHaveBeenCalledWith('session.create', expect.anything())
+  })
+
+  it('cleans up a route-owned draft on the same source when Send drifts', async () => {
+    const route = { connectionId: 'source-a', profile: 'default' }
+    let routeToken = '/::'
+    const ambientRequest = vi.fn(async () => ({}) as never)
+    vi.mocked(requestGatewayForAgent).mockImplementation(async (_connectionId, _profile, method) => {
+      if (method === 'session.create') {
+        routeToken = '/other::'
+
+        return { session_id: RUNTIME_SESSION_ID, stored_session_id: null } as never
+      }
+
+      return {} as never
+    })
+
+    $newChatProfile.set(route.profile)
+    $newChatRoute.set(route)
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness getRouteToken={() => routeToken} onReady={value => (handle = value)} requestGateway={ambientRequest} />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.createBackendSessionForSend()
+    })
+
+    expect(requestGatewayForAgent).toHaveBeenCalledWith('source-a', 'default', 'session.close', {
+      session_id: RUNTIME_SESSION_ID
+    })
+    expect(ambientRequest).not.toHaveBeenCalledWith('session.close', expect.anything())
+  })
+
+  it('applies draft YOLO on the route-owned source', async () => {
+    const route = { connectionId: 'source-a', profile: 'default' }
+    const ambientRequest = vi.fn(async () => ({}) as never)
+    vi.mocked(requestGatewayForAgent).mockResolvedValueOnce({
+      session_id: RUNTIME_SESSION_ID,
+      stored_session_id: null
+    } as never)
+
+    $newChatProfile.set(route.profile)
+    $newChatRoute.set(route)
+    $yoloActive.set(true)
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={value => (handle = value)} requestGateway={ambientRequest} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.createBackendSessionForSend()
+    })
+
+    expect(requestGatewayForAgent).toHaveBeenCalledWith('source-a', 'default', 'config.set', {
+      key: 'yolo',
+      session_id: RUNTIME_SESSION_ID,
+      value: '1'
+    })
+    expect(ambientRequest).not.toHaveBeenCalledWith('config.set', expect.anything())
   })
 
   it('freezes the visible selector state before profile readiness and sends fast: false explicitly', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -33,9 +33,12 @@ import {
   $newChatRoute,
   $showAllProfiles,
   type AgentProfileRoute,
+  beginGatewayRouteIntent,
   ensureGatewayAgent,
   ensureGatewayProfile,
-  normalizeProfileKey
+  isCurrentGatewayRouteIntent,
+  normalizeProfileKey,
+  routeOnCurrentSource
 } from '@/store/profile'
 import {
   $projectScope,
@@ -77,6 +80,7 @@ import {
   setResumeExhaustedSessionId,
   setResumeFailedSessionId,
   setSelectedStoredSessionId,
+  setSessionOwnerHint,
   setSessions,
   setSessionStartedAt,
   setTurnStartedAt,
@@ -501,7 +505,13 @@ export function useSessionActions({
 
         if (drift) {
           console.warn('[submit-drift-abort]', drift, { phase: 'mid-create' })
-          await requestGateway('session.close', { session_id: created.session_id }).catch(() => undefined)
+          const closeCreated = capturedRoute
+            ? requestGatewayForAgent(capturedRoute.connectionId, capturedRoute.profile, 'session.close', {
+                session_id: created.session_id
+              })
+            : requestGateway('session.close', { session_id: created.session_id })
+
+          await closeCreated.catch(() => undefined)
 
           return null
         }
@@ -517,7 +527,15 @@ export function useSessionActions({
           // reads meaningfully while the turn is in flight, instead of flashing
           // "Untitled session" until the turn persists and auto-title runs. The
           // server later returns its own preview/title and supersedes this.
-          upsertOptimisticSession(created, stored, null, preview?.trim() || null)
+          upsertOptimisticSession(
+            created,
+            stored,
+            null,
+            preview?.trim() || null,
+            null,
+            undefined,
+            capturedRoute ?? undefined
+          )
           navigate(sessionRoute(stored), { replace: true })
           // Other windows (e.g. the main window when this is the pop-out) can't
           // see this session until they re-pull the shared list.
@@ -539,7 +557,12 @@ export function useSessionActions({
         // User may have armed YOLO on the new-chat draft before the runtime
         // session existed — apply it to the freshly created session.
         if (yoloArmed) {
-          await setSessionYolo(requestGateway, created.session_id, true).catch(() => undefined)
+          const requestCreatedSession = capturedRoute
+            ? <T>(method: string, params?: Record<string, unknown>) =>
+                requestGatewayForAgent<T>(capturedRoute.connectionId, capturedRoute.profile, method, params)
+            : requestGateway
+
+          await setSessionYolo(requestCreatedSession, created.session_id, true).catch(() => undefined)
         }
 
         return created.session_id
@@ -642,6 +665,10 @@ export function useSessionActions({
           return
         }
 
+        if (capturedRoute) {
+          setSessionOwnerHint(stored, capturedRoute)
+        }
+
         createdThisRun.add(stored)
 
         // Seed the per-runtime cache so the tile renders immediately without a
@@ -649,7 +676,7 @@ export function useSessionActions({
         // unlisted (draft) tab stays out of the session list until its first
         // turn persists and a refresh surfaces it.
         if (listed) {
-          upsertOptimisticSession(created, stored, null, null)
+          upsertOptimisticSession(created, stored, null, null, null, undefined, capturedRoute ?? undefined)
         }
 
         // A tile lives in its OWN worktree, so it must not run the full
@@ -697,6 +724,7 @@ export function useSessionActions({
 
   const resumeSession = useCallback(
     async (storedSessionId: string, replaceRoute = false, capturedOwner?: SessionProfileRoute) => {
+      const routeIntent = beginGatewayRouteIntent()
       const requestId = resumeRequestRef.current + 1
       resumeRequestRef.current = requestId
       const resumedSameSelectedSession = selectedStoredSessionIdRef.current === storedSessionId
@@ -718,6 +746,11 @@ export function useSessionActions({
       resetViewSync()
       setSelectedStoredSessionId(storedSessionId)
       selectedStoredSessionIdRef.current = storedSessionId
+      // An existing-session re-home invalidates any draft route captured for
+      // the previous chat. It is recaptured below from the session's actual
+      // owner after the gateway activation settles, so a later Cmd-N cannot
+      // reuse an older source/profile pair.
+      $newChatRoute.set(null)
 
       // A session is EITHER the main thread OR a tile — never both. openSessionTile
       // enforces this from the tile side (it refuses to tile the selected session);
@@ -825,6 +858,20 @@ export function useSessionActions({
         )
       } else {
         await ensureGatewayProfile(sessionProfile)
+      }
+
+      // Keep the next fresh draft on the owner that is actually active. A
+      // registry route is authoritative when one was known; otherwise derive
+      // the current composite source after the re-home. Primary/local legacy
+      // sessions intentionally produce null here.
+      if (isCurrentGatewayRouteIntent(routeIntent)) {
+        $newChatRoute.set(
+          $showAllProfiles.get()
+            ? routeOnCurrentSource($activeGatewayProfile.get())
+            : sessionOwner && typeof sessionOwner === 'object'
+              ? { ...sessionOwner }
+              : routeOnCurrentSource(sessionProfile || $activeGatewayProfile.get())
+        )
       }
 
       // Request-time routing guard for every session-scoped RPC below. The

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -24,6 +24,7 @@ import {
   setCurrentReasoningEffort,
   setCurrentServiceTier,
   setCurrentUsage,
+  setSessionOwnerHint,
   setSessions,
   setWorkspaceCwdOwner,
   setYoloActive
@@ -1243,13 +1244,16 @@ export function upsertOptimisticSession(
   title: string | null = null,
   preview: string | null = null,
   parentSessionId: string | null = null,
-  lastActive?: number
+  lastActive?: number,
+  ownerRoute?: SessionProfileRoute
 ) {
   const now = lastActive ?? Date.now() / 1000
-  // Stamp the profile the session was just created on (= the live gateway's
-  // profile) so the scoped sidebar shows the new row immediately instead of
-  // filtering it out as "default" until the aggregator re-fetches.
-  const profileKey = normalizeProfileKey($activeGatewayProfile.get())
+  // Stamp the profile/source the session was just created on so the scoped
+  // sidebar shows the new row immediately instead of filtering it out as
+  // "default" until the aggregator re-fetches. The active gateway is only a
+  // presentation detail: a concurrent source switch can move it before this
+  // optimistic row is inserted.
+  const profileKey = normalizeProfileKey(ownerRoute?.profile ?? $activeGatewayProfile.get())
 
   const session: SessionInfo = {
     // Seed cwd so the grouped sidebar can place the new row in its repo/worktree
@@ -1271,7 +1275,12 @@ export function upsertOptimisticSession(
     source: 'tui',
     started_at: now,
     title,
-    tool_call_count: 0
+    tool_call_count: 0,
+    ...(ownerRoute?.connectionId.trim() ? { connection_id: ownerRoute.connectionId.trim() } : {})
+  }
+
+  if (ownerRoute) {
+    setSessionOwnerHint(id, ownerRoute)
   }
 
   setSessions(prev => [session, ...prev.filter(s => s.id !== id)])

--- a/apps/desktop/src/app/settings/profile-scope.test.tsx
+++ b/apps/desktop/src/app/settings/profile-scope.test.tsx
@@ -9,8 +9,10 @@ import type { ProfileInfo } from '@/types/hermes'
 // store/profile.test.ts / profile-tag.test.tsx.
 vi.mock('@/store/gateway', () => ({
   $gateway: atom<unknown>(null),
+  activeGatewayConnectionId: vi.fn(() => null),
   ensureGatewayForAgent: vi.fn(async () => undefined),
   ensureGatewayForProfile: vi.fn(async () => undefined),
+  openGatewayForAgent: vi.fn(async () => undefined),
   openGatewayForProfile: vi.fn(async () => undefined)
 }))
 vi.mock('@/hermes', () => ({

--- a/apps/desktop/src/store/connections.test.ts
+++ b/apps/desktop/src/store/connections.test.ts
@@ -5,6 +5,7 @@ import type { DesktopConnectionsRegistry } from '@/global'
 
 const $activeGatewayProfile = atom('default')
 const $newChatProfile = atom<null | string>(null)
+const $newChatRoute = atom<null | { connectionId: string; profile: string }>(null)
 const $showAllProfiles = atom(false)
 
 const $connection = atom<null | {
@@ -15,20 +16,32 @@ const $connection = atom<null | {
 }>(null)
 
 const ensureGatewayAgent = vi.fn(async (_connectionId: null | string, _profile: string): Promise<void> => undefined)
+const beginGatewayRouteIntent = vi.fn(() => ++routeIntentGeneration)
+const isCurrentGatewayRouteIntent = vi.fn((generation: number) => generation === routeIntentGeneration)
 const refreshActiveProfile = vi.fn(async () => undefined)
 const requestFreshSession = vi.fn()
 const wipeSessionListsForGatewaySwitch = vi.fn()
+let routeIntentGeneration = 0
+
+const selectProfile = vi.fn((profile: string) => {
+  beginGatewayRouteIntent()
+  $newChatRoute.set({ connectionId: 'profile-source', profile })
+})
 
 vi.mock('@/store/session', () => ({ $connection }))
 vi.mock('@/store/gateway-switch', () => ({ wipeSessionListsForGatewaySwitch }))
 vi.mock('@/store/profile', () => ({
   $activeGatewayProfile,
   $newChatProfile,
+  $newChatRoute,
   $showAllProfiles,
+  beginGatewayRouteIntent,
   ensureGatewayAgent,
+  isCurrentGatewayRouteIntent,
   normalizeProfileKey: (name: null | string | undefined) => (name ?? '').trim() || 'default',
   refreshActiveProfile,
-  requestFreshSession
+  requestFreshSession,
+  selectProfile
 }))
 
 const {
@@ -63,15 +76,21 @@ beforeEach(() => {
   $connection.set(null)
   $activeGatewayProfile.set('default')
   $newChatProfile.set(null)
+  $newChatRoute.set(null)
   $showAllProfiles.set(false)
+  routeIntentGeneration = 0
+  beginGatewayRouteIntent.mockClear()
+  isCurrentGatewayRouteIntent.mockClear()
+  selectProfile.mockClear()
   ensureGatewayAgent.mockReset()
-  ensureGatewayAgent.mockImplementation(async connectionId => {
+  ensureGatewayAgent.mockImplementation(async (connectionId, profile) => {
     $connection.set({
       connectionId: connectionId ?? undefined,
       mode: connectionId === 'local' ? 'local' : 'remote',
-      profile: 'default',
+      profile,
       registryScoped: true
     })
+    $activeGatewayProfile.set(profile)
   })
   refreshActiveProfile.mockClear()
   requestFreshSession.mockClear()
@@ -148,6 +167,7 @@ describe('selectConnection', () => {
     expect(requestFreshSession).toHaveBeenCalledTimes(1)
     expect(wipeSessionListsForGatewaySwitch).toHaveBeenCalledTimes(1)
     expect($newChatProfile.get()).toBe('default')
+    expect($newChatRoute.get()).toEqual({ connectionId: 'homelab', profile: 'default' })
     expect(refreshActiveProfile).toHaveBeenCalledTimes(1)
     expect(setLastUsed).toHaveBeenCalledWith('homelab')
   })
@@ -169,6 +189,50 @@ describe('selectConnection', () => {
     await selectConnection('local')
 
     expect(ensureGatewayAgent).toHaveBeenCalledWith('local', 'default')
+    expect($newChatRoute.get()).toEqual({ connectionId: 'local', profile: 'default' })
+  })
+
+  it('replaces a remote A draft owner when switching to the local source before Send', async () => {
+    setConnectionsRegistry(registry)
+    $connection.set({ connectionId: 'homelab', mode: 'remote', profile: 'default', registryScoped: true })
+    $newChatRoute.set({ connectionId: 'homelab', profile: 'publisher' })
+
+    await selectConnection('local')
+
+    expect($newChatRoute.get()).toEqual({ connectionId: 'local', profile: 'default' })
+  })
+
+  it('replaces a remote A draft owner when switching to remote B before Send', async () => {
+    setConnectionsRegistry(registry)
+    $connection.set({ connectionId: 'homelab', mode: 'remote', profile: 'default', registryScoped: true })
+    $newChatRoute.set({ connectionId: 'homelab', profile: 'shared-name' })
+
+    await selectConnection('work-vps')
+
+    expect($newChatRoute.get()).toEqual({ connectionId: 'work-vps', profile: 'default' })
+  })
+
+  it('fails closed when a stale remembered profile falls back on the target source', async () => {
+    setConnectionsRegistry(registry)
+    // Seed the per-source preference from a previously valid local descriptor,
+    // then move the live gateway to another source before selecting local.
+    $connection.set({ connectionId: 'local', mode: 'local', profile: 'stale-local-only', registryScoped: true })
+    $activeGatewayProfile.set('stale-local-only')
+    $connection.set({ connectionId: 'homelab', mode: 'remote', profile: 'default', registryScoped: true })
+    $activeGatewayProfile.set('default')
+    ensureGatewayAgent.mockImplementationOnce(async connectionId => {
+      $connection.set({
+        connectionId: connectionId ?? undefined,
+        mode: 'local',
+        profile: 'default',
+        registryScoped: true
+      })
+      $activeGatewayProfile.set('default')
+    })
+
+    await expect(selectConnection('local')).rejects.toThrow(/profile "stale-local-only"/i)
+    expect(requestFreshSession).not.toHaveBeenCalled()
+    expect($newChatRoute.get()).toBeNull()
   })
 
   it('lets a later source choice win while an earlier dial is still pending', async () => {
@@ -203,6 +267,31 @@ describe('selectConnection', () => {
     // Only the latest intent repaints the profile list.
     expect(refreshActiveProfile).toHaveBeenCalledTimes(1)
     expect(wipeSessionListsForGatewaySwitch).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not let a slow source switch overwrite a newer profile route intent', async () => {
+    let releaseHomelab!: () => void
+    const homelabGate = new Promise<void>(resolve => {
+      releaseHomelab = resolve
+    })
+
+    setConnectionsRegistry(registry)
+    $connection.set({ connectionId: 'local', mode: 'local', profile: 'default', registryScoped: true })
+    ensureGatewayAgent.mockImplementationOnce(async () => {
+      await homelabGate
+      $connection.set({ connectionId: 'homelab', mode: 'remote', profile: 'default', registryScoped: true })
+      $activeGatewayProfile.set('default')
+    })
+
+    const slowSourceSwitch = selectConnection('homelab')
+    await Promise.resolve()
+
+    selectProfile('newer-profile')
+    releaseHomelab()
+    await slowSourceSwitch
+
+    expect($newChatRoute.get()).toEqual({ connectionId: 'profile-source', profile: 'newer-profile' })
+    expect(requestFreshSession).not.toHaveBeenCalled()
   })
 
   it('restores the last profile used on each source', async () => {

--- a/apps/desktop/src/store/connections.ts
+++ b/apps/desktop/src/store/connections.ts
@@ -6,8 +6,11 @@ import { wipeSessionListsForGatewaySwitch } from '@/store/gateway-switch'
 import {
   $activeGatewayProfile,
   $newChatProfile,
+  $newChatRoute,
   $showAllProfiles,
+  beginGatewayRouteIntent,
   ensureGatewayAgent,
+  isCurrentGatewayRouteIntent,
   normalizeProfileKey,
   refreshActiveProfile,
   requestFreshSession
@@ -199,6 +202,7 @@ export async function selectConnection(connectionId: string): Promise<void> {
   if (pendingTarget === null && currentConnectionId === connectionId && currentProfile === targetProfile) {
     $showAllProfiles.set(false)
     $newChatProfile.set(targetProfile)
+    $newChatRoute.set({ connectionId, profile: targetProfile })
     requestFreshSession()
     await rememberConnection(connectionId)
 
@@ -206,6 +210,7 @@ export async function selectConnection(connectionId: string): Promise<void> {
   }
 
   const revision = ++switchRevision
+  const routeIntent = beginGatewayRouteIntent()
   pendingTarget = targetKey
   $pendingConnectionId.set(connectionId)
 
@@ -214,15 +219,31 @@ export async function selectConnection(connectionId: string): Promise<void> {
     // and a registry primary can differ from a legacy per-profile override.
     await ensureGatewayAgent(connectionId, targetProfile)
 
-    if ($connection.get()?.connectionId !== connectionId) {
-      throw new Error(`Connection "${targetConnection.label}" did not become active.`)
+    if (revision !== switchRevision || !isCurrentGatewayRouteIntent(routeIntent)) {
+      return
+    }
+
+    const activeConnection = $connection.get()
+    const activeDescriptorProfile = normalizeProfileKey(activeConnection?.profile)
+
+    if (
+      activeConnection?.connectionId !== connectionId ||
+      normalizeProfileKey($activeGatewayProfile.get()) !== targetProfile ||
+      activeDescriptorProfile !== targetProfile
+    ) {
+      throw new Error(`Connection "${targetConnection.label}" did not become active for profile "${targetProfile}".`)
     }
 
     // A newer click owns the final refresh. Serialized gateway activation
     // already makes the latest source win; this guard also prevents an older
     // request from repainting its profile list after that newer activation.
-    if (revision === switchRevision) {
+    if (revision === switchRevision && isCurrentGatewayRouteIntent(routeIntent)) {
       await rememberConnection(connectionId)
+
+      if (revision !== switchRevision || !isCurrentGatewayRouteIntent(routeIntent)) {
+        return
+      }
+
       wipeSessionListsForGatewaySwitch()
 
       if (!restoreOnBoot) {
@@ -230,11 +251,12 @@ export async function selectConnection(connectionId: string): Promise<void> {
       }
 
       $newChatProfile.set(targetProfile)
+      $newChatRoute.set({ connectionId, profile: targetProfile })
       requestFreshSession()
       await refreshActiveProfile()
     }
   } catch (error) {
-    if (revision === switchRevision) {
+    if (revision === switchRevision && isCurrentGatewayRouteIntent(routeIntent)) {
       throw error
     }
   } finally {

--- a/apps/desktop/src/store/profile-agent-activation.test.ts
+++ b/apps/desktop/src/store/profile-agent-activation.test.ts
@@ -18,14 +18,18 @@ import { deferred } from '../test/deferred'
 
 const ensureGatewayForAgent = vi.fn(async (_connectionId: null | string, _profile: string) => true)
 const ensureGatewayForProfile = vi.fn(async (_profile: string) => undefined)
+const activeGatewayConnectionId = vi.fn<() => null | string>(() => null)
+const openGatewayForAgent = vi.fn(async (_connectionId: null | string, _profile: string) => undefined)
 const openGatewayForProfile = vi.fn(async (_profile: string) => undefined)
 const $gateway = atom<unknown>({ id: 'live-socket' })
 const resetStarmapGraph = vi.fn()
 
 vi.mock('@/store/gateway', () => ({
   $gateway,
+  activeGatewayConnectionId,
   ensureGatewayForAgent,
   ensureGatewayForProfile,
+  openGatewayForAgent,
   openGatewayForProfile
 }))
 vi.mock('@/hermes', () => ({

--- a/apps/desktop/src/store/profile-select-source.test.ts
+++ b/apps/desktop/src/store/profile-select-source.test.ts
@@ -1,3 +1,4 @@
+import { LOCAL_CONNECTION_ID } from '@hermes/shared'
 import { atom } from 'nanostores'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -10,6 +11,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const ensureGatewayForProfile = vi.fn(async (_profile: string) => undefined)
 const ensureGatewayForAgent = vi.fn(async (_connectionId: null | string, _profile: string) => true)
+const openGatewayForAgent = vi.fn(async (_connectionId: null | string, _profile: string) => undefined)
 const openGatewayForProfile = vi.fn(async (_profile: string) => undefined)
 const activeGatewayConnectionId = vi.fn<() => null | string>(() => null)
 const $gateway = atom<unknown>({ id: 'live-socket' })
@@ -20,6 +22,7 @@ vi.mock('@/store/gateway', () => ({
   activeGatewayConnectionId,
   ensureGatewayForAgent,
   ensureGatewayForProfile,
+  openGatewayForAgent,
   openGatewayForProfile
 }))
 vi.mock('@/hermes', () => ({
@@ -29,11 +32,14 @@ vi.mock('@/hermes', () => ({
 vi.mock('@/lib/query-client', () => ({ invalidateProfileScopedQueries: vi.fn() }))
 vi.mock('@/store/starmap', () => ({ resetStarmapGraph }))
 
-const { $activeGatewayProfile, newSessionInProfile, selectProfile } = await import('./profile')
+const { $activeGatewayProfile, $newChatRoute, newSessionInProfile, prewarmProfileBackend, selectProfile } =
+  await import('./profile')
 
 beforeEach(() => {
   ensureGatewayForProfile.mockClear()
   ensureGatewayForAgent.mockClear()
+  openGatewayForAgent.mockClear()
+  openGatewayForProfile.mockClear()
   activeGatewayConnectionId.mockReset()
   activeGatewayConnectionId.mockReturnValue(null)
   $gateway.set({ id: 'live-socket' })
@@ -51,6 +57,7 @@ describe('selectProfile', () => {
 
     await vi.waitFor(() => expect(ensureGatewayForAgent).toHaveBeenCalledWith('mini', 'researcher'))
     expect(ensureGatewayForProfile).not.toHaveBeenCalled()
+    expect($newChatRoute.get()).toEqual({ connectionId: 'mini', profile: 'researcher' })
   })
 
   it('keeps the legacy profile-only path when the primary is live', async () => {
@@ -60,6 +67,17 @@ describe('selectProfile', () => {
 
     await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('ops'))
     expect(ensureGatewayForAgent).not.toHaveBeenCalled()
+    expect($newChatRoute.get()).toBeNull()
+  })
+
+  it('keeps the legacy profile-only path for the explicit local source', async () => {
+    activeGatewayConnectionId.mockReturnValue(LOCAL_CONNECTION_ID)
+
+    selectProfile('ops')
+
+    await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('ops'))
+    expect(ensureGatewayForAgent).not.toHaveBeenCalled()
+    expect($newChatRoute.get()).toBeNull()
   })
 })
 
@@ -71,5 +89,55 @@ describe('newSessionInProfile', () => {
 
     await vi.waitFor(() => expect(ensureGatewayForAgent).toHaveBeenCalledWith('mini', 'designer'))
     expect(ensureGatewayForProfile).not.toHaveBeenCalled()
+    expect($newChatRoute.get()).toEqual({ connectionId: 'mini', profile: 'designer' })
+  })
+
+  it('keeps the legacy profile-only path for a primary new chat', async () => {
+    newSessionInProfile('operator')
+
+    await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('operator'))
+    expect(ensureGatewayForAgent).not.toHaveBeenCalled()
+    expect($newChatRoute.get()).toBeNull()
+  })
+
+  it('keeps the legacy profile-only path for an explicit local new chat', async () => {
+    activeGatewayConnectionId.mockReturnValue(LOCAL_CONNECTION_ID)
+
+    newSessionInProfile('operator')
+
+    await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('operator'))
+    expect(ensureGatewayForAgent).not.toHaveBeenCalled()
+    expect($newChatRoute.get()).toBeNull()
+  })
+})
+
+describe('prewarmProfileBackend', () => {
+  it('prewarms a profile on the live registry source, not the primary', async () => {
+    activeGatewayConnectionId.mockReturnValue('mini')
+
+    prewarmProfileBackend('reviewer')
+
+    await vi.waitFor(() => expect(openGatewayForAgent).toHaveBeenCalledWith('mini', 'reviewer'))
+    expect(openGatewayForProfile).not.toHaveBeenCalled()
+  })
+
+  it('keeps the profile-only prewarm path when the primary is live', async () => {
+    activeGatewayConnectionId.mockReturnValue(null)
+
+    prewarmProfileBackend('operator')
+
+    await vi.waitFor(() => expect(openGatewayForProfile).toHaveBeenCalledWith('operator'))
+    expect(openGatewayForAgent).not.toHaveBeenCalled()
+  })
+
+  it('throttles prewarm independently for the same profile on different sources', () => {
+    activeGatewayConnectionId.mockReturnValue('mini')
+    prewarmProfileBackend('shared-profile')
+
+    activeGatewayConnectionId.mockReturnValue('studio')
+    prewarmProfileBackend('shared-profile')
+
+    expect(openGatewayForAgent).toHaveBeenNthCalledWith(1, 'mini', 'shared-profile')
+    expect(openGatewayForAgent).toHaveBeenNthCalledWith(2, 'studio', 'shared-profile')
   })
 })

--- a/apps/desktop/src/store/profile-share.test.ts
+++ b/apps/desktop/src/store/profile-share.test.ts
@@ -9,7 +9,9 @@ vi.mock('@/store/gateway', async () => {
 
   return {
     $gateway: atom<unknown>(null),
+    activeGatewayConnectionId: vi.fn(() => null),
     ensureGatewayForProfile: vi.fn(async () => undefined),
+    openGatewayForAgent: vi.fn(async () => undefined),
     openGatewayForProfile: vi.fn(async () => undefined)
   }
 })

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -8,11 +8,20 @@ import type { ProfileInfo } from '@/types/hermes'
 // the REST query client must not run for real in a unit test.
 const ensureGatewayForProfile = vi.fn(async () => undefined)
 const ensureGatewayForAgent = vi.fn(async () => undefined)
+const activeGatewayConnectionId = vi.fn<() => null | string>(() => null)
+const openGatewayForAgent = vi.fn(async (_connectionId: null | string, _profile: string) => undefined)
 const openGatewayForProfile = vi.fn(async (_profile: string) => undefined)
 const $gateway = atom<unknown>({ id: 'live-socket' })
 const resetStarmapGraph = vi.fn()
 
-vi.mock('@/store/gateway', () => ({ $gateway, ensureGatewayForAgent, ensureGatewayForProfile, openGatewayForProfile }))
+vi.mock('@/store/gateway', () => ({
+  $gateway,
+  activeGatewayConnectionId,
+  ensureGatewayForAgent,
+  ensureGatewayForProfile,
+  openGatewayForAgent,
+  openGatewayForProfile
+}))
 vi.mock('@/hermes', () => ({
   getProfiles: vi.fn(async () => ({ profiles: [] })),
   setApiRequestProfile: vi.fn()

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -1,3 +1,4 @@
+import { LOCAL_CONNECTION_ID } from '@hermes/shared'
 import { atom, batch, computed } from 'nanostores'
 
 import type { HermesConnection } from '@/global'
@@ -18,6 +19,7 @@ import {
   activeGatewayConnectionId,
   ensureGatewayForAgent,
   ensureGatewayForProfile,
+  openGatewayForAgent,
   openGatewayForProfile
 } from '@/store/gateway'
 import { notifyRemoteOverrideAuthFailure } from '@/store/profile-remote-override'
@@ -210,6 +212,22 @@ export interface AgentProfileRoute {
 // change before the first Send; the draft's owner must not change with it.
 export const $newChatRoute = atom<AgentProfileRoute | null>(null)
 
+// Shared source/profile intent generation. Gateway activation is serialized,
+// but a newer profile pick can be queued behind an older source switch before
+// the gateway's own activation epoch advances. Source-switch finalization uses
+// this generation to avoid publishing stale draft ownership after that race.
+let routeIntentGeneration = 0
+
+export function beginGatewayRouteIntent(): number {
+  routeIntentGeneration += 1
+
+  return routeIntentGeneration
+}
+
+export function isCurrentGatewayRouteIntent(generation: number): boolean {
+  return generation === routeIntentGeneration
+}
+
 // Bumped whenever the open session should be dropped for a fresh new-session
 // draft: a profile switch/create (below), or deleting the project that owns the
 // currently-open session (store/projects). The chat controller subscribes and
@@ -258,18 +276,22 @@ export const $gatewaySwapTarget = atom<string | null>(null)
 // plus the socket connect before the sidebar can repopulate. The pointer
 // entering a profile square in the rail signals the switch a few hundred ms
 // before the click lands, so we run the same spawn + connect chain then
-// (openGatewayForProfile — without activating). `ensureBackend` in the
-// Electron main is idempotent (a pooled profile returns its existing
-// connectionPromise), so the real switch joins the in-flight work instead of
-// duplicating it — and a pre-warm for an already-open profile is a no-op.
-// Throttled per profile so drive-by hovers can't spam spawn attempts; failures
-// stay silent here and surface on the real switch, which owns retry/error UX.
+// (openGatewayForProfile/openGatewayForAgent — without activating).
+// `ensureBackend` in the Electron main is idempotent (a pooled profile returns
+// its existing connectionPromise), so the real switch joins the in-flight work
+// instead of duplicating it — and a pre-warm for an already-open profile is a
+// no-op.
+// Throttled per source/profile so drive-by hovers can't spam spawn attempts;
+// failures stay silent here and surface on the real switch, which owns
+// retry/error UX.
 const PREWARM_MIN_INTERVAL_MS = 60_000
 
 const prewarmedAt = new Map<string, number>()
 
 export function prewarmProfileBackend(name: string): void {
   const key = normalizeProfileKey(name)
+  const connectionId = activeGatewayConnectionId()
+  const scope = `${connectionId === null ? 'primary' : `connection:${connectionId}`}\u0000${key}`
 
   if (key === normalizeProfileKey($activeGatewayProfile.get())) {
     return
@@ -277,12 +299,17 @@ export function prewarmProfileBackend(name: string): void {
 
   const now = Date.now()
 
-  if (now - (prewarmedAt.get(key) ?? 0) < PREWARM_MIN_INTERVAL_MS) {
+  if (now - (prewarmedAt.get(scope) ?? 0) < PREWARM_MIN_INTERVAL_MS) {
     return
   }
 
-  prewarmedAt.set(key, now)
-  openGatewayForProfile(key).catch(() => undefined)
+  prewarmedAt.set(scope, now)
+
+  if (connectionId) {
+    openGatewayForAgent(connectionId, key).catch(() => undefined)
+  } else {
+    openGatewayForProfile(key).catch(() => undefined)
+  }
 }
 
 let gatewaySwitch: Promise<void> | null = null
@@ -512,12 +539,14 @@ export const $profileScope = computed([$showAllProfiles, $activeGatewayProfile],
 // $activeGatewayProfile → name, so $profileScope follows).
 export function selectProfile(name: string): void {
   const target = normalizeProfileKey(name)
+  beginGatewayRouteIntent()
+  const route = routeOnCurrentSource(target)
   // Switching profiles (or coming back from the all-profiles browse view) starts
   // fresh; re-tapping the profile you're already in leaves your session be.
   const switching = $showAllProfiles.get() || target !== normalizeProfileKey($activeGatewayProfile.get())
   $showAllProfiles.set(false)
   $newChatProfile.set(target)
-  $newChatRoute.set(null)
+  $newChatRoute.set(route)
 
   if (switching) {
     requestFreshSession()
@@ -526,7 +555,7 @@ export function selectProfile(name: string): void {
   // A profile with a remote override can fail to activate because the remote
   // host rejected its saved token (rotated/revoked). That must surface as a
   // "re-enter token" affordance, never a silently dead profile (#91349).
-  void activateOnCurrentSource(target).catch(error => notifyRemoteOverrideAuthFailure(target, error))
+  void activateOnCurrentSource(target, route).catch(error => notifyRemoteOverrideAuthFailure(target, error))
 }
 
 // Route a profile pick at the source the user is LOOKING at. $profiles is the
@@ -536,11 +565,16 @@ export function selectProfile(name: string): void {
 // main process answers against the primary — so picking "researcher" on a
 // remote source opened a local backend of the same name and dropped the user
 // back home, making the pick look like it never took. A null connection id
-// means the primary is live, which is exactly the legacy path.
-function activateOnCurrentSource(target: string): Promise<void> {
+// means the primary is live, and the explicit local registry source must also
+// use the legacy path so per-profile remote overrides still resolve.
+export function routeOnCurrentSource(target: string): AgentProfileRoute | null {
   const connectionId = activeGatewayConnectionId()
 
-  return connectionId ? ensureGatewayAgent(connectionId, target) : ensureGatewayProfile(target)
+  return connectionId && connectionId !== LOCAL_CONNECTION_ID ? { connectionId, profile: target } : null
+}
+
+function activateOnCurrentSource(target: string, route = routeOnCurrentSource(target)): Promise<void> {
+  return route ? ensureGatewayAgent(route.connectionId, route.profile) : ensureGatewayProfile(target)
 }
 
 // Start a fresh session in `name` WITHOUT collapsing the "All profiles" browse
@@ -551,16 +585,19 @@ function activateOnCurrentSource(target: string): Promise<void> {
 // message lands in the right place.
 export function newSessionInProfile(name: string): void {
   const target = normalizeProfileKey(name)
+  beginGatewayRouteIntent()
+  const route = routeOnCurrentSource(target)
   $newChatProfile.set(target)
-  $newChatRoute.set(null)
+  $newChatRoute.set(route)
   requestFreshSession()
-  void activateOnCurrentSource(target).catch(error => notifyRemoteOverrideAuthFailure(target, error))
+  void activateOnCurrentSource(target, route).catch(error => notifyRemoteOverrideAuthFailure(target, error))
 }
 
 /** Start a draft owned by a specific registry agent. Foreground activation is
  * only a presentation step; the route stays attached to the draft for the
  * eventual session.create request. */
 export function newSessionInAgent(route: AgentProfileRoute): void {
+  beginGatewayRouteIntent()
   const captured = {
     ...route,
     connectionId: route.connectionId.trim(),

--- a/apps/desktop/src/store/session-request-router.test.ts
+++ b/apps/desktop/src/store/session-request-router.test.ts
@@ -350,4 +350,18 @@ describe('requestForSessionProfile', () => {
 
     expect(ambient).toHaveBeenCalledOnce()
   })
+
+  it('preserves ambient request arity as optional controls are supplied', async () => {
+    const ambient = vi.fn(async () => ({ ambient: true }))
+    const params = { session_id: 'rt-3' }
+    const controller = new AbortController()
+
+    await requestForSessionProfile(null, ambient as never, 'session.usage', params)
+    await requestForSessionProfile(null, ambient as never, 'session.usage', params, 1_800_000)
+    await requestForSessionProfile(null, ambient as never, 'session.usage', params, undefined, controller.signal)
+
+    expect(ambient.mock.calls.map(args => args.length)).toEqual([2, 3, 4])
+    expect(ambient).toHaveBeenNthCalledWith(2, 'session.usage', params, 1_800_000)
+    expect(ambient).toHaveBeenNthCalledWith(3, 'session.usage', params, undefined, controller.signal)
+  })
 })

--- a/apps/desktop/src/store/session-request-router.ts
+++ b/apps/desktop/src/store/session-request-router.ts
@@ -100,9 +100,15 @@ export function requestForSessionProfile<T>(
     // changes the observed call shape for the many callers that never asked
     // for a deadline (the plugin host bridge in contrib/wiring is the only one
     // that does).
-    return timeoutMs === undefined && signal === undefined
-      ? ambientRequest<T>(method, params)
-      : ambientRequest<T>(method, params, timeoutMs, signal)
+    if (signal !== undefined) {
+      return ambientRequest<T>(method, params, timeoutMs, signal)
+    }
+
+    if (timeoutMs !== undefined) {
+      return ambientRequest<T>(method, params, timeoutMs)
+    }
+
+    return ambientRequest<T>(method, params)
   }
 
   return requestGatewayForProfile<T>(normKey(ownerProfile), method, params, timeoutMs, signal)

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -609,6 +609,12 @@ describe('knownOwnerForSession / requestForOwnedSession (#91684 client half)', (
     expect(knownOwnerForSession('stored-2')).toBe('loki')
   })
 
+  it('keeps a session row connection owner when profiles share the same name', () => {
+    setSessions([{ connection_id: 'source-b', id: 'stored-shared', profile: 'default' } as never])
+
+    expect(knownOwnerForSession('stored-shared')).toEqual({ connectionId: 'source-b', profile: 'default' })
+  })
+
   it('returns undefined (ambient) when no owner is known, and for null ids', () => {
     expect(knownOwnerForSession('unknown-session')).toBeUndefined()
     expect(knownOwnerForSession(null)).toBeUndefined()

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -42,7 +42,7 @@ import {
   $selectedStoredSessionId,
   $sessions,
   clearReadBaseline,
-  knownSessionProfile,
+  knownSessionOwner,
   lineageAliases,
   markSessionRead,
   sessionMatchesStoredId,
@@ -742,7 +742,7 @@ export function sessionTileOwnerRoute(storedSessionId: string): SessionProfileRo
 /**
  * Sync owner resolution for a session id that may be a RUNTIME or a STORED id.
  * Tile route first (exact connectionId+profile, survives relaunch), then the
- * known session profile (row or open-time hint). Returns undefined when no
+ * known session owner (row or open-time hint). Returns undefined when no
  * owner is known — the caller falls back to ambient, never to "active".
  */
 export function knownOwnerForSession(sessionId: null | string | undefined): SessionOwnerScope {
@@ -752,7 +752,7 @@ export function knownOwnerForSession(sessionId: null | string | undefined): Sess
 
   const storedSessionId = storedSessionIdForRuntimeId(sessionId) ?? sessionId
 
-  return sessionTileOwnerRoute(storedSessionId) ?? knownSessionProfile($sessions.get(), storedSessionId)
+  return sessionTileOwnerRoute(storedSessionId) ?? knownSessionOwner($sessions.get(), storedSessionId)
 }
 
 /**

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -30,6 +30,7 @@ import {
   getRememberedRoute,
   getRememberedSessionId,
   getSessionOwnerHint,
+  knownSessionOwner,
   knownSessionProfile,
   mergeSessionPage,
   rememberedSessionProfile,
@@ -970,5 +971,23 @@ describe('knownSessionProfile', () => {
     // probe, not silently route the RPC to whatever profile is on screen.
     expect(knownSessionProfile([], 'totally-unknown')).toBeUndefined()
     expect(knownSessionProfile([], null)).toBeUndefined()
+  })
+})
+
+describe('knownSessionOwner', () => {
+  it('preserves a registry connection on a same-named session row', () => {
+    expect(
+      knownSessionOwner(
+        [session({ connection_id: 'source-b', id: 'shared-session', profile: 'default' })],
+        'shared-session'
+      )
+    ).toEqual({ connectionId: 'source-b', profile: 'default' })
+  })
+
+  it('preserves a composite owner hint when the row is not listed', () => {
+    const owner = { connectionId: 'source-a', profile: 'default', targetProfile: 'backend-default' }
+    setSessionOwnerHint('hidden-session', owner)
+
+    expect(knownSessionOwner([], 'hidden-session')).toEqual(owner)
   })
 })

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -126,19 +126,46 @@ export function sessionBelongsToProfile(
  * often the only sync source.
  */
 export function knownSessionProfile(sessions: readonly SessionInfo[], sessionId: null | string): string | undefined {
+  const owner = knownSessionOwner(sessions, sessionId)
+
+  return typeof owner === 'string' ? owner : (owner?.targetProfile ?? owner?.profile)?.trim() || undefined
+}
+
+/**
+ * The complete known owner of a session, including its registry connection
+ * when the row or an open-time hint carries one. Session-scoped RPC callers
+ * must use this instead of `knownSessionProfile`: two sources can expose the
+ * same profile name, so returning only that name silently collapses the route
+ * back to the local/profile-only path.
+ */
+export function knownSessionOwner(
+  sessions: readonly SessionInfo[],
+  sessionId: null | string
+): SessionProfileRoute | string | undefined {
   if (!sessionId) {
     return undefined
   }
 
-  const owner = sessions.find(session => sessionMatchesStoredId(session, sessionId))?.profile?.trim()
-
-  if (owner) {
-    return owner
-  }
-
+  const session = sessions.find(candidate => sessionMatchesStoredId(candidate, sessionId))
+  const profile = session?.profile?.trim()
+  const connectionId = session?.connection_id?.trim()
   const hint = getSessionOwnerHint(sessionId)
 
-  return (hint?.targetProfile ?? hint?.profile)?.trim() || undefined
+  if (connectionId) {
+    return { connectionId, profile: profile || 'default' }
+  }
+
+  const hintProfiles = new Set([hint?.profile.trim() || 'default', hint?.targetProfile?.trim() || 'default'])
+
+  if (hint && (!profile || hintProfiles.has(profile || 'default'))) {
+    return hint
+  }
+
+  if (profile) {
+    return profile
+  }
+
+  return hint
 }
 
 /**
@@ -148,7 +175,7 @@ export function knownSessionProfile(sessions: readonly SessionInfo[], sessionId:
  *
  * Do NOT use this to ROUTE a session-scoped RPC: the active-profile fallback is
  * exactly what sends a hidden/unlisted session's RPC to a backend that never
- * owned it. Routing must use `knownSessionProfile` + a cross-profile probe and
+ * owned it. Routing must use `knownSessionOwner` + a cross-profile probe and
  * surface an error instead of falling back. This remains for the navigation
  * keying it was written for.
  */

--- a/apps/desktop/src/store/settings-scope.test.ts
+++ b/apps/desktop/src/store/settings-scope.test.ts
@@ -5,8 +5,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 // store/profile.test.ts.
 vi.mock('@/store/gateway', () => ({
   $gateway: atom<unknown>(null),
+  activeGatewayConnectionId: vi.fn(() => null),
   ensureGatewayForAgent: vi.fn(async () => undefined),
   ensureGatewayForProfile: vi.fn(async () => undefined),
+  openGatewayForAgent: vi.fn(async () => undefined),
   openGatewayForProfile: vi.fn(async () => undefined)
 }))
 vi.mock('@/hermes', () => ({


### PR DESCRIPTION
## Summary

Desktop profile selection already activates a registered source after #92194, but the composite `(connectionId, profile)` owner was still lost across fresh drafts, optimistic session rows, resume/reconnect, tile actions, and asynchronous source/profile switches. In multi-profile SSH setups this could spawn a same-named local backend, reconnect another registered host, or make a later turn fail against the wrong profile namespace.

This change:

- preserves the selected registered source on fresh drafts and source-aware hover prewarm;
- stores `connection_id` and composite owner hints on optimistic sessions and tiles;
- routes session, delegate, tile, cleanup, YOLO, and reconnect RPCs through the owning source;
- validates both source and profile when activating a connection;
- prevents slow source switches or resumes from overwriting newer route intent;
- recovers registered remote/SSH sockets after `ECONNRESET` or connection-closed failures through the same composite source/profile, including fresh scoped WebSocket tickets;
- preserves primary OAuth/local fallback behavior and leaves unknown legacy sessions on their existing ambient path.

The shared route-intent generation is deliberately narrow: existing `switchRevision` still orders source-to-source switches, while the new generation only prevents stale source/profile intent publication.

## Impact / priority

This is a P1 candidate rather than a normal degraded-path P2: for affected Desktop SSH multi-profile users, switching to a remote profile cannot be used reliably beyond the first activation/turn, and the fallback may touch a different local or registered host rather than merely displaying stale UI.

## Scope note

The authoritative-empty session-list merge reported separately in [#92352](https://github.com/NousResearch/hermes-agent/issues/92352) remains out of scope here. This PR addresses composite ownership and reconnect routing; #92352 needs its own session-list merge fix and zero-row regression matrix.

## Verification

Post-rebase validation against current `main`:

- UI tests: 17 files, 299 tests passed
- Renderer, Electron, and E2E TypeScript projects: passed
- Prettier: all 24 changed TS/TSX files passed
- `git diff --check`: passed
- no manifest or lockfile changes
- focused reconnect coverage includes 12 tests for real secondary recovery, structured transport errors, OAuth reauth/mint failures, missing scoped bridges, and primary/local fallback

ESLint was unavailable in the local dependency tree, so CI remains authoritative for that lane.

Fixes #90477