### PR TITLE
fix(reasoning): consult endpoint /v1/models catalog for custom providers

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1533,16 +1533,7 @@ def endpoint_model_supports_reasoning(
     metadata = fetch_endpoint_model_metadata(base_url, api_key=api_key)
     if not metadata:
         return None
-    # Try exact match first, then single-entry shortcut, then substring match
     entry = metadata.get(model)
-    if entry is None and len(metadata) == 1:
-        entry = next(iter(metadata.values()))
-    if entry is None and model:
-        lower = model.lower()
-        for key, val in metadata.items():
-            if lower in key.lower() or key.lower() in lower:
-                entry = val
-                break
     if entry is None:
         return None
     params = entry.get("supported_parameters")

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1466,6 +1466,13 @@ def fetch_endpoint_model_metadata(
                 pricing = _extract_pricing(model)
                 if pricing:
                     entry["pricing"] = pricing
+                # supported_parameters: OpenRouter (and OpenRouter-compatible)
+                # endpoints advertise per-model capability lists here.
+                # Presence of "reasoning" signals that the model accepts
+                # extra_body.reasoning and returns thinking blocks.
+                supported_params = model.get("supported_parameters")
+                if isinstance(supported_params, list):
+                    entry["supported_parameters"] = supported_params
                 _add_model_aliases(cache, model_id, entry)
 
             # If this is a llama.cpp server, query /props for actual allocated context
@@ -1507,6 +1514,41 @@ def fetch_endpoint_model_metadata(
     _endpoint_model_metadata_cache[normalized] = {}
     _endpoint_model_metadata_cache_time[normalized] = time.time()
     return {}
+
+
+def endpoint_model_supports_reasoning(
+    model: str,
+    base_url: str,
+    api_key: str = "",
+) -> Optional[bool]:
+    """Return True/False when the endpoint's live /v1/models catalog declares
+    whether *model* supports reasoning (via ``supported_parameters`` containing
+    ``"reasoning"``), or None when the catalog is unreachable or the model is
+    not listed.
+
+    Cached via ``fetch_endpoint_model_metadata`` (5-minute TTL per base URL).
+    Designed for OpenRouter-compatible endpoints (e.g. the claudecode-as-openai
+    shim) that advertise capability lists in their /v1/models response.
+    """
+    metadata = fetch_endpoint_model_metadata(base_url, api_key=api_key)
+    if not metadata:
+        return None
+    # Try exact match first, then single-entry shortcut, then substring match
+    entry = metadata.get(model)
+    if entry is None and len(metadata) == 1:
+        entry = next(iter(metadata.values()))
+    if entry is None and model:
+        lower = model.lower()
+        for key, val in metadata.items():
+            if lower in key.lower() or key.lower() in lower:
+                entry = val
+                break
+    if entry is None:
+        return None
+    params = entry.get("supported_parameters")
+    if not isinstance(params, list):
+        return None
+    return "reasoning" in params
 
 
 def _resolve_endpoint_context_length(

--- a/contributors/emails/AllardQuek@users.noreply.github.com
+++ b/contributors/emails/AllardQuek@users.noreply.github.com
@@ -1,0 +1,1 @@
+AllardQuek

--- a/contributors/emails/alan.justino@yahoo.com.br
+++ b/contributors/emails/alan.justino@yahoo.com.br
@@ -1,0 +1,1 @@
+alanjds

--- a/contributors/emails/bear@bearhuddleston.dev
+++ b/contributors/emails/bear@bearhuddleston.dev
@@ -1,0 +1,1 @@
+BearHuddleston

--- a/contributors/emails/brinshadewater@gmail.com
+++ b/contributors/emails/brinshadewater@gmail.com
@@ -1,0 +1,1 @@
+BrinShadewater

--- a/contributors/emails/dan@danbennett.me
+++ b/contributors/emails/dan@danbennett.me
@@ -1,0 +1,1 @@
+DanBennettUK

--- a/contributors/emails/kerpopule@users.noreply.github.com
+++ b/contributors/emails/kerpopule@users.noreply.github.com
@@ -1,0 +1,1 @@
+kerpopule

--- a/run_agent.py
+++ b/run_agent.py
@@ -7713,6 +7713,25 @@ class AIAgent:
         # has it; gemma3 / qwen3-coder don't. Cached per (model, base_url).
         if base_url_host_matches(self._base_url_lower, "ollama.com"):
             return self._ollama_supports_thinking_cached()
+        # For any endpoint that serves an OpenRouter-compatible /v1/models
+        # catalog (e.g. the claudecode-as-openai shim on localhost), consult
+        # the endpoint's own advertised supported_parameters before giving up.
+        # fetch_endpoint_model_metadata() is cached per base URL with a 5-minute
+        # TTL, so this is a dict lookup on every turn after the first call.
+        try:
+            from agent.model_metadata import endpoint_model_supports_reasoning
+
+            catalog_result = endpoint_model_supports_reasoning(
+                self.model,
+                self._base_url or "",
+                api_key=self._api_key or "",
+            )
+            if catalog_result is True:
+                return True
+            # catalog_result is False (model listed but no reasoning) or None
+            # (catalog unreachable / model unlisted) -- fall through.
+        except Exception:
+            pass
         if not self._is_openrouter_url():
             return False
         if base_url_host_matches(self._base_url_lower, "api.mistral.ai"):

--- a/run_agent.py
+++ b/run_agent.py
@@ -7713,26 +7713,28 @@ class AIAgent:
         # has it; gemma3 / qwen3-coder don't. Cached per (model, base_url).
         if base_url_host_matches(self._base_url_lower, "ollama.com"):
             return self._ollama_supports_thinking_cached()
-        # For any endpoint that serves an OpenRouter-compatible /v1/models
-        # catalog (e.g. the claudecode-as-openai shim on localhost), consult
-        # the endpoint's own advertised supported_parameters before giving up.
-        # fetch_endpoint_model_metadata() is cached per base URL with a 5-minute
-        # TTL, so this is a dict lookup on every turn after the first call.
-        try:
-            from agent.model_metadata import endpoint_model_supports_reasoning
-
-            catalog_result = endpoint_model_supports_reasoning(
-                self.model,
-                self._base_url or "",
-                api_key=self._api_key or "",
-            )
-            if catalog_result is True:
-                return True
-            # catalog_result is False (model listed but no reasoning) or None
-            # (catalog unreachable / model unlisted) -- fall through.
-        except Exception:
-            pass
+        # For any non-OpenRouter endpoint that serves an OpenRouter-compatible
+        # /v1/models catalog (e.g. the claudecode-as-openai shim on localhost),
+        # consult the endpoint's own advertised supported_parameters before
+        # giving up. OpenRouter itself is deliberately excluded: its per-model
+        # gating below is intentional and must not be overridden by a catalog
+        # entry. fetch_endpoint_model_metadata() is cached per base URL with a
+        # 5-minute TTL, so this is a dict lookup after the first call.
         if not self._is_openrouter_url():
+            try:
+                from agent.model_metadata import endpoint_model_supports_reasoning
+
+                catalog_result = endpoint_model_supports_reasoning(
+                    self.model,
+                    self.base_url or "",
+                    api_key=self.api_key or "",
+                )
+                if catalog_result is True:
+                    return True
+                # catalog_result is False (model listed but no reasoning) or None
+                # (catalog unreachable / model unlisted) -- fall through.
+            except Exception as exc:
+                logger.debug("Catalog reasoning probe failed for %s: %s", self.base_url, exc)
             return False
         if base_url_host_matches(self._base_url_lower, "api.mistral.ai"):
             return False

--- a/tests/agent/test_endpoint_reasoning_catalog.py
+++ b/tests/agent/test_endpoint_reasoning_catalog.py
@@ -1,0 +1,171 @@
+"""Tests for endpoint_model_supports_reasoning() in agent/model_metadata.py.
+
+Covers the supported_parameters extraction added to fetch_endpoint_model_metadata
+and the model-lookup logic in endpoint_model_supports_reasoning.
+"""
+
+from unittest.mock import patch
+
+from agent.model_metadata import endpoint_model_supports_reasoning
+
+
+def _make_metadata(model_id, supported_parameters=None, context_length=8192):
+    """Build a minimal metadata dict as fetch_endpoint_model_metadata returns."""
+    entry = {"context_length": context_length}
+    if supported_parameters is not None:
+        entry["supported_parameters"] = supported_parameters
+    return {model_id: entry}
+
+
+# ============================================================
+# endpoint_model_supports_reasoning
+# ============================================================
+
+
+class TestEndpointModelSupportsReasoning:
+
+    def test_returns_true_when_reasoning_in_supported_parameters(self):
+        """Exact model match with reasoning in supported_parameters -> True."""
+        metadata = _make_metadata("claude-sonnet", ["temperature", "reasoning", "top_p"])
+        with patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value=metadata):
+            result = endpoint_model_supports_reasoning(
+                "claude-sonnet", "http://127.0.0.1:8977/v1"
+            )
+        assert result is True
+
+    def test_returns_false_when_reasoning_absent_from_supported_parameters(self):
+        """Model listed but reasoning not in supported_parameters -> False."""
+        metadata = _make_metadata("gpt-4o", ["temperature", "top_p", "seed"])
+        with patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value=metadata):
+            result = endpoint_model_supports_reasoning(
+                "gpt-4o", "http://127.0.0.1:8977/v1"
+            )
+        assert result is False
+
+    def test_returns_none_when_catalog_empty(self):
+        """Empty catalog -> None (unreachable / model unlisted)."""
+        with patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}):
+            result = endpoint_model_supports_reasoning(
+                "sonnet", "http://127.0.0.1:8977/v1"
+            )
+        assert result is None
+
+    def test_returns_none_when_model_not_in_catalog(self):
+        """Catalog present with multiple entries but model not listed -> None.
+        (Single-entry shortcut doesn't apply when there are multiple entries and
+        the model name doesn't substring-match any key.)"""
+        metadata = {
+            "claude-haiku-4": {"context_length": 48000, "supported_parameters": ["reasoning"]},
+            "claude-opus-4-6": {"context_length": 200000, "supported_parameters": ["reasoning"]},
+        }
+        with patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value=metadata):
+            # "gpt-4o" has no substring overlap with either key
+            result = endpoint_model_supports_reasoning(
+                "gpt-4o", "http://127.0.0.1:8977/v1"
+            )
+        assert result is None
+
+    def test_returns_none_when_supported_parameters_missing(self):
+        """Model found but entry has no supported_parameters key -> None."""
+        metadata = {"claude-sonnet": {"context_length": 200000}}
+        with patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value=metadata):
+            result = endpoint_model_supports_reasoning(
+                "claude-sonnet", "http://127.0.0.1:8977/v1"
+            )
+        assert result is None
+
+    def test_returns_none_when_supported_parameters_not_a_list(self):
+        """supported_parameters present but not a list -> None (malformed response)."""
+        metadata = {"claude-sonnet": {"context_length": 8192, "supported_parameters": "reasoning"}}
+        with patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value=metadata):
+            result = endpoint_model_supports_reasoning(
+                "claude-sonnet", "http://127.0.0.1:8977/v1"
+            )
+        assert result is None
+
+    def test_single_entry_shortcut_matches_any_model_name(self):
+        """Single-entry catalog: model name mismatch still matches the only entry."""
+        metadata = _make_metadata("claude-sonnet-4-6", ["reasoning"])
+        with patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value=metadata):
+            # Caller uses a shorter alias; single-entry shortcut applies
+            result = endpoint_model_supports_reasoning(
+                "sonnet", "http://127.0.0.1:8977/v1"
+            )
+        assert result is True
+
+    def test_substring_match_used_when_exact_fails_and_multi_entry(self):
+        """Multi-entry catalog falls back to substring match."""
+        metadata = {
+            "claude-sonnet-4-6": {"context_length": 200000, "supported_parameters": ["reasoning"]},
+            "claude-haiku-4": {"context_length": 48000, "supported_parameters": []},
+        }
+        with patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value=metadata):
+            result = endpoint_model_supports_reasoning(
+                "claude-sonnet", "http://127.0.0.1:8977/v1"
+            )
+        assert result is True
+
+    def test_substring_match_negative(self):
+        """Substring match finds model but reasoning absent -> False."""
+        metadata = {
+            "claude-sonnet-4-6": {"context_length": 200000, "supported_parameters": ["temperature"]},
+            "claude-haiku-4": {"context_length": 48000, "supported_parameters": ["reasoning"]},
+        }
+        with patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value=metadata):
+            result = endpoint_model_supports_reasoning(
+                "claude-sonnet", "http://127.0.0.1:8977/v1"
+            )
+        assert result is False
+
+
+# ============================================================
+# supported_parameters extraction via the public lookup function
+# (exercises the extraction indirectly through pre-populated metadata)
+# ============================================================
+
+
+class TestSupportedParametersExtractionViaLookup:
+    """Verify the supported_parameters field is respected in the model lookup.
+    These tests inject already-populated metadata (bypassing the HTTP fetch)
+    to isolate the extraction/lookup logic from network calls.
+    """
+
+    def test_reasoning_detected_from_pre_populated_metadata(self):
+        """When the cache already has supported_parameters populated with
+        reasoning, endpoint_model_supports_reasoning returns True."""
+        metadata = {
+            "claude-sonnet": {
+                "context_length": 200000,
+                "supported_parameters": ["temperature", "reasoning", "top_p"],
+            }
+        }
+        with patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value=metadata):
+            assert endpoint_model_supports_reasoning(
+                "claude-sonnet", "http://127.0.0.1:8977/v1"
+            ) is True
+
+    def test_reasoning_absent_means_false(self):
+        """supported_parameters present but without reasoning -> False."""
+        metadata = {
+            "gpt-4o": {
+                "context_length": 128000,
+                "supported_parameters": ["temperature", "top_p", "seed"],
+            }
+        }
+        with patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value=metadata):
+            assert endpoint_model_supports_reasoning(
+                "gpt-4o", "http://127.0.0.1:8977/v1"
+            ) is False
+
+    def test_non_list_supported_parameters_returns_none(self):
+        """supported_parameters present but not a list -> None (malformed)."""
+        metadata = {
+            "bad-model": {
+                "context_length": 8192,
+                "supported_parameters": "reasoning",  # string, not list
+            }
+        }
+        with patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value=metadata):
+            assert endpoint_model_supports_reasoning(
+                "bad-model", "http://127.0.0.1:8977/v1"
+            ) is None

