### PR TITLE
feat(skills): add optional skill-sync skill — sync skills between machines over SSH/Tailscale

### DIFF
--- a/optional-skills/devops/skill-sync/SKILL.md
+++ b/optional-skills/devops/skill-sync/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: skill-sync
+description: "Sync skills between machines over SSH and Tailscale."
+version: 1.0.0
+author: alt-glitch (alt-glitch), Hermes Agent
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Skills, Sync, SSH, Tailscale, Rsync, Multi-Machine, Cron]
+    category: devops
+    related_skills: []
+---
+
+# Skill Sync
+
+Sync `~/.hermes/skills/` between machines over SSH. Compares modification
+times, pulls newer skills, discovers new ones, and can push the local tree to
+a fresh box. Conflict rule is last-writer-wins by mtime; sync is additive
+(nothing is deleted on either side). Works over any SSH route — Tailscale is
+the recommended transport because it gives every machine a stable name that
+works across networks.
+
+## When to Use
+
+- User has Hermes on two or more machines and wants skills kept in step
+- User got a new machine and wants their skill library on it ("push my skills to the new box")
+- User improved a skill on one box and wants it everywhere
+- User asks for automatic/scheduled skill syncing between machines
+- A skill exists on another machine but not here
+
+## Prerequisites — walk the user through these, don't assume them
+
+Each remote needs: a network route, a running sshd, key-based auth, and
+rsync. **Run the doctor first** — it checks all four and prints the exact fix
+for anything missing:
+
+```
+terminal(command="~/.hermes/skills/devops/skill-sync/scripts/doctor.sh <user@host>")
+```
+
+If the doctor reports failures, guide the user through them in this order:
+
+1. **Network route (Tailscale, recommended).** If the machines aren't on the
+   same LAN, have the user install Tailscale on both ends
+   (https://tailscale.com/download) and run `tailscale up` on each, logged
+   into the same tailnet. Verify with `tailscale status` — every machine gets
+   a stable node name and a `100.x.y.z` IP that work from anywhere. Any other
+   SSH route (LAN hostname, VPN, public IP) also works.
+2. **sshd on the target.** Fresh macOS refuses SSH by default — the user must
+   enable System Settings → General → Sharing → **Remote Login**, or run
+   `sudo systemsetup -setremotelogin on`. Linux: `sudo apt install
+   openssh-server && sudo systemctl enable --now ssh`. Tailscale users can
+   skip sshd entirely with `sudo tailscale set --ssh` on the target.
+3. **Key auth.** No password prompts — the scripts run with `BatchMode=yes`.
+   If the user has no keypair: `ssh-keygen -t ed25519`. Then authorize it:
+   `ssh-copy-id <user@host>` (one password entry, ever).
+4. **The right login name.** With Tailscale the HOST is the node name from
+   `tailscale status`, but the USER is that box's unix login — they usually
+   differ, and the tailnet account name is often NOT an authorized login.
+   Probe candidates before syncing:
+   ```
+   ssh -o BatchMode=yes -o ConnectTimeout=8 <candidate>@<host> 'echo OK'
+   ```
+   `Permission denied (publickey)` = wrong user or key not copied.
+   `Connection refused` = sshd not running (step 2).
+
+Re-run the doctor after each fix until it prints "all checks passed".
+
+## How to Run
+
+Invoke through the `terminal` tool. Scripts live in
+`~/.hermes/skills/devops/skill-sync/scripts/` once installed. Remotes are
+always explicit — positional args or `SKILL_SYNC_REMOTES` (comma-separated).
+
+```bash
+# Pull: bring newer/missing skills from a remote to this machine
+~/.hermes/skills/devops/skill-sync/scripts/sync.sh user@host
+
+# Push: send newer/missing local skills to a remote (new-machine bootstrap)
+~/.hermes/skills/devops/skill-sync/scripts/sync.sh --push user@host
+
+# Preview either direction without transferring
+DRY_RUN=1 ~/.hermes/skills/devops/skill-sync/scripts/sync.sh user@host
+```
+
+## Quick Reference
+
+| Command | What it does |
+|---|---|
+| `doctor.sh <user@host>` | Verify Tailscale/SSH/rsync; prints fixes |
+| `sync.sh <user@host>` | Pull remote-newer + remote-only skills |
+| `sync.sh --push <user@host>` | Push local-newer + local-only skills |
+| `DRY_RUN=1 sync.sh ...` | Preview; read the `[^]`/`[+]` lines |
+| `p2p_sync.py <user@host>` | Per-skill triage picker (no transfers) |
+
+## Procedure
+
+### First-time pairing
+
+1. `doctor.sh <user@host>` — fix anything it flags (see Prerequisites).
+2. `DRY_RUN=1 sync.sh <user@host>` — show the user the plan. The change set
+   is the union of `[^]` (update) and `[+]` (new) lines.
+3. `sync.sh <user@host>` (or `--push` for a new-machine bootstrap).
+4. Verify (see Verification).
+
+### Selective sync
+
+When the user only wants some skills moved, run
+`python3 ~/.hermes/skills/devops/skill-sync/scripts/p2p_sync.py <user@host>`.
+It prints a numbered PULL/PUSH picker (new / updated / divergent per skill)
+and transfers nothing. Present the picker, get the user's selection, then
+rsync the chosen skill directories yourself:
+
+```bash
+rsync -azL -e "ssh -o BatchMode=yes" "user@host:.hermes/skills/<cat>/<skill>/" ~/.hermes/skills/<cat>/<skill>/
+```
+
+### Scheduled sync (cron)
+
+The cron runner passes no args, so bake the remotes into a wrapper:
+
+```bash
+mkdir -p ~/.hermes/scripts
+printf '#!/usr/bin/env bash\nSKILL_SYNC_REMOTES="user@host" exec ~/.hermes/skills/devops/skill-sync/scripts/sync.sh\n' > ~/.hermes/scripts/skill-sync-tick.sh
+chmod +x ~/.hermes/scripts/skill-sync-tick.sh
+hermes cron create "every 6h" --name skill-sync --script ~/.hermes/scripts/skill-sync-tick.sh --no-agent
+```
+
+## Conflict Resolution
+
+The unit of sync is the whole skill directory (SKILL.md + references/ +
+scripts/ + templates/), transferred atomically via rsync. The rule is
+**last-writer-wins by SKILL.md mtime** — skills are single-author documents,
+and this matches how they evolve: one machine gets the fix, the others pick
+it up.
+
+**Exception — the same skill forked on two machines.** If BOTH sides added
+unique content, last-writer-wins is LOSSY: the newer mtime overwrites
+wholesale and drops the loser's additions. `p2p_sync.py` flags these as
+`divergent`. Do NOT sync a divergent skill — do a manual union merge; full
+procedure in `references/merging-forked-skill-copies.md`.
+
+## Pitfalls
+
+- **mtime lies about content.** A copy can be newer AND missing files the
+  older copy has (fork trap). When in doubt, compare file inventories:
+  `ssh <remote> 'find ~/.hermes/skills/<cat>/<skill> -type f'` vs local.
+- **`DRY_RUN=1` plan = the `[^]` + `[+]` lines**, not just the summary count.
+- **Never trust "Push complete" — verify on the remote.** `sync.sh` prints a
+  remote skill count after every push; if it doesn't move, the transfer
+  failed. Spot-check specific paths too (see Verification).
+- **Whole-tree fallback when per-skill sync misbehaves:** one additive pass,
+  no `--delete`, surfaces errors:
+  `rsync -azL -e "ssh -o BatchMode=yes" ~/.hermes/skills/ user@host:.hermes/skills/`
+- **Only one SSH direction may work.** If push to a box is refused but that
+  box can SSH back here, flip it: have the other machine's agent PULL. Write
+  it a handoff note with the source `user@host` and the exact `sync.sh`
+  command rather than fighting the dead direction.
+- Sync is additive — it never deletes local skills missing on the remote.
+  Within an updated skill, `--delete` prunes files the newer side removed.
+- Skills under paths containing `.bak` or `.archive` are always excluded,
+  both directions.
+- macOS vs Linux `stat` flags differ; the scripts handle both.
+- Byte-comparing across OSes: macOS `wc -c` left-pads output — `tr -d ' '`
+  before comparing.
+
+## Verification
+
+```bash
+# Counts converge and a spot-checked skill landed whole:
+ssh -o BatchMode=yes user@host 'find ~/.hermes/skills -name SKILL.md | wc -l'
+ssh -o BatchMode=yes user@host 'find ~/.hermes/skills/<cat>/<skill> -type f | sed "s|.*/skills/||"'
+```
+
+A second `DRY_RUN=1 sync.sh` run should report zero `[^]`/`[+]` lines — the
+trees have converged.

--- a/optional-skills/devops/skill-sync/references/merging-forked-skill-copies.md
+++ b/optional-skills/devops/skill-sync/references/merging-forked-skill-copies.md
@@ -1,0 +1,95 @@
+# Merging forked skill copies into one master
+
+`sync.sh` is **last-writer-wins by mtime** — it's lossy when the SAME skill forked on
+two machines (each side added unique references/sections). The newer mtime wins wholesale
+and silently drops the other side's unique content. When you need a UNION (keep everything
+from every copy), do a manual semantic merge instead of relying on sync.
+
+## When this applies
+- Two+ machines edited the same skill independently (different references added on each).
+- You want one canonical "master" dir combining all copies, optionally folding a second
+  related skill into it.
+- Detection: a sync dry-run shows the skill as `[^] remote newer`, but on inspection the
+  LOCAL copy also has files/sections the remote lacks (not a clean superset).
+  `p2p_sync.py` classifies these as `divergent`.
+
+## Procedure
+
+### 1. Stage every copy side by side
+```bash
+STAGE=$(mktemp -d)/skill-merge-staging; mkdir -p "$STAGE"
+rsync -aL ~/.hermes/skills/<cat>/<skill>/ "$STAGE/<skill>-local/"
+rsync -aL user@host:'.hermes/skills/<cat>/<skill>/' "$STAGE/<skill>-remote/"
+# repeat per source
+```
+
+### 2. Map the divergence (don't eyeball — compute it)
+```bash
+# files unique to each side
+comm -23 <(cd A && find references -type f|sort) <(cd B && find references -type f|sort)  # A-only
+comm -13 <(cd A && find references -type f|sort) <(cd B && find references -type f|sort)  # B-only
+# files in BOTH but byte-different (the dangerous ones — possible forks, not supersets)
+for f in $(comm -12 <(cd A && find references -type f|sort) <(cd B && find references -type f|sort)); do
+  diff -q "A/$f" "B/$f" >/dev/null || echo "DIFF $f ($(wc -l<A/$f)L vs $(wc -l<B/$f)L)"
+done
+```
+
+### 3. Build the file-tree union
+- For each relative path, if all copies are byte-identical → take any.
+- If they differ → **diff them**. A clean superset (one strictly contains the other) →
+  keep the longer. A genuine FORK (each has lines the other dropped, even a 1-line delta)
+  → 3-way union the content by hand. **A length-pick is WRONG for forks** — verify
+  superset-ness before trusting "keep the longer". The trap: a 254-vs-253-line file is
+  almost never a superset; it's two edits that each removed a different line.
+- **A near-tie can be a de-personalizing fork — keep the SCRUBBED copy, not the longer
+  one.** When two copies differ by only a few bytes, diff them: if one side replaced
+  personal names, hostnames, or internal service names with generic terms, that scrubbed
+  copy is the canonical one even if it's a byte or two shorter. A blind length-pick or
+  newest-wins RE-INTRODUCES the names you already cleaned. After merging, grep the whole
+  master for the scrubbed terms to confirm zero leaked back in from the other fork.
+
+### 4. Merge the SKILL.md body
+- Pick the structurally-newer fork as base (the one with more recent top-level sections).
+- Find content sections (`##`/`###` headers) present in the OTHER fork but not the base;
+  graft them in at the right anchor.
+- Merge the top reference-link index: append link one-liners the base lacks (match by the
+  `references/<file>.md` filename, not header text).
+- Fix source bugs you find: duplicate/empty headers, corrupted links (mashed/missing
+  backticks). These accumulate across forks.
+
+### 5. Folding skill B into skill A
+- Strip B's frontmatter + its trailing `## Linked Files` (the loader regenerates that).
+- Demote B's H1 to a banner section, append under a clear divider in A.
+- Merge B's references/scripts/templates into A's tree (union, same rules as step 3).
+
+### 6. Validate before declaring done
+- Every cited artifact (`references/X.md`, `scripts/Y`, `templates/Z`) must exist in the
+  tree. Parse the citations from SKILL.md and diff against an `os.walk` of the dir.
+- A dangling link that points at a path in a TARGET CODEBASE (a repo file, not a skill
+  asset) is fine — don't "fix" it.
+- Uncited reference files are fine to keep (reachable via cross-links inside other refs);
+  a master is allowed to over-include.
+- **Any name scrub must survive the merge.** `grep -ri "<scrubbed-name>" <master>/` after
+  building. If a folded fork re-introduced a name the canonical copy had cleaned, scrub it
+  in the merged sections.
+
+## N-way merges (more than two sources)
+The same procedure scales, but order matters. A first pass may produce a "master" that a
+LATER-discovered copy (a backup archive, a box that was offline during the first sync)
+turns out to be a richer fork of — mostly non-overlapping references. Re-merge: treat
+the new copy as just another source, union its file tree in, fold its unique SKILL.md
+sections, re-apply any hand-unions (a 3-way union built in the first pass can get
+clobbered by a bigger base from the new source — re-inject the lost blocks). Bump the
+version each pass. Don't assume the first master is canonical; the biggest/richest fork
+can arrive last.
+
+## Pitfalls
+- **Scripting the union beats hand-copying** — with 100+ files across several sources, do
+  it in code (os.walk + content-dedup + longest-or-flag-conflict) and print only the
+  conflicts/uniques for human review. Mechanical union is deterministic; only the
+  byte-conflicts need judgment.
+- **Don't install the master blind.** Build it in a scratch dir, validate, then let the
+  user decide whether to install over the live copy. The existing skill keeps working
+  meanwhile.
+- **mtime lies about content.** A copy can be newer AND smaller (someone trimmed it).
+  Newer ≠ superset. Always diff.

