### PR TITLE
Add managed gateway upload for local image references

### DIFF
--- a/tests/tools/test_image_generation_managed_local_upload.py
+++ b/tests/tools/test_image_generation_managed_local_upload.py
@@ -172,3 +172,45 @@ def test_grounding_route_is_visible_in_success_result(image_tool):
 
     assert payload["success"] is True
     assert payload.get("grounding_route") == "managed_gateway_forced_by_local_reference"
+
+
+def test_stale_nous_upload_token_error_has_context_and_setup_guidance(image_tool, tmp_path, monkeypatch):
+    """PR #94307 review Note 1: when arguments already contain a nous-upload:
+    token (i.e. a local source was already uploaded) but managed access is
+    now unavailable, the error must (a) stay explicit about the stale/managed
+    -token situation, (b) reuse the normal actionable setup/remediation
+    guidance from `_build_no_backend_setup_message()`, and (c) the direct FAL
+    route must never receive the managed token."""
+    model_id = "fal-ai/flux-2/klein/9b"
+    meta = image_tool.FAL_MODELS[model_id]
+    direct_client = Mock()
+    direct_client.submit.side_effect = AssertionError("direct route was reached")
+
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    patches = _generation_patches(image_tool, meta)
+    with patches[0], patches[1], patches[2], \
+         patch.object(image_tool, "_resolve_fal_model", return_value=(model_id, meta)), \
+         patch.object(image_tool, "resolve_managed_tool_gateway", return_value=None), \
+         patch.object(image_tool, "fal_client", direct_client):
+        # Simulate arguments that already carry a stale nous-upload: token
+        # (e.g. a previously-uploaded reference) by feeding it straight in
+        # as the image_url — `_upload_local_fal_sources` is bypassed because
+        # a nous-upload: string is not a local path, so it flows straight
+        # into the `_contains_managed_upload` gate unchanged.
+        payload = json.loads(image_tool.image_generate_tool(
+            "edit it", image_url="nous-upload:stale-token",
+        ))
+
+    assert payload["success"] is False
+    error = payload["error"]
+    # Explicit about the stale/managed-token condition.
+    assert "nous-upload:" in error
+    assert "managed FAL" in error
+    assert "unavailable" in error
+    assert "stale" in error.lower() or "lost managed access" in error.lower()
+    # Reuses the normal actionable setup/remediation guidance verbatim
+    # (via `_build_no_backend_setup_message()`), not a duplicated blurb.
+    setup_message = image_tool._build_no_backend_setup_message()
+    assert setup_message in error
+    # The direct FAL route must never be reached / never receive the token.
+    direct_client.submit.assert_not_called()

