### PR TITLE
fix(kanban): distinguish judge transport failures from rejection

### DIFF
--- a/BUG-DESIGN.md
+++ b/BUG-DESIGN.md
@@ -1,0 +1,25 @@
+# Goal-mode judge transport failure
+
+## What
+
+Goal-mode completion and review handoffs must fail open only when `judge_goal()` explicitly classifies an auxiliary-model transport failure. A provider/model 404 is infrastructure failure, not a substantive `continue` judgment on the worker's evidence.
+
+## Why
+
+The K3 bake-off seats use the normalized model ID `moonshotai/kimi-k3`. Their main inference path rewrites that route for Fireworks, but the auxiliary goal judge reached Fireworks with the normalized ID and received HTTP 404. `judge_goal()` correctly returned `transport_failed=True`; both handoff gates discarded that flag and rejected completion as though the judge had found the work incomplete.
+
+An earlier implementation also isolated delegated review children from their parent's `HERMES_KANBAN_*` authority. Equivalent, more comprehensive child isolation is already present on current `main`, so this rebased change does not duplicate it.
+
+## How
+
+- Preserve the full five-value `judge_goal()` contract in the tool and CLI handoff gates.
+- Allow completion and review only when `transport_failed is True`.
+- Continue rejecting `continue`, `wait`, `skipped`, and parsed failures.
+- Validate verdict, reason, and boolean flags so malformed return contracts or uncaught implementation exceptions cannot silently bypass the acceptance gate.
+- Cover tool and CLI completion/review paths plus the contract matrix.
+
+## What could go wrong
+
+- Failing open on every exception would allow implementation bugs to disable the gate. Only the explicit transport signal bypasses it.
+- Treating truthy non-booleans as transport failures would also bypass the gate. The return contract is type-checked before the signal is honored.
+- Failing closed on a real provider outage would re-wedge workers. `judge_goal()` already catches provider/network exceptions and emits `transport_failed=True`; regression tests pin that behavior at both handoff surfaces.

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2228,8 +2228,9 @@ def _goal_mode_handoff_rejection(task: Optional[kb.Task], evidence: str) -> Opti
 
     verdict = "done"
     reason = ""
+    transport_failed = False
     try:
-        verdict, reason, _, _, _ = judge_goal(
+        verdict, reason, _, _, transport_failed = judge_goal(
             goal=f"{task.title}\n\n{task.body or ''}".strip(),
             last_response=evidence.strip(),
         )
@@ -2241,6 +2242,8 @@ def _goal_mode_handoff_rejection(task: Optional[kb.Task], evidence: str) -> Opti
             judge_exc,
             exc_info=True,
         )
+    if transport_failed or verdict == "skipped":
+        return None
     return reason if verdict != "done" else None
 
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2226,25 +2226,36 @@ def _goal_mode_handoff_rejection(task: Optional[kb.Task], evidence: str) -> Opti
 
     from hermes_cli.goals import judge_goal
 
-    verdict = "done"
-    reason = ""
+    verdict = "continue"
+    reason = "goal judge failed without a classified transport error"
+    parse_failed = True
     transport_failed = False
     try:
