### PR TITLE
feat(desktop): per-profile passcode lock (#94028)

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -17,6 +17,7 @@ import { graftRefreshedTailOntoBackfill } from '@/app/chat/transcript-backfill'
 import { resolveSessionProfile } from '@/app/session/hooks/use-session-actions/utils'
 import { formatRefValue } from '@/components/assistant-ui/directive-text'
 import { BootFailureOverlay } from '@/components/boot-failure-overlay'
+import { ProfileLockGate } from '@/components/profile-lock-gate'
 import { ConfirmHost } from '@/components/confirm-host'
 import { DesktopInstallOverlay } from '@/components/desktop-install-overlay'
 import { FindBar } from '@/components/find-bar'
@@ -1213,6 +1214,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
       <UpdatesOverlay />
       <GatewayConnectingOverlay />
       <BootFailureOverlay />
+      <ProfileLockGate />
       <CommandPalette />
       <PluginInstallModal />
       <PetGenerateOverlay />

--- a/apps/desktop/src/app/profiles/index.tsx
+++ b/apps/desktop/src/app/profiles/index.tsx
@@ -33,6 +33,7 @@ import {
 
 import { CreateProfileDialog } from './create-profile-dialog'
 import { DeleteProfileDialog } from './delete-profile-dialog'
+import { ProfilePasscodeSection } from './profile-passcode-section'
 import { RenameProfileDialog } from './rename-profile-dialog'
 
 interface ProfilesViewProps {
@@ -263,6 +264,8 @@ function ProfileDetail({ profile }: { profile: ProfileInfo }) {
       </header>
 
       <SoulEditor profileName={profile.name} />
+
+      <ProfilePasscodeSection profileName={profile.name} />
     </PanelDetail>
   )
 }

--- a/apps/desktop/src/app/profiles/profile-passcode-section.tsx
+++ b/apps/desktop/src/app/profiles/profile-passcode-section.tsx
@@ -1,0 +1,158 @@
+import { useStore } from '@nanostores/react'
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Field } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
+import { PanelSectionLabel } from '@/app/overlays/panel'
+import { useI18n } from '@/i18n'
+import { clearProfilePasscode, hasProfilePasscode, $profileLocks, setProfilePasscode } from '@/store/profile-lock'
+
+const MIN_PASSCODE_LENGTH = 4
+
+/**
+ * Passcode lock management for one profile (#94028): set / change / remove
+ * from the profile detail panel. The gate itself lives in
+ * `components/profile-lock-gate.tsx`; this is only the configuration surface.
+ */
+export function ProfilePasscodeSection({ profileName }: { profileName: string }) {
+  const { t } = useI18n()
+  const g = t.profileLock
+  useStore($profileLocks)
+  const locked = hasProfilePasscode(profileName)
+  const [dialog, setDialog] = useState<'remove' | 'set' | null>(null)
+
+  return (
+    <section className="space-y-2">
+      <PanelSectionLabel>{g.sectionLabel}</PanelSectionLabel>
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-xs text-muted-foreground">{locked ? g.lockedStatus : g.unlockedStatus}</span>
+        <div className="flex shrink-0 gap-1.5">
+          {locked ? (
+            <>
+              <Button onClick={() => setDialog('set')} size="sm" variant="outline">
+                {g.changePasscode}
+              </Button>
+              <Button onClick={() => setDialog('remove')} size="sm" variant="destructive">
+                {g.removePasscode}
+              </Button>
+            </>
+          ) : (
+            <Button onClick={() => setDialog('set')} size="sm" variant="outline">
+              {g.setPasscode}
+            </Button>
+          )}
+        </div>
+      </div>
+      {dialog !== null && (
+        <ProfilePasscodeDialog mode={dialog} onClose={() => setDialog(null)} profileName={profileName} />
+      )}
+    </section>
+  )
+}
+
+function ProfilePasscodeDialog({
+  mode,
+  onClose,
+  profileName
+}: {
+  mode: 'remove' | 'set'
+  onClose: () => void
+  profileName: string
+}) {
+  const { t } = useI18n()
+  const g = t.profileLock
+  const [passcode, setPasscode] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [error, setError] = useState<null | string>(null)
+  const [saving, setSaving] = useState(false)
+
+  const save = async () => {
+    if (saving) {
+      return
+    }
+    if (mode === 'set') {
+      if (passcode.length < MIN_PASSCODE_LENGTH) {
+        setError(g.passcodeTooShort)
+        return
+      }
+      if (passcode !== confirm) {
+        setError(g.passcodeMismatch)
+        return
+      }
+    }
+    setSaving(true)
+    setError(null)
+    try {
+      if (mode === 'remove') {
+        clearProfilePasscode(profileName)
+      } else {
+        await setProfilePasscode(profileName, passcode)
+      }
+      onClose()
+    } catch {
+      setError(g.failedSave)
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={open => !open && !saving && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{mode === 'remove' ? g.removeConfirmTitle : g.setTitle}</DialogTitle>
+          {mode === 'remove' ? <DialogDescription>{g.removeConfirmBody(profileName)}</DialogDescription> : null}
+        </DialogHeader>
+
+        {mode === 'remove' ? (
+          <DialogFooter>
+            <Button disabled={saving} onClick={onClose} variant="outline">
+              {t.common.cancel}
+            </Button>
+            <Button disabled={saving} onClick={() => void save()} variant="destructive">
+              {g.removePasscode}
+            </Button>
+          </DialogFooter>
+        ) : (
+          <div className="grid gap-4">
+            <Field label={g.newPasscodeLabel}>
+              <Input
+                autoComplete="new-password"
+                onChange={event => setPasscode(event.target.value)}
+                placeholder={g.passcodePlaceholder}
+                type="password"
+                value={passcode}
+              />
+            </Field>
+            <Field label={g.confirmPasscodeLabel}>
+              <Input
+                autoComplete="new-password"
+                onChange={event => setConfirm(event.target.value)}
+                placeholder={g.passcodePlaceholder}
+                type="password"
+                value={confirm}
+              />
+            </Field>
+            {error ? <p className="text-xs text-destructive">{error}</p> : null}
+            <DialogFooter>
+              <Button disabled={saving} onClick={onClose} variant="outline">
+                {t.common.cancel}
+              </Button>
+              <Button disabled={saving || passcode.length === 0} onClick={() => void save()}>
+                {g.savePasscode}
+              </Button>
+            </DialogFooter>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/components/profile-lock-gate.test.tsx
+++ b/apps/desktop/src/components/profile-lock-gate.test.tsx
@@ -1,0 +1,94 @@
+import { webcrypto } from 'node:crypto'
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { $activeGatewayProfile } from '@/store/profile'
+import { $profileLocks, setProfilePasscode, $unlockedProfile } from '@/store/profile-lock'
+
+import { ProfileLockGate } from './profile-lock-gate'
+
+if (!globalThis.crypto?.subtle) {
+  Object.defineProperty(globalThis, 'crypto', { configurable: true, value: webcrypto, writable: true })
+}
+
+function renderGate() {
+  return render(
+    <I18nProvider configClient={null} initialLocale="en">
+      <ProfileLockGate />
+    </I18nProvider>
+  )
+}
+
+describe('ProfileLockGate', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    $profileLocks.set({})
+    $unlockedProfile.set(null)
+    $activeGatewayProfile.set('default')
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders nothing for an unlocked profile', () => {
+    renderGate()
+    expect(screen.queryByLabelText('Passcode')).toBeNull()
+  })
+
+  it('covers the app with a passcode prompt for a locked profile at launch', async () => {
+    await setProfilePasscode('work', '1234')
+    $activeGatewayProfile.set('work')
+    renderGate()
+    expect(screen.getByLabelText('Passcode')).toBeTruthy()
+    expect(screen.getByText('Unlock')).toBeTruthy()
+  })
+
+  it('shows an error on a wrong passcode and stays locked', async () => {
+    await setProfilePasscode('work', '1234')
+    $activeGatewayProfile.set('work')
+    renderGate()
+
+    fireEvent.change(screen.getByLabelText('Passcode'), { target: { value: 'nope' } })
+    fireEvent.click(screen.getByText('Unlock'))
+
+    await waitFor(() => expect(screen.getByText('Incorrect passcode. Try again.')).toBeTruthy())
+    expect(screen.getByLabelText('Passcode')).toBeTruthy()
+  })
+
+  it('unlocks with the correct passcode and unmounts the gate', async () => {
+    await setProfilePasscode('work', '1234')
+    $activeGatewayProfile.set('work')
+    renderGate()
+
+    fireEvent.change(screen.getByLabelText('Passcode'), { target: { value: '1234' } })
+    fireEvent.click(screen.getByText('Unlock'))
+
+    await waitFor(() => expect(screen.queryByLabelText('Passcode')).toBeNull())
+  })
+
+  it('re-locks after switching to another profile and back', async () => {
+    await setProfilePasscode('work', '1234')
+    $activeGatewayProfile.set('work')
+    renderGate()
+
+    fireEvent.change(screen.getByLabelText('Passcode'), { target: { value: '1234' } })
+    fireEvent.click(screen.getByText('Unlock'))
+    await waitFor(() => expect(screen.queryByLabelText('Passcode')).toBeNull())
+
+    // Leave the profile; the unlock must not follow.
+    await act(async () => {
+      $activeGatewayProfile.set('default')
+    })
+    expect(screen.queryByLabelText('Passcode')).toBeNull()
+
+    // Come back — the gate re-prompts. The unlock-clear runs in the
+    // noteProfileChange effect, so wait for it (React 19 + useStore).
+    await act(async () => {
+      $activeGatewayProfile.set('work')
+    })
+    await waitFor(() => expect(screen.getByLabelText('Passcode')).toBeTruthy())
+  })
+})

--- a/apps/desktop/src/components/profile-lock-gate.tsx
+++ b/apps/desktop/src/components/profile-lock-gate.tsx
@@ -1,0 +1,93 @@
+import { useStore } from '@nanostores/react'
+import { useEffect, useRef, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useI18n } from '@/i18n'
+import { $activeGatewayProfile } from '@/store/profile'
+import { noteProfileChange, $profileLocks, tryUnlockProfile, $unlockedProfile } from '@/store/profile-lock'
+
+/**
+ * Full-screen gate for the per-profile passcode lock (#94028).
+ *
+ * Renders whenever the active gateway profile has a passcode set and has not
+ * been unlocked in the current activation (boot + live profile swap alike).
+ * An unlock is scoped to one activation: switching to another profile forgets
+ * it, so returning re-prompts instead of switching silently.
+ */
+export function ProfileLockGate() {
+  const { t } = useI18n()
+  const g = t.profileLock
+  const active = useStore($activeGatewayProfile)
+  const locks = useStore($profileLocks)
+  const unlocked = useStore($unlockedProfile)
+  const locked = Boolean(locks[active]) && unlocked !== active
+  const [passcode, setPasscode] = useState('')
+  const [error, setError] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Re-evaluate on every profile change; an unlock never survives a switch.
+  useEffect(() => {
+    noteProfileChange(active)
+    setPasscode('')
+    setError(false)
+    setBusy(false)
+  }, [active])
+
+  useEffect(() => {
+    if (locked) {
+      inputRef.current?.focus()
+    }
+  }, [locked])
+
+  if (!locked) {
+    return null
+  }
+
+  const submit = async () => {
+    if (!passcode || busy) {
+      return
+    }
+    setBusy(true)
+    setError(false)
+    const ok = await tryUnlockProfile(active, passcode)
+    setBusy(false)
+    if (!ok) {
+      setError(true)
+      setPasscode('')
+      inputRef.current?.focus()
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-(--z-setup) flex items-center justify-center bg-(--ui-chat-surface-background) p-6">
+      <form
+        className="w-full max-w-sm space-y-4"
+        onSubmit={event => {
+          event.preventDefault()
+          void submit()
+        }}
+      >
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold tracking-tight text-foreground">{g.gateTitle}</h2>
+          <p className="text-sm text-muted-foreground">{g.gatePrompt(active)}</p>
+        </div>
+        <Input
+          aria-label={g.passcodeLabel}
+          autoComplete="off"
+          disabled={busy}
+          onChange={event => setPasscode(event.target.value)}
+          placeholder={g.gatePlaceholder}
+          ref={inputRef}
+          type="password"
+          value={passcode}
+        />
+        {error ? <p className="text-xs text-destructive">{g.wrongPasscode}</p> : null}
+        <Button className="w-full" disabled={busy || !passcode} type="submit">
+          {g.unlock}
+        </Button>
+      </form>
+    </div>
+  )
+}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1798,6 +1798,31 @@ export const en: Translations = {
     }
   },
 
+  profileLock: {
+    sectionLabel: 'Passcode lock',
+    lockedStatus: 'Requires a passcode to open in this app.',
+    unlockedStatus: 'No passcode — anyone who opens the app can read this profile.',
+    setPasscode: 'Set passcode…',
+    changePasscode: 'Change passcode…',
+    removePasscode: 'Remove passcode',
+    setTitle: 'Set a passcode for this profile',
+    newPasscodeLabel: 'Passcode',
+    confirmPasscodeLabel: 'Confirm passcode',
+    passcodePlaceholder: 'Enter passcode',
+    passcodeTooShort: 'Passcode must be at least 4 characters.',
+    passcodeMismatch: 'Passcodes do not match.',
+    savePasscode: 'Save passcode',
+    removeConfirmTitle: 'Remove this passcode?',
+    removeConfirmBody: profile => `“${profile}” will open without a passcode from now on.`,
+    failedSave: 'Could not save the passcode.',
+    gateTitle: 'Profile locked',
+    gatePrompt: profile => `“${profile}” is locked. Enter its passcode to keep reading.`,
+    gatePlaceholder: 'Enter passcode',
+    unlock: 'Unlock',
+    wrongPasscode: 'Incorrect passcode. Try again.',
+    passcodeLabel: 'Passcode'
+  },
+
   profiles: {
     close: 'Close profiles',
     nameHint: 'Lowercase letters, digits, hyphens, and underscores. Must start with a letter or digit.',

--- a/apps/desktop/src/lib/profile-passcode.test.ts
+++ b/apps/desktop/src/lib/profile-passcode.test.ts
@@ -1,0 +1,68 @@
+import { webcrypto } from 'node:crypto'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  base64ToBytes,
+  bytesToBase64,
+  hashPasscode,
+  PASSCODE_ALGO,
+  PASSCODE_ITERATIONS,
+  timingSafeEqual,
+  verifyPasscode,
+  type PasscodeRecord
+} from './profile-passcode'
+
+// jsdom exposes a `crypto` without `subtle`; the real renderer (Chromium) and
+// Node both provide full WebCrypto. Install Node's implementation for tests.
+if (!globalThis.crypto?.subtle) {
+  Object.defineProperty(globalThis, 'crypto', { configurable: true, value: webcrypto, writable: true })
+}
+
+describe('profile passcode hashing', () => {
+  it('verifies the passcode that produced the record', async () => {
+    const record = await hashPasscode('correct horse battery staple')
+    expect(record.algo).toBe(PASSCODE_ALGO)
+    expect(record.iterations).toBe(PASSCODE_ITERATIONS)
+    expect(await verifyPasscode('correct horse battery staple', record)).toBe(true)
+  })
+
+  it('rejects a wrong passcode (mutation-bite: verify must actually compare)', async () => {
+    const record = await hashPasscode('correct horse battery staple')
+    expect(await verifyPasscode('wrong passcode', record)).toBe(false)
+  })
+
+  it('uses a fresh random salt per hash so equal passcodes never collide', async () => {
+    const a = await hashPasscode('same-passcode')
+    const b = await hashPasscode('same-passcode')
+    expect(a.salt).not.toBe(b.salt)
+    expect(a.hash).not.toBe(b.hash)
+    expect(await verifyPasscode('same-passcode', b)).toBe(true)
+  })
+
+  it('rejects a tampered stored record', async () => {
+    const record = await hashPasscode('secret')
+    const tampered = { ...record, hash: bytesToBase64(new Uint8Array(32)) }
+    expect(await verifyPasscode('secret', tampered)).toBe(false)
+  })
+
+  it('rejects malformed records instead of throwing', async () => {
+    const record = await hashPasscode('secret')
+    expect(await verifyPasscode('secret', { ...record, salt: '!!!not-base64!!!' })).toBe(false)
+    expect(await verifyPasscode('secret', { ...record, algo: 'md5' })).toBe(false)
+    expect(await verifyPasscode('secret', { ...record, iterations: 0 })).toBe(false)
+    expect(await verifyPasscode('secret', { ...record, iterations: 10_000_001 })).toBe(false)
+    expect(await verifyPasscode('secret', null as unknown as PasscodeRecord)).toBe(false)
+  })
+
+  it('round-trips base64', () => {
+    const bytes = new Uint8Array([0, 1, 2, 253, 254, 255, 42])
+    expect(base64ToBytes(bytesToBase64(bytes))).toEqual(bytes)
+  })
+
+  it('compares in constant-time style: mismatches and length drift are unequal', () => {
+    expect(timingSafeEqual(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 3]))).toBe(true)
+    expect(timingSafeEqual(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 4]))).toBe(false)
+    expect(timingSafeEqual(new Uint8Array([1, 2]), new Uint8Array([1, 2, 3]))).toBe(false)
+  })
+})

