### PR TITLE
feat(discord): add resilient music playback

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -22191,6 +22191,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 chat_type="channel",
             )
 
+        # Never inherit the linked text user's role grant. Recompute admission
+        # for the actual speaker before the gateway-level authorization check.
+        source.role_authorized = False
+        voice_auth_checker = vars(type(adapter)).get("_is_allowed_user")
+        if callable(voice_auth_checker) and not inspect.iscoroutinefunction(
+            voice_auth_checker
+        ):
+            voice_guild = (
+                adapter._client.get_guild(guild_id)
+                if getattr(adapter, "_client", None) is not None
+                else None
+            )
+            source.role_authorized = bool(
+                voice_auth_checker(
+                    adapter,
+                    str(user_id),
+                    guild=voice_guild,
+                    is_dm=False,
+                )
+            )
+
         # Check authorization before processing voice input
         if not self._is_user_authorized(source):
             logger.debug("Unauthorized voice input from user %d, ignoring", user_id)
@@ -22203,6 +22224,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 user_id,
                 transcript[:100],
             )
+            return
+
+        natural_music_handler = getattr(
+            type(adapter), "_maybe_handle_natural_music_voice", None
+        )
+        if callable(natural_music_handler) and await natural_music_handler(
+            adapter, guild_id, user_id, transcript
+        ):
             return
 
         # Show transcript in text channel (after auth, with mention sanitization)
@@ -22225,6 +22254,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if callable(resolver):
             try:
                 resolved = resolver(str(text_ch_id))
+                if inspect.isawaitable(resolved):
+                    resolved = await resolved
                 channel_prompt = resolved if isinstance(resolved, str) else None
             except Exception:
                 channel_prompt = None

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1087,6 +1087,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # Voice channel state (per-guild)
         self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
         self._voice_locks: Dict[int, asyncio.Lock] = {}  # guild_id -> serialize join/leave
+        self._voice_leaving: set[int] = set()  # guild_ids completing leave cleanup
         # Public per-guild music queues are created lazily on the first music
         # command so text-only Discord users pay no yt-dlp/import overhead.
         self._music_manager = None
@@ -1429,6 +1430,10 @@ class DiscordAdapter(BasePlatformAdapter):
             @self._client.event
             async def on_voice_state_update(member, before, after):
                 """Track voice channel join/leave events."""
+                if await adapter_self._handle_bot_voice_state_update(
+                    member, before, after
+                ):
+                    return
                 # Only track channels where the bot is connected
                 bot_guild_ids = set(adapter_self._voice_clients.keys())
                 if not bot_guild_ids:
@@ -1436,10 +1441,6 @@ class DiscordAdapter(BasePlatformAdapter):
                 guild_id = member.guild.id
                 if guild_id not in bot_guild_ids:
                     return
-                # Ignore the bot itself
-                if member == adapter_self._client.user:
-                    return
-
                 joined = before.channel is None and after.channel is not None
                 left = before.channel is not None and after.channel is None
                 switched = (
@@ -4568,26 +4569,31 @@ class DiscordAdapter(BasePlatformAdapter):
         guild_id = channel.guild.id
 
         async with self._voice_locks.setdefault(guild_id, asyncio.Lock()):
+            if guild_id in getattr(self, "_voice_leaving", set()):
+                return False
+
+            def _refresh_binding() -> None:
+                if text_channel_id is not None:
+                    self._voice_text_channels[guild_id] = text_channel_id
+                if source is not None:
+                    self._voice_sources[guild_id] = source
+
             # Already connected in this guild?
             existing = self._voice_clients.get(guild_id)
             if existing and existing.is_connected():
                 if existing.channel.id == channel.id:
+                    _refresh_binding()
                     self._reset_voice_timeout(guild_id)
                     return True
                 await existing.move_to(channel)
+                _refresh_binding()
                 self._reset_voice_timeout(guild_id)
                 return True
 
             vc = await channel.connect()
             self._voice_clients[guild_id] = vc
+            _refresh_binding()
             self._reset_voice_timeout(guild_id)
-
-            # Store text-channel binding for automatic/programmatic joins
-            # so voice transcriptions can be routed without /voice join.
-            if text_channel_id is not None:
-                self._voice_text_channels[guild_id] = text_channel_id
-            if source is not None:
-                self._voice_sources[guild_id] = source
 
             # Start voice receiver (Phase 2: listen to users)
             try:
@@ -4611,10 +4617,48 @@ class DiscordAdapter(BasePlatformAdapter):
 
             return True
 
+    async def _handle_bot_voice_state_update(self, member, before, after) -> bool:
+        """Clean stale voice/music state when Discord disconnects the bot."""
+        if self._client is None or member != self._client.user:
+            return False
+        if before.channel is None or after.channel is not None:
+            return True
+        guild_id = int(member.guild.id)
+        voice_lock = self._voice_locks.setdefault(guild_id, asyncio.Lock())
+        if voice_lock.locked():
+            leaving = getattr(self, "_voice_leaving", None)
+            if leaving is None:
+                leaving = self._voice_leaving = set()
+            if guild_id not in leaving:
+                leaving.add(guild_id)
+                asyncio.create_task(self._leave_voice_channel_marked(guild_id))
+        else:
+            await self.leave_voice_channel(guild_id)
+        return True
+
+    async def _leave_voice_channel_marked(self, guild_id: int) -> None:
+        """Finish a leave whose guild marker has already been claimed."""
+        try:
+            await self._leave_voice_channel_impl(guild_id)
+        finally:
+            self._voice_leaving.discard(guild_id)
+
     async def leave_voice_channel(self, guild_id: int) -> None:
+        """Disconnect and keep new joins out until music cleanup finishes."""
+        leaving = getattr(self, "_voice_leaving", None)
+        if leaving is None:
+            leaving = self._voice_leaving = set()
+        if guild_id in leaving:
+            return
+        leaving.add(guild_id)
+        await self._leave_voice_channel_marked(guild_id)
+
+    async def _leave_voice_channel_impl(self, guild_id: int) -> None:
         """Disconnect from the voice channel in a guild."""
-        async with self._voice_locks.setdefault(guild_id, asyncio.Lock()):
-            # Stop voice receiver first
+        voice_lock = self._voice_locks.setdefault(guild_id, asyncio.Lock())
+        async with voice_lock:
+            # Detach the receiver first, but process its final utterance outside
+            # the non-reentrant voice lock. A spoken music request may join voice.
             receiver = self._voice_receivers.pop(guild_id, None)
             pending_inputs = []
             if receiver:
@@ -4624,11 +4668,12 @@ class DiscordAdapter(BasePlatformAdapter):
             if listen_task:
                 listen_task.cancel()
 
-            guild = self._client.get_guild(guild_id) if self._client is not None else None
-            for user_id, pcm_data in pending_inputs:
-                if self._is_allowed_user(str(user_id), guild=guild, is_dm=False):
-                    await self._process_voice_input(guild_id, user_id, pcm_data)
+        guild = self._client.get_guild(guild_id) if self._client is not None else None
+        for user_id, pcm_data in pending_inputs:
+            if self._is_allowed_user(str(user_id), guild=guild, is_dm=False):
+                await self._process_voice_input(guild_id, user_id, pcm_data)
 
+        async with voice_lock:
             # Tear down the mixer (stops the continuous outgoing stream).
             if getattr(self, "_voice_mixers", None) is not None:
                 self._voice_mixers.pop(guild_id, None)
@@ -4642,13 +4687,26 @@ class DiscordAdapter(BasePlatformAdapter):
                     pass
                 await vc.disconnect()
             task = self._voice_timeout_tasks.pop(guild_id, None)
-            if task:
+            current_task = asyncio.current_task()
+            if task and task is not current_task:
                 task.cancel()
             self._voice_text_channels.pop(guild_id, None)
             self._voice_sources.pop(guild_id, None)
-            music_manager = getattr(self, "_music_manager", None)
-            if music_manager is not None:
-                await music_manager.on_voice_disconnected(guild_id)
+
+        # Never acquire the music lock while holding the adapter voice lock.
+        # Adds acquire those locks in the opposite order while joining.
+        music_manager = getattr(self, "_music_manager", None)
+        if music_manager is not None:
+            await music_manager.on_voice_disconnected(guild_id)
+
+    def _music_is_active(self, guild_id: int) -> bool:
+        music_manager = getattr(self, "_music_manager", None)
+        music_session = (
+            getattr(music_manager, "sessions", {}).get(guild_id)
+            if music_manager is not None
+            else None
+        )
+        return music_session is not None and music_session.current is not None
 
     async def play_in_voice_channel(self, guild_id: int, audio_path: str) -> bool:
         """Play an audio file in the connected voice channel.
@@ -4660,6 +4718,13 @@ class DiscordAdapter(BasePlatformAdapter):
         """
         vc = self._voice_clients.get(guild_id)
         if not vc or not vc.is_connected():
+            return False
+        if self._music_is_active(guild_id):
+            logger.info(
+                "[%s] Suppressing TTS playback while music is active (guild=%d)",
+                self.name,
+                guild_id,
+            )
             return False
 
         # Playback is activity. Do not let the inactivity timer disconnect the
@@ -4766,6 +4831,12 @@ class DiscordAdapter(BasePlatformAdapter):
     def _reset_voice_timeout(self, guild_id: int) -> None:
         """Reset the auto-disconnect inactivity timer."""
         self._cancel_voice_timeout(guild_id)
+        if self._music_is_active(guild_id):
+            logger.debug(
+                "Voice inactivity timeout remains suspended for active music (guild=%d)",
+                guild_id,
+            )
+            return
         timeout = self._voice_timeout_limit()
         if timeout <= 0:
             logger.debug("Voice inactivity timeout disabled (guild=%d)", guild_id)
@@ -5852,8 +5923,103 @@ class DiscordAdapter(BasePlatformAdapter):
             self._music_manager = DiscordMusicManager(self)
         return self._music_manager
 
+    async def _maybe_handle_natural_music_message(
+        self, message, *, content: Optional[str] = None
+    ) -> bool:
+        """Route an explicit Jarvis play request without invoking the agent."""
+        from plugins.platforms.discord.music import (
+            discord_no_mentions,
+            parse_natural_music_control,
+            parse_natural_play_request,
+        )
+
+        request_text = content if content is not None else getattr(message, "content", "")
+        action = parse_natural_music_control(request_text)
+        query = parse_natural_play_request(request_text)
+        if action is None and query is None:
+            return False
+        try:
+            manager = self._get_music_manager()
+            if action is not None:
+                await manager.control_message(message, action)
+            else:
+                assert query is not None
+                await manager.add_message(message, query)
+        except Exception as exc:
+            logger.warning("[Discord] natural music request failed: %s", exc)
+            try:
+                await message.channel.send(
+                    "I couldn't complete that music request. Please try again.",
+                    allowed_mentions=discord_no_mentions(),
+                )
+            except Exception:
+                pass
+        return True
+
+    async def _maybe_handle_natural_music_voice(
+        self, guild_id: int, user_id: int, transcript: str
+    ) -> bool:
+        """Route an explicit spoken Jarvis play request to the linked queue."""
+        from types import SimpleNamespace
+
+        from plugins.platforms.discord.music import (
+            discord_no_mentions,
+            parse_natural_music_control,
+            parse_natural_play_request,
+        )
+
+        action = parse_natural_music_control(transcript)
+        query = parse_natural_play_request(transcript)
+        if action is None and query is None:
+            return False
+        guild = self._client.get_guild(int(guild_id)) if self._client else None
+        channel_id = self._voice_text_channels.get(int(guild_id))
+        channel = self._client.get_channel(channel_id) if self._client and channel_id else None
+        member = guild.get_member(int(user_id)) if guild is not None else None
+        if guild is None or channel is None or member is None:
+            logger.warning(
+                "[Discord] could not resolve context for natural voice music request "
+                "(guild=%s user=%s channel=%s)",
+                guild_id,
+                user_id,
+                channel_id,
+            )
+            return False
+        channel_keys = self._discord_channel_keys_from_channel(
+            channel,
+            self._get_parent_channel_id(channel),
+        )
+        allowed_channels = self._get_allowed_channels()
+        if (
+            allowed_channels
+            and "*" not in allowed_channels
+            and not (channel_keys & allowed_channels)
+        ):
+            return False
+        ignored_channels = self._get_ignored_channels()
+        if "*" in ignored_channels or channel_keys & ignored_channels:
+            return False
+        request = SimpleNamespace(guild=guild, channel=channel, author=member)
+        try:
+            manager = self._get_music_manager()
+            if action is not None:
+                await manager.control_message(request, action)
+            else:
+                assert query is not None
+                await manager.add_message(request, query)
+        except Exception as exc:
+            logger.warning("[Discord] natural voice music request failed: %s", exc)
+            try:
+                await channel.send(
+                    "I couldn't complete that music request. Please try again.",
+                    allowed_mentions=discord_no_mentions(),
+                )
+            except Exception:
+                pass
+        return True
+
     async def _send_music_error(self, interaction, exc: Exception) -> None:
-        message = f"Music request failed: {exc}"
+        message = "I couldn't complete that music request. Please try again."
         try:
             if interaction.response.is_done():
                 await interaction.followup.send(message, ephemeral=True)
@@ -5862,8 +6028,26 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception:
             logger.warning("[Discord] Could not deliver music error: %s", exc)
 
+    async def _check_music_slash_access(self, interaction, command: str) -> bool:
+        """Apply the command-level slash policy to native music handlers."""
+        from gateway.slash_access import policy_from_extra
+
+        scope = "dm" if isinstance(interaction.channel, discord.DMChannel) else "group"
+        policy = policy_from_extra(getattr(self.config, "extra", {}) or {}, scope)
+        user_id = str(getattr(getattr(interaction, "user", None), "id", ""))
+        if policy.can_run(user_id, command.lstrip("/")):
+            return True
+        await self._reject_slash(
+            interaction,
+            command,
+            reason="command blocked by slash access policy",
+        )
+        return False
+
     async def _handle_music_play(self, interaction, query: str) -> None:
         if not await self._check_slash_authorization(interaction, "/play"):
+            return
+        if not await self._check_music_slash_access(interaction, "/play"):
             return
         try:
             await self._get_music_manager().add(interaction, query)
@@ -5873,6 +6057,8 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def _handle_music_queue(self, interaction) -> None:
         if not await self._check_slash_authorization(interaction, "/musicqueue"):
+            return
+        if not await self._check_music_slash_access(interaction, "/musicqueue"):
             return
         guild = getattr(interaction, "guild", None)
         if guild is None:
@@ -5886,6 +6072,8 @@ class DiscordAdapter(BasePlatformAdapter):
     async def _handle_music_admin(self, interaction, action: str) -> None:
         command = "/forceskip" if action == "forceskip" else "/clearqueue"
         if not await self._check_slash_authorization(interaction, command):
+            return
+        if not await self._check_music_slash_access(interaction, command):
             return
         guild = getattr(interaction, "guild", None)
         if guild is None:
@@ -5960,7 +6148,15 @@ class DiscordAdapter(BasePlatformAdapter):
                     ),
                 )
             else:
-                sent_message = await channel.send(content)
+                sent_message = await channel.send(
+                    content,
+                    allowed_mentions=getattr(discord, "AllowedMentions")(
+                        everyone=False,
+                        roles=False,
+                        users=True,
+                        replied_user=False,
+                    ),
+                )
         except Exception as exc:
             logger.warning("[Discord] /announce delivery failed: %s", exc)
             await interaction.edit_original_response(
@@ -8327,9 +8523,25 @@ class DiscordAdapter(BasePlatformAdapter):
                 and not self._discord_thread_require_mention()
             )
 
+            # An explicit wake-name music command is itself an address to the bot,
+            # so it may cross the normal @mention gate after channel authorization.
+            if not recovered and await self._maybe_handle_natural_music_message(
+                message, content=normalized_content
+            ):
+                return True
+
             if require_mention and not is_free_channel and not in_bot_thread:
                 if not self._self_is_explicitly_mentioned(message) and not mention_prefix:
                     return False
+
+        if (
+            not recovered
+            and isinstance(message.channel, discord.DMChannel)
+            and await self._maybe_handle_natural_music_message(
+                message, content=normalized_content
+            )
+        ):
+            return True
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).
         # Messages already inside threads or DMs are unaffected.

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1087,6 +1087,9 @@ class DiscordAdapter(BasePlatformAdapter):
         # Voice channel state (per-guild)
         self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
         self._voice_locks: Dict[int, asyncio.Lock] = {}  # guild_id -> serialize join/leave
+        # Public per-guild music queues are created lazily on the first music
+        # command so text-only Discord users pay no yt-dlp/import overhead.
+        self._music_manager = None
         # Text batching: merge rapid successive messages (Telegram-style)
         self._text_batch_delay_seconds = env_float("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", 0.6)
         self._text_batch_split_delay_seconds = env_float("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", 2.0)
@@ -4643,6 +4646,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 task.cancel()
             self._voice_text_channels.pop(guild_id, None)
             self._voice_sources.pop(guild_id, None)
