### PR TITLE
fix(tools): scope the terminal env bridge one-shot to the Hermes home

### DIFF
--- a/tests/tools/test_terminal_env_bridge.py
+++ b/tests/tools/test_terminal_env_bridge.py
@@ -7,17 +7,28 @@ config.yaml.
 """
 
 import os
+import sys
 
 import pytest
 
 import tools.terminal_tool as terminal_tool
-from hermes_constants import get_hermes_home
+from hermes_constants import (
+    get_hermes_home,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
 
 
 @pytest.fixture(autouse=True)
 def _reset_bridge_state(monkeypatch):
     """Each test starts with an un-attempted bridge and clean mapped env."""
     monkeypatch.setattr(terminal_tool, "_terminal_config_bridge_attempted", False)
+    monkeypatch.setattr(
+        terminal_tool, "_terminal_config_bridge_scope", None, raising=False
+    )
+    monkeypatch.setattr(
+        terminal_tool, "_terminal_config_bridge_keys", set(), raising=False
+    )
     for name in (
         "TERMINAL_ENV",
         "TERMINAL_CWD",
@@ -106,6 +117,275 @@ def test_env_is_preserved_when_config_has_no_terminal_section(monkeypatch):
 
     assert config["env_type"] == "ssh"
     assert config["ssh_host"] == "example.test"
+
+
+# -- profile-multiplexing scope handoff (#94200) ------------------------------
+
+
+def test_scope_change_rebridges_instead_of_inheriting_previous_profile(
+    monkeypatch, tmp_path
+):
+    """Multiplexed gateway: a docker profile bridging first must not pin
+    TERMINAL_ENV for a later local profile (#94200)."""
+    home_a = tmp_path / "profile-a"
+    home_b = tmp_path / "profile-b"
+    home_a.mkdir()
+    home_b.mkdir()
+    (home_a / "config.yaml").write_text("terminal:\n  backend: docker\n")
+    (home_b / "config.yaml").write_text("terminal:\n  backend: local\n")
+
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    token_a = set_hermes_home_override(str(home_a))
+    try:
+        config_a = terminal_tool._get_env_config()
+        assert config_a["env_type"] == "docker"
+        assert os.environ["TERMINAL_ENV"] == "docker"
+    finally:
+        reset_hermes_home_override(token_a)
+
+    token_b = set_hermes_home_override(str(home_b))
+    try:
+        config_b = terminal_tool._get_env_config()
+    finally:
+        reset_hermes_home_override(token_b)
+
+    assert config_b["env_type"] == "local"
+    assert os.environ["TERMINAL_ENV"] == "local"
+
+
+def test_scope_change_without_terminal_section_drops_bridged_env(
+    monkeypatch, tmp_path
+):
+    """The leak's worst shape: profile B has no terminal section, so the
+    old `elif TERMINAL_ENV not in os.environ` branch kept profile A's
+    docker selection forever. The bridge-introduced keys must be unset on
+    handoff so B falls back to its own (default local) selection."""
+    home_a = tmp_path / "profile-a"
+    home_b = tmp_path / "profile-b"
+    home_a.mkdir()
+    home_b.mkdir()
+    (home_a / "config.yaml").write_text("terminal:\n  backend: docker\n")
+    (home_b / "config.yaml").write_text("agent:\n  max_turns: 5\n")
+
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    token_a = set_hermes_home_override(str(home_a))
+    try:
+        terminal_tool._get_env_config()
+        assert os.environ["TERMINAL_ENV"] == "docker"
+    finally:
+        reset_hermes_home_override(token_a)
+
+    token_b = set_hermes_home_override(str(home_b))
+    try:
+        config_b = terminal_tool._get_env_config()
+    finally:
+        reset_hermes_home_override(token_b)
+
+    assert config_b["env_type"] == "local"
+
+
+def test_failed_rebridge_purges_previous_profile_before_latching(
+    monkeypatch, tmp_path
+):
+    """If the incoming profile's bridge fails — e.g. the config import
+    raises — the previous profile's bridged TERMINAL_* keys must already
+    be gone: a broken config machinery must not re-leak the previous
+    backend selection while the attempt flag latches the failure (#94200).
+    The call degrades to the historical local default instead."""
+    home_a = tmp_path / "profile-a"
+    home_b = tmp_path / "profile-b"
+    home_a.mkdir()
+    home_b.mkdir()
+    (home_a / "config.yaml").write_text("terminal:\n  backend: docker\n")
+    (home_b / "config.yaml").write_text("terminal:\n  backend: local\n")
+
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    token_a = set_hermes_home_override(str(home_a))
+    try:
+        terminal_tool._get_env_config()
+        assert os.environ["TERMINAL_ENV"] == "docker"
+    finally:
+        reset_hermes_home_override(token_a)
+
+    # Break profile B's bridge where it hurts: the config import itself,
+    # before the old code ever reached the key purge. Scoped so the
+    # post-bridge imports in _get_env_config stay untouched.
+    with monkeypatch.context() as m:
+        m.setitem(sys.modules, "hermes_cli.config", None)
+        token_b = set_hermes_home_override(str(home_b))
+        try:
+            terminal_tool._ensure_terminal_env_bridged()
+        finally:
+            reset_hermes_home_override(token_b)
+
+    # A's bridged key did not survive the failed re-bridge — the call
+    # degrades to the ambient env (no TERMINAL_ENV = local default), not
+    # to profile A's docker selection.
+    assert "TERMINAL_ENV" not in os.environ
+    # The failure still latches, keeping the one-shot semantics: a broken
+    # config must not be re-attempted on every call within this scope.
+    assert terminal_tool._terminal_config_bridge_attempted is True
+
+
+def test_same_scope_keeps_one_shot_semantics(monkeypatch, tmp_path):
+    """Within one profile the bridge still runs at most once (no per-call
+    config re-reads)."""
+    home = tmp_path / "single-profile"
+    home.mkdir()
+    (home / "config.yaml").write_text("terminal:\n  backend: docker\n")
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    token = set_hermes_home_override(str(home))
+
+    import hermes_cli.config as cli_config
+
+    calls = {"n": 0}
+    real_apply = cli_config.apply_terminal_config_to_env
+
+    def _counting_apply(env=None, override=False):
+        calls["n"] += 1
+        return real_apply(env=env, override=override)
+
+    monkeypatch.setattr(cli_config, "apply_terminal_config_to_env", _counting_apply)
+    try:
+        terminal_tool._get_env_config()
+        terminal_tool._get_env_config()
+        terminal_tool._get_env_config()
+
+        assert calls["n"] == 1
+        assert os.environ["TERMINAL_ENV"] == "docker"
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_handoff_never_unsets_shell_exported_terminal_vars(
+    monkeypatch, tmp_path
+):
+    """Keys the user's shell/.env exported are not bridge-owned and must
+    survive a scope handoff."""
+    home_a = tmp_path / "profile-a"
+    home_b = tmp_path / "profile-b"
+    home_a.mkdir()
+    home_b.mkdir()
+    (home_a / "config.yaml").write_text("agent:\n  max_turns: 5\n")
+    (home_b / "config.yaml").write_text("agent:\n  max_turns: 5\n")
+    monkeypatch.setenv("TERMINAL_DOCKER_IMAGE", "shell/image:9")
+
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    token_a = set_hermes_home_override(str(home_a))
+    try:
+        terminal_tool._get_env_config()
+    finally:
+        reset_hermes_home_override(token_a)
+    token_b = set_hermes_home_override(str(home_b))
+    try:
+        terminal_tool._get_env_config()
+    finally:
+        reset_hermes_home_override(token_b)
+
+    assert os.environ["TERMINAL_DOCKER_IMAGE"] == "shell/image:9"
+
+
+# -- unified dashboard profile switcher (#98581) --------------------------------
+
+
+def test_profile_switch_serves_each_profiles_terminal_backend(tmp_path):
+    """A unified dashboard backend serves non-default profiles under a
+    context-local HERMES_HOME override; each profile must execute commands
+    with ITS configured terminal backend, not the launch profile's (#98581 —
+    profiles with ``terminal.backend: docker`` ran on the host instead)."""
+    launch_home = tmp_path / "root"
+    docker_home = tmp_path / "root" / "profiles" / "web"
+    docker_home.mkdir(parents=True)
+    (launch_home / "config.yaml").write_text("terminal:\n  backend: local\n")
+    (docker_home / "config.yaml").write_text(
+        "terminal:\n  backend: docker\n  docker_image: sandbox/image:1\n"
+    )
+
+    launch_token = set_hermes_home_override(str(launch_home))
+    try:
+        assert terminal_tool._get_env_config()["env_type"] == "local"
+
+        profile_token = set_hermes_home_override(str(docker_home))
+        try:
+            config = terminal_tool._get_env_config()
+        finally:
+            reset_hermes_home_override(profile_token)
+
+        assert config["env_type"] == "docker"
+        assert config["docker_image"] == "sandbox/image:1"
+        assert os.environ["TERMINAL_ENV"] == "docker"
+
+        # Back on the launch profile: the profile's docker selection must
+        # not stick, and the launch backend applies again.
+        assert terminal_tool._get_env_config()["env_type"] == "local"
+        assert os.environ["TERMINAL_ENV"] == "local"
+    finally:
+        reset_hermes_home_override(launch_token)
+
+
+def test_profile_switch_drops_launch_terminal_selection(tmp_path):
+    """TERMINAL_* vars owned by the launch profile's terminal section must
+    not survive a switch to a profile without one — the unconfigured profile
+    falls back to the local default, not the launch profile's backend."""
+    launch_home = tmp_path / "root"
+    plain_home = tmp_path / "root" / "profiles" / "plain"
+    plain_home.mkdir(parents=True)
+    (launch_home / "config.yaml").write_text("terminal:\n  backend: docker\n")
+    (plain_home / "config.yaml").write_text("agent:\n  max_turns: 100\n")
+
+    launch_token = set_hermes_home_override(str(launch_home))
+    try:
+        assert terminal_tool._get_env_config()["env_type"] == "docker"
+        assert os.environ["TERMINAL_ENV"] == "docker"
+
+        profile_token = set_hermes_home_override(str(plain_home))
+        try:
+            config = terminal_tool._get_env_config()
+        finally:
+            reset_hermes_home_override(profile_token)
+
+        assert config["env_type"] == "local"
+        assert os.environ["TERMINAL_ENV"] == "local"
+    finally:
+        reset_hermes_home_override(launch_token)
+
+
+def test_handoff_drops_launcher_bridged_selection_before_first_call(
+    monkeypatch, tmp_path
+):
+    """A launcher bridge (CLI ``env_mappings``) can write the launch home's
+    selection BEFORE the first terminal-tool bridge call ever runs. Those
+    vars belong to the launch home's terminal section all the same and must
+    be dropped on handoff — ownership comes from the config section, not
+    from what this bridge happened to introduce (#98581)."""
+    launch_home = tmp_path / "root"
+    plain_home = tmp_path / "root" / "profiles" / "plain"
+    plain_home.mkdir(parents=True)
+    (launch_home / "config.yaml").write_text("terminal:\n  backend: docker\n")
+    (plain_home / "config.yaml").write_text("agent:\n  max_turns: 100\n")
+    # The CLI launcher bridged the launch home's selection into the env
+    # before any terminal-tool call ran in this process.
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+    launch_token = set_hermes_home_override(str(launch_home))
+    try:
+        assert terminal_tool._get_env_config()["env_type"] == "docker"
+
+        profile_token = set_hermes_home_override(str(plain_home))
+        try:
+            config = terminal_tool._get_env_config()
+        finally:
+            reset_hermes_home_override(profile_token)
+
+        assert config["env_type"] == "local"
+        assert os.environ["TERMINAL_ENV"] == "local"
+    finally:
+        reset_hermes_home_override(launch_token)
 
 
 def test_defaults_backfill_when_neither_config_nor_env_selects_backend():

--- a/tests/tools/test_terminal_env_bridge.py
+++ b/tests/tools/test_terminal_env_bridge.py
@@ -388,6 +388,50 @@ def test_handoff_drops_launcher_bridged_selection_before_first_call(
         reset_hermes_home_override(launch_token)
 
 
+def test_launch_profile_unscoped_after_secondary_bridge(monkeypatch, tmp_path):
+    """#107422: in a multiplexed dashboard process the launch (primary) profile
+    runs WITHOUT a home override — its context is the process default home.
+    A secondary profile's unscoped path (agent build probe, execute_code)
+    bridges docker first; the launch profile's own tool call must re-bridge
+    from its own config instead of reading the latched docker selection."""
+    launch_home = tmp_path / "root"
+    docker_home = tmp_path / "root" / "profiles" / "web"
+    docker_home.mkdir(parents=True)
+    (launch_home / "config.yaml").write_text("terminal:\n  backend: local\n")
+    (docker_home / "config.yaml").write_text(
+        "terminal:\n  backend: docker\n  docker_image: sandbox/image:1\n"
+        "  docker_volumes:\n    - /secondary/vol:/vol\n"
+    )
+    # The launch profile has NO context-local override: its home is the
+    # process default (HERMES_HOME env -> platform default), like a launch
+    # profile in a multiplexed dashboard process.
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+
+    # Launch-profile call first (unscoped context).
+    assert terminal_tool._get_env_config()["env_type"] == "local"
+
+    # The secondary profile's unscoped path bridges docker under its
+    # context-local override and latches it into the process env.
+    profile_token = set_hermes_home_override(str(docker_home))
+    try:
+        config = terminal_tool._get_env_config()
+    finally:
+        reset_hermes_home_override(profile_token)
+
+    assert config["env_type"] == "docker"
+    assert os.environ["TERMINAL_ENV"] == "docker"
+
+    # Back in the launch profile's unscoped context: the latched secondary
+    # selection must not stick — the launch profile resolves local again,
+    # and the secondary profile's owned image/volume selections are gone
+    # from the ambient env (the launch bridge may backfill its own defaults
+    # for omitted keys; the secondary profile's values must not survive).
+    assert terminal_tool._get_env_config()["env_type"] == "local"
+    assert os.environ["TERMINAL_ENV"] == "local"
+    assert os.environ.get("TERMINAL_DOCKER_IMAGE") != "sandbox/image:1"
+    assert "/secondary/vol" not in (os.environ.get("TERMINAL_DOCKER_VOLUMES") or "")
+
+
 def test_defaults_backfill_when_neither_config_nor_env_selects_backend():
     _write_config("{}\n")
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -521,9 +521,30 @@ def _resolve_task_host_cwd(config: Dict[str, Any], task_id: Optional[str]) -> Op
     return candidate
 
 
-# One-shot guard for the config-fallback bridge: after the first attempt
-# either TERMINAL_ENV is set or the import failed, so retrying is wasted work.
+# One-shot guard for the config-fallback bridge.  Purely an
+# optimization: after the first attempt either TERMINAL_ENV is set (bridge
+# succeeded — merged config always carries terminal.backend) or the import
+# failed and retrying every call would be wasted work.  The one-shot is
+# keyed to the active Hermes home (context-local profile override →
+# ``HERMES_HOME`` env → platform default, via ``hermes_home_key()``):
+# under profile multiplexing (gateway.multiplex_profiles) each profile runs
+# under its own home, and a unified dashboard backend switches homes
+# per request, so the first home's bridge must not pin TERMINAL_* for the
+# others (#94200, #98581, #107422).
 _terminal_config_bridge_attempted = False
+_terminal_config_bridge_scope: "str | None" = None
+# TERMINAL_* env vars the last bridged home's ``terminal`` config section
+# explicitly owns — unset on the next home change so the incoming profile
+# starts from its own config/.env instead of the previous home's backend
+# selection. Ownership is computed from the config section, so keys a
+# launcher bridge (CLI ``env_mappings``) already wrote for the same section
+# are covered too; keys neither home configured are never touched.
+_terminal_config_bridge_keys: "set[str]" = set()
+# Serializes the check/purge/re-bridge sequence below: under profile
+# multiplexing, agents on different threads can race their first terminal
+# call, and an interleaved snapshot/purge would attribute the wrong
+# TERMINAL_* ownership set (e.g. drop user-exported keys).
+_terminal_config_bridge_lock = threading.Lock()
 
 
 def _ensure_terminal_env_bridged() -> None:
@@ -540,6 +561,22 @@ def _ensure_terminal_env_bridged() -> None:
     suppresses the bridge entirely: writing scope values into the process-global
     env would re-create the first-writer-wins cross-profile leak the scope fixes.
 
+    The bridge runs once per active Hermes home (context-local profile
+    override → ``HERMES_HOME`` env → platform default). Under multiplexed
+    profiles the override is the profile boundary, and a unified dashboard
+    backend serves several profiles through that same override — the first
+    terminal call used to pin the first home's TERMINAL_* into the shared
+    process env, so a docker home bridging first made every later local
+    profile inherit Docker ("sandbox flapping", #94200; docker-profile
+    commands on the host, #98581; the multiplexed-dashboard residual after
+    the per-turn scope fix, where the unscoped launch profile reads the
+    latched secondary profile's bridge, #107422). When the home changes,
+    the env vars the previous home's terminal section explicitly owns are
+    unset before re-bridging, so each profile resolves from its own config
+    — the same re-bridge ``web_server.py`` performs per-request for the
+    embedded chat PTY. Within one home the flag keeps its pure one-shot
+    optimization semantics.
+
     terminal_tool reads ALL terminal settings from os.environ (TERMINAL_*). See #61115, #65696.
     """
     from tools.terminal_scope import get_terminal_scope
@@ -547,18 +584,59 @@ def _ensure_terminal_env_bridged() -> None:
     if get_terminal_scope() is not None:
         return
     global _terminal_config_bridge_attempted
-    if _terminal_config_bridge_attempted:
-        return
-    _terminal_config_bridge_attempted = True
-    # Never let a config problem take the terminal tool down.
-    with _quiet("terminal config → env fallback bridge failed"):
-        from hermes_cli.config import apply_terminal_config_to_env, read_raw_config
+    global _terminal_config_bridge_scope, _terminal_config_bridge_keys
+    with _terminal_config_bridge_lock:
+        try:
+            from hermes_constants import hermes_home_key
 
-        raw_config = read_raw_config()
-        if isinstance(raw_config.get("terminal"), dict):
-            apply_terminal_config_to_env(env=None, override=True)
-        elif "TERMINAL_ENV" not in os.environ:
-            apply_terminal_config_to_env(env=None, override=False)
+            current_scope = hermes_home_key()
+        except Exception:
+            current_scope = None
+        if _terminal_config_bridge_attempted and _terminal_config_bridge_scope == current_scope:
+            return
+        # Profile handoff: drop the TERMINAL_* env vars the previous home's
+        # terminal section explicitly owned (keys the user's shell/.env
+        # exported for sections neither home configured stay put) so the
+        # incoming profile resolves from its own config instead of the
+        # previous home's backend selection (#94200, #98581, #107422). This
+        # runs BEFORE the attempt flags latch: if the config import or
+        # anything below raises, the stale keys are already gone and the
+        # failure path degrades to the historical local default — it must
+        # not re-leak the previous home's backend selection precisely when
+        # the config machinery is broken.
+        for key in _terminal_config_bridge_keys:
+            os.environ.pop(key, None)
+        _terminal_config_bridge_keys = set()
+        _terminal_config_bridge_attempted = True
+        _terminal_config_bridge_scope = current_scope
+        # Never let a config problem take the terminal tool down.
+        with _quiet("terminal config → env fallback bridge failed"):
+            from hermes_cli.config import (
+                apply_terminal_config_to_env,
+                read_raw_config,
+                terminal_config_owned_env_vars,
+            )
+
+            raw_config = read_raw_config()
+            raw_terminal = raw_config.get("terminal")
+
+            if isinstance(raw_terminal, dict):
+                # If config.yaml has an explicit terminal section, bridge with
+                # override enabled. The helper only overrides env vars for keys
+                # present in that raw section; merged defaults remain
+                # backfill-only.
+                apply_terminal_config_to_env(env=None, override=True)
+                # Record what this home's section owns so the next handoff can
+                # drop exactly those vars — including ones a launcher bridge
+                # (CLI env_mappings) wrote for the same section before the
+                # first terminal call, which a before/after diff would miss.
+                _terminal_config_bridge_keys = terminal_config_owned_env_vars(raw_terminal)
+            elif "TERMINAL_ENV" not in os.environ:
+                # No terminal section in config.yaml, TERMINAL_ENV not set —
+                # backfill from config defaults. Backfilled vars are not
+                # section-owned (the section does not exist), so they are left
+                # for the next handoff like any operator-exported value.
+                apply_terminal_config_to_env(env=None, override=False)
 
 
 # Default cwd per backend; anything else (container backends, plugins) is "/root".


### PR DESCRIPTION
## What does this PR do?

Under profile multiplexing (`gateway.multiplex_profiles: true`), `_ensure_terminal_env_bridged()`'s process-global one-shot flag let the first profile to run a terminal call permanently pin its `TERMINAL_*` selection into `os.environ`. With a docker-backend profile (e.g. `coder`) bridging before a local-backend one (e.g. `board-leonard`), every later profile inherited Docker — intermittent "sandbox flapping" depending on cron tick order at gateway boot.

This scopes the one-shot to the Hermes home (the reporter's suggested direction, verified in their fork): the last-bridged home is tracked alongside the flag, and a scope change re-bridges. On top of the reporter's patch it also unsets the `TERMINAL_*` keys the previous bridge introduced before re-bridging — without that, a profile whose config has no `terminal` section keeps the previous profile's backend forever through the `elif "TERMINAL_ENV" not in os.environ` branch, which is the leak's worst shape. Shell/.env-exported `TERMINAL_*` values are never bridge-owned and survive handoffs; within a single profile the one-shot semantics (and its optimization purpose) are unchanged.

## Related Issue

Fixes #94200
Fixes #98581

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/terminal_tool.py` (`_ensure_terminal_env_bridged`):
  - New module globals `_terminal_config_bridge_scope` (last-bridged `str(get_hermes_home())`) and `_terminal_config_bridge_keys` (the `TERMINAL_*` keys the last bridge introduced).
  - The one-shot guard now compares scope; on a scope change the bridge-introduced keys are popped from `os.environ` and the bridge re-runs for the incoming profile's config. Docstring documents the multiplexing failure mode.
- `tests/tools/test_terminal_env_bridge.py`:
  - The autouse reset fixture also resets the two new globals.
  - Four new tests: docker→local handoff re-bridges; a section-less profile no longer inherits the previous profile's docker selection (the `elif` branch path); one-shot within a single scope is preserved (single `apply_terminal_config_to_env` call across three `_get_env_config()` runs); shell-exported `TERMINAL_*` keys survive handoffs.

## How to Test

- Run: `.venv/bin/python -m pytest tests/tools/test_terminal_env_bridge.py tests/tools/test_docker_session_isolation.py tests/tools/test_terminal_degraded_mode.py -q`
- Observed result: `54 passed, 1 failed` — the single failure (`test_terminal_degraded_mode.py::TestConfigBridging::test_degraded_mode_is_bridged_everywhere`) reproduces identically on unpatched `main` (stash-compared), i.e. pre-existing in this environment. Within `test_terminal_env_bridge.py`: `13 passed`. Fail-on-main check (`git stash` of the source change): both scope-handoff tests fail against unpatched `main` (profile B inherits docker); the one-shot and shell-key tests pass both ways.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of the completed code performed
- [x] New and existing unit tests pass locally
- [x] Changes are backward-compatible (single-profile behavior unchanged; only cross-profile handoff gains the re-bridge)