--- a/apps/desktop/src/lib/profile-passcode.ts
+++ b/apps/desktop/src/lib/profile-passcode.ts
@@ -1,0 +1,122 @@
+/**
+ * Per-profile passcode hashing for the desktop lock gate (#94028).
+ *
+ * A UI-level privacy gate, not a security boundary: the passcode is salted and
+ * stretched with PBKDF2-HMAC-SHA256 and compared in constant time, but the
+ * profile directory itself stays readable by the OS user — exactly like every
+ * other desktop pref. The stored record is self-describing, so the KDF
+ * parameters can be raised later without a migration.
+ */
+
+export const PASSCODE_ALGO = 'pbkdf2-sha256'
+export const PASSCODE_ITERATIONS = 210_000
+export const PASSCODE_SALT_BYTES = 16
+export const PASSCODE_HASH_BYTES = 32
+/** Upper bound so a corrupted record can't turn unlock into a CPU stall. */
+const MAX_ITERATIONS = 10_000_000
+
+export interface PasscodeRecord {
+  algo: typeof PASSCODE_ALGO
+  iterations: number
+  /** base64 — random per hash, never reused. */
+  salt: string
+  /** base64 — derived key. */
+  hash: string
+}
+
+const B64 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  let out = ''
+  for (let i = 0; i < bytes.length; i += 3) {
+    const b0 = bytes[i]
+    const b1 = i + 1 < bytes.length ? bytes[i + 1] : 0
+    const b2 = i + 2 < bytes.length ? bytes[i + 2] : 0
+    out += B64[b0 >> 2]
+    out += B64[((b0 & 3) << 4) | (b1 >> 4)]
+    out += i + 1 < bytes.length ? B64[((b1 & 15) << 2) | (b2 >> 6)] : '='
+    out += i + 2 < bytes.length ? B64[b2 & 63] : '='
+  }
+  return out
+}
+
+export function base64ToBytes(b64: string): Uint8Array {
+  const clean = b64.replace(/=+$/, '')
+  const out = new Uint8Array(Math.floor((clean.length * 6) / 8))
+  let acc = 0
+  let bits = 0
+  let n = 0
+  for (const ch of clean) {
+    const v = B64.indexOf(ch)
+    if (v === -1) {
+      throw new Error('Invalid base64')
+    }
+    acc = (acc << 6) | v
+    bits += 6
+    if (bits >= 8) {
+      bits -= 8
+      out[n++] = (acc >> bits) & 0xff
+    }
+  }
+  return out
+}
+
+function subtle(): SubtleCrypto {
+  const s = globalThis.crypto?.subtle
+  if (!s) {
+    throw new Error('WebCrypto is unavailable; cannot hash a profile passcode')
+  }
+  return s
+}
+
+async function deriveKey(passcode: string, salt: Uint8Array, iterations: number): Promise<Uint8Array> {
+  const material = await subtle().importKey('raw', new TextEncoder().encode(passcode), 'PBKDF2', false, ['deriveBits'])
+  const bits = await subtle().deriveBits(
+    { name: 'PBKDF2', hash: 'SHA-256', salt: salt.buffer.slice(salt.byteOffset, salt.byteOffset + salt.byteLength), iterations },
+    material,
+    PASSCODE_HASH_BYTES * 8
+  )
+  return new Uint8Array(bits)
+}
+
+export async function hashPasscode(passcode: string, iterations: number = PASSCODE_ITERATIONS): Promise<PasscodeRecord> {
+  const salt = new Uint8Array(PASSCODE_SALT_BYTES)
+  globalThis.crypto.getRandomValues(salt)
+  const hash = await deriveKey(passcode, salt, iterations)
+  return { algo: PASSCODE_ALGO, iterations, salt: bytesToBase64(salt), hash: bytesToBase64(hash) }
+}
+
+/** Constant-time comparison: returns on the first length check only. */
+export function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) {
+    return false
+  }
+  let diff = 0
+  for (let i = 0; i < a.length; i++) {
+    diff |= a[i] ^ b[i]
+  }
+  return diff === 0
+}
+
+export async function verifyPasscode(passcode: string, record: PasscodeRecord): Promise<boolean> {
+  if (
+    !record ||
+    record.algo !== PASSCODE_ALGO ||
+    typeof record.iterations !== 'number' ||
+    !Number.isInteger(record.iterations) ||
+    record.iterations < 1 ||
+    record.iterations > MAX_ITERATIONS
+  ) {
+    return false
+  }
+  let salt: Uint8Array
+  let expected: Uint8Array
+  try {
+    salt = base64ToBytes(record.salt)
+    expected = base64ToBytes(record.hash)
+  } catch {
+    return false
+  }
+  const actual = await deriveKey(passcode, salt, record.iterations)
+  return timingSafeEqual(actual, expected)
+}

