### PR TITLE
feat(mcp): add 9bot integration

### DIFF
--- a/optional-mcps/9bot/manifest.yaml
+++ b/optional-mcps/9bot/manifest.yaml
@@ -1,3 +1,5 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
 manifest_version: 1
 
 name: 9bot
@@ -8,6 +10,10 @@ description: >-
 
 source: https://github.com/9-bot/mcp
 
+# Official vendor-hosted remote MCP (URL-only — Hermes never spawns a local
+# process for this entry). OAuth + Dynamic Client Registration;
+# Hermes's MCP client + mcp_oauth_manager handle discovery, PKCE, token
+# exchange, and refresh.
 transport:
   type: http
   url: https://mcp.9bot.com.br/mcp

--- a/optional-mcps/9bot/manifest.yaml
+++ b/optional-mcps/9bot/manifest.yaml
@@ -1,0 +1,42 @@
+manifest_version: 1
+
+name: 9bot
+
+description: >-
+  Manage, automate, and analyze WhatsApp groups, communities, and channels
+  through 9bot.
+
+source: https://github.com/9-bot/mcp
+
+transport:
+  type: http
+  url: https://mcp.9bot.com.br/mcp
+
+auth:
+  type: oauth
+
+suggest:
+  keywords:
+    - 9bot
+    - whatsapp groups
+    - whatsapp communities
+    - whatsapp automation
+    - whatsapp community management
+  hosts:
+    - 9bot.com.br
+    - mcp.9bot.com.br
+
+post_install: |
+  On first connection, Hermes opens a browser to authenticate with 9bot.
+
+  Sign in using the WhatsApp number associated with your 9bot account
+  and confirm the verification code sent through WhatsApp.
+
+  An active 9bot subscription is required.
+
+  After authentication, restart your Hermes session so the 9bot tools
+  are loaded.
+
+  To authenticate again, run:
+
+    hermes mcp login 9bot


### PR DESCRIPTION
## Summary

Adds **9bot** to the official Hermes MCP catalog as a hosted Streamable HTTP MCP server with native OAuth authentication.

9bot lets Hermes users manage, automate, and analyze WhatsApp groups, communities, and channels through the 9bot platform.

## What this adds

- New catalog entry: `optional-mcps/9bot/manifest.yaml`
- Hosted MCP endpoint: `https://mcp.9bot.com.br/mcp`
- Native OAuth authentication
- Desktop suggestion keywords for WhatsApp community and automation workflows
- Post-install authentication guidance

## Authentication

9bot exposes standard MCP/OAuth discovery metadata, including:

- Protected Resource Metadata
- Authorization Server Metadata
- OAuth Authorization Code flow
- PKCE with `S256`
- Dynamic Client Registration
- Refresh tokens
- Client ID Metadata Documents
- Resource Indicators

Users authenticate with the WhatsApp number associated with their 9bot account and confirm a verification code sent through WhatsApp.

An active 9bot subscription is required.

## Manual verification

Tested end-to-end on Windows against the production 9bot MCP service.

Verified:

- `hermes mcp catalog` recognizes the 9bot entry
- `hermes mcp install 9bot` installs the remote MCP configuration
- `hermes mcp login 9bot` completes the OAuth authentication flow
- Browser-based 9bot authentication succeeds
- `hermes mcp test 9bot` connects successfully
- Hermes discovers the available 9bot MCP tools

The OAuth server metadata also advertises Dynamic Client Registration and PKCE `S256`.

## Source

- 9bot MCP repository: https://github.com/9-bot/mcp
- MCP endpoint: https://mcp.9bot.com.br/mcp
- Website: https://9bot.com.br/
- Official MCP Registry ID: `br.com.9bot/mcp`

## Scope

This PR adds only the catalog manifest. It does not modify Hermes core code, OAuth handling, MCP transport logic, or existing integrations.

## Checklist

- [x] Searched existing PRs and issues for a duplicate
- [x] PR contains only the 9bot MCP catalog entry
- [x] Tested the production MCP endpoint end-to-end with Hermes
- [x] Tested on Windows
- [x] OAuth login succeeds
- [x] MCP connection and tool discovery succeed