### PR TITLE
fix: separate kanban worker and orchestrator guidance

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1601,16 +1601,19 @@ def init_agent(
     elif not agent.quiet_mode:
         print("🛠️  No tools loaded (all tools filtered out or unavailable)")
 
-    # Kanban worker/orchestrator lifecycle guidance is session-static:
-    # the dispatcher decides at spawn time whether this process is a kanban
-    # worker (kanban_show tool is present iff HERMES_KANBAN_TASK is set).
-    # Resolving the ~835-token block once here avoids re-running the
-    # membership test + reference on every system-prompt rebuild
-    # (init + each context compression).
-    from agent.prompt_builder import KANBAN_GUIDANCE
-    agent._kanban_worker_guidance = (
-        KANBAN_GUIDANCE if "kanban_show" in agent.valid_tool_names else ""
-    )
+    # Kanban guidance is session-static. Resolve task ownership and the loaded
+    # tool surface once here so context compression cannot change the cached
+    # prompt if process-global environment state changes later.
+    from agent.prompt_builder import KANBAN_GUIDANCE, KANBAN_ORCHESTRATOR_GUIDANCE
+    kanban_task = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    if kanban_task and "kanban_show" in agent.valid_tool_names:
+        agent._kanban_guidance = KANBAN_GUIDANCE
+    elif not kanban_task and {
+        "kanban_list", "kanban_create", "kanban_show"
+    }.issubset(agent.valid_tool_names):
+        agent._kanban_guidance = KANBAN_ORCHESTRATOR_GUIDANCE
+    else:
+        agent._kanban_guidance = ""
 
     # Check tool requirements
     if agent.tools and not agent.quiet_mode:

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -354,6 +354,14 @@ KANBAN_GUIDANCE = (
     "cross-agent handoffs that outlive one API loop."
 )
 
+KANBAN_ORCHESTRATOR_GUIDANCE = (
+    "# Kanban board orchestration\n"
+    "No task is implicitly assigned to this chat. Use `kanban_list` to inspect "
+    "board state, `kanban_show(task_id=...)` to inspect a specific card, and "
+    "`kanban_create(...)` to create explicitly requested or agreed work. Only "
+    "act on task ids supplied by the user or returned by board tools."
+)
+
 TOOL_USE_ENFORCEMENT_GUIDANCE = (
     "# Tool-use enforcement\n"
     "You MUST use your tools to take action — do not describe what you would do "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -36,7 +36,6 @@ from agent.prompt_builder import (
     EXECUTION_GUIDANCE_MODELS,
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
     HERMES_AGENT_HELP_GUIDANCE,
-    KANBAN_GUIDANCE,
     MEMORY_GUIDANCE,
     USER_PROFILE_GUIDANCE,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
@@ -435,16 +434,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)
     if "skill_manage" in agent.valid_tool_names:
         tool_guidance.append(SKILLS_GUIDANCE)
-    # Kanban worker/orchestrator lifecycle — only present when the
-    # dispatcher spawned this process (kanban_show check_fn gates on
-    # HERMES_KANBAN_TASK env var). Normal chat sessions never see
-    # this block. Resolved once at __init__ (see _kanban_worker_guidance).
-    _kanban_guidance = getattr(agent, "_kanban_worker_guidance", None)
+    # Worker lifecycle or the shorter orchestrator note, selected once during
+    # agent init from task ownership plus the loaded Kanban tool surface.
+    _kanban_guidance = getattr(agent, "_kanban_guidance", "")
     if _kanban_guidance:
         tool_guidance.append(_kanban_guidance)
-    elif _kanban_guidance is None and "kanban_show" in agent.valid_tool_names:
-        # Fallback for code paths that bypass agent_init (rare).
-        tool_guidance.append(KANBAN_GUIDANCE)
     if tool_guidance:
         stable_parts.append(" ".join(tool_guidance))
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -980,7 +980,79 @@ class TestBuildSystemPrompt:
         assert MEMORY_GUIDANCE not in prompt
         assert USER_PROFILE_GUIDANCE in prompt
 
+    @staticmethod
+    def _agent_with_tools(*tool_names: str) -> AIAgent:
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs(*tool_names),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            return AIAgent(
+                api_key="test-k...7890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
 
+    def test_kanban_worker_guidance_requires_task_and_loaded_tools(self, monkeypatch):
+        from agent.prompt_builder import (
+            KANBAN_GUIDANCE,
+            KANBAN_ORCHESTRATOR_GUIDANCE,
+        )
+
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_worker")
+        prompt_without_tools = self._agent_with_tools("web_search")._build_system_prompt()
+        assert KANBAN_GUIDANCE not in prompt_without_tools
+        assert KANBAN_ORCHESTRATOR_GUIDANCE not in prompt_without_tools
+
+        agent = self._agent_with_tools(
+            "kanban_show", "kanban_complete", "kanban_block"
+        )
+        # Init-time resolution keeps prompt rebuilding cache-stable even if the
+        # process environment changes after this conversation starts.
+        monkeypatch.delenv("HERMES_KANBAN_TASK")
+        prompt = agent._build_system_prompt()
+
+        assert KANBAN_GUIDANCE in prompt
+        assert KANBAN_ORCHESTRATOR_GUIDANCE not in prompt
+
+    def test_kanban_toolset_without_task_gets_orchestrator_guidance(self, monkeypatch):
+        from agent.prompt_builder import (
+            KANBAN_GUIDANCE,
+            KANBAN_ORCHESTRATOR_GUIDANCE,
+        )
+
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        agent = self._agent_with_tools(
+            "kanban_list", "kanban_create", "kanban_show"
+        )
+        prompt = agent._build_system_prompt()
+
+        assert KANBAN_ORCHESTRATOR_GUIDANCE in prompt
+        assert KANBAN_GUIDANCE not in prompt
+        assert "You have been assigned ONE task" not in prompt
+        assert "kanban_show() first" not in prompt
+        assert "$HERMES_KANBAN_WORKSPACE" not in prompt
+        assert "kanban_complete" not in KANBAN_ORCHESTRATOR_GUIDANCE
+        assert "kanban_block" not in KANBAN_ORCHESTRATOR_GUIDANCE
+
+    def test_chat_without_kanban_tools_or_task_gets_no_kanban_guidance(
+        self, monkeypatch
+    ):
+        from agent.prompt_builder import (
+            KANBAN_GUIDANCE,
+            KANBAN_ORCHESTRATOR_GUIDANCE,
+        )
+
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        prompt = self._agent_with_tools("web_search")._build_system_prompt()
+
+        assert KANBAN_GUIDANCE not in prompt
+        assert KANBAN_ORCHESTRATOR_GUIDANCE not in prompt
 
     def test_datetime_is_date_only_not_minute_precision(self, agent):
         """Timestamp must be date-only (no HH:MM) so the system prompt

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1,8 +1,8 @@
 """Tests for the Kanban tool surface (tools/kanban_tools.py).
 
 Verifies:
-  - Tools are gated on HERMES_KANBAN_TASK: a normal chat session sees
-    zero kanban tools in its schema; a worker session sees the kanban set.
+  - Tools are available to dispatcher workers via HERMES_KANBAN_TASK and to
+    profiles that explicitly enable the kanban toolset, but not ordinary chat.
   - Each handler's happy path.
   - Error paths (missing required args, bad metadata type, etc).
 """
@@ -552,9 +552,9 @@ def test_worker_lifecycle_through_tools(worker_env):
 
 
 def test_kanban_guidance_prompt_size_bounded():
-    """KANBAN_GUIDANCE is injected into every kanban-capable process's system
-    prompt and resolved once at agent init, so its size is a per-worker token
-    tax paid on every spawn. Bound it as an invariant, not a change-detector:
+    """KANBAN_GUIDANCE is injected into each dispatcher worker's system prompt
+    and resolved once at agent init, so its size is a per-worker token tax paid
+    on every spawn. Bound it as an invariant, not a change-detector:
     the ceiling (8000 chars, roughly 2000 tokens) leaves headroom above the
     current ~6.2k chars for tight additions, while catching accidental bloat
     (pasted docs, duplicated sections) before it ships to every worker.

--- a/website/docs/user-guide/features/kanban-worker-lanes.md
+++ b/website/docs/user-guide/features/kanban-worker-lanes.md
@@ -85,7 +85,7 @@ The dashboard renders run history with summaries, metadata blocks, and exit-stat
 
 The shape every kanban worker takes today: the assignee is a profile name, the dispatcher spawns `hermes -p <profile>`, the worker gets the `KANBAN_GUIDANCE` system-prompt block injected automatically, and uses the `kanban_*` tools to terminate the run. No setup beyond defining the profile.
 
-When you create profiles for your fleet, choose names that match the *role* you want the orchestrator to route to. The orchestrator (when there is one) discovers your profile names via `hermes profile list` — there's no fixed roster the system assumes (the orchestrator side of the contract is part of the injected `KANBAN_GUIDANCE`).
+When you create profiles for your fleet, choose names that match the *role* you want the orchestrator to route to. The orchestrator (when there is one) discovers your profile names via `hermes profile list` — there's no fixed roster the system assumes. A profile that explicitly enables the `kanban` toolset outside a dispatcher task receives the shorter `KANBAN_ORCHESTRATOR_GUIDANCE`, not the worker lifecycle contract.
 
 ### Orchestrator profile lane
 
@@ -114,4 +114,4 @@ So lane authors don't have to reimplement these:
 
 - [Kanban overview](./kanban) — the user-facing intro.
 - [Kanban tutorial](./kanban-tutorial) — walkthrough with the dashboard open.
-- [`KANBAN_GUIDANCE`](https://github.com/NousResearch/hermes-agent/blob/main/agent/prompt_builder.py) — the worker + orchestrator lifecycle injected into every kanban worker's system prompt.
+- [`KANBAN_GUIDANCE` and `KANBAN_ORCHESTRATOR_GUIDANCE`](https://github.com/NousResearch/hermes-agent/blob/main/agent/prompt_builder.py) — separate task-worker and board-orchestrator prompt contracts.

--- a/website/docs/user-guide/skills/optional/creative/creative-kanban-video-orchestrator.md
+++ b/website/docs/user-guide/skills/optional/creative/creative-kanban-video-orchestrator.md
@@ -187,8 +187,8 @@ task graphs. See **[references/examples.md](https://github.com/NousResearch/herm
    file` toolset, the director's `SOUL.md` rules forbid it from executing
    work itself. It decomposes and routes only — every concrete task becomes
    a `hermes kanban create` call to a specialist profile. The kanban
-   orchestration guidance auto-injected into every kanban worker's system
-   prompt spells this out further.
+   orchestration guidance injected for kanban-enabled orchestrator chats
+   spells this out further.
 
 7. **Don't over-decompose.** A 30-second product video does NOT need 20 tasks.
    Aim for the smallest task graph that still parallelizes well and exposes the


### PR DESCRIPTION
## Summary
- gate the full task-worker `KANBAN_GUIDANCE` on both `HERMES_KANBAN_TASK` and the loaded Kanban worker tool surface
- add a short, separate guidance block for explicitly configured Kanban orchestrator chats with no implicit task ownership
- keep ordinary chats guidance-free and update stale comments/docs

## Tests
- `scripts/run_tests.sh tests/run_agent/test_run_agent.py tests/tools/test_kanban_tools.py tests/agent/test_system_prompt.py tests/agent/test_profile_home_override_precedence.py tests/agent/test_platform_hint_desktop.py tests/hermes_cli/test_kanban_review_surfaces.py` (376 passed)
- `scripts/run_tests.sh tests/agent/test_prompt_builder.py tests/cron/test_cron_kanban_env_isolation.py tests/tools/test_delegate_kanban_isolation.py` (95 passed, 1 skipped)
- `scripts/run_tests.sh tests/run_agent/test_run_agent.py` (283 passed)