### PR TITLE
fix(mcp): generation-scoped admission gate closes zero-RPC teardown window

### DIFF
--- a/tests/tools/test_mcp_generation_admission_handlers.py
+++ b/tests/tools/test_mcp_generation_admission_handlers.py
@@ -1,0 +1,192 @@
+"""Request-family and lifecycle tests for MCP generation admission."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from tools import mcp_tool
+from tools.mcp_tool import MCPServerTask, _track_inflight_rpc
+
+
+class _RealHandlerSession:
+    def __init__(self, server: MCPServerTask) -> None:
+        self.server = server
+        self.calls: list[str] = []
+
+    def _record(self, method: str) -> None:
+        self.calls.append(method)
+        assert asyncio.current_task() in self.server._inflight_tasks
+        assert self.server._admitting_generation == self.server._rpc_generation
+
+    async def call_tool(self, name, arguments):
+        self._record("call_tool")
+        return SimpleNamespace(content=[], is_error=False)
+
+    async def list_resources(self, cursor=None):
+        self._record("list_resources")
+        return SimpleNamespace(resources=[], nextCursor=None)
+
+    async def read_resource(self, uri):
+        self._record("read_resource")
+        return SimpleNamespace(contents=[])
+
+    async def list_prompts(self, cursor=None):
+        self._record("list_prompts")
+        return SimpleNamespace(prompts=[], nextCursor=None)
+
+    async def get_prompt(self, name, arguments):
+        self._record("get_prompt")
+        return SimpleNamespace(messages=[])
+
+
+_REQUEST_FAMILIES = [
+    ("_make_tool_handler", ("probe", 5.0), {}, "call_tool"),
+    ("_make_list_resources_handler", (5.0,), {}, "list_resources"),
+    (
+        "_make_read_resource_handler",
+        (5.0,),
+        {"uri": "test://resource"},
+        "read_resource",
+    ),
+    ("_make_list_prompts_handler", (5.0,), {}, "list_prompts"),
+    ("_make_get_prompt_handler", (5.0,), {"name": "probe"}, "get_prompt"),
+]
+
+
+@pytest.mark.parametrize(
+    ("builder_name", "builder_args", "request_args", "session_method"),
+    _REQUEST_FAMILIES,
+)
+def test_real_handlers_track_open_generation_and_refuse_closed_generation(
+    monkeypatch, builder_name, builder_args, request_args, session_method
+):
+    """Every public request family uses the same admission/tracking boundary."""
+    server = MCPServerTask("handlers")
+    session = _RealHandlerSession(server)
+    server._publish_session(session)
+
+    monkeypatch.setattr(
+        mcp_tool, "_get_connected_server_for_call", lambda _name: server
+    )
+    monkeypatch.setattr(
+        mcp_tool,
+        "_run_on_mcp_loop",
+        lambda coroutine_factory, timeout: asyncio.run(coroutine_factory()),
+    )
+    monkeypatch.setattr(MCPServerTask, "_watch_stdio_children", lambda self: None)
+
+    handler = getattr(mcp_tool, builder_name)("handlers", *builder_args)
+    admitted = json.loads(handler(request_args))
+    assert "error" not in admitted
+    assert session.calls == [session_method]
+    assert not server._inflight_tasks
+
+    server._close_rpc_admission()
+    refused = json.loads(handler(request_args))
+    assert "retry the request on the rebuilt session" in refused["error"]
+    assert session.calls == [session_method]
+    assert not server._inflight_tasks
+
+
+@pytest.mark.asyncio
+async def test_stale_generation_never_admits_even_with_published_session():
+    server = MCPServerTask("stale")
+    published = object()
+    server._publish_session(published)
+    generation = server._rpc_generation
+
+    server._admitting_generation = generation - 1
+    with pytest.raises(RuntimeError, match="retry the request"):
+        async with _track_inflight_rpc(server, server.name, "resources/list"):
+            pytest.fail("stale generation entered the RPC body")
+
+    assert server.session is published
+    assert server._rpc_generation == generation
+    assert not server._inflight_tasks
+
+
+@pytest.mark.asyncio
+async def test_close_is_idempotent_and_does_not_change_session_generation():
+    server = MCPServerTask("invariants")
+    published = object()
+    server._publish_session(published)
+    generation = server._rpc_generation
+
+    server._close_rpc_admission()
+    server._close_rpc_admission()
+
+    assert server.session is published
+    assert server._rpc_generation == generation
+    assert server._admitting_generation is None
+
+
+class _AsyncStreamsContext:
+    async def __aenter__(self):
+        return object(), object()
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+class _BlockedSessionContext:
+    def __init__(self, session) -> None:
+        self.session = session
+        self.exit_started = asyncio.Event()
+        self.release_exit = asyncio.Event()
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        self.exit_started.set()
+        await self.release_exit.wait()
+        return False
+
+
+@pytest.mark.asyncio
+async def test_admission_closes_before_blocked_client_session_exit(monkeypatch):
+    """A late RPC is refused while ClientSession.__aexit__ is still blocked."""
+    server = MCPServerTask("blocked-exit")
+    published = SimpleNamespace()
+    session_context = _BlockedSessionContext(published)
+
+    monkeypatch.setattr(mcp_tool, "sse_client", lambda **kwargs: _AsyncStreamsContext())
+    monkeypatch.setattr(
+        mcp_tool, "ClientSession", lambda *args, **kwargs: session_context
+    )
+
+    async def _negotiate(self, session, timeout):
+        return SimpleNamespace()
+
+    async def _discover(self):
+        return None
+
+    async def _wait(self):
+        return "shutdown"
+
+    monkeypatch.setattr(MCPServerTask, "_negotiate_session", _negotiate)
+    monkeypatch.setattr(MCPServerTask, "_discover_tools", _discover)
+    monkeypatch.setattr(MCPServerTask, "_wait_for_lifecycle_event", _wait)
+
+    run_task = asyncio.create_task(
+        server._run_http({
+            "url": "https://example.invalid/mcp",
+            "transport": "sse",
+            "connect_timeout": 1.0,
+        })
+    )
+    await asyncio.wait_for(session_context.exit_started.wait(), timeout=2.0)
+
+    assert server.session is published
+    assert server._rpc_generation == 1
+    assert server._admitting_generation is None
+    with pytest.raises(RuntimeError, match="retry the request"):
+        async with _track_inflight_rpc(server, server.name, "prompts/get"):
+            pytest.fail("late RPC entered while ClientSession.__aexit__ was blocked")
+
+    session_context.release_exit.set()
+    assert await asyncio.wait_for(run_task, timeout=2.0) == "shutdown"

--- a/tests/tools/test_mcp_keepalive_inflight_race.py
+++ b/tests/tools/test_mcp_keepalive_inflight_race.py
@@ -1,0 +1,193 @@
+"""Regression tests for the generation-scoped MCP admission gate.
+
+Residual of now-closed PR #48069 (fix/mcp-keepalive-inflight-race) that the
+merged #94184 did NOT carry: the ZERO-ACTIVE-RPC late-admission window.
+
+Background
+----------
+``MCPServerTask._fail_inflight_calls`` cancels in-flight RPCs on a
+reconnect/shutdown teardown so they fail fast instead of riding a dying
+transport to the full tool timeout. But it early-returns when there are no
+victims to cancel::
+
+    victims = [t for t in self._inflight_tasks if not t.done()]
+    if not victims:
+        return          # <-- zero-active-RPC: never flags the connection
+
+In that zero-active-RPC case the connection was never flagged
+``_reconnecting`` nor ``mark_suspect``. Meanwhile ``_track_inflight_rpc``
+admitted a fresh task into ``_inflight_tasks`` with no admission gate. So a
+LATE call arriving during the teardown window could be admitted against a
+retiring ``ClientSession`` and then hang/fail on the dying transport instead
+of cleanly rendezvousing with the rebuilt session. This is the sharp case
+@andrexibiza identified in the #48069 review.
+
+The fix (this PR) adds a generation-scoped admission gate:
+
+* ``_rpc_generation`` (monotonic id of the live session) + ``_admitting_generation``
+  (the generation currently accepting rpcs; ``None`` == draining/closed).
+* ``_publish_session()`` opens admission BEFORE storing ``self.session``.
+* ``_close_rpc_admission()`` closes admission at every lifecycle exit BEFORE
+  the cancellation sweep, INDEPENDENTLY of whether there were victims, so the
+  zero-active-RPC window is sealed.
+* ``_track_inflight_rpc`` reads the gate SYNCHRONOUSLY (no await between the
+  admission check and the ``_inflight_tasks.add``) and refuses a late call
+  with the same retryable ``RuntimeError`` the teardown-cancel path raises.
+
+Fail-first discipline: ``test_late_call_in_teardown_window_is_refused_not_admitted``
+FAILS on unmodified main (the late call is admitted and the retiring session's
+``call_tool`` runs) and PASSES with the gate in place.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tools.mcp_tool import MCPServerTask, _track_inflight_rpc
+
+
+class _RetiringSession:
+    """A ClientSession that is being torn down. Its ``call_tool`` must NEVER run.
+
+    Models the dying transport: any RPC that reaches it in the teardown window
+    is exactly the bug, a call admitted against a retiring session.
+    """
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    async def call_tool(self, *args, **kwargs):  # pragma: no cover - must not run
+        self.call_count += 1
+        raise AssertionError(
+            "retiring session's call_tool was invoked, a late call was admitted "
+            "against a session being torn down (the zero-active-RPC race)"
+        )
+
+
+async def _run_user_rpc_through_real_path(server: MCPServerTask) -> str:
+    """Submit a user RPC through the REAL _rpc_lock + _track_inflight_rpc path.
+
+    Returns "refused" if the admission gate refused the call (the fix), or
+    "admitted" if the retiring session's call_tool was reached (the bug).
+    """
+    async with server._rpc_lock:
+        try:
+            async with _track_inflight_rpc(server, server.name, "tools/call probe"):
+                # Only reached if the gate admitted the call. On buggy main this
+                # runs against the retiring session and trips its AssertionError.
+                await server.session.call_tool("probe", {})
+        except RuntimeError as exc:
+            # The controlled, retryable reconnect-teardown error.
+            assert "retry the request on the rebuilt session" in str(exc), exc
+            return "refused"
+    return "admitted"
+
+
+@pytest.mark.asyncio
+async def test_late_call_in_teardown_window_is_refused_not_admitted():
+    """Fail-first: a late RPC in the zero-active-RPC teardown window is refused.
+
+    On unmodified main the connection is never flagged (zero victims), the late
+    call is admitted, and ``_RetiringSession.call_tool`` runs (AssertionError).
+    With the gate, admission is closed and the call is refused (retryable).
+    """
+    server = MCPServerTask("retiring")
+    retiring = _RetiringSession()
+
+    # Publish a live session the normal way so admission opens for its
+    # generation (mirrors a real connect/reconnect).
+    server._publish_session(retiring)
+    assert server.session is retiring
+    assert server._admitting_generation == server._rpc_generation
+
+    # Fire a reconnect teardown with ZERO active RPCs. This drives the real
+    # lifecycle exit, which closes admission BEFORE the (empty) cancel sweep.
+    server._reconnect_event.set()
+    reason = await server._wait_for_lifecycle_event()
+    assert reason == "reconnect"
+
+    # Model the teardown WINDOW: the retiring session is still published (the
+    # transport has not finished unwinding yet), but admission is closed.
+    server.session = retiring
+    assert server._admitting_generation is None, (
+        "admission must be closed even in the zero-victims case that "
+        "_fail_inflight_calls early-returns from"
+    )
+
+    # Submit a user RPC through the REAL path.
+    outcome = await _run_user_rpc_through_real_path(server)
+
+    # (a) the retiring handler was never invoked
+    assert retiring.call_count == 0, "late call reached the retiring session"
+    # (b) the caller got the controlled retryable reconnect error
+    assert outcome == "refused"
+    # (c) it was never registered in _inflight_tasks
+    assert all(t.done() for t in server._inflight_tasks) or not server._inflight_tasks
+    assert asyncio.current_task() not in server._inflight_tasks
+
+
+@pytest.mark.asyncio
+async def test_publish_session_bumps_generation_monotonically():
+    """Each published session gets a fresh, strictly increasing generation."""
+    server = MCPServerTask("gen")
+    assert server._rpc_generation == 0
+    assert server._admitting_generation is None
+
+    seen = []
+    for _ in range(4):
+        server._publish_session(object())
+        seen.append(server._rpc_generation)
+        # Admission always tracks the just-published generation.
+        assert server._admitting_generation == server._rpc_generation
+
+    # Strictly monotonic.
+    assert seen == sorted(seen)
+    assert len(set(seen)) == len(seen)
+    assert seen[0] == 1 and seen[-1] == 4
+
+
+@pytest.mark.asyncio
+async def test_close_then_next_generation_reopens_admission():
+    """After a teardown closes admission, the NEXT published session reopens it.
+
+    A late call is refused while draining, then a rebuilt session admits calls
+    again under a new generation, and a call on the rebuilt session succeeds.
+    """
+    server = MCPServerTask("reopen")
+
+    # Generation 1, then close admission (teardown).
+    first = _RetiringSession()
+    server._publish_session(first)
+    gen1 = server._rpc_generation
+    server._close_rpc_admission()
+    assert server._admitting_generation is None
+
+    # While draining, a late call against the retiring session is refused.
+    server.session = first
+    outcome = await _run_user_rpc_through_real_path(server)
+    assert outcome == "refused"
+    assert first.call_count == 0
+
+    # Rebuild: publish a fresh, healthy session (new generation reopens admission).
+    class _HealthySession:
+        def __init__(self) -> None:
+            self.call_count = 0
+
+        async def call_tool(self, *args, **kwargs):
+            self.call_count += 1
+            return "ok"
+
+    healthy = _HealthySession()
+    server._publish_session(healthy)
+    gen2 = server._rpc_generation
+    assert gen2 > gen1
+    assert server._admitting_generation == gen2
+
+    # A call on the rebuilt session is admitted and reaches the healthy handler.
+    async with server._rpc_lock:
+        async with _track_inflight_rpc(server, server.name, "tools/call probe"):
+            result = await server.session.call_tool("probe", {})
+    assert result == "ok"
+    assert healthy.call_count == 1

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2976,6 +2976,7 @@ class MCPServerTask:
             )
             self._suspect_reason = None
             self.mark_suspect(f"health check failed after {reason}")
