### PR TITLE
feat(photon): opt-in selective reaction tool for iMessage tapbacks

### DIFF
--- a/tests/tools/test_photon_react_tool.py
+++ b/tests/tools/test_photon_react_tool.py
@@ -1,0 +1,99 @@
+"""Tests for the opt-in Photon reaction tool (``photon_react``).
+
+The tool must only be *offered* when the operator enabled reactions
+(``PHOTON_REACTIONS=true``) and a live Photon adapter exists in-process;
+its handler must route to ``adapter.add_reaction`` / ``remove_reaction``
+and default the chat to the Photon home channel when none is given.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+import tools.photon_react_tool as prt
+
+
+class _FakeAdapter:
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    async def add_reaction(self, chat_id, emoji, message_id=None):
+        self.calls.append(("add", chat_id, emoji, message_id))
+        return {"success": True, "message_id": message_id or "m1"}
+
+    async def remove_reaction(self, chat_id, message_id=None):
+        self.calls.append(("remove", chat_id, message_id))
+        return {"success": True, "message_id": message_id or "m1"}
+
+
+@pytest.fixture(autouse=True)
+def _home_channel(monkeypatch):
+    """Photon home channel resolves without touching real config files."""
+    class _Home:
+        chat_id = "any;-;+16265551234"
+
+    class _Config:
+        @staticmethod
+        def get_home_channel(_platform):
+            return _Home()
+
+    monkeypatch.setattr(
+        prt, "_load_gateway_config", lambda: _Config, raising=False
+    )
+    # The handler imports load_gateway_config lazily; patch that path too.
+    import gateway.config as gw_config
+
+    monkeypatch.setattr(gw_config, "load_gateway_config", lambda: _Config)
+
+
+def test_check_fn_requires_env_flag(monkeypatch) -> None:
+    monkeypatch.delenv("PHOTON_REACTIONS", raising=False)
+    assert prt._photon_react_check() is False
+
+
+def test_check_fn_passes_when_enabled(monkeypatch) -> None:
+    monkeypatch.setenv("PHOTON_REACTIONS", "true")
+    assert prt._photon_react_check() is True
+
+
+def test_handler_without_live_adapter_errors(monkeypatch) -> None:
+    monkeypatch.setattr(prt, "_live_photon_adapter", lambda: None)
+    result = json.loads(asyncio.run(prt._photon_react({"emoji": "🔥"})))
+    assert "live Photon adapter" in result["error"]
+
+
+def test_handler_adds_reaction_with_default_chat(monkeypatch) -> None:
+    fake = _FakeAdapter()
+    monkeypatch.setattr(prt, "_live_photon_adapter", lambda: fake)
+    result = asyncio.run(prt._photon_react({"emoji": "🔥"}))
+    assert result["success"] is True
+    assert fake.calls == [("add", "any;-;+16265551234", "🔥", None)]
+
+
+def test_handler_targets_specific_message(monkeypatch) -> None:
+    fake = _FakeAdapter()
+    monkeypatch.setattr(prt, "_live_photon_adapter", lambda: fake)
+    result = asyncio.run(
+        prt._photon_react(
+            {"emoji": "😂", "chat_id": "any;-;+15550001111", "message_id": "abc"}
+        )
+    )
+    assert result["success"] is True
+    assert fake.calls == [("add", "any;-;+15550001111", "😂", "abc")]
+
+
+def test_handler_remove_path(monkeypatch) -> None:
+    fake = _FakeAdapter()
+    monkeypatch.setattr(prt, "_live_photon_adapter", lambda: fake)
+    result = asyncio.run(prt._photon_react({"emoji": "🔥", "remove": True}))
+    assert result["success"] is True
+    assert fake.calls == [("remove", "any;-;+16265551234", None)]
+
+
+def test_handler_requires_emoji(monkeypatch) -> None:
+    monkeypatch.setattr(prt, "_live_photon_adapter", lambda: _FakeAdapter())
+    result = json.loads(asyncio.run(prt._photon_react({})))
+    assert "error" in result

--- a/tests/tools/test_photon_react_tool.py
+++ b/tests/tools/test_photon_react_tool.py
@@ -40,10 +40,7 @@ def _home_channel(monkeypatch):
         def get_home_channel(_platform):
             return _Home()
 
-    monkeypatch.setattr(
-        prt, "_load_gateway_config", lambda: _Config, raising=False
-    )
-    # The handler imports load_gateway_config lazily; patch that path too.
+    # The handler imports load_gateway_config lazily; patch that path.
     import gateway.config as gw_config
 
     monkeypatch.setattr(gw_config, "load_gateway_config", lambda: _Config)
@@ -51,11 +48,19 @@ def _home_channel(monkeypatch):
 
 def test_check_fn_requires_env_flag(monkeypatch) -> None:
     monkeypatch.delenv("PHOTON_REACTIONS", raising=False)
+    monkeypatch.setattr(prt, "_live_photon_adapter", lambda: _FakeAdapter())
+    assert prt._photon_react_check() is False
+
+
+def test_check_fn_requires_live_adapter(monkeypatch) -> None:
+    monkeypatch.setenv("PHOTON_REACTIONS", "true")
+    monkeypatch.setattr(prt, "_live_photon_adapter", lambda: None)
     assert prt._photon_react_check() is False
 
 
 def test_check_fn_passes_when_enabled(monkeypatch) -> None:
     monkeypatch.setenv("PHOTON_REACTIONS", "true")
+    monkeypatch.setattr(prt, "_live_photon_adapter", lambda: _FakeAdapter())
     assert prt._photon_react_check() is True
 
 
@@ -71,6 +76,19 @@ def test_handler_adds_reaction_with_default_chat(monkeypatch) -> None:
     result = asyncio.run(prt._photon_react({"emoji": "🔥"}))
     assert result["success"] is True
     assert fake.calls == [("add", "any;-;+16265551234", "🔥", None)]
+
+
+def test_handler_default_prefers_current_chat_over_home_channel(
+    monkeypatch,
+) -> None:
+    """Omitting chat_id reacts in the conversation being answered, not the
+    home DM — the contract the schema promises (review fix)."""
+    fake = _FakeAdapter()
+    monkeypatch.setattr(prt, "_live_photon_adapter", lambda: fake)
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "any;-;+15559999999")
+    result = asyncio.run(prt._photon_react({"emoji": "👍"}))
+    assert result["success"] is True
+    assert fake.calls == [("add", "any;-;+15559999999", "👍", None)]
 
 
 def test_handler_targets_specific_message(monkeypatch) -> None:

--- a/tools/photon_react_tool.py
+++ b/tools/photon_react_tool.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Selective emoji reactions for Photon / iMessage.
+
+``send_message`` is deliberately not agent-callable (see the note at the
+bottom of ``send_message_tool.py``): an agent that can fire cross-platform
+messages whenever it likes is an agent one prompt injection away from
+spamming every connected channel.  Reactions are a much smaller surface —
+they never deliver new content to anyone — but the same worry applies in a
+milder form: an agent tapbacking every message is noisy.
+
+This module exposes the middle ground as its own opt-in toolset:
+
+* The tool only *exists* when the operator turned reactions on for the
+  Photon platform (``PHOTON_REACTIONS=true``) **and** a live Photon adapter
+  is running in this process — the same state ``add_reaction`` needs.  On
+  every other install the toolset is empty and costs zero prompt tokens.
+* Even when offered, the tool description tells the model to react
+  sparingly and pick emoji by context ("vibes"), mirroring how a human
+  uses tapbacks.  The guardrail is policy-first; the code just refuses to
+  load where the feature was never enabled.
+
+The conversational counterpart is ``react_to_message`` (desktop_ui); this
+is the messaging-platform equivalent, scoped to Photon because iMessage is
+where tapbacks are a first-class native affordance.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+_TOOLSET = "photon_react"
+
+SCHEMA: Dict[str, Any] = {
+    "name": "photon_react",
+    "description": (
+        "React to an iMessage with a tapback emoji (Photon platform). "
+        "USE SPARINGLY — react only to messages that genuinely warrant it "
+        "(good news, a joke worth laughing at, a big win, explicit thanks); "
+        "most messages deserve NO reaction. Pick the emoji by the vibe of "
+        "the message: 🔥 hype, 😂 funny, ❤️ warm, 💀 hilarious-shock, 👍 "
+        "acknowledge, 🙌 celebrate. ❤️👍👎😂‼️❓ render as native Apple "
+        "tapbacks; any other emoji renders as a custom-emoji reaction "
+        "(iOS 17+). Pass message_id to target a specific message, or omit "
+        "it to react to the most recent inbound message in the chat."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "emoji": {
+                "type": "string",
+                "description": "The emoji to react with (e.g. '🔥').",
+            },
+            "chat_id": {
+                "type": "string",
+                "description": (
+                    "Optional chat to react in (space GUID like "
+                    "'any;-;+1555...' or bare E.164). Defaults to the chat "
+                    "of the message currently being answered."
+                ),
+            },
+            "message_id": {
+                "type": "string",
+                "description": (
+                    "Optional id of the message to react to. Omit to target "
+                    "the most recent inbound message in the chat."
+                ),
+            },
+            "remove": {
+                "type": "boolean",
+                "description": "True to retract our tapback instead of adding one.",
+            },
+        },
+        "required": ["emoji"],
+    },
+}
+
+
+def _live_photon_adapter():
+    """Return the running Photon adapter, or None.
+
+    Mirrors ``send_message_tool._send_via_adapter``: reactions need the
+    gateway's live message-id tracking (``_last_inbound_by_chat``), so a
+    standalone sender fallback cannot help here.
+    """
+    try:
+        from gateway.run import _gateway_runner_ref
+
+        runner = _gateway_runner_ref()
+    except Exception:
+        return None
+    if runner is None:
+        return None
+    try:
+        from gateway.config import Platform
+
+        return runner.adapters.get(Platform.PHOTON)
+    except Exception:
+        return None
+
+
+def _reactions_enabled() -> bool:
+    """Same gate as the lifecycle tapbacks in the Photon adapter."""
+    return os.getenv("PHOTON_REACTIONS", "false").strip().lower() in {
+        "true", "1", "yes", "on",
+    }
+
+
+def _photon_react_check() -> bool:
+    """Availability check (runs at schema-assembly time).
+
+    Static gates only — no I/O — so startup never blocks on a dead
+    sidecar.  The adapter lookup itself happens in the handler, which
+    returns a clear error if the gateway went away mid-session.
+    """
+    return _reactions_enabled()
+
+
+async def _photon_react(args: Dict[str, Any], **kw) -> Dict[str, Any]:
+    emoji = str(args.get("emoji") or "").strip()
+    remove = bool(args.get("remove", False))
+    if not emoji and not remove:
+        return tool_error("An 'emoji' is required (or pass remove=true).")
+
+    adapter = _live_photon_adapter()
+    if adapter is None:
+        return tool_error(
+            "No live Photon adapter in this process — reactions require the "
+            "gateway to be running here."
+        )
+
+    chat_id = str(args.get("chat_id") or "").strip()
+    if not chat_id:
+        # Default to the home channel DM, which is the personal-texting case
+        # this tool exists for.
+        try:
+            from gateway.config import load_gateway_config
+
+            config = load_gateway_config()
+            home = config.get_home_channel("photon")
+            chat_id = home.chat_id
+        except Exception:
+            return tool_error(
+                "No chat_id given and no Photon home channel configured."
+            )
+
+    message_id: Optional[str] = str(args.get("message_id") or "").strip() or None
+
+    if remove:
+        result = await adapter.remove_reaction(chat_id, message_id)
+    else:
+        result = await adapter.add_reaction(chat_id, emoji, message_id)
+    return result
+
+
+registry.register(
+    name="photon_react",
+    toolset=_TOOLSET,
+    schema=SCHEMA,
+    handler=lambda args, **kw: _photon_react(args, **kw),
+    check_fn=_photon_react_check,
+    is_async=True,
+    emoji="🔥",
+)

--- a/tools/photon_react_tool.py
+++ b/tools/photon_react_tool.py
@@ -114,11 +114,14 @@ def _reactions_enabled() -> bool:
 def _photon_react_check() -> bool:
     """Availability check (runs at schema-assembly time).
 
