### PR TITLE
fix(photon): derive sidecar mirror set from source globs (fixes #85046)

### DIFF
--- a/plugins/platforms/photon/sidecar_paths.py
+++ b/plugins/platforms/photon/sidecar_paths.py
@@ -45,14 +45,18 @@ logger = logging.getLogger(__name__)
 
 SOURCE_SIDECAR_DIR = Path(__file__).parent / "sidecar"
 
-# The files that define the sidecar. Mirrored into the writable runtime dir
-# when the install tree is read-only. node_modules is deliberately absent —
-# it is either baked (managed image) or installed by npm in the mirror.
-_MIRROR_FILES = (
-    "index.mjs",
+# The runtime files to mirror into a writable runtime dir when the install
+# tree is read-only. Expressed as glob patterns against the source sidecar
+# dir so any module `index.mjs` imports is always present — a hardcoded
+# filename list silently drops new helper modules and crashes the sidecar
+# with ERR_MODULE_NOT_FOUND on hosted installs (see #85046, where
+# send-format.mjs and stream-staleness.mjs were omitted). node_modules is
+# deliberately absent — it is either baked (managed image) or installed by
+# npm in the mirror.
+_MIRROR_FILE_PATTERNS = (
+    "*.mjs",
     "package.json",
     "package-lock.json",
-    "patch-spectrum-mixed-attachments.mjs",
 )
 
 
@@ -122,13 +126,13 @@ def resolve_sidecar_dir(source_dir: Optional[Path] = None) -> Path:
     mirror = get_hermes_home() / "photon" / "sidecar"
     try:
         mirror.mkdir(parents=True, exist_ok=True)
-        for name in _MIRROR_FILES:
-            src = source / name
-            if not src.exists():
-                continue
-            dst = mirror / name
-            if not dst.exists() or not filecmp.cmp(str(src), str(dst), shallow=False):
-                shutil.copy2(str(src), str(dst))
+        for pattern in _MIRROR_FILE_PATTERNS:
+            for src in sorted(source.glob(pattern)):
+                dst = mirror / src.name
+                if not dst.exists() or not filecmp.cmp(
+                    str(src), str(dst), shallow=False
+                ):
+                    shutil.copy2(str(src), str(dst))
         return mirror
     except OSError as exc:
         logger.warning(

--- a/tests/plugins/platforms/photon/test_sidecar_paths.py
+++ b/tests/plugins/platforms/photon/test_sidecar_paths.py
@@ -18,7 +18,16 @@ import plugins.platforms.photon.sidecar_paths as sidecar_paths
 
 def _seed_source(source: Path, *, with_node_modules: bool = False) -> None:
     source.mkdir(parents=True, exist_ok=True)
-    for name in sidecar_paths._MIRROR_FILES:
+    # The real sidecar source set: every *.mjs (including the helper modules
+    # #85046 forgot to mirror) plus the two package manifests.
+    for name in (
+        "index.mjs",
+        "patch-spectrum-mixed-attachments.mjs",
+        "send-format.mjs",
+        "stream-staleness.mjs",
+        "package.json",
+        "package-lock.json",
+    ):
         (source / name).write_text(f"// {name}\n", encoding="utf-8")
     if with_node_modules:
         (source / "node_modules").mkdir()
@@ -86,6 +95,46 @@ def test_mirror_refresh_updates_changed_files_and_keeps_node_modules(
     assert resolved == mirror
     assert (mirror / "index.mjs").read_text(encoding="utf-8") == "// index.mjs v2\n"
     assert (mirror / "node_modules" / "installed.txt").exists()
+
+
+def test_mirror_copies_all_mjs_helpers(tmp_path, monkeypatch) -> None:
+    """#85046 regression: send-format.mjs / stream-staleness.mjs (imported by
+    index.mjs but absent from the old hardcoded _MIRROR_FILES) must reach the
+    mirror, or the sidecar dies with ERR_MODULE_NOT_FOUND on hosted installs."""
+    monkeypatch.delenv("PHOTON_SIDECAR_DIR", raising=False)
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    source = tmp_path / "src"
+    _seed_source(source)
+    _freeze_writability(monkeypatch, writable=False)
+
+    mirror = sidecar_paths.resolve_sidecar_dir(source)
+
+    for name in (
+        "index.mjs",
+        "patch-spectrum-mixed-attachments.mjs",
+        "send-format.mjs",
+        "stream-staleness.mjs",
+        "package.json",
+        "package-lock.json",
+    ):
+        assert (mirror / name).exists(), f"{name} not mirrored"
+
+
+def test_mirror_picks_up_newly_added_helper(tmp_path, monkeypatch) -> None:
+    """A helper module added later is mirrored automatically — no hardcoded
+    list to forget to update (the root fragility of #85046)."""
+    monkeypatch.delenv("PHOTON_SIDECAR_DIR", raising=False)
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    source = tmp_path / "src"
+    _seed_source(source)
+    (source / "future-helper.mjs").write_text("// future\n", encoding="utf-8")
+    _freeze_writability(monkeypatch, writable=False)
+
+    mirror = sidecar_paths.resolve_sidecar_dir(source)
+
+    assert (mirror / "future-helper.mjs").exists()
 
 
 def test_dir_writable_probe(tmp_path) -> None:


### PR DESCRIPTION
## What does this PR do?

Fixes the Photon sidecar crash on managed/hosted installs where the Hermes install tree (`/opt/hermes`) is read-only and the sidecar must be mirrored to the durable data volume.

`_MIRROR_FILES` in `plugins/platforms/photon/sidecar_paths.py` hardcoded a 4-entry filename tuple that omitted `send-format.mjs` and `stream-staleness.mjs` — both imported at the top of `sidecar/index.mjs`. On the mirror path, the sidecar always died with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '<runtime>/photon/sidecar/send-format.mjs' imported from <runtime>/photon/sidecar/index.mjs
```

and the channel retried every 300s forever (see #85046).

The fix derives the mirror set from the source directory via glob patterns (`*.mjs` + the two package manifests) instead of a hardcoded list, so any module `index.mjs` imports is always mirrored — and a future helper module can't be silently dropped again.

## Related Issue

Fixes #85046

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/photon/sidecar_paths.py`: replace `_MIRROR_FILES` tuple with `_MIRROR_FILE_PATTERNS` glob patterns; mirror loop now iterates `source.glob(pattern)` sorted, so every `*.mjs` plus `package.json`/`package-lock.json` is copied (content-compare + copy as before).
- `tests/plugins/platforms/photon/test_sidecar_paths.py`: seed helper now writes the full real source set; added two regression tests — all helper modules reach the mirror, and a newly-added helper is auto-picked-up.

## How to Test

1. `pytest tests/plugins/platforms/photon/test_sidecar_paths.py -v` — 8 passed (incl. 2 new regression tests).
2. E2E: copied the real sidecar dir to a temp source, forced the mirror path, resolved — all 6 files mirrored (`index.mjs`, `patch-spectrum-mixed-attachments.mjs`, `send-format.mjs`, `stream-staleness.mjs`, `package.json`, `package-lock.json`), nothing missing.
3. `ruff check` on both files — clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` (targeted suite) and tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Ubuntu/Docker-managed install, Python 3.13)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] N/A: no config keys added
- [x] N/A: no architecture change
- [x] N/A: cross-platform impact — pure-Python path logic, same behavior on all platforms
- [x] N/A: no tool behavior change

## Screenshots / Logs

```
MIRRORED FILES: ['index.mjs', 'package-lock.json', 'package.json', 'patch-spectrum-mixed-attachments.mjs', 'send-format.mjs', 'stream-staleness.mjs']
MISSING (should be []): []
```
