### PR TITLE
fix(desktop): drop malformed mcp_servers entries instead of crashing

### DIFF
--- a/apps/desktop/src/lib/mcp-servers.test.ts
+++ b/apps/desktop/src/lib/mcp-servers.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { getServers } from './mcp-servers'
+
+describe('getServers', () => {
+  it('returns empty when the map is absent or not a map', () => {
+    expect(getServers(null)).toEqual({})
+    expect(getServers({})).toEqual({})
+    expect(getServers({ mcp_servers: null })).toEqual({})
+    expect(getServers({ mcp_servers: ['files'] })).toEqual({})
+    expect(getServers({ mcp_servers: 'files' })).toEqual({})
+  })
+
+  it('passes object entries through untouched', () => {
+    const servers = { docs: { url: 'https://example.com/mcp' }, files: { args: ['-y', 'pkg'], command: 'npx' } }
+
+    expect(getServers({ mcp_servers: servers })).toEqual(servers)
+  })
+
+  // A key left without a value in config.yaml parses as `null`, and every
+  // reader (the `enabled` gate, the transport label, the probe) reaches
+  // straight into the entry — so one of these used to take the pane down.
+  it('drops non-object entries and keeps their siblings', () => {
+    const servers = { broken: null, list: ['a'], scalar: 3, working: { command: 'npx' } }
+
+    expect(getServers({ mcp_servers: servers })).toEqual({ working: { command: 'npx' } })
+  })
+})

--- a/apps/desktop/src/lib/mcp-servers.test.ts
+++ b/apps/desktop/src/lib/mcp-servers.test.ts
@@ -17,6 +17,15 @@ describe('getServers', () => {
     expect(getServers({ mcp_servers: servers })).toEqual(servers)
   })
 
+  // Field-level junk is the readers' problem, not this filter's — they coerce
+  // and tolerate. Pinned so a later tightening of `isEntry` can't start
+  // dropping entries that merely carry a bad field.
+  it('keeps entries whose fields are junk', () => {
+    const servers = { files: { command: 42, enabled: 'yes' } }
+
+    expect(getServers({ mcp_servers: servers })).toEqual(servers)
+  })
+
   // A key left without a value in config.yaml parses as `null`, and every
   // reader (the `enabled` gate, the transport label, the probe) reaches
   // straight into the entry — so one of these used to take the pane down.

--- a/apps/desktop/src/lib/mcp-servers.ts
+++ b/apps/desktop/src/lib/mcp-servers.ts
@@ -21,9 +21,28 @@ export function normalizeEntry(entry: Record<string, unknown>): Record<string, u
   return entry
 }
 
-/** The `mcp_servers` map out of a config record, or `{}` when absent/malformed. */
+/** A value a reader can reach into: an object, not `null`, an array or a scalar. */
+const isEntry = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === 'object' && !Array.isArray(value)
+
+/** The `mcp_servers` map out of a config record, or `{}` when absent/malformed.
+ *
+ *  Entries that aren't objects are dropped rather than handed on. Every reader
+ *  takes properties straight off the value — `enabled` for the runtime gate,
+ *  `command`/`url` for the transport, `tools` for the filter — so one bad entry
+ *  throws on the first property read and, with nothing between it and the pane,
+ *  takes the whole Capabilities workspace down with it. A `name:` left without
+ *  a value in `config.yaml` parses as `null` and does exactly that. The backend
+ *  already refuses to *write* a non-object entry (`_replace_mcp_servers`), so
+ *  this only has to survive a config edited by hand or by another tool. */
 export function getServers(config: { mcp_servers?: unknown } | null): McpServers {
   const raw = config?.mcp_servers
 
-  return raw && typeof raw === 'object' && !Array.isArray(raw) ? (raw as McpServers) : {}
+  if (!isEntry(raw)) {
+    return {}
+  }
+
+  return Object.fromEntries(
+    Object.entries(raw).filter((entry): entry is [string, Record<string, unknown>] => isEntry(entry[1]))
+  )
 }


### PR DESCRIPTION
## What does this PR do?

`getServers()` now drops `mcp_servers` entries that aren't objects instead of handing them to the readers.

A `mcp_servers` key left without a value parses as `null`. Mine got there when a remote server was written back with its `url`/`headers` one level short:

```yaml
mcp_servers:
  obsidian:
    command: npx
    args: [-y, obsidian-mcp-server@latest]
  tienda-upe: null                      # <- key with no value
  url: http://localhost:3000/api/mcp    # <- meant to be nested under tienda-upe
  headers:
    Authorization: Bearer ...
```

Opening **Capabilities → MCP** then throws in `serverEnabled()` (`apps/desktop/src/app/skills/mcp-tab.tsx`), which does `server.enabled !== false` for every entry:

```
"workspace" failed to render
Cannot read properties of null (reading 'enabled')
```

Because the throw happens during the pane's render, it doesn't fail alone — the whole workspace is replaced by the error card and the app stays unusable until `config.yaml` is fixed by hand, which is a rough failure mode given the MCP tab is exactly where you'd go to fix a bad server entry.

`serverEnabled` is only the first read. The same `null` also flows into `statusOf()`, `costFor()` and `statusLine()`, so guarding that one call site would relocate the crash rather than remove it. `getServers()` is the single choke point every reader goes through (the MCP tab and the `hermes://mcp/install` deeplink dialog), which is why the guard belongs there — and it matches the function's existing contract, which already promises `{}` for a malformed *map*; this extends the same promise to a malformed *entry*.

Dropping is also self-healing: the editor saves the whole map back through `_replace_mcp_servers`, so the bad key disappears on the next save. And nothing legitimate is lost — the backend already refuses to *write* a non-object entry (`Server 'x': expected an object`), so this only has to survive a config edited by hand or by another tool.

## Related Issue

No existing issue found for this one — happy to open one to link if you prefer the issue-first flow.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/mcp-servers.ts` — `getServers()` filters out entries that aren't objects (`null`, arrays, scalars) instead of passing them to the readers; adds a small `isEntry` type guard used for both the map and its entries.
- `apps/desktop/src/lib/mcp-servers.test.ts` — new: covers absent/non-map input, object entries passing through untouched, and a `null` entry being dropped while its valid siblings survive.

## How to Test

1. In `$HERMES_HOME/config.yaml` (`~/.hermes/config.yaml` by default), add a key with no value under `mcp_servers`:

```yaml
   mcp_servers:
     broken:
```

2. Open Hermes Desktop → **Capabilities** → **MCP**.
3. Before this PR: the pane *and the whole workspace* are replaced by `"workspace" failed to render — Cannot read properties of null (reading 'enabled')`. After: the tab renders, `broken` is skipped, and the valid servers list, probe and toggle normally.
4. Unit tests: `cd apps/desktop && npm run test:ui -- src/lib/mcp-servers`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, this touches no Python. Ran the desktop suite instead: `npm run test:ui -- src/lib/mcp-servers` ✅ and `npm run typecheck` clean.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Hermes Desktop v0.20.5, `41447a6`), against the real config that hit this

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer-only TypeScript, no I/O or platform APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before the fix, with the config above:

```
"workspace" failed to render
Cannot read properties of null (reading 'enabled')
```