### PR TITLE
feat: add deterministic tool capability catalog

### DIFF
--- a/docs/rfcs/2026-08-deepseek-harness-absorption.md
+++ b/docs/rfcs/2026-08-deepseek-harness-absorption.md
@@ -1,0 +1,255 @@
+# Research spike: absorbing DeepSeek Harness patterns into Hermes
+
+**Status:** Phase 0/1 implementation candidate; not merged, later phases remain proposed
+**Audited source:** `deepseek-ai/deepseek-harness` at commit `b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`
+**Audited package:** `@deepseek-ai/dsh@0.1.1-rc.2`
+**Method:** static source, documentation, manifest, workflow, package metadata, dependency, and secret-pattern inspection. No DeepSeek Harness CLI, Web application, provider login, plugin, installer, shell runtime, model call, server, MCP connection, lifecycle script, or hook was executed.
+
+## Decision
+
+Hermes remains the runtime. DeepSeek Harness is an untrusted reference implementation, not a dependency, embedded runtime, or replacement.
+
+The useful ideas are translated into Hermes-native contracts and tests. Source is not copied. The design must preserve Hermes's existing multichannel delivery, profile isolation, approvals, prompt-cache stability, toolset routing, durable memory, plugin ownership ledger, and fail-closed security controls.
+
+## Evidence classification
+
+| Classification | Meaning |
+|---|---|
+| Verified implementation | Confirmed in the pinned source tree or package metadata. |
+| First-party claim | Documented by the project but not runtime-certified here. |
+| Video/third-party claim | Secondary evidence; not authoritative. |
+| Auditor inference | A reasoned design conclusion, explicitly not a source claim. |
+
+Notable corrections:
+
+- The project is a large modular runtime, not a thin DeepSeek wrapper. Its profiles compose Cordis plugins for models, tools, sessions, persistence, credentials, telemetry, sandboxing, UI, and extensions (`docs/architecture.md`, `packages/bundle/base/cordis.patch.yml`).
+- It is not DeepSeek-model-only; its provider guide covers Anthropic, OpenAI, Bedrock, Vertex, Azure, Codex authentication, and OpenAI-compatible gateways (`docs/user/guide/providers.md`).
+- The trajectory UI records provider-returned reasoning blocks, messages, tool activity, timing, and tokens. That is not evidence of access to hidden private chain-of-thought (`packages/client/ui-trajectory/README.md`).
+- Worker-thread separation is an execution mechanism, not an OS security boundary. The project says its code-mode and dynamic Cordis paths must not be treated as security sandboxes (`packages/code-runtime/code-runtime/README.md`, `packages/extensions/tool-cordis/README.md`).
+- Current popularity is real, but the video claim that the project reached 100K stars in two days was not independently verified.
+
+## Current Hermes baseline
+
+Hermes already contains more of the desired architecture than a superficial comparison suggests:
+
+- a central, generation-tracked, profile-scoped tool registry with plugin override authorization and reversible restoration (`tools/registry.py`);
+- deferred tool loading and toolset gating (`model_tools.py`, `tools/tool_search_tool.py`);
+- lifecycle hooks, observer-first monitoring, plugin ownership ledgers, profile scoping, and fail-closed security-adjacent paths (`hermes_cli/plugins.py`, `hermes_cli/lifecycle.py`);
+- rich desktop tool timelines and progress events (`apps/desktop/src/components/assistant-ui/thread/timeline.tsx`);
+- durable session storage, local search, compaction, trace export/upload, and child-agent live transcripts (`hermes_state.py`, `agent/trace_upload.py`, `tools/delegation_live_log.py`);
+- bounded delegation with depth/concurrency limits, pause/steer/stop, schema-constrained child output, cancellation propagation, and parent/child identity (`tools/delegate_tool.py`);
+- MCP transport, native plugins, skills, cron, Kanban, background processes, browser/CDP, typed browser, desktop control, and multichannel delivery;
+- monitoring that intentionally excludes prompts, messages, tool arguments/results, usage analytics, and traces by default (`hermes monitoring status`).
+
+Therefore the absorption program should close specific gaps rather than re-platform Hermes.
+
+### Independent comparison synthesis
+
+Three source-grounded comparison tracks converged on the same boundary:
+
+1. **Capability reporting is the safest first foundation.** Hermes already has enough registry, toolset, plugin ownership, profile isolation, and capability-consent metadata to derive a control-plane report. It should add no model tool, prompt content, dispatch path, approval behavior, or plugin loading side effect (`tools/registry.py`, `toolsets.py`, `model_tools.py`, `hermes_cli/plugins.py`, `hermes_cli/plugin_capabilities.py`).
+2. **The smallest observability slice is durable tool-result presentation metadata, not a second session store.** Persist bounded `status`, `duration_ms`, and `is_error` facts through existing session rows and gateway hydration, then render them consistently after resume in Desktop and TUI. A canonical run-event envelope can follow in shadow mode after this compatibility seam is proven (`hermes_state_common.py`, `hermes_state.py`, gateway session hydration, Desktop timeline, TUI message rendering).
+3. **Hermes is ahead on durable autonomous operation but can tighten lifecycle precision.** Preserve restart-recoverable delegation, Kanban, cron, and background work; add common first-wins terminal settlement, owner-scoped teardown, bounded quiescence, and a distinction between wait timeout and execution cancellation rather than copying DeepSeek's process-local job model (`tools/delegate_tool.py`, background process registries, Kanban workers, cron runner).
+
+This ranks the work as: capability facts first; durable tool-execution metadata second; lifecycle/quiescence contracts third; broader trajectory/event and permission-policy work only after those seams are stable.
+
+## Adopt / adapt / isolate / reject
+
+| DeepSeek Harness pattern | Hermes decision | Rationale and Hermes-native form |
+|---|---|---|
+| Event-sourced trajectory model | **Adapt** | Hermes persists conversations and emits rich live events, but does not use one canonical durable event envelope for every model/tool/subagent transition. Add an additive run-event schema and adapters; do not rewrite message storage first. |
+| Trajectory inspector | **Adopt** | Extend the existing desktop timeline into a privacy-preserving inspector with turn/tool/subagent spans, search, timing, tokens, status, and local export. Do not persist hidden reasoning or expose content by default. |
+| Generated capability/config catalog | **Adopt now** | Generate a machine-readable, deterministic catalog from Hermes's registry. It becomes the basis for tool-diff gates, docs, delegation routing, and security review. Phase 1 must be read-only and must not run availability probes unless explicitly requested. |
+| Declarative profile/plugin composition | **Adapt** | Hermes already has toolsets, profiles, plugins, MCP, and scoped overlays. Add validated composition snapshots and diffs rather than importing Cordis or a second DI container. |
+| Reversible plugin effects | **Adopt/continue** | Extend Hermes's existing registration ownership ledger and CAS restoration to every plugin-owned hook, command, provider, and UI contribution. |
+| Provider-neutral adapters | **Continue** | Hermes already has runtime provider resolution and fallback routing. Focus on conformance tests and capability negotiation, not another adapter layer. |
+| Permission presets | **Adapt** | Use capability-based, resource-scoped policies: workspace paths, network destinations, subprocess, credentials, MCP, browser profile, persistence, and external actions. Avoid a single `danger-full-access` mode as a normal profile. |
+| Sandbox enforcement level reporting | **Adopt** | Report `enforced`, `partial`, `brokered`, `none`, and the dimensions covered. Never label worker threads or approval prompts as containment. |
+| Persistent interruption recovery | **Adopt/continue** | Hermes already recovers durable sessions and background work. Add explicit interrupted/cancelled/abandoned terminal states and orphan-resource checks to the run ledger. |
+| Dynamic self-modifying plugin generation | **Investigate only in isolation** | If explored, generate source into a review-only staging directory; no auto-load, no real credentials, no inherited environment, and no host execution. |
+| Worker thread as a sandbox | **Reject** | It is not a security boundary. Use brokered subprocess/container/microVM isolation for untrusted execution. |
+| Broad inherited environment and repository `.env` discovery | **Reject** | Preserve Hermes profile-scoped secret resolution and explicit credential routing. Child agents and plugins receive only declared capabilities. |
+| Public Web control surface without independently verified authentication | **Reject** | Existing Hermes gateway pairing, session authorization, and transport boundaries remain mandatory. |
+| Raw trajectory telemetry by default | **Reject** | Local-first, content-free health metrics by default; explicit opt-in export, schema allowlists, redaction, retention, deletion, and destination preview. |
+| Automatic plugin install/execute from model output | **Reject** | Separate generation, static review, operator approval, installation, and activation. |
+
+## Prioritized absorption roadmap
+
+### Phase 0 — immutable evidence and threat model
+
+Deliverables:
+
+1. This RFC and pinned source/package identifiers.
+2. A source-to-Hermes gap matrix.
+3. Explicit non-goals and security invariants.
+4. No runtime dependency on DeepSeek Harness.
+
+Gate: maintainer review confirms that the proposal complements rather than duplicates the existing plugin/event-bus roadmap.
+
+### Phase 1 — capability catalog and composition snapshot
+
+Build a deterministic, read-only Hermes tool catalog from the active profile's registry:
+
+- tool name, toolset, bounded registration-time origin class, validated environment-variable names (never values), async/sync, result bound, structural schema digest, and availability state; schema annotations/defaults, free-form descriptions, and suspicious environment declarations are omitted because plugin-controlled strings can contain paths, operator values, or secrets;
+- `available`, `unavailable`, or `unknown` availability, with `unknown` as the deterministic default for unprobed dynamic checks regardless of process-global probe-cache state;
+- platform selection status, explicitly distinct from dynamic availability, per-session policy, progressive disclosure, and final model exposure;
+- canonical JSON output suitable for CI diffing;
+- no absolute profile paths, secrets, credential values, tool arguments, or tool results.
+
+The command records plugin discovery honestly: `included` when explicitly requested, `preloaded` when plugin-origin tools were already present in the process-global registry, and `skipped` only when neither condition applies.
+
+Acceptance tests:
+
+- deterministic ordering and structural schema digest, independent of annotation text, defaults, set-like schema ordering, and profile-local paths;
+- default catalog generation invokes no `check_fn`;
+- explicit probe mode invokes each unique `check_fn` at most once and records failures without crashing the catalog;
+- profile-scoped plugin registrations do not leak into another profile snapshot;
+- MCP and plugin origins are distinguishable from built-ins without exposing implementation paths; MCP origin requires registration through the trusted native MCP boundary rather than a caller-controlled `mcp-` toolset label;
+- MCP selections use canonical `mcp-<server>` IDs so a server name cannot be confused with a built-in toolset;
+- credential-shaped identifier components are redacted even inside composed names such as `mcp-<server>`;
+- catalog generation never imports or executes an unrequested post-setup hook.
+- catalog generation does not mutate registry generation or invoke dynamic schema overrides;
+- default catalog startup does not create profile files, open persistent delegation state, restore queues, load external secrets, initialize file logging, clean quarantined executables, or sweep stale bytecode;
+- `selected_for_platform` is never presented as proof that a tool is model-exposed or authorized.
+
+Gate: catalog can be generated locally and in CI; snapshot diff is stable across identical configurations.
+
+### Phase 2 — durable tool-execution metadata, then canonical run events
+
+Start with a compatibility slice in the existing session model:
+
+- persist bounded tool execution `status`, `duration_ms`, and `is_error` metadata;
+- preserve it through session replay and gateway hydration;
+- render the same facts after resume in Desktop and TUI;
+- keep tool arguments/results and exception bodies outside the new metadata fields.
+
+Gate: old rows hydrate safely, interrupted/error/success states remain distinguishable after restart, and both presentation surfaces agree without requiring a storage rewrite.
+
+After that gate, add an additive versioned envelope for observable run transitions:
+
+```json
+{
+  "schema_version": 1,
+  "event_id": "sortable-id",
+  "session_id": "opaque-id",
+  "run_id": "opaque-id",
+  "parent_run_id": null,
+  "sequence": 42,
+  "timestamp": "RFC3339",
+  "kind": "tool.completed",
+  "status": "ok",
+  "duration_ms": 318,
+  "attributes": {},
+  "content_ref": null
+}
+```
+
+Rules:
+
+- event metadata and content are separate;
+- no hidden chain-of-thought field exists;
+- content is local-only and omitted from monitoring/export by default;
+- event IDs are deterministic within a persisted run and sequences are monotonic;
+- observer backpressure cannot block the model/tool hot path;
+- security/approval decisions fail closed and are durably distinguishable from errors.
+
+Acceptance tests:
+
+- model call, tool call/result, approval, compression, delegation spawn/steer/stop/complete, background process, cron/Kanban handoff, interrupt, and recovery all produce valid transitions;
+- duplicate completion is idempotent;
+- crash recovery closes in-flight spans as `interrupted` without inventing success;
+- content-free export contains no prompts, tool arguments/results, credentials, or filesystem payloads;
+- bounded queues drop/coalesce observer events according to a documented policy without changing agent behavior.
+
+Gate: shadow-write only, no model-loop or UI dependency; compare against existing messages/progress events for parity.
+
+### Phase 3 — desktop trajectory inspector
+
+Extend the existing desktop timeline instead of creating a second Web application:
+
+- filterable turn/tool/subagent/event timeline;
+- parent/child run graph;
+- latency, tokens, retries, cost where already available;
+- approval and policy decisions;
+- local redacted export and deletion controls;
+- clear labels for provider-returned reasoning summaries versus ordinary messages—never “complete thinking process.”
+
+Gate: inspector reads Phase 2 events but the agent remains fully functional if the inspector is absent or broken.
+
+### Phase 4 — orchestration contracts
+
+Use the run ledger to strengthen existing delegation/Kanban/cron contracts:
+
+- explicit parent/child lineage and ownership;
+- quiescence definition: no running child, process, pending delivery, or unresolved approval;
+- cancellation acknowledgement and bounded teardown;
+- orphan-resource detection;
+- budget envelopes for iterations, time, tokens, spend, subprocesses, and toolsets;
+- least-tool child routing derived from operator policy and capability catalog—not model choice.
+
+Gate: adversarial tests cover stuck children, late completions, duplicate wakeups, gateway restart, stale authority, and partial batch failure.
+
+### Phase 5 — permission policy and enforcement facts
+
+Introduce declarative policy evaluation while preserving existing approvals:
+
+- workspace/filesystem scopes;
+- subprocess and command classes;
+- network egress destinations and private-network denial;
+- credential aliases rather than values;
+- MCP server/tool allowlists;
+- browser profile and typed-browser trust class;
+- persistence and external-action scopes;
+- enforcement report per dimension: `enforced`, `partial`, `brokered`, or `none`.
+
+Gate: fail-closed negative tests and platform-specific containment tests. Documentation may not call a control a sandbox unless the asserted dimensions are actually enforced.
+
+### Phase 6 — review-gated extension generation
+
+Optional, isolated developer workflow only:
+
+1. generate source and manifest into staging;
+2. run static analysis and tests with scripts/network disabled;
+3. show capability diff and provenance;
+4. require operator approval;
+5. install disabled;
+6. activate in a disposable profile;
+7. support deterministic unload/rollback.
+
+Gate: no model-generated artifact can become executable or gain credentials in the same step that created it.
+
+## Security invariants
+
+1. DeepSeek Harness remains absent from Hermes runtime dependencies and plugin paths.
+2. No real repository, transcript, browser profile, cloud account, or production credential is used in comparative experiments.
+3. Trajectory data is local-first, bounded, redactable, deletable, and excluded from monitoring export by default.
+4. Reasoning visibility is limited to provider-returned content; hidden chain-of-thought is neither requested nor claimed.
+5. Tool/plugin capability grants are deny-by-default and profile-scoped.
+6. Worker threads, permission prompts, and path checks are not represented as OS containment.
+7. Public/LAN control surfaces require authenticated, authorized, session-bound transports.
+8. Generated extensions cannot install, load, execute, or persist themselves.
+9. Static inspection and unit tests do not certify runtime isolation; containment claims require adversarial platform tests.
+
+## Comparative evaluation
+
+Any isolated pilot must run identical synthetic tasks in Hermes and the pinned DeepSeek artifact and measure:
+
+- task completion and verification rate;
+- human intervention count;
+- tool calls, model calls, latency, tokens, and cost;
+- cancellation and restart recovery;
+- unauthorized access attempts and actual reachability;
+- event completeness, privacy leakage, and trajectory usefulness;
+- operational complexity and upgrade/rollback behavior.
+
+Immediate stop conditions: unexpected egress, host filesystem access outside the synthetic workspace, inherited real credentials, approval bypass, uncontrolled subprocess survival, raw telemetry, or cross-session/plugin leakage.
+
+## Deferred decisions
+
+- Whether run events live in a new append-only table or are derived from the existing message/event stores during the shadow phase.
+- Whether the canonical envelope should align directly with OpenTelemetry spans or remain a smaller Hermes schema with an OTLP adapter.
+- Which policy engine format, if any, should represent resource-scoped grants.
+- Whether content references should use encrypted blob storage, existing message rows, or no separate storage.
+- Whether capability metadata belongs on each tool registration, each action variant, or a separate policy registry. Static tool-level risk labels alone are too coarse for multi-action tools.
+
+These decisions must be made from Hermes requirements and tests, not copied from DeepSeek Harness.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -911,6 +911,9 @@ def ensure_hermes_home():
     recreated on the next load, as before). Profile switches change
     ``get_hermes_home()`` and therefore re-run for the new path.
     """
+    if os.getenv("HERMES_CATALOG_READONLY") == "1":
+        return
+
     home = get_hermes_home()
     key = str(home)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -74,6 +74,106 @@ suppress_platform_ver_console()
 import os
 import sys
 
+# ``tools catalog`` is an observation-only audit command. Establish the
+# contract before recovery, dotenv, config, logging, and tool modules import.
+# Match only a real top-level catalog invocation: arbitrary prompt/query text
+# containing the consecutive words ``tools catalog`` must not suppress normal
+# startup maintenance.
+def _is_catalog_readonly_argv(argv: list[str]) -> bool:
+    value_flags = {
+        "--usage-file",
+        "-m",
+        "--model",
+        "--provider",
+        "--reasoning",
+        "-t",
+        "--toolsets",
+        "--in",
+        "--skills",
+        "-s",
+        "--profile",
+        "-p",
+    }
+    disqualifying_flags = {
+        "-z",
+        "--oneshot",
+        "--resume",
+        "-r",
+        "--continue",
+        "-c",
+        "--worktree",
+        "-w",
+        "--version",
+        "-V",
+        "--tui",
+        "--cli",
+        "--dev",
+    }
+    boolean_flags = {
+        "--no-restore-cwd",
+        "--accept-hooks",
+        "--yolo",
+        "--pass-session-id",
+        "--ignore-user-config",
+        "--ignore-rules",
+        "--safe-mode",
+    }
+    long_value_flags = {flag for flag in value_flags if flag.startswith("--")}
+    # argparse accepts attached values for its short options (for example
+    # ``-mMODEL``). ``-p`` is pre-parsed separately by
+    # ``_apply_profile_override`` and intentionally accepts only ``-p value``.
+    short_value_flags = {
+        flag
+        for flag in value_flags
+        if flag.startswith("-") and not flag.startswith("--") and flag != "-p"
+    }
+    long_disqualifying_flags = {
+        flag for flag in disqualifying_flags if flag.startswith("--")
+    }
+    short_disqualifying_value_flags = {"-c", "-r"}
+
+    index = 0
+    while index < len(argv):
+        arg = argv[index]
+        if arg == "tools":
+            return argv[index : index + 2] == ["tools", "catalog"]
+        if arg == "--":
+            return False
+        if arg in disqualifying_flags or any(
+            arg.startswith(flag + "=") for flag in long_disqualifying_flags
+        ):
+            return False
+        if arg in value_flags:
+            if index + 1 >= len(argv):
+                return False
+            index += 2
+            continue
+        if any(arg.startswith(flag + "=") for flag in long_value_flags):
+            index += 1
+            continue
+        if any(arg.startswith(flag) and len(arg) > len(flag) for flag in short_value_flags):
+            index += 1
+            continue
+        if any(
+            arg.startswith(flag) and len(arg) > len(flag)
+            for flag in short_disqualifying_value_flags
+        ):
+            return False
+        if arg in boolean_flags:
+            index += 1
+            continue
+        return False
+    return False
+
+
+_CATALOG_READONLY = _is_catalog_readonly_argv(sys.argv[1:])
+if _CATALOG_READONLY:
+    os.environ["HERMES_CATALOG_READONLY"] = "1"
+else:
+    # This is an internal startup sentinel, not a user-facing mode switch.
+    # Ambient values must not suppress normal CLI initialization.
+    os.environ.pop("HERMES_CATALOG_READONLY", None)
+
 # ── Startup fast-path bootstrap ─────────────────────────────────────────
 # Two lines of inline path math so ``python hermes_cli/main.py`` (script
 # mode — sys.path[0] is hermes_cli/, not the repo root) can import the
@@ -97,10 +197,11 @@ from hermes_cli import _startup_fast  # noqa: E402
 # the full recovery path below.
 from hermes_cli import _early_recovery as _early_recovery_mod
 
-try:
-    _early_recovery_mod.recover_if_needed()
-except Exception:
-    pass
+if not _CATALOG_READONLY:
+    try:
+        _early_recovery_mod.recover_if_needed()
+    except Exception:
+        pass
 
 
 def _exit_after_oneshot(rc: object) -> None:
@@ -702,13 +803,19 @@ _apply_profile_override()
 # profiles resolve. The launcher dir itself is per-machine (the helper
 # anchors on the DEFAULT root, not HERMES_HOME), so profile sessions heal
 # the same shared dir.
-if sys.platform == "win32":
+def _repair_windows_launchers_if_needed() -> None:
+    """Repair shared Windows launchers unless this is an observation-only audit."""
+    if sys.platform != "win32" or _CATALOG_READONLY:
+        return
     try:
         from hermes_cli import _install_repair as _install_repair_mod
 
         _install_repair_mod.ensure_windows_bin_launchers(_bootstrap_root)
     except Exception:
         pass
+
+
+_repair_windows_launchers_if_needed()
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
@@ -722,10 +829,11 @@ from hermes_cli.env_loader import load_hermes_dotenv
 # flags have already been stripped above, so the first remaining argument is
 # the authoritative argparse subcommand.  Dotenv/managed config still loads;
 # only external secret fetches are unnecessary for installation maintenance.
-load_hermes_dotenv(
-    project_env=PROJECT_ROOT / ".env",
-    load_external_secrets=sys.argv[1:2] != ["update"],
-)
+if not _CATALOG_READONLY:
+    load_hermes_dotenv(
+        project_env=PROJECT_ROOT / ".env",
+        load_external_secrets=sys.argv[1:2] != ["update"],
+    )
 
 # Bridge security.redact_secrets from config.yaml → HERMES_REDACT_SECRETS env
 # var BEFORE hermes_logging imports agent.redact (which snapshots the flag at
@@ -775,19 +883,20 @@ except Exception:
 # (chat, setup, gateway, config, etc.) write to agent.log + errors.log.
 # Dashboard entrypoints bootstrap with GUI mode so gui.log is always present
 # during GUI testing, including pre-dispatch startup failures.
-try:
-    from hermes_logging import setup_logging as _setup_logging
+if not _CATALOG_READONLY:
+    try:
+        from hermes_logging import setup_logging as _setup_logging
 
-    _setup_logging(
-        mode=(
-            "gui"
-            if next((arg for arg in sys.argv[1:] if not arg.startswith("-")), "")
-            in {"dashboard", "serve", "gui", "desktop"}
-            else "cli"
+        _setup_logging(
+            mode=(
+                "gui"
+                if next((arg for arg in sys.argv[1:] if not arg.startswith("-")), "")
+                in {"dashboard", "serve", "gui", "desktop"}
+                else "cli"
+            )
         )
-    )
-except Exception:
-    pass  # best-effort — don't crash the CLI if logging setup fails
+    except Exception:
+        pass  # best-effort — don't crash the CLI if logging setup fails
 
 # Apply IPv4 preference early, before any HTTP clients are created.
 # We already determined whether to force IPv4 from the raw yaml read above —
@@ -12458,6 +12567,10 @@ def cmd_tools(args):
         from hermes_cli.tools_config import tools_disable_enable_command
 
         tools_disable_enable_command(args)
+    elif action == "catalog":
+        from hermes_cli.tools_config import tools_catalog_command
+
+        tools_catalog_command(args)
     elif action == "post-setup":
         from hermes_cli.tools_config import run_post_setup_command
 
@@ -12682,19 +12795,20 @@ def main():
     except Exception:
         pass
 
-    # Sweep stale ``hermes.exe.old.*`` quarantine files left by previous
-    # ``hermes update`` runs on Windows. Silent no-op on non-Windows or when
-    # there's nothing to clean. See ``_quarantine_running_hermes_exe``.
-    try:
-        _cleanup_quarantined_exes()
-    except Exception:
-        pass
+    if not _CATALOG_READONLY:
+        # Sweep stale ``hermes.exe.old.*`` quarantine files left by previous
+        # ``hermes update`` runs on Windows. Silent no-op on non-Windows or when
+        # there's nothing to clean. See ``_quarantine_running_hermes_exe``.
+        try:
+            _cleanup_quarantined_exes()
+        except Exception:
+            pass
 
-    # If the checkout changed since the last launch (hermes update, manual
-    # git pull, old-updater update that predates newer clears), sweep stale
-    # __pycache__ once so no process — this one's lazy imports included —
-    # resolves fresh source against old bytecode. Never raises.
-    _sweep_stale_bytecode_if_checkout_changed()
+        # If the checkout changed since the last launch (hermes update, manual
+        # git pull, old-updater update that predates newer clears), sweep stale
+        # __pycache__ once so no process — this one's lazy imports included —
+        # resolves fresh source against old bytecode. Never raises.
+        _sweep_stale_bytecode_if_checkout_changed()
 
     # Self-heal a venv left half-built by an interrupted ``hermes update``
     # (Ctrl-C, terminal close, WSL OOM mid-install). Skip when the user is
@@ -12707,7 +12821,7 @@ def main():
     # under-matching (missing ``hermes -p work update``) would race a recovery
     # install against the real one. Loose wins.
     try:
-        if "update" not in sys.argv[1:]:
+        if not _CATALOG_READONLY and "update" not in sys.argv[1:]:
             _recover_from_interrupted_install()
     except Exception:
         pass

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1778,6 +1778,7 @@ class PluginContext:
             emoji=emoji,
             override=override,
             scope=scope,
+            _registration_owner=self._manager._policy_module_name(self.manifest),
         )
         registered = registry.snapshot_registration(name, scope=scope)
         if (

--- a/hermes_cli/subcommands/tools.py
+++ b/hermes_cli/subcommands/tools.py
@@ -73,6 +73,40 @@ def build_tools_parser(subparsers, *, cmd_tools: Callable) -> None:
         help="Platform to apply to (default: cli)",
     )
 
+    # hermes tools catalog [--platform cli] [--probe] [--include-plugins]
+    tools_catalog_p = tools_sub.add_parser(
+        "catalog",
+        help="Print a deterministic, machine-readable tool capability catalog",
+        description=(
+            "Emit a redacted JSON inventory of registered tools for auditing, "
+            "CI diffs, and least-tool orchestration. Availability probes are "
+            "not executed unless --probe is supplied."
+        ),
+    )
+    tools_catalog_p.add_argument(
+        "--platform",
+        default="cli",
+        help="Platform whose enabled toolsets should be marked (default: cli)",
+    )
+    tools_catalog_p.add_argument(
+        "--probe",
+        action="store_true",
+        help="Explicitly run registered availability checks",
+    )
+    tools_catalog_p.add_argument(
+        "--include-plugins",
+        action="store_true",
+        help=(
+            "Load enabled plugin modules so their tools appear (executes trusted "
+            "plugin import code; omitted by default)"
+        ),
+    )
+    tools_catalog_p.add_argument(
+        "--compact",
+        action="store_true",
+        help="Emit compact JSON instead of indented JSON",
+    )
+
     # hermes tools post-setup <key>
     tools_postsetup_p = tools_sub.add_parser(
         "post-setup",

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -16,7 +16,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Literal, Optional, overload, Set
 
 
 from hermes_cli.config import (
@@ -2281,7 +2281,9 @@ def _parse_enabled_flag(value, default: bool = True) -> bool:
     return default
 
 
-def enabled_mcp_server_names(config: dict) -> Set[str]:
+def enabled_mcp_server_names(
+    config: dict, *, include_portable_plugin_servers: bool = True
+) -> Set[str]:
     """Names of MCP servers globally enabled in config.yaml or by a plugin.
 
     Shared by the gateway/CLI platform resolver (``_get_platform_tools``) and
