### PR TITLE
docs(whatsapp): expand Baileys vs Cloud rich-feature matrix

### DIFF
--- a/plugins/platforms/whatsapp/plugin.yaml
+++ b/plugins/platforms/whatsapp/plugin.yaml
@@ -6,8 +6,9 @@ description: >
   WhatsApp gateway adapter for Hermes Agent.
   Connects to WhatsApp via a local Node.js bridge (WhatsApp Web client) over
   an HTTP API and relays messages between WhatsApp chats and the Hermes agent.
-  Supports DM/group policies, mention gating, free-response chats, and
-  per-user allowlists.
+  Supports DM/group policies, mention gating, free-response chats, per-user
+  allowlists, native polls, location pins, inbound stickers/reactions/contacts,
+  and optional read receipts.
 author: NousResearch
 requires_env:
   - name: WHATSAPP_ENABLED

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -401,12 +401,22 @@ This uses your Nous Portal access token instead of needing a separate OpenAI key
 | Groups | Full support | DMs only (v1) |
 | 24h window | No restriction | Hard rule — templates required after |
 | Voice notes (out) | Native | Native with ffmpeg, MP3 fallback otherwise |
-| Read receipts | No | Yes (blue double-checkmarks) |
+| Read receipts | Optional (`send_read_receipts`) | Yes (blue double-checkmarks) |
 | Typing indicator | No | Yes (auto-dismisses on response) |
-| Interactive buttons | Text fallback only | Native (clarify, approval, slash-confirm) |
+| Interactive buttons | Text fallback; clarify can use native polls | Native (clarify, approval, slash-confirm) |
+| Native polls (out) | Yes (`/send-poll`; clarify-as-poll) | No |
+| Location pins (out) | Yes (`/send-location`) | No |
+| Location inbound | Native location / live location messages | Accepted as text context only |
+| Stickers inbound | Native sticker messages | Accepted as image media |
+| Contact cards inbound | Native contact messages | Accepted as text context only |
+| Reactions inbound | Native reaction messages | Not mapped as a first-class message type |
+| Message edit (out) | Yes (bridge `/edit`) | No Hermes edit path in v1 |
+| Stickers / reactions / contacts (out) | Not exposed as first-class agent send APIs | Cloud-only families (flows, payments, catalogs) not implemented |
 | Production use | Risky (Meta can ban) | Designed for it |
 
 Most users running Hermes for personal projects prefer Baileys. Most users running customer-facing bots prefer Cloud API.
+
+The rows above describe **what Hermes implements today**, not the full Meta product surface. Cloud-only product families such as Flows, payments, and catalogs are not Hermes features yet.
 
 ---
 

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -212,15 +212,18 @@ Code blocks and inline code are preserved as-is since WhatsApp supports triple-b
 
 When the agent calls tools (web search, file operations, etc.), WhatsApp displays real-time progress indicators showing which tool is running. This is enabled by default — no configuration needed.
 
-### Native Polls, Clarify-as-Poll, and Locations
+### Native Polls, Clarify-as-Poll, Locations, and Other Rich Inbound Types
 
 The Baileys-bridge adapter (bot mode) supports several native WhatsApp message types:
 
 - **Polls** — the agent can send a native WhatsApp poll (question + options) via the bridge's `/send-poll` endpoint. Poll votes flow back into the conversation.
 - **Clarify questions as polls** — when the agent asks a multiple-choice clarify question, it's rendered as a native single-select poll; tapping an option answers the question. If the poll fails to send, the adapter falls back to a plain text question. Approval prompts are **never** mapped onto polls — polls are only used for genuine multiple-choice clarifies.
 - **Location pins** — the agent can send a native location pin (latitude/longitude, optional name/address) via `/send-location`, and incoming shared locations (including live locations) are delivered to the agent as location messages.
+- **Stickers, reactions, and contact cards (inbound)** — the bridge decodes sticker, reaction, and contact payloads and delivers them to the agent. Hermes does not currently expose first-class agent APIs to *send* stickers, reactions, or contact cards on Baileys.
 
-All of this works out of the box in bot (Baileys) mode; no configuration needed.
+For a side-by-side Baileys vs Cloud capability matrix (including Cloud degradation for location/contacts/stickers), see [WhatsApp Cloud API Setup — Comparison to the Baileys bridge](whatsapp-cloud.md#comparison-to-the-baileys-bridge).
+
+All of the Baileys features above work out of the box in bot mode; no configuration needed.
 
 ### Message Batching (Debounce)
 


### PR DESCRIPTION
## Summary
- Expand the Baileys vs Cloud comparison table with rich-message capabilities Hermes actually implements (polls, locations, stickers, reactions, contacts, edits) and Cloud degradation paths.
- Correct the Baileys read-receipt row (`send_read_receipts` is optional, not absent) and note clarify-as-poll.
- Document inbound stickers/reactions/contacts on the Baileys guide and point to the matrix.
- Widen `plugins/platforms/whatsapp/plugin.yaml` description so it matches shipped behavior.

Fixes #80108.

## Evidence used
- Baileys: `plugins/platforms/whatsapp/adapter.py` (`send_poll`, `send_location`, `edit_message`, sticker inbound)
- Bridge decode: `scripts/whatsapp-bridge/bridge_helpers.js` (contact, reaction, poll_update)
- Cloud mapping: `gateway/platforms/whatsapp_cloud.py` sticker→PHOTO; location/contacts→TEXT; no `send_poll`/`send_location`

## Test plan
- [x] Diff-only docs/plugin metadata; no runtime code paths changed
- [x] Table claims cross-checked against the files above on current `main`
- [ ] Docs site preview (optional maintainer check)