### PR TITLE
fix(credential_pool): reduce default 429 cooldown from 1 hour to 3 minutes

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -119,10 +119,12 @@ SUPPORTED_POOL_STRATEGIES = {
 
 # Cooldown before retrying an exhausted credential.
 # Transient 401 auth failures cool down briefly so single-key setups can recover.
-# 429 (rate-limited), 402 (billing/quota), and other failures cool down after 1 hour.
-# Provider-supplied reset_at timestamps override these defaults.
+# 429 (rate-limited) cooldown reduced to 3 minutes — burst rate limits typically
+# reset within 1-2 minutes, and the previous 1-hour default caused prolonged
+# lockouts for single-key users. 402 (billing/quota) and other failures still
+# cool down after 1 hour. Provider-supplied reset_at timestamps override these.
 EXHAUSTED_TTL_401_SECONDS = 5 * 60           # 5 minutes
-EXHAUSTED_TTL_429_SECONDS = 60 * 60          # 1 hour
+EXHAUSTED_TTL_429_SECONDS = 60 * 3           # 3 minutes
 EXHAUSTED_TTL_DEFAULT_SECONDS = 60 * 60      # 1 hour
 # When a pool has no other credential to rotate to (the offending key is the
 # sole non-DEAD entry), a 1-hour bench means an hour of hard failures with


### PR DESCRIPTION
## Summary

Reduces the default 429 (rate-limited) credential cooldown from **1 hour** to **3 minutes**.

Burst rate limits typically reset within 1-2 minutes. The previous 1-hour default caused prolonged lockouts for single-key users — if a single credential hit a 429, it would sit in cooldown for an hour even though the rate limit would have cleared in minutes. Provider-supplied `reset_at` timestamps still override this default.

The `EXHAUSTED_TTL_DEFAULT_SECONDS` (1 hour) is unchanged — billing/quota (402) and other non-transient failures still get the long cooldown.

## Changes

- `agent/credential_pool.py`: `EXHAUSTED_TTL_429_SECONDS = 60 * 3` (was `60 * 60`)
- Updated comment block to explain the rationale

## Supersedes

Supersedes #22060 (BLOCKED, 17k+ commits behind main, same fix). Also closes #18713.

## Test Plan

- [ ] Existing credential pool tests pass
- [ ] Verify sole-credential 429 recovery still works with shorter cooldown