### PR TITLE
fix: continue TBS not-ready work until gated

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -8388,6 +8388,51 @@ def run_conversation(
                     final_response = None
                     continue
 
+                # ── TBS CEO-readiness continuation guard ───────────────
+                # TBS routing outputs must not stop at NOT CEO-READY when a
+                # safe-envelope next step remains. Treat that not-ready text as
+                # an interim candidate and nudge the model to keep working until
+                # CEO-ready or a true approval/source/access blocker.
+                try:
+                    from agent.tbs_ceo_ready_guard import (
+                        SYNTHETIC_FLAG as _TBS_CEO_READY_GUARD_FLAG,
+                        build_continuation_nudge as _build_tbs_ceo_nudge,
+                    )
+
+                    _tbs_ceo_nudge = _build_tbs_ceo_nudge(
+                        final_response,
+                        user_message=original_user_message,
+                    )
+                except Exception:
+                    logger.debug("TBS CEO-readiness guard check failed", exc_info=True)
+                    _tbs_ceo_nudge = None
+                    _TBS_CEO_READY_GUARD_FLAG = "_tbs_ceo_ready_guard_synthetic"
+
+                if _tbs_ceo_nudge:
+                    final_msg["finish_reason"] = "tbs_ceo_ready_continuation_required"
+                    final_msg[_TBS_CEO_READY_GUARD_FLAG] = True
+                    append_message(messages, final_msg)
+                    append_message(messages, {
+                        "role": "user",
+                        "content": _tbs_ceo_nudge,
+                        _TBS_CEO_READY_GUARD_FLAG: True,
+                    })
+                    agent._session_messages = messages
+                    logger.info(
+                        "TBS CEO-readiness guard issued continuation nudge "
+                        "(session=%s)",
+                        getattr(agent, "session_id", None) or "none",
+                    )
+                    agent._emit_status(
+                        "↻ NOT CEO-READY is not a stop — continuing safe next step"
+                    )
+                    _pending_verification_response = final_response
+                    _pending_verification_response_previewed = (
+                        agent._interim_content_was_streamed(final_response or "")
+                    )
+                    final_response = None
+                    continue
+
                 append_message(messages, final_msg)
                 # Make the completed answer durable before leaving the loop —
                 # a session torn down before finalize_turn's _persist_session

--- a/agent/tbs_ceo_ready_guard.py
+++ b/agent/tbs_ceo_ready_guard.py
@@ -1,0 +1,108 @@
+"""TBS CEO-readiness continuation guard.
+
+This module is intentionally small and text-only.  It sits at the model-output
+finalization seam and decides whether a TBS-flavored NOT CEO-READY answer is a
+legitimate stopping condition or whether the agent should keep working inside the
+safe envelope.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+SYNTHETIC_FLAG = "_tbs_ceo_ready_guard_synthetic"
+
+_NOT_READY_RE = re.compile(
+    r"\bNOT\s+CEO[-\s]?READY\b|\bNOT\s+READY\s+FOR\s+CEO\b|\bROUTING\s+INCOMPLETE\b",
+    re.IGNORECASE,
+)
+
+# Terms that indicate the response reached a genuine stop/approval boundary.
+# Keep this broad and conservative: false negatives cost one extra model turn;
+# false positives can let unfinished work look final.
+_HARD_STOP_RE = re.compile(
+    r"\b(approval\s+(?:needed|required)|requires?\s+(?:Dave\s+)?approval|"
+    r"awaits?\s+(?:Dave\s+)?approval|pending\s+(?:Dave\s+)?approval|"
+    r"approve\s+(?:the|this|via|before)|hard[-\s]?stop|blocked|auth\s+blocked|"
+    r"login\s+(?:is\s+)?(?:required|needed)|credential(?:s)?|password|"
+    r"missing\s+(?:source|file|access|credential|business\s+direction|context)|"
+    r"source\s+access\s+(?:is\s+)?missing|cannot\s+be\s+retrieved|"
+    r"waiting\s+on\s+worker|worker\s+(?:is\s+)?(?:pending|running)|"
+    r"Dave\s+(?:must|needs\s+to|can|should|reviews?|approve))\b",
+    re.IGNORECASE,
+)
+
+_SAFE_WORK_RE = re.compile(
+    r"\b(next\s+safe[-\s]?envelope\s+step|next\s+safe\s+step|"
+    r"go\s+get\s+evidence|run\s+(?:worker|qa|tests?|verification)|"
+    r"route\s+(?:the\s+)?(?:worker|next)|revise|build|draft|inspect|read|"
+    r"verify|source\s+lookup|prepare\s+(?:the\s+)?approval\s+card|"
+    r"continue\s+(?:safe|the\s+safe|working))\b",
+    re.IGNORECASE,
+)
+
+_TBS_CONTEXT_RE = re.compile(
+    r"\b(TBS|tbs-|worker[-\s]?first|routing\s+log|safe[-\s]?envelope)\b",
+    re.IGNORECASE,
+)
+
+_CONTINUATION_NUDGE = """[SYSTEM CONTINUATION GUARD — TBS CEO-readiness]
+Your last response labeled this TBS work NOT CEO-READY / ROUTING INCOMPLETE, but it did not state a hard-stop approval/source/credential/business-direction blocker.
+Do not present the session as finished yet. Continue the next safe-envelope step now: gather missing evidence, route/run the worker, revise/build the deliverable, run QA/verification, or prepare an approval card.
+Stop only when one of these is true:
+1. the deliverable is CEO-ready and verified;
+2. a hard approval gate is reached (send/publish/config/restart/commit/deploy/accounting mutation/delete/irreversible action);
+3. required source access, credentials, files, or business direction is missing and cannot be retrieved safely;
+4. the user explicitly asked for status-only/review-only output.
+When you finally stop, make the exact stopping condition explicit."""
+
+
+def _as_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        parts: list[str] = []
+        for item in value:
+            if isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+            elif isinstance(item, str):
+                parts.append(item)
+        return "\n".join(parts)
+    return str(value)
+
+
+def response_needs_continuation(response_text: Any, *, user_message: Any = None) -> bool:
+    """Return True when a TBS NOT CEO-READY response should not finalize.
+
+    The guard activates only for TBS-shaped content and only when the response
+    includes a not-ready/readiness-incomplete label. It lets real hard stops
+    through, and otherwise nudges when the answer names safe follow-up work or
+    simply leaves the not-ready state unresolved.
+    """
+    text = _as_text(response_text).strip()
+    if not text or not _NOT_READY_RE.search(text):
+        return False
+
+    context = text + "\n" + _as_text(user_message)
+    if not _TBS_CONTEXT_RE.search(context):
+        return False
+
+    if _HARD_STOP_RE.search(text):
+        return False
+
+    # If the response is not-ready and no hard stop was named, fail closed by
+    # continuing. A listed safe next step makes the intent explicit; absence of
+    # one is also a reason to continue rather than call the turn complete.
+    return True
+
+
+def build_continuation_nudge(response_text: Any, *, user_message: Any = None) -> str | None:
+    if not response_needs_continuation(response_text, user_message=user_message):
+        return None
+    return _CONTINUATION_NUDGE

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -54,6 +54,7 @@ def _is_pure_tool_call_tail(msg: dict) -> bool:
 _VERIFICATION_CONTINUATION_FLAGS = (
     "_verification_stop_synthetic",
     "_pre_verify_synthetic",
+    "_tbs_ceo_ready_guard_synthetic",
 )
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -246,6 +246,10 @@ _EPHEMERAL_SCAFFOLDING_FLAGS = (
     "_pre_verify_synthetic",
     # kanban worker stop-guard: narrated exit without kanban_complete/block
     "_kanban_stop_synthetic",
+    # TBS CEO-readiness continuation guard: a NOT CEO-READY answer without
+    # a hard-stop blocker is an interim candidate plus a synthetic nudge, not
+    # durable transcript content.
+    "_tbs_ceo_ready_guard_synthetic",
     # dropped tool-call re-prompt pair (finish_reason=tool_calls with an
     # empty tool_calls array): the interim narration-only assistant turn
     # and the "issue the actual tool call now" user nudge exist only to

--- a/tests/run_agent/test_tbs_ceo_ready_guard.py
+++ b/tests/run_agent/test_tbs_ceo_ready_guard.py
@@ -1,0 +1,58 @@
+import pytest
+
+from agent.tbs_ceo_ready_guard import SYNTHETIC_FLAG, build_continuation_nudge, response_needs_continuation
+from agent.turn_finalizer import _drop_verification_continuation_scaffolding
+
+
+def test_tbs_not_ceo_ready_without_hard_stop_continues():
+    text = (
+        "Status: NOT CEO-READY / ROUTING INCOMPLETE. "
+        "Next safe step: run QA and revise the deliverable."
+    )
+
+    assert response_needs_continuation(text, user_message="TBS routing work") is True
+    assert build_continuation_nudge(text, user_message="TBS routing work")
+
+
+def test_tbs_not_ceo_ready_with_approval_boundary_stops():
+    text = (
+        "Status: NOT CEO-READY as an implemented control change. "
+        "Close blockers/open questions: skill patch requires Dave approval."
+    )
+
+    assert response_needs_continuation(text, user_message="TBS routing work") is False
+    assert build_continuation_nudge(text, user_message="TBS routing work") is None
+
+
+def test_tbs_auth_blocked_stops():
+    text = "Status: NOT CEO-READY / AUTH BLOCKED until login is completed."
+
+    assert response_needs_continuation(text, user_message="TBS client work") is False
+
+
+def test_non_tbs_not_ready_text_does_not_trigger():
+    text = "This generic draft is NOT CEO-READY, but it is outside the requested operating model."
+
+    assert response_needs_continuation(text, user_message="generic writing") is False
+
+
+def test_ceo_ready_text_does_not_trigger():
+    text = "Status: CEO-ready and verified."
+
+    assert response_needs_continuation(text, user_message="TBS routing work") is False
+
+
+def test_tbs_guard_scaffolding_is_dropped_from_live_history():
+    messages = [
+        {"role": "user", "content": "do TBS routing work"},
+        {"role": "assistant", "content": "interim", SYNTHETIC_FLAG: True},
+        {"role": "user", "content": "continue", SYNTHETIC_FLAG: True},
+        {"role": "assistant", "content": "final CEO-ready answer"},
+    ]
+
+    _drop_verification_continuation_scaffolding(messages)
+
+    assert messages == [
+        {"role": "user", "content": "do TBS routing work"},
+        {"role": "assistant", "content": "final CEO-ready answer"},
+    ]


### PR DESCRIPTION
## Summary
- add a TBS CEO-readiness continuation guard before turn finalization
- nudge the agent to keep working when a TBS response stops at NOT CEO-READY / ROUTING INCOMPLETE without a hard-stop blocker
- keep guard scaffolding ephemeral so resumed transcripts are not polluted

## Tests
- python -m pytest tests/run_agent/test_tbs_ceo_ready_guard.py tests/test_transform_llm_output_hook.py tests/hermes_cli/test_plugins.py -q

## Notes
- Direct push to NousResearch/hermes-agent was denied for the active GitHub account, so this branch is pushed from the TriumphBusinessSolutions fork.