### PR TITLE
fix(feishu): thread fallback must reply-in-thread, not create with thread_id

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4835,34 +4835,50 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_reply_message_request(effective_reply_to, body)
             return await self._run_blocking(self._client.im.v1.message.reply, request)
 
-        # For topic/thread messages that fell back from reply→create, use
-        # thread_id as receive_id so the message lands in the topic instead of
-        # the main chat.
+        # For topic/thread messages that fell back from reply→create we cannot
+        # route by thread: the Feishu create-message API rejects
+        # ``receive_id_type=thread_id`` outright with 99992402 —
+        # ``options: [open_id,user_id,union_id,email,chat_id]``. Instead, anchor
+        # on the last message in the thread and use the reply API with
+        # ``reply_in_thread=true``, which does land the message in the topic.
+        # Falling back to a plain chat_id create() would silently move the
+        # message out of the topic and into the main chat.
         _thread_id = (metadata or {}).get("thread_id")
         if _thread_id:
-            body = self._build_create_message_body(
-                receive_id=_thread_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
+            anchor_id = await self._fetch_last_message_in_thread(_thread_id)
+            if anchor_id:
+                body = self._build_reply_message_body(
+                    content=payload,
+                    msg_type=msg_type,
+                    reply_in_thread=True,
+                    uuid_value=str(uuid.uuid4()),
+                )
+                request = self._build_reply_message_request(anchor_id, body)
+                return await self._run_blocking(
+                    self._client.im.v1.message.reply, request
+                )
+            # No anchor available (empty thread / no read scope): fall through to
+            # a chat_id create so the message is still delivered rather than lost.
+            logger.warning(
+                "[Feishu] No anchor message in thread %s; delivering to main chat instead",
+                _thread_id,
             )
-            request = self._build_create_message_request("thread_id", body)
-        else:
-            receive_id = chat_id
-            receive_id_type = "chat_id"
-            if chat_id.startswith("feishu_user_id:"):
-                receive_id = chat_id.split(":", 1)[1]
-                receive_id_type = "user_id"
-            elif chat_id.startswith("ou_"):
-                receive_id_type = "open_id"
 
-            body = self._build_create_message_body(
-                receive_id=receive_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
-            )
-            request = self._build_create_message_request(receive_id_type, body)
+        receive_id = chat_id
+        receive_id_type = "chat_id"
+        if chat_id.startswith("feishu_user_id:"):
+            receive_id = chat_id.split(":", 1)[1]
+            receive_id_type = "user_id"
+        elif chat_id.startswith("ou_"):
+            receive_id_type = "open_id"
+
+        body = self._build_create_message_body(
+            receive_id=receive_id,
+            msg_type=msg_type,
+            content=payload,
+            uuid_value=str(uuid.uuid4()),
+        )
+        request = self._build_create_message_request(receive_id_type, body)
         return await self._run_blocking(self._client.im.v1.message.create, request)
 
     @staticmethod

--- a/tests/gateway/test_stream_consumer_thread_routing.py
+++ b/tests/gateway/test_stream_consumer_thread_routing.py
@@ -107,39 +107,58 @@ class TestOverflowFirstMessage:
 
 
 class TestFeishuFallbackThreadRouting:
-    """Verify FeishuAdapter._send_raw_message routes to topic on fallback."""
+    """Verify FeishuAdapter._send_raw_message routes to topic on fallback.
 
-    @pytest.mark.asyncio
-    async def test_create_uses_thread_id_when_available(self):
-        """When reply_to=None and metadata has thread_id, message.create
-        should use receive_id_type='thread_id'."""
+    The Feishu create-message API does NOT accept ``receive_id_type=thread_id``
+    — it rejects the request with 99992402 ``field validation failed`` and
+    reports ``options: [open_id,user_id,union_id,email,chat_id]``. So a
+    reply→create fallback for a topic message must anchor on the last message
+    in the thread and use the reply API with ``reply_in_thread=true``.
+    """
+
+    @staticmethod
+    def _make_raw_adapter(mock_client):
+        """Build a MagicMock adapter wired to the real _send_raw_message deps."""
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
-        # We test the _send_raw_message method directly by mocking the client
         adapter = MagicMock(spec=FeishuAdapter)
-
-        # Set up the real _send_raw_message logic manually
-        mock_client = MagicMock()
-        mock_create_response = SimpleNamespace(
-            success=lambda: True,
-            data=SimpleNamespace(message_id="new_msg_1"),
-        )
-        mock_client.im.v1.message.create = MagicMock(return_value=mock_create_response)
-
-        # Use the real implementation path
         adapter._client = mock_client
         adapter._build_create_message_body = FeishuAdapter._build_create_message_body
         adapter._build_create_message_request = FeishuAdapter._build_create_message_request
+        adapter._build_reply_message_body = FeishuAdapter._build_reply_message_body
+        adapter._build_reply_message_request = FeishuAdapter._build_reply_message_request
         # _send_raw_message routes blocking SDK calls through _run_blocking
         # (adapter-owned executor). On a MagicMock(spec=...) that method is
         # auto-mocked and would swallow the real call, so wire a passthrough.
         async def _run_blocking_passthrough(func, *args):
             return func(*args)
         adapter._run_blocking = _run_blocking_passthrough
+        return adapter
 
-        # Call _send_raw_message with reply_to=None and thread_id in metadata
+    @pytest.mark.asyncio
+    async def test_thread_fallback_replies_in_thread_instead_of_create(self):
+        """When reply_to=None and metadata has thread_id, the adapter must
+        anchor on the thread's last message and call message.reply with
+        reply_in_thread=True — never message.create with thread_id."""
         import json
-        result = await FeishuAdapter._send_raw_message(
+
+        mock_client = MagicMock()
+        mock_reply_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="new_msg_1"),
+        )
+        mock_client.im.v1.message.reply = MagicMock(return_value=mock_reply_response)
+        mock_client.im.v1.message.create = MagicMock()
+
+        adapter = self._make_raw_adapter(mock_client)
+
+        async def _fetch_anchor(thread_id):
+            assert thread_id == "omt_topic_abc"
+            return "om_anchor_msg"
+        adapter._fetch_last_message_in_thread = _fetch_anchor
+
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+        await FeishuAdapter._send_raw_message(
             adapter,
             chat_id="oc_main_chat",
             msg_type="text",
@@ -148,27 +167,69 @@ class TestFeishuFallbackThreadRouting:
             metadata={"thread_id": "omt_topic_abc"},
         )
 
