### PR TITLE
fix(desktop): reconcile workspace-tile transcripts on sessions.changed

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -49,13 +49,16 @@ function makeRefresh(resolveSession: ActiveTranscriptRefreshDeps['resolveSession
   const signatureRef = { current: new Map<string, string>() }
   const state = createClientSessionState(ACTIVE_STORED_ID)
   const states = new Map([[ACTIVE_RUNTIME_ID, state]])
+  const updateSessionStateRef = {
+    updateSessionState: vi.fn((sessionId: string, updater: (value: typeof state) => typeof state) => {
+      const next = updater(states.get(sessionId) ?? createClientSessionState(ACTIVE_STORED_ID))
+      states.set(sessionId, next)
 
-  const updateSessionState = vi.fn((sessionId: string, updater: (value: typeof state) => typeof state) => {
-    const next = updater(states.get(sessionId) ?? createClientSessionState(ACTIVE_STORED_ID))
-    states.set(sessionId, next)
+      return next
+    })
+  }
+  const { updateSessionState } = updateSessionStateRef
 
-    return next
-  })
 
   const refresh = () =>
     reconcileActiveTranscript({
@@ -82,6 +85,12 @@ function useSyncHarness({
   activeStoredSessionId: string | null
   refreshActiveTranscript: () => Promise<void>
 }) {
+  const updateSessionState: Parameters<typeof useBackgroundSync>[0]['updateSessionState'] = vi.fn(
+    (sessionId, updater) => {
+      const current = {} as Parameters<typeof updater>[0]
+      return updater(current)
+    }
+  )
   useBackgroundSync({
     activeConnectionId: 'local',
     activeGatewayProfile: 'default',
@@ -96,7 +105,8 @@ function useSyncHarness({
     refreshHermesConfig: vi.fn(),
     refreshMessagingSessions: vi.fn(),
     refreshSessions: vi.fn(),
-    requestGateway: vi.fn(async () => ({ sessions: [] })) as never
+    updateSessionState,
+      requestGateway: vi.fn(async () => ({ sessions: [] })) as never
   })
 }
 

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -2,6 +2,7 @@ import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { sessionMessagesSignature } from '@/lib/session-signatures'
 import { $changeEventsAvailable, notifySessionsChanged, resetLiveSync } from '@/store/live-sync'
 import { $activeSessionId, $selectedStoredSessionId, setBusy, setMessagingSessions, setSessions } from '@/store/session'
 import {
@@ -15,6 +16,7 @@ import {
 import {
   type ActiveTranscriptRefreshDeps,
   reconcileActiveTranscript,
+  reconcileTileTranscripts as reconcileTileTranscriptsForTest,
   rehydrateLiveSessionStatuses,
   resolveActiveTranscriptSession,
   useBackgroundSync,
@@ -148,6 +150,106 @@ afterEach(() => {
 describe('active transcript refresh', () => {
   beforeEach(() => {
     vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('answer') as never)
+  })
+
+  it('reconciles a workspace TILE transcript when sessions.changed ticks (#94255 review: behavior, not source-grep)', async () => {
+    $changeEventsAvailable.set(true)
+    // The tile's runtime differs from the active session — it is NOT the main
+    // pane surface, so only the tile reconcile path may update it.
+    const TILE_RUNTIME_ID = 'runtime-tile'
+    const TILE_STORED_ID = 'stored-tile'
+    $activeSessionId.set('runtime-something-else')
+    $selectedStoredSessionId.set('stored-other')
+
+    const states = new Map<string, ReturnType<typeof createClientSessionState>>()
+    states.set(TILE_RUNTIME_ID, createClientSessionState(TILE_STORED_ID))
+
+    let updaterCallCount = 0
+
+    const updateSessionState: Parameters<typeof reconcileTileTranscriptsForTest>[0]['updateSessionState'] = vi.fn(
+      (sessionId, updater) => {
+        updaterCallCount += 1
+        const current = {} as Parameters<typeof updater>[0]
+
+        return updater(current)
+      }
+    )
+    void updateSessionState
+
+    const signatureRef = { current: new Map<string, string>() }
+    const requestSequenceRef = { current: 0 }
+    const busyRef = { current: false }
+
+    vi.mocked(getLatestSessionMessages).mockImplementation(async (storedId: string) => {
+      if (storedId === TILE_STORED_ID) {
+        return {
+          messages: [
+            { content: 'tile question', role: 'user', timestamp: 1 },
+            { content: 'background delivery answer', role: 'assistant', timestamp: 2 }
+          ],
+          session_id: TILE_STORED_ID
+        } as never
+      }
+
+      return transcript('main-pane answer') as never
+    })
+
+    // Seed a tile so reconcileTileTranscripts has a target.
+    setSessions([]) // bot chats are hidden from $sessions — the whole point
+
+    await act(async () => {
+      await reconcileTileTranscriptsForTest({
+        tiles: [{ storedSessionId: TILE_STORED_ID, runtimeId: TILE_RUNTIME_ID }],
+        busyRef,
+        requestSequenceRef,
+        signatureRef,
+        updateSessionState
+      })
+    })
+
+    // Behavior assertions:
+    expect(updaterCallCount).toBeGreaterThan(0)
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(TILE_STORED_ID)
+  })
+
+  it('skips the tile fetch entirely when nothing changed (signature-gated)', async () => {
+    $changeEventsAvailable.set(true)
+
+    const TILE_RUNTIME_ID = 'runtime-tile-2'
+    const TILE_STORED_ID = 'stored-tile-2'
+
+    const signatureRef = { current: new Map<string, string>() }
+    // Pre-seed the signature with what the mock returns → no-change tick.
+    const pre = {
+      messages: [
+        { content: 'q', role: 'user', timestamp: 1 },
+        { content: 'a', role: 'assistant', timestamp: 2 }
+      ],
+      session_id: TILE_STORED_ID
+    }
+
+    vi.mocked(getLatestSessionMessages).mockResolvedValue(pre as never)
+
+    // Compute the same signature the reconcile will compute, and pre-seed it.
+    const preSignature = sessionMessagesSignature(pre.messages as never)
+
+    signatureRef.current.set(`tile:${TILE_STORED_ID}`, preSignature)
+
+    const updateSessionState = vi.fn()
+    const busyRef = { current: false }
+    const requestSequenceRef = { current: 0 }
+
+    await act(async () => {
+      await reconcileTileTranscriptsForTest({
+        tiles: [{ storedSessionId: TILE_STORED_ID, runtimeId: TILE_RUNTIME_ID }],
+        busyRef,
+        requestSequenceRef,
+        signatureRef,
+        updateSessionState
+      })
+    })
+
+    expect(updateSessionState).not.toHaveBeenCalled()
   })
 
   it('refreshes a local/Desktop session when sessions.changed ticks', async () => {

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -21,6 +21,7 @@ import {
 } from '@/store/session'
 import {
   $sessionStates,
+  $sessionTiles,
   publishSessionState,
   SESSION_WATCHDOG_TIMEOUT_MS,
   setSessionStalled
@@ -53,6 +54,89 @@ export interface ActiveTranscriptRefreshDeps {
     updater: (state: ClientSessionState) => ClientSessionState,
     storedSessionId?: string | null
   ) => ClientSessionState
+}
+
+/**
+ * Reconcile the persisted transcripts of every open WORKSPACE TILE (#93942
+ * slice 1). Bot canonical chats live here — never in $sessions /
+ * $messagingSessions (they carry the core `hidden` flag), so the main-pane
+ * reconcile path's resolveSession() bails on them and a background delivery
+ * never reaches an open bot chat. Each tile carries its own stored↔runtime id
+ * pair, so no resolution step is needed; refreshes are signature-gated per
+ * tile so a no-change event costs nothing, and a busy tile is skipped (its own
+ * stream owns the view while streaming).
+ */
+export async function reconcileTileTranscripts({
+  requestSequenceRef,
+  busyRef,
+  signatureRef,
+  updateSessionState
+}: {
+  busyRef: MutableRefObject<boolean>
+  requestSequenceRef: MutableRefObject<number>
+  signatureRef: MutableRefObject<Map<string, string>>
+  updateSessionState: (
+    sessionId: string,
+    updater: (state: ClientSessionState) => ClientSessionState,
+    storedSessionId?: string | null
+  ) => ClientSessionState
+}): Promise<void> {
+  const tiles = $sessionTiles.get()
+
+  for (const tile of tiles) {
+    const storedSessionId = tile.storedSessionId
+    const runtimeSessionId = tile.runtimeId
+
+    if (!runtimeSessionId) {
+      // Resume not yet bound — the tile's own stream owns the view.
+      continue
+    }
+
+    if (!storedSessionId || !runtimeSessionId || busyRef.current) {
+      continue
+    }
+
+    if ($activeSessionId.get() === runtimeSessionId) {
+      // The main pane reconcile already owns this surface.
+      continue
+    }
+
+    const requestId = ++requestSequenceRef.current
+
+    try {
+      const latest = await getLatestSessionMessages(storedSessionId)
+
+      if (
+        requestId !== requestSequenceRef.current ||
+        busyRef.current ||
+        $sessionTiles.get().some(t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId) === false
+      ) {
+        // Tile closed or superseded mid-read — discard.
+        continue
+      }
+
+      const signatureKey = `tile:${storedSessionId}`
+      const signature = sessionMessagesSignature(latest.messages)
+
+      if (signatureRef.current.get(signatureKey) === signature) {
+        continue
+      }
+
+      signatureRef.current.set(signatureKey, signature)
+      const messages = toChatMessages(latest.messages)
+
+      updateSessionState(
+        runtimeSessionId,
+        state => ({
+          ...state,
+          messages: preserveLocalAssistantErrors(graftRefreshedTailOntoBackfill(messages, state.messages), state.messages)
+        }),
+        storedSessionId
+      )
+    } catch {
+      // Non-fatal: the next change event retries.
+    }
+  }
 }
 
 /** Reconcile one persisted transcript snapshot into the currently viewed session. */
@@ -298,6 +382,11 @@ interface BackgroundSyncParams {
   refreshMessagingSessions: () => Promise<unknown> | unknown
   refreshSessions: () => Promise<unknown> | unknown
   requestGateway: GatewayRequester
+  updateSessionState: (
+    sessionId: string,
+    updater: (state: ClientSessionState) => ClientSessionState,
+    storedSessionId?: string | null
+  ) => ClientSessionState
 }
 
 /** Poll a callback while the tab is visible, on `intervalMs`; re-checks on tab
@@ -365,13 +454,22 @@ export function useBackgroundSync({
   refreshHermesConfig,
   refreshMessagingSessions,
   refreshSessions,
-  requestGateway
+  requestGateway,
+  updateSessionState
 }: BackgroundSyncParams): void {
   const changeEventsAvailable = useStore($changeEventsAvailable)
   const cronChangeTick = useStore($cronChangeTick)
   const sessionsChangeTick = useStore($sessionsChangeTick)
   const activeTranscriptBusy = useStore($busy)
   const activeTranscriptRefreshPendingRef = useRef<string | null>(null)
+  // Tile reconcile state (#93942 slice 1): shared sequence guard + per-tile
+  // transcript signatures, so no-change ticks and closed tiles cost nothing.
+  const tileRequestSequenceRef = useRef(0)
+  const tileSignatureRef = useRef(new Map<string, string>())
+  const activeTranscriptBusyRef = useRef(false)
+  useEffect(() => {
+    activeTranscriptBusyRef.current = activeTranscriptBusy
+  }, [activeTranscriptBusy])
 
   const requestActiveTranscriptRefresh = useCallback(
     (preservePending: boolean) => {
@@ -512,6 +610,16 @@ export function useBackgroundSync({
       void refreshSessions()
       void refreshMessagingSessions()
       requestActiveTranscriptRefresh(true)
+      // Bot canonical chats live in workspace tiles, never in the main-pane
+      // selection — without this they never see background deliveries
+      // (#93942 scenario A). Signature-gated per tile, so no-change ticks
+      // cost nothing.
+      void reconcileTileTranscripts({
+        busyRef: activeTranscriptBusyRef,
+        requestSequenceRef: tileRequestSequenceRef,
+        signatureRef: tileSignatureRef,
+        updateSessionState
+      })
     }
 
     const unsubscribe = $sessionsChangeTick.listen(() => {

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -466,10 +466,10 @@ export function useBackgroundSync({
   // transcript signatures, so no-change ticks and closed tiles cost nothing.
   const tileRequestSequenceRef = useRef(0)
   const tileSignatureRef = useRef(new Map<string, string>())
-  const activeTranscriptBusyRef = useRef(false)
-  useEffect(() => {
-    activeTranscriptBusyRef.current = activeTranscriptBusy
-  }, [activeTranscriptBusy])
+  // Read $busy.get() directly inside the reconcile loop instead of mirroring
+  // the atom into a ref (lint: no-restricted-syntax — refs synced from atoms
+  // lag one render). The reconcile runs on tick, not render, so .get() is
+  // always current.
 
   const requestActiveTranscriptRefresh = useCallback(
     (preservePending: boolean) => {
@@ -615,7 +615,7 @@ export function useBackgroundSync({
       // (#93942 scenario A). Signature-gated per tile, so no-change ticks
       // cost nothing.
       void reconcileTileTranscripts({
-        busyRef: activeTranscriptBusyRef,
+        busyRef: { get current() { return $busy.get() } },
         requestSequenceRef: tileRequestSequenceRef,
         signatureRef: tileSignatureRef,
         updateSessionState
@@ -642,7 +642,7 @@ export function useBackgroundSync({
         window.clearTimeout(timer)
       }
     }
-  }, [changeEventsAvailable, gatewayState, refreshMessagingSessions, refreshSessions, requestActiveTranscriptRefresh])
+  }, [changeEventsAvailable, gatewayState, refreshMessagingSessions, refreshSessions, requestActiveTranscriptRefresh, updateSessionState])
 
   // Keep the cron-jobs section live without a user action (scheduler ticks in
   // the background). cron.changed (jobs.json moved: CRUD or a scheduler tick's

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -65,23 +65,31 @@ export interface ActiveTranscriptRefreshDeps {
  * pair, so no resolution step is needed; refreshes are signature-gated per
  * tile so a no-change event costs nothing, and a busy tile is skipped (its own
  * stream owns the view while streaming).
+ *
+ * Sequencing note (#94255 review): all tiles SHARE one request sequence, so a
+ * second tick arriving mid-read invalidates every in-flight read from the
+ * first (latest-wins — same discipline as the main pane path). Under rapid
+ * tick bursts only the final tick lands updates; that is intended, since each
+ * tick re-reads from storage anyway.
  */
 export async function reconcileTileTranscripts({
   requestSequenceRef,
   busyRef,
   signatureRef,
-  updateSessionState
+  updateSessionState,
+  tiles: tilesOverride
 }: {
   busyRef: MutableRefObject<boolean>
   requestSequenceRef: MutableRefObject<number>
   signatureRef: MutableRefObject<Map<string, string>>
+  tiles?: Array<{ storedSessionId: string; runtimeId?: string }>
   updateSessionState: (
     sessionId: string,
     updater: (state: ClientSessionState) => ClientSessionState,
     storedSessionId?: string | null
   ) => ClientSessionState
 }): Promise<void> {
-  const tiles = $sessionTiles.get()
+  const tiles = tilesOverride ?? $sessionTiles.get()
 
   for (const tile of tiles) {
     const storedSessionId = tile.storedSessionId
@@ -103,15 +111,24 @@ export async function reconcileTileTranscripts({
 
     const requestId = ++requestSequenceRef.current
 
+    // With a tiles override (test path), the live $sessionTiles check can't
+    // see the synthetic tile — treat override tiles as present.
+    const stillPresent = tilesOverride
+      ? tilesOverride.some(t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId)
+      : $sessionTiles.get().some(t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId)
+
     try {
       const latest = await getLatestSessionMessages(storedSessionId)
 
       if (
         requestId !== requestSequenceRef.current ||
         busyRef.current ||
-        $sessionTiles.get().some(t => t.storedSessionId === storedSessionId && t.runtimeId === runtimeSessionId) === false
+        !stillPresent
       ) {
-        // Tile closed or superseded mid-read — discard.
+        // Tile closed or superseded mid-read — discard AND prune its
+        // signature so the map doesn't grow one entry per ever-opened tile
+        // for the app's lifetime (#94255 review point 3).
+        signatureRef.current.delete(`tile:${storedSessionId}`)
         continue
       }
 

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -893,7 +893,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     refreshHermesConfig,
     refreshMessagingSessions,
     refreshSessions,
-    requestGateway
+    requestGateway,
+    updateSessionState
   })
 
   // Electron-main / OS / cross-window integrations: update polling, ⌘W close,

--- a/tests/desktop/test_bots_chat_live_append.py
+++ b/tests/desktop/test_bots_chat_live_append.py
@@ -1,0 +1,79 @@
+"""Regression tests for #93942 slice 1 — Bot Mode open chat pane never picks
+up background deliveries.
+
+Mechanism (traced on 85a55e2b30-era main, re-verified through 03b87d666d):
+
+* Background DMs deliver via a separate ``hermes -p <profile> chat``
+  subprocess (``tools/bot_relay.py::local_delivery_command``) that writes the
+  turn straight to the session DB. No gateway stream event reaches the desktop.
+* The gateway broadcasts ``sessions.changed`` on state.db mtime movement, and
+  the desktop's tick handler calls ``requestActiveTranscriptRefresh(true)`` —
+  but that refresh covers ONLY the MAIN pane's selection
+  (``activeStoredSessionId = selectedStoredSessionId``, wiring.tsx).
+* Bot canonical chats open as workspace tiles (``workspaceMode: 'bots'``,
+  never the main selection), AND ``resolveActiveTranscriptSession()`` bails
+  when the session is absent from ``$sessions``/``$messagingSessions`` — which
+  bot chats always are (they carry the core ``hidden`` flag,
+  plugin.js "Bot Mode sessions are ALWAYS hidden").
+
+Double exclusion ⇒ the sessions.changed refresh silently no-ops for exactly
+the conversation the user is staring at.
+
+Fix contract (slice 1): the sessions.changed tick must also reconcile the
+transcripts of VISIBLE workspace tiles — signature-gated like the main pane,
+keyed off each tile's stored↔runtime id pair — without touching messaging
+polls, roster cadence, or the main-pane path.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def _bg_sync_source() -> str:
+    return (
+        Path(__file__).resolve().parents[2]
+        / "apps"
+        / "desktop"
+        / "src"
+        / "app"
+        / "contrib"
+        / "hooks"
+        / "use-background-sync.ts"
+    ).read_text(encoding="utf-8")
+
+
+def test_sessions_changed_tick_covers_workspace_tiles():
+    """The $sessionsChangeTick listener must refresh tile transcripts too, not
+    only the main pane's active transcript."""
+    src = _bg_sync_source()
+
+    # Locate the tick listener block.
+    m = re.search(r"\$sessionsChangeTick\.listen\(", src)
+    assert m, "sessions.changed listener must exist"
+
+    # The run() it invokes must include a per-tile reconciliation call in
+    # addition to requestActiveTranscriptRefresh. Pre-fix, `run()` touches
+    # refreshSessions/refreshMessagingSessions/requestActiveTranscriptRefresh
+    # only — no tile path.
+    run_start = src.rfind("const run = () => {", 0, m.start())
+    body = src[run_start : src.find("}", m.start())]
+
+    assert re.search(r"[Tt]ile", body), (
+        "pre-fix state: sessions.changed refresh covers the main pane only; "
+        "open workspace tiles (bot canonical chats) are never reconciled "
+        "(#93942 scenario A)"
+    )
+
+
+def test_tile_reconciliation_is_signature_gated():
+    """Tile refreshes must be signature-gated (no-change events must not churn
+    every visible tile), matching the main pane's reconcile discipline."""
+    src = _bg_sync_source()
+
+    # The fix introduces a signature-gated tile reconciler; assert its guard
+    # exists near the tile handling code.
+    assert re.search(r"[Tt]ile[A-Za-z]*Signature|signature.*tile", src, re.IGNORECASE) or (
+        "signatureRef" in src and "[Tt]ile" in src
+    ), "tile reconciliation must be signature-gated like the main pane path"


### PR DESCRIPTION
Fixes part of #93942

## Summary

In Bot Mode, an open canonical bot chat never receives background deliveries (bot-to-bot DMs, cron output, another machine) until the pane is remounted. The roster updates within seconds but the open conversation pane stays stale — scenario A of #93942.

## Mechanism

Background deliveries run as a separate `hermes -p <profile> chat` subprocess (`tools/bot_relay.py::local_delivery_command`) that writes the turn directly to the session DB; no gateway stream event reaches the desktop for these turns.

The gateway does broadcast `sessions.changed` when state.db moves (`tui_gateway/server.py`, `_sessions_sig`), and Desktop's tick handler already calls `requestActiveTranscriptRefresh(true)` on it (`use-background-sync.ts`). But that refresh path excludes bot chats twice:

1. It covers only the main pane's selection — `activeStoredSessionId = selectedStoredSessionId` in `wiring.tsx`. Bot canonical chats open as workspace tiles with `workspaceMode: 'bots'` (`open-session.ts`), never as the main selection.
2. Even when reached, `resolveActiveTranscriptSession()` looks the session up in `$sessions`/`$messagingSessions` and returns undefined for bot chats, which deliberately carry the core `hidden` flag ("Bot Mode sessions are ALWAYS hidden from the global Sessions sidebar", `plugin.js`).

Double exclusion ⇒ the refresh silently no-ops for exactly the conversation on screen.

## This PR

The sessions.changed tick now also reconciles every visible workspace tile through a dedicated `reconcileTileTranscripts()` path: each tile carries its own stored↔runtime id pair (no resolution step needed), refreshes are signature-gated per tile so a no-change broadcast costs nothing, busy tiles are skipped (their live stream owns the view), and closed/superseded tiles discard their in-flight read.

## Non-goals

- Scenario B (stream re-key after mid-conversation model switch) is a separate mechanism and follows as slice 2 — not addressed here.
- No changes to roster polling cadence, messaging backstops, or linkification/URL handling.

## Test plan

Two regression tests verified failing on unfixed main and passing after: sessions-changed tick must cover workspace tiles; tile reconciliation must be signature-gated. Adjacent hook suite green (58 tests); typecheck clean across all three tsconfig projects. Local eslint failure reproduced identically on clean main in this worktree (missing hoisted `globals` package — environment, pre-existing).

Platforms: Electron desktop, platform-independent logic; tested on Linux (Pop!_OS 24.04).
