### PR TITLE
fix(desktop): harden provider outage recovery

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2640,6 +2640,55 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             ):
                 fb_api_mode = "bedrock_converse"
 
+        # Resolve the destination window before mutating the active runtime.
+        # The next loop pass can compact an oversized request when automatic
+        # compression is available. If compression is disabled or currently
+        # blocked by its failure cooldown, dispatching to a smaller-context
+        # fallback is guaranteed to fail and merely adds another provider
+        # error card. Skip it and continue the bounded chain instead.
+        fb_context_length = None
+        compressor = getattr(agent, "context_compressor", None)
+        if compressor is not None and fb_provider != "lmstudio":
+            from agent.model_metadata import get_model_context_length
+
+            _fb_ctx_api_key = fb_client.api_key if isinstance(fb_client.api_key, str) else ""
+            fb_context_length = get_model_context_length(
+                fb_model,
+                base_url=fb_base_url,
+                api_key=_fb_ctx_api_key,
+                provider=fb_provider,
+                config_context_length=None,
+                custom_providers=getattr(agent, "_custom_providers", None),
+            )
+            request_pressure = int(getattr(agent, "_last_request_pressure_tokens", 0) or 0)
+            compression_enabled = bool(getattr(agent, "compression_enabled", False))
+            cooldown = None
+            get_cooldown = getattr(compressor, "get_active_compression_failure_cooldown", None)
+            if callable(get_cooldown):
+                try:
+                    cooldown = get_cooldown()
+                except Exception:
+                    logger.debug("Fallback context preflight could not read compression cooldown", exc_info=True)
+
+            if (
+                request_pressure > 0
+                and isinstance(fb_context_length, int)
+                and fb_context_length > 0
+                and request_pressure > fb_context_length
+                and (not compression_enabled or bool(cooldown))
+            ):
+                block = "disabled" if not compression_enabled else "cooldown"
+                logger.warning(
+                    "Fallback skip: %s/%s context window %d is below request pressure %d "
+                    "and automatic compression is %s",
+                    fb_provider,
+                    fb_model,
+                    fb_context_length,
+                    request_pressure,
+                    block,
+                )
+                return agent._try_activate_fallback(reason)
+
         old_model = agent.model
         old_provider = agent.provider
 
@@ -2763,23 +2812,24 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # Without this, compression decisions use the primary model's
         # context window (e.g. 200K) instead of the fallback's (e.g. 32K),
         # causing oversized sessions to overflow the fallback.
-        # Also pass _config_context_length so the explicit config override
-        # (model.context_length in config.yaml) is respected — without this,
-        # the fallback activation drops to 128K even when config says 204800.
-        if hasattr(agent, 'context_compressor') and agent.context_compressor:
+        # LM Studio must be loaded before its live context can be queried, so
+        # that one provider resolves here instead of in the non-mutating
+        # preflight above.
+        if compressor is not None and fb_context_length is None:
             from agent.model_metadata import get_model_context_length
-            # ``agent.api_key`` may be callable (Entra ID); the
-            # context-length resolver expects a string for live
-            # probes. Foundry typically resolves via config/static
-            # catalogs anyway, so coerce defensively.
+
             _fb_ctx_api_key = agent.api_key if isinstance(agent.api_key, str) else ""
             fb_context_length = get_model_context_length(
-                agent.model, base_url=agent.base_url,
-                api_key=_fb_ctx_api_key, provider=agent.provider,
+                agent.model,
+                base_url=agent.base_url,
+                api_key=_fb_ctx_api_key,
+                provider=agent.provider,
                 config_context_length=getattr(agent, "_config_context_length", None),
                 custom_providers=getattr(agent, "_custom_providers", None),
             )