--- a/optional-skills/devops/skill-sync/scripts/doctor.sh
+++ b/optional-skills/devops/skill-sync/scripts/doctor.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# skill-sync doctor: verify everything a sync needs, and print the exact fix
+# for whatever is missing.
+#
+# Usage: doctor.sh <user@host> [user@host2 ...]
+#
+# Checks, in order:
+#   local : ssh client, rsync, an SSH keypair, Tailscale state (optional)
+#   remote: SSH reachability + key auth, rsync, skills dir
+#
+# Exit 0 when every remote is ready to sync; 1 otherwise.
+
+set -uo pipefail
+
+SSH_TIMEOUT="${SKILL_SYNC_SSH_TIMEOUT:-8}"
+SSH_OPTS="-o ConnectTimeout=$SSH_TIMEOUT -o BatchMode=yes -o StrictHostKeyChecking=accept-new"
+FAILURES=0
+
+ok()   { echo "  [ok] $1"; }
+warn() { echo "  [--] $1"; }
+bad()  { echo "  [!!] $1"; FAILURES=$((FAILURES + 1)); }
+fix()  { echo "        fix: $1"; }
+
+if [ $# -eq 0 ]; then
+    echo "Usage: doctor.sh <user@host> [user@host2 ...]"
+    echo ""
+    echo "Tip: pick the right login. With Tailscale, the hostname is the machine's"
+    echo "node name ('tailscale status', first column) but the USER is that box's"
+    echo "unix login — they usually differ. Probe candidates with:"
+    echo "  ssh -o BatchMode=yes -o ConnectTimeout=8 <user>@<host> 'echo OK'"
+    exit 1
+fi
+
+echo "== Local checks =="
+
+command -v ssh >/dev/null 2>&1 && ok "ssh client present" || {
+    bad "ssh client missing"
+    fix "install OpenSSH (macOS: built-in; Debian/Ubuntu: sudo apt install openssh-client)"
+}
+
+command -v rsync >/dev/null 2>&1 && ok "rsync present" || {
+    bad "rsync missing"
+    fix "macOS: built-in / brew install rsync; Debian/Ubuntu: sudo apt install rsync"
+}
+
+if ls "$HOME"/.ssh/id_* >/dev/null 2>&1; then
+    ok "SSH keypair found in ~/.ssh"
+else
+    bad "no SSH keypair in ~/.ssh"
+    fix "ssh-keygen -t ed25519   (then: ssh-copy-id <user@host> for each remote)"
+fi
+
+if command -v tailscale >/dev/null 2>&1; then
+    ts_state=$(tailscale status --json 2>/dev/null | grep -o '"BackendState": *"[^"]*"' | head -1 | sed 's/.*"BackendState": *"//;s/"//')
+    case "$ts_state" in
+        Running) ok "Tailscale running" ;;
+        "")      warn "Tailscale installed but status unreadable" ;;
+        *)       bad "Tailscale installed but state is '$ts_state'"
+                 fix "tailscale up   (log in with the same tailnet on every machine)" ;;
+    esac
+else
+    warn "Tailscale not installed (optional — any SSH route works)"
+    fix "recommended for cross-network sync: https://tailscale.com/download, then 'tailscale up' on every machine"
+fi
+
+for remote in "$@"; do
+    echo ""
+    echo "== Remote: $remote =="
+
+    # shellcheck disable=SC2086
+    out=$(ssh $SSH_OPTS "$remote" 'echo __SKILL_SYNC_OK__' 2>&1)
+    if printf '%s' "$out" | grep -q '__SKILL_SYNC_OK__'; then
+        ok "SSH key auth works"
+    else
+        case "$out" in
+            *"Permission denied"*)
+                bad "SSH reachable but key NOT authorized ($remote)"
+                fix "ssh-copy-id $remote   (enter the password once)"
+                fix "wrong user? Tailscale login name != unix user — try the box's actual unix login, e.g. ssh <unixuser>@${remote#*@}"
+                ;;
+            *"Connection refused"*)
+                bad "host up but sshd not listening ($remote)"
+                fix "macOS remote: System Settings > General > Sharing > Remote Login ON (or: sudo systemsetup -setremotelogin on)"
+                fix "Linux remote: sudo apt install openssh-server && sudo systemctl enable --now ssh"
+                fix "or use Tailscale SSH: run 'sudo tailscale set --ssh' on the remote"
+                fix "or flip direction: run the sync FROM that machine, pulling from this one"
+                ;;
+            *"Could not resolve hostname"*)
+                bad "hostname does not resolve ($remote)"
+                fix "use the Tailscale node name ('tailscale status', first column) or its 100.x.y.z IP"
+                ;;
+            *"timed out"*|*"Operation timed out"*|*"No route to host"*)
+                bad "host unreachable ($remote)"
+                fix "check 'tailscale status' on BOTH machines; 'tailscale ping ${remote#*@}'; is the box awake?"
+                ;;
+            *)
+                bad "SSH failed ($remote): $(printf '%s' "$out" | head -1)"
+                fix "run manually to see the full error: ssh -v $remote 'echo OK'"
+                ;;
+        esac
+        continue
+    fi
+
+    # shellcheck disable=SC2086
+    if ssh $SSH_OPTS "$remote" 'command -v rsync' >/dev/null 2>&1; then
+        ok "remote rsync present"
+    else
+        bad "remote rsync missing"
+        fix "install rsync on $remote (Debian/Ubuntu: sudo apt install rsync)"
+    fi
+
+    # shellcheck disable=SC2086
+    count=$(ssh $SSH_OPTS "$remote" 'find "${HERMES_HOME:-$HOME/.hermes}/skills" -name SKILL.md 2>/dev/null | wc -l' 2>/dev/null | tr -d ' ')
+    if [ -n "$count" ] && [ "$count" -gt 0 ] 2>/dev/null; then
+        ok "remote skills dir present ($count skills)"
+    else
+        warn "remote has no ~/.hermes/skills yet (fine for a first push — it will be created)"
+    fi
+done
+
+echo ""
+if [ "$FAILURES" -gt 0 ]; then
+    echo "Doctor: $FAILURES problem(s) found. Apply the fixes above, then re-run."
+    exit 1
+fi
+echo "Doctor: all checks passed. Ready to sync."

