### PR TITLE
fix(e2e): unbreak Install & Update E2E (MITM proxy keep-alive, Node CA trust, uv fixture)

### DIFF
--- a/scripts/sandbox/proxy.py
+++ b/scripts/sandbox/proxy.py
@@ -30,8 +30,20 @@ ROOT, CERTS, REAL_CA = map(pathlib.Path, sys.argv[1:])
 
 LISTEN_ADDRESS = ('127.0.0.1', 8080)
 MAX_REQUEST_BYTES = 65536
-UPSTREAM_TIMEOUT_SECONDS = 30
+# Cap on a single upstream connect; generous because it now also bounds the
+# idle time between keep-alive requests on a reused connection.
+UPSTREAM_IDLE_SECONDS = 30
 CERT_VALIDITY_DAYS = 2
+
+
+def strip_proxy_headers(request):
+    """Drop hop-by-hop proxy headers from an inner (tunneled) request."""
+    headers, separator, body = request.partition(b'\r\n\r\n')
+    lines = [
+        line for line in headers.split(b'\r\n')
+        if not line.lower().startswith((b'proxy-', b'proxy-connection:'))
+    ]
+    return b'\r\n'.join(lines) + separator + body
 
 
 def read_request(conn):
@@ -151,11 +163,56 @@ def relay(source, destination):
 
 
 def forward_https(conn, host, port, request):
+    # Keep the tunnel open for as long as BOTH peers want it: npm reuses
+    # keep-alive sockets aggressively, and serving a single request per
+    # CONNECT turns every reused socket into a dead tunnel (client sees
+    # unexpected EOF / SSLEOF; retries exhaust; install fails).
+    #
+    # Two pumps run concurrently: client->upstream (new requests) and
+    # upstream->client (responses). Each ends when its peer EOFs or errors;
+    # when either side finishes, the whole tunnel is torn down.
     context = ssl.create_default_context(cafile=str(REAL_CA))
-    with socket.create_connection((host, port), timeout=UPSTREAM_TIMEOUT_SECONDS) as raw:
-        with context.wrap_socket(raw, server_hostname=host) as upstream:
-            upstream.sendall(close_request(request))
-            relay(upstream, conn)
+    try:
+        raw = socket.create_connection((host, port), timeout=UPSTREAM_IDLE_SECONDS)
+        upstream = context.wrap_socket(raw, server_hostname=host)
+    except OSError:
+        return
+
+    def c2u():
+        # Client requests: forward verbatim (minus hop-by-hop headers).
+        # `request` is the first one, already read by handle_connect.
+        try:
+            upstream.sendall(strip_proxy_headers(request))
+            while True:
+                req = read_request(conn)
+                if not req:
+                    break
+                upstream.sendall(strip_proxy_headers(req))
+        except OSError:
+            pass
+        finally:
+            try:
+                upstream.shutdown(socket.SHUT_WR)
+            except OSError:
+                pass
+
+    t = threading.Thread(target=c2u, daemon=True)
+    t.start()
+    try:
+        while True:
+            chunk = upstream.recv(65536)
+            if not chunk:
+                break
+            conn.sendall(chunk)
+    except OSError:
+        pass
+    finally:
+        try:
+            conn.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+        t.join(timeout=5)
+        upstream.close()
 
 
 def forward_http(conn, host, port, request, target):
@@ -163,7 +220,7 @@ def forward_http(conn, host, port, request, target):
     path = parsed.path or '/'
     if parsed.query:
         path += f'?{parsed.query}'
-    with socket.create_connection((host, port), timeout=UPSTREAM_TIMEOUT_SECONDS) as upstream:
+    with socket.create_connection((host, port), timeout=UPSTREAM_IDLE_SECONDS) as upstream:
         upstream.sendall(close_request(request, path))
         relay(upstream, conn)
 

--- a/scripts/sandbox/proxy.py
+++ b/scripts/sandbox/proxy.py
@@ -24,6 +24,7 @@ import ssl
 import subprocess
 import sys
 import threading
+import time
 from urllib.parse import unquote, urlsplit
 
 ROOT, CERTS, REAL_CA = map(pathlib.Path, sys.argv[1:])
@@ -172,11 +173,19 @@ def forward_https(conn, host, port, request):
     # upstream->client (responses). Each ends when its peer EOFs or errors;
     # when either side finishes, the whole tunnel is torn down.
     context = ssl.create_default_context(cafile=str(REAL_CA))
