### PR TITLE
fix(desktop): render Bot group MEDIA directives inline

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.media.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.media.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $connection } from '@/store/session'
 
-import { MarkdownImage, MarkdownTextContent } from './markdown-text'
+import { MarkdownImage, MarkdownTextContent, MessageTextContent } from './markdown-text'
 
 const REMOTE_IMAGE_PATH = '/home/user/project/images/remote-preview.png'
 const REMOTE_IMAGE_DATA_URL = 'data:image/png;base64,cmVtb3RlLWltYWdl'
@@ -77,5 +77,16 @@ describe('MarkdownImage media routing', () => {
 
     expect(container.querySelector('video')).toBeNull()
     expect(container.querySelector('audio')).toBeNull()
+  })
+})
+
+describe('MessageTextContent MEDIA directives', () => {
+  afterEach(cleanup)
+
+  it('renders a raw audio MEDIA directive through the canonical player instead of exposing the directive', async () => {
+    const { container } = render(<MessageTextContent text="MEDIA:/tmp/group-voice.mp3" />)
+
+    await waitFor(() => expect(container.querySelector('audio[controls]')).not.toBeNull())
+    expect(container.textContent).not.toContain('MEDIA:')
   })
 })

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -16,6 +16,7 @@ import { chunkByLines, SyntaxHighlighter } from '@/components/chat/shiki-highlig
 import { ZoomableImage } from '@/components/chat/zoomable-image'
 import { ErrorBoundary } from '@/components/error-boundary'
 import { detectArtifact } from '@/lib/artifact-detect'
+import { renderMediaTags } from '@/lib/chat-messages/parts'
 import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/external-link'
 import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { parseMarkdownIntoBlocksCached } from '@/lib/markdown-blocks'
