### PR TITLE
fix(bluebubbles): send via private-api whenever the helper is connected

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -13,9 +13,9 @@ import json
 import logging
 import os
 import re
+import time
 import uuid
 from collections import OrderedDict
-from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
@@ -520,7 +520,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         payload = {
             "addresses": [address],
             "message": message,
-            "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+            "tempGuid": f"temp-{time.time_ns()}",
         }
         if self._use_private_api_send():
             payload["method"] = "private-api"
@@ -578,7 +578,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 )
             payload: Dict[str, Any] = {
                 "chatGuid": guid,
-                "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+                "tempGuid": f"temp-{time.time_ns()}",
                 "message": chunk,
             }
             if self._use_private_api_send():

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -570,10 +570,18 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
                 "message": chunk,
             }
-            if reply_to and self._private_api_enabled and self._helper_connected:
+            if self._private_api_enabled and self._helper_connected:
+                # The server treats an omitted ``method`` as "apple-script",
+                # which drives Messages.app through AppleScript and needs the
+                # helper's macOS user to hold an active GUI session. Private
+                # API sends also work from a fast-user-switched or otherwise
+                # backgrounded login, so prefer it whenever the helper is
+                # connected -- replies already did, and reactions, typing
+                # indicators and read receipts require the helper anyway.
                 payload["method"] = "private-api"
-                payload["selectedMessageGuid"] = reply_to
-                payload["partIndex"] = 0
+                if reply_to:
+                    payload["selectedMessageGuid"] = reply_to
+                    payload["partIndex"] = 0
             try:
                 res = await self._api_post("/api/v1/message/text", payload)
                 data = res.get("data") or {}

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -504,6 +504,15 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             pass
         return None
 
+    def _use_private_api_send(self) -> bool:
+        """Send through the Private API helper when it is available.
+
+        An omitted ``method`` defaults to AppleScript on the server, which
+        cannot drive Messages.app unless the BlueBubbles macOS user is the
+        active GUI login.
+        """
+        return bool(self._private_api_enabled and self._helper_connected)
+
     async def _create_chat_for_handle(
         self, address: str, message: str
     ) -> SendResult:
@@ -513,6 +522,8 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             "message": message,
             "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
         }
+        if self._use_private_api_send():
+            payload["method"] = "private-api"
         try:
             res = await self._api_post("/api/v1/chat/new", payload)
             data = res.get("data") or {}
@@ -570,14 +581,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
                 "message": chunk,
             }
-            if self._private_api_enabled and self._helper_connected:
-                # The server treats an omitted ``method`` as "apple-script",
-                # which drives Messages.app through AppleScript and needs the
-                # helper's macOS user to hold an active GUI session. Private
-                # API sends also work from a fast-user-switched or otherwise
-                # backgrounded login, so prefer it whenever the helper is
-                # connected -- replies already did, and reactions, typing
-                # indicators and read receipts require the helper anyway.
+            if self._use_private_api_send():
                 payload["method"] = "private-api"
                 if reply_to:
                     payload["selectedMessageGuid"] = reply_to
@@ -629,6 +633,8 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             }
             if is_audio_message:
                 data["isAudioMessage"] = "true"
