### PR TITLE
fix(web): keep dashboard TUI alive across OS app-switch

### DIFF
--- a/web/src/lib/pty-reconnect.test.ts
+++ b/web/src/lib/pty-reconnect.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  isPtyFocusReport,
   shouldBlockPtyInput,
   shouldReconnectPtyOnPageResume,
 } from "./pty-reconnect";
@@ -80,6 +81,20 @@ describe("shouldReconnectPtyOnPageResume", () => {
     ).toBe(false);
   });
 
+  it("does not reconnect an open PTY just because the socket ref is briefly missing", () => {
+    // window `focus` / visibilitychange on OS app-switch can read wsRef as
+    // null for a tick. ptyState still "open" must not tear down xterm.
+    expect(
+      shouldReconnectPtyOnPageResume({
+        isActive: true,
+        visibilityState: "visible",
+        online: true,
+        socketReadyState: null,
+        ptyState: "open",
+      }),
+    ).toBe(false);
+  });
+
   it("does not fire a redundant reconnect while a connect is in flight (wsRef not yet assigned)", () => {
     // The async socket-open IIFE has begun but not yet assigned wsRef, so
     // socketReadyState reads null. Without the connectInFlight guard this
@@ -109,6 +124,16 @@ describe("shouldReconnectPtyOnPageResume", () => {
         connectInFlight: true,
       }),
     ).toBe(true);
+  });
+});
+
+describe("isPtyFocusReport", () => {
+  it("recognizes DECSET 1004 focus-in / focus-out and ignores other input", () => {
+    expect(isPtyFocusReport("\x1b[I")).toBe(true);
+    expect(isPtyFocusReport("\x1b[O")).toBe(true);
+    expect(isPtyFocusReport("v")).toBe(false);
+    expect(isPtyFocusReport("\x1b[<0;12;8M")).toBe(false);
+    expect(isPtyFocusReport("\x1b[A")).toBe(false);
   });
 });
 