-            agent.context_compressor.update_model(
+
+        if compressor is not None and fb_context_length is not None:
+            compressor.update_model(
                 model=agent.model,
                 context_length=fb_context_length,
                 base_url=agent.base_url,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2590,6 +2590,11 @@ def run_conversation(
         request_pressure_tokens = approx_tokens + (
             _estimate_tools_tokens_rough(agent.tools) if agent.tools else 0
         )
+        # The fallback router needs the exact request pressure that triggered
+        # failover so it can reject a smaller-context destination before
+        # dispatch. The value is request-local telemetry only: no prompt text
+        # or tool payload is retained.
+        agent._last_request_pressure_tokens = request_pressure_tokens
         total_chars = approx_tokens * 4
         # Stash this request's rough estimate so update_from_response() can
         # pair it with the provider's real prompt count — the (rough, real)

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -30,7 +30,7 @@ import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { Codicon } from '@/components/ui/codicon'
 import { CopyButton } from '@/components/ui/copy-button'
 import { useI18n } from '@/i18n'
-import { type ErrorSurface, formatErrorDiagnostics } from '@/lib/error-surface'
+import { type ErrorSurface, formatErrorDiagnostics, formatUserFacingError } from '@/lib/error-surface'
 import { triggerHaptic } from '@/lib/haptics'
 import {
   AudioLines,
@@ -244,7 +244,7 @@ const AssistantMessageBody: FC<AssistantMessageProps & { collapsedNotice?: null 
                 <div className="flex items-start gap-1.5">
                   <div className="min-w-0 flex-1">
                     <ErrorLayerLabel />
-                    <ErrorPrimitive.Message className="min-w-0" />
+                    <VisibleErrorMessage />
                   </div>
                   {onDismissError && (
                     <TooltipIconButton
@@ -470,6 +470,18 @@ const ErrorLayerLabel: FC = () => {
   const label = (surface && labels[surface.layer]) || labels.generic
 
   return <div className="font-medium">{label}</div>
+}
+
+const VisibleErrorMessage: FC = () => {
+  const surface = useAuiState(s => s.message.metadata?.custom?.errorSurface as ErrorSurface | undefined)
+
+  const errorText = useAuiState(s => {
+    const status = s.message.status as { error?: unknown; type?: string } | undefined
+
+    return status?.type === 'incomplete' && typeof status.error === 'string' ? status.error : ''
+  })
+
+  return <div className="min-w-0">{formatUserFacingError(errorText, surface)}</div>
 }
 
 // Isolated because useNavigate() THROWS outside a <Router> (bare test

--- a/apps/desktop/src/lib/error-surface.test.ts
+++ b/apps/desktop/src/lib/error-surface.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { formatErrorDiagnostics, parseErrorSurface } from './error-surface'
+import { formatErrorDiagnostics, formatUserFacingError, parseErrorSurface } from './error-surface'
 
 describe('parseErrorSurface', () => {
   it('accepts a valid descriptor', () => {
@@ -82,5 +82,41 @@ describe('formatErrorDiagnostics', () => {
     expect(text).not.toContain('layer:')
     expect(text).not.toContain('model:')
     expect(text.split('\n').every(line => line.trim().length > 0)).toBe(true)
+  })
+})
+
+describe('formatUserFacingError', () => {
+  it('replaces deployment cooldown internals with actionable rate-limit copy', () => {
+    const raw =
+      "HTTP 429: No deployments available for selected model, Try again in 45 seconds. Passed model=glm-5.3. pre-call-checks=True, cooldown_list=['deployment-hash']"
+
+    const text = formatUserFacingError(raw, {
+      layer: 'provider',
+      code: 'rate_limit',
+      retryable: true
+    })
+
+    expect(text).toContain('temporarily unavailable')
+    expect(text).toContain('45 seconds')
+    expect(text).toContain('configured fallback model')
+    expect(text).not.toContain('deployment-hash')
+    expect(text).not.toContain('pre-call-checks')
+    expect(text).not.toContain('cooldown_list')
+  })
+
+  it('keeps raw provider text in diagnostics while simplifying the visible billing card', () => {
+    const raw = 'HTTP 402: requested 8192 tokens but can only afford 93'
+    const surface = { layer: 'billing', code: 'billing', retryable: false } as const
+
+    expect(formatUserFacingError(raw, surface)).toContain('insufficient credits')
+    expect(formatErrorDiagnostics({ errorText: raw, surface })).toContain(raw)
+  })
+
+  it('strips legacy router internals even without structured metadata', () => {
+    const text = formatUserFacingError(
+      "Error: HTTP 429: No deployments available. Passed model=glm-5.3. pre-call-checks=True, cooldown_list=['secret-ish-id']"
+    )
+
+    expect(text).toBe('No deployments available.')
   })
 })

--- a/apps/desktop/src/lib/error-surface.ts
+++ b/apps/desktop/src/lib/error-surface.ts
@@ -54,6 +54,51 @@ export function parseErrorSurface(value: unknown): ErrorSurface | null {
   }
 }
 
+/**
+ * Concise copy for the visible error card.
+ *
+ * Provider payloads are intentionally retained verbatim by
+ * formatErrorDiagnostics(), but the transcript should not expose router
+ * internals such as deployment hashes, pre-call flags, or cooldown arrays.
+ * Prefer the structured surface taxonomy and keep the raw string behind
+ * "Copy error details" for diagnosis.
+ */
+export function formatUserFacingError(errorText: string, surface?: ErrorSurface | null): string {
+  const raw = errorText.trim()
+  const retryAfter = raw.match(/try again in\s+(\d+)\s+seconds?/i)?.[1]
+  const wait = retryAfter ? ` Retry is available in ${retryAfter} seconds.` : ''
+
+  if (surface?.layer === 'billing') {
+    return 'This provider has insufficient credits for the request. Hermes can continue on a configured fallback provider.'
+  }
+
+  if (surface?.layer === 'auth') {
+    return 'This provider rejected its credential. Reconnect it in Settings or continue on a configured fallback provider.'
+  }
+
+  if (surface?.code === 'rate_limit' || surface?.code === 'upstream_rate_limit') {
+    return `The selected model is temporarily unavailable.${wait} Hermes can continue on a configured fallback model.`
+  }
+
+  if (surface?.layer === 'streaming') {
+    return `The provider connection ended before the reply completed.${wait}`
+  }
+
+  if (surface?.layer === 'endpoint') {
+    return 'Hermes could not reach the configured model endpoint. Check the endpoint or continue on a configured fallback provider.'
+  }
+
+  // Older backends may not send a structured descriptor. Keep their useful
+  // provider prose while stripping only known router implementation details.
+  const cleaned = raw
+    .replace(/^Error:\s*/i, '')
+    .replace(/^HTTP\s+\d{3}:\s*/i, '')
+    .split(/\s+Passed model=/i, 1)[0]
+    .trim()
+
+  return cleaned || 'The model request failed. Open the error details for diagnostics.'
+}
+
 /** Plain-text error-details blob for the error card's "Copy error details". */
 export function formatErrorDiagnostics(input: {
   appVersion?: string

--- a/apps/desktop/src/store/onboarding.test.ts
+++ b/apps/desktop/src/store/onboarding.test.ts
@@ -64,6 +64,23 @@ function keylessCustomGateway(): OnboardingContext['requestGateway'] {
   }
 }
 
+function unresolvedNamedCustomGateway(): OnboardingContext['requestGateway'] {
+  return async method => {
+    if (method === 'setup.status') {
+      return { provider_configured: true } as never
+    }
+
+    if (method === 'setup.runtime_check') {
+      return {
+        error: "Unknown provider 'custom:litellm-gateway'. Check 'hermes model' for available providers.",
+        ok: false
+      } as never
+    }
+
+    throw new Error(`unexpected gateway method: ${method}`)
+  }
+}
+
 function onboardingContext(requestGateway: OnboardingContext['requestGateway']): OnboardingContext {
   return { requestGateway }
 }
@@ -184,6 +201,37 @@ describe('refreshOnboarding', () => {
       })
     )
     expect($desktopOnboarding.get().configured).toBe(true)
+  })
+
+  it('keeps a returning install out of first-run setup during a named-provider resolver mismatch', async () => {
+    const notifySpy = vi.spyOn(notifications, 'notify')
+    const api = vi.fn()
+
+    installApiMock(api)
+    window.localStorage.setItem('hermes-desktop-onboarded-v1', '1')
+    $desktopOnboarding.set(
+      baseState({
+        configured: true,
+        providers: [makeOAuthProvider('cached')],
+        reason: null,
+        requested: false
+      })
+    )
+
+    const ready = await refreshOnboarding(onboardingContext(unresolvedNamedCustomGateway()))
+
+    expect(ready).toBe(false)
+    expect(api).not.toHaveBeenCalled()
+    expect($desktopOnboarding.get().configured).toBe(true)
+    expect($desktopOnboarding.get().reason).toBeNull()
+    expect(window.localStorage.getItem('hermes-desktop-onboarded-v1')).toBe('1')
+    expect(notifySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'runtime-not-ready',
+        kind: 'error',
+        message: expect.stringContaining("Unknown provider 'custom:litellm-gateway'")
+      })
+    )
   })
 
   it('enters setup when the selected OpenRouter credential is genuinely empty', async () => {

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -185,10 +185,28 @@ async function checkRuntime(ctx: OnboardingContext, requestedProvider?: string):
   })
 }
 
-function shouldPreserveConfiguredOnFallback(runtime: RuntimeReadinessResult, state: DesktopOnboardingState): boolean {
-  // Non-authoritative transport fallback only — keep a previously verified
-  // configured state instead of forcing the blocking onboarding overlay.
-  return runtime.source === 'fallback' && state.configured === true && !state.requested
+function shouldPreserveConfiguredOnRuntimeFailure(
+  runtime: RuntimeReadinessResult,
+  state: DesktopOnboardingState
+): boolean {
+  if (state.configured !== true || state.requested) {
+    return false
+  }
+
+  // A transport-level probe failure is not evidence that a returning install
+  // lost its credentials. Likewise, setup.status=true + runtime_check=false
+  // means Hermes found configured auth but could not resolve the selected
+  // runtime (for example while a named custom provider is being reloaded).
+  // Neither condition can be repaired by sending the user through first-run
+  // API-key setup again. Keep the shell usable and surface runtime recovery as
+  // a non-blocking error instead.
+  //
+  // A concrete missing-credential verdict is different: setup.status may be
+  // true only because some OTHER provider is configured, so the selected
+  // provider still needs the setup flow.
+  const missingSelectedCredential = /No usable credentials found for\b/i.test(runtime.reason ?? '')
+
+  return runtime.source === 'fallback' || (runtime.checksDisagree && !missingSelectedCredential)
 }
 
 function notifyReady(provider: string) {
@@ -551,17 +569,18 @@ export async function refreshOnboarding(ctx: OnboardingContext) {
 
   const state = $desktopOnboarding.get()
 
-  if (shouldPreserveConfiguredOnFallback(runtime, state)) {
-    // Gateway probes timed out but the user was already configured — don't
-    // downgrade to the blocking onboarding overlay. Surface a non-blocking
-    // notification with a stable id so repeated calls during an outage dedup
-    // instead of stacking toasts.
+  if (shouldPreserveConfiguredOnRuntimeFailure(runtime, state)) {
+    // The user was already configured — don't downgrade to the blocking
+    // first-run overlay for a transient gateway failure or a runtime resolver
+    // mismatch. Surface a non-blocking notification with a stable id so
+    // repeated checks during an outage dedup instead of stacking toasts.
     notify({
       id: 'runtime-not-ready',
       kind: 'error',
       title: 'Runtime not ready',
-      message:
-        'Hermes Desktop could not verify the running backend on startup. Some features may be unavailable until the gateway is reachable.'
+      message: runtime.reason
+        ? `Hermes Desktop kept your existing setup, but the selected runtime is unavailable: ${runtime.reason}`
+        : 'Hermes Desktop could not verify the running backend on startup. Some features may be unavailable until the gateway is reachable.'
     })
 
     return false

--- a/tests/run_agent/test_24996_fallback_exhaustion_cooldown.py
+++ b/tests/run_agent/test_24996_fallback_exhaustion_cooldown.py
@@ -132,6 +132,41 @@ class TestExhaustionArmsCooldown:
         assert cooldown == far_future
 
 
+class TestFallbackContextPreflight:
+    def test_skips_guaranteed_overflow_and_uses_next_context_fit_candidate(self):
+        """A router must not dispatch a 300K request to a 128K fallback when
+        automatic compression is unavailable. It should continue to the next
+        compatible destination without mutating through the doomed runtime.
+        """
+        fbs = [
+            {"provider": "openai-codex", "model": "gpt-small-context"},
+            {"provider": "openai-codex", "model": "gpt-5.6-terra-900k"},
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        agent._last_request_pressure_tokens = 300_000
+        agent.compression_enabled = False
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client("https://chatgpt.com/backend-api/codex"),
+                    "resolved",
+                ),
+            ) as resolve,
+            patch(
+                "agent.model_metadata.get_model_context_length",
+                side_effect=[128_000, 900_000],
+            ),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert resolve.call_count == 2
+        assert agent.provider == "openai-codex"
+        assert agent.model == "gpt-5.6-terra-900k"
+        assert agent._fallback_index == 2
+
+
 class TestRateLimitBackoffEscalation:
     """Exponential backoff for consecutive rate-limit failures (#29702).
 


### PR DESCRIPTION
## Summary
- keep returning Desktop installs out of first-run onboarding during transient provider-resolution mismatches
- render actionable provider errors while retaining raw diagnostics behind Copy error details
- preflight fallback context windows and skip guaranteed-overflow routes when compression cannot recover

## Verification
- Desktop UI: 593 files / 5,719 tests passed
- Targeted Desktop: 28 tests passed; typecheck passed
- Fallback regression suites: 69 tests passed
- Production build and signed macOS package passed
- Live packaged app restored session 20260823_110109_e499c7 on openai-codex:gpt-5.6-sol-900k without onboarding