@@ -2304,6 +2306,8 @@ def enabled_mcp_server_names(config: dict) -> Set[str]:
         if isinstance(server_cfg, dict)
         and _parse_enabled_flag(server_cfg.get("enabled", True), default=True)
     }
+    if not include_portable_plugin_servers:
+        return names
     try:
         from hermes_cli.plugins import (
             get_plugin_manager,
@@ -2400,12 +2404,42 @@ def _enable_recently_shipped_toolsets(
         enabled_toolsets.add(ts_key)
 
 
+@overload
 def _get_platform_tools(
     config: dict,
     platform: str,
     *,
     include_default_mcp_servers: bool = True,
-) -> Set[str]:
+    include_plugin_toolsets: bool = True,
+    include_portable_plugin_mcp_servers: bool = True,
+    probe_credentials: bool = True,
+    return_selection_details: Literal[False] = False,
+) -> Set[str]: ...
+
+
+@overload
+def _get_platform_tools(
+    config: dict,
+    platform: str,
+    *,
+    include_default_mcp_servers: bool = True,
+    include_plugin_toolsets: bool = True,
+    include_portable_plugin_mcp_servers: bool = True,
+    probe_credentials: bool = True,
+    return_selection_details: Literal[True],
+) -> tuple[Set[str], Set[str]]: ...
+
+
+def _get_platform_tools(
+    config: dict,
+    platform: str,
+    *,
+    include_default_mcp_servers: bool = True,
+    include_plugin_toolsets: bool = True,
+    include_portable_plugin_mcp_servers: bool = True,
+    probe_credentials: bool = True,
+    return_selection_details: bool = False,
+) -> Set[str] | tuple[Set[str], Set[str]]:
     """Resolve which individual toolset names are enabled for a platform."""
     from toolsets import resolve_toolset, TOOLSETS
 
@@ -2431,7 +2465,10 @@ def _get_platform_tools(
     toolset_names = [str(ts) for ts in toolset_names]
 
     configurable_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
-    plugin_ts_keys = _get_plugin_toolset_keys()
+    # Audit/catalog callers can intentionally avoid plugin discovery because
+    # discovering Python plugins executes their import code. Normal runtime and
+    # configuration callers preserve the historical default.
+    plugin_ts_keys = _get_plugin_toolset_keys() if include_plugin_toolsets else set()
     platform_default_keys = {p["default_toolset"] for p in PLATFORMS.values()}
     # Plugin-provided toolsets are first-class on a platform-toolsets list —
     # explicit config like ``[hermes-cli, a2a]`` must survive filtering just
@@ -2481,7 +2518,11 @@ def _get_platform_tools(
             default_off = set(_DEFAULT_OFF_TOOLSETS)
             if platform in default_off and platform not in _TOOLSET_PLATFORM_RESTRICTIONS:
                 default_off.remove(platform)
-            if "homeassistant" in default_off and _homeassistant_credentials_present():
+            if (
+                probe_credentials
+                and "homeassistant" in default_off
+                and _homeassistant_credentials_present()
+            ):
                 default_off.remove("homeassistant")
             _exempt_explicit_platform_native(
                 default_off, platform, explicitly_configured=explicitly_configured
@@ -2523,6 +2564,7 @@ def _get_platform_tools(
         # do, the saved list is authoritative.
         x_search_auto_enabled = (
             _toolset_allowed_for_platform("x_search", platform)
+            and probe_credentials
             and _xai_credentials_present()
         )
         if x_search_auto_enabled:
@@ -2543,7 +2585,11 @@ def _get_platform_tools(
         # (e.g. cron) that run through _get_platform_tools without an
         # explicit saved toolset list. Without this, Norbert's HA cron jobs
         # regressed after #14798 made cron honor per-platform tool config.
-        if "homeassistant" in default_off and _homeassistant_credentials_present():
+        if (
+            probe_credentials
+            and "homeassistant" in default_off
+            and _homeassistant_credentials_present()
+        ):
             default_off.remove("homeassistant")
         # Symmetric carve-out for x_search auto-enable (see the inject
         # block above). Without this, the default_off subtraction would
@@ -2648,7 +2694,10 @@ def _get_platform_tools(
     # If the platform explicitly lists one or more MCP server names, treat that
     # as an allowlist. Otherwise include every globally enabled MCP server.
     # Special sentinel: "no_mcp" in the toolset list disables all MCP servers.
-    enabled_mcp_servers = enabled_mcp_server_names(config)
+    enabled_mcp_servers = enabled_mcp_server_names(
+        config,
+        include_portable_plugin_servers=include_portable_plugin_mcp_servers,
+    )
     # Allow "no_mcp" sentinel to opt out of all MCP servers for this platform
     if "no_mcp" in toolset_names:
         explicit_mcp_servers = set()
@@ -2656,13 +2705,15 @@ def _get_platform_tools(
     else:
         explicit_mcp_servers = explicit_passthrough & enabled_mcp_servers
         enabled_toolsets.update(explicit_passthrough - enabled_mcp_servers)
+    native_enabled_toolsets = set(enabled_toolsets)
     if include_default_mcp_servers:
         if explicit_mcp_servers or "no_mcp" in toolset_names:
-            enabled_toolsets.update(explicit_mcp_servers)
+            selected_mcp_servers = explicit_mcp_servers
         else:
-            enabled_toolsets.update(enabled_mcp_servers)
+            selected_mcp_servers = enabled_mcp_servers
     else:
-        enabled_toolsets.update(explicit_mcp_servers)
+        selected_mcp_servers = explicit_mcp_servers
+    enabled_toolsets.update(selected_mcp_servers)
 
     # Honor agent.disabled_toolsets from config.yaml — allows users to
     # globally suppress specific toolsets (e.g. "memory") across all
@@ -2679,6 +2730,8 @@ def _get_platform_tools(
             name.strip() for name in parse_config_string_list(disabled_toolsets) if name.strip()
         }
         enabled_toolsets -= disabled_set
+        native_enabled_toolsets -= disabled_set
+        selected_mcp_servers -= disabled_set
 
     # #38798: if this platform was explicitly configured but every toolset name
     # is invalid (e.g. a migration or hand-edit left `hermes` instead of
@@ -2705,6 +2758,8 @@ def _get_platform_tools(
                 ", ".join(_named),
             )
 
+    if return_selection_details:
+        return native_enabled_toolsets, selected_mcp_servers
     return enabled_toolsets
 
 
@@ -5904,6 +5959,99 @@ def _known_tool_platforms() -> set[str]:
         # third-party plugin is malformed or its dependencies are unavailable.
         pass
     return known
+
+
+def tools_catalog_command(args) -> None:
+    """Print a redacted, deterministic inventory of registered tools.
+
+    Built-in tool registration is loaded by default. Third-party/profile plugin
+    modules are not imported unless the operator explicitly supplies
+    ``--include-plugins``: Python imports execute plugin code, which is a
+    materially different action from reading registry metadata. Availability
+    checks likewise require an explicit ``--probe``.
+    """
+    include_plugins = bool(getattr(args, "include_plugins", False))
+    platform = str(getattr(args, "platform", "cli") or "cli")
+    if include_plugins:
+        valid_platforms = _known_tool_platforms()
+    else:
+        valid_platforms = set(PLATFORMS)
+        try:
+            from gateway.platform_registry import platform_registry
+
+            valid_platforms.update(platform_registry.registered_names())
+        except Exception:
+            pass
+    if platform not in valid_platforms:
+        _print_error(
+            f"Unknown platform '{platform}'. Valid: {', '.join(sorted(valid_platforms))}"
+        )
+        raise SystemExit(2)
+
+    from tools.registry import (
+        catalog_identifier,
+        catalog_prefixed_identifier,
+        discover_builtin_tools,
+        registry,
+    )
+
+    if include_plugins:
+        import model_tools  # noqa: F401 -- normal trusted-plugin discovery path
+    else:
+        discover_builtin_tools(read_only=True)
+
+    config = load_config()
+    enabled_toolsets, enabled_mcp_servers = _get_platform_tools(
+        config,
+        platform,
+        include_default_mcp_servers=True,
+        include_plugin_toolsets=include_plugins,
+        include_portable_plugin_mcp_servers=include_plugins,
+        probe_credentials=False,
+        return_selection_details=True,
+    )
+    payload = registry.get_capability_catalog(probe=bool(getattr(args, "probe", False)))
+    payload["platform"] = platform
+    plugin_preloaded = any(
+        tool.get("origin", {}).get("kind") == "plugin" for tool in payload["tools"]
+    )
+    payload["plugin_loading"] = (
+        "included"
+        if include_plugins
+        else "preloaded"
+        if plugin_preloaded
+        else "skipped"
+    )
+    catalog_toolsets = set(payload["toolsets"])
+    safe_mcp_toolsets = {
+        catalog_prefixed_identifier("mcp-", server) for server in enabled_mcp_servers
+    }
+    safe_enabled_toolsets = {
+        catalog_identifier(toolset) for toolset in enabled_toolsets
+    } | safe_mcp_toolsets
+    # Config is user-controlled and may contain stale names or secret-like
+    # strings. Only serialize identifiers that correspond to capabilities
+    # actually observed in this catalog process.
+    safe_enabled_toolsets &= catalog_toolsets
+    payload["enabled_toolsets"] = sorted(safe_enabled_toolsets)
+    for tool in payload["tools"]:
+        # Selection is only one stage of exposure. Availability checks,
+        # per-session filtering, progressive disclosure, and policy can still
+        # keep a selected tool out of the model-facing definitions.
+        toolset = tool["toolset"]
+        selected = toolset in safe_enabled_toolsets
+        tool["selected_for_platform"] = selected
+
+    compact = bool(getattr(args, "compact", False))
+    print(
+        _json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            indent=None if compact else 2,
+            separators=(",", ":") if compact else None,
+        )
+    )
 
 
 def tools_disable_enable_command(args):

--- a/tests/hermes_cli/test_tools_capability_catalog.py
+++ b/tests/hermes_cli/test_tools_capability_catalog.py
@@ -1,0 +1,418 @@
+"""CLI coverage for ``hermes tools catalog``."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.subcommands.tools import build_tools_parser
+from hermes_cli.tools_config import tools_catalog_command
+
+
+def test_tools_catalog_process_does_not_create_profile_files(tmp_path):
+    home = tmp_path / "fresh-hermes-home"
+    env = os.environ.copy()
+    env.update({"HERMES_HOME": str(home), "PYTHONDONTWRITEBYTECODE": "1"})
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from hermes_cli.main import main; main()",
+            "tools",
+            "catalog",
+            "--compact",
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["schema_version"] == 1
+    assert not home.exists() or not any(home.rglob("*"))
+
+
+def test_tools_catalog_process_rejects_unknown_platform_without_writes(tmp_path):
+    home = tmp_path / "fresh-hermes-home"
+    env = os.environ.copy()
+    env.update({"HERMES_HOME": str(home), "PYTHONDONTWRITEBYTECODE": "1"})
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from hermes_cli.main import main; main()",
+            "tools",
+            "catalog",
+            "--platform",
+            "definitely-not-a-platform",
+            "--compact",
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "Unknown platform" in result.stdout
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(result.stdout)
+    assert not home.exists() or not any(home.rglob("*"))
+
+
+def test_tools_catalog_process_skips_startup_maintenance_paths(tmp_path):
+    home = tmp_path / "existing-hermes-home"
+    home.mkdir()
+    env = os.environ.copy()
+    env.update({"HERMES_HOME": str(home), "PYTHONDONTWRITEBYTECODE": "1"})
+    script = """
+import json
+import sys
+
+sys.argv = ["hermes", "tools", "catalog", "--compact"]
+import hermes_cli.main as cli_main
+
+import hermes_cli
+from types import SimpleNamespace
+
+called = []
+cli_main._cleanup_quarantined_exes = lambda: called.append("quarantine")
+cli_main._sweep_stale_bytecode_if_checkout_changed = lambda: called.append("bytecode")
+original_platform = cli_main.sys.platform
+cli_main.sys.platform = "win32"
+hermes_cli._install_repair = SimpleNamespace(
+    ensure_windows_bin_launchers=lambda _root: called.append("windows-launcher")
+)
+cli_main._repair_windows_launchers_if_needed()
+cli_main.sys.platform = original_platform
+cli_main.main()
+if called:
+    raise SystemExit("startup maintenance reached: " + ",".join(called))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["schema_version"] == 1
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (["hermes", "tools", "catalog", "--compact"], True),
+        (["hermes", "--profile", "work", "tools", "catalog"], True),
+        (["hermes", "--profile=work", "tools", "catalog"], True),
+        (["hermes", "-pwork", "tools", "catalog"], False),
+        (["hermes", "-mMODEL", "-tfile", "-sskill", "tools", "catalog"], True),
+        (["hermes", "-z", "tools", "catalog"], False),
+        (["hermes", "--oneshot=tools", "tools", "catalog"], False),
+        (["hermes", "-rsession", "tools", "catalog"], False),
+        (["hermes", "-cname", "tools", "catalog"], False),
+        (["hermes", "--worktree", "tools", "catalog"], False),
+        (["hermes", "chat", "-q", "tools", "catalog"], False),
+    ],
+)
+def test_catalog_readonly_detection_matches_only_the_catalog_command(
+    tmp_path, argv, expected
+):
+    home = tmp_path / "home"
+    (home / "profiles" / "work").mkdir(parents=True)
+    env = os.environ.copy()
+    env.update(
+        {
+            "HERMES_HOME": str(home),
+            "HERMES_CATALOG_READONLY": "1",
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "TEST_ARGV": json.dumps(argv),
+        }
+    )
+    script = """
+import json
+import os
+import sys
+sys.argv = json.loads(os.environ["TEST_ARGV"])
+import hermes_cli.main as cli_main
+print(json.dumps({
+    "readonly": cli_main._CATALOG_READONLY,
+    "sentinel": os.environ.get("HERMES_CATALOG_READONLY"),
+}))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["readonly"] is expected
+    assert payload["sentinel"] == ("1" if expected else None)
+
+
+def test_tools_catalog_parser_is_noninteractive_and_probe_is_explicit():
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    handler = lambda args: None
+    build_tools_parser(subparsers, cmd_tools=handler)
+
+    args = parser.parse_args([
+        "tools",
+        "catalog",
+        "--platform",
+        "discord",
+        "--probe",
+        "--include-plugins",
+        "--compact",
+    ])
+
+    assert args.command == "tools"
+    assert args.tools_action == "catalog"
+    assert args.platform == "discord"
+    assert args.probe is True
+    assert args.include_plugins is True
+    assert args.compact is True
+    assert args.func is handler
+
+
+def test_tools_catalog_command_marks_platform_exposure_without_values(capsys):
+    catalog = {
+        "schema_version": 1,
+        "probe_performed": False,
+        "toolsets": ["file", "network"],
+        "tools": [
+            {
+                "name": "read_file",
+                "toolset": "file",
+                "requires_env": [],
+                "origin": {"kind": "builtin", "id": "tools.file_tools"},
+            },
+            {
+                "name": "remote_search",
+                "toolset": "network",
+                "requires_env": ["TEST_API_KEY"],
+                "origin": {"kind": "plugin", "id": "example.plugin"},
+            },
+        ],
+    }
+    fake_registry = SimpleNamespace(get_capability_catalog=lambda *, probe: catalog)
+    args = SimpleNamespace(
+        platform="cli", probe=False, include_plugins=False, compact=True
+    )
+    with (
+        patch("tools.registry.registry", fake_registry),
+        patch("tools.registry.discover_builtin_tools") as discover_builtins,
+        patch(
+            "hermes_cli.tools_config.load_config",
+            return_value={"platform_toolsets": {"cli": ["file"]}},
+        ),
+        patch(
+            "hermes_cli.tools_config._get_platform_tools",
+            return_value=({"file", "hunter2"}, {"unobserved-secret-server"}),
+        ) as get_platform_tools,
+    ):
+        tools_catalog_command(args)
+
+    discover_builtins.assert_called_once_with(read_only=True)
+    get_platform_tools.assert_called_once_with(
+        {"platform_toolsets": {"cli": ["file"]}},
+        "cli",
+        include_default_mcp_servers=True,
+        include_plugin_toolsets=False,
+        include_portable_plugin_mcp_servers=False,
+        probe_credentials=False,
+        return_selection_details=True,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["platform"] == "cli"
+    assert payload["enabled_toolsets"] == ["file"]
+    assert "hunter2" not in json.dumps(payload)
+    assert "unobserved-secret-server" not in json.dumps(payload)
+    # The command did not request discovery, but a plugin contribution was
+    # already present in the process-global registry. Report the observed
+    # state rather than incorrectly claiming that plugins were skipped.
+    assert payload["plugin_loading"] == "preloaded"
+    assert payload["tools"][0]["selected_for_platform"] is True
+    assert payload["tools"][1]["selected_for_platform"] is False
+    assert all("enabled" not in tool for tool in payload["tools"])
+    assert "TEST_API_KEY" in json.dumps(payload)
+
+
+def test_tools_catalog_redacts_composed_credential_shaped_mcp_servers(capsys):
+    from tools.registry import ToolRegistry
+
+    temporary_access_key = "AS" + "IA" + "IOSFODNN7EXAMPLE"
+    github_token = "gh" + "p_exampletoken"
+    fake_registry = ToolRegistry()
+    fake_registry.register(
+        "temporary_server_tool",
+        f"mcp-{temporary_access_key}",
+        {"name": "temporary_server_tool", "parameters": {"type": "object"}},
+        lambda: None,
+    )
+    fake_registry.register(
+        "github_token_server_tool",
+        f"mcp-{github_token}",
+        {"name": "github_token_server_tool", "parameters": {"type": "object"}},
+        lambda: None,
+    )
+    args = SimpleNamespace(
+        platform="cli", probe=False, include_plugins=False, compact=True
+    )
+    with (
+        patch("tools.registry.registry", fake_registry),
+        patch("tools.registry.discover_builtin_tools"),
+        patch("hermes_cli.tools_config.load_config", return_value={}),
+        patch(
+            "hermes_cli.tools_config._get_platform_tools",
+            return_value=(set(), {temporary_access_key, github_token}),
+        ),
+    ):
+        tools_catalog_command(args)
+
+    payload = json.loads(capsys.readouterr().out)
+    encoded = json.dumps(payload, sort_keys=True)
+    assert temporary_access_key not in encoded
+    assert github_token not in encoded
+    assert all(
+        toolset.startswith("redacted-") for toolset in payload["enabled_toolsets"]
+    )
+    assert all(tool["selected_for_platform"] for tool in payload["tools"])
+
+
+def test_tools_catalog_uses_real_mcp_platform_resolution(capsys):
+    catalog = {
+        "schema_version": 1,
+        "probe_performed": False,
+        "toolsets": ["mcp-github"],
+        "tools": [
+            {
+                "name": "github_search",
+                "toolset": "mcp-github",
+                "requires_env": [],
+                "origin": {"kind": "mcp", "id": "github"},
+            }
+        ],
+    }
+    from tools.registry import registry
+
+    args = SimpleNamespace(
+        platform="cli", probe=False, include_plugins=False, compact=True
+    )
+    config = {
+        "platform_toolsets": {"cli": []},
+        "mcp_servers": {"github": {"command": "unused"}},
+    }
+
+    with (
+        patch.object(registry, "get_capability_catalog", return_value=catalog),
+        patch("tools.registry.discover_builtin_tools"),
+        patch("hermes_cli.tools_config.load_config", return_value=config),
+        patch("hermes_cli.plugins.discover_plugins") as discover_plugins,
+    ):
+        tools_catalog_command(args)
+
+    discover_plugins.assert_not_called()
+    payload = json.loads(capsys.readouterr().out)
+    assert "mcp-github" in payload["enabled_toolsets"]
+    assert payload["tools"][0]["selected_for_platform"] is True
+
+
+@pytest.mark.parametrize(
+    ("platform_toolsets", "server_config", "builtin_expected", "mcp_expected"),
+    [
+        (["file"], {"enabled": False}, True, False),
+        (["file", "github"], {"enabled": True}, True, False),
+        ([], {"enabled": True}, False, True),
+    ],
+)
+def test_tools_catalog_mcp_selection_does_not_collide_with_builtin_toolset(
+    capsys, platform_toolsets, server_config, builtin_expected, mcp_expected
+):
+    catalog = {
+        "schema_version": 1,
+        "probe_performed": False,
+        "toolsets": ["file", "mcp-file"],
+        "tools": [
+            {
+                "name": "read_file",
+                "toolset": "file",
+                "requires_env": [],
+                "origin": {"kind": "builtin", "id": "tools.file_tools"},
+            },
+            {
+                "name": "mcp_read_file",
+                "toolset": "mcp-file",
+                "requires_env": [],
+                "origin": {"kind": "mcp", "id": "file"},
+            },
+        ],
+    }
+    config = {
+        "platform_toolsets": {"cli": platform_toolsets},
+        "mcp_servers": {
+            "file": server_config,
+            "github": {"enabled": True, "command": "unused"},
+        },
+    }
+    from tools.registry import registry
+
+    args = SimpleNamespace(
+        platform="cli", probe=False, include_plugins=False, compact=True
+    )
+    with (
+        patch.object(registry, "get_capability_catalog", return_value=catalog),
+        patch("tools.registry.discover_builtin_tools"),
+        patch("hermes_cli.tools_config.load_config", return_value=config),
+    ):
+        tools_catalog_command(args)
+
+    payload = json.loads(capsys.readouterr().out)
+    by_name = {tool["name"]: tool for tool in payload["tools"]}
+    assert by_name["read_file"]["selected_for_platform"] is builtin_expected
+    assert by_name["mcp_read_file"]["selected_for_platform"] is mcp_expected
+    assert ("mcp-file" in payload["enabled_toolsets"]) is mcp_expected
+
+
+def test_tools_catalog_rejects_unknown_platform_before_resolving(capsys):
+    args = SimpleNamespace(
+        platform="definitely-not-a-platform",
+        probe=False,
+        include_plugins=False,
+        compact=True,
+    )
+
+    with (
+        patch("tools.registry.discover_builtin_tools"),
+        patch("hermes_cli.tools_config.load_config") as load_config,
+    ):
+        with pytest.raises(SystemExit) as raised:
+            tools_catalog_command(args)
+
+    assert raised.value.code == 2
+    load_config.assert_not_called()
+    assert "Unknown platform" in capsys.readouterr().out

--- a/tests/tools/test_registry_capability_catalog.py
+++ b/tests/tools/test_registry_capability_catalog.py
@@ -1,0 +1,735 @@
+"""Tests for the read-only tool capability catalog.
+
+The catalog is the machine-readable foundation for capability diffs and
+least-tool orchestration.  Its default path must not execute availability
+probes or expose environment values/implementation paths.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import ContextVar
+from functools import partial
+from types import FunctionType
+from typing import Callable, cast
+from unittest.mock import Mock
+
+import tools.registry as registry_module
+from tools.registry import ToolRegistry
+
+
+def _schema(name: str) -> dict:
+    return {
+        "name": name,
+        "description": f"{name} description",
+        "parameters": {"type": "object", "properties": {}},
+    }
+
+
+def _handler():
+    return "ok"
+
+
+def _handler_in_module(module_name: str):
+    return FunctionType(_handler.__code__, {"__name__": module_name})
+
+
+def test_catalog_is_deterministic_redacted_and_does_not_probe(monkeypatch):
+    calls = []
+
+    def check():
+        calls.append("called")
+        return True
+
+    registry = ToolRegistry()
+    suspicious_access_key = "AK" + "IA" + "IOSFODNN7EXAMPLE"
+    suspicious_temporary_access_key = "AS" + "IA" + "IOSFODNN7EXAMPLE"
+    suspicious_github_token = "gh" + "p_" + "exampletoken"
+    monkeypatch.setenv("CATALOG_TEST_TOKEN", "do-not-leak")
+    registry.register(
+        name="zeta",
+        toolset="network",
+        schema=_schema("zeta"),
+        handler=_handler,
+        check_fn=check,
+        requires_env=[
+            "CATALOG_TEST_TOKEN",
+            suspicious_access_key,
+            suspicious_temporary_access_key,
+            suspicious_github_token,
+            "/Users/alice/.secrets/token",
+            "token=secret-value",
+        ],
+        is_async=True,
+        max_result_size_chars=4096,
+    )
+    registry.register(
+        name="alpha",
+        toolset="local",
+        schema=_schema("alpha"),
+        handler=_handler,
+    )
+
+    first = registry.get_capability_catalog()
+    second = registry.get_capability_catalog()
+
+    assert first == second
+    assert calls == []
+    assert first["schema_version"] == 1
+    assert [tool["name"] for tool in first["tools"]] == ["alpha", "zeta"]
+    assert first["toolsets"] == ["local", "network"]
+
+    zeta = first["tools"][1]
+    assert zeta["availability"] == "unknown"
+    assert zeta["requires_env"] == ["CATALOG_TEST_TOKEN"]
+    assert zeta["requires_env_redacted"] is True
+    assert zeta["is_async"] is True
+    assert zeta["max_result_size_chars"] == 4096
+    assert "description" not in zeta
+    assert "probe_error" not in zeta
+    assert (
+        zeta["schema_sha256"]
+        == hashlib.sha256(
+            json.dumps(
+                {
+                    "name": "zeta",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode()
+        ).hexdigest()
+    )
+
+    serialized = json.dumps(first)
+    assert "do-not-leak" not in serialized
+    assert suspicious_access_key not in serialized
+    assert suspicious_temporary_access_key not in serialized
+    assert suspicious_github_token not in serialized
+    assert "Users/" not in serialized
+
+
+def test_schema_digest_ignores_annotations_defaults_and_set_order():
+    first = ToolRegistry()
+    second = ToolRegistry()
+    first.register(
+        "stable",
+        "local",
+        {
+            "name": "stable",
+            "description": "path /Users/private/one",
+            "parameters": {
+                "type": "object",
+                "required": ["beta", "alpha"],
+                "properties": {
+                    "alpha": {"type": "string", "default": "secret-one"},
+                    "beta": {"type": "string", "examples": ["private-one"]},
+                },
+            },
+        },
+        _handler,
+    )
+    second.register(
+        "stable",
+        "local",
+        {
+            "name": "stable",
+            "description": "path /Users/private/two",
+            "parameters": {
+                "type": "object",
+                "required": ["alpha", "beta"],
+                "properties": {
+                    "alpha": {"type": "string", "default": "secret-two"},
+                    "beta": {"type": "string", "examples": ["private-two"]},
+                },
+            },
+        },
+        _handler,
+    )
+
+    first_digest = first.get_capability_catalog()["tools"][0]["schema_sha256"]
+    second_digest = second.get_capability_catalog()["tools"][0]["schema_sha256"]
+
+    assert first_digest == second_digest
+
+
+def test_schema_digest_preserves_id_and_ignores_standard_annotations():
+    def digest(*, schema_id: str, marker: str) -> str:
+        registry = ToolRegistry()
+        registry.register(
+            "stable",
+            "local",
+            {
+                "name": "stable",
+                "parameters": {
+                    "$id": schema_id,
+                    "$ref": "child.json",
+                    "deprecated": marker == "deprecated",
+                    "readOnly": marker == "read-only",
+                    "writeOnly": marker == "write-only",
+                },
+            },
+            _handler,
+        )
+        return registry.get_capability_catalog()["tools"][0]["schema_sha256"]
+
+    base = digest(schema_id="https://example.test/a/", marker="base")
+    assert base != digest(schema_id="https://example.test/b/", marker="base")
+    for marker in ("deprecated", "read-only", "write-only"):
+        assert base == digest(schema_id="https://example.test/a/", marker=marker)
+
+
+def test_schema_digest_preserves_annotation_named_parameters():
+    with_description_parameter = ToolRegistry()
+    without_description_parameter = ToolRegistry()
+
+    with_description_parameter.register(
+        "sample",
+        "local",
+        {
+            "name": "sample",
+            "description": "ignored tool annotation",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "type": "string",
+                        "description": "ignored property annotation",
+                    }
+                },
+            },
+        },
+        _handler,
+    )
+    without_description_parameter.register(
+        "sample",
+        "local",
+        {
+            "name": "sample",
+            "description": "different ignored annotation",
+            "parameters": {"type": "object", "properties": {}},
+        },
+        _handler,
+    )
+
+    with_digest = with_description_parameter.get_capability_catalog()["tools"][0][
+        "schema_sha256"
+    ]
+    without_digest = without_description_parameter.get_capability_catalog()["tools"][
+        0
+    ]["schema_sha256"]
+    assert with_digest != without_digest
+
+
+def test_schema_digest_ignores_annotations_for_named_map_colliding_parameters():
+    def digest(parameter_name: str, marker: str) -> str:
+        registry = ToolRegistry()
+        registry.register(
+            "sample",
+            "local",
+            {
+                "name": "sample",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        parameter_name: {
+                            "type": "string",
+                            "description": f"ignored-{marker}",
+                            "default": f"ignored-{marker}",
+                        }
+                    },
+                },
+            },
+            _handler,
+        )
+        return registry.get_capability_catalog()["tools"][0]["schema_sha256"]
+
+    for parameter_name in (
+        "$defs",
+        "definitions",
+        "dependencies",
+        "dependentRequired",
+        "dependentSchemas",
+        "patternProperties",
+        "properties",
+    ):
+        assert digest(parameter_name, "one") == digest(parameter_name, "two")
+
+
+def test_schema_digest_preserves_annotation_named_instance_data():
+    def digest(constraint: dict) -> str:
+        registry = ToolRegistry()
+        registry.register(
+            "sample",
+            "local",
+            {
+                "name": "sample",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"value": constraint},
+                },
+            },
+            _handler,
+        )
+        return registry.get_capability_catalog()["tools"][0]["schema_sha256"]
+
+    assert digest({"const": {"description": "one"}}) != digest(
+        {"const": {"description": "two"}}
+    )
+    assert digest({"enum": [{"default": "one"}]}) != digest(
+        {"enum": [{"default": "two"}]}
+    )
+    assert digest(
+        {"enum": [{"description": "one"}, {"default": "two"}]}
+    ) == digest({"enum": [{"default": "two"}, {"description": "one"}]})
+
+
+def test_schema_digest_ignores_type_array_order():
+    def digest(types: list[str]) -> str:
+        registry = ToolRegistry()
+        registry.register(
+            "sample",
+            "local",
+            {
+                "name": "sample",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"value": {"type": types}},
+                },
+            },
+            _handler,
+        )
+        return registry.get_capability_catalog()["tools"][0]["schema_sha256"]
+
+    assert digest(["string", "null"]) == digest(["null", "string"])
+
+
+def test_schema_digest_ignores_dependent_required_order():
+    def digest(dependencies: list[str]) -> str:
+        registry = ToolRegistry()
+        registry.register(
+            "sample",
+            "local",
+            {
+                "name": "sample",
+                "parameters": {
+                    "type": "object",
+                    "dependentRequired": {"credit_card": dependencies},
+                },
+            },
+            _handler,
+        )
+        return registry.get_capability_catalog()["tools"][0]["schema_sha256"]
+
+    assert digest(["billing_address", "security_code"]) == digest(
+        ["security_code", "billing_address"]
+    )
+
+
+def test_schema_digest_ignores_legacy_dependency_order():
+    def digest(dependencies: list[str]) -> str:
+        registry = ToolRegistry()
+        registry.register(
+            "sample",
+            "local",
+            {
+                "name": "sample",
+                "parameters": {
+                    "type": "object",
+                    "dependencies": {"credit_card": dependencies},
+                },
+            },
+            _handler,
+        )
+        return registry.get_capability_catalog()["tools"][0]["schema_sha256"]
+
+    assert digest(["billing_address", "security_code"]) == digest(
+        ["security_code", "billing_address"]
+    )
+
+
+def test_schema_digest_preserves_each_named_map_grammar():
+    def digest(
+        map_keyword: str,
+        entry_name: str,
+        marker: str,
+        *,
+        entry_type: str = "string",
+    ) -> str:
+        registry = ToolRegistry()
+        if map_keyword == "dependentRequired":
+            entry_value = ["sibling"]
+        else:
+            entry_value = {
+                "type": entry_type,
+                "description": f"ignored-{marker}",
+                "default": f"ignored-{marker}",
+            }
+        registry.register(
+            "sample",
+            "local",
+            {
+                "name": "sample",
+                "parameters": {
+                    "type": "object",
+                    map_keyword: {entry_name: entry_value},
+                },
+            },
+            _handler,
+        )
+        return registry.get_capability_catalog()["tools"][0]["schema_sha256"]
+
+    named_map_keywords = (
+        "$defs",
+        "definitions",
+        "dependencies",
+        "dependentRequired",
+        "dependentSchemas",
+        "patternProperties",
+        "properties",
+    )
+    colliding_entry_names = ("description", "default", "properties", "$defs")
+    for map_keyword in named_map_keywords:
+        control = digest(map_keyword, "control", "one")
+        for entry_name in colliding_entry_names:
+            one = digest(map_keyword, entry_name, "one")
+            assert control != one
+            if map_keyword != "dependentRequired":
+                assert one == digest(map_keyword, entry_name, "two")
+
+    assert digest(
+        "dependentSchemas", "description", "one", entry_type="string"
+    ) != digest("dependentSchemas", "description", "one", entry_type="integer")
+
+
+def test_probe_deduplicates_shared_check_and_contains_probe_failure(monkeypatch):
+    registry = ToolRegistry()
+
+    def shared_check():
+        raise RuntimeError("credential at /Users/alice/.secrets/token")
+
+    for name in ("alpha", "beta"):
+        registry.register(
+            name=name,
+            toolset="network",
+            schema=_schema(name),
+            handler=_handler,
+            check_fn=shared_check,
+        )
+
+    calls = []
+    original_probe = registry_module._check_fn_cached
+
+    def counting_probe(fn):
+        calls.append(fn)
+        return original_probe(fn)
+
+    monkeypatch.setattr(registry_module, "_check_fn_cached", counting_probe)
+    catalog = registry.get_capability_catalog(probe=True)
+
+    assert calls == [shared_check]
+    assert [tool["availability"] for tool in catalog["tools"]] == [
+        "unavailable",
+        "unavailable",
+    ]
+    assert all("probe_error" not in tool for tool in catalog["tools"])
+    assert "/Users/alice" not in json.dumps(catalog)
+
+
+def test_default_catalog_ignores_process_global_cached_check_results(monkeypatch):
+    registry = ToolRegistry()
+
+    def check():
+        return True
+
+    registry.register(
+        name="dynamic",
+        toolset="network",
+        schema=_schema("dynamic"),
+        handler=_handler,
+        check_fn=check,
+    )
+    monkeypatch.setattr(
+        registry_module,
+        "get_cached_check_fn_result",
+        lambda _fn: True,
+    )
+
+    [entry] = registry.get_capability_catalog()["tools"]
+    assert entry["availability"] == "unknown"
+
+
+def test_origin_classification_does_not_trust_partial_handler_metadata():
+    registry = ToolRegistry()
+
+    plugin_handler = FunctionType(
+        (lambda prefix, **_kwargs: prefix).__code__,
+        {"__name__": "hermes_plugins.example.tool"},
+    )
+    registry.register(
+        name="partial_plugin",
+        toolset="plugin_example",
+        schema=_schema("partial_plugin"),
+        handler=partial(plugin_handler, "ok"),
+    )
+
+    [entry] = registry.get_capability_catalog()["tools"]
+
+    assert entry["origin"] == {"kind": "runtime", "id": "runtime"}
+
+
+def test_origin_classification_does_not_trust_callable_object_metadata():
+    registry = ToolRegistry()
+    plugin_callable_type = type(
+        "PluginCallable",
+        (),
+        {
+            "__module__": "hermes_plugins.example.callables",
+            "__call__": lambda self, **_kwargs: "ok",
+        },
+    )
+    registry.register(
+        name="callable_plugin",
+        toolset="plugin_example",
+        schema=_schema("callable_plugin"),
+        handler=cast(Callable[..., object], plugin_callable_type()),
+    )
+
+    [entry] = registry.get_capability_catalog()["tools"]
+
+    assert entry["origin"] == {"kind": "runtime", "id": "runtime"}
+
+
+def test_origin_classes_do_not_expose_filesystem_paths(monkeypatch):
+    registry = ToolRegistry()
+
+    builtin_handler = _handler_in_module("tools.example")
+    plugin_handler = _handler_in_module("hermes_plugins.example.actions")
+
+    monkeypatch.setattr(registry, "_caller_module", lambda: "tools.example")
+    registry.register("builtin", "file", _schema("builtin"), builtin_handler)
+    monkeypatch.setattr(
+        registry, "_caller_module", lambda: "hermes_plugins.example.actions"
+    )
+    registry.register("plugin", "custom", _schema("plugin"), plugin_handler)
+    monkeypatch.setattr(registry, "_caller_module", lambda: "tools.mcp_tool")
+    registry.register("trusted_mcp", "mcp-github", _schema("trusted_mcp"), _handler)
+    monkeypatch.setattr(registry, "_caller_module", lambda: __name__)
+    registry.register("forged_mcp", "mcp-attacker", _schema("forged_mcp"), _handler)
+
+    by_name = {
+        tool["name"]: tool for tool in registry.get_capability_catalog()["tools"]
+    }
+    assert by_name["builtin"]["origin"] == {"kind": "builtin", "id": "tools.example"}
+    assert by_name["plugin"]["origin"] == {
+        "kind": "plugin",
+        "id": "hermes_plugins.example",
+    }
+    assert by_name["trusted_mcp"]["origin"] == {"kind": "mcp", "id": "github"}
+    assert by_name["forged_mcp"]["origin"] == {
+        "kind": "runtime",
+        "id": "runtime",
+    }
+
+
+def test_origin_prefers_host_registration_owner_over_wrapped_builtin_handler(
+    monkeypatch,
+):
+    registry = ToolRegistry()
+    builtin_handler = _handler_in_module("tools.example")
+    monkeypatch.setattr(registry, "_caller_module", lambda: "hermes_cli.plugins")
+    registry.register(
+        "plugin_wrapped_builtin",
+        "plugin_example",
+        _schema("plugin_wrapped_builtin"),
+        builtin_handler,
+        _registration_owner="hermes_plugins.example",
+    )
+
+    [entry] = registry.get_capability_catalog()["tools"]
+
+    assert entry["origin"] == {
+        "kind": "plugin",
+        "id": "hermes_plugins.example",
+    }
+
+
+def test_plugin_cannot_forge_host_registration_owner(monkeypatch):
+    registry = ToolRegistry()
+    monkeypatch.setattr(
+        registry, "_caller_module", lambda: "hermes_plugins.attacker.actions"
+    )
+    monkeypatch.setattr(registry, "current_scope_key", lambda: "global")
+    registry.register(
+        "forged",
+        "custom",
+        _schema("forged"),
+        _handler,
+        scope="global",
+        _registration_owner="hermes_plugins.victim",
+    )
+
+    [entry] = registry.get_capability_catalog()["tools"]
+
+    assert entry["origin"] == {
+        "kind": "plugin",
+        "id": "hermes_plugins.attacker",
+    }
+
+
+def test_catalog_redacts_unsafe_identifiers_without_leaking_source_text():
+    registry = ToolRegistry()
+    unsafe_handler = _handler_in_module("/Users/private/secret_module.py")
+    registry.register(
+        "/Users/private/API_KEY=secret-tool",
+        "mcp-/Users/private/token=secret",
+        _schema("unsafe"),
+        unsafe_handler,
+    )
+
+    catalog = registry.get_capability_catalog()
+    encoded = json.dumps(catalog, sort_keys=True)
+
+    assert "/Users/private" not in encoded
+    assert "API_KEY" not in encoded
+    assert "token=secret" not in encoded
+    [entry] = catalog["tools"]
+    assert entry["name"].startswith("redacted-")
+    assert entry["toolset"].startswith("redacted-")
+    assert entry["origin"] == {"kind": "runtime", "id": "runtime"}
+
+
+def test_catalog_redacts_credential_shaped_identifier_components():
+    registry = ToolRegistry()
+    temporary_access_key = "AS" + "IA" + "IOSFODNN7EXAMPLE"
+    long_lived_access_key = "AK" + "IA" + "IOSFODNN7EXAMPLE"
+    github_token = "gh" + "p_exampletoken"
+    slack_token = "xo" + "xb-exampletoken"
+    registry.register(
+        f"tool-{github_token}",
+        f"mcp-{temporary_access_key}",
+        _schema("credential-shaped"),
+        _handler,
+    )
+    registry.register(
+        f"tool:{slack_token}",
+        f"custom.{long_lived_access_key}",
+        _schema("credential-shaped-two"),
+        _handler,
+    )
+
+    catalog = registry.get_capability_catalog()
+    encoded = json.dumps(catalog, sort_keys=True)
+
+    for credential in (
+        temporary_access_key,
+        long_lived_access_key,
+        github_token,
+        slack_token,
+    ):
+        assert credential not in encoded
+    assert all(tool["name"].startswith("redacted-") for tool in catalog["tools"])
+    assert all(tool["toolset"].startswith("redacted-") for tool in catalog["tools"])
+
+
+def test_read_only_discovery_does_not_persist_cache_or_log_exception_text(
+    monkeypatch, caplog, tmp_path
+):
+    (tmp_path / "broken.py").write_text(
+        'registry.register("broken", "file", {}, handler)\n',
+        encoding="utf-8",
+    )
+    save_cache = Mock()
+    monkeypatch.setattr(registry_module, "_load_discovery_cache", lambda: {})
+    monkeypatch.setattr(registry_module, "_save_discovery_cache", save_cache)
+    monkeypatch.setattr(
+        registry_module.importlib,
+        "import_module",
+        Mock(side_effect=RuntimeError("/Users/private/API_KEY=secret")),
+    )
+
+    registry_module.discover_builtin_tools(tmp_path, read_only=True)
+
+    save_cache.assert_not_called()
+    assert "/Users/private" not in caplog.text
+    assert "API_KEY" not in caplog.text
+
+
+def test_catalog_respects_profile_scope_and_does_not_mutate_registry(monkeypatch):
+    registry = ToolRegistry()
+    dynamic_schema_calls = []
+
+    def dynamic_schema():
+        dynamic_schema_calls.append("called")
+        return {"properties": {"secret": {"type": "string"}}}
+
+    registry.register("global", "file", _schema("global"), _handler)
+    registry.register(
+        "profile_a_only",
+        "custom",
+        _schema("profile_a_only"),
+        _handler,
+        dynamic_schema_overrides=dynamic_schema,
+        scope="profile-a",
+    )
+    registry.register(
+        "profile_b_only",
+        "custom",
+        _schema("profile_b_only"),
+        _handler,
+        scope="profile-b",
+    )
+
+    generation_before = registry._generation
+    monkeypatch.setattr(registry, "current_scope_key", lambda: "profile-a")
+    profile_a = registry.get_capability_catalog()
+    monkeypatch.setattr(registry, "current_scope_key", lambda: "profile-b")
+    profile_b = registry.get_capability_catalog()
+
+    assert [tool["name"] for tool in profile_a["tools"]] == [
+        "global",
+        "profile_a_only",
+    ]
+    assert [tool["name"] for tool in profile_b["tools"]] == [
+        "global",
+        "profile_b_only",
+    ]
+    assert registry._generation == generation_before
+    assert dynamic_schema_calls == []
+
+
+def test_catalog_keeps_concurrent_profile_snapshots_isolated(monkeypatch):
+    registry = ToolRegistry()
+    active_scope = ContextVar("catalog_test_scope", default="profile-a")
+    registry.register("global", "file", _schema("global"), _handler)
+    registry.register(
+        "profile_a_only",
+        "custom",
+        _schema("profile_a_only"),
+        _handler,
+        scope="profile-a",
+    )
+    registry.register(
+        "profile_b_only",
+        "custom",
+        _schema("profile_b_only"),
+        _handler,
+        scope="profile-b",
+    )
+    monkeypatch.setattr(registry, "current_scope_key", active_scope.get)
+
+    def read_names(scope):
+        token = active_scope.set(scope)
+        try:
+            return [tool["name"] for tool in registry.get_capability_catalog()["tools"]]
+        finally:
+            active_scope.reset(token)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        profile_a = executor.submit(read_names, "profile-a")
+        profile_b = executor.submit(read_names, "profile-b")
+
+    assert profile_a.result() == ["global", "profile_a_only"]
+    assert profile_b.result() == ["global", "profile_b_only"]

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -465,11 +465,13 @@ class ProcessRegistry:
         self.completion_queue: _queue_mod.Queue = _queue_mod.Queue()
         # Rehydrate durable delegation completions only at registry startup.
         # Consumers still inject them as fresh turns through this existing rail.