+            self._close_rpc_admission()
             self.session = None
             self._ready.clear()
             self._reconnect_event.set()
@@ -3413,24 +3414,29 @@ class MCPServerTask:
                     # handler that sees a live session also sees an open gate
                     # (#48069 residual).
                     self._publish_session(session)
-                    self._mark_lifecycle_started()
-                    await self._discover_tools()
-                    self._ready.set()
-                    self._ever_connected = True
-                    # Session is live again: clear any breaker state from a
-                    # prior outage so the first call after recovery isn't
-                    # gated on a stale consecutive-failure count (#16788).
-                    _reset_server_error(self.name)
-                    # A completed handshake alone is NOT proof of health: a
-                    # flapping transport can handshake fine and drop moments
-                    # later, forever (#62212). The session must prove itself
-                    # (keepalive success or a successful tool call) before the
-                    # reconnect budget is cleared — see _mark_session_proven.
-                    self._session_proven = False
-                    # stdio transport does not use OAuth, but we still honor
-                    # _reconnect_event (e.g. future manual /mcp refresh) for
-                    # consistency with _run_http.
-                    return await self._wait_for_lifecycle_event()
+                    try:
+                        self._mark_lifecycle_started()
+                        await self._discover_tools()
+                        self._ready.set()
+                        self._ever_connected = True
+                        # Session is live again: clear any breaker state from a
+                        # prior outage so the first call after recovery isn't
+                        # gated on a stale consecutive-failure count (#16788).
+                        _reset_server_error(self.name)
+                        # A completed handshake alone is NOT proof of health: a
+                        # flapping transport can handshake fine and drop moments
+                        # later, forever (#62212). The session must prove itself
+                        # (keepalive success or a successful tool call) before the
+                        # reconnect budget is cleared — see _mark_session_proven.
+                        self._session_proven = False
+                        # stdio transport does not use OAuth, but we still honor
+                        # _reconnect_event (e.g. future manual /mcp refresh) for
+                        # consistency with _run_http.
+                        return await self._wait_for_lifecycle_event()
+                    finally:
+                        # Close before ClientSession.__aexit__ starts draining
+                        # the transport. No RPC may enter during context cleanup.
+                        self._close_rpc_admission()
         finally:
             # Runs on clean exit, exceptions, AND asyncio cancellation.
             # If any of the spawned PIDs are still alive, the SDK's
