### PR TITLE
fix(desktop): recover stale fullscreen normal bounds

### DIFF
--- a/apps/desktop/electron/window-state.test.ts
+++ b/apps/desktop/electron/window-state.test.ts
@@ -119,6 +119,21 @@ test('computeWindowOptions does not clamp when displays are unknown', () => {
   assert.deepEqual(computeWindowOptions(saved, []), { width: 2560, height: 1440 })
 })
 
+test('computeWindowOptions recovers stale fullscreen normal bounds to a centered windowed size', () => {
+  const saved = sanitizeWindowState({ x: 0, y: 0, width: 1920, height: 1040, isMaximized: false })
+  assert.deepEqual(computeWindowOptions(saved, PRIMARY), { width: 1536, height: 832 })
+})
+
+test('computeWindowOptions preserves full bounds when the saved state is actually maximized', () => {
+  const saved = sanitizeWindowState({ x: 0, y: 0, width: 1920, height: 1040, isMaximized: true })
+  assert.deepEqual(computeWindowOptions(saved, PRIMARY), { width: 1920, height: 1040, x: 0, y: 0 })
+})
+
+test('computeWindowOptions does not shrink a large normal window away from the work-area origin', () => {
+  const saved = sanitizeWindowState({ x: 240, y: 120, width: 1740, height: 950, isMaximized: false })
+  assert.deepEqual(computeWindowOptions(saved, PRIMARY), { width: 1740, height: 950, x: 240, y: 120 })
+})
+
 // ─── debounce ──────────────────────────────────────────────────────────────
 
 test('debounce coalesces a burst into one trailing run', () => {

--- a/apps/desktop/electron/window-state.test.ts
+++ b/apps/desktop/electron/window-state.test.ts
@@ -119,19 +119,29 @@ test('computeWindowOptions does not clamp when displays are unknown', () => {
   assert.deepEqual(computeWindowOptions(saved, []), { width: 2560, height: 1440 })
 })
 
-test('computeWindowOptions recovers stale fullscreen normal bounds to a centered windowed size', () => {
+test('computeWindowOptions recovers stale fullscreen normal bounds to a centered windowed size on Windows', () => {
   const saved = sanitizeWindowState({ x: 0, y: 0, width: 1920, height: 1040, isMaximized: false })
-  assert.deepEqual(computeWindowOptions(saved, PRIMARY), { width: 1536, height: 832 })
+  assert.deepEqual(computeWindowOptions(saved, PRIMARY, 'win32'), { width: 1536, height: 832 })
+})
+
+test('computeWindowOptions preserves deliberate near-fullscreen normal bounds outside Windows', () => {
+  const saved = sanitizeWindowState({ x: 0, y: 0, width: 1920, height: 1040, isMaximized: false })
+  assert.deepEqual(computeWindowOptions(saved, PRIMARY, 'darwin'), {
+    width: 1920,
+    height: 1040,
+    x: 0,
+    y: 0
+  })
 })
 
 test('computeWindowOptions preserves full bounds when the saved state is actually maximized', () => {
   const saved = sanitizeWindowState({ x: 0, y: 0, width: 1920, height: 1040, isMaximized: true })
-  assert.deepEqual(computeWindowOptions(saved, PRIMARY), { width: 1920, height: 1040, x: 0, y: 0 })
+  assert.deepEqual(computeWindowOptions(saved, PRIMARY, 'win32'), { width: 1920, height: 1040, x: 0, y: 0 })
 })
 
 test('computeWindowOptions does not shrink a large normal window away from the work-area origin', () => {
   const saved = sanitizeWindowState({ x: 240, y: 120, width: 1740, height: 950, isMaximized: false })
-  assert.deepEqual(computeWindowOptions(saved, PRIMARY), { width: 1740, height: 950, x: 240, y: 120 })
+  assert.deepEqual(computeWindowOptions(saved, PRIMARY, 'win32'), { width: 1740, height: 950, x: 240, y: 120 })
 })
 
 // ─── debounce ──────────────────────────────────────────────────────────────

--- a/apps/desktop/electron/window-state.ts
+++ b/apps/desktop/electron/window-state.ts
@@ -18,6 +18,15 @@ const MIN_HEIGHT = 620
 // a saved position, so the title bar stays grabbable after a monitor unplugs.
 const MIN_VISIBLE = 48
 
+// A stale normal-bounds snapshot can be almost identical to the work area while
+// isMaximized=false (for example after a DPI/display transition). Restoring that
+// verbatim leaves Windows with no meaningful restore-down size. Treat a window
+// that covers at least 90% of both work-area dimensions and starts near that
+// work area's origin as the stuck-fullscreen shape, then recover to a centered
+// 80% windowed size.
+const STALE_FULLSCREEN_RATIO = 0.9
+const RECOVERED_WINDOW_RATIO = 0.8
+
 const finite = v => typeof v === 'number' && Number.isFinite(v)
 const clamp = (v, lo, hi) => Math.max(lo, Math.min(v, hi))
 
@@ -76,6 +85,35 @@ interface WindowOptions {
   y?: number
 }
 
+function staleFullscreenWorkArea(state, displays) {
+  if (
+    !state ||
+    state.isMaximized ||
+    !finite(state.x) ||
+    !finite(state.y) ||
+    !finite(state.width) ||
+    !finite(state.height) ||
+    !Array.isArray(displays)
+  ) {
+    return null
+  }
+
+  return (
+    displays.find(({ workArea: a } = {}) => {
+      if (!a || !finite(a.x) || !finite(a.y) || !finite(a.width) || !finite(a.height)) {
+        return false
+      }
+
+      const nearOriginX = Math.abs(state.x - a.x) <= a.width * (1 - STALE_FULLSCREEN_RATIO)
+      const nearOriginY = Math.abs(state.y - a.y) <= a.height * (1 - STALE_FULLSCREEN_RATIO)
+      const fillsWidth = state.width >= a.width * STALE_FULLSCREEN_RATIO
+      const fillsHeight = state.height >= a.height * STALE_FULLSCREEN_RATIO
+
+      return nearOriginX && nearOriginY && fillsWidth && fillsHeight
+    })?.workArea ?? null
+  )
+}
+
 // Sanitized state (or null) → BrowserWindow size/position options. Always sets
 // width/height, capped to the largest current display so a size saved on a
 // since-disconnected bigger monitor can't exceed any screen the user now has.
@@ -97,6 +135,13 @@ function computeWindowOptions(state, displays): WindowOptions {
   if (cap.width && cap.height) {
     opts.width = clamp(opts.width, MIN_WIDTH, cap.width)
     opts.height = clamp(opts.height, MIN_HEIGHT, cap.height)
+  }
+
+  const staleWorkArea = staleFullscreenWorkArea(state, displays)
+  if (staleWorkArea) {
+    opts.width = clamp(Math.round(staleWorkArea.width * RECOVERED_WINDOW_RATIO), MIN_WIDTH, staleWorkArea.width)
+    opts.height = clamp(Math.round(staleWorkArea.height * RECOVERED_WINDOW_RATIO), MIN_HEIGHT, staleWorkArea.height)
+    return opts
   }
 
   if (

--- a/apps/desktop/electron/window-state.ts
+++ b/apps/desktop/electron/window-state.ts
@@ -118,7 +118,7 @@ function staleFullscreenWorkArea(state, displays) {
 // width/height, capped to the largest current display so a size saved on a
 // since-disconnected bigger monitor can't exceed any screen the user now has.
 // Sets x/y only when still on-screen; otherwise Electron centers the window.
-function computeWindowOptions(state, displays): WindowOptions {
+function computeWindowOptions(state, displays, platform = process.platform): WindowOptions {
   const opts: WindowOptions = {
     width: finite(state?.width) ? state.width : DEFAULT_WIDTH,
     height: finite(state?.height) ? state.height : DEFAULT_HEIGHT
@@ -137,7 +137,11 @@ function computeWindowOptions(state, displays): WindowOptions {
     opts.height = clamp(opts.height, MIN_HEIGHT, cap.height)
   }
 
-  const staleWorkArea = staleFullscreenWorkArea(state, displays)
+  // The motivating restore-down failure is Windows-specific. Keeping the
+  // geometry heuristic there avoids rewriting deliberate near-fullscreen
+  // layouts from tiling WMs or user placement on macOS/Linux. This early return
+  // intentionally omits stale x/y so Electron centers the recovered window.
+  const staleWorkArea = platform === 'win32' ? staleFullscreenWorkArea(state, displays) : null
   if (staleWorkArea) {
     opts.width = clamp(Math.round(staleWorkArea.width * RECOVERED_WINDOW_RATIO), MIN_WIDTH, staleWorkArea.width)
     opts.height = clamp(Math.round(staleWorkArea.height * RECOVERED_WINDOW_RATIO), MIN_HEIGHT, staleWorkArea.height)


### PR DESCRIPTION
## Summary

Addresses the saved-window-state portion of #94319.

A stale `window-state.json` can preserve work-area-sized bounds with `isMaximized: false`. Restoring those bounds verbatim on Windows makes the window visually fullscreen while still being a normal window, so restore-down has nowhere meaningful to go.

This patch keeps the scope in the pure window geometry helper:

- detects the stale fullscreen-normal geometry only on Windows;
- recovers it to 80% of that work area and omits stale x/y so Electron centers the restored window;
- leaves genuinely maximized states unchanged;
- leaves large normal windows away from the work-area origin unchanged;
- preserves deliberate near-fullscreen normal layouts on macOS/Linux;
- adds focused regression coverage for the Windows recovery and non-Windows preservation paths.

This intentionally does **not** address the separate layered/translucent native maximize-button behavior described in #94319.

## Validation

Focused window-state tests cover:
- stale fullscreen-normal → `1536x832` on a `1920x1040` Windows work area;
- the same geometry is preserved on non-Windows platforms;
- ordinary large normal and true-maximized cases remain unchanged.

Hosted CI is the execution gate for the updated head.

## Scope

2 files: `apps/desktop/electron/window-state.ts` and its focused test file only.