--- a/tests/agent/test_endpoint_reasoning_catalog.py
+++ b/tests/agent/test_endpoint_reasoning_catalog.py
@@ -2,6 +2,9 @@
 
 Covers the supported_parameters extraction added to fetch_endpoint_model_metadata
 and the model-lookup logic in endpoint_model_supports_reasoning.
+
+Lookup is exact-match only: no substring fallback, no single-entry shortcut.
+A model not listed by its exact name returns None.
 """
 
 from unittest.mock import patch
@@ -43,30 +46,48 @@ class TestEndpointModelSupportsReasoning:
         assert result is False
 
     def test_returns_none_when_catalog_empty(self):
-        """Empty catalog -> None (unreachable / model unlisted)."""
+        """Empty catalog -> None."""
         with patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}):
             result = endpoint_model_supports_reasoning(
                 "sonnet", "http://127.0.0.1:8977/v1"
             )
         assert result is None
 
-    def test_returns_none_when_model_not_in_catalog(self):
-        """Catalog present with multiple entries but model not listed -> None.
-        (Single-entry shortcut doesn't apply when there are multiple entries and
-        the model name doesn't substring-match any key.)"""
+    def test_returns_none_when_model_not_listed_by_exact_name(self):
+        """Catalog present but model name is not an exact key -> None.
+        No fuzzy/substring/shortcut matching."""
         metadata = {
+            "claude-sonnet-4-6": {"context_length": 200000, "supported_parameters": ["reasoning"]},
             "claude-haiku-4": {"context_length": 48000, "supported_parameters": ["reasoning"]},
-            "claude-opus-4-6": {"context_length": 200000, "supported_parameters": ["reasoning"]},
         }
         with patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value=metadata):