-    Static gates only — no I/O — so startup never blocks on a dead
-    sidecar.  The adapter lookup itself happens in the handler, which
-    returns a clear error if the gateway went away mid-session.
+    Enforces the dual gate documented at module level: the operator flag
+    is on AND a live Photon adapter exists in this process.  The adapter
+    probe is the same in-process helper the handler uses — a runner-ref
+    lookup, no I/O — so startup never blocks on a dead sidecar.  The
+    handler still re-checks and returns a clear error if the gateway went
+    away mid-session.
     """
-    return _reactions_enabled()
+    return _reactions_enabled() and _live_photon_adapter() is not None
 
 
 async def _photon_react(args: Dict[str, Any], **kw) -> Dict[str, Any]:
@@ -136,8 +139,16 @@ async def _photon_react(args: Dict[str, Any], **kw) -> Dict[str, Any]:
 
     chat_id = str(args.get("chat_id") or "").strip()
     if not chat_id:
-        # Default to the home channel DM, which is the personal-texting case
-        # this tool exists for.
+        # Honor the promise in the schema: default to the chat of the
+        # message currently being answered (the gateway tracks this per
+        # conversation), falling back to the Photon home channel DM.
+        try:
+            from gateway.session_context import get_session_env
+
+            chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "").strip()
+        except Exception:
+            chat_id = ""
+    if not chat_id:
         try:
             from gateway.config import load_gateway_config
 
@@ -146,7 +157,8 @@ async def _photon_react(args: Dict[str, Any], **kw) -> Dict[str, Any]:
             chat_id = home.chat_id
         except Exception:
             return tool_error(
-                "No chat_id given and no Photon home channel configured."
+                "No chat_id given and no current-chat context or Photon "
+                "home channel available."
             )
 
     message_id: Optional[str] = str(args.get("message_id") or "").strip() or None

--- a/toolsets.py
+++ b/toolsets.py
@@ -283,7 +283,17 @@ TOOLSETS = {
         ],
         "includes": []
     },
-    
+
+    # Opt-in: only offered when PHOTON_REACTIONS=true and the gateway runs a
+    # live Photon adapter (the check_fn on the tool enforces both at runtime;
+    # listing it here just names the bucket). Selective vibe-based iMessage
+    # tapbacks — see tools/photon_react_tool.py.
+    "photon_react": {
+        "description": "Selective emoji tapbacks on iMessage via Photon (opt-in)",
+        "tools": ["photon_react"],
+        "includes": []
+    },
+
     "clarify": {
         "description": "Ask the user clarifying questions (multiple-choice or open-ended)",
         "tools": ["clarify"],


### PR DESCRIPTION
## What does this PR do?

Gives the agent a way to react to iMessages with tapback emoji — selectively, by context — through an opt-in `photon_react` tool.

**Why:** `send_message` is intentionally not agent-callable (`tools/send_message_tool.py` bottom note: the agent shouldn't fire cross-platform messages/reactions on its own). That leaves iMessage reactions unreachable from the agent even when the operator enabled them (`PHOTON_REACTIONS=true`) — the only agent-facing react tool is desktop-only (`react_to_message` in `desktop_ui`). Meanwhile the Photon adapter already has full reaction support (lifecycle 👀/👍 tapbacks, `add_reaction`/`remove_reaction`), and spectrum-ts passes arbitrary emoji through as iOS 17+ custom reactions.

This PR adds the missing piece as a **separate opt-in toolset**, following the same pattern the codebase already uses for gating expensive/sensitive tools:

- `check_fn` returns True only when `PHOTON_REACTIONS` is enabled — installs without the feature never see the tool and pay zero prompt tokens for it
- the tool lives in its own `photon_react` toolset, so surfaces that don't want it simply don't enable that toolset
- **selectivity is policy-in-the-schema**: the description tells the model to react sparingly and pick emoji by the vibe of the message (🔥 hype, 😂 funny, ❤️ warm...), mirroring how humans actually use tapbacks. The code enforces *capability*; the description encodes *taste* — same split as every other agent-judgment tool
- handler routes to the live adapter's `add_reaction`/`remove_reaction`, defaulting to the Photon home channel + most recent inbound message (no message-id threading needed)

## Related Issue

None — this came out of real usage: iMessage is a personal-texting channel where a well-chosen tapback lands better than another text bubble, but only if it's rare and contextual.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests

## Changes Made

- `tools/photon_react_tool.py` (new): the tool — schema w/ selectivity policy, `check_fn` env gate, async handler routing to `adapter.add_reaction`/`remove_reaction`
- `toolsets.py`: register the `photon_react` toolset (opt-in bucket)
- `tests/tools/test_photon_react_tool.py` (new): 7 tests — check_fn gating, no-adapter error path, add/remove routing, default chat resolution, explicit message targeting, emoji-required validation

## How to Test

1. `pytest tests/tools/test_photon_react_tool.py -v` — 7 passed
2. With `PHOTON_REACTIONS=true` + gateway running, ask the agent to react to your last iMessage with any emoji (e.g. 🔥) → custom reaction appears; classic 6 render as native tapbacks
3. Without `PHOTON_REACTIONS`, `hermes tools` shows no `photon_react` (gated out)

## Checklist

### Code

- [x] Contributing Guide read
- [x] Conventional Commits followed
- [x] No duplicate PR (searched)
- [x] Only related changes
- [x] Targeted tests pass
- [x] Tests added
- [x] Tested on Linux (Docker-managed install, Python 3.13, live Photon sidecar)

### Documentation & Housekeeping

- [x] Docstrings updated
- [x] N/A: config keys (uses existing PHOTON_REACTIONS)
- [x] N/A: architecture unchanged
- [x] N/A: cross-platform (pure Python, photon-only surface)
- [x] N/A: tool schemas elsewhere unchanged