### PR TITLE
fix(desktop): strip live session tiles from saved layout presets

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/preset-tree.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/preset-tree.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+
+import { allPaneIds, group, split } from './model'
+import { isPresetExcludedPaneId, stripPresetLivePanes } from './preset-tree'
+
+describe('stripPresetLivePanes', () => {
+  it('drops session tiles and keeps structural rails', () => {
+    const tree = split(
+      'row',
+      [
+        group(['sessions', 'preview'], { active: 'sessions', id: 'grp-sessions' }),
+        group(['workspace', 'session-tile:20260823_193634_728a24', 'session-tile:20260823_193532_a7dbd9'], {
+          active: 'session-tile:20260823_193634_728a24',
+          id: 'grp-main'
+        }),
+        group(['files'], { active: 'files', id: 'grp-files' })
+      ],
+      [1, 3.4, 1.25],
+      'spl-root'
+    )
+
+    const next = stripPresetLivePanes(tree)
+
+    expect(next).not.toBeNull()
+    expect(allPaneIds(next!)).toEqual(['sessions', 'preview', 'workspace', 'files'])
+    expect(next).toMatchObject({
+      type: 'split',
+      id: 'spl-root',
+      children: [{ id: 'grp-sessions' }, { id: 'grp-main', active: 'workspace', panes: ['workspace'] }, { id: 'grp-files' }]
+    })
+  })
+
+  it('drops preview-tile:undefined and route tiles, then collapses the empty zone', () => {
+    const tree = split('row', [
+      group(['workspace'], { active: 'workspace', id: 'grp-main' }),
+      group(['preview-tile:undefined', 'route-tile:skills'], { active: 'preview-tile:undefined', id: 'grp-ghost' })
+    ])
+
+    const next = stripPresetLivePanes(tree)
+
+    expect(next).toMatchObject({ type: 'group', id: 'grp-main', panes: ['workspace'] })
+    expect(allPaneIds(next!)).not.toEqual(expect.arrayContaining(['preview-tile:undefined', 'route-tile:skills']))
+  })
+
+  it('returns the same reference when the tree is already clean', () => {
+    const tree = group(['workspace', 'files'], { active: 'workspace', id: 'grp-main' })
+
+    expect(stripPresetLivePanes(tree)).toBe(tree)
+  })
+
+  it('returns null when a preset is only live tiles (nothing structural left)', () => {
+    const tree = group(['session-tile:abc', 'preview-tile:file:/tmp/x'], { active: 'session-tile:abc', id: 'only' })
+
+    expect(stripPresetLivePanes(tree)).toBeNull()
+  })
+
+  it('classifies the prefixes the field report baked into user-jrl', () => {
+    expect(isPresetExcludedPaneId('session-tile:20260823_193634_728a24')).toBe(true)
+    expect(isPresetExcludedPaneId('preview-tile:undefined')).toBe(true)
+    expect(isPresetExcludedPaneId('route-tile:page')).toBe(true)
+    expect(isPresetExcludedPaneId('workspace')).toBe(false)
+    expect(isPresetExcludedPaneId('hermes-bots:pane')).toBe(false)
+    expect(isPresetExcludedPaneId('terminal')).toBe(false)
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/preset-tree.ts
+++ b/apps/desktop/src/components/pane-shell/tree/preset-tree.ts
@@ -1,0 +1,46 @@
+/**
+ * User layout presets are geometry (splits, rails, weights), not a snapshot of
+ * live conversations. Saving `session-tile:<id>` / `preview-tile:*` / `route-tile:*`
+ * into `hermes.desktop.layoutPresets.v2` remounts those chats on apply
+ * (`session.resume` → agent init) across profiles, then the tile WS drops and
+ * the gateway `ws_orphan_reap`s the runtime (#94260).
+ *
+ * #92818 / PRs that strip preview tiles from the *persisted live tree* do not
+ * cover this path: presets clone the live tree via `saveLayoutPresetTree`.
+ */
+
+import { type LayoutNode, normalize } from './model'
+
+/** Panes that must never ride along in a named layout preset. */
+export const PRESET_EXCLUDED_PANE_PREFIXES = ['session-tile:', 'preview-tile:', 'route-tile:'] as const
+
+export const isPresetExcludedPaneId = (paneId: string): boolean =>
+  PRESET_EXCLUDED_PANE_PREFIXES.some(prefix => paneId.startsWith(prefix))
+
+/**
+ * Pure copy of `tree` without live/ephemeral tile panes. Empty groups collapse
+ * via `normalize`. Returns `null` only when nothing structural remains.
+ */
+export function stripPresetLivePanes(tree: LayoutNode): LayoutNode | null {
+  const walk = (node: LayoutNode): LayoutNode => {
+    if (node.type === 'group') {
+      const panes = node.panes.filter(paneId => !isPresetExcludedPaneId(paneId))
+
+      if (panes.length === node.panes.length) {
+        return node
+      }
+
+      return { ...node, panes, active: panes.includes(node.active) ? node.active : (panes[0] ?? '') }
+    }
+
+    const children = node.children.map(walk)
+
+    if (children.every((child, i) => child === node.children[i])) {
+      return node
+    }
+
+    return { ...node, children }
+  }
+
+  return normalize(walk(tree))
+}

--- a/apps/desktop/src/components/pane-shell/tree/presets.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/presets.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { allPaneIds, group, split } from './model'
+
+const USER_KEY = 'hermes.desktop.layoutPresets.v2'
+
+function dirtyJrlTree() {
+  return split(
+    'row',
+    [
+      group(['sessions', 'preview'], { active: 'sessions', id: 'grp-sessions' }),
+      group(['workspace', 'session-tile:20260823_193634_728a24'], {
+        active: 'session-tile:20260823_193634_728a24',
+        id: 'grp-main'
+      }),
+      group(['preview-tile:undefined'], { active: 'preview-tile:undefined', id: 'grp-ghost' })
+    ],
+    [1, 3.4, 1],
+    'spl-root'
+  )
+}
+
+describe('user layout presets strip live tiles (#94260)', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('heals a stored preset that baked in session and preview tiles', async () => {
+    window.localStorage.setItem(
+      USER_KEY,
+      JSON.stringify({ 'user-jrl': { name: 'JRL', tree: dirtyJrlTree() } })
+    )
+
+    await import('./presets')
+
+    const stored = JSON.parse(window.localStorage.getItem(USER_KEY) ?? 'null') as {
+      'user-jrl': { name: string; tree: ReturnType<typeof dirtyJrlTree> }
+    }
+
+    expect(stored['user-jrl'].name).toBe('JRL')
+    expect(allPaneIds(stored['user-jrl'].tree)).toEqual(['sessions', 'preview', 'workspace'])
+    expect(allPaneIds(stored['user-jrl'].tree).some(id => id.startsWith('session-tile:'))).toBe(false)
+    expect(allPaneIds(stored['user-jrl'].tree)).not.toContain('preview-tile:undefined')
+  })
+
+  it('saves only geometry, not the open session tiles', async () => {
+    const { saveLayoutPresetTree } = await import('./presets')
+
+    const id = saveLayoutPresetTree('JRL', dirtyJrlTree())
+
+    expect(id).toBe('user-jrl')
+
+    const stored = JSON.parse(window.localStorage.getItem(USER_KEY) ?? 'null') as {
+      'user-jrl': { tree: ReturnType<typeof dirtyJrlTree> }
+    }
+
+    expect(allPaneIds(stored['user-jrl'].tree)).toEqual(['sessions', 'preview', 'workspace'])
+  })
+
+  it('applies a dirty snapshot without resurrecting baked-in session tiles', async () => {
+    const store = await import('./store')
+    const apply = vi.spyOn(store, 'applyTree')
+    const { applyLayoutPreset } = await import('./presets')
+
+    applyLayoutPreset('user-jrl', dirtyJrlTree())
+
+    expect(apply).toHaveBeenCalledTimes(1)
+    const passed = apply.mock.calls[0]?.[0]
+    expect(passed).toBeDefined()
+    expect(allPaneIds(passed!)).toEqual(['sessions', 'preview', 'workspace'])
+    apply.mockRestore()
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/presets.ts
+++ b/apps/desktop/src/components/pane-shell/tree/presets.ts
@@ -12,6 +12,7 @@ import { registry } from '@/contrib/registry'
 import { readJson, writeJson, writeKey } from '@/lib/storage'
 
 import { isLayoutNode, type LayoutNode } from './model'
+import { stripPresetLivePanes } from './preset-tree'
 import { $layoutTree, applyTree, markActivePreset } from './store'
 
 export const LAYOUTS_AREA = 'layouts'
@@ -31,11 +32,29 @@ const userDisposers = new Map<string, () => void>()
 function loadUserPresets(): Record<string, StoredPreset> {
   const parsed = readJson<Record<string, StoredPreset>>(USER_KEY) ?? {}
   const out: Record<string, StoredPreset> = {}
+  let healed = false
 
   for (const [id, preset] of Object.entries(parsed)) {
-    if (preset && typeof preset.name === 'string' && isLayoutNode(preset.tree)) {
-      out[id] = preset
+    if (!preset || typeof preset.name !== 'string' || !isLayoutNode(preset.tree)) {
+      continue
     }
+
+    const tree = stripPresetLivePanes(preset.tree)
+
+    if (!tree) {
+      healed = true
+      continue
+    }
+
+    if (tree !== preset.tree) {
+      healed = true
+    }
+
+    out[id] = { name: preset.name, tree }
+  }
+
+  if (healed) {
+    persistUserPresets(out)
   }
 
   return out
@@ -68,6 +87,12 @@ export function saveLayoutPresetTree(name: string, tree: LayoutNode): string | n
     return null
   }
 
+  const geometry = stripPresetLivePanes(tree)
+
+  if (!geometry) {
+    return null
+  }
+
   const id = `user-${
     trimmed
       .toLowerCase()
@@ -75,7 +100,7 @@ export function saveLayoutPresetTree(name: string, tree: LayoutNode): string | n
       .replace(/^-+|-+$/g, '') || Date.now().toString(36)
   }`
 
-  userPresets[id] = { name: trimmed, tree }
+  userPresets[id] = { name: trimmed, tree: geometry }
   persistUserPresets(userPresets)
   registerUserPreset(id, userPresets[id])
   markActivePreset(id)
@@ -107,5 +132,13 @@ export const isUserPreset = (id: string) => id in userPresets
 
 /** Apply a preset's tree (deep-cloned so live edits never mutate the preset). */
 export function applyLayoutPreset(id: string, tree: LayoutNode) {
-  applyTree(structuredClone(tree), id)
+  const geometry = stripPresetLivePanes(structuredClone(tree))
+
+  if (!geometry) {
+    return
+  }
+
+  // applyTree adopts currently-open tiles (session tabs, previews) into the
+  // new geometry — they must not come from the snapshot (#94260).
+  applyTree(geometry, id)
 }


### PR DESCRIPTION
## What does this PR do?

User-saved Desktop layouts (`saveLayoutPresetTree` / `hermes.desktop.layoutPresets.v2`) cloned the **live** tree, including `session-tile:<storedSessionId>`, `preview-tile:*`, and `route-tile:*`. Applying that snapshot remounted those conversations (`session.resume` → agent init) across profiles — the layout tree is global — then the tile WebSocket dropped and the gateway `ws_orphan_reap`'d the runtime. The UI kept RPCing the dead id and sometimes showed **Turn failed / agent init failed: xAI OAuth state is missing access_token** when a remounted Grok tile landed on the default/root home.

This PR treats presets as **geometry only**. `applyTree` already adopts currently-open tiles into the new arrangement, so open tabs stay put; they just no longer come from the snapshot.

This does **not** change `persist()` of the live `layoutTree.v2`. That path is #92818 / #93179 / #93202 (preview tiles across *restarts*). Those PRs do not touch presets or `session-tile:`.

## Related Issue

Fixes #94260

Related: #92818

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/pane-shell/tree/preset-tree.ts` — `stripPresetLivePanes()` (pure)
- `apps/desktop/src/components/pane-shell/tree/presets.ts` — strip on save, apply, and load (heals existing dirty presets)
- `preset-tree.test.ts` / `presets.test.ts` — 8 tests

## How to Test

1. `cd apps/desktop && npm run test:ui -- src/components/pane-shell/tree/preset-tree.test.ts src/components/pane-shell/tree/presets.test.ts` — 8 passed
2. Manual (Windows, 2+ profiles): open session tabs from different profiles, save a named layout, switch to Default, apply the saved layout. Session tabs that were **already open** should be adopted into the new geometry; chats that were only in the snapshot should **not** remount / `session.resume`. `hermes.desktop.layoutPresets.v2` should no longer contain `session-tile:` or `preview-tile:undefined`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched existing PRs to make sure this isn't a duplicate (#93179 / #93202 cover persist of preview tiles, not presets)
- [x] My PR contains only changes related to this fix
- [x] Targeted desktop vitest: 8 passed
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation updates — N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md / AGENTS.md — N/A
- [x] Cross-platform impact considered — renderer-only TypeScript
- [x] Tool descriptions/schemas — N/A