-            # "gpt-4o" has no substring overlap with either key
             result = endpoint_model_supports_reasoning(
                 "gpt-4o", "http://127.0.0.1:8977/v1"
             )
         assert result is None
 
+    def test_substring_of_catalog_key_does_not_match(self):
+        """A model name that is a substring of a listed key still returns None.
+        Callers must use the exact same name the endpoint lists."""
+        metadata = _make_metadata("claude-sonnet-4-6", ["reasoning"])
+        with patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value=metadata):
+            # "sonnet" is a substring of "claude-sonnet-4-6" but is not the same key
+            result = endpoint_model_supports_reasoning(
+                "sonnet", "http://127.0.0.1:8977/v1"
+            )
+        assert result is None
+
+    def test_single_entry_catalog_requires_exact_name(self):
+        """Even a one-model catalog must not match a request for a different model name."""
+        metadata = _make_metadata("claude-sonnet-4-6", ["reasoning"])
+        with patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value=metadata):
+            result = endpoint_model_supports_reasoning(
+                "sonnet", "http://127.0.0.1:8977/v1"
+            )
+        assert result is None
+
     def test_returns_none_when_supported_parameters_missing(self):
-        """Model found but entry has no supported_parameters key -> None."""
+        """Model found by exact name but entry has no supported_parameters key -> None."""
         metadata = {"claude-sonnet": {"context_length": 200000}}
         with patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value=metadata):
             result = endpoint_model_supports_reasoning(
@@ -82,40 +103,6 @@ class TestEndpointModelSupportsReasoning:
                 "claude-sonnet", "http://127.0.0.1:8977/v1"
             )
         assert result is None
