### PR TITLE
fix(desktop): do not resolve the venv interpreter in launcher entry

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -25,6 +25,7 @@ Electron main process both use this without loading the full CLI.
 
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import subprocess
@@ -33,6 +34,7 @@ from pathlib import Path
 from typing import Optional
 
 DESKTOP_ENTRY_NAME = "hermes.desktop"
+logger = logging.getLogger(__name__)
 
 
 def is_supported() -> bool:
@@ -78,11 +80,14 @@ def resolve_exec_command() -> str:
             # third-party import (#90292) — silently, since Terminal=false.
             # sys.executable is the interpreter actually running Hermes (the
             # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            # Do not resolve the venv interpreter symlink. Python finds
+            # ``pyvenv.cfg`` relative to the original venv path; resolving it
+            # would invoke the base interpreter and lose Hermes' packages.
+            argv = [str(sys.executable), str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        argv = [str(sys.executable), "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
 
 
@@ -92,7 +97,14 @@ def _needs_interpreter(bin_path: Path) -> bool:
     try:
         with open(bin_path, "rb") as fh:
             head = fh.readline(256)
-    except OSError:
+    except OSError as exc:
+        # Keep the launcher best-effort, but make the fallback diagnosable:
+        # Terminal=false otherwise hides the same failure from the user.
+        logger.warning(
+            "Could not inspect desktop launcher %s; using it without an explicit interpreter: %s",
+            bin_path,
+            exc,
+        )
         return False
     if not head.startswith(b"#!"):
         # Native binary (uv tool shim, PyInstaller, distro package) — its own
@@ -100,8 +112,10 @@ def _needs_interpreter(bin_path: Path) -> bool:
         return False
     shebang = head.decode("utf-8", errors="replace").strip().lower()
     if "python" not in shebang:
-        # A shell wrapper (e.g. the installer's bash launcher) execs the venv
-        # python itself — leave it alone.
+        # Shell wrappers are intentionally outside this check. Hermes' own
+        # wrappers exec an absolute venv interpreter. A third-party wrapper
+        # that later resolves bare ``hermes`` remains PATH-dependent, but
+        # pinning it safely would require understanding its shell semantics.
         return False
     # A python shebang pointing INSIDE the running interpreter's environment
     # already resolves correctly; anything else (``/usr/bin/env python3``,

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import stat
 from pathlib import Path
 
@@ -107,7 +108,9 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    interpreter = str(Path(sys.executable).resolve())
+    # Keep the venv path intact. Resolving this symlink would point the
+    # desktop entry at the base interpreter and bypass pyvenv.cfg.
+    interpreter = sys.executable
     assert exec_line.split(" ")[0].strip('"') == interpreter
     assert str(hermes_bin) in exec_line
     assert exec_line.endswith("desktop")
@@ -127,6 +130,22 @@ def test_exec_leaves_shell_wrapper_launchers_alone(tmp_path, xdg_home, monkeypat
 
     # A bash wrapper execs the venv python itself — no interpreter prefix.
     assert exec_line == f"{hermes_bin} desktop"
+
+
+def test_needs_interpreter_warns_when_launcher_cannot_be_read(tmp_path, monkeypatch, caplog):
+    hermes_bin = tmp_path / "bin" / "hermes"
+
+    def unreadable(*_args, **_kwargs):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr("builtins.open", unreadable)
+
+    with caplog.at_level(logging.WARNING, logger=lde.__name__):
+        assert lde._needs_interpreter(hermes_bin) is False
+
+    assert "Could not inspect desktop launcher" in caplog.text
+    assert str(hermes_bin) in caplog.text
+    assert "permission denied" in caplog.text
 
 
 def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch):


### PR DESCRIPTION
## Problem

The desktop launcher starts Hermes with a minimal environment. It has no shell profile and no venv on PATH. When the launcher entry runs the `hermes` script bare, the script finds the system Python. The system Python does not have the Hermes packages. The app stops on the first import with no visible error, because `Terminal=false`.

## The earlier fix

The fix merged in #94187 pins the interpreter in the Exec line. It writes `Path(sys.executable).resolve()` as the interpreter path.

A venv is a thin wrapper. Its `bin/python` is a symlink to the base interpreter. The `pyvenv.cfg` file next to the symlink tells Python that it is in a venv. When Python runs from the resolved path, it cannot find `pyvenv.cfg`. It uses the base interpreter and loses the venv packages. The app fails the same way as before.

This affects all venvs, not only uv-managed venvs. A plain `python3 -m venv` has the same layout:

```
/tmp/plain-venv/bin/python3 -> /usr/bin/python3
launched via symlink:  sys.prefix = /tmp/plain-venv   (venv intact)
launched via resolved: sys.prefix = /usr              (venv lost)
```

I verified this on the venv that runs this Hermes instance:

```
$ ~/.local/share/uv/python/.../bin/python3.11 hermes desktop
Traceback (most recent call last):
  File ".../hermes", line 10, in <module>
    from hermes_cli.main import main
  File ".../hermes_cli/main.py", line 715, in <module>
    from hermes_cli.config import get_hermes_home   <- ModuleNotFoundError
```

## Why the tests did not catch it

The test for the merged fix asserts the resolved path as the expected prefix:

```python
interpreter = str(Path(sys.executable).resolve())
assert exec_line.split(" ")[0].strip('"') == interpreter
```

The test mirrors the implementation. It does not verify that the entry launches. The failure is also silent by design (`Terminal=false`). The menu icon does nothing, and nothing prints to a log. Maintainers run `hermes desktop` from a terminal, where the shell environment hides the problem.

## The fix

Keep `sys.executable` as-is. Python finds `pyvenv.cfg` relative to the original venv path. The venv stays intact:

```python
argv = [str(sys.executable), str(resolved), "desktop"]
```

This works for symlinked venvs, uv-managed venvs, and plain venvs.

## Other changes

The AI review on the original PR (#83358, now closed) had three points:

- Read the shebang with `readline(256)`. The merged fix already does this.
- Shell wrappers are outside the python-shebang check. The comment now says this.
- Log a warning when the launcher script cannot be read. The fix adds a `logger.warning` call and a test for it.

## Tests

16 passed, 2 skipped.