### PR TITLE
fix(platforms): dedupe MEDIA attachments on canonicalized path

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5016,8 +5016,13 @@ class BasePlatformAdapter(ABC):
                     # Skip a crafted ~\x00 path rather than aborting extraction
                     # and dropping every other attachment in the response.
                     continue
-                if expanded not in seen_paths:
-                    seen_paths.add(expanded)
+                # Dedupe on a canonicalized path so the same file referenced via
+                # different separator styles (forward slashes from the MEDIA tag
+                # vs. native backslashes from extensionless resolution on
+                # Windows) collapses to one entry instead of delivering twice.
+                canonical = os.path.normcase(os.path.normpath(os.path.abspath(expanded)))
+                if canonical not in seen_paths:
+                    seen_paths.add(canonical)
                     media.append((expanded, is_voice))
 
         for match in MEDIA_EXTENSIONLESS_TAG_RE.finditer(scan_content):
@@ -5028,10 +5033,11 @@ class BasePlatformAdapter(ABC):
             if resolved is None:
                 continue
             safe = resolved[0]
-            if safe not in seen_paths:
+            safe_canonical = os.path.normcase(os.path.normpath(os.path.abspath(safe)))
+            if safe_canonical not in seen_paths:
                 _safe_ext = os.path.splitext(safe)[1].lower()
                 media.append((safe, has_voice_tag and _safe_ext in _AUDIO_EXTS))
-                seen_paths.add(safe)
+                seen_paths.add(safe_canonical)
 
         # Remove the delivered MEDIA tags from the user-visible text. Mask a
         # length-equal copy of ``cleaned`` (same union of protected regions) to


### PR DESCRIPTION
Fixes #94328

## Problem

A `MEDIA:<path>` tag delivering a file whose path contains a space sends the **same attachment twice** on Windows.

`extract_media` (`gateway/platforms/base.py`) matches the file twice with different separators: `MEDIA_TAG_CLEANUP_RE` captures the path as written (forward slashes), while the extensionless fallback `_match_extensionless_path` resolves the same file to its native **backslash** form on Windows. `seen_paths` dedupes on the raw `os.path.expanduser()` string, so `/` and `\` are treated as distinct and the file is delivered twice.

## Fix

Dedupe on a canonicalized path key — `os.path.normcase(os.path.normpath(os.path.abspath(path)))` — in both the main `MEDIA_TAG_CLEANUP_RE` loop and the extensionless fallback, while still delivering the original path. The `try/except` guard for crafted `~\x00` paths is preserved.

## Test environment

Windows 11, Hermes main @ 6ed8bcee8, WeChat adapter. Cross-platform: any OS where filenames may contain spaces is affected; the separator mismatch is most visible on Windows.

## Verification

- Before: `extract_media('MEDIA:F:/work/Kina Bank guide.md')` returned 2 media entries.
- After: returns 1 entry.

```python
from gateway.platforms.base import BasePlatformAdapter
m, _ = BasePlatformAdapter.extract_media('MEDIA:F:/work/Kina Bank guide.md')
assert len(m) == 1
```