-        verdict, reason, _, _, transport_failed = judge_goal(
+        verdict, reason, parse_failed, _, transport_failed = judge_goal(
             goal=f"{task.title}\n\n{task.body or ''}".strip(),
             last_response=evidence.strip(),
         )
+        if (
+            verdict not in {"done", "continue", "wait", "skipped"}
+            or not isinstance(reason, str)
+            or not isinstance(parse_failed, bool)
+            or not isinstance(transport_failed, bool)
+        ):
+            raise ValueError("invalid goal judge return contract")
     except Exception as judge_exc:
         import logging as _logging
 
         _logging.getLogger(__name__).warning(
-            "goal judge check failed, allowing lifecycle handoff: %s",
+            "goal judge check failed, rejecting lifecycle handoff: %s",
             judge_exc,
             exc_info=True,
         )
-    if transport_failed or verdict == "skipped":
+        return f"judge error: {type(judge_exc).__name__}"
+    if transport_failed is True:
         return None
-    return reason if verdict != "done" else None
+    if parse_failed or verdict != "done":
+        return reason or "goal judge response could not be validated"
+    return None
 
 
 def _cmd_complete(args: argparse.Namespace) -> int:

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -145,7 +145,8 @@ class TestCLIJudgeGate:
     """
 
     def _run(self, monkeypatch, *, goal_mode=True, judge_available=True,
-             verdict="done", reason="", complete_ok=True, summary="done"):
+             verdict="done", reason="", transport_failed=False,
+             complete_ok=True, summary="done"):
         import argparse
         import types
         from unittest.mock import MagicMock
@@ -184,7 +185,7 @@ class TestCLIJudgeGate:
         # (verdict, reason, parse_failed, wait_directive, transport_failed)
         monkeypatch.setattr(
             "hermes_cli.goals.judge_goal",
-            lambda **kw: (verdict, reason, False, None, False),
+            lambda **kw: (verdict, reason, False, None, transport_failed),
         )
 
         args = argparse.Namespace(task_ids=["t1"], summary=summary, result=None, metadata=None)
@@ -199,9 +200,97 @@ class TestCLIJudgeGate:
             "complete_task must NOT be invoked when the judge rejects"
         )
 
+    def test_judge_fail_open_on_transport_failure(self, monkeypatch):
+        rc, complete_calls = self._run(
+            monkeypatch,
+            verdict="continue",
+            reason="judge error: ConnectError",
+            transport_failed=True,
+        )
+        assert rc == 0, "transport failure must fail open and allow completion"
+        assert complete_calls == ["t1"]
+
 
     def test_non_goal_mode_task_skips_gate(self, monkeypatch):
         """Plain (non-goal_mode) tasks are never sent to the judge."""
         rc, complete_calls = self._run(monkeypatch, goal_mode=False)
         assert rc == 0
         assert complete_calls == ["t1"]
+
+
+class TestCLIHandoffRejection:
+    """Unit tests for hermes_cli.kanban._goal_mode_handoff_rejection (#83610)."""
+
+    @staticmethod
+    def _task():
+        import types
+
+        return types.SimpleNamespace(
+            goal_mode=True,
+            title="Review handoff",
+            body="request independent review",
+        )
+
+    @pytest.mark.parametrize(
+        ("judge_return", "judge_side_effect", "expected"),
+        [
+            (
+                ("continue", "criteria not met", False, None, False),
+                None,
+                "criteria not met",
+            ),
+            (
+                ("continue", "judge error: ConnectError", False, None, True),
+                None,
+                None,
+            ),
+            (
+                ("skipped", "empty goal", False, None, False),
+                None,
+                None,
+            ),
+            (
+                ("done", "achieved", False, None, False),
+                None,
+                None,
+            ),
+            (
+                None,
+                RuntimeError("boom"),
+                None,
+            ),
+        ],
+        ids=[
+            "real_rejection",
+            "transport_failure",
+            "skipped",
+            "success",
+            "exception",
+        ],
+    )
+    def test_handoff_rejection_matrix(
+        self,
+        monkeypatch,
+        judge_return,
+        judge_side_effect,
+        expected,
+    ):
+        from hermes_cli import kanban as kc
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client.get_text_auxiliary_client",
+            lambda name: (object(), "judge-model"),
+        )
+        if judge_side_effect is not None:
+            monkeypatch.setattr(
+                "hermes_cli.goals.judge_goal",
+                lambda **kw: (_ for _ in ()).throw(judge_side_effect),
+            )
+        else:
+            monkeypatch.setattr(
+                "hermes_cli.goals.judge_goal",
+                lambda **kw: judge_return,
+            )
+
+        result = kc._goal_mode_handoff_rejection(self._task(), "implementation complete")
+        assert result == expected

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -247,7 +247,7 @@ class TestCLIHandoffRejection:
             (
                 ("skipped", "empty goal", False, None, False),
                 None,
-                None,
+                "empty goal",
             ),
             (
                 ("done", "achieved", False, None, False),
@@ -255,9 +255,24 @@ class TestCLIHandoffRejection:
                 None,
             ),
             (
+                ("done", "malformed response", True, None, False),
+                None,
+                "malformed response",
+            ),
+            (
+                ("done", "achieved", False, None, "false"),
+                None,
+                "judge error: ValueError",
+            ),
+            (
+                ("unknown", "unexpected verdict", False, None, False),
+                None,
+                "judge error: ValueError",
+            ),
+            (
                 None,
                 RuntimeError("boom"),
-                None,
+                "judge error: RuntimeError",
             ),
         ],
         ids=[
@@ -265,6 +280,9 @@ class TestCLIHandoffRejection:
             "transport_failure",
             "skipped",
             "success",
+            "parse_failure",
+            "nonboolean_transport_flag",
+            "unknown_verdict",
             "exception",
         ],
     )

