### PR TITLE
fix(desktop): persist session titles on unrestored tab tiles

### DIFF
--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -447,7 +447,12 @@ export function tileStoredRow(storedSessionId: string): SessionInfo | undefined 
  *  rather than its live composer title (`tabTitle` renders that): re-registering
  *  per keystroke would re-render the strip, and holding the draft's text here
  *  would let the registered name already match the row that lands on send —
- *  skipping the re-register that hands the tab back to this string. */
+ *  skipping the re-register that hands the tab back to this string.
+ *
+ *  Restored background tabs do not mount, so they never pull an unlisted
+ *  session row into `$sessions`. `workspaceTabTitle` is the persisted name
+ *  from open/rename, which is what keeps those tabs from reading
+ *  "New session" until first click (#94167). */
 function tileTitle(storedSessionId: string): string {
   const stored = tileStoredRow(storedSessionId)
   const explicit = $sessionTiles.get().find(tile => tile.storedSessionId === storedSessionId)?.workspaceTabTitle

--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -5,6 +5,7 @@ import type { CSSProperties, ReactElement, PointerEvent as ReactPointerEvent } f
 import { SessionDraftTitle } from '@/app/chat/session-draft-title'
 import { SessionStatusDot } from '@/app/chat/session-status-dot'
 import { PALETTE_AREA, type PaletteContribution, paletteToggle } from '@/app/command-palette/contrib'
+import { resolveStoredSession } from '@/app/session/hooks/use-session-actions/utils'
 import { type StatusbarItem } from '@/app/shell/statusbar-controls'
 import { InlinePreviewDirective } from '@/components/assistant-ui/inline-preview-directive'
 import { IdleMount } from '@/components/idle-mount'
@@ -70,6 +71,7 @@ import {
 } from '@/store/review'
 import { $currentCwd, $selectedStoredSessionId, $sessions, $yoloActive, sessionMatchesStoredId } from '@/store/session'
 import { watchSessionPins } from '@/store/session-pin-sync'
+import { startUnrestoredTileTitleBackfill } from '@/store/session-states'
 import { watchUnreadWriteGuard } from '@/store/session-unread-remote'
 import { $statusbarVisible } from '@/store/statusbar-prefs'
 import { isBrowserWindow, isHudWindow } from '@/store/windows'
@@ -457,6 +459,7 @@ watchContributedPanes()
 // into the transparent overlay).
 if (!isBrowserWindow() && !isHudWindow()) {
   watchSessionTiles()
+  startUnrestoredTileTitleBackfill((id, route) => resolveStoredSession(id, route))
   watchRouteTiles()
   watchPreviewTiles()
 }

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -19,6 +19,7 @@ import {
   $focusedStoredSessionId,
   $sessionStates,
   $sessionTiles,
+  backfillUnrestoredTileTitles,
   blankDraftTile,
   clearAllSessionStates,
   closeAllOpenSessionTiles,
@@ -732,6 +733,54 @@ describe('session tile tab titles persist without mounting (#94167)', () => {
     setSessions([{ id: 'chat', title: 'Renamed' } as never])
 
     expect($sessionTiles.get()[0]?.workspaceTabTitle).toBe('Renamed')
+  })
+
+  it('backfills unrestored untitled tiles by id, preferring ownerRoute', async () => {
+    const ownerRoute = { connectionId: 'conn-a', profile: 'writer' }
+
+    const lookup = vi.fn(async (id: string, route?: { connectionId: string; profile: string }) => {
+      expect(id).toBe('old-chat')
+      expect(route).toEqual(ownerRoute)
+
+      return { id: 'old-chat', title: 'Quarterly review' } as never
+    })
+
+    $sessionTiles.set([{ ownerRoute, storedSessionId: 'old-chat' }])
+
+    await backfillUnrestoredTileTitles(lookup)
+
+    expect(lookup).toHaveBeenCalledTimes(1)
+    expect($sessionTiles.get()[0]?.workspaceTabTitle).toBe('Quarterly review')
+  })
+
+  it('does not backfill drafts, live runtimes, titled tiles, or the New session placeholder', async () => {
+    const lookup = vi.fn(async (id: string) => {
+      if (id === 'draft') {
+        return undefined
+      }
+
+      if (id === 'placeholder') {
+        return { id, title: 'New session' } as never
+      }
+
+      return { id, title: 'Should not apply' } as never
+    })
+
+    $sessionTiles.set([
+      { storedSessionId: 'draft' },
+      { runtimeId: 'rt-live', storedSessionId: 'live' },
+      { storedSessionId: 'named', workspaceTabTitle: 'Kept' },
+      { storedSessionId: 'placeholder' }
+    ])
+    await backfillUnrestoredTileTitles(lookup)
+
+    expect(lookup.mock.calls.map(call => call[0])).toEqual(['draft', 'placeholder'])
+    expect($sessionTiles.get()).toEqual([
+      { storedSessionId: 'draft' },
+      { runtimeId: 'rt-live', storedSessionId: 'live' },
+      { storedSessionId: 'named', workspaceTabTitle: 'Kept' },
+      { storedSessionId: 'placeholder' }
+    ])
   })
 })
 

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -696,6 +696,45 @@ describe('dropTilesForProfile', () => {
   })
 })
 