+            music_manager = getattr(self, "_music_manager", None)
+            if music_manager is not None:
+                await music_manager.on_voice_disconnected(guild_id)
 
     async def play_in_voice_channel(self, guild_id: int, audio_path: str) -> bool:
         """Play an audio file in the connected voice channel.
@@ -5839,6 +5845,138 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.debug("Discord interaction cleanup failed: %s", e)
 
+    def _get_music_manager(self):
+        if self._music_manager is None:
+            from plugins.platforms.discord.music import DiscordMusicManager
+
+            self._music_manager = DiscordMusicManager(self)
+        return self._music_manager
+
+    async def _send_music_error(self, interaction, exc: Exception) -> None:
+        message = f"Music request failed: {exc}"
+        try:
+            if interaction.response.is_done():
+                await interaction.followup.send(message, ephemeral=True)
+            else:
+                await interaction.response.send_message(message, ephemeral=True)
+        except Exception:
+            logger.warning("[Discord] Could not deliver music error: %s", exc)
+
+    async def _handle_music_play(self, interaction, query: str) -> None:
+        if not await self._check_slash_authorization(interaction, "/play"):
+            return
+        try:
+            await self._get_music_manager().add(interaction, query)
+        except Exception as exc:
+            logger.warning("[Discord] /play failed: %s", exc)
+            await self._send_music_error(interaction, exc)
+
+    async def _handle_music_queue(self, interaction) -> None:
+        if not await self._check_slash_authorization(interaction, "/musicqueue"):
+            return
+        guild = getattr(interaction, "guild", None)
+        if guild is None:
+            await interaction.response.send_message(
+                "Music queues are only available in a server.", ephemeral=True
+            )
+            return
+        manager = self._get_music_manager()
+        await manager.show_queue(interaction, int(guild.id))
+
+    async def _handle_music_admin(self, interaction, action: str) -> None:
+        command = "/forceskip" if action == "forceskip" else "/clearqueue"
+        if not await self._check_slash_authorization(interaction, command):
+            return
+        guild = getattr(interaction, "guild", None)
+        if guild is None:
+            await interaction.response.send_message(
+                "Music administration is only available in a server.", ephemeral=True
+            )
+            return
+        await self._get_music_manager().admin_action(interaction, int(guild.id), action)
+
+    async def _handle_announce_slash(
+        self,
+        interaction: "discord.Interaction",
+        channel: "discord.TextChannel",
+        message: str,
+        ping_everyone: bool = False,
+    ) -> None:
+        """Post an exact announcement to a selected channel after authorization."""
+        if not await self._check_slash_authorization(interaction, "/announce"):
+            return
+
+        # Direct native handlers do not pass through GatewayRunner's command
+        # dispatcher, so apply the optional slash access split here as well.
+        from gateway.slash_access import policy_from_extra
+
+        scope = "dm" if isinstance(interaction.channel, discord.DMChannel) else "group"
+        policy = policy_from_extra(getattr(self.config, "extra", {}) or {}, scope)
+        user_id = str(getattr(getattr(interaction, "user", None), "id", ""))
+        if not policy.can_run(user_id, "announce"):
+            await self._reject_slash(
+                interaction,
+                "/announce",
+                reason="command blocked by slash access policy",
+            )
+            return
+
+        source_guild = getattr(interaction, "guild", None)
+        target_guild = getattr(channel, "guild", None)
+        if (
+            source_guild is None
+            or target_guild is None
+            or getattr(source_guild, "id", None) != getattr(target_guild, "id", None)
+        ):
+            await interaction.response.send_message(
+                "Choose a text channel in this server.", ephemeral=True
+            )
+            return
+
+        if not message or not message.strip():
+            await interaction.response.send_message(
+                "Announcement text cannot be empty.", ephemeral=True
+            )
+            return
+        prefix = "@everyone\n\n" if ping_everyone and "@everyone" not in message else ""
+        content = prefix + message
+        if len(content) > 2000:
+            await interaction.response.send_message(
+                "Announcement text must be 2,000 characters or fewer.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        try:
+            if ping_everyone:
+                sent_message = await channel.send(
+                    content,
+                    allowed_mentions=getattr(discord, "AllowedMentions")(
+                        everyone=True,
+                        roles=False,
+                        users=True,
+                        replied_user=False,
+                    ),
+                )
+            else:
+                sent_message = await channel.send(content)
+        except Exception as exc:
+            logger.warning("[Discord] /announce delivery failed: %s", exc)
+            await interaction.edit_original_response(
+                content=f"Announcement failed: {exc}"
+            )
+            return
+
+        message_id = str(getattr(sent_message, "id", ""))
+        if message_id:
+            self._nonconversational_messages.mark_many([message_id])
+        jump_url = str(getattr(sent_message, "jump_url", "") or "")
+        receipt = f"Announcement posted in <#{channel.id}>"
+        if jump_url:
+            receipt += f": {jump_url}"
+        await interaction.edit_original_response(content=receipt)
+
     def _register_slash_commands(self) -> None:
         """Register Discord slash commands on the command tree."""
         if not self._client:
@@ -5966,6 +6104,23 @@ class DiscordAdapter(BasePlatformAdapter):
         async def slash_voice(interaction: discord.Interaction, mode: str = ""):
             await self._run_simple_slash(interaction, f"/voice {mode}".strip())
 
+        @tree.command(name="play", description="Add a song or streaming link to the public music queue")
+        @discord.app_commands.describe(query="Song name, Spotify link, YouTube link, or supported media URL")
+        async def slash_play(interaction: discord.Interaction, query: str):
+            await self._handle_music_play(interaction, query)
+
+        @tree.command(name="musicqueue", description="Show or refresh the public music queue")
+        async def slash_musicqueue(interaction: discord.Interaction):
+            await self._handle_music_queue(interaction)
+
+        @tree.command(name="forceskip", description="Administrator: force-skip the current song")
+        async def slash_forceskip(interaction: discord.Interaction):
+            await self._handle_music_admin(interaction, "forceskip")
+
+        @tree.command(name="clearqueue", description="Administrator: stop playback and clear the music queue")
+        async def slash_clearqueue(interaction: discord.Interaction):
+            await self._handle_music_admin(interaction, "clear")
+
         @tree.command(name="update", description="Update Hermes Agent to the latest version")
         async def slash_update(interaction: discord.Interaction):
             await self._run_simple_slash(interaction, "/update", "Update initiated~")
@@ -6009,6 +6164,22 @@ class DiscordAdapter(BasePlatformAdapter):
         @discord.app_commands.describe(prompt="The prompt to run in the background")
         async def slash_background(interaction: discord.Interaction, prompt: str):
             await self._run_simple_slash(interaction, f"/background {prompt}", "Background task started~")
+
+        @tree.command(name="announce", description="Confirm and post an announcement")
+        @discord.app_commands.describe(
+            channel="Channel where the announcement will be posted",
+            message="Announcement text, exactly as it should appear",
+            ping_everyone="Whether to notify everyone in the server",
+        )
+        async def slash_announce(
+            interaction: "discord.Interaction",
+            channel: "discord.TextChannel",
+            message: str,
+            ping_everyone: bool = False,
+        ):
+            await self._handle_announce_slash(
+                interaction, channel, message, ping_everyone
+            )
 
         # ── Auto-register any gateway-available commands not yet on the tree ──
         # This ensures new commands added to COMMAND_REGISTRY in

--- a/plugins/platforms/discord/music.py
+++ b/plugins/platforms/discord/music.py
@@ -13,8 +13,10 @@ import logging
 import queue
 import re
 import threading
+import time
 from collections import deque
 from dataclasses import dataclass, field
+from types import SimpleNamespace
 from typing import Callable, Deque, Iterable, Optional
 from urllib.parse import urlparse
 
@@ -28,6 +30,68 @@ class MusicResolutionError(RuntimeError):
     """A user-facing media-resolution failure."""
 
 
+_NATURAL_WAKE_RE = re.compile(
+    r"^\s*(?:hey[\s,]+)?jarvis\s*[,;:\-]?\s+(?:please\s+)?(.+?)\s*[.!?]?\s*$",
+    re.IGNORECASE,
+)
+_NATURAL_PLAY_RE = re.compile(r"^play\s+(.+?)$", re.IGNORECASE)
+_NATURAL_CONTROL_PATTERNS = (
+    ("pause", re.compile(r"^(?:pause|hold)(?:\s+(?:the\s+)?(?:song|music|track|playback))?$", re.I)),
+    ("resume", re.compile(r"^(?:resume|continue)(?:\s+(?:the\s+)?(?:song|music|track|playback))?$", re.I)),
+    ("resume", re.compile(r"^play(?:\s+(?:the\s+)?(?:current\s+)?(?:song|music|track))?$", re.I)),
+    ("skip", re.compile(r"^(?:skip|next)(?:\s+(?:(?:the|this)\s+)?(?:song|music|track))?$", re.I)),
+    ("skip", re.compile(r"^play\s+(?:the\s+)?next(?:\s+(?:song|track))?$", re.I)),
+    ("previous", re.compile(r"^(?:previous|back)(?:\s+(?:song|track))?$", re.I)),
+    ("previous", re.compile(r"^(?:go\s+back\s+to|play)\s+(?:the\s+)?previous(?:\s+(?:song|track))?$", re.I)),
+    ("repeat", re.compile(r"^(?:repeat|loop)(?:\s+(?:(?:the|this)\s+)?(?:song|music|track))?$", re.I)),
+    ("queue", re.compile(r"^(?:show|display|list)(?:\s+(?:the\s+)?)?(?:music\s+)?queue$", re.I)),
+    ("clear", re.compile(r"^clear(?:\s+(?:the\s+)?)?(?:music\s+)?queue$", re.I)),
+)
+
+
+def _natural_music_body(text: str) -> Optional[str]:
+    match = _NATURAL_WAKE_RE.match(str(text or ""))
+    return match.group(1).strip() if match else None
+
+
+def parse_natural_music_control(text: str) -> Optional[str]:
+    """Return a deterministic playback action from an explicit Jarvis command."""
+    body = _natural_music_body(text)
+    if not body:
+        return None
+    for action, pattern in _NATURAL_CONTROL_PATTERNS:
+        if pattern.fullmatch(body):
+            return action
+    return None
+
+
+def parse_natural_play_request(text: str) -> Optional[str]:
+    """Return the media query from an explicit natural Jarvis play command."""
+    if parse_natural_music_control(text) is not None:
+        return None
+    body = _natural_music_body(text)
+    match = _NATURAL_PLAY_RE.fullmatch(body or "")
+    if not match:
+        return None
+    query = match.group(1).strip()
+    return query or None
+
+
+def discord_no_mentions():
+    import discord as discord_module
+
+    allowed_mentions_cls = discord_module.AllowedMentions
+    none_factory = getattr(allowed_mentions_cls, "none", None)
+    if callable(none_factory):
+        return none_factory()
+    return allowed_mentions_cls(
+        everyone=False,
+        roles=False,
+        users=False,
+        replied_user=False,
+    )
+
+
 class TrackResolver:
     """Turn user input into queue metadata and fresh playable stream URLs."""
 
@@ -35,17 +99,6 @@ class TrackResolver:
     TRUSTED_STREAM_HOSTS = (
         "googlevideo.com",
         "youtube.com",
-        "sndcdn.com",
-        "soundcloud.com",
-        "bcbits.com",
-        "bandcamp.com",
-        "vimeocdn.com",
-        "akamaized.net",
-        "twitchcdn.net",
-        "jtvnw.net",
-        "mixcloud.com",
-        "dmcdn.net",
-        "dailymotion.com",
     )
 
     def __init__(
@@ -151,6 +204,13 @@ class TrackResolver:
             if not isinstance(item, dict):
                 continue
             webpage_url = str(item.get("webpage_url") or item.get("url") or lookup)
+            if is_direct_url and (
+                not self._url_guard(webpage_url)
+                or not self._is_youtube_lookup(webpage_url)
+            ):
+                raise MusicResolutionError(
+                    "A playlist entry was not from a supported public media source."
+                )
             tracks.append(
                 MusicTrack(
                     title=str(item.get("title") or "Unknown track"),
@@ -169,6 +229,14 @@ class TrackResolver:
         return tracks
 
     def resolve_stream(self, track: "MusicTrack") -> str:
+        lookup_url = urlparse(track.lookup)
+        if lookup_url.scheme in {"http", "https"} and (
+            not self._url_guard(track.lookup)
+            or not self._is_youtube_lookup(track.lookup)
+        ):
+            raise MusicResolutionError(
+                "The queued media lookup is not from a supported public source."
+            )
         info = self._media_extractor(track.lookup, flat=False)
         if isinstance(info, dict) and info.get("entries"):
             info = next((item for item in info["entries"] if item), {})
@@ -205,21 +273,7 @@ class TrackResolver:
 
     @staticmethod
     def _has_supported_extractor(url: str) -> bool:
-        try:
-            from yt_dlp.extractor import gen_extractor_classes
-        except ImportError as exc:
-            raise MusicResolutionError(
-                "Music playback requires yt-dlp. Reinstall Hermes with messaging support."
-            ) from exc
-        for extractor_cls in gen_extractor_classes():
-            try:
-                if extractor_cls.suitable(url):
-                    return (
-                        str(getattr(extractor_cls, "IE_NAME", "")).lower() != "generic"
-                    )
-            except Exception:
-                continue
-        return False
+        return TrackResolver._is_youtube_lookup(url)
 
     @staticmethod
     def _extract_media(query: str, *, flat: bool) -> dict:
@@ -361,6 +415,7 @@ class MusicSession:
     history: Deque[MusicTrack] = field(default_factory=lambda: deque(maxlen=50))
     current: Optional[MusicTrack] = None
     repeat_current: bool = False
+    suppress_repeat_generation: Optional[int] = None
     playback_generation: int = 0
     last_error: Optional[str] = None
     text_channel: object = None
@@ -436,6 +491,7 @@ class BufferedAudioSource(_AudioSourceBase):
         *,
         prebuffer_frames: int = 100,
         max_buffer_frames: int = 500,
+        stall_timeout: float = 30.0,
     ) -> None:
         self.source = source
         self._prebuffer_frames = max(1, int(prebuffer_frames))
@@ -447,6 +503,8 @@ class BufferedAudioSource(_AudioSourceBase):
         self._cleanup_lock = threading.Lock()
         self._cleaned = False
         self._current_error = None
+        self._stall_timeout = max(0.1, float(stall_timeout))
+        self._last_progress_at = time.monotonic()
         self._producer = threading.Thread(
             target=self._fill,
             name="discord-music-buffer",
@@ -465,6 +523,7 @@ class BufferedAudioSource(_AudioSourceBase):
                     break
                 if len(frame) < self.FRAME_SIZE:
                     frame += b"\x00" * (self.FRAME_SIZE - len(frame))
+                self._last_progress_at = time.monotonic()
                 while not self._stop.is_set():
                     try:
                         self._frames.put(frame, timeout=0.1)
@@ -490,6 +549,12 @@ class BufferedAudioSource(_AudioSourceBase):
             return self._frames.get_nowait()
         except queue.Empty:
             if self._finished.is_set():
+                return b""
+            if time.monotonic() - self._last_progress_at >= self._stall_timeout:
+                self._current_error = MusicResolutionError(
+                    "The audio stream stalled and was stopped."
+                )
+                self._stop.set()
                 return b""
             return self.SILENCE_FRAME
 
@@ -519,6 +584,7 @@ class DiscordMusicManager:
         resolver: Optional[TrackResolver] = None,
         audio_source_factory: Optional[Callable[[str], object]] = None,
         view_factory: Optional[Callable[["DiscordMusicManager", int], object]] = None,
+        stop_reconcile_delay: float = 0.75,
     ) -> None:
         self.adapter = adapter
         self.resolver = resolver or TrackResolver()
@@ -528,6 +594,88 @@ class DiscordMusicManager:
         self._view_factory = view_factory or (
             lambda manager, guild_id: MusicControlView(manager, guild_id)
         )
+        self._stop_reconcile_delay = max(0.0, float(stop_reconcile_delay))
+
+    def _schedule_stop_reconciliation(self, guild_id: int, generation: int) -> None:
+        loop = asyncio.get_running_loop()
+        loop.call_later(
+            self._stop_reconcile_delay,
+            lambda: asyncio.create_task(
+                self._reconcile_stopped_playback(guild_id, generation)
+            ),
+        )
+
+    def _schedule_completion_watch(self, guild_id: int, generation: int) -> None:
+        """Keep watching until playback stops or the generation becomes stale."""
+        loop = asyncio.get_running_loop()
+        loop.call_later(
+            max(0.01, self._stop_reconcile_delay),
+            lambda: asyncio.create_task(
+                self._reconcile_lost_completion(guild_id, generation)
+            ),
+        )
+
+    async def _reconcile_lost_completion(
+        self, guild_id: int, generation: int
+    ) -> None:
+        async with self._locks.setdefault(guild_id, asyncio.Lock()):
+            session = self.sessions.get(guild_id)
+            if (
+                session is None
+                or session.current is None
+                or session.playback_generation != generation
+            ):
+                return
+            vc = getattr(self.adapter, "_voice_clients", {}).get(guild_id)
+            if vc is not None and (vc.is_playing() or vc.is_paused()):
+                self._schedule_completion_watch(guild_id, generation)
+                return
+            suppress_repeat = session.suppress_repeat_generation == generation
+            if suppress_repeat:
+                session.suppress_repeat_generation = None
+            self._finish_current(session, allow_repeat=not suppress_repeat)
+            await self._start_next(session)
+            await self._update_panel(session)
+
+    async def _reconcile_stopped_playback(
+        self, guild_id: int, generation: int
+    ) -> None:
+        """Advance after an explicit stop even if discord.py loses its callback."""
+        async with self._locks.setdefault(guild_id, asyncio.Lock()):
+            session = self.sessions.get(guild_id)
+            if (
+                session is None
+                or session.current is None
+                or session.playback_generation != generation
+            ):
+                return
+            vc = getattr(self.adapter, "_voice_clients", {}).get(guild_id)
+            if vc is not None and (vc.is_playing() or vc.is_paused()):
+                return
+            if session.suppress_repeat_generation == generation:
+                session.suppress_repeat_generation = None
+            self._finish_current(session, allow_repeat=False)
+            await self._start_next(session)
+            await self._update_panel(session)
+
+    @staticmethod
+    def _finish_current(
+        session: MusicSession,
+        *,
+        error=None,
+        allow_repeat: bool = True,
+    ) -> Optional[MusicTrack]:
+        finished = session.current
+        if finished is None:
+            return None
+        session.current = None
+        if error is not None:
+            return finished
+        if allow_repeat and session.repeat_current:
+            session.queue.appendleft(finished)
+        else:
+            session.history.append(finished)
+        return finished
 
     @staticmethod
     def _default_audio_source(stream_url: str):
@@ -549,6 +697,65 @@ class DiscordMusicManager:
             )
         )
 
+    async def _add_request(
+        self,
+        *,
+        guild,
+        user,
+        text_channel,
+        voice_channel,
+        query: str,
+    ) -> list[MusicTrack]:
+        guild_id = int(guild.id)
+        async with self._locks.setdefault(guild_id, asyncio.Lock()):
+            tracks = await asyncio.to_thread(
+                self.resolver.resolve,
+                query,
+                requester_id=int(user.id),
+                requester_name=str(
+                    getattr(user, "display_name", None)
+                    or getattr(user, "name", user.id)
+                ),
+            )
+            joined = await self.adapter.join_voice_channel(
+                voice_channel,
+                text_channel_id=getattr(text_channel, "id", None),
+            )
+            if not joined:
+                raise MusicResolutionError("I could not join your voice channel.")
+
+            session = self.sessions.setdefault(
+                guild_id, MusicSession(guild_id=guild_id)
+            )
+            session.text_channel = text_channel
+            session.enqueue(tracks)
+            voice_client = getattr(self.adapter, "_voice_clients", {}).get(guild_id)
+            if (
+                session.current is not None
+                and voice_client is not None
+                and voice_client.is_connected()
+                and not voice_client.is_playing()
+                and not voice_client.is_paused()
+            ):
+                logger.warning(
+                    "Recovering stale Discord music state in guild %s after a lost completion callback",
+                    guild_id,
+                )
+                suppress_repeat = (
+                    session.playback_generation
+                    == session.suppress_repeat_generation
+                )
+                if suppress_repeat:
+                    session.suppress_repeat_generation = None
+                self._finish_current(
+                    session,
+                    allow_repeat=not suppress_repeat,
+                )
+            await self._update_panel(session)
+            if session.current is None:
+                await self._start_next(session)
+            return tracks
+
     async def add(self, interaction, query: str) -> None:
         guild = getattr(interaction, "guild", None)
         if guild is None:
@@ -556,7 +763,8 @@ class DiscordMusicManager:
                 "Music playback is only available in a server.", ephemeral=True
             )
             return
-        voice_state = getattr(getattr(interaction, "user", None), "voice", None)
+        user = getattr(interaction, "user", None)
+        voice_state = getattr(user, "voice", None)
         voice_channel = getattr(voice_state, "channel", None)
         if voice_channel is None:
             await interaction.response.send_message(
@@ -565,64 +773,79 @@ class DiscordMusicManager:
             return
 
         await interaction.response.defer(ephemeral=True)
-        tracks = await asyncio.to_thread(
-            self.resolver.resolve,
-            query,
-            requester_id=int(interaction.user.id),
-            requester_name=str(
-                getattr(interaction.user, "display_name", None)
-                or getattr(interaction.user, "name", interaction.user.id)
-            ),
+        tracks = await self._add_request(
+            guild=guild,
+            user=user,
+            text_channel=interaction.channel,
+            voice_channel=voice_channel,
+            query=query,
         )
-        joined = await self.adapter.join_voice_channel(
-            voice_channel,
-            text_channel_id=getattr(interaction.channel, "id", None),
-        )
-        if not joined:
-            raise MusicResolutionError("I could not join your voice channel.")
-
-        guild_id = int(guild.id)
-        async with self._locks.setdefault(guild_id, asyncio.Lock()):
-            session = self.sessions.setdefault(
-                guild_id, MusicSession(guild_id=guild_id)
-            )
-            session.text_channel = interaction.channel
-            session.enqueue(tracks)
-            await self._update_panel(session)
-            if session.current is None:
-                await self._start_next(session)
-
         label = tracks[0].title if len(tracks) == 1 else f"{len(tracks)} tracks"
         await interaction.followup.send(
             f"Added **{label}** to the music queue.", ephemeral=True
         )
 
-    async def _update_panel(self, session: MusicSession) -> None:
-        import discord
+    async def add_message(self, message, query: str) -> None:
+        """Add a natural-language text request without a slash interaction."""
+        guild = getattr(message, "guild", None)
+        channel = getattr(message, "channel", None)
+        user = getattr(message, "author", None)
+        if guild is None or channel is None:
+            if channel is not None:
+                await channel.send("Music playback is only available in a server.")
+            return
+        voice_state = getattr(user, "voice", None)
+        voice_channel = getattr(voice_state, "channel", None)
+        if voice_channel is None:
+            await channel.send("Join a voice channel first, then ask me to play it again.")
+            return
 
-        content = session.render_queue()
-        view = self._view_factory(self, session.guild_id)
-        allowed_mentions_cls = discord.AllowedMentions
-        none_factory = getattr(allowed_mentions_cls, "none", None)
-        if callable(none_factory):
-            allowed_mentions = none_factory()
-        else:
-            # Some Discord-compatible adapters expose the constructor but not
-            # discord.py's convenience classmethod. Preserve fail-closed mention
-            # behavior across both forms.
-            allowed_mentions = allowed_mentions_cls(
-                everyone=False,
-                roles=False,
-                users=False,
-                replied_user=False,
-            )
-        if session.panel_message is None:
+        tracks = await self._add_request(
+            guild=guild,
+            user=user,
+            text_channel=channel,
+            voice_channel=voice_channel,
+            query=query,
+        )
+        label = tracks[0].title if len(tracks) == 1 else f"{len(tracks)} tracks"
+        await channel.send(
+            f"Added **{label}** to the music queue.",
+            allowed_mentions=discord_no_mentions(),
+        )
+
+    async def _update_panel(self, session: MusicSession) -> None:
+        """Best-effort queue UI refresh; panel failures never alter playback."""
+        if session.text_channel is None:
+            return
+        try:
+            content = session.render_queue()
+            view = self._view_factory(self, session.guild_id)
+            allowed_mentions = discord_no_mentions()
+            if session.panel_message is not None:
+                try:
+                    await session.panel_message.edit(
+                        content=content,
+                        view=view,
+                        allowed_mentions=allowed_mentions,
+                    )
+                    return
+                except Exception:
+                    logger.warning(
+                        "Could not edit Discord music panel in guild %s; recreating it",
+                        session.guild_id,
+                        exc_info=True,
+                    )
+                    session.panel_message = None
             session.panel_message = await session.text_channel.send(
-                content, view=view, allowed_mentions=allowed_mentions
+                content,
+                view=view,
+                allowed_mentions=allowed_mentions,
             )
-        else:
-            await session.panel_message.edit(
-                content=content, view=view, allowed_mentions=allowed_mentions
+        except Exception:
+            logger.warning(
+                "Could not publish Discord music panel in guild %s",
+                session.guild_id,
+                exc_info=True,
             )
 
     async def _start_next(self, session: MusicSession) -> None:
@@ -654,9 +877,9 @@ class DiscordMusicManager:
                 if vc is None or not vc.is_connected():
                     raise MusicResolutionError("The voice connection was lost.")
                 self.adapter._cancel_voice_timeout(session.guild_id)
-                receiver = self.adapter._voice_receivers.get(session.guild_id)
-                if receiver:
-                    receiver.pause()
+                # Keep the receiver live so spoken pause/resume/skip commands
+                # remain usable while music is playing. Discord does not feed
+                # the bot's own outbound audio back as a member stream.
                 self.adapter._voice_mixers.pop(session.guild_id, None)
                 if vc.is_playing() or vc.is_paused():
                     vc.stop()
@@ -665,11 +888,12 @@ class DiscordMusicManager:
                 generation = session.playback_generation
 
                 def _after(error):
+                    terminal_error = error or getattr(source, "_current_error", None)
                     loop.call_soon_threadsafe(
                         lambda: asyncio.create_task(
                             self._on_track_end(
                                 session.guild_id,
-                                error,
+                                terminal_error,
                                 generation=generation,
                             )
                         )
@@ -681,7 +905,7 @@ class DiscordMusicManager:
                     bitrate=192,
                     signal_type="music",
                 )
-                session.last_error = None
+                self._schedule_completion_watch(session.guild_id, generation)
                 await self._update_panel(session)
                 return
             except asyncio.CancelledError:
@@ -712,6 +936,45 @@ class DiscordMusicManager:
         else:
             await interaction.response.send_message(message, ephemeral=True)
 
+    async def control_message(self, message, action: str) -> None:
+        """Apply a natural text/voice playback command through existing controls."""
+        guild = getattr(message, "guild", None)
+        channel = getattr(message, "channel", None)
+        user = getattr(message, "author", None)
+        if guild is None or channel is None or user is None:
+            return
+
+        class _Response:
+            @staticmethod
+            def is_done() -> bool:
+                return False
+
+            @staticmethod
+            async def send_message(content: str, **_kwargs) -> None:
+                await channel.send(content, allowed_mentions=discord_no_mentions())
+
+        interaction = SimpleNamespace(
+            guild=guild,
+            channel=channel,
+            user=user,
+            response=_Response(),
+        )
+        guild_id = int(guild.id)
+        if action == "queue":
+            async with self._locks.setdefault(guild_id, asyncio.Lock()):
+                session = self.sessions.get(guild_id)
+                if session is None:
+                    await _Response.send_message("The music queue is empty.")
+                    return
+                session.text_channel = channel
+                await self._update_panel(session)
+                await _Response.send_message("The public music queue is up to date.")
+            return
+        if action == "clear":
+            await self.admin_action(interaction, guild_id, "clear")
+            return
+        await self.control(interaction, guild_id, action)
+
     async def show_queue(self, interaction, guild_id: int) -> None:
         """Acknowledge, then serialize the public panel refresh for a guild."""
         guild_id = int(guild_id)
@@ -735,6 +998,35 @@ class DiscordMusicManager:
             await interaction.response.defer(ephemeral=True)
         async with self._locks.setdefault(guild_id, asyncio.Lock()):
             session = self.sessions.get(guild_id)
+            allow_user = getattr(self.adapter, "_is_allowed_user", None)
+            guild = getattr(interaction, "guild", None)
+            user = interaction.user
+            channel = getattr(interaction, "channel", None)
+            channel_keys = None
+            channel_key_resolver = getattr(
+                self.adapter, "_discord_channel_keys_from_channel", None
+            )
+            parent_resolver = getattr(self.adapter, "_get_parent_channel_id", None)
+            if (
+                channel is not None
+                and callable(channel_key_resolver)
+                and callable(parent_resolver)
+            ):
+                channel_keys = channel_key_resolver(
+                    channel, parent_resolver(channel)
+                )
+            if callable(allow_user) and not allow_user(
+                str(user.id),
+                author=user,
+                guild=guild,
+                is_dm=False,
+                channel_ids=channel_keys,
+            ):
+                await self._reply(
+                    interaction,
+                    "You are not authorized to use music controls.",
+                )
+                return
             administrator = bool(
                 getattr(
                     getattr(interaction.user, "guild_permissions", None),
@@ -742,8 +1034,17 @@ class DiscordMusicManager:
                     False,
                 )
             )
-            if session is None or not session.can_control(
-                user_id=int(interaction.user.id), administrator=administrator
+            user_id = int(interaction.user.id)
+            owns_finished_history = bool(
+                session is not None
+                and action == "previous"
+                and session.current is None
+                and session.history
+                and session.history[-1].requester_id == user_id
+            )
+            if session is None or not (
+                session.can_control(user_id=user_id, administrator=administrator)
+                or owns_finished_history
             ):
                 await self._reply(
                     interaction,
@@ -752,23 +1053,59 @@ class DiscordMusicManager:
                 return
             vc = self.adapter._voice_clients.get(guild_id)
             if action == "skip":
-                if vc is None:
+                if vc is None or not vc.is_connected():
                     await self._reply(interaction, "The voice connection was lost.")
                     return
-                vc.stop()
+                if vc.is_playing() or vc.is_paused():
+                    generation = session.playback_generation
+                    session.suppress_repeat_generation = generation
+                    vc.stop()
+                    self._schedule_stop_reconciliation(guild_id, generation)
+                else:
+                    self._finish_current(session, allow_repeat=False)
+                    await self._start_next(session)
+                    await self._update_panel(session)
                 await self._reply(interaction, "Skipped.")
                 return
             if action == "play_pause":
-                if vc is None:
+                if vc is None or not vc.is_connected():
                     await self._reply(interaction, "The voice connection was lost.")
                     return
                 if vc.is_paused():
                     vc.resume()
                     message = "Resumed."
-                else:
+                elif vc.is_playing():
                     vc.pause()
                     message = "Paused."
+                else:
+                    message = "Nothing is playing."
                 await self._reply(interaction, message)
+                return
+            if action == "pause":
+                if vc is None or not vc.is_connected():
+                    await self._reply(interaction, "The voice connection was lost.")
+                    return
+                if vc.is_paused():
+                    await self._reply(interaction, "Music is already paused.")
+                    return
+                if not vc.is_playing():
+                    await self._reply(interaction, "Nothing is playing.")
+                    return
+                vc.pause()
+                await self._reply(interaction, "Paused.")
+                return
+            if action == "resume":
+                if vc is None or not vc.is_connected():
+                    await self._reply(interaction, "The voice connection was lost.")
+                    return
+                if vc.is_paused():
+                    vc.resume()
+                    await self._reply(interaction, "Resumed.")
+                    return
+                if vc.is_playing():
+                    await self._reply(interaction, "Music is already playing.")
+                    return
+                await self._reply(interaction, "Nothing is paused.")
                 return
             if action == "repeat":
                 session.repeat_current = not session.repeat_current
@@ -781,7 +1118,7 @@ class DiscordMusicManager:
                 if not session.history:
                     await self._reply(interaction, "There is no previous song yet.")
                     return
-                if vc is None:
+                if vc is None or not vc.is_connected():
                     await self._reply(interaction, "The voice connection was lost.")
                     return
                 interrupted = session.current
@@ -852,10 +1189,18 @@ class DiscordMusicManager:
                 await self._reply(interaction, "Music queue cleared.")
                 return
             if action == "forceskip":
-                if vc is None:
+                if vc is None or not vc.is_connected():
                     await self._reply(interaction, "The voice connection was lost.")
                     return
-                vc.stop()
+                if vc.is_playing() or vc.is_paused():
+                    generation = session.playback_generation
+                    session.suppress_repeat_generation = generation
+                    vc.stop()
+                    self._schedule_stop_reconciliation(guild_id, generation)
+                else:
+                    self._finish_current(session, allow_repeat=False)
+                    await self._start_next(session)
+                    await self._update_panel(session)
                 await self._reply(interaction, "Force-skipped.")
                 return
             await self._reply(interaction, "Unknown administrator action.")
@@ -879,12 +1224,21 @@ class DiscordMusicManager:
                 return
             if session.current is None:
                 return
-            finished = session.current
-            session.current = None
-            if session.repeat_current and error is None:
-                session.queue.appendleft(finished)
-            else:
-                session.history.append(finished)
+            suppress_repeat = (
+                generation is not None
+                and generation == session.suppress_repeat_generation
+            )
+            if suppress_repeat:
+                session.suppress_repeat_generation = None
+            if error is not None and session.current is not None:
+                session.last_error = (
+                    f"Playback failed for **{session.current.title}**."
+                )
+            self._finish_current(
+                session,
+                error=error,
+                allow_repeat=not suppress_repeat,
+            )
             await self._start_next(session)
             await self._update_panel(session)
 

--- a/plugins/platforms/discord/music.py
+++ b/plugins/platforms/discord/music.py
@@ -236,22 +236,31 @@ class TrackResolver:
             "noplaylist": False,
             "extract_flat": "in_playlist" if flat else False,
             "playlistend": TrackResolver.MAX_TRACKS_PER_REQUEST,
-            # YouTube's direct GVS URLs can return HTTP 403 even when freshly
-            # extracted. Require its lowest-bandwidth HLS stream and discard
-            # the video in FFmpeg. Other providers retain audio-only formats.
+            # Prefer audio-only or bandwidth-conscious HLS when available;
+            # retain a direct-format fallback for videos without HLS.
             "format": (
                 None
                 if flat
                 else (
                     "bestaudio[protocol^=m3u8]/"
                     "best[protocol^=m3u8][acodec!=none][height<=480]/"
-                    "worst[protocol^=m3u8][acodec!=none]"
+                    "worst[protocol^=m3u8][acodec!=none]/"
+                    "bestaudio/best"
                     if is_youtube
                     else "bestaudio/best"
                 )
             ),
+            # The default/Android-VR client currently emits signed direct
+            # audio URLs that FFmpeg receives as HTTP 403. The Android client
+            # falls back to a directly playable muxed MP4 when HLS and
+            # audio-only formats are unavailable.
+            "extractor_args": (
+                {"youtube": {"player_client": ["android"]}}
+                if is_youtube
+                else {}
+            ),
             # Search several candidates and let yt-dlp omit YouTube results
-            # that do not expose a playable HLS stream.
+            # that do not expose a playable stream.
             "ignoreerrors": is_youtube,
             # yt-dlp enables Deno by default but not Node. Hermes installations
             # already ship Node, so allow either supported runtime to solve

--- a/plugins/platforms/discord/music.py
+++ b/plugins/platforms/discord/music.py
@@ -1,0 +1,806 @@
+"""Per-guild Discord music queues and playback controls.
+
+Streaming is intentionally resolved at playback time so expiring media URLs are
+never persisted. Spotify links contribute metadata only; audio is resolved from
+a supported source by yt-dlp rather than attempting to bypass Spotify DRM.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import logging
+import re
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Callable, Deque, Iterable, Optional
+from urllib.parse import urlparse
+
+
+class MusicResolutionError(RuntimeError):
+    """A user-facing media-resolution failure."""
+
+
+class TrackResolver:
+    """Turn user input into queue metadata and fresh playable stream URLs."""
+
+    MAX_TRACKS_PER_REQUEST = 25
+    TRUSTED_STREAM_HOSTS = (
+        "googlevideo.com",
+        "youtube.com",
+        "sndcdn.com",
+        "soundcloud.com",
+        "bcbits.com",
+        "bandcamp.com",
+        "vimeocdn.com",
+        "akamaized.net",
+        "twitchcdn.net",
+        "jtvnw.net",
+        "mixcloud.com",
+        "dmcdn.net",
+        "dailymotion.com",
+    )
+
+    def __init__(
+        self,
+        *,
+        spotify_metadata: Optional[Callable[[str], list[dict]]] = None,
+        media_extractor: Optional[Callable[..., dict]] = None,
+        http_get: Optional[Callable[..., object]] = None,
+        url_guard: Optional[Callable[[str], bool]] = None,
+        url_support_checker: Optional[Callable[[str], bool]] = None,
+    ):
+        if url_guard is None:
+            from tools.url_safety import is_safe_url
+
+            url_guard = is_safe_url
+        self._url_guard = url_guard
+        self._url_support_checker = url_support_checker or self._has_supported_extractor
+        self._http_get = http_get or self._default_http_get
+        self._spotify_metadata = spotify_metadata or self._fetch_spotify_metadata
+        self._media_extractor = media_extractor or self._extract_media
+
+    @staticmethod
+    def _is_spotify_url(value: str) -> bool:
+        host = (urlparse(value).hostname or "").lower()
+        return host in {"open.spotify.com", "spotify.link"} or host.endswith(
+            ".spotify.com"
+        )
+
+    @staticmethod
+    def _is_youtube_lookup(value: str) -> bool:
+        host = (urlparse(value).hostname or "").lower()
+        return bool(
+            re.match(r"^ytsearch\d*:", value)
+            or host == "youtu.be"
+            or host == "youtube.com"
+            or host.endswith(".youtube.com")
+        )
+
+    def resolve(
+        self,
+        query: str,
+        *,
+        requester_id: int,
+        requester_name: str,
+    ) -> list["MusicTrack"]:
+        query = str(query or "").strip()
+        if not query:
+            raise MusicResolutionError("Provide a song name or supported music link.")
+        parsed = urlparse(query)
+        if parsed.scheme in {"http", "https"} and not self._url_guard(query):
+            raise MusicResolutionError(
+                "For safety, private or local media URLs are not allowed."
+            )
+        if self._is_spotify_url(query):
+            path_parts = [part for part in parsed.path.split("/") if part]
+            if parsed.hostname == "open.spotify.com" and (
+                not path_parts or path_parts[0] != "track"
+            ):
+                raise MusicResolutionError(
+                    "Only Spotify track links are currently supported; albums and playlists need Spotify API metadata access."
+                )
+            items = self._spotify_metadata(query)
+            tracks = []
+            for item in items[: self.MAX_TRACKS_PER_REQUEST]:
+                title = str(item.get("title") or "Unknown track").strip()
+                artist = str(item.get("artist") or "").strip()
+                display = f"{title} — {artist}" if artist else title
+                search = " ".join(part for part in (title, artist, "audio") if part)
+                tracks.append(
+                    MusicTrack(
+                        title=display,
+                        webpage_url=str(item.get("webpage_url") or query),
+                        lookup=f"ytsearch5:{search}",
+                        requester_id=int(requester_id),
+                        requester_name=str(requester_name),
+                        duration=item.get("duration"),
+                        thumbnail=item.get("thumbnail"),
+                    )
+                )
+            if not tracks:
+                raise MusicResolutionError(
+                    "No playable tracks were found in that Spotify link."
+                )
+            return tracks
+
+        if parsed.scheme in {"http", "https"} and not self._url_support_checker(query):
+            raise MusicResolutionError(
+                "That URL is not from a supported streaming platform. Try a song name, Spotify, YouTube, or another yt-dlp-supported service."
+            )
+        is_direct_url = parsed.scheme in {"http", "https"}
+        lookup = query if is_direct_url else f"ytsearch5:{query}"
+        info = self._media_extractor(lookup, flat=True)
+        entries = info.get("entries") if isinstance(info, dict) else None
+        if entries is None:
+            entries = [info]
+        elif not is_direct_url:
+            # A text search queues one requested song, not every fallback
+            # candidate. Keep the broader search lookup on that track so
+            # playback can skip YouTube results without a usable HLS stream.
+            entries = list(entries)[:1]
+        tracks = []
+        for item in list(entries)[: self.MAX_TRACKS_PER_REQUEST]:
+            if not isinstance(item, dict):
+                continue
+            webpage_url = str(item.get("webpage_url") or item.get("url") or lookup)
+            tracks.append(
+                MusicTrack(
+                    title=str(item.get("title") or "Unknown track"),
+                    webpage_url=webpage_url,
+                    lookup=webpage_url if is_direct_url else lookup,
+                    requester_id=int(requester_id),
+                    requester_name=str(requester_name),
+                    duration=item.get("duration"),
+                    thumbnail=item.get("thumbnail"),
+                )
+            )
+        if not tracks:
+            raise MusicResolutionError(
+                "No playable tracks were found for that request."
+            )
+        return tracks
+
+    def resolve_stream(self, track: "MusicTrack") -> str:
+        info = self._media_extractor(track.lookup, flat=False)
+        if isinstance(info, dict) and info.get("entries"):
+            info = next((item for item in info["entries"] if item), {})
+        stream_url = str((info or {}).get("url") or "")
+        if not stream_url:
+            raise MusicResolutionError(
+                f"Could not obtain an audio stream for {track.title}."
+            )
+        parsed_stream = urlparse(stream_url)
+        if parsed_stream.scheme not in {"http", "https"}:
+            raise MusicResolutionError("Resolved audio streams must use HTTP or HTTPS.")
+        stream_host = (parsed_stream.hostname or "").lower()
+        protocol = str((info or {}).get("protocol") or "").lower()
+        if (
+            protocol.startswith("m3u8")
+            and self._is_youtube_lookup(track.lookup)
+            and stream_host != "manifest.googlevideo.com"
+        ):
+            raise MusicResolutionError(
+                "The resolved HLS stream is not on YouTube's trusted manifest host."
+            )
+        if not any(
+            stream_host == host or stream_host.endswith(f".{host}")
+            for host in self.TRUSTED_STREAM_HOSTS
+        ):
+            raise MusicResolutionError(
+                "The resolved audio stream is not on a trusted media host."
+            )
+        if not self._url_guard(stream_url):
+            raise MusicResolutionError(
+                "The resolved audio stream points to a private or local address."
+            )
+        return stream_url
+
+    @staticmethod
+    def _has_supported_extractor(url: str) -> bool:
+        try:
+            from yt_dlp.extractor import gen_extractor_classes
+        except ImportError as exc:
+            raise MusicResolutionError(
+                "Music playback requires yt-dlp. Reinstall Hermes with messaging support."
+            ) from exc
+        for extractor_cls in gen_extractor_classes():
+            try:
+                if extractor_cls.suitable(url):
+                    return (
+                        str(getattr(extractor_cls, "IE_NAME", "")).lower() != "generic"
+                    )
+            except Exception:
+                continue
+        return False
+
+    @staticmethod
+    def _extract_media(query: str, *, flat: bool) -> dict:
+        try:
+            import yt_dlp
+        except ImportError as exc:
+            raise MusicResolutionError(
+                "Music playback requires yt-dlp. Reinstall Hermes with messaging support."
+            ) from exc
+        is_youtube = TrackResolver._is_youtube_lookup(query)
+        options = {
+            "quiet": True,
+            "no_warnings": True,
+            "noplaylist": False,
+            "extract_flat": "in_playlist" if flat else False,
+            "playlistend": TrackResolver.MAX_TRACKS_PER_REQUEST,
+            # YouTube's direct GVS URLs can return HTTP 403 even when freshly
+            # extracted. Require its lowest-bandwidth HLS stream and discard
+            # the video in FFmpeg. Other providers retain audio-only formats.
+            "format": (
+                None
+                if flat
+                else (
+                    "worst[protocol^=m3u8][acodec!=none]"
+                    if is_youtube
+                    else "bestaudio/best"
+                )
+            ),
+            # Search several candidates and let yt-dlp omit YouTube results
+            # that do not expose a playable HLS stream.
+            "ignoreerrors": is_youtube,
+            # yt-dlp enables Deno by default but not Node. Hermes installations
+            # already ship Node, so allow either supported runtime to solve
+            # YouTube's JavaScript challenges.
+            "js_runtimes": {
+                "deno": {"path": None},
+                "node": {"path": None},
+            },
+        }
+        try:
+            with yt_dlp.YoutubeDL(options) as ydl:
+                result = ydl.extract_info(query, download=False)
+        except Exception as exc:
+            raise MusicResolutionError(
+                f"Could not resolve that music source: {exc}"
+            ) from exc
+        return result or {}
+
+    @staticmethod
+    def _default_http_get(url: str, **kwargs):
+        from tools.url_safety import create_ssrf_safe_client
+
+        with create_ssrf_safe_client(**kwargs) as client:
+            return client.get(url)
+
+    def _fetch_spotify_metadata(self, url: str) -> list[dict]:
+        try:
+            page = self._http_get(
+                url,
+                follow_redirects=True,
+                timeout=15.0,
+                headers={"User-Agent": "Hermes-Agent music queue"},
+            )
+            page.raise_for_status()
+            canonical_url = str(getattr(page, "url", None) or url)
+            canonical = urlparse(canonical_url)
+            canonical_parts = [part for part in canonical.path.split("/") if part]
+            if (
+                canonical.hostname != "open.spotify.com"
+                or not canonical_parts
+                or canonical_parts[0] != "track"
+            ):
+                raise MusicResolutionError(
+                    "Only Spotify track links are currently supported; albums and playlists need Spotify API metadata access."
+                )
+            oembed = self._http_get(
+                "https://open.spotify.com/oembed",
+                params={"url": canonical_url},
+                follow_redirects=True,
+                timeout=15.0,
+            )
+            oembed.raise_for_status()
+            embed_data = oembed.json() or {}
+        except Exception as exc:
+            raise MusicResolutionError(
+                f"Spotify metadata could not be resolved: {exc}"
+            ) from exc
+
+        description_match = re.search(
+            r'<meta[^>]+(?:property|name)=["\']og:description["\'][^>]+content=["\']([^"\']+)',
+            str(getattr(page, "text", "")),
+            re.IGNORECASE,
+        )
+        description = (
+            html.unescape(description_match.group(1)) if description_match else ""
+        )
+        parts = [part.strip() for part in description.split("·") if part.strip()]
+        title = str(
+            embed_data.get("title")
+            or (parts[1] if len(parts) > 1 else parts[0] if parts else "Spotify track")
+        )
+        artist = parts[0] if len(parts) > 1 else ""
+        return [
+            {
+                "title": title,
+                "artist": artist,
+                "webpage_url": canonical_url,
+                "thumbnail": embed_data.get("thumbnail_url"),
+            }
+        ]
+
+
+@dataclass(slots=True)
+class MusicTrack:
+    title: str
+    webpage_url: str
+    lookup: str
+    requester_id: int
+    requester_name: str
+    duration: Optional[int] = None
+    thumbnail: Optional[str] = None
+
+
+@dataclass
+class MusicSession:
+    guild_id: int
+    queue: Deque[MusicTrack] = field(default_factory=deque)
+    history: Deque[MusicTrack] = field(default_factory=lambda: deque(maxlen=50))
+    current: Optional[MusicTrack] = None
+    repeat_current: bool = False
+    playback_generation: int = 0
+    last_error: Optional[str] = None
+    text_channel: object = None
+    panel_message: object = None
+
+    def enqueue(self, tracks: Iterable[MusicTrack]) -> None:
+        self.queue.extend(tracks)
+
+    def can_control(self, *, user_id: int, administrator: bool) -> bool:
+        return bool(
+            administrator
+            or (self.current is not None and self.current.requester_id == int(user_id))
+        )
+
+    def render_queue(self) -> str:
+        lines = []
+        if self.current:
+            lines.append(
+                f"Now playing: **{self.current.title}** — requested by "
+                f"{self.current.requester_name}"
+            )
+        else:
+            lines.append("Nothing is playing.")
+        if self.queue:
+            lines.append("\nUp next:")
+            for index, track in enumerate(list(self.queue)[:10], start=1):
+                lines.append(
+                    f"{index}. **{track.title}** — requested by {track.requester_name}"
+                )
+            remaining = len(self.queue) - 10
+            if remaining > 0:
+                lines.append(f"…and {remaining} more")
+        else:
+            lines.append("\nQueue is empty.")
+        if self.repeat_current:
+            lines.append("\nRepeat: current song")
+        if self.last_error:
+            lines.append(f"\n⚠️ {self.last_error}")
+        return "\n".join(lines)
+
+
+logger = logging.getLogger(__name__)
+
+
+class DiscordMusicManager:
+    """Own one visible FIFO player per Discord guild."""
+
+    def __init__(
+        self,
+        adapter,
+        *,
+        resolver: Optional[TrackResolver] = None,
+        audio_source_factory: Optional[Callable[[str], object]] = None,
+        view_factory: Optional[Callable[["DiscordMusicManager", int], object]] = None,
+    ) -> None:
+        self.adapter = adapter
+        self.resolver = resolver or TrackResolver()
+        self.sessions: dict[int, MusicSession] = {}
+        self._locks: dict[int, asyncio.Lock] = {}
+        self._audio_source_factory = audio_source_factory or self._default_audio_source
+        self._view_factory = view_factory or (
+            lambda manager, guild_id: MusicControlView(manager, guild_id)
+        )
+
+    @staticmethod
+    def _default_audio_source(stream_url: str):
+        import discord
+
+        from plugins.platforms.discord.ffmpeg_utils import resolve_ffmpeg_executable
+
+        return discord.FFmpegPCMAudio(
+            stream_url,
+            executable=resolve_ffmpeg_executable(),
+            before_options=(
+                "-protocol_whitelist http,https,tcp,tls,crypto "
+                "-reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5"
+            ),
+            options="-vn -loglevel warning",
+        )
+
+    async def add(self, interaction, query: str) -> None:
+        guild = getattr(interaction, "guild", None)
+        if guild is None:
+            await interaction.response.send_message(
+                "Music playback is only available in a server.", ephemeral=True
+            )
+            return
+        voice_state = getattr(getattr(interaction, "user", None), "voice", None)
+        voice_channel = getattr(voice_state, "channel", None)
+        if voice_channel is None:
+            await interaction.response.send_message(
+                "Join a voice channel first, then run `/play` again.", ephemeral=True
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        tracks = await asyncio.to_thread(
+            self.resolver.resolve,
+            query,
+            requester_id=int(interaction.user.id),
+            requester_name=str(
+                getattr(interaction.user, "display_name", None)
+                or getattr(interaction.user, "name", interaction.user.id)
+            ),
+        )
+        joined = await self.adapter.join_voice_channel(
+            voice_channel,
+            text_channel_id=getattr(interaction.channel, "id", None),
+        )
+        if not joined:
+            raise MusicResolutionError("I could not join your voice channel.")
+
+        guild_id = int(guild.id)
+        async with self._locks.setdefault(guild_id, asyncio.Lock()):
+            session = self.sessions.setdefault(
+                guild_id, MusicSession(guild_id=guild_id)
+            )
+            session.text_channel = interaction.channel
+            session.enqueue(tracks)
+            await self._update_panel(session)
+            if session.current is None:
+                await self._start_next(session)
+
+        label = tracks[0].title if len(tracks) == 1 else f"{len(tracks)} tracks"
+        await interaction.followup.send(
+            f"Added **{label}** to the music queue.", ephemeral=True
+        )
+
+    async def _update_panel(self, session: MusicSession) -> None:
+        import discord
+
+        content = session.render_queue()
+        view = self._view_factory(self, session.guild_id)
+        allowed_mentions_cls = discord.AllowedMentions
+        none_factory = getattr(allowed_mentions_cls, "none", None)
+        if callable(none_factory):
+            allowed_mentions = none_factory()
+        else:
+            # Some Discord-compatible adapters expose the constructor but not
+            # discord.py's convenience classmethod. Preserve fail-closed mention
+            # behavior across both forms.
+            allowed_mentions = allowed_mentions_cls(
+                everyone=False,
+                roles=False,
+                users=False,
+                replied_user=False,
+            )
+        if session.panel_message is None:
+            session.panel_message = await session.text_channel.send(
+                content, view=view, allowed_mentions=allowed_mentions
+            )
+        else:
+            await session.panel_message.edit(
+                content=content, view=view, allowed_mentions=allowed_mentions
+            )
+
+    async def _start_next(self, session: MusicSession) -> None:
+        if session.current is not None:
+            return
+        while session.queue and session.current is None:
+            track = session.queue.popleft()
+            session.current = track
+            source = None
+            try:
+                stream_url = await asyncio.to_thread(
+                    self.resolver.resolve_stream, track
+                )
+                source = self._audio_source_factory(stream_url)
+                vc = self.adapter._voice_clients.get(session.guild_id)
+                if vc is None or not vc.is_connected():
+                    raise MusicResolutionError("The voice connection was lost.")
+                self.adapter._cancel_voice_timeout(session.guild_id)
+                receiver = self.adapter._voice_receivers.get(session.guild_id)
+                if receiver:
+                    receiver.pause()
+                self.adapter._voice_mixers.pop(session.guild_id, None)
+                if vc.is_playing() or vc.is_paused():
+                    vc.stop()
+                loop = asyncio.get_running_loop()
+                session.playback_generation += 1
+                generation = session.playback_generation
+
+                def _after(error):
+                    loop.call_soon_threadsafe(
+                        lambda: asyncio.create_task(
+                            self._on_track_end(
+                                session.guild_id,
+                                error,
+                                generation=generation,
+                            )
+                        )
+                    )
+
+                vc.play(source, after=_after)
+                session.last_error = None
+                await self._update_panel(session)
+                return
+            except Exception as exc:
+                logger.warning(
+                    "Skipping unplayable Discord music track %r in guild %s: %s",
+                    track.title,
+                    session.guild_id,
+                    exc,
+                )
+                if source is not None and hasattr(source, "cleanup"):
+                    source.cleanup()
+                session.last_error = f"Skipped **{track.title}**: {exc}"
+                session.current = None
+                await self._update_panel(session)
+        if session.current is None:
+            await self._restore_voice_listening(session.guild_id)
+
+    async def _reply(self, interaction, message: str) -> None:
+        is_done = getattr(getattr(interaction, "response", None), "is_done", None)
+        if callable(is_done) and is_done():
+            await interaction.followup.send(message, ephemeral=True)
+        else:
+            await interaction.response.send_message(message, ephemeral=True)
+
+    async def show_queue(self, interaction, guild_id: int) -> None:
+        """Acknowledge, then serialize the public panel refresh for a guild."""
+        guild_id = int(guild_id)
+        await interaction.response.defer(ephemeral=True)
+        async with self._locks.setdefault(guild_id, asyncio.Lock()):
+            session = self.sessions.get(guild_id)
+            if session is None:
+                await interaction.followup.send(
+                    "The music queue is empty.", ephemeral=True
+                )
+                return
+            session.text_channel = interaction.channel
+            await self._update_panel(session)
+        await interaction.followup.send(
+            "The public music queue is up to date.", ephemeral=True
+        )
+
+    async def control(self, interaction, guild_id: int, action: str) -> None:
+        guild_id = int(guild_id)
+        if hasattr(interaction.response, "defer"):
+            await interaction.response.defer(ephemeral=True)
+        async with self._locks.setdefault(guild_id, asyncio.Lock()):
+            session = self.sessions.get(guild_id)
+            administrator = bool(
+                getattr(
+                    getattr(interaction.user, "guild_permissions", None),
+                    "administrator",
+                    False,
+                )
+            )
+            if session is None or not session.can_control(
+                user_id=int(interaction.user.id), administrator=administrator
+            ):
+                await self._reply(
+                    interaction,
+                    "Only the requester of the current song or a server administrator can use these controls.",
+                )
+                return
+            vc = self.adapter._voice_clients.get(guild_id)
+            if action == "skip":
+                if vc is None:
+                    await self._reply(interaction, "The voice connection was lost.")
+                    return
+                vc.stop()
+                await self._reply(interaction, "Skipped.")
+                return
+            if action == "play_pause":
+                if vc is None:
+                    await self._reply(interaction, "The voice connection was lost.")
+                    return
+                if vc.is_paused():
+                    vc.resume()
+                    message = "Resumed."
+                else:
+                    vc.pause()
+                    message = "Paused."
+                await self._reply(interaction, message)
+                return
+            if action == "repeat":
+                session.repeat_current = not session.repeat_current
+                if session.panel_message is not None:
+                    await self._update_panel(session)
+                state = "on" if session.repeat_current else "off"
+                await self._reply(interaction, f"Repeat is {state}.")
+                return
+            if action == "previous":
+                if not session.history:
+                    await self._reply(interaction, "There is no previous song yet.")
+                    return
+                if vc is None:
+                    await self._reply(interaction, "The voice connection was lost.")
+                    return
+                interrupted = session.current
+                previous = session.history.pop()
+                if interrupted is not None:
+                    session.queue.appendleft(interrupted)
+                session.queue.appendleft(previous)
+                session.current = None
+                session.playback_generation += 1
+                vc.stop()
+                await self._start_next(session)
+                await self._reply(interaction, "Playing the previous song.")
+                return
+            await self._reply(interaction, "Unknown music control.")
+
+    async def on_voice_disconnected(self, guild_id: int) -> None:
+        """Discard playback state after any manual or automatic voice leave."""
+        guild_id = int(guild_id)
+        # Retain the lock object so waiters and future operations cannot split
+        # into two independent critical sections for the same guild.
+        async with self._locks.setdefault(guild_id, asyncio.Lock()):
+            session = self.sessions.pop(guild_id, None)
+            if session is None:
+                return
+            session.playback_generation += 1
+            session.queue.clear()
+            session.history.clear()
+            session.repeat_current = False
+            session.current = None
+            if session.panel_message is not None:
+                await self._update_panel(session)
+
+    async def admin_action(self, interaction, guild_id: int, action: str) -> None:
+        administrator = bool(
+            getattr(
+                getattr(interaction.user, "guild_permissions", None),
+                "administrator",
+                False,
+            )
+        )
+        if not administrator:
+            await self._reply(
+                interaction,
+                "This command requires the Discord Administrator permission.",
+            )
+            return
+        if hasattr(interaction.response, "defer"):
+            await interaction.response.defer(ephemeral=True)
+        guild_id = int(guild_id)
+        async with self._locks.setdefault(guild_id, asyncio.Lock()):
+            session = self.sessions.get(guild_id)
+            if session is None:
+                await self._reply(interaction, "There is no active music queue.")
+                return
+            vc = self.adapter._voice_clients.get(guild_id)
+            if action == "clear":
+                session.queue.clear()
+                session.history.clear()
+                session.repeat_current = False
+                if vc is not None and session.current is not None:
+                    session.playback_generation += 1
+                session.current = None
+                if vc is not None:
+                    vc.stop()
+                if session.panel_message is not None:
+                    await self._update_panel(session)
+                await self._restore_voice_listening(guild_id)
+                await self._reply(interaction, "Music queue cleared.")
+                return
+            if action == "forceskip":
+                if vc is None:
+                    await self._reply(interaction, "The voice connection was lost.")
+                    return
+                vc.stop()
+                await self._reply(interaction, "Force-skipped.")
+                return
+            await self._reply(interaction, "Unknown administrator action.")
+
+    async def _on_track_end(
+        self,
+        guild_id: int,
+        error=None,
+        *,
+        generation: Optional[int] = None,
+    ) -> None:
+        if error:
+            logger.warning(
+                "Discord music playback failed in guild %s: %s", guild_id, error
+            )
+        async with self._locks.setdefault(guild_id, asyncio.Lock()):
+            session = self.sessions.get(guild_id)
+            if session is None:
+                return
+            if generation is not None and generation != session.playback_generation:
+                return
+            if session.current is None:
+                return
+            finished = session.current
+            session.current = None
+            if session.repeat_current and error is None:
+                session.queue.appendleft(finished)
+            else:
+                session.history.append(finished)
+            await self._start_next(session)
+            await self._update_panel(session)
+
+    async def _restore_voice_listening(self, guild_id: int) -> None:
+        receiver = getattr(self.adapter, "_voice_receivers", {}).get(guild_id)
+        if receiver is not None:
+            try:
+                receiver.resume()
+            except Exception:
+                logger.debug("Failed to resume Discord voice receiver", exc_info=True)
+        voice_fx = getattr(self.adapter, "_voice_fx_cfg", {}) or {}
+        mixers = getattr(self.adapter, "_voice_mixers", {})
+        vc = getattr(self.adapter, "_voice_clients", {}).get(guild_id)
+        install_mixer = getattr(self.adapter, "_install_voice_mixer", None)
+        if (
+            voice_fx.get("enabled")
+            and guild_id not in mixers
+            and vc is not None
+            and callable(install_mixer)
+        ):
+            try:
+                await install_mixer(guild_id, vc)
+            except Exception:
+                logger.warning("Failed to restore Discord voice mixer", exc_info=True)
+        reset_timeout = getattr(self.adapter, "_reset_voice_timeout", None)
+        if callable(reset_timeout):
+            reset_timeout(guild_id)
+
+
+try:
+    import discord
+except ImportError:  # pragma: no cover - Discord adapter is unavailable too
+    discord = None
+
+
+if discord is not None:
+
+    class MusicControlView(discord.ui.View):
+        """Persistent public controls; authorization is checked per click."""
+
+        _BUTTONS = (
+            ("Previous", "hermes_music_previous", "secondary", "previous"),
+            ("Play/Pause", "hermes_music_play_pause", "primary", "play_pause"),
+            ("Repeat", "hermes_music_repeat", "secondary", "repeat"),
+            ("Skip", "hermes_music_skip", "danger", "skip"),
+        )
+
+        def __init__(self, manager: DiscordMusicManager, guild_id: int):
+            super().__init__(timeout=None)
+            self.manager = manager
+            self.guild_id = int(guild_id)
+            for label, custom_id, style_name, action in self._BUTTONS:
+                button = discord.ui.Button(
+                    label=label,
+                    style=getattr(discord.ButtonStyle, style_name),
+                    custom_id=custom_id,
+                )
+
+                async def callback(interaction, _action=action):
+                    await self.manager.control(interaction, self.guild_id, _action)
+
+                button.callback = callback
+                self.add_item(button)
+
+else:
+
+    class MusicControlView:  # pragma: no cover - import guard only
+        def __init__(self, *_args, **_kwargs):
+            raise RuntimeError("discord.py is required for music controls")

--- a/plugins/platforms/discord/music.py
+++ b/plugins/platforms/discord/music.py
@@ -10,11 +10,18 @@ from __future__ import annotations
 import asyncio
 import html
 import logging
+import queue
 import re
+import threading
 from collections import deque
 from dataclasses import dataclass, field
 from typing import Callable, Deque, Iterable, Optional
 from urllib.parse import urlparse
+
+try:
+    import discord
+except ImportError:  # pragma: no cover - Discord adapter is unavailable too
+    discord = None
 
 
 class MusicResolutionError(RuntimeError):
@@ -236,6 +243,8 @@ class TrackResolver:
                 None
                 if flat
                 else (
+                    "bestaudio[protocol^=m3u8]/"
+                    "best[protocol^=m3u8][acodec!=none][height<=480]/"
                     "worst[protocol^=m3u8][acodec!=none]"
                     if is_youtube
                     else "bestaudio/best"
@@ -387,6 +396,110 @@ class MusicSession:
 logger = logging.getLogger(__name__)
 
 
+if discord is None:
+
+    class _AudioSourceBase:
+        pass
+
+else:
+
+    class _AudioSourceBase(discord.AudioSource):
+        pass
+
+
+class BufferedAudioSource(_AudioSourceBase):
+    """Read FFmpeg ahead so network stalls never make Discord burst packets.
+
+    discord.py reads one 20 ms PCM frame at a time from its audio sender thread.
+    A blocking network-backed source makes that thread fall behind; its scheduler
+    then sends later frames without delay to catch up, which sounds like random
+    speed-ups.  This wrapper decouples FFmpeg from the sender with a bounded
+    read-ahead queue and emits silence during a rare buffer underrun instead of
+    blocking the sender.
+    """
+
+    FRAME_SIZE = 3840  # 48 kHz * 2 channels * 2 bytes * 20 ms
+    SILENCE_FRAME = b"\x00" * FRAME_SIZE
+
+    def __init__(
+        self,
+        source,
+        *,
+        prebuffer_frames: int = 100,
+        max_buffer_frames: int = 500,
+    ) -> None:
+        self.source = source
+        self._prebuffer_frames = max(1, int(prebuffer_frames))
+        capacity = max(self._prebuffer_frames, int(max_buffer_frames))
+        self._frames: queue.Queue[bytes] = queue.Queue(maxsize=capacity)
+        self._ready = threading.Event()
+        self._finished = threading.Event()
+        self._stop = threading.Event()
+        self._cleanup_lock = threading.Lock()
+        self._cleaned = False
+        self._current_error = None
+        self._producer = threading.Thread(
+            target=self._fill,
+            name="discord-music-buffer",
+            daemon=True,
+        )
+        self._producer.start()
+
+    def _fill(self) -> None:
+        try:
+            while not self._stop.is_set():
+                frame = self.source.read()
+                if not frame:
+                    self._current_error = getattr(
+                        self.source, "_current_error", None
+                    )
+                    break
+                if len(frame) < self.FRAME_SIZE:
+                    frame += b"\x00" * (self.FRAME_SIZE - len(frame))
+                while not self._stop.is_set():
+                    try:
+                        self._frames.put(frame, timeout=0.1)
+                        break
+                    except queue.Full:
+                        continue
+                if self._frames.qsize() >= self._prebuffer_frames:
+                    self._ready.set()
+        except Exception as exc:
+            self._current_error = exc
+        finally:
+            self._finished.set()
+            self._ready.set()
+
+    def wait_until_ready(self, timeout: float = 10.0) -> bool:
+        """Wait for the startup cushion without blocking the asyncio loop."""
+        if not self._ready.wait(timeout=max(0.0, float(timeout))):
+            return False
+        return not self._frames.empty()
+
+    def read(self) -> bytes:
+        try:
+            return self._frames.get_nowait()
+        except queue.Empty:
+            if self._finished.is_set():
+                return b""
+            return self.SILENCE_FRAME
+
+    def is_opus(self) -> bool:
+        return False
+
+    def cleanup(self) -> None:
+        with self._cleanup_lock:
+            if self._cleaned:
+                return
+            self._cleaned = True
+            self._stop.set()
+            try:
+                self.source.cleanup()
+            finally:
+                if self._producer is not threading.current_thread():
+                    self._producer.join(timeout=1.0)
+
+
 class DiscordMusicManager:
     """Own one visible FIFO player per Discord guild."""
 
@@ -413,14 +526,18 @@ class DiscordMusicManager:
 
         from plugins.platforms.discord.ffmpeg_utils import resolve_ffmpeg_executable
 
-        return discord.FFmpegPCMAudio(
-            stream_url,
-            executable=resolve_ffmpeg_executable(),
-            before_options=(
-                "-protocol_whitelist http,https,tcp,tls,crypto "
-                "-reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5"
-            ),
-            options="-vn -loglevel warning",
+        return BufferedAudioSource(
+            discord.FFmpegPCMAudio(
+                stream_url,
+                executable=resolve_ffmpeg_executable(),
+                before_options=(
+                    "-protocol_whitelist http,https,tcp,tls,crypto "
+                    "-reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5"
+                ),
+                options=(
+                    "-vn -af aresample=48000 -loglevel warning"
+                ),
+            )
         )
 
     async def add(self, interaction, query: str) -> None:
@@ -507,11 +624,24 @@ class DiscordMusicManager:
             session.current = track
             source = None
             try:
+                vc = self.adapter._voice_clients.get(session.guild_id)
+                if vc is None or not vc.is_connected():
+                    raise MusicResolutionError("The voice connection was lost.")
                 stream_url = await asyncio.to_thread(
                     self.resolver.resolve_stream, track
                 )
                 source = self._audio_source_factory(stream_url)
-                vc = self.adapter._voice_clients.get(session.guild_id)
+                if isinstance(source, BufferedAudioSource):
+                    ready = await asyncio.to_thread(source.wait_until_ready, 10.0)
+                    if not ready:
+                        startup_error = getattr(source, "_current_error", None)
+                        if startup_error is not None:
+                            raise MusicResolutionError(
+                                f"The audio decoder failed: {startup_error}"
+                            )
+                        raise MusicResolutionError(
+                            "The audio stream did not buffer enough to start reliably."
+                        )
                 if vc is None or not vc.is_connected():
                     raise MusicResolutionError("The voice connection was lost.")
                 self.adapter._cancel_voice_timeout(session.guild_id)
@@ -536,10 +666,20 @@ class DiscordMusicManager:
                         )
                     )
 
-                vc.play(source, after=_after)
+                vc.play(
+                    source,
+                    after=_after,
+                    bitrate=192,
+                    signal_type="music",
+                )
                 session.last_error = None
                 await self._update_panel(session)
                 return
+            except asyncio.CancelledError:
+                cleanup = getattr(source, "cleanup", None)
+                if callable(cleanup):
+                    await asyncio.to_thread(cleanup)
+                raise
             except Exception as exc:
                 logger.warning(
                     "Skipping unplayable Discord music track %r in guild %s: %s",
@@ -547,8 +687,9 @@ class DiscordMusicManager:
                     session.guild_id,
                     exc,
                 )
-                if source is not None and hasattr(source, "cleanup"):
-                    source.cleanup()
+                cleanup = getattr(source, "cleanup", None)
+                if callable(cleanup):
+                    await asyncio.to_thread(cleanup)
                 session.last_error = f"Skipped **{track.title}**: {exc}"
                 session.current = None
                 await self._update_panel(session)
@@ -762,12 +903,6 @@ class DiscordMusicManager:
         reset_timeout = getattr(self.adapter, "_reset_voice_timeout", None)
         if callable(reset_timeout):
             reset_timeout(guild_id)
-
-
-try:
-    import discord
-except ImportError:  # pragma: no cover - Discord adapter is unavailable too
-    discord = None
 
 
 if discord is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,7 @@ daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.7.2"]
 hindsight = ["hindsight-client==0.6.1"]
 dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==2.0.0", "httpx2==2.7.0", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==83.0.0"]  # starlette: CVE-2026-48710; setuptools: 83 (torch >=2.13 requires setuptools 83)