-        try:
-            from tools.async_delegation import restore_undelivered_completions
-            restore_undelivered_completions(self.completion_queue)
-        except Exception as exc:
-            logger.warning("Could not restore async delegation completions: %s", exc)
+        if os.getenv("HERMES_CATALOG_READONLY") != "1":
+            try:
+                from tools.async_delegation import restore_undelivered_completions
+
+                restore_undelivered_completions(self.completion_queue)
+            except Exception as exc:
+                logger.warning("Could not restore async delegation completions: %s", exc)
 
         # Track sessions whose completion was already consumed by the agent
         # via wait/log.  Drain loops AND gateway/tui watchers skip notifications

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -16,9 +16,11 @@ Import chain (circular-import safe):
 
 import ast
 import functools
+import hashlib
 import importlib
 import json
 import logging
+import re
 import sys
 import threading
 import time
@@ -28,6 +30,142 @@ from typing import Callable, Dict, List, Optional, Set
 from hermes_constants import hermes_home_key
 
 logger = logging.getLogger(__name__)
+
+
+_CATALOG_SECRET_IDENTIFIER_RE = re.compile(
+    r"(?i)(?:^|[_.:-])(?:"
+    r"sk-[A-Za-z0-9]|"
+    r"gh[pousr]_[A-Za-z0-9]|"
+    r"github_pat_[A-Za-z0-9]|"
+    r"xox[baprs]-[A-Za-z0-9]|"
+    r"(?:AKIA|ASIA)[0-9A-Z]"
+    r")"
+)
+
+
+def catalog_identifier(value: object) -> str:
+    """Return a bounded path/secret-safe identifier for machine output."""
+    text = str(value or "")
+    safe_shape = re.fullmatch(r"[A-Za-z0-9_][A-Za-z0-9_.:-]{0,127}", text)
+    secret_shape = _CATALOG_SECRET_IDENTIFIER_RE.search(text)
+    if safe_shape and not secret_shape:
+        return text
+    digest = hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()[:16]
+    return f"redacted-{digest}"
+
+
+def catalog_prefixed_identifier(prefix: str, component: object) -> str:
+    """Compose a catalog ID only after validating its untrusted component."""
+    text = str(component or "")
+    composed = f"{prefix}{text}"
+    if catalog_identifier(text) != text:
+        digest = hashlib.sha256(
+            composed.encode("utf-8", errors="replace")
+        ).hexdigest()[:16]
+        return f"redacted-{digest}"
+    return catalog_identifier(composed)
+
+
+_CATALOG_SCHEMA_ANNOTATIONS = {
+    "$comment",
+    "default",
+    "deprecated",
+    "description",
+    "example",
+    "examples",
+    "readOnly",
+    "title",
+    "writeOnly",
+}
+_CATALOG_SCHEMA_UNORDERED_ARRAYS = {
+    "allOf",
+    "anyOf",
+    "dependencies",
+    "dependentRequired",
+    "enum",
+    "oneOf",
+    "required",
+    "type",
+}
+_CATALOG_SCHEMA_NAMED_MAPS = {
+    "$defs",
+    "definitions",
+    "dependencies",
+    "dependentRequired",
+    "dependentSchemas",
+    "patternProperties",
+    "properties",
+}
+_CATALOG_SCHEMA_INSTANCE_DATA = {"const", "enum"}
+
+
+def _catalog_schema_contract(
+    value: object,
+    *,
+    parent_key: str = "",
+    _named_map_keyword: Optional[str] = None,
+    _instance_data: bool = False,
+) -> object:
+    """Return the stable structural subset used for a catalog schema digest.
+
+    Annotation/default fields can contain profile paths, operator values, or
+    generated prose. They are not part of the observation-safe contract. JSON
+    Schema set-like arrays are sorted so registration order cannot perturb the
+    digest; order-sensitive arrays such as ``prefixItems`` remain untouched.
+    Named-map entry names are kept separate from schema keyword context so a
+    parameter named ``properties`` cannot change canonicalization semantics.
+    Object-valued ``const`` and ``enum`` members are instance data, so keys
+    that happen to match annotation names remain digest-significant there.
+    """
+    if isinstance(value, dict):
+        if _instance_data:
+            return {
+                str(key): _catalog_schema_contract(item, _instance_data=True)
+                for key, item in value.items()
+            }
+        in_named_map = _named_map_keyword is not None
+        contract = {}
+        for key, item in value.items():
+            key_text = str(key)
+            if not in_named_map and key_text in _CATALOG_SCHEMA_ANNOTATIONS:
+                continue
+            if in_named_map:
+                child_parent_key = (
+                    _named_map_keyword
+                    if _named_map_keyword in {"dependencies", "dependentRequired"}
+                    else ""
+                )
+                child_named_map = None
+            else:
+                child_parent_key = key_text
+                child_named_map = (
+                    key_text if key_text in _CATALOG_SCHEMA_NAMED_MAPS else None
+                )
+            contract[key_text] = _catalog_schema_contract(
+                item,
+                parent_key=child_parent_key,
+                _named_map_keyword=child_named_map,
+                _instance_data=(
+                    not in_named_map and key_text in _CATALOG_SCHEMA_INSTANCE_DATA
+                ),
+            )
+        return contract
+    if isinstance(value, list):
+        items = [
+            _catalog_schema_contract(item, _instance_data=_instance_data)
+            for item in value
+        ]
+        if parent_key in _CATALOG_SCHEMA_UNORDERED_ARRAYS:
+            items.sort(
+                key=lambda item: json.dumps(
+                    item,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    ensure_ascii=False,
+                )
+            )
+        return items
+    return value
 
 # Cap on a tool error body; only trims runaway interpolated exceptions (static msgs are ~115 chars).
 _MAX_TOOL_ERROR_CHARS = 2048
