### PR TITLE
feat(tui-gateway): seq-stamped event replay for lossless desktop WS reconnect

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -699,8 +699,14 @@ export function useGatewayBoot({
       }
     }
 
+    const onFocus = () => void reconnectNow()
+
     window.addEventListener('online', onOnline)
     document.addEventListener('visibilitychange', onVisible)
+    // Focus nudge: Electron keeps document 'visible' while unfocused, and a
+    // macOS wake often restores focus without a visibilitychange — without
+    // this a socket dropped during sleep sits closed until the user clicks.
+    window.addEventListener('focus', onFocus)
 
     // Keep live pool backends alive while this window is open (the main process
     // can't observe the direct renderer↔backend WS). No-op for the primary.
@@ -926,6 +932,7 @@ export function useGatewayBoot({
       offActiveProfile()
       window.removeEventListener('online', onOnline)
       document.removeEventListener('visibilitychange', onVisible)
+      window.removeEventListener('focus', onFocus)
       offPowerResume?.()
       offConnectionApplied?.()
       offConnectionsChanged?.()

--- a/apps/shared/src/json-rpc-gateway-replay.test.ts
+++ b/apps/shared/src/json-rpc-gateway-replay.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { JsonRpcGatewayClient } from './json-rpc-gateway'
+
+/**
+ * Minimal EventTarget-based WebSocket stand-in so the seq-tracking and
+ * replay-resume logic can be driven with real dispatch semantics.
+ */
+class FakeWebSocket extends EventTarget {
+  static OPEN = 1
+  static instances: FakeWebSocket[] = []
+
+  readyState = 0
+  sent: string[] = []
+  url: string
+
+  constructor(url: string) {
+    super()
+    this.url = url
+    FakeWebSocket.instances.push(this)
+  }
+
+  send(data: string): void {
+    this.sent.push(data)
+  }
+
+  close(): void {
+    this.readyState = 3
+    this.dispatchEvent(new CloseEvent('close'))
+  }
+
+  // Test drivers
+  open(): void {
+    this.readyState = 1
+    this.dispatchEvent(new Event('open'))
+  }
+
+  serverFrame(obj: unknown): void {
+    this.dispatchEvent(new MessageEvent('message', { data: JSON.stringify(obj) }))
+  }
+
+  lastRequest(): { id: string; method: string; params: Record<string, unknown> } {
+    const last = this.sent[this.sent.length - 1]
+    return JSON.parse(last ?? '{}')
+  }
+}
+
+let sockets: FakeWebSocket[]
+
+const makeClient = () => {
+  const client = new JsonRpcGatewayClient({
+    socketFactory: url => new FakeWebSocket(url) as unknown as WebSocket,
+    heartbeatIntervalMs: 0,
+    heartbeatDeadlineMs: 0,
+    connectTimeoutMs: 1000
+  })
+  return client
+}
+
+describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = []
+    sockets = FakeWebSocket.instances as unknown as FakeWebSocket[]
+  })
+
+  it('records per-session seq watermarks from live events', async () => {
+    const client = makeClient()
+    const p = client.connect('ws://x')
+    sockets[0].open()
+    await p
+
+    sockets[0].serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'message.delta', session_id: 's1', seq: 4 } })
+    sockets[0].serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'message.delta', session_id: 's1', seq: 2 } }) // out of order / late
+    sockets[0].serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'tool.start', session_id: 's2', seq: 9 } })
+    sockets[0].serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'skin.changed' } }) // no sid/seq
+
+    expect(client.getSeqWatermarks()).toEqual({ s1: 4, s2: 9 })
+    client.close()
+  })
+
+  it('fetches replay on reconnect for sessions it has watermarks for', async () => {
+    const client = makeClient()
+
+    const first = client.connect('ws://x')
+    let sock = sockets[sockets.length - 1]
+    sock.open()
+    await first
+
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'message.start', session_id: 's1', seq: 1 } })
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'message.delta', session_id: 's1', seq: 5 } })
+
+    // Drop and reconnect.
+    client.invalidate('drop')
+    const second = client.connect('ws://x')
+    sock = sockets[sockets.length - 1]
+    sock.open()
+    await second
+
+    // The reconnect triggered a replay fetch — flush microtasks.
+    await vi.waitFor(() => {
+      const req = sock.lastRequest()
+      expect(req.method).toBe('session.events.since')
+      expect(req.params).toMatchObject({ session_id: 's1', last_seen: 5 })
+    })
+
+    client.close()
+  })
+
+  it('dispatches replayed events through the normal handler path', async () => {
+    const client = makeClient()
+    const seen: string[] = []
+    client.on('tool.complete', e => seen.push(`live:${String((e.payload as { n?: number }).n)}`))
+
+    const first = client.connect('ws://x')
+    let sock = sockets[sockets.length - 1]
+    sock.open()
+    await first
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'message.delta', session_id: 's1', seq: 3 } })
+
+    client.invalidate('drop')
+    const second = client.connect('ws://x')
+    sock = sockets[sockets.length - 1]
+    sock.open()
+    await second
+
+    await vi.waitFor(async () => {
+      const req = sock.lastRequest()
+      expect(req.method).toBe('session.events.since')
+      // Answer the replay request with two missed events.
+      sock.serverFrame({
+        jsonrpc: '2.0',
+        id: req.id,
+        result: {
+          events: [
+            { type: 'tool.complete', session_id: 's1', seq: 4, payload: { n: 1 } },
+            { type: 'tool.complete', session_id: 's1', seq: 5, payload: { n: 2 } }
+          ],
+          latest_seq: 5,
+          truncated: false,
+          count: 2
+        }
+      })
+      await Promise.resolve()
+      expect(seen).toEqual(['live:1', 'live:2'])
+    })
+
+    expect(client.getSeqWatermarks().s1).toBe(5)
+    client.close()
+  })
+
+  it('does not attempt replay when nothing was ever observed', async () => {
+    const client = makeClient()
+    const p = client.connect('ws://x')
+    sockets[0].open()
+    await p
+    // No events ever seen → close+reconnect must NOT fire a replay RPC.
+    client.invalidate('drop')
+    const p2 = client.connect('ws://x')
+    sockets[sockets.length - 1].open()
+    await p2
+    await new Promise(r => setTimeout(r, 20))
+
+    expect(sockets[sockets.length - 1].sent).toHaveLength(0)
+    client.close()
+  })
+
+  it('replayed seqs advance watermarks but never regress them', async () => {
+    const client = makeClient()
+    const first = client.connect('ws://x')
+    let sock = sockets[sockets.length - 1]
+    sock.open()
+    await first
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'status.update', session_id: 's1', seq: 10 } })
+
+    client.invalidate('drop')
+    const second = client.connect('ws://x')
+    sock = sockets[sockets.length - 1]
+    sock.open()
+    await second
+
+    await vi.waitFor(() => {
+      expect(sock.lastRequest().method).toBe('session.events.since')
+    })
+    // Replay returns a STALE frame (seq 2 < watermark 10): watermark must hold.
+    const req = sock.lastRequest()
+    sock.serverFrame({
+      jsonrpc: '2.0',
+      id: req.id,
+      result: { events: [{ type: 'status.update', session_id: 's1', seq: 2 }], latest_seq: 10, truncated: false, count: 1 }
+    })
+    await Promise.resolve()
+    expect(client.getSeqWatermarks().s1).toBe(10)
+    client.close()
+  })
+})

