### PR TITLE
fix(terminal): bound env.execute wait so a wedged poll cannot disable every timer (#94285)

### DIFF
--- a/agent/deadline.py
+++ b/agent/deadline.py
@@ -63,6 +63,7 @@ Design invariants:
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import faulthandler
 import logging
 import os
@@ -99,6 +100,12 @@ MAX_SAFE_TIMEOUT_S = 31_536_000.0  # 365 days
 # Grace period after a deadline fires before concluding the event loop thread
 # is blocked in a synchronous call and dumping stacks (family A diagnostics).
 _LOOP_BLOCKED_DUMP_GRACE_S = 5.0
+
+# ``Event.wait`` is a C-level block: KeyboardInterrupt / SetAsyncExc only
+# land when the thread returns to Python. Slice the wait so a /stop or
+# SIGINT during a bounded sync call is observed within this window rather
+# than at the full deadline (#94285, tools/test_local_interrupt_cleanup).
+_BOUNDED_SYNC_WAIT_SLICE_S = 0.2
 
 
 class DeadlineExpired(TimeoutError):
@@ -407,6 +414,14 @@ def run_bounded_sync(
     in a retry loop would accumulate them.
 
     ``timeout=None`` (or non-positive) blocks until ``fn`` returns.
+
+    The worker runs under ``contextvars.copy_context()`` so profile secret
+    scope, session id, and delegated-child guards set on the caller survive
+    the thread hop (terminal env.execute — #94285 CI).
+
+    The caller's wait is sliced (``_BOUNDED_SYNC_WAIT_SLICE_S``) so a
+    ``KeyboardInterrupt`` or ``PyThreadState_SetAsyncExc`` lands within
+    that window instead of only at the full deadline.
     """
     timeout_s = clamp_timeout(timeout)
     start = time.monotonic()
@@ -415,10 +430,11 @@ def run_bounded_sync(
 
     box: dict[str, Any] = {}
     done = threading.Event()
+    ctx = contextvars.copy_context()
 
     def _worker() -> None:
         try:
-            box["value"] = fn()
+            box["value"] = ctx.run(fn)
         except BaseException as exc:  # re-raised in caller; must not vanish
             box["exc"] = exc
         finally:
@@ -428,7 +444,14 @@ def run_bounded_sync(
         target=_worker, name=f"deadline-{label}", daemon=True
     )
     thread.start()
-    if not done.wait(timeout_s):
+    deadline = start + timeout_s
+    while not done.is_set():
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        done.wait(min(_BOUNDED_SYNC_WAIT_SLICE_S, remaining))
+
+    if not done.is_set():
         logger.warning("[deadline] %r timed out after %.1fs; worker abandoned", label, timeout_s)
         if on_timeout is not None:
             try:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -37,7 +37,7 @@ except ImportError:
     except ImportError:
         msvcrt = None
 from pathlib import Path
-from typing import Any, List, Optional, Protocol
+from typing import Any, Callable, List, Optional, Protocol
 
 # Add parent directory to path for imports BEFORE repo-level imports.
 # Without this, standalone invocations (e.g. after `hermes update` reloads
@@ -1310,6 +1310,34 @@ _terminal_cwd_lock = _ReadWriteLock()
 # (stagger schedules / drop the workdir) is actionable.
 _CWD_LOCK_TIMEOUT_FLOOR_SECONDS = 120.0
 _CWD_LOCK_TIMEOUT_MARGIN_SECONDS = 60.0
+
+
+def _inactivity_watchdog_loop(
+    *,
+    get_idle_seconds: Callable[[], float],
+    limit_s: float,
+    poll_s: float,
+    stop: threading.Event,
+    future_done: Callable[[], bool],
+) -> bool:
+    """Poll job idle time until the limit, stop, or the watched future completes.
+
+    Driven by ``threading.Event.wait`` (a kernel timeout), not asyncio, so a
+    blocked event-loop / ``run_job`` thread cannot disable this watchdog the
+    way ``asyncio.sleep`` / ``wait_for`` would (family A of #94285 — the
+    4118s-idle-on-a-600s-limit cron hang). Returns True when *limit_s* of
+    inactivity was observed.
+    """
+    while not stop.wait(poll_s):
+        if future_done():
+            return False
+        try:
+            idle = float(get_idle_seconds() or 0.0)
+        except Exception:
+            idle = 0.0
+        if idle >= limit_s:
+            return True
+    return False
 
 
 def _cron_inactivity_seconds() -> float:
@@ -6159,24 +6187,44 @@ def run_job(
         _audit_t_start = time.monotonic()
         _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
         _inactivity_timeout = False
-        try:
+        _watch_stop = threading.Event()
+
+        def _idle_seconds() -> float:
+            if not hasattr(agent, "get_activity_summary"):
+                return 0.0
+            try:
+                _act = agent.get_activity_summary()
+                return float(_act.get("seconds_since_activity", 0.0) or 0.0)
+            except Exception:
+                return 0.0
+
+        def _watch_inactivity() -> None:
+            nonlocal _inactivity_timeout
             if _cron_inactivity_limit is None:
-                # Unlimited — no inactivity watchdog, but a one-shot still
-                # needs its run_claim heartbeat, so poll instead of blocking.
-                if _is_oneshot or cancel_event is not None:
-                    result = None
-                    while True:
-                        done, _ = concurrent.futures.wait(
-                            {_cron_future}, timeout=_POLL_INTERVAL,
-                        )
-                        if done:
-                            _abort_if_fire_claim_lost()
-                            result = _cron_future.result()
-                            break
-                        _abort_if_fire_claim_lost()
-                        _heartbeat_run_claim_if_due()
-                else:
-                    result = _cron_future.result()
+                return
+            if _inactivity_watchdog_loop(
+                get_idle_seconds=_idle_seconds,
+                limit_s=_cron_inactivity_limit,
+                poll_s=_POLL_INTERVAL,
+                stop=_watch_stop,
+                future_done=_cron_future.done,
+            ):
+                _inactivity_timeout = True
+
+        _watch_thread = threading.Thread(
+            target=_watch_inactivity,
+            name=f"cron-inactivity-{str(job_id)[:8]}",
+            daemon=True,
+        )
+        try:
+            if _cron_inactivity_limit is not None:
+                # Daemon thread: kernel ``Event.wait`` timeout, independent of
+                # the ``run_job`` thread. A blocked loop / hung
+                # ``get_activity_summary`` on this thread can no longer keep
+                # the 600s inactivity limit from firing (#94285).
+                _watch_thread.start()
+            if _cron_inactivity_limit is None and not _is_oneshot and cancel_event is None:
+                result = _cron_future.result()
             else:
                 result = None
                 while True:
@@ -6187,23 +6235,15 @@ def run_job(
                         _abort_if_fire_claim_lost()
                         result = _cron_future.result()
                         break
+                    if _inactivity_timeout:
+                        break
                     _abort_if_fire_claim_lost()
                     _heartbeat_run_claim_if_due()
-                    # Agent still running — check inactivity.
-                    _idle_secs = 0.0
-                    if hasattr(agent, "get_activity_summary"):
-                        try:
-                            _act = agent.get_activity_summary()
-                            _idle_secs = _act.get("seconds_since_activity", 0.0)
-                        except Exception:
-                            pass
-                    if _idle_secs >= _cron_inactivity_limit:
-                        _inactivity_timeout = True
-                        break
         except Exception:
             _cron_pool.shutdown(wait=False, cancel_futures=True)
             raise
         finally:
+            _watch_stop.set()
             _cron_pool.shutdown(wait=False, cancel_futures=True)
 
         if _inactivity_timeout:

--- a/tests/agent/test_deadline.py
+++ b/tests/agent/test_deadline.py
@@ -204,10 +204,53 @@ class TestRunBoundedSync:
         assert result.timed_out is True
         release.set()
 
+    def test_keyboard_interrupt_lands_before_full_deadline(self):
+        """Sliced Event.wait must observe SetAsyncExc within one poll slice."""
+        release = threading.Event()
+        holder: dict = {}
+
+        def _run():
+            try:
+                holder["result"] = run_bounded_sync(
+                    lambda: release.wait(30),
+                    10.0,
+                    label="ki",
+                )
+            except KeyboardInterrupt:
+                holder["exc"] = "KeyboardInterrupt"
+
+        t = threading.Thread(target=_run)
+        t.start()
+        time.sleep(0.15)
+        import ctypes
+
+        assert t.ident is not None
+        ret = ctypes.pythonapi.PyThreadState_SetAsyncExc(
+            ctypes.c_ulong(t.ident), ctypes.py_object(KeyboardInterrupt),
+        )
+        assert ret == 1
+        t.join(timeout=2.0)
+        release.set()
+        assert not t.is_alive()
+        assert holder.get("exc") == "KeyboardInterrupt"
+
     def test_deadline_expired_is_a_timeout_error(self):
         # Error-classification contract: our deadline must be catchable as
         # TimeoutError but distinguishable by type from transport timeouts.
         assert issubclass(DeadlineExpired, TimeoutError)
+
+    def test_worker_inherits_caller_contextvars(self):
+        """Profile secret scope / session id must survive the thread hop."""
+        import contextvars
+
+        var = contextvars.ContextVar("deadline_sync_ctx")
+        token = var.set("from-caller")
+        try:
+            result = run_bounded_sync(lambda: var.get(None), 5.0, label="ctx")
+        finally:
+            var.reset(token)
+        assert result.timed_out is False
+        assert result.value == "from-caller"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cron/test_cron_inactivity_timeout.py
+++ b/tests/cron/test_cron_inactivity_timeout.py
@@ -11,6 +11,7 @@ Tests cover:
 import concurrent.futures
 import os
 import sys
+import threading
 import time
 from pathlib import Path
 
@@ -234,4 +235,74 @@ class TestSysPathOrdering:
         # This import would fail if sys.path.insert comes after the import
         from cron.scheduler import _hermes_now
         assert callable(_hermes_now)
+
+
+class TestInactivityWatchdogLoop:
+    """The daemon-thread inactivity helper must not depend on the caller thread."""
+
+    def test_fires_when_idle_crosses_limit(self):
+        from cron.scheduler import _inactivity_watchdog_loop
+
+        stop = threading.Event()
+        idle = {"s": 0.0}
+        results: list = []
+
+        def _watch():
+            results.append(
+                _inactivity_watchdog_loop(
+                    get_idle_seconds=lambda: idle["s"],
+                    limit_s=0.2,
+                    poll_s=0.05,
+                    stop=stop,
+                    future_done=lambda: False,
+                )
+            )
+
+        watcher = threading.Thread(target=_watch, daemon=True)
+        watcher.start()
+        time.sleep(0.12)
+        idle["s"] = 1.0
+        watcher.join(timeout=2.0)
+        stop.set()
+        assert results == [True]
+        assert not watcher.is_alive()
+
+    def test_stops_when_future_completes_before_idle_limit(self):
+        from cron.scheduler import _inactivity_watchdog_loop
+
+        stop = threading.Event()
+        fired = _inactivity_watchdog_loop(
+            get_idle_seconds=lambda: 0.0,
+            limit_s=10.0,
+            poll_s=0.05,
+            stop=stop,
+            future_done=lambda: True,
+        )
+        assert fired is False
+
+    def test_fires_while_caller_thread_is_blocked(self):
+        """#94285: a blocked run_job thread must not disable the watchdog."""
+        from cron.scheduler import _inactivity_watchdog_loop
+
+        stop = threading.Event()
+        idle = {"s": 1.0}
+        result = {"fired": None}
+
+        def _watch():
+            result["fired"] = _inactivity_watchdog_loop(
+                get_idle_seconds=lambda: idle["s"],
+                limit_s=0.15,
+                poll_s=0.05,
+                stop=stop,
+                future_done=lambda: False,
+            )
+
+        watcher = threading.Thread(target=_watch, daemon=True)
+        watcher.start()
+        # Simulate the family-A stall: this thread cannot poll.
+        time.sleep(0.4)
+        watcher.join(timeout=2.0)
+        stop.set()
+        assert result["fired"] is True
+        assert not watcher.is_alive()
 

--- a/tests/tools/test_interrupt.py
+++ b/tests/tools/test_interrupt.py
@@ -27,6 +27,20 @@ class TestInterruptModule:
         set_interrupt(False)
         assert not is_interrupted()
 
+    def test_is_thread_interrupted_checks_target_tid_not_caller(self):
+        from tools.interrupt import (
+            set_interrupt, is_interrupted, is_thread_interrupted, _interrupted_threads, _lock,
+        )
+        with _lock:
+            _interrupted_threads.clear()
+        other_tid = threading.get_ident() + 1
+        set_interrupt(True, thread_id=other_tid)
+        assert not is_interrupted()
+        assert is_thread_interrupted(other_tid)
+        assert is_thread_interrupted(None) is False
+        set_interrupt(False, thread_id=other_tid)
+        assert not is_thread_interrupted(other_tid)
+
 
     def test_clear_current_thread_interrupt_leaves_other_threads(self):
         """clear_current_thread_interrupt only touches the calling thread."""

--- a/tests/tools/test_terminal_bounded_execute.py
+++ b/tests/tools/test_terminal_bounded_execute.py
@@ -1,0 +1,115 @@
+"""Foreground terminal execute must return when the inner wait loop wedges.
+
+#94285: a hung ``_wait_for_process`` (Windows pipe/poll, blocked loop thread)
+silently disabled every asyncio timer in the process. ``execute()`` now
+bounds spawn+wait with ``run_bounded_sync`` so the wall-clock deadline
+survives a wedged wait, and ``on_timeout`` kills the process tree.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+from tools.environments.local import LocalEnvironment
+import tools.environments.base as base_mod
+
+
+def test_execute_returns_when_wait_loop_never_returns(monkeypatch):
+    """A wedged inner wait cannot hold execute() past timeout + grace."""
+    monkeypatch.setattr(base_mod, "_EXECUTE_WAIT_BOUND_GRACE_S", 0.05)
+
+    env = LocalEnvironment()
+    fake_proc = SimpleNamespace(pid=424242)
+    monkeypatch.setattr(env, "_run_bash", lambda *a, **k: fake_proc)
+
+    def _hang(*_a, **_k):
+        time.sleep(30)
+        return {"output": "late", "returncode": 0}
+
+    monkeypatch.setattr(env, "_wait_for_process", _hang)
+    killed: list = []
+    monkeypatch.setattr(env, "_kill_process", lambda proc: killed.append(("kill", proc)))
+    monkeypatch.setattr(
+        "agent.deadline.kill_process_tree",
+        lambda pid, **_k: killed.append(("tree", pid)),
+    )
+    monkeypatch.setattr(env, "_update_cwd", lambda _result: None)
+
+    start = time.monotonic()
+    result = env.execute("sleep 30", timeout=1)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 4.0, f"execute hung {elapsed:.1f}s past the 1s bound"
+    assert result["returncode"] == 124
+    assert "timed out" in result["output"].lower()
+    assert ("kill", fake_proc) in killed
+    assert ("tree", 424242) in killed
+
+
+def test_execute_parent_interrupt_still_kills_wait_on_deadline_worker(monkeypatch):
+    """/stop targets the tool-worker tid; the deadline worker must honor it."""
+    from tools.interrupt import set_interrupt, is_interrupted
+
+    env = LocalEnvironment()
+    fake_proc = SimpleNamespace(pid=None, poll=lambda: None, stdout=None)
+    monkeypatch.setattr(env, "_run_bash", lambda *a, **k: fake_proc)
+
+    seen = {"parent": False}
+
+    def _wait(_proc, timeout=120, *, bounded_capture=False, watch_interrupt_tid=None):
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            from tools.interrupt import is_thread_interrupted
+
+            if is_interrupted() or is_thread_interrupted(watch_interrupt_tid):
+                seen["parent"] = True
+                return {"output": "[Command interrupted]", "returncode": 130}
+            time.sleep(0.02)
+        return {"output": "missed interrupt", "returncode": 0}
+
+    monkeypatch.setattr(env, "_wait_for_process", _wait)
+    monkeypatch.setattr(env, "_kill_process", lambda _proc: None)
+    monkeypatch.setattr(env, "_update_cwd", lambda _result: None)
+
+    parent_tid = __import__("threading").get_ident()
+
+    def _interrupt_soon():
+        time.sleep(0.05)
+        set_interrupt(True, thread_id=parent_tid)
+
+    import threading
+
+    threading.Thread(target=_interrupt_soon, daemon=True).start()
+    result = env.execute("sleep 30", timeout=5)
+    set_interrupt(False, thread_id=parent_tid)
+
+    assert seen["parent"] is True
+    assert result["returncode"] == 130
+
+
+def test_execute_worker_sees_caller_activity_callback(monkeypatch):
+    """Heartbeats must fire on the deadline worker, not only the tool thread."""
+    env = LocalEnvironment()
+    fake_proc = SimpleNamespace(pid=None)
+    monkeypatch.setattr(env, "_run_bash", lambda *a, **k: fake_proc)
+    seen = {"cb": "unset"}
+
+    def _wait(*_a, **_k):
+        seen["cb"] = base_mod.get_activity_callback()
+        return {"output": "ok", "returncode": 0}
+
+    monkeypatch.setattr(env, "_wait_for_process", _wait)
+    monkeypatch.setattr(env, "_update_cwd", lambda _r: None)
+
+    def _cb(_msg):
+        pass
+
+    base_mod.set_activity_callback(_cb)
+    try:
+        result = env.execute("echo ok", timeout=5)
+    finally:
+        base_mod.set_activity_callback(None)
+
+    assert result["returncode"] == 0
+    assert seen["cb"] is _cb

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -25,7 +25,7 @@ from typing import IO, Callable, Iterable, Protocol
 
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
-from tools.interrupt import is_interrupted
+from tools.interrupt import is_interrupted, is_thread_interrupted
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +34,14 @@ logger = logging.getLogger(__name__)
 # every is_interrupted() state change from _wait_for_process.  Off by default
 # to avoid flooding production gateway logs.
 _DEBUG_INTERRUPT = bool(os.getenv("HERMES_DEBUG_INTERRUPT"))
+
+# Extra seconds the ``run_bounded_sync`` backstop waits past the inner
+# ``_wait_for_process`` deadline. The inner poll loop is what returns
+# partial output + returncode 124; this outer bound only exists for when
+# that loop itself never returns (family A of #94285: a blocked wait
+# that silently disables asyncio timers). Keep it small so a healthy
+# timeout still comes from the inner path.
+_EXECUTE_WAIT_BOUND_GRACE_S = 2.0
 
 if _DEBUG_INTERRUPT:
     # AIAgent's quiet_mode path (run_agent.py) forces the `tools` logger to
@@ -1029,7 +1037,12 @@ class BaseEnvironment(ABC):
     # ------------------------------------------------------------------
 
     def _wait_for_process(
-        self, proc: ProcessHandle, timeout: int = 120, *, bounded_capture: bool = False
+        self,
+        proc: ProcessHandle,
+        timeout: int = 120,
+        *,
+        bounded_capture: bool = False,
+        watch_interrupt_tid: int | None = None,
     ) -> dict:
         """Poll-based wait with interrupt checking and stdout draining.
 
@@ -1046,6 +1059,11 @@ class BaseEnvironment(ABC):
         Fires the ``activity_callback`` (if set on this instance) every 10s
         while the process is running so the gateway's inactivity timeout
         doesn't kill long-running commands.
+
+        ``watch_interrupt_tid`` is the tool-worker thread that submitted this
+        wait. ``execute()`` may move the wait onto a ``run_bounded_sync``
+        worker; ``/stop`` still interrupts the original worker tid, so the
+        poll loop must honor that bit as well as the current thread's.
 
         Also wraps the poll loop in a ``try/finally`` that guarantees we
         call ``self._kill_process(proc)`` if we exit via ``KeyboardInterrupt``
@@ -1243,7 +1261,7 @@ class BaseEnvironment(ABC):
             _poll_sleep = 0.005
             while proc.poll() is None:
                 _iter_count += 1
-                if is_interrupted():
+                if is_interrupted() or is_thread_interrupted(watch_interrupt_tid):
                     if _DEBUG_INTERRUPT:
                         logger.info(
                             "[interrupt-debug] _wait_for_process INTERRUPT DETECTED "
@@ -1470,6 +1488,10 @@ class BaseEnvironment(ABC):
         full-fidelity consumers — file operations ``cat`` reads that feed
         the patch engine, code-execution RPC reads, log reads — MUST leave
         it False: truncating those corrupts data, not just display.
+
+        The wait is bounded by ``agent.deadline.run_bounded_sync`` so a
+        wedged poll loop cannot hang past ``timeout`` and silently disable
+        every asyncio timer in the process (#94285).
         """
         self._before_execute()
 
@@ -1502,12 +1524,82 @@ class BaseEnvironment(ABC):
         # unless login itself is broken — then non-login is the only path.
         login = not self._snapshot_ready and not self._prefer_nonlogin
 
-        proc = self._run_bash(
-            wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
-        )
-        result = self._wait_for_process(
-            proc, timeout=effective_timeout, bounded_capture=bounded_capture
-        )
+        parent_tid = threading.current_thread().ident
+        # Activity callback is thread-local (see set_activity_callback). The
+        # wait runs on the deadline worker, so copy it across or long
+        # commands look idle to cron/gateway heartbeats.
+        parent_activity_cb = get_activity_callback()
+        proc_holder: list = []
+
+        def _spawn_and_wait() -> dict:
+            if parent_activity_cb is not None:
+                set_activity_callback(parent_activity_cb)
+            spawned = self._run_bash(
+                wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
+            )
+            proc_holder.append(spawned)
+            return self._wait_for_process(
+                spawned,
+                timeout=effective_timeout,
+                bounded_capture=bounded_capture,
+                watch_interrupt_tid=parent_tid,
+            )
+
+        def _on_timeout() -> None:
+            if not proc_holder:
+                return
+            spawned = proc_holder[0]
+            try:
+                self._kill_process(spawned)
+            except Exception:
+                logger.debug(
+                    "terminal wait-bound kill_process failed", exc_info=True
+                )
+            pid = getattr(spawned, "pid", None)
+            if not pid:
+                return
+            try:
+                from agent.deadline import kill_process_tree
+
+                kill_process_tree(int(pid))
+            except Exception:
+                logger.debug(
+                    "terminal wait-bound kill_process_tree failed", exc_info=True
+                )
+
+        # Hard wall-clock backstop (#94285): ``_wait_for_process`` already
+        # polls to ``effective_timeout``, but that loop runs on the tool
+        # thread. If that thread is the event-loop thread — or the wait
+        # itself never returns (Windows pipe/poll hang) — every asyncio
+        # timer in the process is silently disabled, including the 420s
+        # sequential-tool deadline and the cron inactivity monitor.
+        # ``run_bounded_sync`` drives expiry from a daemon worker +
+        # ``Event.wait`` so a blocked loop cannot disable it. Grace lets
+        # the inner poll return the partial-output 124 path on a healthy
+        # timeout; the outer bound only fires when that loop is wedged.
+        from agent.deadline import run_bounded_sync
+
+        try:
+            bound_s = float(effective_timeout) + _EXECUTE_WAIT_BOUND_GRACE_S
+        except (TypeError, ValueError):
+            bound_s = None
+
+        try:
+            bounded = run_bounded_sync(
+                _spawn_and_wait,
+                bound_s,
+                label=f"terminal.wait:{type(self).__name__}",
+                on_timeout=_on_timeout,
+            )
+        except (KeyboardInterrupt, SystemExit):
+            _on_timeout()
+            raise
+
+        if bounded.timed_out:
+            timeout_msg = f"\n[Command timed out after {effective_timeout}s]"
+            result = {"output": timeout_msg.lstrip(), "returncode": 124}
+        else:
+            result = bounded.value
         self._update_cwd(result)
 
         return result

--- a/tools/interrupt.py
+++ b/tools/interrupt.py
@@ -79,9 +79,20 @@ def is_interrupted() -> bool:
     Safe to call from any thread — each thread only sees its own
     interrupt state.
     """
-    tid = threading.current_thread().ident
+    return is_thread_interrupted(threading.current_thread().ident)
+
+
+def is_thread_interrupted(thread_id: int | None) -> bool:
+    """Check whether *thread_id* has an interrupt bit set.
+
+    Used when a wait is moved onto a deadline worker (``run_bounded_sync``)
+    so ``/stop`` targeting the original tool-worker tid still kills the
+    subprocess (#94285). ``None`` is never interrupted.
+    """
+    if thread_id is None:
+        return False
     with _lock:
-        return tid in _interrupted_threads
+        return thread_id in _interrupted_threads
 
 
 def get_interrupt_reason() -> str | None:


### PR DESCRIPTION
## Summary
- A hung foreground `terminal` wait on the loop thread silently disabled every asyncio timer in the process, so both the 420s sequential-tool deadline and the 600s cron inactivity monitor failed to fire (field report: idle 4118s, limit 600s, last activity `executing tool: terminal`).
- Bound `BaseEnvironment.execute` spawn+wait with `agent.deadline.run_bounded_sync` (sliced `Event.wait` so KeyboardInterrupt/`/stop` still land, `on_timeout` kills the process tree) and honor `/stop` on the original tool-worker tid from the deadline worker.
- Drive the cron inactivity monitor from a daemon thread using the same kernel-timeout primitive, so a blocked `run_job` thread can no longer push an "idle for Ns (limit Ns)" record arbitrarily far past `HERMES_CRON_TIMEOUT`.

Fixes https://github.com/NousResearch/hermes-agent/issues/94285

## Test plan
- [x] `scripts/run_tests.sh tests/tools/test_terminal_bounded_execute.py tests/tools/test_terminal_timeout_output.py tests/tools/test_interrupt.py tests/tools/test_local_interrupt_cleanup.py tests/cron/test_cron_inactivity_timeout.py tests/agent/test_deadline.py tests/run_agent/test_sequential_tool_timeout.py tests/agent/test_sequential_tool_interrupt.py tests/run_agent/test_tool_activity_heartbeat.py -q`
- [ ] Confirm a foreground `sleep 9999` via `terminal` returns at the configured timeout (default 180s) instead of hanging the cron inactivity monitor
- [ ] Confirm `/stop` still kills an in-flight terminal command (interrupt bit is on the tool-worker tid, not only the deadline worker)