### PR TITLE
fix(auth): let setup continue when Nous Portal is unreachable

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3925,39 +3925,57 @@ def select_provider_and_model(args=None):
     ordered.append(("aux-config", "Configure auxiliary models...", []))
     ordered.append(("cancel", "Leave unchanged", []))
 
-    provider_idx = _prompt_provider_choice(
-        [label for _, label, _ in ordered],
-        default=default_idx,
-    )
-    if provider_idx is None or ordered[provider_idx][0] == "cancel":
+    def _select_provider() -> str | None:
+        provider_idx = _prompt_provider_choice(
+            [label for _, label, _ in ordered],
+            default=default_idx,
+        )
+        if provider_idx is None or ordered[provider_idx][0] == "cancel":
+            return None
+
+        selected_key = ordered[provider_idx][0]
+        selected_members = ordered[provider_idx][2]
+
+        # Group row → drill into a member sub-picker. Default to the active member
+        # if the active provider lives in this group. The descriptive text lives on
+        # the group row itself, so member rows show only their short label here.
+        if selected_members:
+            member_default = 0
+            if active in selected_members:
+                member_default = selected_members.index(active)
+            member_labels = [provider_labels.get(m, m) for m in selected_members]
+            group_label = ordered[provider_idx][1].split(" ▸", 1)[0]
+            member_idx = _prompt_provider_choice(
+                member_labels,
+                default=member_default,
+                title=f"Select {group_label} provider:",
+            )
+            if member_idx is None:
+                return None
+            return selected_members[member_idx]
+        return selected_key
+
+    selected_provider = _select_provider()
+    if selected_provider is None:
         print("No change.")
         return
 