--- a/apps/desktop/src/store/profile-lock.test.ts
+++ b/apps/desktop/src/store/profile-lock.test.ts
@@ -1,0 +1,78 @@
+import { webcrypto } from 'node:crypto'
+
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  clearProfilePasscode,
+  hasProfilePasscode,
+  isProfileLocked,
+  noteProfileChange,
+  PROFILE_LOCK_STORAGE_KEY,
+  $profileLocks,
+  setProfilePasscode,
+  tryUnlockProfile,
+  $unlockedProfile
+} from './profile-lock'
+
+if (!globalThis.crypto?.subtle) {
+  Object.defineProperty(globalThis, 'crypto', { configurable: true, value: webcrypto, writable: true })
+}
+
+describe('profile lock store', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    $profileLocks.set({})
+    $unlockedProfile.set(null)
+  })
+
+  it('starts unlocked for profiles without a record', () => {
+    expect(hasProfilePasscode('default')).toBe(false)
+    expect(isProfileLocked('default')).toBe(false)
+  })
+
+  it('locks only the profile a passcode was set for', async () => {
+    await setProfilePasscode('work', '1234')
+    expect(hasProfilePasscode('work')).toBe(true)
+    expect(isProfileLocked('work')).toBe(true)
+    expect(isProfileLocked('default')).toBe(false)
+  })
+
+  it('persists the hashed record, never the plaintext passcode', async () => {
+    await setProfilePasscode('work', 'hunter2')
+    const raw = window.localStorage.getItem(PROFILE_LOCK_STORAGE_KEY)
+    expect(raw).toBeTruthy()
+    expect(raw).not.toContain('hunter2')
+    expect(JSON.parse(raw!).work.algo).toBe('pbkdf2-sha256')
+  })
+
+  it('unlocks only with the correct passcode', async () => {
+    await setProfilePasscode('work', '1234')
+    expect(await tryUnlockProfile('work', 'nope')).toBe(false)
+    expect(isProfileLocked('work')).toBe(true)
+    expect(await tryUnlockProfile('work', '1234')).toBe(true)
+    expect(isProfileLocked('work')).toBe(false)
+  })
+
+  it('forgets the unlock when the active profile changes away (re-prompt on return)', async () => {
+    await setProfilePasscode('work', '1234')
+    await tryUnlockProfile('work', '1234')
+    expect(isProfileLocked('work')).toBe(false)
+    noteProfileChange('default')
+    expect(isProfileLocked('work')).toBe(true)
+  })
+
+  it('keeps the unlock when the note matches the unlocked profile', async () => {
+    await setProfilePasscode('work', '1234')
+    await tryUnlockProfile('work', '1234')
+    noteProfileChange('work')
+    expect(isProfileLocked('work')).toBe(false)
+  })
+
+  it('clears the lock and the persisted record', async () => {
+    await setProfilePasscode('work', '1234')
+    clearProfilePasscode('work')
+    expect(hasProfilePasscode('work')).toBe(false)
+    expect(isProfileLocked('work')).toBe(false)
+    expect(window.localStorage.getItem(PROFILE_LOCK_STORAGE_KEY)).not.toContain('work')
+  })
+})

