### PR TITLE
feat(desktop): make blocked background chats easier to identify

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/attention-notification.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/attention-notification.test.tsx
@@ -1,0 +1,98 @@
+import { act, cleanup } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { NATIVE_NOTIFICATION_KINDS, setNativeNotifyEnabled, setNativeNotifyKind } from '@/store/native-notifications'
+import { __resetNativeNotifyBaselineForTests } from '@/store/notify-baseline'
+import { clearApprovalRequest } from '@/store/prompts'
+import { setMessagingSessions, setSessions } from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
+
+import { renderMessageStream } from './test-harness'
+
+const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
+const initialHermesDesktop = desktopWindow.hermesDesktop
+const notify = vi.fn().mockResolvedValue(true)
+
+const session = (id: string, title: string): SessionInfo =>
+  ({ id, message_count: 1, source: 'desktop', started_at: 0, title }) as SessionInfo
+
+describe('background prompt notifications', () => {
+  beforeEach(() => {
+    notify.mockClear()
+    desktopWindow.hermesDesktop = { notify } as unknown as Window['hermesDesktop']
+    Object.defineProperty(window.document, 'hidden', { configurable: true, value: false })
+    Object.defineProperty(window.document, 'hasFocus', { configurable: true, value: () => true })
+    setNativeNotifyEnabled(true)
+
+    for (const kind of NATIVE_NOTIFICATION_KINDS) {
+      setNativeNotifyKind(kind, true)
+    }
+
+    __resetNativeNotifyBaselineForTests()
+    setSessions([])
+    setMessagingSessions([])
+  })
+
+  afterEach(() => {
+    cleanup()
+    clearApprovalRequest()
+    setSessions([])
+    setMessagingSessions([])
+
+    if (initialHermesDesktop) {
+      desktopWindow.hermesDesktop = initialHermesDesktop
+    } else {
+      delete desktopWindow.hermesDesktop
+    }
+  })
+
+  it('names the off-screen chat that is waiting for approval', () => {
+    const stream = renderMessageStream('foreground')
+    setSessions([session('background-approval', 'Release checklist')])
+
+    act(() =>
+      stream.handleEvent({
+        payload: {
+          command: 'npm run test',
+          description: 'Run the test suite',
+          request_id: 'approval-1'
+        },
+        session_id: 'background-approval',
+        type: 'approval.request'
+      })
+    )
+
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'approval',
+        sessionId: 'background-approval',
+        title: expect.stringMatching(/ · Release checklist$/)
+      })
+    )
+  })
+
+  it('names a messaging-platform chat from the separate session list', () => {
+    const stream = renderMessageStream('foreground')
+    setMessagingSessions([session('telegram-approval', 'Release room')])
+
+    act(() =>
+      stream.handleEvent({
+        payload: {
+          command: 'npm run test',
+          description: 'Run the test suite',
+          request_id: 'approval-2'
+        },
+        session_id: 'telegram-approval',
+        type: 'approval.request'
+      })
+    )
+
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'approval',
+        sessionId: 'telegram-approval',
+        title: expect.stringMatching(/ · Release room$/)
+      })
+    )
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
@@ -1,6 +1,7 @@
 import { pendingClarifyToolPayload } from '@/app/session/hooks/use-session-actions/restore-pending-clarify'
 import { translateNow } from '@/i18n'
 import { restorePendingClarifyToolCall, settlePendingClarifyToolCall } from '@/lib/chat-messages'
