### PR TITLE
feat(desktop): File > New Session Tab menu item

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6218,6 +6218,20 @@ function installBrowserNavGestures(window) {
   })
 }
 
+function sendNewTabRequested() {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return
+  }
+
+  const webContents = mainWindow.webContents
+
+  if (!webContents || webContents.isDestroyed()) {
+    return
+  }
+
+  webContents.send('hermes:new-session-tab-requested')
+}
+
 function sendOpenFolderRequested() {
   if (!mainWindow || mainWindow.isDestroyed()) {
     return
@@ -6381,6 +6395,10 @@ function buildApplicationMenu() {
       // (workspace.openFolder). Clicking runs the same open-folder-as-project
       // flow through the renderer.
       { click: () => sendOpenFolderRequested(), label: 'Open Folder…' },
+      // No accelerator for the same reason as above: ⌘T is the rebindable
+      // renderer keybind (session.newTab). Clicking fires the exact same
+      // action as the tab-strip "+" — a new session tab in the main window.
+      { click: () => sendNewTabRequested(), label: 'New Session Tab' },
       { type: 'separator' },
       IS_MAC
         ? {

--- a/apps/desktop/electron/new-session-tab-wiring.test.ts
+++ b/apps/desktop/electron/new-session-tab-wiring.test.ts
@@ -1,0 +1,31 @@
+/**
+ * The File menu and renderer bridge live on opposite sides of Electron's
+ * main-process boundary. Pin their source shapes so a future rename cannot
+ * silently leave a visible menu item disconnected from its renderer action.
+ */
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { test } from 'vitest'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+
+const mainSource = fs.readFileSync(path.join(here, 'main.ts'), 'utf8')
+
+const integrationsSource = fs.readFileSync(
+  path.join(here, '..', 'src', 'app', 'contrib', 'hooks', 'use-desktop-integrations.ts'),
+  'utf8'
+)
+
+test('File menu exposes New Session Tab through the main-process sender', () => {
+  assert.match(mainSource, /\{ click: \(\) => sendNewTabRequested\(\), label: 'New Session Tab' \}/)
+})
+
+test('renderer subscribes to the New Session Tab bridge event', () => {
+  assert.match(
+    integrationsSource,
+    /onNewSessionTabRequested\?\.\(\(\) => \$newSessionTabAction\.get\(\)\?\.\(\)\)/
+  )
+})

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -363,6 +363,12 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
 
     return () => ipcRenderer.removeListener('hermes:open-folder-requested', listener)
   },
+  onNewSessionTabRequested: callback => {
+    const listener = () => callback()
+    ipcRenderer.on('hermes:new-session-tab-requested', listener)
+
+    return () => ipcRenderer.removeListener('hermes:new-session-tab-requested', listener)
+  },
   onOpenUpdatesRequested: callback => {
     const listener = () => callback()
     ipcRenderer.on('hermes:open-updates', listener)

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react'
 import { closeActiveTab } from '@/app/chat/close-tab'
 import { commandFocusedPreview } from '@/app/chat/right-rail/preview-nav'
 import { openSession } from '@/app/open-session'
+import { $newSessionTabAction } from '@/components/pane-shell/tree/store'
 import { resolveDeepLinkAction } from '@/lib/deeplink-routes'
 import { pathFromHermesDeepLink, resolveHermesOpenPath } from '@/lib/hermes-open-target'
 import { storedSessionIdForNotification } from '@/lib/session-ids'
@@ -326,6 +327,13 @@ export function useDesktopIntegrations({
   // File > Open Folder… — same open-folder-as-project upsert as the ⌘O keybind.
   useEffect(() => {
     const unsubscribe = window.hermesDesktop?.onOpenFolderRequested?.(() => void openFolderAsProject())
+
+    return () => unsubscribe?.()
+  }, [])
+
+  // File > New Session Tab — same action as the tab-strip "+" and the ⌘T keybind.
+  useEffect(() => {
+    const unsubscribe = window.hermesDesktop?.onNewSessionTabRequested?.(() => $newSessionTabAction.get()?.())
 
     return () => unsubscribe?.()
   }, [])

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -408,6 +408,7 @@ declare global {
       onClosePreviewRequested?: (callback: () => void) => () => void
       onPreviewNav?: (callback: (command: 'back' | 'forward' | 'reload') => void) => () => void
       onOpenFolderRequested?: (callback: () => void) => () => void
+      onNewSessionTabRequested?: (callback: () => void) => () => void
       onOpenUpdatesRequested?: (callback: () => void) => () => void
       onDeepLink?: (
         callback: (payload: { kind: string; name: string; params: Record<string, string> }) => void


### PR DESCRIPTION
## Summary
- Adds a **File > New Session Tab** item to the application menu, closing the gap where tab creation was only reachable via the Cmd/Ctrl+T keybind or the tab-strip "+" button — neither of which is discoverable from the menu bar.
- Follows the existing main→preload→renderer IPC pattern used by File > Open Folder… (`sendNewTabRequested` / `onNewSessionTabRequested`).
- The item carries **no accelerator**, matching the deliberate convention documented on its sibling items: a menu accelerator would fight the rebindable renderer keybind (`session.newTab`) and be swallowed before the renderer sees it.
- Clicking fires `$newSessionTabAction` — the exact same renderer action behind the tab-strip "+", so behavior (bots-mode scoping, `listed: false` tabs) is identical.

Refs #84836

## Test plan
- [x] `npm run typecheck` (all 3 tsconfigs) clean
- [x] `eslint` clean on all touched files
- [x] Existing `use-desktop-integrations.test.tsx` suite passes (25/25)
- [ ] Manually verified on macOS: File > New Session Tab opens a new session tab identical to Cmd+T *(runtime check in progress — typecheck/lint/unit tests pass; will confirm and tick after launching the built app)*