-    try:
-        raw = socket.create_connection((host, port), timeout=UPSTREAM_IDLE_SECONDS)
-        upstream = context.wrap_socket(raw, server_hostname=host)
-    except OSError:
-        return
+    upstream = None
+    # A transient upstream connect/TLS failure looks like "empty reply" to the
+    # client, which reads as a broken installer rather than a network blip.
+    # Retry the handshake a few times before giving up on this tunnel.
+    for attempt in range(3):
+        try:
+            raw = socket.create_connection((host, port), timeout=UPSTREAM_IDLE_SECONDS)
+            upstream = context.wrap_socket(raw, server_hostname=host)
+            break
+        except OSError:
+            if attempt == 2:
+                return
+            time.sleep(1)
 
     def c2u():
         # Client requests: forward verbatim (minus hop-by-hop headers).

--- a/scripts/sandbox/stage2-run.sh
+++ b/scripts/sandbox/stage2-run.sh
@@ -216,7 +216,7 @@ exec bwrap \
   --setenv CURL_CA_BUNDLE /work/certs/ca.pem \
   --setenv SSL_CERT_FILE /work/certs/ca.pem \
   --setenv GIT_SSL_CAINFO /work/certs/ca.pem \
-  --setenv NODE_EXTRA_CA_CERTS /work/certs/real-ca.pem \
+  --setenv NODE_EXTRA_CA_CERTS /work/certs/ca.pem \
   --setenv OPENSSL_CONF /work/certs/openssl.cnf \
   --setenv HTTP_PROXY http://127.0.0.1:8080 \
   --setenv HTTPS_PROXY http://127.0.0.1:8080 \

--- a/tests/install/install-update-e2e.sh
+++ b/tests/install/install-update-e2e.sh
@@ -255,24 +255,40 @@ require_hermes_works() {
 }
 
 # ── install the earlier Hermes ─────────────────────────────────────────────
-# Prefetch the astral.sh uv installer so the sandbox can serve it as a
-# fixture. Best-effort with retries: if every attempt fails we proceed
-# without the fixture and let the in-sandbox curl try upstream itself.
+# Prefetch the astral.sh uv installer AND binary so the sandbox serves them as
+# fixtures. astral.sh's CDN and the GitHub release mirror intermittently return
+# empty replies to GitHub runner egress IPs (curl 52), which fails the install
+# at its first step. Best-effort: if prefetching fails we proceed without the
+# fixture and let the in-sandbox curl try upstream itself.
 UV_INSTALLER_FIXTURE=""
 if command -v curl >/dev/null 2>&1; then
   UV_FIXTURE_DIR="$LOG_DIR/http-fixture"
+  UV_SCRIPT="$UV_FIXTURE_DIR/astral.sh/uv/install.sh"
   mkdir -p "$UV_FIXTURE_DIR/astral.sh/uv"
   for _attempt in 1 2 3 4 5; do
     if curl -fsSL --retry 3 --retry-delay 2 https://astral.sh/uv/install.sh \
-        -o "$UV_FIXTURE_DIR/astral.sh/uv/install.sh" 2>/dev/null \
-       && [ -s "$UV_FIXTURE_DIR/astral.sh/uv/install.sh" ]; then
+        -o "$UV_SCRIPT" 2>/dev/null && [ -s "$UV_SCRIPT" ]; then
       UV_INSTALLER_FIXTURE="$UV_FIXTURE_DIR"
       break
     fi
     sleep 3
   done
 fi
+# Also cache the uv tarball for both download hosts the installer tries, keyed
+# by the version the fetched installer resolves to.
 if [ -n "$UV_INSTALLER_FIXTURE" ]; then
