### PR TITLE
fix(update): use managed method for plan guidance

### DIFF
--- a/hermes_cli/update_inventory.py
+++ b/hermes_cli/update_inventory.py
@@ -143,12 +143,13 @@ def collect_runtime_inventory() -> UpdatePlan:
         )
 
         method = detect_install_method()
-        plan.install_method = method
         managed = get_managed_system()
-        if managed:
-            plan.install_method = managed
-        plan.updatable_in_place = method in ("git", "unknown") and not managed
-        plan.update_mechanism = recommended_update_command_for_method(method)
+        effective_method = managed or method
+        plan.install_method = effective_method
+        # A managed marker always prevents self-mutation, even if a future or
+        # malformed marker happens to use a mutable install-method name.
+        plan.updatable_in_place = effective_method in ("git", "unknown") and not managed
+        plan.update_mechanism = recommended_update_command_for_method(effective_method)
     except Exception as exc:
         logger.debug("Install-method probe failed: %s", exc)
 

--- a/tests/hermes_cli/test_update_inventory.py
+++ b/tests/hermes_cli/test_update_inventory.py
@@ -76,6 +76,38 @@ class TestCollectInventory:
         assert plan.updatable_in_place is False
         assert "docker pull" in plan.update_mechanism
 
+    def test_managed_marker_drives_update_command_and_capability(self, fleet, monkeypatch):
+        """A managed marker overrides both the displayed method and update policy."""
+        requested_methods = []
+        monkeypatch.setattr("hermes_cli.config.detect_install_method", lambda *a, **k: "git")
+        monkeypatch.setattr("hermes_cli.config.get_managed_system", lambda: "nixos")
+        monkeypatch.setattr(
+            "hermes_cli.config.recommended_update_command_for_method",
+            lambda method: requested_methods.append(method) or f"update:{method}",
+        )
+
+        plan = ui.collect_runtime_inventory()
+
+        assert plan.install_method == "nixos"
+        assert plan.updatable_in_place is False
+        assert plan.update_mechanism == "update:nixos"
+        assert requested_methods == ["nixos"]
+
+    def test_managed_marker_blocks_self_update_even_if_named_git(self, fleet, monkeypatch):
+        """Any managed marker retains the legacy no-self-mutation boundary."""
+        monkeypatch.setattr("hermes_cli.config.detect_install_method", lambda *a, **k: "unknown")
+        monkeypatch.setattr("hermes_cli.config.get_managed_system", lambda: "git")
+        monkeypatch.setattr(
+            "hermes_cli.config.recommended_update_command_for_method",
+            lambda method: f"update:{method}",
+        )
+
+        plan = ui.collect_runtime_inventory()
+
+        assert plan.install_method == "git"
+        assert plan.updatable_in_place is False
+        assert plan.update_mechanism == "update:git"
+
     def test_dead_pids_excluded(self, fleet, monkeypatch):
         monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
         plan = ui.collect_runtime_inventory()


### PR DESCRIPTION
## Summary
- derive `hermes update --plan` command guidance from the effective install method after a managed-system marker overrides raw detection
- keep managed installations non-updatable in place, including future/unrecognized markers that happen to match `git` or `unknown`
- add regressions for a raw Git detection overridden by NixOS and for the managed no-self-mutation boundary

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_update_inventory.py -q` (13 passed)
- `scripts/run_tests.sh tests/hermes_cli/test_managed_install_shapes.py -q` (18 passed)
- `$HOME/.hermes/hermes-agent/venv/bin/python -m ruff check hermes_cli/update_inventory.py tests/hermes_cli/test_update_inventory.py`
- `git diff --check`

Fixes an update-plan consistency issue; no corresponding tracked issue exists.