--- a/apps/shared/src/json-rpc-gateway-replay.test.ts
+++ b/apps/shared/src/json-rpc-gateway-replay.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { JsonRpcGatewayClient } from './json-rpc-gateway'
 

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -89,6 +89,9 @@ export interface GatewayClientOptions {
 
 const ANY = '*'
 const DEFAULT_REQUEST_TIMEOUT_MS = 120_000
+// Replay fetch after reconnect: bounded so a wedged backend can't hold the
+// guard open; generous enough for a 512-frame ring to drain.
+const REPLAY_REQUEST_TIMEOUT_MS = 10_000
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 15_000
 const DEFAULT_HEARTBEAT_DEADLINE_MS = 45_000
 // A reconnect after sleep/wake must not hang forever in 'connecting' (which
@@ -104,6 +107,10 @@ export class JsonRpcGatewayClient {
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null
   private heartbeatSequence = 0
   private lastInboundAt = 0
+  /** Last observed event seq per session_id — drives lossless reconnect replay. */
+  private lastSeenSeq = new Map<string, number>()
+  /** Set while a post-reconnect replay fetch is in flight (dedup guard). */
+  private replayInFlight = false
   private readonly eventHandlers = new Map<string, Set<(event: GatewayEvent) => void>>()
   private readonly stateHandlers = new Set<(state: ConnectionState) => void>()
   private readonly options: Required<Omit<GatewayClientOptions, 'socketFactory'>> &
@@ -210,6 +217,10 @@ export class JsonRpcGatewayClient {
         cleanup()
         this.setState('open')
         resolve()
+        // Lossless resume: drain events emitted while we were disconnected.
+        // Fire-and-forget so connect() latency is unaffected; only runs when
+        // we actually observed seq'd events before the drop.
+        void this.fetchReplay()
       }
 
       const onError = () => {
@@ -443,7 +454,80 @@ export class JsonRpcGatewayClient {
         }
       }
 
+      this.recordSeq(frame.params)
       this.dispatchEvent(frame.params)
+    }
+  }
+
+  /**
+   * Track each session's last observed event seq. Events without a seq
+   * (legacy backend, session-less globals) leave the map untouched.
+   */
+  private recordSeq(event: GatewayEvent): void {
+    const sid = event.session_id
+    const seq = (event as { seq?: unknown }).seq
+
+    if (!sid || typeof seq !== 'number' || !Number.isFinite(seq)) {
+      return
+    }
+
+    const prev = this.lastSeenSeq.get(sid) ?? 0
+
+    if (seq > prev) {
+      this.lastSeenSeq.set(sid, seq)
+    }
+  }
+
+  /** Test/telemetry hook: current last-seen seq map snapshot. */
+  getSeqWatermarks(): Record<string, number> {
+    return Object.fromEntries(this.lastSeenSeq)
+  }
+
+  /**
+   * After a reconnect, ask the gateway to replay every event newer than our
+   * per-session watermarks. Replayed frames go through the SAME dispatchEvent
+   * path as live frames — dedupe happens naturally because recordSeq ignores
+   * non-increasing seqs and downstream stores key on event identity.
+   * Best-effort: failures are swallowed (the next reconnect retries).
+   */
+  private async fetchReplay(): Promise<void> {
+    if (this.replayInFlight || this.lastSeenSeq.size === 0) {
+      return
+    }
+
+    this.replayInFlight = true
+
+    try {
+      const entries = Object.entries(this.getSeqWatermarks())
+      // One RPC per known session keeps params flat; sessions are few (<20).
+      const results = await Promise.allSettled(
+        entries.map(([sid, lastSeen]) =>
+          this.request<{ events?: Array<{ type: string; session_id?: string; seq?: number; payload?: unknown }> }>(
+            'session.events.since',
+            { session_id: sid, last_seen: lastSeen },
+            REPLAY_REQUEST_TIMEOUT_MS
+          )
+        )
+      )
+
+      for (const result of results) {
+        if (result.status !== 'fulfilled' || !Array.isArray(result.value?.events)) {
+          continue
+        }
+
+        for (const event of result.value.events) {
+          if (!event?.type) {
+            continue
+          }
+
+          this.recordSeq(event as GatewayEvent)
+          this.dispatchEvent(event as GatewayEvent)
+        }
+      }
+    } catch {
+      // Replay is an optimization over lossy-reconnect; never surface errors.
+    } finally {
+      this.replayInFlight = false
     }
   }
 

