### PR TITLE
fix(memory): harden Hindsight lifecycle durability

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -46,7 +46,7 @@ Points the plugin at an existing Hindsight instance you're already running (Dock
 
 ## Config
 
-Config file: `~/.hermes/hindsight/config.json`
+Config file: `$HERMES_HOME/hindsight/config.json` (for the default profile, `$HERMES_HOME` is `~/.hermes`)
 
 ### Connection
 
@@ -69,14 +69,17 @@ Config file: `~/.hermes/hindsight/config.json`
 | Key | Default | Description |
 |-----|---------|-------------|
 | `recall_budget` | `mid` | Recall thoroughness: `low` / `mid` / `high` |
-| `recall_prefetch_method` | `recall` | Auto-recall method: `recall` (raw facts) or `reflect` (LLM synthesis) |
-| `recall_max_tokens` | `4096` | Maximum tokens for recall results |
+| `recall_prefetch_method` | `recall` | Auto-recall method: `recall` (ranked results filtered by `auto_recall_types` / `recall_types`) or `reflect` (LLM synthesis) |
+| `recall_max_tokens` | `4096` | Maximum tokens for explicit `hindsight_recall` results |
+| `auto_recall_budget` | value of `recall_budget` | Thoroughness for automatic recall |
+| `auto_recall_max_tokens` | value of `recall_max_tokens` | Maximum tokens requested by automatic recall when `recall_prefetch_method` is `recall` |
 | `recall_max_input_chars` | `800` | Maximum input query length for auto-recall |
 | `recall_prompt_preamble` | — | Custom preamble for recalled memories in context |
 | `recall_tags` | — | Tags to filter when searching memories |
 | `recall_tags_match` | `any` | Tag matching mode: `any` / `all` / `any_strict` / `all_strict` |
-| `recall_types` | `observation` | Fact types surfaced by recall (both auto-recall and the `hindsight_recall` tool). Comma-separated string or JSON list. **Default narrowed to `observation` only** (see "Behavior change" below). Set to `observation,world,experience` to also include raw facts. |
-| `auto_recall` | `true` | Automatically recall memories before each turn |
+| `recall_types` | `observation` | Fact types surfaced by the `hindsight_recall` tool and used as the auto-recall fallback. Comma-separated string or JSON list. |
+| `auto_recall_types` | value of `recall_types` | Optional fact types for automatic recall only. Set this to `observation` while broadening `recall_types` when prompt injection should stay dense but explicit lookup must include recent raw facts. |
+| `auto_recall` | `true` | Automatically recall memories. With `recall_sync: false`, the background result is injected on the next turn and labeled as previous-turn context. |
 | `recall_sync` | `false` | Recall synchronously against the *current* message each turn (higher relevance, adds recall latency). Default off: recall runs in the background and is injected on the next turn. |
 | `recall_indicator` | `true` | Show a `👁️ Hindsight — recalled N memories` status line when auto-recall injects memory. Turn off for customer-facing agents. |
 
@@ -86,19 +89,19 @@ Config file: `~/.hermes/hindsight/config.json`
 >
 > Per [Hindsight's docs](https://hindsight.vectorize.io/developer/observations), observations are the **consolidated** knowledge layer Hindsight builds on top of raw facts: deduplicated beliefs grounded in evidence, refined as new facts arrive, with proof counts and freshness signals. Raw `world` / `experience` facts are the individual supporting evidence that feeds them. For per-turn context injection, observations are denser per token and avoid feeding the model multiple raw facts that one observation already summarizes.
 >
-> Restore the broad recall with `"recall_types": "observation,world,experience"` (string or JSON list) in `~/.hermes/hindsight/config.json`. This applies to **both** auto-recall and the `hindsight_recall` tool — both read the same `recall_types` setting (the tool schema has no per-call `types` argument), so narrowing the default narrows both paths.
+> Restore broad explicit recall with `"recall_types": "observation,world,experience"` (string or JSON list) in `$HERMES_HOME/hindsight/config.json`. To keep automatic prompt injection observation-only, also set `"auto_recall_types": "observation"`.
 
 ### Retain
 
 | Key | Default | Description |
 |-----|---------|-------------|
 | `auto_retain` | `true` | Automatically retain conversation turns |
-| `retain_async` | `true` | Process retain asynchronously on the Hindsight server |
-| `retain_every_n_turns` | `1` | Retain every N turns (1 = every turn) |
+| `retain_async` | `true` | Controls explicit `hindsight_retain` tool calls. Automatic conversation writes run on the background writer and always wait for the server result so lifecycle durability can be confirmed. Append writes use a process-scoped document, are serialized, and reconcile an ambiguous failure with an idempotent local-document replacement before later deltas continue. |
+| `retain_every_n_turns` | `1` | Retain every N turns (1 = every turn). A partial batch is flushed on session switch and shutdown. |
 | `retain_context` | `conversation between Hermes Agent and the User` | Context label for retained memories |
 | `retain_tags` | — | Default tags applied to retained memories; merged with per-call tool tags |
 | `retain_source` | — | Opt-in `metadata.source` attached to retained memories (identifies the storing client, e.g. `hermes`). Empty by default — no attribution tag ships unless you set it. |
-| `retain_indicator` | `true` | Show a `👁️ Hindsight — saving to memory…` status line when a turn is saved. Turn off for customer-facing agents. |
+| `retain_indicator` | `true` | Show a `👁️ Hindsight — saving to memory…` status line when a turn is queued for persistence. Turn off for customer-facing agents. |
 | `retain_user_prefix` | `User` | Label used before user turns in auto-retained transcripts |
 | `retain_assistant_prefix` | `Assistant` | Label used before assistant turns in auto-retained transcripts |
 
@@ -121,7 +124,7 @@ Config file: `~/.hermes/hindsight/config.json`
 | `llm_model` | per-provider | Model name (e.g. `gpt-4o-mini`, `qwen/qwen3.5-9b`) |
 | `llm_base_url` | — | Endpoint URL for `openai_compatible` (e.g. `http://192.168.1.10:8080/v1`) |
 
-The LLM API key is stored in `~/.hermes/.env` as `HINDSIGHT_LLM_API_KEY`.
+The LLM API key is stored in `$HERMES_HOME/.env` as `HINDSIGHT_LLM_API_KEY`.
 
 ## Tools
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -35,6 +35,7 @@ import atexit
 import importlib
 import json
 import logging
+import math
 import os
 import queue
 import sys
@@ -68,6 +69,14 @@ class _RecallResult:
 
     text: str
     count: int
+
+
+@dataclass
+class _AppendRetainProgress:
+    """Successful retain watermarks shared by queued session jobs."""
+
+    succeeded_turn_count: int = 0
+    legacy_succeeded_turn_count: int = 0
 
 _DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
 _DEFAULT_LOCAL_URL = "http://localhost:8888"
@@ -114,6 +123,20 @@ def _parse_int_setting(value: Any, default: int) -> int:
         return default
 
 
+def _parse_nonnegative_float_setting(value: Any, default: float) -> float:
+    """Parse a finite nonnegative float, falling back on invalid input."""
+    if value is None or value == "":
+        return default
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        parsed = math.nan
+    if not math.isfinite(parsed) or parsed < 0:
+        logger.warning("Invalid numeric Hindsight setting %r; using default %s", value, default)
+        return default
+    return parsed
+
+
 # Env var the embedded daemon manager reads (at import time, as a module-level
 # constant) to size the grace window it waits for a slow /health before
 # declaring a daemon stale and killing it. Default upstream is 30s; on
@@ -142,9 +165,9 @@ def _export_port_health_grace_timeout(config: dict[str, Any]) -> None:
             "Invalid Hindsight port_health_grace_timeout %r; ignoring.", raw
         )
         return
-    if seconds < 0:
+    if not math.isfinite(seconds) or seconds < 0:
         logger.warning(
-            "Negative Hindsight port_health_grace_timeout %r; ignoring.", raw
+            "Invalid Hindsight port_health_grace_timeout %r; ignoring.", raw
         )
         return
     # setdefault: an explicit env var the operator set wins over config.
@@ -794,6 +817,10 @@ class HindsightMemoryProvider(MemoryProvider):
         self._prefetch_count = 0
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread = None
+        # Monotonic generation for background recall. Each queued recall and
+        # every session switch invalidates older workers so a slow request
+        # cannot repopulate the next session's context after the bounded join.
+        self._prefetch_generation = 0
         # State for the model-independent recall indicator (see recall_status()).
         # _last_recall_returned tracks whether the most recent prefetch() handed
         # any memory to the agent this turn; _last_recall_count is how many.
@@ -812,6 +839,10 @@ class HindsightMemoryProvider(MemoryProvider):
         self._retain_queue: queue.Queue = queue.Queue()
         self._writer_thread: threading.Thread | None = None
         self._shutting_down = threading.Event()
+        # Serializes retain admission against the shutdown sentinel. An RLock
+        # lets shutdown call the lifecycle-flush helper while holding the same
+        # boundary without deadlocking.
+        self._lifecycle_lock = threading.RLock()
         self._atexit_registered = False
         # Server-side async retain operations still in flight. With
         # retain_async=True, aretain_batch returns as soon as the write is
@@ -820,9 +851,10 @@ class HindsightMemoryProvider(MemoryProvider):
         # background prefetch gates on these via get_operation_status so recall
         # observes the just-completed turn (draining the local queue alone is
         # not a read-after-write signal for async retains).
-        self._pending_retain_ops: set[str] = set()
+        # Operation ids are bank-scoped, so identity is the pair. The same
+        # operation id may exist in two session-templated banks concurrently.
+        self._pending_retain_ops: set[tuple[str, str]] = set()
         self._pending_retain_ops_lock = threading.Lock()
-        self._retain_ops_bank_id = ""
         # Seconds between get_operation_status polls while waiting for server-
         # side retain completion. Each poll is a server round trip, so this is
         # deliberately coarser than the 0.05s local queue-drain poll: ~20 calls
@@ -862,11 +894,17 @@ class HindsightMemoryProvider(MemoryProvider):
         # send only the new delta on subsequent retains when the API supports
         # update_mode='append' (legacy/overwrite path still sends everything).
         self._last_retained_turn_count = 0
+        self._append_retain_progress = _AppendRetainProgress()
 
         # Recall controls
         self._auto_recall = True
         self._recall_sync = False
         self._recall_max_tokens = 4096
+        # Automatic recall is independently tunable from deliberate tool
+        # recall. This keeps always-on context compact without weakening an
+        # explicit hindsight_recall request.
+        self._auto_recall_budget = self._budget
+        self._auto_recall_max_tokens = self._recall_max_tokens
         # Default to observation-only recall. Observations are Hindsight's
         # consolidated knowledge layer — deduplicated, evidence-grounded
         # beliefs built from many raw facts, with proof counts and
@@ -876,6 +914,7 @@ class HindsightMemoryProvider(MemoryProvider):
         # `recall_max_tokens` budget. Users can restore the broader
         # recall via the `recall_types` config key.
         self._recall_types: list[str] = ["observation"]
+        self._auto_recall_types: list[str] = ["observation"]
         self._recall_prompt_preamble = ""
         self._recall_max_input_chars = 800
 
@@ -883,6 +922,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._bank_mission = ""
         self._bank_retain_mission: str | None = None
         self._bank_id_template = ""
