### PR TITLE
fix(doctor): don't skip ssh/daytona/vercel_sandbox diagnostics inside containers

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2098,13 +2098,16 @@ def run_doctor(args):
         # not found" warning. If the user has explicitly chosen
         # TERMINAL_ENV=docker inside the container they likely mounted
         # /var/run/docker.sock, so fall through to the normal check.
-        if terminal_env != "docker":
+        if terminal_env == "local":
             check_info(
                 "Running inside a container — using local terminal backend "
                 "(docker-in-docker is not configured by default)"
             )
-            # Skip to next section; Docker isn't relevant here.
-            terminal_env = "local"
+        # NOTE: do NOT reset terminal_env here.  Earlier code forced any
+        # non-docker backend to "local" inside containers, which silently
+        # skipped the ssh/daytona/vercel_sandbox diagnostic sections for
+        # every containerized run.  The docker check below is already
+        # guarded by terminal_env == "docker".
     if terminal_env == "docker":
         if _safe_which("docker"):
             # Check if docker daemon is running


### PR DESCRIPTION
`run_doctor`'s in-container branch resets any non-docker `terminal_env` to `local`, silently skipping the ssh/daytona/vercel_sandbox diagnostic sections for every containerized run — doctor reports nothing about the backend the user actually configured.

Only the docker check needs skipping (already guarded by `terminal_env == "docker"`); the reset is removed and the informational note now only prints for the default local backend.

Found when a containerized CI runner failed `test_doctor_reports_vercel_backend_diagnostics` — the test was correct; the product skipped the section. Existing doctor tests (145) green with the fix.