### PR TITLE
fix(kanban): serialize created_at to the host timeAgo milliseconds contract (#94025)

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -156,12 +156,24 @@ BOARD_COLUMNS: list[str] = [
 _CARD_SUMMARY_PREVIEW_CHARS = 200
 
 
+def _epoch_ms(ts) -> Any:
+    """Convert a stored Unix-seconds timestamp to the milliseconds contract
+    the drawer's host ``timeAgo`` (``apps/desktop/src/lib/time.ts``:
+    ``formatAgo(fromMs, nowMs=Date.now())``) expects. Idempotent: values
+    already in milliseconds (>= 1e12) pass through unchanged."""
+    if ts is None:
+        return None
+    ts = int(ts)
+    return ts * 1000 if ts < 10**12 else ts
+
+
 def _task_dict(
     task: kanban_db.Task,
     *,
     latest_summary: Optional[str] = None,
 ) -> dict[str, Any]:
     d = asdict(task)
+    d["created_at"] = _epoch_ms(d["created_at"])
     # Add derived age metrics so the UI can colour stale cards without
     # computing deltas client-side.
     try:
@@ -183,7 +195,7 @@ def _event_dict(event: kanban_db.Event) -> dict[str, Any]:
         "task_id": event.task_id,
         "kind": event.kind,
         "payload": event.payload,
-        "created_at": event.created_at,
+        "created_at": _epoch_ms(event.created_at),
         "run_id": event.run_id,
     }
 
@@ -194,7 +206,7 @@ def _comment_dict(c: kanban_db.Comment) -> dict[str, Any]:
         "task_id": c.task_id,
         "author": c.author,
         "body": c.body,
-        "created_at": c.created_at,
+        "created_at": _epoch_ms(c.created_at),
     }
 
 
@@ -209,7 +221,7 @@ def _attachment_dict(a: kanban_db.Attachment) -> dict[str, Any]:
         "size": a.size,
         "uploaded_by": a.uploaded_by,
         "stored_path": a.stored_path,
-        "created_at": a.created_at,
+        "created_at": _epoch_ms(a.created_at),
     }
 
 
@@ -2955,7 +2967,7 @@ async def stream_events(ws: WebSocket):
                     "run_id": r["run_id"],
                     "kind": r["kind"],
                     "payload": payload,
-                    "created_at": r["created_at"],
+                    "created_at": _epoch_ms(r["created_at"]),
                 })
                 new_cursor = r["id"]
             return new_cursor, out

--- a/tests/plugins/test_kanban_epoch_ms.py
+++ b/tests/plugins/test_kanban_epoch_ms.py
@@ -1,0 +1,72 @@
+"""Kanban dashboard plugin: timestamps serialized to the host ``timeAgo``
+milliseconds contract (#94025).
+
+The kanban SQL store keeps ``created_at`` in Unix SECONDS (``int(time.time())``
+in ``hermes_cli/kanban_db.py``), but the drawer's host ``timeAgo``
+(``apps/desktop/src/lib/time.ts``: ``formatAgo(fromMs, nowMs=Date.now())``)
+expects MILLISECONDS. Without the conversion the drawer renders "NaNd ago".
+Regression guard: every serialization path that feeds the drawer must expose
+``created_at`` in ms (idempotent for already-ms values).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+def _load_plugin_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+    spec = importlib.util.spec_from_file_location("hermes_kanban_plugin_epoch_ms_test", plugin_file)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def plugin(kanban_home):
+    return _load_plugin_module()
+
+
+def test_epoch_ms_converts_seconds_and_is_idempotent(plugin):
+    now_s = int(time.time())
+    assert plugin._epoch_ms(now_s) == now_s * 1000
+    assert plugin._epoch_ms(now_s * 1000) == now_s * 1000  # already ms
+    assert plugin._epoch_ms(None) is None
+
+
+def test_task_dict_created_at_in_ms(plugin, kanban_home):
+    kb.create_board("board-ms")
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="t1", body="b")
+        task = kb.get_task(conn, tid)
+    d = plugin._task_dict(task)
+    assert d["created_at"] == int(task.created_at) * 1000
+
+
+def test_comment_dict_created_at_in_ms(plugin, kanban_home):
+    kb.create_board("board-ms")
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="t1")
+        kb.add_comment(conn, tid, "alice", "hello")
+        comment = kb.list_comments(conn, tid)[0]
+    d = plugin._comment_dict(comment)
+    assert d["created_at"] == int(comment.created_at) * 1000

--- a/tests/plugins/test_kanban_ws_idle_disconnect.py
+++ b/tests/plugins/test_kanban_ws_idle_disconnect.py
@@ -139,7 +139,7 @@ async def test_stream_events_reuses_connection_and_closes_after_disconnect(
         "run_id": None,
         "kind": "updated",
         "payload": '{"status": "running"}',
-        "created_at": 1234,
+        "created_at": 1234,  # stored SQL seconds; stream serializes to ms (#94025)
     }
     conn = _TrackingConnection(rows_by_poll=[[], [event_row]])
     connect_threads: list[int] = []
@@ -177,7 +177,7 @@ async def test_stream_events_reuses_connection_and_closes_after_disconnect(
             "run_id": None,
             "kind": "updated",
             "payload": {"status": "running"},
-            "created_at": 1234,
+            "created_at": 1234000,  # #94025: serialized to the host timeAgo ms contract
         }],
         "cursor": 7,
     }]


### PR DESCRIPTION
## Summary

Fixes #94025 — kanban dashboard renders `NaNd ago` for every timestamp because the store keeps `created_at` in **Unix seconds** while the drawer's host `timeAgo` (`apps/desktop/src/lib/time.ts` → `formatAgo(fromMs, nowMs = Date.now())`) expects **milliseconds**.

## Fix

Convert seconds → ms at the **plugin_api serialization boundary** (the only place that feeds the JS drawer), idempotently:

- `_task_dict` (board task), `_event_dict`, `_comment_dict`, `_attachment_dict`, and the live event stream — all now emit `created_at` in ms via a small `_epoch_ms()` helper (values already ≥ 1e12 pass through unchanged).

Internal SQL ordering (`ORDER BY created_at`) and the seconds-based delta logic in `hermes_cli/kanban_db.py` are untouched — no blast radius outside the serialization contract.

## Tests

- New `tests/plugins/test_kanban_epoch_ms.py` (3 tests): helper idempotency + task/comment dict serialization — **proven RED without the fix** (mutation-bite), GREEN with it.
- `tests/plugins/test_kanban_ws_idle_disconnect.py`: stream expectation updated to the new ms contract (the old expectation encoded the buggy seconds value).
- `tests/plugins/test_kanban_epoch_ms.py` + `test_kanban_ws_idle_disconnect.py` + `test_kanban_board_project_api.py`: **12 passed**.