### PR TITLE
fix(mcp): un-invert the stdio children liveness check

### DIFF
--- a/tests/tools/test_mcp_stdio_children_dead.py
+++ b/tests/tools/test_mcp_stdio_children_dead.py
@@ -1,0 +1,41 @@
+"""Regression tests for ``_stdio_children_dead`` (#94335).
+
+The liveness check was inverted: the loop returned True ("all children dead")
+on the first LIVE pid, so the #81995 pre-call fast-fail raised
+``TimeoutError: MCP stdio subprocess ... has exited`` for every tools/call in
+oneshot (-z) sessions even though the subprocess was demonstrably alive.
+"""
+
+from unittest.mock import patch
+
+from tools.mcp_tool import MCPServerTask
+
+
+def _task_with_pids(pids, *, http=False):
+    task = object.__new__(MCPServerTask)
+    task._stdio_child_pids = pids
+    task._config = {"url": "http://example.invalid"} if http else {"command": "x"}
+    return task
+
+
+def test_live_child_reports_not_dead():
+    """The reported bug: an alive tracked pid must NOT report all-dead."""
+    with patch("psutil.pid_exists", return_value=True):
+        assert _task_with_pids([60634])._stdio_children_dead() is False
+
+
+def test_all_children_dead_reports_dead():
+    with patch("psutil.pid_exists", return_value=False):
+        assert _task_with_pids([111, 222])._stdio_children_dead() is True
+
+
+def test_mixed_liveness_reports_not_dead():
+    """One live sibling is enough — dead others must not flip the verdict."""
+    with patch("psutil.pid_exists", side_effect=lambda pid: pid != 111):
+        assert _task_with_pids([111, 222])._stdio_children_dead() is False
+
+
+def test_no_captured_pids_stays_fail_open():
+    """Unknown (no tracked pids / HTTP transport) must not fail fast."""
+    assert _task_with_pids([])._stdio_children_dead() is False
+    assert _task_with_pids([1], http=True)._stdio_children_dead() is False

