### PR TITLE
fix(agent): distinguish OpenRouter key limits from billing

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1070,8 +1070,8 @@ def recover_with_credential_pool(
         if _credential_id:
             kwargs["credential_id"] = _credential_id
         # Hand the pool the classified semantics, not just the status. A
-        # billing 403 (OpenRouter "key limit exceeded", xAI spending limit)
-        # and an edge-throttle 403 are the same number but need opposite
+        # capacity 403 (OpenRouter key limit, xAI spending limit) and an
+        # edge-throttle 403 are the same number but need opposite
         # cooldowns — the pool can only tell them apart if we say which.
         # ``effective_reason`` is resolved below; this closure runs after.
         if effective_reason is not None:
@@ -1112,7 +1112,7 @@ def recover_with_credential_pool(
             )
         return False, has_retried_429
 
-    if effective_reason == FailoverReason.billing:
+    if effective_reason in {FailoverReason.billing, FailoverReason.key_limit}:
         rotate_status = status_code if status_code is not None else 402
         # Runtime credentials can be resolved by a separate pool instance,
         # leaving this recovery pool without ``current_id``. Match the key
@@ -1120,8 +1120,9 @@ def recover_with_credential_pool(
         next_entry = _rotate_failed_credential(rotate_status)
         if next_entry is not None:
             _ra().logger.info(
-                "Credential %s (billing) — rotated to pool entry %s",
+                "Credential %s (%s) — rotated to pool entry %s",
                 rotate_status,
+                effective_reason.value,
                 getattr(next_entry, "id", "?"),
             )
             agent._swap_credential(next_entry)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2471,7 +2471,12 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     auth resolution and client construction — no duplicated provider→key
     mappings.
     """
-    if reason in {FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit}:
+    if reason in {
+        FailoverReason.rate_limit,
+        FailoverReason.billing,
+        FailoverReason.key_limit,
+        FailoverReason.upstream_rate_limit,
+    }:
         # Only start cooldown when leaving the primary provider.  If we're
         # already on a fallback and chain-switching, the primary wasn't the
         # source of the 429 so the cooldown should not be reset/extended.
@@ -2502,7 +2507,12 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # provider again.  Guards the cross-turn replay storm in #24996.
         if (
             len(agent._fallback_chain) > 0
-            and reason not in {FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit}
+            and reason not in {
+                FailoverReason.rate_limit,
+                FailoverReason.billing,
+                FailoverReason.key_limit,
+                FailoverReason.upstream_rate_limit,
+            }
         ):
             _existing_cooldown = getattr(agent, "_rate_limited_until", 0) or 0
             agent._rate_limited_until = max(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -798,6 +798,12 @@ def _print_key_limit_guidance(agent, *, provider: str, model: str) -> bool:
     return bool(message)
 
 
+def _key_limit_terminal_response(*, summary: str, provider: str, model: str) -> str:
+    """Build the canonical terminal response for a per-key spending cap."""
+    guidance = _key_limit_message(provider=provider, model=model)
+    return f"API key spending limit reached: {summary}\n\n{guidance}"
+
+
 def _key_limit_failure_result(
     *,
     classified,
@@ -808,9 +814,12 @@ def _key_limit_failure_result(
     model: str,
 ) -> dict:
     """Structured terminal result for a per-credential spend-cap failure."""
-    guidance = _key_limit_message(provider=provider, model=model)
     return {
-        "final_response": f"API key spending limit reached: {summary}\n\n{guidance}",
+        "final_response": _key_limit_terminal_response(
+            summary=summary,
+            provider=provider,
+            model=model,
+        ),
         "messages": messages,
         "api_calls": api_call_count,
         "completed": False,
@@ -6604,9 +6613,10 @@ def run_conversation(
                             unverified=_billing_unverified,
                         )
                     elif classified.reason == FailoverReason.key_limit:
-                        _final_response = (
-                            f"API key spending limit reached: {_final_summary}\n\n"
-                            f"{_key_limit_message(provider=_provider, model=_model)}"
+                        _final_response = _key_limit_terminal_response(
+                            summary=_final_summary,
+                            provider=_provider,
+                            model=_model,
                         )
                     else:
                         _final_response = f"API call failed after {max_retries} retries: {_final_summary}"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -774,6 +774,53 @@ def _billing_terminal_label(summary: str, unverified: bool) -> str:
     return f"Billing or credits exhausted: {summary}"
 
 
+def _key_limit_message(*, provider: str, model: str) -> str:
+    """Actionable guidance for an explicit per-credential spend cap."""
+    provider_label = (provider or "").strip() or "The selected provider"
+    model_label = (model or "").strip() or "the selected model"
+    lines = [
+        (
+            f"{provider_label} reported that the selected API key reached its "
+            f"configured spending limit for {model_label}. This does not mean "
+            "the provider account is out of credits."
+        ),
+        "Switch to another key or provider, raise the key limit, or wait for its configured reset.",
+    ]
+    if provider_label.lower() == "openrouter":
+        lines.append("Manage OpenRouter keys: https://openrouter.ai/settings/keys")
+    return "\n".join(lines)
+
+
+def _print_key_limit_guidance(agent, *, provider: str, model: str) -> bool:
+    message = _key_limit_message(provider=provider, model=model)
+    for line in message.splitlines():
+        agent._vprint(f"{agent.log_prefix}   💡 {line}", force=True)
+    return bool(message)
+
+
+def _key_limit_failure_result(
+    *,
+    classified,
+    summary: str,
+    messages,
+    api_call_count: int,
+    provider: str,
+    model: str,
+) -> dict:
+    """Structured terminal result for a per-credential spend-cap failure."""
+    guidance = _key_limit_message(provider=provider, model=model)
+    return {
+        "final_response": f"API key spending limit reached: {summary}\n\n{guidance}",
+        "messages": messages,
+        "api_calls": api_call_count,
+        "completed": False,
+        "failed": True,
+        "error": summary,
+        "failure_reason": classified.reason.value,
+        "failure_retryable": bool(classified.retryable),
+    }
+
+
 def _billing_failure_result(
     *,
     classified,
@@ -5423,6 +5470,7 @@ def run_conversation(
                 is_rate_limited = classified.reason in {
                     FailoverReason.rate_limit,
                     FailoverReason.billing,
+                    FailoverReason.key_limit,
                     FailoverReason.upstream_rate_limit,
                 }
                 # Relay-wrapped output-cap errors: some gateways wrap an
@@ -5497,6 +5545,10 @@ def run_conversation(
                                 agent._buffer_status(
                                     "⚠️ Billing or credits exhausted — switching to fallback provider..."
                                 )
+                        elif classified.reason == FailoverReason.key_limit:
+                            agent._buffer_status(
+                                "⚠️ API key spending limit reached — switching to fallback provider..."
+                            )
                         elif _is_transport_failure:
                             agent._buffer_status(
                                 "⚠️ Provider unreachable — switching to fallback provider..."
@@ -6182,6 +6234,11 @@ def run_conversation(
                             f"❌ TLS certificate verification failed: "
                             f"{_nonretryable_summary}"
                         )
+                    elif classified.reason == FailoverReason.key_limit:
+                        agent._emit_status(
+                            f"❌ API key spending limit reached: "
+                            f"{_nonretryable_summary}"
+                        )
                     else:
                         agent._emit_status(
                             f"❌ Non-retryable error (HTTP {status_code}): "
@@ -6191,7 +6248,10 @@ def run_conversation(
                     agent._vprint(f"{agent.log_prefix}   🔌 Provider: {_provider}  Model: {_model}", force=True)
                     agent._vprint(f"{agent.log_prefix}   🌐 Endpoint: {_base}", force=True)
                     # Actionable guidance for common auth errors
-                    if classified.is_auth or classified.reason == FailoverReason.billing:
+                    if classified.is_auth or classified.reason in {
+                        FailoverReason.billing,
+                        FailoverReason.key_limit,
+                    }:
                         if classified.reason == FailoverReason.billing and _print_billing_or_entitlement_guidance(
                             agent,
                             capability="model access",
@@ -6199,6 +6259,12 @@ def run_conversation(
                             base_url=str(_base),
                             model=_model,
                             unverified=classified.billing_unverified,
+                        ):
+                            pass
+                        elif classified.reason == FailoverReason.key_limit and _print_key_limit_guidance(
+                            agent,
+                            provider=_provider,
+                            model=_model,
                         ):
                             pass
                         elif _provider == "nous" and _print_nous_entitlement_guidance(
@@ -6334,6 +6400,15 @@ def run_conversation(
                             base_url=_base,
                             model=_model,
                         )
+                    if classified.reason == FailoverReason.key_limit:
+                        return _key_limit_failure_result(
+                            classified=classified,
+                            summary=_nonretryable_summary,
+                            messages=messages,
+                            api_call_count=api_call_count,
+                            provider=_provider,
+                            model=_model,
+                        )
                     return {
                         "final_response": _nonretryable_summary,
                         "messages": messages,
@@ -6399,6 +6474,15 @@ def run_conversation(
                             base_url=str(_base),
                             model=_model,
                             unverified=classified.billing_unverified,
+                        )
+                    elif classified.reason == FailoverReason.key_limit:
+                        agent._emit_status(
+                            f"❌ API key spending limit reached — {_final_summary}"
+                        )
+                        _print_key_limit_guidance(
+                            agent,
+                            provider=_provider,
+                            model=_model,
                         )
                     elif is_rate_limited:
                         agent._emit_status(f"❌ Rate limited after {max_retries} retries — {_final_summary}")
@@ -6518,6 +6602,11 @@ def run_conversation(
                         _billing_block = _billing_block_dict(
                             _provider, _base, _model, _billing_guidance,
                             unverified=_billing_unverified,
+                        )
+                    elif classified.reason == FailoverReason.key_limit:
+                        _final_response = (
+                            f"API key spending limit reached: {_final_summary}\n\n"
+                            f"{_key_limit_message(provider=_provider, model=_model)}"
                         )
                     else:
                         _final_response = f"API call failed after {max_retries} retries: {_final_summary}"

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -136,6 +136,11 @@ EXHAUSTED_TTL_SOLE_CREDENTIAL_SECONDS = 60   # 1 minute
 # the classifier), so the value is duplicated here rather than referenced.
 FAILURE_REASON_BILLING = "billing"
 
+# An explicit per-credential spend cap. Like billing exhaustion, retrying the
+# same key after a minute cannot help; unlike billing, it must not be surfaced
+# as evidence that the account itself is out of credits.
+FAILURE_REASON_KEY_LIMIT = "key_limit"
+
 # Billing verdict that rests on an ambiguous body (#82154): Anthropic's
 # "out of extra usage" 400 is returned both for genuine overage depletion and
 # for a server-side content-filter rejection of the request. The latter leaves
@@ -332,8 +337,8 @@ def _exhausted_ttl(
     *failure_reason* is the classified semantics from
     ``agent/error_classifier.py``. The raw status alone can't size the
     cooldown: an OpenRouter ``key limit exceeded`` and an xAI spending-limit
-    block both arrive as **403** but classify as ``billing``, and a 60s retry
-    on a spent account just re-fails every minute. Billing keeps the full
+    block both arrive as **403**, and a 60s retry against either exhausted
+    capacity just fails again. Billing and explicit key limits keep the full
     bench regardless of status; 402 does too, since it is billing by
     definition even when nothing classified it.
     """
@@ -353,8 +358,11 @@ def _exhausted_ttl(
     # edge-throttle, 5xx server, or unknown). Billing exhaustion — whether
     # classified as such or self-evident from a 402 — is a genuine depletion
     # where a quick retry can't help, so it keeps the full bench.
-    is_billing = error_code == 402 or failure_reason == FAILURE_REASON_BILLING
-    if sole_credential and not is_billing:
+    is_capacity_exhausted = error_code == 402 or failure_reason in {
+        FAILURE_REASON_BILLING,
+        FAILURE_REASON_KEY_LIMIT,
+    }
+    if sole_credential and not is_capacity_exhausted:
         return min(base, EXHAUSTED_TTL_SOLE_CREDENTIAL_SECONDS)
     return base
 

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -36,6 +36,7 @@ class FailoverReason(enum.Enum):
 
     # Billing / quota
     billing = "billing"                  # 402 or confirmed credit exhaustion — rotate immediately
+    key_limit = "key_limit"              # Per-credential spend cap — rotate immediately
     rate_limit = "rate_limit"            # 429 or quota-based throttling — backoff then rotate
     # Upstream model rate-limited (aggregator 429) — fallback to a different
     # model, NOT credential rotation. The user's key is healthy.
@@ -1229,15 +1230,31 @@ def _classify_by_status(
             should_fallback=True,
         )
 
+    # OpenRouter's explicit per-key cap is credential capacity, not proof that
+    # the account balance is exhausted. The reported incident arrived as 403;
+    # current OpenRouter documentation groups key-credit exhaustion under 402.
+    # Handle both only for the provider's explicit marker so generic provider
+    # 402s retain their existing account-billing semantics.
+    if (
+        status_code in {402, 403}
+        and provider == "openrouter"
+        and "key limit exceeded" in error_msg
+    ):
+        return result_fn(
+            FailoverReason.key_limit,
+            retryable=False,
+            should_rotate_credential=True,
+            should_fallback=True,
+        )
+
     if status_code == 403:
-        # OpenRouter 403 "key limit exceeded" is actually billing. Other
-        # providers also use 403 for account-plan or credit exhaustion.
+
+        # Other providers also use 403 for account-plan or credit exhaustion.
         if (
             (
                 provider == "xai-oauth"
                 and error_code.lower() == _XAI_SPENDING_LIMIT_ERROR_CODE
             )
-            or "key limit exceeded" in error_msg
             or "spending limit" in error_msg
             or any(p in error_msg for p in _BILLING_PATTERNS)
         ):

--- a/agent/error_surface.py
+++ b/agent/error_surface.py
@@ -71,6 +71,7 @@ _NON_RETRYABLE_REASONS = {
     "auth_permanent",
     "billing",
     "billing_unverified",
+    "key_limit",
     "content_policy_blocked",
     "provider_policy_blocked",
     "model_not_found",

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -516,11 +516,10 @@ class TestFailureAttribution:
     def test_classified_billing_403_recorded_on_entry(self, tmp_path, monkeypatch):
         """A billing-classified 403 must reach the pool as `billing`, not a bare 403.
 
-        `error_classifier` maps OpenRouter's `key limit exceeded` 403 (and xAI
-        spending-limit blocks) to FailoverReason.billing, but the pool only
-        ever saw the raw status — so a sole-credential pool gave a spent
-        account the 60s transient cooldown and re-failed every minute. The
-        recovery path now forwards the classified reason so the pool can size
+        Providers such as xAI can return spending-limit blocks as 403, but the
+        pool only ever saw the raw status — so a sole-credential pool gave a
+        spent account the 60s transient cooldown and re-failed every minute.
+        The recovery path forwards the classified reason so the pool can size
         the bench correctly.
         """
         from agent.error_classifier import FailoverReason
@@ -545,6 +544,34 @@ class TestFailureAttribution:
         assert failed.last_status == "exhausted"
         assert failed.failure_reason == "billing"
 
+    def test_classified_key_limit_403_rotates_and_records_distinct_reason(
+        self, tmp_path, monkeypatch
+    ):
+        """A per-key cap rotates credentials without becoming account billing."""
+        from agent.error_classifier import FailoverReason
+
+        pool = self._make_pool(
+            tmp_path, monkeypatch,
+            [self._entry(0, "key-a"), self._entry(1, "key-b")],
+        )
+        agent = self._agent(pool, failing_key="key-b")
+        agent._is_entitlement_failure = MagicMock(return_value=False)
+
+        from agent.agent_runtime_helpers import recover_with_credential_pool
+
+        recovered, _ = recover_with_credential_pool(
+            agent,
+            status_code=403,
+            has_retried_429=False,
+            classified_reason=FailoverReason.key_limit,
+        )
+
+        failed = {e.id: e for e in pool.entries()}["cred-1"]
+        assert recovered is True
+        assert failed.last_status == "exhausted"
+        assert failed.failure_reason == "key_limit"
+        agent._swap_credential.assert_called_once()
+
     def test_unclassified_403_records_no_billing_reason(self, tmp_path, monkeypatch):
         """An unclassified 403 stays transient — no billing verdict is invented."""
         pool = self._make_pool(
@@ -562,4 +589,3 @@ class TestFailureAttribution:
 
         failed = {e.id: e for e in pool.entries()}["cred-1"]
         assert failed.failure_reason != "billing"
-

--- a/tests/agent/test_credential_pool_sole_cooldown.py
+++ b/tests/agent/test_credential_pool_sole_cooldown.py
@@ -81,16 +81,27 @@ def test_sole_credential_403_recovers_after_short_cooldown(tmp_path, monkeypatch
 def test_sole_credential_billing_403_keeps_full_bench(tmp_path, monkeypatch):
     """A 403 classified as BILLING must keep the full bench, not the 60s cooldown.
 
-    Providers overload 403: OpenRouter returns it for `key limit exceeded` and
-    xAI for a spending-limit block, both of which `error_classifier` maps to
-    FailoverReason.billing. Status alone can't tell those from an edge
-    throttle, so retrying a spent account every 60s just re-fails forever.
+    Providers overload 403: xAI returns it for a spending-limit block, which
+    `error_classifier` maps to FailoverReason.billing. Status alone can't tell
+    that from an edge throttle, so retrying a spent account every 60s just
+    re-fails forever.
     The classified reason rides along on the entry and wins over the status.
     """
     pool = _load(
         tmp_path,
         monkeypatch,
         [_entry(403, age_seconds=90, failure_reason="billing")],
+    )
+    assert pool.has_available() is False
+    assert pool.select() is None
+
+
+def test_sole_credential_key_limit_403_keeps_full_bench(tmp_path, monkeypatch):
+    """A configured key cap must not be retried every minute."""
+    pool = _load(
+        tmp_path,
+        monkeypatch,
+        [_entry(403, age_seconds=90, failure_reason="key_limit")],
     )
     assert pool.has_available() is False
     assert pool.select() is None

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -56,7 +56,7 @@ class TestFailoverReason:
 
     def test_enum_members_exist(self):
         expected = {
-            "auth", "auth_permanent", "billing", "rate_limit",
+            "auth", "auth_permanent", "billing", "key_limit", "rate_limit",
             "upstream_rate_limit",
             "overloaded", "server_error", "timeout",
             "ssl_cert_verification",
@@ -202,6 +202,36 @@ class TestClassifyApiError:
         result = classify_api_error(e, provider="anthropic")
         assert result.reason == FailoverReason.auth
         assert result.should_fallback is True
+
+    def test_openrouter_403_key_cap_is_not_account_billing(self):
+        e = MockAPIError(
+            "Key limit exceeded (daily limit)",
+            status_code=403,
+            body={"error": {"message": "Key limit exceeded (daily limit)"}},
+        )
+
+        result = classify_api_error(e, provider="OpenRouter", model="test/model")
+
+        assert result.reason == FailoverReason.key_limit
+        assert result.retryable is False
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
+
+    def test_openrouter_402_key_cap_is_not_account_billing(self):
+        e = MockAPIError("Key limit exceeded", status_code=402)
+
+        result = classify_api_error(e, provider="openrouter")
+
+        assert result.reason == FailoverReason.key_limit
+        assert result.retryable is False
+        assert result.should_rotate_credential is True
+
+    def test_non_openrouter_403_key_phrase_does_not_invent_key_cap(self):
+        e = MockAPIError("API key limit exceeded", status_code=403)
+
+        result = classify_api_error(e, provider="custom")
+
+        assert result.reason == FailoverReason.auth
 
 
 
@@ -1577,5 +1607,3 @@ class TestServerInjectedParameterRejection:
         result = classify_api_error(e, provider="custom", model="m")
         assert result.reason == FailoverReason.format_error
         assert result.retryable is False
-
-

--- a/tests/agent/test_error_surface.py
+++ b/tests/agent/test_error_surface.py
@@ -64,6 +64,15 @@ def test_result_billing_reason_without_block():
     assert surface == {"layer": LAYER_BILLING, "code": "billing", "retryable": False}
 
 
+def test_result_key_limit_is_nonretryable_provider_capacity_not_billing():
+    surface = build_error_surface_from_result(_failed_result("key_limit"))
+    assert surface == {
+        "layer": LAYER_PROVIDER,
+        "code": "key_limit",
+        "retryable": False,
+    }
+
+
 def test_result_provider_default_for_classified_reasons():
     for reason in (
         "rate_limit",

--- a/tests/agent/test_openrouter_key_limit_guidance.py
+++ b/tests/agent/test_openrouter_key_limit_guidance.py
@@ -1,0 +1,40 @@
+"""Regression coverage for OpenRouter per-key spending-cap guidance."""
+
+from agent.conversation_loop import _key_limit_failure_result, _key_limit_message
+from agent.error_classifier import ClassifiedError, FailoverReason
+
+
+def test_key_limit_guidance_distinguishes_key_cap_from_account_balance():
+    message = _key_limit_message(
+        provider="openrouter",
+        model="anthropic/claude-sonnet-4",
+    )
+
+    assert "selected API key" in message
+    assert "does not mean the provider account is out of credits" in message
+    assert "https://openrouter.ai/settings/keys" in message
+    assert "Add credits" not in message
+
+
+def test_key_limit_result_never_emits_a_billing_block():
+    classified = ClassifiedError(
+        reason=FailoverReason.key_limit,
+        retryable=False,
+        should_rotate_credential=True,
+        should_fallback=True,
+    )
+
+    result = _key_limit_failure_result(
+        classified=classified,
+        summary="Key limit exceeded (daily limit)",
+        messages=[],
+        api_call_count=1,
+        provider="openrouter",
+        model="anthropic/claude-sonnet-4",
+    )
+
+    assert result["failure_reason"] == "key_limit"
+    assert result["failure_retryable"] is False
+    assert "billing_block" not in result
+    assert "Add credits" not in result["final_response"]
+    assert "selected API key" in result["final_response"]

--- a/tests/run_agent/test_24996_fallback_exhaustion_cooldown.py
+++ b/tests/run_agent/test_24996_fallback_exhaustion_cooldown.py
@@ -111,6 +111,25 @@ class TestExhaustionArmsCooldown:
         # ~60s past the frozen clock, far past the short exhaustion window.
         assert cooldown == frozen + 60
 
+    def test_key_limit_exhaustion_uses_capacity_cooldown(self):
+        """A per-key spend cap follows the established capacity fallback path."""
+        fbs = [{"provider": "openai", "model": "gpt-4o"}]
+        agent = _make_agent(fallback_model=fbs)
+        agent._rate_limited_until = 0
+        frozen = 1_000.0
+        with (
+            patch("agent.chat_completion_helpers.time.monotonic", return_value=frozen),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(_mock_client(), "resolved"),
+            ),
+        ):
+            assert agent._try_activate_fallback(reason=FailoverReason.key_limit) is True
+            assert agent._try_activate_fallback(reason=FailoverReason.key_limit) is False
+            cooldown = getattr(agent, "_rate_limited_until", 0)
+
+        assert cooldown == frozen + 60
+
     def test_cooldown_never_shrinks_existing_window(self):
         """If a longer cooldown is already armed, exhaustion must not reduce
         it (we take the max)."""


### PR DESCRIPTION
## Summary

Separates OpenRouter's explicit per-key spending-cap response from account credit exhaustion. Fixes #93979.

The new `key_limit` reason preserves credential rotation, fallback, and exhausted-key cooldown behavior, but does not emit a billing block. Desktop and other clients therefore stop showing “Out of credits” / “Add credits” for a funded account and instead receive actionable key-limit guidance. The classifier covers the reported 403 response and OpenRouter's currently documented 402 credit-limit status without adding a provider preflight request.

## Testing

- `scripts/run_tests.sh tests/agent/test_error_classifier.py tests/agent/test_error_surface.py tests/agent/test_credential_pool_routing.py tests/agent/test_credential_pool_sole_cooldown.py tests/agent/test_openrouter_key_limit_guidance.py tests/run_agent/test_24996_fallback_exhaustion_cooldown.py -q` (185 passed)
- Existing billing, plugin-classification, and fallback regressions (32 passed)
- Ruff on all changed Python files
- `git diff --check`