-        # Verify message.create was called (not message.reply)
-        mock_client.im.v1.message.create.assert_called_once()
+        # reply API is used; create() must NOT be called with thread_id, since
+        # the API rejects receive_id_type=thread_id with 99992402.
+        mock_client.im.v1.message.reply.assert_called_once()
+        mock_client.im.v1.message.create.assert_not_called()
 
-        # The request should have receive_id_type="thread_id"
-        call_args = mock_client.im.v1.message.create.call_args[0][0]
-        # Lark SDK builder exposes .body; the in-tree fallback exposes .request_body.
-        # The contributor's branch had the lark SDK installed, the test environment
-        # may not — handle both shapes.
+        # The reply must be anchored on the thread's last message...
+        call_args = mock_client.im.v1.message.reply.call_args[0][0]
+        message_id = getattr(call_args, "message_id", None)
+        assert message_id == "om_anchor_msg", (
+            f"Expected reply anchored on 'om_anchor_msg', got '{message_id}'"
+        )
+        # ...and carry reply_in_thread=True so it lands in the topic.
         body = getattr(call_args, "body", None) or getattr(call_args, "request_body", None)
         assert body is not None, "request has neither .body nor .request_body"
-        # receive_id should be the thread_id, not the chat_id
+        reply_in_thread = getattr(body, "reply_in_thread", None)
+        if reply_in_thread is None and isinstance(body, str):
+            import json as _json
+            reply_in_thread = _json.loads(body).get("reply_in_thread")
+        assert reply_in_thread is True, (
+            f"Expected reply_in_thread=True, got {reply_in_thread!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_thread_fallback_without_anchor_delivers_to_main_chat(self):
+        """If no anchor message can be found (empty thread / missing read
+        scope), the message must still be delivered via a chat_id create
+        rather than silently lost."""
+        import json
+
+        mock_client = MagicMock()
+        mock_create_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="new_msg_2"),
+        )
+        mock_client.im.v1.message.create = MagicMock(return_value=mock_create_response)
+        mock_client.im.v1.message.reply = MagicMock()
+
+        adapter = self._make_raw_adapter(mock_client)
+
+        async def _no_anchor(thread_id):
+            return None
+        adapter._fetch_last_message_in_thread = _no_anchor
+
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+        await FeishuAdapter._send_raw_message(
+            adapter,
+            chat_id="oc_main_chat",
+            msg_type="text",
+            payload=json.dumps({"text": "hello"}),
+            reply_to=None,
+            metadata={"thread_id": "omt_topic_abc"},
+        )
+
+        mock_client.im.v1.message.reply.assert_not_called()
+        mock_client.im.v1.message.create.assert_called_once()
+
+        # Falls back to a chat_id create — an API-accepted receive_id_type.
+        call_args = mock_client.im.v1.message.create.call_args[0][0]
+        assert getattr(call_args, "receive_id_type", None) == "chat_id"
+        body = getattr(call_args, "body", None) or getattr(call_args, "request_body", None)
         receive_id = getattr(body, "receive_id", None)
         if receive_id is None and isinstance(body, str):
             import json as _json
             receive_id = _json.loads(body).get("receive_id")