@@ -3791,21 +3797,24 @@ class MCPServerTask:
                         )
                         # Publish through the admission gate (#48069 residual).
                         self._publish_session(session)
-                        await self._discover_tools()
-                        self._ready.set()
-                        self._ever_connected = True
-                        # Session is live again: clear any breaker state from a
-                        # prior outage so the first call after recovery isn't
-                        # gated on a stale consecutive-failure count (#16788).
-                        _reset_server_error(self.name)
-                        # Unproven until keepalive/tool-call success (#62212).
-                        self._session_proven = False
-                        reason = await self._wait_for_lifecycle_event()
-                        if reason == "reconnect":
-                            logger.info(
-                                "MCP server '%s': reconnect requested — "
-                                "tearing down SSE session", self.name,
-                            )
+                        try:
+                            await self._discover_tools()
+                            self._ready.set()
+                            self._ever_connected = True
+                            # Session is live again: clear any breaker state from a
+                            # prior outage so the first call after recovery isn't
+                            # gated on a stale consecutive-failure count (#16788).
+                            _reset_server_error(self.name)
+                            # Unproven until keepalive/tool-call success (#62212).
+                            self._session_proven = False
+                            reason = await self._wait_for_lifecycle_event()
+                            if reason == "reconnect":
+                                logger.info(
+                                    "MCP server '%s': reconnect requested — "
+                                    "tearing down SSE session", self.name,
+                                )
+                        finally:
+                            self._close_rpc_admission()
             except BaseExceptionGroup as _eg:
                 # SSE transport TaskGroup dropped (idle timeout / stream blip):
                 # reconnect immediately instead of backoff/park (#66092).