--- a/apps/desktop/src/store/profile-lock.ts
+++ b/apps/desktop/src/store/profile-lock.ts
@@ -1,0 +1,93 @@
+import { atom } from 'nanostores'
+
+import { hashPasscode, type PasscodeRecord, verifyPasscode } from '@/lib/profile-passcode'
+import { normalizeProfileKey } from '@/store/profile'
+
+/**
+ * Per-profile desktop passcode lock (#94028).
+ *
+ * Records live in renderer-persisted storage keyed by normalized profile key —
+ * the same home as the other per-profile desktop prefs (user themes, layout
+ * tree). This is a UI-level privacy gate, not a security boundary: nothing
+ * here blocks the CLI or the gateway, only the desktop surface.
+ *
+ * An unlock is scoped to the current profile activation: switching to a
+ * different profile forgets it, so coming back re-prompts (the issue asks for
+ * a re-prompt on switch, not silent reuse).
+ */
+
+export const PROFILE_LOCK_STORAGE_KEY = 'hermes.desktop.profile-lock.v1'
+
+export type ProfileLockMap = Record<string, PasscodeRecord>
+
+function readPersistedLocks(): ProfileLockMap {
+  try {
+    const raw = window.localStorage.getItem(PROFILE_LOCK_STORAGE_KEY)
+    if (!raw) {
+      return {}
+    }
+    const parsed: unknown = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as ProfileLockMap) : {}
+  } catch {
+    return {}
+  }
+}
+
+function writePersistedLocks(locks: ProfileLockMap): void {
+  window.localStorage.setItem(PROFILE_LOCK_STORAGE_KEY, JSON.stringify(locks))
+}
+
+export const $profileLocks = atom<ProfileLockMap>(readPersistedLocks())
+
+/** Profile key unlocked in this window session (null = nothing unlocked). */
+export const $unlockedProfile = atom<string | null>(null)
+
+export function hasProfilePasscode(profileKey: string): boolean {
+  return Boolean($profileLocks.get()[normalizeProfileKey(profileKey)])
+}
+
+export function isProfileLocked(profileKey: string): boolean {
+  const key = normalizeProfileKey(profileKey)
+  return hasProfilePasscode(key) && $unlockedProfile.get() !== key
+}
+
+export async function setProfilePasscode(profileKey: string, passcode: string): Promise<void> {
+  const key = normalizeProfileKey(profileKey)
+  const record = await hashPasscode(passcode)
+  const next = { ...$profileLocks.get(), [key]: record }
+  $profileLocks.set(next)
+  writePersistedLocks(next)
+}
+
+export function clearProfilePasscode(profileKey: string): void {
+  const key = normalizeProfileKey(profileKey)
+  const next = { ...$profileLocks.get() }
+  delete next[key]
+  $profileLocks.set(next)
+  writePersistedLocks(next)
+  if ($unlockedProfile.get() === key) {
+    $unlockedProfile.set(null)
+  }
+}
+
+export async function tryUnlockProfile(profileKey: string, passcode: string): Promise<boolean> {
+  const key = normalizeProfileKey(profileKey)
+  const record = $profileLocks.get()[key]
+  if (!record) {
+    return true
+  }
+  const ok = await verifyPasscode(passcode, record)
+  if (ok) {
+    $unlockedProfile.set(key)
+  }
+  return ok
+}
+
+/** Forget the current unlock when the active profile changes away. */
+export function noteProfileChange(nextProfileKey: string): void {
+  const key = normalizeProfileKey(nextProfileKey)
+  const unlocked = $unlockedProfile.get()
+  if (unlocked !== null && unlocked !== key) {
+    $unlockedProfile.set(null)
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #94028 — on a shared household machine, anyone who opens the desktop app can switch to any profile and read every other user's chat history, memory, and profile. There is no lock surface at all.

This adds a **UI-level privacy gate**: a profile with a passcode set prompts on activation (boot and live profile swap alike) and an unlock is scoped to one activation — leaving the profile forgets it, so returning re-prompts instead of switching silently.

## Scope (blast-radius honored)

- Pure **desktop renderer** surface: no CLI/gateway/backend changes, exactly as the issue asks ("UI-level privacy gate").
- Passcode stored only as a PBKDF2 hash (WebCrypto) in the per-profile localStorage — the same home as existing per-profile prefs (themes, layout tree). No plaintext.
- No infra existed to reuse (`git log -S passcode` empty on upstream/main); follows the desktop's established localStorage + overlay patterns.

## Files

- `apps/desktop/src/lib/profile-passcode.ts` — hash/verify helpers
- `apps/desktop/src/store/profile-lock.ts` — per-profile lock state; unlock cleared on profile change
- `apps/desktop/src/components/profile-lock-gate.tsx` — full-screen gate (useStore-driven for React 19 re-render safety)
- `apps/desktop/src/app/profiles/profile-passcode-section.tsx` — set/change/remove UI in the profile panel
- i18n keys (en)

## Tests

19 tests: passcode helper (7), lock store incl. re-prompt on switch (7), gate incl. unlock + re-lock flow (5).