### PR TITLE
feat(discord): add planning-only thread command

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6000,6 +6000,20 @@ class DiscordAdapter(BasePlatformAdapter):
             # so a rejected invoker can receive an ephemeral rejection.
             await self._handle_thread_create_slash(interaction, name, message, auto_archive_duration)
 
+        @tree.command(name="plan", description="Create a thread and have Hermes return a plan only")
+        @discord.app_commands.describe(request="What you want Hermes to plan")
+        async def slash_plan(interaction: discord.Interaction, request: str):
+            request = (request or "").strip()
+            thread_name = self._derive_auto_thread_name(request)
+            await self._handle_thread_create_slash(
+                interaction,
+                thread_name,
+                request,
+                10080,
+                command_text="/plan",
+                dispatch_text=f"/plan {request}".strip(),
+            )
+
         @tree.command(name="queue", description="Queue a prompt for the next turn (doesn't interrupt)")
         @discord.app_commands.describe(prompt="The prompt to queue")
         async def slash_queue(interaction: discord.Interaction, prompt: str):
@@ -6441,9 +6455,12 @@ class DiscordAdapter(BasePlatformAdapter):
         name: str,
         message: str = "",
         auto_archive_duration: int = 1440,
+        *,
+        command_text: str = "/thread",
+        dispatch_text: Optional[str] = None,
     ) -> None:
         """Create a Discord thread from a slash command and start a session in it."""
-        if not await self._check_slash_authorization(interaction, "/thread"):
+        if not await self._check_slash_authorization(interaction, command_text):
             return
         deferred_response = False
         try:
@@ -6453,14 +6470,16 @@ class DiscordAdapter(BasePlatformAdapter):
             if not self._is_discord_unknown_interaction(e):
                 raise
             logger.warning(
-                "[Discord] /thread: interaction expired before defer. "
+                "[Discord] %s: interaction expired before defer. "
                 "Creating the thread anyway, skipping interaction followups.",
+                command_text,
             )
         result = await self._create_thread(
             interaction,
             name=name,
             message=message,
             auto_archive_duration=auto_archive_duration,
+            requested_via=command_text,
         )
 
         if not result.get("success"):
@@ -6482,7 +6501,7 @@ class DiscordAdapter(BasePlatformAdapter):
             self._threads.mark(thread_id)
 
         # If a message was provided, kick off a new Hermes session in the thread
-        starter = (message or "").strip()
+        starter = (dispatch_text if dispatch_text is not None else message or "").strip()
         if starter and thread_id:
             await self._dispatch_thread_session(interaction, thread_id, thread_name, starter)
 
@@ -7133,6 +7152,7 @@ class DiscordAdapter(BasePlatformAdapter):
         name: str,
         message: str = "",
         auto_archive_duration: int = 1440,
+        requested_via: str = "/thread",
     ) -> Dict[str, Any]:
         """Create a thread in the current Discord channel.
 
@@ -7159,7 +7179,7 @@ class DiscordAdapter(BasePlatformAdapter):
             return {"error": "Could not determine a parent text channel for the new thread."}
 
         display_name = getattr(getattr(interaction, "user", None), "display_name", None) or "unknown user"
-        reason = f"Requested by {display_name} via /thread"
+        reason = f"Requested by {display_name} via {requested_via}"
         starter_message = (message or "").strip()
 
         try:

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -142,6 +142,45 @@ async def test_registers_native_thread_slash_command(adapter):
 
 
 @pytest.mark.asyncio
+async def test_registers_plan_slash_as_planning_only_thread(adapter):
+    adapter._handle_thread_create_slash = AsyncMock()
+    adapter._register_slash_commands()
+
+    command = adapter._client.tree.commands["plan"]
+    interaction = SimpleNamespace()
+
+    await command(interaction, request="Add audit logging")
+
+    adapter._handle_thread_create_slash.assert_awaited_once_with(
+        interaction,
+        "Add audit logging",
+        "Add audit logging",
+        10080,
+        command_text="/plan",
+        dispatch_text="/plan Add audit logging",
+    )
+
+
+@pytest.mark.asyncio
+async def test_plan_slash_trims_request_and_thread_title(adapter):
+    adapter._handle_thread_create_slash = AsyncMock()
+    adapter._register_slash_commands()
+
+    command = adapter._client.tree.commands["plan"]
+    interaction = SimpleNamespace()
+    request = "  " + "x" * 90 + "  "
+
+    await command(interaction, request=request)
+
+    call = adapter._handle_thread_create_slash.await_args
+    assert call is not None
+    assert call.args[1] == "x" * 77 + "..."
+    assert call.args[2] == "x" * 90
+    assert call.kwargs["command_text"] == "/plan"
+    assert call.kwargs["dispatch_text"] == "/plan " + "x" * 90
+
+
+@pytest.mark.asyncio
 async def test_run_simple_slash_executes_when_defer_interaction_expired(adapter):
     class UnknownInteraction(Exception):
         status = 404
@@ -344,6 +383,44 @@ async def test_handle_thread_create_slash_falls_back_to_seed_message(adapter):
         reason="Requested by Jezza via /thread",
     )
     interaction.followup.send.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_plan_thread_displays_request_but_dispatches_plan_skill(adapter):
+    created_thread = SimpleNamespace(id=555, name="Add audit logging", send=AsyncMock())
+    parent_channel = SimpleNamespace(create_thread=AsyncMock(return_value=created_thread), send=AsyncMock())
+    interaction = SimpleNamespace(
+        channel=parent_channel,
+        channel_id=123,
+        user=SimpleNamespace(display_name="Jezza", id=42),
+        guild=SimpleNamespace(name="TestGuild"),
+        followup=SimpleNamespace(send=AsyncMock()),
+        response=SimpleNamespace(defer=AsyncMock()),
+    )
+    adapter._dispatch_thread_session = AsyncMock()
+
+    await adapter._handle_thread_create_slash(
+        interaction,
+        "Add audit logging",
+        "Add audit logging",
+        10080,
+        command_text="/plan",
+        dispatch_text="/plan Add audit logging",
+    )
+
+    adapter._check_slash_authorization.assert_awaited_once_with(interaction, "/plan")
+    parent_channel.create_thread.assert_awaited_once_with(
+        name="Add audit logging",
+        auto_archive_duration=10080,
+        reason="Requested by Jezza via /plan",
+    )
+    created_thread.send.assert_awaited_once_with("Add audit logging")
+    adapter._dispatch_thread_session.assert_awaited_once_with(
+        interaction,
+        "555",
+        "Add audit logging",
+        "/plan Add audit logging",
+    )
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a native Discord `/plan` command that creates a dedicated thread
- show the requested task in the thread while dispatching `/plan <request>` through the normal Hermes skill pipeline
- preserve slash authorization, thread tracking, and command-specific audit reasons

## Verification
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/gateway/test_discord_slash_commands.py tests/gateway/test_discord_slash_auth.py tests/gateway/test_discord_thread_slash_expired_defer.py tests/gateway/test_discord_channel_controls.py -q` (38 passed)
- `uv run --with ruff ruff check plugins/platforms/discord/adapter.py tests/gateway/test_discord_slash_commands.py`
- `python3 -m py_compile plugins/platforms/discord/adapter.py tests/gateway/test_discord_slash_commands.py`
- `git diff --check`