### PR TITLE
fix(slack): keep task card updates visible

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2640,8 +2640,9 @@ class SlackAdapter(BasePlatformAdapter):
                     "ts": stream.stream_ts,
                     "chunks": chunks,
                 }
-                if fallback_text:
-                    append_payload["markdown_text"] = fallback_text
+                # Slack accepts either structured chunks or markdown_text on an
+                # append, never both. The caller owns fallback_text when native
+                # task cards fail and it switches to the editable-text fallback.
                 await client.api_call("chat.appendStream", json=append_payload)
                 return SendResult(success=True, message_id=stream.stream_ts)
             except Exception as exc:  # pragma: no cover - defensive logging

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -4580,6 +4580,35 @@ class TestNativeTaskCardProgress:
         ).native_task_cards_enabled() is False
 
     @pytest.mark.asyncio
+    async def test_native_chunks_do_not_mix_markdown_fallback(self, adapter):
+        client = adapter._app.client
+
+        async def api_call(method, *, json):
+            if method == "chat.startStream":
+                return {"ts": "stream-1"}
+            if method == "chat.appendStream":
+                if "chunks" in json and "markdown_text" in json:
+                    raise RuntimeError(
+                        "cannot_provide_both_markdown_text_and_chunks"
+                    )
+                return {"ok": True}
+            raise AssertionError(f"unexpected Slack method: {method}")
+
+        client.api_call.side_effect = api_call
+
+        result = await adapter.send_native_task_card_progress(
+            "C1",
+            [{"id": "call-1", "title": "terminal", "status": "in_progress"}],
+            metadata={"thread_id": "thread-1"},
+            fallback_text="Hermes is working",
+        )
+
+        assert result.success is True
+        append_payload = client.api_call.await_args_list[1].kwargs["json"]
+        assert "chunks" in append_payload
+        assert "markdown_text" not in append_payload
+
+    @pytest.mark.asyncio
     async def test_native_updates_are_serialized_and_workspace_scoped(self, adapter):
         team_client = AsyncMock()
         start_count = 0


### PR DESCRIPTION
## What does this PR do?

Slack task cards stay visible while Hermes works. Native progress updates now send structured `chunks` without also sending `markdown_text`, which Slack rejects with `cannot_provide_both_markdown_text_and_chunks`.

## Related Issue

No linked issue. This was reproduced from a live Slack API error.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Keep `chat.appendStream` task-card requests mutually exclusive by sending `chunks` without `markdown_text`.
- Add a regression test that models Slack rejecting a request that contains both fields.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_slack.py tests/gateway/test_run_progress_topics.py tests/gateway/relay/test_relay_live_cards.py tests/gateway/relay/test_relay_task_card_failures.py tests/gateway/relay/test_relay_turn_keying.py tests/gateway/relay/test_live_cards_flow_trace.py -q`.
2. Confirm all 220 Slack and progress tests pass.
3. Enable Slack native task cards and run a tool call. Confirm the interactive working card appears and the gateway logs do not contain `cannot_provide_both_markdown_text_and_chunks`.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 and the live Linux gateway

The focused suite passes 220 tests. The full gateway suite passes 6,202 tests and reports eight unrelated existing or environment-specific failures in readiness, macOS Unix sockets/systemd, and optional WeCom XML support.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior matches the existing task-card contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config change
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Slack payload construction is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model tool change

## Screenshots / Logs

Live verification: [Slack thread](https://successionorg.slack.com/archives/C0941KNPN2H/p1787603702886709). The interactive task card appeared during a 35-second tool call, the final response arrived, and the prior Slack API error did not recur.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