--- a/optional-skills/devops/skill-sync/scripts/p2p_sync.py
+++ b/optional-skills/devops/skill-sync/scripts/p2p_sync.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""P2P skill-sync triage: list, filter, classify, and print a per-direction picker.
+
+Unlike sync.sh (all-or-nothing per direction), this:
+  - lists local + each remote's skills by mtime
+  - filters out .bak / .archive and any user-named excludes
+  - intersects remote-pull candidates with the REMOTE-READABLE set (so
+    permission-restricted skills are reported, not silently dropped)
+  - classifies each remote-newer skill as NEW / superset / divergent (needs merge)
+  - prints a numbered picker for PULL and PUSH per remote
+
+Usage:
+  python3 p2p_sync.py user@host [user@host2 ...]
+  python3 p2p_sync.py --exclude some-skill user@host
+
+It only REPORTS. The agent reads the picker, gets the user's selection, then
+executes rsync (clean copies) + union merges (divergent) itself. Nothing is
+written or transferred by this script.
+"""
+import difflib
+import os
+import subprocess
+import sys
+
+HOME = os.path.expanduser("~")
+LOCAL = os.path.join(os.environ.get("HERMES_HOME", os.path.join(HOME, ".hermes")), "skills")
+SSH = "ssh -o ConnectTimeout=8 -o BatchMode=yes"
+
+EXCLUDE_SUBSTR = [".bak", ".archive"]  # always skipped
+
+
+def parse_args(argv):
+    excludes, remotes = [], []
+    i = 0
+    while i < len(argv):
+        if argv[i] == "--exclude":
+            excludes.append(argv[i + 1])
+            i += 2
+        else:
+            remotes.append(argv[i])
+            i += 1
+    return excludes, remotes
+
+
+def is_excluded(path, name_excludes):
+    if any(s in path for s in EXCLUDE_SUBSTR):
+        return True
+    return any(path.endswith(x) or f"/{x}" in f"/{path}" for x in name_excludes)
+
+
+def listing(host):
+    """Return {skill_path: mtime} for local or a remote host."""
+    if host == "local":
+        d = {}
+        for root, _dirs, files in os.walk(LOCAL, followlinks=True):
+            if "SKILL.md" in files:
+                p = os.path.join(root, "SKILL.md")
+                rel = os.path.relpath(root, LOCAL)
+                d[rel] = int(os.stat(p).st_mtime)
+        return d
+    rem = (
+        'SK="${HERMES_HOME:-$HOME/.hermes}/skills"; [ -d "$SK" ] || exit 0; '
+        "find \"$SK\" -name SKILL.md -type f | while read -r f; do "
+        'rel="${f#$SK/}"; d="${rel%/SKILL.md}"; '
+        'm=$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f"); printf "%s\\t%s\\n" "$d" "$m"; done'
+    )
+    out = subprocess.run([*SSH.split(), host, rem], capture_output=True, text=True).stdout
+    d = {}
+    for line in out.strip().splitlines():
+        if "\t" in line:
+            p, m = line.rsplit("\t", 1)
+            d[p] = int(m)
+    return d
+
+
+def readable_set(host):
+    """Skills on the remote whose SKILL.md is readable by the SSH user."""
+    rem = (
+        'cd "${HERMES_HOME:-$HOME/.hermes}/skills" 2>/dev/null && '
+        "for f in $(find . -name SKILL.md -readable -type f 2>/dev/null || find . -name SKILL.md -type f); "
+        'do echo "${f#./}" | sed "s|/SKILL.md||"; done'
+    )
+    out = subprocess.run([*SSH.split(), host, rem], capture_output=True, text=True).stdout
+    return set(out.split())
+
+
+def classify(local_md, remote_md):
+    """NEW handled by caller. Here: 'identical' | 'superset' | 'divergent'."""
+    with open(local_md) as fh:
+        L = fh.read().splitlines()
+    with open(remote_md) as fh:
+        R = fh.read().splitlines()
+    if L == R:
+        return "identical"
+    diff = list(difflib.unified_diff(L, R, lineterm=""))
+    removed = sum(
+        1 for d in diff if d.startswith("-") and not d.startswith("---") and d.strip() != "-"
+    )
+    return "superset" if removed == 0 else "divergent"
+
+
+def main():
+    excludes, remotes = parse_args(sys.argv[1:])
+    if not remotes:
+        print("usage: p2p_sync.py [--exclude NAME]... user@host [user@host2 ...]")
+        sys.exit(1)
+
+    L = listing("local")
+    for host in remotes:
+        print("=" * 72)
+        print(f"REMOTE: {host}")
+        print("=" * 72)
+        R = listing(host)
+        if not R:
+            print("  [!] no skills / SSH failed — run doctor.sh to diagnose")
+            continue
+        rd = readable_set(host)
+
+        pull_new, pull_upd, skipped_perms = [], [], []
+        for p, m in sorted(R.items()):
+            if is_excluded(p, excludes):
+                continue
+            if p not in rd:
+                skipped_perms.append(p)
+                continue
+            if p not in L:
+                pull_new.append(p)
+            elif m > L[p]:
+                pull_upd.append((p, (m - L[p]) // 60))
+
+        push = []
+        for p, m in sorted(L.items()):
+            if is_excluded(p, excludes):
+                continue
+            if p not in R:
+                push.append((p, "NEW"))
+            elif L[p] > m:
+                push.append((p, f"upd {(L[p] - m) // 60}m"))
+
+        n = 0
+        print(f"\n-- PULL <- {host}: {len(pull_new)} new, {len(pull_upd)} updated --")
+        for p in pull_new:
+            n += 1
+            print(f"{n:>3}. {p:<55} [NEW]")
+        for p, age in pull_upd:
+            n += 1
+            print(f"{n:>3}. {p:<55} [upd {age}m — diff to bucket it]")
+        if skipped_perms:
+            print(f"\n  [!] {len(skipped_perms)} skill(s) UNREADABLE over SSH (permissions):")
+            for p in skipped_perms:
+                print(f"      - {p}")
+            print("      Fix: chown/chmod on remote. NOT silently dropped.")
+
+        n = 0
+        print(f"\n-- PUSH -> {host}: {len(push)} --")
+        for p, s in push:
+            n += 1
+            print(f"{n:>3}. {p:<55} [{s}]")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/devops/skill-sync/scripts/sync.sh
+++ b/optional-skills/devops/skill-sync/scripts/sync.sh
@@ -59,7 +59,15 @@ try_ssh() {
 }
 
 get_mtime() {
-    stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || echo 0
+    # GNU first: BSD stat rejects -c with no stdout. The reverse order is a
+    # trap — GNU 'stat -f %m <file>' is FILESYSTEM mode, which dumps a
+    # multi-line info block to stdout (exit 1) that pollutes the capture.
+    local m
+    m=$(stat -c %Y "$1" 2>/dev/null) || m=$(stat -f %m "$1" 2>/dev/null) || m=0
+    case "$m" in
+        ''|*[!0-9]*) m=0 ;;
+    esac
+    echo "$m"
 }
 
 # Archived/backup copies are never synced.

--- a/optional-skills/devops/skill-sync/scripts/sync.sh
+++ b/optional-skills/devops/skill-sync/scripts/sync.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# skill-sync: pull/push skills between machines via SSH + rsync
+#
+# Pull (default): sync.sh <user@host> [user@host2 ...]
+# Push:           sync.sh --push <user@host> [user@host2 ...]
+# Dry run:        DRY_RUN=1 sync.sh <user@host>
+#
+# Remotes come from positional args and/or SKILL_SYNC_REMOTES (comma- or
+# space-separated). There are no built-in defaults — the script exits with
+# usage if no remote is given.
+#
+# Run doctor.sh first on a new pairing: it verifies Tailscale/SSH/rsync and
+# prints the exact fix for whatever is missing.
+
+set -uo pipefail
+
+LOCAL_SKILLS="${HERMES_HOME:-$HOME/.hermes}/skills"
+mkdir -p "$LOCAL_SKILLS"
+
+DRY_RUN="${DRY_RUN:-0}"
+SSH_TIMEOUT="${SKILL_SYNC_SSH_TIMEOUT:-8}"
+SSH_OPTS="-o ConnectTimeout=$SSH_TIMEOUT -o BatchMode=yes -o StrictHostKeyChecking=accept-new"
+PUSH_MODE=0
+TARGETS=""
+TOTAL_ERRORS=0
+
+usage() {
+    echo "Usage: sync.sh [--push] <user@host> [user@host2 ...]"
+    echo "       DRY_RUN=1 sync.sh <user@host>        # preview only"
+    echo "Remotes may also come from SKILL_SYNC_REMOTES (comma/space separated)."
+    echo "First time? Run doctor.sh <user@host> to verify connectivity."
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --push) PUSH_MODE=1 ;;
+        -h|--help) usage; exit 0 ;;
+        *) TARGETS="$TARGETS $1" ;;
+    esac
+    shift
+done
+
+if [ -n "${SKILL_SYNC_REMOTES:-}" ]; then
+    TARGETS="$TARGETS $(echo "$SKILL_SYNC_REMOTES" | tr ',' ' ')"
+fi
+# Dedupe, drop empties
+TARGETS=$(echo "$TARGETS" | tr ' ' '\n' | awk 'NF && !seen[$0]++')
+
+if [ -z "$TARGETS" ]; then
+    echo "No remotes configured."
+    usage
+    exit 1
+fi
+
+try_ssh() {
+    local remote="$1"; shift
+    # shellcheck disable=SC2086
+    ssh $SSH_OPTS "$remote" "$@"
+}
+
+get_mtime() {
+    stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || echo 0
+}
+
+# Archived/backup copies are never synced.
+is_excluded() {
+    case "$1" in
+        *.bak*|*.archive*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Resolve the remote skills dir once (honors a remote HERMES_HOME override).
+remote_skills_dir() {
+    try_ssh "$1" 'echo "${HERMES_HOME:-$HOME/.hermes}/skills"' 2>/dev/null | tail -1
+}
+
+# Print "<category/skill>\t<mtime>" per skill on the remote.
+remote_skill_list() {
+    try_ssh "$1" '
+        SKILLS="${HERMES_HOME:-$HOME/.hermes}/skills"
+        [ -d "$SKILLS" ] || exit 0
+        find "$SKILLS" -name "SKILL.md" -type f | while read -r f; do
+            rel="${f#$SKILLS/}"
+            dir="${rel%/SKILL.md}"
+            mtime=$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null || echo 0)
+            printf "%s\t%s\n" "$dir" "$mtime"
+        done
+    ' 2>/dev/null
+}
+
+do_rsync() {
+    # do_rsync <src> <dst> [--delete] — errors are VISIBLE, never swallowed
+    local src="$1" dst="$2" del="${3:-}"
+    # shellcheck disable=SC2086
+    rsync -azL $del -e "ssh $SSH_OPTS" "$src" "$dst"
+}
+
+pull_from_remote() {
+    local remote="$1"
+    local synced=0 skipped=0 new_count=0 errors=0
+
+    echo ">> Pulling from $remote ..."
+
+    local listing rdir
+    if ! listing=$(remote_skill_list "$remote"); then
+        echo "   [!] SSH failed — run doctor.sh $remote to diagnose"
+        TOTAL_ERRORS=$((TOTAL_ERRORS + 1))
+        return
+    fi
+    [ -z "$listing" ] && { echo "   No skills found on remote"; return; }
+    rdir=$(remote_skills_dir "$remote")
+    [ -z "$rdir" ] && rdir=".hermes/skills"
+
+    while IFS="$(printf '\t')" read -r skill_path remote_mtime; do
+        [ -z "$skill_path" ] && continue
+        is_excluded "$skill_path" && continue
+        skill_name="${skill_path##*/}"
+        local_dir="$LOCAL_SKILLS/$skill_path"
+        local_skill="$local_dir/SKILL.md"
+
+        if [ -f "$local_skill" ]; then
+            local_mtime=$(get_mtime "$local_skill")
+            if [ "$remote_mtime" -gt "$local_mtime" ]; then
+                age_diff=$(( (remote_mtime - local_mtime) / 60 ))
+                echo "   [^] $skill_name  (remote ${age_diff}m newer)"
+                synced=$((synced + 1))
+                if [ "$DRY_RUN" != "1" ]; then
+                    mkdir -p "$local_dir"
+                    do_rsync "$remote:$rdir/$skill_path/" "$local_dir/" --delete \
+                        || { echo "   [!] rsync failed for $skill_name"; errors=$((errors + 1)); }
+                fi
+            else
+                skipped=$((skipped + 1))
+            fi
+        else
+            echo "   [+] $skill_name  (new, from $skill_path)"
+            new_count=$((new_count + 1))
+            if [ "$DRY_RUN" != "1" ]; then
+                mkdir -p "$local_dir"
+                do_rsync "$remote:$rdir/$skill_path/" "$local_dir/" \
+                    || { echo "   [!] rsync failed for $skill_name"; errors=$((errors + 1)); }
+            fi
+        fi
+    done <<< "$listing"
+
+    TOTAL_ERRORS=$((TOTAL_ERRORS + errors))
+    total=$((synced + new_count))
+    if [ "$DRY_RUN" = "1" ]; then
+        echo "   Dry run: would update $synced, pull $new_count new; $skipped unchanged."
+    else
+        echo "   Done: $((synced + new_count - errors)) transferred ($synced updated, $new_count new), $skipped unchanged, $errors errors."
+    fi
+}
+
+push_to_remote() {
+    local remote="$1"
+    local synced=0 new_count=0 skipped=0 errors=0
+
+    echo ">> Pushing to $remote ..."
+
+    local rdir
+    if ! rdir=$(remote_skills_dir "$remote") || [ -z "$rdir" ]; then
+        echo "   [!] SSH failed — run doctor.sh $remote to diagnose"
+        TOTAL_ERRORS=$((TOTAL_ERRORS + 1))
+        return
+    fi
+    try_ssh "$remote" "mkdir -p '$rdir'" 2>/dev/null
+
+    local remote_listing local_listing
+    remote_listing=$(remote_skill_list "$remote" || true)
+    local_listing=$(find "$LOCAL_SKILLS" -name "SKILL.md" -type f)
+    [ -z "$local_listing" ] && { echo "   No local skills to push"; return; }
+
+    # NOTE: loop reads from a heredoc, NOT a pipe — counters survive.
+    while read -r f; do
+        [ -z "$f" ] && continue
+        rel="${f#$LOCAL_SKILLS/}"
+        skill_path="${rel%/SKILL.md}"
+        is_excluded "$skill_path" && continue
+        skill_name="${skill_path##*/}"
+        local_mtime=$(get_mtime "$f")
+
+        remote_mtime=0
+        if [ -n "$remote_listing" ]; then
+            match=$(printf '%s\n' "$remote_listing" | grep "^${skill_path}$(printf '\t')" || true)
+            [ -n "$match" ] && remote_mtime=$(printf '%s' "$match" | cut -f2)
+        fi
+
+        if [ "$local_mtime" -gt "$remote_mtime" ]; then
+            if [ "$remote_mtime" -eq 0 ]; then
+                echo "   [+] $skill_name  (new on remote)"
+                new_count=$((new_count + 1))
+            else
+                age_diff=$(( (local_mtime - remote_mtime) / 60 ))
+                echo "   [^] $skill_name  (local ${age_diff}m newer)"
+                synced=$((synced + 1))
+            fi
+            if [ "$DRY_RUN" != "1" ]; then
+                try_ssh "$remote" "mkdir -p '$rdir/$skill_path'" 2>/dev/null
+                do_rsync "$LOCAL_SKILLS/$skill_path/" "$remote:$rdir/$skill_path/" --delete \
+                    || { echo "   [!] rsync failed for $skill_name"; errors=$((errors + 1)); }
+            fi
+        else
+            skipped=$((skipped + 1))
+        fi
+    done <<< "$local_listing"
+
+    TOTAL_ERRORS=$((TOTAL_ERRORS + errors))
+    total=$((synced + new_count))
+    if [ "$DRY_RUN" = "1" ]; then
+        echo "   Dry run: would update $synced, push $new_count new; $skipped unchanged."
+        return
+    fi
+    echo "   Done: $((total - errors)) transferred ($synced updated, $new_count new), $skipped unchanged, $errors errors."
+
+    # Verify on the remote — never trust a silent rsync loop.
+    local remote_count
+    remote_count=$(try_ssh "$remote" 'find "${HERMES_HOME:-$HOME/.hermes}/skills" -name SKILL.md 2>/dev/null | wc -l' 2>/dev/null | tr -d ' ')
+    local local_count
+    local_count=$(printf '%s\n' "$local_listing" | wc -l | tr -d ' ')
+    echo "   Verify: remote now has $remote_count skills (local: $local_count)."
+}
+
+for target in $TARGETS; do
+    if [ "$PUSH_MODE" -eq 1 ]; then
+        push_to_remote "$target"
+    else
+        pull_from_remote "$target"
+    fi
+done
+
+if [ "$TOTAL_ERRORS" -gt 0 ]; then
+    echo "!! Completed with $TOTAL_ERRORS error(s)."
+    exit 1
+fi

--- a/tests/skills/test_skill_sync_skill.py
+++ b/tests/skills/test_skill_sync_skill.py
@@ -1,0 +1,332 @@
+"""Tests for the skill-sync optional skill.
+
+Validates:
+  - SKILL.md frontmatter conforms to the authoring standards
+  - No personal machine names / logins leak into the shipped skill
+  - sync.sh behaves correctly end-to-end against two local "machines"
+    (HERMES_HOME-style skill trees synced over a loopback SSH stub)
+  - doctor.sh diagnoses missing prerequisites with actionable fixes
+  - p2p_sync.py classifies divergent copies without transferring anything
+"""
+from __future__ import annotations
+
+import os
+import re
+import stat
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "devops"
+    / "skill-sync"
+)
+SCRIPTS = SKILL_DIR / "scripts"
+
+
+@pytest.fixture(scope="module")
+def skill_source() -> str:
+    return (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def frontmatter(skill_source) -> dict:
+    m = re.search(r"^---\n(.*?)\n---", skill_source, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter / authoring standards
+# ---------------------------------------------------------------------------
+
+def test_skill_dir_exists() -> None:
+    assert SKILL_DIR.is_dir()
+
+
+def test_description_under_60_chars(frontmatter) -> None:
+    desc = frontmatter["description"]
+    assert len(desc) <= 60, f"description is {len(desc)} chars: {desc!r}"
+
+
+def test_required_frontmatter_fields(frontmatter) -> None:
+    for field in ("name", "description", "version", "author", "license", "platforms"):
+        assert field in frontmatter, f"missing required field: {field}"
+    assert frontmatter["name"] == "skill-sync"
+    assert set(frontmatter["platforms"]) == {"linux", "macos"}
+
+
+def test_no_hardcoded_remotes() -> None:
+    """Shipped scripts must not bake in anyone's machines: every user@host
+    occurrence must be a generic placeholder."""
+    allowed = re.compile(
+        r"(user@(host2?|newbox|workstation|laptop|testbox)"
+        r"|<user>@|<user@host>|<candidate>@|user@box\d)"
+    )
+    remote_like = re.compile(r"[A-Za-z0-9_.<>-]+@[A-Za-z0-9_.<>-]+")
+    for path in sorted(SKILL_DIR.rglob("*")):
+        if not path.is_file() or "__pycache__" in path.parts:
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for m in remote_like.finditer(text):
+            token = m.group(0)
+            # emails and generic placeholders are fine
+            if "." in token.split("@")[1] or allowed.search(token):
+                continue
+            assert allowed.search(token), (
+                f"possible hardcoded remote {token!r} in {path.name}"
+            )
+
+
+def test_scripts_shipped_and_referenced(skill_source) -> None:
+    for script in ("sync.sh", "doctor.sh", "p2p_sync.py"):
+        assert (SCRIPTS / script).is_file(), f"missing scripts/{script}"
+        assert script in skill_source, f"SKILL.md never mentions {script}"
+    assert (SKILL_DIR / "references" / "merging-forked-skill-copies.md").is_file()
+
+
+def test_sync_sh_requires_explicit_remotes() -> None:
+    """No baked-in default remotes: bare invocation must fail with usage."""
+    env = {k: v for k, v in os.environ.items() if k != "SKILL_SYNC_REMOTES"}
+    proc = subprocess.run(
+        ["bash", str(SCRIPTS / "sync.sh")],
+        capture_output=True, text=True, timeout=30, env=env,
+    )
+    assert proc.returncode != 0
+    assert "No remotes configured" in proc.stdout + proc.stderr
+
+
+# ---------------------------------------------------------------------------
+# E2E harness: fake "remote" via an ssh/rsync-intercepting PATH shim
+# ---------------------------------------------------------------------------
+#
+# sync.sh shells out to `ssh <opts> <remote> <cmd>` and
+# `rsync -azL [-e ssh...] src dst`. We put stub ssh/rsync executables first on
+# PATH: ssh runs the command locally against a fake remote HERMES_HOME; rsync
+# strips `remote:` prefixes and falls through to a local copy. This exercises
+# the real control flow (listing, mtime compare, counters, verification)
+# without a network.
+
+
+def _make_skill(root: Path, cat: str, name: str, body: str, mtime: int) -> None:
+    d = root / "skills" / cat / name
+    d.mkdir(parents=True, exist_ok=True)
+    f = d / "SKILL.md"
+    f.write_text(body, encoding="utf-8")
+    os.utime(f, (mtime, mtime))
+    os.utime(d, (mtime, mtime))
+
+
+@pytest.fixture()
+def fake_fleet(tmp_path):
+    """Two HERMES_HOMEs (local + 'remote') plus PATH shims for ssh/rsync."""
+    local_home = tmp_path / "local-hermes"
+    remote_home = tmp_path / "remote-hermes"
+    (local_home / "skills").mkdir(parents=True)
+    (remote_home / "skills").mkdir(parents=True)
+
+    now = int(time.time())
+    # remote-newer skill (should be pulled)
+    _make_skill(local_home, "devops", "alpha", "old alpha\n", now - 7200)
+    _make_skill(remote_home, "devops", "alpha", "new alpha\n", now - 60)
+    # remote-only skill (should be pulled as new)
+    _make_skill(remote_home, "research", "beta", "beta content\n", now - 60)
+    # local-newer skill (pull must NOT touch it; push should send it)
+    _make_skill(local_home, "devops", "gamma", "local gamma newer\n", now - 60)
+    _make_skill(remote_home, "devops", "gamma", "remote gamma old\n", now - 7200)
+    # remote archived skill (must be excluded from pull)
+    _make_skill(remote_home, ".archive", "old-junk", "archived\n", now - 60)
+    # local backup copy (must be excluded from push)
+    _make_skill(local_home, "devops", "gamma.bak", "backup copy\n", now - 30)
+
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+
+    import shutil
+
+    real_rsync = shutil.which("rsync")
+    assert real_rsync, "rsync required for this test"
+
+    ssh_stub = bindir / "ssh"
+    ssh_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "# consume ssh options; the last two args are <remote> <command...>\n"
+        "args=()\n"
+        "while [ $# -gt 0 ]; do\n"
+        "  case \"$1\" in\n"
+        "    -o) shift 2 ;;\n"
+        "    *) args+=(\"$1\"); shift ;;\n"
+        "  esac\n"
+        "done\n"
+        "# args[0] = remote, rest = command\n"
+        f"export HERMES_HOME=\"{remote_home}\"\n"
+        "export HOME=\"$HOME\"\n"
+        "cmd=\"${args[*]:1}\"\n"
+        "exec bash -c \"$cmd\"\n",
+        encoding="utf-8",
+    )
+    ssh_stub.chmod(ssh_stub.stat().st_mode | stat.S_IEXEC)
+
+    rsync_stub = bindir / "rsync"
+    rsync_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "# strip -e '<ssh cmd>' and remote: prefixes, then local rsync\n"
+        f"real=\"{real_rsync}\"\n"
+        "args=()\n"
+        "while [ $# -gt 0 ]; do\n"
+        "  case \"$1\" in\n"
+        "    -e) shift 2 ;;\n"
+        "    *) args+=(\"${1#*:}\"); shift ;;\n"
+        "  esac\n"
+        "done\n"
+        "exec \"$real\" \"${args[@]}\"\n",
+        encoding="utf-8",
+    )
+    rsync_stub.chmod(rsync_stub.stat().st_mode | stat.S_IEXEC)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["HERMES_HOME"] = str(local_home)
+    # The ssh stub sets HERMES_HOME for "remote" commands, but rsync paths
+    # produced by sync.sh embed the remote skills dir absolutely, so the
+    # stubbed transfers land in the right tree.
+    return {"local": local_home, "remote": remote_home, "env": env}
+
+
+def _run_sync(fleet, *args):
+    return subprocess.run(
+        ["bash", str(SCRIPTS / "sync.sh"), *args],
+        capture_output=True, text=True, timeout=60, env=fleet["env"],
+    )
+
+
+def test_e2e_pull_updates_and_news(fake_fleet) -> None:
+    proc = _run_sync(fake_fleet, "user@testbox")
+    out = proc.stdout
+    assert proc.returncode == 0, out + proc.stderr
+    assert "[^] alpha" in out
+    assert "[+] beta" in out
+    # archived remote skills are never pulled
+    assert "old-junk" not in out
+    local = fake_fleet["local"]
+    assert not (local / "skills/.archive").exists()
+    # local-newer gamma must not be pulled over
+    assert (local / "skills/devops/alpha/SKILL.md").read_text() == "new alpha\n"
+    assert (local / "skills/research/beta/SKILL.md").read_text() == "beta content\n"
+    assert (local / "skills/devops/gamma/SKILL.md").read_text() == "local gamma newer\n"
+
+
+def test_e2e_pull_dry_run_transfers_nothing(fake_fleet) -> None:
+    proc = _run_sync(fake_fleet, "user@testbox")
+    # first run synced; touch remote alpha newer again, then dry-run
+    remote_alpha = fake_fleet["remote"] / "skills/devops/alpha/SKILL.md"
+    remote_alpha.write_text("even newer alpha\n", encoding="utf-8")
+    future = int(time.time()) + 10
+    os.utime(remote_alpha, (future, future))
+
+    proc = _run_sync(fake_fleet, "user@testbox")
+    assert "[^] alpha" in proc.stdout
+
+    # DRY_RUN must report but not transfer
+    remote_alpha.write_text("dry run bait\n", encoding="utf-8")
+    os.utime(remote_alpha, (future + 100, future + 100))
+    env = dict(fake_fleet["env"])
+    env["DRY_RUN"] = "1"
+    proc = subprocess.run(
+        ["bash", str(SCRIPTS / "sync.sh"), "user@testbox"],
+        capture_output=True, text=True, timeout=60, env=env,
+    )
+    assert "[^] alpha" in proc.stdout
+    assert "Dry run" in proc.stdout
+    local_alpha = fake_fleet["local"] / "skills/devops/alpha/SKILL.md"
+    assert local_alpha.read_text() != "dry run bait\n"
+
+
+def test_e2e_push_sends_local_newer_and_verifies(fake_fleet) -> None:
+    proc = _run_sync(fake_fleet, "--push", "user@testbox")
+    out = proc.stdout
+    assert proc.returncode == 0, out + proc.stderr
+    assert "[^] gamma" in out
+    # backup copies are never pushed
+    assert "gamma.bak" not in out
+    remote = fake_fleet["remote"]
+    assert not (remote / "skills/devops/gamma.bak").exists()
+    assert (remote / "skills/devops/gamma/SKILL.md").read_text() == "local gamma newer\n"
+    # push must print a remote-count verification line
+    assert "Verify: remote now has" in out
+
+
+def test_doctor_reports_connection_refused_fix(tmp_path) -> None:
+    """doctor.sh must translate 'Connection refused' into the Remote Login fix."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    ssh_stub = bindir / "ssh"
+    ssh_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "echo 'ssh: connect to host testbox port 22: Connection refused' >&2\n"
+        "exit 255\n",
+        encoding="utf-8",
+    )
+    ssh_stub.chmod(ssh_stub.stat().st_mode | stat.S_IEXEC)
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    proc = subprocess.run(
+        ["bash", str(SCRIPTS / "doctor.sh"), "user@testbox"],
+        capture_output=True, text=True, timeout=60, env=env,
+    )
+    assert proc.returncode == 1
+    assert "sshd not listening" in proc.stdout
+    assert "Remote Login" in proc.stdout
+
+
+def test_doctor_reports_permission_denied_fix(tmp_path) -> None:
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    ssh_stub = bindir / "ssh"
+    ssh_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        "echo 'user@testbox: Permission denied (publickey).' >&2\n"
+        "exit 255\n",
+        encoding="utf-8",
+    )
+    ssh_stub.chmod(ssh_stub.stat().st_mode | stat.S_IEXEC)
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    proc = subprocess.run(
+        ["bash", str(SCRIPTS / "doctor.sh"), "user@testbox"],
+        capture_output=True, text=True, timeout=60, env=env,
+    )
+    assert proc.returncode == 1
+    assert "key NOT authorized" in proc.stdout
+    assert "ssh-copy-id" in proc.stdout
+
+
+def test_p2p_sync_classify_divergent(tmp_path) -> None:
+    """classify() must call a genuine fork 'divergent', not 'superset'."""
+    import importlib.util
+    import sys
+
+    sys.dont_write_bytecode = True
+    try:
+        spec = importlib.util.spec_from_file_location("p2p_sync", SCRIPTS / "p2p_sync.py")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    finally:
+        sys.dont_write_bytecode = False
+
+    a = tmp_path / "a.md"
+    b = tmp_path / "b.md"
+    a.write_text("line1\nline2\nlocal-only\n")
+    b.write_text("line1\nline2\nremote-only\n")
+    assert mod.classify(str(a), str(b)) == "divergent"
+
+    b.write_text("line1\nline2\nlocal-only\nplus-more\n")
+    assert mod.classify(str(a), str(b)) == "superset"
+
+    b.write_text("line1\nline2\nlocal-only\n")
+    assert mod.classify(str(a), str(b)) == "identical"

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -86,6 +86,7 @@ hermes skills uninstall <skill-name>
 | [**hermes-s6-container-supervision**](/docs/user-guide/skills/optional/devops/devops-hermes-s6-container-supervision) | Modify or debug s6 services in the Hermes Docker image. |
 | [**inference-sh-cli**](/docs/user-guide/skills/optional/devops/devops-inference-sh-cli) | Run 150+ AI apps (image, video, LLM) via inference.sh CLI. |
 | [**pinggy-tunnel**](/docs/user-guide/skills/optional/devops/devops-pinggy-tunnel) | Zero-install localhost tunnels over SSH via Pinggy. |
