### PR TITLE
fix(anthropic): enforce Claude Code credential isolation

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1108,6 +1108,48 @@ def _read_claude_code_credentials_from_file() -> Optional[Dict[str, Any]]:
     }
 
 
+def _claude_code_source_is_suppressed() -> bool:
+    """Return whether Hermes must not access Claude Code credentials.
+
+    Suppression is a credential-access boundary, so uncertainty fails closed.
+    Read both the active profile store and the global fallback through the auth
+    layer's path resolver; never hardcode ``~/.hermes``.
+    """
+
+    def _store_suppresses(store: Dict[str, Any]) -> bool:
+        if not isinstance(store, dict):
+            raise TypeError("auth store is not a mapping")
+        suppressed = store.get("suppressed_sources", {})
+        if not isinstance(suppressed, dict):
+            raise TypeError("suppressed_sources is not a mapping")
+        raw_sources = suppressed.get("anthropic", [])
+        if isinstance(raw_sources, dict):
+            return "claude_code" in raw_sources
+        if isinstance(raw_sources, list):
+            return "claude_code" in raw_sources
+        if raw_sources is None:
+            return False
+        raise TypeError("anthropic suppressed sources are malformed")
+
+    try:
+        from hermes_cli.auth import _global_auth_file_path, _load_auth_store
+
+        if _store_suppresses(_load_auth_store()):
+            return True
+        global_auth_path = _global_auth_file_path()
+        if global_auth_path is not None and _store_suppresses(
+            _load_auth_store(global_auth_path)
+        ):
+            return True
+        return False
+    except Exception:
+        logger.debug(
+            "Unable to determine Claude Code suppression state; denying credential access",
+            exc_info=True,
+        )
+        return True
+
+
 def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
     """Read refreshable Claude Code OAuth credentials.
 
@@ -1129,6 +1171,9 @@ def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
 
     Returns dict with {accessToken, refreshToken?, expiresAt?, source} or None.
     """
+    if _claude_code_source_is_suppressed():
+        return None
+
     kc_creds = _read_claude_code_credentials_from_keychain()
     file_creds = _read_claude_code_credentials_from_file()
 
@@ -1241,6 +1286,10 @@ def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
     has already produced a valid token, adopt it and skip the POST entirely.
     Only fall back to refreshing ourselves when no fresh credential is found.
     """
+    if _claude_code_source_is_suppressed():
+        logger.debug("Claude Code source is suppressed; skipping OAuth refresh")
+        return None
+
     # Claude Code may have already refreshed — adopt its token rather than
     # racing it with our (possibly already-rotated) refresh token. Only adopt
     # when the live re-read produced a DIFFERENT token with a real future
@@ -1294,6 +1343,10 @@ def _write_claude_code_credentials(
     as valid.  Claude Code >=2.1.81 gates on the presence of ``"user:inference"``
     in the stored scopes before it will use the token.
     """
+    if _claude_code_source_is_suppressed():
+        logger.debug("Claude Code source is suppressed; skipping credential write")
+        return
+
     cred_path = Path.home() / ".claude" / ".credentials.json"
     try:
         # Read existing file to preserve other fields

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1444,7 +1444,19 @@ def resolve_anthropic_token() -> Optional[str]:
     def _read_creds() -> Optional[Dict[str, Any]]:
         nonlocal creds, creds_loaded
         if not creds_loaded:
-            creds = read_claude_code_credentials()
+            try:
+                from hermes_cli.auth import is_source_suppressed
+
+                claude_code_suppressed = is_source_suppressed(
+                    "anthropic", "claude_code"
+                )
+            except Exception:
+                logger.debug(
+                    "Unable to read Claude Code suppression state; skipping credential access",
+                    exc_info=True,
+                )
+                claude_code_suppressed = True
+            creds = None if claude_code_suppressed else read_claude_code_credentials()
             creds_loaded = True
         return creds
 

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -277,6 +277,10 @@ def auth_add_command(args) -> None:
             )
             suppressed = _load_auth_store().get("suppressed_sources", {})
             for src in list(suppressed.get(provider, []) or []):
+                # Adding a Hermes-owned Anthropic credential must not re-enable
+                # auto-discovery of Claude Code's separate rotating token.
+                if provider == "anthropic" and src == "claude_code":
+                    continue
                 unsuppress_credential_source(provider, src)
         except Exception:
             pass

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4424,6 +4424,13 @@ def use_anthropic_claude_code_credentials(save_fn=None):
     writer("ANTHROPIC_TOKEN", "")
     writer("ANTHROPIC_API_KEY", "")
 