-messaging = ["python-telegram-bot[webhooks]==22.8", "discord.py[voice]==2.7.1", "aiohttp==3.14.3", "brotlicffi==1.2.0.1", "slack-bolt==1.30.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
+messaging = ["python-telegram-bot[webhooks]==22.8", "discord.py[voice]==2.7.1", "yt-dlp==2026.7.4", "yt-dlp-ejs==0.8.0", "aiohttp==3.14.3", "brotlicffi==1.2.0.1", "slack-bolt==1.30.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.30.0", "slack-sdk==3.43.0", "aiohttp==3.14.3"]
 matrix = ["mautrix[encryption]==0.21.1", "aiosqlite==0.22.1", "asyncpg==0.31.0", "aiohttp-socks==0.11.0", "aiohttp==3.14.3"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7 (mautrix/aiohttp-socks only cap aiohttp<4 / >=3.10, so pin the patched floor directly)

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -205,6 +205,46 @@ async def test_discord_free_response_in_server_channels(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_explicit_jarvis_play_request_bypasses_discord_mention_gate(
+    adapter, monkeypatch
+):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    adapter._maybe_handle_natural_music_message = AsyncMock(return_value=True)
+    message = make_message(
+        channel=FakeTextChannel(channel_id=321),
+        content="Hey Jarvis play Paranoid by Rich Amiri",
+    )
+
+    handled = await adapter._handle_message(message)
+
+    assert handled is True
+    adapter._maybe_handle_natural_music_message.assert_awaited_once_with(
+        message, content="Hey Jarvis play Paranoid by Rich Amiri"
+    )
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recovered_music_request_does_not_start_delayed_playback(
+    adapter, monkeypatch
+):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    adapter._maybe_handle_natural_music_message = AsyncMock(return_value=True)
+    message = make_message(
+        channel=FakeTextChannel(channel_id=321),
+        content="Hey Jarvis play Paranoid by Rich Amiri",
+    )
+
+    handled = await adapter._handle_message(message, recovered=True)
+
+    assert handled is True
+    adapter._maybe_handle_natural_music_message.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_discord_accepts_and_strips_bot_mentions_when_required(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)

--- a/tests/gateway/test_discord_music.py
+++ b/tests/gateway/test_discord_music.py
@@ -17,6 +17,8 @@ from plugins.platforms.discord.music import (
     MusicSession,
     MusicTrack,
     TrackResolver,
+    parse_natural_music_control,
+    parse_natural_play_request,
 )
 from gateway.config import PlatformConfig
 from plugins.platforms.discord.adapter import DiscordAdapter
@@ -29,6 +31,61 @@ def _track(title: str, requester_id: int = 42) -> MusicTrack:
         lookup=f"ytsearch1:{title}",
         requester_id=requester_id,
         requester_name=f"user-{requester_id}",
+    )
+
+
+def test_natural_play_request_extracts_song_title_and_artist():
+    assert (
+        parse_natural_play_request("Hey Jarvis, play Paranoid by Rich Amiri")
+        == "Paranoid by Rich Amiri"
+    )
+
+
+def test_natural_play_request_preserves_supported_link_queries():
+    url = "https://www.youtube.com/watch?v=example"
+    assert parse_natural_play_request(f"Jarvis play {url}") == url
+
+
+def test_natural_play_request_ignores_unaddressed_play_chatter():
+    assert parse_natural_play_request("play Paranoid by Rich Amiri") is None
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("Hey Jarvis pause the song", "pause"),
+        ("Jarvis resume the music", "resume"),
+        ("Jarvis play", "resume"),
+        ("Jarvis play the current song", "resume"),
+        ("Jarvis play the next song", "skip"),
+        ("Jarvis skip this song", "skip"),
+        ("Jarvis go back to the previous song", "previous"),
+        ("Jarvis repeat this song", "repeat"),
+        ("Jarvis show the music queue", "queue"),
+        ("Jarvis clear the music queue", "clear"),
+    ],
+)
+def test_natural_music_controls_are_distinguished_from_track_requests(text, expected):
+    assert parse_natural_music_control(text) == expected
+    assert parse_natural_play_request(text) is None
+
+
+@pytest.mark.asyncio
+async def test_slash_music_errors_do_not_expose_exception_details():
+    adapter = object.__new__(DiscordAdapter)
+    interaction = SimpleNamespace(
+        response=SimpleNamespace(
+            is_done=MagicMock(return_value=False),
+            send_message=AsyncMock(),
+        )
+    )
+
+    await adapter._send_music_error(
+        interaction, RuntimeError("@everyone signed-url backend detail")
+    )
+
+    interaction.response.send_message.assert_awaited_once_with(
+        "I couldn't complete that music request. Please try again.", ephemeral=True
     )
 
 