--- a/tests/tools/test_image_generation_managed_local_upload.py
+++ b/tests/tools/test_image_generation_managed_local_upload.py
@@ -1,0 +1,174 @@
+"""Tests for the managed FAL local-image-reference upload adapter.
+
+Covers `_upload_local_fal_sources`, `_contains_managed_upload`,
+`_is_local_image_source`, and the per-request managed-routing override in
+`_submit_fal_request` / `image_generate_tool`. Does not exercise a real
+network call or a real Nous/FAL credential — all gateway/upload/FAL-client
+behavior is mocked.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+
+@pytest.fixture
+def image_tool():
+    """Fresh import of tools.image_generation_tool per test."""
+    import tools.image_generation_tool as mod
+    return importlib.reload(mod)
+
+
+class _Handler:
+    """Minimal stand-in for the object `_submit_fal_request` returns."""
+
+
+def _generation_patches(image_tool, meta):
+    """Common patches so `image_generate_tool` reaches `_submit_fal_request`
+    without touching real model resolution, waiting, or debug logging."""
+    return (
+        patch.object(image_tool, "_resolve_fal_model", return_value=("fal/test", meta)),
+        patch.object(image_tool, "_wait_fal_result", return_value={
+            "images": [{"url": "https://fal.example/out.png"}],
+        }),
+        patch.object(image_tool, "_debug", Mock(log_call=lambda *a, **k: None, save=lambda: None)),
+    )
+
+
+def test_is_local_image_source_classification(image_tool):
+    assert image_tool._is_local_image_source("/opt/data/x.png") is True
+    assert image_tool._is_local_image_source("x.png") is True
+    assert image_tool._is_local_image_source("file:///opt/data/x.png") is True
+    assert image_tool._is_local_image_source("https://example.com/x.png") is False
+    assert image_tool._is_local_image_source("data:image/png;base64,AA==") is False
+    assert image_tool._is_local_image_source("nous-upload:abc123") is False
+    assert image_tool._is_local_image_source(None) is False
+    assert image_tool._is_local_image_source("") is False
+
+
+def test_contains_managed_upload_detects_nested_tokens(image_tool):
+    assert image_tool._contains_managed_upload("nous-upload:abc") is True
+    assert image_tool._contains_managed_upload("https://x.com/y.png") is False
+    assert image_tool._contains_managed_upload({"image_urls": ["nous-upload:abc"]}) is True
+    assert image_tool._contains_managed_upload(["a", "https://x.com"]) is False
+
+
+def test_upload_local_fal_sources_passthrough_for_remote_and_none(image_tool):
+    sources = ["https://example.test/a.png", "data:image/png;base64,AA==", None]
+    with patch.object(image_tool, "resolve_managed_tool_gateway") as resolve_gateway:
+        result = image_tool._upload_local_fal_sources(sources)
+    assert result == sources
+    resolve_gateway.assert_not_called()
+
+
+def test_upload_local_fal_sources_uploads_via_managed_gateway(image_tool, tmp_path):
+    png = tmp_path / "reference.png"
+    png.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+
+    fake_uploader = AsyncMock(return_value="nous-upload:opaque-token")
+    resolved = Mock(data=b"\x89PNG\r\n\x1a\nfake", mime="image/png")
+
+    with patch.object(image_tool, "resolve_managed_tool_gateway", return_value=Mock()), \
+         patch.object(image_tool, "managed_vendor_endpoints", return_value={
+             "base_url": "https://tool-gateway.example/api/fal",
+             "upload_path": "/api/uploads/fal",
+         }), \
+         patch.object(image_tool, "build_managed_media_uploader", return_value=fake_uploader), \
+         patch("tools.image_source.resolve_image_source", new=AsyncMock(return_value=resolved)):
+        result = image_tool._upload_local_fal_sources([str(png)])
+
+    assert result == ["nous-upload:opaque-token"]
+    fake_uploader.assert_awaited_once_with(b"\x89PNG\r\n\x1a\nfake", "image/png")
+
+
+def test_upload_local_fal_sources_direct_fal_only_preserves_passthrough(image_tool, tmp_path):
+    png = tmp_path / "reference.png"
+    png.write_bytes(b"fake")
+
+    with patch.object(image_tool, "resolve_managed_tool_gateway", return_value=None), \
+         patch.object(image_tool, "fal_key_is_configured", return_value=True):
+        result = image_tool._upload_local_fal_sources([str(png)])
+
+    assert result == [str(png)]
+
+
+def test_upload_local_fal_sources_neither_backend_raises_explicit_error(image_tool, tmp_path):
+    png = tmp_path / "reference.png"
+    png.write_bytes(b"fake")
+
+    with patch.object(image_tool, "resolve_managed_tool_gateway", return_value=None), \
+         patch.object(image_tool, "fal_key_is_configured", return_value=False):
+        with pytest.raises(ValueError, match="neither is available"):
+            image_tool._upload_local_fal_sources([str(png)])
+
+
+def test_submit_fal_request_forces_managed_route_for_nous_upload_token(image_tool, caplog):
+    managed_client = Mock()
+    managed_client.submit.return_value = _Handler()
+    direct_client = Mock()
+    direct_client.submit.side_effect = AssertionError("direct route was reached")
+
+    with caplog.at_level(logging.INFO), \
+         patch.object(image_tool, "_load_fal_client"), \
+         patch.object(image_tool, "resolve_managed_tool_gateway", return_value=Mock()), \
+         patch.object(image_tool, "_get_managed_fal_client", return_value=managed_client), \
+         patch.object(image_tool, "fal_client", direct_client):
+        image_tool._submit_fal_request("fal/test/edit", {"image_urls": ["nous-upload:opaque"]})
+
+    managed_client.submit.assert_called_once()
+    direct_client.submit.assert_not_called()
+    sent = managed_client.submit.call_args.kwargs["arguments"]
+    assert sent["image_urls"] == ["nous-upload:opaque"]
+    assert "Forcing managed FAL gateway routing" in caplog.text
+
+
+def test_submit_fal_request_without_nous_upload_uses_normal_selection(image_tool):
+    """Requests without a managed-upload token must not be affected at all —
+    the pre-existing selection-based routing (_resolve_managed_fal_gateway)
+    decides, exactly as before this adapter existed."""
+    direct_client = Mock()
+    direct_client.submit.return_value = _Handler()
+
+    with patch.object(image_tool, "_load_fal_client"), \
+         patch.object(image_tool, "_resolve_managed_fal_gateway", return_value=None) as resolve_direct, \
+         patch.object(image_tool, "resolve_managed_tool_gateway") as resolve_managed, \
+         patch.object(image_tool, "fal_client", direct_client):
+        image_tool._submit_fal_request("fal/test/edit", {"image_url": "https://x.com/y.png"})
+
+    resolve_direct.assert_called_once()
+    resolve_managed.assert_not_called()
+    direct_client.submit.assert_called_once()
+
+
+def test_grounding_route_is_visible_in_success_result(image_tool):
+    """The 'never silent' contract: a forced managed reroute must surface in
+    the actual JSON result, not just a log line."""
+    model_id = "fal-ai/flux-2/klein/9b"
+    meta = image_tool.FAL_MODELS[model_id]
+    managed_client = Mock()
+    managed_client.submit.return_value = _Handler()
+
+    patches = _generation_patches(image_tool, meta)
+    with patches[0], patches[1], patches[2], \
+         patch.object(image_tool, "_resolve_fal_model", return_value=(model_id, meta)), \
+         patch.object(image_tool, "resolve_managed_tool_gateway", return_value=Mock()), \
+         patch.object(image_tool, "managed_vendor_endpoints", return_value={
+             "base_url": "https://tool-gateway.example/api/fal", "upload_path": "/api/uploads/fal",
+         }), \
+         patch.object(image_tool, "build_managed_media_uploader",
+                       return_value=AsyncMock(return_value="nous-upload:opaque")), \
+         patch("tools.image_source.resolve_image_source",
+               new=AsyncMock(return_value=Mock(data=b"fake", mime="image/png"))), \
+         patch.object(image_tool, "_load_fal_client"), \
+         patch.object(image_tool, "_get_managed_fal_client", return_value=managed_client):
+        payload = json.loads(image_tool.image_generate_tool(
+            "edit it", image_url="/opt/data/reference.png",
+        ))
+
+    assert payload["success"] is True
+    assert payload.get("grounding_route") == "managed_gateway_forced_by_local_reference"

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -64,7 +64,11 @@ from tools.fal_common import (
     _extract_http_status,
     _normalize_fal_queue_url_format,  # noqa: F401 — re-exported for tests
 )
-from tools.managed_tool_gateway import resolve_managed_tool_gateway
+from tools.managed_tool_gateway import (
+    build_managed_media_uploader,
+    managed_vendor_endpoints,
+    resolve_managed_tool_gateway,
+)
 from tools.tool_backend_helpers import (
     NOUS_MANAGED_PROVIDER,
     fal_key_is_configured,
@@ -844,7 +848,20 @@ def _submit_fal_request(model: str, arguments: Dict[str, Any]):
     # Trigger the lazy import on first call. Idempotent.
     _load_fal_client()
     request_headers = {"x-idempotency-key": str(uuid.uuid4())}
-    managed_gateway = _resolve_managed_fal_gateway()
+    force_managed = _contains_managed_upload(arguments)
+    if force_managed:
+        managed_gateway = resolve_managed_tool_gateway("fal-queue")
+        if managed_gateway is None:
+            raise ValueError(
+                "A local image was uploaded to the Nous managed gateway, but "
+                "managed FAL generation is unavailable for this request."
+            )
+        logger.info(
+            "Forcing managed FAL gateway routing for this request because "
+            "its arguments contain a nous-upload: local-reference token"
+        )
+    else:
+        managed_gateway = _resolve_managed_fal_gateway()
     if managed_gateway is None:
         return fal_client.submit(model, arguments=arguments, headers=request_headers)
 
@@ -880,6 +897,77 @@ def _submit_fal_request(model: str, arguments: Dict[str, Any]):
                 f"{gateway_message}"
             ) from exc
         raise
+
+
+def _contains_managed_upload(value: Any) -> bool:
+    """Return whether a nested request value contains a managed upload token."""
+    if isinstance(value, str):
+        return value.startswith("nous-upload:")
+    if isinstance(value, dict):
+        return any(_contains_managed_upload(item) for item in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(_contains_managed_upload(item) for item in value)
+    return False
+
+
+def _is_local_image_source(value: Any) -> bool:
+    """Identify path-like sources without changing URL/data/token handling."""
+    if not isinstance(value, str) or not value.strip():
+        return False
+    source = value.strip().lower()
+    if source.startswith(("http://", "https://", "data:", "nous-upload:")):
+        return False
+    # Explicit non-file URL schemes are provider inputs, not local paths.
+    if "://" in source and not source.startswith("file://"):
+        return False
+    return True
+
+
+def _upload_local_fal_sources(source_images: list) -> list:
+    """Upload local FAL edit sources when managed access is available.
+
+    Direct-FAL-only installations retain the historical local-path pass-through.
+    The resolver returns bytes, and those exact in-memory bytes are uploaded;
+    the path is never reopened by this adapter.
+    """
+    if not any(_is_local_image_source(source) for source in source_images):
+        return source_images
+
+    managed_gateway = resolve_managed_tool_gateway("fal-queue")
+    if managed_gateway is None:
+        if fal_key_is_configured():
+            return source_images
+        raise ValueError(
+            "A local image path requires either Nous managed FAL access for "
+            "secure upload or a configured FAL_KEY for legacy direct-FAL "
+            "pass-through; neither is available."
+        )
+
+    endpoints = managed_vendor_endpoints("fal")
+    uploader = None
+    if endpoints is not None:
+        uploader = build_managed_media_uploader(
+            endpoints["base_url"], endpoints["upload_path"]
+        )
+    if uploader is None:
+        raise ValueError(
+            "Nous managed FAL access is available, but its local-image upload "
+            "endpoint could not be configured."
+        )
+
+    from model_tools import _run_async
+    from tools.image_source import ResolveContext, resolve_image_source
+
+    resolved_sources = []
+    for source in source_images:
+        if not _is_local_image_source(source):
+            resolved_sources.append(source)
+            continue
+        resolved = _run_async(resolve_image_source(
+            source, ResolveContext(), permitted=("image",)
+        ))
+        resolved_sources.append(_run_async(uploader(resolved.data, resolved.mime)))
+    return resolved_sources
 
 
 # ---------------------------------------------------------------------------
@@ -1259,15 +1347,28 @@ def image_generate_tool(
     }
 
     start_time = datetime.datetime.now()
+    grounding_route = None
 
     try:
         if not prompt or not isinstance(prompt, str) or len(prompt.strip()) == 0:
             raise ValueError("Prompt is required and must be a non-empty string")
 
+        # This is the in-tree FAL path: plugin and Krea dispatch has already
+        # happened, while non-local sources were confined to data: URLs.
+        backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
+        if backend in ("", "local") and source_images:
+            source_images = _upload_local_fal_sources(source_images)
+
         # Strict selection check: a stored-but-broken selection raises the
         # honest selection-naming error from _resolve_managed_fal_gateway();
         # only the never-configured path can report "no backend at all".
-        if not (fal_key_is_configured() or _resolve_managed_fal_gateway()):
+        if _contains_managed_upload(source_images):
+            if resolve_managed_tool_gateway("fal-queue") is None:
+                raise ValueError(
+                    "A nous-upload: image reference requires managed FAL "
+                    "gateway access, but it is unavailable."
+                )
+        elif not (fal_key_is_configured() or _resolve_managed_fal_gateway()):
             raise ValueError(_build_no_backend_setup_message())
 
         # If the caller supplied source images but the active model has no
@@ -1322,6 +1423,9 @@ def image_generate_tool(
                 "Generating image with %s (%s) — prompt: %s",
                 meta.get("display", model_id), model_id, prompt[:80],
             )
+
+        if _contains_managed_upload(arguments):
+            grounding_route = "managed_gateway_forced_by_local_reference"
 
         handler = _submit_fal_request(endpoint, arguments=arguments)
         result = _wait_fal_result(handler)
@@ -1381,6 +1485,8 @@ def image_generate_tool(
             "modality": modality,
             "upscaled": bool(formatted_images and formatted_images[0].get("upscaled")),
         }
+        if grounding_route is not None:
+            response_data["grounding_route"] = grounding_route
 
         debug_call_data["success"] = True
         debug_call_data["images_generated"] = len(formatted_images)
@@ -1401,6 +1507,8 @@ def image_generate_tool(
             "error": str(e),
             "error_type": type(e).__name__,
         }
+        if grounding_route is not None:
+            response_data["grounding_route"] = grounding_route
 
         debug_call_data["error"] = error_msg
         debug_call_data["generation_time"] = generation_time

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -911,7 +911,12 @@ def _contains_managed_upload(value: Any) -> bool:
 
 
 def _is_local_image_source(value: Any) -> bool:
-    """Identify path-like sources without changing URL/data/token handling."""
+    """Identify path-like sources without changing URL/data/token handling.
+
+    By contract, callers only ever pass a URL, a ``data:`` URI, a
+    ``nous-upload:`` token, or a local filesystem path — this treats
+    anything not matching one of the recognized non-local schemes as local.
+    """
     if not isinstance(value, str) or not value.strip():
         return False
     source = value.strip().lower()
@@ -1366,7 +1371,8 @@ def image_generate_tool(
             if resolve_managed_tool_gateway("fal-queue") is None:
                 raise ValueError(
                     "A nous-upload: image reference requires managed FAL "
-                    "gateway access, but it is unavailable."
+                    "gateway access, but it is unavailable (stale token or "
+                    "lost managed access).\n\n" + _build_no_backend_setup_message()
                 )
         elif not (fal_key_is_configured() or _resolve_managed_fal_gateway()):
             raise ValueError(_build_no_backend_setup_message())


### PR DESCRIPTION
## Summary

Local reference images passed to `image_generate` currently have no supported path to FAL when running with `TERMINAL_ENV=local`: `_confine_source_images()` is a deliberate no-op on that backend (by design — providers keep their own host reads there), so a raw local path is forwarded to FAL's API as-is and fails with `file_download_error`. There is no way today to ground an edit/generation on a local file without either (a) manually building an inline `data:` URI (works, but is brittle for larger images and isn't a supported/durable mechanism), or (b) extracting a raw FAL credential to upload directly (which the Nous-managed gateway's governance — allowlisting, billing, audit — should own, not the tool).

This PR wires local-file grounding through **infrastructure that already exists and already works for a different vendor**: `tools/managed_tool_gateway.py`'s presigned-upload primitive (`managed_vendor_endpoints` + `build_managed_media_uploader`), already used in production by `tools/flux3_video_tool.py` for BFL video generation. Nothing in `managed_tool_gateway.py` or `tools/image_source.py` needs to change — this PR only adds the missing FAL-side integration.

## What changed

One file: `tools/image_generation_tool.py`. See the attached diff.

- `_upload_local_fal_sources()` — resolves each local source **once**, into memory, via the existing `resolve_image_source()` (already TOCTOU-safe: reads bytes once, never reopens by path), then uploads those exact bytes via `build_managed_media_uploader(managed_vendor_endpoints("fal"))`, producing a `nous-upload:<token>` string.
- `_contains_managed_upload()` — detects a `nous-upload:` token anywhere in the final nested request arguments.
- `_submit_fal_request()` — when a `nous-upload:` token is present, forces managed-gateway routing **for that one request only**. This does not read or write `image_gen`'s stored provider selection (`read_selection("image_gen")` / `NOUS_MANAGED_PROVIDER`); it's a request-scoped override, because a `nous-upload:` token is only ever redeemable through the gateway that issued it — sending it through the direct-credential branch would just fail, or worse, leak an opaque token to the wrong service.

### Honoring the existing "never silent" contract

`_resolve_managed_fal_gateway()`'s own docstring states the existing selection model's design intent explicitly: *"never a silent fall back to FAL_KEY... never a silent managed reroute."* A request-scoped override needed to respect that spirit even though it's mechanically necessary (the token literally cannot go anywhere else). Two visible signals were added:

1. `logger.info(...)` fires whenever routing is forced, naming the reason.
2. The JSON result (success **and** error) gains `"grounding_route": "managed_gateway_forced_by_local_reference"` whenever this happened, so it's visible in the actual tool-call result, not just a log line a user might not read.

### Backward compatibility

- Direct-FAL-only installations (no managed gateway, `FAL_KEY` configured) keep the **exact prior local-path pass-through behavior** for that population — this PR does not change what happens for them beyond adding the (currently unreachable, since they have no managed gateway) upload attempt.
- Installations with **neither** managed access nor `FAL_KEY` now get an explicit, actionable error instead of a confusing downstream `file_download_error`.
- `http(s)://`, `data:`, `None`/text-only, non-local terminal backends, plugin providers, and managed Krea routing are all completely untouched — verified by test and by construction (the new code only activates inside the in-tree FAL branch, after all of those have already had first refusal).

## Testing

5 unit tests (mocked, no network calls) in the attached `test_adapter.py`:
- local path + managed gateway available → upload occurs, routing forced, `grounding_route` visible in the result
- local path + direct-FAL-only (no managed gateway) → old raw-path pass-through preserved
- local path + neither available → explicit `ValueError`, not silent
- `http(s)://` / `data:` / `None` sources → completely untouched, gateway resolution never even consulted
- a `nous-upload:` token is proven, via a tripwire mock that raises if reached, to be structurally incapable of reaching the direct-credential `fal_client.submit()` call

## Prior investigation and review

This PR is the output of a full architecture investigation and two independent review passes done against an earlier version of this codebase (before the `read_selection`/`NOUS_MANAGED_PROVIDER` refactor landed): Claude Code reviewed the original design and found it **secure as written** with zero BLOCKER/HIGH findings (one MEDIUM functional-regression finding, already incorporated as the direct-FAL-only pass-through logic above). A parallel Grok adversarial review did not complete after several attempts due to CLI instability — noted here for transparency rather than omitted.

## Known open question for reviewers

The direct-FAL-only pass-through branch preserves *historical* behavior (a raw local path reaching `fal_client.submit()` unmodified), which — as before this PR — will still fail against FAL's own API for most models. This PR does not attempt to fix that population's underlying problem (no gateway access to upload through); it only avoids regressing them further. Whether that population deserves its own follow-up fix is a separate discussion.

## Status

**Draft.** Not deployment-ready — needs maintainer review, and has not been tested against a real (non-mocked) managed FAL gateway or a real generation call. No credentials of any kind were used in preparing this PR.