--- a/web/src/lib/pty-reconnect.ts
+++ b/web/src/lib/pty-reconnect.ts
@@ -66,6 +66,13 @@ export function shouldReconnectPtyOnPageResume({
   if (socketReadyState === WS_OPEN) {
     return false;
   }
+  // An "open" PTY with no socket handle is a transient ref gap (app-switch
+  // `focus`/`visibilitychange` can read wsRef before it is rebound), not a
+  // dead connection. Reconnecting here disposes xterm and force-redraws the
+  // TUI — the dashboard "session reload" that eats paste.
+  if (ptyState === "open") {
+    return socketReadyState === WS_CLOSING || socketReadyState === WS_CLOSED;
+  }
   // A connect is mid-flight (the async socket-open IIFE is awaiting its
   // ticket URL and hasn't assigned wsRef yet, or the socket is still
   // CONNECTING on a non-stuck attempt). Don't fire a redundant reconnect
@@ -90,4 +97,14 @@ export function shouldReconnectPtyOnPageResume({
 
 export function shouldBlockPtyInput(ptyState: PtyConnectionState): boolean {
   return ptyState !== "open";
+}
+
+// xterm.js emits these when DECSET 1004 is on (Ink enables it). Forwarding
+// them into the dashboard PTY makes Ink erase + full-repaint on every OS
+// app-switch — the TUI looks like it reloaded and Ctrl+V races the redraw.
+const PTY_FOCUS_IN = "\x1b[I";
+const PTY_FOCUS_OUT = "\x1b[O";
+
+export function isPtyFocusReport(data: string): boolean {
+  return data === PTY_FOCUS_IN || data === PTY_FOCUS_OUT;
 }

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -47,6 +47,7 @@ import {
   PTY_RESUME_SANITIZE_WINDOW_MS,
   PTY_TICKET_TIMEOUT_MS,
   type PtyConnectionState,
+  isPtyFocusReport,
   shouldBlockPtyInput,
   shouldReconnectPtyOnPageResume,
 } from "@/lib/pty-reconnect";
@@ -1442,7 +1443,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         // Mouse reports (scroll wheel etc.) are not typed input — swallow
         // them before the blocked-input check so scrolling a disconnected
         // terminal doesn't trip the "reconnecting" notice.
-        if (SGR_MOUSE_RE.test(data)) {
+        if (SGR_MOUSE_RE.test(data) || isPtyFocusReport(data)) {
           return;
         }
 
@@ -1475,7 +1476,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // normal onData path.
       sendComposedText = (data) => forwardPtyData(data, false);
       onDataDisposable = term.onData((data) => {
-        if (!SGR_MOUSE_RE.test(data)) {
+        if (!SGR_MOUSE_RE.test(data) && !isPtyFocusReport(data)) {
           compositionForwarder.noteTerminalData(data);
         }
         forwardPtyData(data);
@@ -1669,16 +1670,42 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 
     document.addEventListener("visibilitychange", onResume);
     window.addEventListener("pageshow", onResume);
-    window.addEventListener("focus", onResume);
     window.addEventListener("online", onResume);
 
     return () => {
       document.removeEventListener("visibilitychange", onResume);
       window.removeEventListener("pageshow", onResume);
-      window.removeEventListener("focus", onResume);
       window.removeEventListener("online", onResume);
     };
   }, [isActive, maybeReconnectOnPageResume]);
+
+  // OS app-switch focuses the window but must not reconnect the PTY (that
+  // disposes xterm and force-redraws Ink). Restore terminal focus so Ctrl+V
+  // paste lands in the composer instead of the browser chrome.
+  useEffect(() => {
+    if (!isActive || typeof window === "undefined") {
+      return;
+    }
+
+    const restoreTerminalFocus = () => {
+      const host = hostRef.current;
+      const active =
+        typeof document !== "undefined" ? document.activeElement : null;
+      const focusIsElsewhereInChatPage =
+        active !== null &&
+        active !== document.body &&
+        host !== null &&
+        !host.contains(active);
+      if (!focusIsElsewhereInChatPage) {
+        termRef.current?.focus();
+      }
+    };
+
+    window.addEventListener("focus", restoreTerminalFocus);
+    return () => {
+      window.removeEventListener("focus", restoreTerminalFocus);
+    };
+  }, [isActive]);
 
   // Keep the live xterm theme in sync when the active theme's terminal
   // colors change (e.g. user switches to a custom YAML theme mid-session).


### PR DESCRIPTION
## Bug Description

Switching from the dashboard Chat tab to another OS application (to copy text) resets the embedded TUI and blocks paste. The terminal looks like it reloaded the session; Ctrl+V after returning does not land in the composer.

## Root Cause

Two cooperating paths in the dashboard xterm embed:

1. Ink enables DECSET 1004. xterm.js emits `FOCUS_OUT` / `FOCUS_IN` on every OS app-switch. Ink treats focus-in as "this pane was hidden and needs a clean slate" and erases + full-repaints.
2. `ChatPage` listened for `window` `focus` and called `reconnectPty()` whenever `shouldReconnectPtyOnPageResume` was true. That predicate treated `ptyState === "open"` + a briefly-null `wsRef` as a dead socket, so it disposed xterm, reattached, and force-redrew (``). Input is blocked during reconnect, so paste races the remount.

## Fix

- Swallow DEC 1004 focus reports in the WebUI PTY forwarder (same class as dropped SGR mouse bytes). Hidden-tab recovery still happens via visibility/pageshow reconnect when the socket is actually dead.
- Do not reconnect on `window` `focus`. Keep visibilitychange / pageshow / online.
- If `ptyState` is still `open`, reconnect only when the socket is CLOSING or CLOSED — never because the ref is briefly missing.
- On window focus, restore xterm focus so Ctrl+V hits the composer.

## How to Verify

1. Open `hermes dashboard` Chat and start a session.
2. Alt-tab to another app, copy some text, alt-tab back.
3. Confirm the TUI does **not** flash/reload or show a reconnect overlay.
4. Ctrl+V — text should land in the composer.
5. Minimize the browser until the tab is hidden, restore it — chat should still reconnect only if the websocket actually dropped.

## Test Plan

- [x] Added regression tests in `web/src/lib/pty-reconnect.test.ts` (`isPtyFocusReport`, open-PTY + null socket must not reconnect)
- [x] Existing `pty-reconnect` + `ChatPage` vitest suite still passes (17 tests)
- [ ] Manual verification of the fix on Windows dashboard (reporter)

## Risk Assessment

Low — dashboard Chat embed only. Native `hermes --tui` is unchanged. Real dead-socket recovery on visibility/pageshow/online is preserved.