-
-    def test_single_entry_shortcut_matches_any_model_name(self):
-        """Single-entry catalog: model name mismatch still matches the only entry."""
-        metadata = _make_metadata("claude-sonnet-4-6", ["reasoning"])
-        with patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value=metadata):
-            # Caller uses a shorter alias; single-entry shortcut applies
-            result = endpoint_model_supports_reasoning(
-                "sonnet", "http://127.0.0.1:8977/v1"
-            )
-        assert result is True
-
-    def test_substring_match_used_when_exact_fails_and_multi_entry(self):
-        """Multi-entry catalog falls back to substring match."""
-        metadata = {
-            "claude-sonnet-4-6": {"context_length": 200000, "supported_parameters": ["reasoning"]},
-            "claude-haiku-4": {"context_length": 48000, "supported_parameters": []},
-        }
-        with patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value=metadata):
-            result = endpoint_model_supports_reasoning(
-                "claude-sonnet", "http://127.0.0.1:8977/v1"
-            )
-        assert result is True
-
-    def test_substring_match_negative(self):
-        """Substring match finds model but reasoning absent -> False."""
-        metadata = {
-            "claude-sonnet-4-6": {"context_length": 200000, "supported_parameters": ["temperature"]},
-            "claude-haiku-4": {"context_length": 48000, "supported_parameters": ["reasoning"]},
-        }
-        with patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value=metadata):
-            result = endpoint_model_supports_reasoning(
-                "claude-sonnet", "http://127.0.0.1:8977/v1"
-            )
-        assert result is False
 
 
 # ============================================================

