### PR TITLE
fix(agent): refresh DeepSeek pricing to the 2026-08-16 official rates

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -506,52 +506,69 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         pricing_version="anthropic-pricing-2026-05",
     ),
     # DeepSeek
-    # Snapshot of https://api-docs.deepseek.com/quick_start/pricing (2026-07).
+    # Snapshot of https://api-docs.deepseek.com/quick_start/pricing (2026-08-24),
+    # after the 2026-08-16 rate change. DeepSeek now bills PEAK hours
+    # (01:00-04:00 and 06:00-10:00 UTC, Mon-Fri) at exactly DOUBLE the rates
+    # below; the estimator has no time-of-day axis, so these rows carry the
+    # OFF-PEAK rates — treat estimates as an off-peak floor.
     # deepseek-chat / deepseek-reasoner are deprecated 2026-07-24 and now alias
     # deepseek-v4-flash's non-thinking / thinking modes — same rates.
     (
         "deepseek",
         "deepseek-chat",
     ): PricingEntry(
-        input_cost_per_million=Decimal("0.14"),
-        output_cost_per_million=Decimal("0.28"),
-        cache_read_cost_per_million=Decimal("0.0028"),
+        input_cost_per_million=Decimal("0.22"),
+        output_cost_per_million=Decimal("0.66"),
+        cache_read_cost_per_million=Decimal("0.007"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-07",
+        pricing_version="deepseek-pricing-2026-08-offpeak",
     ),
     (
         "deepseek",
         "deepseek-reasoner",
     ): PricingEntry(
-        input_cost_per_million=Decimal("0.14"),
-        output_cost_per_million=Decimal("0.28"),
-        cache_read_cost_per_million=Decimal("0.0028"),
+        input_cost_per_million=Decimal("0.22"),
+        output_cost_per_million=Decimal("0.66"),
+        cache_read_cost_per_million=Decimal("0.007"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-07",
+        pricing_version="deepseek-pricing-2026-08-offpeak",
     ),
     (
         "deepseek",
         "deepseek-v4-pro",
     ): PricingEntry(
-        input_cost_per_million=Decimal("0.435"),
-        output_cost_per_million=Decimal("0.87"),
-        cache_read_cost_per_million=Decimal("0.003625"),
+        input_cost_per_million=Decimal("0.66"),
+        output_cost_per_million=Decimal("1.98"),
+        cache_read_cost_per_million=Decimal("0.022"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-07",
+        pricing_version="deepseek-pricing-2026-08-offpeak",
     ),
     (
         "deepseek",
         "deepseek-v4-flash",
     ): PricingEntry(
-        input_cost_per_million=Decimal("0.14"),
-        output_cost_per_million=Decimal("0.28"),
-        cache_read_cost_per_million=Decimal("0.0028"),
+        input_cost_per_million=Decimal("0.22"),
+        output_cost_per_million=Decimal("0.66"),
+        cache_read_cost_per_million=Decimal("0.007"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-07",
+        pricing_version="deepseek-pricing-2026-08-offpeak",
+    ),
+    (
+        "deepseek",
+        "deepseek-v4-flash-vision-exp",
+    ): PricingEntry(
+        # Image tokens are billed as input tokens at the flash rates (docs:
+        # "Vision: Token Usage").
+        input_cost_per_million=Decimal("0.22"),
+        output_cost_per_million=Decimal("0.66"),
+        cache_read_cost_per_million=Decimal("0.007"),
+        source="official_docs_snapshot",
+        source_url="https://api-docs.deepseek.com/quick_start/pricing",
+        pricing_version="deepseek-pricing-2026-08-offpeak",
     ),
     # Google Gemini
     (

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -50,6 +50,7 @@ from typing import Any, Callable, Dict, List, Optional
 from agent.secret_scope import (
     build_profile_secret_scope,
     get_secret,
+    is_multiplex_active,
     reset_secret_scope,
     set_secret_scope,
 )
@@ -57,6 +58,7 @@ from agent.secret_scope import (
 from agent.memory_provider import MemoryProvider, RecallStatus
 from hermes_constants import (
     get_hermes_home,
+    get_hermes_home_override,
     reset_hermes_home_override,
     set_hermes_home_override,
 )
@@ -755,8 +757,23 @@ class HindsightMemoryProvider(MemoryProvider):
         self._api_key = None
         # Captured at construction time: under multiplexing the constructor
         # runs inside the adapter's per-profile context, while the background
-        # threads spawned later do not (see _profile_scope).
+        # threads spawned later do not (see _profile_scope). The scope mapping
+        # is built once here and reused by every background body — building it
+        # per job would re-parse the profile .env on each retain/recall for no
+        # benefit (the snapshot tracks this provider instance's lifecycle).
         self._profile_home = Path(get_hermes_home())
+        self._profile_secret_scope = build_profile_secret_scope(self._profile_home)
+        if is_multiplex_active() and get_hermes_home_override() is None:
+            # Constructed with no profile override active while multiplexing:
+            # _profile_home likely baked in the process-default home, and every
+            # background secret read will resolve against that profile. Almost
+            # certainly a misconstruction — make it diagnosable in debug logs.
+            logger.debug(
+                "HindsightMemoryProvider constructed under multiplexing without "
+                "a HERMES_HOME override; captured home %s is likely the "
+                "process default rather than a profile home",
+                self._profile_home,
+            )
         self._api_url = _DEFAULT_API_URL
         self._bank_id = "hermes"
         self._budget = "mid"
@@ -1493,9 +1510,16 @@ class HindsightMemoryProvider(MemoryProvider):
         #76574/#86402), so every background body re-installs the scope this
         instance captured at construction — mirroring the gateway's thread
         wrapping (gateway/run.py).
+
+        The scope mapping is built ONCE at construction and reused: retain
+        jobs and recalls are network-bound, so re-parsing the profile .env per
+        job would only add filesystem IO. Mid-session .env edits are picked up
+        when the provider instance is recreated (gateway session lifecycle);
+        the daemon-restart path reads config changes separately via
+        _build/_materialize_embedded_profile_env.
         """
         home_token = set_hermes_home_override(str(self._profile_home))
-        secret_token = set_secret_scope(build_profile_secret_scope(self._profile_home))
+        secret_token = set_secret_scope(self._profile_secret_scope)
         try:
             yield
         finally:
@@ -1811,51 +1835,54 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._mode = "disabled"
                 return
 
-            def _start_daemon():
-                with self._profile_scope():
-                    _start_daemon_scoped()
-
-            def _start_daemon_scoped():
-                import traceback
-                log_dir = get_hermes_home() / "logs"
-                log_dir.mkdir(parents=True, exist_ok=True)
-                log_path = log_dir / "hindsight-embed.log"
-                try:
-                    # Redirect the daemon manager's Rich console to our log file
-                    # instead of stderr. This avoids global fd redirects that
-                    # would capture output from other threads.
-                    import hindsight_embed.daemon_embed_manager as dem
-                    from rich.console import Console
-                    dem.console = Console(file=open(log_path, "a", encoding="utf-8"), force_terminal=False)
-
-                    client = self._get_client()
-                    profile = self._config.get("profile", "hermes")
-
-                    # Update the profile .env to match our current config so
-                    # the daemon always starts with the right settings.
-                    # If the config changed and the daemon is running, stop it.
-                    profile_env = _embedded_profile_env_path(self._config)
-                    expected_env = _build_embedded_profile_env(self._config)
-                    saved = _load_simple_env(profile_env)
-                    config_changed = saved != expected_env
-
-                    if config_changed:
-                        profile_env = _materialize_embedded_profile_env(self._config)
-                        if client._manager.is_running(profile):
-                            with open(log_path, "a", encoding="utf-8") as f:
-                                f.write("\n=== Config changed, restarting daemon ===\n")
-                            client._manager.stop(profile)
-
-                    client._ensure_started()
-                    with open(log_path, "a", encoding="utf-8") as f:
-                        f.write("\n=== Daemon started successfully ===\n")
-                except Exception as e:
-                    with open(log_path, "a", encoding="utf-8") as f:
-                        f.write(f"\n=== Daemon startup failed: {e} ===\n")
-                        traceback.print_exc(file=f)
-
-            t = threading.Thread(target=_start_daemon, daemon=True, name="hindsight-daemon-start")
+            t = threading.Thread(
+                target=self._spawn_embedded_daemon, daemon=True, name="hindsight-daemon-start"
+            )
             t.start()
+
+    def _spawn_embedded_daemon(self):
+        """Run the embedded daemon startup under this profile's secret scope."""
+        with self._profile_scope():
+            self._daemon_start_body()
+
+    def _daemon_start_body(self):
+        import traceback
+        log_dir = get_hermes_home() / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / "hindsight-embed.log"
+        try:
+            # Redirect the daemon manager's Rich console to our log file
+            # instead of stderr. This avoids global fd redirects that
+            # would capture output from other threads.
+            import hindsight_embed.daemon_embed_manager as dem
+            from rich.console import Console
+            dem.console = Console(file=open(log_path, "a", encoding="utf-8"), force_terminal=False)
+
+            client = self._get_client()
+            profile = self._config.get("profile", "hermes")
+
+            # Update the profile .env to match our current config so
+            # the daemon always starts with the right settings.
+            # If the config changed and the daemon is running, stop it.
+            profile_env = _embedded_profile_env_path(self._config)
+            expected_env = _build_embedded_profile_env(self._config)
+            saved = _load_simple_env(profile_env)
+            config_changed = saved != expected_env
+
+            if config_changed:
+                profile_env = _materialize_embedded_profile_env(self._config)
+                if client._manager.is_running(profile):
+                    with open(log_path, "a", encoding="utf-8") as f:
+                        f.write("\n=== Config changed, restarting daemon ===\n")
+                    client._manager.stop(profile)
+
+            client._ensure_started()
+            with open(log_path, "a", encoding="utf-8") as f:
+                f.write("\n=== Daemon started successfully ===\n")
+        except Exception as e:
+            with open(log_path, "a", encoding="utf-8") as f:
+                f.write(f"\n=== Daemon startup failed: {e} ===\n")
+                traceback.print_exc(file=f)
 
     def system_prompt_block(self) -> str:
         if self._memory_mode == "context":
@@ -1995,25 +2022,27 @@ class HindsightMemoryProvider(MemoryProvider):
         if self._recall_disabled():
             return
 
-        def _run():
-            # Ensure the just-completed turn's retain is recall-visible on the
-            # server before we recall, so the warmed context for the next turn
-            # includes it. This waits for the local writer queue to drain AND
-            # for the server-side async retain op(s) to complete (an explicit
-            # read-after-write signal), because async retain returns on
-            # acceptance rather than durability. Runs on the background prefetch
-            # thread, never the reply path, so it adds no response latency.
-            with self._profile_scope():
-                if self._prefetch_waits_for_retain:
-                    self._wait_for_retains_drained(self._prefetch_retain_drain_timeout)
-                recalled = self._do_recall(query)
-                if recalled.text:
-                    with self._prefetch_lock:
-                        self._prefetch_result = recalled.text
-                        self._prefetch_count = recalled.count
-
-        self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="hindsight-prefetch")
+        self._prefetch_thread = threading.Thread(
+            target=self._prefetch_background, args=(query,), daemon=True, name="hindsight-prefetch"
+        )
         self._prefetch_thread.start()
+
+    def _prefetch_background(self, query: str) -> None:
+        # Ensure the just-completed turn's retain is recall-visible on the
+        # server before we recall, so the warmed context for the next turn
+        # includes it. This waits for the local writer queue to drain AND
+        # for the server-side async retain op(s) to complete (an explicit
+        # read-after-write signal), because async retain returns on
+        # acceptance rather than durability. Runs on the background prefetch
+        # thread, never the reply path, so it adds no response latency.
+        with self._profile_scope():
+            if self._prefetch_waits_for_retain:
+                self._wait_for_retains_drained(self._prefetch_retain_drain_timeout)
+            recalled = self._do_recall(query)
+            if recalled.text:
+                with self._prefetch_lock:
+                    self._prefetch_result = recalled.text
+                    self._prefetch_count = recalled.count
 
     def _build_turn_messages(self, user_content: str, assistant_content: str) -> List[Dict[str, str]]:
         now = datetime.now(timezone.utc).isoformat()

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -40,15 +40,26 @@ import queue
 import sys
 import threading
 import time
+from contextlib import contextmanager
+from pathlib import Path
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional
 
-from agent.secret_scope import get_secret
+from agent.secret_scope import (
+    build_profile_secret_scope,
+    get_secret,
+    reset_secret_scope,
+    set_secret_scope,
+)
 
 from agent.memory_provider import MemoryProvider, RecallStatus
-from hermes_constants import get_hermes_home
+from hermes_constants import (
+    get_hermes_home,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
 from tools.registry import tool_error
 from hermes_cli.config import cfg_get
 
@@ -742,6 +753,10 @@ class HindsightMemoryProvider(MemoryProvider):
     def __init__(self):
         self._config = None
         self._api_key = None
+        # Captured at construction time: under multiplexing the constructor
+        # runs inside the adapter's per-profile context, while the background
+        # threads spawned later do not (see _profile_scope).
+        self._profile_home = Path(get_hermes_home())
         self._api_url = _DEFAULT_API_URL
         self._bank_id = "hermes"
         self._budget = "mid"
@@ -1467,6 +1482,26 @@ class HindsightMemoryProvider(MemoryProvider):
                 return False
             time.sleep(self._RETAIN_OP_POLL_INTERVAL_S)
 
+    @contextmanager
+    def _profile_scope(self):
+        """Install this profile's secret scope + HERMES_HOME override.
+
+        Background threads (writer, daemon start, prefetch) are spawned raw,
+        without the constructing context's contextvars. Under multiplexing
+        ``get_secret`` fails closed on unscoped reads rather than risk
+        returning another profile's credential (#92608; same family as
+        #76574/#86402), so every background body re-installs the scope this
+        instance captured at construction — mirroring the gateway's thread
+        wrapping (gateway/run.py).
+        """
+        home_token = set_hermes_home_override(str(self._profile_home))
+        secret_token = set_secret_scope(build_profile_secret_scope(self._profile_home))
+        try:
+            yield
+        finally:
+            reset_secret_scope(secret_token)
+            reset_hermes_home_override(home_token)
+
     def _writer_loop(self) -> None:
         """Drain the retain queue serially. Exits on sentinel.
 
@@ -1484,7 +1519,8 @@ class HindsightMemoryProvider(MemoryProvider):
                 if job is _WRITER_SENTINEL:
                     return
                 try:
-                    job()
+                    with self._profile_scope():
+                        job()
                 except Exception as exc:
                     logger.warning("Hindsight retain failed: %s", exc, exc_info=True)
             finally:
@@ -1776,6 +1812,10 @@ class HindsightMemoryProvider(MemoryProvider):
                 return
 
             def _start_daemon():
+                with self._profile_scope():
+                    _start_daemon_scoped()
+
+            def _start_daemon_scoped():
                 import traceback
                 log_dir = get_hermes_home() / "logs"
                 log_dir.mkdir(parents=True, exist_ok=True)
@@ -1963,13 +2003,14 @@ class HindsightMemoryProvider(MemoryProvider):
             # read-after-write signal), because async retain returns on
             # acceptance rather than durability. Runs on the background prefetch
             # thread, never the reply path, so it adds no response latency.
-            if self._prefetch_waits_for_retain:
-                self._wait_for_retains_drained(self._prefetch_retain_drain_timeout)
-            recalled = self._do_recall(query)
-            if recalled.text:
-                with self._prefetch_lock:
-                    self._prefetch_result = recalled.text
-                    self._prefetch_count = recalled.count
+            with self._profile_scope():
+                if self._prefetch_waits_for_retain:
+                    self._wait_for_retains_drained(self._prefetch_retain_drain_timeout)
+                recalled = self._do_recall(query)
+                if recalled.text:
+                    with self._prefetch_lock:
+                        self._prefetch_result = recalled.text
+                        self._prefetch_count = recalled.count
 
         self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="hindsight-prefetch")
         self._prefetch_thread.start()

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -89,8 +89,11 @@ def test_deepseek_v4_pro_pricing_entry_exists():
 
     Before this fix, deepseek-v4-pro sessions showed as unknown cost
     in hermes insights because the _OFFICIAL_DOCS_PRICING table had no
-    entry for that model.  See #24218.  Rates track the 2026-07 price cut
-    ($1.74/$3.48 → $0.435/$0.87).
+    entry for that model.  See #24218.  Rates track DeepSeek's official
+    pricing page as of the 2026-08-16 change (verified against
+    api-docs.deepseek.com/quick_start/pricing on 2026-08-24); entries
+    carry OFF-PEAK rates — peak hours bill exactly double and the
+    estimator has no time-of-day axis.
     """
     entry = get_pricing_entry(
         "deepseek-v4-pro",
@@ -100,9 +103,23 @@ def test_deepseek_v4_pro_pricing_entry_exists():
     assert entry is not None
     assert entry.input_cost_per_million is not None
     assert entry.output_cost_per_million is not None
-    assert float(entry.input_cost_per_million) == 0.435
-    assert float(entry.output_cost_per_million) == 0.87
-    assert float(entry.cache_read_cost_per_million) == 0.003625
+    assert float(entry.input_cost_per_million) == 0.66
+    assert float(entry.output_cost_per_million) == 1.98
+    assert float(entry.cache_read_cost_per_million) == 0.022
+
+
+def test_deepseek_vision_exp_prices_as_v4_flash():
+    """Invariant: deepseek-v4-flash-vision-exp bills at flash rates — image
+    tokens convert to input tokens on the same table (official docs)."""
+    flash = get_pricing_entry("deepseek-v4-flash", provider="deepseek")
+    assert flash is not None
+    entry = get_pricing_entry(
+        "deepseek-v4-flash-vision-exp", provider="deepseek"
+    )
+    assert entry is not None
+    assert entry.input_cost_per_million == flash.input_cost_per_million
+    assert entry.output_cost_per_million == flash.output_cost_per_million
+    assert entry.cache_read_cost_per_million == flash.cache_read_cost_per_million
 
 
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1561,3 +1561,110 @@ class TestClientAutoUpgradeRoutesThroughLazyDeps:
         assert len(calls) == 1  # attempted exactly once, init still completed
         assert any("runtime installs are disabled" in r.getMessage()
                    for r in caplog.records)
+
+
+class TestBackgroundSecretScope:
+    """Background threads must re-install the captured profile scope (#92608).
+
+    Under multiplexing, get_secret fails closed on unscoped reads rather
+    than risk leaking another profile's credential. The writer/daemon/
+    prefetch threads are spawned raw (no contextvars propagation), so each
+    body wraps itself in _profile_scope using the home captured at
+    construction — same contract as gateway/run.py's thread wrapping.
+    """
+
+    @staticmethod
+    def _bare_provider(home):
+        provider = HindsightMemoryProvider.__new__(HindsightMemoryProvider)
+        provider._profile_home = home
+        provider._retain_queue = __import__("queue").Queue()
+        provider._shutting_down = __import__("threading").Event()
+        return provider
+
+    def test_writer_job_reads_profile_secret_and_resets_scope(self, tmp_path):
+        import queue as _queue
+        import threading as _threading
+
+        from agent.secret_scope import current_secret_scope
+        from plugins.memory.hindsight import (
+            _WRITER_SENTINEL,
+            get_secret as plugin_get_secret,
+        )
+
+        (tmp_path / ".env").write_text("HINDSIGHT_LLM_API_KEY=scope-key\n", encoding="utf-8")
+        observed = {}
+
+        def job():
+            observed["scope"] = current_secret_scope()
+            observed["key"] = plugin_get_secret("HINDSIGHT_LLM_API_KEY", "MISSING")
+
+        provider = self._bare_provider(tmp_path)
+        provider._retain_queue = _queue.Queue()
+        provider._shutting_down = _threading.Event()
+        provider._retain_queue.put(job)
+        provider._retain_queue.put(_WRITER_SENTINEL)
+        provider._writer_loop()
+
+        assert observed["key"] == "scope-key"
+        assert observed["scope"] is not None
+        # Scope must not leak past the thread body.
+        assert current_secret_scope() is None
+
+    def test_writer_job_sees_captured_hermes_home(self, tmp_path, monkeypatch):
+        import queue as _queue
+        import threading as _threading
+
+        from hermes_constants import get_hermes_home as real_get_hermes_home
+        from plugins.memory.hindsight import _WRITER_SENTINEL
+
+        fake_process_home = tmp_path / "elsewhere"
+        monkeypatch.setenv("HERMES_HOME", str(fake_process_home))
+        observed = {}
+
+        def job():
+            observed["home"] = real_get_hermes_home()
+
+        provider = HindsightMemoryProvider.__new__(HindsightMemoryProvider)
+        provider._profile_home = tmp_path
+        provider._retain_queue = _queue.Queue()
+        provider._shutting_down = _threading.Event()
+        provider._retain_queue.put(job)
+        provider._retain_queue.put(_WRITER_SENTINEL)
+        provider._writer_loop()
+
+        assert observed["home"] == tmp_path
+
+    def test_unscoped_read_fails_closed_under_multiplex(self, monkeypatch):
+        from agent import secret_scope as secret_scope_module
+
+        monkeypatch.setattr(secret_scope_module, "_MULTIPLEX_ACTIVE", True)
+        with pytest.raises(secret_scope_module.UnscopedSecretError):
+            secret_scope_module.get_secret("HINDSIGHT_LLM_API_KEY", "")
+
+    def test_writer_job_survives_fail_closed_multiplex_guard(self, tmp_path, monkeypatch):
+        """The reported crash shape: multiplex on, key only in profile .env,
+        read from the raw writer thread — must succeed inside the scope."""
+        import queue as _queue
+        import threading as _threading
+
+        from agent import secret_scope as secret_scope_module
+        from plugins.memory.hindsight import _WRITER_SENTINEL
+
+        monkeypatch.setattr(secret_scope_module, "_MULTIPLEX_ACTIVE", True)
+        (tmp_path / ".env").write_text("HINDSIGHT_LLM_API_KEY=scope-key\n", encoding="utf-8")
+        observed = {}
+
+        def job():
+            observed["key"] = secret_scope_module.get_secret(
+                "HINDSIGHT_LLM_API_KEY", "MISSING"
+            )
+
+        provider = HindsightMemoryProvider.__new__(HindsightMemoryProvider)
+        provider._profile_home = tmp_path
+        provider._retain_queue = _queue.Queue()
+        provider._shutting_down = _threading.Event()
+        provider._retain_queue.put(job)
+        provider._retain_queue.put(_WRITER_SENTINEL)
+        provider._writer_loop()  # must not raise UnscopedSecretError
+
+        assert observed["key"] == "scope-key"

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -6,10 +6,12 @@ turn counting, tags), and schema completeness.
 """
 
 import json
+import queue
 import os
 import re
 import stat
 import sys
+import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -18,6 +20,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from hermes_cli.memory_setup import _CANCELLED
+from agent.secret_scope import build_profile_secret_scope
 from plugins.memory.hindsight import (
     HindsightMemoryProvider,
     RECALL_SCHEMA,
@@ -1569,29 +1572,61 @@ class TestBackgroundSecretScope:
     Under multiplexing, get_secret fails closed on unscoped reads rather
     than risk leaking another profile's credential. The writer/daemon/
     prefetch threads are spawned raw (no contextvars propagation), so each
-    body wraps itself in _profile_scope using the home captured at
-    construction — same contract as gateway/run.py's thread wrapping.
+    body wraps itself in _profile_scope using the home + scope mapping
+    captured at construction — same contract as gateway/run.py's thread
+    wrapping.
     """
 
     @staticmethod
-    def _bare_provider(home):
+    def _bare_provider(home, **attrs):
         provider = HindsightMemoryProvider.__new__(HindsightMemoryProvider)
         provider._profile_home = home
-        provider._retain_queue = __import__("queue").Queue()
-        provider._shutting_down = __import__("threading").Event()
+        provider._profile_secret_scope = build_profile_secret_scope(home)
+        provider._retain_queue = queue.Queue()
+        provider._shutting_down = threading.Event()
+        for name, value in attrs.items():
+            setattr(provider, name, value)
         return provider
 
-    def test_writer_job_reads_profile_secret_and_resets_scope(self, tmp_path):
-        import queue as _queue
-        import threading as _threading
+    @pytest.fixture
+    def multiplex_on(self):
+        """Activate multiplex mode via the public hook, restoring after."""
+        from agent import secret_scope as secret_scope_module
 
+        secret_scope_module.set_multiplex_active(True)
+        yield
+        secret_scope_module.set_multiplex_active(False)
+
+    @pytest.fixture
+    def sync_threads(self, monkeypatch):
+        """Make hindsight's Thread(...) spawns synchronous and capturable."""
+        started = []
+
+        class _SyncThread:
+            def __init__(self, target=None, args=(), daemon=False, name=None):
+                self._target = target
+                self._args = args
+                self.name = name
+                started.append(self)
+
+            def start(self):
+                pass
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.threading.Thread", _SyncThread
+        )
+        return started
+
+    def test_writer_job_reads_profile_secret_and_resets_scope(self, tmp_path):
         from agent.secret_scope import current_secret_scope
         from plugins.memory.hindsight import (
             _WRITER_SENTINEL,
             get_secret as plugin_get_secret,
         )
 
-        (tmp_path / ".env").write_text("HINDSIGHT_LLM_API_KEY=scope-key\n", encoding="utf-8")
+        (tmp_path / ".env").write_text(
+            "HINDSIGHT_LLM_API_KEY=scope-key\n", encoding="utf-8"
+        )
         observed = {}
 
         def job():
@@ -1599,8 +1634,6 @@ class TestBackgroundSecretScope:
             observed["key"] = plugin_get_secret("HINDSIGHT_LLM_API_KEY", "MISSING")
 
         provider = self._bare_provider(tmp_path)
-        provider._retain_queue = _queue.Queue()
-        provider._shutting_down = _threading.Event()
         provider._retain_queue.put(job)
         provider._retain_queue.put(_WRITER_SENTINEL)
         provider._writer_loop()
@@ -1611,9 +1644,6 @@ class TestBackgroundSecretScope:
         assert current_secret_scope() is None
 
     def test_writer_job_sees_captured_hermes_home(self, tmp_path, monkeypatch):
-        import queue as _queue
-        import threading as _threading
-
         from hermes_constants import get_hermes_home as real_get_hermes_home
         from plugins.memory.hindsight import _WRITER_SENTINEL
 
@@ -1624,47 +1654,134 @@ class TestBackgroundSecretScope:
         def job():
             observed["home"] = real_get_hermes_home()
 
-        provider = HindsightMemoryProvider.__new__(HindsightMemoryProvider)
-        provider._profile_home = tmp_path
-        provider._retain_queue = _queue.Queue()
-        provider._shutting_down = _threading.Event()
+        provider = self._bare_provider(tmp_path)
         provider._retain_queue.put(job)
         provider._retain_queue.put(_WRITER_SENTINEL)
         provider._writer_loop()
 
         assert observed["home"] == tmp_path
 
-    def test_unscoped_read_fails_closed_under_multiplex(self, monkeypatch):
-        from agent import secret_scope as secret_scope_module
+    def test_unscoped_read_fails_closed_under_multiplex(self, multiplex_on):
+        from agent.secret_scope import (
+            get_secret as scope_get_secret,
+            UnscopedSecretError,
+        )
 
-        monkeypatch.setattr(secret_scope_module, "_MULTIPLEX_ACTIVE", True)
-        with pytest.raises(secret_scope_module.UnscopedSecretError):
-            secret_scope_module.get_secret("HINDSIGHT_LLM_API_KEY", "")
+        with pytest.raises(UnscopedSecretError):
+            scope_get_secret("HINDSIGHT_LLM_API_KEY", "")
 
-    def test_writer_job_survives_fail_closed_multiplex_guard(self, tmp_path, monkeypatch):
+    def test_writer_job_survives_fail_closed_multiplex_guard(
+        self, tmp_path, multiplex_on
+    ):
         """The reported crash shape: multiplex on, key only in profile .env,
         read from the raw writer thread — must succeed inside the scope."""
-        import queue as _queue
-        import threading as _threading
-
-        from agent import secret_scope as secret_scope_module
+        from agent.secret_scope import get_secret as scope_get_secret
         from plugins.memory.hindsight import _WRITER_SENTINEL
 
-        monkeypatch.setattr(secret_scope_module, "_MULTIPLEX_ACTIVE", True)
-        (tmp_path / ".env").write_text("HINDSIGHT_LLM_API_KEY=scope-key\n", encoding="utf-8")
+        (tmp_path / ".env").write_text(
+            "HINDSIGHT_LLM_API_KEY=scope-key\n", encoding="utf-8"
+        )
         observed = {}
 
         def job():
-            observed["key"] = secret_scope_module.get_secret(
-                "HINDSIGHT_LLM_API_KEY", "MISSING"
-            )
+            observed["key"] = scope_get_secret("HINDSIGHT_LLM_API_KEY", "MISSING")
 
-        provider = HindsightMemoryProvider.__new__(HindsightMemoryProvider)
-        provider._profile_home = tmp_path
-        provider._retain_queue = _queue.Queue()
-        provider._shutting_down = _threading.Event()
+        provider = self._bare_provider(tmp_path)
         provider._retain_queue.put(job)
         provider._retain_queue.put(_WRITER_SENTINEL)
-        provider._writer_loop()  # must not raise UnscopedSecretError
+        provider._writer_loop()
 
         assert observed["key"] == "scope-key"
+
+    def test_prefetch_body_runs_inside_captured_profile_scope(self, tmp_path, sync_threads):
+        from agent.secret_scope import current_secret_scope
+        from hermes_constants import get_hermes_home as real_get_hermes_home
+
+        (tmp_path / ".env").write_text(
+            "HINDSIGHT_LLM_API_KEY=scope-key\n", encoding="utf-8"
+        )
+        observed = {}
+
+        def fake_recall(query, *, session_id=""):
+            observed["scope"] = current_secret_scope()
+            observed["home"] = real_get_hermes_home()
+            return SimpleNamespace(text="hit", count=1)
+
+        provider = self._bare_provider(
+            tmp_path,
+            _recall_sync=False,
+            _memory_mode="hybrid",
+            _auto_recall=True,
+            _prefetch_waits_for_retain=False,
+            _prefetch_retain_drain_timeout=1.0,
+            _prefetch_lock=threading.Lock(),
+            _prefetch_result=None,
+            _prefetch_count=0,
+            _do_recall=fake_recall,
+        )
+        provider.queue_prefetch("query", session_id="s")
+        assert len(sync_threads) == 1
+        sync_threads[0]._target(*sync_threads[0]._args)
+
+        assert observed["scope"] is not None
+        assert observed["home"] == tmp_path
+        assert current_secret_scope() is None
+
+    def test_daemon_start_body_runs_inside_captured_profile_scope(
+        self, tmp_path, multiplex_on, sync_threads, monkeypatch
+    ):
+        import types
+
+        from agent.secret_scope import (
+            current_secret_scope,
+            get_secret as scope_get_secret,
+        )
+        from hermes_constants import get_hermes_home as real_get_hermes_home
+
+        (tmp_path / ".env").write_text(
+            "HINDSIGHT_LLM_API_KEY=scope-key\n", encoding="utf-8"
+        )
+
+        # Stub hindsight_embed + rich so the scoped body can run end-to-end
+        # without the real packages installed.
+        dem_mod = types.ModuleType("hindsight_embed.daemon_embed_manager")
+        dem_mod.console = None
+        he_pkg = types.ModuleType("hindsight_embed")
+        he_pkg.daemon_embed_manager = dem_mod
+        rich_console_mod = types.ModuleType("rich.console")
+        rich_console_mod.Console = lambda **kwargs: object()
+        rich_pkg = types.ModuleType("rich")
+        rich_pkg.console = rich_console_mod
+        monkeypatch.setitem(sys.modules, "hindsight_embed", he_pkg)
+        monkeypatch.setitem(sys.modules, "hindsight_embed.daemon_embed_manager", dem_mod)
+        monkeypatch.setitem(sys.modules, "rich", rich_pkg)
+        monkeypatch.setitem(sys.modules, "rich.console", rich_console_mod)
+
+        observed = {}
+
+        def fake_get_client():
+            observed["scope"] = current_secret_scope()
+            observed["home"] = real_get_hermes_home()
+            observed["key"] = scope_get_secret("HINDSIGHT_LLM_API_KEY", "MISSING")
+            return SimpleNamespace(
+                _manager=SimpleNamespace(is_running=lambda profile: False),
+                _ensure_started=lambda: None,
+            )
+
+        provider = self._bare_provider(
+            tmp_path,
+            _config={
+                "profile": "p",
+                "llm_provider": "openai_compatible",
+                "llm_base_url": "http://127.0.0.1:9002/v1",
+                "llm_model": "m",
+            },
+            _get_client=fake_get_client,
+        )
+        provider._spawn_embedded_daemon()
+
+        assert observed["scope"] is not None
+        assert observed["key"] == "scope-key"
+        assert observed["home"] == tmp_path
+        # Scope must reset even though the body left log/env artifacts.
+        assert current_secret_scope() is None


### PR DESCRIPTION
Partial for #94221 (point 5 — the Python-side slice; the desktop Node/ekko layer lives outside this repo).

## What & why

DeepSeek changed API pricing effective **2026-08-16** and added peak-hour
billing. The pricing table still carried the retired 2026-07 snapshot, so
every DeepSeek session's cost display under-reported real spend:

| model | old (table) | new official |
|---|---|---|
| v4-pro | 0.435 / 0.87 in-out | **0.66 / 1.98** off-peak |
| v4-flash (+ deprecated chat/reasoner aliases) | 0.14 / 0.28 | **0.22 / 0.66** off-peak |
| cache-hit input | 0.003625 / 0.0028 | **0.022 / 0.007** |

Verified today against DeepSeek's own pricing page
(`api-docs.deepseek.com/quick_start/pricing`), not third-party trackers.

**Peak-hour caveat, documented in-table**: DeepSeek now bills
01:00–04:00 and 06:00–10:00 UTC Mon–Fri at exactly **2×** the rates above.
`PricingEntry` has no time-of-day axis and `estimate_usage_cost` sees no
timestamp, so rows carry the OFF-PEAK rates — estimates are an off-peak
floor, never a peak quote. Modeling the split would be a schema change;
flagging it as possible follow-up rather than smuggling it into a data
refresh.

Also adds the now-listed `deepseek-v4-flash-vision-exp` row at flash
parity (image tokens bill as input tokens per the docs), preventing the
next "unknown cost" report for that model.

## How to test

```python
from agent.usage_pricing import get_pricing_entry
e = get_pricing_entry("deepseek-v4-pro", provider="deepseek")
float(e.input_cost_per_million)   # 0.66 (was 0.435)
```

Updated `test_deepseek_v4_pro_pricing_entry_exists` to the new rates;
added `test_deepseek_vision_exp_prices_as_v4_flash` parity invariant; the
existing alias invariant (`chat`/`reasoner` ≡ flash) passes untouched.

Suite: `scripts/run_tests.sh tests/agent/test_usage_pricing.py tests/agent/test_billing_usage.py tests/agent/test_account_usage.py` → 53 passed, 0 failed at head. macOS 26, Python 3.11.
