### PR TITLE
fix(desktop): persist Bot Mode Close All session tiles

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -100,6 +100,7 @@ vi.mock('@/store/session-color', () => ({
 }))
 vi.mock('@/store/session-states', () => ({
   $sessionTiles: atom<unknown[]>([]),
+  closeAllOpenSessionTiles: vi.fn(),
   openSessionTile: vi.fn()
 }))
 vi.mock('@/store/windows', () => ({

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -44,7 +44,7 @@ import {
   setSessions
 } from '@/store/session'
 import { $sessionColorOverrides, setSessionColorOverride } from '@/store/session-color'
-import { $sessionTiles } from '@/store/session-states'
+import { $sessionTiles, closeAllOpenSessionTiles } from '@/store/session-states'
 import { ackStoredSessionId } from '@/store/session-unread'
 import { canOpenSessionInTerminal, canOpenSessionWindow, openSessionInTerminal } from '@/store/windows'
 
@@ -415,6 +415,10 @@ function useSessionActions({
                   label: t.zones.closeAll,
                   onSelect: () => {
                     triggerHaptic('selection')
+                    // Persist-close session tiles before dismissing the
+                    // remaining tree panes, or Bot Mode rehydrates them
+                    // from the shared tile bucket (#94137).
+                    closeAllOpenSessionTiles(tabPaneId)
                     closeAllTreeTabs(tabPaneId)
                   }
                 })

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -30,6 +30,7 @@ import { useContributions } from '@/contrib/react/use-contributions'
 import { useI18n } from '@/i18n'
 import { useKeybindHint } from '@/lib/keybinds/use-keybind-hint'
 import { cn } from '@/lib/utils'
+import { closeAllOpenSessionTiles } from '@/store/session-states'
 
 import { $layoutEditMode } from '../../edit-mode'
 import { useWindowControlsOverlap } from '../../geometry'
@@ -142,7 +143,12 @@ function ZoneMenu({
         {paneTabCloseItems(kit, {
           counts: treeTabCloseTargets(targetId),
           onClose: paneId !== undefined ? () => closeTabPane(paneId) : undefined,
-          onCloseAll: () => closeAllTreeTabs(targetId),
+          onCloseAll: () => {
+            // Persist-close session tiles first so Bot Mode cannot
+            // rehydrate them from the shared tile bucket (#94137).
+            closeAllOpenSessionTiles(targetId)
+            closeAllTreeTabs(targetId)
+          },
           onCloseOthers: () => closeOtherTreeTabs(targetId),
           onCloseToRight: () => closeTreeTabsToRight(targetId)
         })}

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -10,6 +10,7 @@ import {
   $sessionStates,
   $sessionTiles,
   blankDraftTile,
+  closeAllOpenSessionTiles,
   focusedSessionNeedsRoute,
   focusOpenSession,
   knownOwnerForSession,
@@ -265,6 +266,54 @@ describe('SessionTile workspace scope', () => {
       workspaceMode: 'bots',
       workspaceOwnerKey: 'connection-a::default'
     })
+  })
+})
+
+describe('closeAllOpenSessionTiles persists Bot Mode Close All (#94137)', () => {
+  afterEach(() => {
+    $activeGatewayProfile.set('default')
+    $layoutTree.set(null)
+    $sessionTiles.set([])
+  })
+
+  it('drops persisted bot tiles so a roster/profile rehydrate cannot restore them', () => {
+    openSessionTile('chat-a', 'center', 'workspace', undefined, {
+      workspaceMode: 'bots',
+      workspaceOwnerKey: 'bot:a'
+    })
+    openSessionTile('chat-b', 'center', 'workspace', undefined, {
+      workspaceMode: 'bots',
+      workspaceOwnerKey: 'bot:b'
+    })
+    $layoutTree.set(
+      group(['workspace', tilePane('chat-a'), tilePane('chat-b')], { active: 'workspace', id: 'main' })
+    )
+
+    closeAllOpenSessionTiles('workspace')
+
+    expect($sessionTiles.get()).toEqual([])
+
+    // Profile swap re-reads the shared Bot bucket. Close All must have
+    // emptied it, not only dismissed the tree panes.
+    $activeGatewayProfile.set('other-profile')
+    expect($sessionTiles.get()).toEqual([])
+    $activeGatewayProfile.set('default')
+    expect($sessionTiles.get()).toEqual([])
+  })
+
+  it('leaves session tiles stacked in a different zone open', () => {
+    openSessionTile('keep', 'right', 'workspace')
+    openSessionTile('close-me', 'center', 'workspace')
+    $layoutTree.set(
+      split('row', [
+        group(['workspace', tilePane('close-me')], { active: 'workspace', id: 'main' }),
+        group([tilePane('keep')], { active: tilePane('keep'), id: 'right' })
+      ])
+    )
+
+    closeAllOpenSessionTiles('workspace')
+
+    expect($sessionTiles.get().map(tile => tile.storedSessionId)).toEqual(['keep'])
   })
 })
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1256,7 +1256,9 @@ export function closeSessionTile(storedSessionId: string) {
  */
 export function closeAllOpenSessionTiles(paneId: string): void {
   const tree = $layoutTree.get()
-  const panes = (tree ? findGroupOfPane(tree, paneId) : null)?.panes ?? []
+  // Copy the live group list. closeSessionTile can rewrite the layout
+  // tree; iterating the original array would skip every other pane.
+  const panes = [...((tree ? findGroupOfPane(tree, paneId) : null)?.panes ?? [])]
 
   for (const id of panes) {
     if (id.startsWith(TILE_PANE_PREFIX)) {

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1246,6 +1246,25 @@ export function closeSessionTile(storedSessionId: string) {
   }
 }
 
+/** Persist-close every session tile whose pane lives in `paneId`'s group.
+ *
+ * Close All used to only dismiss layout-tree panes. Bot Mode tiles are
+ * stored in the shared `__bots_workspace__` bucket, so a later roster
+ * click or profile swap rehydrated `$sessionTiles` and the closed tabs
+ * came back (#94137). Routing through {@link closeSessionTile} writes that
+ * bucket, so the closed set survives those rehydrations and a restart.
+ */
+export function closeAllOpenSessionTiles(paneId: string): void {
+  const tree = $layoutTree.get()
+  const panes = (tree ? findGroupOfPane(tree, paneId) : null)?.panes ?? []
+
+  for (const id of panes) {
+    if (id.startsWith(TILE_PANE_PREFIX)) {
+      closeSessionTile(id.slice(TILE_PANE_PREFIX.length))
+    }
+  }
+}
+
 /** Drop a DEAD tile — a persisted tile whose session no longer exists on the
  *  backend (resume 404s). Unlike close, it leaves no ⌘⇧T undo (resurrecting it
  *  would just 404 again) and evicts any cached state. This is what clears the


### PR DESCRIPTION
## What does this PR do?

In Desktop Bot Mode, **Close All** removed extra session tabs from the strip only until the next bot-roster click (or a profile swap / restart). The layout-tree panes were dismissed, but the tiles stayed in the shared `__bots_workspace__` bucket (`hermes.desktop.sessionTiles.v2`), so `$sessionTiles` rehydrated them and the tabs came back.

Close All now persist-closes every session tile whose pane is in that group (`closeSessionTile`) before dismissing remaining tree panes. Clicking a bot afterward should only open/focus that bot's chat, not restore the tabs the user just closed.

## Related Issue

Fixes #94137

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/session-states.ts`: `closeAllOpenSessionTiles()` persist-closes tiles in the target group
- `apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx` and `tree-group.tsx`: Close All uses that path before `closeAllTreeTabs`
- Tests: bot tiles stay gone across a profile rehydrate; tiles in another zone are left open

## How to Test

```text
cd apps/desktop
npx vitest run --project ui \
  src/store/session-states.test.ts \
  src/app/chat/sidebar/session-actions-menu.test.tsx \
  src/components/pane-shell/tree/hide-only-strip-tabs.test.ts
# 53 passed
```

Not runtime-tested in the packaged Desktop app.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A (logic-only Desktop change; not packaged-app verified)