--- a/tests/run_agent/test_custom_provider_reasoning_catalog.py
+++ b/tests/run_agent/test_custom_provider_reasoning_catalog.py
@@ -17,7 +17,7 @@ def _make_custom_agent(base_url="http://127.0.0.1:8977/v1", model="sonnet"):
     agent.base_url = base_url
     agent._base_url_lower = base_url.lower()
     agent.model = model
-    agent._api_key = ""  # required by the catalog lookup path
+    agent.api_key = ""
     return agent
 
 
@@ -64,31 +64,41 @@ class TestCustomProviderReasoningFromCatalog:
             result = agent._supports_reasoning_extra_body()
         assert result is False
 
-    def test_openrouter_url_still_uses_openrouter_path(self):
-        """OpenRouter URLs must not be short-circuited by a False catalog result --
-        they already went through the catalog gate and fall through to the existing
-        OpenRouter logic which handles them correctly."""
+    def test_openrouter_url_skips_the_catalog_entirely(self):
+        """OpenRouter must never take the catalog path: its per-model gating below
+        is deliberate, and a catalog entry advertising reasoning for a model that
+        gating excludes would silently flip behavior."""
         agent = object.__new__(AIAgent)
         agent.provider = "openrouter"
         agent.base_url = "https://openrouter.ai/api/v1"
         agent._base_url_lower = agent.base_url.lower()
         agent.model = "anthropic/claude-sonnet-4-5"