+  UV_VER="$(grep -om1 'releases/download/[0-9][0-9.]*' "$UV_SCRIPT" | cut -d/ -f3)"
+  if [ -n "$UV_VER" ]; then
+    _uv_rel="github/uv/releases/download/$UV_VER/uv-x86_64-unknown-linux-gnu.tar.gz"
+    mkdir -p "$UV_FIXTURE_DIR/releases.astral.sh/$(dirname "$_uv_rel")" \
+             "$UV_FIXTURE_DIR/github.com/astral-sh/$(dirname "${_uv_rel#github/}")"
+    curl -fsSL --retry 3 --retry-delay 2 \
+      "https://releases.astral.sh/$_uv_rel" \
+      -o "$UV_FIXTURE_DIR/releases.astral.sh/$_uv_rel" 2>/dev/null \
+      && cp "$UV_FIXTURE_DIR/releases.astral.sh/$_uv_rel" \
+         "$UV_FIXTURE_DIR/github.com/astral-sh/${_uv_rel#github/}" \
+      || echo "⚠ could not prefetch uv $UV_VER tarball; binary will fetch upstream" >&2
+  fi
   ok "prefetched uv installer for sandbox fixture"
 else
   echo "⚠ could not prefetch uv installer; install will fetch astral.sh directly" >&2

--- a/tests/install/install-update-e2e.sh
+++ b/tests/install/install-update-e2e.sh
@@ -188,6 +188,14 @@ install_in_sandbox() {
   local log="$LOG_DIR/$tag.log"
   local args=(install --persistent)
   [ -n "$ref" ] && args+=(--install-ref "$ref")
+  # Serve the uv installer script from the sandbox's fixture root: astral.sh
+  # intermittently returns empty replies to GitHub runner egress IPs, which
+  # kills the install with a bare `curl: (52)` that looks like a broken
+  # installer. Prefetch it once on the runner (with retries) and let the MITM
+  # proxy serve the copy; the binary download it performs still goes upstream.
+  if [ -n "$UV_INSTALLER_FIXTURE" ]; then
+    args+=(--http-root "$UV_INSTALLER_FIXTURE")
+  fi
 
   # Installer flags have to match the installer being run, not this checkout's.
   # Older releases reject options added later ("Unknown option: --skip-browser"),
@@ -247,6 +255,29 @@ require_hermes_works() {
 }
 
 # ── install the earlier Hermes ─────────────────────────────────────────────
+# Prefetch the astral.sh uv installer so the sandbox can serve it as a
+# fixture. Best-effort with retries: if every attempt fails we proceed
+# without the fixture and let the in-sandbox curl try upstream itself.
+UV_INSTALLER_FIXTURE=""
+if command -v curl >/dev/null 2>&1; then
+  UV_FIXTURE_DIR="$LOG_DIR/http-fixture"
+  mkdir -p "$UV_FIXTURE_DIR/astral.sh/uv"
+  for _attempt in 1 2 3 4 5; do
+    if curl -fsSL --retry 3 --retry-delay 2 https://astral.sh/uv/install.sh \
+        -o "$UV_FIXTURE_DIR/astral.sh/uv/install.sh" 2>/dev/null \
+       && [ -s "$UV_FIXTURE_DIR/astral.sh/uv/install.sh" ]; then
+      UV_INSTALLER_FIXTURE="$UV_FIXTURE_DIR"
+      break
+    fi
+    sleep 3
+  done
+fi
+if [ -n "$UV_INSTALLER_FIXTURE" ]; then
+  ok "prefetched uv installer for sandbox fixture"
+else
+  echo "⚠ could not prefetch uv installer; install will fetch astral.sh directly" >&2
+fi
+
 step "installing upstream $INSTALL_REF (real curl | install.sh: uv, Python, Node, venv)"
 install_in_sandbox "install of upstream $INSTALL_REF" "$INSTALL_REF" install
 


### PR DESCRIPTION
## Summary

Every scheduled **Install & Update E2E** run has failed since ~Aug 20 — the `installer` legs die with hundreds of `proxy request failed: SSLEOFError` followed by `✗ npm install failed or timed out`, while `update` legs stay green. Three root causes, all fixed here:

### 1. Node.js didn't trust the sandbox MITM CA
The sandbox proxy re-signs upstream TLS certs with a throwaway CA. curl/git/python trust it via `CURL_CA_BUNDLE`/`SSL_CERT_FILE`/`GIT_SSL_CAINFO`, but `NODE_EXTRA_CA_CERTS` pointed at `real-ca.pem` (public roots only) — so npm rejected every proxied connection. One-line fix in `stage2-run.sh`.

### 2. The MITM proxy served one request per CONNECT tunnel
`forward_https` forced `Connection: close` upstream and relayed a single response before tearing the tunnel down. npm aggressively reuses keep-alive sockets, so every reused socket hit a dead tunnel → client abort mid-read → SSLEOF → retries exhausted → fatal. The proxy now pumps the tunnel in both directions for its whole life (client→upstream request thread + upstream→client relay loop), and retries transient upstream connect failures instead of surfacing them as bare `curl: (52)`.

### 3. astral.sh / GitHub release CDN empty replies on runner IPs
Even with 1+2 fixed, installs intermittently died at the first step: `https://astral.sh/uv/install.sh` and both uv tarball hosts return `curl: (52) Empty reply from server` to GitHub runner egress IPs (confirmed by empty proxy logs — the CDN dropped the connection before/without proxy errors). The E2E now prefetches the uv installer script and tarball once on the runner with retries and serves them from the sandbox's existing fixture root (`--http-root`); the checksum is inline in the installer so no extra fixture is needed.

## Verification

- Local repro through the patched proxy: a 5-package dependency tree (81 modules) installs cleanly; the unpatched proxy failed even 3 packages.
- Full CI run on this exact commit tree (`FixItFoundry/hermes-agent` run 32784432692): ✅ installer leg (2m48s), ✅ update leg (5m18s) — first green since Aug 20 after 9+ consecutive reds.