+        self._static_bank_id = "hermes"
 
     @property
     def name(self) -> str:
@@ -1211,7 +1251,8 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "retain_assistant_prefix", "description": "Label used before assistant turns in retained transcripts", "default": "Assistant"},
             {"key": "recall_tags", "description": "Tags to filter when searching memories (comma-separated)", "default": ""},
             {"key": "recall_tags_match", "description": "Tag matching mode for recall", "default": "any", "choices": ["any", "all", "any_strict", "all_strict"]},
-            {"key": "recall_types", "description": "Fact types to surface on recall — applies to both auto-recall and the hindsight_recall tool (comma-separated or list). Defaults to observation-only — observations are Hindsight's consolidated, deduplicated, evidence-grounded knowledge layer; raw world/experience facts are the supporting evidence observations already summarize. Set to e.g. 'observation,world,experience' to also include raw facts.", "default": "observation"},
+            {"key": "recall_types", "description": "Fact types surfaced by the hindsight_recall tool and used as the auto-recall fallback (comma-separated or list). Defaults to observation-only.", "default": "observation"},
+            {"key": "auto_recall_types", "description": "Optional fact types for automatic recall only. Defaults to recall_types, allowing dense observation-only prompt injection while explicit recall still searches world/experience facts.", "default": ""},
             {"key": "auto_recall", "description": "Automatically recall memories before each turn", "default": True},
             {"key": "recall_sync", "description": "Recall synchronously against the current message before each turn (higher relevance, adds recall latency to the turn). Default off: recall runs in the background and is injected on the next turn.", "default": False},
             {"key": "recall_indicator", "description": "Show a '👁️ Hindsight — recalled N memories' status line when auto-recall injects memory (turn off for customer-facing agents)", "default": True},
@@ -1222,7 +1263,9 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "prefetch_waits_for_retain", "description": "Have the background next-turn prefetch wait for the just-completed retain to become recall-visible on the server (local queue drain + async operation completion) before recalling, so recall includes the just-completed turn (runs off the reply path, adds no response latency)", "default": True},
             {"key": "prefetch_retain_drain_timeout", "description": "Max seconds the background prefetch waits for the retain to become recall-visible (queue drain + server-side completion) before recalling anyway", "default": 10.0},
             {"key": "retain_context", "description": "Context label for retained memories", "default": "conversation between Hermes Agent and the User"},