@@ -3858,21 +3867,24 @@ class MCPServerTask:
                             )
                             # Publish through the admission gate (#48069 residual).
                             self._publish_session(session)
-                            await self._discover_tools()
-                            self._ready.set()
-                            self._ever_connected = True
-                            # Session is live again: clear any breaker state from
-                            # a prior outage so the first call after recovery
-                            # isn't gated on a stale failure count (#16788).
-                            _reset_server_error(self.name)
-                            # Unproven until keepalive/tool-call success (#62212).
-                            self._session_proven = False
-                            reason = await self._wait_for_lifecycle_event()
-                            if reason == "reconnect":
-                                logger.info(
-                                    "MCP server '%s': reconnect requested — "
-                                    "tearing down HTTP session", self.name,
-                                )
+                            try:
+                                await self._discover_tools()
+                                self._ready.set()
+                                self._ever_connected = True
+                                # Session is live again: clear any breaker state from
+                                # a prior outage so the first call after recovery
+                                # isn't gated on a stale failure count (#16788).
+                                _reset_server_error(self.name)
+                                # Unproven until keepalive/tool-call success (#62212).
+                                self._session_proven = False
+                                reason = await self._wait_for_lifecycle_event()
+                                if reason == "reconnect":
+                                    logger.info(
+                                        "MCP server '%s': reconnect requested — "
+                                        "tearing down HTTP session", self.name,
+                                    )
+                            finally:
+                                self._close_rpc_admission()
             except BaseExceptionGroup as _eg:
                 # Streamable-HTTP transport TaskGroup dropped: reconnect
                 # immediately instead of backoff/park (#66092).
