### PR TITLE
fix(web): keyword-align titles of six high-impression docs pages

### DIFF
--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -1,10 +1,10 @@
 ---
 sidebar_position: 1
-title: "Quickstart"
+title: "Hermes Agent Quickstart"
 description: "Your first conversation with Hermes Agent — from install to chatting in under 5 minutes"
 ---
 
-# Quickstart
+# Hermes Agent Quickstart
 
 This guide gets you from zero to a working Hermes setup that survives real use. Install, choose a provider, verify a working chat, and know exactly what to do when something breaks.
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1,10 +1,10 @@
 ---
-title: "AI Providers"
+title: "LLM and Model Providers"
 sidebar_label: "AI Providers"
 sidebar_position: 1
 ---
 
-# AI Providers
+# LLM and Model Providers
 
 This page covers setting up inference providers for Hermes Agent — from cloud APIs like OpenRouter and Anthropic, to self-hosted endpoints like Ollama and vLLM, to advanced routing and fallback configurations. You need at least one provider configured to use Hermes.
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1,10 +1,10 @@
 ---
 sidebar_position: 2
-title: "Configuration"
+title: "Hermes Agent Configuration"
 description: "Configure Hermes Agent — config.yaml, providers, models, API keys, and more"
 ---
 
-# Configuration
+# Hermes Agent Configuration
 
 All settings are stored in the `~/.hermes/` directory for easy access.
 

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -1,10 +1,10 @@
 ---
 sidebar_position: 3
-title: "Desktop App"
+title: "Hermes Desktop"
 description: "The native Hermes desktop app — a polished experience for chatting with Hermes, with streaming tool output, side-by-side previews, a file browser, voice, cron, profiles, skills, and settings. macOS, Windows, and Linux."
 ---
 
-# Desktop App
+# Hermes Desktop
 
 The Hermes desktop app is a native app built around the **same** agent you get from the CLI and the gateway — same config, same API keys, same sessions, same skills, same memory. It is not a separate product or a lightweight clone; it uses the same Hermes Agent core and settings, and drives it through a modern & thoughtfully designed UI. If you have used `hermes` in a terminal, everything you set up there is already here, and anything you do here shows up there.
 
@@ -22,7 +22,7 @@ Pick whichever fits the moment. They share state, so you can start a session in 
 
 ## Install
 
-Follow the [installation instructions for Hermes Desktop](../getting-started/installation.md).
+Download the app from the [Hermes Desktop product page](https://hermes-agent.nousresearch.com/desktop), or follow the [installation instructions for Hermes Desktop](../getting-started/installation.md).
 
 If you already have Hermes installed, simply run
 

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -1,10 +1,10 @@
 ---
 sidebar_position: 7
-title: "Docker"
+title: "Hermes Docker Setup"
 description: "Running Hermes Agent in Docker and using Docker as a terminal backend"
 ---
 
-# Hermes Agent — Docker
+# Hermes Docker Setup
 
 There are two distinct ways Docker intersects with Hermes Agent:
 

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -1,10 +1,10 @@
 ---
 sidebar_position: 15
-title: "Web Dashboard"
+title: "Hermes Web Dashboard"
 description: "Browser-based administration panel for managing configuration, API keys, MCP servers, messaging pairing, webhooks, the gateway, memory, credentials, sessions, logs, analytics, cron jobs, and skills"
 ---
 
-# Web Dashboard
+# Hermes Web Dashboard
 
 The web dashboard is a browser-based UI for managing your Hermes Agent installation. Instead of editing YAML files or running CLI commands, you can configure settings, manage API keys, and monitor sessions from a clean web interface.
 


### PR DESCRIPTION
## Problem

GSC page-level data (Aug 18-24) shows the docs' biggest impression pages losing ranking headroom because their titles and H1s are bare nouns instead of the terms people search:

| Page | Impr | Pos | Was |
|---|---|---|---|
| user-guide/configuration | 171K | 5.3 | "Configuration" |
| getting-started/quickstart | 135K | 5.3 | "Quickstart" |
| integrations/providers | 123K | 5.3 | "AI Providers" |
| features/web-dashboard | 68K | 6.5 | "Web Dashboard" |
| user-guide/docker | 37K | 6.3 | "Docker" |
| user-guide/desktop | 98K | 3.9 | "Desktop App" |

## What changed

- Frontmatter `title` and the page H1 now carry the query terms on all six pages (e.g. "Hermes Agent Configuration", "Hermes Web Dashboard", "Hermes Docker Setup", "Hermes Desktop")
- The desktop docs page now links to the marketing `/desktop` product page so Google sees the two official pages as a cluster and users get a direct download path

Non-English locale copies are untouched; zh-Hans already ranks independently.

Done by Hermes Agent (deepseek-v4-pro via nous), Nous Research.