--- a/tests/hermes_cli/test_kanban_review_surfaces.py
+++ b/tests/hermes_cli/test_kanban_review_surfaces.py
@@ -361,6 +361,91 @@ def test_goal_mode_review_handoff_cannot_bypass_judge(
         assert cli_after.status == "running"
 
 
+def test_goal_mode_review_handoff_fail_open_on_transport_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Transient judge transport errors must not block request-review (#83610)."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+
+    with kb.connect() as conn:
+        tool_task = kb.create_task(
+            conn,
+            title="Goal-mode tool task",
+            assignee="builder",
+            goal_mode=True,
+        )
+        claimed = kb.claim_task(conn, tool_task, claimer="builder:1")
+        assert claimed is not None
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tool_task)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
+
+    from tools import kanban_tools as tools
+
+    monkeypatch.setattr(tools, "_goal_judge_available", lambda: True)
+    monkeypatch.setattr(
+        tools,
+        "judge_goal",
+        lambda *args, **kwargs: (
+            "continue",
+            "judge error: ConnectError",
+            False,
+            None,
+            True,
+        ),
+    )
+    ok = json.loads(tools._handle_request_review({"summary": "Looks ready."}))
+    assert ok.get("ok") is True
+    assert ok.get("status") == "review"
+    with kb.connect() as conn:
+        tool_after = kb.get_task(conn, tool_task)
+        assert tool_after is not None
+        assert tool_after.status == "review"
+
+    with kb.connect() as conn:
+        cli_task = kb.create_task(
+            conn,
+            title="Goal-mode CLI task",
+            assignee="builder",
+            goal_mode=True,
+        )
+        cli_claimed = kb.claim_task(conn, cli_task, claimer="builder:2")
+        assert cli_claimed is not None
+    monkeypatch.setenv("HERMES_KANBAN_TASK", cli_task)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(cli_claimed.current_run_id))
+
+    import agent.auxiliary_client as auxiliary_client
+    from hermes_cli import goals
+
+    monkeypatch.setattr(
+        auxiliary_client,
+        "get_text_auxiliary_client",
+        lambda purpose: (object(), "judge-model"),
+    )
+    monkeypatch.setattr(
+        goals,
+        "judge_goal",
+        lambda *args, **kwargs: (
+            "continue",
+            "judge error: ConnectError",
+            False,
+            None,
+            True,
+        ),
+    )
+    output = kc.run_slash(f"request-review {cli_task} --summary 'Looks ready.'")
+    assert "rejected by judge" not in output
+    with kb.connect() as conn:
+        cli_after = kb.get_task(conn, cli_task)
+        assert cli_after is not None
+        assert cli_after.status == "review"
+
+
 def test_goal_loop_stops_after_reviewer_requests_changes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -215,6 +215,79 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
         conn2.close()
 
 
