### PR TITLE
fix(desktop): public_url must not gate Desktop-private loopback backends

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -725,6 +725,8 @@ def should_require_auth(host: str, allow_public: bool = False) -> bool:
 def should_require_dashboard_auth(
     host: str,
     trusted_public_hosts: Optional[frozenset[str]] = None,
+    *,
+    desktop_private: bool = False,
 ) -> bool:
     """Return whether the dashboard auth gate must be active.
 
@@ -732,7 +734,14 @@ def should_require_dashboard_auth(
     ``dashboard.public_url`` requires authentication even when a reverse proxy
     reaches a backend bound to loopback. Callers may pass the already-resolved
     host set so startup and request validation use the same snapshot.
+
+    Desktop-spawned profile backends are private, ephemeral loopback listeners;
+    the configured public dashboard URL does not route to them. They retain the
+    per-process session-token boundary minted by Desktop. A non-loopback bind
+    remains gated regardless of this flag.
     """
+    if desktop_private and not should_require_auth(host):
+        return False
     if trusted_public_hosts is None:
         trusted_public_hosts = _dashboard_public_hosts()
     return should_require_auth(host) or any(
@@ -19393,7 +19402,9 @@ def start_server(
     # WS-auth paths can branch on it consistently. It also decides whether to
     # refuse startup, log the gate-on banner, and enable uvicorn proxy_headers.
     app.state.auth_required = should_require_dashboard_auth(
-        host, app.state.trusted_public_hosts
+        host,
+        app.state.trusted_public_hosts,
+        desktop_private=os.environ.get("HERMES_DESKTOP") == "1",
     )
 
     # ``--insecure`` no longer disables the auth gate (June 2026 hardening:

--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -255,6 +255,19 @@ def test_public_url_aware_gate_preserves_local_only_mode(monkeypatch):
     assert should_require_dashboard_auth("127.0.0.1") is False
 
 
+def test_public_url_does_not_gate_desktop_private_loopback_backend(monkeypatch):
+    """Desktop's ephemeral loopback backend keeps its minted-token auth."""
+    from hermes_cli.web_server import should_require_dashboard_auth
+
+    monkeypatch.setenv(
+        "HERMES_DASHBOARD_PUBLIC_URL",
+        "https://dashboard.example.test:9443",
+    )
+    assert should_require_dashboard_auth(
+        "127.0.0.1", desktop_private=True
+    ) is False
+
+
 def test_start_server_loopback_public_url_enables_gate(monkeypatch):
     """A declared external URL turns a loopback reverse proxy into gated mode."""
     from hermes_cli.dashboard_auth import clear_providers, register_provider


### PR DESCRIPTION
## Problem

When `dashboard.public_url` is configured, every Desktop-spawned profile backend fails WebSocket auth (`/api/ws` returns 401). All local profiles show as disconnected in Desktop even though the gateway itself is healthy.

## Root cause

Desktop spawns per-profile backends as **private, ephemeral loopback listeners** protected by a minted per-process session token. The configured `dashboard.public_url` never routes to them. But `should_require_dashboard_auth()` treated the public-URL declaration as global, forcing OAuth onto these private backends and breaking their token handshake.

This reproduces on any machine where Desktop runs alongside a configured Tailscale/reverse-proxy dashboard URL. The public dashboard itself was never affected; only the private profile backends were collateral damage.

## Fix

Add a keyword-only `desktop_private` flag to `should_require_dashboard_auth()`:

- Set from `HERMES_DESKTOP == "1"` at server startup only
- Carve-out applies **only when the bind host is loopback** (non-loopback binds remain gated regardless)
- Genuinely public dashboards keep authentication unchanged
- Per-process session-token boundary remains active for Desktop backends

## Verification

- Test suite: 29 passed / 2 failed in `tests/hermes_cli/test_dashboard_auth_gate.py`
- Both failures were proven **pre-existing on pristine upstream** by stashing the patch and re-running: clean HEAD shows 28 passed / same 2 failures. The patch adds one passing regression test and breaks nothing.
- Live regression test on the affected machine: all 21 local profiles connect under the device, `/api/ws` auth succeeds, Telegram gateway stayed running throughout.

Patch developed by a Codex seat, verified independently before commit.