### PR TITLE
fix(tools): keep file-operation stdout free of shell-hook stderr

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -15,7 +15,7 @@ class _TestableEnv(BaseEnvironment):
     def __init__(self, cwd="/tmp", timeout=10):
         super().__init__(cwd=cwd, timeout=timeout)
 
-    def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):
+    def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None, merge_stderr=True):
         raise NotImplementedError("Use mock")
 
     def cleanup(self):
@@ -139,7 +139,7 @@ class TestAtomicSnapshotWrite:
         env = _TestableEnv()
         captured = {}
 
-        def fake_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None):
+        def fake_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None, merge_stderr=True):
             captured.setdefault("cmd", cmd_string)  # only the bootstrap; ignore the failure-path probe
             raise RuntimeError("stop after capture")
 
@@ -159,7 +159,7 @@ class TestAtomicSnapshotWrite:
         env = _TestableEnv()
         captured = {}
 
-        def fake_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None):
+        def fake_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None, merge_stderr=True):
             captured.setdefault("cmd", cmd_string)  # only the bootstrap; ignore the failure-path probe
             raise RuntimeError("stop after capture")
 
@@ -272,7 +272,7 @@ class TestSnapshotFileModes:
             def get_temp_dir(self):
                 return self._temp_dir
 
-            def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):
+            def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None, merge_stderr=True):
                 proc = subprocess.Popen(
                     ["/bin/bash", "-lc", cmd_string],
                     stdout=subprocess.PIPE,
@@ -364,7 +364,7 @@ class TestInitSessionFailure:
         """Login snapshot failure + working non-login probe → don't use bash -l."""
         env = _TestableEnv()
 
-        def mock_run_bash(cmd, *, login=False, timeout=120, stdin_data=None):
+        def mock_run_bash(cmd, *, login=False, timeout=120, stdin_data=None, merge_stderr=True):
             mock = MagicMock()
             mock.poll.return_value = 0
             mock.stdout = iter([])
@@ -382,7 +382,7 @@ class TestInitSessionFailure:
 
         calls = []
 
-        def track_run_bash(cmd, *, login=False, timeout=120, stdin_data=None):
+        def track_run_bash(cmd, *, login=False, timeout=120, stdin_data=None, merge_stderr=True):
             calls.append({"login": login})
             mock = MagicMock()
             mock.poll.return_value = 0

--- a/tests/tools/test_file_tools_live.py
+++ b/tests/tools/test_file_tools_live.py
@@ -97,6 +97,15 @@ class TestLocalEnvironmentExecute:
         assert result["output"] == "exact"
         _assert_clean(result["output"])
 
+    def test_merged_stderr_still_shows_bash_env_hook(self, env, tmp_path, monkeypatch):
+        """Interactive terminal commands keep hook diagnostics on the merged pipe."""
+        hook = tmp_path / "hook.sh"
+        hook.write_text("printf 'HOOK_WARNING\\n' >&2\n")
+        monkeypatch.setenv("BASH_ENV", str(hook))
+        result = env.execute("printf 'PAYLOAD\\n'")
+        assert result["returncode"] == 0
+        assert "HOOK_WARNING" in result["output"]
+        assert "PAYLOAD" in result["output"]
 
     def test_cat_deterministic_content(self, env, tmp_path):
         f = tmp_path / "det.txt"
@@ -105,6 +114,32 @@ class TestLocalEnvironmentExecute:
         assert result["returncode"] == 0
         assert result["output"] == SIMPLE_CONTENT
         _assert_clean(result["output"])
+
+    def test_split_stderr_still_appended_on_failure(self, env, tmp_path, monkeypatch):
+        """File-ops split streams on success; failures still keep stderr text."""
+        hook = tmp_path / "hook.sh"
+        hook.write_text("printf 'HOOK_WARNING\\n' >&2\n")
+        monkeypatch.setenv("BASH_ENV", str(hook))
+        result = env.execute("printf 'PAYLOAD\\n'; printf 'CMD_ERR\\n' >&2; exit 3", merge_stderr=False)
+        assert result["returncode"] == 3
+        assert "PAYLOAD" in result["output"]
+        assert "CMD_ERR" in result["output"]
+
+
+class TestFileOpsExactStdout:
+    def test_read_file_drops_bash_env_hook_warning(self, tmp_path, monkeypatch):
+        """Internal file-ops must not treat shell-hook stderr as file bytes (#94078)."""
+        hook = tmp_path / "hook.sh"
+        hook.write_text("printf 'HOOK_WARNING\\n' >&2\n")
+        monkeypatch.setenv("BASH_ENV", str(hook))
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+        ops = ShellFileOperations(env, cwd=str(tmp_path))
+        target = tmp_path / "payload.txt"
+        target.write_text("PAYLOAD\n")
+        result = ops.read_file(str(target))
+        assert result.error is None
+        assert "HOOK_WARNING" not in (result.content or "")
+        assert "PAYLOAD" in (result.content or "")
 
 
 # ── _has_command ─────────────────────────────────────────────────────────

--- a/tests/tools/test_file_tools_live.py
+++ b/tests/tools/test_file_tools_live.py
@@ -125,6 +125,24 @@ class TestLocalEnvironmentExecute:
         assert "PAYLOAD" in result["output"]
         assert "CMD_ERR" in result["output"]
 
+    def test_split_stderr_kept_when_returncode_is_none(self, env, tmp_path, monkeypatch):
+        """A missing wait code must not drop captured stderr (#94078 review)."""
+        hook = tmp_path / "hook.sh"
+        hook.write_text("printf 'HOOK_WARNING\\n' >&2\n")
+        monkeypatch.setenv("BASH_ENV", str(hook))
+        real_wait = env._wait_for_process
+
+        def wait_without_code(proc, **kwargs):
+            result = real_wait(proc, **kwargs)
+            result["returncode"] = None
+            return result
+
+        monkeypatch.setattr(env, "_wait_for_process", wait_without_code)
+        result = env.execute("printf 'PAYLOAD\\n'; printf 'CMD_ERR\\n' >&2", merge_stderr=False)
+        assert result["returncode"] is None
+        assert "PAYLOAD" in result["output"]
+        assert "CMD_ERR" in result["output"]
+
 
 class TestFileOpsExactStdout:
     def test_read_file_drops_bash_env_hook_warning(self, tmp_path, monkeypatch):

--- a/tests/tools/test_init_session_cwd_respect.py
+++ b/tests/tools/test_init_session_cwd_respect.py
@@ -25,7 +25,7 @@ class _TestableEnv(BaseEnvironment):
     def __init__(self, cwd="/tmp", timeout=10):
         super().__init__(cwd=cwd, timeout=timeout)
 
-    def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):
+    def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None, merge_stderr=True):
         raise NotImplementedError("Use mock")
 
     def cleanup(self):
