### PR TITLE
fix(gateway): withhold compaction-handoff echoes + refuse auto-attaching harness files

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5081,6 +5081,29 @@ class BasePlatformAdapter(ABC):
         return cleaned.rstrip()
 
     @staticmethod
+    def _is_protected_local_file(expanded: str) -> bool:
+        """Never auto-attach these by bare-path mention (exfil guard).
+
+        A reply that merely *names* one of these paths must not ship the file
+        to a chat surface: harness state (config, credentials, memory and
+        identity files) can appear in echoed scaffolding — the 2026-08-19
+        incident attached 6 internal .md files because a compaction-handoff
+        echo contained their paths.  Deliberate delivery of harness files
+        stays possible via explicit send/upload tools; only the implicit
+        bare-path route is closed.
+        """
+        p = os.path.abspath(os.path.expanduser(expanded))
+        home = os.path.expanduser("~")
+        for root in (os.path.join(home, ".hermes"), "/root/.hermes"):
+            if p == root or p.startswith(root + os.sep):
+                return True
+        protected_names = {
+            "AGENTS.md", "SOUL.md", "MEMORY.md", "USER.md", "IDENTITY.md",
+            "HEARTBEAT.md", "TOOLS.md", "config.yaml", "auth.json", ".env",
+        }
+        return os.path.basename(p) in protected_names
+
+    @staticmethod
     def extract_local_files(content: str) -> Tuple[List[str], str]:
         """
         Detect bare local file paths in response text for native delivery.
@@ -5134,6 +5157,12 @@ class BasePlatformAdapter(ABC):
             raw = match.group(0)
             expanded = os.path.expanduser(raw)
             if os.path.isfile(expanded):
+                if BasePlatformAdapter._is_protected_local_file(expanded):
+                    logger.warning(
+                        "Refusing to auto-attach protected file mentioned in "
+                        "reply: %s", _log_safe_path(raw),
+                    )
+                    continue
                 found.append((raw, expanded))
             else:
                 # The reply mentions a deliverable-looking path that does not

--- a/gateway/response_filters.py
+++ b/gateway/response_filters.py
@@ -145,3 +145,33 @@ def is_partial_silence_marker(text: Any) -> bool:
         if candidate and any(marker.startswith(candidate) for marker in LIVE_GATEWAY_SILENT_MARKERS):
             return True
     return False
+
+
+# ---------------------------------------------------------------------------
+# Leaked-scaffolding guard
+# ---------------------------------------------------------------------------
+
+# Prefix stamped on compaction handoff summaries by agent/context_compressor.py.
+# Small local models can echo the injected handoff block verbatim as their
+# visible reply on the first turn after an auto-compaction; that block embeds
+# excerpts of memory/identity files and must never reach a chat surface
+# (2026-08-19 incident: 5.9k-char handoff echo delivered to Telegram, and the
+# bare file paths inside it triggered native attachment of 6 internal files).
+COMPACTION_HANDOFF_MARKER = "[CONTEXT COMPACTION"
+
+
+def is_leaked_scaffolding_response(response: Any) -> bool:
+    """True when a response is (or leads with) an echoed compaction handoff.
+
+    An echo reproduces the handoff header as its own line at the head of the
+    reply; prose that merely *discusses* compaction mentions the marker
+    mid-sentence (often in backticks) and must be delivered.  So: flag only
+    when one of the first few lines starts with the marker (allowing quote/
+    heading decoration).
+    """
+    if not isinstance(response, str):
+        return False
+    for line in response.lstrip().split("\n", 5)[:5]:
+        if line.lstrip().lstrip(">*# ").startswith(COMPACTION_HANDOFF_MARKER):
+            return True
+    return False

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20473,6 +20473,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "results. This can happen with some models — try again or "
                     "rephrase your question."
                 )
+
+            # Post-compaction scaffolding echo: the model reproduced the
+            # injected compaction handoff as its visible reply (it embeds
+            # memory-file excerpts, and bare paths inside it can trigger
+            # native file attachment — 2026-08-19 incident). Withhold it
+            # from the channel; the turn itself is preserved in history.
+            try:
+                from gateway.response_filters import is_leaked_scaffolding_response
+                if is_leaked_scaffolding_response(response):
+                    logger.warning(
+                        "Withholding leaked compaction-handoff echo from delivery "
+                        "(%d chars)", len(response),
+                    )
+                    response = (
+                        "⚠️ Response withheld: the model echoed internal context "
+                        "scaffolding after a compaction. Nothing was lost — "
+                        "just ask again."
+                    )
+            except Exception:
+                pass
             agent_messages = agent_result.get("messages", [])
             _response_time = time.time() - _msg_start_time
             _api_calls = agent_result.get("api_calls", 0)

--- a/tests/gateway/test_scaffolding_leak_guards.py
+++ b/tests/gateway/test_scaffolding_leak_guards.py
@@ -1,0 +1,84 @@
+"""Guards against the 2026-08-19 compaction-echo leak.
+
+Two independent layers, tested separately:
+1. is_leaked_scaffolding_response — withholds a reply that reproduces the
+   injected compaction handoff block.
+2. extract_local_files — refuses to auto-attach harness-internal files whose
+   bare paths appear in reply text (the echoed handoff mentioned 6 of them).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+from gateway.response_filters import is_leaked_scaffolding_response  # noqa: E402
+
+
+HANDOFF = (
+    "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted "
+    "into the summary below. This is a handoff from a previous context window."
+)
+
+
+class TestLeakedScaffoldingFilter:
+    def test_verbatim_echo_is_flagged(self):
+        assert is_leaked_scaffolding_response(HANDOFF)
+
+    def test_echo_after_preamble_line_is_flagged(self):
+        assert is_leaked_scaffolding_response("Here's where we are:\n" + HANDOFF)
+
+    def test_quoted_echo_is_flagged(self):
+        assert is_leaked_scaffolding_response("> " + HANDOFF)
+
+    def test_discussion_of_marker_is_delivered(self):
+        prose = (
+            "Compaction ran at 20:41; the summary is stamped with the "
+            "`[CONTEXT COMPACTION` header by context_compressor.py — that's "
+            "internal and shouldn't be delivered."
+        )
+        assert not is_leaked_scaffolding_response(prose)
+
+    def test_marker_deep_in_reply_is_delivered(self):
+        prose = "line\n" * 10 + HANDOFF
+        assert not is_leaked_scaffolding_response(prose)
+
+    def test_non_strings_pass(self):
+        assert not is_leaked_scaffolding_response(None)
+        assert not is_leaked_scaffolding_response(42)
+        assert not is_leaked_scaffolding_response("")
+
+
+class TestProtectedFileAttachment:
+    def _extract(self, content):
+        from gateway.platforms.base import BasePlatformAdapter
+        return BasePlatformAdapter.extract_local_files(content)
+
+    def test_hermes_dir_file_not_attached(self, tmp_path, monkeypatch):
+        import os
+        from gateway.platforms import base as base_mod
+        fake_home = tmp_path
+        hermes = fake_home / ".hermes"
+        hermes.mkdir()
+        f = hermes / "notes.md"
+        f.write_text("internal")
+        monkeypatch.setenv("HOME", str(fake_home))
+        files, _ = self._extract(f"see {f} for details")
+        assert files == []
+
+    def test_identity_files_not_attached_anywhere(self, tmp_path):
+        f = tmp_path / "AGENTS.md"
+        f.write_text("rules")
+        files, _ = self._extract(f"the rules live at {f}")
+        assert files == []
+
+    def test_ordinary_artifact_still_attached(self, tmp_path):
+        f = tmp_path / "report.md"
+        f.write_text("# report")
+        files, cleaned = self._extract(f"wrote the report to {f}")
+        assert files == [str(f)]
+        assert str(f) not in cleaned


