### PR TITLE
fix(agent): defer hard-close while a delegated worker is still in SSL read

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -875,6 +875,13 @@ def init_agent(
     agent._interrupt_thread_signal_pending = False
     agent._client_lock = threading.RLock()
     agent._model_request_active = threading.Event()
+    # #94248: close() from a timeout/interrupt thread must not release TLS FDs
+    # or the owned SessionDB handle while run_conversation is still on-stack
+    # (typically blocked in OpenSSL read). Starts idle (Event set).
+    agent._run_conversation_active = False
+    agent._run_conversation_idle = threading.Event()
+    agent._run_conversation_idle.set()
+    agent._deferred_close_scheduled = False
     agent._supports_active_turn_redirect = True
 
     # /steer mechanism — inject a user note into the next tool result

--- a/run_agent.py
+++ b/run_agent.py
@@ -4598,6 +4598,80 @@ class AIAgent:
         except Exception:
             pass
 
+    def _mark_run_conversation_started(self) -> None:
+        """Fence close() until this turn's ``run_conversation`` fully unwinds.
+
+        Delegate timeout (#94248) and stranger-thread interrupts call
+        ``close()`` while the worker is still inside OpenSSL ``read``. Hard
+        ``client.close()`` / ``SessionDB.close()`` from that other thread is
+        the TLS-FD → SQLite SIGSEGV family (#29507 / #67142 / #70773).
+        """
+        self._run_conversation_active = True
+        idle = getattr(self, "_run_conversation_idle", None)
+        if idle is None:
+            idle = threading.Event()
+            self._run_conversation_idle = idle
+        idle.clear()
+
+    def _mark_run_conversation_finished(self) -> None:
+        """Release the close() fence after SessionDB-touching turn cleanup."""
+        self._run_conversation_active = False
+        idle = getattr(self, "_run_conversation_idle", None)
+        if idle is not None:
+            idle.set()
+
+    def _should_defer_hard_close(self) -> bool:
+        """True when this thread must not release TLS FDs or SessionDB.
+
+        The owning ``run_conversation`` thread may close on its own unwind.
+        A timeout / interrupt / parent-finally thread must not.
+        """
+        tid = getattr(self, "_execution_thread_id", None)
+        if isinstance(tid, int) and tid == threading.current_thread().ident:
+            return False
+        if getattr(self, "_run_conversation_active", False):
+            return True
+        model_active = getattr(self, "_model_request_active", None)
+        return bool(model_active is not None and model_active.is_set())
+
+    def _wait_until_safe_to_hard_close(self) -> None:
+        """Block until the worker turn has left SessionDB and SSL."""
+        idle = getattr(self, "_run_conversation_idle", None)
+        if idle is not None:
+            idle.wait()
+        model_active = getattr(self, "_model_request_active", None)
+        while model_active is not None and model_active.is_set():
+            time.sleep(0.05)
+        while getattr(self, "_run_conversation_active", False):
+            time.sleep(0.05)
+
+    def _schedule_deferred_close(self) -> None:
+        """Finish close() on a daemon thread after the in-flight worker unwinds."""
+        if getattr(self, "_deferred_close_scheduled", False):
+            return
+        self._deferred_close_scheduled = True
+
+        def _finish() -> None:
+            try:
+                self._wait_until_safe_to_hard_close()
+            finally:
+                self._deferred_close_scheduled = False
+                try:
+                    self.close()
+                except Exception:
+                    logger.debug(
+                        "Deferred agent close after in-flight worker failed",
+                        exc_info=True,
+                    )
+
+        thread = threading.Thread(
+            target=_finish,
+            name="agent-deferred-close",
+            daemon=True,
+        )
+        self._deferred_close_thread = thread
+        thread.start()
+
     def close(self) -> None:
         """Release all resources held by this agent instance.
 
@@ -4611,17 +4685,26 @@ class AIAgent:
 
         Safe to call multiple times (idempotent).  Each cleanup step is
         independently guarded so a failure in one does not prevent the rest.
+
+        When a worker thread is still inside ``run_conversation`` (delegate
+        deadline, interrupt), this thread only shuts sockets down and skips
+        SQLite / httpx FD release — see ``_should_defer_hard_close`` (#94248).
         """
+        in_flight = self._should_defer_hard_close()
+
         # AIAgent.close() is the hard owner boundary. Gateway cleanup may
         # call shutdown_memory_provider() first; its idempotence prevents
         # duplicate extraction while direct callers cannot skip provider close.
-        try:
-            session_messages = getattr(self, "_session_messages", None)
-            self.shutdown_memory_provider(
-                session_messages if isinstance(session_messages, list) else None
-            )
-        except Exception:
-            pass
+        # Skip it while a worker still owns the turn — memory providers may
+        # touch the same SQLite file the worker is flushing.
+        if not in_flight:
+            try:
+                session_messages = getattr(self, "_session_messages", None)
+                self.shutdown_memory_provider(
+                    session_messages if isinstance(session_messages, list) else None
+                )
+            except Exception:
+                pass
 
         task_id = getattr(self, "session_id", None) or ""
 
@@ -4669,17 +4752,27 @@ class AIAgent:
         except Exception:
             pass
 
-        # 6. Close the OpenAI/httpx client
+        # 6. Shared OpenAI/httpx client. #94248 / #70773: a stranger thread
+        # must only shutdown() sockets. client.close() releases FDs under a
+        # still-live SSL BIO (KERN_INVALID_ADDRESS in pysqlite 17-72ms later).
         try:
             client = getattr(self, "client", None)
             if client is not None:
-                self._close_openai_client(client, reason="agent_close", shared=True)
+                if in_flight:
+                    self._retire_shared_openai_client(
+                        client, reason="agent_close_in_flight"
+                    )
+                else:
+                    self._close_openai_client(
+                        client, reason="agent_close", shared=True
+                    )
                 self.client = None
         except Exception:
             pass
 
         # 6b. Close the cached per-request wire client (reused across
         # sequential LLM calls; see _create_request_openai_client).
+        # Already aborts without FD release when in_use.
         try:
             self._close_cached_request_openai_client(reason="agent_close")
         except Exception:
@@ -4688,6 +4781,10 @@ class AIAgent:
             self._close_cached_request_anthropic_client(reason="agent_close")
         except Exception:
             pass
+
+        if in_flight:
+            self._schedule_deferred_close()
+            return
 
         # 6c. Close the Codex app-server session. The runtime already drops
         # it on turn crash / retirement (agent/codex_runtime.py), but hard
@@ -8644,6 +8741,11 @@ class AIAgent:
                     _clear_if_owned()
 
         try:
+            # getattr: test doubles / third-party agents bind this method
+            # onto a stub that has no fence helpers (#94248 CI).
+            _mark_started = getattr(self, "_mark_run_conversation_started", None)
+            if callable(_mark_started):
+                _mark_started()
             # Serialize the full load -> run -> flush region across Hermes
             # processes. Gateway's asyncio lease closes alias routing inside one
             # process; this durable lease covers Desktop, CLI resume, gateway,
@@ -8973,57 +9075,65 @@ class AIAgent:
             raise
         finally:
             try:
-                if relay_turn is not None:
-                    relay_runtime.SESSION_COORDINATOR.end_turn(
-                        relay_turn,
-                        outcome=relay_outcome,
-                    )
-            finally:
                 try:
-                    if relay_lease is not None:
-                        relay_runtime.SESSION_COORDINATOR.release_conversation(
-                            relay_lease
+                    if relay_turn is not None:
+                        relay_runtime.SESSION_COORDINATOR.end_turn(
+                            relay_turn,
+                            outcome=relay_outcome,
                         )
                 finally:
-                    _stop_durable_turn_lease_refresher()
-                    if (
-                        durable_turn_lease_thread is not None
-                        and durable_turn_lease_thread.is_alive()
-                    ):
-                        durable_turn_lease_thread.join(timeout=1.0)
-                    # Clear any interrupt the refresher may have fired between
-                    # the inner stop and this join. Must run AFTER join so a
-                    # late interrupt does not survive into the next turn.
-                    _clear_durable_turn_lease_interrupt()
-                    if durable_turn_lease is not None:
-                        try:
-                            _turn_db.release_session_turn_lease(
-                                session_id, durable_turn_lease
-                            )
-                        except Exception:
-                            logger.error(
-                                "Failed to release session turn lease: %s",
-                                session_id,
-                                exc_info=True,
-                            )
-                        if (
-                            getattr(self, "_active_session_turn_lease_holder", None)
-                            == durable_turn_lease
-                        ):
-                            self._active_session_turn_lease_holder = None
-                            self._active_session_turn_lease_ttl_seconds = None
-                    # Always clear mid-turn labels when the turn exits — including
-                    # interrupted early returns that skip finalize_turn. Keep ts.
                     try:
-                        self._reset_activity_labels_after_turn()
-                    except Exception:
-                        pass
-                    if getattr(self, "_relay_pending_turn_id", None) == relay_turn_id:
-                        self._relay_pending_turn_id = None
-                    if acct_token is not None:
-                        reset_accounting_context(acct_token)
-                    if token is not None:
-                        reset_conversation_context(token)
+                        if relay_lease is not None:
+                            relay_runtime.SESSION_COORDINATOR.release_conversation(
+                                relay_lease
+                            )
+                    finally:
+                        _stop_durable_turn_lease_refresher()
+                        if (
+                            durable_turn_lease_thread is not None
+                            and durable_turn_lease_thread.is_alive()
+                        ):
+                            durable_turn_lease_thread.join(timeout=1.0)
+                        # Clear any interrupt the refresher may have fired between
+                        # the inner stop and this join. Must run AFTER join so a
+                        # late interrupt does not survive into the next turn.
+                        _clear_durable_turn_lease_interrupt()
+                        if durable_turn_lease is not None:
+                            try:
+                                _turn_db.release_session_turn_lease(
+                                    session_id, durable_turn_lease
+                                )
+                            except Exception:
+                                logger.error(
+                                    "Failed to release session turn lease: %s",
+                                    session_id,
+                                    exc_info=True,
+                                )
+                            if (
+                                getattr(self, "_active_session_turn_lease_holder", None)
+                                == durable_turn_lease
+                            ):
+                                self._active_session_turn_lease_holder = None
+                                self._active_session_turn_lease_ttl_seconds = None
+                        # Always clear mid-turn labels when the turn exits — including
+                        # interrupted early returns that skip finalize_turn. Keep ts.
+                        try:
+                            self._reset_activity_labels_after_turn()
+                        except Exception:
+                            pass
+                        if getattr(self, "_relay_pending_turn_id", None) == relay_turn_id:
+                            self._relay_pending_turn_id = None
+                        if acct_token is not None:
+                            reset_accounting_context(acct_token)
+                        if token is not None:
+                            reset_conversation_context(token)
+            finally:
+                # After SessionDB-touching turn cleanup above. Deferred close()
+                # waiters must not hard-close the handle while this finally
+                # still holds it (#94248).
+                _mark_finished = getattr(self, "_mark_run_conversation_finished", None)
+                if callable(_mark_finished):
+                    _mark_finished()
 
     def chat(self, message: str, stream_callback: Optional[callable] = None) -> str:
         """

--- a/tests/run_agent/test_94248_in_flight_close.py
+++ b/tests/run_agent/test_94248_in_flight_close.py
@@ -1,0 +1,210 @@
+"""#94248: close() must not release TLS FDs or SessionDB from a stranger thread.
+
+A delegated Codex worker that hits its 600s deadline is still blocked in
+OpenSSL read. The parent then calls ``AIAgent.close()`` 17-72ms later.
+``client.close()`` plus ``SessionDB.close()`` from that thread is the
+#29507 / #70773 family: kernel FD recycle into SQLite, then SIGSEGV in
+pysqlite_connection_execute.
+
+The owning run_conversation thread (or a deferred close after it idles)
+is the only one allowed to hard-close those resources.
+"""
+from __future__ import annotations
+
+import threading
+
+
+class _RecordingClient:
+    def __init__(self):
+        self.close_calls = 0
+        self.close_threads = []
+        self.is_closed = False
+
+    def close(self):
+        self.close_calls += 1
+        self.close_threads.append(threading.current_thread().ident)
+        self.is_closed = True
+
+
+class _RecordingDB:
+    def __init__(self):
+        self.close_calls = 0
+        self.end_session_calls = 0
+
+    def close(self):
+        self.close_calls += 1
+
+    def end_session(self, *_a, **_k):
+        self.end_session_calls += 1
+
+
+def _bare_agent(**attrs):
+    """AIAgent with __init__ bypassed, carrying only what close() reads."""
+    from unittest.mock import patch
+
+    with patch("run_agent.AIAgent.__init__", return_value=None):
+        from run_agent import AIAgent
+
+        agent = AIAgent.__new__(AIAgent)
+    agent.session_id = "sid-94248"
+    agent._active_children = []
+    agent._active_children_lock = threading.Lock()
+    agent.client = _RecordingClient()
+    agent._session_db = _RecordingDB()
+    agent._owns_session_db = True
+    agent._end_session_on_close = True
+    agent._session_messages = []
+    agent.quiet_mode = True
+    agent.provider = "openai-codex"
+    agent.base_url = "https://example.test/v1"
+    agent.model = "gpt-5.6"
+    agent._execution_thread_id = None
+    agent._run_conversation_active = False
+    agent._run_conversation_idle = threading.Event()
+    agent._run_conversation_idle.set()
+    agent._deferred_close_scheduled = False
+    agent._model_request_active = threading.Event()
+    agent._client_lock = threading.RLock()
+    agent.shutdown_memory_provider = lambda *a, **k: None
+    for key, value in attrs.items():
+        setattr(agent, key, value)
+    return agent
+
+
+def _mark_stranger_in_flight(agent):
+    """Simulate a live run_conversation on another thread (SSL still blocked)."""
+    agent._run_conversation_active = True
+    agent._execution_thread_id = (threading.current_thread().ident or 0) + 1_000_003
+    agent._run_conversation_idle = threading.Event()  # uncleared: still in-flight
+    agent._model_request_active.set()
+    return agent._run_conversation_idle
+
+
+def _release_in_flight(agent, idle=None):
+    agent._run_conversation_active = False
+    agent._model_request_active.clear()
+    if idle is None:
+        idle = getattr(agent, "_run_conversation_idle", None)
+    if idle is not None:
+        idle.set()
+    deferred = getattr(agent, "_deferred_close_thread", None)
+    if deferred is not None:
+        deferred.join(timeout=2.0)
+    return deferred
+
+
+def test_idle_close_still_hard_closes_owned_sqlite_and_client():
+    agent = _bare_agent()
+    client = agent.client
+    db = agent._session_db
+
+    agent.close()
+
+    assert client.close_calls == 1
+    assert db.close_calls == 1
+    assert db.end_session_calls == 1
+
+
+def test_stranger_close_during_ssl_read_does_not_release_fds():
+    agent = _bare_agent()
+    client = agent.client
+    db = agent._session_db
+    idle = _mark_stranger_in_flight(agent)
+
+    try:
+        agent.close()
+
+        assert client.close_calls == 0
+        assert db.close_calls == 0
+        assert db.end_session_calls == 0
+        assert agent._owns_session_db is True
+        assert getattr(agent, "_deferred_close_scheduled", False) is True
+    finally:
+        _release_in_flight(agent, idle)
+
+
+def test_owner_thread_close_during_turn_still_hard_closes():
+    """close() from the run_conversation thread is the FD-owner path."""
+    agent = _bare_agent()
+    client = agent.client
+    db = agent._session_db
+    agent._run_conversation_active = True
+    agent._execution_thread_id = threading.current_thread().ident
+    agent._model_request_active.set()
+
+    agent.close()
+
+    assert client.close_calls == 1
+    assert db.close_calls == 1
+
+
+def test_deferred_close_hard_closes_after_worker_idles():
+    agent = _bare_agent()
+    client = agent.client
+    db = agent._session_db
+    idle = _mark_stranger_in_flight(agent)
+
+    agent.close()
+    assert db.close_calls == 0
+    assert client.close_calls == 0
+
+    agent._run_conversation_active = False
+    agent._model_request_active.clear()
+    idle.set()
+
+    deferred = getattr(agent, "_deferred_close_thread", None)
+    assert deferred is not None
+    deferred.join(timeout=2.0)
+    assert not deferred.is_alive()
+
+    assert db.close_calls == 1
+    # Shared client was retired (shutdown only) and dropped on the first
+    # close(); FD release is GC / owner-thread, never a stranger client.close().
+    assert client.close_calls == 0
+    assert agent._owns_session_db is False
+
+
+def test_model_request_flag_alone_defers_hard_close():
+    """Codex SSL read sets _model_request_active even if a test skipped the wrapper flag."""
+    agent = _bare_agent()
+    db = agent._session_db
+    agent._execution_thread_id = (threading.current_thread().ident or 0) + 7
+    agent._model_request_active.set()
+
+    agent.close()
+
+    assert db.close_calls == 0
+    agent._model_request_active.clear()
+    deferred = getattr(agent, "_deferred_close_thread", None)
+    if deferred is not None:
+        deferred.join(timeout=2.0)
+    assert db.close_calls == 1
+
+
+def test_should_defer_false_when_idle():
+    from run_agent import AIAgent
+
+    agent = _bare_agent()
+    assert agent._should_defer_hard_close() is False
+    assert isinstance(agent, AIAgent)
+
+
+def test_in_flight_close_does_not_close_codex_session():
+    class _Codex:
+        def __init__(self):
+            self.closed = 0
+
+        def close(self):
+            self.closed += 1
+
+    session = _Codex()
+    agent = _bare_agent(_codex_session=session)
+    idle = _mark_stranger_in_flight(agent)
+
+    try:
+        agent.close()
+
+        assert session.closed == 0
+        assert agent._codex_session is session
+    finally:
+        _release_in_flight(agent, idle)

--- a/tests/tools/test_94248_delegate_timeout_close.py
+++ b/tests/tools/test_94248_delegate_timeout_close.py
@@ -1,0 +1,105 @@
+"""#94248: delegate timeout must not hard-close the child's TLS/SQLite from the parent.
+
+Mirrors the production sequence: worker blocked in a Codex-like read,
+``result(timeout=)`` fires, parent ``child.close()`` runs ~tens of ms later
+while the worker is still on-stack.
+"""
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from run_agent import AIAgent
+from tests.run_agent.test_94248_in_flight_close import (
+    _RecordingClient,
+    _RecordingDB,
+    _bare_agent,
+)
+
+
+class _TimeoutChild(AIAgent):
+    """Real close()/interrupt ABI, but hard_interrupt does not unblock SSL."""
+
+    def hard_interrupt(self, message=None, *, tool_reason=None):
+        return
+
+
+def _child_for_timeout():
+    child = _bare_agent()
+    # Re-bind as the subclass so request_hard_interrupt finds hard_interrupt
+    # on this type, not the real AIAgent implementation.
+    child.__class__ = _TimeoutChild
+    child._delegate_saved_tool_names = ["terminal"]
+    child.session_id = "timed-out-codex-child"
+    child._hang = threading.Event()
+    child._started = threading.Event()
+    child.client = _RecordingClient()
+    child._session_db = _RecordingDB()
+    child._owns_session_db = True
+
+    def run_conversation(**_kwargs):
+        child._execution_thread_id = threading.current_thread().ident
+        child._mark_run_conversation_started()
+        child._model_request_active.set()
+        child._started.set()
+        try:
+            child._hang.wait(timeout=30)
+            return {
+                "final_response": "",
+                "completed": False,
+                "interrupted": True,
+                "api_calls": 1,
+                "messages": [],
+            }
+        finally:
+            child._model_request_active.clear()
+            child._mark_run_conversation_finished()
+
+    child.run_conversation = run_conversation
+    child.get_activity_summary = lambda: {"api_call_count": 1}
+    return child
+
+
+def test_timed_out_delegate_does_not_close_sqlite_while_ssl_read_blocked(
+    monkeypatch, tmp_path
+):
+    from tools.delegate_tool import _run_single_child
+
+    parent = MagicMock()
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    child = _child_for_timeout()
+    parent._active_children.append(child)
+    client = child.client
+    db = child._session_db
+    monkeypatch.setattr("tools.delegate_tool._get_child_timeout", lambda: 0.15)
+
+    token = set_hermes_home_override(tmp_path / "profile-94248")
+    try:
+        result = _run_single_child(
+            task_index=0,
+            goal="blocked Codex SSL read",
+            child=child,
+            parent_agent=parent,
+        )
+        assert child._started.wait(timeout=2.0)
+        assert result["status"] == "timeout"
+        # Parent close() ran in _run_single_child's finally while the worker
+        # was still in hang.wait (SSL stand-in). Must not close SQLite or
+        # httpx FDs yet.
+        assert db.close_calls == 0
+        assert client.close_calls == 0
+        assert child.client is None
+        assert child._owns_session_db is True
+    finally:
+        child._hang.set()
+        deferred = getattr(child, "_deferred_close_thread", None)
+        if deferred is not None:
+            deferred.join(timeout=2.0)
+        reset_hermes_home_override(token)
+
+    # After the worker unwinds, deferred close releases the dedicated handle.
+    assert db.close_calls == 1
+    assert client.close_calls == 0
+    assert child._owns_session_db is False

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3367,6 +3367,9 @@ def _run_single_child(
         # Close tool resources (terminal sandboxes, browser daemons,
         # background processes, httpx clients) so subagent subprocesses
         # don't outlive the delegation.
+        # #94248: a timed-out worker may still be inside SSL read.
+        # AIAgent.close() retires sockets only and defers SessionDB /
+        # httpx FD release until that worker unwinds.
         try:
             if hasattr(child, "close"):
                 child.close()


### PR DESCRIPTION
## Summary
- Gateway SIGSEGV on macOS arm64 was correlating 17–72 ms after `Subagent N timed out`: the parent thread called `AIAgent.close()` while the child worker was still blocked in OpenSSL `read` (Codex / httpx). That stranger-thread `client.close()` plus owned `SessionDB.close()` is the TLS-FD → SQLite family (#29507 / #67142 / #70773).
- `close()` now detects an in-flight `run_conversation` (or a live `_model_request_active` SSL read). It only `shutdown()`s pooled sockets (`_retire_shared_openai_client`), skips SQLite `end_session`/`close`, and finishes hard teardown on a daemon thread after the worker unwinds.
- The owning `run_conversation` thread can still hard-close on its own unwind. Idle `/new` / session-end `close()` is unchanged.

Fixes https://github.com/NousResearch/hermes-agent/issues/94248

## Test plan
- [x] `scripts/run_tests.sh tests/run_agent/test_94248_in_flight_close.py tests/tools/test_94248_delegate_timeout_close.py`
- [x] `scripts/run_tests.sh tests/tui_gateway/test_session_db_ownership_teardown.py tests/tools/test_zombie_process_cleanup.py tests/tools/test_delegate.py tests/run_agent/test_70773_shared_client_fd_corruption.py`
- [ ] Reproduce on a long-lived macOS arm64 gateway: 1–3 Codex `delegate_task` workers hitting the 600s child deadline while a Responses stream is in `ssl.read`; process must stay up, the timeout must return a bounded failure, and the next provider call on that session must succeed.