@@ -286,6 +343,19 @@ def test_youtube_hls_is_limited_to_provider_controlled_manifest_host():
         resolver.resolve_stream(track)
 
 
+def test_non_youtube_multitenant_cdn_stream_is_rejected():
+    track = _track("unsafe")
+    resolver = TrackResolver(
+        media_extractor=lambda *_args, **_kwargs: {
+            "url": "https://attacker.akamaized.net/audio.mp4"
+        },
+        url_guard=lambda _url: True,
+    )
+
+    with pytest.raises(MusicResolutionError, match="trusted media host"):
+        resolver.resolve_stream(track)
+
+
 def test_ffmpeg_source_restricts_nested_network_protocols(monkeypatch):
     upstream = MagicMock()
     ffmpeg = MagicMock(return_value=upstream)
@@ -355,6 +425,32 @@ def test_buffered_audio_source_returns_silence_instead_of_blocking_on_underflow(
 
     source.cleanup()
     assert upstream.cleaned is True
+
+
+def test_buffered_audio_source_ends_a_permanently_stalled_stream():
+    release_read = threading.Event()
+
+    class StuckSource:
+        def read(self):
+            release_read.wait(timeout=2)
+            return b""
+
+        def cleanup(self):
+            release_read.set()
+
+    source = BufferedAudioSource(
+        StuckSource(),
+        prebuffer_frames=1,
+        max_buffer_frames=2,
+        stall_timeout=0.1,
+    )
+    try:
+        assert source.read() == BufferedAudioSource.SILENCE_FRAME
+        time.sleep(0.11)
+        assert source.read() == b""
+        assert "stalled" in str(source._current_error).lower()
+    finally:
+        source.cleanup()
 
 
 @pytest.mark.asyncio
@@ -511,9 +607,41 @@ def test_generic_web_urls_without_a_supported_extractor_are_rejected():
 
 def test_only_curated_streaming_hosts_are_allowed_for_ytdlp():
     assert TrackResolver._has_supported_extractor("https://www.youtube.com/watch?v=abc")
+    assert TrackResolver._has_supported_extractor("https://youtu.be/abc")
+    assert not TrackResolver._has_supported_extractor(
+        "https://soundcloud.com/artist/track"
+    )
+    assert not TrackResolver._has_supported_extractor("https://vimeo.com/123")
     assert not TrackResolver._has_supported_extractor(
         "https://www.facebook.com/watch/abc"
     )
+
+
+def test_playlist_entry_lookup_is_revalidated_before_playback():
+    extractor = MagicMock(
+        return_value={
+            "entries": [
+                {
+                    "title": "unsafe",
+                    "webpage_url": "http://127.0.0.1/private",
+                }
+            ]
+        }
+    )
+    resolver = TrackResolver(
+        media_extractor=extractor,
+        url_guard=lambda url: "127.0.0.1" not in url,
+        url_support_checker=lambda _url: True,
+    )
+
+    with pytest.raises(MusicResolutionError, match="playlist entry"):
+        resolver.resolve(
+            "https://www.youtube.com/playlist?list=abc",
+            requester_id=42,
+            requester_name="nahv",
+        )
+
+    extractor.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -598,6 +726,224 @@ async def test_add_joins_requesters_vc_starts_fifo_playback_and_updates_public_p
 
 
 @pytest.mark.asyncio
+async def test_add_message_accepts_a_song_name_without_an_interaction_or_link(monkeypatch):
+    import discord
+
+    class CompatibleAllowedMentions:
+        def __init__(self, *, everyone=True, roles=True, users=True, replied_user=True):
+            self.everyone = everyone
+            self.roles = roles
+            self.users = users
+            self.replied_user = replied_user
+
+    monkeypatch.setattr(discord, "AllowedMentions", CompatibleAllowedMentions)
+    track = _track("Paranoid — Rich Amiri")
+    resolver = MagicMock()
+    resolver.resolve.return_value = [track]
+    resolver.resolve_stream.return_value = "https://cdn.example/audio"
+    panel = SimpleNamespace(edit=AsyncMock())
+    text_channel = SimpleNamespace(id=99, send=AsyncMock(return_value=panel))
+    voice_channel = SimpleNamespace(id=12, guild=SimpleNamespace(id=7))
+    voice_client = MagicMock()
+    voice_client.is_connected.return_value = True
+    voice_client.is_playing.return_value = False
+    adapter = SimpleNamespace(
+        _voice_clients={7: voice_client},
+        _voice_receivers={},
+        _voice_mixers={},
+        join_voice_channel=AsyncMock(return_value=True),
+        _cancel_voice_timeout=MagicMock(),
+    )
+    message = SimpleNamespace(
+        guild=SimpleNamespace(id=7),
+        channel=text_channel,
+        author=SimpleNamespace(
+            id=42,
+            display_name="nahv",
+            voice=SimpleNamespace(channel=voice_channel),
+        ),
+    )
+    manager = DiscordMusicManager(
+        adapter,
+        resolver=resolver,
+        audio_source_factory=lambda _url: object(),
+        view_factory=lambda *_args: "controls",
+    )
+
+    await manager.add_message(message, "Paranoid by Rich Amiri")
+
+    resolver.resolve.assert_called_once_with(
+        "Paranoid by Rich Amiri",
+        requester_id=42,
+        requester_name="nahv",
+    )
+    adapter.join_voice_channel.assert_awaited_once_with(
+        voice_channel,
+        text_channel_id=99,
+    )
+    assert manager.sessions[7].current is track
+    assert text_channel.send.await_count == 2
+    ack_mentions = text_channel.send.await_args_list[1].kwargs["allowed_mentions"]
+    assert ack_mentions.everyone is False
+    assert ack_mentions.roles is False
+    assert ack_mentions.users is False
+
+
+@pytest.mark.asyncio
+async def test_add_request_waits_for_guild_lock_before_joining_voice():
+    resolver = MagicMock()
+    resolver.resolve.return_value = [_track("queued")]
+    adapter = SimpleNamespace(join_voice_channel=AsyncMock(return_value=True))
+    manager = DiscordMusicManager(adapter, resolver=resolver)
+    manager._update_panel = AsyncMock()
+    manager._start_next = AsyncMock()
+    guild = SimpleNamespace(id=7)
+    user = SimpleNamespace(id=42, display_name="nahv")
+    text_channel = SimpleNamespace(id=99)
+    voice_channel = SimpleNamespace(id=12)
+    lock = manager._locks.setdefault(7, asyncio.Lock())
+    await lock.acquire()
+
+    request = asyncio.create_task(
+        manager._add_request(
+            guild=guild,
+            user=user,
+            text_channel=text_channel,
+            voice_channel=voice_channel,
+            query="Paranoid by Rich Amiri",
+        )
+    )
+    await asyncio.sleep(0.05)
+
+    adapter.join_voice_channel.assert_not_awaited()
+
+    lock.release()
+    await request
+    adapter.join_voice_channel.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_adding_music_preserves_an_existing_paused_queue():
+    resolver = MagicMock()
+    resolver.resolve.return_value = [_track("next")]
+    vc = MagicMock()
+    vc.is_paused.return_value = True
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        join_voice_channel=AsyncMock(return_value=True),
+    )
+    manager = DiscordMusicManager(adapter, resolver=resolver)
+    manager._update_panel = AsyncMock()
+    current = _track("current")
+    manager.sessions[7] = MusicSession(guild_id=7, current=current)
+
+    await manager._add_request(
+        guild=SimpleNamespace(id=7),
+        user=SimpleNamespace(id=42, display_name="nahv"),
+        text_channel=SimpleNamespace(id=99),
+        voice_channel=SimpleNamespace(id=12),
+        query="another song",
+    )
+
+    vc.resume.assert_not_called()
+    assert manager.sessions[7].current is current
+    assert [track.title for track in manager.sessions[7].queue] == ["next"]
+
+
+@pytest.mark.asyncio
+async def test_adding_music_recovers_if_a_completion_callback_was_lost():
+    resolver = MagicMock()
+    resolver.resolve.return_value = [_track("next")]
+    resolver.resolve_stream.return_value = "https://cdn.example/next"
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    vc.is_playing.return_value = False
+    vc.is_paused.return_value = False
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        _voice_receivers={},
+        _voice_mixers={},
+        join_voice_channel=AsyncMock(return_value=True),
+        _cancel_voice_timeout=MagicMock(),
+    )
+    manager = DiscordMusicManager(
+        adapter,
+        resolver=resolver,
+        audio_source_factory=lambda _url: object(),
+        view_factory=lambda *_args: "controls",
+    )
+    stale = _track("stale")
+    manager.sessions[7] = MusicSession(guild_id=7, current=stale)
+
+    await manager._add_request(
+        guild=SimpleNamespace(id=7),
+        user=SimpleNamespace(id=42, display_name="nahv"),
+        text_channel=SimpleNamespace(id=99, send=AsyncMock()),
+        voice_channel=SimpleNamespace(id=12),
+        query="next song",
+    )
+
+    session = manager.sessions[7]
+    assert list(session.history) == [stale]
+    assert session.current.title == "next"
+    vc.play.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_lost_skip_callback_still_bypasses_repeat_when_new_music_is_added():
+    current = _track("current", 42)
+    resolver = MagicMock()
+    resolver.resolve.return_value = [_track("next", 42)]
+    resolver.resolve_stream.return_value = "https://cdn.example/next"
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    vc.is_playing.return_value = True
+    vc.is_paused.return_value = False
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        _voice_receivers={},
+        _voice_mixers={},
+        join_voice_channel=AsyncMock(return_value=True),
+        _cancel_voice_timeout=MagicMock(),
+    )
+    manager = DiscordMusicManager(
+        adapter,
+        resolver=resolver,
+        audio_source_factory=lambda _url: object(),
+        view_factory=lambda *_args: "controls",
+    )
+    session = MusicSession(
+        guild_id=7,
+        current=current,
+        repeat_current=True,
+        playback_generation=1,
+    )
+    session.text_channel = SimpleNamespace(send=AsyncMock())
+    manager.sessions[7] = session
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(
+            id=42,
+            guild_permissions=SimpleNamespace(administrator=False),
+        ),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await manager.control(interaction, 7, "skip")
+    vc.is_playing.return_value = False
+    await manager._add_request(
+        guild=SimpleNamespace(id=7),
+        user=SimpleNamespace(id=42, display_name="nahv"),
+        text_channel=session.text_channel,
+        voice_channel=SimpleNamespace(id=12),
+        query="next song",
+    )
+
+    assert list(session.history) == [current]
+    assert session.current is not None
+    assert session.current.title == "next"
+
+
+@pytest.mark.asyncio
 async def test_unplayable_track_is_skipped_and_next_track_starts():
     bad = _track("bad")
     good = _track("good")
