### PR TITLE
fix(curator): let read-before-write guard pass across review tool worker threads (#94324)

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -25,6 +25,7 @@ import os
 from pathlib import Path
 import threading
 from typing import Any, Dict, List, Optional
+import uuid
 
 from agent.thread_scoped_output import thread_scoped_silence
 
@@ -1244,6 +1245,11 @@ def _run_review_in_thread(
             )
             review_agent._memory_write_origin = "background_review"
             review_agent._memory_write_context = "background_review"
+            # Unique per-fork identity so read-before-write marks in
+            # tools.skill_manager_tool (keyed by this id) round-trip through
+            # tool-call worker threads; turn_context binds it onto the fork
+            # ContextVar at turn start.
+            review_agent._review_fork_id = f"bg-review-{uuid.uuid4().hex[:12]}"
             # The review fork pins the parent's cached system prompt and keeps
             # ``tools[]`` byte-identical to the parent so its outbound request
             # hits the same provider cache prefix (see the toolset-parity note
@@ -1477,6 +1483,19 @@ def _run_review_in_thread(
                     )
             finally:
                 clear_thread_tool_whitelist()
+                # Drop this fork's read-before-write mark bucket so a later
+                # fork never inherits stale "already read" approvals.
+                try:
+                    from tools.skill_manager_tool import clear_background_review_read_marks
+
+                    clear_background_review_read_marks(
+                        getattr(review_agent, "_review_fork_id", None)
+                    )
+                except Exception:
+                    logger.debug(
+                        "Failed to clear background-review read marks",
+                        exc_info=True,
+                    )
                 # Attribute the review fork's usage to the PARENT session.
                 # Snapshot BEFORE unregister/close so counters survive teardown.
                 # Placed in this finally so a fork that consumed tokens and THEN

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -29,6 +29,7 @@ import threading
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set
+import uuid
 
 from hermes_constants import get_hermes_home
 from tools import skill_usage
@@ -1961,6 +1962,10 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         # turn_context.py binds this onto the write-origin ContextVar at turn
         # start (see agent/turn_context.py).
         review_agent._memory_write_origin = "background_review"
+        # Unique per-fork identity for read-before-write marks in
+        # tools.skill_manager_tool; turn_context binds it onto the fork
+        # ContextVar at turn start.
+        review_agent._review_fork_id = f"curator-{uuid.uuid4().hex[:12]}"
 
         # Redirect the forked agent's stdout/stderr to /dev/null while it
         # runs so its tool-call chatter doesn't pollute the foreground
@@ -2006,6 +2011,15 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
                 review_agent.close()
             except Exception:
                 pass
+            try:
+                from tools.skill_manager_tool import clear_background_review_read_marks
+
+                clear_background_review_read_marks(review_agent._review_fork_id)
+            except Exception:
+                logger.debug(
+                    "Failed to clear background-review read marks",
+                    exc_info=True,
+                )
     return result_meta
 
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -504,6 +504,16 @@ def build_turn_context(
 
     # Bind the skill write-origin ContextVar for this thread.
     set_current_write_origin(getattr(agent, "_memory_write_origin", "assistant_tool"))
+    # Bind the background-review fork id the same way, so skill
+    # read-before-write marks (tools/skill_manager_tool) resolve to this
+    # fork's bucket inside tool-call worker threads. Lazy import: this
+    # module sits high in the import graph.
+    try:
+        from tools.skill_manager_tool import set_background_review_fork_id
+
+        set_background_review_fork_id(getattr(agent, "_review_fork_id", None))
+    except Exception:
+        logger.debug("Could not bind background-review fork id", exc_info=True)
 
     # Restore the primary runtime if the previous turn activated fallback.
     agent._restore_primary_runtime()

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -52,9 +52,66 @@ from agent.skill_utils import (
 
 logger = logging.getLogger(__name__)
 
-_background_review_read_paths: "_ctxvars.ContextVar[frozenset[str]]" = _ctxvars.ContextVar(
-    "background_review_read_paths", default=frozenset()
+# Read-before-write marks for the background-review fork.
+#
+# These must NOT live in a ContextVar. The fork's tool calls run in worker
+# threads via ``propagate_context_to_thread``, which executes each tool in a
+# *snapshot* of the fork's context (``contextvars.copy_context()`` +
+# ``ctx.run()``). A mark set by skill_view inside that snapshot is discarded
+# when the worker returns, so a later skill_manage in a different worker
+# never saw it — the read-before-write guard could never pass and the
+# background curator was stuck refusing every patch/edit of an existing
+# skill, retrying and logging WARNINGs forever. Marks are therefore stored
+# in a module-level dict keyed by a per-fork id bound through the same
+# ContextVar path as the write origin (so mark and guard in worker threads
+# resolve the same bucket; concurrent review forks never share marks).
+# A fork drops its key when it finishes via clear_background_review_read_marks.
+_background_review_read_paths: "Dict[str, set]" = {}
+
+_background_review_fork_id: "_ctxvars.ContextVar[Optional[str]]" = _ctxvars.ContextVar(
+    "background_review_fork_id", default=None
 )
+
+
+def set_background_review_fork_id(fork_id: Optional[str]) -> None:
+    """Bind the current background-review fork's identity in this context.
+
+    Called at fork turn start (agent/turn_context.py) from the fork's
+    ``_review_fork_id`` attribute; the value propagates into every tool-call
+    worker snapshot alongside the write origin.
+    """
+    _background_review_fork_id.set(fork_id)
+
+
+def clear_background_review_read_marks(fork_id: Optional[str] = None) -> None:
+    """Drop read-before-write marks.
+
+    With ``fork_id`` given, only that fork's marks are cleared (called when
+    a review fork finishes). With ``None``, every fork's marks are cleared
+    (test helper / shutdown).
+    """
+    if fork_id is None:
+        _background_review_read_paths.clear()
+        return
+    _background_review_read_paths.pop(fork_id, None)
+
+
+def _background_review_fork_bucket() -> Optional[str]:
+    """Resolve the mark bucket for the current execution context.
+
+    Only the background-review fork participates: its write origin is bound
+    on the fork thread at turn start and propagates into worker snapshots,
+    and the fork id picks the specific fork's bucket. Falls back to the
+    origin string when no explicit id is bound (same-thread test paths and
+    any fork that did not bind an id still get a consistent bucket).
+    """
+    try:
+        from tools.skill_provenance import is_background_review
+        if not is_background_review():
+            return None
+    except Exception:
+        return None
+    return _background_review_fork_id.get() or "background_review"
 
 
 def mark_background_review_skill_read(path: Path) -> None:
@@ -66,33 +123,32 @@ def mark_background_review_skill_read(path: Path) -> None:
     paths below require the corresponding target path to be present when the
     current origin is ``background_review``.
     """
-    try:
-        from tools.skill_provenance import is_background_review
-        if not is_background_review():
-            return
-    except Exception:
+    bucket = _background_review_fork_bucket()
+    if bucket is None:
         return
 
     try:
         resolved = str(path.resolve())
     except Exception:
         resolved = str(path)
-    current = set(_background_review_read_paths.get())
-    current.add(resolved)
-    _background_review_read_paths.set(frozenset(current))
+    _background_review_read_paths.setdefault(bucket, set()).add(resolved)
 
 
 def _background_review_has_read(path: Path) -> bool:
+    bucket = _background_review_fork_bucket()
+    if bucket is None:
+        return False
+
     try:
         resolved = str(path.resolve())
     except Exception:
         resolved = str(path)
-    return resolved in _background_review_read_paths.get()
+    return resolved in _background_review_read_paths.get(bucket, ())
 
 
 def _reset_background_review_read_marks() -> None:
     """Test helper: clear read-before-write marks for the current context."""
-    _background_review_read_paths.set(frozenset())
+    clear_background_review_read_marks()
 
 # Import security scanner — external hub installs always get scanned;
 # agent-created skills only get scanned when skills.guard_agent_created is on.


### PR DESCRIPTION
Closes #94324.

## Problem

The background curator's read-before-write guard in `tools/skill_manager_tool.py` can **never** pass for existing skills, so the curator's "improve existing skills" path is dead: it retries after every post-turn review, spams WARNING logs, and burns tokens.

The guard requires the review fork to load the exact target via `skill_view` before `skill_manage` mutates it. The curator *does* follow that instruction — but the "has read" marks are stored in a **ContextVar**:

```python
_background_review_read_paths: ContextVar[frozenset[str]] = ContextVar(...)
```

Hermes executes tool calls in worker threads via `copy_context()` + `ctx.run()` snapshots. A mark set by `skill_view` inside its worker snapshot is discarded when that worker returns; the guard consulted by `skill_manage` in a *different* worker snapshot only ever sees the default empty frozenset. Observed loop from production logs:

1. `skill_manage(patch)` -> refused ("not loaded in this review turn")
2. `skill_view` -> content returned
3. `skill_manage(patch)` -> refused again
4. `skill_view` (full SKILL.md) -> refused again
5. `skill_manage(edit)` -> refused
6. curator gives up

Same-thread unit tests can't catch this (mark and check share one context there), so the suite is green while the production path is permanently broken.

## Fix

Move the marks out of the ContextVar into a **module-level dict keyed by a per-fork id**:

- `agent/background_review.py` (`_run_review_in_thread`) and `agent/curator.py` (`_run_llm_review`) each generate a unique `_review_fork_id` (e.g. `bg-review-<uuid>`).
- `agent/turn_context.py` binds it onto a ContextVar at fork turn start — the same propagation path the write-origin ContextVar already uses — so every worker snapshot in that fork resolves the same bucket id.
- `tools/skill_manager_tool.py` stores/checks marks in the module-level dict under that bucket (`mark_background_review_skill_read` / `_background_review_has_read`).
- Each fork clears its own bucket in `finally` (`clear_background_review_read_marks`), so no later fork inherits stale "already read" approvals.

With this, the exact reproduction sequence passes: `skill_view` -> `skill_manage(patch)` succeeds, and the curator can finally improve existing skills.

## Validation

- Reproduction script simulating the real chain (thread snapshot -> `skill_view` -> another thread `skill_manage`): patch now lands on disk.
- 102 tests pass; the single failure is a Windows symlink-privilege environment issue (WinError 1314) unrelated to this change.

## Notes

- Rebased onto current `main` (includes #93057's detached-compaction rework of `agent/background_review.py`; the fork-id binding and bucket cleanup land cleanly alongside it).
- Follow-up option: the same guard design could be relaxed further (e.g. accept a `content` echo in the write call), but this PR keeps the read-before-write requirement intact — it only makes it actually satisfiable.
