### PR TITLE
fix(matrix): honor NO_PROXY for the homeserver host when resolving proxy

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1320,7 +1320,18 @@ class MatrixAdapter(BasePlatformAdapter):
         self._reaction_redaction_tasks: Set[asyncio.Task] = set()
 
         # Proxy support — resolve once at init, reuse for all HTTP traffic.
-        self._proxy_url: str | None = resolve_proxy_url(platform_env_var="MATRIX_PROXY")
+        # Pass the homeserver host so NO_PROXY is honored: a local/tailnet
+        # homeserver (e.g. http://127.0.0.1:6167 with 127.0.0.1 in NO_PROXY)
+        # must not be force-proxied through HTTPS_PROXY — that sends every
+        # Matrix request to a proxy with no route to the homeserver and
+        # connect fails with the proxy's error page (observed 2026-08-20:
+        # whoami -> 500 XML from the upstream proxy).
+        from urllib.parse import urlparse as _urlparse
+        _hs_host = _urlparse(self._homeserver).hostname if self._homeserver else None
+        self._proxy_url: str | None = resolve_proxy_url(
+            platform_env_var="MATRIX_PROXY",
+            target_hosts=_hs_host,
+        )
         if self._proxy_url:
             logger.info("Matrix: proxy configured — %s", self._proxy_url)
         try:


### PR DESCRIPTION
## Problem

`resolve_proxy_url(platform_env_var="MATRIX_PROXY")` is called without `target_hosts`, so the NO_PROXY bypass never evaluates. A local or tailnet homeserver (e.g. `http://127.0.0.1:6167` with `127.0.0.1` listed in NO_PROXY) still has all Matrix traffic force-routed through HTTPS_PROXY — whoami comes back as the upstream proxy's error page and connect fails with a confusing `MatrixUnknownRequestError: 500`.

Observed in production: gateway behind a corporate-style HTTP proxy, Conduit homeserver on localhost, NO_PROXY correctly listing `localhost,127.0.0.1` — matrix adapter unable to connect until this patch.

## Fix

Pass the homeserver hostname as `target_hosts` so `should_bypass_proxy()` gets its chance. One call site, no behavior change for setups without NO_PROXY entries.

## Testing

Existing matrix adapter tests pass on current main. Verified live: same config fails before, connects clean after (token auth, initial sync, message round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrB5MqBqW1DiBzcJdnYPcJ