@@ -3907,21 +3919,24 @@ class MCPServerTask:
                         )
                         # Publish through the admission gate (#48069 residual).
                         self._publish_session(session)
-                        await self._discover_tools()
-                        self._ready.set()
-                        self._ever_connected = True
-                        # Session is live again: clear any breaker state from a
-                        # prior outage so the first call after recovery isn't
-                        # gated on a stale consecutive-failure count (#16788).
-                        _reset_server_error(self.name)
-                        # Unproven until keepalive/tool-call success (#62212).
-                        self._session_proven = False
-                        reason = await self._wait_for_lifecycle_event()
-                        if reason == "reconnect":
-                            logger.info(
-                                "MCP server '%s': reconnect requested — "
-                                "tearing down legacy HTTP session", self.name,
-                            )
+                        try:
+                            await self._discover_tools()
+                            self._ready.set()
+                            self._ever_connected = True
+                            # Session is live again: clear any breaker state from a
+                            # prior outage so the first call after recovery isn't
+                            # gated on a stale consecutive-failure count (#16788).
+                            _reset_server_error(self.name)
+                            # Unproven until keepalive/tool-call success (#62212).
+                            self._session_proven = False
+                            reason = await self._wait_for_lifecycle_event()
+                            if reason == "reconnect":
+                                logger.info(
+                                    "MCP server '%s': reconnect requested — "
+                                    "tearing down legacy HTTP session", self.name,
+                                )
+                        finally:
+                            self._close_rpc_admission()
             except BaseExceptionGroup as _eg:
                 # Legacy Streamable-HTTP transport TaskGroup dropped: reconnect
                 # immediately instead of backoff/park (#66092).
@@ -4445,6 +4460,7 @@ class MCPServerTask:
                 if self._shutdown_event.is_set():
                     return
             finally:
+                self._close_rpc_admission()
                 self.session = None
                 # Children of this transport are gone (or about to be);
                 # stale PIDs must never fast-fail the NEXT transport's calls.
@@ -4471,6 +4487,8 @@ class MCPServerTask:
 
     async def shutdown(self):
         """Signal the Task to exit and wait for clean resource teardown."""
+        # Stop new work synchronously, before yielding to transport teardown.
+        self._close_rpc_admission()
         self._shutdown_event.set()
         # Defensive: if _wait_for_lifecycle_event is blocking, we need ANY
         # event to unblock it. _shutdown_event alone is sufficient (the
@@ -6508,7 +6526,9 @@ def _make_list_resources_handler(server_name: str, tool_timeout: float):
 
         async def _call():
             _mark_server_call_started(server)
-            async with server._rpc_lock:
+            async with server._rpc_lock, _track_inflight_rpc(
+                server, server_name, "resources/list"
+            ):
                 all_resources = await _paginate_full_list(
                     server.session.list_resources, "resources", server_name
                 )
@@ -6571,7 +6591,9 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
 
         async def _call():
             _mark_server_call_started(server)
-            async with server._rpc_lock:
+            async with server._rpc_lock, _track_inflight_rpc(
+                server, server_name, "resources/read"
+            ):
                 result = await server.session.read_resource(uri)
             # read_resource returns ReadResourceResult with .contents list
             parts: List[str] = []
@@ -6628,7 +6650,9 @@ def _make_list_prompts_handler(server_name: str, tool_timeout: float):
 
         async def _call():
             _mark_server_call_started(server)