+            if self._use_private_api_send():
+                data["method"] = "private-api"
             res = await self.client.post(
                 self._api_url("/api/v1/message/attachment"),
                 files=files,

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -317,59 +317,150 @@ class TestBlueBubblesAttachmentSend:
 
 class TestBlueBubblesTextSend:
     @staticmethod
-    def _capture_send(monkeypatch, adapter):
-        captured = {}
+    def _capture_send(monkeypatch, adapter, *, private_api=True, helper=True):
+        adapter._private_api_enabled = private_api
+        adapter._helper_connected = helper
+        posts = []
 
         async def fake_resolve_chat_guid(chat_id):
             return "iMessage;-;+15551234567"
 
         async def fake_api_post(path, payload):
-            captured.update(path=path, payload=payload)
+            posts.append((path, payload))
             return {"status": 200, "data": {"guid": "message-guid"}}
 
         monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
         monkeypatch.setattr(adapter, "_api_post", fake_api_post)
-        return captured
+        return posts
 
     @pytest.mark.asyncio
     async def test_send_uses_private_api_when_helper_connected(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
-        adapter._private_api_enabled = True
-        adapter._helper_connected = True
-        captured = self._capture_send(monkeypatch, adapter)
+        posts = self._capture_send(monkeypatch, adapter)
 
         result = await adapter.send("+15551234567", "hello")
 
         assert result.success is True
-        assert captured["path"] == "/api/v1/message/text"
-        assert captured["payload"]["method"] == "private-api"
-        assert "selectedMessageGuid" not in captured["payload"]
+        (path, payload), = posts
+        assert path == "/api/v1/message/text"
+        assert payload["method"] == "private-api"
+        assert "selectedMessageGuid" not in payload
+        assert "partIndex" not in payload
 
     @pytest.mark.asyncio
     async def test_send_omits_method_when_helper_not_connected(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
-        adapter._private_api_enabled = True
-        adapter._helper_connected = False
-        captured = self._capture_send(monkeypatch, adapter)
+        posts = self._capture_send(monkeypatch, adapter, helper=False)
 
         result = await adapter.send("+15551234567", "hello")
 
         assert result.success is True
-        assert "method" not in captured["payload"]
+        assert "method" not in posts[0][1]
+
+    @pytest.mark.asyncio
+    async def test_send_omits_method_when_private_api_disabled(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        posts = self._capture_send(monkeypatch, adapter, private_api=False, helper=True)
+
+        result = await adapter.send("+15551234567", "hello")
+
+        assert result.success is True
+        assert "method" not in posts[0][1]
 
     @pytest.mark.asyncio
     async def test_reply_keeps_selected_message_guid(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
-        adapter._private_api_enabled = True
-        adapter._helper_connected = True
-        captured = self._capture_send(monkeypatch, adapter)
+        posts = self._capture_send(monkeypatch, adapter)
 
-        await adapter.send("+15551234567", "hello", reply_to="orig-guid")
+        result = await adapter.send("+15551234567", "hello", reply_to="orig-guid")
 
-        payload = captured["payload"]
+        assert result.success is True
+        payload = posts[0][1]
         assert payload["method"] == "private-api"
         assert payload["selectedMessageGuid"] == "orig-guid"
         assert payload["partIndex"] == 0
+
+    @pytest.mark.asyncio
+    async def test_reply_without_helper_stays_plain_send(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        posts = self._capture_send(monkeypatch, adapter, helper=False)
+
+        await adapter.send("+15551234567", "hello", reply_to="orig-guid")
+
+        payload = posts[0][1]
+        assert "method" not in payload
+        assert "selectedMessageGuid" not in payload
+
+    @pytest.mark.asyncio
+    async def test_every_chunk_carries_method(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        posts = self._capture_send(monkeypatch, adapter)
+
+        await adapter.send("+15551234567", "first paragraph\n\nsecond paragraph")
+
+        assert len(posts) == 2
+        assert all(payload["method"] == "private-api" for _, payload in posts)
+
+    @pytest.mark.asyncio
+    async def test_new_chat_uses_private_api_when_helper_connected(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        posts = self._capture_send(monkeypatch, adapter)
+
+        result = await adapter._create_chat_for_handle("+15559876543", "hello")
+
+        assert result.success is True
+        (path, payload), = posts
+        assert path == "/api/v1/chat/new"
+        assert payload["method"] == "private-api"
+
+
+class TestBlueBubblesAttachmentMethod:
+    @staticmethod
+    async def _post_attachment(monkeypatch, tmp_path, adapter):
+        file_path = tmp_path / "payload.bin"
+        file_path.write_bytes(b"attachment-payload")
+        captured = {}
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;+;chat-guid"
+
+        class MockResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"status": 200, "data": {"guid": "message-guid"}}
+
+        class MockClient:
+            async def post(self, url, *, files, data, timeout):
+                captured.update(data=data)
+                return MockResponse()
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        adapter.client = MockClient()
+        result = await adapter._send_attachment("target", str(file_path))
+        assert result.success is True
+        return captured["data"]
+
+    @pytest.mark.asyncio
+    async def test_attachment_uses_private_api_when_helper_connected(self, monkeypatch, tmp_path):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = True
+
+        data = await self._post_attachment(monkeypatch, tmp_path, adapter)
+
+        assert data["method"] == "private-api"
+
+    @pytest.mark.asyncio
+    async def test_attachment_omits_method_without_helper(self, monkeypatch, tmp_path):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = False
+
+        data = await self._post_attachment(monkeypatch, tmp_path, adapter)
+
+        assert "method" not in data
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -315,6 +315,63 @@ class TestBlueBubblesAttachmentSend:
         assert captured["data"]["chatGuid"] == "iMessage;+;chat-guid"
 
 
+class TestBlueBubblesTextSend:
+    @staticmethod
+    def _capture_send(monkeypatch, adapter):
+        captured = {}
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;+15551234567"
+
+        async def fake_api_post(path, payload):
+            captured.update(path=path, payload=payload)
+            return {"status": 200, "data": {"guid": "message-guid"}}
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        return captured
+
+    @pytest.mark.asyncio
+    async def test_send_uses_private_api_when_helper_connected(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = True
+        captured = self._capture_send(monkeypatch, adapter)
+
+        result = await adapter.send("+15551234567", "hello")
+
+        assert result.success is True
+        assert captured["path"] == "/api/v1/message/text"
+        assert captured["payload"]["method"] == "private-api"
+        assert "selectedMessageGuid" not in captured["payload"]
+
+    @pytest.mark.asyncio
+    async def test_send_omits_method_when_helper_not_connected(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = False
+        captured = self._capture_send(monkeypatch, adapter)
+
+        result = await adapter.send("+15551234567", "hello")
+
+        assert result.success is True
+        assert "method" not in captured["payload"]
+
+    @pytest.mark.asyncio
+    async def test_reply_keeps_selected_message_guid(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = True
+        captured = self._capture_send(monkeypatch, adapter)
+
+        await adapter.send("+15551234567", "hello", reply_to="orig-guid")
+
+        payload = captured["payload"]
+        assert payload["method"] == "private-api"
+        assert payload["selectedMessageGuid"] == "orig-guid"
+        assert payload["partIndex"] == 0
+
+
 # ---------------------------------------------------------------------------
 # Webhook registration
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/messaging/bluebubbles.md
+++ b/website/docs/user-guide/messaging/bluebubbles.md
@@ -151,7 +151,7 @@ Some features require the BlueBubbles [Private API helper](https://docs.bluebubb
 - Read receipts
 - Creating new chats by address
 
-When Private API is enabled and the helper is connected, outbound text, attachments and new chats are also sent through the Private API. This keeps sends working when the macOS user running BlueBubbles is not the active GUI login (fast user switching, a headless Mac mini), where the server's default AppleScript send path cannot reach Messages.app.
+When Private API is enabled and the helper is connected, outbound text, attachments and new chats are also sent through the Private API. This keeps sends working when the macOS user running BlueBubbles is not the active GUI login (fast user switching, a headless Mac mini), where the server's default AppleScript send path cannot reach Messages.app. The check is made per request, so a long reply that is split into several chunks re-evaluates it for each chunk: if the helper disconnects mid-message, the remaining chunks fall back to the AppleScript path instead of failing — one visible message can therefore be delivered by both mechanisms.
 
 Without the Private API, basic text messaging and media still work.
 

--- a/website/docs/user-guide/messaging/bluebubbles.md
+++ b/website/docs/user-guide/messaging/bluebubbles.md
@@ -151,6 +151,8 @@ Some features require the BlueBubbles [Private API helper](https://docs.bluebubb
 - Read receipts
 - Creating new chats by address
 
+When the helper is connected, outbound text is also sent through the Private API. That keeps sends working when the macOS user running BlueBubbles is not the active login (fast user switching, a headless Mac mini), where the server's default AppleScript send path cannot drive Messages.app.
+
 Without the Private API, basic text messaging and media still work.
 
 ## Troubleshooting

--- a/website/docs/user-guide/messaging/bluebubbles.md
+++ b/website/docs/user-guide/messaging/bluebubbles.md
@@ -151,7 +151,7 @@ Some features require the BlueBubbles [Private API helper](https://docs.bluebubb
 - Read receipts
 - Creating new chats by address
 
-When the helper is connected, outbound text is also sent through the Private API. That keeps sends working when the macOS user running BlueBubbles is not the active login (fast user switching, a headless Mac mini), where the server's default AppleScript send path cannot drive Messages.app.
+When Private API is enabled and the helper is connected, outbound text, attachments and new chats are also sent through the Private API. This keeps sends working when the macOS user running BlueBubbles is not the active GUI login (fast user switching, a headless Mac mini), where the server's default AppleScript send path cannot reach Messages.app.
 
 Without the Private API, basic text messaging and media still work.
 


### PR DESCRIPTION
## What does this PR do?

Sends through the BlueBubbles Private API whenever it is enabled and the helper is connected — for all text, not only replies, and for attachments and new chats too.

Today only replies set `method: "private-api"`. Every other send omits `method`, and the server defaults that to AppleScript (`sendMessageSync`, `sendAttachmentSync` and `ChatInterface.create` all default `method = "apple-script"`: [messageInterface.ts@f2e2286#L55](https://github.com/BlueBubblesApp/bluebubbles-server/blob/f2e2286241a7c3b6617a82b37d4afaab4df3a6b9/packages/server/src/server/api/interfaces/messageInterface.ts#L55), [chatInterface.ts@f2e2286#L285](https://github.com/BlueBubblesApp/bluebubbles-server/blob/f2e2286241a7c3b6617a82b37d4afaab4df3a6b9/packages/server/src/server/api/interfaces/chatInterface.ts#L285)). AppleScript can only drive Messages.app while the BlueBubbles macOS user is the active GUI login. When that user is fast-user-switched away — the usual arrangement for a shared or headless Mac mini — `/api/v1/server/info` still reports the server healthy and the helper connected, the gateway logs a successful POST, and nothing is delivered.

The change is one predicate (`_use_private_api_send`, true iff `private_api` is enabled **and** the helper is connected) applied to `send()`, `_send_attachment()` and `_create_chat_for_handle()`. Reply fields (`selectedMessageGuid`, `partIndex`) are still only added when `reply_to` is given. Setups without the helper, or with Private API disabled, send exactly what they send today; both paths are pinned by tests.

Note for users who already had the helper connected on an active login: plain sends now go through the Private API instead of AppleScript, the same way replies already did.

We have run the text-send half of this in production since 2026-07-18 on a fast-user-switched Mac mini (BlueBubbles server 1.9.9, macOS 15.7.5) — about 400 sends so far, mostly DMs plus a group chat.

## Related Issue

None found — searched issues and PRs for `bluebubbles private-api`, `bluebubbles applescript`, `bluebubbles method`.

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `gateway/platforms/bluebubbles.py` — `_use_private_api_send()`; `method: "private-api"` on `/message/text`, `/message/attachment` and `/chat/new` when it is true.
- `tests/gateway/test_bluebubbles.py` — `TestBlueBubblesTextSend` and `TestBlueBubblesAttachmentMethod` (9 tests): helper connected / helper down / Private API disabled / reply fields / every chunk / new chat / attachment.
- `website/docs/user-guide/messaging/bluebubbles.md` — one sentence in *Private API*.

## How to Test

1. BlueBubbles server with the Private API helper connected, running under a macOS user that is **not** the active login (fast user switching).
2. Before: a plain send from Hermes returns 200 but nothing arrives.
3. After: the same send is delivered; the request carries `"method": "private-api"`.
4. `scripts/run_tests.sh tests/gateway/test_bluebubbles.py` — 28 passed.

## Checklist

- [x] Read the Contributing Guide; Conventional Commits; searched existing PRs
- [x] Only changes related to this fix
- [x] `scripts/run_tests.sh tests/gateway/test_bluebubbles.py` passes; tests added
- [x] Tested on Ubuntu 24.04 (gateway) ↔ macOS 15.7.5 Mac mini running BlueBubbles server 1.9.9 with the Private API helper
- [x] Docs updated; no config keys added
