### PR TITLE
fix(telegram): retry control sends (approval/clarify) after flood-control, with per-prompt-type caps

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6144,7 +6144,41 @@ class TelegramAdapter(BasePlatformAdapter):
 
         return SendResult(success=False, error="draft_rejected")
 
+    # Control sends (approval/clarify prompts) block an agent that waits up
+    # to the approval timeout (120s), so unlike streaming edits — which bail
+    # after 5s and fall back — they are worth holding through a flood
+    # cooldown.  Telegram's RetryAfter hint during a busy stream is commonly
+    # 15–80s; the cap keeps a pathological hint from pinning the send task
+    # past the approval window entirely.
+    _CONTROL_FLOOD_RETRY_CAP = 90.0
+
     async def _send_message_with_thread_fallback(self, **kwargs):
+        """Send a control-style Telegram message with flood-control retry.
+
+        Flood control: if the send fails with RetryAfter and the hinted wait
+        fits under ``_CONTROL_FLOOD_RETRY_CAP``, sleep it out and retry once.
+        Without this, an approval/clarify prompt raised mid-stream (exactly
+        when flood control bites, because the agent has been spamming
+        progress edits) is silently lost and the approval times out as
+        "user did not consent" even though the user never saw it.
+        """
+        try:
+            return await self._send_control_message(**kwargs)
+        except Exception as e:
+            retry_after = getattr(e, "retry_after", None)
+            if retry_after is None and "retry after" not in str(e).lower():
+                raise
+            wait = float(retry_after or 3.0)
+            if wait > self._CONTROL_FLOOD_RETRY_CAP:
+                raise
+            logger.warning(
+                "[%s] Flood control on control send; retrying in %.1fs",
+                self.name, wait,
+            )
+            await asyncio.sleep(wait + 0.5)
+            return await self._send_control_message(**kwargs)
+
+    async def _send_control_message(self, **kwargs):
         """Send a Telegram message, retrying once without message_thread_id
         if Telegram returns 'Message thread not found'.
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6148,35 +6148,47 @@ class TelegramAdapter(BasePlatformAdapter):
     # to the approval timeout (120s), so unlike streaming edits — which bail
     # after 5s and fall back — they are worth holding through a flood
     # cooldown.  Telegram's RetryAfter hint during a busy stream is commonly
-    # 15–80s; the cap keeps a pathological hint from pinning the send task
-    # past the approval window entirely.
+    # 15–80s in a normal chat — but a heavily-streamed DM accumulates
+    # penalties of 100–265s (observed 2026-08-20). The cap must match the
+    # prompt's own wait window: exec approvals time out at 120s so waiting
+    # longer than ~90s is pointless, while a clarify waits on the human for
+    # hours and should sleep out even a multi-minute penalty.
     _CONTROL_FLOOD_RETRY_CAP = 90.0
+    _CLARIFY_FLOOD_RETRY_CAP = 600.0
 
-    async def _send_message_with_thread_fallback(self, **kwargs):
+    async def _send_message_with_thread_fallback(
+        self, _flood_retry_cap: float = None, **kwargs
+    ):
         """Send a control-style Telegram message with flood-control retry.
 
         Flood control: if the send fails with RetryAfter and the hinted wait