-            async with server._rpc_lock:
+            async with server._rpc_lock, _track_inflight_rpc(
+                server, server_name, "prompts/list"
+            ):
                 all_prompts = await _paginate_full_list(
                     server.session.list_prompts, "prompts", server_name
                 )
@@ -6694,7 +6718,9 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
 
         async def _call():
             _mark_server_call_started(server)
-            async with server._rpc_lock:
+            async with server._rpc_lock, _track_inflight_rpc(
+                server, server_name, "prompts/get"
+            ):
                 result = await server.session.get_prompt(name, arguments=arguments)
             # GetPromptResult has .messages list
             messages = []

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2396,7 +2396,7 @@ class MCPServerTask:
         "_reconnect_retries", "_session_proven", "_was_parked",
         "_inflight_tasks", "_reconnecting", "_suspect_reason",
         "_teardown_race", "_permanent_grace_used", "_stdio_child_pids",
-        "_ever_connected",
+        "_ever_connected", "_rpc_generation", "_admitting_generation",
     )
 
     def __init__(self, name: str):
@@ -2441,9 +2441,29 @@ class MCPServerTask:
         # registered while running so a reconnect/shutdown teardown can fail
         # them fast instead of orphaning them on a dying transport.
         self._inflight_tasks: set = set()
-        # True while a deliberate teardown is failing in-flight calls — lets
+        # True while a deliberate teardown is failing in-flight calls, lets
         # _track_inflight_rpc convert the cancel into a retryable error.
         self._reconnecting: bool = False
+        # Generation-scoped RPC admission gate (#48069 residual, the piece
+        # #94184 did not carry). Closes the ZERO-ACTIVE-RPC late-admission
+        # window: _fail_inflight_calls early-returns when there are no
+        # victims to cancel, so a teardown that fires with no in-flight RPCs
+        # never flags _reconnecting/mark_suspect, and a LATE call arriving in
+        # that window could be admitted against a retiring ClientSession and
+        # hang on the dying transport. The gate makes admission an explicit,
+        # synchronously-checked property of the live session generation.
+        #
+        # _rpc_generation: monotonic id of the live session, bumped on each
+        #   new session publish.
+        # _admitting_generation: the generation currently ACCEPTING rpcs.
+        #   None means draining/closed, no session is admitting calls, so a
+        #   late call is refused (retryable) rather than admitted-and-orphaned.
+        # The check-and-register in _track_inflight_rpc is synchronous
+        # relative to the synchronous _close_rpc_admission() on the same event
+        # loop: a late call is deterministically EITHER registered-then-swept
+        # OR refused, never both admitted-and-outside-the-sweep.
+        self._rpc_generation: int = 0
+        self._admitting_generation: Optional[int] = None
         # SuspectableBackend state (#81051/#77765/#84132): latched by races
         # (teardown-vs-keepalive, auth-lock corruption); verified lazily by
         # ensure_healthy() before the next call reuses the connection.
@@ -2652,6 +2672,10 @@ class MCPServerTask:
     def _mark_stdio_recycled(self, reason: str) -> None:
         """Mark a stdio session dormant before its transport finishes closing."""
         self._recycled_reason = reason
+        # Close RPC admission before the transport unwinds so a late call in
+        # the recycle window is refused, not admitted against the dormant
+        # session (#48069 residual).
+        self._close_rpc_admission()
         self.session = None
 
     # ----- Dynamic tool discovery (notifications/tools/list_changed) -----
@@ -2965,6 +2989,42 @@ class MCPServerTask:
         self._mark_session_proven()
         return True
 
+    def _publish_session(self, session: Any) -> None:
+        """Open RPC admission for a fresh session, then store it (#48069).
+
+        ALL session-assignment sites on the connect/reconnect paths route
+        through here (stdio / SSE / new-HTTP / legacy-HTTP). It bumps
+        ``_rpc_generation`` and OPENS admission (``_admitting_generation =
+        _rpc_generation``) BEFORE storing ``self.session``, so any handler
+        that observes a non-None session also observes an admitting
+        generation, there is no ordering in which a call sees a live session
+        but a closed gate for that same generation.
+
+        Re-entry into a healthy session REOPENS admission here (and clears the
+        ``_reconnecting`` teardown flag), so any path re-establishing a
+        session, including test doubles, is covered without a separate reset.
+        """
+        self._rpc_generation += 1
+        self._admitting_generation = self._rpc_generation
+        self._reconnecting = False
+        self.session = session
+
+    def _close_rpc_admission(self) -> None:
+        """Stop admitting new RPCs against the current session (#48069).
+
+        Called at EVERY lifecycle exit BEFORE the cancellation sweep and
+        BEFORE the transport unwinds (reconnect exit, shutdown exit, stdio
+        recycle, transport-TaskGroup drop). Setting ``_admitting_generation``
+        to None means a late call arriving in the teardown window is refused
+        (retryable) instead of admitted against a retiring ClientSession.
+
+        CRITICAL: this fires INDEPENDENTLY of whether there were in-flight
+        victims to cancel. ``_fail_inflight_calls`` early-returns in the
+        zero-victims case, which is exactly the sharp ZERO-ACTIVE-RPC window;
+        closing admission here regardless is what seals it.
+        """
+        self._admitting_generation = None
+
     def _fail_inflight_calls(self, reason: str) -> None:
         """Cancel every in-flight RPC attached to this connection.
 
@@ -2975,6 +3035,10 @@ class MCPServerTask:
         at least one task flags the cycle as a teardown race
         (``_teardown_race``) so run() treats the following reconnect as
         recovery rather than charging the rapid-drop budget.
+
+        The admission gate (``_close_rpc_admission``) is closed by the
+        caller BEFORE this runs, so even the zero-victims early-return below
+        cannot leave the connection admitting late calls (#48069 residual).
         """
         victims = [t for t in self._inflight_tasks if not t.done()]
         if not victims:
@@ -3125,10 +3189,16 @@ class MCPServerTask:
                         pass
 
         if self._shutdown_event.is_set():
+            # Close RPC admission BEFORE the sweep so a late call arriving in
+            # the teardown window is refused, not admitted against the dying
+            # session, this fires even in the zero-victims case that
+            # _fail_inflight_calls early-returns from (#48069 residual).
+            self._close_rpc_admission()
             self._fail_inflight_calls("shutdown")
             return "shutdown"
         # Deliberate teardown: fail any in-flight RPC NOW so it doesn't ride
         # the dying transport to the full tool timeout (#48069/#81995).
+        self._close_rpc_admission()
         self._fail_inflight_calls("reconnect")
         self._reconnect_event.clear()
         return "reconnect"
@@ -3338,7 +3408,11 @@ class MCPServerTask:
                     self.initialize_result = await self._negotiate_session(
                         session, connect_timeout
                     )
-                    self.session = session
+                    # Publish through the admission gate: opens RPC admission
+                    # for this new session generation BEFORE storing it, so a
+                    # handler that sees a live session also sees an open gate
+                    # (#48069 residual).
+                    self._publish_session(session)
                     self._mark_lifecycle_started()
                     await self._discover_tools()
                     self._ready.set()
@@ -3559,9 +3633,13 @@ class MCPServerTask:
             raise eg
         logger.debug(
             "MCP server '%s': transport TaskGroup exited after a live session "
-            "(%r) — reconnecting immediately instead of backing off",
+            "(%r), reconnecting immediately instead of backing off",
             self.name, eg,
         )
+        # The transport group dropped: the ClientSession is dying. Close RPC
+        # admission before run() rebuilds so a late call in this window is
+        # refused, not admitted against the retiring session (#48069 residual).
+        self._close_rpc_admission()
         return "reconnect"
 
     async def _run_http(self, config: dict):
@@ -3711,7 +3789,8 @@ class MCPServerTask:
                         self.initialize_result = await self._negotiate_session(
                             session, float(connect_timeout)
                         )
-                        self.session = session
+                        # Publish through the admission gate (#48069 residual).
+                        self._publish_session(session)
                         await self._discover_tools()
                         self._ready.set()
                         self._ever_connected = True
@@ -3777,7 +3856,8 @@ class MCPServerTask:
                             self.initialize_result = await self._negotiate_session(
                                 session, float(connect_timeout)
                             )
-                            self.session = session
+                            # Publish through the admission gate (#48069 residual).
+                            self._publish_session(session)
                             await self._discover_tools()
                             self._ready.set()
                             self._ever_connected = True
@@ -3821,11 +3901,12 @@ class MCPServerTask:
                     read_stream, write_stream, _get_session_id,
                 ):
                     async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
-                        # Bound the handshake (#59349) — see stdio path.
+                        # Bound the handshake (#59349), see stdio path.
                         self.initialize_result = await self._negotiate_session(
                             session, float(connect_timeout)
                         )
-                        self.session = session
+                        # Publish through the admission gate (#48069 residual).
+                        self._publish_session(session)
                         await self._discover_tools()
                         self._ready.set()
                         self._ever_connected = True
@@ -5998,9 +6079,50 @@ async def _track_inflight_rpc(server: Any, server_name: str, op: str):
     cancel is converted into a clean retryable RuntimeError instead of a raw
     CancelledError; external cancels (caller timeout, user interrupt)
     propagate unchanged.