+
+describe('session tile tab titles persist without mounting (#94167)', () => {
+  afterEach(() => {
+    $activeGatewayProfile.set('default')
+    $layoutTree.set(null)
+    $selectedStoredSessionId.set(null)
+    $sessionTiles.set([])
+    setSessions([])
+  })
+
+  it('stores the recents title on open so a later recents miss still names the tab', () => {
+    setSessions([{ id: 'old-chat', title: 'Quarterly review' } as never])
+    openSessionTile('old-chat')
+
+    expect($sessionTiles.get()[0]?.workspaceTabTitle).toBe('Quarterly review')
+
+    setSessions([])
+    expect($sessionTiles.get()[0]?.workspaceTabTitle).toBe('Quarterly review')
+  })
+
+  it('keeps an explicit Bot tab title', () => {
+    openSessionTile('bot-chat', 'center', undefined, undefined, {
+      workspaceMode: 'bots',
+      workspaceOwnerKey: 'owner-a',
+      workspaceTabTitle: 'Bot Chat'
+    })
+
+    expect($sessionTiles.get()[0]?.workspaceTabTitle).toBe('Bot Chat')
+  })
+
+  it('updates the persisted title when the session is renamed in recents', () => {
+    setSessions([{ id: 'chat', title: 'Draft' } as never])
+    openSessionTile('chat')
+    setSessions([{ id: 'chat', title: 'Renamed' } as never])
+
+    expect($sessionTiles.get()[0]?.workspaceTabTitle).toBe('Renamed')
+  })
+})
+
 describe('releaseSessionTranscript', () => {
   afterEach(() => {
     $sessionStates.set({})

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -37,7 +37,6 @@ import { readJson, writeJson } from '@/lib/storage'
 import type { SessionInfo } from '@/types/hermes'
 
 import { $activeGatewayProfile, normalizeProfileKey } from './profile'
-import { $projectTree } from './projects'
 import { clearAllProviderWaits, clearSessionProviderWait } from './provider-wait'
 import {
   $activeSessionId,
@@ -1149,7 +1148,8 @@ export function isBotChatSession(sessionId: null | string | undefined): boolean 
 /** Title to persist on a tile so the tab strip can name it without mounting
  *  the pane. Restored background tabs never run the resume/title-resolution
  *  effect, so without this they stay "New session" until first click (#94167).
- *  Prefer an explicit scope title (Bot Chat), then the recents/project row. */
+ *  Prefer an explicit scope title (Bot Chat), then the recents row.
+ *  Uncached unrestored tiles are filled by {@link backfillUnrestoredTileTitles}. */
 function knownSessionTabTitle(storedSessionId: string, scope?: SessionTileWorkspaceScope): string | undefined {
   const fromScope = scope?.workspaceTabTitle?.trim()
 
@@ -1157,17 +1157,7 @@ function knownSessionTabTitle(storedSessionId: string, scope?: SessionTileWorksp
     return fromScope
   }
 
-  const match = (session: SessionInfo) => sessionMatchesStoredId(session, storedSessionId)
-
-  const row =
-    $sessions.get().find(match) ??
-    $projectTree
-      .get()
-      .flatMap(project => [
-        ...project.repos.flatMap(repo => repo.groups.flatMap(group => group.sessions)),
-        ...(project.previewSessions ?? [])
-      ])
-      .find(match)
+  const row = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
 
   return row ? sessionTitle(row) : undefined
 }

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -31,7 +31,7 @@ import {
 } from '@/components/pane-shell/tree/store'
 import { $workspaceMode, resolveRememberedActivePane, workspaceScopeKey } from '@/components/pane-shell/workspace-scope'
 import type { WorkspaceMode } from '@/contrib/types'
-import { sessionTitle } from '@/lib/chat-runtime'
+import { NEW_SESSION_TITLE, sessionTitle } from '@/lib/chat-runtime'
 import { stableArray } from '@/lib/stable-array'
 import { readJson, writeJson } from '@/lib/storage'
 import type { SessionInfo } from '@/types/hermes'
@@ -42,6 +42,7 @@ import { clearAllProviderWaits, clearSessionProviderWait } from './provider-wait
 import {
   $activeSessionId,
   $connection,
+  $gatewayState,
   $lastReadAtBySessionId,
   $selectedStoredSessionId,
   $sessions,
@@ -1169,6 +1170,76 @@ function knownSessionTabTitle(storedSessionId: string, scope?: SessionTileWorksp
       .find(match)
 
   return row ? sessionTitle(row) : undefined
+}
+
+export type SessionTileTitleLookup = (
+  storedSessionId: string,
+  ownerRoute?: SessionProfileRoute
+) => Promise<SessionInfo | undefined>
+
+function persistResolvedTileTitle(storedSessionId: string, row: SessionInfo): void {
+  const title = sessionTitle(row).trim()
+
+  // Drafts keep the live composer label. Never stamp the placeholder onto
+  // disk — that would freeze "New session" and skip SessionDraftTitle.
+  if (!title || title === NEW_SESSION_TITLE) {
+    return
+  }
+
+  const tile = $sessionTiles.get().find(candidate => candidate.storedSessionId === storedSessionId)
+
+  if (!tile || tile.workspaceTabTitle?.trim()) {
+    return
+  }
+
+  patchSessionTile(storedSessionId, { workspaceTabTitle: title })
+}
+
+/** Tiles restored from disk have no runtimeId (process-scoped) and, before
+ *  this PR, no persisted title. They never remount `openSessionTile`. */
+export function isUntitledUnrestoredTile(tile: SessionTile): boolean {
+  return !tile.runtimeId && !tile.workspaceTabTitle?.trim()
+}
+
+/** One-shot by-id fill for unrestored untitled tiles (#94167 review).
+ *
+ * Persist-on-open covers new tabs. Tiles already on disk, or opened while
+ * the recents row was uncached, still need a lookup. Prefer `ownerRoute`
+ * so a Bot/cross-profile tile does not resolve against the ambient gateway.
+ * A miss (draft / 404) leaves the composer title in charge. */
+export async function backfillUnrestoredTileTitles(lookup: SessionTileTitleLookup): Promise<void> {
+  const targets = $sessionTiles.get().filter(isUntitledUnrestoredTile)
+
+  await Promise.all(
+    targets.map(async tile => {
+      const row = await lookup(tile.storedSessionId, tile.ownerRoute).catch(() => undefined)
+
+      if (row) {
+        persistResolvedTileTitle(tile.storedSessionId, row)
+      }
+    })
+  )
+}
+
+/** Run {@link backfillUnrestoredTileTitles} once the gateway can answer by-id. */
+export function startUnrestoredTileTitleBackfill(lookup: SessionTileTitleLookup): void {
+  if (isSecondaryWindow()) {
+    return
+  }
+
+  let ran = false
+
+  const run = () => {
+    if (ran || $gatewayState.get() !== 'open') {
+      return
+    }
+
+    ran = true
+    void backfillUnrestoredTileTitles(lookup)
+  }
+
+  run()
+  $gatewayState.listen(run)
 }
 
 export function setSessionTileWorkspaceScope(storedSessionId: string, scope: SessionTileWorkspaceScope): boolean {

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -31,11 +31,13 @@ import {
 } from '@/components/pane-shell/tree/store'
 import { $workspaceMode, resolveRememberedActivePane, workspaceScopeKey } from '@/components/pane-shell/workspace-scope'
 import type { WorkspaceMode } from '@/contrib/types'
+import { sessionTitle } from '@/lib/chat-runtime'
 import { stableArray } from '@/lib/stable-array'
 import { readJson, writeJson } from '@/lib/storage'
 import type { SessionInfo } from '@/types/hermes'
 
 import { $activeGatewayProfile, normalizeProfileKey } from './profile'
+import { $projectTree } from './projects'
 import { clearAllProviderWaits, clearSessionProviderWait } from './provider-wait'
 import {
   $activeSessionId,
@@ -913,6 +915,34 @@ if (!isSecondaryWindow() && !isBrowserWindow()) {
   $activeGatewayProfile.subscribe(() => {
     $sessionTiles.set([...(tilesByProfile[profileKey()] ?? []), ...(tilesByProfile[BOTS_TILE_BUCKET] ?? [])])
   })
+
+  // Keep persisted tab names in sync with rename / recents refresh so a
+  // later restart still shows the current title, not the name from open.
+  $sessions.listen(() => {
+    const tiles = $sessionTiles.get()
+
+    if (tiles.length === 0) {
+      return
+    }
+
+    let next: SessionTile[] | null = null
+
+    for (let i = 0; i < tiles.length; i++) {
+      const tile = tiles[i]
+      const title = knownSessionTabTitle(tile.storedSessionId)
+
+      if (!title || title === tile.workspaceTabTitle) {
+        continue
+      }
+
+      next ??= tiles.slice()
+      next[i] = { ...tile, workspaceTabTitle: title }
+    }
+
+    if (next) {
+      saveTiles(next)
+    }
+  })
 }
 
 export function patchSessionTile(storedSessionId: string, patch: Partial<SessionTile>) {
@@ -1115,6 +1145,32 @@ export function isBotChatSession(sessionId: null | string | undefined): boolean 
   return Boolean(stored && $botChatSessionIds.get().has(stored))
 }
 
+/** Title to persist on a tile so the tab strip can name it without mounting
+ *  the pane. Restored background tabs never run the resume/title-resolution
+ *  effect, so without this they stay "New session" until first click (#94167).
+ *  Prefer an explicit scope title (Bot Chat), then the recents/project row. */
+function knownSessionTabTitle(storedSessionId: string, scope?: SessionTileWorkspaceScope): string | undefined {
+  const fromScope = scope?.workspaceTabTitle?.trim()
+
+  if (fromScope) {
+    return fromScope
+  }
+
+  const match = (session: SessionInfo) => sessionMatchesStoredId(session, storedSessionId)
+
+  const row =
+    $sessions.get().find(match) ??
+    $projectTree
+      .get()
+      .flatMap(project => [
+        ...project.repos.flatMap(repo => repo.groups.flatMap(group => group.sessions)),
+        ...(project.previewSessions ?? [])
+      ])
+      .find(match)
+
+  return row ? sessionTitle(row) : undefined
+}
+
 export function setSessionTileWorkspaceScope(storedSessionId: string, scope: SessionTileWorkspaceScope): boolean {
   // Before the tile lookup: openSession routes every open through here, and a
   // bot chat usually has no tile to record the scope on.
@@ -1123,7 +1179,7 @@ export function setSessionTileWorkspaceScope(storedSessionId: string, scope: Ses
   const tile = $sessionTiles.get().find(candidate => candidate.storedSessionId === storedSessionId)
   const workspaceOwnerKey = scope.workspaceMode === 'bots' ? scope.workspaceOwnerKey : undefined
   const ownerRoute = scope.workspaceMode === 'bots' ? scope.ownerRoute : undefined
-  const workspaceTabTitle = scope.workspaceMode === 'bots' ? scope.workspaceTabTitle : undefined
+  const workspaceTabTitle = knownSessionTabTitle(storedSessionId, scope) ?? tile?.workspaceTabTitle
 
   if (
     !tile ||
@@ -1390,7 +1446,9 @@ export function openSessionTile(
         storedSessionId,
         workspaceMode: workspaceScope.workspaceMode,
         workspaceOwnerKey,
-        workspaceTabTitle: workspaceScope.workspaceMode === 'bots' ? workspaceScope.workspaceTabTitle : undefined
+        // Persist for Sessions as well as Bots: restored background tabs
+        // do not mount, so they cannot resolve a recents-page miss (#94167).
+        workspaceTabTitle: knownSessionTabTitle(storedSessionId, workspaceScope)
       }
     ])
     // Adoption is async via the registry — order sync runs after the move path


### PR DESCRIPTION
## What does this PR do?

A restored Desktop background tab can sit labeled **New session** until the user clicks it. The real title is on the session row; the tab strip never sees it because unrestored panes do not mount, so the resume/title-resolution effect never runs, and `tileTitle()` falls back to the placeholder when the row is off the recents page and project tree.

Persist the session title on the tile (`workspaceTabTitle`) for Sessions as well as Bots: at open, from an explicit scope title, and when recents rename/refresh. The tab strip already prefers that field when no live row is loaded.

## Related Issue

Fixes #94167

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/session-states.ts`: persist `workspaceTabTitle` from recents/project tree (or Bot scope) on open; keep it current on `$sessions` updates
- `apps/desktop/src/app/chat/session-tile.tsx`: document the unrestored fallback
- Tests: title survives a recents miss; Bot Chat stays explicit; rename updates the persisted name

## How to Test

```text
cd apps/desktop
npx vitest run --project ui src/store/session-states.test.ts
# 43 passed
```

Not runtime-tested in the packaged Desktop app.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A (logic-only Desktop change; not packaged-app verified)
