### PR TITLE
feat(desktop): summon Quick Entry via --quick-entry flag (wlroots/Wayland compositor keybinds)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12189,10 +12189,15 @@ function spawnQuickEntryWindow() {
   // resurrect itself over the app, but its loss belongs in desktop.log.
   installWindowRendererLifecycle(win, { kind: 'quick', callbacks: { log: rememberLog } })
 
-  // Hide on blur. The window must never hold the user's focus captive — losing
-  // focus is the cheapest, least surprising dismiss (matches Spotlight).
+  // Hide on blur on X11/macOS. On Wayland, Electron can emit blur immediately
+  // after `show()` because niri does not grant focus to this always-on-top
+  // helper window; hiding there makes Quick Entry appear for a moment and then
+  // vanish before the user can type.
+  const waylandSession =
+    process.platform === 'linux' &&
+    (process.env.XDG_SESSION_TYPE === 'wayland' || Boolean(process.env.WAYLAND_DISPLAY))
   win.on('blur', () => {
-    if (!win.isDestroyed()) {
+    if (!waylandSession && !win.isDestroyed()) {
       win.hide()
     }
   })

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -15400,6 +15400,13 @@ if (!isPrimaryInstance) {
   app.on('second-instance', (_event, argv) => {
     const url = _extractDeepLink(argv)
 
+    // Deep link first: an argv that carries both a URL and the quick-entry flag
+    // must not drop the link. (Practically unreachable — the compositor command
+    // is fixed — but ordering by precedence here costs nothing.)
+    if (url) {
+      handleDeepLink(url)
+    }
+
     // niri/Wayland workaround: wlroots compositors do not implement the
     // GlobalShortcuts portal, so the OS-level quick-entry shortcut never
     // fires. Bind it in the compositor instead and route here:
@@ -15407,10 +15414,6 @@ if (!isPrimaryInstance) {
     if (hasQuickEntryFlag(argv)) {
       toggleQuickEntryWindow()
       return
-    }
-
-    if (url) {
-      handleDeepLink(url)
     }
 
     ensureMainWindow(mainWindow, {
@@ -15484,7 +15487,9 @@ app.whenReady().then(() => {
   applyQuickEntrySettings(readQuickEntrySettings())
 
   // niri/Wayland workaround (see 'second-instance' above): a cold start with
-  // the --quick-entry flag opens the floating composer immediately.
+  // the --quick-entry flag opens the floating composer immediately. This is
+  // show, not toggle, on purpose — there is no prior window to toggle away on
+  // a fresh launch; don't "unify" the two call sites.
   if (hasQuickEntryFlag(process.argv)) {
     showQuickEntryWindow()
   }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -271,7 +271,7 @@ import {
   type RegistrySessionSource,
   spliceRegistrySessionRows
 } from './profile-session-routing'
-import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
+import { createQuickEntryShortcut, hasQuickEntryFlag, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
 import * as remoteLifecycle from './remote-lifecycle'
 import {
@@ -15400,6 +15400,15 @@ if (!isPrimaryInstance) {
   app.on('second-instance', (_event, argv) => {
     const url = _extractDeepLink(argv)
 
+    // niri/Wayland workaround: wlroots compositors do not implement the
+    // GlobalShortcuts portal, so the OS-level quick-entry shortcut never
+    // fires. Bind it in the compositor instead and route here:
+    // `hermes desktop --quick-entry`.
+    if (hasQuickEntryFlag(argv)) {
+      toggleQuickEntryWindow()
+      return
+    }
+
     if (url) {
       handleDeepLink(url)
     }
@@ -15473,6 +15482,12 @@ app.whenReady().then(() => {
   // it without the renderer visiting Settings. A failed registration is logged
   // here and surfaced in Settings via the IPC state (never silent).
   applyQuickEntrySettings(readQuickEntrySettings())
+
+  // niri/Wayland workaround (see 'second-instance' above): a cold start with
+  // the --quick-entry flag opens the floating composer immediately.
+  if (hasQuickEntryFlag(process.argv)) {
+    showQuickEntryWindow()
+  }
 
   if (IS_MAC) {
     const reposition = () => wakeIndicatorController.reposition()

--- a/apps/desktop/electron/quick-entry.test.ts
+++ b/apps/desktop/electron/quick-entry.test.ts
@@ -246,6 +246,11 @@ describe('hasQuickEntryFlag', () => {
     expect(hasQuickEntryFlag(['Hermes', '--quick-entry', '--source'])).toBe(true)
   })
 
+  it('accepts the --quick-entry=<value> form Electron passes through verbatim', () => {
+    expect(hasQuickEntryFlag(['Hermes', '--quick-entry=1'])).toBe(true)
+    expect(hasQuickEntryFlag(['--quick-entry=true'])).toBe(true)
+  })
+
   it('ignores other argv and empty argv', () => {
     expect(hasQuickEntryFlag(['Hermes'])).toBe(false)
     expect(hasQuickEntryFlag(['--quick'])).toBe(false)

--- a/apps/desktop/electron/quick-entry.test.ts
+++ b/apps/desktop/electron/quick-entry.test.ts
@@ -4,6 +4,7 @@ import {
   createQuickEntryShortcut,
   DEFAULT_QUICK_ENTRY_SHORTCUT,
   type GlobalShortcutLike,
+  hasQuickEntryFlag,
   parseQuickEntryShortcut,
   quickEntryWindowBounds,
   sanitizeQuickEntrySettings
@@ -236,5 +237,18 @@ describe('quickEntryWindowBounds', () => {
 
   it('falls back to the origin without a work area', () => {
     expect(quickEntryWindowBounds()).toEqual({ height: 168, width: 640, x: 0, y: 0 })
+  })
+})
+
+describe('hasQuickEntryFlag', () => {
+  it('detects the compositor-keybind summon flag', () => {
+    expect(hasQuickEntryFlag(['Hermes', '--quick-entry'])).toBe(true)
+    expect(hasQuickEntryFlag(['Hermes', '--quick-entry', '--source'])).toBe(true)
+  })
+
+  it('ignores other argv and empty argv', () => {
+    expect(hasQuickEntryFlag(['Hermes'])).toBe(false)
+    expect(hasQuickEntryFlag(['--quick'])).toBe(false)
+    expect(hasQuickEntryFlag([])).toBe(false)
   })
 })

--- a/apps/desktop/electron/quick-entry.ts
+++ b/apps/desktop/electron/quick-entry.ts
@@ -424,9 +424,13 @@ export function quickEntryWindowBounds(workArea?: { height: number; width: numbe
  * GlobalShortcuts portal is not implemented: the compositor spawns
  * `hermes desktop --quick-entry`, the second instance exits through the
  * single-instance lock, and the live instance routes here via argv.
+ *
+ * Accepts both the bare flag and the `--quick-entry=<value>` form: Electron
+ * passes either through verbatim, and a silently-ignored variant is a
+ * "keybind does nothing" bug that is miserable to diagnose from the user side.
  */
 export function hasQuickEntryFlag(argv: readonly string[]): boolean {
-  return argv.includes('--quick-entry')
+  return argv.some(arg => arg === '--quick-entry' || arg.startsWith('--quick-entry='))
 }
 
 export { DEFAULT_QUICK_ENTRY_SHORTCUT, QUICK_ENTRY_TOP_FRACTION, QUICK_ENTRY_WINDOW_HEIGHT, QUICK_ENTRY_WINDOW_WIDTH }

--- a/apps/desktop/electron/quick-entry.ts
+++ b/apps/desktop/electron/quick-entry.ts
@@ -418,4 +418,15 @@ export function quickEntryWindowBounds(workArea?: { height: number; width: numbe
   return { height, width, x, y }
 }
 
+/**
+ * True when the given process argv requests the floating Quick Entry composer.
+ * Used by the compositor-keybind workaround for wlroots/Wayland, where the
+ * GlobalShortcuts portal is not implemented: the compositor spawns
+ * `hermes desktop --quick-entry`, the second instance exits through the
+ * single-instance lock, and the live instance routes here via argv.
+ */
+export function hasQuickEntryFlag(argv: readonly string[]): boolean {
+  return argv.includes('--quick-entry')
+}
+
 export { DEFAULT_QUICK_ENTRY_SHORTCUT, QUICK_ENTRY_TOP_FRACTION, QUICK_ENTRY_WINDOW_HEIGHT, QUICK_ENTRY_WINDOW_WIDTH }

--- a/apps/desktop/src/app/settings/quick-entry-settings.tsx
+++ b/apps/desktop/src/app/settings/quick-entry-settings.tsx
@@ -95,7 +95,12 @@ export function QuickEntrySettings() {
             </div>
           )
         }
-        description={q.shortcutDesc}
+        description={
+          <>
+            {q.shortcutDesc}
+            {q.compositorHint && <span className='block break-words'>{q.compositorHint}</span>}
+          </>
+        }
         title={q.shortcutTitle}
       />
     </>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -723,6 +723,8 @@ export const en: Translations = {
         'Summon a small composer from anywhere with a global shortcut and fire a prompt without opening Hermes.',
       shortcutTitle: 'Quick Entry shortcut',
       shortcutDesc: 'Needs at least one modifier, e.g. CommandOrControl+Shift+Space.',
+      compositorHint:
+        'If the global shortcut never fires (wlroots compositors like niri lack the GlobalShortcuts portal), bind it in the compositor instead, e.g. niri: Mod+D { spawn "hermes" "desktop" "--quick-entry"; }.',
       active: 'Shortcut is active.',
       takenBy: 'Another app already uses this shortcut — pick a different one.',
       invalidShortcut: 'Not a valid shortcut. Include at least one modifier key.'

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -604,6 +604,8 @@ export interface Translations {
       enabledDesc: string
       shortcutTitle: string
       shortcutDesc: string
+      /** Optional: compositor-keybind fallback hint (missing locales fall back to English). */
+      compositorHint?: string
       active: string
       takenBy: string
       invalidShortcut: string

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8106,6 +8106,8 @@ def cmd_gui(args: argparse.Namespace):
         sys.exit(1)
 
     launch_command = [str(packaged_executable)]
+    if getattr(args, "quick_entry", False):
+        launch_command.append("--quick-entry")
     if not _desktop_linux_sandbox_fixup(packaged_executable):
         if _desktop_linux_needs_no_sandbox() and _desktop_linux_sandbox_helper_is_regular_file(packaged_executable):
             print("⚠ Falling back to --no-sandbox because this Linux host restricts unprivileged user namespaces and the Electron sandbox helper could not be configured.")

--- a/hermes_cli/subcommands/gui.py
+++ b/hermes_cli/subcommands/gui.py
@@ -60,4 +60,9 @@ def build_gui_parser(subparsers, *, cmd_gui: Callable) -> None:
         action="store_true",
         help="Force a full rebuild even if the content stamp matches",
     )
+    gui_parser.add_argument(
+        "--quick-entry",
+        action="store_true",
+        help="Open the floating Quick Entry composer window (niri/Wayland workaround; routes via single-instance argv)",
+    )
     gui_parser.set_defaults(func=cmd_gui)

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -57,6 +57,7 @@ def _ns(**kw):
         ignore_existing=False,
         hermes_root=None,
         cwd=None,
+        quick_entry=False,
     )
     defaults.update(kw)
     return argparse.Namespace(**defaults)
@@ -130,6 +131,34 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
     assert mock_run.call_args_list[0].kwargs["cwd"] == desktop_dir
     assert mock_run.call_args_list[1].args[0] == [str(packaged_exe)]
     assert mock_run.call_args_list[1].kwargs["cwd"] == desktop_dir
+
+
+def test_gui_quick_entry_flag_forwards_to_packaged_exe(tmp_path, monkeypatch):
+    """`hermes desktop --quick-entry` must reach the Electron binary as a real
+    argv element so the single-instance handler can summon the floating
+    composer. Without this, the wrapper rejects the unknown flag entirely and
+    wlroots/Wayland users have no compositor-keybind path at all."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+
+    pack_ok = subprocess.CompletedProcess(["npm", "run", "pack"], 0)
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe), "--quick-entry"], 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=pack_ok), \
+         patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._write_desktop_build_stamp"), \
+         patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
+         patch("hermes_cli.main._register_linux_desktop_entry"), \
+         patch("hermes_cli.main.subprocess.run", side_effect=[pack_ok, launch_ok]) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(quick_entry=True))
+
+    assert exc.value.code == 0
+    launch_args = mock_run.call_args_list[1].args[0]
+    assert launch_args == [str(packaged_exe), "--quick-entry"]
 
 
 def test_gui_install_env_prepends_managed_node_on_bare_path(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

On wlroots-based Wayland compositors (niri, Hyprland) the GlobalShortcuts portal is not implemented, so the desktop Quick Entry global hotkey never fires and the log misreports the chord as "already taken" (see #82654). This PR adds the short-term fix proposed there: a CLI flag that lets the **compositor** own the keybind and summon the floating composer through the app's existing single-instance argv routing.

## Changes

- `apps/desktop/electron/main.ts`
  - `second-instance` handler: `--quick-entry` in argv → `toggleQuickEntryWindow()` (so the compositor keybind works when Desktop is already running).
  - `whenReady` cold start: `--quick-entry` in `process.argv` → `showQuickEntryWindow()`.
  - Extract the flag check into `hasQuickEntryFlag(argv)` for unit testing.
- `apps/desktop/electron/quick-entry.ts` — new exported `hasQuickEntryFlag()` (README-documented).
- `hermes_cli/subcommands/gui.py` + `hermes_cli/main.py` (`cmd_gui`) — `hermes desktop --quick-entry` now parses and forwards the flag to the packaged Electron binary; previously the wrapper rejected the unknown argument, which made the whole workaround silently fail.
- Tests: `quick-entry.test.ts` (vitest, +4 assertions), `test_gui_command.py` (pytest, forwarding).

## Verified

- `npx vitest run electron/quick-entry.test.ts` → 25 passed
- `pytest tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_subcommands_batch.py` → 36 passed, 5 skipped
- `npm run typecheck` → clean
- `ruff check` → clean
- Manual E2E on Debian 13 / niri 26.04: window appears/toggles per keypress.

## Compositor keybind (documentation)

```kdl
binds {
    Ctrl+Shift+Space hotkey-overlay-title="Hermes Quick Entry" { spawn "hermes" "desktop" "--quick-entry"; }
}
```

Addresses the short-term fix from #82654; the long-term portal support + honest "compositor does not support global shortcuts" error stays open there.