+class TestGoalModeHandoffRejectionTool:
+    """Unit tests for tools.kanban_tools._goal_mode_handoff_rejection (#83610)."""
+
+    @staticmethod
+    def _task():
+        import types
+
+        return types.SimpleNamespace(
+            goal_mode=True,
+            title="Review handoff",
+            body="request independent review",
+        )
+
+    @pytest.mark.parametrize(
+        ("judge_return", "judge_side_effect", "expected"),
+        [
+            (
+                ("continue", "criteria not met", False, None, False),
+                None,
+                "criteria not met",
+            ),
+            (
+                ("continue", "judge error: ConnectError", False, None, True),
+                None,
+                None,
+            ),
+            (
+                ("skipped", "empty goal", False, None, False),
+                None,
+                None,
+            ),
+            (
+                ("done", "achieved", False, None, False),
+                None,
+                None,
+            ),
+            (
+                None,
+                RuntimeError("boom"),
+                None,
+            ),
+        ],
+        ids=[
+            "real_rejection",
+            "transport_failure",
+            "skipped",
+            "success",
+            "exception",
+        ],
+    )
+    def test_handoff_rejection_matrix(
+        self,
+        monkeypatch,
+        judge_return,
+        judge_side_effect,
+        expected,
+    ):
+        from tools import kanban_tools as kt
+
+        monkeypatch.setattr(kt, "_goal_judge_available", lambda: True)
+        if judge_side_effect is not None:
+            monkeypatch.setattr(
+                kt,
+                "judge_goal",
+                lambda **kw: (_ for _ in ()).throw(judge_side_effect),
+            )
+        else:
+            monkeypatch.setattr(kt, "judge_goal", lambda **kw: judge_return)
+
+        result = kt._goal_mode_handoff_rejection(self._task(), "implementation complete")
+        assert result == expected
+
+
 def test_block_happy_path(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_block({"reason": "need clarification"})
@@ -254,6 +327,74 @@ def _make_goal_mode_worker_env(monkeypatch, tmp_path):
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", goal_task_id)
     return goal_task_id
+
+
+def test_complete_goal_mode_fail_open_on_transport_failure(monkeypatch, tmp_path):
+    """Transient judge transport errors must not block kanban_complete (#83610)."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    tid = _make_goal_mode_worker_env(monkeypatch, tmp_path)
+
+    monkeypatch.setattr(kt, "_goal_judge_available", lambda: True)
+    monkeypatch.setattr(
+        kt,
+        "judge_goal",
+        lambda **kw: (
+            "continue",
+            "judge error: ConnectError",
+            False,
+            None,
+            True,
+        ),
+    )
+
+    out = json.loads(kt._handle_complete({"summary": "implementation complete"}))
+    assert out.get("ok") is True
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, tid).status == "done"
+    finally:
+        conn.close()
+
+
+def test_request_review_goal_mode_fail_open_on_transport_failure(monkeypatch, tmp_path):
+    """Transient judge transport errors must not block kanban_request_review (#83610)."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    tid = _make_goal_mode_worker_env(monkeypatch, tmp_path)
+    conn = kb.connect()
+    try:
+        run = kb.latest_run(conn, tid)
+        assert run is not None
+        monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run.id))
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(kt, "_goal_judge_available", lambda: True)
+    monkeypatch.setattr(
+        kt,
+        "judge_goal",
+        lambda **kw: (
+            "continue",
+            "judge error: ConnectError",
+            False,
+            None,
+            True,
+        ),
+    )
+
+    out = json.loads(kt._handle_request_review({"summary": "implementation complete"}))
+    assert out.get("ok") is True
+    assert out.get("status") == "review"
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, tid).status == "review"
+    finally:
+        conn.close()
 
 
 def test_block_goal_mode_rejects_missing_kind(monkeypatch, tmp_path):

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -244,7 +244,7 @@ class TestGoalModeHandoffRejectionTool:
             (
                 ("skipped", "empty goal", False, None, False),
                 None,
-                None,
+                "empty goal",
             ),
             (
                 ("done", "achieved", False, None, False),
@@ -252,9 +252,24 @@ class TestGoalModeHandoffRejectionTool:
                 None,
             ),
             (
+                ("done", "malformed response", True, None, False),
+                None,
+                "malformed response",
+            ),
+            (
+                ("done", "achieved", False, None, "false"),
+                None,
+                "judge error: ValueError",
+            ),
+            (
+                ("unknown", "unexpected verdict", False, None, False),
+                None,
+                "judge error: ValueError",
+            ),
+            (
                 None,
                 RuntimeError("boom"),
-                None,
+                "judge error: RuntimeError",
             ),
         ],
         ids=[
@@ -262,6 +277,9 @@ class TestGoalModeHandoffRejectionTool:
             "transport_failure",
             "skipped",
             "success",
+            "parse_failure",
+            "nonboolean_transport_flag",
+            "unknown_verdict",
             "exception",
         ],
     )

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -257,8 +257,9 @@ def _goal_mode_handoff_rejection(task, evidence: str) -> Optional[str]:
         return None
     verdict = "done"
     reason = ""
+    transport_failed = False
     try:
-        verdict, reason, _, _, _ = judge_goal(
+        verdict, reason, _, _, transport_failed = judge_goal(
             goal=f"{task.title}\n\n{task.body or ''}".strip(),
             last_response=evidence.strip(),
         )
@@ -270,6 +271,8 @@ def _goal_mode_handoff_rejection(task, evidence: str) -> Optional[str]:
             judge_exc,
             exc_info=True,
         )