+    # This function is reached only after the user explicitly chooses Claude
+    # Code credentials, so it is the narrow re-engagement signal for this
+    # otherwise isolated credential source.
+    from hermes_cli.auth import unsuppress_credential_source
+
+    unsuppress_credential_source("anthropic", "claude_code")
+
 
 def save_anthropic_api_key(value: str, save_fn=None):
     """Persist an Anthropic API key and clear the OAuth/setup-token slot."""

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14227,6 +14227,8 @@ async def add_credential_pool_entry(body: CredentialPoolAdd):
                 )
                 suppressed = _load_auth_store().get("suppressed_sources", {})
                 for src in list(suppressed.get(provider, []) or []):
+                    if provider == "anthropic" and src == "claude_code":
+                        continue
                     unsuppress_credential_source(provider, src)
             except Exception:
                 _log.exception("unsuppress after pool add failed (non-fatal)")

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -42,6 +42,93 @@ class TestIsOAuthToken:
         assert _is_oauth_token("sk-ant-api03-abcdef1234567890") is False
 
 
+class TestClaudeCodeSuppressionBoundary:
+    @pytest.mark.parametrize(
+        ("profile_store", "global_store"),
+        [
+            ({"suppressed_sources": {"anthropic": ["claude_code"]}}, {}),
+            ({}, {"suppressed_sources": {"anthropic": ["claude_code"]}}),
+        ],
+    )
+    def test_suppression_prevents_all_credential_source_reads(
+        self, monkeypatch, profile_store, global_store
+    ):
+        global_auth_path = object()
+
+        def _load_auth_store(path=None):
+            return profile_store if path is None else global_store
+
+        monkeypatch.setattr("hermes_cli.auth._load_auth_store", _load_auth_store)
+        monkeypatch.setattr(
+            "hermes_cli.auth._global_auth_file_path", lambda: global_auth_path
+        )
+        with patch(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain"
+        ) as read_keychain, patch(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_file"
+        ) as read_file:
+            assert read_claude_code_credentials() is None
+        read_keychain.assert_not_called()
+        read_file.assert_not_called()
+
+    def test_suppression_lookup_failure_prevents_all_credential_source_reads(
+        self, monkeypatch
+    ):
+        def _raise_auth_error(_path=None):
+            raise OSError("auth store unavailable")
+
+        monkeypatch.setattr("hermes_cli.auth._load_auth_store", _raise_auth_error)
+        with patch(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain"
+        ) as read_keychain, patch(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_file"
+        ) as read_file:
+            assert read_claude_code_credentials() is None
+        read_keychain.assert_not_called()
+        read_file.assert_not_called()
+
+    def test_suppression_prevents_refresh_of_already_loaded_credentials(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._claude_code_source_is_suppressed",
+            lambda: True,
+        )
+        creds = {
+            "accessToken": "expired",
+            "refreshToken": "shared-refresh-token",
+            "expiresAt": 1,
+        }
+        refreshed = {
+            "access_token": "rotated-access-token",
+            "refresh_token": "rotated-refresh-token",
+            "expires_at_ms": 9999999999999,
+        }
+        with patch(
+            "agent.anthropic_adapter.refresh_anthropic_oauth_pure",
+            return_value=refreshed,
+        ) as refresh, patch(
+            "agent.anthropic_adapter._write_claude_code_credentials"
+        ) as write:
+            assert _refresh_oauth_token(creds) is None
+        refresh.assert_not_called()
+        write.assert_not_called()
+
+    def test_suppression_prevents_writing_claude_credential_store(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._claude_code_source_is_suppressed",
+            lambda: True,
+        )
+
+        _write_claude_code_credentials(
+            "rotated-access-token", "rotated-refresh-token", 9999999999999
+        )
+
+        assert not (tmp_path / ".claude" / ".credentials.json").exists()
+
 
 
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -376,6 +376,44 @@ class TestResolveAnthropicToken:
         assert resolve_anthropic_token() == "pool-oauth-token"
         assert captured == {"clear_expired": False, "refresh": False}
 
+    def test_suppression_lookup_failure_does_not_read_claude_code_credentials(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "«redacted:sk-…»")
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+
+        def _raise_suppression_error(_provider, _source):
+            raise OSError("auth store unavailable")
+
+        monkeypatch.setattr(
+            "hermes_cli.auth.is_source_suppressed",
+            _raise_suppression_error,
+        )
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_claude_code_credentials",
+            self._assert_not_called,
+        )
+
+        assert resolve_anthropic_token() == "«redacted:sk-…»"
+
+    def test_suppressed_claude_code_source_is_not_read_for_static_anthropic_token(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "«redacted:sk-…»")
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.auth.is_source_suppressed",
+            lambda provider, source: provider == "anthropic" and source == "claude_code",
+        )
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_claude_code_credentials",
+            self._assert_not_called,
+        )
+
+        assert resolve_anthropic_token() == "«redacted:sk-…»"
+
     def test_prefers_refreshable_claude_code_credentials_over_static_anthropic_token(self, monkeypatch, tmp_path):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-static-token")

