### PR TITLE
fix(desktop): HUD frost follows the scrim, and enumeration says why it failed

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -340,7 +340,7 @@ import {
 } from './venv-blocker-scan'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
 import { createWakeIndicatorWindowController } from './wake-indicator-window'
-import { enumerateWindowsFrontToBack, readWindowBelow } from './window-below'
+import { enumerateWindowsFrontToBack, enumerationFailed, readWindowBelow } from './window-below'
 import { installWindowRendererLifecycle } from './window-renderer-lifecycle'
 import { createWindowRevealController } from './window-reveal'
 import {
@@ -11833,8 +11833,29 @@ function startHudGameOverlayFeed(win: BrowserWindow) {
   // did-finish-load also covers HMR full reloads during development.
   win.webContents.on('did-finish-load', () => push(last))
 
+  // The watch gives up after two failed enumerations and never says so, which
+  // is how a HUD that cannot see the screen at all — no game cue, and
+  // read_window_below failing beside it — leaves nothing in the log to explain
+  // itself. Report the reason once; the null keeps the watch's contract.
+  let reported = false
+
+  const enumerate = async () => {
+    const windows = await enumerateWindowsFrontToBack(process.pid, titlesAvailable)
+
+    if (!enumerationFailed(windows)) {
+      return windows
+    }
+
+    if (!reported) {
+      reported = true
+      console.warn(`[hermes] HUD cannot enumerate windows: ${windows.reason}`)
+    }
+
+    return null
+  }
+
   const dispose = startHudGameOverlayWatch({
-    enumerate: () => enumerateWindowsFrontToBack(process.pid, titlesAvailable),
+    enumerate,
     displayBounds: () => screen.getDisplayMatching(win.getBounds()).bounds,
     selfPid: process.pid,
     send: state => {

--- a/apps/desktop/electron/window-below.test.ts
+++ b/apps/desktop/electron/window-below.test.ts
@@ -125,4 +125,23 @@ describe('enumerationFailureNote', () => {
       expect(note.length).toBeGreaterThan(0)
     }
   })
+
+  // The macOS/Windows note used to be one fixed sentence, so a real report came
+  // back saying only "could not enumerate windows on this system" — the module
+  // failing to load, the helper failing to spawn, and the OS answering with
+  // nothing are three different fixes and all three said that.
+  it('carries the enumerator\u2019s own reason where there is no environmental fork', () => {
+    for (const platform of ['darwin', 'win32']) {
+      expect(enumerationFailureNote(platform, {}, 'the helper failed: spawn EACCES')).toMatch(/spawn EACCES/)
+    }
+  })
+
+  // Linux's notes name the fix (change session type, install xprop); the raw
+  // exception underneath would only bury it.
+  it('keeps the actionable Linux advice instead of the raw reason', () => {
+    const note = enumerationFailureNote('linux', { XDG_SESSION_TYPE: 'x11', DISPLAY: ':0' }, 'ENOENT')
+
+    expect(note).toMatch(/xprop/)
+    expect(note).not.toMatch(/ENOENT/)
+  })
 })

--- a/apps/desktop/electron/window-below.ts
+++ b/apps/desktop/electron/window-below.ts
@@ -57,10 +57,18 @@ export interface WindowBelowUnavailable {
  * A session with both `WAYLAND_DISPLAY` and `DISPLAY` is Wayland running
  * XWayland, where `xprop` can still answer — so it is treated as X11 and gets
  * the tooling advice rather than being told to change session type.
+ *
+ * macOS and Windows have no environmental fork like that, so their note is
+ * whatever the enumerator actually said. That `detail` is the whole point: a
+ * bare "could not enumerate windows on this system" is what a real report came
+ * back with (macOS 26, packaged app), and neither the tool result nor the
+ * desktop log said whether the module failed to load, the helper failed to
+ * spawn, or the OS answered with nothing — three failures with three different
+ * fixes, all collapsed into one sentence.
  */
-export function enumerationFailureNote(platform: string, env: NodeJS.ProcessEnv): string {
+export function enumerationFailureNote(platform: string, env: NodeJS.ProcessEnv, detail?: string): string {
   if (platform !== 'linux') {
-    return 'Could not enumerate windows on this system.'
+    return detail ? `Could not enumerate windows: ${detail}` : 'Could not enumerate windows on this system.'
   }
 
   // Hyprland is asked over its own IPC, so reaching here means the socket
@@ -128,9 +136,21 @@ type GetWindowsModule = {
   >
 }
 
-let getWindowsModule: Promise<GetWindowsModule | null> | null = null
+/** Enumeration couldn't run at all, and why. Distinct from an empty list,
+ *  which is a real answer meaning "nothing else is on screen". */
+export interface EnumerationFailure {
+  reason: string
+}
 
-const loadGetWindows = (): Promise<GetWindowsModule | null> => {
+export const enumerationFailed = <T>(result: EnumerationFailure | T): result is EnumerationFailure =>
+  typeof result === 'object' && result !== null && 'reason' in result
+
+const describeError = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error ?? 'unknown error')
+
+let getWindowsModule: Promise<GetWindowsModule | EnumerationFailure> | null = null
+
+const loadGetWindows = (): Promise<GetWindowsModule | EnumerationFailure> => {
   // get-windows is an optionalDependency: `npm ci` can skip it when its native
   // install fails, including Linux and Windows ARM64 where 9.3.0 has no
   // prebuilt. A missing module is therefore a normal state on those targets,
@@ -150,52 +170,63 @@ const loadGetWindows = (): Promise<GetWindowsModule | null> => {
   // the binding directly, so it is the more reliable of the two everywhere.
   getWindowsModule ??= (async () => {
     const staged = path.join(app.getAppPath(), 'dist', 'node_modules', 'get-windows', 'index.js')
+    let stagedError = 'not staged in this build'
 
     if (fs.existsSync(staged)) {
-      const mod = await import(pathToFileURL(staged).href).catch(() => null)
-
-      if (mod) {
-        return mod as GetWindowsModule
+      try {
+        return (await import(pathToFileURL(staged).href)) as GetWindowsModule
+      } catch (error) {
+        stagedError = describeError(error)
       }
     }
 
-    return import('get-windows').catch(() => null)
+    try {
+      return (await import('get-windows')) as GetWindowsModule
+    } catch (error) {
+      return {
+        reason:
+          'the get-windows module could not be loaded ' +
+          `(staged copy: ${stagedError}; node_modules copy: ${describeError(error)})`
+      }
+    }
   })()
 
   return getWindowsModule
 }
 
 /**
- * Enumerate windows and serialize the one underneath `selfBounds`.
+ * Every window `get-windows` can see, front-to-back, or why it could not look.
  *
  * `titlesAvailable` is the macOS Screen Recording grant (pass true on other
- * platforms, where titles are free). When enumeration itself is unavailable
- * (Wayland, missing xprop, addon load failure) this answers with the reason
- * rather than nothing, so the agent can tell the user what to fix instead of
- * reporting a blank failure.
+ * platforms, where titles are free). The three ways this can fail — the module
+ * not loading, the enumerator throwing, the enumerator answering with
+ * something that isn't a list — each say so, because they have three different
+ * fixes and the caller has no other way to tell them apart.
  */
-async function enumerateViaGetWindows(titlesAvailable: boolean): Promise<EnumeratedWindow[] | null> {
+async function enumerateViaGetWindows(titlesAvailable: boolean): Promise<EnumeratedWindow[] | EnumerationFailure> {
+  const getWindows = await loadGetWindows()
+
+  if (enumerationFailed(getWindows)) {
+    return getWindows
+  }
+
   let raw
 
   try {
-    const getWindows = await loadGetWindows()
-
-    if (!getWindows) {
-      return null
-    }
-
-    const { openWindows } = getWindows
-    raw = await openWindows(
+    raw = await getWindows.openWindows(
       process.platform === 'darwin'
         ? { accessibilityPermission: false, screenRecordingPermission: titlesAvailable }
         : undefined
     )
-  } catch {
-    return null
+  } catch (error) {
+    // On macOS this is the helper binary failing to spawn — a missing or
+    // non-executable `main`, or the OS refusing to run it — which is invisible
+    // from the outside and used to surface as the generic note.
+    return { reason: `the window enumerator failed: ${describeError(error)}` }
   }
 
   if (!Array.isArray(raw)) {
-    return null
+    return { reason: 'the window enumerator returned no window list' }
   }
 
   // get-windows documents openWindows() as front-to-back, and macOS/Windows
@@ -220,7 +251,7 @@ async function enumerateViaGetWindows(titlesAvailable: boolean): Promise<Enumera
 }
 
 /**
- * Front-to-back window enumeration, or null when the platform cannot answer.
+ * Front-to-back window enumeration, or why the platform could not answer.
  *
  * Hyprland first, and only ever on Hyprland — its own IPC sees native Wayland
  * windows, which the X11 enumerator cannot, and it answers null everywhere
@@ -231,7 +262,7 @@ async function enumerateViaGetWindows(titlesAvailable: boolean): Promise<Enumera
 export async function enumerateWindowsFrontToBack(
   selfPid: number,
   titlesAvailable: boolean
-): Promise<EnumeratedWindow[] | null> {
+): Promise<EnumeratedWindow[] | EnumerationFailure> {
   return (await readHyprlandWindows(selfPid)) ?? (await enumerateViaGetWindows(titlesAvailable))
 }
 
@@ -242,9 +273,9 @@ export async function readWindowBelow(
 ): Promise<WindowBelowResult | WindowBelowUnavailable> {
   const windows = await enumerateWindowsFrontToBack(selfPid, titlesAvailable)
 
-  if (!windows) {
+  if (enumerationFailed(windows)) {
     return {
-      error: enumerationFailureNote(process.platform, process.env),
+      error: enumerationFailureNote(process.platform, process.env, windows.reason),
       platform: process.platform
     }
   }

--- a/apps/desktop/src/app/hud/glass.test.tsx
+++ b/apps/desktop/src/app/hud/glass.test.tsx
@@ -1,0 +1,76 @@
+import { act, render } from '@testing-library/react'
+import { useRef } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useHudGlass } from './glass'
+
+const setFrost = vi.fn()
+
+/** The HUD's real shape as far as the frost is concerned: the shell, the
+ *  composer input that owns the caret, and — when it is open — the completion
+ *  drawer that takes the surface over. */
+function Harness({ backing, drawer }: { backing: boolean; drawer?: boolean }) {
+  const ref = useRef<HTMLDivElement | null>(null)
+
+  useHudGlass(ref, backing)
+
+  return (
+    <div data-hud-shell ref={ref}>
+      <input data-slot="composer-rich-input" />
+      {drawer && <div data-slot="composer-completion-drawer" />}
+    </div>
+  )
+}
+
+const frostState = () => setFrost.mock.calls.at(-1)?.[0]
+
+const nextFrame = () => act(() => new Promise(resolve => requestAnimationFrame(() => resolve(undefined))))
+
+afterEach(() => {
+  setFrost.mockClear()
+})
+
+Object.assign(window, { hermesDesktop: { hud: { setFrost } } })
+
+describe('useHudGlass', () => {
+  // The bug this replaced: the caller widened the gate to "recent or held", so
+  // a turn merely running raised the window's material while the scrim that is
+  // supposed to be painted over it — focus-gated in styles.css — stayed down.
+  // On a light theme that is a white slab under the band's white ink.
+  it('leaves the window bare while a turn runs with the composer unfocused', () => {
+    render(<Harness backing />)
+
+    expect(frostState()).toBe(false)
+  })
+
+  it('frosts once the caret is in the composer, and lets go when it leaves', () => {
+    const { container } = render(<Harness backing />)
+    const input = container.querySelector('input')!
+
+    act(() => input.focus())
+    expect(frostState()).toBe(true)
+
+    act(() => input.blur())
+    expect(frostState()).toBe(false)
+  })
+
+  it('stays off while the band is not covering the window, however engaged', () => {
+    const { container } = render(<Harness backing={false} />)
+
+    act(() => container.querySelector('input')!.focus())
+
+    expect(frostState()).toBe(false)
+  })
+
+  it('drops the frost when a completion drawer takes the surface over', async () => {
+    const { container, rerender } = render(<Harness backing />)
+
+    act(() => container.querySelector('input')!.focus())
+    expect(frostState()).toBe(true)
+
+    rerender(<Harness backing drawer />)
+    await nextFrame()
+
+    expect(frostState()).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/hud/glass.ts
+++ b/apps/desktop/src/app/hud/glass.ts
@@ -28,20 +28,27 @@ const DRAWER_SELECTOR = '[data-slot="composer-completion-drawer"]'
  * untinted frost on screen — a grey blurred rectangle that pops out at the end
  * instead of a band fading away.
  *
- * Engaged means the caret is in the composer, matching the stylesheet. Merely
- * holding window focus does not count: activating a window restores focus to
- * whatever had it last, so grabbing the bar to drag the HUD would otherwise
- * read as sitting down to use it. Queried live rather than tracked from
- * document.activeElement, which stays put when the window is blurred and would
- * latch the frost on forever once the user had ever typed here.
+ * Engaged means the caret is in the composer, and it is the SAME gate the
+ * `[data-hud-glass]` scrim runs on — the frost is what that scrim is painted
+ * over, so a frost the scrim doesn't cover is bare material. The caller used
+ * to widen this to "recent or held", which put the window's material up for
+ * the whole of a turn while the scrim stayed down: on a light theme that is a
+ * white slab under the band's unconditionally white ink, and there is nothing
+ * to read. One gate, or the two drift again.
+ *
+ * Merely holding window focus does not count: activating a window restores
+ * focus to whatever had it last, so grabbing the bar to drag the HUD would
+ * otherwise read as sitting down to use it. Queried live rather than tracked
+ * from document.activeElement, which stays put when the window is blurred and
+ * would latch the frost on forever once the user had ever typed here — the
+ * window's own focus changes are listened for so the query is re-run when
+ * `:focus` stops matching under an inactive window.
  *
  * Two vetoes sit over that:
  *
  * - `backing` — because the frost is the window and not the sheet, it is only
  *   ever right when the sheet covers the window; short of that the excess is
- *   frost over empty space. Gating the caller's `engaged` alone would not do
- *   it — focus turns the frost on by itself, which is how a brand new thread
- *   still frosted its whole empty window.
+ *   frost over empty space.
  * - An open completion drawer, which drops the band to 25% and blurs it
  *   (see the `composer-completion-drawer` rule in styles.css). Full-strength
  *   frost behind a band that has deliberately stepped back is the same bare
@@ -53,7 +60,7 @@ const DRAWER_SELECTOR = '[data-slot="composer-completion-drawer"]'
  * that answer lives in main (`hudFrostFor`) next to the state it reads. This
  * hook reports what the band is doing; it does not decide the material.
  */
-export function useHudGlass(rootRef: RefObject<HTMLElement | null>, engaged: boolean, backing: boolean): void {
+export function useHudGlass(rootRef: RefObject<HTMLElement | null>, backing: boolean): void {
   useEffect(() => {
     const root = rootRef.current
     const setFrost = window.hermesDesktop?.hud?.setFrost
@@ -66,9 +73,7 @@ export function useHudGlass(rootRef: RefObject<HTMLElement | null>, engaged: boo
 
     const apply = () => {
       const next =
-        backing &&
-        root.querySelector(DRAWER_SELECTOR) === null &&
-        (engaged || root.querySelector(TYPING_SELECTOR) !== null)
+        backing && root.querySelector(DRAWER_SELECTOR) === null && root.querySelector(TYPING_SELECTOR) !== null
 
       if (on !== next) {
         on = next
@@ -99,6 +104,12 @@ export function useHudGlass(rootRef: RefObject<HTMLElement | null>, engaged: boo
     apply()
     root.addEventListener('focusin', apply)
     root.addEventListener('focusout', apply)
+    // Clicking away to another APP fires no focusout — the composer stays
+    // document.activeElement — but `:focus` stops matching, so the scrim goes
+    // and the frost would be left behind as a bare slab. Deferred a frame so
+    // the query runs after the deactivation has landed.
+    window.addEventListener('blur', schedule)
+    window.addEventListener('focus', schedule)
 
     return () => {
       void setFrost(false)
@@ -110,6 +121,8 @@ export function useHudGlass(rootRef: RefObject<HTMLElement | null>, engaged: boo
 
       root.removeEventListener('focusin', apply)
       root.removeEventListener('focusout', apply)
+      window.removeEventListener('blur', schedule)
+      window.removeEventListener('focus', schedule)
     }
-  }, [backing, engaged, rootRef])
+  }, [backing, rootRef])
 }

--- a/apps/desktop/src/app/hud/hud-shell.tsx
+++ b/apps/desktop/src/app/hud/hud-shell.tsx
@@ -368,7 +368,7 @@ export function HudShell() {
     }
   }, [])
 
-  useHudGlass(rootRef, recent || held, filled)
+  useHudGlass(rootRef, filled)
   useHudClickThrough(rootRef)
   useHudThreadFocus(rootRef)
 


### PR DESCRIPTION
Two HUD-mode fixes off one user report: the band went white-on-white while the
agent was thinking, and the HUD could not see the browser window sitting behind
it with nothing in any log to say why.

## The white slab

The HUD's frost is a native window material — the whole rectangle, unclippable
from the page — and the `[data-hud-glass]` scrim is what turns it into a
readable surface under the band's unconditionally white ink. The two ran on
different gates: the scrim is focus-only, but `HudShell` widened the frost to
`recent || held`, which is true for the whole of a turn. Thinking with the
composer unfocused therefore raised bare material with no scrim over it. On a
light theme that is a white slab with white text on it, which is what the
reporter saw.

The frost now runs on the scrim's own gate, and re-evaluates on the window's
focus changes — clicking away to another app fires no `focusout`, so the scrim
would leave and the frost would stay behind. While a turn runs unfocused the
band is now what it is meant to be: white text on transparent.

## The silent enumeration failure

`read_window_below` came back with `Could not enumerate windows on this system.`
on macOS 26. That sentence is every non-Linux failure: the `get-windows` module
not loading, its helper failing to spawn, or the enumerator answering with
something that isn't a list. Each of the three swallowed its error, so neither
the tool result nor `desktop.log` could tell them apart, and they have three
different fixes.

Enumeration now returns the reason and the tool's error carries it. The HUD's
game-overlay watch — which shares the enumerator, retries twice and then goes
quiet for the rest of the session — logs the reason once, which is the other
half of why the log was empty. Linux keeps its environment-derived advice
(Wayland vs. missing `xprop` vs. Hyprland), which beats the raw exception.

## Test plan

- [x] `npx vitest run src/app/hud electron/window-below electron/hud-game-overlay` (59 passed)
- [x] `npx tsc --noEmit` for both the renderer and electron projects, eslint, prettier
- [ ] Light theme, HUD mode: submit a prompt, click away, confirm the thinking
      text is white on transparent with no panel behind it
- [ ] Focus the composer: the dark scrim and the frost come up together