+    if transport_failed or verdict == "skipped":
+        return None
     return reason if verdict != "done" else None
 
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -255,25 +255,38 @@ def _goal_mode_handoff_rejection(task, evidence: str) -> Optional[str]:
     """Return a rejection reason when a goal-mode terminal handoff is premature."""
     if not task or not task.goal_mode or not _goal_judge_available():
         return None
-    verdict = "done"
-    reason = ""
+    verdict = "continue"
+    reason = "goal judge failed without a classified transport error"
+    parse_failed = True
     transport_failed = False
     try:
-        verdict, reason, _, _, transport_failed = judge_goal(
+        verdict, reason, parse_failed, _, transport_failed = judge_goal(
             goal=f"{task.title}\n\n{task.body or ''}".strip(),
             last_response=evidence.strip(),
         )
+        if (
+            verdict not in {"done", "continue", "wait", "skipped"}
+            or not isinstance(reason, str)
+            or not isinstance(parse_failed, bool)
+            or not isinstance(transport_failed, bool)
+        ):
+            raise ValueError("invalid goal judge return contract")
     except Exception as judge_exc:
-        # Keep the existing fail-open semantics: an unavailable/broken
-        # auxiliary judge must not permanently wedge goal-mode work.
+        # Provider/network failures are classified by judge_goal via
+        # transport_failed=True. Unclassified exceptions and malformed return
+        # contracts are implementation failures, so they must not bypass the
+        # goal-mode acceptance gate.
         logger.warning(
-            "goal judge check failed, allowing lifecycle handoff: %s",
+            "goal judge check failed, rejecting lifecycle handoff: %s",
             judge_exc,
             exc_info=True,
         )
-    if transport_failed or verdict == "skipped":
+        return f"judge error: {type(judge_exc).__name__}"
+    if transport_failed is True:
         return None
-    return reason if verdict != "done" else None
+    if parse_failed or verdict != "done":
+        return reason or "goal judge response could not be validated"
+    return None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- fail open goal-mode completion and review handoffs when `judge_goal()` explicitly reports `transport_failed=True`
- keep genuine `continue`, `wait`, `skipped`, parse-failure, malformed-contract, and unclassified-exception paths fail closed
- apply the same behavior to both tool and CLI handoff surfaces, with completion and request-review regression coverage

Fixes #83610.

## Duplicate / scope decision

This PR **supersedes #83746 rather than stacking on it**. It includes #83746's commit with original authorship preserved, then addresses the automated review concerns on that PR:

1. `skipped` does not bypass the gate; only an explicit transport classification does.
2. malformed return contracts and uncaught implementation exceptions fail closed instead of silently disabling the gate.

#73119 is a much broader judge-gate redesign (shared module, rejection ceilings, config policy, dashboard overrides) and is currently stale against `main`. This PR is the focused, current-main salvage for the production 404 wedge without taking those additional policy changes.

The original local branch also carried delegated-child Kanban isolation. Current `main` already contains an equivalent, more comprehensive implementation and regression suite, so the rebase intentionally dropped those duplicate commits.

## Failure mode

Fireworks requires a wire model route such as `accounts/fireworks/models/kimi-k3`. The auxiliary judge received the normalized route `moonshotai/kimi-k3` and returned HTTP 404. `judge_goal()` correctly classified that as `transport_failed=True`, but both handoff gates discarded the fifth tuple element and treated the fallback `continue` verdict as a merit rejection.

## Test plan

- `scripts/run_tests.sh tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_goal_mode.py tests/hermes_cli/test_kanban_review_surfaces.py -q`
  - 65 passed
- broad suite reached 8,179 passing tests before an unrelated pre-existing timing assertion failed in `tests/agent/test_auxiliary_client.py::TestCodexAuxiliaryAdapterTimeout::test_enforces_total_timeout_while_stream_keeps_emitting_events` (0.156s observed vs 0.14s threshold); this branch does not modify that file or its implementation path.

## Risk controls

- transport bypass requires the literal boolean `True`; truthy strings are rejected
- verdict, reason, parse flag, and transport flag are type/enum validated
- parsed failures cannot claim a `done` verdict
- both completion and request-review surfaces are covered for CLI and tool paths