--- a/tests/hermes_cli/test_anthropic_provider_persistence.py
+++ b/tests/hermes_cli/test_anthropic_provider_persistence.py
@@ -32,3 +32,21 @@ def test_use_anthropic_claude_code_credentials_clears_env_slots(tmp_path, monkey
     assert env_vars["ANTHROPIC_API_KEY"] == ""
 
 
+def test_use_anthropic_claude_code_credentials_clears_source_suppression(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from hermes_cli.auth import is_source_suppressed, suppress_credential_source
+    from hermes_cli.config import use_anthropic_claude_code_credentials
+
+    suppress_credential_source("anthropic", "claude_code")
+    assert is_source_suppressed("anthropic", "claude_code")
+
+    use_anthropic_claude_code_credentials()
+
+    assert not is_source_suppressed("anthropic", "claude_code")
+
+

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -116,6 +116,34 @@ def test_auth_add_api_key_persists_manual_entry(tmp_path, monkeypatch):
     assert entry["access_token"] == "sk-or-manual"
 
 
+def test_auth_add_anthropic_manual_key_preserves_claude_code_suppression(
+    tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {},
+            "suppressed_sources": {"anthropic": ["claude_code"]},
+        },
+    )
+
+    from hermes_cli.auth import is_source_suppressed
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "anthropic"
+        auth_type = "api-key"
+        api_key = "test-anthropic-key"
+        label = "hermes-owned"
+
+    auth_add_command(_Args())
+
+    assert is_source_suppressed("anthropic", "claude_code")
+
+
 def test_auth_add_configured_provider_uses_canonical_pool_key(tmp_path, monkeypatch):
     """A keyed providers row must keep its runtime slug in the auth pool."""
     hermes_home = tmp_path / "hermes"

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -209,6 +209,20 @@ class TestCredentialPoolEndpoints:
         sources = sorted(e.source for e in load_pool("openrouter").entries())
         assert sources == ["env:OPENROUTER_API_KEY", "manual"]
 
+    def test_post_anthropic_manual_key_preserves_claude_code_suppression(self):
+        from hermes_cli.auth import is_source_suppressed, suppress_credential_source
+
+        suppress_credential_source("anthropic", "claude_code")
+        assert is_source_suppressed("anthropic", "claude_code")
+
+        response = self.client.post(
+            "/api/credentials/pool",
+            json={"provider": "anthropic", "api_key": "test-anthropic-key"},
+        )
+
+        assert response.status_code == 200
+        assert is_source_suppressed("anthropic", "claude_code")
+
 
 
 


### PR DESCRIPTION
## Summary

- Enforce `anthropic/claude_code` suppression at the Claude credential boundary, not only inside `resolve_anthropic_token()`.
- Block Keychain and fallback-file reads before they happen.
- Block refresh and write-back even when a caller already holds stale Claude credentials.
- Read profile and global suppression through Hermes's auth path helpers. If the state cannot be determined, deny access.
- Preserve Claude Code suppression when a user adds a separate Hermes-owned Anthropic credential. Clear it only when the user explicitly chooses Claude Code credentials.

## Relationship to #64738

#64738 identified the same resolver bypass, but its current patch:

- gates only `resolve_anthropic_token()`;
- hardcodes `~/.hermes/auth.json` for the global fallback;
- fails open when suppression lookup fails;
- leaves `hermes auth add anthropic` and the dashboard credential endpoint clearing the `claude_code` marker.

This revision addresses those review findings and the sibling refresh path documented in #83338. `agent/auxiliary_client.py` can read and refresh Claude credentials directly after an Anthropic 401, bypassing a resolver-only guard.

## Behavior

When `anthropic/claude_code` is suppressed:

- `read_claude_code_credentials()` returns before accessing Keychain or `~/.claude/.credentials.json`;
- `_refresh_oauth_token()` cannot consume an already-loaded rotating refresh token;
- `_write_claude_code_credentials()` cannot create or rewrite Claude's fallback store;
- profile and global-root markers both apply, including custom `HERMES_HOME` and native-Windows path rules;
- malformed or unreadable suppression state fails closed.

Adding a manual Anthropic API key or Hermes PKCE credential keeps `claude_code` suppressed. Explicitly selecting Claude Code credentials clears that marker.

## Verification

```text
120 passed  adapter, Keychain, token-scope, and pool-fallback suites
31 passed   auth command and Anthropic persistence suites
42 passed   dashboard admin endpoint suite
193 passed  total
```

A live macOS check also confirmed that Hermes resolved its independent Anthropic token without changing the Claude Code Keychain entry or recreating `~/.claude/.credentials.json`. Standalone Claude Fable 5 and a fresh T3 Code Fable 5 thread both passed afterward.