-            {"key": "recall_max_tokens", "description": "Maximum tokens for recall results", "default": 4096},
+            {"key": "recall_max_tokens", "description": "Maximum tokens for explicit hindsight_recall results", "default": 4096},
+            {"key": "auto_recall_budget", "description": "Automatic recall thoroughness; defaults to recall_budget", "choices": ["low", "mid", "high"]},
+            {"key": "auto_recall_max_tokens", "description": "Maximum tokens requested by automatic recall when recall_prefetch_method=recall; defaults to recall_max_tokens"},
             {"key": "recall_max_input_chars", "description": "Maximum input query length for auto-recall", "default": 800},
             {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
             {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
@@ -1345,9 +1388,8 @@ class HindsightMemoryProvider(MemoryProvider):
             # synchronously). Nothing to poll — local queue drain is the only
             # available signal in that case.
             return
-        self._retain_ops_bank_id = bank_id
         with self._pending_retain_ops_lock:
-            self._pending_retain_ops.update(ids)
+            self._pending_retain_ops.update((bank_id, op_id) for op_id in ids)
 
     def _is_retain_op_complete(self, bank_id: str, op_id: str) -> bool:
         """Return True when a server-side async retain op is done (or gone).
@@ -1395,7 +1437,9 @@ class HindsightMemoryProvider(MemoryProvider):
         Returns True if both barriers cleared within the budget, False on
         timeout/shutdown.
         """
-        deadline = None if timeout <= 0 else time.monotonic() + timeout
+        # This setting is a maximum wait. Zero therefore means "do not wait",
+        # not an unbounded deadline (which would hang prefetch on a stuck op).
+        deadline = time.monotonic() + max(0.0, timeout)
 
         def _expired() -> bool:
             return deadline is not None and time.monotonic() >= deadline
@@ -1439,23 +1483,22 @@ class HindsightMemoryProvider(MemoryProvider):
         """
         while True:
             with self._pending_retain_ops_lock:
-                bank_id = getattr(self, "_retain_ops_bank_id", "") or self._bank_id
                 pending = list(self._pending_retain_ops)
             if not pending:
                 return True
             if self._shutting_down.is_set():
                 return False
 
-            done: set[str] = set()
+            done: set[tuple[str, str]] = set()
             expired = False
-            for op_id in pending:
+            for bank_id, op_id in pending:
                 if self._shutting_down.is_set():
                     return False
                 if deadline is not None and time.monotonic() >= deadline:
                     expired = True
                     break
                 if self._is_retain_op_complete(bank_id, op_id):
-                    done.add(op_id)
+                    done.add((bank_id, op_id))
 
             if expired:
                 with self._pending_retain_ops_lock:
@@ -1532,13 +1575,26 @@ class HindsightMemoryProvider(MemoryProvider):
         except Exception as exc:
             logger.debug("Hindsight atexit shutdown failed: %s", exc)
 
-    def _run_hindsight_operation(self, operation):
-        """Run an async Hindsight client operation, retrying once after idle shutdown."""
+    def _run_hindsight_operation(
+        self,
+        operation,
+        *,
+        retry_embedded_connection: bool = True,
+    ):
+        """Run an async operation, optionally retrying after idle shutdown.
+
+        Append writes disable the internal retry because their durable outcome
+        is ambiguous after a connection failure; their caller reconciles with
+        an idempotent full-document replace instead.
+        """
         client = self._get_client()
         try:
             return self._run_sync(operation(client))
         except Exception as exc:
-            if not self._is_retriable_embedded_connection_error(exc):
+            if (
+                not retry_embedded_connection
+                or not self._is_retriable_embedded_connection_error(exc)
+            ):
                 raise
             logger.info(
                 "Hindsight embedded daemon appears unreachable; recreating client and retrying once: %s",
@@ -1565,13 +1621,13 @@ class HindsightMemoryProvider(MemoryProvider):
     def _resolve_retain_target(self, fallback_document_id: str) -> tuple[str, str | None]:
         """Pick (document_id, update_mode) based on live API capability.
 
-        On Hindsight ≥ 0.5.0 the API supports ``update_mode='append'``,
-        which lets us reuse a stable session-scoped ``document_id`` across
-        process lifecycles without overwriting prior turns. On older APIs
-        we fall back to *fallback_document_id* (the per-process unique
-        ``f"{session_id}-{start_ts}"`` minted at initialize / switch time)
-        and don't pass ``update_mode`` at all — that's the only way the
-        resume-overwrite fix (#6654) keeps working on legacy servers.
+        On Hindsight ≥ 0.5.0 the API supports ``update_mode='append'``.
+        Keep the document id process-scoped even in append mode: ambiguous
+        append recovery may replace the local snapshot, and a stable
+        cross-process document would let that replacement erase turns from a
+        concurrently resumed provider. Recall still spans all documents in
+        the bank, while session tags preserve lineage. Older APIs use the same
+        process-scoped id without passing ``update_mode``.
 
         Probe is cached at module level per API URL, so this is one HTTP
         round-trip per (process, api_url) pair regardless of how many
@@ -1580,7 +1636,7 @@ class HindsightMemoryProvider(MemoryProvider):
         if not self._session_id:
             return fallback_document_id, None
         if _check_api_supports_update_mode_append(self._probe_url(), self._api_key):
-            return self._session_id, "append"
+            return fallback_document_id, "append"
         return fallback_document_id, None
 
     def initialize(self, session_id: str, **kwargs) -> None:
@@ -1636,6 +1692,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._turn_index = 0
         self._session_turns = []
         self._last_retained_turn_count = 0
+        self._append_retain_progress = _AppendRetainProgress()
         self._mode = self._config.get("mode", "cloud")
         # Read timeout from config or env var, fall back to default
         self._timeout = _parse_int_setting(
@@ -1669,6 +1726,7 @@ class HindsightMemoryProvider(MemoryProvider):
 
         banks = cfg_get(self._config, "banks", "hermes", default={})
         static_bank_id = self._config.get("bank_id") or banks.get("bankId", "hermes")
+        self._static_bank_id = static_bank_id
         self._bank_id_template = self._config.get("bank_id_template", "") or ""
         self._bank_id = _resolve_bank_id_template(
             self._bank_id_template,
@@ -1702,7 +1760,7 @@ class HindsightMemoryProvider(MemoryProvider):
             self._config.get("observation_scopes")
             or os.environ.get("HINDSIGHT_RETAIN_OBSERVATION_SCOPES", "")
         )
-        self._recall_tags = self._config.get("recall_tags") or None
+        self._recall_tags = _normalize_retain_tags(self._config.get("recall_tags")) or None
         self._recall_tags_match = self._config.get("recall_tags_match", "any")
         self._retain_source = str(
             self._config.get("retain_source") or os.environ.get("HINDSIGHT_RETAIN_SOURCE", _DEFAULT_RETAIN_SOURCE)
@@ -1716,13 +1774,28 @@ class HindsightMemoryProvider(MemoryProvider):
 
         # Retain controls
         self._auto_retain = self._config.get("auto_retain", True)
-        self._retain_every_n_turns = max(1, int(self._config.get("retain_every_n_turns", 1)))
+        self._retain_every_n_turns = max(
+            1, _parse_int_setting(self._config.get("retain_every_n_turns"), 1)
+        )
         self._retain_context = self._config.get("retain_context", "conversation between Hermes Agent and the User")
 
         # Recall controls
         self._auto_recall = self._config.get("auto_recall", True)
         self._recall_sync = bool(self._config.get("recall_sync", False))
-        self._recall_max_tokens = int(self._config.get("recall_max_tokens", 4096))
+        self._recall_max_tokens = max(
+            1, _parse_int_setting(self._config.get("recall_max_tokens"), 4096)
+        )
+        configured_auto_budget = str(self._config.get("auto_recall_budget", self._budget))
+        self._auto_recall_budget = (
+            configured_auto_budget if configured_auto_budget in _VALID_BUDGETS else self._budget
+        )
+        self._auto_recall_max_tokens = max(
+            1,
+            _parse_int_setting(
+                self._config.get("auto_recall_max_tokens"),
+                self._recall_max_tokens,
+            ),
+        )
         # Default narrows recall to observation-only; pass an explicit
         # `recall_types` list in config.json to broaden (e.g. include
         # "world" / "experience") or to disable the filter entirely.
@@ -1734,6 +1807,22 @@ class HindsightMemoryProvider(MemoryProvider):
             self._recall_types = [t.strip() for t in configured_types.split(",") if t.strip()]
         else:
             self._recall_types = list(configured_types) or ["observation"]
+        configured_auto_types = self._config.get("auto_recall_types", self._recall_types)
+        if configured_auto_types is None:
+            self._auto_recall_types = list(self._recall_types)
+        elif isinstance(configured_auto_types, str):
+            self._auto_recall_types = [
+                t.strip() for t in configured_auto_types.split(",") if t.strip()
+            ] or list(self._recall_types)
+        elif isinstance(configured_auto_types, (list, tuple, set)):
+            normalized_auto_types = [
+                value.strip()
+                for value in configured_auto_types
+                if isinstance(value, str) and value.strip()
+            ]
+            self._auto_recall_types = normalized_auto_types or list(self._recall_types)
+        else:
+            self._auto_recall_types = list(self._recall_types)
         self._recall_prompt_preamble = self._config.get("recall_prompt_preamble", "")
         # On-by-default deterministic indicator: when auto-recall injects memory,
         # Hermes emits a "👁️ Hindsight — recalled N memories" status line so the
@@ -1743,11 +1832,13 @@ class HindsightMemoryProvider(MemoryProvider):
         # Companion retain indicator: "👁️ Hindsight — saving to memory…" emitted
         # when a turn is dispatched to the writer. Same off switch rationale.
         self._retain_indicator = bool(self._config.get("retain_indicator", True))
-        self._recall_max_input_chars = int(self._config.get("recall_max_input_chars", 800))
+        self._recall_max_input_chars = max(
+            0, _parse_int_setting(self._config.get("recall_max_input_chars"), 800)
+        )
         self._retain_async = self._config.get("retain_async", True)
         self._prefetch_waits_for_retain = self._config.get("prefetch_waits_for_retain", True)
-        self._prefetch_retain_drain_timeout = float(
-            self._config.get("prefetch_retain_drain_timeout", 10.0)
+        self._prefetch_retain_drain_timeout = _parse_nonnegative_float_setting(
+            self._config.get("prefetch_retain_drain_timeout"), 10.0
         )
 
         _client_version = "unknown"
@@ -1763,9 +1854,11 @@ class HindsightMemoryProvider(MemoryProvider):
                          self._bank_id_template, self._agent_identity, self._agent_workspace,
                          self._platform, self._user_id, self._bank_id)
         logger.debug("Hindsight config: auto_retain=%s, auto_recall=%s, retain_every_n=%d, "
-                     "retain_async=%s, retain_context=%s, recall_max_tokens=%d, recall_max_input_chars=%d, tags=%s, recall_tags=%s",
+                     "retain_async=%s, retain_context=%s, recall_max_tokens=%d, auto_recall_budget=%s, "
+                     "auto_recall_max_tokens=%d, recall_max_input_chars=%d, tags=%s, recall_tags=%s",
                      self._auto_retain, self._auto_recall, self._retain_every_n_turns,
-                     self._retain_async, self._retain_context, self._recall_max_tokens, self._recall_max_input_chars,
+                     self._retain_async, self._retain_context, self._recall_max_tokens,
+                     self._auto_recall_budget, self._auto_recall_max_tokens, self._recall_max_input_chars,
                      self._tags, self._recall_tags)
 
         # For local mode, start the embedded daemon in the background so it
@@ -1839,25 +1932,37 @@ class HindsightMemoryProvider(MemoryProvider):
             t.start()
 
     def system_prompt_block(self) -> str:
+        recall_guidance = (
+            "Relevant memories are automatically injected into context. "
+            if self._auto_recall and self._memory_mode != "tools"
+            else ""
+        )
+        retain_guidance = (
+            "Normal completed turns are automatically retained; use hindsight_retain "
+            "only for durable information not already captured or an immediate checkpoint."
+            if self._auto_retain
+            else "Use hindsight_retain for durable information or an immediate checkpoint."
+        )
         if self._memory_mode == "context":
             return (
                 f"# Hindsight Memory\n"
                 f"Active (context mode). Bank: {self._bank_id}, budget: {self._budget}.\n"
-                f"Relevant memories are automatically injected into context."
+                f"{recall_guidance}".rstrip()
             )
+        tool_guidance = (
+            "When they are present in your tool list, use hindsight_recall to search, "
+            "hindsight_reflect for synthesis, and hindsight_retain to store facts. "
+        )
         if self._memory_mode == "tools":
             return (
                 f"# Hindsight Memory\n"
                 f"Active (tools mode). Bank: {self._bank_id}, budget: {self._budget}.\n"
-                f"Use hindsight_recall to search, hindsight_reflect for synthesis, "
-                f"hindsight_retain to store facts."
+                f"{tool_guidance}{retain_guidance}"
             )
         return (
             f"# Hindsight Memory\n"
             f"Active. Bank: {self._bank_id}, budget: {self._budget}.\n"
-            f"Relevant memories are automatically injected into context. "
-            f"Use hindsight_recall to search, hindsight_reflect for synthesis, "
-            f"hindsight_retain to store facts."
+            f"{recall_guidance}{tool_guidance}{retain_guidance}"
         )
 
     def _recall_disabled(self) -> bool:
@@ -1873,7 +1978,14 @@ class HindsightMemoryProvider(MemoryProvider):
             return True
         return False
 
-    def _do_recall(self, query: str) -> _RecallResult:
+    def _do_recall(
+        self,
+        query: str,
+        *,
+        bank_id: str | None = None,
+        budget: str | None = None,
+        max_tokens: int | None = None,
+    ) -> _RecallResult:
         """Run one recall/reflect for *query*.
 
         Returns the formatted memory text plus the number of discrete memories
@@ -1885,23 +1997,32 @@ class HindsightMemoryProvider(MemoryProvider):
         # Truncate query to max chars
         if self._recall_max_input_chars and len(query) > self._recall_max_input_chars:
             query = query[:self._recall_max_input_chars]
+        effective_budget = budget or self._budget
+        effective_max_tokens = max_tokens or self._recall_max_tokens
+        effective_bank_id = bank_id or self._bank_id
         try:
             if self._prefetch_method == "reflect":
-                logger.debug("Recall: calling reflect (bank=%s, query_len=%d)", self._bank_id, len(query))
-                resp = self._run_hindsight_operation(lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget))
+                logger.debug("Recall: calling reflect (bank=%s, query_len=%d)", effective_bank_id, len(query))
+                resp = self._run_hindsight_operation(
+                    lambda client: client.areflect(
+                        bank_id=effective_bank_id,
+                        query=query,
+                        budget=effective_budget,
+                    )
+                )
                 # Reflect synthesizes across many memories -> no discrete count.
                 return _RecallResult(resp.text or "", 0)
             recall_kwargs: dict = {
-                "bank_id": self._bank_id, "query": query,
-                "budget": self._budget, "max_tokens": self._recall_max_tokens,
+                "bank_id": effective_bank_id, "query": query,
+                "budget": effective_budget, "max_tokens": effective_max_tokens,
             }
             if self._recall_tags:
                 recall_kwargs["tags"] = self._recall_tags
                 recall_kwargs["tags_match"] = self._recall_tags_match
-            if self._recall_types:
-                recall_kwargs["types"] = self._recall_types
+            if self._auto_recall_types:
+                recall_kwargs["types"] = self._auto_recall_types
             logger.debug("Recall: calling recall (bank=%s, query_len=%d, budget=%s)",
-                         self._bank_id, len(query), self._budget)
+                         effective_bank_id, len(query), effective_budget)
             resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
             num_results = len(resp.results) if resp.results else 0
             logger.debug("Recall: returned %d results", num_results)
@@ -1911,7 +2032,7 @@ class HindsightMemoryProvider(MemoryProvider):
             logger.debug("Hindsight recall failed: %s", e, exc_info=True)
             return _RecallResult("", 0)
 
-    def _format_recall(self, result: str) -> str:
+    def _format_recall(self, result: str, *, previous_turn: bool = False) -> str:
         if not result:
             logger.debug("Prefetch: no results available")
             return ""
@@ -1921,6 +2042,13 @@ class HindsightMemoryProvider(MemoryProvider):
             "Use this to answer questions about the user and prior sessions. "
             "Do not call tools to look up information that is already present here."
         )
+        if previous_turn:
+            provenance = (
+                "These memories were retrieved in the background for the previous user turn. "
+                "Use them only if relevant to the current request; otherwise ignore them and, "
+                "when available, use hindsight_recall for a current-query lookup."
+            )
+            return f"{header}\n{provenance}\n\n{result}"
         return f"{header}\n\n{result}"
 
     def _record_recall_indicator(self, *, returned: bool, count: int) -> None:
@@ -1940,7 +2068,11 @@ class HindsightMemoryProvider(MemoryProvider):
             if self._recall_disabled():
                 self._record_recall_indicator(returned=False, count=0)
                 return ""
-            recalled = self._do_recall(query)
+            recalled = self._do_recall(
+                query,
+                budget=self._auto_recall_budget,
+                max_tokens=self._auto_recall_max_tokens,
+            )
             self._record_recall_indicator(returned=bool(recalled.text), count=recalled.count)
             return self._format_recall(recalled.text)
 
@@ -1955,7 +2087,7 @@ class HindsightMemoryProvider(MemoryProvider):
             self._prefetch_result = ""
             self._prefetch_count = 0
         self._record_recall_indicator(returned=bool(result), count=count)
-        return self._format_recall(result)
+        return self._format_recall(result, previous_turn=True)
 
     def recall_status(self) -> Optional[RecallStatus]:
         """Report the count injected by the last prefetch (for the UI indicator).
@@ -1973,8 +2105,16 @@ class HindsightMemoryProvider(MemoryProvider):
         # there's nothing to prime in the background.
         if self._recall_sync:
             return
-        if self._recall_disabled():
-            return
+        with self._lifecycle_lock:
+            if self._recall_disabled():
+                return
+            # Capture generation and bank atomically with session rotation. A
+            # worker that outlives a switch may finish its old query, but it
+            # must never send that query to the newly selected session bank.
+            with self._prefetch_lock:
+                self._prefetch_generation += 1
+                generation = self._prefetch_generation
+                target_bank_id = self._bank_id
 
         def _run():
             # Ensure the just-completed turn's retain is recall-visible on the
@@ -1986,9 +2126,17 @@ class HindsightMemoryProvider(MemoryProvider):
             # thread, never the reply path, so it adds no response latency.
             if self._prefetch_waits_for_retain:
                 self._wait_for_retains_drained(self._prefetch_retain_drain_timeout)
-            recalled = self._do_recall(query)
+            recalled = self._do_recall(
+                query,
+                bank_id=target_bank_id,
+                budget=self._auto_recall_budget,
+                max_tokens=self._auto_recall_max_tokens,
+            )
             if recalled.text:
                 with self._prefetch_lock:
+                    if generation != self._prefetch_generation:
+                        logger.debug("Prefetch: discarding stale generation %d", generation)
+                        return
                     self._prefetch_result = recalled.text
                     self._prefetch_count = recalled.count
 
@@ -2078,23 +2226,40 @@ class HindsightMemoryProvider(MemoryProvider):
         return kwargs
 
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
-        """Enqueue a retain for the current turn. Non-blocking.
-
-        The actual aretain_batch runs on a single long-lived writer thread
-        that drains an in-memory queue. Once shutdown() has been called,
-        further sync_turn() calls are dropped — this prevents post-exit
-        retains from reaching aiohttp after interpreter shutdown begins.
-        """
+        """Atomically admit a turn for buffered or queued retention."""
         if not self._auto_retain:
             logger.debug("sync_turn: skipped (auto_retain disabled)")
             return
-        if self._shutting_down.is_set():
-            logger.debug("sync_turn: skipped (shutting down)")
-            return
+        with self._lifecycle_lock:
+            if self._shutting_down.is_set():
+                logger.debug("sync_turn: skipped (shutting down)")
+                return
+            requested_session_id = str(session_id or "").strip()
+            if requested_session_id and requested_session_id != self._session_id:
+                logger.warning(
+                    "sync_turn: rejected mismatched session id %s (active=%s); "
+                    "rotate through on_session_switch first",
+                    requested_session_id,
+                    self._session_id,
+                )
+                return
+            dispatched = self._sync_turn_locked(
+                user_content, assistant_content, session_id=session_id
+            )
+        if dispatched:
+            # Status callbacks are user-provided and may re-enter shutdown.
+            # Invoke them only after lifecycle admission and queue insertion
+            # have completed and the lifecycle lock has been released.
+            self._emit_saving_indicator()
 
-        if session_id:
-            self._session_id = str(session_id).strip()
+    def _sync_turn_locked(
+        self, user_content: str, assistant_content: str, *, session_id: str = ""
+    ) -> bool:
+        """Buffer and, at the configured boundary, queue one retain job.
 
+        Caller holds ``_lifecycle_lock`` so shutdown cannot place its sentinel
+        between the admission check and queue insertion.
+        """
         turn = json.dumps(self._build_turn_messages(user_content, assistant_content), ensure_ascii=False)
         self._session_turns.append(turn)
         self._turn_counter += 1
@@ -2103,83 +2268,251 @@ class HindsightMemoryProvider(MemoryProvider):
         if self._turn_counter % self._retain_every_n_turns != 0:
             logger.debug("sync_turn: buffered turn %d (will retain at turn %d)",
                          self._turn_counter, self._turn_counter + (self._retain_every_n_turns - self._turn_counter % self._retain_every_n_turns))
-            return
+            return False
 
         document_id, update_mode = self._resolve_retain_target(self._document_id)
+        watermark_before = self._last_retained_turn_count
+        append_progress = self._append_retain_progress
+        turns_snapshot = list(self._session_turns)
+        turn_count_after = len(turns_snapshot)
 
         # On append-capable APIs each retain only needs to ship the turns
-        # accumulated since the last retain — the server appends them to the
-        # existing document. On legacy/overwrite APIs we must resend the whole
-        # session because each retain replaces the document.
+        # accumulated since the last queued retain. Queued jobs share a
+        # successful-write watermark so a later job can repair an earlier gap.
         if update_mode == "append":
-            turns_to_retain = self._session_turns[self._last_retained_turn_count:]
+            turns_to_retain = turns_snapshot[watermark_before:]
             if not turns_to_retain:
                 logger.debug("sync_turn: skipped append retain; no new turns since last retain")
-                return
+                return False
         else:
-            turns_to_retain = list(self._session_turns)
+            turns_to_retain = turns_snapshot
 
         logger.debug("sync_turn: retaining %d/%d turns, payload %d chars",
                      len(turns_to_retain), len(self._session_turns),
                      sum(len(t) for t in turns_to_retain))
-        content = "[" + ",".join(turns_to_retain) + "]"
-
         lineage_tags: list[str] = []
         if self._session_id:
             lineage_tags.append(f"session:{self._session_id}")
         if self._parent_session_id:
             lineage_tags.append(f"parent:{self._parent_session_id}")
 
-        # Snapshot the state needed for the retain. The writer may run after
-        # _session_turns / _turn_index are mutated by a later sync_turn().
         metadata_snapshot = self._build_metadata(
             message_count=len(turns_to_retain) * 2,
             turn_index=self._turn_index,
         )
-        num_turns = len(turns_to_retain)
         bank_id = self._bank_id
-        retain_async_flag = self._retain_async
+        # Append ordering depends on knowing whether the preceding delta was
+        # accepted successfully. The writer is already off the reply path, so
+        # wait for the server result here rather than advancing on an async
+        # operation that may later fail and leave a permanent gap.
+        # Automatic conversation retention runs on the background writer, so
+        # waiting for a definitive server result adds no reply-path latency.
+        # This also prevents an older asynchronous legacy overwrite from
+        # finishing after a lifecycle recovery and regressing the document.
+        retain_async_flag = False
         retain_context = self._retain_context
 
         def _do_retain() -> None:
-            item = self._build_retain_kwargs(
-                content,
-                context=retain_context,
-                metadata=metadata_snapshot,
-                tags=lineage_tags or None,
-            )
-            item.pop("bank_id", None)
-            item.pop("retain_async", None)
-            if update_mode is not None:
-                item["update_mode"] = update_mode
-            logger.debug("Hindsight retain: bank=%s, doc=%s, mode=%s, async=%s, content_len=%d, num_turns=%d",
-                         bank_id, document_id, update_mode, retain_async_flag, len(content), num_turns)
-            resp = self._run_hindsight_operation(
-                lambda client: client.aretain_batch(
-                    bank_id=bank_id,
-                    items=[item],
-                    document_id=document_id,
-                    retain_async=retain_async_flag,
+            try:
+                delivery_turns = turns_to_retain
+                delivery_update_mode = update_mode
+                if update_mode == "append":
+                    with self._lifecycle_lock:
+                        succeeded_before = append_progress.succeeded_turn_count
+                    if succeeded_before < watermark_before:
+                        # A failed append has an ambiguous durable outcome. A
+                        # blind append retry could duplicate accepted content,
+                        # so reconcile by idempotently replacing the document
+                        # with this full session snapshot.
+                        delivery_turns = turns_snapshot
+                        delivery_update_mode = "replace"
+                content = "[" + ",".join(delivery_turns) + "]"
+                delivery_metadata = dict(metadata_snapshot)
+                delivery_metadata["message_count"] = str(len(delivery_turns) * 2)
+                item = self._build_retain_kwargs(
+                    content,
+                    context=retain_context,
+                    metadata=delivery_metadata,
+                    tags=lineage_tags or None,
                 )
-            )
-            # For async retains the write is only *accepted* here; track the
-            # returned operation id(s) so the next-turn prefetch can wait for
-            # true server-side completion (read-after-write) before recalling.
-            if retain_async_flag:
-                self._track_retain_ops(resp, bank_id)
-            logger.debug("Hindsight retain succeeded")
+                item.pop("bank_id", None)
+                item.pop("retain_async", None)
+                if delivery_update_mode is not None:
+                    item["update_mode"] = delivery_update_mode
+                logger.debug("Hindsight retain: bank=%s, doc=%s, mode=%s, async=%s, content_len=%d, num_turns=%d",
+                             bank_id, document_id, delivery_update_mode, retain_async_flag,
+                             len(content), len(delivery_turns))
+                resp = self._run_hindsight_operation(
+                    lambda client: client.aretain_batch(
+                        bank_id=bank_id,
+                        items=[item],
+                        document_id=document_id,
+                        retain_async=retain_async_flag,
+                    ),
+                    retry_embedded_connection=delivery_update_mode != "append",
+                )
+                if retain_async_flag:
+                    self._track_retain_ops(resp, bank_id)
+                if update_mode == "append":
+                    with self._lifecycle_lock:
+                        append_progress.succeeded_turn_count = max(
+                            append_progress.succeeded_turn_count,
+                            turn_count_after,
+                        )
+                elif not retain_async_flag:
+                    with self._lifecycle_lock:
+                        append_progress.legacy_succeeded_turn_count = max(
+                            append_progress.legacy_succeeded_turn_count,
+                            turn_count_after,
+                        )
+                logger.debug("Hindsight retain succeeded")
+            except Exception:
+                raise
 
         self._ensure_writer()
         self._register_atexit()
-        # Deterministic "saving to memory" indicator — emitted the moment a
-        # real retain is dispatched (past every skip/buffer gate above), so it
-        # only fires on turns that actually persist.
-        self._emit_saving_indicator()
+        # Enqueue before returning control to sync_turn, which invokes the
+        # user-provided status callback only after releasing the lifecycle lock.
         self._retain_queue.put(_do_retain)
-        # Advance the append watermark only after the delta is queued, so a
-        # later retain doesn't re-ship turns we've already handed to the writer.
+        self._last_retained_turn_count = len(self._session_turns)
+        return True
+
+    def _enqueue_buffered_flush(self, *, reason: str) -> bool:
+        with self._lifecycle_lock:
+            return self._enqueue_buffered_flush_locked(reason=reason)
+
+    def _enqueue_buffered_flush_locked(self, *, reason: str) -> bool:
+        """Queue the not-yet-retained tail of the current session.
+
+        Append-capable servers already have the prefix through
+        ``_last_retained_turn_count``. Re-sending that prefix at a session
+        boundary duplicates the conversation. Legacy overwrite servers still
+        need the full snapshot whenever new turns exist.
+        """
+        if not self._session_turns or self._shutting_down.is_set():
+            return False
+        document_id, update_mode = self._resolve_retain_target(self._document_id)
+        turns_snapshot = list(self._session_turns)
+        turn_count_after = len(turns_snapshot)
+        watermark_before = self._last_retained_turn_count
+        append_progress = self._append_retain_progress
         if update_mode == "append":
-            self._last_retained_turn_count = len(self._session_turns)
+            if (
+                turn_count_after <= self._last_retained_turn_count
+                and append_progress.succeeded_turn_count >= turn_count_after
+            ):
+                return False
+            turns = turns_snapshot[self._last_retained_turn_count:]
+        else:
+            if append_progress.legacy_succeeded_turn_count >= turn_count_after:
+                return False
+            turns = turns_snapshot
+        if not turns and update_mode != "append":
+            return False
+
+        metadata = self._build_metadata(
+            message_count=len(turns) * 2,
+            turn_index=self._turn_index,
+        )
+        lineage_tags: list[str] = []
+        if self._session_id:
+            lineage_tags.append(f"session:{self._session_id}")
+        if self._parent_session_id:
+            lineage_tags.append(f"parent:{self._parent_session_id}")
+        bank_id = self._bank_id
+        # Lifecycle flushes require a definitive server result before their
+        # successful watermark advances. A preceding async legacy overwrite
+        # may therefore be repeated here; replace mode makes that idempotent.
+        retain_async = False
+        retain_context = self._retain_context
+
+        def _flush() -> None:
+            for attempt in range(2):
+                try:
+                    delivery_turns = turns
+                    delivery_update_mode = update_mode
+                    if update_mode != "append":
+                        with self._lifecycle_lock:
+                            legacy_succeeded = (
+                                append_progress.legacy_succeeded_turn_count
+                            )
+                        # A successful legacy overwrite queued ahead of this
+                        # lifecycle flush already persisted the full snapshot.
+                        if legacy_succeeded >= turn_count_after:
+                            return
+                    if update_mode == "append":
+                        with self._lifecycle_lock:
+                            succeeded_before = append_progress.succeeded_turn_count
+                        if attempt > 0 or succeeded_before < watermark_before:
+                            # Reconcile an ambiguous append outcome by replacing
+                            # the document with the captured full session.
+                            delivery_turns = turns_snapshot
+                            delivery_update_mode = "replace"
+                        else:
+                            delivery_turns = turns_snapshot[succeeded_before:turn_count_after]
+                        if not delivery_turns:
+                            return
+                    content = "[" + ",".join(delivery_turns) + "]"
+                    delivery_metadata = dict(metadata)
+                    delivery_metadata["message_count"] = str(len(delivery_turns) * 2)
+                    item = self._build_retain_kwargs(
+                        content,
+                        context=retain_context,
+                        metadata=delivery_metadata,
+                        tags=lineage_tags or None,
+                    )
+                    item.pop("bank_id", None)
+                    item.pop("retain_async", None)
+                    if delivery_update_mode is not None:
+                        item["update_mode"] = delivery_update_mode
+                    logger.debug(
+                        "Hindsight flush-on-%s: bank=%s, doc=%s, mode=%s, num_turns=%d",
+                        reason, bank_id, document_id, delivery_update_mode, len(delivery_turns),
+                    )
+                    resp = self._run_hindsight_operation(
+                        lambda client: client.aretain_batch(
+                            bank_id=bank_id,
+                            items=[item],
+                            document_id=document_id,
+                            retain_async=retain_async,
+                        ),
+                        retry_embedded_connection=delivery_update_mode != "append",
+                    )
+                    if retain_async:
+                        self._track_retain_ops(resp, bank_id)
+                    if update_mode == "append":
+                        with self._lifecycle_lock:
+                            append_progress.succeeded_turn_count = max(
+                                append_progress.succeeded_turn_count,
+                                turn_count_after,
+                            )
+                    else:
+                        with self._lifecycle_lock:
+                            append_progress.legacy_succeeded_turn_count = max(
+                                append_progress.legacy_succeeded_turn_count,
+                                turn_count_after,
+                            )
+                    return
+                except Exception as e:
+                    if attempt == 0:
+                        logger.warning(
+                            "Hindsight flush-on-%s failed; retrying once: %s",
+                            reason,
+                            e,
+                        )
+                        continue
+                    logger.warning(
+                        "Hindsight flush-on-%s failed after retry: %s",
+                        reason,
+                        e,
+                        exc_info=True,
+                    )
+
+        self._ensure_writer()
+        self._register_atexit()
+        self._retain_queue.put(_flush)
+        self._last_retained_turn_count = len(self._session_turns)
+        return True
 
     def _emit_saving_indicator(self) -> None:
         """Surface a model-independent "saving to memory" status line.
@@ -2202,6 +2535,15 @@ class HindsightMemoryProvider(MemoryProvider):
         return [RETAIN_SCHEMA, RECALL_SCHEMA, REFLECT_SCHEMA]
 
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
+        # Serialize explicit provider I/O with session rotation and shutdown.
+        # This pins the selected bank for the whole call and prevents teardown
+        # from closing the shared client while a tool operation is in flight.
+        with self._lifecycle_lock:
+            if self._shutting_down.is_set():
+                return tool_error("Hindsight memory provider is shutting down")
+            return self._handle_tool_call_locked(tool_name, args, **kwargs)
+
+    def _handle_tool_call_locked(self, tool_name: str, args: dict, **kwargs) -> str:
         if tool_name == "hindsight_retain":
             content = args.get("content", "")
             if not content:
@@ -2318,106 +2660,86 @@ class HindsightMemoryProvider(MemoryProvider):
         if not new_id:
             return
 
-        # 1. Flush any buffered turns under the OLD identifiers. Snapshot
-        # everything before mutating self._* so metadata + tags + doc_id
-        # all reference the old session consistently.
-        if self._session_turns:
-            old_turns = list(self._session_turns)
-            old_session_id = self._session_id
-            old_parent_session_id = self._parent_session_id
-            old_turn_index = self._turn_index
-            old_metadata = self._build_metadata(
-                message_count=len(old_turns) * 2,
-                turn_index=old_turn_index,
-            )
-            old_lineage_tags: list[str] = []
-            if old_session_id:
-                old_lineage_tags.append(f"session:{old_session_id}")
-            if old_parent_session_id:
-                old_lineage_tags.append(f"parent:{old_parent_session_id}")
-            old_content = "[" + ",".join(old_turns) + "]"
-            # Resolve doc_id + update_mode against the OLD session BEFORE
-            # we rotate _session_id, so the flush lands in the old
-            # session's document either way (legacy: per-process unique;
-            # ≥0.5.0: stable session-scoped + append).
-            old_document_id, old_update_mode = self._resolve_retain_target(
-                self._document_id
+        with self._lifecycle_lock:
+            self._on_session_switch_locked(
+                new_id,
+                parent_session_id=parent_session_id,
+                reset=reset,
             )
 
-            def _flush():
-                try:
-                    item = self._build_retain_kwargs(
-                        old_content,
-                        context=self._retain_context,
-                        metadata=old_metadata,
-                        tags=old_lineage_tags or None,
-                    )
-                    item.pop("bank_id", None)
-                    item.pop("retain_async", None)
-                    if old_update_mode is not None:
-                        item["update_mode"] = old_update_mode
-                    logger.debug(
-                        "Hindsight flush-on-switch: bank=%s, doc=%s, mode=%s, num_turns=%d",
-                        self._bank_id, old_document_id, old_update_mode, len(old_turns),
-                    )
-                    self._run_hindsight_operation(
-                        lambda client: client.aretain_batch(
-                            bank_id=self._bank_id,
-                            items=[item],
-                            document_id=old_document_id,
-                            retain_async=self._retain_async,
-                        )
-                    )
-                except Exception as e:
-                    logger.warning("Hindsight flush-on-switch failed: %s", e, exc_info=True)
+    def _on_session_switch_locked(
+        self,
+        new_id: str,
+        *,
+        parent_session_id: str,
+        reset: bool,
+    ) -> None:
+        """Rotate session state while retain admission is paused."""
 
-            # Route the flush through the same writer queue sync_turn
-            # uses. That serializes it behind any still-queued retains
-            # from the old session (FIFO by document_id), avoids racing
-            # two threads on aretain_batch against the same document, and
-            # keeps shutdown's drain semantics intact. Skip enqueue if
-            # shutdown has already fired — the writer is draining/gone.
-            if not self._shutting_down.is_set():
-                self._ensure_writer()
-                self._register_atexit()
-                self._retain_queue.put(_flush)
+        # 1. Flush only the not-yet-retained tail under the OLD identifiers
+        # before rotating any session state.
+        self._enqueue_buffered_flush_locked(reason="switch")
 
-        # 2. Drain any in-flight prefetch from the old session and drop
+        # 2. Invalidate the old recall before the bounded join. If it outlives
+        # the timeout, its generation check prevents it from repopulating the
+        # new session's cache later.
+        with self._prefetch_lock:
+            self._prefetch_generation += 1
+
+        # 3. Drain any in-flight prefetch from the old session and drop
         # its cached result so the new session doesn't see stale recall.
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             self._prefetch_thread.join(timeout=3.0)
         with self._prefetch_lock:
             self._prefetch_result = ""
+            self._prefetch_count = 0
 
-        # 3. Now rotate to the new session.
-        if parent_session_id:
-            self._parent_session_id = str(parent_session_id).strip()
+        # 4. Now rotate to the new session.
+        self._parent_session_id = str(parent_session_id or "").strip()
         self._session_id = new_id
+        self._bank_id = _resolve_bank_id_template(
+            self._bank_id_template,
+            fallback=self._static_bank_id,
+            profile=self._agent_identity,
+            workspace=self._agent_workspace,
+            platform=self._platform,
+            user=self._user_id,
+            session=self._session_id,
+        )
         start_ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         self._document_id = f"{self._session_id}-{start_ts}"
         self._session_turns = []
         self._turn_counter = 0
         self._turn_index = 0
         self._last_retained_turn_count = 0
+        self._append_retain_progress = _AppendRetainProgress()
         logger.debug(
             "Hindsight on_session_switch: new_session=%s parent=%s reset=%s doc=%s",
             self._session_id, self._parent_session_id, reset, self._document_id,
         )
 
     def shutdown(self) -> None:
-        logger.debug("Hindsight shutdown: stopping writer + waiting for background threads")
-        # Stop accepting new retain jobs first so anyone still calling
-        # sync_turn() during teardown is dropped, not enqueued.
-        self._shutting_down.set()
+        logger.debug("Hindsight shutdown: flushing buffered turns + waiting for background threads")
+        with self._lifecycle_lock:
+            # Queue any partial N-turn batch before closing admission. The same
+            # FIFO writer then drains scheduled retains and this final tail.
+            self._enqueue_buffered_flush_locked(reason="shutdown")
+            # Invalidate any background recall that outlives its bounded join.
+            with self._prefetch_lock:
+                self._prefetch_generation += 1
+            # No sync_turn can cross this flag/sentinel boundary while the
+            # lifecycle lock is held.
+            self._shutting_down.set()
+            writer = self._writer_thread
+            if writer is not None and writer.is_alive():
+                try:
+                    self._retain_queue.put(_WRITER_SENTINEL)
+                except Exception:
+                    pass
         # Drain the writer: it will finish in-flight work, then exit on
         # the sentinel. Bounded join keeps shutdown predictable even if
         # the daemon is wedged.
-        writer = self._writer_thread
         if writer is not None and writer.is_alive():
-            try:
-                self._retain_queue.put(_WRITER_SENTINEL)
-            except Exception:
-                pass
             writer.join(timeout=10.0)
             if writer.is_alive():
                 logger.warning(

--- a/tests/agent/test_memory_session_switch.py
+++ b/tests/agent/test_memory_session_switch.py
@@ -164,6 +164,8 @@ def _make_hindsight_provider():
     provider._parent_session_id = ""
     provider._document_id = "old-sid-20260101_000000_000000"
     provider._session_turns = ["turn-1", "turn-2"]
+    provider._last_retained_turn_count = 0
+    provider._append_retain_progress = hindsight_mod._AppendRetainProgress()
     provider._turn_counter = 2
     provider._turn_index = 2
     # Attrs read by _build_metadata / _build_retain_kwargs when the
@@ -187,6 +189,9 @@ def _make_hindsight_provider():
     provider._prefetch_thread = None
     provider._prefetch_lock = threading.Lock()
     provider._prefetch_result = ""
+    provider._prefetch_count = 0
+    provider._prefetch_generation = 0
+    provider._lifecycle_lock = threading.RLock()
     # Sync thread tracking (legacy alias at the writer).
     provider._sync_thread = None
     # Writer queue infra the flush-on-switch path enqueues onto. We stub
@@ -206,6 +211,8 @@ def _make_hindsight_provider():
     provider._mode = "cloud"
     provider._api_url = ""
     provider._api_key = ""
+    provider._bank_id_template = ""
+    provider._static_bank_id = "test-bank"
     provider._client = None
     provider._resolve_retain_target = lambda fb: (fb, None)
     # Stub the network-touching helper so any enqueued flush closure is

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -269,6 +269,7 @@ class TestConfig:
         # aggregate facts that often crowd out concrete-event signal during
         # auto-recall. Users opt back in via the recall_types config key.
         assert provider._recall_types == ["observation"]
+        assert provider._auto_recall_types == ["observation"]
         assert provider._bank_mission == ""
         assert provider._bank_retain_mission is None
         assert provider._retain_context == "conversation between Hermes Agent and the User"
@@ -316,9 +317,101 @@ class TestConfig:
         assert p._bank_retain_mission == "Extract key facts"
         assert p._recall_max_tokens == 2048
         assert p._recall_types == ["world", "experience"]
+        assert p._auto_recall_types == ["world", "experience"]
         assert p._recall_prompt_preamble == "Custom preamble:"
         assert p._recall_max_input_chars == 500
         assert p._bank_mission == "Test agent mission"
+
+    def test_auto_recall_uses_separate_budget_and_token_limit(self, provider_with_config):
+        p = provider_with_config(
+            budget="mid",
+            recall_max_tokens=4096,
+            auto_recall_budget="low",
+            auto_recall_max_tokens=1024,
+            prefetch_waits_for_retain=False,
+        )
+
+        p.queue_prefetch("remember my backup policy")
+        p._prefetch_thread.join(timeout=5.0)
+
+        kwargs = p._client.arecall.await_args.kwargs
+        assert kwargs["budget"] == "low"
+        assert kwargs["max_tokens"] == 1024
+
+        p.handle_tool_call("hindsight_recall", {"query": "remember my backup policy"})
+        kwargs = p._client.arecall.await_args.kwargs
+        assert kwargs["budget"] == "mid"
+        assert kwargs["max_tokens"] == 4096
+
+    def test_auto_recall_can_use_denser_types_than_explicit_recall(
+        self, provider_with_config
+    ):
+        p = provider_with_config(
+            recall_types="observation,world,experience",
+            auto_recall_types="observation",
+            prefetch_waits_for_retain=False,
+        )
+
+        p.queue_prefetch("what changed in VCF")
+        p._prefetch_thread.join(timeout=5.0)
+        assert p._client.arecall.await_args.kwargs["types"] == ["observation"]
+
+        p.handle_tool_call("hindsight_recall", {"query": "what changed in VCF"})
+        assert p._client.arecall.await_args.kwargs["types"] == [
+            "observation",
+            "world",
+            "experience",
+        ]
+
+    @pytest.mark.parametrize("invalid_types", [None, 123, False, [123], [None]])
+    def test_invalid_auto_recall_types_inherit_explicit_types(
+        self, provider_with_config, invalid_types
+    ):
+        p = provider_with_config(
+            recall_types=["world", "experience"],
+            auto_recall_types=invalid_types,
+        )
+
+        assert p._auto_recall_types == ["world", "experience"]
+
+    def test_invalid_recall_token_limits_fall_back_to_safe_defaults(
+        self, provider_with_config
+    ):
+        p = provider_with_config(
+            recall_max_tokens="not-an-integer",
+            auto_recall_max_tokens="also-invalid",
+        )
+
+        assert p._recall_max_tokens == 4096
+        assert p._auto_recall_max_tokens == 4096
+
+    def test_invalid_numeric_lifecycle_settings_fall_back_to_safe_defaults(
+        self, provider_with_config
+    ):
+        p = provider_with_config(
+            retain_every_n_turns="not-an-integer",
+            recall_max_input_chars="also-invalid",
+            prefetch_retain_drain_timeout="NaN",
+        )
+
+        assert p._retain_every_n_turns == 1
+        assert p._recall_max_input_chars == 800
+        assert p._prefetch_retain_drain_timeout == 10.0
+
+    def test_recall_tags_csv_is_normalized_for_auto_and_explicit_recall(
+        self, provider_with_config
+    ):
+        p = provider_with_config(
+            recall_tags="project:x, source:y",
+            prefetch_waits_for_retain=False,
+        )
+
+        p.queue_prefetch("automatic")
+        p._prefetch_thread.join(timeout=5.0)
+        assert p._client.arecall.await_args.kwargs["tags"] == ["project:x", "source:y"]
+
+        p.handle_tool_call("hindsight_recall", {"query": "explicit"})
+        assert p._client.arecall.await_args.kwargs["tags"] == ["project:x", "source:y"]
 
     def test_retain_source_defaults_empty(self, provider):
         # Opt-in per AGENTS.md: no attribution tag ships by default.
@@ -515,6 +608,61 @@ class TestToolHandlers:
         ))
         assert result["result"] == "Synthesized answer"
 
+    @pytest.mark.parametrize(
+        ("tool_name", "args", "client_method"),
+        [
+            ("hindsight_retain", {"content": "old-session fact"}, "aretain_batch"),
+            ("hindsight_recall", {"query": "old-session query"}, "arecall"),
+            ("hindsight_reflect", {"query": "old-session query"}, "areflect"),
+        ],
+    )
+    def test_tool_call_holds_origin_bank_across_session_switch(
+        self, provider_with_config, tool_name, args, client_method
+    ):
+        import threading
+
+        p = provider_with_config(bank_id_template="bank-{session}")
+        original_get_client = p._get_client
+        entered = threading.Event()
+        release = threading.Event()
+        switch_done = threading.Event()
+
+        def _blocked_get_client():
+            entered.set()
+            release.wait(timeout=5.0)
+            return original_get_client()
+
+        p._get_client = _blocked_get_client
+        tool_thread = threading.Thread(target=lambda: p.handle_tool_call(tool_name, args))
+        tool_thread.start()
+        assert entered.wait(timeout=2.0)
+
+        switch_thread = threading.Thread(
+            target=lambda: (p.on_session_switch("new-session"), switch_done.set())
+        )
+        switch_thread.start()
+        switched_while_tool_was_in_flight = switch_done.wait(timeout=0.1)
+
+        release.set()
+        tool_thread.join(timeout=5.0)
+        switch_thread.join(timeout=5.0)
+
+        assert switched_while_tool_was_in_flight is False
+        call = getattr(p._client, client_method).call_args
+        assert call.kwargs["bank_id"] == "bank-test-session"
+        assert p._bank_id == "bank-new-session"
+
+    def test_tool_call_is_rejected_after_shutdown_begins(self, provider):
+        provider._shutting_down.set()
+
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "must not run"}
+        ))
+
+        assert "error" in result
+        assert "shutting down" in result["error"].lower()
+        provider._client.arecall.assert_not_called()
+
 
     def test_unknown_tool(self, provider):
         result = json.loads(provider.handle_tool_call(
@@ -593,6 +741,14 @@ class TestPrefetch:
         assert "buffered from previous turn" in result
         provider._client.arecall.assert_not_called()
 
+    def test_async_prefetch_labels_result_as_previous_turn_context(self, provider):
+        provider._prefetch_result = "- buffered from previous turn"
+
+        result = provider.prefetch("a different current request")
+
+        assert "previous user turn" in result
+        assert "only if relevant to the current request" in result
+
     def test_queue_prefetch_skipped_in_tools_mode(self, provider_with_config):
         p = provider_with_config(memory_mode="tools")
         p.queue_prefetch("test")
@@ -641,12 +797,9 @@ class TestPrefetch:
 
 
 class TestPrefetchServerRetainVisibility:
-    """PR #62871 review follow-up: draining the local writer queue is not a
-    read-after-write signal for async retains. With ``retain_async=True`` the
-    server accepts the write and returns an ``operation_id`` that stays
-    ``pending`` until the write is durable/recall-visible. The background
-    prefetch must gate on server-side operation completion, not just the local
-    queue, before recalling.
+    """Explicit asynchronous retains can return an operation id that remains
+    pending until the write is recall-visible. Background prefetch must gate
+    on server-side completion when such operations are tracked.
     """
 
     def _client_with_ops(self, statuses):
@@ -668,22 +821,36 @@ class TestPrefetchServerRetainVisibility:
         return client
 
     def test_tracks_async_operation_id_from_retain(self, provider):
-        provider._client.aretain_batch = AsyncMock(
-            return_value=SimpleNamespace(operation_id="op-async-1", operation_ids=None)
+        provider._track_retain_ops(
+            SimpleNamespace(operation_id="op-async-1", operation_ids=None),
+            "test-bank",
         )
-        provider.sync_turn("hello", "world")
-        provider._retain_queue.join()
-        assert "op-async-1" in provider._pending_retain_ops
+        assert ("test-bank", "op-async-1") in provider._pending_retain_ops
 
     def test_tracks_multiple_operation_ids(self, provider):
-        provider._client.aretain_batch = AsyncMock(
-            return_value=SimpleNamespace(
-                operation_id=None, operation_ids=["op-a", "op-b"]
-            )
+        provider._track_retain_ops(
+            SimpleNamespace(operation_id=None, operation_ids=["op-a", "op-b"]),
+            "test-bank",
         )
-        provider.sync_turn("hello", "world")
-        provider._retain_queue.join()
-        assert {"op-a", "op-b"} <= provider._pending_retain_ops
+        assert {("test-bank", "op-a"), ("test-bank", "op-b")} <= provider._pending_retain_ops
+
+    def test_tracks_each_async_operation_against_its_origin_bank(self, provider):
+        provider._track_retain_ops(
+            SimpleNamespace(operation_id="op-shared", operation_ids=None),
+            "bank-old-session",
+        )
+        provider._track_retain_ops(
+            SimpleNamespace(operation_id="op-shared", operation_ids=None),
+            "bank-new-session",
+        )
+        checked = []
+        provider._is_retain_op_complete = lambda bank, op: checked.append((bank, op)) or True
+
+        assert provider._wait_for_server_retain_ops(None, 1.0) is True
+        assert set(checked) == {
+            ("bank-old-session", "op-shared"),
+            ("bank-new-session", "op-shared"),
+        }
 
     def test_sync_retain_tracks_no_ops(self, provider_with_config):
         p = provider_with_config(retain_async=False)
@@ -698,10 +865,14 @@ class TestPrefetchServerRetainVisibility:
 
     def test_prefetch_waits_for_server_completion_before_recall(self, provider):
         """Recall must not run until the tracked async op reports completed."""
+        import threading
+
         order = []
+        recall_started = threading.Event()
 
         async def _recall(**kwargs):
             order.append("recall")
+            recall_started.set()
             return SimpleNamespace(results=[SimpleNamespace(text="m")])
 
         provider._client = self._client_with_ops(["pending", "pending", "completed"])
@@ -709,9 +880,14 @@ class TestPrefetchServerRetainVisibility:
 
         provider.sync_turn("hello", "world")
         provider._retain_queue.join()
-        assert "op-1" in provider._pending_retain_ops
+        provider._track_retain_ops(
+            SimpleNamespace(operation_id="op-1", operation_ids=None),
+            "test-bank",
+        )
+        assert ("test-bank", "op-1") in provider._pending_retain_ops
 
         provider.queue_prefetch("next turn query")
+        assert recall_started.wait(timeout=15.0), "recall did not start after retain completion"
         if provider._prefetch_thread:
             provider._prefetch_thread.join(timeout=5.0)
 
@@ -746,6 +922,26 @@ class TestPrefetchServerRetainVisibility:
         assert order == ["recall"], "prefetch should recall after the timeout"
         assert elapsed < 3.0, "prefetch must not block well past the drain budget"
 
+    def test_zero_server_wait_timeout_is_immediate_not_unbounded(self, provider):
+        import threading
+
+        provider._pending_retain_ops.add(("test-bank", "op-pending"))
+        provider._is_retain_op_complete = lambda *_args: False
+        finished = threading.Event()
+        result = []
+
+        thread = threading.Thread(
+            target=lambda: (result.append(provider._wait_for_retains_drained(0)), finished.set())
+        )
+        thread.start()
+        returned_immediately = finished.wait(timeout=0.2)
+        if not returned_immediately:
+            provider._shutting_down.set()
+        thread.join(timeout=2.0)
+
+        assert returned_immediately is True
+        assert result == [False]
+
     def test_timed_out_ops_are_dropped_not_repolled(self, provider_with_config):
         """Ops unresolved at deadline must be EVICTED so a permanently failing
         status endpoint can't make every later prefetch re-burn the full
@@ -759,6 +955,10 @@ class TestPrefetchServerRetainVisibility:
 
         p.sync_turn("hello", "world")
         p._retain_queue.join()
+        p._track_retain_ops(
+            SimpleNamespace(operation_id="op-1", operation_ids=None),
+            "test-bank",
+        )
         assert p._pending_retain_ops, "op should be tracked before the wait"
 
         # First prefetch burns the budget and must DROP the wedged op.
@@ -890,6 +1090,20 @@ class TestRecallStatus:
 
 
 class TestSyncTurn:
+    def test_rejects_mismatched_session_id_without_mutating_active_state(
+        self, provider_with_config
+    ):
+        p = provider_with_config(retain_async=False)
+        original_session = p._session_id
+        original_document = p._document_id
+
+        p.sync_turn("late user", "late assistant", session_id="different-session")
+
+        assert p._session_id == original_session
+        assert p._document_id == original_document
+        assert p._session_turns == []
+        p._client.aretain_batch.assert_not_called()
+
     def test_sync_turn_retains_metadata_rich_turn(self, provider_with_config, monkeypatch):
         event_time = datetime(2026, 8, 10, 11, 9, tzinfo=ZoneInfo("Asia/Shanghai"))
         monkeypatch.setattr("plugins.memory.hindsight._hermes_now", lambda: event_time)
@@ -919,7 +1133,7 @@ class TestSyncTurn:
         call_kwargs = p._client.aretain_batch.call_args.kwargs
         assert call_kwargs["bank_id"] == "test-bank"
         assert call_kwargs["document_id"].startswith("session-1-")
-        assert call_kwargs["retain_async"] is True
+        assert call_kwargs["retain_async"] is False
         assert len(call_kwargs["items"]) == 1
         item = call_kwargs["items"][0]
         assert item["context"] == "conversation between Hermes Agent and the User"
@@ -1054,6 +1268,17 @@ class TestRetainIndicator:
         p.sync_turn("hello", "hi")  # must not raise
         p._retain_queue.join()
 
+    def test_reentrant_shutdown_callback_cannot_orphan_retain(self, provider_with_config):
+        p = provider_with_config(retain_async=False)
+        client = p._client
+        p._status_callback = lambda _message: p.shutdown()
+
+        p.sync_turn("hello", "hi")
+
+        assert p._retain_queue.empty()
+        assert p._writer_thread is None or not p._writer_thread.is_alive()
+        client.aretain_batch.assert_called_once()
+
     def test_status_callback_wired_from_initialize(self, tmp_path, monkeypatch):
         cb = lambda _m: None
         p = _provider_for_mode(tmp_path, monkeypatch, "cloud")
@@ -1092,9 +1317,60 @@ class TestShutdownRace:
         provider.sync_turn("a", "b")
         provider.sync_turn("c", "d")
         provider.shutdown()
-        # Both retains drained before shutdown returned.
+        # Both queued synchronous retains are durable before shutdown returns.
         assert client.aretain_batch.call_count == 2
         assert provider._retain_queue.empty()
+
+    def test_shutdown_flushes_partial_turn_batch(self, provider_with_config):
+        p = provider_with_config(retain_every_n_turns=2, retain_async=False)
+        client = p._client
+
+        p.sync_turn("only-user", "only-assistant")
+        client.aretain_batch.assert_not_called()
+
+        p.shutdown()
+
+        client.aretain_batch.assert_called_once()
+        content = client.aretain_batch.call_args.kwargs["items"][0]["content"]
+        assert "only-user" in content
+
+    def test_sync_turn_racing_shutdown_cannot_enqueue_after_sentinel(
+        self, provider_with_config
+    ):
+        import threading
+
+        p = provider_with_config(retain_async=False)
+        entered = threading.Event()
+        release = threading.Event()
+        shutdown_done = threading.Event()
+        retain_calls = []
+        original_ensure_writer = p._ensure_writer
+
+        def _blocking_ensure_writer():
+            entered.set()
+            release.wait(timeout=5.0)
+            original_ensure_writer()
+
+        p._ensure_writer = _blocking_ensure_writer
+        p._run_hindsight_operation = lambda _op, **_kwargs: retain_calls.append("retain")
+
+        sync_thread = threading.Thread(target=lambda: p.sync_turn("user", "assistant"))
+        sync_thread.start()
+        assert entered.wait(timeout=2.0)
+
+        shutdown_thread = threading.Thread(
+            target=lambda: (p.shutdown(), shutdown_done.set())
+        )
+        shutdown_thread.start()
+        returned_before_admission_finished = shutdown_done.wait(timeout=0.2)
+
+        release.set()
+        sync_thread.join(timeout=5.0)
+        shutdown_thread.join(timeout=5.0)
+
+        assert returned_before_admission_finished is False
+        assert retain_calls == ["retain"]
+        assert p._retain_queue.empty()
 
 
 # ---------------------------------------------------------------------------
@@ -1169,6 +1445,114 @@ class TestSessionSwitchBufferFlush:
         assert finished.is_set(), "switch returned before prefetch thread settled"
         assert provider._prefetch_result == ""
 
+    def test_timed_out_old_prefetch_cannot_repopulate_new_session(self, provider):
+        """A recall that outlives the switch join timeout must be discarded."""
+        import threading
+
+        started = threading.Event()
+        release = threading.Event()
+
+        async def _slow_recall(**kwargs):
+            started.set()
+            release.wait(timeout=5.0)
+            return SimpleNamespace(results=[SimpleNamespace(text="stale old-session memory")])
+
+        provider._client.arecall = AsyncMock(side_effect=_slow_recall)
+        provider.queue_prefetch("old-session query")
+        assert started.wait(timeout=2.0)
+
+        # Make the test fast while preserving the production timeout path.
+        original_thread = provider._prefetch_thread
+        original_join = original_thread.join
+        original_thread.join = lambda timeout=None: original_join(timeout=0.01)
+        provider.on_session_switch("new-sid")
+        release.set()
+        original_join(timeout=5.0)
+
+        assert provider._prefetch_result == ""
+
+    def test_timed_out_old_prefetch_uses_origin_bank_after_switch(
+        self, provider_with_config
+    ):
+        """A worker delayed before recall must not send the old query to the
+        newly selected session bank after the switch join times out."""
+        import threading
+
+        p = provider_with_config(
+            bank_id_template="bank-{session}",
+            prefetch_waits_for_retain=True,
+        )
+        waiting = threading.Event()
+        release = threading.Event()
+
+        def _slow_drain(_timeout):
+            waiting.set()
+            release.wait(timeout=5.0)
+            return True
+
+        p._wait_for_retains_drained = _slow_drain
+        p.queue_prefetch("old-session query")
+        assert waiting.wait(timeout=2.0)
+
+        original_thread = p._prefetch_thread
+        original_join = original_thread.join
+        original_thread.join = lambda timeout=None: original_join(timeout=0.01)
+        p.on_session_switch("new-sid")
+        release.set()
+        original_join(timeout=5.0)
+
+        assert p._client.arecall.call_args.kwargs["bank_id"] == "bank-test-session"
+        assert p._bank_id == "bank-new-sid"
+        assert p._prefetch_result == ""
+
+    def test_session_switch_flushes_only_unretained_append_delta(
+        self, provider_with_config, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_api_supports_update_mode_append",
+            lambda *_args, **_kwargs: True,
+        )
+        p = provider_with_config(retain_every_n_turns=2, retain_async=False)
+
+        p.sync_turn("retained-user-1", "retained-assistant-1")
+        p.sync_turn("retained-user-2", "retained-assistant-2")
+        p._retain_queue.join()
+        assert p._client.aretain_batch.call_count == 1
+
+        p.sync_turn("pending-user-3", "pending-assistant-3")
+        p.on_session_switch("new-session")
+        p._retain_queue.join()
+
+        assert p._client.aretain_batch.call_count == 2
+        content = p._client.aretain_batch.call_args_list[1].kwargs["items"][0]["content"]
+        assert "pending-user-3" in content
+        assert "retained-user-1" not in content
+        assert "retained-user-2" not in content
+
+    def test_session_switch_recomputes_session_bank_template(
+        self, provider_with_config
+    ):
+        p = provider_with_config(bank_id_template="bank-{session}")
+        assert p._bank_id == "bank-test-session"
+
+        p.on_session_switch("new-sid")
+
+        assert p._bank_id == "bank-new-sid"
+
+    def test_session_switch_without_parent_clears_previous_lineage(
+        self, provider_with_config
+    ):
+        p = provider_with_config(retain_async=False)
+        p.on_session_switch("branch", parent_session_id="test-session")
+        assert p._parent_session_id == "test-session"
+
+        p.on_session_switch("unrelated")
+        p.sync_turn("user", "assistant")
+        p._retain_queue.join()
+
+        tags = p._client.aretain_batch.call_args.kwargs["items"][0].get("tags", [])
+        assert "parent:test-session" not in tags
+
     def test_flush_serializes_behind_pending_retains_via_writer_queue(
         self, provider_with_config
     ):
@@ -1236,6 +1620,26 @@ class TestUpdateModeAppendCapability:
         with _append_capability_lock:
             _append_capability_cache.clear()
 
+    def test_append_write_disables_ambiguous_embedded_retry(
+        self, provider_with_config, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_api_supports_update_mode_append",
+            lambda *_args, **_kwargs: True,
+        )
+        p = provider_with_config(retain_async=False)
+        retry_flags = []
+
+        def _run(_operation, *, retry_embedded_connection=True):
+            retry_flags.append(retry_embedded_connection)
+            return None
+
+        p._run_hindsight_operation = _run
+        p.sync_turn("user", "assistant")
+        p._retain_queue.join()
+
+        assert retry_flags == [False]
+
     def test_legacy_api_falls_back_to_per_process_doc_id(self, provider, monkeypatch):
         """API returns no /version (or pre-0.5.0) — sync_turn must use the
         per-process unique doc_id and NOT pass update_mode."""
@@ -1254,8 +1658,9 @@ class TestUpdateModeAppendCapability:
         item = kw["items"][0]
         assert "update_mode" not in item
 
-    def test_modern_api_uses_stable_doc_id_with_append(self, provider, monkeypatch):
-        """API on >=0.5.0 — retain uses stable session_id and sets update_mode='append'."""
+    def test_modern_api_uses_process_doc_id_with_append(self, provider, monkeypatch):
+        """Append mode stays process-scoped so recovery replace cannot erase
+        turns written concurrently by another resumed provider."""
         self._clear_capability_cache()
         monkeypatch.setattr(
             "plugins.memory.hindsight._fetch_hindsight_api_version",
@@ -1265,17 +1670,196 @@ class TestUpdateModeAppendCapability:
         provider._retain_queue.join()
 
         kw = provider._client.aretain_batch.call_args.kwargs
-        # Stable: just the session id, no per-process timestamp suffix.
-        assert kw["document_id"] == "test-session"
+        assert kw["document_id"] == provider._document_id
+        assert kw["document_id"].startswith("test-session-")
         item = kw["items"][0]
         assert item["update_mode"] == "append"
+
+    def test_legacy_auto_retain_waits_for_durable_result(
+        self, provider_with_config, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_api_supports_update_mode_append",
+            lambda *_args, **_kwargs: False,
+        )
+        p = provider_with_config(retain_async=True)
+
+        p.sync_turn("user", "assistant")
+        p._retain_queue.join()
+
+        call = p._client.aretain_batch.call_args
+        assert call.kwargs["retain_async"] is False
+        assert p._pending_retain_ops == set()
+
+    def test_failed_append_retain_is_retried_in_next_delta(
+        self, provider_with_config, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_api_supports_update_mode_append",
+            lambda *_args, **_kwargs: True,
+        )
+        p = provider_with_config(retain_async=False)
+        p._client.aretain_batch = AsyncMock(
+            side_effect=[RuntimeError("transient"), None]
+        )
+
+        p.sync_turn("failed-user", "failed-assistant")
+        p._retain_queue.join()
+        p.sync_turn("next-user", "next-assistant")
+        p._retain_queue.join()
+
+        assert p._client.aretain_batch.call_count == 2
+        retry_content = p._client.aretain_batch.call_args_list[1].kwargs["items"][0]["content"]
+        assert "failed-user" in retry_content
+        assert "next-user" in retry_content
+
+    def test_append_mode_waits_for_server_result_before_advancing(self, provider, monkeypatch):
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_api_supports_update_mode_append",
+            lambda *_args, **_kwargs: True,
+        )
+        provider._retain_async = True
+
+        provider.sync_turn("user", "assistant")
+        provider._retain_queue.join()
+
+        call = provider._client.aretain_batch.call_args
+        assert call.kwargs["retain_async"] is False
+        assert provider._pending_retain_ops == set()
+
+    def test_queued_append_after_failure_repairs_gap_without_later_duplicates(
+        self, provider_with_config, monkeypatch
+    ):
+        import threading
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_api_supports_update_mode_append",
+            lambda *_args, **_kwargs: True,
+        )
+        p = provider_with_config(retain_async=False)
+        first_started = threading.Event()
+        release_first = threading.Event()
+        contents = []
+
+        async def _retain(**kwargs):
+            contents.append(kwargs["items"][0]["content"])
+            if len(contents) == 1:
+                first_started.set()
+                release_first.wait(timeout=5.0)
+                raise RuntimeError("first append failed")
+
+        p._client.aretain_batch = AsyncMock(side_effect=_retain)
+
+        p.sync_turn("failed-user", "failed-assistant")
+        assert first_started.wait(timeout=2.0)
+        p.sync_turn("queued-user", "queued-assistant")
+        release_first.set()
+        p._retain_queue.join()
+        p.sync_turn("later-user", "later-assistant")
+        p._retain_queue.join()
+
+        assert "failed-user" in contents[1]
+        assert "queued-user" in contents[1]
+        assert "failed-user" not in contents[2]
+        assert "queued-user" not in contents[2]
+        assert "later-user" in contents[2]
+        assert p._client.aretain_batch.call_args_list[1].kwargs["items"][0]["update_mode"] == "replace"
+
+    def test_shutdown_retries_a_failed_legacy_overwrite(self, provider_with_config, monkeypatch):
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_api_supports_update_mode_append",
+            lambda *_args, **_kwargs: False,
+        )
+        p = provider_with_config(retain_async=False)
+        client = p._client
+        client.aretain_batch = AsyncMock(
+            side_effect=[RuntimeError("legacy retain failed"), None]
+        )
+
+        p.sync_turn("recover-user", "recover-assistant")
+        p._retain_queue.join()
+        p.shutdown()
+
+        assert client.aretain_batch.call_count == 2
+        retry = client.aretain_batch.call_args_list[1]
+        assert "recover-user" in retry.kwargs["items"][0]["content"]
+        assert "update_mode" not in retry.kwargs["items"][0]
+
+    def test_shutdown_retries_a_failed_append_gap(
+        self, provider_with_config, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_api_supports_update_mode_append",
+            lambda *_args, **_kwargs: True,
+        )
+        p = provider_with_config(retain_async=False)
+        client = p._client
+        client.aretain_batch = AsyncMock(
+            side_effect=[RuntimeError("first append failed"), None]
+        )
+
+        p.sync_turn("recover-user", "recover-assistant")
+        p._retain_queue.join()
+        p.shutdown()
+
+        assert client.aretain_batch.call_count == 2
+        retry_content = client.aretain_batch.call_args_list[1].kwargs["items"][0]["content"]
+        assert "recover-user" in retry_content
+        assert client.aretain_batch.call_args_list[1].kwargs["items"][0]["update_mode"] == "replace"
+
+    def test_shutdown_flush_retries_once_after_transient_failure(
+        self, provider_with_config, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_api_supports_update_mode_append",
+            lambda *_args, **_kwargs: True,
+        )
+        p = provider_with_config(retain_async=False, retain_every_n_turns=2)
+        client = p._client
+        client.aretain_batch = AsyncMock(
+            side_effect=[RuntimeError("transient flush failure"), None]
+        )
+
+        p.sync_turn("buffered-user", "buffered-assistant")
+        assert client.aretain_batch.call_count == 0
+        p.shutdown()
+
+        assert client.aretain_batch.call_count == 2
+        retry = client.aretain_batch.call_args_list[1]
+        assert "buffered-user" in retry.kwargs["items"][0]["content"]
+        assert retry.kwargs["items"][0]["update_mode"] == "replace"
+
+    def test_session_switch_retries_a_failed_append_under_old_identity(
+        self, provider_with_config, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_api_supports_update_mode_append",
+            lambda *_args, **_kwargs: True,
+        )
+        p = provider_with_config(retain_async=False, bank_id_template="bank-{session}")
+        client = p._client
+        old_document_id = p._document_id
+        client.aretain_batch = AsyncMock(
+            side_effect=[RuntimeError("first append failed"), None]
+        )
+
+        p.sync_turn("old-user", "old-assistant")
+        p._retain_queue.join()
+        p.on_session_switch("new-session")
+        p._retain_queue.join()
+
+        retry = client.aretain_batch.call_args_list[1]
+        assert retry.kwargs["bank_id"] == "bank-test-session"
+        assert retry.kwargs["document_id"] == old_document_id
+        assert "old-user" in retry.kwargs["items"][0]["content"]
+        assert retry.kwargs["items"][0]["update_mode"] == "replace"
 
 
     def test_session_switch_flush_picks_capability_against_old_session(
         self, provider_with_config, monkeypatch
     ):
-        """When the API supports append, the flush on /reset must land
-        in the OLD session's stable document, not a per-process id."""
+        """When the API supports append, the flush on /reset must land in the
+        old process-scoped document, not a new-session document."""
         self._clear_capability_cache()
         monkeypatch.setattr(
             "plugins.memory.hindsight._fetch_hindsight_api_version",
@@ -1288,8 +1872,7 @@ class TestUpdateModeAppendCapability:
         p._retain_queue.join()
 
         kw = p._client.aretain_batch.call_args.kwargs
-        # Flush goes to the OLD session's stable doc, not new-sid's.
-        assert kw["document_id"] == "test-session"
+        assert kw["document_id"].startswith("test-session-")
         assert kw["items"][0]["update_mode"] == "append"
 
 
@@ -1304,6 +1887,17 @@ class TestSystemPrompt:
         assert "Hindsight Memory" in block
         assert "hindsight_recall" in block
         assert "automatically injected" in block
+        assert "when they are present in your tool list" in block.lower()
+        assert "Normal completed turns are automatically retained" in block
+
+    def test_prompt_does_not_claim_disabled_automatic_memory(self, provider_with_config):
+        p = provider_with_config(auto_recall=False, auto_retain=False)
+
+        block = p.system_prompt_block()
+
+        assert "automatically injected" not in block
+        assert "automatically retained" not in block
+        assert "hindsight_recall" in block
 
 
 # ---------------------------------------------------------------------------
@@ -1324,7 +1918,8 @@ class TestConfigSchema:
             "recall_tags", "recall_tags_match",
             "auto_recall", "auto_retain",
             "retain_every_n_turns", "retain_async", "retain_context",
-            "recall_max_tokens", "recall_max_input_chars",
+            "recall_max_tokens", "auto_recall_budget", "auto_recall_max_tokens",
+            "recall_max_input_chars",
             "recall_prompt_preamble",
         }
         assert expected_keys.issubset(keys), f"Missing: {expected_keys - keys}"

--- a/tests/plugins/test_hindsight_health_grace_timeout.py
+++ b/tests/plugins/test_hindsight_health_grace_timeout.py
@@ -46,13 +46,16 @@ def test_blank_and_missing_are_noops(monkeypatch):
     assert _ENV not in os.environ
 
 
-def test_invalid_and_negative_ignored(monkeypatch):
+def test_invalid_negative_and_nonfinite_ignored(monkeypatch):
     import os
 
     _export({"port_health_grace_timeout": "not-a-number"})
     assert _ENV not in os.environ
     _export({"port_health_grace_timeout": -5})
     assert _ENV not in os.environ
+    for value in ("NaN", "inf", "-inf"):
+        _export({"port_health_grace_timeout": value})
+        assert _ENV not in os.environ
 
 
 def test_explicit_env_wins_over_config(monkeypatch):


### PR DESCRIPTION
## Summary

This consolidates a set of Hindsight memory lifecycle hardening changes found through profile-level runtime testing:

- pin queued retain, explicit tool, and prefetch work to the originating bank/session;
- serialize session rotation and shutdown with provider operations;
- prevent stale prefetch results from crossing session boundaries;
- flush partial retain batches on session switch and shutdown;
- make append recovery idempotent by replacing the captured session snapshot after ambiguous failures instead of blindly replaying an append;
- preserve legacy overwrite durability by waiting for definitive automatic-retain results and using confirmed-success watermarks;
- reject new explicit memory operations after shutdown begins;
- validate malformed timeout and automatic-recall configuration safely;
- allow automatic recall budget/token/type controls without changing explicit recall semantics;
- invoke retain status callbacks after queue admission and outside the lifecycle lock, avoiding reentrant-shutdown deadlocks and orphaned jobs.

The patch also documents the updated recall/retain behavior and adds focused concurrency, retry, session-switch, shutdown, and configuration regression coverage.

## Scope

Exactly five files:

- `plugins/memory/hindsight/README.md`
- `plugins/memory/hindsight/__init__.py`
- `tests/agent/test_memory_session_switch.py`
- `tests/plugins/memory/test_hindsight_provider.py`
- `tests/plugins/test_hindsight_health_grace_timeout.py`

## Verification

- focused memory/session/health suite: **405 passed, 0 failed**
- `git diff --check`: passed
- Python compilation of affected source/tests: passed
- added-line security scan: no hardcoded secret, shell injection, eval/exec, pickle, or SQL-format matches
- independent fail-closed review: no security or logic findings

The full repository suite was additionally observed through 24.3% (9,274 passing, 0 failing) before it was intentionally interrupted for the authorized local runtime rollout; the focused canonical scope completed in full.

## Related work

This patch overlaps and consolidates several narrower open Hindsight lifecycle efforts, including #70019, #80503, #64745, #64499, and #89801. It does not claim those implementations are identical; they were reviewed to avoid presenting the same root cause as novel.
