### PR TITLE
fix(serve): serve Desktop token page at / in headless mode

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17760,6 +17760,28 @@ def mount_spa(application: FastAPI):
             else "Frontend not built. Run: cd web && npm run build"
         )
 
+        if _headless:
+            # The Desktop renderer loads `/` to extract
+            # ``window.__HERMES_SESSION_TOKEN__`` for its WebSocket auth, even
+            # though `serve` never mounts the SPA. Serve a minimal token-only
+            # HTML page at the exact root path in non-gated (loopback) mode so
+            # the Desktop can authenticate without shipping the full SPA. Every
+            # other path stays JSON 404 — only the JSON-RPC/WS/API surface is
+            # reachable. When the auth gate is on (non-loopback/remote serve),
+            # dispense nothing: the token must not leak past the loopback
+            # boundary. (#62666 — replaces the getBackendArgsForRuntime →
+            # `dashboard --no-open` workaround.)
+            @application.get("/")
+            async def headless_token_page():
+                if getattr(application.state, "auth_required", False):
+                    return JSONResponse({"error": _msg}, status_code=404)
+                return HTMLResponse(
+                    "<!doctype html><html><head>"
+                    f"<script>window.__HERMES_SESSION_TOKEN__={json.dumps(_SESSION_TOKEN)};"
+                    f'window.__HERMES_AUTH_REQUIRED__="false";'
+                    "</script></head><body></body></html>"
+                )
+
         @application.get("/{full_path:path}")
         async def no_frontend(full_path: str):
             return JSONResponse({"error": _msg}, status_code=404)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4848,6 +4848,47 @@ class TestServeIndexMissingIndex:
         assert "SPA-rebuilt" in resp.text
 
 
+class TestHeadlessServeTokenPage:
+    """`hermes serve` (headless) must serve a minimal token page at `/` in
+    loopback (non-gated) mode so the Desktop renderer can extract
+    ``window.__HERMES_SESSION_TOKEN__`` for its WebSocket auth, while keeping
+    every other path (and the gated/remote case) a JSON 404. (#62666)"""
+
+    @staticmethod
+    def _headless_client(monkeypatch, *, auth_required):
+        import json
+
+        from fastapi import FastAPI
+        from starlette.testclient import TestClient
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setenv("HERMES_SERVE_HEADLESS", "1")
+        spa_app = FastAPI()
+        spa_app.state.auth_required = auth_required
+        ws.mount_spa(spa_app)
+        return TestClient(spa_app), json.dumps(ws._SESSION_TOKEN)
+
+    def test_root_serves_token_page_in_loopback(self, monkeypatch):
+        client, token_json = self._headless_client(monkeypatch, auth_required=False)
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert f"window.__HERMES_SESSION_TOKEN__={token_json}" in resp.text
+        assert 'window.__HERMES_AUTH_REQUIRED__="false"' in resp.text
+
+    def test_root_is_json_404_when_auth_gated(self, monkeypatch):
+        client, _ = self._headless_client(monkeypatch, auth_required=True)
+        resp = client.get("/")
+        assert resp.status_code == 404
+        assert "web UI disabled" in resp.json()["error"]
+
+    def test_other_paths_stay_json_404(self, monkeypatch):
+        client, _ = self._headless_client(monkeypatch, auth_required=False)
+        for route in ("/chat", "/api/status", "/assets/app.js"):
+            resp = client.get(route)
+            assert resp.status_code == 404
+            assert "web UI disabled" in resp.json()["error"]
+
+
 class TestHashedAssetCacheHeaders:
     """Hashed /assets/* responses must be immutable-cacheable; index.html
     must stay no-store so it always references the current hashes


### PR DESCRIPTION
## Problem

The Desktop app spawns its backend via \`hermes serve\`, which sets
\`HERMES_SERVE_HEADLESS=1\` and disables the SPA at \`/\`. The renderer loads
\`/\` to extract \`window.__HERMES_SESSION_TOKEN__\` for WebSocket auth, gets a
404 JSON body, and the boot fails:

\`\`\`
could not read served dashboard token: 404: {"error":"Headless backend (hermes serve): web UI disabled"}
Desktop boot failed: WebSocket (/api/ws) rejected the session token
\`\`\`

This is upstream #62666. The historical workaround (rewriting
\`getBackendArgsForRuntime\` to \`dashboard --no-open\` had to be re-applied
after every `hermes update` because it was a frontend patch that upstream
overwrote.

## Fix

In `mount_spa()`'s headless branch, serve a minimal token-only HTML page at
the exact root path `/` when **not** auth-gated:

```html
<script>window.__HERMES_SESSION_TOKEN__=…;window.__HERMES_AUTH_REQUIRED__=false;</script>
```

This matches the renderer's extraction regex exactly. When the auth gate is
on (`should_require_dashboard_auth` — non-loopback/remote `serve`), the
route returns the existing 404 JSON, so the session token never leaks past
the loopback boundary. Every other path stays 404 JSON; only the
JSON-RPC/WS/API surface is reachable.

## Tests

Added `TestHeadlessServeTokenPage` (3 cases) to
`tests/hermes_cli/test_web_server.py`:
- loopback (non-gated) `/` → 200 + token page
- gated `/` → 404 JSON
- other paths (`/chat`, `/api/status`, `/assets/\*`) → 404 JSON

`test_web_server.py` + `test_serve_command.py`: 173 passed, 0 failed.

## Verification

Live `hermes serve` on loopback: `GET /` → 200 with token; `GET /chat` →
404 JSON. Full Desktop relaunch boots to `Hermes backend is ready` with zero
failure markers and the backend running as `serve` (no `dashboard --no-open`
fallback).
EOF
)