@@ -42,7 +42,7 @@ class TestInitSessionCwdRespect:
         # Capture the bootstrap script that init_session would pass to _run_bash
         captured = {}
 
-        def mock_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None):
+        def mock_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None, merge_stderr=True):
             captured["cmd"] = cmd_string
             mock = MagicMock()
             mock.poll.return_value = 0
@@ -81,7 +81,7 @@ class TestInitSessionCwdRespect:
 
         captured = {}
 
-        def mock_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None):
+        def mock_run_bash(cmd_string, *, login=False, timeout=120, stdin_data=None, merge_stderr=True):
             captured["cmd"] = cmd_string
             mock = MagicMock()
             mock.poll.return_value = 0

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -311,7 +311,7 @@ class TestWrapCommandWindowsNativeCwd:
     def test_init_session_bootstrap_rewrites_backslash_snapshot_paths(self, monkeypatch):
         captured = {}
 
-        def fake_run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):
+        def fake_run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None, merge_stderr=True):
             captured.setdefault("script", cmd_string)  # bootstrap only; ignore the failure-path probe
             raise RuntimeError("stop after capturing bootstrap")
 

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -703,11 +703,17 @@ class BaseEnvironment(ABC):
         login: bool = False,
         timeout: int = 120,
         stdin_data: str | None = None,