@@ -626,6 +972,267 @@ async def test_unplayable_track_is_skipped_and_next_track_starts():
     await manager._start_next(session)
 
     assert session.current is good
+    vc.play.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_panel_edit_failure_cannot_discard_a_track_that_started_playing():
+    first = _track("first")
+    second = _track("second")
+    resolver = MagicMock()
+    resolver.resolve_stream.return_value = "https://cdn.example/audio"
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    vc.is_playing.return_value = False
+    vc.is_paused.return_value = False
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        _voice_receivers={},
+        _voice_mixers={},
+        _cancel_voice_timeout=MagicMock(),
+    )
+    manager = DiscordMusicManager(
+        adapter,
+        resolver=resolver,
+        audio_source_factory=lambda _url: object(),
+        view_factory=lambda *_args: "controls",
+    )
+    session = MusicSession(guild_id=7, queue=deque([first, second]))
+    session.panel_message = SimpleNamespace(
+        edit=AsyncMock(side_effect=RuntimeError("deleted panel"))
+    )
+    session.text_channel = SimpleNamespace(send=AsyncMock(side_effect=RuntimeError("forbidden")))
+
+    await manager._start_next(session)
+
+    assert session.current is first
+    assert list(session.queue) == [second]
+    vc.play.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_panel_render_failure_cannot_discard_a_track_that_started_playing():
+    first = _track("first")
+    second = _track("second")
+    resolver = MagicMock()
+    resolver.resolve_stream.return_value = "https://cdn.example/audio"
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    vc.is_playing.return_value = False
+    vc.is_paused.return_value = False
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        _voice_receivers={},
+        _voice_mixers={},
+        _cancel_voice_timeout=MagicMock(),
+    )
+    manager = DiscordMusicManager(
+        adapter,
+        resolver=resolver,
+        audio_source_factory=lambda _url: object(),
+        view_factory=MagicMock(side_effect=RuntimeError("broken controls")),
+    )
+    session = MusicSession(guild_id=7, queue=deque([first, second]))
+    session.text_channel = SimpleNamespace(send=AsyncMock())
+
+    await manager._start_next(session)
+
+    assert session.current is first
+    assert list(session.queue) == [second]
+    vc.play.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_track_completion_advances_to_the_next_queued_song():
+    first = _track("first")
+    second = _track("second")
+    resolver = MagicMock()
+    resolver.resolve_stream.return_value = "https://cdn.example/second"
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    vc.is_playing.return_value = False
+    vc.is_paused.return_value = False
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        _voice_receivers={},
+        _voice_mixers={},
+        _cancel_voice_timeout=MagicMock(),
+    )
+    manager = DiscordMusicManager(
+        adapter,
+        resolver=resolver,
+        audio_source_factory=lambda _url: object(),
+        view_factory=lambda *_args: "controls",
+    )
+    session = MusicSession(guild_id=7, current=first, queue=deque([second]))
+    session.playback_generation = 1
+    session.panel_message = SimpleNamespace(edit=AsyncMock())
+    session.text_channel = SimpleNamespace(send=AsyncMock())
+    manager.sessions[7] = session
+
+    await manager._on_track_end(7, generation=1)
+
+    assert session.current is second
+    assert list(session.history) == [first]
+    assert not session.queue
+    vc.play.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_lost_natural_completion_callback_still_advances_existing_queue():
+    first = _track("first")
+    second = _track("second")
+    resolver = MagicMock()
+    resolver.resolve_stream.side_effect = [
+        "https://cdn.example/first",
+        "https://cdn.example/second",
+    ]
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    vc.is_playing.return_value = False
+    vc.is_paused.return_value = False
+
+    def _play(*_args, **_kwargs):
+        vc.is_playing.return_value = True
+
+    vc.play.side_effect = _play
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        _voice_receivers={},
+        _voice_mixers={},
+        _cancel_voice_timeout=MagicMock(),
+    )
+    manager = DiscordMusicManager(
+        adapter,
+        resolver=resolver,
+        audio_source_factory=lambda _url: object(),
+        view_factory=lambda *_args: "controls",
+        stop_reconcile_delay=0.01,
+    )
+    session = MusicSession(guild_id=7, queue=deque([first, second]))
+    session.text_channel = SimpleNamespace(send=AsyncMock())
+    manager.sessions[7] = session
+
+    await manager._start_next(session)
+    vc.is_playing.return_value = False
+    await asyncio.sleep(0.05)
+
+    assert session.current is second
+    assert list(session.history) == [first]
+    assert vc.play.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_playback_failure_is_reported_and_not_added_to_history():
+    failed = _track("failed")
+    next_track = _track("next")
+    resolver = MagicMock()
+    resolver.resolve_stream.return_value = "https://cdn.example/next"
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    vc.is_playing.return_value = False
+    vc.is_paused.return_value = False
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        _voice_receivers={},
+        _voice_mixers={},
+        _cancel_voice_timeout=MagicMock(),
+    )
+    manager = DiscordMusicManager(
+        adapter,
+        resolver=resolver,
+        audio_source_factory=lambda _url: object(),
+        view_factory=lambda *_args: "controls",
+    )
+    session = MusicSession(
+        guild_id=7,
+        current=failed,
+        queue=deque([next_track]),
+        playback_generation=1,
+    )
+    session.text_channel = SimpleNamespace(send=AsyncMock())
+    manager.sessions[7] = session
+
+    await manager._on_track_end(
+        7,
+        error=RuntimeError("decoder stalled"),
+        generation=1,
+    )
+
+    assert session.current is next_track
+    assert failed not in session.history
+    assert session.last_error == "Playback failed for **failed**."
+    assert "decoder stalled" not in session.last_error
+
+
+@pytest.mark.asyncio
+async def test_source_terminal_error_reaches_the_completion_handler():
+    source = SimpleNamespace(
+        _current_error=RuntimeError("stream stalled"),
+        cleanup=MagicMock(),
+    )
+    resolver = MagicMock()
+    resolver.resolve_stream.return_value = "https://cdn.example/current"
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    vc.is_playing.return_value = False
+    vc.is_paused.return_value = False
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        _voice_receivers={},
+        _voice_mixers={},
+        _cancel_voice_timeout=MagicMock(),
+    )
+    manager = DiscordMusicManager(
+        adapter,
+        resolver=resolver,
+        audio_source_factory=lambda _url: source,
+        view_factory=lambda *_args: "controls",
+    )
+    track = _track("current")
+    session = MusicSession(guild_id=7, queue=deque([track]))
+    session.text_channel = SimpleNamespace(send=AsyncMock())
+    manager.sessions[7] = session
+
+    await manager._start_next(session)
+    after = vc.play.call_args.kwargs["after"]
+    after(None)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert session.current is None
+    assert track not in session.history
+    assert session.last_error == "Playback failed for **current**."
+    assert "stream stalled" not in session.last_error
+
+
+@pytest.mark.asyncio
+async def test_music_playback_keeps_voice_receiver_live_for_spoken_controls():
+    receiver = SimpleNamespace(pause=MagicMock())
+    resolver = MagicMock()
+    resolver.resolve_stream.return_value = "https://cdn.example/audio"
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    vc.is_playing.return_value = False
+    vc.is_paused.return_value = False
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        _voice_receivers={7: receiver},
+        _voice_mixers={},
+        _cancel_voice_timeout=MagicMock(),
+    )
+    manager = DiscordMusicManager(
+        adapter,
+        resolver=resolver,
+        audio_source_factory=lambda _url: object(),
+        view_factory=lambda *_args: "controls",
+    )
+    session = MusicSession(guild_id=7, queue=deque([_track("current")]))
+    session.text_channel = SimpleNamespace(send=AsyncMock())
+
+    await manager._start_next(session)
+
+    receiver.pause.assert_not_called()
     vc.play.assert_called_once()
 
 
@@ -661,6 +1268,213 @@ async def test_skip_button_rejects_non_requester_and_allows_current_requester():
 
 
 @pytest.mark.asyncio
+async def test_panel_control_rejects_user_outside_hermes_allowlist():
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    vc.is_playing.return_value = True
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        _is_allowed_user=MagicMock(return_value=False),
+    )
+    manager = DiscordMusicManager(
+        adapter,
+        view_factory=lambda *_args: "controls",
+    )
+    manager.sessions[7] = MusicSession(guild_id=7, current=_track("current", 42))
+    interaction = SimpleNamespace(
+        guild=SimpleNamespace(id=7),
+        user=SimpleNamespace(
+            id=99, guild_permissions=SimpleNamespace(administrator=True)
+        ),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await manager.control(interaction, 7, "skip")
+
+    adapter._is_allowed_user.assert_called_once_with(
+        "99",
+        author=interaction.user,
+        guild=interaction.guild,
+        is_dm=False,
+        channel_ids=None,
+    )
+    vc.stop.assert_not_called()
+    assert "not authorized" in interaction.response.send_message.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_panel_control_passes_validated_channel_scope_to_authorization():
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    vc.is_playing.return_value = True
+    channel = SimpleNamespace(id=99)
+    user = SimpleNamespace(
+        id=42, guild_permissions=SimpleNamespace(administrator=False)
+    )
+    allow_user = MagicMock(
+        side_effect=lambda _uid, **kwargs: kwargs.get("channel_ids") == {"99"}
+    )
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        _is_allowed_user=allow_user,
+        _discord_channel_keys_from_channel=MagicMock(return_value={"99"}),
+        _get_parent_channel_id=MagicMock(return_value=None),
+    )
+    manager = DiscordMusicManager(adapter, view_factory=lambda *_args: "controls")
+    manager.sessions[7] = MusicSession(guild_id=7, current=_track("current", 42))
+    interaction = SimpleNamespace(
+        guild=SimpleNamespace(id=7),
+        channel=channel,
+        user=user,
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await manager.control(interaction, 7, "skip")
+
+    vc.stop.assert_called_once()
+    allow_user.assert_called_once_with(
+        "42",
+        author=user,
+        guild=interaction.guild,
+        is_dm=False,
+        channel_ids={"99"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_skip_recovers_and_advances_when_the_audio_player_is_already_stopped():
+    current = _track("current", 42)
+    next_track = _track("next", 42)
+    resolver = MagicMock()
+    resolver.resolve_stream.return_value = "https://cdn.example/next"
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    vc.is_playing.return_value = False
+    vc.is_paused.return_value = False
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        _voice_receivers={},
+        _voice_mixers={},
+        _cancel_voice_timeout=MagicMock(),
+    )
+    manager = DiscordMusicManager(
+        adapter,
+        resolver=resolver,
+        audio_source_factory=lambda _url: object(),
+        view_factory=lambda *_args: "controls",
+    )
+    session = MusicSession(guild_id=7, current=current, queue=deque([next_track]))
+    session.text_channel = SimpleNamespace(send=AsyncMock())
+    manager.sessions[7] = session
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(
+            id=42,
+            guild_permissions=SimpleNamespace(administrator=False),
+        ),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await manager.control(interaction, 7, "skip")
+
+    assert session.current is next_track
+    assert list(session.history) == [current]
+    vc.play.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_skip_advances_when_voice_stop_loses_its_completion_callback():
+    current = _track("current", 42)
+    next_track = _track("next", 42)
+    resolver = MagicMock()
+    resolver.resolve_stream.return_value = "https://cdn.example/next"
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    vc.is_playing.side_effect = [True, False, False]
+    vc.is_paused.return_value = False
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        _voice_receivers={},
+        _voice_mixers={},
+        _cancel_voice_timeout=MagicMock(),
+    )
+    manager = DiscordMusicManager(
+        adapter,
+        resolver=resolver,
+        audio_source_factory=lambda _url: object(),
+        view_factory=lambda *_args: "controls",
+        stop_reconcile_delay=0.01,
+    )
+    session = MusicSession(
+        guild_id=7,
+        current=current,
+        queue=deque([next_track]),
+        playback_generation=1,
+    )
+    session.text_channel = SimpleNamespace(send=AsyncMock())
+    manager.sessions[7] = session
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(
+            id=42,
+            guild_permissions=SimpleNamespace(administrator=False),
+        ),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await manager.control(interaction, 7, "skip")
+    await asyncio.sleep(0.05)
+
+    assert session.current is next_track
+    assert list(session.history) == [current]
+    vc.play.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_skip_advances_instead_of_repeating_when_repeat_is_enabled():
+    current = _track("current", 42)
+    next_track = _track("next", 42)
+    resolver = MagicMock()
+    resolver.resolve_stream.return_value = "https://cdn.example/next"
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    vc.is_playing.return_value = True
+    vc.is_paused.return_value = False
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        _voice_receivers={},
+        _voice_mixers={},
+        _cancel_voice_timeout=MagicMock(),
+    )
+    manager = DiscordMusicManager(
+        adapter,
+        resolver=resolver,
+        audio_source_factory=lambda _url: object(),
+        view_factory=lambda *_args: "controls",
+    )
+    session = MusicSession(
+        guild_id=7,
+        current=current,
+        queue=deque([next_track]),
+        repeat_current=True,
+        playback_generation=1,
+    )
+    session.text_channel = SimpleNamespace(send=AsyncMock())
+    manager.sessions[7] = session
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(
+            id=42,
+            guild_permissions=SimpleNamespace(administrator=False),
+        ),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await manager.control(interaction, 7, "skip")
+    await manager._on_track_end(7, generation=1)
+
+    assert session.current is next_track
+    assert list(session.history) == [current]
+
+
+@pytest.mark.asyncio
 async def test_play_pause_button_toggles_voice_client_state():
     vc = MagicMock()
     vc.is_paused.side_effect = [False, True]
@@ -679,6 +1493,66 @@ async def test_play_pause_button_toggles_voice_client_state():
 
     await manager.control(interaction, 7, "play_pause")
     vc.resume.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_play_pause_button_does_not_claim_it_paused_a_stopped_player():
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    vc.is_paused.return_value = False
+    vc.is_playing.return_value = False
+    adapter = SimpleNamespace(_voice_clients={7: vc})
+    manager = DiscordMusicManager(adapter, view_factory=lambda *_args: "controls")
+    manager.sessions[7] = MusicSession(guild_id=7, current=_track("stale", 42))
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(
+            id=42,
+            guild_permissions=SimpleNamespace(administrator=False),
+        ),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await manager.control(interaction, 7, "play_pause")
+
+    vc.pause.assert_not_called()
+    assert "nothing is playing" in interaction.response.send_message.await_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_natural_pause_and_play_commands_are_idempotent_not_a_toggle():
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    vc.is_playing.return_value = True
+    vc.is_paused.return_value = False
+    channel = SimpleNamespace(send=AsyncMock())
+    member = SimpleNamespace(
+        id=42,
+        guild_permissions=SimpleNamespace(administrator=False),
+    )
+    message = SimpleNamespace(
+        guild=SimpleNamespace(id=7),
+        channel=channel,
+        author=member,
+    )
+    manager = DiscordMusicManager(
+        SimpleNamespace(_voice_clients={7: vc}),
+        view_factory=lambda *_args: "controls",
+    )
+    manager.sessions[7] = MusicSession(guild_id=7, current=_track("current", 42))
+
+    await manager.control_message(message, "pause")
+    vc.pause.assert_called_once_with()
+
+    vc.is_playing.return_value = False
+    vc.is_paused.return_value = True
+    await manager.control_message(message, "resume")
+    vc.resume.assert_called_once_with()
+
+    vc.is_playing.return_value = True
+    vc.is_paused.return_value = False
+    await manager.control_message(message, "resume")
+    vc.pause.assert_called_once_with()
+    assert "already playing" in channel.send.await_args.args[0].lower()
 
 
 @pytest.mark.asyncio