-    selected_key = ordered[provider_idx][0]
-    selected_members = ordered[provider_idx][2]
-
-    # Group row → drill into a member sub-picker. Default to the active member
-    # if the active provider lives in this group. The descriptive text lives on
-    # the group row itself, so member rows show only their short label here.
-    if selected_members:
-        member_default = 0
-        if active in selected_members:
-            member_default = selected_members.index(active)
-        member_labels = [
-            provider_labels.get(m, m) for m in selected_members
-        ]
-        group_label = ordered[provider_idx][1].split(" ▸", 1)[0]
-        member_idx = _prompt_provider_choice(
-            member_labels,
-            default=member_default,
-            title=f"Select {group_label} provider:",
+    # A Portal outage must not terminate first-run setup. Keep this recovery at
+    # the provider-picker boundary so the user can immediately choose any BYOK
+    # or local provider without restarting Hermes.
+    while selected_provider == "nous":
+        if _model_flow_nous(config, current_model, args=args) is not False:
+            break
+        print()
+        print(
+            "Nous Portal login failed. You can choose another provider; "
+            "Portal access is not required for OpenRouter, Anthropic, or local/custom endpoints."
         )
-        if member_idx is None:
+        print()
+        selected_provider = _select_provider()
+        if selected_provider is None:
             print("No change.")
             return
-        selected_provider = selected_members[member_idx]
-    else:
-        selected_provider = selected_key
 
     if selected_provider == "aux-config":
         _aux_config_menu()
@@ -3971,7 +3989,7 @@ def select_provider_and_model(args=None):
     elif selected_provider == "ai-gateway":
         _model_flow_ai_gateway(config, current_model)
     elif selected_provider == "nous":
-        _model_flow_nous(config, current_model, args=args)
+        pass  # handled above so Portal failures can reopen the provider picker
     elif selected_provider == "openai-codex":
         _model_flow_openai_codex(config, current_model)
     elif selected_provider == "xai-oauth":

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -397,7 +397,7 @@ def _model_flow_moa(config, current_model=""):
 
 
 def _model_flow_nous(config, current_model="", args=None):
-    """Nous Portal provider: ensure logged in, then pick model."""
+    """Set up Nous, returning False when login fails and may be retried elsewhere."""
     from hermes_cli.auth import (
         get_provider_auth_state,
         _prompt_model_selection,
@@ -439,12 +439,14 @@ def _model_flow_nous(config, current_model="", args=None):
                 prompt_enable_tool_gateway(_refreshed)
             except Exception:
                 pass
-        except SystemExit:
+        except SystemExit as exc:
             print("Login cancelled or failed.")
-            return
+            if exc.code == 130:
+                return
+            return False
         except Exception as exc:
             print(f"Login failed: {exc}")
-            return
+            return False
         # login_nous already handles model selection + config update
         return
 

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -488,8 +488,14 @@ def _model_flow_nous(config, current_model="", args=None):
                     insecure=False,
                 )
                 _login_nous(mock_args, PROVIDER_REGISTRY["nous"])
+            except SystemExit as login_exc:
+                print("Re-login cancelled or failed.")
+                if login_exc.code == 130:
+                    return
+                return False
             except Exception as login_exc:
                 print(f"Re-login failed: {login_exc}")
+                return False
             return
         print(f"Could not verify credentials: {msg}")
         return

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2885,11 +2885,9 @@ def _run_portal_one_shot(config: dict) -> None:
 
         _model_flow_nous(config)
     except (KeyboardInterrupt, EOFError, SystemExit):
-        # _login_nous raises SystemExit(130)/(1) on cancel/failure; the
-        # logged-out path inside _model_flow_nous catches it, but the
-        # expired-session re-login path only catches Exception, so a
-        # SystemExit there would otherwise escape and kill the whole CLI.
-        # Treat all of these as a graceful cancel/abort for the portal flow.
+        # _model_flow_nous converts expected login failures into recoverable
+        # return values. Keep SystemExit at this command boundary for explicit
+        # cancellation and unexpected aborts so they do not kill the whole CLI.
         print()
         print_info("  Setup cancelled.")
         print_info("  You can retry later with `hermes portal`.")

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -122,6 +122,54 @@ def test_select_provider_and_model_warns_if_named_custom_provider_disappears(
     assert "selected saved custom provider is no longer available" in out
 
 
+def test_select_provider_and_model_reopens_picker_after_nous_login_failure(
+    tmp_path, monkeypatch, capsys
+):
+    """A blocked Portal must not strand onboarding on the Nous choice."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+    save_config({"model": {}})
+
+    selections = iter(("Nous", "OpenRouter"))
+
+    def pick_provider(labels, default=0, title="Select provider:"):
+        del default, title
+        selected = next(selections)
+        return next(i for i, label in enumerate(labels) if selected in label)
+
+    openrouter_calls = []
+    monkeypatch.setattr("hermes_cli.main._prompt_provider_choice", pick_provider)
+    monkeypatch.setattr("hermes_cli.main._model_flow_nous", lambda *a, **k: False)
+    monkeypatch.setattr(
+        "hermes_cli.main._model_flow_openrouter",
+        lambda *a, **k: openrouter_calls.append(True),
+    )
+
+    from hermes_cli.main import select_provider_and_model
+
+    select_provider_and_model()
+
+    assert openrouter_calls == [True]
+    output = capsys.readouterr().out
+    assert "choose another provider" in output
+    assert "Portal access is not required" in output
+
+
+def test_model_flow_nous_signals_recoverable_login_failure(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_provider_auth_state", lambda provider: None
+    )
+
+    def fail_login(*args, **kwargs):
+        raise SystemExit(1)
+
+    monkeypatch.setattr("hermes_cli.auth._login_nous", fail_login)
+
+    from hermes_cli.main import _model_flow_nous
+
+    assert _model_flow_nous({}, current_model="") is False
+
+
 
 
 

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -170,6 +170,64 @@ def test_model_flow_nous_signals_recoverable_login_failure(monkeypatch):
     assert _model_flow_nous({}, current_model="") is False
 
 
+def test_model_flow_nous_signals_recoverable_expired_session_relogin_failure(
+    monkeypatch,
+):
+    from hermes_cli.auth import AuthError
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_provider_auth_state",
+        lambda provider: {"access_token": "expired"},
+    )
+
+    def expired_credentials(*args, **kwargs):
+        raise AuthError(
+            "Stored credentials expired.",
+            provider="nous",
+            relogin_required=True,
+        )
+
+    def fail_relogin(*args, **kwargs):
+        raise SystemExit(1)
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_nous_runtime_credentials", expired_credentials
+    )
+    monkeypatch.setattr("hermes_cli.auth._login_nous", fail_relogin)
+
+    from hermes_cli.main import _model_flow_nous
+
+    assert _model_flow_nous({}, current_model="") is False
+
+
+def test_model_flow_nous_preserves_expired_session_relogin_cancellation(monkeypatch):
+    from hermes_cli.auth import AuthError
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_provider_auth_state",
+        lambda provider: {"access_token": "expired"},
+    )
+
+    def expired_credentials(*args, **kwargs):
+        raise AuthError(
+            "Stored credentials expired.",
+            provider="nous",
+            relogin_required=True,
+        )
+
+    def cancel_relogin(*args, **kwargs):
+        raise SystemExit(130)
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_nous_runtime_credentials", expired_credentials
+    )
+    monkeypatch.setattr("hermes_cli.auth._login_nous", cancel_relogin)
+
+    from hermes_cli.main import _model_flow_nous
+
+    assert _model_flow_nous({}, current_model="") is None
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

When Nous Portal authentication fails during provider setup, Hermes now explains that Portal access is optional and immediately reopens the provider picker. Users whose network cannot reach Portal can continue onboarding with OpenRouter, Anthropic, another API-key provider, or a local/custom endpoint instead of restarting setup with no configured provider.

### Symptom

Selecting Nous Portal from `hermes model` or first-run setup ends the provider-selection flow after a device-code request fails, including the reported `403 Forbidden` response. The user is left without an immediate path to select a provider that does not depend on Portal.

### Impact

Users on networks where Nous Portal is unavailable cannot complete the selected Nous login and must restart provider setup manually before they can configure a third-party or local provider.

### Bug Cause

**Trigger:** `hermes_cli/main.py:3973` / `select_provider_and_model()` after `_model_flow_nous()` handles a failed login.

**Causal chain:**
1. The user selects Nous and the device-code endpoint rejects or cannot serve the login request.
2. `_login_nous()` reports the authentication error, while `_model_flow_nous()` returns control to the single-shot provider dispatcher.
3. `select_provider_and_model()` exits without reopening its provider menu, so onboarding cannot continue directly with an independent provider.

**Why it is wrong:** A provider-specific authentication failure was treated as the end of provider selection rather than a recoverable choice failure.

**Working sibling / contrast:** Selecting OpenRouter, Anthropic, API-key providers, or custom/local endpoints does not require Nous Portal; those paths remain usable when Portal is unavailable.

**Ruled out:** Provider resolution and local-endpoint credential handling are not the cause. The failure happens before another provider can be selected, at the picker control-flow boundary.

### Fix

The provider picker is now a reusable local selection step. Nous setup reports a recoverable failure signal for unsuccessful logins, and the picker consumes that signal by showing actionable guidance and prompting for another provider. Successful Nous setup and explicit cancellation preserve their existing behavior.

## Related Issue

Closes #94193

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_setup_flows.py` - distinguish failed Nous login from successful setup or cancellation.
- `hermes_cli/main.py` - reopen provider selection after a Nous login failure and explain independent provider options.
- `tests/hermes_cli/test_setup.py` - cover both the recoverable failure signal and Nous-to-OpenRouter fallback flow.

## How to Test

1. Start `hermes model`, select Nous Portal, and let login fail at the device-code request.
2. Confirm Hermes explains that Portal access is optional and shows the provider picker again.
3. Select OpenRouter, Anthropic, or a local/custom endpoint and continue its normal setup flow.

Automated tests run locally:

```bash
scripts/run_tests.sh tests/hermes_cli/test_setup.py tests/hermes_cli/test_model_picker_excluded_providers.py tests/hermes_cli/test_custom_provider_model_switch.py -q
scripts/run_tests.sh tests/cli/test_cli_provider_resolution.py -q
```

37 relevant tests passed on Windows 11.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant test entry points and all selected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is not required; the CLI guidance is updated inline
- [x] `cli-config.yaml.example` is not affected
- [x] `CONTRIBUTING.md` and `AGENTS.md` are not affected
- [x] Cross-platform impact was considered; the change is platform-independent Python control flow
- [x] Tool descriptions and schemas are not affected

## Screenshots / Logs

N/A
