### PR TITLE
fix(update): defer interactive CUA installs on Windows

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1006,7 +1006,9 @@ def install_cua_driver(
     ``_CUA_INSTALLER_TIMEOUT`` and install.ps1's concurrency lock can add
     a further ~600s wait on Windows). ``hermes computer-use install
     --upgrade`` leaves it False — an explicit upgrade request should still
-    reinstall when the check is indeterminate.
+    reinstall when the check is indeterminate. On Windows this flag also
+    prevents every installer run, because install.ps1 may require console or
+    UAC consent; automatic updates instead point at the explicit command.
 
     ``show_installer_progress`` controls the installer's own progress line.
     ``hermes update`` already prints a contextual line before its update
@@ -1124,6 +1126,16 @@ def install_cua_driver(
                 "the override and run: hermes computer-use install --upgrade"
             )
             return False
+        if is_windows and require_confirmed_update:
+            _print_info(
+                "    Automatic Windows updates cannot safely run cua-driver's "
+                "interactive repair installer."
+            )
+            _print_info(
+                "    Repair it from an interactive terminal with: "
+                "hermes computer-use install --upgrade"
+            )
+            return False
         _print_info("    Repairing it with the current upstream installer.")
 
     # upgrade=True path — refresh to the latest upstream release.
@@ -1178,6 +1190,18 @@ def install_cua_driver(
             )
             return True
         if _state is not None and _state.get("update_available"):
+            if is_windows and require_confirmed_update:
+                _latest = _state.get("latest_version") or "a newer version"
+                _print_info(
+                    f"    {driver_cmd} {_latest} is available; keeping the "
+                    "installed version because its Windows installer may "
+                    "require interactive consent."
+                )
+                _print_info(
+                    "    Update it from an interactive terminal with: "
+                    "hermes computer-use install --upgrade"
+                )
+                return True
             # Pin the installer to the release check-update just confirmed.
             # `latest_version` comes from the GitHub Releases API, so its
             # assets are published — unlike the installer script's baked

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -7409,7 +7409,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 # An indeterminate check (offline, rate-limited, old
                 # driver) keeps the installed version — `hermes update`
                 # must stay fast; `hermes computer-use install --upgrade`
-                # remains the force path.
+                # remains the force path. Windows also defers confirmed
+                # updates and contract repairs to that explicit command
+                # because the upstream installer may prompt for console/UAC
+                # consent that this hidden updater cannot provide.
                 install_cua_driver(
                     upgrade=True,
                     require_confirmed_update=True,

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -6,8 +6,9 @@ must:
 
 * Be supported-platform-only — no-op silently elsewhere so ``hermes update``
   can call it unconditionally without warning unsupported-platform users.
-* Re-run the installer even when the binary is already on PATH (this is the
-  fix for the "we only pulled cua-driver once on enable" complaint).
+* Re-run the installer for explicit upgrades even when the binary is already
+  on PATH (this is the fix for the "we only pulled cua-driver once on enable"
+  complaint). Automatic Windows updates defer because the installer can prompt.
 * For ``upgrade=False``, keep compatible installations, repair old or
   incomplete installations, and install when missing.
 
@@ -439,7 +440,7 @@ class TestRequireConfirmedUpdate:
     still reinstall when the check can't answer.
     """
 
-    def _install(self, check_state, require_confirmed):
+    def _install(self, check_state, require_confirmed, contract_status=None):
         """Drive ``install_cua_driver`` on the host, whatever it is.
 
         The old signature took a ``system`` string and faked
@@ -463,7 +464,11 @@ class TestRequireConfirmedUpdate:
              patch.object(
                  tools_config,
                  "_cua_driver_contract_status",
-                 return_value={"ready": True, "version": "0.20.0", "reason": ""},
+                 return_value=contract_status or {
+                     "ready": True,
+                     "version": "0.20.0",
+                     "reason": "",
+                 },
              ), \
              patch("tools.computer_use.cua_backend.cua_driver_update_check",
                    return_value=check_state), \
@@ -497,12 +502,49 @@ class TestRequireConfirmedUpdate:
             for call in info.call_args_list
         )
 
-    def test_confirmed_update_still_runs_installer(self):
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="automatic Windows updates must not launch an interactive installer",
+    )
+    def test_confirmed_update_still_runs_installer_on_posix(self):
         state = {"current_version": "0.5.0", "latest_version": "0.6.0",
                  "update_available": True}
         ok, runner, _ = self._install(state, require_confirmed=True)
         assert ok is True
         runner.assert_called_once()