@@ -743,6 +1617,73 @@ async def test_previous_button_replays_history_then_returns_to_interrupted_song(
     assert list(session.queue)[0] is current
     vc.stop.assert_called_once_with()
     vc.play.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_previous_replays_finished_history_for_its_requester():
+    previous = _track("previous", 42)
+    resolver = MagicMock()
+    resolver.resolve_stream.return_value = "https://cdn.example/audio"
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    vc.is_playing.return_value = False
+    vc.is_paused.return_value = False
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        _voice_receivers={},
+        _voice_mixers={},
+        _cancel_voice_timeout=MagicMock(),
+    )
+    manager = DiscordMusicManager(
+        adapter,
+        resolver=resolver,
+        audio_source_factory=lambda _url: object(),
+        view_factory=lambda *_args: "controls",
+    )
+    session = MusicSession(guild_id=7)
+    session.history.append(previous)
+    session.text_channel = SimpleNamespace(send=AsyncMock())
+    manager.sessions[7] = session
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(
+            id=42, guild_permissions=SimpleNamespace(administrator=False)
+        ),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await manager.control(interaction, 7, "previous")
+
+    assert session.current is previous
+    vc.play.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_previous_preserves_queue_state_when_voice_is_disconnected():
+    previous = _track("previous", 42)
+    current = _track("current", 42)
+    vc = MagicMock()
+    vc.is_connected.return_value = False
+    manager = DiscordMusicManager(
+        SimpleNamespace(_voice_clients={7: vc}),
+        view_factory=lambda *_args: "controls",
+    )
+    session = MusicSession(guild_id=7, current=current)
+    session.history.append(previous)
+    manager.sessions[7] = session
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(
+            id=42,
+            guild_permissions=SimpleNamespace(administrator=False),
+        ),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await manager.control(interaction, 7, "previous")
+
+    assert session.current is current
+    assert list(session.history) == [previous]
+    assert not session.queue
+    vc.stop.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -924,11 +1865,125 @@ async def test_adapter_voice_leave_notifies_music_manager():
     adapter._voice_timeout_tasks = {}
     adapter._voice_text_channels = {}
     adapter._voice_sources = {}
-    adapter._music_manager = SimpleNamespace(on_voice_disconnected=AsyncMock())
+    lock_was_held = None
+
+    async def _on_voice_disconnected(_guild_id):
+        nonlocal lock_was_held
+        lock_was_held = adapter._voice_locks[7].locked()
+
+    adapter._music_manager = SimpleNamespace(
+        on_voice_disconnected=AsyncMock(side_effect=_on_voice_disconnected)
+    )
 
     await adapter.leave_voice_channel(7)
 
     adapter._music_manager.on_voice_disconnected.assert_awaited_once_with(7)
+    assert lock_was_held is False
+
+
+@pytest.mark.asyncio
+async def test_join_is_rejected_while_voice_leave_cleanup_is_in_progress():
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = object()
+    adapter._voice_locks = {}
+    adapter._voice_leaving = {7}
+    channel = SimpleNamespace(guild=SimpleNamespace(id=7))
+
+    joined = await adapter.join_voice_channel(channel)
+
+    assert joined is False
+
+
+@pytest.mark.asyncio
+async def test_add_racing_with_leave_cannot_orphan_a_new_voice_player():
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = SimpleNamespace(get_guild=MagicMock(return_value=None))
+    adapter._voice_locks = {}
+    adapter._voice_leaving = set()
+    adapter._voice_receivers = {}
+    adapter._voice_listen_tasks = {}
+    adapter._voice_mixers = {}
+    adapter._voice_timeout_tasks = {}
+    adapter._voice_text_channels = {}
+    adapter._voice_sources = {}
+    adapter._is_allowed_user = MagicMock(return_value=True)
+
+    disconnect_started = asyncio.Event()
+    allow_disconnect = asyncio.Event()
+    old_vc = MagicMock()
+    old_vc.is_connected.return_value = True
+    old_vc.is_playing.return_value = False
+
+    async def _disconnect():
+        disconnect_started.set()
+        await allow_disconnect.wait()
+
+    old_vc.disconnect = _disconnect
+    adapter._voice_clients = {7: old_vc}
+
+    resolver = MagicMock()
+    resolver.resolve.return_value = [_track("new", 42)]
+    manager = DiscordMusicManager(
+        adapter,
+        resolver=resolver,
+        audio_source_factory=lambda _url: object(),
+        view_factory=lambda *_args: "controls",
+    )
+    adapter._music_manager = manager
+    new_channel = SimpleNamespace(
+        id=12,
+        guild=SimpleNamespace(id=7),
+        connect=AsyncMock(),
+    )
+
+    leave_task = asyncio.create_task(adapter.leave_voice_channel(7))
+    await asyncio.wait_for(disconnect_started.wait(), timeout=1)
+    add_task = asyncio.create_task(
+        manager._add_request(
+            guild=SimpleNamespace(id=7),
+            user=SimpleNamespace(id=42, display_name="user-42"),
+            text_channel=SimpleNamespace(id=99),
+            voice_channel=new_channel,
+            query="new",
+        )
+    )
+    await asyncio.sleep(0)
+    allow_disconnect.set()
+
+    with pytest.raises(MusicResolutionError, match="could not join"):
+        await asyncio.wait_for(add_task, timeout=1)
+    await asyncio.wait_for(leave_task, timeout=1)
+
+    new_channel.connect.assert_not_awaited()
+    assert 7 not in adapter._voice_clients
+    assert 7 not in manager.sessions
+    assert 7 not in adapter._voice_leaving
+
+
+@pytest.mark.asyncio
+async def test_joining_an_existing_voice_connection_refreshes_its_text_binding():
+    adapter = object.__new__(DiscordAdapter)
+    adapter._client = object()
+    adapter._voice_locks = {}
+    adapter._voice_text_channels = {}
+    adapter._voice_sources = {}
+    adapter._reset_voice_timeout = MagicMock()
+    existing = SimpleNamespace(
+        channel=SimpleNamespace(id=12),
+        is_connected=lambda: True,
+    )
+    adapter._voice_clients = {7: existing}
+    channel = SimpleNamespace(id=12, guild=SimpleNamespace(id=7))
+
+    joined = await adapter.join_voice_channel(
+        channel,
+        text_channel_id=99,
+        source={"chat_id": "99"},
+    )
+
+    assert joined is True
+    assert adapter._voice_text_channels[7] == 99
+    assert adapter._voice_sources[7] == {"chat_id": "99"}
 
 
 @pytest.mark.asyncio
@@ -1044,6 +2099,52 @@ async def test_admin_action_defers_before_waiting_for_guild_lock():
     interaction.followup.send.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_force_skip_bypasses_repeat_and_advances_the_queue():
+    current = _track("current", 42)
+    next_track = _track("next", 42)
+    resolver = MagicMock()
+    resolver.resolve_stream.return_value = "https://cdn.example/next"
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    vc.is_playing.return_value = True
+    vc.is_paused.return_value = False
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        _voice_receivers={},
+        _voice_mixers={},
+        _cancel_voice_timeout=MagicMock(),
+    )
+    manager = DiscordMusicManager(
+        adapter,
+        resolver=resolver,
+        audio_source_factory=lambda _url: object(),
+        view_factory=lambda *_args: "controls",
+    )
+    session = MusicSession(
+        guild_id=7,
+        current=current,
+        queue=deque([next_track]),
+        repeat_current=True,
+        playback_generation=1,
+    )
+    session.text_channel = SimpleNamespace(send=AsyncMock())
+    manager.sessions[7] = session
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(
+            id=1,
+            guild_permissions=SimpleNamespace(administrator=True),
+        ),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await manager.admin_action(interaction, 7, "forceskip")
+    await manager._on_track_end(7, generation=1)
+
+    assert session.current is next_track
+    assert list(session.history) == [current]
+
+
 class _FakeTree:
     def __init__(self):
         self.commands = {}
@@ -1071,3 +2172,182 @@ def test_discord_registers_music_queue_and_admin_slash_commands():
     assert {"play", "musicqueue", "forceskip", "clearqueue"}.issubset(
         adapter._client.tree.commands
     )
+
+
+@pytest.mark.asyncio
+async def test_natural_text_play_command_routes_directly_to_music_manager():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    manager = SimpleNamespace(add_message=AsyncMock())
+    adapter._music_manager = manager
+    message = SimpleNamespace(content="Hey Jarvis play Paranoid by Rich Amiri")
+
+    handled = await adapter._maybe_handle_natural_music_message(message)
+
+    assert handled is True
+    manager.add_message.assert_awaited_once_with(
+        message, "Paranoid by Rich Amiri"
+    )
+
+
+@pytest.mark.asyncio
+async def test_natural_text_pause_routes_directly_to_music_controls():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    manager = SimpleNamespace(
+        add_message=AsyncMock(),
+        control_message=AsyncMock(),
+    )
+    adapter._music_manager = manager
+    message = SimpleNamespace(content="Hey Jarvis pause the song")
+
+    handled = await adapter._maybe_handle_natural_music_message(message)
+
+    assert handled is True
+    manager.control_message.assert_awaited_once_with(message, "pause")
+    manager.add_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_natural_text_music_error_disables_discord_mentions(monkeypatch):
+    import discord
+
+    class CompatibleAllowedMentions:
+        def __init__(self, *, everyone=True, roles=True, users=True, replied_user=True):
+            self.everyone = everyone
+            self.roles = roles
+            self.users = users
+            self.replied_user = replied_user
+
+    monkeypatch.setattr(discord, "AllowedMentions", CompatibleAllowedMentions)
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._music_manager = SimpleNamespace(
+        add_message=AsyncMock(side_effect=RuntimeError("@everyone"))
+    )
+    channel = SimpleNamespace(send=AsyncMock())
+    message = SimpleNamespace(
+        content="Hey Jarvis play Paranoid by Rich Amiri",
+        channel=channel,
+    )
+
+    handled = await adapter._maybe_handle_natural_music_message(message)
+
+    assert handled is True
+    mentions = channel.send.await_args.kwargs["allowed_mentions"]
+    assert "@everyone" not in channel.send.await_args.args[0]
+    assert mentions.everyone is False
+    assert mentions.roles is False
+    assert mentions.users is False
+
+
+@pytest.mark.asyncio
+async def test_natural_voice_play_command_routes_to_linked_music_queue():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    guild = SimpleNamespace(id=7)
+    member = SimpleNamespace(
+        id=42,
+        display_name="nahv",
+        voice=SimpleNamespace(channel=SimpleNamespace(id=12)),
+    )
+    guild.get_member = MagicMock(return_value=member)
+    channel = SimpleNamespace(id=99, send=AsyncMock())
+    adapter._client = SimpleNamespace(
+        get_guild=MagicMock(return_value=guild),
+        get_channel=MagicMock(return_value=channel),
+    )
+    adapter._voice_text_channels = {7: 99}
+    manager = SimpleNamespace(add_message=AsyncMock())
+    adapter._music_manager = manager
+
+    handled = await adapter._maybe_handle_natural_music_voice(
+        7, 42, "Hey Jarvis play Paranoid by Rich Amiri"
+    )
+
+    assert handled is True
+    request = manager.add_message.await_args.args[0]
+    assert request.guild is guild
+    assert request.author is member
+    assert request.channel is channel
+    assert manager.add_message.await_args.args[1] == "Paranoid by Rich Amiri"
+
+
+@pytest.mark.asyncio
+async def test_natural_voice_resume_routes_directly_to_music_controls():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    guild = SimpleNamespace(id=7)
+    member = SimpleNamespace(
+        id=42,
+        display_name="nahv",
+        voice=SimpleNamespace(channel=SimpleNamespace(id=12)),
+    )
+    guild.get_member = MagicMock(return_value=member)
+    channel = SimpleNamespace(id=99, send=AsyncMock())
+    adapter._client = SimpleNamespace(
+        get_guild=MagicMock(return_value=guild),
+        get_channel=MagicMock(return_value=channel),
+    )
+    adapter._voice_text_channels = {7: 99}
+    manager = SimpleNamespace(
+        add_message=AsyncMock(),
+        control_message=AsyncMock(),
+    )
+    adapter._music_manager = manager
+
+    handled = await adapter._maybe_handle_natural_music_voice(
+        7, 42, "Hey Jarvis play"
+    )
+
+    assert handled is True
+    request = manager.control_message.await_args.args[0]
+    assert request.guild is guild
+    assert request.author is member
+    assert request.channel is channel
+    assert manager.control_message.await_args.args[1] == "resume"
+    manager.add_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_natural_voice_music_respects_the_linked_channels_ignore_gate():
+    adapter = DiscordAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={"ignored_channels": ["99"]},
+        )
+    )
+    guild = SimpleNamespace(id=7)
+    member = SimpleNamespace(id=42)
+    guild.get_member = MagicMock(return_value=member)
+    channel = SimpleNamespace(id=99, name="music", send=AsyncMock())
+    adapter._client = SimpleNamespace(
+        get_guild=MagicMock(return_value=guild),
+        get_channel=MagicMock(return_value=channel),
+    )
+    adapter._voice_text_channels = {7: 99}
+    manager = SimpleNamespace(
+        add_message=AsyncMock(),
+        control_message=AsyncMock(),
+    )
+    adapter._music_manager = manager
+
+    handled = await adapter._maybe_handle_natural_music_voice(
+        7, 42, "Hey Jarvis skip this song"
+    )
+
+    assert handled is False
+    manager.control_message.assert_not_awaited()
+    manager.add_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_natural_voice_play_falls_back_when_discord_context_is_missing():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = SimpleNamespace(
+        get_guild=MagicMock(return_value=None),
+        get_channel=MagicMock(return_value=None),
+    )
+    adapter._voice_text_channels = {7: 99}
+
+    handled = await adapter._maybe_handle_natural_music_voice(
+        7, 42, "Hey Jarvis play Paranoid by Rich Amiri"
+    )
+
+    assert handled is False

