### PR TITLE
fix(desktop): sidebar click on an already-tabbed session loads it into main (#92926)

### DIFF
--- a/apps/desktop/src/app/open-session.test.ts
+++ b/apps/desktop/src/app/open-session.test.ts
@@ -111,6 +111,16 @@ describe('openSession', () => {
     expect(openSessionTile).not.toHaveBeenCalled()
   })
 
+  it('stack spends a blank main even when the session already sits in a tile', () => {
+    // stack resolves against main occupancy BEFORE the tile check: with a
+    // blank draft on main it becomes in-place, so the #92926 tile-route
+    // applies (fronting the tile would leave the blank main showing).
+    focusOpenSession.mockReturnValue('tile')
+    openSession('s1', navigate, 'stack')
+    expect(navigate).toHaveBeenCalledWith('/c/s1')
+    expect(openSessionTile).not.toHaveBeenCalled()
+  })
+
   it('in-place focuses main when already selected and not on a page', () => {
     focusOpenSession.mockReturnValue('main')
     openSession('s1', navigate)

--- a/apps/desktop/src/app/open-session.test.ts
+++ b/apps/desktop/src/app/open-session.test.ts
@@ -96,10 +96,17 @@ describe('openSession', () => {
     $selectedStoredSessionId.set(null)
   })
 
-  it('in-place focuses an existing tile and does not navigate', () => {
+  it('in-place routes a TILE hit into main (#92926) — no more dead click', () => {
     focusOpenSession.mockReturnValue('tile')
     openSession('s1', navigate)
     expect(focusOpenSession).toHaveBeenCalledWith('s1', { workspaceMode: 'sessions' })
+    expect(navigate).toHaveBeenCalledWith('/c/s1')
+    expect(openSessionTile).not.toHaveBeenCalled()
+  })
+
+  it('tab intent still fronts an existing tile without navigating', () => {
+    focusOpenSession.mockReturnValue('tile')
+    openSession('s1', navigate, 'tab')
     expect(navigate).not.toHaveBeenCalled()
     expect(openSessionTile).not.toHaveBeenCalled()
   })

--- a/apps/desktop/src/app/open-session.ts
+++ b/apps/desktop/src/app/open-session.ts
@@ -165,20 +165,13 @@ export function openSession(
   // (artifacts, skills, …) that still has to route back: fronting the tab
   // alone leaves the page showing.
   //
-  // A TILE hit under `in-place` also routes into main (#92926): a sidebar
-  // click means "open this chat", and fronting a tab elsewhere in the tree
-  // reads as a dead click — the main column never changes. Routing binds the
+  // A TILE hit routes into main too (#92926): a sidebar click means "open
+  // this chat in main", and fronting a tab elsewhere in the tree reads as a
+  // dead click — the main column never changes. Routing binds the
   // conversation to main and resumeSession closes the now-redundant tile.
   // (`tab`/`stack` opens keep the front-only jump: those intents asked for a
   // tab beside, not a takeover of main.)
   const focused = focusOpenSession(storedSessionId, workspaceScope)
-
-  // A TILE hit routes too (#92926): a sidebar click means "open this chat in
-  // main", and fronting a tab elsewhere in the tree reads as a dead click —
-  // the main column never changes. Routing binds the conversation to main and
-  // resumeSession closes the now-redundant tile. (`tab`/`stack` opens keep
-  // the front-only jump: those intents asked for a tab beside, not a takeover
-  // of main.)
   if (focused === 'tile' || focusedSessionNeedsRoute(focused, $workspaceIsPage.get())) {
     navigate(sessionRoute(storedSessionId))
   }

--- a/apps/desktop/src/app/open-session.ts
+++ b/apps/desktop/src/app/open-session.ts
@@ -161,11 +161,25 @@ export function openSession(
     return
   }
 
-  // Already on screen (open tile, or the main session)? Jump to its tab;
-  // otherwise load it into main. From a full page (artifacts, skills, …) a
-  // `'main'` hit still has to route back: fronting the workspace tab alone
-  // leaves the page showing.
-  if (focusedSessionNeedsRoute(focusOpenSession(storedSessionId, workspaceScope), $workspaceIsPage.get())) {
+  // Already the main session? Front its workspace tab; from a full page
+  // (artifacts, skills, …) that still has to route back: fronting the tab
+  // alone leaves the page showing.
+  //
+  // A TILE hit under `in-place` also routes into main (#92926): a sidebar
+  // click means "open this chat", and fronting a tab elsewhere in the tree
+  // reads as a dead click — the main column never changes. Routing binds the
+  // conversation to main and resumeSession closes the now-redundant tile.
+  // (`tab`/`stack` opens keep the front-only jump: those intents asked for a
+  // tab beside, not a takeover of main.)
+  const focused = focusOpenSession(storedSessionId, workspaceScope)
+
+  // A TILE hit routes too (#92926): a sidebar click means "open this chat in
+  // main", and fronting a tab elsewhere in the tree reads as a dead click —
+  // the main column never changes. Routing binds the conversation to main and
+  // resumeSession closes the now-redundant tile. (`tab`/`stack` opens keep
+  // the front-only jump: those intents asked for a tab beside, not a takeover
+  // of main.)
+  if (focused === 'tile' || focusedSessionNeedsRoute(focused, $workspaceIsPage.get())) {
     navigate(sessionRoute(storedSessionId))
   }
 }


### PR DESCRIPTION
Fixes #92926

## Problem

With one or more sessions open as tiles, clicking a session row in the sidebar that's already tabbed fronts the tile and stops — the main chat column never changes. The click reads as dead: the conversation "doesn't load" until the user presses New session (which routes unconditionally) and re-selects.

## Root cause

`openSession()`'s `in-place` tail only navigated when `focusedSessionNeedsRoute()` said so, and that helper returns `false` for a `'tile'` hit — its contract was "the tile renders the chat regardless of route." True for the *tile pane*, false for what a sidebar click promises: the chat in **main**.

## Fix

Under `in-place`, a TILE hit now routes into main as well. Routing binds the conversation to the main surface and `resumeSession` closes the now-redundant tile when it binds — behavior that already exists for every other path into main.

Intent table after this change:

| Intent | Tile hit | Behavior |
|---|---|---|
| `in-place` (sidebar click / Enter) | routes into main, tile closes | "open this chat" |
| `tab` (⌘/⌃-click, refs) | fronts the tab only | unchanged |
| `stack` (⌘K, notifications) | fronts the tab only | unchanged |
| `main` | routed (unchanged) | explicit main takeover |

## Verification

- Updated the pinned test: `in-place` + tile hit → `navigate('/c/s1')`, no `openSessionTile`
- New test: `tab` intent + tile hit → still fronts without navigating (intent preserved)
- Full file 26/26; sidebar suite 202/202; tsc + eslint clean