@@ -108,7 +246,11 @@ def _module_registers_tools(module_path: Path) -> bool:
     return any(_is_registry_register_call(stmt) for stmt in tree.body)
 
 
-def discover_builtin_tools(tools_dir: Optional[Path] = None) -> List[str]:
+def discover_builtin_tools(
+    tools_dir: Optional[Path] = None,
+    *,
+    read_only: bool = False,
+) -> List[str]:
     """Import built-in self-registering tool modules and return their module names.
 
     The per-file AST scan (:func:`_module_registers_tools`) costs ~145 ms over
@@ -116,7 +258,8 @@ def discover_builtin_tools(tools_dir: Optional[Path] = None) -> List[str]:
     ``(mtime_ns, size)``. A file whose mtime_ns+size match the cached entry is
     trusted without re-reading; any mismatch (or a corrupt/missing cache file)
     falls back to a fresh scan for that file. The cache write is best-effort
-    and atomic, so concurrent processes can race harmlessly.
+    and atomic, so concurrent processes can race harmlessly. ``read_only=True``
+    suppresses cache writes and exception details for audit/catalog callers.
     """
     tools_path = Path(tools_dir) if tools_dir is not None else Path(__file__).resolve().parent
 
@@ -149,7 +292,7 @@ def discover_builtin_tools(tools_dir: Optional[Path] = None) -> List[str]:
             module_names.append(f"tools.{path.stem}")
 
     # Drop entries for files that no longer exist; rewrite only when changed.
