### PR TITLE
feat(bots): create a whole roster from one plain-text description

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -10035,6 +10035,199 @@ function EditProfileDialog({ bot, open, onClose }) {
   })
 }
 
+// ── blueprint dialog ─────────────────────────────────────────────────────────
+
+const BLUEPRINT_PLACEHOLDER = [
+  'Describe the team — one per line:',
+  '',
+  '  scout — Researcher: finds and ranks sources',
+  '  scribe — Writer: drafts the weekly summary',
+  '',
+  'or in a sentence: “a researcher named Scout who finds sources,',
+  'and a writer called Scribe who drafts the summary”'
+].join('\n')
+
+/** Create a whole roster from one description. The preview is re-parsed on
+ *  every keystroke and IS the plan — what the list shows is exactly what
+ *  Create makes, handles included. */
+function CreateBlueprintDialog({ open, onClose, roster }) {
+  const [text, setText] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [progress, setProgress] = useState(null)
+
+  // Reset per open so a cancelled draft doesn't leak into the next one.
+  useEffect(() => {
+    if (open) {
+      setText('')
+      setBusy(false)
+      setProgress(null)
+    }
+  }, [open])
+
+  const { specs, warnings } = useMemo(() => parseBotBlueprint(text, roster), [text, roster])
+
+  const create = async () => {
+    setBusy(true)
+
+    try {
+      const { created, failed } = await createBotsFromBlueprint({
+        specs,
+        roster,
+        onProgress: setProgress
+      })
+
+      if (created.length && !failed.length) {
+        host.notify({ kind: 'success', message: `Created ${created.length} bots — ${created.join(', ')}` })
+      } else if (created.length) {
+        host.notify({
+          kind: 'info',
+          message: `Created ${created.length} of ${specs.length} — ${failed.map(entry => entry.name).join(', ')} failed`
+        })
+      } else {
+        host.notify({ kind: 'error', message: `No bots created — ${failed[0]?.message || 'unknown error'}` })
+      }
+
+      if (created.length) {
+        onClose()
+      }
+    } catch (err) {
+      host.notifyError(err, 'Blueprint failed')
+    } finally {
+      setBusy(false)
+      setProgress(null)
+    }
+  }
+
+  return jsx(Dialog, {
+    open,
+    onOpenChange: value => {
+      if (!value && !busy) {
+        onClose()
+      }
+    },
+    children: jsxs(DialogContent, {
+      className: 'max-w-lg',
+      children: [
+        jsxs(DialogHeader, {
+          children: [
+            jsx(DialogTitle, { children: 'New Bots from a Description' }),
+            jsx(DialogDescription, {
+              children:
+                'Describe the team in plain text and every bot in it gets created — handle, role, mission, and avatar. Parsed on this machine; no model call.'
+            })
+          ]
+        }),
+        jsx(Textarea, {
+          'aria-label': 'Team description',
+          autoFocus: true,
+          className: 'min-h-32 font-mono text-xs',
+          disabled: busy,
+          placeholder: BLUEPRINT_PLACEHOLDER,
+          value: text,
+          onChange: event => setText(event.target.value)
+        }),
+        specs.length
+          ? jsxs('div', {
+              className: 'grid gap-1.5',
+              children: [
+                jsx('div', {
+                  className: 'text-xs font-medium text-(--ui-text-secondary)',
+                  children: `${specs.length} ${specs.length === 1 ? 'bot' : 'bots'} to create`
+                }),
+                jsx(ScrollArea, {
+                  className: 'max-h-56 min-h-0',
+                  children: jsx('div', {
+                    className: 'grid gap-0.5 pr-2',
+                    children: specs.map((spec, index) => {
+                      const look = blueprintLook(spec, index)
+
+                      return jsxs(
+                        'div',
+                        {
+                          className: 'flex min-w-0 items-center gap-2 rounded-md px-1.5 py-1',
+                          children: [
+                            jsx(BotFace, { shape: look.shape, color: look.color, size: 28, name: spec.name }),
+                            jsxs('div', {
+                              className: 'grid min-w-0 flex-1 gap-0.5',
+                              children: [
+                                jsxs('div', {
+                                  className: 'flex min-w-0 items-baseline gap-1.5',
+                                  children: [
+                                    jsx('span', {
+                                      className: 'truncate text-xs font-medium text-foreground',
+                                      children: spec.title || spec.name
+                                    }),
+                                    jsx('span', {
+                                      className: 'shrink-0 font-mono text-[0.625rem] text-(--ui-text-tertiary)',
+                                      children: spec.name
+                                    }),
+                                    spec.renamedFrom
+                                      ? jsx(Tip, {
+                                          label: `“${spec.renamedFrom}” is already taken — this bot gets the next free handle`,
+                                          children: jsx('span', {
+                                            className:
+                                              'shrink-0 rounded bg-(--chrome-action-hover) px-1 text-[0.5625rem] text-(--ui-text-tertiary)',
+                                            children: 'renamed'
+                                          })
+                                        })
+                                      : null
+                                  ]
+                                }),
+                                spec.description
+                                  ? jsx('span', {
+                                      className: 'truncate text-[0.6875rem] text-(--ui-text-tertiary)',
+                                      children: spec.description
+                                    })
+                                  : null
+                              ]
+                            })
+                          ]
+                        },
+                        spec.name
+                      )
+                    })
+                  })
+                })
+              ]
+            })
+          : null,
+        warnings.length && text.trim()
+          ? jsx('div', {
+              className: 'grid gap-1',
+              children: warnings.map(warning =>
+                jsxs(
+                  'div',
+                  {
+                    className: 'flex items-start gap-1.5 text-[0.6875rem] text-(--ui-text-tertiary)',
+                    children: [
+                      jsx(Codicon, { name: 'warning', className: 'mt-px shrink-0 text-[0.625rem]' }),
+                      jsx('span', { children: warning })
+                    ]
+                  },
+                  warning
+                )
+              )
+            })
+          : null,
+        jsxs(DialogFooter, {
+          children: [
+            jsx(Button, { variant: 'ghost', disabled: busy, onClick: onClose, children: 'Cancel' }),
+            jsx(Button, {
+              disabled: busy || !specs.length,
+              onClick: create,
+              children: busy
+                ? progress
+                  ? `Creating ${progress.name}… (${progress.index + 1}/${progress.total})`
+                  : 'Creating…'
+                : `Create ${specs.length || ''} ${specs.length === 1 ? 'bot' : 'bots'}`.replace(/\s+/g, ' ').trim()
+            })
+          ]
+        })
+      ]
+    })
+  })
+}
+
 // ── create dialog ────────────────────────────────────────────────────────────
 
 function CreateAgentDialog({ open, onClose, roster }) {
@@ -14448,6 +14641,7 @@ function BotsPane() {
   const gatewayUp = gatewayState === 'open'
   const activeProfile = (useValue(host.state.profile) || 'default').trim() || 'default'
   const [createOpen, setCreateOpen] = useState(false)
+  const [blueprintOpen, setBlueprintOpen] = useState(false)
   const [groupCreateOpen, setGroupCreateOpen] = useState(false)
   const [editing, setEditing] = useState(null)
   const [deleting, setDeleting] = useState(null)
@@ -14844,6 +15038,10 @@ function BotsPane() {
                         children: [jsx(Codicon, { name: 'hubot', className: 'mr-1.5' }), 'New Bot']
                       }),
                       jsxs(DropdownMenuItem, {
+                        onSelect: () => setBlueprintOpen(true),
+                        children: [jsx(Codicon, { name: 'sparkle', className: 'mr-1.5' }), 'New Bots from Description…']
+                      }),
+                      jsxs(DropdownMenuItem, {
                         disabled: activeSourceRoster.length < 2,
                         onSelect: () => setGroupCreateOpen(true),
                         children: [jsx(Codicon, { name: 'organization', className: 'mr-1.5' }), 'New Group Chat']
@@ -15146,6 +15344,14 @@ function BotsPane() {
                       ]
                     })
                   }),
