### PR TITLE
fix(terminal): bound Windows Git Bash startup probes

### DIFF
--- a/tests/tools/test_find_shell.py
+++ b/tests/tools/test_find_shell.py
@@ -135,24 +135,64 @@ class TestFindBashSkipsBrokenCustomPath:
 class TestGitBashExternalProgramProbe:
     """The Windows health check must exercise MSYS child-process creation."""
 
-    def test_probe_runs_external_msys_programs(self, monkeypatch):
+    def test_probe_runs_external_msys_programs_with_bounded_runner(self, monkeypatch):
         """``_bash_starts`` builds the same external-program probe argv on
-        every host, so this stays on the Linux runner with ``subprocess.run``
-        mocked — no platform faking needed."""
+        every host, so this stays on the Linux runner with the shared bounded
+        probe seam mocked — no platform faking needed."""
         import tools.environments.local as local_mod
 
         local_mod._bash_starts_cache.clear()
         local_mod._bash_probe_details_cache.clear()
         calls = []
 
-        def fake_run(argv, **kwargs):
+        def fake_probe(argv, **kwargs):
             calls.append((argv, kwargs))
             return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
 
-        monkeypatch.setattr(local_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(local_mod, "bounded_probe_run", fake_probe)
 
         assert local_mod._bash_starts(r"C:\Git\bin\bash.exe") is True
         assert calls[0][0][-1] == "/usr/bin/true; /usr/bin/cat --version >/dev/null"
+        assert calls[0][1]["timeout"] == 15
+
+    def test_probe_timeout_fails_closed_without_unbounded_run_cleanup(self, monkeypatch):
+        """A timed-out MSYS child probe must return instead of entering
+        subprocess.run's unbounded post-kill pipe drain on Windows."""
+        import tools.environments.local as local_mod
+
+        local_mod._bash_starts_cache.clear()
+        local_mod._bash_probe_details_cache.clear()
+        bash = r"C:\Git\bin\bash.exe"
+
+        monkeypatch.setattr(local_mod, "bounded_probe_run", lambda *_a, **_kw: None)
+        monkeypatch.setattr(
+            local_mod.subprocess,
+            "run",
+            lambda *_a, **_kw: pytest.fail("unbounded subprocess.run probe used"),
+        )
+
+        assert local_mod._bash_starts(bash) is False
+        assert "timed out" in local_mod._bash_probe_details_cache[bash]
+
+    def test_aslr_probe_uses_bounded_runner(self, monkeypatch):
+        import tools.environments.local as local_mod
+
+        local_mod._mandatory_aslr_enabled_cache = None
+        calls = []
+
+        def fake_probe(argv, **kwargs):
+            calls.append((argv, kwargs))
+            return subprocess.CompletedProcess(argv, 0, stdout="NOTSET\n", stderr="")
+
+        monkeypatch.setattr(local_mod, "bounded_probe_run", fake_probe)
+        monkeypatch.setattr(
+            local_mod.subprocess,
+            "run",
+            lambda *_a, **_kw: pytest.fail("unbounded subprocess.run probe used"),
+        )
+
+        assert local_mod._mandatory_aslr_enabled() is False
+        assert calls[0][1]["timeout"] == 10
 
     @pytest.mark.windows_only
     def test_aslr_failure_surfaces_targeted_windows_command(

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 from hermes_constants import get_process_hermes_home
 from tools.environments.base import BaseEnvironment, _pipe_stdin
-from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli._subprocess_compat import bounded_probe_run, windows_hide_flags
 
 _IS_WINDOWS = platform.system() == "Windows"
 
@@ -859,7 +859,7 @@ def _mandatory_aslr_enabled() -> "bool | None":
 
     try:
         powershell = shutil.which("powershell.exe") or "powershell.exe"
-        result = subprocess.run(
+        result = bounded_probe_run(
             [
                 powershell,
                 "-NoProfile",
@@ -867,11 +867,10 @@ def _mandatory_aslr_enabled() -> "bool | None":
                 "-Command",
                 "(Get-ProcessMitigation -System).Aslr.ForceRelocateImages.ToString()",
             ],
-            capture_output=True,
-            text=True, encoding="utf-8", errors="replace",
             timeout=10,
-            creationflags=windows_hide_flags(),
         )
+        if result is None:
+            return None
         if result.returncode != 0:
             return None
         value = (result.stdout or "").strip().upper()
@@ -931,18 +930,19 @@ def _bash_starts(bash: str) -> bool:
         return cached
 
     try:
-        result = subprocess.run(
+        result = bounded_probe_run(
             [bash, "--noprofile", "--norc", "-c", _BASH_EXTERNAL_PROGRAM_PROBE],
-            capture_output=True,
-            text=True, encoding="utf-8", errors="replace",
             timeout=15,
-            creationflags=windows_hide_flags() if _IS_WINDOWS else 0,
         )
-        ok = result.returncode == 0
-        if not ok:
-            combined = f"{result.stdout or ''}{result.stderr or ''}"
-            _bash_probe_details_cache[bash] = combined.strip()[:2000]
-            logger.debug("bash probe failed for %s: %s", bash, combined.strip()[:200])
+        if result is None:
+            _bash_probe_details_cache[bash] = "probe timed out after 15s or failed to spawn"
+            ok = False
+        else:
+            ok = result.returncode == 0
+            if not ok:
+                combined = f"{result.stdout or ''}{result.stderr or ''}"
+                _bash_probe_details_cache[bash] = combined.strip()[:2000]
+                logger.debug("bash probe failed for %s: %s", bash, combined.strip()[:200])
     except Exception as exc:
         _bash_probe_details_cache[bash] = str(exc)[:2000]
         logger.debug("bash probe error for %s: %s", bash, exc)


### PR DESCRIPTION
## Summary

- route the Windows Git Bash external-program health check through the shared deadlock-safe bounded probe runner
- apply the same bounded process-tree cleanup to the fallback Mandatory ASLR PowerShell probe
- preserve actionable timeout diagnostics when a Git Bash candidate cannot complete its child-process probe

## Root cause

`_find_bash()` checks each Windows Git Bash candidate by launching external MSYS programs with `subprocess.run(..., capture_output=True, timeout=15)`. When the probe times out, Python kills only the direct process and then performs an unbounded pipe drain. A descendant that still owns a captured pipe handle can therefore keep terminal initialization blocked beyond both the probe timeout and `LocalEnvironment._snapshot_timeout`.

The shared `bounded_probe_run()` helper already handles this Windows failure class by tree-killing timed-out descendants and bounding the post-kill drain.

## Testing

- `scripts/run_tests.sh tests/hermes_cli/test_bounded_probe_run.py tests/tools/test_find_shell.py -k 'bounded_probe_run or GitBashExternalProgramProbe' -q` (11 passed, 1 skipped)

Closes #94304