-    if cache_dirty or set(fresh_cache) != set(cache):
+    if not read_only and (cache_dirty or set(fresh_cache) != set(cache)):
         _save_discovery_cache(fresh_cache)
 
     imported: List[str] = []
@@ -158,7 +301,10 @@ def discover_builtin_tools(tools_dir: Optional[Path] = None) -> List[str]:
             importlib.import_module(mod_name)
             imported.append(mod_name)
         except Exception as e:
-            logger.warning("Could not import tool module %s: %s", mod_name, e)
+            if read_only:
+                logger.warning("Could not import tool module %s", mod_name)
+            else:
+                logger.warning("Could not import tool module %s: %s", mod_name, e)
     return imported
 
 
@@ -207,12 +353,14 @@ class ToolEntry:
     __slots__ = (
         "name", "toolset", "schema", "handler", "check_fn",
         "requires_env", "is_async", "description", "emoji",
-        "max_result_size_chars", "dynamic_schema_overrides",
+        "max_result_size_chars", "dynamic_schema_overrides", "registration_owner",
+        "registration_module",
     )
 
     def __init__(self, name, toolset, schema, handler, check_fn,
                  requires_env, is_async, description, emoji,
-                 max_result_size_chars=None, dynamic_schema_overrides=None):
+                 max_result_size_chars=None, dynamic_schema_overrides=None,
+                 registration_owner=None, registration_module=None):
         self.name = name
         self.toolset = toolset
         self.schema = schema