+        merge_stderr: bool = True,
     ) -> ProcessHandle:
         """Spawn a bash process to run *cmd_string*.
 
         Returns a ProcessHandle (subprocess.Popen or _ThreadedProcessHandle).
         Must be overridden by every backend.
+
+        ``merge_stderr=False`` asks the backend to keep stderr off the
+        stdout pipe so internal file-operation consumers get an exact
+        data channel (#94078). Backends that cannot split streams may
+        ignore the flag.
         """
         raise NotImplementedError(f"{type(self).__name__} must implement _run_bash()")
 
@@ -1213,6 +1219,34 @@ class BaseEnvironment(ABC):
 
         drain_thread = threading.Thread(target=_drain, daemon=True)
         drain_thread.start()
+
+        # When stdout and stderr are separate pipes (file-operation path),
+        # drain stderr too or a chatty hook can fill the pipe and deadlock
+        # the child. Terminal commands still merge stderr into stdout, so
+        # proc.stderr is None there.
+        stderr_chunks: list[str] = []
+        stderr_thread: threading.Thread | None = None
+        if getattr(proc, "stderr", None) is not None:
+            def _drain_stderr() -> None:
+                stream = proc.stderr
+                try:
+                    data = stream.read() if stream is not None else None
+                except Exception:
+                    return
+                if not data:
+                    return
+                if isinstance(data, bytes):
+                    stderr_chunks.append(data.decode("utf-8", errors="replace"))
+                else:
+                    stderr_chunks.append(str(data))
+
+            stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
+            stderr_thread.start()
+
+        def _join_io(timeout: float = 2) -> None:
+            drain_thread.join(timeout=timeout)
+            if stderr_thread is not None:
+                stderr_thread.join(timeout=timeout)
         deadline = time.monotonic() + timeout
         _now = time.monotonic()
         _activity_state = {
@@ -1251,11 +1285,12 @@ class BaseEnvironment(ABC):
                             _tid, _pid, _iter_count, time.monotonic() - _activity_state["start"],
                         )
                     self._kill_process(proc)
-                    drain_thread.join(timeout=2)
+                    _join_io()
                     return self._finalize_wait_result(
                         output,
                         output.render(suffix="\n[Command interrupted]"),
                         130,
+                        stderr="".join(stderr_chunks),
                     )
                 if time.monotonic() > deadline:
                     if _DEBUG_INTERRUPT:
@@ -1265,7 +1300,7 @@ class BaseEnvironment(ABC):
                             _tid, _pid, _iter_count, timeout,
                         )
                     self._kill_process(proc)
-                    drain_thread.join(timeout=2)
+                    _join_io()
                     timeout_msg = f"\n[Command timed out after {timeout}s]"
                     return self._finalize_wait_result(
                         output,
@@ -1273,6 +1308,7 @@ class BaseEnvironment(ABC):
                         if output.total_chars == 0
                         else output.render(suffix=timeout_msg),
                         124,
+                        stderr="".join(stderr_chunks),
                     )
                 # Periodic activity touch so the gateway knows we're alive
                 touch_activity_if_due(_activity_state, "terminal command running")
@@ -1323,7 +1359,7 @@ class BaseEnvironment(ABC):
                 )
             try:
                 self._kill_process(proc)
-                drain_thread.join(timeout=2)
+                _join_io()
             except Exception:
                 pass  # cleanup is best-effort
             raise
@@ -1331,10 +1367,15 @@ class BaseEnvironment(ABC):
         # Drain thread now exits promptly after bash does (~300ms idle
         # check).  A short join is enough; a long one would be a bug since
         # it means the non-blocking loop itself stopped cooperating.
