### PR TITLE
fix(profiles): flatten structured message previews

### DIFF
--- a/agent/message_content.py
+++ b/agent/message_content.py
@@ -37,6 +37,8 @@ def flatten_message_text(content: Any, *, sep: str = "\n") -> str:
         return ""
     if isinstance(content, str):
         return content
+    if isinstance(content, Mapping):
+        return _text_from_part(content)
     if isinstance(content, list):
         chunks = [_text_from_part(part) for part in content]
         return sep.join(chunk for chunk in chunks if chunk)
@@ -44,6 +46,8 @@ def flatten_message_text(content: Any, *, sep: str = "\n") -> str:
     text = _text_from_part(content)
     if text:
         return text
+    if _field(content, "type") is not None:
+        return ""
     try:
         return str(content)
     except Exception:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -10293,6 +10293,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # surrogate as \udXXX — already safe to bind.
             return cls._CONTENT_JSON_PREFIX + json.dumps(content)
         except (TypeError, ValueError):
+            try:
+                part_type = getattr(content, "type", None)
+            except Exception:
+                part_type = None
+            if part_type is not None:
+                try:
+                    from agent.message_content import flatten_message_text
+
+                    return _sanitize_surrogates(flatten_message_text(content))
+                except Exception:
+                    pass
             # Last-resort fallback: stringify so persistence never fails.
             return _sanitize_surrogates(str(content))
 

--- a/tests/agent/test_message_content.py
+++ b/tests/agent/test_message_content.py
@@ -23,3 +23,21 @@ def test_flatten_message_text_accepts_object_parts():
     ]
 
     assert flatten_message_text(content) == "object text\nlegacy content"
+
+
+def test_flatten_message_text_omits_top_level_image_mapping():
+    content = {
+        "type": "image_url",
+        "image_url": {"url": "https://example.invalid/private.png"},
+    }
+
+    assert flatten_message_text(content) == ""
+
+
+def test_flatten_message_text_omits_top_level_image_object():
+    content = SimpleNamespace(
+        type="image_url",
+        image_url={"url": "https://example.invalid/private.png"},
+    )
+
+    assert flatten_message_text(content) == ""

--- a/tests/tui_gateway/test_profiles_list_canonical_session.py
+++ b/tests/tui_gateway/test_profiles_list_canonical_session.py
@@ -26,6 +26,8 @@ Contract under test:
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 import tui_gateway.server as srv
@@ -97,6 +99,111 @@ def test_canonical_session_is_the_bot_chat_row_not_latest(home):
     assert "forever chat content" in canonical["preview"]
     # last_session keeps its own contract: the most recently active session.
     assert row["last_session"]["id"] == "other1"