-        agent._api_key = ""
+        agent.api_key = ""
 
-        # Catalog returns None (not listed on OpenRouter's own /v1/models metadata,
-        # because OpenRouter is not the final provider endpoint). The function must
-        # NOT return False here; it should fall through to the OpenRouter-specific
-        # path and let that decide.
+        # Even a True catalog verdict must not be consulted for OpenRouter.
         with patch(
             "agent.model_metadata.endpoint_model_supports_reasoning",
-            return_value=None,
+            return_value=True,
+        ) as mock_catalog:
+            agent._supports_reasoning_extra_body()
+
+        mock_catalog.assert_not_called()
+
+    def test_catalog_failure_is_logged_at_debug(self):
+        """The catalog probe's except branch must log rather than silently pass,
+        so a real bug (e.g. AttributeError) stays diagnosable."""
+        agent = _make_custom_agent()
+        with patch(
+            "agent.model_metadata.endpoint_model_supports_reasoning",
+            side_effect=RuntimeError("boom"),
         ):
-            # We only assert it doesn't raise and doesn't return True from the catalog
-            # path. The actual OpenRouter path decision is tested by existing tests.
-            result = agent._supports_reasoning_extra_body()
-        # For a non-reasoning OpenRouter model the result is False; for a known
-        # reasoning model it would be True. Just assert no exception propagates.
-        assert result in (True, False)
+            with patch("run_agent.logger") as mock_logger:
+                result = agent._supports_reasoning_extra_body()
+
+        assert result is False
+        assert mock_logger.debug.called
+        logged = " ".join(str(a) for a in mock_logger.debug.call_args[0])
+        assert "atalog reasoning probe failed" in logged
 
     def test_nousresearch_url_unaffected_by_catalog(self):
         """nousresearch.com returns True before the catalog lookup runs."""
@@ -97,7 +107,7 @@ class TestCustomProviderReasoningFromCatalog:
         agent.base_url = "https://inference.nousresearch.com/v1"
         agent._base_url_lower = agent.base_url.lower()
         agent.model = "hermes-3"
-        agent._api_key = ""
+        agent.api_key = ""
 
         # Even if catalog were reachable it must never be called for this host,
         # because the nousresearch.com short-circuit fires first.