### PR DESCRIPTION
## Problem

On the first turn after an auto-compaction, a small local model can echo the injected `[CONTEXT COMPACTION — REFERENCE ONLY]` handoff block verbatim as its visible reply. That block embeds excerpts of memory/identity files — and worse, `extract_local_files()` then treats bare paths inside the echoed text as deliverables and natively attaches the actual files to the chat.

Observed in production (Qwen3.8-27B on Telegram): a 5.9k-char handoff echo was delivered, and 6 internal harness `.md` files were auto-attached because their paths appeared in it. In a private DM this is embarrassing; in a group chat it is a disclosure.

## Fix — two independent guards

1. `is_leaked_scaffolding_response()` (gateway/response_filters.py): the delivery path withholds any reply whose head lines reproduce the handoff header (line-start match, so prose *discussing* the marker still delivers). The user gets a short "response withheld — just ask again" notice instead of the dump.
2. `_is_protected_local_file()` (gateway/platforms/base.py): bare-path auto-attachment refuses `~/.hermes/**` and identity/config basenames (AGENTS.md, SOUL.md, MEMORY.md, USER.md, config.yaml, auth.json, .env, …) everywhere. Explicit send/upload tools remain the deliberate route for harness files.

## Testing

`tests/gateway/test_scaffolding_leak_guards.py` — 9 cases covering verbatim/quoted/preamble echoes, discussion-not-echo delivery, protected-dir and identity-basename refusal, and ordinary artifacts still attaching. All pass on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrB5MqBqW1DiBzcJdnYPcJ