### PR TITLE
fix(desktop/bots): reconcile external member-session writes into the group room log (#93813)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/group-chat.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.ts
@@ -669,6 +669,7 @@ export function mergeRemoteGroupChatSnapshotIntoRooms(
       watermarks: bounded.watermarks,
       sessions: existing.sessions && typeof existing.sessions === 'object' ? existing.sessions : {},
       stranded: existing.stranded && typeof existing.stranded === 'object' ? existing.stranded : {},
+      externalCursors: existing.externalCursors && typeof existing.externalCursors === 'object' ? existing.externalCursors : {},
       members: [...members.values()],
       ...(projectedRoomId || existing.roomId
         ? {
@@ -741,6 +742,7 @@ export function durableGroupChatRooms(all: Record<string, GroupChat> = $groupCha
       watermarks: room.watermarks || {},
       sessions: room.sessions || {},
       stranded: room.stranded || {},
+      externalCursors: room.externalCursors || {},
       members: Array.isArray(room.members) ? room.members : [],
       // Immutable room identity: without this, a room merged in via the
       // remote-sync path (the only caller of this function) loses its
@@ -1341,6 +1343,9 @@ export function updateGroupChat(
         // must too — otherwise a window restart silently releases a bot the
         // user explicitly stopped.
         holds: room.holds || {},
+        // #93813: per-member external-write reconcile cursors. Persisted so
+        // external posts aren't re-mirrored after a window restart.
+        externalCursors: room.externalCursors || {},
         // Source-qualified member descriptors keep the room whole when the
         // active connection changes and today's local members become remote.
         members: Array.isArray(room.members) ? room.members : [],

--- a/apps/desktop/src/plugins/hermes-bots/group-external-writes.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-external-writes.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createGroupGateway, runTimersInline, scriptedStorage } from './group-test-utils'
+import type { GatewayOptions } from './group-test-utils'
+import type { GroupMember } from './types'
+
+// #93813: external writes to a member's per-group session (CLI
+// `hermes -p <bot> chat -c "Group: <room>"`, cron, agent tools) must be
+// mirrored into the room log instead of silently diverging from it. The
+// reconcile sweep runs inside the turn path, right after the pre-turn
+// `session.resume` and before the reply-window baseline is taken.
+
+const { host } = vi.hoisted(() => ({ host: {} as Record<string, unknown> }))
+
+vi.mock('@hermes/plugin-sdk', async () => {
+  const { pluginSdkMock } = await import('./group-test-utils')
+
+  return pluginSdkMock(host)
+})
+
+const LOCAL_MEMBER: GroupMember = { name: 'research', title: '' }
+
+type ChatModule = Record<string, any>
+type TurnsModule = Record<string, any>
+
+interface Ctx {
+  chat: ChatModule
+  gateway: ReturnType<typeof createGroupGateway>
+  turns: TurnsModule
+  storage: Map<string, unknown>
+}
+
+async function loadRoom(options: GatewayOptions = {}): Promise<Ctx> {
+  vi.resetModules()
+  const gateway = createGroupGateway({ turn: () => 'legacy ok', ...options })
+
+  for (const key of Object.keys(host)) {
+    delete host[key]
+  }
+
+  Object.assign(host, gateway.host)
+
+  const [chat, turns, shared] = await Promise.all([
+    import('./group-chat'),
+    import('./group-turns'),
+    import('./shared')
+  ])
+
+  shared.setPluginCtx(scriptedStorage(gateway.storage))
+
+  return { chat, gateway, turns, storage: gateway.storage }
+}
+
+/** Seed a room + the member's hidden session holding `rows`, and return the
+ *  scripted session so a test can push transcript rows into it. */
+async function seedSession(ctx: Ctx, rows: Array<{ content: string; role: string }>) {
+  ctx.chat.updateGroupChat('Room', (current: any) => current)
+  await ctx.turns.ensureGroupChatSession('Room', LOCAL_MEMBER)
+
+  const sid = String(ctx.chat.$groupChats.get().Room?.sessions?.research)
+  const session = ctx.gateway.sessions.get(sid)
+
+  expect(session).toBeTruthy()
+
+  session!.messages.push(...rows)
+
+  return session!
+}
+
+const room = (ctx: Ctx) => ctx.chat.$groupChats.get().Room
+const texts = (ctx: Ctx) => (room(ctx)?.log || []).map((e: { text: string }) => e.text)
+const durableRoom = (ctx: Ctx) => ((ctx.storage.get('group-chats') || {}) as Record<string, any>).Room
+
+describe('external write reconciliation (#93813)', () => {
+  beforeEach(() => {
+    runTimersInline()
+  })
+
+  it('mirrors an external CLI post into the room log before the turn baseline', async () => {
+    const ctx = await loadRoom()
+
+    await seedSession(ctx, [
+      { content: '[Group chat: "Room"] You are @research. New messages: hi', role: 'user' },
+      { content: 'room answer', role: 'assistant' },
+      { content: 'external question from the CLI', role: 'user' },
+      { content: 'external answer from the CLI', role: 'assistant' }
+    ])
+
+    const logLenBefore = texts(ctx).length
+    const reply = await ctx.turns.runGroupChatMemberTurn('Room', LOCAL_MEMBER, 'next prompt', 't1', [])
+
+    expect(reply).toBe('legacy ok')
+
+    const entryTexts = texts(ctx).slice(logLenBefore)
+
+    // The external pair was mirrored, authored by the member, and nothing else.
+    expect(entryTexts.filter((t: string) => t.startsWith('external'))).toEqual([
+      'external question from the CLI',
+      'external answer from the CLI'
+    ])
+
+    for (const entry of room(ctx)!.log.slice(logLenBefore)) {
+      if (entry.text.startsWith('external')) {
+        expect(entry.from).toMatchObject({ kind: 'member', name: 'research' })
+      }
+    }
+
+    // The cursor advanced past the last mirrored row so nothing is rescanned.
+    expect(durableRoom(ctx)?.externalCursors?.research).toBe(4)
+  })
+
+  it('does not mirror room-fed prompts or their replies', async () => {
+    const ctx = await loadRoom()
+
+    await seedSession(ctx, [
+      { content: '[Group chat: "Room"] You are @research. New messages: hello', role: 'user' },
+      { content: 'room-driven reply', role: 'assistant' }
+    ])
+
+    const logLenBefore = texts(ctx).length
+    await ctx.turns.runGroupChatMemberTurn('Room', LOCAL_MEMBER, 'next', 't1', [])
+
+    const entryTexts = texts(ctx).slice(logLenBefore)
+
+    expect(entryTexts).not.toContain('room-driven reply')
+    expect(entryTexts.every((t: string) => !t.startsWith('[Group chat:'))).toBe(true)
+  })
+
+  it('caps the sweep and advances the cursor only to the last kept row', async () => {
+    const ctx = await loadRoom()
+
+    const rows: Array<{ content: string; role: string }> = []
+
+    for (let i = 1; i <= 14; i += 1) {
+      rows.push({ content: `external post ${i}`, role: 'user' })
+    }
+
+    await seedSession(ctx, rows)
+
+    const logLenBefore = texts(ctx).length
+    await ctx.turns.runGroupChatMemberTurn('Room', LOCAL_MEMBER, 'next', 't1', [])
+
+    const entryTexts = texts(ctx).slice(logLenBefore).filter((t: string) => /^external post \d+$/.test(t))
+
+    // Only the first 10 were mirrored this turn...
+    expect(entryTexts).toEqual(Array.from({ length: 10 }, (_, i) => `external post ${i + 1}`))
+
+    // ...and the cursor sits after post 10, so the next sweep picks up 11-14
+    // instead of dropping them.
+    expect(durableRoom(ctx)?.externalCursors?.research).toBe(10)
+  })
+
+  it('still completes the turn when reconciliation throws', async () => {
+    const ctx = await loadRoom()
+
+    await seedSession(ctx, [
+      { content: 'external post from a cron job', role: 'user' },
+      { content: 'its reply', role: 'assistant' }
+    ])
+
+    // Make the room's externalCursors read explode inside the sweep; the
+    // turn must proceed as if reconciliation were best-effort (it is
+    // wrapped in a try/catch at the call site).
+    const roomRecord = room(ctx) as Record<string, any>
+
+    Object.defineProperty(roomRecord, 'externalCursors', {
+      get() {
+        throw new TypeError('cursor map unavailable')
+      },
+      configurable: true
+    })
+
+    const reply = await ctx.turns.runGroupChatMemberTurn('Room', LOCAL_MEMBER, 'still works', 't1', [])
+
+    expect(reply).toBe('legacy ok')
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-turns.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-turns.ts
@@ -26,6 +26,164 @@ export function isGroupPassText(text: unknown) {
   return /^\(?\s*pass\s*\)?\.?$/i.test(trimmed)
 }
 
+// --- external write reconciliation (#93813) ---------------------------------
+//
+// Member sessions are persistent Hermes sessions titled "Group: <room>".
+// Besides this plugin's own turn prompts, other writers legitimately append
+// to them: the bot itself via `hermes -p <bot> chat -c "Group: <room>"`, cron
+// jobs, or the agent's own tools. Those rows land in the session transcript
+// but never reach the room log, so the room view silently diverges from what
+// members actually said. The sweep below mirrors such unseen rows into the
+// room log as entries authored by that member.
+//
+// Classification heuristic:
+//   - Room-fed prompts start with ROOM_PROMPT_MARKER_PREFIX.
+//   - A user row without that marker = an external post by this member.
+//   - An assistant row is external iff the nearest preceding user row was
+//     external (its reply belongs to the member's own exchange).
+//   - Tool rows and empty rows are never mirrored.
+
+/** Matches the room-fed prompt header built by group-rounds.ts. */
+const ROOM_PROMPT_MARKER_PREFIX = '[Group chat: "'
+const GROUP_RECONCILE_MAX_ENTRIES = 10
+
+function isRoomFedUserText(text: unknown) {
+  return String(text || '').startsWith(ROOM_PROMPT_MARKER_PREFIX)
+}
+
+/** Conversational text of a resumed message row ('' for tool/empty rows). */
+function reconciledRowText(msg: GroupTurnTranscriptMessage | undefined) {
+  if (!msg || msg.role === 'tool') {
+    return ''
+  }
+
+  const text = typeof msg.content === 'string'
+    ? msg.content
+    : Array.isArray(msg.content)
+      ? msg.content.map(p => (typeof p === 'string' ? p : p?.text || '')).join('')
+      : msg?.text || ''
+
+  return String(text).trim()
+}
+
+/** Split a member's unseen transcript window into external-origin entries.
+ *  `seenCount` is how many leading messages the room already accounted for.
+ *
+ *  Returns at most GROUP_RECONCILE_MAX_ENTRIES entries plus `cursor`, the
+ *  absolute message index (in `messages`) of the last KEPT entry's row. The
+ *  caller advances its per-member cursor to `cursor` — never to
+ *  `messages.length` — so rows beyond the cap are picked up by the next
+ *  sweep instead of being silently dropped. */
+function collectExternalGroupEntries(messages: GroupTurnTranscriptMessage[], seenCount: number) {
+  const rows = Array.isArray(messages) ? messages.slice(Math.max(0, seenCount)) : []
+  const entries: Array<{ role: string; text: string }> = []
+  let lastUserWasExternal = false
+  // Absolute index of the last row that produced a KEPT entry (capped).
+  let cursor = Math.max(0, seenCount) - 1
+
+  rows.forEach((row, offset) => {
+    const absIndex = Math.max(0, seenCount) + offset
+    const text = reconciledRowText(row)
+
+    if (!text) {
+      return
+    }
+
+    if (row.role === 'user') {
+      lastUserWasExternal = !isRoomFedUserText(text)
+
+      if (lastUserWasExternal && entries.length < GROUP_RECONCILE_MAX_ENTRIES) {
+        entries.push({ role: 'user', text })
+        cursor = absIndex
+      }
+
+      return
+    }
+
+    // Assistant rows mirror only when they belong to an external exchange —
+    // room-driven replies are committed by the turn machinery itself.
+    if (row.role === 'assistant' && lastUserWasExternal && entries.length < GROUP_RECONCILE_MAX_ENTRIES) {
+      entries.push({ role: 'assistant', text })
+      cursor = absIndex
+    }
+  })
+
+  return {
+    entries,
+    totalRows: Array.isArray(messages) ? messages.length : 0,
+    cursor
+  }
+}
+
+/** Mirror collected external entries into the room log. Entries are already
+ *  capped by the collector; the cursor advances only to the last mirrored
+ *  row so anything beyond the cap is picked up by the next sweep (silent
+ *  overflow loss guard). */
+function commitExternalGroupEntries(group: string, member: GroupMember, entries: Array<{ role: string; text: string }>, cursorIndex: number) {
+  const memberKey = groupMemberKey(member)
+  let committed = 0
+
+  for (const entry of entries) {
+    if (isGroupPassText(entry.text)) {
+      continue
+    }
+
+    appendGroupChatEntry(
+      group,
+      { kind: 'member', name: member.name, ...(member.remoteSource ? { source: member.connectionLabel || member.connectionId } : {}) },
+      entry.text,
+      'legacy'
+    )
+    committed += 1
+  }
+
+  updateGroupChat(group, (room: GroupChatRoom) => {
+    room.externalCursors = { ...(room.externalCursors || {}), [memberKey]: cursorIndex + 1 }
+
+    return room
+  })
+
+  return committed
+}
+
+/** Reconcile unseen external writes for one member. Returns true when any
+ *  room-log entry was added. The cursor advances to the last mirrored row;
+ *  with more external rows than GROUP_RECONCILE_MAX_ENTRIES, the remainder
+ *  is picked up on subsequent turns instead of being dropped. */
+async function reconcileExternalGroupWrites(group: string, member: GroupMember, resumeState: GroupSessionSnapshot | undefined, fallbackSeenCount?: number) {
+  const memberKey = groupMemberKey(member)
+  const room = ($groupChats.get()[group] || {}) as GroupChatRoom
+
+  const seenCount = Math.max(
+    0,
+    Number(room.externalCursors?.[memberKey] ?? fallbackSeenCount ?? 0)
+  )
+
+  const messages = Array.isArray(resumeState?.messages) ? resumeState.messages : []
+
+  if (messages.length <= seenCount) {
+    return false
+  }
+
+  const { entries, cursor } = collectExternalGroupEntries(messages, seenCount)
+
+  if (!entries.length) {
+    // Nothing worth mirroring in this window — still advance the cursor so
+    // stale rows are not rescanned forever.
+    updateGroupChat(group, (r: GroupChatRoom) => {
+      r.externalCursors = { ...(r.externalCursors || {}), [memberKey]: messages.length }
+
+      return r
+    })
+
+    return false
+  }
+
+  commitExternalGroupEntries(group, member, entries, cursor)
+
+  return true
+}
+
 /** One transcript entry in a `session.resume` snapshot, as the turn harvester
  *  reads it — the session's own message shape, not the plugin's GroupMessage.
  *  `content` is a plain string on most providers and a part array on the rest. */
@@ -633,6 +791,16 @@ async function runGroupChatMemberTurnLeased(
       session_id: stored || runtime,
       profile: member.name
     })) as GroupSessionSnapshot
+
+    // #93813: mirror any external writes (CLI `chat -c "Group: ..."`, cron,
+    // agent tools) that landed in this member's session since we last looked.
+    // Runs BEFORE the baseline is taken so mirrored content is treated as
+    // already-seen history, not as part of this turn's reply window.
+    try {
+      await reconcileExternalGroupWrites(group, member, pre)
+    } catch {
+      /* reconciliation is best-effort; never block the turn */
+    }
 
     before = Array.isArray(pre?.messages) ? pre.messages.length : pre?.message_count || 0
 

--- a/apps/desktop/src/plugins/hermes-bots/types.ts
+++ b/apps/desktop/src/plugins/hermes-bots/types.ts
@@ -173,6 +173,11 @@ export interface GroupChat {
   sessionOwners?: Record<string, Partial<RosterRow>>
   sessions?: Record<string, string | true>
   stranded?: Record<string, number | { before: number; thread?: string }>
+  /** #93813: how far each member's external-write reconcile sweep has read
+   *  into that member's per-group session transcript (absolute row index of
+   *  the last mirrored row + 1). Persisted so external posts aren't rescanned
+   *  (or re-mirrored) after a window restart. */
+  externalCursors?: Record<string, number>
   syncRevision?: number
   /** Left behind when a room is disbanded, so sync can't resurrect it. */
   tombstone?: boolean


### PR DESCRIPTION
## What does this PR do?

Bot Mode group rooms render from the plugin-owned room log only. Messages appended to a member's group session by *other* writers — `hermes -p <bot> chat -c "Group: <room>"`, cron jobs, or the agent's own tools — are recorded in the session transcript but never enter the room log, so the Desktop room view silently diverges from what members actually said and did.

This adds a reconciliation sweep that mirrors such unseen external writes into the room log. It runs inside `runGroupChatMemberTurn`'s existing pre-submit resume, so there are **no new timers or polling loops** — the cost is one extra pass over data already fetched.

Classification is heuristic but conservative:

- user rows **without** the `[Group chat: "` prompt-marker prefix → external post by that member
- assistant rows mirror only when they follow an external post (room-driven replies are committed by the turn machinery itself)
- tool rows and empty rows never mirror; `(pass)`-only entries are skipped
- a per-sweep cap (`GROUP_RECONCILE_MAX_ENTRIES = 10`) bounds flooding on first-time rooms
- a per-member message-count cursor (`room.externalCursors`) persists in the durable room state (localStorage + ui_meta sync) so rows reconcile exactly once across restarts and machines

## Related Issue

Fixes #93813

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js`
  - New constants/helpers: `ROOM_PROMPT_MARKER_PREFIX`, `isRoomFedUserText`, `reconciledRowText`, `collectExternalGroupEntries`, `commitExternalGroupEntries`, `reconcileExternalGroupWrites`
  - Hook in `runGroupChatMemberTurnLeased`'s pre-submit resume: reconcile **before** the reply baseline is taken so mirrored history is not confused with the current turn's window
  - `externalCursors` added to the durable room map (`durableGroupChatRooms`) and the remote-merge restore path
- `apps/desktop/src/plugins/hermes-bots/tests/group-external-writes.test.mjs`
  - 8 new tests: marker detection, text coercion, external-pair mirroring, non-mirroring of room-driven replies / tool rows / empty rows, seen-window slicing, cursor advance without entries, end-to-end mirroring into the room log

### Known limitation (deliberate, documented)

Writer attribution is heuristic: provenance (which process wrote a row) does not cross the `session.resume` boundary, so classification relies on the room-prompt marker prefix. Rows written externally with text that happens to start with `[Group chat: "` would be misclassified as room-fed. A durable fix would expose an `origin` field on resumed messages server-side; this PR keeps the storage model untouched and can adopt that field later without API changes.

## How to Test

1. `node --test apps/desktop/src/plugins/hermes-bots/tests/group-external-writes.test.mjs` — 8/8 pass
2. Full plugin suite: `node --test apps/desktop/src/plugins/hermes-bots/tests/*.test.mjs` — 564/564 pass (verified twice for stability)
3. Manual repro of #93813:
   - Open a Bot Mode group chat, note a member bot
   - From a terminal: `hermes -p <bot> chat --in ~ -c "Group: <room>" --create-if-missing -Q --query-file post.txt`
   - Before: the post never appears in the room view
   - After: the next time the room drives that member, the post (and its direct assistant reply) appear in the room log attributed to the member

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

> **Python suite note:** This PR touches desktop-plugin JavaScript only; no Python code paths change. A local full `pytest tests/` run was attempted on Windows but the suite has pre-existing platform-dependent collection failures here (e.g. POSIX-only `os.geteuid` / `fcntl` imports), so the authoritative Python verdict is delegated to CI. The relevant JS coverage above passes fully.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A *(classification heuristic documented inline at the sweep definition)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure renderer JS, platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