+import { formatSessionNotificationTitle, notificationSessionTitle } from '@/lib/notification-session-title'
 import {
   $clarifyRequests,
   clearClarifyRequest,
@@ -13,9 +14,24 @@ import { $gateway } from '@/store/gateway'
 import { setMcpSetupRequest } from '@/store/mcp-setup'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { receiveApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
+import { $messagingSessions, $sessions } from '@/store/session'
 import { requestScrollToBottom } from '@/store/thread-scroll'
 
 import type { GatewayEventContext } from './types'
+
+function promptNotificationTitle(ctx: GatewayEventContext, baseTitle: string): string {
+  const { deps, event, sessionId } = ctx
+  const storedSessionId = sessionId ? deps.sessionStateByRuntimeIdRef.current.get(sessionId)?.storedSessionId : null
+
+  const title = notificationSessionTitle([...$sessions.get(), ...$messagingSessions.get()], {
+    connectionId: event.connectionId,
+    profile: event.profile,
+    runtimeSessionId: sessionId,
+    storedSessionId
+  })
+
+  return formatSessionNotificationTitle(baseTitle, title)
+}
 
 /** The blocking-input family: clarify / MCP setup consent / approval / sudo /
  *  secret requests. The Python side is blocked on the matching *.respond, so
@@ -102,7 +118,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         body: questions.map(q => q.question).join(' · '),
         kind: 'input',
         sessionId,
-        title: translateNow('notifications.native.inputTitle')
+        title: promptNotificationTitle(ctx, translateNow('notifications.native.inputTitle'))
       })
     } else if (requestId && question) {
       if (rawChoices != null && choices.length === 0) {
@@ -150,7 +166,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         body: question,
         kind: 'input',
         sessionId,
-        title: translateNow('notifications.native.inputTitle')
+        title: promptNotificationTitle(ctx, translateNow('notifications.native.inputTitle'))
       })
     }
 
@@ -219,7 +235,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         body: reason || server,
         kind: 'input',
         sessionId,
-        title: translateNow('notifications.native.inputTitle')
+        title: promptNotificationTitle(ctx, translateNow('notifications.native.inputTitle'))
       })
     }
 
@@ -261,7 +277,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
       body: command || description,
       kind: 'approval',
       sessionId,
-      title: translateNow('notifications.native.approvalTitle')
+      title: promptNotificationTitle(ctx, translateNow('notifications.native.approvalTitle'))
     })
 
     return true
@@ -283,7 +299,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         body: translateNow('notifications.native.inputBody'),
         kind: 'input',
         sessionId,
-        title: translateNow('notifications.native.inputTitle')
+        title: promptNotificationTitle(ctx, translateNow('notifications.native.inputTitle'))
       })
     }
 
@@ -314,7 +330,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         body: promptText || envVar || translateNow('notifications.native.inputBody'),
         kind: 'input',
         sessionId,
-        title: translateNow('notifications.native.inputTitle')
+        title: promptNotificationTitle(ctx, translateNow('notifications.native.inputTitle'))
       })
     }
 

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -23,7 +23,7 @@ import {
   togglePanesFlipped,
   toggleSidebarOpen
 } from '@/store/layout'
-import { $unreadSessionCount } from '@/store/session-dot-state'
+import { $sessionNoticeCount } from '@/store/session-dot-state'
 
 import { appViewForPath, isOverlayView } from '../routes'
 
@@ -135,9 +135,9 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
   const fileBrowserOpen = useStore($fileBrowserOpen)
   const panesFlipped = useStore($panesFlipped)
   const sidebarOpen = useStore($sidebarOpen)
-  const unreadCount = useStore($unreadSessionCount)
-  const unreadBadge = unreadCount > 0 ? unreadCount : undefined
-  const unreadHint = unreadBadge ? ` · ${t.titlebar.unreadSessions(unreadBadge)}` : ''
+  const noticeCount = useStore($sessionNoticeCount)
+  const noticeBadge = noticeCount > 0 ? noticeCount : undefined
+  const noticeHint = noticeBadge ? ` · ${t.titlebar.sessionNotices(noticeBadge)}` : ''
 
   const toggleHaptics = () => {
     if (!hapticsMuted) {
@@ -164,10 +164,10 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
   const leftToolbarTools: TitlebarTool[] = [
     {
       actionId: 'view.toggleSidebar',
-      badge: panesFlipped ? undefined : unreadBadge,
+      badge: panesFlipped ? undefined : noticeBadge,
       icon: <TitlebarIcon name="layout-sidebar-left" />,
       id: 'sidebar',
-      label: `${leftLabel}${panesFlipped ? '' : unreadHint}`,
+      label: `${leftLabel}${panesFlipped ? '' : noticeHint}`,
       onSelect: () => {
         triggerHaptic('tap')
         leftEdge.toggle()
@@ -188,10 +188,10 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
 
   const rightSidebarTool: TitlebarTool = {
     actionId: 'view.toggleRightSidebar',
-    badge: panesFlipped ? unreadBadge : undefined,
+    badge: panesFlipped ? noticeBadge : undefined,
     icon: <TitlebarIcon name="layout-sidebar-right" />,
     id: 'right-sidebar',
-    label: `${rightLabel}${panesFlipped ? unreadHint : ''}`,
+    label: `${rightLabel}${panesFlipped ? noticeHint : ''}`,
     onSelect: () => {
       triggerHaptic('tap')
       rightEdge.toggle()

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -211,7 +211,7 @@ export const ar = defineLocale({
     swapSidebarSides: 'تبديل جانبي الأشرطة',
     hideRightSidebar: 'إخفاء الشريط الأيمن',
     showRightSidebar: 'إظهار الشريط الأيمن',
-    unreadSessions: count => (count === 1 ? 'جلسة واحدة غير مقروءة' : `${count} جلسات غير مقروءة`),
+    sessionNotices: count => (count === 1 ? 'جلسة واحدة تحتاج إلى انتباهك' : `${count} جلسات تحتاج إلى انتباهك`),
     muteHaptics: 'كتم الاهتزازات',
     unmuteHaptics: 'تفعيل الاهتزازات',
     openSettings: 'فتح الإعدادات',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -244,7 +244,7 @@ export const en: Translations = {
     swapSidebarSides: 'Swap sidebar sides',
     hideRightSidebar: 'Hide right sidebar',
     showRightSidebar: 'Show right sidebar',
-    unreadSessions: count => (count === 1 ? '1 unread session' : `${count} unread sessions`),
+    sessionNotices: count => (count === 1 ? '1 session needs attention' : `${count} sessions need attention`),
     muteHaptics: 'Mute haptics',
     unmuteHaptics: 'Unmute haptics',
     openSettings: 'Open settings',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -245,7 +245,7 @@ export const ja = defineLocale({
     swapSidebarSides: 'サイドバーの向きを切り替え',
     hideRightSidebar: '右サイドバーを非表示',
     showRightSidebar: '右サイドバーを表示',
-    unreadSessions: count => (count === 1 ? '未読セッション 1 件' : `未読セッション ${count} 件`),
+    sessionNotices: count => `確認が必要なセッション ${count} 件`,
     muteHaptics: '触覚フィードバックをオフ',
     unmuteHaptics: '触覚フィードバックをオン',
     openSettings: '設定を開く',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -280,7 +280,7 @@ export interface Translations {
     swapSidebarSides: string
     hideRightSidebar: string
     showRightSidebar: string
-    unreadSessions: (count: number) => string
+    sessionNotices: (count: number) => string
     muteHaptics: string
     unmuteHaptics: string
     openSettings: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -237,7 +237,7 @@ export const zhHant = defineLocale({
     swapSidebarSides: '交換側邊欄位置',
     hideRightSidebar: '隱藏右側邊欄',
     showRightSidebar: '顯示右側邊欄',
-    unreadSessions: count => (count === 1 ? '1 個未讀工作階段' : `${count} 個未讀工作階段`),
+    sessionNotices: count => `${count} 個工作階段需要處理`,
     muteHaptics: '靜音觸感回饋',
     unmuteHaptics: '開啟觸感回饋',
     openSettings: '開啟設定',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -237,7 +237,7 @@ export const zh: Translations = {
     swapSidebarSides: '交换侧边栏位置',
     hideRightSidebar: '隐藏右侧栏',
     showRightSidebar: '显示右侧栏',
-    unreadSessions: count => (count === 1 ? '1 个未读会话' : `${count} 个未读会话`),
+    sessionNotices: count => `${count} 个会话需要处理`,
     muteHaptics: '关闭触感反馈',
     unmuteHaptics: '开启触感反馈',
     openSettings: '打开设置',

--- a/apps/desktop/src/lib/notification-session-title.test.ts
+++ b/apps/desktop/src/lib/notification-session-title.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionInfo } from '@/types/hermes'
+
+import { formatSessionNotificationTitle, notificationSessionTitle } from './notification-session-title'
+
+const row = (id: string, extra: Partial<SessionInfo> = {}): SessionInfo =>
+  ({ id, message_count: 1, source: 'desktop', started_at: 0, ...extra }) as SessionInfo
+
+describe('notificationSessionTitle', () => {
+  it('maps a runtime event through its stored session id', () => {
+    expect(
+      notificationSessionTitle([row('stored', { title: 'Fix authentication refresh' })], {
+        runtimeSessionId: 'runtime',
+        storedSessionId: 'stored'
+      })
+    ).toBe('Fix authentication refresh')
+  })
+
+  it('matches a compression lineage root', () => {
+    expect(
+      notificationSessionTitle([row('tip', { _lineage_root_id: 'root', title: 'Ship the release' })], {
+        storedSessionId: 'root'
+      })
+    ).toBe('Ship the release')
+  })
+
+  it('uses profile and connection scope to disambiguate identical ids', () => {
+    const sessions = [
+      row('same', { connection_id: 'west', profile: 'default', title: 'West chat' }),
+      row('same', { connection_id: 'east', profile: 'ops', title: 'East ops chat' })
+    ]
+
+    expect(
+      notificationSessionTitle(sessions, {
+        connectionId: 'east',
+        profile: 'ops',
+        runtimeSessionId: 'same'
+      })
+    ).toBe('East ops chat')
+  })
+
+  it('omits an ambiguous or mismatched label instead of naming the wrong chat', () => {
+    const sessions = [row('same', { title: 'One' }), row('same', { title: 'Two' })]
+
+    expect(notificationSessionTitle(sessions, { runtimeSessionId: 'same' })).toBe('')
+    expect(
+      notificationSessionTitle([row('same', { connection_id: 'remote', title: 'Remote' })], {
+        runtimeSessionId: 'same'
+      })
+    ).toBe('')
+  })
+
+  it('falls back to a compact preview', () => {
+    expect(
+      notificationSessionTitle([row('stored', { preview: `  ${'long '.repeat(20)}  ` })], { storedSessionId: 'stored' })
+    ).toMatch(/^long long .*…$/)
+  })
+})
+
+describe('formatSessionNotificationTitle', () => {
+  it('adds the chat label without changing the localized base title', () => {
+    expect(formatSessionNotificationTitle('Approval needed', 'Fix authentication')).toBe(
+      'Approval needed · Fix authentication'
+    )
+  })
+
+  it('keeps the original title when no safe label is available', () => {
+    expect(formatSessionNotificationTitle('Input needed', '')).toBe('Input needed')
+  })
+})

--- a/apps/desktop/src/lib/notification-session-title.ts
+++ b/apps/desktop/src/lib/notification-session-title.ts
@@ -1,0 +1,62 @@
+import type { SessionInfo } from '@/types/hermes'
+
+const MAX_NOTIFICATION_SESSION_TITLE = 64
+
+export interface NotificationSessionTitleContext {
+  connectionId?: null | string
+  profile?: null | string
+  runtimeSessionId?: null | string
+  storedSessionId?: null | string
+}
+
+const profileKey = (value: null | string | undefined): string => value?.trim() || 'default'
+
+const compact = (value: null | string | undefined): string => {
+  const normalized = value?.replace(/\s+/g, ' ').trim() || ''
+
+  if (normalized.length <= MAX_NOTIFICATION_SESSION_TITLE) {
+    return normalized
+  }
+
+  return `${normalized.slice(0, MAX_NOTIFICATION_SESSION_TITLE - 1).trimEnd()}…`
+}
+
+/** Resolve a chat label only when the event's session identity maps to one
+ *  unambiguous visible row. A wrong title is worse than no title when two
+ *  connected gateways happen to expose the same session id. */
+export function notificationSessionTitle(
+  sessions: readonly SessionInfo[],
+  context: NotificationSessionTitleContext
+): string {
+  const ids = new Set([context.runtimeSessionId, context.storedSessionId].filter((id): id is string => Boolean(id)))
+
+  if (ids.size === 0) {
+    return ''
+  }
+
+  let candidates = sessions.filter(
+    session => ids.has(session.id) || Boolean(session._lineage_root_id && ids.has(session._lineage_root_id))
+  )
+
+  if (context.connectionId?.trim()) {
+    const connectionId = context.connectionId.trim()
+    candidates = candidates.filter(session => session.connection_id?.trim() === connectionId)
+  } else {
+    candidates = candidates.filter(session => !session.connection_id?.trim())
+  }
+
+  if (context.profile != null) {
+    const profile = profileKey(context.profile)
+    candidates = candidates.filter(session => profileKey(session.profile) === profile)
+  }
+
+  if (candidates.length !== 1) {
+    return ''
+  }
+
+  return compact(candidates[0].title) || compact(candidates[0].preview)
+}
+
+export function formatSessionNotificationTitle(baseTitle: string, sessionTitle: string): string {
+  return sessionTitle ? `${baseTitle} · ${sessionTitle}` : baseTitle
+}

--- a/apps/desktop/src/store/session-dot-state.test.ts
+++ b/apps/desktop/src/store/session-dot-state.test.ts
@@ -16,10 +16,10 @@ import {
 import {
   $delegatingSessionIds,
   $sessionDotStateById,
-  $unreadSessionCount,
+  $sessionNoticeCount,
   hasLiveTurn,
-  showsRunningArc,
-  unreadSessionCount
+  sessionNoticeCount,
+  showsRunningArc
 } from './session-dot-state'
 import { clearAllSessionStates, publishSessionState } from './session-states'
 import { $unreadWriteGuard } from './session-unread-remote'
@@ -165,24 +165,29 @@ describe('persisted unread (backend watermark)', () => {
   })
 })
 
-describe('unreadSessionCount', () => {
-  it('counts listed unread rows and skips archived', () => {
+describe('sessionNoticeCount', () => {
+  it('counts listed unread and needs-input rows and skips archived', () => {
     expect(
-      unreadSessionCount({ a: 'unread', b: 'working', c: 'unread' }, [
+      sessionNoticeCount({ a: 'unread', b: 'needs-input', c: 'unread', d: 'working' }, [
         { id: 'a' },
         { id: 'b' },
         { archived: true, id: 'c' },
+        { id: 'd' },
         { id: 'missing' }
       ])
-    ).toBe(1)
+    ).toBe(2)
   })
 
   it('does not count alias keys that are not listed rows', () => {
-    expect(unreadSessionCount({ tip: 'unread', root: 'unread' }, [{ id: 'tip' }])).toBe(1)
+    expect(sessionNoticeCount({ tip: 'unread', root: 'unread' }, [{ id: 'tip' }])).toBe(1)
+  })
+
+  it('does not double-count a row present in two visible lists', () => {
+    expect(sessionNoticeCount({ same: 'needs-input' }, [{ id: 'same' }], [{ id: 'same' }])).toBe(1)
   })
 })
 
-describe('$unreadSessionCount (titlebar badge)', () => {
+describe('$sessionNoticeCount (collapsed-sidebar badge)', () => {
   beforeEach(() => {
     clearAllSessionStates()
     $sessions.set([])
@@ -208,13 +213,20 @@ describe('$unreadSessionCount (titlebar badge)', () => {
     // The cron row itself still paints unread in the sidebar cron section...
     expect($sessionDotStateById.get()['cron-1']).toBe('unread')
     // ...but the titlebar badge stays quiet.
-    expect($unreadSessionCount.get()).toBe(0)
+    expect($sessionNoticeCount.get()).toBe(0)
   })
 
   it('counts an unread regular session', () => {
     setSessions([storedRow('reg-1', { unread: true })])
 
-    expect($unreadSessionCount.get()).toBe(1)
+    expect($sessionNoticeCount.get()).toBe(1)
+  })
+
+  it('counts a regular session that needs input', () => {
+    setSessions([storedRow('reg-1')])
+    publishSessionState('runtime-1', { ...createClientSessionState('reg-1'), needsInput: true })
+
+    expect($sessionNoticeCount.get()).toBe(1)
   })
 
   it('counts regular + messaging but never cron', () => {
@@ -223,7 +235,7 @@ describe('$unreadSessionCount (titlebar badge)', () => {
     setCronSessions([storedRow('cron-1', { source: 'cron' })])
     $unreadFinishedSessionIds.set(['msg-1', 'cron-1'])
 
-    expect($unreadSessionCount.get()).toBe(2)
+    expect($sessionNoticeCount.get()).toBe(2)
   })
 
   it('mark-all-read clears regular and cron unread alike', () => {
@@ -231,12 +243,12 @@ describe('$unreadSessionCount (titlebar badge)', () => {
     setCronSessions([storedRow('cron-1', { source: 'cron' })])
     $unreadFinishedSessionIds.set(['reg-1', 'cron-1'])
 
-    expect($unreadSessionCount.get()).toBe(1)
+    expect($sessionNoticeCount.get()).toBe(1)
     expect($sessionDotStateById.get()['cron-1']).toBe('unread')
 
     markAllSessionsRead()
 
-    expect($unreadSessionCount.get()).toBe(0)
+    expect($sessionNoticeCount.get()).toBe(0)
     expect($sessionDotStateById.get()['cron-1']).not.toBe('unread')
   })
 })

--- a/apps/desktop/src/store/session-dot-state.ts
+++ b/apps/desktop/src/store/session-dot-state.ts
@@ -183,31 +183,35 @@ export const $sessionDotStateById = computed(
   }
 )
 
-/** Listed, non-archived rows whose resolved status is unread. Alias keys in
- *  `$sessionDotStateById` are ignored unless they are themselves a listed row. */
-export function unreadSessionCount(
+/** Listed, non-archived rows that have something new OR need an answer. Alias
+ *  keys in `$sessionDotStateById` are ignored unless they are themselves a
+ *  listed row. The resolved state is mutually exclusive, so a session that is
+ *  both unread and blocked still contributes exactly one notice. */
+export function sessionNoticeCount(
   byId: Readonly<Record<string, SessionDotState>>,
   ...lists: Array<readonly { archived?: boolean; id: string }[]>
 ): number {
-  let n = 0
+  const counted = new Set<string>()
 
   for (const rows of lists) {
     for (const row of rows) {
-      if (!row.archived && byId[row.id] === 'unread') {
-        n++
+      const state = byId[row.id]
+
+      if (!row.archived && (state === 'needs-input' || state === 'unread')) {
+        counted.add(row.id)
       }
     }
   }
 
-  return n
+  return counted.size
 }
 
-/** The titlebar badge. Cron sessions are deliberately EXCLUDED: cron runs
+/** The collapsed-sidebar badge. Cron sessions are deliberately EXCLUDED: cron runs
  *  finish unwatched by design, so counting them turns the badge into a cron
  *  run counter that is permanently lit (#93552). Their unread state stays
  *  visible where it belongs — the sidebar's cron section rows — and
  *  "mark all as read" still acks them (ackAllSessionsRead iterates cron rows). */
-export const $unreadSessionCount = computed(
+export const $sessionNoticeCount = computed(
   [$sessionDotStateById, $sessions, $messagingSessions],
-  (byId, sessions, messaging) => unreadSessionCount(byId, sessions, messaging)
+  (byId, sessions, messaging) => sessionNoticeCount(byId, sessions, messaging)
 )


### PR DESCRIPTION
## Why

Hermes already parks blocking prompts per session, paints the amber **Needs your input** dot, and sends native Desktop notifications. In a multi-chat workflow, two small gaps still make the waiting chat easy to miss:

- a native notification says **Approval needed** or **Input needed**, but not which chat needs it;
- when the sidebar is collapsed, its global badge counts unread finished work but not chats waiting for an answer.

This PR extends those existing attention surfaces. It does not add a notification subsystem, backend endpoint, model tool, or prompt change.

## What changes

- Names the originating chat in every blocking-input notification family: clarify, MCP setup consent, approval, sudo, and secret prompts. Example: **Approval needed · Release checklist**.
- Covers both ordinary Desktop sessions and messaging-platform sessions through their existing separate session lists.
- Generalizes the collapsed-sidebar badge to count sessions that are either unread or waiting for input.
- Keeps archived and cron sessions out of the global count and deduplicates rows shared by the regular and messaging lists.
- Resolves notification labels across runtime, stored, and lineage-root session IDs, scoped by profile and connection.
- Fails closed when identity is missing or ambiguous: Hermes keeps the original localized notification title instead of risking the wrong chat name.
- Normalizes whitespace, falls back to the session preview, and caps the label at 64 characters.
- Updates the titlebar copy in all currently shipped Desktop locales.

## Demo

![A background Hermes chat marked with an amber Needs your input dot and a global one-session attention badge](https://raw.githubusercontent.com/JinUltimate1995/hermes-agent/codex/pr-assets-94209/.github/pr-assets/94209/session-attention.jpg)

The amber row is the existing per-session signal. This PR makes it contribute to the global titlebar badge, so the waiting state remains visible when the user is in another chat or collapses the sidebar.

## Existing-work alignment

- Builds on #45866 (cross-platform Electron native notifications) and #38631 (per-session parked prompts and the amber waiting dot).
- Related to the broader visibility requests in #50718 and #59784.
- Deliberately does **not** duplicate the approval-registry polling fix tracked in #86565: #86621 and #88140 already propose that backend correction. This PR is complementary—the notification label works at event time, while the global approval cue stays persistent across refreshes once that registry fix lands.
- Existing approval choices remain unchanged: Manual, Smart, Off, and session-only `/yolo`.

## Validation

- `npm run typecheck`
- ESLint on every changed TypeScript file
- 72 focused tests covering the message-stream event path, native notification dispatch, regular and messaging session identity resolution, parked clarify hydration, and session-dot aggregation
- Full Desktop UI suite: **5,725 tests passed** across 595 files
- Isolated live Desktop test on macOS: created a contained public demo session, triggered a real manual approval, switched to another chat, observed the amber waiting dot plus **1 session needs attention**, then rejected the demo approval

No Python, backend, model, prompt-caching, or core-tool code is changed.