@@ -231,6 +379,13 @@ class ToolEntry:
         # on every get_definitions() call; results are merged shallow on top
         # of the base schema before the {"type": "function", ...} wrap.
         self.dynamic_schema_overrides = dynamic_schema_overrides
+        # Canonical owner assigned by the host registration boundary. Plugins
+        # may wrap or reuse built-in callables without joining the built-in
+        # trust domain.
+        self.registration_owner = registration_owner
+        # Capture the registration boundary once. Catalog provenance must not
+        # be recomputed later from mutable/spoofable handler metadata.
+        self.registration_module = registration_module
 
 
 class _PluginOverridePolicy:
@@ -562,6 +717,105 @@ class ToolRegistry:
         """Return the active profile's merged tool entries."""
         return self._snapshot_entries()
 
+    def _catalog_origin(self, entry: ToolEntry) -> dict:
+        """Return a stable, path-free origin descriptor for a catalog entry.
+
+        The capability catalog is intended for diagnostics, CI diffs, and
+        orchestration policy.  It must identify trust domains without leaking
+        absolute source paths or relying on a handler's repr (which may contain
+        an address). MCP origin requires both the canonical toolset shape and the
+        trusted native registration boundary; plugin identity comes from the
+        host ownership ledger rather than callable metadata.
+        """
+        if entry.registration_owner:
+            return {
+                "kind": "plugin",
+                "id": catalog_identifier(entry.registration_owner),
+            }
+        if (
+            entry.registration_module == "tools.mcp_tool"
+            and entry.toolset.startswith("mcp-")
+        ):
+            return {
+                "kind": "mcp",
+                "id": catalog_identifier(entry.toolset.removeprefix("mcp-")),
+            }
+
+        module_name = str(entry.registration_module or "")
+        if module_name == "tools" or module_name.startswith("tools."):
+            return {"kind": "builtin", "id": catalog_identifier(module_name)}
+        return {"kind": "runtime", "id": "runtime"}
+
+    def get_capability_catalog(self, *, probe: bool = False) -> dict:
+        """Return a deterministic, redacted inventory of registered tools.
+
+        ``probe=False`` is deliberately side-effect free: availability checks
+        may touch Docker, browsers, SDKs, credentials, or the network, so the
+        default path reports dynamic checks as unknown without consulting the
+        process-global probe cache.
+        ``probe=True`` executes each unique check function at most once through
+        the registry's bounded/cache-aware probe wrapper. Probe exceptions are
+        contained by that wrapper and represented as unavailable without
+        exposing exception text, which may include host paths or
+        credential-adjacent details.
+
+        The catalog contains environment variable *names* but never values,
+        handler paths, tool arguments/results, or profile filesystem paths.
+        Dynamic schema overrides are intentionally not invoked; the digest is
+        over the declared registration schema and therefore remains a safe,
+        deterministic drift signal.
+        """
+        entries = sorted(self._snapshot_entries(), key=lambda item: item.name)
+        probe_results: Dict[Callable, str] = {}
+
+        tools = []
+        for entry in entries:
+            availability = "available"
+            if entry.check_fn is not None:
+                cached = probe_results.get(entry.check_fn)
+                if cached is None:
+                    if probe:
+                        available = bool(_check_fn_cached(entry.check_fn))
+                        cached = "available" if available else "unavailable"
+                    else:
+                        cached = "unknown"
+                    probe_results[entry.check_fn] = cached
+                availability = cached
+
+            declared_env = [str(name) for name in entry.requires_env]
+            safe_env = sorted(
+                name
+                for name in declared_env
+                if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name)
+                and catalog_identifier(name) == name
+            )
+
+            canonical_schema = json.dumps(
+                _catalog_schema_contract(entry.schema),
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+            ).encode("utf-8")
+            tools.append({
+                "name": catalog_identifier(entry.name),
+                "toolset": catalog_identifier(entry.toolset),
+                "origin": self._catalog_origin(entry),
+                "requires_env": safe_env,
+                "requires_env_redacted": len(safe_env) != len(declared_env),
+                "is_async": bool(entry.is_async),
+                "max_result_size_chars": entry.max_result_size_chars,
+                "schema_sha256": hashlib.sha256(canonical_schema).hexdigest(),
+                "availability": availability,
+                "check_declared": entry.check_fn is not None,
+            })
+
+        return {
+            "schema_version": 1,
+            "probe_performed": bool(probe),
+            "toolsets": sorted({catalog_identifier(entry.toolset) for entry in entries}),
+            "tools": tools,
+        }
+
     def get_tool_names_for_toolset(self, toolset: str) -> List[str]:
         """Return sorted tool names registered under a given toolset."""
         return sorted(
@@ -669,6 +923,24 @@ class ToolRegistry:
             return None
         return self._plugin_namespace_of_module(mod)
 
+    def _registered_plugin_owner_of(self, handler: Callable) -> Optional[str]:
+        """Resolve a handler only through the host's recorded plugin ledger.
+
+        Unlike ``_plugin_owner_of``, this does not treat an arbitrary
+        ``hermes_plugins.*`` string embedded in callable metadata as authority.
+        It is used when capturing catalog provenance at registration time.
+        """
+        module_name = self._callable_module(handler)
+        if not module_name:
+            return None
+        with self._lock:
+            matches = [
+                namespace
+                for namespace in self._plugin_module_scopes
+                if module_name == namespace or module_name.startswith(f"{namespace}.")
+            ]
+        return max(matches, key=len) if matches else None
+
     @staticmethod
     def _callable_module(handler: Callable) -> str:
         """Resolve defining module through wrappers, partials, and objects."""
@@ -775,6 +1047,7 @@ class ToolRegistry:
         dynamic_schema_overrides: Callable = None,
         override: bool = False,
         scope: Optional[str] = None,
+        _registration_owner: Optional[str] = None,
     ):
         """Register a tool.  Called at module-import time by each tool file.
 
@@ -784,9 +1057,18 @@ class ToolRegistry:
         registrations that would shadow an existing tool from a different
         toolset are rejected to prevent accidental overwrites.
         """
