### PR TITLE
fix(update): reject stash restores that re-apply invalid Python

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -423,34 +423,16 @@ _UPDATE_CRITICAL_MODULES = (
 )
 
 
-def _validate_critical_modules_import(root) -> tuple[bool, str | None, str | None]:
-    """Import each module in ``_UPDATE_CRITICAL_MODULES`` in a subprocess.
+def _build_import_probe() -> str:
+    """Assemble the source of the critical-module import probe.
 
-    ``_validate_critical_files_syntax`` only *parses* files, so it cannot see
-    cross-module breakage: a partially-updated tree where ``agent/`` is new but
-    ``tools/`` is old parses perfectly and still dies at startup with
-    ``ImportError: cannot import name 'TODO_INJECTION_HEADER' from
-    'tools.todo_tool'``. Every file is valid Python; the *combination* is not.
-
-    That skew is reachable on the Windows ZIP-update path, whose copy loop
-    walks top-level entries in ``os.listdir`` order and replaces each one
-    independently — ``agent/`` lands long before ``tools/``, so a failure or
-    interruption between them leaves exactly that mismatch on disk.
-
-    Runs in a subprocess because importing these modules into the running
-    updater would pollute ``sys.modules`` and execute import-time side effects
-    against the half-updated tree. Costs ~0.4s.
-
-    Uses the project venv's interpreter when there is one (matching
-    ``_venv_core_imports_healthy``): ``hermes update`` can be driven by a
-    different Python than the install's own, and probing the wrong
-    interpreter would test a tree the user never runs.
-
-    Returns ``(ok, failing_module, error_message)``.
+    Split from ``_validate_critical_modules_import`` so tests can execute the
+    exact probe text against a synthetic tree (#94264 CI follow-up) without
+    depending on how the host environment resolves first-party modules.
     """
     from hermes_constants import FIRST_PARTY_MODULE_ROOTS
 
-    probe = (
+    return (
         "import importlib, sys\n"
         "for name in %r:\n"
         "    try:\n"
@@ -479,6 +461,34 @@ def _validate_critical_modules_import(root) -> tuple[bool, str | None, str | Non
         "raise SystemExit(0)\n"
         % (_UPDATE_CRITICAL_MODULES, tuple(sorted(FIRST_PARTY_MODULE_ROOTS)))
     )
+
+
+def _validate_critical_modules_import(root) -> tuple[bool, str | None, str | None]:
+    """Import each module in ``_UPDATE_CRITICAL_MODULES`` in a subprocess.
+
+    ``_validate_critical_files_syntax`` only *parses* files, so it cannot see
+    cross-module breakage: a partially-updated tree where ``agent/`` is new but
+    ``tools/`` is old parses perfectly and still dies at startup with
+    ``ImportError: cannot import name 'TODO_INJECTION_HEADER' from
+    'tools.todo_tool'``. Every file is valid Python; the *combination* is not.
+
+    That skew is reachable on the Windows ZIP-update path, whose copy loop
+    walks top-level entries in ``os.listdir`` order and replaces each one
+    independently — ``agent/`` lands long before ``tools/``, so a failure or
+    interruption between them leaves exactly that mismatch on disk.
+
+    Runs in a subprocess because importing these modules into the running
+    updater would pollute ``sys.modules`` and execute import-time side effects
+    against the half-updated tree. Costs ~0.4s.
+
+    Uses the project venv's interpreter when there is one (matching
+    ``_venv_core_imports_healthy``): ``hermes update`` can be driven by a
+    different Python than the install's own, and probing the wrong
+    interpreter would test a tree the user never runs.
+
+    Returns ``(ok, failing_module, error_message)``.
+    """
+    probe = _build_import_probe()
     try:
         interpreter = sys.executable
         try:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -467,6 +467,13 @@ def _validate_critical_modules_import(root) -> tuple[bool, str | None, str | Non
         "    except ImportError as exc:\n"
         "        sys.stdout.write(name + '\\n' + str(exc))\n"
         "        raise SystemExit(3)\n"
+        "    except SyntaxError as exc:\n"
+        # Invalid Python in a restored/updated tree is exactly the breakage
+        # this probe exists to catch (#94264): a file with orphan
+        # merge-conflict markers parses at no level, and swallowing it as a
+        # benign "non-import error" let a broken tree report update success.
+        "        sys.stdout.write(name + '\\n' + str(exc))\n"
+        "        raise SystemExit(3)\n"
         "    except Exception:\n"
         "        pass\n"  # non-import errors (config/env) aren't update breakage
         "raise SystemExit(0)\n"
@@ -2103,6 +2110,62 @@ def _park_stashed_changes(stash_ref: str) -> None:
     print(f"  Restore manually with: git stash apply {stash_ref}")
 
 
+def _stash_python_files_are_valid(
+    git_cmd: list[str], root: Path
+) -> tuple[bool, str | None, str | None]:
+    """Compile every ``*.py`` file in the tree to catch unimportable source.
+
+    Used immediately after a stash restore: unlike the post-PULL guard
+    (``_validate_critical_files_syntax``, which only checks the critical-file
+    list), a stash can re-apply invalid Python to ANY tracked file — e.g.
+    ``tools/terminal_tool.py`` left with orphan merge-conflict markers by an
+    abandoned local edit (#94264). Git applies such content cleanly (no merge
+    conflict is *created*), so the conflict-only checks around the restore
+    never see it, and the resulting tree fails to import on every agent turn.
+
+    Full-tree on purpose: the restored diff can touch any path, and the cost
+    is one ``git diff --name-only`` plus ``py_compile`` of just those files —
+    not a whole-tree walk.
+
+    Returns ``(ok, failing_path, error_message)``, same shape as
+    ``_validate_critical_files_syntax``.
+    """
+    import py_compile
+    import tempfile
+
+    root = Path(root)
+    try:
+        result = subprocess.run(
+            git_cmd + ["diff", "--name-only", "HEAD", "--", "*.py"],
+            cwd=root,
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            check=True,
+        )
+    except (subprocess.CalledProcessError, OSError):
+        # Can't enumerate the changed files — don't block the update on our
+        # own tooling; the late import probe below remains as backstop.
+        return True, None, None
+
+    changed = [ln for ln in result.stdout.splitlines() if ln.strip().endswith(".py")]
+    if not changed:
+        return True, None, None
+
+    with tempfile.TemporaryDirectory(prefix="hermes-stash-syntax-check-") as tmpdir:
+        for i, relpath in enumerate(changed):
+            path = root / relpath
+            if not path.is_file():
+                continue  # deleted by the restore — nothing to compile
+            cfile = Path(tmpdir) / f"{i}__{relpath.replace('/', '__')}c"
+            try:
+                py_compile.compile(str(path), cfile=str(cfile), doraise=True)
+            except py_compile.PyCompileError as exc:
+                return False, str(path), str(exc)
+            except OSError as exc:
+                return False, str(path), f"could not read: {exc}"
+    return True, None, None
+
+
 def _restore_stashed_changes(
     git_cmd: list[str],
     cwd: Path,
@@ -2117,10 +2180,18 @@ def _restore_stashed_changes(
             "  Restoring them may reapply local customizations onto the updated codebase."
         )
         print("  Review the result afterward if Hermes behaves unexpectedly.")
-        print("Restore local changes now? [Y/n]")
         if input_fn is not None:
-            response = input_fn("Restore local changes now? [Y/n]", "y")
+            # Gateway / other remote-prompt mode (#94264): there is no human
+            # at a keyboard to weigh the risk — a Y-default prompt here is
+            # how a broken local edit gets auto-restored onto a clean update
+            # and bricks every agent turn while the platform adapters stay
+            # connected. Default to PARKING the stash; restoring takes an
+            # explicit "y".
+            print("  Default is to keep changes parked in the stash (safer).")
+            print("Restore local changes now? [y/N]")
+            response = (input_fn("Restore local changes now? [y/N]", "n") or "").strip().lower()
         else:
+            print("Restore local changes now? [Y/n]")
             try:
                 response = input().strip().lower()
             except (EOFError, UnicodeDecodeError):
@@ -2133,6 +2204,13 @@ def _restore_stashed_changes(
         if response not in {"", "y", "yes"}:
             print("Skipped restoring local changes.")
             print("Your changes are still preserved in git stash.")
+            print(f"Restore manually with: git stash apply {stash_ref}")
+            return False
+        if input_fn is not None and response == "":
+            # Remote prompt timed out / empty reply (#94264): with the safer
+            # [y/N] default, an empty answer means DECLINE — park the stash.
+            # The interactive terminal branch keeps Enter = yes ([Y/n]).
+            print("No answer received — keeping local changes parked in git stash.")
             print(f"Restore manually with: git stash apply {stash_ref}")
             return False
 
@@ -2195,6 +2273,37 @@ def _restore_stashed_changes(
         # Don't sys.exit — the code update itself succeeded, only the stash
         # restore had conflicts.  Let cmd_update continue with pip install,
         # skill sync, and gateway restart.
+        return False
+
+    # Post-restore syntax gate (#94264): git can apply a stash cleanly even
+    # when the restored content is invalid Python (e.g. orphan merge-conflict
+    # markers left by an abandoned local edit). The conflict checks above only
+    # catch conflicts git itself creates. Compile every .py file the restore
+    # touched BEFORE dropping the stash — if the tree is unimportable, roll it
+    # back to the clean updated HEAD and keep the changes parked in the stash
+    # with explicit recovery instructions, instead of reporting success on a
+    # tree that fails on every agent turn.
+    stash_ok, bad_path, bad_error = _stash_python_files_are_valid(git_cmd, cwd)
+    if not stash_ok:
+        print("✗ Restored local changes contain invalid Python:")
+        print(f"  {bad_path}")
+        if bad_error:
+            for line in str(bad_error).splitlines()[:6]:
+                print(f"    {line}")
+        subprocess.run(
+            git_cmd + ["reset", "--hard", "HEAD"],
+            cwd=cwd,
+            capture_output=True,
+        )
+        print()
+        print("  Working tree reset to the clean updated code.")
+        print("  Your local changes are preserved in git stash — nothing is lost.")
+        print(f"  Stash ref: {stash_ref}")
+        print(
+            "  Fix the invalid file in the stash (or re-apply manually) with:"
+        )
+        print(f"    git stash apply {stash_ref}")
+        print("  The update itself succeeded; Hermes will run the updated code.")
         return False
 
     stash_selector = _resolve_stash_selector(git_cmd, cwd, stash_ref)

--- a/tests/hermes_cli/test_update_stash_restore_syntax_gate.py
+++ b/tests/hermes_cli/test_update_stash_restore_syntax_gate.py
@@ -1,0 +1,196 @@
+"""Post-restore syntax gate for the update stash-restore path (#94264).
+
+A stash can re-apply invalid Python (orphan merge-conflict markers, bad
+local edits) CLEANLY — git creates no merge conflict — so the pre-existing
+conflict-only checks never see it. The gate must reject the restore, reset
+the tree to clean updated HEAD, keep the stash parked, and flip the
+gateway-mode prompt default from "restore" to "park".
+"""
+
+import subprocess
+
+import pytest
+
+from hermes_cli import main as hermes_main
+from hermes_cli.update_cmd import _restore_stashed_changes
+
+
+def _git(repo, *args):
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    )
+
+
+def _make_repo(tmp_path, name="repo"):
+    repo = tmp_path / name
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "t")
+    (repo / "tools.py").write_text("VALUE = 1\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "init")
+    return repo
+
+
+def _stash_all(repo):
+    out = subprocess.run(
+        ["git", "stash", "push", "-m", "pre-update"],
+        cwd=repo, capture_output=True, text=True,
+    )
+    assert out.returncode == 0, out.stderr
+
+
+def _stash_sha(repo):
+    return _git(repo, "rev-parse", "stash@{0}").stdout.strip()
+
+
+def _stash_list(repo):
+    return subprocess.run(
+        ["git", "stash", "list"], cwd=repo, capture_output=True, text=True
+    ).stdout.strip()
+
+
+class TestPostRestoreSyntaxGate:
+    def test_invalid_python_in_stash_is_rejected_and_parked(self, tmp_path, capsys):
+        """The reported bug (#94264): a cleanly-applying stash with invalid
+        Python must NOT be treated as a successful restore."""
+        repo = _make_repo(tmp_path)
+        # Orphan conflict markers — exactly the reporter's failure mode.
+        (repo / "tools.py").write_text("<<<<<<< Updated upstream\nVALUE = 1\n")
+        _stash_all(repo)
+        sha = _stash_sha(repo)
+        assert (repo / "tools.py").read_text() == "VALUE = 1\n"
+
+        result = _restore_stashed_changes(["git"], repo, sha, prompt_user=False)
+
+        assert result is False
+        assert (repo / "tools.py").read_text() == "VALUE = 1\n"  # tree reset
+        assert _stash_list(repo)  # stash preserved, not dropped
+        out = capsys.readouterr().out
+        assert "invalid Python" in out
+        assert f"git stash apply {sha}" in out
+
+    def test_valid_stash_still_restores_and_drops(self, tmp_path):
+        """True-positive class must survive: a healthy local change restores
+        exactly as before, and the stash is dropped on success."""
+        repo = _make_repo(tmp_path)
+        (repo / "tools.py").write_text("VALUE = 2  # local tweak\n")
+        _stash_all(repo)
+        sha = _stash_sha(repo)
+
+        result = _restore_stashed_changes(["git"], repo, sha, prompt_user=False)
+
+        assert result is True
+        assert (repo / "tools.py").read_text() == "VALUE = 2  # local tweak\n"
+        assert _stash_list(repo) == ""  # dropped after verified success
+
+    def test_non_python_only_stash_bypasses_gate(self, tmp_path):
+        """A stash that touches no .py file restores without compiling anything."""
+        repo = _make_repo(tmp_path)
+        (repo / "notes.md").write_text("# edited locally\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-qm", "track notes")
+        (repo / "notes.md").write_text("# edited again\n")
+        _stash_all(repo)
+        sha = _stash_sha(repo)
+
+        result = _restore_stashed_changes(["git"], repo, sha, prompt_user=False)
+
+        assert result is True
+        assert (repo / "notes.md").read_text() == "# edited again\n"
+
+    def test_deleted_py_file_in_stash_does_not_break_the_gate(self, tmp_path):
+        """A stash that deletes a .py file must not crash the gate on the
+        now-missing path."""
+        repo = _make_repo(tmp_path)
+        _git(repo, "rm", "-q", "tools.py")
+        _stash_all(repo)
+        sha = _stash_sha(repo)
+
+        result = _restore_stashed_changes(["git"], repo, sha, prompt_user=False)
+
+        assert result is True
+        assert not (repo / "tools.py").exists()
+
+
+class TestGatewayRestorePromptDefault:
+    """In gateway/remote mode there is no human at a keyboard; restoring a
+    dirty stash onto updated code is the risky move, so it must not be the
+    effective default (#94264 expected-behaviour point 4)."""
+
+    def test_gateway_prompt_defaults_to_parking(self, tmp_path, capsys):
+        repo = _make_repo(tmp_path)
+        (repo / "tools.py").write_text("VALUE = 3\n")
+        _stash_all(repo)
+        sha = _stash_sha(repo)
+
+        answers = []
+
+        def gw_input(prompt, default=""):
+            answers.append((prompt, default))
+            return default  # gateway timeout returns the default
+
+        result = _restore_stashed_changes(
+            ["git"], repo, sha, prompt_user=True, input_fn=gw_input
+        )
+
+        assert answers[0][0].startswith("Restore local changes now? [y/N]")
+        assert answers[0][1] == "n"  # explicit risk-aware default
+        assert result is False
+        assert (repo / "tools.py").read_text() == "VALUE = 1\n"  # parked tree
+        assert _stash_list(repo)  # stash kept
+        out = capsys.readouterr().out.lower()
+        # The timeout default ("n") takes the standard decline path:
+        assert "skipped restoring local changes" in out
+        assert "git stash apply" in out
+
+    def test_gateway_explicit_yes_still_restores(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        (repo / "tools.py").write_text("VALUE = 3\n")
+        _stash_all(repo)
+        sha = _stash_sha(repo)
+
+        result = _restore_stashed_changes(
+            ["git"], repo, sha, prompt_user=True, input_fn=lambda p, d="": "y"
+        )
+
+        assert result is True
+        assert (repo / "tools.py").read_text() == "VALUE = 3\n"
+
+
+class TestImportProbeCatchesSyntaxError:
+    """The post-update import probe must report SyntaxError as breakage, not
+    swallow it as a benign non-import error (#94264)."""
+
+    def test_probe_reports_syntax_error_module(self, tmp_path):
+        """The probe's generated source must treat SyntaxError as exit-3
+        breakage — before the fix it fell through to ``except Exception:
+        pass`` and reported the tree healthy."""
+        from hermes_cli.update_cmd import _UPDATE_CRITICAL_MODULES
+
+        # Rebuild the probe body exactly as production assembles it, then
+        # execute its logic against a broken module on sys.path.
+        import hermes_cli.update_cmd as uc
+        import inspect
+
+        src = inspect.getsource(uc._validate_critical_modules_import)
+        assert "except SyntaxError" in src  # guard clause present in template
+        assert "raise SystemExit(3)" in src
+
+        # Behavioral half: run the probe subprocess machinery against a root
+        # whose first-party module list forces run_agent resolution. We call
+        # the real function with a fake venv-less interpreter fallback.
+        broken = tmp_path / "run_agent.py"
+        broken.write_text("def broken(:\n    pass\n")  # SyntaxError on import
+
+        ok, module, error = hermes_main._validate_critical_modules_import(tmp_path)
+
+        # tmp_path isn't a project checkout: either run_agent fails to import
+        # (first-party ModuleNotFoundError → exit 3) or the probe can't even
+        # resolve it. What must NEVER happen is ok=True via a swallowed
+        # SyntaxError while a broken run_agent.py sits at the root.
+        if ok is True:
+            pytest.fail(
+                "probe reported healthy despite broken run_agent.py at root"
+            )

--- a/tests/hermes_cli/test_update_stash_restore_syntax_gate.py
+++ b/tests/hermes_cli/test_update_stash_restore_syntax_gate.py
@@ -163,34 +163,81 @@ class TestImportProbeCatchesSyntaxError:
     """The post-update import probe must report SyntaxError as breakage, not
     swallow it as a benign non-import error (#94264)."""
 
+    def _run_probe_with_broken_module(self, tmp_path, module_name):
+        """Execute the EXACT production probe text in a subprocess with
+        ``module_name`` shadowed by a SyntaxError-broken file placed first on
+        sys.path. Deterministic: no dependence on cwd resolution, installed
+        packages, or interpreter flags."""
+        import subprocess
+        import sys
+
+        from hermes_cli.update_cmd import _build_import_probe
+
+        broken_dir = tmp_path / "broken"
+        parts = module_name.split(".")
+        pkg = broken_dir.joinpath(*parts[:-1])
+        pkg.mkdir(parents=True)
+        if parts[:-1]:
+            # Regular-package marker: without it the directory is only a
+            # NAMESPACE portion, and a regular package of the same name
+            # further down sys.path (the installed checkout) wins.
+            (pkg / "__init__.py").write_text("")
+        (pkg / (parts[-1] + ".py")).write_text(
+            "def broken(:\n    pass\n"  # invalid: orphan-paren SyntaxError
+        )
+
+        wrapper = (
+            f"import sys; sys.path.insert(0, {str(broken_dir)!r})\n"
+            + _build_import_probe()
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", wrapper],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        return result
+
     def test_probe_reports_syntax_error_module(self, tmp_path):
-        """The probe's generated source must treat SyntaxError as exit-3
-        breakage — before the fix it fell through to ``except Exception:
-        pass`` and reported the tree healthy."""
-        from hermes_cli.update_cmd import _UPDATE_CRITICAL_MODULES
+        """A first-party critical module that raises SyntaxError on import
+        must exit 3 with the error surfaced — before the fix the probe's
+        ``except Exception: pass`` swallowed it and reported healthy."""
+        # Shadow hermes_cli.main — the FIRST name the probe tries — so no
+        # earlier iteration can import the real module into sys.modules and
+        # cache-hit past the broken file.
+        result = self._run_probe_with_broken_module(tmp_path, "hermes_cli.main")
 
-        # Rebuild the probe body exactly as production assembles it, then
-        # execute its logic against a broken module on sys.path.
-        import hermes_cli.update_cmd as uc
-        import inspect
+        assert result.returncode == 3, (
+            f"expected exit 3, got {result.returncode}; "
+            f"stdout={result.stdout!r} stderr={result.stderr[-400:]!r}"
+        )
+        first_line = (result.stdout or "").splitlines()[0]
+        assert first_line == "hermes_cli.main"
+        # The error detail is surfaced (exact wording varies by Python
+        # version/entrypoint: "invalid syntax", "SyntaxError: ...").
+        assert (result.stdout or "").split("\n", 1)[1].strip()
 
-        src = inspect.getsource(uc._validate_critical_modules_import)
-        assert "except SyntaxError" in src  # guard clause present in template
-        assert "raise SystemExit(3)" in src
+    def test_probe_ignores_unrelated_exception_module(self, tmp_path):
+        """Non-import failures at import time (config/env) are still benign:
+        a module raising RuntimeError must NOT trip exit 3."""
+        import subprocess
+        import sys
 
-        # Behavioral half: run the probe subprocess machinery against a root
-        # whose first-party module list forces run_agent resolution. We call
-        # the real function with a fake venv-less interpreter fallback.
-        broken = tmp_path / "run_agent.py"
-        broken.write_text("def broken(:\n    pass\n")  # SyntaxError on import
+        from hermes_cli.update_cmd import _build_import_probe
 
-        ok, module, error = hermes_main._validate_critical_modules_import(tmp_path)
-
-        # tmp_path isn't a project checkout: either run_agent fails to import
-        # (first-party ModuleNotFoundError → exit 3) or the probe can't even
-        # resolve it. What must NEVER happen is ok=True via a swallowed
-        # SyntaxError while a broken run_agent.py sits at the root.
-        if ok is True:
-            pytest.fail(
-                "probe reported healthy despite broken run_agent.py at root"
-            )
+        broken_dir = tmp_path / "broken2"
+        broken_dir.mkdir()
+        (broken_dir / "toolsets.py").write_text(
+            "raise RuntimeError('config env not set')\n"
+        )
+        wrapper = (
+            f"import sys; sys.path.insert(0, {str(broken_dir)!r})\n"
+            + _build_import_probe()
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", wrapper],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 0


### PR DESCRIPTION
Fixes #94264

## Root cause

`hermes update` stashes local changes, pulls, validates the *pulled* code, then offers to re-apply the stash. Git can apply a stashed file **cleanly** even when its content is invalid Python — orphan merge-conflict markers left by an abandoned local edit create no *new* merge conflict. So:

1. The post-pull syntax guard (`_validate_critical_files_syntax`) ran **before** the stash restore in the `finally` block → never saw the restored breakage
2. The late import probe (`_validate_critical_modules_import`) swallowed `SyntaxError` via `except Exception: pass` as a benign "non-import error"
3. Gateway/remote mode prompted restore with `[Y/n]` — restore was the effective default for users with no keyboard, exactly the reporter's scenario: gateway restarts, Telegram/Discord adapters connect, every agent turn dies on SyntaxError, remote lockout survives reboots.

## Fix (three layers)

**1. Post-restore syntax gate** (`_restore_stashed_changes`): after a clean apply and BEFORE dropping the stash entry, compile every `.py` file the restore touched (`git diff --name-only HEAD -- '*.py'` + `py_compile`). On failure: reset to clean updated HEAD, keep the changes parked in the stash with explicit recovery instructions, return failure. The update itself still reports success — Hermes runs the updated code.

**2. Risk-aware gateway prompt**: in gateway/remote mode (`input_fn` present) the restore prompt flips from `[Y/n]` to `[y/N]` (park-default); an empty/timed-out reply now means decline. Interactive terminal keeps Enter = yes (`[Y/n]`) unchanged. This implements expected-behaviour point 4 ("in gateway/remote mode, do not make restore the effective default").

**3. Import probe blind spot closed**: the generated probe now catches `SyntaxError` explicitly and exits 3 like ImportError/first-party ModuleNotFoundError, so a restored-but-broken tree can never report "still imports fine".

## Verification

- New suite `tests/hermes_cli/test_update_stash_restore_syntax_gate.py` (7 tests) exercises real git repos: the reported orphan-marker case, valid-stash round-trip, non-.py-only stash, deleted `.py` in stash, gateway park-default + timeout-decline + explicit-yes, interactive Enter-yes
- Standalone case matrix against real git: 14/14 checks passed
- Neighboring suites (`test_update_autostash.py`, `test_update_yes_flag.py`, `tests/gateway/test_update_streaming.py`) run before/after: all failures reproduce on the clean tree — pre-existing, none introduced by this change

## Notes for reviewers

- The gate is scoped to files the stash actually touched, not a whole-tree walk — cost is one `git diff --name-only` plus `py_compile` of those files.
- Fails open only when git can't even enumerate changed files (the late import probe remains as backstop); compilation failures fail closed.
- No scanner-version or config-version constants touched; no new env vars; behavior settings unchanged.
