### PR TITLE
fix(gateway): resolve MEDIA-tag producer-tool id through the canonical tool_call_id policy

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1768,6 +1768,13 @@ from agent.replay_cleanup import (  # noqa: E402
     strip_stale_dangerous_confirmations,
 )
 
+# Single policy owner for tool_call/tool_result pairing (id vs call_id
+# precedence, pipe-encoded bridge ids) — see agent/message_sanitization.py.
+from agent.message_sanitization import (  # noqa: E402
+    tool_call_id_variants,
+    tool_result_id_variants,
+)
+
 
 _AUTO_CONTINUE_NOTE_PREFIX = "[System note: Your previous turn"
 _AUTO_CONTINUE_FALLBACK_PREFIX = "[System note: A new message"
@@ -1854,27 +1861,41 @@ def _collect_auto_append_media_tags(
     else:
         new_messages = messages
 
+    # Register every wire spelling of each tool_call's pairing id (Codex/
+    # Responses calls carry ``id`` and ``call_id`` separately, and a tool
+    # result pairs on whichever one its ``tool_call_id`` happens to carry —
+    # see agent/message_sanitization.py's tool_call_id_variants(), the single
+    # policy owner for this. A one-field-only lookup here silently drops the
+    # producer-tool name for exactly that divergent-id shape, which makes
+    # this function fail closed (treats a real TTS/image-generate result as
+    # an untrusted tool and never appends its MEDIA: tag).
     tool_name_by_call_id: Dict[str, str] = {}
     for msg in new_messages:
         if msg.get("role") != "assistant":
             continue
         for call in msg.get("tool_calls") or []:
-            call_id = call.get("id") or call.get("call_id")
             fn = call.get("function") or {}
             name = str(fn.get("name") or call.get("name") or "")
-            if call_id and name:
-                tool_name_by_call_id[str(call_id)] = name
+            if not name:
+                continue
+            for variant in tool_call_id_variants(call):
+                tool_name_by_call_id[variant] = name
 
     media_tags: List[str] = []
     has_voice_directive = False
     for msg in new_messages:
         if msg.get("role") not in ("tool", "function"):
             continue
-        call_id = str(msg.get("tool_call_id") or msg.get("call_id") or "")
-        if tool_name_by_call_id.get(call_id) not in _AUTO_APPEND_MEDIA_TOOL_NAMES:
+        result_variants = tool_result_id_variants(
+            msg.get("tool_call_id") or msg.get("call_id")
+        )
+        tool_name = next(
+            (tool_name_by_call_id[v] for v in result_variants if v in tool_name_by_call_id),
+            None,
+        )
+        if tool_name not in _AUTO_APPEND_MEDIA_TOOL_NAMES:
             continue
         content = str(msg.get("content") or "")
-        tool_name = tool_name_by_call_id.get(call_id)
         # JSON-payload tools (image_generate) return a local-file path in a
         # known field rather than a MEDIA: tag. Extract it so delivery is
         # deterministic even when the model omits the path from its reply.
@@ -1932,14 +1953,21 @@ def _collect_history_media_paths(agent_history: List[Dict[str, Any]]) -> set:
         media_files, _ = BasePlatformAdapter.extract_media(content)
         paths.update(path for path, _is_voice in media_files)
 
+    # Register every wire spelling of each tool_call's pairing id — a
+    # Codex/Responses call's ``id`` and ``call_id`` diverge, and the paired
+    # result's ``tool_call_id`` may carry either one. See
+    # agent/message_sanitization.py's tool_call_id_variants(), the single
+    # policy owner for this (same divergent-id shape as
+    # _collect_auto_append_media_tags above).
     for msg in agent_history:
         if msg.get("role") == "assistant":
             for call in msg.get("tool_calls") or []:
-                cid = call.get("id") or call.get("call_id")
                 fn = call.get("function") or {}
                 name = str(fn.get("name") or call.get("name") or "")
-                if cid and name:
-                    tool_name_by_call_id[str(cid)] = name
+                if not name:
+                    continue
+                for variant in tool_call_id_variants(call):
+                    tool_name_by_call_id[variant] = name
     for msg in agent_history:
         role = msg.get("role")
         if role == "assistant":
@@ -1953,8 +1981,14 @@ def _collect_history_media_paths(agent_history: List[Dict[str, Any]]) -> set:
         if "MEDIA:" in content:
             _add_text_media_paths(content)
             continue
-        cid = str(msg.get("tool_call_id") or msg.get("call_id") or "")
-        if tool_name_by_call_id.get(cid) == "image_generate":
+        result_variants = tool_result_id_variants(
+            msg.get("tool_call_id") or msg.get("call_id")
+        )
+        tool_name = next(
+            (tool_name_by_call_id[v] for v in result_variants if v in tool_name_by_call_id),
+            None,
+        )
+        if tool_name == "image_generate":
             try:
                 payload = json.loads(content)
             except Exception:

--- a/tests/gateway/test_media_tag_divergent_call_id.py
+++ b/tests/gateway/test_media_tag_divergent_call_id.py
@@ -1,0 +1,152 @@
+"""Regression tests: MEDIA-tag collection must resolve the producer tool
+name through the same id/call_id policy as the rest of the codebase.
+
+``_collect_auto_append_media_tags`` and ``_collect_history_media_paths``
+(``gateway/run.py``) each built a private ``id`` (before ``call_id``)
+producer-name map and looked it up via a tool result's ``tool_call_id`` —
+which for a Codex/Responses-style tool call is populated from ``call_id``,
+not ``id``. For a tool_call whose ``id`` ("fc_...") and ``call_id``
+("call_...") diverge, the registration key and the lookup key never match,
+so the producer-tool name is never resolved and a real TTS/image-generate
+result is silently treated as an untrusted tool: its ``MEDIA:`` tag is
+never auto-appended (data loss, no error surfaced) and its JSON-payload
+path is never collected for history dedup.
+
+The fix routes both functions through
+``agent.message_sanitization.tool_call_id_variants`` /
+``tool_result_id_variants`` — the single policy owner the rest of the
+codebase (``agent/agent_runtime_helpers.py``, ``agent/conversation_loop.py``)
+already consolidated behind for this exact divergent-id shape.
+"""
+
+from gateway.run import _collect_auto_append_media_tags, _collect_history_media_paths
+
+
+def _divergent_id_tool_call(name: str) -> dict:
+    """A Codex/Responses-shaped tool_call: ``id`` and ``call_id`` differ."""
+    return {
+        "id": "fc_abc123",
+        "call_id": "call_xyz789",
+        "function": {"name": name},
+    }
+
+
+class TestCollectAutoAppendMediaTagsDivergentId:
+    def test_text_media_tag_survives_divergent_id(self):
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [_divergent_id_tool_call("text_to_speech")],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_xyz789",
+                "content": "MEDIA:/tmp/audio_output.mp3",
+            },
+        ]
+
+        tags, _voice = _collect_auto_append_media_tags(messages, history_offset=0)
+
+        assert tags == ["MEDIA:/tmp/audio_output.mp3"], (
+            "auto-append lost the tag when the tool result paired on "
+            "call_id while the registration map only trusted id"
+        )
+
+    def test_image_generate_json_payload_survives_divergent_id(self):
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [_divergent_id_tool_call("image_generate")],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_xyz789",
+                "content": '{"success": true, "image": "/tmp/gen/cat.png"}',
+            },
+        ]
+
+        tags, _voice = _collect_auto_append_media_tags(messages, history_offset=0)
+
+        assert tags == ["MEDIA:/tmp/gen/cat.png"], (
+            "image_generate JSON-payload path was lost for a divergent "
+            "id/call_id tool_call"
+        )
+
+    def test_matching_single_id_still_works(self):
+        """Control: a tool_call with only one id spelling (the common,
+        non-Codex shape) must keep working exactly as before."""
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [{"id": "c1", "function": {"name": "text_to_speech"}}],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": "MEDIA:/tmp/single_id.mp3",
+            },
+        ]
+
+        tags, _voice = _collect_auto_append_media_tags(messages, history_offset=0)
+
+        assert tags == ["MEDIA:/tmp/single_id.mp3"]
+
+    def test_untrusted_tool_still_filtered_with_divergent_id(self):
+        """The producer-tool allowlist must still reject a non-eligible
+        tool even when its id/call_id diverge — this fix must not widen
+        the allowlist, only fix id resolution."""
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [_divergent_id_tool_call("execute_code")],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_xyz789",
+                "content": "some log mentioning MEDIA:/etc/passwd as an example",
+            },
+        ]
+
+        tags, _voice = _collect_auto_append_media_tags(messages, history_offset=0)
+
+        assert tags == []
+
+
+class TestCollectHistoryMediaPathsDivergentId:
+    def test_image_generate_json_path_dedup_survives_divergent_id(self):
+        history = [
+            {
+                "role": "assistant",
+                "tool_calls": [_divergent_id_tool_call("image_generate")],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_xyz789",
+                "content": '{"success": true, "image": "/tmp/gen/dog.png"}',
+            },
+        ]
+
+        paths = _collect_history_media_paths(history)
+
+        assert "/tmp/gen/dog.png" in paths, (
+            "history-dedup path collection lost the image_generate JSON "
+            "payload path for a divergent id/call_id tool_call, which "
+            "would let the same file be re-delivered on a later turn"
+        )
+
+    def test_matching_single_id_still_works(self):
+        history = [
+            {
+                "role": "assistant",
+                "tool_calls": [{"id": "c1", "function": {"name": "image_generate"}}],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": '{"success": true, "image": "/tmp/single_id.png"}',
+            },
+        ]
+
+        paths = _collect_history_media_paths(history)
+
+        assert "/tmp/single_id.png" in paths