--- a/tests/run_agent/test_custom_provider_reasoning_catalog.py
+++ b/tests/run_agent/test_custom_provider_reasoning_catalog.py
@@ -1,0 +1,122 @@
+"""Tests for the catalog-based reasoning gate in run_agent._supports_reasoning_extra_body.
+
+Covers the new path that consults endpoint_model_supports_reasoning() before
+falling through to the _is_openrouter_url() wall, which previously returned
+False for all custom/localhost endpoints unconditionally.
+"""
+
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+def _make_custom_agent(base_url="http://127.0.0.1:8977/v1", model="sonnet"):
+    """Minimal AIAgent stub pointing at a custom (non-OpenRouter) endpoint."""
+    agent = object.__new__(AIAgent)
+    agent.provider = "custom"
+    agent.base_url = base_url
+    agent._base_url_lower = base_url.lower()
+    agent.model = model
+    agent._api_key = ""  # required by the catalog lookup path
+    return agent
+
+
+class TestCustomProviderReasoningFromCatalog:
+
+    def test_returns_true_when_catalog_says_reasoning_supported(self):
+        """A localhost shim that advertises reasoning in /v1/models must enable it."""
+        agent = _make_custom_agent()
+        with patch(
+            "agent.model_metadata.endpoint_model_supports_reasoning",
+            return_value=True,
+        ):
+            result = agent._supports_reasoning_extra_body()
+        assert result is True
+
+    def test_falls_through_to_false_when_catalog_says_no_reasoning(self):
+        """Model listed but reasoning absent -> catalog returns False -> falls through
+        _is_openrouter_url() check -> returns False for non-OpenRouter URL."""
+        agent = _make_custom_agent()
+        with patch(
+            "agent.model_metadata.endpoint_model_supports_reasoning",
+            return_value=False,
+        ):
+            result = agent._supports_reasoning_extra_body()
+        assert result is False
+
+    def test_falls_through_to_false_when_catalog_unreachable(self):
+        """Catalog unavailable (None) -> falls through -> non-OpenRouter URL -> False."""
+        agent = _make_custom_agent()
+        with patch(
+            "agent.model_metadata.endpoint_model_supports_reasoning",
+            return_value=None,
+        ):
+            result = agent._supports_reasoning_extra_body()
+        assert result is False
+
+    def test_exception_in_catalog_lookup_is_swallowed(self):
+        """Any exception from catalog lookup must not propagate -- fall through to False."""
+        agent = _make_custom_agent()
+        with patch(
+            "agent.model_metadata.endpoint_model_supports_reasoning",
+            side_effect=RuntimeError("network failure"),
+        ):
+            result = agent._supports_reasoning_extra_body()
+        assert result is False
+
+    def test_openrouter_url_still_uses_openrouter_path(self):
+        """OpenRouter URLs must not be short-circuited by a False catalog result --
+        they already went through the catalog gate and fall through to the existing
+        OpenRouter logic which handles them correctly."""
+        agent = object.__new__(AIAgent)
+        agent.provider = "openrouter"
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "anthropic/claude-sonnet-4-5"
+        agent._api_key = ""
+
+        # Catalog returns None (not listed on OpenRouter's own /v1/models metadata,
+        # because OpenRouter is not the final provider endpoint). The function must
+        # NOT return False here; it should fall through to the OpenRouter-specific
+        # path and let that decide.
+        with patch(
+            "agent.model_metadata.endpoint_model_supports_reasoning",
+            return_value=None,
+        ):
+            # We only assert it doesn't raise and doesn't return True from the catalog
+            # path. The actual OpenRouter path decision is tested by existing tests.
+            result = agent._supports_reasoning_extra_body()
+        # For a non-reasoning OpenRouter model the result is False; for a known
+        # reasoning model it would be True. Just assert no exception propagates.
+        assert result in (True, False)
+
+    def test_nousresearch_url_unaffected_by_catalog(self):
+        """nousresearch.com returns True before the catalog lookup runs."""
+        agent = object.__new__(AIAgent)
+        agent.provider = "custom"
+        agent.base_url = "https://inference.nousresearch.com/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "hermes-3"
+        agent._api_key = ""
+
+        # Even if catalog were reachable it must never be called for this host,
+        # because the nousresearch.com short-circuit fires first.
+        with patch(
+            "agent.model_metadata.endpoint_model_supports_reasoning"
+        ) as mock_catalog:
+            result = agent._supports_reasoning_extra_body()
+
+        assert result is True
+        mock_catalog.assert_not_called()
+
+    def test_localhost_without_catalog_returns_false(self):
+        """Localhost endpoint with unreachable catalog still returns False,
+        not an exception -- guards the regression where AttributeError on
+        self._api_key was leaking through the bare except."""
+        agent = _make_custom_agent(base_url="http://localhost:8080/v1")
+        with patch(
+            "agent.model_metadata.endpoint_model_supports_reasoning",
+            return_value=None,
+        ):
+            result = agent._supports_reasoning_extra_body()
+        assert result is False


