### PR TITLE
feat(cron): persist delivery message references

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2133,7 +2133,8 @@ def create_job(
         "last_status": None,
         "last_error": None,
         "last_delivery_error": None,
-        # Structured transport references from the latest successful delivery.
+        # Structured transport references confirmed during the latest delivery
+        # attempt. A later failed attempt intentionally clears these receipts.
         # Keep provider responses and message content out of persistent job state.
         "last_delivery_receipts": [],
         "failure_streak": 0,

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2133,6 +2133,9 @@ def create_job(
         "last_status": None,
         "last_error": None,
         "last_delivery_error": None,
+        # Structured transport references from the latest successful delivery.
+        # Keep provider responses and message content out of persistent job state.
+        "last_delivery_receipts": [],
         "failure_streak": 0,
         # Delivery configuration
         "deliver": deliver,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2861,11 +2861,14 @@ def _record_delivery_receipt(
     configured_thread_id: Optional[str],
     send_result: Any,
 ) -> None:
-    """Persist safe identifiers for a confirmed delivery, never provider payloads.
+    """Persist safe identifiers for a confirmed *text* delivery, never payloads.
 
     This lets automation link a just-created Slack discussion to an external
     artifact without depending on the bot receiving its own outbound message.
     A root message is its own Slack thread anchor; replies retain their parent.
+    Attachment-only sends do not currently create receipts. ``thread_id`` is a
+    platform-routing identifier: on non-Slack platforms consumers must treat it
+    as opaque rather than assume it names a discussion thread.
     """
     if isinstance(send_result, dict):
         message_id = send_result.get("message_id")
@@ -2889,8 +2892,9 @@ def _record_delivery_receipt(
     receipts = job.setdefault("_delivery_receipts", [])
     if receipt not in receipts:
         receipts.append(receipt)
-        # update_job acquires the job-store lock, so concurrent cron executions
-        # cannot clobber a receipt while marking another job run.
+        # One job has one active delivery attempt: claim_job_for_fire() fences
+        # concurrent fires before they reach _deliver_result. update_job's lock
+        # then serializes this persistence with other job-store mutations.
         update_job(job["id"], {"last_delivery_receipts": receipts})
 
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -544,6 +544,7 @@ from cron.jobs import (
     heartbeat_run_claim,
     mark_job_run,
     save_job_output,
+    update_job,
     use_cron_store,
 )
 from cron.executions import create_execution, finish_execution, mark_execution_running
@@ -2853,6 +2854,46 @@ def _is_channel_dm_topic(
     return is_channel
 
 
+def _record_delivery_receipt(
+    job: dict,
+    platform_name: str,
+    chat_id: str,
+    configured_thread_id: Optional[str],
+    send_result: Any,
+) -> None:
+    """Persist safe identifiers for a confirmed delivery, never provider payloads.
+
+    This lets automation link a just-created Slack discussion to an external
+    artifact without depending on the bot receiving its own outbound message.
+    A root message is its own Slack thread anchor; replies retain their parent.
+    """
+    if isinstance(send_result, dict):
+        message_id = send_result.get("message_id")
+        raw = send_result.get("raw_response")
+    else:
+        message_id = getattr(send_result, "message_id", None)
+        raw = getattr(send_result, "raw_response", None)
+    if not message_id and isinstance(raw, dict):
+        message_id = raw.get("ts") or (raw.get("message") or {}).get("ts")
+    if not message_id:
+        return
+    thread_id = configured_thread_id
+    if isinstance(raw, dict):
+        thread_id = raw.get("thread_ts") or (raw.get("message") or {}).get("thread_ts") or thread_id
+    receipt = {
+        "platform": str(platform_name),
+        "chat_id": str(chat_id),
+        "message_id": str(message_id),
+        "thread_id": str(thread_id or message_id),
+    }
+    receipts = job.setdefault("_delivery_receipts", [])
+    if receipt not in receipts:
+        receipts.append(receipt)
+        # update_job acquires the job-store lock, so concurrent cron executions
+        # cannot clobber a receipt while marking another job run.
+        update_job(job["id"], {"last_delivery_receipts": receipts})
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -2865,6 +2906,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     Returns None on success, or an error string on failure.
     """
     targets = _resolve_delivery_targets(job)
+    # Receipts describe this run only. Keep the working copy local until a
+    # confirmed provider response supplies a safe message identifier.
+    job.pop("_delivery_receipts", None)
+    update_job(job["id"], {"last_delivery_receipts": []})
     if not targets:
         deliver_value = _normalize_deliver_value(job.get("deliver", "local"))
         if deliver_value == "local":
@@ -3418,6 +3463,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                 )
                                 logger.warning("Job '%s': %s", job["id"], msg)
                                 delivery_errors.append(msg)
+                            else:
+                                _record_delivery_receipt(
+                                    job, platform_name, chat_id, thread_id, send_result,
+                                )
 
                 # Send extracted media files as native attachments via the live
                 # adapter, using the same DM-topic-aware routing as the text send
@@ -3644,6 +3693,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 logger.error("Job '%s': %s", job["id"], msg)
                 delivery_errors.append(msg)
 
+            _record_delivery_receipt(
+                job, platform_name, chat_id, thread_id, result,
+            )
             logger.info("Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id)
             _maybe_mirror_cron_delivery(
                 job, platform_name, chat_id, mirror_text,

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -335,6 +335,49 @@ class TestRoutingIntents:
         assert "matrix" not in platforms
 
 
+class TestDeliveryReceipts:
+    """Cron stores only provider routing identifiers, not outbound content."""
+
+    def test_records_slack_root_message_as_its_own_thread(self):
+        from cron.scheduler import _record_delivery_receipt
+
+        job = {"id": "receipt-job"}
+        sent = MagicMock(
+            message_id="1787612400.000100",
+            raw_response={"ts": "1787612400.000100", "text": "must not persist"},
+        )
+        with patch("cron.scheduler.update_job") as update:
+            _record_delivery_receipt(job, "slack", "C123", None, sent)
+
+        assert job["_delivery_receipts"] == [{
+            "platform": "slack",
+            "chat_id": "C123",
+            "message_id": "1787612400.000100",
+            "thread_id": "1787612400.000100",
+        }]
+        update.assert_called_once_with("receipt-job", {
+            "last_delivery_receipts": job["_delivery_receipts"],
+        })
+
+    def test_records_parent_thread_for_a_reply(self):
+        from cron.scheduler import _record_delivery_receipt
+
+        job = {"id": "reply-receipt-job"}
+        result = {
+            "message_id": "1787612401.000200",
+            "raw_response": {"ts": "1787612401.000200", "thread_ts": "1787612400.000100"},
+        }
+        with patch("cron.scheduler.update_job"):
+            _record_delivery_receipt(job, "slack", "C123", None, result)
+
+        assert job["_delivery_receipts"] == [{
+            "platform": "slack",
+            "chat_id": "C123",
+            "message_id": "1787612401.000200",
+            "thread_id": "1787612400.000100",
+        }]
+
+
 class TestDeliverResultWrapping:
     """Verify that cron deliveries are wrapped with header/footer and no longer mirrored."""
 


### PR DESCRIPTION
## Summary
- persist safe platform/chat/message/thread identifiers for confirmed cron deliveries
- capture the reference from both live-adapter and standalone transport paths
- retain only routing identifiers, never provider response payloads or message content

This enables follow-on automation to link a cron-created Slack discussion to an external artifact without relying on the gateway receiving the bot’s own outbound message.

## Test plan
- `scripts/run_tests.sh tests/cron/test_scheduler.py -q`
  - 105 passed