@@ -690,6 +691,13 @@ function MarkdownTextSurface({
 interface MarkdownTextContentProps extends MarkdownTextSurfaceProps {
   isRunning: boolean
   text: string
+}
+
+/** Render raw assistant-style message text through the complete Desktop text
+ * pipeline. `MEDIA:` directives must be transformed before Markdown rendering
+ * so the canonical link component can route them to inline players/previews. */
+export function MessageTextContent({ text }: { text: string }) {
+  return <MarkdownTextContent isRunning={false} text={renderMediaTags(text)} />
 }
 
 export function MarkdownTextContent({ isRunning, text, ...surfaceProps }: MarkdownTextContentProps) {

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -75,6 +75,7 @@ const SkillsView = typeof sdk === 'undefined' ? undefined : sdk.SkillsView
 // ACTIVE gateway's skills under the remote bot's name (the wrong machine),
 // so those builds keep the staged checklists for remote targets.
 const skillsViewRoutesConnections = Boolean(SkillsView && SkillsView.supportsFixedConnection)
+const MessageTextContent = typeof sdk === 'undefined' ? undefined : sdk.MessageTextContent
 const Streamdown = typeof sdk === 'undefined' ? undefined : sdk.Streamdown
 // Deterministic blob avatars (name → face). Feature-detected: older SDKs
 // without the export fall back to the legacy math-face shapes below.
@@ -13005,7 +13006,11 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
                             // The app shell sets user-select: none globally; message bodies opt
                             // back in so drag-select and ⌘C work in group chat logs.
                             'data-selectable-text': 'true',
-                            children: Streamdown ? jsx(Streamdown, { children: entry.text }) : entry.text
+                            children: MessageTextContent
+                              ? jsx(MessageTextContent, { text: entry.text })
+                              : Streamdown
+                                ? jsx(Streamdown, { children: entry.text })
+                                : entry.text
                           }),
                           // User attachments: what every responding bot was
                           // shown — image previews, or a named chip for

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat-media.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat-media.test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+test('group room uses the canonical raw-message renderer with an older-SDK fallback (#93728)', () => {
+  const setup = source.slice(0, source.indexOf('export default'))
+  const workspace = source.slice(source.indexOf('function GroupChatWorkspace'))
+  const renderEntry = workspace.slice(workspace.indexOf('const renderEntry'), workspace.indexOf('// Threads:'))
+
+  assert.match(setup, /MessageTextContent = typeof sdk === 'undefined' \? undefined : sdk\.MessageTextContent/)
+  assert.match(renderEntry, /MessageTextContent\s*\? jsx\(MessageTextContent, \{ text: entry\.text \}\)/)
+  assert.match(renderEntry, /Streamdown\s*\? jsx\(Streamdown, \{ children: entry\.text \}\)/)
+})

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -1204,6 +1204,10 @@ export {
 
 export { PALETTE_AREA, type PaletteContribution } from '@/app/command-palette/contrib'
 export { type RouteContribution, ROUTES_AREA, SIDEBAR_NAV_AREA, type SidebarNavContribution } from '@/app/routes'
+/** Canonical raw message renderer: applies Desktop message transforms (including
+ * `MEDIA:` delivery directives) and the same rich Markdown/media components as
+ * core chat. Prefer this over raw Streamdown for transcript-style messages. */
+export { MessageTextContent } from '@/components/assistant-ui/markdown-text'
 /** THE full per-toolset config panel core Settings renders — provider picker,
  *  env vars / API keys, model catalog picker, and post-setup runners. Route-
  *  decoupled (the "manage keys" deep link is a no-op outside the router); pass


### PR DESCRIPTION
## What does this PR do?

Fixes Bot Mode group rooms displaying raw `MEDIA:` filesystem directives instead of the inline media UI used by standard Desktop chat.

Standard chat already transforms raw directives with `renderMediaTags()` and renders the resulting Hermes media links through `MarkdownTextContent` / `MediaAttachment`. Group rooms bypassed that pipeline and passed `entry.text` directly to raw `Streamdown`.

This adds one canonical raw-message component, `MessageTextContent`, which composes the existing transform and rich renderer. The Plugin SDK exports it additively, and Bot Mode feature-detects it before retaining the existing `Streamdown` → plain-text compatibility fallback for older Desktop builds. No parser, player, filesystem access, or remote-download logic is duplicated.

## Related Issue

Fixes #93728

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/assistant-ui/markdown-text.tsx`
  - Add `MessageTextContent`, the canonical raw-message entry point: `renderMediaTags()` → `MarkdownTextContent` → existing inline media components.
- `apps/desktop/src/sdk/index.ts`
  - Export the component through the additive Plugin SDK surface.
- `apps/desktop/src/plugins/hermes-bots/plugin.js`
  - Render group entries through the canonical component when available; preserve the older-SDK fallback.
- Tests
  - Assert a raw audio directive becomes an actual `<audio controls>` player without exposing `MEDIA:` text.
  - Lock the Bot group wiring and fallback contract.

The change does not modify media persistence, Bot messaging, TTS generation, group composers, sessions, profiles, or routing.

## How to Test

1. Open a Bot Mode group room.
2. Have a member return a directive such as `MEDIA:C:\\Temp\\group-voice.mp3`.
3. Confirm the room shows the standard inline audio player and filename instead of the raw directive/path.

Validation on rebased exact head `46630c942959398c81cbfd1aa56e04ca11911ca9` over `main@5ef1409f50484dddc38c9665b32a837ff1b191af`:

- Raw-media component regression: **5/5 passed**
- Full bundled Hermes Bots plugin suite: **557/557 passed**
- Desktop TypeScript typecheck: passed
- Production build + dist assertion: passed
- Shipped Electron boot baseline: **5/5 passed**
- Isolated real Electron Bot group MEDIA E2E: **1/1 passed**
  - visible `audio[controls]`
  - raw `MEDIA:` directive absent
  - media filename visible
- `git diff --check`: passed
- Claude Code exact-SHA review: **PASS**
- Codex exact-SHA review: **PASS**

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — not selected for this renderer-only Desktop change; no Python source changed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user workflow or configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; existing rendering/SDK architecture is reused
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — media resolution remains in the existing cross-platform pipeline
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model tool changed

## Screenshots / Logs

The isolated Electron E2E exercised the real visible Bot group workspace and verified the rendered player directly. No user transcript or local filesystem details are attached.
