### PR TITLE
fix(desktop): keep modal context menus inside dialogs

### DIFF
--- a/apps/desktop/src/app/context-menu/app-context-menu.test.tsx
+++ b/apps/desktop/src/app/context-menu/app-context-menu.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { registerTerminalContextMenu } from '@/app/right-sidebar/terminal/terminal-context-menu'
 import { ContextMenu, ContextMenuTrigger, HERMES_CONTEXT_MENU_TRIGGER_ATTR } from '@/components/ui/context-menu'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { formatCombo } from '@/lib/keybinds/combo'
 import { $previewTabs, closeRightRail } from '@/store/preview'
 import { $connection } from '@/store/session'
@@ -82,6 +83,13 @@ describe('resolveDomTarget', () => {
 
     expect(resolveDomTarget(host.querySelector('textarea')).editable).toBeTruthy()
     expect(resolveDomTarget(host.querySelector('input')).editable).toBeNull()
+  })
+
+  it('resolves the enclosing dialog as the menu portal container', () => {
+    const host = attach('<div data-slot="dialog-content"><a href="https://example.com">link</a></div>')
+    const dialog = host.firstElementChild
+
+    expect(resolveDomTarget(host.querySelector('a')).dialogPortalContainer).toBe(dialog)
   })
 })
 
@@ -197,6 +205,43 @@ describe('AppContextMenu', () => {
 
     await waitFor(() => expect(contextMenuEdit).toHaveBeenCalledWith('copy'))
     expect($contextMenu.get()).toBeNull()
+    expect(document.activeElement).toBe(textarea)
+  })
+
+  it('keeps a modal textarea paste menu inside its dialog and restores focus', async () => {
+    const contextMenuEdit = vi.fn().mockResolvedValue(undefined)
+
+    installBridge({
+      contextMenuEdit: contextMenuEdit as unknown as Window['hermesDesktop']['contextMenuEdit'],
+      readClipboard: vi.fn().mockResolvedValue('clipboard payload')
+    })
+    render(
+      <MemoryRouter>
+        <AppContextMenu />
+        <Dialog open>
+          <DialogContent>
+            <DialogTitle>Modal editor</DialogTitle>
+            <textarea aria-label="modal textarea" />
+          </DialogContent>
+        </Dialog>
+      </MemoryRouter>
+    )
+    const textarea = screen.getByLabelText('modal textarea')
+
+    fireEvent.contextMenu(textarea)
+
+    const paste = (await screen.findByText('Paste')).closest('[data-slot="dropdown-menu-item"]') as HTMLElement
+
+    await waitFor(() => expect(paste.getAttribute('data-disabled')).toBeNull())
+
+    const menu = paste.closest('[data-slot="dropdown-menu-content"]')
+    const dialog = screen.getByRole('dialog')
+
+    expect(dialog.contains(menu)).toBe(true)
+
+    fireEvent.click(paste)
+
+    await waitFor(() => expect(contextMenuEdit).toHaveBeenCalledWith('paste'))
     expect(document.activeElement).toBe(textarea)
   })
 

--- a/apps/desktop/src/app/context-menu/app-context-menu.tsx
+++ b/apps/desktop/src/app/context-menu/app-context-menu.tsx
@@ -690,6 +690,7 @@ export function AppContextMenu() {
         align="start"
         className="w-56"
         onCloseAutoFocus={event => event.preventDefault()}
+        portalContainer={open.kind === 'dom' ? open.target.dialogPortalContainer : undefined}
         side="bottom"
       >
         {sections.map((section, index) => (

--- a/apps/desktop/src/app/context-menu/target.ts
+++ b/apps/desktop/src/app/context-menu/target.ts
@@ -8,6 +8,8 @@
  */
 
 export interface ContextMenuDomTarget {
+  /** The enclosing dialog content node, when the click landed inside one. */
+  dialogPortalContainer: HTMLElement | null
   /** The clicked editable, when the click landed in one. */
   editable: HTMLElement | null
   /** `href` of the enclosing anchor, as written (never absolutized). */
@@ -39,10 +41,12 @@ function editableFrom(element: Element | null): HTMLElement | null {
 
 export function resolveDomTarget(element: Element | null): ContextMenuDomTarget {
   const anchor = element?.closest('a[href]')
+  const dialogContent = element?.closest('[data-slot="dialog-content"]')
   const image = element?.closest('img')
   const linkUrl = anchor?.getAttribute('href')?.trim() ?? ''
 
   return {
+    dialogPortalContainer: dialogContent instanceof HTMLElement ? dialogContent : null,
     editable: editableFrom(element),
     // A placeholder anchor is not a link the menu can act on.
     linkUrl: linkUrl === '#' ? '' : linkUrl,

--- a/apps/desktop/src/components/ui/dropdown-menu.tsx
+++ b/apps/desktop/src/components/ui/dropdown-menu.tsx
@@ -71,12 +71,16 @@ function DropdownMenuSearch({
 function DropdownMenuContent({
   className,
   collisionPadding = 8,
+  portalContainer,
   sideOffset = 4,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
-  // Portal into the enclosing dialog when nested in one, so dismissing the menu
-  // doesn't close the dialog; document.body otherwise.
-  const container = usePopoverPortalContainer()
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content> & {
+  portalContainer?: HTMLElement | null
+}) {
+  // An explicit target-owned container supports global menus whose component
+  // lives outside the dialog's React context. Nested menus still inherit the
+  // enclosing dialog; everything else falls back to document.body.
+  const container = usePopoverPortalContainer(portalContainer)
 
   return (
     <DropdownMenuPrimitive.Portal container={container}>


### PR DESCRIPTION
## What does this PR do?

Keeps the app-wide Desktop context menu inside the modal dialog containing the element that was right-clicked.

`AppContextMenu` is mounted above individual dialogs, so it cannot inherit `DialogPortalContainerContext`. Its dropdown therefore fell back to `document.body` even when the click target was a textarea inside a modal. That moved the menu outside the dialog's focus boundary and could leave paste operating without the original field focused.

The DOM target resolver now records the enclosing dialog content node. `DropdownMenuContent` accepts that target-owned node as an explicit portal container while preserving the existing inherited-dialog and `document.body` fallbacks. This covers every DOM-owned global menu inside a modal, including inputs, textareas, links, and images.

## Related Issue

None. Reported through support.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Capture the enclosing `[data-slot="dialog-content"]` when resolving a DOM context-menu target.
- Allow shared dropdown content to use an explicit portal container for global menus outside a dialog's React context.
- Portal `AppContextMenu` into the target dialog when applicable.
- Add a Radix modal regression covering clipboard-enabled Paste, dialog containment, command dispatch, and focus restoration.

## How to Test

1. Open a Desktop modal containing an editable field, such as the Create Bot dialog's optional SOUL field.
2. Right-click the field and choose Paste.
3. Confirm the context menu stays inside the modal, Paste targets the field, and the field remains focused.

Focused verification:

- `npm run test:ui -- src/app/context-menu/app-context-menu.test.tsx` (36 passed)
- `npm run typecheck`
- `npm exec -- eslint src/app/context-menu/app-context-menu.test.tsx src/app/context-menu/app-context-menu.tsx src/app/context-menu/target.ts src/components/ui/dropdown-menu.tsx` (0 errors; existing restricted-global warnings in the test file)
- Prettier check on all four changed files

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not applicable to this Desktop-only TypeScript change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

No visual changes. The focused renderer regression passes all 36 tests and Desktop TypeScript typechecking passes.