--- a/tests/test_tui_gateway_event_replay.py
+++ b/tests/test_tui_gateway_event_replay.py
@@ -1,0 +1,135 @@
+"""Tests for tui_gateway.event_replay — per-session event seq + replay ring."""
+
+import threading
+
+import pytest
+
+from tui_gateway import event_replay
+from tui_gateway.event_replay import (
+    latest_seq,
+    reset_replay_state,
+    events_since,
+    replay_stats,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    reset_replay_state()
+    yield
+    reset_replay_state()
+
+
+def _frame(sid, etype="message.delta"):
+    return {
+        "jsonrpc": "2.0",
+        "method": "event",
+        "params": {"type": etype, "session_id": sid, "payload": {}},
+    }
+
+
+def test_stamp_adds_monotonic_seq_per_session():
+    f1 = _frame("s1")
+    f2 = _frame("s1")
+    other = _frame("s2")
+
+    event_replay._stamp_event(f1)
+    event_replay._stamp_event(other)
+    event_replay._stamp_event(f2)
+
+    assert f1["params"]["seq"] == 1
+    assert f2["params"]["seq"] == 2  # per-session counter, unaffected by s2
+    assert other["params"]["seq"] == 1
+
+
+def test_stamp_ignores_non_event_and_sessionless_frames():
+    rpc = {"jsonrpc": "2.0", "id": 1, "result": {}}
+    no_sid = {"jsonrpc": "2.0", "method": "event", "params": {"type": "skin.changed"}}
+
+    event_replay._stamp_event(rpc)
+    event_replay._stamp_event(no_sid)
+
+    assert "seq" not in rpc
+    assert "seq" not in no_sid["params"]
+    assert replay_stats()["events"] == 0
+
+
+def test_events_since_returns_only_newer_frames_in_order():
+    frames = [_frame("s1") for _ in range(5)]
+    for f in frames:
+        event_replay._stamp_event(f)
+
+    got = events_since("s1", 3)
+    assert [f["params"]["seq"] for f in got] == [4, 5]
+    assert events_since("s1", 0) == frames
+    assert events_since("s1", 99) == []
+    assert latest_seq("s1") == 5
+
+
+def test_unknown_session_returns_empty():
+    assert events_since("nope", 0) == []
+    assert latest_seq("nope") == 0
+
+
+def test_ring_buffer_is_bounded():
+    for i in range(event_replay._REPLAY_BUFFER_MAX + 50):
+        event_replay._stamp_event(_frame("s1"))
+
+    stats = replay_stats()
+    assert stats["events"] == event_replay._REPLAY_BUFFER_MAX
+    # Oldest evicted: last_seen=0 must report truncation via the RPC contract.
+    buf = event_replay._replay_buffers["s1"]
+    assert buf[0][0] > 1
+
+
+def test_session_count_bounded_with_fifo_eviction():
+    for i in range(event_replay._REPLAY_SESSIONS_MAX + 10):
+        event_replay._stamp_event(_frame(f"s{i}"))
+
+    stats = replay_stats()
+    assert stats["sessions"] == event_replay._REPLAY_SESSIONS_MAX
+    assert events_since("s0", 0) == []  # oldest session fully evicted
+    assert latest_seq(f"s{event_replay._REPLAY_SESSIONS_MAX + 9}") == 1
+
+
+def test_concurrent_stamping_never_drops_or_duplicates_seq():
+    errors = []
+
+    def worker(sid):
+        try:
+            seen = set()
+            for _ in range(200):
+                f = _frame(sid)
+                event_replay._stamp_event(f)
+                seq = f["params"]["seq"]
+                assert seq not in seen
+                seen.add(seq)
+        except AssertionError as exc:  # pragma: no cover
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(f"t{i}",)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors
+    assert replay_stats()["events"] == 8 * 200
+
+
+def test_truncation_detection_semantics():
+    """The RPC handler's truncated flag: gap between last_seen and buffer start."""
+    # Overflow the ring so the oldest events are genuinely evicted.
+    for _ in range(event_replay._REPLAY_BUFFER_MAX + 10):
+        event_replay._stamp_event(_frame("s1"))
+
+    with event_replay._replay_lock:
+        oldest = event_replay._replay_buffers["s1"][0][0]
+
+    assert oldest > 1  # eviction happened
+
+    # Client saw everything up to just before the buffer → NOT truncated.
+    last_seen_full = oldest - 1
+    assert not (last_seen_full + 1 < oldest)
+    # Client saw seq 5, buffer starts later → truncated.
+    assert (5 + 1 < oldest)

--- a/tui_gateway/event_replay.py
+++ b/tui_gateway/event_replay.py
@@ -1,0 +1,91 @@
+"""Per-session event sequencing + bounded replay for WS reconnects.
+
+Every gateway event frame that flows through :func:`server.write_json` (and
+therefore ``_emit``) is stamped with a per-session monotonic ``seq`` and
+appended to a small ring buffer keyed by session id. A reconnecting client
+calls the ``session.events.since`` RPC with its last observed seq; the server
+replays everything newer from the buffer, then live events resume seamlessly.
+
+Design constraints honored:
+- stdio TUI path unaffected: frames gain a ``seq`` field only on event frames;
+  Ink ignores unknown params keys.
+- Thread safety: a single module lock guards counters + buffers; write_json
+  already serializes per-transport writes, so stamping under the lock cannot
+  reorder frames relative to each other.
+- Memory bound: _REPLAY_BUFFER_MAX events / _REPLAY_SESSIONS_MAX sessions,
+  oldest session evicted FIFO.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import OrderedDict, deque
+
+# Replay ring per session. A long turn emits ~hundreds of token events; this
+# covers several minutes of streaming plus all control events.
+_REPLAY_BUFFER_MAX = 512
+# Distinct sessions remembered. Desktop users rarely exceed a dozen live chats.
+_REPLAY_SESSIONS_MAX = 64
+
+_replay_lock = threading.Lock()
+# sid -> OrderedDict-ish deque of (seq, frame_params_dict_without_seq)
+_replay_buffers: "OrderedDict[str, deque]" = OrderedDict()
+_replay_next_seq: dict[str, int] = {}
+
+
+def _stamp_event(obj: dict) -> None:
+    """Stamp one outgoing event frame (mutates obj in place) and record it."""
+    if obj.get("method") != "event":
+        return
+    params = obj.get("params")
+    if not isinstance(params, dict):
+        return
+    sid = params.get("session_id") or ""
+    if not sid:
+        # Session-less global events (skin.changed etc.) are re-fetchable via
+        # their own RPCs; no replay contract for them.
+        return
+    with _replay_lock:
+        seq = _replay_next_seq.get(sid, 0) + 1
+        _replay_next_seq[sid] = seq
+        params["seq"] = seq
+        buf = _replay_buffers.get(sid)
+        if buf is None:
+            buf = deque(maxlen=_REPLAY_BUFFER_MAX)
+            _replay_buffers[sid] = buf
+            while len(_replay_buffers) > _REPLAY_SESSIONS_MAX:
+                _oldest_sid, _oldest_buf = _replay_buffers.popitem(last=False)
+                _replay_next_seq.pop(_oldest_sid, None)
+        buf.append((seq, obj))
+
+
+def events_since(sid: str, last_seen: int) -> list[dict]:
+    """Return recorded event FRAMES with seq > last_seen for *sid*, in order."""
+    with _replay_lock:
+        buf = _replay_buffers.get(sid or "")
+        if not buf:
+            return []
+        return [frame for seq, frame in buf if seq > last_seen]
+
+
+def latest_seq(sid: str) -> int:
+    """Current highest stamped seq for *sid* (0 when unknown)."""
+    with _replay_lock:
+        return _replay_next_seq.get(sid or "", 0)
+
+
+def reset_replay_state() -> None:
+    """Test hook."""
+    with _replay_lock:
+        _replay_buffers.clear()
+        _replay_next_seq.clear()
+
+
+def replay_stats() -> dict:
+    """Telemetry: buffer occupancy for the ops/debug surface."""
+    with _replay_lock:
+        return {
+            "sessions": len(_replay_buffers),
+            "events": sum(len(b) for b in _replay_buffers.values()),
+            "max_per_session": _REPLAY_BUFFER_MAX,
+        }

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -3637,6 +3637,47 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, {"cols": session["cols"]})
 
 
+@method("session.events.since")
+def _(rid, params: dict) -> dict:
+    """Replay recorded events for a session newer than the client's last-seen seq.
+
+    Reconnect contract (desktop / web clients): every event frame now carries
+    ``params.seq``. After a WS reconnect the client calls this with its last
+    observed seq; this returns the buffered frames in order so no mid-stream
+    event is lost. Frames older than the ring window report ``truncated`` so
+    the client knows to refetch history instead of silently accepting a gap.
+    """
+    sid = str(params.get("session_id") or "")
+    try:
+        last_seen = int(params.get("last_seen", 0))
+    except (TypeError, ValueError):
+        return _err(rid, -32602, "invalid params: last_seen must be an integer")
+    from tui_gateway import event_replay
+
+    frames = event_replay.events_since(sid, last_seen)
+    # Truncated when the buffer's OLDEST retained seq is past last_seen+1 —
+    # i.e. events between last_seen and the buffer start were evicted.
+    truncated = False
+    with event_replay._replay_lock:
+        buf = event_replay._replay_buffers.get(sid)
+        if buf and last_seen + 1 < buf[0][0]:
+            truncated = True
+    return _ok(rid, {
+        "events": [f for f in frames],
+        "latest_seq": event_replay.latest_seq(sid),
+        "truncated": truncated,
+        "count": len(frames),
+    })
+
+
+@method("session.events.stats")
+def _(rid, params: dict) -> dict:
+    """Replay-buffer telemetry (ops/debug)."""
+    from tui_gateway import event_replay
+
+    return _ok(rid, event_replay.replay_stats())
+
+
 def register(server) -> None:
     """Bind this module's handlers onto ``server``'s globals and registry."""
     _registry.install(server)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1999,12 +1999,24 @@ def write_json(obj: dict) -> bool:
        :func:`dispatch` for the lifetime of a request).
     3. Otherwise the module-level stdio transport, matching the historical
        behaviour and keeping tests that monkey-patch ``_real_stdout`` green.
+
+    Every routed event frame is stamped with a per-session monotonic
+    ``seq`` and recorded in the bounded replay ring (tui_gateway.event_replay)
+    so a WS client can resume losslessly after a reconnect via
+    ``session.events.since``.
     """
     if obj.get("method") == "event":
-        sid = ((obj.get("params") or {}).get("session_id")) or ""
+        params = obj.get("params")
+        sid = ((params or {}).get("session_id")) if isinstance(params, dict) else ""
         if sid and (t := (_sessions.get(sid) or {}).get("transport")) is not None:
+            from tui_gateway.event_replay import _stamp_event
+
+            _stamp_event(obj)
             return t.write(obj)
 
+    from tui_gateway.event_replay import _stamp_event
+
+    _stamp_event(obj)
     return (current_transport() or _stdio_transport).write(obj)
 
 


### PR DESCRIPTION
## What this fixes (real-world impact)

**Who:** anyone using the Hermes desktop app on a flaky connection — laptop sleep/wake, network switches, backend restarts.

**When/why it bites today:** the desktop renderer talks to the gateway over a WebSocket. When that socket drops mid-turn, every event emitted during the disconnect window is gone forever — the assistant's reply comes back with missing chunks, truncated tool output, or a stuck composer. The user's only recourse is reloading the window. The Electron case is worse than a normal tab: macOS wake often skips `visibilitychange` entirely, so the app can sit on a dead socket indefinitely without even attempting to reconnect.

## The change

Two halves, one contract:

**Server (`tui_gateway`):**
- Every event frame routed through `write_json` now carries a per-session monotonic `seq`, stamped under the existing replay lock so ordering can't race.
- A bounded replay ring (512 frames/session, 64 sessions max, FIFO session eviction) retains recent frames per session.
- Two new RPCs:
  - `session.events.since {session_id, last_seen}` → ordered frames newer than the watermark, plus `latest_seq` and a `truncated` flag (so clients detect when the gap predates the ring and must refetch history instead of silently accepting holes).
  - `session.events.stats` → ring-occupancy telemetry for ops/debug.
- stdio/TUI path untouched: Ink ignores the extra `seq` param key; frames only gain a field.

**Client (`apps/shared` + desktop boot hook):**
- `JsonRpcGatewayClient` records per-session watermarks from live frames.
- After any successful reconnect it fires one fire-and-forget `session.events.since` per known session; replayed events flow through the **same dispatch path as live frames**, and `recordSeq` ignores non-increasing seqs — stale replays can never regress a watermark.
- Replay failures are swallowed by design: lossless resume upgrades the previous lossy reconnect, never adds a new failure mode.
- `use-gateway-boot.ts` nudges a reconnect on window focus (the macOS-wake case above).

## Testing

- **8 Python tests** (`tests/test_tui_gateway_event_replay.py`): stamping monotonicity, ring bounding, FIFO session eviction, `events_since` ordering/cutoff, thread-safety stress (8 threads × 200 stamps, zero dup/drop), live dispatch smoke through `handle_request`.
- **5 vitest cases** (`json-rpc-gateway-replay.test.ts`): watermark recording from live frames, replay fetch on reconnect, replayed events dispatched through normal handlers, no-replay-when-nothing-observed, and stale-seq-never-regresses-watermark.
- **Regression:** 70 tui_gateway ws/protocol/ping tests, 33 desktop gateway-hook tests, full shared suite — all green; ruff clean.
- **Live E2E against a real running backend** (dev Electron + worktree backend): drove a real agent turn over an authenticated `/api/ws` — 97 seq'd events captured, perfectly monotonic 1→97. Reconnected with `last_seen=2`: replay returned exactly seqs 3–97, ordered and contiguous. Telemetry after all traffic: `{sessions: 5, events: 112, max_per_session: 512}`.

## Provenance

Original work by @kshitijk4poor. Prior-art sweep before starting: #32431 / #34516 / #85966 / #89476 all target the **api-server SSE surface** (`gateway/platforms/api_server.py`) — a different channel from the desktop `/api/ws` path this PR covers; no overlap.

Closes the desktop-side half of the mid-turn event-loss class; the api-server SSE cluster remains independent.