-        fits under ``_CONTROL_FLOOD_RETRY_CAP``, sleep it out and retry once.
-        Without this, an approval/clarify prompt raised mid-stream (exactly
-        when flood control bites, because the agent has been spamming
-        progress edits) is silently lost and the approval times out as
-        "user did not consent" even though the user never saw it.
+        fits under the cap (default ``_CONTROL_FLOOD_RETRY_CAP``; callers
+        with longer wait windows pass ``_flood_retry_cap``), sleep it out
+        and retry — up to twice, staying under the cap in total. Without
+        this, an approval/clarify prompt raised mid-stream (exactly when
+        flood control bites, because the agent has been spamming progress
+        edits) is silently lost and the approval times out as "user did not
+        consent" even though the user never saw it.
         """
-        try:
-            return await self._send_control_message(**kwargs)
-        except Exception as e:
-            retry_after = getattr(e, "retry_after", None)
-            if retry_after is None and "retry after" not in str(e).lower():
-                raise
-            wait = float(retry_after or 3.0)
-            if wait > self._CONTROL_FLOOD_RETRY_CAP:
-                raise
-            logger.warning(
-                "[%s] Flood control on control send; retrying in %.1fs",
-                self.name, wait,
-            )
-            await asyncio.sleep(wait + 0.5)
-            return await self._send_control_message(**kwargs)
+        cap = self._CONTROL_FLOOD_RETRY_CAP if _flood_retry_cap is None else _flood_retry_cap
+        slept = 0.0
+        for attempt in range(3):
+            try:
+                return await self._send_control_message(**kwargs)
+            except Exception as e:
+                retry_after = getattr(e, "retry_after", None)
+                if retry_after is None and "retry after" not in str(e).lower():
+                    raise
+                wait = float(retry_after or 3.0)
+                if attempt == 2 or slept + wait > cap:
+                    raise
+                logger.warning(
+                    "[%s] Flood control on control send; retrying in %.1fs "
+                    "(attempt %d, cap %.0fs)",
+                    self.name, wait, attempt + 1, cap,
+                )
+                await asyncio.sleep(wait + 0.5)
+                slept += wait + 0.5
 
     async def _send_control_message(self, **kwargs):
         """Send a Telegram message, retrying once without message_thread_id
@@ -6469,7 +6481,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             )
 
-            msg = await self._send_message_with_thread_fallback(**kwargs)
+            msg = await self._send_message_with_thread_fallback(
+                _flood_retry_cap=self._CLARIFY_FLOOD_RETRY_CAP, **kwargs
+            )
             self._clarify_state[clarify_id] = session_key
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:

