### PR TITLE
fix(auth): defer config import until after PROVIDER_REGISTRY exists (provider-plugin import-order)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -81,12 +81,6 @@ from pathlib import Path
 from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Tuple
 from urllib.parse import parse_qs, urlencode, urlparse
 
-from hermes_cli.config import (
-    get_hermes_home,
-    get_config_path,
-    read_raw_config,
-    require_readable_config_before_write,
-)
 from hermes_constants import OPENROUTER_BASE_URL, secure_parent_dir
 from agent.credential_persistence import sanitize_borrowed_credential_payload
 from utils import atomic_replace, atomic_yaml_write, env_float, is_truthy_value
@@ -562,6 +556,17 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         base_url_env_var="AZURE_FOUNDRY_BASE_URL",
     ),
 }
+
+# ``hermes_cli.config`` discovers model-provider plugins while importing.  A
+# provider plugin may in turn interact with this module's registry.  Keep this
+# import below ProviderConfig and PROVIDER_REGISTRY so that TUI startup never
+# exposes a partially initialized auth module to those plugins.
+from hermes_cli.config import (  # noqa: E402
+    get_hermes_home,
+    get_config_path,
+    read_raw_config,
+    require_readable_config_before_write,
+)
 
 # Auto-extend PROVIDER_REGISTRY with any api-key provider registered in
 # providers/ that is not already declared above.  New providers only need a

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -561,6 +561,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
 # provider plugin may in turn interact with this module's registry.  Keep this
 # import below ProviderConfig and PROVIDER_REGISTRY so that TUI startup never
 # exposes a partially initialized auth module to those plugins.
+#
+# CONTRACT: during discovery a plugin may rely ONLY on ``ProviderConfig`` and
+# ``PROVIDER_REGISTRY`` from this module.  Names defined below this import are
+# NOT initialized yet at discovery time; a plugin that touches them reopens the
+# partial-init hazard this ordering closes.  (Longer term the cycle could be
+# removed entirely with a post-import hook — config calling back into a fully
+# built auth module — rather than sequenced around.)
+
 from hermes_cli.config import (  # noqa: E402
     get_hermes_home,
     get_config_path,

--- a/tests/providers/test_auth_registry_import_order.py
+++ b/tests/providers/test_auth_registry_import_order.py
@@ -1,0 +1,70 @@
+"""Regression coverage for provider auth registration during TUI imports."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_tui_import_exposes_auth_registry_to_provider_plugins(tmp_path):
+    """Provider discovery must not see a partially initialized auth module."""
+    hermes_home = tmp_path / ".hermes"
+    plugin_dir = hermes_home / "plugins" / "model-providers" / "import-order-probe"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "__init__.py").write_text(
+        "from providers import register_provider\n"
+        "from providers.base import ProviderProfile\n"
+        "\n"
+        "profile = ProviderProfile(\n"
+        "    name='import-order-probe',\n"
+        "    display_name='Profile fallback',\n"
+        "    env_vars=('IMPORT_ORDER_PROBE_KEY',),\n"
+        "    base_url='https://profile.example/v1',\n"
+        "    auth_type='api_key',\n"
+        ")\n"
+        "register_provider(profile)\n"
+        "\n"
+        "from hermes_cli.auth import PROVIDER_REGISTRY, ProviderConfig\n"
+        "PROVIDER_REGISTRY['import-order-probe'] = ProviderConfig(\n"
+        "    id='import-order-probe',\n"
+        "    name='Plugin injection',\n"
+        "    auth_type='api_key',\n"
+        "    inference_base_url='https://plugin.example/v1',\n"
+        "    api_key_env_vars=('IMPORT_ORDER_PROBE_KEY',),\n"
+        ")\n",
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    env.pop("HERMES_PROFILE", None)
+    env["PYTHONPATH"] = os.pathsep.join([
+        str(REPO_ROOT),
+        env.get("PYTHONPATH", ""),
+    ]).rstrip(os.pathsep)
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST; "
+            "from hermes_cli.auth import PROVIDER_REGISTRY; "
+            "cfg = PROVIDER_REGISTRY['import-order-probe']; "
+            "assert cfg.name == 'Plugin injection', cfg; "
+            "assert cfg.inference_base_url == 'https://plugin.example/v1', cfg; "
+            "assert 'IMPORT_ORDER_PROBE_KEY' in _HERMES_PROVIDER_ENV_BLOCKLIST",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert probe.returncode == 0, probe.stdout + probe.stderr
+    assert "partially initialized module 'hermes_cli.auth'" not in probe.stderr


### PR DESCRIPTION
hermes_cli.auth imports hermes_cli.config at module top; config performs provider-plugin discovery at import time, so a provider plugin can execute against a partially initialized auth module during TUI startup — its registry interaction silently loses and core fallback metadata wins.

One choke-point import move (below ProviderConfig/PROVIDER_REGISTRY) with the ordering contract documented inline — no per-plugin changes needed.

Regression test spawns a clean interpreter with a probe plugin and asserts registration lands: **red on current main, green with this fix** (verified both directions).

Found while root-causing a TUI startup issue on our fork; fork-side equivalent merged as ANG-Ventures#637.