### PR TITLE
fix(desktop): reconcile background bot deliveries

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -366,6 +366,32 @@ describe('toChatMessages', () => {
     }
   })
 
+  it('never paints persisted wait-interrupt metadata as an assistant bubble', () => {
+    const messages = toChatMessages([
+      { role: 'user', content: 'check every bot', timestamp: 1 },
+      {
+        role: 'assistant',
+        content: 'Operation interrupted: waiting for model response (7.9s elapsed).',
+        timestamp: 2
+      },
+      { role: 'user', content: 'why did that appear?', timestamp: 3 }
+    ])
+
+    expect(messages.map(chatMessageText)).toEqual(['check every bot', 'why did that appear?'])
+  })
+
+  it('keeps assistant prose that only starts like wait-interrupt metadata', () => {
+    const lookalike =
+      'Operation interrupted: waiting for model response (7.9s elapsed). This is what the cancellation notice looks like.'
+
+    const messages = toChatMessages([
+      { role: 'user', content: 'show me the notice', timestamp: 1 },
+      { role: 'assistant', content: lookalike, timestamp: 2 }
+    ])
+
+    expect(messages.map(chatMessageText)).toEqual(['show me the notice', lookalike])
+  })
+
   it('projects persisted composite compaction carriers to their live user turn', () => {
     const messages = toChatMessages([
       {

--- a/apps/desktop/src/lib/chat-messages/hydration.ts
+++ b/apps/desktop/src/lib/chat-messages/hydration.ts
@@ -19,6 +19,12 @@ const ATTACHED_CONTEXT_MARKER_RE = /(?:^|\n)--- Attached Context ---\s*\n/
 const CONTEXT_WARNINGS_MARKER_RE = /(?:^|\n)--- Context Warnings ---[\s\S]*$/
 const CONTEXT_REF_RE = /@(file|folder|url|image|tool|terminal):(?:"[^"\n]+"|'[^'\n]+'|`[^`\n]+`|\S+)/g
 
+// Must match the complete sentinel emitted from
+// agent/conversation_loop.py:INTERRUPT_WAITING_FOR_MODEL_PREFIX. Keep this
+// structural and exact: prefix matching can hide legitimate assistant prose.
+const INTERRUPT_WAITING_FOR_MODEL_RE =
+  /^Operation interrupted: waiting for model response \(\d+(?:\.\d+)?s elapsed\)\.$/
+
 function displayContentForMessage(role: SessionMessage['role'], content: unknown): string {
   const textContent = textFromUnknown(content)
 
@@ -53,7 +59,18 @@ function displayContentForMessage(role: SessionMessage['role'], content: unknown
   return [missing.join('\n'), visibleText].filter(Boolean).join('\n\n') || visibleText
 }
 
-function transcriptContent(displayKind: SessionMessage['display_kind'], content: string): string | null {
+function transcriptContent(
+  role: SessionMessage['role'],
+  displayKind: SessionMessage['display_kind'],
+  content: string
+): string | null {
+  // This persisted cancellation sentinel is transport metadata, not assistant
+  // prose. The live gateway suppresses it; hydration must do the same or a
+  // reconnect paints the metadata as a fresh assistant card.
+  if (role === 'assistant' && INTERRUPT_WAITING_FOR_MODEL_RE.test(content.trim())) {
+    return null
+  }
+
   return displayKind === 'hidden' ? null : content
 }
 
@@ -195,6 +212,7 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
         : message.content || message.text || message.context || message.name
 
     const rawDisplayContent = transcriptContent(
+      message.role,
       message.display_kind,
       timelineDisplayContent(message, displayContentForMessage(message.role, content))
     )

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -116,6 +116,50 @@ const $botUnread = atom({})
 // last_active watermark per source-qualified bot, seeded on first poll so a
 // fresh mount doesn't mark ancient history unread.
 const rosterWatermarks = new Map()
+
+/** One durable-history reconciliation per selected Bot Chat at a time. Rapid
+ *  activity edges collapse to the latest trailing snapshot instead of
+ *  repeatedly reloading the full transcript. */
+const botChatReconciles = new Map()
+
+function reconcileSelectedBotChat(bot, key, storedId, activity, prev, ts) {
+  const payload = { bot, storedId, activity, prev, ts }
+  const active = botChatReconciles.get(key)
+
+  if (active) {
+    active.trailing = payload
+    return
+  }
+
+  const state = { trailing: null }
+  botChatReconciles.set(key, state)
+
+  const run = next => {
+    Promise.resolve()
+      .then(() => openStoredBotChat(next.bot, next.storedId, next.activity))
+      .then(() => {
+        rosterWatermarks.set(key, Math.max(rosterWatermarks.get(key) || 0, next.ts))
+      })
+      .catch(() => {
+        // Restore this edge so the existing roster-poll cadence owns retry.
+        rosterWatermarks.set(key, next.prev)
+        console.debug?.('[hermes-bots] durable transcript reconciliation failed', { bot: key })
+      })
+      .finally(() => {
+        const trailing = state.trailing
+
+        if (trailing) {
+          state.trailing = null
+          run(trailing)
+          return
+        }
+
+        botChatReconciles.delete(key)
+      })
+  }
+
+  run(payload)
+}
 let watermarksSeeded = false
 
 /** User pref: toast on every new bot activity. Default OFF — a busy roster
@@ -154,9 +198,19 @@ function trackInboundActivity(roster) {
       continue
     }
 
-    // Activity in the exact bot owner the user is currently looking at is
-    // already visible — never badge the open chat or its same-named twin.
+    // Activity in the exact bot owner the user is currently looking at is not
+    // necessarily visible. Bot-to-bot and background deliveries write through
+    // another client, so this window can miss their stream frames even though
+    // the roster already sees the durable reply. Re-open the SAME stored chat
+    // to reconcile it from history; the watermark makes this one-shot per
+    // activity edge. Do not badge the open chat or its same-named twin.
     if ($selectedBot.get() === key) {
+      const storedId = activity?.resolved_id || activity?.id
+
+      if ($botChatFocused.get() && storedId) {
+        reconcileSelectedBotChat(bot, key, storedId, activity, prev, ts)
+      }
+
       continue
     }
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/activity-toasts.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/activity-toasts.test.mjs
@@ -10,7 +10,7 @@ import vm from 'node:vm'
 
 const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
-function loadTracker(toastsEnabled) {
+function loadTracker(toastsEnabled, options = {}) {
   const start = source.indexOf('const rosterWatermarks = new Map()')
   const end = source.indexOf('/** Last good cron list', start)
   // The tracker keys watermarks off the REAL botActivitySession helper
@@ -19,7 +19,9 @@ function loadTracker(toastsEnabled) {
   const helperEnd = source.indexOf('/** Bots that are working', helperStart)
   assert.ok(helperStart >= 0 && helperEnd > helperStart, 'botActivitySession must remain extractable')
   const notifications = []
+  const reconciled = []
   const context = {
+    console: { debug: (...args) => options.onDebug?.(...args) },
     pluginCtx: null,
     atom: initial => {
       let value = initial
@@ -27,6 +29,7 @@ function loadTracker(toastsEnabled) {
     },
     host: { notify: params => notifications.push(params) },
     $selectedBot: { get: () => 'default' },
+    $botChatFocused: { get: () => true },
     $botMeta: { get: () => ({}) },
     $botUnread: (() => {
       let value = {}
@@ -34,7 +37,9 @@ function loadTracker(toastsEnabled) {
     })(),
     botRosterMeta: (bot, meta) => meta?.[bot.name] || null,
     botSelectionKey: bot => bot.name,
-    displayName: bot => bot.name
+    displayName: bot => bot.name,
+    openStoredBotChat:
+      options.openStoredBotChat || ((bot, storedId) => reconciled.push({ bot: bot.name, storedId }))
   }
   const section = source
     .slice(helperStart, helperEnd)
@@ -44,7 +49,7 @@ function loadTracker(toastsEnabled) {
   if (toastsEnabled) {
     context.__t.$activityToasts.set(true)
   }
-  return { ...context.__t, notifications, $botUnread: context.$botUnread }
+  return { ...context.__t, notifications, reconciled, $botUnread: context.$botUnread }
 }
 
 function rosterAt(ts) {
@@ -91,4 +96,92 @@ test('activity in the hidden canonical Bot Chat still badges (the "6d ago" class
   t.trackInboundActivity(at(150)) // seeding poll
   t.trackInboundActivity(at(250)) // Bot Chat got a DM; last_session unchanged
   assert.equal(t.$botUnread.get().researcher, true, 'hidden Bot Chat activity must set unread')
+})
+
+test('activity in the selected open Bot Chat rehydrates its durable transcript', async () => {
+  const t = loadTracker(false)
+  const at = ts => [
+    {
+      name: 'default',
+      canonical_session: { id: 'root', resolved_id: 'tip-1', last_active: ts }
+    }
+  ]
+
+  t.trackInboundActivity(at(100))
+  t.trackInboundActivity(at(200))
+  await new Promise(resolve => setImmediate(resolve))
+
+  assert.deepEqual(t.reconciled, [{ bot: 'default', storedId: 'tip-1' }])
+  assert.equal(t.$botUnread.get().default, undefined, 'the open bot must not badge itself')
+})
+
+test('selected Bot Chat coalesces rapid activity into one trailing reconciliation', async () => {
+  const calls = []
+  let finishFirst
+  const t = loadTracker(false, {
+    openStoredBotChat: (bot, storedId) => {
+      calls.push({ bot: bot.name, storedId })
+
+      if (calls.length === 1) {
+        return new Promise(resolve => {
+          finishFirst = resolve
+        })
+      }
+
+      return Promise.resolve()
+    }
+  })
+  const at = ts => [
+    {
+      name: 'default',
+      canonical_session: { id: 'root', resolved_id: `tip-${ts}`, last_active: ts }
+    }
+  ]
+
+  t.trackInboundActivity(at(100))
+  t.trackInboundActivity(at(200))
+  t.trackInboundActivity(at(300))
+  t.trackInboundActivity(at(400))
+  await Promise.resolve()
+
+  assert.deepEqual(calls, [{ bot: 'default', storedId: 'tip-200' }])
+
+  finishFirst()
+  await new Promise(resolve => setImmediate(resolve))
+
+  assert.deepEqual(calls, [
+    { bot: 'default', storedId: 'tip-200' },
+    { bot: 'default', storedId: 'tip-400' }
+  ])
+})
+
+test('failed reconciliation logs once and retries only on the next roster poll', async () => {
+  let calls = 0
+  const debug = []
+  const t = loadTracker(false, {
+    openStoredBotChat: () => {
+      calls += 1
+      return Promise.reject(new Error('profile wake failed'))
+    },
+    onDebug: (...args) => debug.push(args)
+  })
+  const at = ts => [
+    {
+      name: 'default',
+      canonical_session: { id: 'root', resolved_id: 'tip-1', last_active: ts }
+    }
+  ]
+
+  t.trackInboundActivity(at(100))
+  t.trackInboundActivity(at(200))
+  await new Promise(resolve => setImmediate(resolve))
+
+  assert.equal(calls, 1)
+  assert.equal(debug.length, 1)
+
+  t.trackInboundActivity(at(200))
+  await new Promise(resolve => setImmediate(resolve))
+
+  assert.equal(calls, 2, 'retry must be driven by the next roster poll')
+  assert.equal(debug.length, 2)
 })


### PR DESCRIPTION
## Summary

- Suppress persisted wait-interrupt metadata from rendering as assistant chat bubbles.
- Rehydrate durable transcript state when new activity reaches the currently selected Bot Chat.

## Tests

- `vitest run --project ui src/lib/chat-messages.test.ts` — 73 passed
- `node --test src/plugins/hermes-bots/tests/activity-toasts.test.mjs` — 5 passed
- Full plugin suite — 556 passed
