### PR TITLE
fix(kanban): keep block-loop escalations in triage

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1649,7 +1649,7 @@ class GatewayKanbanWatchersMixin:
                 try:
                     os.environ["HERMES_KANBAN_BOARD"] = slug
                     try:
-                        triage_ids = _decomp.list_triage_ids()
+                        triage_ids = _decomp.list_triage_ids(automatic=True)
                     except Exception as exc:
                         logger.debug(
                             "kanban auto-decompose: list_triage_ids failed on board %s (%s)",
@@ -1662,7 +1662,9 @@ class GatewayKanbanWatchersMixin:
                         attempted += 1
                         try:
                             outcome = _decomp.decompose_task(
-                                tid, author="auto-decomposer",
+                                tid,
+                                author="auto-decomposer",
+                                automatic=True,
                             )
                         except Exception:
                             logger.exception(

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -268,11 +268,26 @@ def _normalize_assignee_choice(
     return chosen
 
 
+def _requires_human_triage(task: kb.Task) -> bool:
+    """Return whether ``task`` reached triage via the block-loop breaker.
+
+    ``block_task`` records the recurrence count on the task before routing it
+    to triage. Normal rough-input triage cards keep the default count of zero.
+    This distinction lets the gateway skip human-decision cards without
+    weakening manual ``kanban decompose`` / ``kanban specify`` actions.
+    """
+    return (
+        task.status == "triage"
+        and task.block_recurrences >= kb.BLOCK_RECURRENCE_LIMIT
+    )
+
+
 def decompose_task(
     task_id: str,
     *,
     author: Optional[str] = None,
     timeout: Optional[int] = None,
+    automatic: bool = False,
 ) -> DecomposeOutcome:
     """Decompose a triage task into a graph of child tasks.
 
@@ -288,6 +303,12 @@ def decompose_task(
     if task.status != "triage":
         return DecomposeOutcome(
             task_id, False, f"task is not in triage (status={task.status!r})"
+        )
+    if automatic and _requires_human_triage(task):
+        return DecomposeOutcome(
+            task_id,
+            False,
+            "block-loop escalation requires human triage",
         )
 
     cfg = _load_config()
@@ -456,8 +477,17 @@ def decompose_task(
     )
 
 
-def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
-    """Return task ids currently in the triage column."""
+def list_triage_ids(
+    *,
+    tenant: Optional[str] = None,
+    automatic: bool = False,
+) -> list[str]:
+    """Return triage task ids eligible for the requested caller.
+
+    Automatic sweeps omit cards escalated by the block-loop breaker. Manual
+    callers retain the complete triage list so a human can deliberately
+    specify or decompose one of those cards.
+    """
     with kb.connect_closing() as conn:
         rows = kb.list_tasks(
             conn,
@@ -465,4 +495,6 @@ def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
             tenant=tenant,
             limit=1000,
         )
+    if automatic:
+        rows = [row for row in rows if not _requires_human_triage(row)]
     return [row.id for row in rows]

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -161,3 +161,74 @@ def test_decompose_returns_false_when_task_not_triage(kanban_home):
     assert "not in triage" in outcome.reason
 
 
+def test_auto_decompose_skips_block_loop_triage_before_llm(kanban_home):
+    """A loop-breaker escalation is human triage, not rough-input triage."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="needs a human", assignee="worker")
+        assert kb.claim_task(conn, tid, claimer="worker") is not None
+        assert kb.block_task(
+            conn, tid, reason="waiting on Caleb", kind="needs_input"
+        )
+        assert kb.unblock_task(conn, tid)
+        assert kb.claim_task(conn, tid, claimer="worker") is not None
+        assert kb.block_task(
+            conn, tid, reason="still waiting on Caleb", kind="needs_input"
+        )
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "triage"
+
+    assert tid in decomp.list_triage_ids()
+    assert tid not in decomp.list_triage_ids(automatic=True)
+
+    with patch("agent.auxiliary_client.call_llm") as call_llm:
+        outcome = decomp.decompose_task(
+            tid,
+            author="auto-decomposer",
+            automatic=True,
+        )
+
+    assert outcome.ok is False
+    assert "human triage" in outcome.reason
+    call_llm.assert_not_called()
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "triage"
+
+
+def test_auto_decompose_still_specifies_normal_triage(kanban_home):
+    """The loop guard must not disable normal rough-card specification."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="rough idea", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": False,
+        "rationale": "single unit",
+        "title": "Concrete task",
+        "body": "Implement the requested outcome.",
+        "assignee": "orchestrator",
+    })
+    patches = _patch_list_profiles(["orchestrator"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload) as call_llm:
+            outcome = decomp.decompose_task(
+                tid,
+                author="auto-decomposer",
+                automatic=True,
+            )
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    call_llm.assert_called_once()
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+    assert task is not None
+    assert task.status == "ready"
+    assert task.title == "Concrete task"
+
+


### PR DESCRIPTION
## Summary

- mark the gateway auto-decomposer path as automatic
- filter `block_loop_detected` triage escalations out of automatic candidates and guard direct automatic calls before any auxiliary LLM request
- preserve manual triage decomposition while normal rough-input triage cards continue to specify and promote

## Tests

- `python -m pytest tests/hermes_cli/test_kanban_decompose.py tests/hermes_cli/test_kanban_decompose_db.py tests/hermes_cli/test_kanban_block_kinds.py tests/gateway/test_kanban_auto_decompose_live.py -q -o 'addopts='` (11 passed)

## Context

The unblock-loop breaker intentionally routes repeated same-cause blocks to triage for a human decision. The gateway auto-decomposer was treating those cards like fresh rough-input triage work, specifying and promoting them back into the dispatch queue on the next tick.