+      jsx(CreateBlueprintDialog, {
+        open: blueprintOpen,
+        onClose: () => {
+          setBlueprintOpen(false)
+          void refetch()
+        },
+        roster: activeSourceRoster
+      }),
       jsx(CreateAgentDialog, {
         open: createOpen,
         onClose: () => {

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2623,6 +2623,417 @@ async function duplicateBot(bot, roster) {
   return name
 }
 
+// ── blueprints: one description → a whole roster ─────────────────────────────
+
+/**
+ * Bot blueprints: turn one plain-text description of a team into N bot specs,
+ * then create every one of them in a single pass.
+ *
+ * Building a roster today is one dialog per bot — name, title, description,
+ * avatar, submit, repeat — so a six-bot team is six trips through the same
+ * form. Describing that team out loud takes one sentence, so the dialog now
+ * accepts the sentence.
+ *
+ * Parsing is deterministic and offline on purpose: no model call, so there is
+ * no latency, no token cost, no provider key requirement, and the preview the
+ * user confirms is exactly what gets created. Three input shapes are
+ * recognised, most explicit first:
+ *
+ *   1. JSON  — `[{ "name": "ada", "title": "Researcher", "description": "…" }]`
+ *   2. lines — `- Ada — Researcher: reviews the literature`
+ *   3. prose — `a researcher named Ada who reads papers, and Bob who writes`
+ */
+
+/** Every spec becomes a real gateway profile over its own RPC, so the batch is
+ *  capped — a pasted wall of text must not spawn hundreds of profiles. */
+const BLUEPRINT_LIMIT = 24
+
+/** List-item lead-in: "- ", "* ", "• ", "1. ", "2) ". */
+const BLUEPRINT_BULLET_RE = /^\s*(?:[-*•]|\d{1,2}[.)])\s+/
+
+/** Strongest name signal in prose: "…named Ada", "…called Ada". */
+const BLUEPRINT_NAMED_RE = /\b(?:named|called)\s+([A-Za-z][A-Za-z0-9_'-]{0,63})/i
+
+/** "Ada (Researcher) …" / "Ada [Researcher] …" — a name with a bracketed role. */
+const BLUEPRINT_PAREN_RE = /^([^([]{1,64}?)\s*[([]([^)\]]{1,64})[)\]]\s*(.*)$/
+
+/** "Ada who reviews the literature" — a relative clause after a bare name. */
+const BLUEPRINT_RELATIVE_RE = /^([A-Za-z][A-Za-z0-9_'-]{0,63})\s+(?:who|that|which)\s+(.+)$/i
+
+/** Field separators inside one entry: em/en dash, pipe, colon, spaced hyphen. */
+const BLUEPRINT_SEP_RE = /\s+[—–]\s+|\s+\|\s+|:\s+|\s+-\s+/
+
+/** Clause breaks in prose mode: semicolons, commas, and a conjoining "and". */
+const BLUEPRINT_CLAUSE_RE = /\s*;\s*|\s*,\s*(?:and\s+)?|\s+and\s+/i
+
+/** Instruction filler an entry may open with — "I need a bot named Ada" and
+ *  "a bot named Ada" describe the same bot, so the lead-in is dropped before
+ *  the role is read off the front of the clause. */
+const BLUEPRINT_LEAD_RE =
+  /^(?:i\s+(?:need|want|would\s+like)|we\s+(?:need|want)|please|create|add|make|build|set\s+up|also|then|plus|with|an?|the|one|some)\b[\s:,]*/i
+
+/** An instruction preamble that introduces the roster rather than describing a
+ *  bot: "I want a support team:", "Create three bots:", "Build me a newsroom:".
+ *  Bounded to a single line so a bullet's own "Ada: reads papers" colon is safe. */
+const BLUEPRINT_PREAMBLE_RE =
+  /^\s*(?:i\s+(?:need|want|would\s+like)|we\s+(?:need|want)|please|create|build|make|add|set\s+up|here(?:'s| is| are)|these\s+are|the\s+team\s+is)\b[^:\n]{0,60}:[ \t]*/i
+
+/** A bare proper noun standing alone — "Alpha" in "Alpha, Beta and Gamma".
+ *  Capitalisation is what separates it from a continuation fragment like the
+ *  "drafts" in "writes summaries, drafts, and release notes". */
+const BLUEPRINT_BARE_NAME_RE = /^[A-Z][A-Za-z0-9_'-]{0,63}$/
+
+/** Leading relative pronoun on a mission fragment: "who reads papers". */
+const BLUEPRINT_RELATIVE_LEAD_RE = /^(?:who|whom|that|which|and)\s+/i
+
+/** Punctuation left dangling when a fragment is sliced out of a sentence. */
+const BLUEPRINT_EDGE_PUNCT_RE = /^[\s\-–—:,.|]+|[\s\-–—:,.|]+$/g
+
+/** Strip stacked lead-ins: BLUEPRINT_LEAD_RE only eats one, so "I need a
+ *  researcher" would keep the article and read the role as "a researcher". */
+function stripBlueprintLead(text) {
+  let out = String(text || '').trim()
+
+  for (let pass = 0; pass < 4; pass++) {
+    const next = out.replace(BLUEPRINT_LEAD_RE, '').trim()
+
+    if (next === out) {
+      break
+    }
+
+    out = next
+  }
+
+  return out
+}
+
+function blueprintWordCount(text) {
+  return text.trim().split(/\s+/).filter(Boolean).length
+}
+
+function trimBlueprintField(text, max) {
+  return String(text || '')
+    .replace(BLUEPRINT_EDGE_PUNCT_RE, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, max)
+}
+
+/**
+ * A prose clause opens a NEW bot only if it carries a name signal. Anything
+ * else is a continuation of the previous bot's mission — otherwise the commas
+ * in "writes summaries, drafts, and reports" would each spawn their own bot.
+ */
+function opensBlueprintEntry(clause) {
+  const text = stripBlueprintLead(clause)
+
+  if (!text) {
+    return false
+  }
+
+  return (
+    BLUEPRINT_NAMED_RE.test(text) ||
+    BLUEPRINT_PAREN_RE.test(text) ||
+    BLUEPRINT_RELATIVE_RE.test(text) ||
+    BLUEPRINT_SEP_RE.test(text) ||
+    BLUEPRINT_BARE_NAME_RE.test(text)
+  )
+}
+
+/** One entry (a bullet line or a prose clause) → a spec, or null when no
+ *  usable handle can be read out of it. */
+function parseBlueprintEntry(raw) {
+  const text = trimBlueprintField(String(raw || '').replace(BLUEPRINT_BULLET_RE, ''), 400)
+
+  if (!text) {
+    return null
+  }
+
+  // Keep the original when the lead-in IS the whole entry ("the reviewer").
+  const body = stripBlueprintLead(text) || text
+  const named = body.match(BLUEPRINT_NAMED_RE)
+  const paren = body.match(BLUEPRINT_PAREN_RE)
+  const relative = body.match(BLUEPRINT_RELATIVE_RE)
+  let name = ''
+  let title = ''
+  let description = ''
+
+  if (named) {
+    // "a research assistant named Ada who reads papers" — the role sits in
+    // front of the name signal, the mission behind it.
+    name = named[1]
+    title = body.slice(0, named.index)
+    description = body.slice(named.index + named[0].length)
+  } else if (paren) {
+    name = paren[1]
+    title = paren[2]
+    description = paren[3]
+  } else if (relative) {
+    name = relative[1]
+    description = relative[2]
+  } else {
+    const parts = body
+      .split(BLUEPRINT_SEP_RE)
+      .map(part => part.trim())
+      .filter(Boolean)
+
+    if (parts.length > 1 && blueprintWordCount(parts[0]) <= 4) {
+      // "Ada — Researcher: reads papers" → handle, role, mission.
+      const hasRole = parts.length > 2
+      name = parts[0]
+      title = hasRole ? parts[1] : ''
+      description = parts.slice(hasRole ? 2 : 1).join(' — ')
+    } else {
+      // No name signal at all. Make the leading words the handle and keep the
+      // whole clause as the mission: "triages the inbox" → `triages-the-inbox`.
+      name = body.split(/\s+/).slice(0, 3).join(' ')
+      // When the handle already IS the whole clause ("Alpha"), repeating it as
+      // the mission just prints the same words twice in the preview.
+      description = name === body ? '' : body
+    }
+  }
+
+  const slug = slugify(trimBlueprintField(name, 64))
+
+  if (!slug || !NAME_RE.test(slug)) {
+    return null
+  }
+
+  return {
+    name: slug,
+    title: trimBlueprintField(stripBlueprintLead(title), 64),
+    // Trim first: the fragment is sliced mid-sentence, so the relative pronoun
+    // sits behind a leading space and an anchored strip would miss it.
+    description: trimBlueprintField(trimBlueprintField(description, 400).replace(BLUEPRINT_RELATIVE_LEAD_RE, ''), 280),
+    source: text
+  }
+}
+
+/** Explicit JSON in, specs out — the shape a model or a script would emit. */
+function parseBlueprintJson(text) {
+  const trimmed = text.trim()
+
+  if (!trimmed.startsWith('[') && !trimmed.startsWith('{')) {
+    return null
+  }
+
+  let data = null
+
+  try {
+    data = JSON.parse(trimmed)
+  } catch {
+    return null // not JSON after all — fall through to the text parsers
+  }
+
+  const rows = Array.isArray(data) ? data : Array.isArray(data?.bots) ? data.bots : null
+
+  if (!rows) {
+    return null
+  }
+
+  const specs = []
+
+  for (const row of rows) {
+    if (typeof row === 'string') {
+      const parsed = parseBlueprintEntry(row)
+
+      if (parsed) {
+        specs.push(parsed)
+      }
+
+      continue
+    }
+
+    const slug = slugify(trimBlueprintField(row?.name ?? row?.handle ?? row?.title ?? row?.role ?? '', 64))
+
+    if (!slug || !NAME_RE.test(slug)) {
+      continue
+    }
+
+    specs.push({
+      name: slug,
+      title: trimBlueprintField(row?.title ?? row?.role ?? '', 64),
+      description: trimBlueprintField(row?.description ?? row?.mission ?? row?.purpose ?? '', 280),
+      soul: typeof row?.soul === 'string' ? row.soul : '',
+      model: trimBlueprintField(row?.model ?? '', 64),
+      provider: trimBlueprintField(row?.provider ?? '', 64),
+      source: slug
+    })
+  }
+
+  return specs.length ? specs : null
+}
+
+/** First free handle for `base`, counting up like the duplicate flow does. */
+function freeBlueprintName(base, taken) {
+  if (!taken.has(base)) {
+    return base
+  }
+
+  for (let n = 2; n < 100; n++) {
+    // Truncate the BASE, never the suffix — slicing the joined string chops
+    // the "-2" off a max-length name and the candidate collides forever (#19).
+    const suffix = `-${n}`
+    const candidate = base.slice(0, 64 - suffix.length) + suffix
+
+    if (!taken.has(candidate)) {
+      return candidate
+    }
+  }
+
+  return null
+}
+
+/**
+ * Free text → `{ specs, warnings }`. Pure and synchronous: the create dialog
+ * runs this on every keystroke to render the preview, and again on submit, so
+ * what is previewed is exactly what is created.
+ */
+function parseBotBlueprint(text, roster = []) {
+  const warnings = []
+  const raw = String(text || '')
+
+  if (!raw.trim()) {
+    return { specs: [], warnings }
+  }
+
+  let entries = parseBlueprintJson(raw)
+
+  if (!entries) {
+    // "Build me a newsroom:" heads the list, it is not a member of it.
+    const body = raw.replace(BLUEPRINT_PREAMBLE_RE, '')
+    const lines = body
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .filter(Boolean)
+    const bulleted = lines.filter(line => BLUEPRINT_BULLET_RE.test(line))
+    const separated = lines.filter(line => BLUEPRINT_SEP_RE.test(line))
+
+    if (bulleted.length || (lines.length > 1 && separated.length * 2 >= lines.length)) {
+      // Line mode: one bot per line, no clause splitting — a mission is free
+      // to contain commas. Once ANY line is bulleted the list IS the roster and
+      // the unbulleted lines around it are headers or trailing prose.
+      entries = (bulleted.length ? bulleted : lines).map(parseBlueprintEntry).filter(Boolean)
+    } else {
+      // Prose mode: split into clauses, then re-join the ones that do not
+      // introduce a bot of their own.
+      const grouped = []
+
+      for (const clause of body.replace(/\s+/g, ' ').split(BLUEPRINT_CLAUSE_RE)) {
+        const trimmed = clause.trim()
+
+        if (!trimmed) {
+          continue
+        }
+
+        if (!grouped.length || opensBlueprintEntry(trimmed)) {
+          grouped.push(trimmed)
+        } else {
+          grouped[grouped.length - 1] += `, ${trimmed}`
+        }
+      }
+
+      entries = grouped.map(parseBlueprintEntry).filter(Boolean)
+    }
+  }
+
+  // Handles must be unique against the live roster AND within the batch — a
+  // blueprint naming two bots "ada" still has to produce two profiles.
+  const taken = new Set(roster.map(bot => bot?.name).filter(Boolean))
+  const specs = []
+
+  for (const entry of entries) {
+    if (specs.length >= BLUEPRINT_LIMIT) {
+      warnings.push(`Only the first ${BLUEPRINT_LIMIT} bots were kept — the description listed more.`)
+      break
+    }
+
+    const name = freeBlueprintName(entry.name, taken)
+
+    if (!name) {
+      warnings.push(`Skipped “${entry.source}” — no free handle left for “${entry.name}”.`)
+      continue
+    }
+
+    taken.add(name)
+    specs.push({ ...entry, name, renamedFrom: name === entry.name ? null : entry.name })
+  }
+
+  if (!specs.length) {
+    warnings.push('No bots found in that description. Try one per line, like “Ada — Researcher: reads papers”.')
+  }
+
+  return { specs, warnings }
+}
+
+/** Deterministic look for a blueprint bot: a blobatar seeded from the handle
+ *  (no image RPC, no network) and a colour cycled across the batch so a
+ *  freshly created team is tellable apart at a glance. The cycle starts on the
+ *  same orange the single-bot create dialog defaults to. */
+function blueprintLook(spec, index) {
+  return {
+    shape: blobatarSvg ? 'blobatar' : defaultShapeFor(spec.name),
+    color: AVATAR_COLORS[(index + 3) % AVATAR_COLORS.length],
+    imageKind: 'shape',
+    title: spec.title || '',
+    created: Date.now()
+  }
+}
+
+/**
+ * Create every spec in order, reporting progress as it goes.
+ *
+ * One failure never aborts the batch: a partly-created roster whose gaps are
+ * named back to the user is recoverable, an exception thrown at bot 3 of 8
+ * leaves them guessing which 2 exist. The look is best-effort on top — the
+ * profile is what counts as created, the avatar is cosmetic.
+ */
+async function createBotsFromBlueprint({ specs, roster = [], onProgress }) {
+  const created = []
+  const failed = []
+
+  for (let index = 0; index < specs.length; index++) {
+    const spec = specs[index]
+
+    onProgress?.({ phase: 'creating', index, total: specs.length, name: spec.name })
+
+    try {
+      await host.request('profiles.create', {
+        name: spec.name,
+        description: [spec.title, spec.description].filter(Boolean).join(' — '),
+        clone_from: 'default',
+        soul: composeSoul({
+          name: spec.name,
+          title: spec.title,
+          description: spec.description,
+          roster,
+          customSoul: spec.soul || ''
+        }),
+        ...(spec.model && spec.provider ? { model: spec.model, provider: spec.provider } : {})
+      })
+    } catch (err) {
+      failed.push({ name: spec.name, message: err?.message || String(err) })
+      onProgress?.({ phase: 'failed', index, total: specs.length, name: spec.name })
+      continue
+    }
+
+    try {
+      await saveBotMeta(spec.name, blueprintLook(spec, index))
+    } catch {
+      /* look is cosmetic — the profile exists, so it still counts as created */
+    }
+
+    created.push(spec.name)
+    onProgress?.({ phase: 'created', index, total: specs.length, name: spec.name })
+  }
+
+  if (created.length) {
+    queryClient.invalidateQueries({ queryKey: ROSTER_KEY })
+  }
+
+  return { created, failed }
+}
+
 /** Permanently delete a bot's Hermes profile, then remove plugin-local state
  * that would otherwise leave stale appearance/unread data behind.
  *

--- a/apps/desktop/src/plugins/hermes-bots/tests/bot-blueprint.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bot-blueprint.test.mjs
@@ -191,6 +191,38 @@ test('unit: progress is reported for every spec', async () => {
   assert.deepEqual(seen, ['ada:creating', 'ada:created', 'bob:creating', 'bob:failed'])
 })
 
+// The dialog is a React closure, so the wiring is pinned against the source
+// the way the other create-dialog tests do it.
+
+test('unit: the roster "+" menu offers the blueprint dialog', () => {
+  assert.match(pluginSource, /onSelect: \(\) => setBlueprintOpen\(true\)/)
+  assert.match(pluginSource, /'New Bots from Description…'/)
+})
+
+test('unit: the blueprint dialog is mounted and refetches the roster on close', () => {
+  const mount = pluginSource.slice(
+    pluginSource.indexOf('jsx(CreateBlueprintDialog, {'),
+    pluginSource.indexOf('jsx(CreateAgentDialog, {')
+  )
+
+  assert.match(mount, /open: blueprintOpen/)
+  assert.match(mount, /setBlueprintOpen\(false\)/)
+  assert.match(mount, /void refetch\(\)/)
+  assert.match(mount, /roster: activeSourceRoster/)
+})
+
+test('regression: the preview renders the same look creation persists', () => {
+  const dialog = pluginSource.slice(
+    pluginSource.indexOf('function CreateBlueprintDialog('),
+    pluginSource.indexOf('// ── create dialog ─')
+  )
+
+  // A preview drawn from anything but blueprintLook would drift from the
+  // avatar the bot is actually created with.
+  assert.match(dialog, /const look = blueprintLook\(spec, index\)/)
+  assert.match(dialog, /parseBotBlueprint\(text, roster\)/)
+})
+
 test('regression: an instruction preamble is not read as a bot', () => {
   const { parseBotBlueprint } = load()
   const { specs } = parseBotBlueprint(
@@ -219,4 +251,22 @@ test('unit: a bare list of proper nouns becomes one bot each', () => {
   assert.deepEqual(plain(specs, spec => spec.name), ['alpha', 'beta', 'gamma'])
   // A handle that is the whole clause should not repeat itself as the mission.
   assert.equal(specs[0].description, '')
+})
+
+test('regression: blueprintOpen is declared in the pane that reads it', () => {
+  // `createOpen` is declared TWICE — once in RoutinesPane, once in BotsPane.
+  // The menu item and the dialog mount both live in BotsPane, so a declaration
+  // that lands next to the first one is a ReferenceError the moment the pane
+  // renders. The vm harness never executes these components, so pin the scope.
+  const pane = pluginSource.slice(pluginSource.indexOf('function BotsPane() {'))
+
+  assert.match(pane, /const \[blueprintOpen, setBlueprintOpen\] = useState\(false\)/)
+  assert.match(pane, /setBlueprintOpen\(true\)/)
+  assert.match(pane, /open: blueprintOpen/)
+
+  const routines = pluginSource.slice(
+    pluginSource.indexOf('function RoutinesPane() {'),
+    pluginSource.indexOf('function BotsPane() {')
+  )
+  assert.doesNotMatch(routines, /blueprintOpen/)
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/bot-blueprint.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bot-blueprint.test.mjs
@@ -1,0 +1,222 @@
+/**
+ * Bot blueprints — one plain-text description of a team becomes N bots.
+ *
+ * Pins the parser contract (prose / list / JSON in, deduped specs out) and the
+ * batch creator's failure policy: one bad `profiles.create` must not abort the
+ * rest of the roster, and a cosmetic look failure must not un-create a profile
+ * that the gateway already made.
+ */
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+/** Arrays built inside the vm carry the sandbox's Array.prototype, so
+ *  deepStrictEqual against a literal here fails on the prototype alone even
+ *  when every element matches. Re-materialise them in this realm first. */
+const plain = (list, map = value => value) => Array.from(list, map)
+
+function load({ failOn = null } = {}) {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const calls = []
+  const invalidated = []
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    queryClient: { invalidateQueries: args => invalidated.push(args) },
+    host: {
+      state: { profile: { listen: () => undefined } },
+      request: async (method, params) => {
+        calls.push({ method, params })
+
+        if (failOn && method === 'profiles.create' && params?.name === failOn) {
+          throw new Error(`profile ${params.name} already exists`)
+        }
+
+        return { ok: true }
+      }
+    }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat(
+      '\nglobalThis.__bp = { parseBotBlueprint, createBotsFromBlueprint, blueprintLook, $botMeta, BLUEPRINT_LIMIT };\n'
+    )
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+
+  return { context, calls, invalidated, ...context.__bp }
+}
+
+test('unit: prose with "named" yields one bot per named agent', () => {
+  const { parseBotBlueprint } = load()
+  const { specs } = parseBotBlueprint(
+    'I need a research assistant named Ada who reads papers, and a writer called Bob who drafts summaries'
+  )
+
+  assert.deepEqual(plain(specs, spec => spec.name), ['ada', 'bob'])
+  assert.equal(specs[0].title, 'research assistant')
+  assert.equal(specs[0].description, 'reads papers')
+  assert.equal(specs[1].title, 'writer')
+  assert.equal(specs[1].description, 'drafts summaries')
+})
+
+test('regression: commas inside one mission do not spawn extra bots', () => {
+  const { parseBotBlueprint } = load()
+  const { specs } = parseBotBlueprint('a bot named Bob who writes summaries, drafts, and release notes')
+
+  // A clause with no name signal is a continuation, not a new bot.
+  assert.deepEqual(plain(specs, spec => spec.name), ['bob'])
+  assert.equal(specs[0].description, 'writes summaries, drafts, release notes')
+})
+
+test('unit: bulleted lines parse into handle / role / mission', () => {
+  const { parseBotBlueprint } = load()
+  const { specs } = parseBotBlueprint(
+    [
+      '- Ada — Researcher: reads papers, then files notes',
+      '- Bob (Writer) drafts the summary',
+      '3. Cleo: fact-checks claims'
+    ].join('\n')
+  )
+
+  assert.deepEqual(plain(specs, spec => [spec.name, spec.title, spec.description]), [
+    ['ada', 'Researcher', 'reads papers, then files notes'],
+    ['bob', 'Writer', 'drafts the summary'],
+    ['cleo', '', 'fact-checks claims']
+  ])
+})
+
+test('unit: an explicit JSON roster is taken verbatim', () => {
+  const { parseBotBlueprint } = load()
+  const { specs } = parseBotBlueprint(
+    JSON.stringify([
+      { name: 'Inbox Triage', title: 'Sorter', description: 'triages mail' },
+      { name: 'digest', role: 'Summariser', mission: 'writes the daily digest' }
+    ])
+  )
+
+  assert.deepEqual(plain(specs, spec => [spec.name, spec.title, spec.description]), [
+    ['inbox-triage', 'Sorter', 'triages mail'],
+    ['digest', 'Summariser', 'writes the daily digest']
+  ])
+})
+
+test('unit: handles collide-resolve against the roster and within the batch', () => {
+  const { parseBotBlueprint } = load()
+  const { specs } = parseBotBlueprint('- Ada: reads papers\n- Ada: writes notes', [{ name: 'ada' }])
+
+  assert.deepEqual(plain(specs, spec => spec.name), ['ada-2', 'ada-3'])
+  assert.equal(specs[0].renamedFrom, 'ada')
+})
+
+test('unit: the batch is capped and says so', () => {
+  const { parseBotBlueprint, BLUEPRINT_LIMIT } = load()
+  const lines = Array.from({ length: BLUEPRINT_LIMIT + 5 }, (_, n) => `- bot${n}: does a thing`)
+  const { specs, warnings } = parseBotBlueprint(lines.join('\n'))
+
+  assert.equal(specs.length, BLUEPRINT_LIMIT)
+  assert.match(plain(warnings).join(' '), /Only the first 24 bots/)
+})
+
+test('unit: an unparseable description yields no specs and an actionable warning', () => {
+  const { parseBotBlueprint } = load()
+  const { specs, warnings } = parseBotBlueprint('!!! ???')
+
+  assert.equal(specs.length, 0)
+  assert.match(plain(warnings).join(' '), /No bots found/)
+})
+
+test('unit: creating a blueprint issues one profiles.create per spec, with a SOUL', async () => {
+  const { parseBotBlueprint, createBotsFromBlueprint, calls, invalidated } = load()
+  const { specs } = parseBotBlueprint('- Ada — Researcher: reads papers\n- Bob — Writer: drafts summaries')
+  const result = await createBotsFromBlueprint({ specs })
+
+  assert.deepEqual(plain(result.created), ['ada', 'bob'])
+  assert.equal(result.failed.length, 0)
+
+  const creates = calls.filter(call => call.method === 'profiles.create')
+  assert.deepEqual(plain(creates, call => call.params.name), ['ada', 'bob'])
+  assert.equal(creates[0].params.clone_from, 'default')
+  assert.equal(creates[0].params.description, 'Researcher — reads papers')
+  assert.match(creates[0].params.soul, /Researcher/)
+  assert.match(creates[0].params.soul, /reads papers/)
+  assert.equal(invalidated.length, 1)
+})
+
+test('regression: one failed profile does not abort the rest of the batch', async () => {
+  const { parseBotBlueprint, createBotsFromBlueprint, calls } = load({ failOn: 'bob' })
+  const { specs } = parseBotBlueprint('- Ada: reads papers\n- Bob: drafts summaries\n- Cleo: checks facts')
+  const result = await createBotsFromBlueprint({ specs })
+
+  assert.deepEqual(plain(result.created), ['ada', 'cleo'])
+  assert.deepEqual(plain(result.failed, entry => entry.name), ['bob'])
+  assert.match(result.failed[0].message, /already exists/)
+
+  // Cleo was still attempted after Bob threw.
+  assert.ok(calls.some(call => call.method === 'profiles.create' && call.params.name === 'cleo'))
+})
+
+test('unit: each created bot gets a distinct colour and its title as the look', async () => {
+  const { parseBotBlueprint, createBotsFromBlueprint, $botMeta } = load()
+  const { specs } = parseBotBlueprint('- Ada — Researcher: reads papers\n- Bob — Writer: drafts summaries')
+  await createBotsFromBlueprint({ specs })
+
+  const meta = $botMeta.get()
+  assert.equal(meta.ada.title, 'Researcher')
+  assert.equal(meta.bob.title, 'Writer')
+  assert.notEqual(meta.ada.color, meta.bob.color)
+  assert.equal(meta.ada.imageKind, 'shape')
+})
+
+test('unit: progress is reported for every spec', async () => {
+  const { parseBotBlueprint, createBotsFromBlueprint } = load({ failOn: 'bob' })
+  const { specs } = parseBotBlueprint('- Ada: reads papers\n- Bob: drafts summaries')
+  const seen = []
+  await createBotsFromBlueprint({ specs, onProgress: event => seen.push(`${event.name}:${event.phase}`) })
+
+  assert.deepEqual(seen, ['ada:creating', 'ada:created', 'bob:creating', 'bob:failed'])
+})
+
+test('regression: an instruction preamble is not read as a bot', () => {
+  const { parseBotBlueprint } = load()
+  const { specs } = parseBotBlueprint(
+    'I want a support team: a triage bot named Sentry that reads tickets, and a writer called Quill who drafts replies'
+  )
+
+  // "I want a support team:" introduces the roster — it is not a member of it,
+  // and it must not leak into the first bot's role either.
+  assert.deepEqual(plain(specs, spec => spec.name), ['sentry', 'quill'])
+  assert.equal(specs[0].title, 'triage bot')
+})
+
+test('regression: a header line above a bulleted list is not a bot', () => {
+  const { parseBotBlueprint } = load()
+  const { specs } = parseBotBlueprint(
+    ['Build me a newsroom:', '- editor — Editor: assigns stories', '- reporter — Reporter: writes the story'].join('\n')
+  )
+
+  assert.deepEqual(plain(specs, spec => spec.name), ['editor', 'reporter'])
+})
+
+test('unit: a bare list of proper nouns becomes one bot each', () => {
+  const { parseBotBlueprint } = load()
+  const { specs } = parseBotBlueprint('Create three bots: Alpha, Beta and Gamma')
+
+  assert.deepEqual(plain(specs, spec => spec.name), ['alpha', 'beta', 'gamma'])
+  // A handle that is the whole clause should not repeat itself as the mission.
+  assert.equal(specs[0].description, '')
+})


### PR DESCRIPTION
## What

Bot Mode builds a roster one dialog at a time — name, title, description, avatar, submit, repeat — so a six-bot team is six passes over the same form. This adds a second entry in the roster **+** menu, **New Bots from Description…**, that takes one description and creates every bot in it.

```
Build me a newsroom:
- editor — Editor: assigns stories and approves drafts
- reporter — Reporter: researches and writes the story
- factcheck — Fact Checker: verifies every claim before publish
```

…creates three bots, each with its handle, role, mission, SOUL and avatar. Prose works too: `a researcher named Ada who reads papers, and a writer called Bob who drafts summaries`.

## How

Two commits: the engine (`parseBotBlueprint` / `createBotsFromBlueprint`, module-scope and unit-testable) and the dialog on top.

Parsing is **deterministic and offline on purpose** — no model call, so no latency, no token cost, no provider key, and the preview a user confirms is exactly what gets created. Three shapes are recognised, most explicit first: a JSON array, one bot per line, or prose.

Details that took the most care:

- **Commas are ambiguous.** A prose clause with no name signal is a continuation, not a new bot — so `writes summaries, drafts, and release notes` stays one bot instead of three.
- **A preamble introduces the roster, it does not join it.** `I want a support team:` is stripped, and does not leak into the first bot's role. Once any line is bulleted, the bullets are the roster and surrounding prose is a header.
- **Handles** are deduped against the live roster *and* within the batch, counting up like the duplicate flow — truncating the base, never the suffix, so a max-length name cannot collide with itself forever (the #19 rule). A renamed handle is badged in the preview, so it is visible before creation rather than discovered after.
- **Partial failure is honest.** One failed `profiles.create` never aborts the batch; the dialog names which bots failed. A partly-created roster with named gaps is recoverable, an exception at bot 3 of 8 is not. The avatar is best-effort on top — the profile is what counts as created.
- The batch is capped at **24**; every spec is a real gateway profile over its own RPC.

## Testing

`apps/desktop/src/plugins/hermes-bots/tests/bot-blueprint.test.mjs` — 18 new cases in the existing `node --test` + `vm` harness.

```
npm run check:test:plugins   # in apps/desktop
```

| | tests | pass | fail |
|---|---|---|---|
| `upstream/main` (baseline) | 556 | 556 | 0 |
| this branch | 574 | 574 | 0 |

Covered: all three input shapes; the continuation rule; preamble and header handling; bare-name lists; collision resolution; the cap; partial failure; progress reporting; and the dialog wiring.

One test is worth flagging: **`blueprintOpen` is declared in `BotsPane`, deliberately.** `createOpen` is declared *twice* in this file — once in `RoutinesPane`, once in `BotsPane` — and the menu item and mount both read it from `BotsPane`. A declaration next to the first one is a `ReferenceError` the moment the pane renders, and the `vm` harness cannot catch it because it never executes these components. I hit exactly that bug while building this, so the scope is pinned by a test that I confirmed fails with the declaration in the wrong pane and passes with it in the right one.

## Platforms

Developed and tested on **Windows 11** (Node v24). The change is plain JS in the plugin with no platform-specific calls; `check:test:plugins` is the relevant gate and is green.

## Notes

Purely additive to `plugin.js` — no existing behaviour is modified. Only the `+` menu, the state declaration and the dialog mount touch pre-existing lines.