--- a/tests/gateway/test_telegram_control_flood_retry.py
+++ b/tests/gateway/test_telegram_control_flood_retry.py
@@ -1,0 +1,88 @@
+"""Control sends (approval/clarify prompts) must survive Telegram flood control.
+
+Regression for the 2026-08-16 failure: an exec-approval prompt raised while
+the agent was streaming progress edits hit "Flood control exceeded. Retry in
+16 seconds", was never retried, and the approval timed out as "user did not
+consent" even though the user never saw the prompt.  The fix retries the
+control send once after Telegram's RetryAfter hint (capped at
+_CONTROL_FLOOD_RETRY_CAP).
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+from tests.gateway.test_telegram_approval_buttons import (  # noqa: E402
+    _ensure_telegram_mock,
+)
+
+_ensure_telegram_mock()
+
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+from gateway.config import PlatformConfig  # noqa: E402
+
+
+class _FloodError(Exception):
+    """Mimics telegram.error.RetryAfter: has .retry_after."""
+
+    def __init__(self, retry_after):
+        super().__init__(f"Flood control exceeded. Retry in {retry_after} seconds")
+        self.retry_after = retry_after
+
+
+def _make_adapter():
+    config = PlatformConfig(enabled=True, token="test-token", extra={})
+    adapter = TelegramAdapter(config)
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_control_send_retries_after_flood_hint():
+    adapter = _make_adapter()
+    ok = MagicMock(message_id=42)
+    adapter._bot.send_message = AsyncMock(side_effect=[_FloodError(2), ok])
+
+    with patch("asyncio.sleep", new=AsyncMock()) as slept:
+        msg = await adapter._send_message_with_thread_fallback(
+            chat_id="123", text="approve?"
+        )
+
+    assert msg is ok
+    assert adapter._bot.send_message.call_count == 2
+    # slept the hinted wait (+jitter), not a made-up constant
+    assert slept.await_args.args[0] == pytest.approx(2.5)
+
+
+@pytest.mark.asyncio
+async def test_control_send_gives_up_past_cap():
+    adapter = _make_adapter()
+    adapter._bot.send_message = AsyncMock(
+        side_effect=_FloodError(TelegramAdapter._CONTROL_FLOOD_RETRY_CAP + 10)
+    )
+
+    with pytest.raises(_FloodError):
+        await adapter._send_message_with_thread_fallback(
+            chat_id="123", text="approve?"
+        )
+    # no retry: hint exceeds the cap, caller's text fallback should proceed
+    assert adapter._bot.send_message.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_control_send_non_flood_errors_pass_through():
+    adapter = _make_adapter()
+    adapter._bot.send_message = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with pytest.raises(RuntimeError):
+        await adapter._send_message_with_thread_fallback(
+            chat_id="123", text="approve?"
+        )
+    assert adapter._bot.send_message.call_count == 1

--- a/tests/gateway/test_telegram_control_flood_retry.py
+++ b/tests/gateway/test_telegram_control_flood_retry.py
@@ -18,11 +18,7 @@ _repo = str(Path(__file__).resolve().parents[2])
 if _repo not in sys.path:
     sys.path.insert(0, _repo)
 
-from tests.gateway.test_telegram_approval_buttons import (  # noqa: E402
-    _ensure_telegram_mock,
-)
-
-_ensure_telegram_mock()
+# telegram mock is installed by tests/gateway/conftest.py at import time
 
 from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
 from gateway.config import PlatformConfig  # noqa: E402
@@ -86,3 +82,50 @@ async def test_control_send_non_flood_errors_pass_through():
             chat_id="123", text="approve?"
         )
     assert adapter._bot.send_message.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_clarify_cap_rides_out_long_penalty():
+    """A 115s hint (2026-08-20 incident) exceeds the approval cap but must
+    be retried under the clarify cap."""
+    adapter = _make_adapter()
+    ok = MagicMock(message_id=7)
+    adapter._bot.send_message = AsyncMock(side_effect=[_FloodError(115), ok])
+
+    with patch("asyncio.sleep", new=AsyncMock()):
+        msg = await adapter._send_message_with_thread_fallback(
+            _flood_retry_cap=TelegramAdapter._CLARIFY_FLOOD_RETRY_CAP,
+            chat_id="123", text="which option?",
+        )
+    assert msg is ok
+    assert adapter._bot.send_message.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_double_flood_within_cap_retries_twice():
+    adapter = _make_adapter()
+    ok = MagicMock(message_id=8)
+    adapter._bot.send_message = AsyncMock(
+        side_effect=[_FloodError(100), _FloodError(120), ok]
+    )
+    with patch("asyncio.sleep", new=AsyncMock()):
+        msg = await adapter._send_message_with_thread_fallback(
+            _flood_retry_cap=600.0, chat_id="123", text="q",
+        )
+    assert msg is ok
+    assert adapter._bot.send_message.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_cumulative_waits_respect_cap():
+    adapter = _make_adapter()
+    adapter._bot.send_message = AsyncMock(
+        side_effect=[_FloodError(300), _FloodError(350), MagicMock()]
+    )
+    with patch("asyncio.sleep", new=AsyncMock()):
+        with pytest.raises(_FloodError):
+            await adapter._send_message_with_thread_fallback(
+                _flood_retry_cap=600.0, chat_id="123", text="q",
+            )
+    # first wait (300) fits; second (300+350) would exceed 600 -> raise
+    assert adapter._bot.send_message.call_count == 2


### PR DESCRIPTION
## Problem

An approval or clarify prompt raised mid-stream — exactly when Telegram flood control bites, because the agent has been streaming progress edits — is sent once, fails with `Flood control exceeded. Retry in Ns`, and is silently lost. The waiting approval then times out as "user did not consent" even though the user never saw a prompt.

Observed in production: three lost clarify prompts and one lost exec-approval over two days; per-chat flood penalties in a heavily-streamed DM reached 115–265s.

## Fix

- Control-style sends (exec-approval, clarify, slash-confirm, model-picker, update prompts) retry through the shared `_send_message_with_thread_fallback` path: sleep out Telegram's RetryAfter hint and retry, up to twice, cumulative wait bounded by a cap.
- The cap is per prompt type: approvals keep a tight 90s (their wait window is 120s — waiting longer is pointless), while clarify prompts get 600s (they wait on the human for hours; a multi-minute penalty should delay the buttons, not kill them).

## Testing

`tests/gateway/test_telegram_control_flood_retry.py` — 6 cases: hinted-wait retry, cap refusal + text-fallback path, non-flood passthrough, long-penalty clarify retry, double-flood within cap, cumulative-cap enforcement. All pass on current main; the telegram mock comes from `tests/gateway/conftest.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrB5MqBqW1DiBzcJdnYPcJ