+
+
+def test_profile_session_previews_flatten_structured_message_content(home):
+    db = _db(home)
+    _add_session(
+        db,
+        "structured1",
+        title="Bot Chat",
+        ts=1000,
+        text=[
+            {"type": "output_text", "text": "structured preview"},
+            {"type": "image_url", "image_url": {"url": "https://example.invalid/private.png"}},
+        ],
+    )
+    db.close()
+
+    row = _row(_profiles({}), "default")
+
+    assert row["canonical_session"]["preview"] == "structured preview"
+    assert row["last_session"]["preview"] == "structured preview"
+
+
+def test_profile_session_previews_omit_top_level_image_mapping(home):
+    db = _db(home)
+    _add_session(
+        db,
+        "image1",
+        title="Bot Chat",
+        ts=1000,
+        text={
+            "type": "image_url",
+            "image_url": {"url": "https://example.invalid/private.png"},
+        },
+    )
+    db.close()
+
+    row = _row(_profiles({}), "default")
+
+    assert row["canonical_session"]["preview"] == ""
+    assert row["last_session"]["preview"] == ""
+
+
+def test_profile_session_previews_omit_malformed_structured_content(home):
+    db = _db(home)
+    _add_session(
+        db,
+        "corrupt1",
+        title="Bot Chat",
+        ts=1000,
+        text="seed",
+    )
+    malformed = (
+        '\x00json:{"type":"image_url","image_url":'
+        '{"url":"https://example.invalid/private.png"}'
+    )
+    conn = db._conn
+    assert conn is not None
+    with db._lock:
+        conn.execute(
+            "UPDATE messages SET content = ? WHERE session_id = ?",
+            (malformed, "corrupt1"),
+        )
+    db.close()
+
+    row = _row(_profiles({}), "default")
+
+    assert row["canonical_session"]["preview"] == ""
+    assert row["last_session"]["preview"] == ""
+
+
+def test_profile_session_previews_flatten_nonserializable_text_object(home):
+    db = _db(home)
+    _add_session(
+        db,
+        "object-text1",
+        title="Bot Chat",
+        ts=1000,
+        text=SimpleNamespace(type="output_text", text="object preview"),
+    )
+    db.close()
+
+    row = _row(_profiles({}), "default")
+
+    assert row["canonical_session"]["preview"] == "object preview"
+    assert row["last_session"]["preview"] == "object preview"
+
+
+def test_profile_session_previews_omit_nonserializable_image_object(home):
+    db = _db(home)
+    _add_session(
+        db,
+        "object-image1",
+        title="Bot Chat",
+        ts=1000,
+        text=SimpleNamespace(
+            type="image_url",
+            image_url={"url": "https://example.invalid/private.png"},
+        ),
+    )
+    db.close()
+
+    row = _row(_profiles({}), "default")
+
+    assert row["canonical_session"]["preview"] == ""
+    assert row["last_session"]["preview"] == ""
 
 
 def test_canonical_session_resolves_hidden_row(home):

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -55,7 +55,17 @@ def _(rid, params: dict) -> dict:
             return ""
         if not row:
             return ""
-        text = " ".join(str(row[0] or "").split()).strip()
+        from agent.message_content import flatten_message_text
+
+        raw = row[0]
+        decoded = db._decode_content(raw)
+        if (
+            isinstance(raw, str)
+            and raw.startswith(db._CONTENT_JSON_PREFIX)
+            and decoded == raw
+        ):
+            return ""
+        text = " ".join(flatten_message_text(decoded).split()).strip()
         if len(text) > 80:
             return text[:80] + "..."
         return text


### PR DESCRIPTION
## Summary

- decode persisted structured/multimodal message content before building `profiles.list` previews
- flatten previews to visible text for list, mapping, and typed object content parts
- fail closed for malformed sentinel payloads and omit non-text media metadata, including image URLs

## Root cause

`profiles.list` previously converted the raw SQLite `content` value directly to `str`. Structured content is stored behind `SessionDB._CONTENT_JSON_PREFIX`, so previews could expose the encoded payload or a Python representation instead of user-visible text. Empty non-text parts also fell through to `str(...)`, which could expose image URLs.

This change reuses the existing `flatten_message_text` contract, decodes persisted content first, and makes structured non-text fallbacks fail closed.

## Verification

- TDD regressions observed RED before each production fix and GREEN afterward
- `scripts/run_tests.sh tests/agent/test_message_content.py tests/tui_gateway/test_profiles_list_canonical_session.py tests/hermes_state/test_append_messages_batch.py tests/run_agent/test_66267_multimodal_interim.py`: **39 passed**
- broader affected contour: **1069 passed**; one unrelated FTS trace assertion reproduced identically on clean `main`
- `uvx ruff check .`: passed
- `scripts/check-windows-footguns.py --all`: passed, 1010 files scanned
- `ty`: 0 diagnostics on the 151 changed lines (186 pre-existing diagnostics in the checked legacy files)
- full `scripts/run_tests.sh`: no new reproducible failures; **30 files / 74 tests failed**, exactly matching the clean local `main` baseline
- independent fail-closed review: passed with no security or logic findings

## Update safety

The maintained branch was updated through Hermes' official `updates.parked_branch_strategy: update_in_place` path. It reached `behind 0`, preserved the feature commit behind a pre-update safety tag, and the post-update PR patch was byte-identical to the reviewed patch.
