### PR TITLE
fix(bot-mode): bridge protected approvals to desktop

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -21561,6 +21561,26 @@ def main(
                         # (they check agent.tool_progress_mode, initialized
                         # from display.tool_progress at construction).
                         cli.agent.tool_progress_mode = "off"
+                        # Bot Mode query-file deliveries run outside the target
+                        # profile gateway process, so route approvals through a
+                        # durable mailbox that the open Bot Chat gateway polls.
+                        try:
+                            from tools.bot_mode_approval import (
+                                install_bot_mode_approval_callback,
+                            )
+
+                            install_bot_mode_approval_callback(
+                                cli,
+                                timeout=int(
+                                    CLI_CONFIG.get("approvals", {}).get(
+                                        "timeout", 300
+                                    )
+                                ),
+                            )
+                        except Exception:
+                            # Fail closed: without the bridge, protected tools
+                            # retain their normal timeout/deny behavior.
+                            pass
                         try:
                             result = cli.agent.run_conversation(
                                 user_message=effective_query,

--- a/tests/tools/test_bot_mode_approval.py
+++ b/tests/tools/test_bot_mode_approval.py
@@ -1,0 +1,264 @@
+import threading
+import time
+from unittest.mock import patch
+
+
+def test_query_file_bot_mode_approval_round_trip(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.bot_mode_approval import (
+        get_pending_bot_mode_approval,
+        request_bot_mode_approval,
+        resolve_bot_mode_approval,
+    )
+
+    result = []
+    worker = threading.Thread(
+        target=lambda: result.append(
+            request_bot_mode_approval(
+                session_key="bot-chat-session",
+                command="write: /other-profile/SOUL.md",
+                description="Protected instruction file write",
+                choices=["once", "deny"],
+                timeout=2.0,
+            )
+        ),
+        daemon=True,
+    )
+    worker.start()
+
+    pending = None
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        pending = get_pending_bot_mode_approval("bot-chat-session")
+        if pending is not None:
+            break
+        time.sleep(0.01)
+
+    assert pending is not None
+    assert pending["command"] == "write: /other-profile/SOUL.md"
+    assert pending["choices"] == ["once", "deny"]
+    assert resolve_bot_mode_approval(
+        "bot-chat-session", "once", request_id=pending["request_id"]
+    )
+
+    worker.join(timeout=1.0)
+    assert not worker.is_alive()
+    assert result == ["once"]
+    assert get_pending_bot_mode_approval("bot-chat-session") is None
+
+
+def test_bridge_rejects_unoffered_choice_and_invalid_request_id(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.bot_mode_approval import (
+        get_pending_bot_mode_approval,
+        request_bot_mode_approval,
+        resolve_bot_mode_approval,
+    )
+
+    result = []
+    worker = threading.Thread(
+        target=lambda: result.append(
+            request_bot_mode_approval(
+                session_key="bot-chat-session",
+                command="write: /other-profile/SOUL.md",
+                description="Protected instruction file write",
+                choices=["once", "deny"],
+                timeout=2.0,
+            )
+        ),
+        daemon=True,
+    )
+    worker.start()
+
+    pending = None
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        pending = get_pending_bot_mode_approval("bot-chat-session")
+        if pending is not None:
+            break
+        time.sleep(0.01)
+
+    assert pending is not None
+    request_id = pending["request_id"]
+    assert not resolve_bot_mode_approval(
+        "bot-chat-session", "session", request_id=request_id
+    )
+    assert not resolve_bot_mode_approval(
+        "bot-chat-session", "once", request_id="../outside"
+    )
+    assert resolve_bot_mode_approval(
+        "bot-chat-session", "deny", request_id=request_id
+    )
+
+    worker.join(timeout=1.0)
+    assert not worker.is_alive()
+    assert result == ["deny"]
+
+
+def test_installed_callback_routes_one_operation_approval(monkeypatch):
+    monkeypatch.setenv("HERMES_BOT_MODE_QUERY_FILE", "1")
+
+    import tools.bot_mode_approval as bridge
+    from tools.terminal_tool import _get_approval_callback, set_approval_callback
+
+    seen = {}
+
+    def fake_request(**kwargs):
+        seen.update(kwargs)
+        return "once"
+
+    class FakeCli:
+        session_id = "bot-chat-session"
+
+        @staticmethod
+        def _approval_choices(command, **kwargs):
+            assert kwargs["allow_session"] is False
+            return ["once", "deny"]
+
+    monkeypatch.setattr(bridge, "request_bot_mode_approval", fake_request)
+    try:
+        assert bridge.install_bot_mode_approval_callback(FakeCli(), timeout=60.0)
+        callback = _get_approval_callback()
+        assert callback is not None
+        assert callback(
+            "write: /other-profile/SOUL.md",
+            "Protected instruction file write",
+            allow_permanent=False,
+            allow_session=False,
+        ) == "once"
+    finally:
+        set_approval_callback(None)
+
+    assert seen == {
+        "session_key": "bot-chat-session",
+        "command": "write: /other-profile/SOUL.md",
+        "description": "Protected instruction file write",
+        "choices": ["once", "deny"],
+        "timeout": 60.0,
+    }
+
+
+def test_installed_callback_timeout_is_a_downstream_denial(monkeypatch):
+    monkeypatch.setenv("HERMES_BOT_MODE_QUERY_FILE", "1")
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+
+    import tools.bot_mode_approval as bridge
+    from tools import approval
+    from tools.terminal_tool import set_approval_callback
+
+    class FakeCli:
+        session_id = "bot-chat-session"
+
+        @staticmethod
+        def _approval_choices(command, **kwargs):
+            return ["once", "deny"]
+
+    monkeypatch.setattr(bridge, "request_bot_mode_approval", lambda **kwargs: "timeout")
+    approval._session_approved.clear()
+    approval._permanent_approved.clear()
+
+    try:
+        assert bridge.install_bot_mode_approval_callback(FakeCli(), timeout=0.01)
+
+        with patch("hermes_cli.config.load_config_readonly", return_value={"approvals": {"mode": "manual"}}):
+            result = approval.check_all_command_guards("rm -rf /var/data", "local")
+    finally:
+        set_approval_callback(None)
+
+    assert result["approved"] is False
+    assert result["outcome"] == "timeout"
+    assert result["user_consent"] is False
+    assert "Silence is not consent" in result["message"]
+
+
+def test_resolution_lock_allows_only_one_writer(tmp_path):
+    from tools.bot_mode_approval import _resolution_lock
+
+    record = tmp_path / "approval.json"
+
+    with _resolution_lock(record) as first:
+        assert first
+
+        with _resolution_lock(record) as second:
+            assert not second
+
+    with _resolution_lock(record) as after_release:
+        assert after_release
+
+
+def test_desktop_gateway_surfaces_and_resolves_query_file_approval(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.bot_mode_approval import request_bot_mode_approval
+    from tui_gateway import server
+
+    result = []
+    worker = threading.Thread(
+        target=lambda: result.append(
+            request_bot_mode_approval(
+                session_key="bot-chat-session",
+                command="write: /other-profile/SOUL.md",
+                description="Protected instruction file write",
+                choices=["once", "deny"],
+                timeout=2.0,
+            )
+        ),
+        daemon=True,
+    )
+    worker.start()
+
+    payload = None
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        payload = server._pending_approval_request_payload("bot-chat-session")
+        if payload is not None:
+            break
+        time.sleep(0.01)
+
+    assert payload is not None
+    assert payload["choices"] == ["once", "deny"]
+    assert payload["command"] == "write: /other-profile/SOUL.md"
+
+    emitted = []
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, data=None: emitted.append((event, sid, data)),
+    )
+    seen_request_ids = set()
+    server._poll_bot_mode_approval(
+        "live-bot-chat",
+        {"session_key": "bot-chat-session"},
+        seen_request_ids,
+    )
+    server._poll_bot_mode_approval(
+        "live-bot-chat",
+        {"session_key": "bot-chat-session"},
+        seen_request_ids,
+    )
+    assert emitted == [("approval.request", "live-bot-chat", payload)]
+
+    server._sessions["live-bot-chat"] = {"session_key": "bot-chat-session"}
+    try:
+        response = server.handle_request(
+            {
+                "id": "approval-1",
+                "method": "approval.respond",
+                "params": {
+                    "session_id": "live-bot-chat",
+                    "request_id": payload["request_id"],
+                    "choice": "once",
+                },
+            }
+        )
+    finally:
+        server._sessions.pop("live-bot-chat", None)
+
+    assert response is not None
+    assert type(response["result"]["resolved"]) is int
+    assert response["result"]["resolved"] == 1
+    worker.join(timeout=1.0)
+    assert not worker.is_alive()
+    assert result == ["once"]

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -369,6 +369,30 @@ def test_delivery_runner_unlinks_when_child_launch_raises(tmp_path, monkeypatch)
     assert not dm_file.exists()
 
 
+def test_query_file_delivery_marks_bot_mode_approval_bridge(tmp_path):
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+    observed = tmp_path / "observed.txt"
+    child = tmp_path / "child.py"
+    child.write_text(
+        "import os, pathlib, sys\n"
+        "pathlib.Path(sys.argv[1]).write_text(\n"
+        "    os.environ.get('HERMES_BOT_MODE_QUERY_FILE', ''), encoding='utf-8'\n"
+        ")\n",
+        encoding="utf-8",
+    )
+
+    returncode = bot_mode_dm._run_delivery(
+        [sys.executable, str(child), str(observed)],
+        str(dm_file),
+        stdin_file=False,
+    )
+
+    assert returncode == 0
+    assert observed.read_text(encoding="utf-8") == "1"
+    assert not dm_file.exists()
+
+
 def test_delivery_runner_preserves_child_failure_and_unlinks(tmp_path):
     dm_file = tmp_path / "message.txt"
     dm_file.write_text("secret", encoding="utf-8")

--- a/tools/bot_mode_approval.py
+++ b/tools/bot_mode_approval.py
@@ -1,0 +1,266 @@
+"""Cross-process approval bridge for Bot Mode query-file deliveries.
+
+Mailbox modes are a POSIX privacy boundary. On Windows, ``chmod`` only
+controls the read-only bit, so records follow Hermes' usual same-user threat
+model: other processes running as that user can read or write them.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator, Optional
+
+from hermes_constants import get_hermes_home
+
+_BRIDGE_ENV = "HERMES_BOT_MODE_QUERY_FILE"
+_ALLOWED_CHOICES = {"once", "session", "always", "deny"}
+
+
+def bridge_enabled() -> bool:
+    return os.getenv(_BRIDGE_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def install_bot_mode_approval_callback(cli: Any, *, timeout: float) -> bool:
+    """Install the durable callback only in marked Bot Mode query processes."""
+    if not bridge_enabled() or not str(getattr(cli, "session_id", "") or ""):
+        return False
+
+    from tools.terminal_tool import set_approval_callback
+
+    def callback(
+        command: str,
+        description: str,
+        *,
+        allow_permanent: bool = True,
+        allow_session: bool = True,
+        smart_denied: bool = False,
+    ) -> str:
+        choices = cli._approval_choices(
+            command,
+            allow_permanent=allow_permanent,
+            allow_session=allow_session,
+            smart_denied=smart_denied,
+        )
+        return request_bot_mode_approval(
+            session_key=str(cli.session_id),
+            command=command,
+            description=description,
+            choices=choices,
+            timeout=timeout,
+        )
+
+    set_approval_callback(callback)
+    return True
+
+
+def _mailbox_dir(home: Optional[Path] = None, *, create: bool = False) -> Path:
+    root = Path(home) if home is not None else get_hermes_home()
+    directory = root / "runtime" / "bot-mode-approvals"
+    if create:
+        directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        try:
+            directory.chmod(0o700)
+        except OSError:
+            pass
+    return directory
+
+
+def _write_record(path: Path, record: dict) -> None:
+    fd, temp_name = tempfile.mkstemp(prefix=".approval-", dir=str(path.parent))
+    temp_path = Path(temp_name)
+    try:
+        os.chmod(temp_path, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(record, stream, ensure_ascii=False, separators=(",", ":"))
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temp_path, path)
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            temp_path.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def _read_record(path: Path) -> Optional[dict]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+@contextmanager
+def _resolution_lock(path: Path) -> Iterator[bool]:
+    """Atomically elect one resolver for ``path`` across local processes.
+
+    A crashed resolver leaves the lock behind and the request times out denied,
+    which is safer than allowing a second choice to overwrite the first.
+    """
+    lock_path = path.with_name(f"{path.name}.lock")
+
+    try:
+        lock_path.mkdir(mode=0o700)
+    except FileExistsError:
+        yield False
+        return
+
+    try:
+        yield True
+    finally:
+        try:
+            lock_path.rmdir()
+        except OSError:
+            pass
+
+
+def _timestamp(value: object) -> float:
+    if not isinstance(value, (int, float, str)):
+        return 0.0
+    try:
+        return float(value or 0)
+    except ValueError:
+        return 0.0
+
+
+def _valid_request_id(value: object) -> bool:
+    if not isinstance(value, str) or len(value) != 32:
+        return False
+    return all(char in "0123456789abcdef" for char in value)
+
+
+def request_bot_mode_approval(
+    *,
+    session_key: str,
+    command: str,
+    description: str,
+    choices: list[str],
+    timeout: float,
+) -> str:
+    """Publish one request and block until the profile gateway answers or times out."""
+    offered = [choice for choice in choices if choice in _ALLOWED_CHOICES]
+    if not session_key or not offered:
+        return "deny"
+
+    request_id = uuid.uuid4().hex
+    now = time.time()
+    timeout = max(0.0, float(timeout))
+    record = {
+        "request_id": request_id,
+        "session_key": session_key,
+        "command": command,
+        "description": description,
+        "choices": offered,
+        "created_at": now,
+        "expires_at": now + timeout,
+        "status": "pending",
+    }
+    path = _mailbox_dir(create=True) / f"{request_id}.json"
+    _write_record(path, record)
+
+    deadline = time.monotonic() + timeout
+    try:
+        while time.monotonic() < deadline:
+            current = _read_record(path)
+            if current is None:
+                return "deny"
+            if current.get("status") == "resolved":
+                choice = current.get("choice")
+                return choice if choice in offered else "deny"
+            time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
+        return "timeout"
+    finally:
+        try:
+            path.unlink()
+        except OSError:
+            pass
+
+
+def get_pending_bot_mode_approval(
+    session_key: str, *, home: Optional[Path] = None
+) -> Optional[dict]:
+    """Return the oldest non-expired pending request for a durable session."""
+    directory = _mailbox_dir(home)
+    if not directory.is_dir() or not session_key:
+        return None
+
+    now = time.time()
+    pending: list[dict] = []
+    for path in directory.glob("*.json"):
+        record = _read_record(path)
+        if record is None:
+            continue
+        expires_at = _timestamp(record.get("expires_at"))
+        if expires_at <= now:
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            continue
+        if record.get("status") != "pending" or record.get("session_key") != session_key:
+            continue
+        request_id = record.get("request_id")
+        choices = record.get("choices")
+        if not _valid_request_id(request_id) or not isinstance(choices, list):
+            continue
+        if not choices or any(choice not in _ALLOWED_CHOICES for choice in choices):
+            continue
+        pending.append(record)
+
+    pending.sort(
+        key=lambda item: (
+            _timestamp(item.get("created_at")),
+            str(item.get("request_id") or ""),
+        )
+    )
+    return pending[0] if pending else None
+
+
+def resolve_bot_mode_approval(
+    session_key: str,
+    choice: str,
+    *,
+    request_id: str,
+    home: Optional[Path] = None,
+) -> bool:
+    """Resolve one request, validating identity and the originally offered choice."""
+    if (
+        not session_key
+        or not _valid_request_id(request_id)
+        or choice not in _ALLOWED_CHOICES
+    ):
+        return False
+    path = _mailbox_dir(home) / f"{request_id}.json"
+
+    with _resolution_lock(path) as won:
+        if not won:
+            return False
+
+        record = _read_record(path)
+        if record is None or record.get("status") != "pending":
+            return False
+        if record.get("session_key") != session_key:
+            return False
+        choices = record.get("choices")
+        if not isinstance(choices, list) or choice not in choices:
+            return False
+        if _timestamp(record.get("expires_at")) <= time.time():
+            return False
+
+        updated = dict(record)
+        updated["status"] = "resolved"
+        updated["choice"] = choice
+        updated["resolved_at"] = time.time()
+        _write_record(path, updated)
+        return True

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -569,11 +569,14 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
                 # after subprocess.run returns, not merely after stdin reaches EOF.
                 with open(dm_file, "r", encoding="utf-8") as stream:
                     return subprocess.run(argv, stdin=stream, check=False).returncode
+            env = os.environ.copy()
+            env["HERMES_BOT_MODE_QUERY_FILE"] = "1"
             proc = subprocess.run(
                 [*argv, "--query-file", dm_file],
                 check=False,
                 capture_output=True,
                 text=True,
+                env=env,
             )
             if proc.returncode != 0:
                 from tools.bot_failure_reasons import (
@@ -589,6 +592,7 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
                         check=False,
                         capture_output=True,
                         text=True,
+                        env=env,
                     )
             # Re-emit the transport's streams: stdout is the reply text the
             # completion notification carries back to the sending agent.

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -1678,17 +1678,27 @@ def _(rid, params: dict) -> dict:
     try:
         from tools.approval import resolve_gateway_approval
 
-        return _ok(
-            rid,
-            {
-                "resolved": resolve_gateway_approval(
-                    session["session_key"],
-                    params.get("choice", "deny"),
-                    resolve_all=params.get("all", False),
-                    request_id=params.get("request_id"),
-                )
-            },
+        choice = params.get("choice", "deny")
+        request_id = params.get("request_id")
+        resolved = resolve_gateway_approval(
+            session["session_key"],
+            choice,
+            resolve_all=params.get("all", False),
+            request_id=request_id,
         )
+        if not resolved and request_id:
+            from tools.bot_mode_approval import resolve_bot_mode_approval
+
+            # Match resolve_gateway_approval's integer count contract so RPC
+            # clients see the same payload shape on both resolution paths.
+            resolved = int(
+                resolve_bot_mode_approval(
+                    session["session_key"],
+                    choice,
+                    request_id=request_id,
+                )
+            )
+        return _ok(rid, {"resolved": resolved})  # type: ignore[name-defined]
     except Exception as e:
         return _err(rid, 5004, str(e))
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2333,15 +2333,37 @@ def _pending_clarify_request_payload(sid: str) -> dict | None:
 
 
 def _pending_approval_request_payload(session_key: str) -> dict | None:
-    """Read the oldest unresolved approval in a session, if there is one."""
+    """Read the oldest unresolved in-process or Bot Mode approval."""
     try:
         from tools.approval import get_pending_gateway_approval
 
         approval = get_pending_gateway_approval(session_key)
+        if not approval:
+            from tools.bot_mode_approval import get_pending_bot_mode_approval
+
+            approval = get_pending_bot_mode_approval(session_key)
     except Exception:
         logger.debug("failed to read pending approval for %s", session_key, exc_info=True)
         return None
     return _approval_request_payload(approval) if approval else None
+
+
+def _poll_bot_mode_approval(sid: str, session: dict, seen: set[str]) -> None:
+    """Surface a new approval owned by an external Bot Mode query process."""
+    try:
+        from tools.bot_mode_approval import get_pending_bot_mode_approval
+
+        approval = get_pending_bot_mode_approval(str(session.get("session_key") or ""))
+    except Exception:
+        logger.debug("failed to poll Bot Mode approvals for %s", sid, exc_info=True)
+        return
+    if not approval:
+        return
+    request_id = str(approval.get("request_id") or "")
+    if not request_id or request_id in seen:
+        return
+    seen.add(request_id)
+    _emit_approval_request(sid, approval)
 
 
 def _emit_approval_request(sid: str, data: dict | None) -> None:
@@ -10804,9 +10826,13 @@ def _notification_poller_loop(
     from tools.process_registry import process_registry, format_process_notification
 
     _emitted = set()  # dedup re-queued events so same completion isn't emitted 50 times while session is busy
+    # Per-session and bounded by approvals surfaced during this poller's
+    # lifetime; the set is discarded when the session finalizes.
+    _bot_mode_approvals_seen: set[str] = set()
     _last_kanban_poll = 0.0
     _last_loop_poll = 0.0
     while not stop_event.is_set() and not session.get("_finalized"):
+        _poll_bot_mode_approval(sid, session, _bot_mode_approvals_seen)
         _now = time.monotonic()
         # ── /loop wakeup driver ──────────────────────────────────────
         # Fire a due /loop tick for THIS session while it's idle. Same


### PR DESCRIPTION
## Summary

- Add a cross-process approval bridge for Bot Mode query-file deliveries.
- Surface protected choices through the desktop gateway and return the selected choice to the originating turn.
- Reject stale request IDs and choices that were not offered.

## Tests

- `pytest -q tests/tools/test_bot_mode_approval.py tests/tools/test_bot_mode_dm.py` — 44 passed
- Relevant approval and gateway suites verified independently.