--- a/tests/tools/test_mcp_stdio_children_dead.py
+++ b/tests/tools/test_mcp_stdio_children_dead.py
@@ -1,12 +1,19 @@
-"""Regression tests for ``_stdio_children_dead`` (#94335).
+"""Regression tests for MCP stdio aggregate liveness (#94335 / #94637).
 
-The liveness check was inverted: the loop returned True ("all children dead")
-on the first LIVE pid, so the #81995 pre-call fast-fail raised
-``TimeoutError: MCP stdio subprocess ... has exited`` for every tools/call in
-oneshot (-z) sessions even though the subprocess was demonstrably alive.
+The #81995 fast-fail gate consumes ``_stdio_children_dead`` as a boolean
+state machine: True means every tracked child is gone; False means at least
+one child is alive or liveness is unknown. The live-child branch was inverted,
+so healthy stdio RPCs were cancelled while their subprocesses were still alive.
+
+Watcher-consumer cases are distilled from #94521. Dependency/probe fail-open
+cases are distilled from #94661 into the canonical #94339 carrier.
 """
 
+import asyncio
+import builtins
 from unittest.mock import patch
+
+import pytest
 
 from tools.mcp_tool import MCPServerTask
 
@@ -39,3 +46,49 @@ def test_no_captured_pids_stays_fail_open():
     """Unknown (no tracked pids / HTTP transport) must not fail fast."""
     assert _task_with_pids([])._stdio_children_dead() is False
     assert _task_with_pids([1], http=True)._stdio_children_dead() is False
+
+
+def test_psutil_unavailable_stays_fail_open():
+    """Missing probe support is unknown, never proof of child death."""
+    real_import = builtins.__import__
+
+    def _without_psutil(name, *args, **kwargs):
+        if name == "psutil":
+            raise ImportError("psutil unavailable")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=_without_psutil):
+        assert _task_with_pids([1])._stdio_children_dead() is False
+
+
+def test_pid_probe_error_stays_fail_open():
+    """A failed probe cannot authorize the destructive fast-fail."""
+    with patch("psutil.pid_exists", side_effect=OSError("probe failed")):
+        assert _task_with_pids([1])._stdio_children_dead() is False
+
+
+def test_watcher_does_not_resolve_while_a_child_is_alive():
+    """The watcher must not cancel an RPC while any child is still live."""
+
+    async def _run():
+        with patch("psutil.pid_exists", return_value=True):
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(
+                    _task_with_pids([60634])._watch_stdio_children(),
+                    timeout=0.05,
+                )
+
+    asyncio.run(_run())
+
+
+def test_watcher_resolves_when_all_children_are_dead():
+    """The watcher completes only when the aggregate verdict is all-dead."""
+
+    async def _run():
+        with patch("psutil.pid_exists", return_value=False):
+            await asyncio.wait_for(
+                _task_with_pids([111, 222])._watch_stdio_children(),
+                timeout=0.1,
+            )
+
+    asyncio.run(_run())

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2987,18 +2987,20 @@ class MCPServerTask:
         pids = getattr(self, "_stdio_child_pids", None)
         if not pids or self._is_http():
             return False
-        for pid in pids:
-            # windows-footgun: ok — psutil.pid_exists handles Windows; the
-            # os.kill probe below only runs when psutil is unavailable.
+        try:
             import psutil
-
-            if not psutil.pid_exists(pid):
-                continue  # this one is dead
-            return False  # at least one child alive (signal permission
-            # irrelevant for liveness) — inverting this fail-fasted every
-            # stdio call in oneshot (-z) sessions while the subprocess was
-            # demonstrably alive (#94335)
-        return True
+        except ImportError:
+            return False  # unknown → don't fail fast
+        for pid in pids:
+            # pid_exists handles Windows without signal-permission noise; a
+            # probe failure is unknown, not proof that every child exited.
+            try:
+                alive = psutil.pid_exists(pid)
+            except Exception:
+                return False  # unknown → don't fail fast
+            if alive:
+                return False  # at least one child alive → not all dead
+        return True  # every tracked child has exited
 
     async def _watch_stdio_children(self) -> None:
         """Poll child liveness while a stdio RPC is in flight (#81995).

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2994,8 +2994,10 @@ class MCPServerTask:
 
             if not psutil.pid_exists(pid):
                 continue  # this one is dead
-            return True  # alive (signal permission irrelevant for liveness)
-            return False  # at least one child alive
+            return False  # at least one child alive (signal permission
+            # irrelevant for liveness) — inverting this fail-fasted every
+            # stdio call in oneshot (-z) sessions while the subprocess was
+            # demonstrably alive (#94335)
         return True
 
     async def _watch_stdio_children(self) -> None:


### PR DESCRIPTION
## What does this PR do?

`_stdio_children_dead()` returned `True` ("all children dead") on the first **live** pid — the intended `False` sat dead-coded directly beneath it. In any spawn path that captures child PIDs (observed in `hermes -z` oneshots), the #81995 pre-call fast-fail then raised `TimeoutError: MCP stdio subprocess ... has exited; failing the call fast` on **every** `tools/call` while the subprocess was demonstrably alive (the reporter's child-watcher poll caught it running at the moment of failure). Long-lived gateway/dashboard sessions were unaffected only because `_stdio_child_pids` stays empty there (the `if not pids` short-circuit) — which is also why production gateways never noticed.

This PR restores the documented decision table at the fast-fail boundary — no captured PIDs / HTTP transport ⇒ fail open; every tracked child dead ⇒ `True`; any live tracked child ⇒ `False` — and additionally fails open when `psutil` is unavailable or a PID probe raises, so unknown liveness can never authorize the destructive fast-fail. The destructive consumer `_watch_stdio_children()` stays pending while a child is alive and resolves once every tracked child has exited.

## Related Issue

Fixes #94335

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/mcp_tool.py` (`MCPServerTask._stdio_children_dead`) — restore the aggregate liveness polarity and fail open when `psutil` is unavailable or a PID probe raises; unknown liveness cannot authorize the pre-call fast-fail.
- `tests/tools/test_mcp_stdio_children_dead.py` — eight regressions covering live, all-dead, mixed, absent-PID/HTTP, missing-`psutil`, probe-error, watcher-live, and watcher-all-dead behavior.

## Provenance and Credit

- Watcher-consumer cases distilled from #94521 by @wngmlaprk-ship-it.
- Missing-dependency / probe-error fail-open cases distilled from #94661 by @Finn763.
- Independent macOS/Moraine control-path witness: https://github.com/NousResearch/hermes-agent/pull/94339#issuecomment-5416115887 by @SJBanister.
- #94339 remains the sole runtime carrier for #94335 / #94637; the duplicate implementations are not imported.

## How to Test

- Run: `.venv/bin/python -m pytest tests/tools/test_mcp_stdio_children_dead.py -q`
- Observed result: `8 passed`. On unfixed `main` the same file reports `5 failed, 3 passed` — failing exactly the live-child, mixed-liveness, missing-`psutil`, probe-error, and watcher-live pins.
- Adjacent MCP fast-fail/cancellation sweep (`test_mcp_bridge_single_failure.py`, `test_mcp_circuit_breaker.py`, `test_mcp_cancelled_error_propagation.py`, `test_mcp_failure_classification.py`): `30 passed`.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of the completed code performed
- [x] New and existing unit tests pass locally
- [x] Changes are backward-compatible (the all-dead verdict and unknown/fail-open paths are preserved; the live-pid verdict flips to correct and dependency/probe failures now fail open)
