### PR TITLE
fix(desktop): keep delegate children out of sessions

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts
@@ -112,6 +112,15 @@ describe('resolveStoredSession profile ownership', () => {
     expect($sessions.get().find(s => s.id === 's1')?.profile).toBe('meta')
   })
 
+  it('returns an internal delegate child without promoting it into regular sessions', async () => {
+    mockGetSession.mockResolvedValueOnce(session({ id: 'child', is_internal_child: true }))
+
+    const resolved = await resolveStoredSession('child')
+
+    expect(resolved).toMatchObject({ id: 'child', is_internal_child: true, profile: 'meta' })
+    expect($sessions.get()).toEqual([])
+  })
+
   it('probed desktop profile overrides a remote backend answering as its own "default"', async () => {
     // Per-profile remote override: Electron strips the desktop alias before
     // forwarding, so the standalone backend stamps its backend-local root.

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1290,6 +1290,14 @@ export function sessionShouldHaveTranscript(session: SessionInfo | undefined): b
 }
 
 function upsertResolvedSession(session: SessionInfo, storedSessionId: string) {
+  // Exact-id lookup intentionally resolves internal delegate children so a
+  // watch tile can open them. They are not ordinary user conversations,
+  // though, and the authoritative list endpoints omit them; caching one here
+  // would bypass that boundary and leak it into the Sessions sidebar.
+  if (session.is_internal_child) {
+    return
+  }
+
   const lineage = session._lineage_root_id ?? session.id
 
   setSessions(prev => [

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -199,6 +199,17 @@ describe('mergeSessionPage', () => {
     expect(merged.find(s => s.id === 'a')?.message_count).toBe(2)
   })
 
+  it('does not preserve an omitted internal delegate child even when selected or working', () => {
+    const previous = [
+      session({ id: 'delegate-child', is_internal_child: true, parent_session_id: 'parent' }),
+      session({ id: 'visible-branch', parent_session_id: 'parent' })
+    ]
+
+    const merged = mergeSessionPage(previous, [], ['delegate-child', 'visible-branch'])
+
+    expect(merged.map(s => s.id)).toEqual(['visible-branch'])
+  })
+
   it('does not duplicate a working session the server already returned', () => {
     const previous = [session({ id: 'b' }), session({ id: 'a' })]
     const incoming = [session({ id: 'b', message_count: 4 }), session({ id: 'a' })]

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -437,15 +437,19 @@ export function mergeSessionPage(
   // root so a mid-turn refresh can't drop a touchSessionActivity bump.
   const prevByLineage = new Map(previous.map(session => [session._lineage_root_id ?? session.id, session]))
 
-  const merged = incoming.map(session => {
-    const prev = prevById.get(session.id) ?? prevByLineage.get(session._lineage_root_id ?? session.id)
-    // User-send stamps last_active before the DB flushes the user row
-    // (last_active = MAX(messages.timestamp)). Keep the fresher of the two.
-    const last_active = Math.max(prev?.last_active ?? 0, session.last_active ?? 0)
-    const title = session.title?.trim() ? session.title : prev?.title?.trim() ? prev.title : session.title
+  const merged = incoming
+    .filter(session => !session.is_internal_child)
+    .map(session => {
+      const prev = prevById.get(session.id) ?? prevByLineage.get(session._lineage_root_id ?? session.id)
+      // User-send stamps last_active before the DB flushes the user row
+      // (last_active = MAX(messages.timestamp)). Keep the fresher of the two.
+      const last_active = Math.max(prev?.last_active ?? 0, session.last_active ?? 0)
+      const title = session.title?.trim() ? session.title : prev?.title?.trim() ? prev.title : session.title
 
-    return last_active === session.last_active && title === session.title ? session : { ...session, last_active, title }
-  })
+      return last_active === session.last_active && title === session.title
+        ? session
+        : { ...session, last_active, title }
+    })
 
   if (keep.size === 0) {
     return merged
@@ -461,6 +465,7 @@ export function mergeSessionPage(
 
   const survivors = previous.filter(
     session =>
+      !session.is_internal_child &&
       !incomingIds.has(session.id) &&
       !incomingLineageKeys.has(session._lineage_root_id ?? session.id) &&
       (keep.has(session.id) || (session._lineage_root_id != null && keep.has(session._lineage_root_id)))

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -507,6 +507,10 @@ export interface SessionInfo {
   output_tokens: number
   /** Parent conversation when this row is a /branch fork. */
   parent_session_id?: null | string
+  /** True for an internal delegate_task child. Exact-id endpoints return these
+   *  rows for direct watch/resume, but ordinary session lists must not surface
+   *  them. Undefined against backends predating the projection. */
+  is_internal_child?: boolean
   /** Durable server-side pin flag (`sessions.pinned`). The list endpoints
    *  back-fill pinned conversations past their LIMIT, so a pinned row is
    *  always present in a page — which makes this authoritative for the

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4181,6 +4181,23 @@ class APIServerAdapter(BasePlatformAdapter):
         # callers only need to know whether those snapshots exist.
         payload["has_system_prompt"] = bool(session.get("system_prompt"))
         payload["has_model_config"] = bool(session.get("model_config"))
+        raw_model_config = session.get("model_config")
+        try:
+            model_config = (
+                json.loads(raw_model_config)
+                if isinstance(raw_model_config, str)
+                else raw_model_config
+            )
+        except (TypeError, json.JSONDecodeError):
+            model_config = None
+        # Exact-id consumers may inspect/resume delegate children even though
+        # list endpoints intentionally omit them. Project only the provenance
+        # bit the client needs so it cannot accidentally promote such a row
+        # into an ordinary session list; never expose the model snapshot.
+        payload["is_internal_child"] = bool(
+            isinstance(model_config, dict)
+            and model_config.get("_delegate_from") is not None
+        )
         return payload
 
     @staticmethod

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -83,6 +83,39 @@ async def test_capabilities_advertises_session_control_surface(adapter):
 
 
 @pytest.mark.asyncio
+async def test_get_session_projects_delegate_provenance_without_model_config(
+    adapter, session_db
+):
+    session_db.create_session("parent", "desktop")
+    child_id = session_db.create_session(
+        "delegate-child",
+        "desktop",
+        parent_session_id="parent",
+        model_config={"_delegate_from": "parent", "api_key": "must-not-leak"},
+    )
+    branch_id = session_db.create_session(
+        "visible-branch",
+        "desktop",
+        parent_session_id="parent",
+        model_config={"_branched_from": "parent"},
+    )
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        child_resp = await cli.get(f"/api/sessions/{child_id}")
+        branch_resp = await cli.get(f"/api/sessions/{branch_id}")
+        assert child_resp.status == 200
+        assert branch_resp.status == 200
+        child = (await child_resp.json())["session"]
+        branch = (await branch_resp.json())["session"]
+
+    assert child["is_internal_child"] is True
+    assert branch["is_internal_child"] is False
+    assert "model_config" not in child
+    assert "must-not-leak" not in str(child)
+
+
+@pytest.mark.asyncio
 async def test_session_messages_default_to_latest_bounded_page(adapter, session_db):
     session_id = session_db.create_session("bounded-messages", "api_server")
     session_db.replace_messages(


### PR DESCRIPTION
## Summary

Keeps exact-ID delegate children directly resolvable for watch/resume without promoting them into Desktop's ordinary Sessions cache. Fixes #94124.

The API now projects a client-safe internal-child bit from trusted delegate provenance without exposing `model_config`. Desktop uses that bit both when resolving an exact ID and when reconciling authoritative session pages, while genuine user-created branch children remain visible.

## Testing

- `scripts/run_tests.sh tests/gateway/test_session_api.py -q` (21 passed)
- `npm run test:ui -- src/app/session/hooks/use-session-actions/resolve-stored-session.test.ts src/store/session.test.ts` (85 passed)
- `npm run typecheck`
- `npm run lint` (0 errors)