+| [**skill-sync**](/docs/user-guide/skills/optional/devops/devops-skill-sync) | Sync skills between machines over SSH and Tailscale. |
 | [**watchers**](/docs/user-guide/skills/optional/devops/devops-watchers) | Poll RSS, JSON APIs, and GitHub with watermark dedup. |
 
 ## dogfood

--- a/website/docs/user-guide/skills/optional/devops/devops-skill-sync.md
+++ b/website/docs/user-guide/skills/optional/devops/devops-skill-sync.md
@@ -1,0 +1,193 @@
+---
+title: "Skill Sync — Sync skills between machines over SSH and Tailscale"
+sidebar_label: "Skill Sync"
+description: "Sync skills between machines over SSH and Tailscale"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Skill Sync
+
+Sync skills between machines over SSH and Tailscale.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/devops/skill-sync` |
+| Path | `optional-skills/devops/skill-sync` |
+| Version | `1.0.0` |
+| Author | alt-glitch (alt-glitch), Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos |
+| Tags | `Skills`, `Sync`, `SSH`, `Tailscale`, `Rsync`, `Multi-Machine`, `Cron` |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Skill Sync
+
+Sync `~/.hermes/skills/` between machines over SSH. Compares modification
+times, pulls newer skills, discovers new ones, and can push the local tree to
+a fresh box. Conflict rule is last-writer-wins by mtime; sync is additive
+(nothing is deleted on either side). Works over any SSH route — Tailscale is
+the recommended transport because it gives every machine a stable name that
+works across networks.
+
+## When to Use
+
+- User has Hermes on two or more machines and wants skills kept in step
+- User got a new machine and wants their skill library on it ("push my skills to the new box")
+- User improved a skill on one box and wants it everywhere
+- User asks for automatic/scheduled skill syncing between machines
+- A skill exists on another machine but not here
+
+## Prerequisites — walk the user through these, don't assume them
+
+Each remote needs: a network route, a running sshd, key-based auth, and
+rsync. **Run the doctor first** — it checks all four and prints the exact fix
+for anything missing:
+
+```
+terminal(command="~/.hermes/skills/devops/skill-sync/scripts/doctor.sh <user@host>")
+```
+
+If the doctor reports failures, guide the user through them in this order:
+
+1. **Network route (Tailscale, recommended).** If the machines aren't on the
+   same LAN, have the user install Tailscale on both ends
+   (https://tailscale.com/download) and run `tailscale up` on each, logged
+   into the same tailnet. Verify with `tailscale status` — every machine gets
+   a stable node name and a `100.x.y.z` IP that work from anywhere. Any other
+   SSH route (LAN hostname, VPN, public IP) also works.
+2. **sshd on the target.** Fresh macOS refuses SSH by default — the user must
+   enable System Settings → General → Sharing → **Remote Login**, or run
+   `sudo systemsetup -setremotelogin on`. Linux: `sudo apt install
+   openssh-server && sudo systemctl enable --now ssh`. Tailscale users can
+   skip sshd entirely with `sudo tailscale set --ssh` on the target.
+3. **Key auth.** No password prompts — the scripts run with `BatchMode=yes`.
+   If the user has no keypair: `ssh-keygen -t ed25519`. Then authorize it:
+   `ssh-copy-id <user@host>` (one password entry, ever).
+4. **The right login name.** With Tailscale the HOST is the node name from
+   `tailscale status`, but the USER is that box's unix login — they usually
+   differ, and the tailnet account name is often NOT an authorized login.
+   Probe candidates before syncing:
+   ```
+   ssh -o BatchMode=yes -o ConnectTimeout=8 <candidate>@<host> 'echo OK'
+   ```
+   `Permission denied (publickey)` = wrong user or key not copied.
+   `Connection refused` = sshd not running (step 2).
+
+Re-run the doctor after each fix until it prints "all checks passed".
+
+## How to Run
+
+Invoke through the `terminal` tool. Scripts live in
+`~/.hermes/skills/devops/skill-sync/scripts/` once installed. Remotes are
+always explicit — positional args or `SKILL_SYNC_REMOTES` (comma-separated).
+
+```bash
+# Pull: bring newer/missing skills from a remote to this machine
+~/.hermes/skills/devops/skill-sync/scripts/sync.sh user@host
+
+# Push: send newer/missing local skills to a remote (new-machine bootstrap)
+~/.hermes/skills/devops/skill-sync/scripts/sync.sh --push user@host
+
+# Preview either direction without transferring
+DRY_RUN=1 ~/.hermes/skills/devops/skill-sync/scripts/sync.sh user@host
+```
+
+## Quick Reference
+
+| Command | What it does |
+|---|---|
+| `doctor.sh <user@host>` | Verify Tailscale/SSH/rsync; prints fixes |
+| `sync.sh <user@host>` | Pull remote-newer + remote-only skills |
+| `sync.sh --push <user@host>` | Push local-newer + local-only skills |
+| `DRY_RUN=1 sync.sh ...` | Preview; read the `[^]`/`[+]` lines |
+| `p2p_sync.py <user@host>` | Per-skill triage picker (no transfers) |
+
+## Procedure
+
+### First-time pairing
+
+1. `doctor.sh <user@host>` — fix anything it flags (see Prerequisites).
+2. `DRY_RUN=1 sync.sh <user@host>` — show the user the plan. The change set
+   is the union of `[^]` (update) and `[+]` (new) lines.
+3. `sync.sh <user@host>` (or `--push` for a new-machine bootstrap).
+4. Verify (see Verification).
+
+### Selective sync
+
+When the user only wants some skills moved, run
+`python3 ~/.hermes/skills/devops/skill-sync/scripts/p2p_sync.py <user@host>`.
+It prints a numbered PULL/PUSH picker (new / updated / divergent per skill)
+and transfers nothing. Present the picker, get the user's selection, then
+rsync the chosen skill directories yourself:
+
+```bash
+rsync -azL -e "ssh -o BatchMode=yes" "user@host:.hermes/skills/<cat>/<skill>/" ~/.hermes/skills/<cat>/<skill>/
+```
+
+### Scheduled sync (cron)
+
+The cron runner passes no args, so bake the remotes into a wrapper:
+
+```bash
+mkdir -p ~/.hermes/scripts
+printf '#!/usr/bin/env bash\nSKILL_SYNC_REMOTES="user@host" exec ~/.hermes/skills/devops/skill-sync/scripts/sync.sh\n' > ~/.hermes/scripts/skill-sync-tick.sh
+chmod +x ~/.hermes/scripts/skill-sync-tick.sh
+hermes cron create "every 6h" --name skill-sync --script ~/.hermes/scripts/skill-sync-tick.sh --no-agent
+```
+
+## Conflict Resolution
+
+The unit of sync is the whole skill directory (SKILL.md + references/ +
+scripts/ + templates/), transferred atomically via rsync. The rule is
+**last-writer-wins by SKILL.md mtime** — skills are single-author documents,
+and this matches how they evolve: one machine gets the fix, the others pick
+it up.
+
+**Exception — the same skill forked on two machines.** If BOTH sides added
+unique content, last-writer-wins is LOSSY: the newer mtime overwrites
+wholesale and drops the loser's additions. `p2p_sync.py` flags these as
+`divergent`. Do NOT sync a divergent skill — do a manual union merge; full
+procedure in `references/merging-forked-skill-copies.md`.
+
+## Pitfalls
+
+- **mtime lies about content.** A copy can be newer AND missing files the
+  older copy has (fork trap). When in doubt, compare file inventories:
+  `ssh <remote> 'find ~/.hermes/skills/<cat>/<skill> -type f'` vs local.
+- **`DRY_RUN=1` plan = the `[^]` + `[+]` lines**, not just the summary count.
+- **Never trust "Push complete" — verify on the remote.** `sync.sh` prints a
+  remote skill count after every push; if it doesn't move, the transfer
+  failed. Spot-check specific paths too (see Verification).
+- **Whole-tree fallback when per-skill sync misbehaves:** one additive pass,
+  no `--delete`, surfaces errors:
+  `rsync -azL -e "ssh -o BatchMode=yes" ~/.hermes/skills/ user@host:.hermes/skills/`
+- **Only one SSH direction may work.** If push to a box is refused but that
+  box can SSH back here, flip it: have the other machine's agent PULL. Write
+  it a handoff note with the source `user@host` and the exact `sync.sh`
+  command rather than fighting the dead direction.
+- Sync is additive — it never deletes local skills missing on the remote.
+  Within an updated skill, `--delete` prunes files the newer side removed.
+- Skills under paths containing `.bak` or `.archive` are always excluded,
+  both directions.
+- macOS vs Linux `stat` flags differ; the scripts handle both.
+- Byte-comparing across OSes: macOS `wc -c` left-pads output — `tr -d ' '`
+  before comparing.
+
+## Verification
+
+```bash
+# Counts converge and a spot-checked skill landed whole:
+ssh -o BatchMode=yes user@host 'find ~/.hermes/skills -name SKILL.md | wc -l'
+ssh -o BatchMode=yes user@host 'find ~/.hermes/skills/<cat>/<skill> -type f | sed "s|.*/skills/||"'
+```
+
+A second `DRY_RUN=1 sync.sh` run should report zero `[^]`/`[+]` lines — the
+trees have converged.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -416,6 +416,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/optional/devops/devops-hermes-s6-container-supervision',
                     'user-guide/skills/optional/devops/devops-inference-sh-cli',
                     'user-guide/skills/optional/devops/devops-pinggy-tunnel',
+                    'user-guide/skills/optional/devops/devops-skill-sync',
                     'user-guide/skills/optional/devops/devops-watchers',
                   ],
                 },


### PR DESCRIPTION
## Summary

Adds an optional `skill-sync` skill: sync `~/.hermes/skills/` between machines over SSH, with Tailscale as the recommended transport and a guided setup flow that walks the user through every missing prerequisite.

Skills are where a Hermes install accumulates its value, and today there is no supported way to keep two machines' skill libraries in step (open asks in this space: #70578, #52529). This skill covers the multi-machine SSH case: pull newer/missing skills from a remote, push the local library to a fresh box, or triage per-skill with a report-only picker.

## Changes

- `optional-skills/devops/skill-sync/SKILL.md` — playbook with a prerequisite flow the agent drives interactively: Tailscale install/login, enabling sshd (incl. macOS Remote Login, which is off by default), `ssh-keygen`/`ssh-copy-id`, and probing for the right login name (Tailscale node name ≠ unix user)
- `scripts/doctor.sh` — checks local ssh/rsync/keypair/Tailscale plus per-remote reachability, key auth, rsync, and skills dir; every failure prints the exact fix (verified live against a real Tailscale remote)
- `scripts/sync.sh` — pull/push by SKILL.md mtime, whole-skill-directory rsync as the atomic unit; explicit remotes only, rsync errors surfaced (no `2>/dev/null`), counters survive the transfer loop (heredoc, not a pipe subshell), post-push remote verification, `.bak`/`.archive` trees excluded, non-zero exit on any error
- `scripts/p2p_sync.py` — report-only per-skill picker that classifies remote copies as NEW / superset / divergent so forked skills are union-merged instead of clobbered
- `references/merging-forked-skill-copies.md` — the manual union-merge procedure for divergent copies
- `tests/skills/test_skill_sync_skill.py` — 12 tests: authoring-standards conformance, no hardcoded remotes, and E2E pull/push/dry-run against two temp HERMES_HOME trees driven through ssh/rsync PATH shims (real script control flow, no network)
- docs: auto-gen page, one catalog row, one sidebar line

## Validation

| Check | Result |
|---|---|
| `tests/skills/test_skill_sync_skill.py` | 12/12 pass |
| `tests/skills/test_authoring_standards.py` (full tree) | 1214/1214 pass |
| `doctor.sh` against a live Tailscale remote | all checks pass, 404 skills detected |
| `DRY_RUN=1 sync.sh` against the same remote | correct `[^]`/`[+]` plan, archives excluded, no transfers |
| `cd website && npx docusaurus build` | SUCCESS |

## Infographic

![skill-sync](https://v3b.fal.media/files/b/0aa7b032/Su3k7sm_xp0SUXPlST7Jj_sS5d4hiP.png)
