### PR TITLE
fix(acp): honor configured agent.max_turns when building the session agent

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -647,8 +647,15 @@ class SessionManager:
         # Honor agent.max_turns like the CLI, gateway, and cron paths do.
         # load_config() already folds the legacy root-level ``max_turns`` into
         # ``agent.max_turns``; resolve_turn_limit() handles the unlimited
-        # spellings (none / unlimited / -1 / ...).  When the key is absent the
-        # AIAgent constructor default applies, so nothing is forwarded.
+        # spellings (none / unlimited / -1 / ...).
+        #
+        # The ``is not None`` guard is the load-bearing check, not the dict
+        # guard: load_config() starts from a DEFAULT_CONFIG deepcopy, so
+        # ``agent.max_turns`` is materialised on every load and carries the
+        # schema default (``None`` = unlimited) when the user never set it.
+        # Leaving it unforwarded in that case defers to the AIAgent
+        # constructor default rather than coupling ACP to whichever sentinel
+        # resolve_turn_limit(None) happens to return.
         agent_cfg = config.get("agent")
         configured_max_turns = agent_cfg.get("max_turns") if isinstance(agent_cfg, dict) else None
         if configured_max_turns is not None:

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -613,7 +613,7 @@ class SessionManager:
             return self._agent_factory()
 
         from run_agent import AIAgent
-        from hermes_cli.config import load_config
+        from hermes_cli.config import load_config, resolve_turn_limit
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
         config = load_config()
@@ -643,6 +643,16 @@ class SessionManager:
             "session_db": self._get_db(),
             "model": model or default_model,
         }
+
+        # Honor agent.max_turns like the CLI, gateway, and cron paths do.
+        # load_config() already folds the legacy root-level ``max_turns`` into
+        # ``agent.max_turns``; resolve_turn_limit() handles the unlimited
+        # spellings (none / unlimited / -1 / ...).  When the key is absent the
+        # AIAgent constructor default applies, so nothing is forwarded.
+        agent_cfg = config.get("agent")
+        configured_max_turns = agent_cfg.get("max_turns") if isinstance(agent_cfg, dict) else None
+        if configured_max_turns is not None:
+            kwargs["max_iterations"] = resolve_turn_limit(configured_max_turns)
 
         try:
             runtime = resolve_runtime_provider(requested=requested_provider or config_provider)

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -66,6 +66,63 @@ class TestCreateSession:
         assert fetched is state
 
 
+    @staticmethod
+    def _patch_make_agent_env(monkeypatch, config):
+        """Route _make_agent through a kwargs-capturing FakeAgent with *config*."""
+
+        class FakeAgent:
+            model = "fake-model"
+
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested=None: {
+                "provider": requested,
+                "api_mode": "chat_completions",
+                "base_url": "https://example.invalid",
+                "api_key": "test-key",
+            },
+        )
+        monkeypatch.setattr("acp_adapter.session._register_task_cwd", lambda task_id, cwd: None)
+
+    def test_make_agent_honors_configured_max_turns(self, monkeypatch):
+        self._patch_make_agent_env(monkeypatch, {
+            "model": {"default": "fake-model", "provider": "fake-provider"},
+            "agent": {"max_turns": 150},
+            "mcp_servers": {},
+        })
+
+        state = SessionManager(db=None).create_session(cwd="/tmp/project")
+
+        assert state.agent.kwargs["max_iterations"] == 150
+
+    def test_make_agent_resolves_unlimited_max_turns_spelling(self, monkeypatch):
+        import sys
+
+        self._patch_make_agent_env(monkeypatch, {
+            "model": {"default": "fake-model", "provider": "fake-provider"},
+            "agent": {"max_turns": "unlimited"},
+            "mcp_servers": {},
+        })
+
+        state = SessionManager(db=None).create_session(cwd="/tmp/project")
+
+        assert state.agent.kwargs["max_iterations"] == sys.maxsize
+
+    def test_make_agent_omits_max_iterations_when_max_turns_unset(self, monkeypatch):
+        self._patch_make_agent_env(monkeypatch, {
+            "model": {"default": "fake-model", "provider": "fake-provider"},
+            "mcp_servers": {},
+        })
+
+        state = SessionManager(db=None).create_session(cwd="/tmp/project")
+
+        assert "max_iterations" not in state.agent.kwargs
+
     def test_make_agent_stamps_session_cwd_for_codex_runtime(self, monkeypatch):
         class FakeAgent:
             model = "fake-model"

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -113,7 +113,29 @@ class TestCreateSession:
 
         assert state.agent.kwargs["max_iterations"] == sys.maxsize
 
-    def test_make_agent_omits_max_iterations_when_max_turns_unset(self, monkeypatch):
+    def test_make_agent_omits_max_iterations_for_default_config_payload(self, monkeypatch):
+        """The shape ``load_config()`` really returns when the user never set a cap.
+
+        ``load_config()`` starts from a ``DEFAULT_CONFIG`` deepcopy, so
+        ``agent.max_turns`` is materialised on every load and carries the schema
+        default instead of being absent.  This is the production invariant the
+        ``is not None`` guard in ``_make_agent`` exists for.
+        """
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["agent"]["max_turns"] is None
+
+        self._patch_make_agent_env(monkeypatch, {
+            "model": {"default": "fake-model", "provider": "fake-provider"},
+            "agent": {"max_turns": DEFAULT_CONFIG["agent"]["max_turns"]},
+            "mcp_servers": {},
+        })
+
+        state = SessionManager(db=None).create_session(cwd="/tmp/project")
+
+        assert "max_iterations" not in state.agent.kwargs
+
+    def test_make_agent_omits_max_iterations_when_agent_block_missing(self, monkeypatch):
         self._patch_make_agent_env(monkeypatch, {
             "model": {"default": "fake-model", "provider": "fake-provider"},
             "mcp_servers": {},


### PR DESCRIPTION
## What does this PR do?

`SessionManager._make_agent()` loads `config.yaml` but never forwards `agent.max_turns` to `AIAgent`, so ACP sessions always run with the constructor default no matter what cap the user configured. This resolves the value through `hermes_cli.config.resolve_turn_limit` (the same helper the CLI, gateway, and cron paths use, so `none` / `unlimited` / `-1` spellings behave identically) and forwards it as `max_iterations` when set. When the key is absent nothing is forwarded, preserving the existing `AIAgent` default.

Note on the issue text: on current `main` the `AIAgent` default is `sys.maxsize`, not 90, so the observable symptom today is that a configured cap is silently ignored and ACP runs unlimited. The omission and the fix are the same either way.

Supersedes #70592, which addresses the same omission but is a month old and in a conflicting state.

## Related Issue

Fixes #94271

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `acp_adapter/session.py`: read `agent.max_turns` from the already-loaded config, normalize via `resolve_turn_limit`, pass as `max_iterations`.
- `tests/acp/test_session.py`: regression tests for a numeric cap, an unlimited spelling, and the unset case (kwarg omitted). The first two fail on `main` and pass with this change.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the ACP suite (`tests/acp`, 139 passed) and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] Documentation: N/A (no new config keys; existing `agent.max_turns` now applies to ACP)
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact: N/A (pure config plumbing)
- [x] Tool descriptions/schemas: N/A