-        handler_owner = self._plugin_owner_of(handler)
-        caller_owner = self._plugin_namespace_of_module(self._caller_module())
-        owner = caller_owner or handler_owner
+        registration_module = self._caller_module()
+        caller_owner = self._plugin_namespace_of_module(registration_module)
+        handler_owner = self._registered_plugin_owner_of(handler)
+        # The explicit owner is a host-only handoff from PluginRegistrationFacade.
+        # A plugin calling registry.register() directly must not be able to forge
+        # another trust domain through this private compatibility parameter.
+        declared_owner = (
+            _registration_owner
+            if registration_module == "hermes_cli.plugins"
+            else None
+        )
+        owner = caller_owner or declared_owner or handler_owner
         if scope is None and owner is not None:
             scope = self._plugin_scope_of(owner)
         with self._lock:
@@ -870,6 +1152,8 @@ class ToolRegistry:
                 emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
                 dynamic_schema_overrides=dynamic_schema_overrides,
+                registration_owner=owner,
+                registration_module=registration_module,
             )
             # Availability is now derived per-tool (_toolset_has_exposable_tools),
             # so this map no longer gates a toolset. It is still consumed by

--- a/website/docs/user-guide/features/tools.md
+++ b/website/docs/user-guide/features/tools.md
@@ -42,12 +42,21 @@ Paid [Nous Portal](https://portal.nousresearch.com) subscribers can use web sear
 # Use specific toolsets
 hermes chat --toolsets "web,terminal"
 
-# See all available tools
-hermes tools
-
 # Configure tools per platform (interactive)
 hermes tools
+
+# Emit a deterministic, redacted JSON catalog for audit or CI diffing
+# (availability checks are NOT run by default)
+hermes tools catalog --platform cli
+
+# Explicitly probe dynamic availability checks when needed
+hermes tools catalog --platform cli --probe
+
+# Include trusted profile/plugin tools (imports and executes plugin modules)
+hermes tools catalog --platform cli --include-plugins
 ```
+
+The capability catalog includes registered tool names, toolsets, bounded registration-time origin classes, validated environment-variable names (never values), structural schema digests, platform selection, and `available` / `unavailable` / `unknown` status. MCP origin is assigned only to tools registered through Hermes's native MCP boundary, not from an `mcp-` label alone. Credential-shaped identifier components are redacted even inside composed names such as `mcp-<server>`. Schema annotations/defaults, free-form descriptions, suspicious environment declarations, and configured identifiers with no observed capability are omitted because plugin-controlled strings can contain local paths, operator values, or secrets. MCP selections use canonical `mcp-<server>` IDs so a server name such as `file` cannot be mistaken for the built-in `file` toolset. `selected_for_platform` means the tool's toolset is selected for that platform; availability, per-session filtering, policy, and progressive disclosure can still keep it out of model-facing definitions. Unknown platforms fail instead of producing a misleading empty selection. The default command requests built-in registration only: it reports dynamic checks as `unknown` independently of process-global probe-cache state, does not execute availability probes, request profile/plugin discovery, create profile files, restore persistent delegation state, load external secrets, initialize file logging, clean quarantined executables, or sweep stale bytecode. Because the registry is process-global, `plugin_loading` reports `preloaded` when plugin contributions were already present, rather than incorrectly claiming they were skipped. `--probe` explicitly runs availability checks. `--include-plugins` follows the normal trusted-plugin import path and therefore executes plugin import code. Use `--compact` for single-line JSON.
 
 Common toolsets include `web`, `search`, `terminal`, `file`, `browser`, `vision`, `image_gen`, `skills`, `tts`, `todo`, `memory`, `session_search`, `cronjob`, `code_execution`, `delegation`, `clarify`, `homeassistant`, `messaging`, `spotify`, `discord`, `discord_admin`, `debugging`, and `safe`.
 


### PR DESCRIPTION
## Summary
- add a deterministic, redacted `hermes tools catalog` JSON inventory for audits and CI diffs
- preserve read-only startup behavior by default, with explicit `--probe` and `--include-plugins` opt-ins
- record bounded registration provenance and semantic schema digests without leaking values, paths, or incidental Python metadata
- harden plugin ownership and process-registry startup behavior; document the capability-catalog contract and absorption rationale

## How to test
```bash
hermes tools catalog --compact
hermes tools catalog --platform discord --compact
hermes tools catalog --probe --compact
```

## Verification
- macOS 26.5.2, Python project venv
- `530 passed, 5 skipped` across 14 focused catalog, registry, plugin, config, MCP, and startup test files
- regression coverage includes annotation-named schema parameters and instance data, structurally significant `$id`, standard annotations, every supported JSON Schema named-map grammar (including keyword-colliding `dependentSchemas` entries), unordered `type`/`dependentRequired`/legacy `dependencies` arrays, embedded and composed credential-shaped identifiers, trusted MCP provenance boundaries, attached short-option values, ambient-sentinel rejection on non-catalog startup paths, and cache-independent default availability
- Ruff passed for the touched implementation and test modules
- compileall and `git diff --check` passed
- isolated clean-home catalog audit created no files or SQLite connections
- repeated isolated catalog output was byte-identical
- invalid platforms fail with exit 2, emit no catalog JSON, and create no files
- platform-specific skips remain covered by the repository's Linux and Windows CI lanes

## Safety notes
- normal catalog mode skips plugin discovery/execution and dynamic availability probes
- `--probe` and `--include-plugins` are explicit side-effect boundaries
- schema digests strip annotations/default values while preserving legitimate annotation-named parameters
- the implementation was rebased onto the current upstream `main` before final verification
