### PR TITLE
fix(agent): charge stale thinking on DeepSeek/Kimi replay

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1384,6 +1384,28 @@ _NEWEST_TURN_ONLY_BUDGET_KEYS = (
     "reasoning_content",
 )
 
+# DeepSeek/Kimi thinking chat endpoints echo every historical
+# reasoning_content block on each request. Newest-turn-only accounting
+# then undercounts the tail, compaction fires late, and the session
+# hits an upstream 400 (#80246). Anthropic still strips all-but-newest
+# at convert time; Bedrock Converse never replays thinking.
+_STALE_THINKING_REPLAY_MARKERS = (
+    "deepseek",
+    "kimi",
+    "moonshot",
+)
+
+
+def _stale_thinking_reaches_the_wire(model: str = "", provider: str = "") -> bool:
+    """True when older-turn thinking is still sent on the wire.
+
+    Match model id and provider slug so ``deepseek-v4-flash``,
+    ``kimi-k2.5``, and a ``moonshot`` provider all charge historical
+    reasoning_content. Unrelated models keep the #73624 skip.
+    """
+    blob = f"{model} {provider}".lower()
+    return any(token in blob for token in _STALE_THINKING_REPLAY_MARKERS)
+
 # Replay keys that can be safely pruned from stale assistant messages during
 # compaction.  ``codex_reasoning_items`` carries encrypted reasoning blobs that
 # are only needed for the current turn's replay — prior-turn items are pure
@@ -3784,14 +3806,19 @@ class ContextCompressor(ContextEngine):
                 len(result),
                 _MAX_TAIL_MESSAGE_FLOOR,
             )
-            # Same newest-turn-only thinking charge as the tail-cut walk
-            # (#73624) — this boundary decides which tool results stay
-            # prunable, and overcharging stale thinking shrinks that window.
+            # Same thinking charge as the tail-cut walk: newest-turn-only
+            # except DeepSeek/Kimi, which replay historical reasoning
+            # (#73624, #80246). This boundary decides which tool results
+            # stay prunable.
             _newest_asst_idx = _last_assistant_index(result)
+            _charge_all_thinking = _stale_thinking_reaches_the_wire(
+                getattr(self, "model", ""), getattr(self, "provider", "")
+            )
             for i in range(len(result) - 1, -1, -1):
                 msg = result[i]
                 msg_tokens = _estimate_msg_budget_tokens(
-                    msg, charge_stale_thinking=(i == _newest_asst_idx)
+                    msg,
+                    charge_stale_thinking=_charge_all_thinking or (i == _newest_asst_idx),
                 )
                 if accumulated + msg_tokens > protect_tail_tokens and (len(result) - i) >= min_protect:
                     boundary = i
@@ -6352,16 +6379,21 @@ This compaction should PRIORITISE preserving all information related to the focu
         accumulated = 0
         cut_idx = n  # start from beyond the end
 
-        # Newest assistant turn: the only message whose generic thinking
-        # fields any transport still replays (#73624) — every older turn's
-        # reasoning/reasoning_content is stripped or padded at send time,
-        # so charging it here spends tail budget on bytes that never ship.
+        # Anthropic/Bedrock only replay newest-turn thinking, so charging
+        # older reasoning_content here would spend tail budget on bytes
+        # that never ship (#73624). DeepSeek/Kimi echo every historical
+        # block, so those transports MUST charge stale thinking or the
+        # cut lands late and the next request 400s (#80246).
         _newest_asst_idx = _last_assistant_index(messages)
+        _charge_all_thinking = _stale_thinking_reaches_the_wire(
+            getattr(self, "model", ""), getattr(self, "provider", "")
+        )
 
         for i in range(n - 1, head_end - 1, -1):
             msg = messages[i]
             msg_tokens = _estimate_msg_budget_tokens(
-                msg, charge_stale_thinking=(i == _newest_asst_idx)
+                msg,
+                charge_stale_thinking=_charge_all_thinking or (i == _newest_asst_idx),
             )
             # Stop once we exceed the soft ceiling (unless we haven't hit min_tail yet)
             if accumulated + msg_tokens > soft_ceiling and (n - i) >= min_tail:
@@ -6389,7 +6421,8 @@ This compaction should PRIORITISE preserving all information related to the focu
             for j in range(n - 1, head_end - 1, -1):
                 raw_msg = messages[j]
                 raw_tok = _estimate_msg_budget_tokens(
-                    raw_msg, charge_stale_thinking=(j == _newest_asst_idx)
+                    raw_msg,
+                    charge_stale_thinking=_charge_all_thinking or (j == _newest_asst_idx),
                 )
                 if raw_accumulated + raw_tok > raw_budget and (n - j) >= min_tail:
                     cut_idx = j

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2101,6 +2101,12 @@ class ContextCompressor(ContextEngine):
       5. On subsequent compactions, iteratively update the previous summary
     """
 
+    # Tests (and any object.__new__ stub) can call tail/prune walks
+    # without __init__. Empty defaults keep newest-turn-only accounting
+    # — the same as an unset provider in production.
+    model = ""
+    provider = ""
+
     @property
     def name(self) -> str:
         return "compressor"

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3812,7 +3812,7 @@ class ContextCompressor(ContextEngine):
             # stay prunable.
             _newest_asst_idx = _last_assistant_index(result)
             _charge_all_thinking = _stale_thinking_reaches_the_wire(
-                getattr(self, "model", ""), getattr(self, "provider", "")
+                self.model, self.provider
             )
             for i in range(len(result) - 1, -1, -1):
                 msg = result[i]
@@ -6386,7 +6386,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         # cut lands late and the next request 400s (#80246).
         _newest_asst_idx = _last_assistant_index(messages)
         _charge_all_thinking = _stale_thinking_reaches_the_wire(
-            getattr(self, "model", ""), getattr(self, "provider", "")
+            self.model, self.provider
         )
 
         for i in range(n - 1, head_end - 1, -1):

--- a/tests/agent/test_replay_budget_accounting.py
+++ b/tests/agent/test_replay_budget_accounting.py
@@ -1,11 +1,14 @@
-"""Tests for provider-aware replay-field accounting in tail-budget walks (#73624).
+"""Tests for provider-aware replay-field accounting in tail-budget walks (#73624, #80246).
 
 Generic thinking fields (``reasoning`` / ``reasoning_content`` + the
 ``reasoning_details`` text charge) are replayed for at most the NEWEST
-assistant turn on every transport — Anthropic strips all-but-newest at
-convert time, Bedrock never replays thinking, strict chat-completions
-providers reject or one-space-pad the field. Charging them on every message
-spent 19-24% of the tail budget on bytes that never reach the wire.
+assistant turn on Anthropic (strips all-but-newest at convert time) and
+Bedrock (never replays thinking). Charging them on every message spent
+19-24% of the tail budget on bytes that never reach the wire (#73624).
+
+DeepSeek and Kimi thinking-mode chat endpoints echo every historical
+``reasoning_content`` block. Skipping those bytes undercounts the tail,
+compaction fires late, and the session hits an upstream 400 (#80246).
 
 Codex sidecar fields (``codex_reasoning_items`` / ``codex_message_items``)
 ARE wire-replayed on every retained turn and stay charged unconditionally
@@ -18,6 +21,7 @@ from agent.context_compressor import (
     _REPLAY_BUDGET_KEYS,
     _estimate_msg_budget_tokens,
     _last_assistant_index,
+    _stale_thinking_reaches_the_wire,
 )
 
 
@@ -156,3 +160,87 @@ class TestTailCutBehavior:
         # index = more messages in the tail), and strictly more here because
         # the stale thinking dominates each message's old-cost.
         assert cut < old_cut
+
+    def test_deepseek_charges_stale_thinking_so_tail_is_smaller_than_skip_stale(self):
+        """DeepSeek echoes historical reasoning_content; skip-stale undercounts (#80246).
+
+        Do not reimplement the compressor's min_tail / fallback / align
+        walk here — those steps move the cut independently of thinking
+        charge. Compare two compressors on the same transcript instead.
+        """
+        from agent.context_compressor import ContextCompressor
+
+        msgs = [{"role": "system", "content": "sys"}]
+        for i in range(30):
+            msgs.append({"role": "user", "content": f"question {i}"})
+            msgs.append(
+                {
+                    "role": "assistant",
+                    "content": f"answer {i}",
+                    "reasoning": BIG_THINKING,
+                    "reasoning_content": BIG_THINKING,
+                }
+            )
+        budget = 3_000
+        skip_stale = ContextCompressor(
+            model="claude-opus-5",
+            provider="anthropic",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+        charge_stale = ContextCompressor(
+            model="deepseek-v4-flash",
+            provider="deepseek",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+        skip_cut = skip_stale._find_tail_cut_by_tokens(msgs, 1, token_budget=budget)
+        charge_cut = charge_stale._find_tail_cut_by_tokens(msgs, 1, token_budget=budget)
+        # Higher cut index = fewer messages kept verbatim. Charging the
+        # echoed thinking spends the budget faster so compaction fires
+        # before the wire request exceeds the model limit.
+        assert charge_cut > skip_cut
+
+    def test_kimi_matches_deepseek_stale_thinking_charge(self):
+        """Kimi thinking mode has the same historical-echo requirement as DeepSeek."""
+        from agent.context_compressor import ContextCompressor
+
+        msgs = [{"role": "system", "content": "sys"}]
+        for i in range(30):
+            msgs.append({"role": "user", "content": f"question {i}"})
+            msgs.append(
+                {
+                    "role": "assistant",
+                    "content": f"answer {i}",
+                    "reasoning": BIG_THINKING,
+                    "reasoning_content": BIG_THINKING,
+                }
+            )
+        budget = 3_000
+        deepseek = ContextCompressor(
+            model="deepseek-v4-flash",
+            provider="deepseek",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+        kimi = ContextCompressor(
+            model="kimi-k2.5",
+            provider="moonshot",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+        assert deepseek._find_tail_cut_by_tokens(msgs, 1, token_budget=budget) == kimi._find_tail_cut_by_tokens(
+            msgs, 1, token_budget=budget
+        )
+
+
+class TestStaleThinkingWireReplay:
+    def test_deepseek_and_kimi_replay_stale_thinking(self):
+        assert _stale_thinking_reaches_the_wire("deepseek-v4-flash", "deepseek")
+        assert _stale_thinking_reaches_the_wire("kimi-k2.5", "")
+        assert _stale_thinking_reaches_the_wire("moonshot-v1", "moonshot")
+        # Custom-provider DeepSeek still matches on the model id.
+        assert _stale_thinking_reaches_the_wire("deepseek-v4-flash", "custom")
+        assert not _stale_thinking_reaches_the_wire("claude-opus-5", "anthropic")
+        assert not _stale_thinking_reaches_the_wire("gpt-5", "openai")
+        assert not _stale_thinking_reaches_the_wire("", "")

--- a/tests/agent/test_replay_budget_accounting.py
+++ b/tests/agent/test_replay_budget_accounting.py
@@ -201,6 +201,62 @@ class TestTailCutBehavior:
         # before the wire request exceeds the model limit.
         assert charge_cut > skip_cut
 
+    def test_deepseek_prune_boundary_charges_stale_thinking(self):
+        """The tool-result prune walk must use the same charge-all flag as tail-cut."""
+        from agent.context_compressor import ContextCompressor
+
+        msgs = [{"role": "system", "content": "sys"}]
+        bulky = "tool output " * 80  # well above _PRUNE_MIN_CHARS
+        for i in range(20):
+            msgs.append({"role": "user", "content": f"question {i}"})
+            msgs.append(
+                {
+                    "role": "assistant",
+                    "content": f"answer {i}",
+                    "reasoning": BIG_THINKING,
+                    "reasoning_content": BIG_THINKING,
+                    "tool_calls": [
+                        {
+                            "id": f"call-{i}",
+                            "type": "function",
+                            "function": {"name": "terminal", "arguments": "{}"},
+                        }
+                    ],
+                }
+            )
+            msgs.append({"role": "tool", "tool_call_id": f"call-{i}", "content": bulky})
+
+        def surviving_full_tools(messages):
+            return [
+                i
+                for i, msg in enumerate(messages)
+                if msg.get("role") == "tool"
+                and str(msg.get("content") or "").startswith("tool output")
+            ]
+
+        skip_stale = ContextCompressor(
+            model="claude-opus-5",
+            provider="anthropic",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+        charge_stale = ContextCompressor(
+            model="deepseek-v4-flash",
+            provider="deepseek",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+        # 8k is large enough that the two charge policies land different
+        # prune boundaries; a tight budget collapses both onto the floor
+        # and the later pressure pass hides the difference.
+        skip_msgs, _ = skip_stale._prune_old_tool_results(
+            msgs, protect_tail_count=20, protect_tail_tokens=8_000
+        )
+        charge_msgs, _ = charge_stale._prune_old_tool_results(
+            msgs, protect_tail_count=20, protect_tail_tokens=8_000
+        )
+        assert surviving_full_tools(skip_msgs) != surviving_full_tools(charge_msgs)
+
     def test_kimi_matches_deepseek_stale_thinking_charge(self):
         """Kimi thinking mode has the same historical-echo requirement as DeepSeek."""
         from agent.context_compressor import ContextCompressor


### PR DESCRIPTION
## What does this PR do?

Compaction treats `reasoning` / `reasoning_content` as newest-turn-only (#73624). That is correct for Anthropic (strips all-but-newest at convert time) and Bedrock (never replays thinking). DeepSeek and Kimi thinking-mode chat endpoints echo **every** historical `reasoning_content` block on each request.

The tail walk then undercounts by the full stale-thinking volume, compaction fires late, and the session hits an upstream HTTP 400 (`This model's maximum context length is …`). Studio already counts `reasoning_content` in its threshold check; this is the core compressor half of the same miss.

Charge historical thinking when the model id or provider slug matches `deepseek`, `kimi`, or `moonshot`. Other transports keep the #73624 skip.

## Related Issue

Fixes #80246

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `agent/context_compressor.py`: `_stale_thinking_reaches_the_wire()`; tail-cut and prune-boundary walks charge stale thinking on DeepSeek/Kimi/Moonshot
- `tests/agent/test_replay_budget_accounting.py`: DeepSeek tail is smaller than Claude's skip-stale walk; Kimi matches DeepSeek; marker coverage

## How to Test

```text
scripts/run_tests.sh tests/agent/test_replay_budget_accounting.py
# 12 passed
```

Not runtime-tested against a live DeepSeek/Kimi tenant.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A (no UI change)
