### PR TITLE
fix(skills): keep curator read marks across tool-call worker threads

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -947,3 +947,54 @@ class TestCuratorConsolidationDeleteGuard:
             assert allowed["success"] is True, allowed
 
         _reset_background_review_read_marks()
+
+    def test_read_mark_survives_across_tool_call_threads(self, tmp_path, monkeypatch):
+        """The reporter's loop: skill_view runs in one tool-call worker thread,
+        skill_manage(patch) in another. A ContextVar mark set in the first
+        worker's contextvars snapshot was discarded when that worker returned,
+        so the guard in the second worker never passed and every patch of an
+        existing skill was refused (#94324)."""
+        import threading
+
+        from tools.skill_manager_tool import _reset_background_review_read_marks
+
+        _reset_background_review_read_marks()
+        with _curator_pass(tmp_path, monkeypatch=monkeypatch):
+            _create_curator_skill("widgets", _skill_content("widgets"))
+
+            def _run_skill_view():
+                from tools.skills_tool import skill_view
+                from tools.skill_provenance import (
+                    BACKGROUND_REVIEW,
+                    reset_current_write_origin,
+                    set_current_write_origin,
+                )
+                token = set_current_write_origin(BACKGROUND_REVIEW)
+                try:
+                    assert json.loads(skill_view("widgets"))["success"] is True
+                finally:
+                    reset_current_write_origin(token)
+
+            worker = threading.Thread(target=_run_skill_view)
+            worker.start()
+            worker.join()
+
+            from tools.skill_provenance import (
+                BACKGROUND_REVIEW,
+                reset_current_write_origin,
+                set_current_write_origin,
+            )
+            token = set_current_write_origin(BACKGROUND_REVIEW)
+            try:
+                result = json.loads(skill_manage(
+                    action="patch",
+                    name="widgets",
+                    old_string=_skill_content("widgets").splitlines()[-1],
+                    new_string="patched line (#94324)",
+                ))
+            finally:
+                reset_current_write_origin(token)
+
+            assert result["success"] is True, result
+
+        _reset_background_review_read_marks()

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -36,7 +36,7 @@ import json
 import logging
 import re
 import shutil
-import contextvars as _ctxvars
+import threading
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -52,9 +52,14 @@ from agent.skill_utils import (
 
 logger = logging.getLogger(__name__)
 
-_background_review_read_paths: "_ctxvars.ContextVar[frozenset[str]]" = _ctxvars.ContextVar(
-    "background_review_read_paths", default=frozenset()
-)
+# Read-before-write marks live in a plain Lock-guarded module set, NOT a
+# ContextVar: Hermes runs each tool call in a worker thread under its own
+# contextvars snapshot, so a ContextVar set inside skill_view's worker was
+# discarded when that worker returned — the guard in skill_manage's worker
+# only ever saw the empty default and refused every patch/edit of an
+# existing skill, deadlocking the background curator's improve path (#94324).
+_background_review_read_lock = threading.Lock()
+_background_review_read_paths: "set[str]" = set()
 
 
 def mark_background_review_skill_read(path: Path) -> None:
@@ -77,9 +82,8 @@ def mark_background_review_skill_read(path: Path) -> None:
         resolved = str(path.resolve())
     except Exception:
         resolved = str(path)
-    current = set(_background_review_read_paths.get())
-    current.add(resolved)
-    _background_review_read_paths.set(frozenset(current))
+    with _background_review_read_lock:
+        _background_review_read_paths.add(resolved)
 
 
 def _background_review_has_read(path: Path) -> bool:
@@ -87,12 +91,14 @@ def _background_review_has_read(path: Path) -> bool:
         resolved = str(path.resolve())
     except Exception:
         resolved = str(path)
-    return resolved in _background_review_read_paths.get()
+    with _background_review_read_lock:
+        return resolved in _background_review_read_paths
 
 
 def _reset_background_review_read_marks() -> None:
     """Test helper: clear read-before-write marks for the current context."""
-    _background_review_read_paths.set(frozenset())
+    with _background_review_read_lock:
+        _background_review_read_paths.clear()
 
 # Import security scanner — external hub installs always get scanned;
 # agent-created skills only get scanned when skills.guard_agent_created is on.


### PR DESCRIPTION
## What does this PR do?

The background curator's read-before-write guard stored its "the model has seen this SKILL.md" marks in a `ContextVar`. Hermes runs each tool call in a worker thread under its own contextvars snapshot, so the mark set inside `skill_view`'s worker was discarded when that worker returned — the guard consulting it from `skill_manage`'s worker only ever saw the empty default. The curator's improve-existing-skill path could never pass its own guard: on every post-turn review it patched, was refused with "call skill_view, then retry", obeyed, was refused again (the reporter's log shows the exact 7-step loop), and gave up — burning tokens and WARNING logs each time. Same-thread unit tests stayed green because mark and check shared one context there.

This replaces the ContextVar with a plain `threading.Lock`-guarded module-level set. Marks are already scoped to the review fork — `mark_background_review_skill_read` no-ops unless `is_background_review()` — so thread confinement bought nothing and was exactly the bug. The separate `skill_gate_bypass` ContextVar is untouched: its set and consult happen inside the same `apply_skill_pending` call stack, not across tool-call workers.

## Related Issue

Fixes #94324

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/skill_manager_tool.py` — `_background_review_read_paths` is now a Lock-guarded `set[str]`; `mark_background_review_skill_read` / `_background_review_has_read` / `_reset_background_review_read_marks` take the lock around add/membership/clear; the `contextvars` import at the storage site is dropped (the second, same-stack ContextVar for gate replay stays). A comment documents the worker-thread snapshot failure mode.
- `tests/tools/test_skill_manager_tool.py` — `test_read_mark_survives_across_tool_call_threads`: runs `skill_view` on a real `threading.Thread` (the production shape: mark set in a discarded worker snapshot), then patches the same skill from the main thread; on unpatched `main` the patch is refused with `_read_before_write_required`, with the fix it succeeds.

## How to Test

- Run: `.venv/bin/python -m pytest tests/tools/test_skill_manager_tool.py -q`
- Observed result: `48 passed`. Fail-on-main check (source checked out at the parent commit): the new cross-thread test fails with the reporter's refusal (`_read_before_write_required`); with the fix all green. All pre-existing read-before-write pins (including `test_background_review_support_file_overwrite_requires_that_file_read`) pass unchanged.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of the completed code performed
- [x] New and existing unit tests pass locally
- [x] Changes are backward-compatible (guard semantics unchanged for same-thread callers; marks are still review-fork-scoped and cleared between tests)