-        drain_thread.join(timeout=2)
+        _join_io()
 
         try:
             proc.stdout.close()
+        except Exception:
+            pass
+        try:
+            if getattr(proc, "stderr", None) is not None:
+                proc.stderr.close()
         except Exception:
             pass
 
@@ -1356,7 +1397,9 @@ class BaseEnvironment(ABC):
         if stdin_thread is not None:
             stdin_thread.join(timeout=5)
         rendered = output.render()
-        result = self._finalize_wait_result(output, rendered, proc.returncode)
+        result = self._finalize_wait_result(
+            output, rendered, proc.returncode, stderr="".join(stderr_chunks)
+        )
         stdin_errors = getattr(proc, "_hermes_stdin_errors", None)
         if stdin_errors:
             err = str(stdin_errors[0])
@@ -1366,9 +1409,12 @@ class BaseEnvironment(ABC):
 
     @staticmethod
     def _finalize_wait_result(collector: "_BoundedOutputCollector",
-                              rendered: str, returncode: int | None) -> dict:
+                              rendered: str, returncode: int | None,
+                              stderr: str = "") -> dict:
         """Assemble a wait result, attaching spill metadata when overflow occurred."""
         result = {"output": rendered, "returncode": returncode}
+        if stderr:
+            result["stderr"] = stderr
         spill = collector.close_spill()
         if spill:
             result["output_total_chars"] = collector.total_chars
@@ -1459,6 +1505,7 @@ class BaseEnvironment(ABC):
         stdin_data: str | None = None,
         rewrite_compound_background: bool = True,
         bounded_capture: bool = False,
+        merge_stderr: bool = True,
     ) -> dict:
         """Execute a command, return {"output": str, "returncode": int}.
 
@@ -1470,6 +1517,11 @@ class BaseEnvironment(ABC):
         full-fidelity consumers — file operations ``cat`` reads that feed
         the patch engine, code-execution RPC reads, log reads — MUST leave
         it False: truncating those corrupts data, not just display.
+
+        ``merge_stderr=False`` keeps hook/diagnostic stderr off the stdout
+        used as a file-operation data channel (#94078). Failed commands still
+        append stderr so error text is not lost. The default remains merged
+        so interactive terminal commands keep showing shell-hook warnings.
         """
         self._before_execute()
 
@@ -1503,13 +1555,24 @@ class BaseEnvironment(ABC):
         login = not self._snapshot_ready and not self._prefer_nonlogin
 
         proc = self._run_bash(
-            wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
+            wrapped,
+            login=login,
+            timeout=effective_timeout,
+            stdin_data=effective_stdin,
+            merge_stderr=merge_stderr,
         )
         result = self._wait_for_process(
             proc, timeout=effective_timeout, bounded_capture=bounded_capture
         )
         self._update_cwd(result)
 
+        if not merge_stderr:
+            # Success: stdout is the data. Failure: keep stderr so callers
+            # still see rg/python diagnostics that used to ride on the
+            # merged pipe.
+            extra = result.pop("stderr", "") or ""
+            if result.get("returncode"):
+                result["output"] = f"{result.get('output') or ''}{extra}"
         return result
 
     # ------------------------------------------------------------------

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -1567,11 +1567,12 @@ class BaseEnvironment(ABC):
         self._update_cwd(result)
 
         if not merge_stderr:
-            # Success: stdout is the data. Failure: keep stderr so callers
-            # still see rg/python diagnostics that used to ride on the
-            # merged pipe.
+            # Success (exit 0): stdout is the data. Any other outcome —
+            # nonzero *or* a missing code (killed/interrupted before
+            # wait set one) — keeps stderr so rg/python diagnostics
+            # that used to ride the merged pipe are not dropped.
             extra = result.pop("stderr", "") or ""
