### PR TITLE
fix(tests): repair three test-isolation leaks in tests/gateway

### DIFF
--- a/tests/gateway/test_discord_imports.py
+++ b/tests/gateway/test_discord_imports.py
@@ -14,6 +14,20 @@ class TestDiscordImportSafety:
                 raise ImportError("discord unavailable for test")
             return original_import(name, globals, locals, fromlist, level)
 
+        # Snapshot what is cached right now so the broken copy this test is
+        # about to create can be swapped back out at the end.
+        import plugins.platforms as platforms_pkg
+
+        _MISSING = object()
+        saved_modules = {
+            name: sys.modules.get(name)
+            for name in (
+                "plugins.platforms.discord.adapter",
+                "plugins.platforms.discord",
+            )
+        }
+        saved_parent_attr = getattr(platforms_pkg, "discord", _MISSING)
+
         # Purge the cached module so the import below actually re-runs the
         # module body with discord.py simulated-missing.
         monkeypatch.delitem(sys.modules, "plugins.platforms.discord.adapter", raising=False)
@@ -24,3 +38,24 @@ class TestDiscordImportSafety:
 
         assert module.DISCORD_AVAILABLE is False
         assert module.discord is None
+
+        # The import above cached a discord-less copy of the adapter under its
+        # real name and rebound it on the parent package. monkeypatch.delitem
+        # only restores what was there before, so when the module had not been
+        # imported yet that broken copy would survive this test and every later
+        # one would see ``discord is None``.
+        #
+        # Put back the exact module objects that were cached on entry (or drop
+        # them when there were none). Restoring the original objects rather
+        # than re-importing matters: fixtures built from the old module object
+        # keep patching the same one the code under test uses.
+        for name, original in saved_modules.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+        if saved_parent_attr is _MISSING:
+            if hasattr(platforms_pkg, "discord"):
+                delattr(platforms_pkg, "discord")
+        else:
+            platforms_pkg.discord = saved_parent_attr