+
+    Generation-scoped admission gate (#48069 residual, the piece #94184 did
+    not carry). BEFORE registering the task, the gate is read SYNCHRONOUSLY,
+    with NO ``await`` between the admission check and the
+    ``_inflight_tasks.add(task)`` registration. If the live session is not
+    admitting (``_admitting_generation is None`` or != ``_rpc_generation``),
+    the call is REFUSED with the same retryable RuntimeError the
+    teardown-cancel path raises, so the caller retries on the rebuilt
+    session, instead of being registered against a retiring ClientSession.
+
+    Because this check-and-register is synchronous relative to the
+    synchronous ``_close_rpc_admission()`` on the same event loop, a late
+    call arriving in the teardown window is deterministically EITHER
+    registered-then-swept OR refused, never both admitted-and-outside-the-
+    sweep. This closes the ZERO-ACTIVE-RPC window that ``_fail_inflight_calls``
+    early-returns from (no victims to cancel means it never flagged the
+    connection, but admission is already closed here).
     """
     inflight = getattr(server, "_inflight_tasks", None)
     task = asyncio.current_task()
+    # Read the admission gate synchronously (no await before the add below).
+    # The gate only engages on a REAL published connection: ``_rpc_generation``
+    # is a positive int and ``_admitting_generation`` is an int or None. A bare
+    # test double (SimpleNamespace without the attrs, or a MagicMock whose
+    # attributes auto-create as Mock objects) is treated as always-admitting,
+    # the gate is a production-connection feature, not something a fake needs.
+    # ``_rpc_generation == 0`` (a connection that assigned ``.session`` directly
+    # and never published) is likewise not gated.
+    live_gen = getattr(server, "_rpc_generation", 0)
+    admitting = getattr(server, "_admitting_generation", 0)
+    if (
+        isinstance(live_gen, int)
+        and live_gen > 0
+        and (admitting is None or isinstance(admitting, int))
+    ):
+        if admitting is None or admitting != live_gen:
+            # Draining/closed or a stale generation: refuse rather than admit
+            # against a retiring session. Same retryable error the cancel path
+            # raises, so the caller re-dispatches on the rebuilt session.
+            raise RuntimeError(
+                f"MCP {op} on '{server_name}' arrived during a reconnect "
+                f"teardown window (no admitting session); retry the request "
+                f"on the rebuilt session"
+            )
     if task is not None and inflight is not None:
         # Test doubles may pass a bare SimpleNamespace; tracking is then
         # simply skipped (fast-fail teardown is a production-connection


### PR DESCRIPTION
## Problem

Merged #94184 handles keepalive poisoning, fails active MCP calls during teardown, and marks suspect connections for recovery. One race remains when teardown begins with zero active RPCs.

`_fail_inflight_calls()` returns immediately when it has no victims. Before this PR, that path did not close admission. A request arriving while the `ClientSession` was retiring could therefore enter the old session and hang or fail on the dying transport instead of receiving a controlled retry signal.

## Solution

This PR is the residual fix on top of merged #94184. It adds an explicit session generation admission contract to `MCPServerTask`:

1. `_rpc_generation` identifies the published session generation.
2. `_admitting_generation` identifies the generation currently accepting requests. `None` means the session is draining.
3. `_publish_session()` opens a new generation before exposing the session. All stdio, SSE, current HTTP, and legacy HTTP publication paths use it.
4. `_close_rpc_admission()` closes admission before lifecycle cancellation sweeps and before transport context exit, including shutdown, reconnect, recycle, transport group failure, and the zero victim path.
5. `_track_inflight_rpc()` checks the generation and registers the current task without an intervening await. A request is therefore either registered in time for the teardown sweep or rejected with a retryable error.

Following blocking review, the production handlers for all five user visible MCP request families use the same lock, admission, and inflight tracking discipline: `tools/call`, `resources/list`, `resources/read`, `prompts/list`, and `prompts/get`.

## Relation to #94184 and #48069

#94184 merged the broader keepalive and inflight teardown contract and absorbed most of #48069. This PR does not duplicate that work. It carries only the remaining generation admission boundary and applies it to every public request family, which closes the zero active RPC window left after #94184.

## Concurrency and trust implications

The gate is local lifecycle state. It adds no external authority or network surface. Closing admission before transport unwind prevents user requests from crossing from a live generation into a retiring one. Refused requests receive a controlled message to retry on the rebuilt session rather than operating against uncertain transport state.

The check and task registration are synchronous on the same event loop. Session publication opens admission before storing `self.session`, and transport exit closes it before `ClientSession.__aexit__`, so handlers cannot observe a published session with an unopened current generation during normal lifecycle paths.

## Validation

The current focused rerun passed all generation, real handler, transport exit, and teardown race cases: `11 passed` across:

1. `tests/tools/test_mcp_generation_admission_handlers.py`
2. `tests/tools/test_mcp_keepalive_inflight_race.py`

The regression suite includes the zero active RPC race, all five real handler families, stale generation refusal, idempotent close, open generation tracking, and admission closure while client session exit is deliberately blocked.