-            if result.get("returncode"):
+            if result.get("returncode") != 0:
                 result["output"] = f"{result.get('output') or ''}{extra}"
         return result
 

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -218,8 +218,10 @@ class DaytonaEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None):
+                  stdin_data: str | None = None,
+                  merge_stderr: bool = True):
         """Return a _ThreadedProcessHandle wrapping a blocking Daytona SDK call."""
+        del merge_stderr
         sandbox = self._sandbox
         lock = self._lock
 

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -1609,7 +1609,8 @@ class DockerEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None) -> subprocess.Popen:
+                  stdin_data: str | None = None,
+                  merge_stderr: bool = True) -> subprocess.Popen:
         """Spawn a bash process inside the Docker container."""
         assert self._container_id, "Container not started"
         cmd = [self._docker_exe, "exec"]

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1787,7 +1787,8 @@ class LocalEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None) -> subprocess.Popen:
+                  stdin_data: str | None = None,
+                  merge_stderr: bool = True) -> subprocess.Popen:
         bash = _find_bash()
         # For login-shell invocations (used by init_session to build the
         # environment snapshot), prepend sources for the user's bashrc /
@@ -1838,7 +1839,11 @@ class LocalEnvironment(BaseEnvironment):
             encoding="utf-8",
             errors="replace",
             stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
+            # File operations need stdout as an exact data channel. Merging
+            # stderr here lets BASH_ENV / shell-hook warnings become part of
+            # a file read or patch payload (#94078). Interactive terminal
+            # commands still merge (default) so those diagnostics stay visible.
+            stderr=subprocess.STDOUT if merge_stderr else subprocess.PIPE,
             stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
             start_new_session=True,
             cwd=_popen_cwd,

--- a/tools/environments/modal.py
+++ b/tools/environments/modal.py
@@ -407,8 +407,10 @@ class ModalEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None):
+                  stdin_data: str | None = None,
+                  merge_stderr: bool = True):
         """Return a _ThreadedProcessHandle wrapping an async Modal sandbox exec."""
+        del merge_stderr
         sandbox = self._sandbox
         worker = self._worker
 

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -239,7 +239,8 @@ class SingularityEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None) -> subprocess.Popen:
+                  stdin_data: str | None = None,
+                  merge_stderr: bool = True) -> subprocess.Popen:
         """Spawn a bash process inside the Singularity instance."""
         if not self._instance_started:
             raise RuntimeError("Singularity instance not started")

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -402,7 +402,8 @@ class SSHEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None) -> subprocess.Popen:
+                  stdin_data: str | None = None,
+                  merge_stderr: bool = True) -> subprocess.Popen:
         """Spawn an SSH process that runs bash on the remote host."""
         cmd = self._build_ssh_command()
         if login:

--- a/tools/environments/vercel_sandbox.py
+++ b/tools/environments/vercel_sandbox.py
@@ -601,6 +601,7 @@ class VercelSandboxEnvironment(BaseEnvironment):
         login: bool = False,
         timeout: int = 120,
         stdin_data: str | None = None,
+        merge_stderr: bool = True,
     ):
         """Run a bash command in the Vercel sandbox.
 
@@ -615,6 +616,7 @@ class VercelSandboxEnvironment(BaseEnvironment):
         """
         del timeout
         del stdin_data