### PR DESCRIPTION
## Summary

`_collect_auto_append_media_tags()` and `_collect_history_media_paths()` (`gateway/run.py`) each build a private tool-call-id → producer-name map when scanning an assistant message's `tool_calls`, using `call.get("id") or call.get("call_id")` to register the key, then look up the paired `role="tool"` result via `msg.get("tool_call_id") or msg.get("call_id")`.

For a Codex/Responses-style tool_call whose `id` (`"fc_..."`) and `call_id` (`"call_..."`) diverge — the exact shape `agent/message_sanitization.py`'s `tool_call_id_variants()` / `coalesce_tool_call_id()` were consolidated to handle (see #55626 / #58168 / #63000, and the same-week id-variant cluster in `agent/agent_runtime_helpers.py`) — the registration key (id-first) and the lookup key (`tool_call_id`, populated from `call_id` on Responses-shaped calls) never match.

**Effect:** the producer-tool name is never resolved, so a genuinely allowlisted `text_to_speech` / `image_generate` result is treated as an untrusted tool:
- Its `MEDIA:` text tag is never auto-appended — the file is silently never delivered, no error surfaced.
- Its `image_generate` JSON-payload path (`host_image`/`image`/`agent_visible_image`) is invisible to both the auto-append collector *and* the history-dedup collector, which would also let the same file be re-delivered on a later turn once the id happens to line up (e.g. after compression rewrites message shapes).