### PR DESCRIPTION
## What does this PR do?

Custom and localhost endpoints (e.g. `provider: custom` with
`base_url: http://127.0.0.1:8977/v1`) were silently excluded from
reasoning emission, even when `reasoning_effort` was configured and
the model fully supported it.

`_supports_reasoning_extra_body()` gates `extra_body.reasoning` on a
hardcoded list of known provider domains. Any URL outside that list
(including `127.0.0.1`, `localhost`, or a self-hosted proxy) hit
`return False` before any capability check ran -- so Hermes never sent
reasoning to those endpoints, regardless of user config.

This PR fixes the gap by consulting the endpoint's own `/v1/models`
catalog before falling through to that wall. OpenRouter-compatible
servers (and any endpoint following the OpenRouter schema) advertise
per-model capability lists via `supported_parameters`. When a model
entry includes `"reasoning"` in that list, `_supports_reasoning_extra_body()`
returns True. The metadata is cached per base URL with a 5-minute TTL,
so after the first call this is a dict lookup with no network cost.

This is not hypothetical. [claudecode-as-openai](https://github.com/alanjds/claudecode-as-openai)
is a local OpenAI-compatible shim over the Claude Code CLI: its `/v1/models`
advertises `"reasoning"` in `supported_parameters`, and it genuinely returns
extended-thinking content when asked. Pointed at it, Hermes silently drops
`reasoning_effort` on every request purely because the base URL is
`127.0.0.1` -- the endpoint's own advertised capability is never consulted.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py` -- `fetch_endpoint_model_metadata()`: extract
  `supported_parameters` from each model entry in the `/v1/models` response
  and store it alongside the existing `context_length` / `pricing` fields.
- `agent/model_metadata.py` -- new public helper
  `endpoint_model_supports_reasoning(model, base_url, api_key)`: looks up the
  cached metadata and returns `True` / `False` / `None` depending on whether
  `"reasoning"` appears in the model's `supported_parameters`. Returns `None`
  when the catalog is unreachable or the model is not listed, so the existing
  OpenRouter logic still applies as a fallback.
- `run_agent.py` -- `_supports_reasoning_extra_body()`: for non-OpenRouter
  URLs, calls `endpoint_model_supports_reasoning()` and returns `True` on a
  catalog hit; falls through on `False` or `None`. OpenRouter URLs skip the
  catalog lookup entirely so their existing per-model gating is unaffected.

## How to Test

1. Configure Hermes with a custom local endpoint:
   ```yaml
   model:
     provider: custom
     base_url: http://127.0.0.1:8977/v1
     reasoning_effort: high
   ```
2. Ensure the endpoint's `GET /v1/models` returns entries with
   `"supported_parameters": [..., "reasoning", ...]` for the active model.
   (`claudecode-as-openai` does this, if you want a ready-made local endpoint
   to test against.)
3. Start a conversation and observe `extra_body.reasoning` is now included
   in the outbound request. Thinking blocks should appear in the response.
4. Set `reasoning_effort: none` (or remove it) and verify reasoning is no
   longer sent -- a catalog result of `True` does not force reasoning, it
   only unlocks the gate.
5. Test with an endpoint whose `/v1/models` is unreachable or returns no
   `supported_parameters` -- `_supports_reasoning_extra_body()` must fall
   through to the existing logic unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora (Bazzite) / Ubuntu Distrobox

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) -- or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys -- or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- or N/A
- [x] I've considered cross-platform impact (Windows, macOS) -- pure Python, no OS-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- or N/A