+        del merge_stderr
 
         sandbox = self._sandbox
         if sandbox is None:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -367,10 +367,10 @@ def _search_stdout_and_limit(result: ExecuteResult) -> tuple[str, Optional[str]]
 def _split_tool_diagnostics(output: str) -> tuple[str, str]:
     """Separate rg/grep diagnostic lines from real match output.
 
-    ``_exec`` runs commands with ``stderr=subprocess.STDOUT``, so error and
-    warning text from ``rg``/``grep`` is interleaved with match lines in a
-    single stream. Diagnostics must not be parsed as matches, and on a hard
-    failure they are the error message to surface.
+    Failed commands still append stderr so ``rg``/``grep`` diagnostics remain
+    in the captured output. On success, stdout is exact match text. Diagnostics
+    must not be parsed as matches, and on a hard failure they are the error
+    message to surface.
 
     Returns ``(diagnostics, payload)`` where ``payload`` contains only lines
     that look like real search output — a match line (``file:line:content``),
@@ -945,7 +945,12 @@ class ShellFileOperations(FileOperations):
         # Resolve cwd from the live env so `cd` commands are picked up.
         # Fall through to init-time self.cwd only if the env doesn't track cwd.
         effective_cwd = cwd or getattr(self.env, 'cwd', None) or self.cwd
-        result = self.env.execute(command, cwd=effective_cwd, **kwargs)
+        # Keep stdout exact: BASH_ENV / shell-hook warnings on stderr must
+        # not become part of a file read, write verify, or patch payload
+        # (#94078). Interactive terminal execute() still merges by default.
+        result = self.env.execute(
+            command, cwd=effective_cwd, merge_stderr=False, **kwargs
+        )
         exit_code = result.get("returncode", 0)
         # A stdin write failure with an otherwise-clean child exit is still
         # a failure: the child never received the intended input. write_file
@@ -3178,8 +3183,8 @@ class ShellFileOperations(FileOperations):
         result = self._exec(cmd, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
 
-        # _exec merges stderr into stdout (stderr=subprocess.STDOUT), so rg's
-        # diagnostic lines ("rg: <file>: <error>", "rg: regex parse error:")
+        # Failed _exec still appends stderr, so rg's diagnostic lines
+        # ("rg: <file>: <error>", "rg: regex parse error:")
         # are interleaved with match output. Split them out: diagnostics must
         # not be parsed as matches, and on a hard error they ARE the message.
         diagnostics, payload = _split_tool_diagnostics(stdout)
@@ -3326,8 +3331,8 @@ class ShellFileOperations(FileOperations):
         result = self._exec(cmd, timeout=60)
         stdout, limit_reason = _search_stdout_and_limit(result)
 
-        # _exec merges stderr into stdout, so grep's diagnostic lines
-        # ("grep: <file>: <error>") are interleaved with matches. Split them
+        # Failed _exec still appends stderr, so grep's diagnostic lines
+        # ("grep: <file>: <error>") stay available. Split them
         # out so they're never parsed as matches and so a hard error has a
         # clean message.
         diagnostics, payload = _split_tool_diagnostics(stdout)


### PR DESCRIPTION
## What does this PR do?

Internal file operations (`read_file`, write verify, patch, search) treat command stdout as data. The local backend merged stderr into that stream, so a noisy `BASH_ENV` / shell-hook warning became part of a file read or patch payload.

Split stdout/stderr on the file-operation `execute()` path only (`merge_stderr=False`). Interactive terminal `execute()` still merges so hook diagnostics stay visible. Failed commands still append stderr so `rg`/`grep` errors are not lost. No internal-operation marker and no auth bypass.

## Related Issue

Fixes #94078

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tools/file_operations.py`: `ShellFileOperations._exec()` calls `execute(..., merge_stderr=False)`
- `tools/environments/base.py`: `merge_stderr` on `execute()` / `_run_bash()`; drain stderr to avoid pipe deadlock; append stderr on failure
- `tools/environments/local.py`: `stderr=PIPE` when not merging (other backends accept the flag; those that cannot split may ignore it)
- Tests: file-ops stdout stays exact under a noisy `BASH_ENV`; merged terminal path still shows the hook; failed split execute still keeps stderr

## How to Test

```text
scripts/run_tests.sh \
  tests/tools/test_file_tools_live.py \
  tests/tools/test_base_environment.py \
  tests/tools/test_init_session_cwd_respect.py \
  tests/tools/test_local_env_windows_msys.py
# 57 passed, 16 skipped (windows_only on linux)
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A (no UI change)