--- a/tests/gateway/test_discord_music.py
+++ b/tests/gateway/test_discord_music.py
@@ -1,0 +1,903 @@
+"""Discord music queue and playback-control behavior."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from plugins.platforms.discord.music import (
+    DiscordMusicManager,
+    MusicControlView,
+    MusicResolutionError,
+    MusicSession,
+    MusicTrack,
+    TrackResolver,
+)
+from gateway.config import PlatformConfig
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+def _track(title: str, requester_id: int = 42) -> MusicTrack:
+    return MusicTrack(
+        title=title,
+        webpage_url=f"https://example.com/{title}",
+        lookup=f"ytsearch1:{title}",
+        requester_id=requester_id,
+        requester_name=f"user-{requester_id}",
+    )
+
+
+def test_music_session_exposes_now_playing_and_fifo_queue():
+    session = MusicSession(guild_id=7)
+    first = _track("first")
+    second = _track("second", requester_id=99)
+
+    session.enqueue([first, second])
+    session.current = session.queue.popleft()
+
+    assert session.current is first
+    assert list(session.queue) == [second]
+    assert "first" in session.render_queue()
+    assert "second" in session.render_queue()
+    assert "user-99" in session.render_queue()
+
+
+def test_only_current_requester_or_administrator_can_use_playback_controls():
+    session = MusicSession(guild_id=7, current=_track("current", requester_id=42))
+
+    assert session.can_control(user_id=42, administrator=False)
+    assert not session.can_control(user_id=99, administrator=False)
+    assert session.can_control(user_id=99, administrator=True)
+
+
+def test_spotify_track_is_translated_to_a_searchable_audio_track():
+    resolver = TrackResolver(
+        spotify_metadata=lambda _url: [
+            {
+                "title": "Cut To The Feeling",
+                "artist": "Carly Rae Jepsen",
+                "webpage_url": "https://open.spotify.com/track/abc",
+                "thumbnail": "https://i.scdn.co/image/cover",
+            }
+        ]
+    )
+
+    tracks = resolver.resolve(
+        "https://open.spotify.com/track/abc",
+        requester_id=42,
+        requester_name="nahv",
+    )
+
+    assert len(tracks) == 1
+    assert tracks[0].title == "Cut To The Feeling — Carly Rae Jepsen"
+    assert tracks[0].lookup == "ytsearch5:Cut To The Feeling Carly Rae Jepsen audio"
+    assert tracks[0].requester_id == 42
+
+
+def test_spotify_public_metadata_fallback_extracts_artist_title_and_cover():
+    class Response:
+        def __init__(
+            self, *, text="", payload=None, url="https://open.spotify.com/track/abc"
+        ):
+            self.text = text
+            self._payload = payload
+            self.url = url
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    def http_get(url, **kwargs):
+        if "/oembed" in url:
+            return Response(
+                payload={"title": "A Song", "thumbnail_url": "https://i.scdn.co/cover"}
+            )
+        return Response(
+            text='<meta property="og:description" content="Artist Name · A Song · Song · 2026">'
+        )
+
+    resolver = TrackResolver(http_get=http_get)
+    tracks = resolver.resolve(
+        "https://open.spotify.com/track/abc",
+        requester_id=42,
+        requester_name="nahv",
+    )
+
+    assert tracks[0].title == "A Song — Artist Name"
+    assert tracks[0].thumbnail == "https://i.scdn.co/cover"
+
+
+def test_spotify_album_and_playlist_links_are_rejected_explicitly():
+    resolver = TrackResolver(http_get=MagicMock(), url_guard=lambda _url: True)
+
+    with pytest.raises(MusicResolutionError, match="Spotify track links"):
+        resolver.resolve(
+            "https://open.spotify.com/playlist/abc",
+            requester_id=42,
+            requester_name="nahv",
+        )
+
+
+def test_spotify_short_link_cannot_redirect_to_a_collection():
+    class Response:
+        text = ""
+        url = "https://open.spotify.com/playlist/abc"
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"title": "Playlist", "thumbnail_url": None}
+
+    resolver = TrackResolver(
+        http_get=lambda *_args, **_kwargs: Response(), url_guard=lambda _url: True
+    )
+    with pytest.raises(MusicResolutionError, match="Spotify track links"):
+        resolver.resolve(
+            "https://spotify.link/short",
+            requester_id=42,
+            requester_name="nahv",
+        )
+
+
+def test_youtube_link_metadata_and_fresh_audio_stream_are_resolved_lazily():
+    calls = []
+
+    def extract(query, *, flat):
+        calls.append((query, flat))
+        if flat:
+            return {
+                "title": "A Song",
+                "webpage_url": "https://www.youtube.com/watch?v=abc",
+                "duration": 123,
+                "thumbnail": "https://i.ytimg.com/abc.jpg",
+            }
+        return {
+            "title": "A Song",
+            "webpage_url": "https://www.youtube.com/watch?v=abc",
+            "url": "https://rr.example.googlevideo.com/audio",
+        }
+
+    resolver = TrackResolver(media_extractor=extract, url_guard=lambda _url: True)
+    tracks = resolver.resolve(
+        "https://www.youtube.com/watch?v=abc",
+        requester_id=42,
+        requester_name="nahv",
+    )
+
+    assert tracks[0].title == "A Song"
+    assert calls == [("https://www.youtube.com/watch?v=abc", True)]
+    assert (
+        resolver.resolve_stream(tracks[0]) == "https://rr.example.googlevideo.com/audio"
+    )
+    assert calls[-1] == ("https://www.youtube.com/watch?v=abc", False)
+
+
+def test_text_search_queues_one_result_but_keeps_playback_fallback_candidates():
+    def extract(query, *, flat):
+        assert query == "ytsearch5:requested song"
+        assert flat is True
+        return {
+            "entries": [
+                {
+                    "title": "First result",
+                    "webpage_url": "https://www.youtube.com/watch?v=first",
+                },
+                {
+                    "title": "Second result",
+                    "webpage_url": "https://www.youtube.com/watch?v=second",
+                },
+            ]
+        }
+
+    tracks = TrackResolver(media_extractor=extract).resolve(
+        "requested song",
+        requester_id=42,
+        requester_name="nahv",
+    )
+
+    assert [track.title for track in tracks] == ["First result"]
+    assert tracks[0].lookup == "ytsearch5:requested song"
+
+
+def test_ytdlp_prefers_low_bandwidth_hls_and_enables_packaged_js_runtime(monkeypatch):
+    captured = {}
+
+    class FakeYoutubeDL:
+        def __init__(self, options):
+            captured.update(options)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def extract_info(self, query, download):
+            assert query == "https://www.youtube.com/watch?v=abc"
+            assert download is False
+            return {"url": "https://manifest.googlevideo.com/audio.m3u8"}
+
+    monkeypatch.setattr("yt_dlp.YoutubeDL", FakeYoutubeDL)
+
+    TrackResolver._extract_media(
+        "https://www.youtube.com/watch?v=abc",
+        flat=False,
+    )
+
+    assert captured["format"] == "worst[protocol^=m3u8][acodec!=none]"
+    assert captured["ignoreerrors"] is True
+    assert "node" in captured["js_runtimes"]
+
+
+def test_non_http_or_untrusted_extractor_streams_are_rejected():
+    track = _track("unsafe")
+    file_resolver = TrackResolver(
+        media_extractor=lambda *_args, **_kwargs: {"url": "file:///etc/passwd"},
+        url_guard=lambda _url: True,
+    )
+    with pytest.raises(MusicResolutionError, match="HTTP or HTTPS"):
+        file_resolver.resolve_stream(track)
+
+    untrusted_resolver = TrackResolver(
+        media_extractor=lambda *_args, **_kwargs: {
+            "url": "https://attacker.example/audio"
+        },
+        url_guard=lambda _url: True,
+    )
+    with pytest.raises(MusicResolutionError, match="trusted media host"):
+        untrusted_resolver.resolve_stream(track)
+
+
+def test_youtube_hls_is_limited_to_provider_controlled_manifest_host():
+    track = MusicTrack(
+        title="youtube",
+        webpage_url="https://www.youtube.com/watch?v=abc",
+        lookup="https://www.youtube.com/watch?v=abc",
+        requester_id=42,
+        requester_name="nahv",
+    )
+    resolver = TrackResolver(
+        media_extractor=lambda *_args, **_kwargs: {
+            "url": "https://attacker.akamaized.net/playlist.m3u8",
+            "protocol": "m3u8_native",
+        },
+        url_guard=lambda _url: True,
+    )
+
+    with pytest.raises(MusicResolutionError, match="trusted manifest host"):
+        resolver.resolve_stream(track)
+
+
+def test_ffmpeg_source_restricts_nested_network_protocols(monkeypatch):
+    ffmpeg = MagicMock(return_value="source")
+    monkeypatch.setattr("discord.FFmpegPCMAudio", ffmpeg)
+
+    source = DiscordMusicManager._default_audio_source(
+        "https://manifest.googlevideo.com/audio.m3u8"
+    )
+
+    assert source == "source"
+    before_options = ffmpeg.call_args.kwargs["before_options"]
+    assert ffmpeg.call_args.kwargs["executable"]
+    assert "-protocol_whitelist http,https,tcp,tls,crypto" in before_options
+    assert "file" not in before_options
+
+
+def test_spotify_http_uses_connect_time_ssrf_safe_client(monkeypatch):
+    client = MagicMock()
+    client.get.return_value = "response"
+    context = MagicMock()
+    context.__enter__.return_value = client
+    monkeypatch.setattr(
+        "tools.url_safety.create_ssrf_safe_client",
+        MagicMock(return_value=context),
+    )
+
+    result = TrackResolver._default_http_get(
+        "https://open.spotify.com/track/abc",
+        follow_redirects=True,
+        timeout=15.0,
+    )
+
+    assert result == "response"
+    client.get.assert_called_once_with("https://open.spotify.com/track/abc")
+
+
+def test_private_or_local_media_urls_are_rejected_before_extraction():
+    extractor = MagicMock()
+    resolver = TrackResolver(
+        media_extractor=extractor,
+        url_guard=lambda url: not url.startswith("http://127.0.0.1"),
+    )
+
+    with pytest.raises(MusicResolutionError, match="private or local"):
+        resolver.resolve(
+            "http://127.0.0.1:8080/secrets",
+            requester_id=42,
+            requester_name="nahv",
+        )
+
+    extractor.assert_not_called()
+
+
+def test_generic_web_urls_without_a_supported_extractor_are_rejected():
+    extractor = MagicMock()
+    resolver = TrackResolver(
+        media_extractor=extractor,
+        url_guard=lambda _url: True,
+        url_support_checker=lambda _url: False,
+    )
+
+    with pytest.raises(MusicResolutionError, match="supported streaming platform"):
+        resolver.resolve(
+            "https://attacker.example/redirect",
+            requester_id=42,
+            requester_name="nahv",
+        )
+
+    extractor.assert_not_called()
+
+
+def test_only_curated_streaming_hosts_are_allowed_for_ytdlp():
+    assert TrackResolver._has_supported_extractor("https://www.youtube.com/watch?v=abc")
+    assert not TrackResolver._has_supported_extractor(
+        "https://www.facebook.com/watch/abc"
+    )
+
+
+@pytest.mark.asyncio
+async def test_panel_disables_mentions_with_compatible_allowed_mentions(monkeypatch):
+    import discord
+
+    class CompatibleAllowedMentions:
+        def __init__(self, *, everyone=True, roles=True, users=True, replied_user=True):
+            self.everyone = everyone
+            self.roles = roles
+            self.users = users
+            self.replied_user = replied_user
+
+    monkeypatch.setattr(discord, "AllowedMentions", CompatibleAllowedMentions)
+    manager = DiscordMusicManager(SimpleNamespace(_voice_clients={}))
+    session = MusicSession(guild_id=7, current=_track("@everyone"))
+    session.panel_message = SimpleNamespace(edit=AsyncMock())
+    session.text_channel = SimpleNamespace()
+
+    await manager._update_panel(session)
+
+    mentions = session.panel_message.edit.await_args.kwargs["allowed_mentions"]
+    assert mentions.everyone is False
+    assert mentions.roles is False
+    assert mentions.users is False
+    assert mentions.replied_user is False
+
+
+@pytest.mark.asyncio
+async def test_add_joins_requesters_vc_starts_fifo_playback_and_updates_public_panel():
+    track = _track("first")
+    resolver = MagicMock()
+    resolver.resolve.return_value = [track]
+    resolver.resolve_stream.return_value = "https://cdn.example/audio"
+
+    panel = SimpleNamespace(edit=AsyncMock())
+    text_channel = SimpleNamespace(send=AsyncMock(return_value=panel))
+    voice_channel = SimpleNamespace(id=12, guild=SimpleNamespace(id=7))
+    voice_client = MagicMock()
+    voice_client.is_connected.return_value = True
+    voice_client.is_playing.return_value = False
+    adapter = SimpleNamespace(
+        _voice_clients={7: voice_client},
+        _voice_receivers={},
+        _voice_mixers={},
+        join_voice_channel=AsyncMock(return_value=True),
+        _cancel_voice_timeout=MagicMock(),
+    )
+    interaction = SimpleNamespace(
+        guild=SimpleNamespace(id=7),
+        channel=text_channel,
+        user=SimpleNamespace(
+            id=42,
+            display_name="nahv",
+            voice=SimpleNamespace(channel=voice_channel),
+        ),
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+    source = object()
+    manager = DiscordMusicManager(
+        adapter,
+        resolver=resolver,
+        audio_source_factory=lambda _url: source,
+        view_factory=lambda _manager, _guild_id: "controls",
+    )
+
+    await manager.add(interaction, "first")
+
+    adapter.join_voice_channel.assert_awaited_once_with(
+        voice_channel,
+        text_channel_id=None,
+    )
+    voice_client.play.assert_called_once()
+    assert voice_client.play.call_args.args[0] is source
+    assert manager.sessions[7].current is track
+    text_channel.send.assert_awaited_once()
+    panel.edit.assert_awaited()
+    assert "first" in panel.edit.await_args.kwargs["content"]
+
+
+@pytest.mark.asyncio
+async def test_unplayable_track_is_skipped_and_next_track_starts():
+    bad = _track("bad")
+    good = _track("good")
+    resolver = MagicMock()
+    resolver.resolve_stream.side_effect = [
+        MusicResolutionError("unplayable"),
+        "https://cdn.example/good",
+    ]
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    vc.is_playing.return_value = False
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        _voice_receivers={},
+        _voice_mixers={},
+        _cancel_voice_timeout=MagicMock(),
+    )
+    manager = DiscordMusicManager(
+        adapter, resolver=resolver, view_factory=lambda *_args: "controls"
+    )
+    session = MusicSession(guild_id=7)
+    session.enqueue([bad, good])
+    session.panel_message = SimpleNamespace(edit=AsyncMock())
+    session.text_channel = SimpleNamespace()
+
+    await manager._start_next(session)
+
+    assert session.current is good
+    vc.play.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_skip_button_rejects_non_requester_and_allows_current_requester():
+    vc = MagicMock()
+    adapter = SimpleNamespace(_voice_clients={7: vc})
+    manager = DiscordMusicManager(
+        adapter,
+        view_factory=lambda *_args: "controls",
+    )
+    manager.sessions[7] = MusicSession(guild_id=7, current=_track("current", 42))
+
+    denied = SimpleNamespace(
+        user=SimpleNamespace(
+            id=99, guild_permissions=SimpleNamespace(administrator=False)
+        ),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+    allowed = SimpleNamespace(
+        user=SimpleNamespace(
+            id=42, guild_permissions=SimpleNamespace(administrator=False)
+        ),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await manager.control(denied, 7, "skip")
+    vc.stop.assert_not_called()
+    assert denied.response.send_message.await_args.kwargs["ephemeral"] is True
+
+    await manager.control(allowed, 7, "skip")
+    vc.stop.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_play_pause_button_toggles_voice_client_state():
+    vc = MagicMock()
+    vc.is_paused.side_effect = [False, True]
+    adapter = SimpleNamespace(_voice_clients={7: vc})
+    manager = DiscordMusicManager(adapter, view_factory=lambda *_args: "controls")
+    manager.sessions[7] = MusicSession(guild_id=7, current=_track("current", 42))
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(
+            id=42, guild_permissions=SimpleNamespace(administrator=False)
+        ),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await manager.control(interaction, 7, "play_pause")
+    vc.pause.assert_called_once_with()
+
+    await manager.control(interaction, 7, "play_pause")
+    vc.resume.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_repeat_button_toggles_current_track_repeat_mode():
+    adapter = SimpleNamespace(_voice_clients={7: MagicMock()})
+    manager = DiscordMusicManager(adapter, view_factory=lambda *_args: "controls")
+    session = MusicSession(guild_id=7, current=_track("current", 42))
+    session.panel_message = SimpleNamespace(edit=AsyncMock())
+    session.text_channel = SimpleNamespace()
+    manager.sessions[7] = session
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(
+            id=42, guild_permissions=SimpleNamespace(administrator=False)
+        ),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await manager.control(interaction, 7, "repeat")
+    assert session.repeat_current is True
+
+    await manager.control(interaction, 7, "repeat")
+    assert session.repeat_current is False
+
+
+@pytest.mark.asyncio
+async def test_previous_button_replays_history_then_returns_to_interrupted_song():
+    previous = _track("previous", 42)
+    current = _track("current", 42)
+    resolver = MagicMock()
+    resolver.resolve_stream.return_value = "https://cdn.example/audio"
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    vc.is_playing.return_value = False
+    vc.is_paused.return_value = False
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        _voice_receivers={},
+        _voice_mixers={},
+        _cancel_voice_timeout=MagicMock(),
+    )
+    manager = DiscordMusicManager(
+        adapter,
+        resolver=resolver,
+        audio_source_factory=lambda _url: object(),
+        view_factory=lambda *_args: "controls",
+    )
+    session = MusicSession(guild_id=7, current=current)
+    session.history.append(previous)
+    session.panel_message = SimpleNamespace(edit=AsyncMock())
+    session.text_channel = SimpleNamespace()
+    manager.sessions[7] = session
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(
+            id=42, guild_permissions=SimpleNamespace(administrator=False)
+        ),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await manager.control(interaction, 7, "previous")
+
+    assert session.current is previous
+    assert list(session.queue)[0] is current
+    vc.stop.assert_called_once_with()
+    vc.play.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_previous_defers_before_resolving_stream():
+    previous = _track("previous", 42)
+    current = _track("current", 42)
+    resolver = MagicMock()
+    resolver.resolve_stream.return_value = "https://cdn.example/previous"
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    vc.is_playing.return_value = False
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        _voice_receivers={},
+        _voice_mixers={},
+        _cancel_voice_timeout=MagicMock(),
+    )
+    manager = DiscordMusicManager(
+        adapter, resolver=resolver, view_factory=lambda *_args: "controls"
+    )
+    session = MusicSession(guild_id=7, current=current)
+    session.history.append(previous)
+    session.panel_message = SimpleNamespace(edit=AsyncMock())
+    session.text_channel = SimpleNamespace()
+    manager.sessions[7] = session
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(
+            id=42, guild_permissions=SimpleNamespace(administrator=False)
+        ),
+        response=SimpleNamespace(defer=AsyncMock(), is_done=lambda: True),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+
+    await manager.control(interaction, 7, "previous")
+
+    interaction.response.defer.assert_awaited_once_with(ephemeral=True)
+    interaction.followup.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_missing_voice_client_does_not_claim_skip_succeeded():
+    adapter = SimpleNamespace(_voice_clients={})
+    manager = DiscordMusicManager(adapter)
+    session = MusicSession(guild_id=7, current=_track("current", 42))
+    manager.sessions[7] = session
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(
+            id=42, guild_permissions=SimpleNamespace(administrator=False)
+        ),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await manager.control(interaction, 7, "skip")
+
+    assert session.current is not None
+    assert "lost" in interaction.response.send_message.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_music_panel_has_previous_play_pause_repeat_and_skip_buttons():
+    manager = SimpleNamespace(control=AsyncMock())
+    view = MusicControlView(manager, 7)
+
+    labels = {item.label for item in view.children}
+    assert labels == {"Previous", "Play/Pause", "Repeat", "Skip"}
+    assert view.timeout is None
+
+
+@pytest.mark.asyncio
+async def test_finishing_an_empty_queue_restores_voice_listening_and_inactivity_timer():
+    receiver = SimpleNamespace(resume=MagicMock())
+    adapter = SimpleNamespace(
+        _voice_clients={7: MagicMock()},
+        _voice_receivers={7: receiver},
+        _voice_mixers={},
+        _voice_fx_cfg={"enabled": True},
+        _install_voice_mixer=AsyncMock(),
+        _reset_voice_timeout=MagicMock(),
+    )
+    manager = DiscordMusicManager(adapter, view_factory=lambda *_args: "controls")
+    session = MusicSession(guild_id=7, current=_track("last", 42))
+    session.panel_message = SimpleNamespace(edit=AsyncMock())
+    session.text_channel = SimpleNamespace()
+    manager.sessions[7] = session
+
+    await manager._on_track_end(7)
+
+    assert session.current is None
+    receiver.resume.assert_called_once_with()
+    adapter._install_voice_mixer.assert_awaited_once_with(7, adapter._voice_clients[7])
+    adapter._reset_voice_timeout.assert_called_once_with(7)
+
+
+@pytest.mark.asyncio
+async def test_voice_disconnect_discards_stale_music_state_and_updates_panel():
+    adapter = SimpleNamespace(_voice_clients={})
+    manager = DiscordMusicManager(adapter, view_factory=lambda *_args: "controls")
+    session = MusicSession(guild_id=7, current=_track("current", 42))
+    session.enqueue([_track("next", 99)])
+    session.panel_message = SimpleNamespace(edit=AsyncMock())
+    session.text_channel = SimpleNamespace()
+    manager.sessions[7] = session
+
+    await manager.on_voice_disconnected(7)
+
+    assert 7 not in manager.sessions
+    session.panel_message.edit.assert_awaited_once()
+    assert (
+        "Nothing is playing" in session.panel_message.edit.await_args.kwargs["content"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_voice_disconnect_serializes_on_persistent_guild_lock():
+    import asyncio
+
+    adapter = SimpleNamespace(_voice_clients={})
+    manager = DiscordMusicManager(adapter, view_factory=lambda *_args: "controls")
+    session = MusicSession(guild_id=7, current=_track("current", 42))
+    session.panel_message = SimpleNamespace(edit=AsyncMock())
+    session.text_channel = SimpleNamespace()
+    manager.sessions[7] = session
+    lock = manager._locks.setdefault(7, asyncio.Lock())
+
+    await lock.acquire()
+    disconnect = asyncio.create_task(manager.on_voice_disconnected(7))
+    await asyncio.sleep(0)
+
+    assert 7 in manager.sessions
+
+    lock.release()
+    await disconnect
+
+    assert 7 not in manager.sessions
+    assert manager._locks[7] is lock
+
+
+@pytest.mark.asyncio
+async def test_show_queue_defers_before_waiting_for_guild_lock():
+    import asyncio
+
+    adapter = SimpleNamespace(_voice_clients={})
+    manager = DiscordMusicManager(adapter, view_factory=lambda *_args: "controls")
+    session = MusicSession(guild_id=7, current=_track("current", 42))
+    session.panel_message = SimpleNamespace(edit=AsyncMock())
+    manager.sessions[7] = session
+    interaction = SimpleNamespace(
+        channel=SimpleNamespace(),
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+    lock = manager._locks.setdefault(7, asyncio.Lock())
+
+    await lock.acquire()
+    show = asyncio.create_task(manager.show_queue(interaction, 7))
+    await asyncio.sleep(0)
+
+    interaction.response.defer.assert_awaited_once_with(ephemeral=True)
+    session.panel_message.edit.assert_not_awaited()
+
+    lock.release()
+    await show
+
+    session.panel_message.edit.assert_awaited_once()
+    interaction.followup.send.assert_awaited_once_with(
+        "The public music queue is up to date.", ephemeral=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_adapter_voice_leave_notifies_music_manager():
+    adapter = object.__new__(DiscordAdapter)
+    adapter._voice_locks = {}
+    adapter._voice_receivers = {}
+    adapter._voice_listen_tasks = {}
+    adapter._client = None
+    adapter._voice_mixers = {}
+    adapter._voice_clients = {7: SimpleNamespace(is_connected=lambda: False)}
+    adapter._voice_timeout_tasks = {}
+    adapter._voice_text_channels = {}
+    adapter._voice_sources = {}
+    adapter._music_manager = SimpleNamespace(on_voice_disconnected=AsyncMock())
+
+    await adapter.leave_voice_channel(7)
+
+    adapter._music_manager.on_voice_disconnected.assert_awaited_once_with(7)
+
+
+@pytest.mark.asyncio
+async def test_clear_queue_is_administrator_only_and_stops_current_song():
+    vc = MagicMock()
+    receiver = SimpleNamespace(resume=MagicMock())
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        _voice_receivers={7: receiver},
+        _reset_voice_timeout=MagicMock(),
+    )
+    manager = DiscordMusicManager(adapter, view_factory=lambda *_args: "controls")
+    session = MusicSession(guild_id=7, current=_track("current", 42))
+    session.enqueue([_track("next", 99)])
+    manager.sessions[7] = session
+
+    member = SimpleNamespace(
+        user=SimpleNamespace(
+            id=42, guild_permissions=SimpleNamespace(administrator=False)
+        ),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+    admin = SimpleNamespace(
+        user=SimpleNamespace(
+            id=1, guild_permissions=SimpleNamespace(administrator=True)
+        ),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await manager.admin_action(member, 7, "clear")
+    assert list(session.queue)
+    vc.stop.assert_not_called()
+
+    await manager.admin_action(admin, 7, "clear")
+    assert not session.queue
+    assert session.current is None
+    vc.stop.assert_called_once_with()
+    receiver.resume.assert_called_once_with()
+    adapter._reset_voice_timeout.assert_called_once_with(7)
+
+
+@pytest.mark.asyncio
+async def test_clear_suppresses_delayed_stop_callback_from_old_track():
+    vc = MagicMock()
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        _voice_receivers={},
+        _reset_voice_timeout=MagicMock(),
+    )
+    manager = DiscordMusicManager(adapter)
+    session = MusicSession(guild_id=7, current=_track("old", 42))
+    old_generation = session.playback_generation
+    manager.sessions[7] = session
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(
+            id=1, guild_permissions=SimpleNamespace(administrator=True)
+        ),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await manager.admin_action(interaction, 7, "clear")
+    replacement = _track("replacement", 99)
+    session.current = replacement
+    await manager._on_track_end(7, generation=old_generation)
+
+    assert session.current is replacement
+
+
+@pytest.mark.asyncio
+async def test_stale_callback_cannot_consume_replacement_track_if_callbacks_reorder():
+    adapter = SimpleNamespace(
+        _voice_clients={},
+        _voice_receivers={},
+        _voice_mixers={},
+        _reset_voice_timeout=MagicMock(),
+    )
+    manager = DiscordMusicManager(adapter)
+    replacement = _track("replacement", 99)
+    session = MusicSession(guild_id=7, current=replacement)
+    session.playback_generation = 2
+    session.panel_message = SimpleNamespace(edit=AsyncMock())
+    session.text_channel = SimpleNamespace()
+    manager.sessions[7] = session
+
+    await manager._on_track_end(7, generation=1)
+
+    assert session.current is replacement
+    assert not session.history
+
+    await manager._on_track_end(7, generation=2)
+
+    assert session.current is None
+    assert list(session.history) == [replacement]
+
+
+@pytest.mark.asyncio
+async def test_admin_action_defers_before_waiting_for_guild_lock():
+    vc = MagicMock()
+    adapter = SimpleNamespace(_voice_clients={7: vc})
+    manager = DiscordMusicManager(adapter)
+    manager.sessions[7] = MusicSession(guild_id=7, current=_track("current", 42))
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(
+            id=1, guild_permissions=SimpleNamespace(administrator=True)
+        ),
+        response=SimpleNamespace(defer=AsyncMock(), is_done=lambda: True),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+
+    await manager.admin_action(interaction, 7, "forceskip")
+
+    interaction.response.defer.assert_awaited_once_with(ephemeral=True)
+    interaction.followup.send.assert_awaited_once()
+
+
+class _FakeTree:
+    def __init__(self):
+        self.commands = {}
+
+    def command(self, *, name, description):
+        def decorator(callback):
+            self.commands[name] = callback
+            return callback
+
+        return decorator
+
+    def add_command(self, command):
+        self.commands[command.name] = command
+
+    def get_commands(self):
+        return [SimpleNamespace(name=name) for name in self.commands]
+
+
+def test_discord_registers_music_queue_and_admin_slash_commands():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = SimpleNamespace(tree=_FakeTree())
+
+    adapter._register_slash_commands()
+
+    assert {"play", "musicqueue", "forceskip", "clearqueue"}.issubset(
+        adapter._client.tree.commands
+    )

--- a/tests/gateway/test_discord_music.py
+++ b/tests/gateway/test_discord_music.py
@@ -1,11 +1,16 @@
 """Discord music queue and playback-control behavior."""
 
+import asyncio
+import threading
+import time
+from collections import deque
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from plugins.platforms.discord.music import (
+    BufferedAudioSource,
     DiscordMusicManager,
     MusicControlView,
     MusicResolutionError,
@@ -202,7 +207,9 @@ def test_text_search_queues_one_result_but_keeps_playback_fallback_candidates():
     assert tracks[0].lookup == "ytsearch5:requested song"
 
 
-def test_ytdlp_prefers_low_bandwidth_hls_and_enables_packaged_js_runtime(monkeypatch):
+def test_ytdlp_prefers_audio_or_bounded_quality_hls_and_enables_packaged_js_runtime(
+    monkeypatch,
+):
     captured = {}
 
     class FakeYoutubeDL:
@@ -227,7 +234,11 @@ def test_ytdlp_prefers_low_bandwidth_hls_and_enables_packaged_js_runtime(monkeyp
         flat=False,
     )
 
-    assert captured["format"] == "worst[protocol^=m3u8][acodec!=none]"
+    assert captured["format"] == (
+        "bestaudio[protocol^=m3u8]/"
+        "best[protocol^=m3u8][acodec!=none][height<=480]/"
+        "worst[protocol^=m3u8][acodec!=none]"
+    )
     assert captured["ignoreerrors"] is True
     assert "node" in captured["js_runtimes"]
 
@@ -272,18 +283,171 @@ def test_youtube_hls_is_limited_to_provider_controlled_manifest_host():
 
 
 def test_ffmpeg_source_restricts_nested_network_protocols(monkeypatch):
-    ffmpeg = MagicMock(return_value="source")
+    upstream = MagicMock()
+    ffmpeg = MagicMock(return_value=upstream)
     monkeypatch.setattr("discord.FFmpegPCMAudio", ffmpeg)
 
     source = DiscordMusicManager._default_audio_source(
         "https://manifest.googlevideo.com/audio.m3u8"
     )
 
-    assert source == "source"
+    assert isinstance(source, BufferedAudioSource)
+    assert source.source is upstream
     before_options = ffmpeg.call_args.kwargs["before_options"]
+    options = ffmpeg.call_args.kwargs["options"]
     assert ffmpeg.call_args.kwargs["executable"]
     assert "-protocol_whitelist http,https,tcp,tls,crypto" in before_options
     assert "file" not in before_options
+    assert "aresample=48000" in options
+    assert "resampler=soxr" not in options
+    source.cleanup()
+
+
+def test_buffered_audio_source_returns_silence_instead_of_blocking_on_underflow():
+    first = b"a" * BufferedAudioSource.FRAME_SIZE
+    second = b"b" * BufferedAudioSource.FRAME_SIZE
+    release_second = threading.Event()
+
+    class StallingSource:
+        def __init__(self):
+            self.reads = 0
+            self.cleaned = False
+
+        def read(self):
+            self.reads += 1
+            if self.reads == 1:
+                return first
+            if self.reads == 2:
+                release_second.wait(timeout=2)
+                return second
+            return b""
+
+        def cleanup(self):
+            self.cleaned = True
+
+        def is_opus(self):
+            return False
+
+    upstream = StallingSource()
+    source = BufferedAudioSource(
+        upstream,
+        prebuffer_frames=1,
+        max_buffer_frames=4,
+    )
+    assert source.wait_until_ready(timeout=1)
+    assert source.read() == first
+
+    started = time.perf_counter()
+    assert source.read() == BufferedAudioSource.SILENCE_FRAME
+    assert time.perf_counter() - started < 0.05
+
+    release_second.set()
+    deadline = time.monotonic() + 1
+    frame = BufferedAudioSource.SILENCE_FRAME
+    while frame == BufferedAudioSource.SILENCE_FRAME and time.monotonic() < deadline:
+        time.sleep(0.01)
+        frame = source.read()
+    assert frame == second
+
+    source.cleanup()
+    assert upstream.cleaned is True
+
+
+@pytest.mark.asyncio
+async def test_startup_cancellation_cleans_buffered_source():
+    release_read = threading.Event()
+
+    class BlockingSource:
+        cleaned = False
+
+        def read(self):
+            release_read.wait(timeout=2)
+            return b""
+
+        def cleanup(self):
+            self.cleaned = True
+            release_read.set()
+
+    upstream = BlockingSource()
+    source = BufferedAudioSource(upstream, prebuffer_frames=1, max_buffer_frames=2)
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    adapter = SimpleNamespace(_voice_clients={7: vc})
+    resolver = MagicMock()
+    resolver.resolve_stream.return_value = "https://cdn.example/audio"
+    manager = DiscordMusicManager(
+        adapter,
+        resolver=resolver,
+        audio_source_factory=lambda _url: source,
+    )
+    session = MusicSession(guild_id=7, queue=deque([_track("cancelled")]))
+
+    task = asyncio.create_task(manager._start_next(session))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    try:
+        assert upstream.cleaned is True
+    finally:
+        source.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_startup_decoder_error_is_reported_instead_of_buffer_timeout():
+    class BrokenSource:
+        def read(self):
+            raise RuntimeError("decoder exploded")
+
+        def cleanup(self):
+            return None
+
+    source = BufferedAudioSource(BrokenSource(), prebuffer_frames=1)
+    vc = MagicMock()
+    vc.is_connected.return_value = True
+    adapter = SimpleNamespace(
+        _voice_clients={7: vc},
+        _voice_receivers={},
+        _voice_mixers={},
+    )
+    resolver = MagicMock()
+    resolver.resolve_stream.return_value = "https://cdn.example/audio"
+    manager = DiscordMusicManager(
+        adapter,
+        resolver=resolver,
+        audio_source_factory=lambda _url: source,
+    )
+    session = MusicSession(guild_id=7, queue=deque([_track("broken")]))
+    session.panel_message = SimpleNamespace(edit=AsyncMock())
+    session.text_channel = SimpleNamespace()
+
+    await manager._start_next(session)
+
+    assert session.last_error is not None
+    assert "decoder exploded" in session.last_error
+
+
+@pytest.mark.asyncio
+async def test_missing_voice_connection_is_rejected_before_audio_source_creation():
+    factory = MagicMock()
+    adapter = SimpleNamespace(
+        _voice_clients={},
+        _voice_receivers={},
+        _voice_mixers={},
+    )
+    resolver = MagicMock()
+    resolver.resolve_stream.return_value = "https://cdn.example/audio"
+    manager = DiscordMusicManager(adapter, resolver=resolver, audio_source_factory=factory)
+    session = MusicSession(guild_id=7, queue=deque([_track("disconnected")]))
+    session.panel_message = SimpleNamespace(edit=AsyncMock())
+    session.text_channel = SimpleNamespace()
+
+    await manager._start_next(session)
+
+    factory.assert_not_called()
+    assert session.last_error is not None
+    assert "voice connection was lost" in session.last_error.lower()
 
 
 def test_spotify_http_uses_connect_time_ssrf_safe_client(monkeypatch):
@@ -421,6 +585,8 @@ async def test_add_joins_requesters_vc_starts_fifo_playback_and_updates_public_p
     )
     voice_client.play.assert_called_once()
     assert voice_client.play.call_args.args[0] is source
+    assert voice_client.play.call_args.kwargs["bitrate"] == 192
+    assert voice_client.play.call_args.kwargs["signal_type"] == "music"
     assert manager.sessions[7].current is track
     text_channel.send.assert_awaited_once()
     panel.edit.assert_awaited()

--- a/tests/gateway/test_discord_music.py
+++ b/tests/gateway/test_discord_music.py
@@ -237,9 +237,13 @@ def test_ytdlp_prefers_audio_or_bounded_quality_hls_and_enables_packaged_js_runt
     assert captured["format"] == (
         "bestaudio[protocol^=m3u8]/"
         "best[protocol^=m3u8][acodec!=none][height<=480]/"
-        "worst[protocol^=m3u8][acodec!=none]"
+        "worst[protocol^=m3u8][acodec!=none]/"
+        "bestaudio/best"
     )
     assert captured["ignoreerrors"] is True
+    assert captured["extractor_args"] == {
+        "youtube": {"player_client": ["android"]}
+    }
     assert "node" in captured["js_runtimes"]
 
 

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -238,7 +238,10 @@ async def test_announce_slash_posts_exact_text_to_selected_channel(adapter):
         ping_everyone=False,
     )
 
-    target.send.assert_awaited_once_with("**Deploy complete**")
+    target.send.assert_awaited_once()
+    send_args, send_kwargs = target.send.await_args
+    assert send_args == ("**Deploy complete**",)
+    assert "allowed_mentions" in send_kwargs
     interaction.response.defer.assert_awaited_once_with(ephemeral=True)
     interaction.edit_original_response.assert_awaited_once_with(
         content=(
@@ -260,6 +263,50 @@ def test_announce_slash_signature_matches_existing_guild_command(adapter):
         "message",
         "ping_everyone",
     ]
+
+
+@pytest.mark.asyncio
+async def test_announce_slash_suppresses_literal_mass_mentions_without_opt_in(adapter):
+    guild = SimpleNamespace(id=456, name="TestGuild")
+    sent_message = SimpleNamespace(id=777, jump_url="")
+    target = SimpleNamespace(
+        id=321,
+        name="announcements",
+        guild=guild,
+        send=AsyncMock(return_value=sent_message),
+    )
+    interaction = SimpleNamespace(
+        channel=_FakeTextChannel(channel_id=123, name="operations"),
+        channel_id=123,
+        guild=guild,
+        guild_id=guild.id,
+        user=SimpleNamespace(id=42, name="Jezza", display_name="Jezza"),
+        response=SimpleNamespace(defer=AsyncMock(), send_message=AsyncMock()),
+        edit_original_response=AsyncMock(),
+    )
+
+    mentions = object()
+    with patch(
+        "plugins.platforms.discord.adapter.discord.AllowedMentions",
+        return_value=mentions,
+    ) as allowed_mentions:
+        await adapter._handle_announce_slash(
+            interaction,
+            target,
+            "@everyone maintenance starts now",
+            ping_everyone=False,
+        )
+
+    allowed_mentions.assert_called_once_with(
+        everyone=False,
+        roles=False,
+        users=True,
+        replied_user=False,
+    )
+    target.send.assert_awaited_once_with(
+        "@everyone maintenance starts now",
+        allowed_mentions=mentions,
+    )
 
 
 @pytest.mark.asyncio
@@ -286,6 +333,46 @@ async def test_announce_slash_rejects_cross_guild_destination(adapter):
     interaction.response.send_message.assert_awaited_once_with(
         "Choose a text channel in this server.", ephemeral=True
     )
+
+
+@pytest.mark.parametrize(
+    ("handler_name", "handler_args", "command"),
+    [
+        ("_handle_music_play", ("song",), "/play"),
+        ("_handle_music_queue", (), "/musicqueue"),
+        ("_handle_music_admin", ("forceskip",), "/forceskip"),
+        ("_handle_music_admin", ("clear",), "/clearqueue"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_music_slash_commands_honor_command_policy(
+    adapter, handler_name, handler_args, command
+):
+    adapter.config.extra = {"group_allow_admin_from": ["99"]}
+    adapter._reject_slash = AsyncMock()
+    manager = SimpleNamespace(
+        add=AsyncMock(),
+        show_queue=AsyncMock(),
+        admin_action=AsyncMock(),
+    )
+    adapter._get_music_manager = MagicMock(return_value=manager)
+    guild = SimpleNamespace(id=456)
+    interaction = SimpleNamespace(
+        channel=_FakeTextChannel(channel_id=123, name="operations"),
+        guild=guild,
+        user=SimpleNamespace(id=42, name="Jezza", display_name="Jezza"),
+    )
+
+    await getattr(adapter, handler_name)(interaction, *handler_args)
+
+    adapter._reject_slash.assert_awaited_once_with(
+        interaction,
+        command,
+        reason="command blocked by slash access policy",
+    )
+    manager.add.assert_not_awaited()
+    manager.show_queue.assert_not_awaited()
+    manager.admin_action.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import sys
 
 import pytest
+import inspect
 
 from gateway.config import PlatformConfig
 
@@ -200,6 +201,146 @@ async def test_auto_registers_plugin_commands_for_discord(adapter):
     await metricas_cmd.callback(interaction, args="dias:7 formato:json")
     adapter._run_simple_slash.assert_awaited_once_with(
         interaction, "/metricas dias:7 formato:json"
+    )
+
+
+@pytest.mark.asyncio
+async def test_announce_slash_posts_exact_text_to_selected_channel(adapter):
+    """The native command should publish directly to the selected channel."""
+    adapter._register_slash_commands()
+
+    guild = SimpleNamespace(id=456, name="TestGuild")
+    sent_message = SimpleNamespace(
+        id=777,
+        jump_url="https://discord.com/channels/456/321/777",
+    )
+    target = SimpleNamespace(
+        id=321,
+        name="announcements",
+        guild=guild,
+        send=AsyncMock(return_value=sent_message),
+    )
+    interaction = SimpleNamespace(
+        channel=_FakeTextChannel(channel_id=123, name="operations"),
+        channel_id=123,
+        guild=guild,
+        guild_id=guild.id,
+        user=SimpleNamespace(id=42, name="Jezza", display_name="Jezza"),
+        response=SimpleNamespace(defer=AsyncMock(), send_message=AsyncMock()),
+        edit_original_response=AsyncMock(),
+    )
+
+    command = adapter._client.tree.commands["announce"]
+    await command(
+        interaction,
+        channel=target,
+        message="**Deploy complete**",
+        ping_everyone=False,
+    )
+
+    target.send.assert_awaited_once_with("**Deploy complete**")
+    interaction.response.defer.assert_awaited_once_with(ephemeral=True)
+    interaction.edit_original_response.assert_awaited_once_with(
+        content=(
+            "Announcement posted in <#321>: "
+            "https://discord.com/channels/456/321/777"
+        )
+    )
+    assert "777" in adapter._nonconversational_messages
+
+
+def test_announce_slash_signature_matches_existing_guild_command(adapter):
+    """The callback must match Discord's installed guild-command payload."""
+    adapter._register_slash_commands()
+
+    callback = adapter._client.tree.commands["announce"]
+    assert list(inspect.signature(callback).parameters) == [
+        "interaction",
+        "channel",
+        "message",
+        "ping_everyone",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_announce_slash_rejects_cross_guild_destination(adapter):
+    source_guild = SimpleNamespace(id=456, name="SourceGuild")
+    target = SimpleNamespace(
+        id=321,
+        name="announcements",
+        guild=SimpleNamespace(id=999, name="OtherGuild"),
+        send=AsyncMock(),
+    )
+    interaction = SimpleNamespace(
+        channel=_FakeTextChannel(channel_id=123, name="operations"),
+        channel_id=123,
+        guild=source_guild,
+        guild_id=source_guild.id,
+        user=SimpleNamespace(id=42, name="Jezza", display_name="Jezza"),
+        response=SimpleNamespace(defer=AsyncMock(), send_message=AsyncMock()),
+    )
+
+    await adapter._handle_announce_slash(interaction, target, "Do not send")
+
+    target.send.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once_with(
+        "Choose a text channel in this server.", ephemeral=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_announce_slash_honors_admin_command_policy(adapter):
+    adapter.config.extra = {"group_allow_admin_from": ["99"]}
+    adapter._reject_slash = AsyncMock(return_value=False)
+    guild = SimpleNamespace(id=456, name="TestGuild")
+    target = SimpleNamespace(
+        id=321,
+        name="announcements",
+        guild=guild,
+        send=AsyncMock(),
+    )
+    interaction = SimpleNamespace(
+        channel=_FakeTextChannel(channel_id=123, name="operations"),
+        channel_id=123,
+        guild=guild,
+        guild_id=guild.id,
+        user=SimpleNamespace(id=42, name="Jezza", display_name="Jezza"),
+    )
+
+    await adapter._handle_announce_slash(interaction, target, "Do not send")
+
+    target.send.assert_not_awaited()
+    adapter._reject_slash.assert_awaited_once_with(
+        interaction,
+        "/announce",
+        reason="command blocked by slash access policy",
+    )
+
+
+@pytest.mark.asyncio
+async def test_announce_slash_rejects_messages_over_discord_limit(adapter):
+    guild = SimpleNamespace(id=456, name="TestGuild")
+    target = SimpleNamespace(
+        id=321,
+        name="announcements",
+        guild=guild,
+        send=AsyncMock(),
+    )
+    interaction = SimpleNamespace(
+        channel=_FakeTextChannel(channel_id=123, name="operations"),
+        channel_id=123,
+        guild=guild,
+        guild_id=guild.id,
+        user=SimpleNamespace(id=42, name="Jezza", display_name="Jezza"),
+        response=SimpleNamespace(defer=AsyncMock(), send_message=AsyncMock()),
+    )
+
+    await adapter._handle_announce_slash(interaction, target, "x" * 2001)
+
+    target.send.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once_with(
+        "Announcement text must be 2,000 characters or fewer.",
+        ephemeral=True,
     )
 
 

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -632,6 +632,37 @@ class TestVoiceChannelCommands:
         assert event.source.chat_type == "channel"
 
     @pytest.mark.asyncio
+    async def test_spoken_natural_play_command_bypasses_agent_dispatch(self, runner):
+        """An addressed music command should control playback directly."""
+        from gateway.config import Platform
+
+        class VoiceMusicAdapter:
+            def __init__(self):
+                self._voice_text_channels = {111: 123}
+                self._voice_sources = {}
+                self._client = MagicMock()
+                self.handle_message = AsyncMock()
+                self.music_requests = []
+
+            async def _maybe_handle_natural_music_voice(
+                self, guild_id, user_id, transcript
+            ):
+                self.music_requests.append((guild_id, user_id, transcript))
+                return True
+
+        adapter = VoiceMusicAdapter()
+        runner.adapters[Platform.DISCORD] = adapter
+
+        await runner._handle_voice_channel_input(
+            111, 42, "Hey Jarvis play Paranoid by Rich Amiri"
+        )
+
+        assert adapter.music_requests == [
+            (111, 42, "Hey Jarvis play Paranoid by Rich Amiri")
+        ]
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_input_resolves_channel_prompt(self, runner):
         """Voice input must carry the bound text channel's channel_prompt (#50149)."""
         from gateway.config import Platform
@@ -680,6 +711,46 @@ class TestVoiceChannelCommands:
         assert event.source.chat_type == "group"
         assert event.source.chat_name == "Hermes Server / #general"
         assert event.source.user_id == "42"
+
+    @pytest.mark.asyncio
+    async def test_voice_input_does_not_inherit_linking_users_role_authorization(
+        self, runner
+    ):
+        from gateway.config import Platform
+
+        bound_source = SessionSource(
+            chat_id="123",
+            chat_type="group",
+            user_id="linking-user",
+            user_name="linking-user",
+            platform=Platform.DISCORD,
+            role_authorized=True,
+        )
+        class VoiceAuthAdapter:
+            def __init__(self):
+                self._voice_text_channels = {111: 123}
+                self._voice_sources = {111: bound_source.to_dict()}
+                self._client = MagicMock()
+                self._client.get_guild = MagicMock(
+                    return_value=SimpleNamespace(id=111)
+                )
+                self.handle_message = AsyncMock()
+                self.auth_calls = []
+
+            def _is_allowed_user(self, user_id, *, guild, is_dm):
+                self.auth_calls.append((user_id, guild, is_dm))
+                return False
+
+        adapter = VoiceAuthAdapter()
+        runner._is_user_authorized = lambda source: bool(source.role_authorized)
+        runner.adapters[Platform.DISCORD] = adapter
+
+        await runner._handle_voice_channel_input(111, 42, "Hello from VC")
+
+        assert adapter.auth_calls == [
+            ("42", adapter._client.get_guild.return_value, False)
+        ]
+        adapter.handle_message.assert_not_awaited()
 
 
     # -- _get_guild_id --
@@ -757,6 +828,7 @@ class TestDiscordVoiceChannelMethods:
         adapter._is_allowed_user = MagicMock(return_value=True)
 
         async def process(guild_id, user_id, pcm_data):
+            assert not adapter._voice_locks[111].locked()
             events.append("process")
 
         adapter._process_voice_input = process
@@ -824,6 +896,58 @@ class TestDiscordVoiceChannelMethods:
         assert result is mock_vc
 
 
+    @pytest.mark.asyncio
+    async def test_unexpected_bot_voice_disconnect_clears_music_state(self):
+        adapter = self._make_adapter()
+        bot_user = SimpleNamespace(id=1, guild=SimpleNamespace(id=111))
+        adapter._client.user = bot_user
+        vc = MagicMock()
+        vc.is_connected.return_value = False
+        adapter._voice_clients[111] = vc
+        adapter._voice_text_channels[111] = 123
+        adapter._voice_sources[111] = {"chat_id": "123"}
+        manager = SimpleNamespace(on_voice_disconnected=AsyncMock())
+        adapter._music_manager = manager
+        member = bot_user
+        before = SimpleNamespace(channel=SimpleNamespace(id=12))
+        after = SimpleNamespace(channel=None)
+
+        handled = await adapter._handle_bot_voice_state_update(member, before, after)
+
+        assert handled is True
+        assert 111 not in adapter._voice_clients
+        assert 111 not in adapter._voice_text_channels
+        assert 111 not in adapter._voice_sources
+        manager.on_voice_disconnected.assert_awaited_once_with(111)
+
+
+    @pytest.mark.asyncio
+    async def test_unexpected_disconnect_marks_guild_leaving_before_deferred_cleanup(self):
+        adapter = self._make_adapter()
+        bot_user = SimpleNamespace(id=1, guild=SimpleNamespace(id=111))
+        adapter._client.user = bot_user
+        adapter._voice_clients[111] = SimpleNamespace(is_connected=lambda: False)
+        adapter._music_manager = SimpleNamespace(on_voice_disconnected=AsyncMock())
+        voice_lock = adapter._voice_locks.setdefault(111, asyncio.Lock())
+        await voice_lock.acquire()
+
+        handled = await adapter._handle_bot_voice_state_update(
+            bot_user,
+            SimpleNamespace(channel=SimpleNamespace(id=12)),
+            SimpleNamespace(channel=None),
+        )
+
+        assert handled is True
+        assert 111 in adapter._voice_leaving
+        voice_lock.release()
+        for _ in range(10):
+            if adapter._music_manager.on_voice_disconnected.await_count:
+                break
+            await asyncio.sleep(0)
+        adapter._music_manager.on_voice_disconnected.assert_awaited_once_with(111)
+        assert 111 not in adapter._voice_leaving
+
+
     def test_voice_timeout_zero_disables_auto_leave(self):
         adapter = self._make_adapter()
         adapter._voice_timeout_seconds = 0
@@ -834,6 +958,21 @@ class TestDiscordVoiceChannelMethods:
 
         existing_task.cancel.assert_called_once()
         assert adapter._voice_timeout_tasks == {}
+
+    def test_active_music_does_not_rearm_voice_inactivity_timeout(self):
+        adapter = self._make_adapter()
+        adapter._voice_timeout_seconds = 300
+        adapter._music_manager = SimpleNamespace(
+            sessions={111: SimpleNamespace(current=object())}
+        )
+
+        adapter._reset_voice_timeout(111)
+
+        try:
+            assert adapter._voice_timeout_tasks == {}
+        finally:
+            for task in adapter._voice_timeout_tasks.values():
+                task.cancel()
 
     def test_discord_voice_timeout_config_loaded(self):
         from plugins.platforms.discord.adapter import DiscordAdapter
@@ -885,6 +1024,29 @@ class TestDiscordVoiceChannelMethods:
         adapter._playback_timeout_for_audio.assert_awaited_once_with("/tmp/long.mp3")
         adapter._cancel_voice_timeout.assert_called_once_with(111)
         adapter._reset_voice_timeout.assert_called_once_with(111)
+
+
+    @pytest.mark.asyncio
+    async def test_tts_does_not_interrupt_active_music_playback(self):
+        adapter = self._make_adapter()
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        vc.is_playing.return_value = True
+        adapter._voice_clients[111] = vc
+        adapter._music_manager = SimpleNamespace(
+            sessions={111: SimpleNamespace(current=object())}
+        )
+        adapter._playback_timeout_for_audio = AsyncMock(return_value=30.0)
+        adapter._cancel_voice_timeout = MagicMock()
+        adapter._reset_voice_timeout = MagicMock()
+
+        result = await adapter.play_in_voice_channel(111, "/tmp/reply.mp3")
+
+        assert result is False
+        vc.stop.assert_not_called()
+        vc.play.assert_not_called()
+        adapter._playback_timeout_for_audio.assert_not_awaited()
+        adapter._cancel_voice_timeout.assert_not_called()
 
 
     def test_is_allowed_user_wildcard_only(self):

--- a/uv.lock
+++ b/uv.lock
@@ -1716,6 +1716,8 @@ messaging = [
     { name = "qrcode" },
     { name = "slack-bolt" },
     { name = "slack-sdk" },
+    { name = "yt-dlp" },
+    { name = "yt-dlp-ejs" },
 ]
 mistral = [
     { name = "mistralai" },
@@ -1945,6 +1947,8 @@ requires-dist = [
     { name = "vercel", marker = "extra == 'vercel'", specifier = "==0.7.2" },
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
+    { name = "yt-dlp", marker = "extra == 'messaging'", specifier = "==2026.7.4" },
+    { name = "yt-dlp-ejs", marker = "extra == 'messaging'", specifier = "==0.8.0" },
 ]
 provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
@@ -5007,6 +5011,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/60/43/4104185a2eaa839daa693b30e15c37e7e58795e8e09ec414f22b3db54bec/youtube_transcript_api-1.2.4.tar.gz", hash = "sha256:b72d0e96a335df599d67cee51d49e143cff4f45b84bcafc202ff51291603ddcd", size = 469839, upload-time = "2026-01-29T09:09:17.088Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/95/129ea37efd6cd6ed00f62baae6543345c677810b8a3bf0026756e1d3cf3c/youtube_transcript_api-1.2.4-py3-none-any.whl", hash = "sha256:03878759356da5caf5edac77431780b91448fb3d8c21d4496015bdc8a7bc43ff", size = 485227, upload-time = "2026-01-29T09:09:15.427Z" },
+]
+
+[[package]]
+name = "yt-dlp"
+version = "2026.7.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c5/9972af4b472b0d55badf841ebafd2f98944cb0ae0f46e11d01f363ea5b91/yt_dlp-2026.7.4.tar.gz", hash = "sha256:b094813404f87a9dd2186f00815231df32e5fd8a5403be0f807b3bb2d21a4432", size = 3049326, upload-time = "2026-07-04T22:42:14.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/8a/cd4c9b02c10c563adfe78118310129641900e1cd6de888cfae2452072696/yt_dlp-2026.7.4-py3-none-any.whl", hash = "sha256:f11f2b11d5a8ac4059f9bdf29fa4407dc7c6bb00c5097e95ca22a7a9db518266", size = 3184705, upload-time = "2026-07-04T22:42:12.989Z" },
+]
+
+[[package]]
+name = "yt-dlp-ejs"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/e6/cceb9530e8f4e5940f6f7822d90e9d94f1b85343329a16baaf47bbbb3de1/yt_dlp_ejs-0.8.0.tar.gz", hash = "sha256:d5fa1639f63b5c4af8d932495f60689d5370f1a095782c944f7f62a303eb104e", size = 96571, upload-time = "2026-03-17T22:49:19.299Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/bd/520769863744b669440a924271a6159ddd82ad5ae26b4ac4d4b69e9f8d44/yt_dlp_ejs-0.8.0-py3-none-any.whl", hash = "sha256:79300e5fca7f937a1eeede11f0456862c1b41107ce1d726871e0207424f4bdb4", size = 53443, upload-time = "2026-03-17T22:49:17.736Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add resilient per-guild Discord music queues and playback controls
- support Spotify metadata-to-YouTube playback and YouTube HLS fallback
- harden extractor, FFmpeg, callback-race, and voice lifecycle boundaries
- add comprehensive Discord music and slash-command regression coverage

## Verification
- focused Discord music, slash-command, and voice tests passed
- real Spotify and YouTube playback probes passed
- Ruff and dependency lock validation passed
- full gateway baseline comparison found only the same 6 unrelated failures already present on `origin/main`
- independent security and race-condition review approved the final commit