-        assert receive_id == "omt_topic_abc", (
-            f"Expected receive_id='omt_topic_abc', got '{receive_id}'"
-        )
-        # And receive_id_type must be 'thread_id', not 'chat_id'
-        receive_id_type = getattr(call_args, "receive_id_type", None)
-        assert receive_id_type == "thread_id", (
-            f"Expected receive_id_type='thread_id', got '{receive_id_type}'"
-        )
+        assert receive_id == "oc_main_chat"
 


### PR DESCRIPTION
## Problem

Cron jobs (and any other non-reply send) targeting a Feishu **topic** fail with `[99992402] field validation failed` and the message is silently dropped. The job itself records `last_status: ok` and only `last_delivery_error` carries the failure, so a scheduled daily report can go missing for days with no visible symptom:

```
"last_delivery_error": "live adapter send failed: [99992402] field validation failed; live adapter delivery to feishu:oc_... failed: [99992402] field validation failed"
"last_status": "ok"
```

## Root cause

The reply→create fallback in `FeishuAdapter._send_raw_message` builds a create-message request with `receive_id_type="thread_id"`:

```python
request = self._build_create_message_request("thread_id", body)
```

The Feishu create-message API does not accept that value. It rejects the request with 99992402 and reports:

```
options: [open_id,user_id,union_id,email,chat_id]
```

`thread_id` is a valid `container_id_type` for the *message list* API, but not a valid `receive_id_type` for *create*. Interestingly the adapter already knows this in one place — the audio send path has a 99992402 retry that falls back to the reply API (`_fetch_last_message_in_thread`) precisely because of this. That workaround only covers audio; every other message type still hits the broken create path.

## Fix

When a topic message has no reply anchor, anchor on the thread's last message and send via the reply API with `reply_in_thread=true`, which does land the message in the topic. This reuses the existing `_fetch_last_message_in_thread` helper rather than adding new surface.

If no anchor is available (empty thread, or the app lacks message-read scope), fall through to a `chat_id` create and log a warning — the message is delivered to the main chat rather than lost. Silently dropping it would be worse than a slightly misplaced message.

## Verification

Verified end-to-end on a live Feishu workspace, not just in mocks. A cron job delivering to a topic previously failed with 99992402 on every fire; after the fix the same job completes with `last_delivery_error: null` and the message arrives in the topic.

```
Result: ok    Delivery target: origin
last_status: ok    last_delivery_error: null
```

## Tests

`tests/gateway/test_stream_consumer_thread_routing.py::TestFeishuFallbackThreadRouting::test_create_uses_thread_id_when_available` asserted the broken behavior — that `create()` is called with `receive_id_type="thread_id"`. Since that is exactly the request the API rejects, the test was locking in the bug and had to change. It is replaced with two tests covering the real contract:

- `test_thread_fallback_replies_in_thread_instead_of_create` — reply API is used, anchored on the thread's last message, with `reply_in_thread=True`; `create()` is never called.
- `test_thread_fallback_without_anchor_delivers_to_main_chat` — no anchor available ⇒ `chat_id` create fallback, message still delivered.

```
tests/gateway/test_stream_consumer_thread_routing.py  5 passed
tests/gateway/ -k "feishu or thread"                  487 passed, 1 skipped
```

Note: `tests/gateway/test_feishu_approval_buttons.py` has 2 failures (`test_rejects_approval_click_from_unauthorized_user`, `test_update_prompt_unauthorized_operator_returns_no_card`) that reproduce identically on unmodified `main` — pre-existing and unrelated to this change.
