### PR TITLE
fix(desktop): scope registered ssh primary gateway

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -17,6 +17,7 @@ import {
 } from '@/store/boot'
 import {
   $gateway,
+  activeGatewayConnectionId,
   closeSecondaryGateways,
   configureGatewayRegistry,
   disposeSecondariesForConnection,
@@ -28,6 +29,7 @@ import {
   reconnectSecondaryGateways,
   reportPrimaryGatewayState,
   setPrimaryGateway,
+  setPrimaryGatewayConnectionId,
   touchSecondaryGateways
 } from '@/store/gateway'
 import { registerGatewayReconnect } from '@/store/gateway-reconnect'
@@ -181,6 +183,7 @@ export function useGatewayBoot({
     const publish = (next: HermesConnection | null) => {
       callbacksRef.current.onConnectionReady(next)
       setConnection(next)
+      setPrimaryGatewayConnectionId(next?.connectionId)
     }
 
     if (!desktop) {
@@ -668,9 +671,17 @@ export function useGatewayBoot({
 
     const sourceProfile = normalizeProfileKey($activeGatewayProfile.get())
 
-    const offEvent = gateway.onEvent(event =>
-      callbacksRef.current.handleGatewayEvent({ ...event, profile: sourceProfile })
-    )
+    const offEvent = gateway.onEvent(event => {
+      const connectionId = activeGatewayConnectionId()
+      const scopedEvent = {
+        ...event,
+        profile: sourceProfile,
+        ...(connectionId ? { connectionId } : {})
+      }
+
+      recordSessionEventScope(scopedEvent)
+      callbacksRef.current.handleGatewayEvent(scopedEvent)
+    })
 
     // Wake signals: power resume (macOS/Windows), network coming back, and the
     // window regaining focus/visibility. Each nudges an immediate reconnect.

--- a/apps/desktop/src/store/gateway-connection-scope.test.ts
+++ b/apps/desktop/src/store/gateway-connection-scope.test.ts
@@ -40,13 +40,16 @@ vi.mock('@/store/session', () => ({
 vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() }))
 
 const {
+  activeGatewayConnectionId,
   closeSecondaryGateways,
   configureGatewayRegistry,
   ensureGatewayForAgent,
   openGatewayForAgent,
   pruneSecondaryGateways,
-  setPrimaryGateway
+  setPrimaryGateway,
+  setPrimaryGatewayConnectionId
 } = await import('./gateway')
+const { setApiRequestConnection } = await import('@/hermes')
 
 function installDesktop(): void {
   ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
@@ -82,6 +85,25 @@ afterEach(() => {
   closeSecondaryGateways()
   vi.clearAllMocks()
   delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+describe('primary gateway registry scope', () => {
+  it('publishes a registered primary connection id for ambient API/WebSocket helpers', () => {
+    setPrimaryGateway({ connectionState: 'open' } as never, 'default')
+    setPrimaryGatewayConnectionId(' homelab-ssh ')
+
+    expect(activeGatewayConnectionId()).toBe('homelab-ssh')
+    expect(setApiRequestConnection).toHaveBeenLastCalledWith('homelab-ssh')
+  })
+
+  it('clears primary connection scope when the primary becomes legacy/local again', () => {
+    setPrimaryGateway({ connectionState: 'open' } as never, 'default')
+    setPrimaryGatewayConnectionId('homelab-ssh')
+    setPrimaryGateway({ connectionState: 'open' } as never, 'default')
+
+    expect(activeGatewayConnectionId()).toBeNull()
+    expect(setApiRequestConnection).toHaveBeenLastCalledWith(null)
+  })
 })
 
 describe('pruneSecondaryGateways with registry-scoped entries', () => {

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -100,6 +100,7 @@ const ACTIVATION_LEASE_MS = 30_000
 interface GatewayRegistryState {
   config: RegistryConfig | null
   primaryGateway: HermesGateway | null
+  primaryConnectionId: null | string
   primaryProfile: string
   activeKey: string
   activationEpoch: number
@@ -114,6 +115,7 @@ function createRegistryState(): GatewayRegistryState {
   return {
     config: null,
     primaryGateway: null,
+    primaryConnectionId: null,
     primaryProfile: 'default',
     activeKey: 'default',
     activationEpoch: 0,
@@ -187,7 +189,20 @@ export function emitLocalGatewayEvent(event: GatewayEvent): void {
 
 export function setPrimaryGateway(gateway: HermesGateway | null, profile = 'default'): void {
   g.primaryGateway = gateway
+  g.primaryConnectionId = null
   g.primaryProfile = normKey(profile)
+
+  if (g.activeKey === g.primaryProfile) {
+    setApiRequestConnection(null)
+  }
+}
+
+export function setPrimaryGatewayConnectionId(connectionId: null | string | undefined): void {
+  g.primaryConnectionId = (connectionId ?? '').trim() || null
+
+  if (g.activeKey === g.primaryProfile) {
+    setApiRequestConnection(g.primaryConnectionId)
+  }
 }
 
 export function isActivePrimary(): boolean {
@@ -222,7 +237,7 @@ export function activeGateway(): HermesGateway | null {
  */
 export function activeGatewayConnectionId(): null | string {
   if (g.activeKey === g.primaryProfile) {
-    return null
+    return g.primaryConnectionId
   }
 
   return g.secondaries.get(g.activeKey)?.connectionId ?? null


### PR DESCRIPTION
## Summary

Fixes the registered-SSH primary gateway path so the renderer keeps the selected SSH source identity after the main process successfully launches, forwards, and authenticates the remote dashboard. A registered SSH primary now publishes its `connectionId` to ambient API/WebSocket helpers and tags primary gateway events with that same source, instead of falling back to the legacy/local route after the SSH lifecycle succeeds.

---

## Changes

### `apps/desktop/src/store/gateway.ts`
- Tracks the registry connection id that backs the primary gateway.
- Returns that id from `activeGatewayConnectionId()` when the active socket is the primary registered source.
- Publishes/clears the ambient API request connection whenever the primary descriptor changes.

### `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts`
- Copies the booted primary connection id into the gateway registry store when `$connection` is published.
- Tags primary gateway events with the active registered connection id so session/runtime ownership stays on the SSH source.

### `apps/desktop/src/store/gateway-connection-scope.test.ts`
- Adds regression coverage for publishing and clearing a registered primary connection id.

---

## How to Test

```bash
npm --workspace apps/desktop exec -- vitest run src/store/gateway-connection-scope.test.ts src/app/gateway/hooks/use-gateway-boot.test.tsx
NODE_OPTIONS=--max-old-space-size=4096 npm --workspace apps/desktop run typecheck -- --pretty false
git diff --check
python scripts/check-windows-footguns.py --diff upstream/main
ruff check .
```

```text
Test Files  2 passed (2)
Tests       30 passed (30)
TYPECHECK_OK
✓ No Windows footguns found (0 file(s) scanned)
All checks passed!
```

ESLint was attempted but remains blocked in this Termux workspace: `npm --workspace apps/desktop run lint` exits with `eslint: Permission denied`; direct/transient ESLint resolution also cannot load the repo ESLint config package (`@eslint/js`) from this Android install.

---

## Checklist

- [x] Scoped fix only
- [x] Regression test added
- [x] Duplicate PR check completed
- [x] Cross-platform impact assessed: Windows SSH primary routing path
- [x] No `.env` behavioral setting added
- [x] No hardcoded `~/.hermes` path added

---

## Risk & Impact

Low. The change only affects renderer-side source identity propagation for the primary gateway; local/legacy primary connections still clear the ambient connection id, and secondary registry connections keep their existing behavior.

Type: Bug fix

Closes #94119