--- a/tests/gateway/test_session_store_prune.py
+++ b/tests/gateway/test_session_store_prune.py
@@ -31,10 +31,19 @@ def test_session_store_default_db_uses_runtime_hermes_home(tmp_path, monkeypatch
     hermes_state before a fixture redirected HERMES_HOME used to pin every
     default SessionDB() at the developer's real ~/.hermes/state.db.
     """
+    import hermes_state
+
     config = GatewayConfig(default_reset_policy=SessionResetPolicy(mode="none"))
     fake_home = tmp_path / "alt_hermes_home"
     fake_home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(fake_home))
+    # The hermetic conftest re-points DEFAULT_DB_PATH at its own sandbox, and a
+    # re-pointed constant takes precedence over the runtime lookup in
+    # _default_db_path(). Put the import-time value back for this test so the
+    # HERMES_HOME fallback is the branch actually under test.
+    monkeypatch.setattr(
+        hermes_state, "DEFAULT_DB_PATH", hermes_state._IMPORT_DEFAULT_DB_PATH
+    )
 
     with patch("gateway.session.SessionStore._ensure_loaded"):
         store = SessionStore(sessions_dir=tmp_path / "sessions", config=config)

--- a/tests/gateway/test_telegram_polling_health_confirmation.py
+++ b/tests/gateway/test_telegram_polling_health_confirmation.py
@@ -46,6 +46,11 @@ class TestPollingHealthConfirmation:
         must not spam one INFO per getUpdates poll."""
         a = _bare_adapter()
         a._record_polling_progress(1)  # first — logs
+        # caplog collects for the whole test, not just the at_level block, so
+        # the first call lands in caplog.records as soon as some earlier test
+        # leaves this logger at INFO. Drop what came before to assert only on
+        # the calls under test.
+        caplog.clear()
         with caplog.at_level(logging.INFO, logger="plugins.platforms.telegram.adapter"):
             a._record_polling_progress(1)  # second — silent
             a._record_polling_progress(1)  # third — silent


### PR DESCRIPTION
## What does this PR do?

Fixes three independent test-isolation bugs in `tests/gateway/`. Each of the six affected tests passes on its own and fails in a full `pytest tests/gateway/` run, so the failures look flaky while the causes are deterministic — each is one test leaving global state behind for the next.

**1. `test_discord_imports` leaks a discord-less adapter module.**

The test simulates a missing `discord.py` and re-imports `plugins.platforms.discord.adapter` so the module body runs with the dependency unavailable. That import caches the resulting copy under the real module name and rebinds it on the parent package. `monkeypatch.delitem` only restores what was cached on entry, so when the adapter had not been imported yet, nothing was restored and the broken copy survived for the rest of the process.

Four tests died on `AttributeError: None has no attribute 'File'` as a result:

- `test_discord_send.py::test_send_video_uses_path_based_files_kwarg`
- `test_discord_send.py::test_send_video_fails_loud_when_message_has_no_attachments`
- `test_discord_send.py::test_send_file_attachment_forum_uses_files_kwarg`
- `test_send_multiple_images.py::TestDiscordMultiImage::test_url_batch_follows_safe_redirect_location_header`

The fix snapshots the cached module objects and the parent-package attribute on entry and puts them back at the end. Restoring the original objects rather than re-importing matters: fixtures built from the old module object keep patching the same one the code under test uses. (Re-importing instead makes `test_url_batch_follows_safe_redirect_location_header` fail, because its `adapter` fixture then patches a different module object than the one running.)

**2. `test_subsequent_progress_is_silent` reads records from before its `at_level` block.**

The test primes `_record_polling_progress` once outside the block — the call that is *meant* to log — then asserts no `confirmed healthy` record was captured for the two calls inside it. But `caplog` collects for the whole test, so the priming call is captured as soon as any earlier test leaves the `plugins.platforms.telegram.adapter` logger at INFO, and the assertion fails on a record the test itself provoked. A `caplog.clear()` after the priming call scopes the assertion to the calls under test.

**3. `test_session_store_default_db_uses_runtime_hermes_home` never reaches the branch it is named after.**

The test sets `HERMES_HOME` and expects `SessionDB` to resolve its default path from it. `_default_db_path()` gives precedence to a re-pointed `DEFAULT_DB_PATH`, and the hermetic conftest re-points that constant at its own sandbox — so the first branch always wins and the assertion compares the sandbox path against the fixture path. Restoring the import-time value for the duration of the test makes the runtime lookup reachable. `HERMES_HOME` still points at the `tmp_path` fixture, so no real `state.db` is touched.

## Related Issue

No issue filed. On the third commit: #94004 and #50695 both work on the production side of this default-path resolution. This change is test-only and touches no `hermes_state.py`, so it should not conflict with either.

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tests/gateway/test_discord_imports.py` — snapshot and restore `sys.modules` entries and the parent-package attribute around the simulated-missing-dependency import
- `tests/gateway/test_telegram_polling_health_confirmation.py` — `caplog.clear()` after the priming call
- `tests/gateway/test_session_store_prune.py` — restore the import-time `DEFAULT_DB_PATH` so the `HERMES_HOME` fallback is exercised

No production code is touched.

## How to Test

1. Reproduce the leak in isolation:
   `pytest tests/gateway/test_discord_imports.py tests/gateway/test_discord_send.py -q`
   — 3 failed before, 12 passed after.
2. Same for the caplog bleed, which needs a run where something leaves the logger at INFO:
   `pytest tests/gateway/ -q` — `test_subsequent_progress_is_silent` failed before, passes after.
3. Full suite: `pytest tests/gateway/ -q` — **6228 passed, 29 skipped, 1 xfailed, 0 failed** (was 6 failed).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (three test files, one commit each)
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran `pytest tests/gateway/ -q` (6228 passed, 0 failed), which covers every test involved. The full `tests/` suite was not run.
- [x] I've added tests for my changes — N/A, this repairs existing tests
- [x] I've tested on my platform: Debian 13 (trixie), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — the fixes are platform-independent (`sys.modules` bookkeeping, caplog scoping, a module constant); only tested on Linux
- [x] I've updated tool descriptions/schemas — N/A