+
+    @pytest.mark.windows_only
+    def test_windows_confirmed_update_defers_interactive_installer(self):
+        state = {"current_version": "0.5.0", "latest_version": "0.6.0",
+                 "update_available": True}
+        ok, runner, info = self._install(state, require_confirmed=True)
+
+        assert ok is True
+        runner.assert_not_called()
+        assert any(
+            "computer-use install --upgrade" in call.args[0]
+            for call in info.call_args_list
+        )
+
+    @pytest.mark.windows_only
+    def test_windows_incompatible_driver_defers_interactive_repair(self):
+        incompatible = {
+            "ready": False,
+            "version": "0.19.3",
+            "reason": "Hermes computer use requires cua-driver 0.20.0 or newer",
+        }
+        ok, runner, info = self._install(
+            None,
+            require_confirmed=True,
+            contract_status=incompatible,
+        )
+
+        assert ok is False
+        runner.assert_not_called()
+        assert any(
+            "computer-use install --upgrade" in call.args[0]
+            for call in info.call_args_list
+        )
 
     def test_up_to_date_short_circuits(self):
         state = {"current_version": "0.6.0", "latest_version": "0.6.0",
@@ -518,7 +560,11 @@ class TestRequireConfirmedUpdate:
         assert ok is True
         runner.assert_called_once()
 
-    def test_incompatible_driver_repairs_despite_indeterminate_check(self):
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="automatic Windows updates must not launch an interactive repair",
+    )
+    def test_incompatible_driver_repairs_on_posix_despite_indeterminate_check(self):
         """Hermes' own version floor is the confirmation. When the installed
         driver fails the runtime contract, the `hermes update` refresh must
         repair it even though ``check-update`` can't confirm a newer release
@@ -1106,13 +1152,7 @@ class TestConfirmedVersionPinning:
     """
 
     def _install(self, check_state):
-        """Host-agnostic: version pinning is string handling, not an OS branch.
-
-        The old ``platform.system`` → "Windows" fake was incidental — the
-        pin flows into ``CUA_DRIVER_RS_VERSION`` identically on every host
-        (both upstream installers honour it), and this test never reaches the
-        installer anyway because ``_run_cua_driver_installer`` is mocked.
-        """
+        """Version pinning also applies to explicit installer runs."""
         from unittest.mock import MagicMock
 
         from hermes_cli import tools_config
@@ -1139,7 +1179,7 @@ class TestConfirmedVersionPinning:
              patch.object(tools_config, "_print_warning"), \
              patch.object(tools_config, "_print_info"):
             ok = tools_config.install_cua_driver(
-                upgrade=True, require_confirmed_update=True
+                upgrade=True, require_confirmed_update=False
             )
         return ok, runner
 


### PR DESCRIPTION
## What does this PR do?

On native Windows, `hermes update` no longer launches CUA's interactive installer from its hidden automatic-update process. A confirmed CUA update or required contract repair now leaves the installed driver in place, keeps the Hermes update moving, and prints the explicit `hermes computer-use install --upgrade` command.

This prevents an optional Computer Use refresh from holding the core updater for up to 660 seconds. CUA's current Windows installer can ask for console input while repairing a stale high-integrity daemon and can wait for UAC while registering auto-start. The explicit command remains unchanged, and automatic POSIX refreshes still use the installer.

## Related Issue

Related: #92879 (the live Windows updater proof that exposed this separate optional-installer hang).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/tools_config.py` defers both confirmed updates and contract repairs when the caller is the automatic Windows updater.
- `hermes_cli/update_cmd.py` documents the Windows boundary at the production call site.
- `tests/hermes_cli/test_install_cua_driver.py` proves automatic Windows paths never invoke the installer while explicit upgrades and POSIX behavior remain intact.

## How to Test

1. On Windows, run `py -3.11 -m pytest tests/hermes_cli/test_install_cua_driver.py::TestRequireConfirmedUpdate tests/hermes_cli/test_install_cua_driver.py::TestConfirmedVersionPinning -q`.
2. Confirm the Windows update-available and incompatible-driver cases do not call `_run_cua_driver_installer` and both print `hermes computer-use install --upgrade`.
3. Confirm an explicit upgrade (`require_confirmed_update=False`) still calls the installer.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings and call-site rationale updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

The production reproduction was a hidden PowerShell process blocked inside CUA's installer after the CUA 0.22.0 files had already been placed. Stopping only that optional installer allowed the Hermes update to complete normally.

Focused Windows contract tests: **10 passed, 2 skipped**. `scripts/check-windows-footguns.py --diff upstream/main` reported one existing `Path.write_text()` encoding match in the changed test file; this PR does not alter that line or add a new footgun match.

Live Windows Desktop proof on 2026-08-24:

- The exact PR commit was composed into the maintained `fork-integration` line at `98b543a09f6422588aa83101dc9feb6eda98e91b` and published with the prior live-proven tip retained as a rollback ref.
- The visible Desktop updater moved the managed install from `9d52c89edc1d135f4abcb35e52785e7c4d83929b` to that exact SHA through the production hand-off command (`hermes update --yes --gateway --force --branch fork-integration --keep-stash`).
- The updater completed with exit code 0, removed its in-progress marker, relaunched Desktop, and the recovered gateway reported the exact target SHA with Telegram, Discord, Buzz, and API Server connected.
- The installed CUA driver was already current at 0.22.0, so the live CUA stage returned immediately without an installer, console prompt, UAC wait, or hang. The update-available and incompatible-driver deferral branches are covered by the focused Windows tests above; this run does not claim a live CUA downgrade/update-available reproduction.