## Fix

Route both functions through the single policy owner the rest of the codebase already uses for this exact divergent-id shape:
- `tool_call_id_variants(call)` when registering — every wire spelling of a tool_call's pairing id (`id`, `call_id`, `response_item_id`, pipe-encoded bridge ids) maps to the producer name, not just one.
- `tool_result_id_variants(msg.get("tool_call_id") or msg.get("call_id"))` when looking a result up — checked against every registered variant.

No behavior change for the common (single, matching id) case — only the divergent-id case is affected.

## Verification

- **Empirically verified** pre-fix: a tool_call with `id="fc_abc123"`, `call_id="call_xyz789"` paired with a tool result whose `tool_call_id` is `"call_xyz789"` returns zero media tags for both the `MEDIA:` text-tag path and the `image_generate` JSON-payload path.
- **New regression tests** (`tests/gateway/test_media_tag_divergent_call_id.py`, 6 tests): divergent-id text-tag survival, divergent-id JSON-payload survival (both functions), a control case (single matching id, unaffected), and a control case confirming the producer-tool allowlist still rejects an ineligible tool even with a divergent id.
- **Mutation-verified**: stashing the fix reproduces the failure in exactly the 3 divergent-id tests; the 3 control tests are unaffected either way.
- Full `tests/gateway/test_73771_media_resend_dedup.py`, `test_media_extraction.py`, `test_media_spaced_paths_and_history_dedupe.py` (28 tests) pass unchanged.
- Broad `tests/gateway/` sweep (5849 tests, excluding files that fail to collect in this environment due to a pre-existing `aiohttp.test_utils` import gap unrelated to this change): 12 pre-existing failures reproduce byte-for-byte with the fix stashed — confirmed independent of this change.
- `ruff check` clean on both changed files.

## Competitor / conflict notes (checked fresh before opening)

- **#65745** (open, "handle silent audio and media producers") touches the same 3-line region in `_collect_auto_append_media_tags` for an unrelated concern — adding a fallback that reads `msg.get("tool_name")`/`msg.get("name")` directly when the call_id-based lookup misses entirely (e.g. a message that never went through a `tool_calls` pairing at all). Textual proximity only; no semantic overlap with this fix's id-resolution change. Whichever lands first will need a small rebase for the other.
- **#77706** (open, "slice 8 of #54962" — a large-scale extraction of helpers out of `gateway/run.py`) moves both target functions verbatim (bug intact) into a new `gateway/auto_continue_helpers.py` module. Pure relocation, no logic change on that branch — if it lands, this fix would need to be re-applied at the new location, but there is no semantic conflict.
- No open or closed PR fixes the id-resolution logic itself in either function.