### PR TITLE
fix(update): fail closed on unproven stash restore

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2074,6 +2074,38 @@ from hermes_constants import get_hermes_home, get_hermes_home_override
 from utils import atomic_json_write, base_url_hostname, is_truthy_value
 _hermes_home = get_hermes_home()
 
+_UPDATE_EXIT_PENDING = "2"
+_POST_RESTART_AGENT_HEALTH_TIMEOUT_SECONDS = 120
+
+
+def _post_restart_agent_health_check() -> tuple[bool, str | None]:
+    """Prove that the freshly restarted agent entrypoint can be imported.
+
+    Platform adapters can connect while ``run_agent`` is unimportable.  The
+    updater therefore leaves a pending marker before restart, and the new
+    gateway consumes it only after this isolated probe succeeds.  A subprocess
+    keeps import-time side effects out of the long-lived gateway process and
+    disables bytecode writes in the checkout.
+    """
+    probe_env = os.environ.copy()
+    probe_env["PYTHONDONTWRITEBYTECODE"] = "1"
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", "import run_agent"],
+            cwd=str(Path(__file__).resolve().parent.parent),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_POST_RESTART_AGENT_HEALTH_TIMEOUT_SECONDS,
+            env=probe_env,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return False, f"could not run agent import probe: {type(exc).__name__}"
+    if result.returncode != 0:
+        return False, f"agent import probe exited with status {result.returncode}"
+    return True, None
+
 # Load environment variables from ~/.hermes/.env first.
 # User-managed env files should override stale shell exports on restart.
 from dotenv import load_dotenv  # noqa: F401  # backward-compat for tests that monkeypatch this symbol
@@ -13273,6 +13305,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         
         # Check if we're restarting after a /update command. If the update is
         # still running, keep watching so we notify once it actually finishes.
+        self._finalize_pending_update_health()
         notified = await self._send_update_notification()
         if not notified and any(
             path.exists()
@@ -24013,6 +24046,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
 
 
+    def _finalize_pending_update_health(self) -> None:
+        """Finalize a gateway update only after the new agent proves healthy."""
+        exit_code_path = _hermes_home / ".update_exit_code"
+        try:
+            if exit_code_path.read_text(encoding="utf-8").strip() != _UPDATE_EXIT_PENDING:
+                return
+        except OSError:
+            return
+
+        healthy, detail = _post_restart_agent_health_check()
+        try:
+            exit_code_path.write_text("0" if healthy else "1", encoding="utf-8")
+        except OSError as exc:
+            # Leaving the pending marker is fail-closed: the watcher will not
+            # announce success without a durable final outcome.
+            logger.warning("Could not persist post-restart update outcome: %s", exc)
+            return
+        if healthy:
+            logger.info("Post-restart agent health probe passed")
+        else:
+            logger.error("Post-restart agent health probe failed: %s", detail)
+
     def _schedule_update_notification_watch(self) -> None:
         """Ensure a background task is watching for update completion."""
         existing_task = getattr(self, "_update_notification_task", None)
@@ -24146,6 +24201,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         while loop.time() < deadline:
             # Check for completion
             if exit_code_path.exists():
+                try:
+                    if exit_code_path.read_text(encoding="utf-8").strip() == _UPDATE_EXIT_PENDING:
+                        await asyncio.sleep(poll_interval)
+                        continue
+                except OSError:
+                    pass
                 # Read any remaining output
                 if output_path.exists():
                     try:
@@ -24325,6 +24386,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return False
 
             exit_code_raw = exit_code_path.read_text(encoding="utf-8").strip() or "1"
+            if exit_code_raw == _UPDATE_EXIT_PENDING:
+                logger.info("Update notification deferred: post-restart health is pending")
+                cleanup = False
+                active_pending_path = pending_path
+                claimed_path.replace(pending_path)
+                return False
             exit_code = int(exit_code_raw)
 
             # Read the captured update output

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2087,8 +2087,13 @@ def _post_restart_agent_health_check() -> tuple[bool, str | None]:
     keeps import-time side effects out of the long-lived gateway process and
     disables bytecode writes in the checkout.
     """
-    probe_env = os.environ.copy()
-    probe_env["PYTHONDONTWRITEBYTECODE"] = "1"
+    from tools.environments.local import build_subprocess_env
+
+    probe_env = build_subprocess_env(
+        scrub_secrets=False,
+        inherit_profile_home=False,
+        extra={"PYTHONDONTWRITEBYTECODE": "1"},
+    )
     try:
         result = subprocess.run(
             [sys.executable, "-c", "import run_agent"],

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -6066,9 +6066,29 @@ class GatewaySlashCommandsMixin:
                     env["PYTHONUNBUFFERED"] = "1"
                     with open(output_path, "wb") as f:
                         proc = subprocess.Popen(cmd, stdout=f, stderr=subprocess.STDOUT, env=env)
-                        rc = proc.wait(timeout=3600)
-                    with open(exit_code_path, "w", encoding="utf-8") as f:
-                        f.write(str(rc))
+                        try:
+                            rc = proc.wait(timeout=1800)
+                        except subprocess.TimeoutExpired:
+                            proc.kill()
+                            proc.wait()
+                            rc = 124
+                    marker = ""
+                    try:
+                        with open(exit_code_path, encoding="utf-8") as f:
+                            marker = f.read().strip()
+                    except OSError:
+                        pass
+                    # A non-zero child result is terminal.  A successful
+                    # child must leave every existing marker alone: code 2 is
+                    # waiting for the new gateway, while 0/1 are already
+                    # terminal outcomes written by one of the two processes.
+                    if rc != 0:
+                        with open(exit_code_path, "w", encoding="utf-8") as f:
+                            f.write(str(rc))
+                    elif not marker:
+                        # No durable marker means no proof of the update path.
+                        with open(exit_code_path, "w", encoding="utf-8") as f:
+                            f.write("1")
                     """
                 ).strip()
                 subprocess.Popen(
@@ -6091,7 +6111,16 @@ class GatewaySlashCommandsMixin:
                     # in zsh, and this command string is copied/reused in macOS/zsh
                     # operator wrappers. Keep the template zsh-safe even though this
                     # specific subprocess currently runs under bash.
-                    f"rc=$?; printf '%s' \"$rc\" > {shlex.quote(str(exit_code_path))}"
+                    f"rc=$?; marker_state=''; "
+                    f"if [ -f {shlex.quote(str(exit_code_path))} ]; then "
+                    f"IFS= read -r marker_state < {shlex.quote(str(exit_code_path))} || true; fi; "
+                    # Code 2 is a restart-pending outcome.  Keep it until the
+                    # new gateway completes the post-restart agent probe; a
+                    # failed child result still becomes the terminal outcome.
+                    f"if [ \"$rc\" -ne 0 ]; then "
+                    f"printf '%s' \"$rc\" > {shlex.quote(str(exit_code_path))}; "
+                    f"elif [ -z \"$marker_state\" ]; then "
+                    f"printf '%s' '1' > {shlex.quote(str(exit_code_path))}; fi"
                 )
                 setsid_bin = shutil.which("setsid")
                 if setsid_bin:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -428,66 +428,45 @@ _UPDATE_CRITICAL_MODULES = (
 )
 
 
-def _validate_critical_modules_import(
-    root, *, strict: bool = False
-) -> tuple[bool, str | None, str | None]:
-    """Import each module in ``_UPDATE_CRITICAL_MODULES`` in a subprocess.
+_IMPORT_PROBE_MARKER = "__HERMES_IMPORT_PROBE__"
 
-    ``_validate_critical_files_syntax`` only *parses* files, so it cannot see
-    cross-module breakage: a partially-updated tree where ``agent/`` is new but
-    ``tools/`` is old parses perfectly and still dies at startup with
-    ``ImportError: cannot import name 'TODO_INJECTION_HEADER' from
-    'tools.todo_tool'``. Every file is valid Python; the *combination* is not.
 
-    That skew is reachable on the Windows ZIP-update path, whose copy loop
-    walks top-level entries in ``os.listdir`` order and replaces each one
-    independently — ``agent/`` lands long before ``tools/``, so a failure or
-    interruption between them leaves exactly that mismatch on disk.
-
-    Runs in a subprocess because importing these modules into the running
-    updater would pollute ``sys.modules`` and execute import-time side effects
-    against the half-updated tree. Costs ~0.4s.
-
-    Uses the project venv's interpreter when there is one (matching
-    ``_venv_core_imports_healthy``): ``hermes update`` can be driven by a
-    different Python than the install's own, and probing the wrong
-    interpreter would test a tree the user never runs.
-
-    ``strict=True`` is used after applying user source changes. In that phase,
-    failing to execute the proof is itself unsafe: the updater must not drop
-    the recovery stash or proceed to a gateway restart without a verdict.
-    Existing post-install callers keep the historical best-effort behavior
-    with the default ``strict=False`` because they may run before dependency
-    installation.
-
-    Returns ``(ok, failing_module, error_message)``.
-    """
+def _critical_module_import_failures(
+    root, *, report_runtime_errors: bool = False, strict: bool = False
+) -> tuple[dict[str, str], str | None]:
+    """Return import failures plus any failure to obtain a reliable probe."""
     from hermes_constants import FIRST_PARTY_MODULE_ROOTS
 
     probe = (
-        "import importlib, sys\n"
+        "import importlib, json, sys\n"
+        "failures = []\n"
         "for name in %r:\n"
         "    try:\n"
         "        importlib.import_module(name)\n"
         "    except ModuleNotFoundError as exc:\n"
-        # A missing *third-party* module means dependencies aren't installed
-        # yet, not a skewed checkout. Only our own packages count as breakage.
-        # The root set is injected from hermes_constants so this can't drift
-        # from the hint the user is shown (they disagreed once already).
+        # A missing third-party module means dependencies are not installed
+        # yet, not that the checkout is inconsistent.
         "        missing = (getattr(exc, 'name', '') or '').split('.')[0]\n"
         "        if missing in %r or missing.startswith('hermes_'):\n"
-        "            sys.stdout.write(name + '\\n' + str(exc))\n"
-        "            raise SystemExit(3)\n"
+        "            failures.append((name, str(exc)))\n"
         "    except ImportError as exc:\n"
-        "        sys.stdout.write(name + '\\n' + str(exc))\n"
-        "        raise SystemExit(3)\n"
+        "        failures.append((name, str(exc)))\n"
         "    except SyntaxError as exc:\n"
-        "        sys.stdout.write(name + '\\n' + str(exc))\n"
-        "        raise SystemExit(3)\n"
-        "    except Exception:\n"
-        "        pass\n"  # non-import errors (config/env) aren't update breakage
-        "raise SystemExit(0)\n"
-        % (_UPDATE_CRITICAL_MODULES, tuple(sorted(FIRST_PARTY_MODULE_ROOTS)))
+        "        failures.append((name, str(exc)))\n"
+        "    except Exception as exc:\n"
+        "        if %r:\n"
+        "            failures.append((name, str(exc)))\n"
+        "    except BaseException as exc:\n"
+        "        if %r:\n"
+        "            failures.append((name, str(exc)))\n"
+        "sys.stdout.write(%r + json.dumps(failures))\n"
+        % (
+            _UPDATE_CRITICAL_MODULES,
+            tuple(sorted(FIRST_PARTY_MODULE_ROOTS)),
+            report_runtime_errors,
+            report_runtime_errors,
+            _IMPORT_PROBE_MARKER,
+        )
     )
     try:
         interpreter = sys.executable
@@ -510,23 +489,48 @@ def _validate_critical_modules_import(
         )
     except (OSError, subprocess.SubprocessError) as exc:
         if strict:
-            return False, "critical-module-import-probe", f"could not run probe: {exc}"
-        # The pre-dependency-install callers cannot always execute the probe;
-        # preserve their existing best-effort behavior.
-        return True, None, None
-    if result.returncode == 3:
-        parts = (result.stdout or "").split("\n", 1)
-        module = parts[0].strip() or "unknown"
-        detail = parts[1].strip() if len(parts) > 1 else ""
-        return False, module, detail
-    if strict and result.returncode != 0:
-        detail = (result.stderr or result.stdout or "").strip()
-        suffix = f": {detail[:400]}" if detail else ""
-        return (
-            False,
-            "critical-module-import-probe",
-            f"probe exited with status {result.returncode}{suffix}",
-        )
+            return {}, f"could not run probe: {exc}"
+        return {}, None
+
+    output = result.stdout or ""
+    if result.returncode != 0:
+        if strict:
+            detail = (result.stderr or output).strip()
+            suffix = f": {detail[:400]}" if detail else ""
+            return {}, f"probe exited with status {result.returncode}{suffix}"
+        return {}, None
+
+    marker_at = output.rfind(_IMPORT_PROBE_MARKER)
+    if marker_at < 0:
+        if strict:
+            return {}, "probe did not emit a complete health verdict"
+        return {}, None
+    try:
+        import json
+
+        raw_failures = json.loads(output[marker_at + len(_IMPORT_PROBE_MARKER) :])
+        failures: dict[str, str] = {}
+        for item in raw_failures:
+            if not isinstance(item, list) or len(item) != 2:
+                raise ValueError("invalid import failure entry")
+            failures[str(item[0])] = str(item[1])
+        return failures, None
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        if strict:
+            return {}, f"probe emitted invalid health data: {exc}"
+        return {}, None
+
+
+def _validate_critical_modules_import(
+    root, *, strict: bool = False
+) -> tuple[bool, str | None, str | None]:
+    """Return the first critical-module import failure, if any."""
+    failures, probe_error = _critical_module_import_failures(root, strict=strict)
+    if probe_error:
+        return False, "critical-module-import-probe", probe_error
+    if failures:
+        module = next(iter(failures))
+        return False, module, failures[module]
     return True, None, None
 
 def _gateway_prompt(prompt_text: str, default: str = "", timeout: float = 300.0) -> str:
@@ -2298,6 +2302,16 @@ def _restore_stashed_changes(
         print(f"  Restore manually after checking the checkout: git stash apply {stash_ref}")
         raise SystemExit(1)
 
+    clean_import_failures, probe_error = _critical_module_import_failures(
+        cwd, report_runtime_errors=True, strict=True
+    )
+    if probe_error:
+        print("✗ Cannot safely restore local changes without an import health verdict.")
+        print(f"  {probe_error}")
+        print(f"  Your changes remain preserved in stash: {stash_ref}")
+        print(f"  Restore manually after checking the checkout: git stash apply {stash_ref}")
+        raise SystemExit(1)
+
     print("→ Restoring local changes...")
     restore = subprocess.run(
         git_cmd + ["stash", "apply", stash_ref],
@@ -2383,16 +2397,34 @@ def _restore_stashed_changes(
             syntax_error,
         )
 
-    import_ok, failing_module, import_error = _validate_critical_modules_import(
-        cwd, strict=True
+    restored_import_failures, probe_error = _critical_module_import_failures(
+        cwd, report_runtime_errors=True, strict=True
     )
-    if not import_ok:
+    if probe_error:
         _reject_unsafe_stash_restore(
             git_cmd,
             cwd,
             stash_ref,
             preexisting_untracked,
-            f"agent import {failing_module or 'unknown'}",
+            "critical-module-import-probe",
+            probe_error,
+        )
+    changed_import_failure = next(
+        (
+            (module, error)
+            for module, error in restored_import_failures.items()
+            if clean_import_failures.get(module) != error
+        ),
+        None,
+    )
+    if changed_import_failure is not None:
+        failing_module, import_error = changed_import_failure
+        _reject_unsafe_stash_restore(
+            git_cmd,
+            cwd,
+            stash_ref,
+            preexisting_untracked,
+            f"agent import {failing_module}",
             import_error,
         )
 

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -478,6 +478,8 @@ def _critical_module_import_failures(
                 interpreter = str(venv_python)
         except Exception:
             pass  # fall back to the running interpreter
+        probe_env = os.environ.copy()
+        probe_env["PYTHONDONTWRITEBYTECODE"] = "1"
         result = subprocess.run(
             [interpreter, "-c", probe],
             cwd=str(root),
@@ -486,6 +488,7 @@ def _critical_module_import_failures(
             encoding="utf-8",
             errors="replace",
             timeout=120,
+            env=probe_env,
         )
     except (OSError, subprocess.SubprocessError) as exc:
         if strict:
@@ -1519,10 +1522,22 @@ def _print_update_summary(
         _print_update_completion(_update_complete_message(pre_update_version))
 
 
-def _write_gateway_update_exit_code(ok: bool) -> None:
+_GATEWAY_UPDATE_EXIT_PENDING = "2"
+
+
+def _write_gateway_update_exit_code(
+    ok: bool, *, pending_restart: bool = False, only_if_pending: bool = False
+) -> None:
     path = get_hermes_home() / ".update_exit_code"
     try:
-        path.write_text("0" if ok else "1", encoding="utf-8")
+        if only_if_pending and path.read_text(encoding="utf-8").strip() != _GATEWAY_UPDATE_EXIT_PENDING:
+            return
+        value = (
+            _GATEWAY_UPDATE_EXIT_PENDING
+            if pending_restart and ok
+            else ("0" if ok else "1")
+        )
+        path.write_text(value, encoding="utf-8")
     except OSError:
         pass
 
@@ -2175,6 +2190,124 @@ def _untracked_paths(
     return set(paths), error
 
 
+def _stash_untracked_blob_ids(
+    git_cmd: list[str], cwd: Path, stash_ref: str
+) -> tuple[dict[str, str], str | None]:
+    """Return the paths and blob IDs captured as untracked stash content.
+
+    ``git stash push --include-untracked`` stores untracked files in the third
+    parent of the stash commit.  The parent is the authority for cleanup after
+    a failed restore; comparing only the current working-tree inventory with a
+    pre-restore snapshot would also match a file created concurrently by the
+    user and could delete data that never came from the stash.
+    """
+    command = git_cmd + ["cat-file", "-p", stash_ref]
+    try:
+        commit = subprocess.run(
+            command,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="surrogateescape",
+        )
+    except OSError as exc:
+        return {}, f"{command!r} could not run: {exc}"
+    if commit.returncode != 0:
+        detail = (commit.stderr or "").strip()
+        suffix = f": {detail.splitlines()[0][:400]}" if detail else ""
+        return {}, f"{command!r} exited with status {commit.returncode}{suffix}"
+
+    parents = [
+        line.split(maxsplit=1)[1]
+        for line in (commit.stdout or "").splitlines()
+        if line.startswith("parent ") and len(line.split(maxsplit=1)) == 2
+    ]
+    if len(parents) < 3:
+        return {}, None
+
+    tree_command = git_cmd + ["ls-tree", "-r", "-z", parents[2]]
+    try:
+        tree = subprocess.run(
+            tree_command,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="surrogateescape",
+        )
+    except OSError as exc:
+        return {}, f"{tree_command!r} could not run: {exc}"
+    if tree.returncode != 0:
+        detail = (tree.stderr or "").strip()
+        suffix = f": {detail.splitlines()[0][:400]}" if detail else ""
+        return {}, f"{tree_command!r} exited with status {tree.returncode}{suffix}"
+
+    entries: dict[str, str] = {}
+    for raw_entry in (tree.stdout or "").split("\0"):
+        if not raw_entry:
+            continue
+        metadata, separator, path = raw_entry.partition("\t")
+        fields = metadata.split()
+        if not separator or len(fields) != 3 or fields[1] != "blob" or not path:
+            return {}, "git stash untracked-file inventory contained an invalid entry"
+        entries[path] = fields[2]
+    return entries, None
+
+
+def _safe_restored_untracked_paths(
+    git_cmd: list[str],
+    cwd: Path,
+    stash_ref: str,
+    preexisting_untracked: set[str],
+) -> tuple[set[str], str | None]:
+    """Return only untracked paths proven to have come from ``stash_ref``.
+
+    A path is removable only when it is present in the stash's untracked tree,
+    was absent before restore, and its current content hashes to the exact blob
+    captured by the stash.  If a user or another process created or modified a
+    same-named file while the restore ran, the hash mismatch leaves it in place
+    instead of treating a name collision as ownership proof.
+    """
+    stash_entries, error = _stash_untracked_blob_ids(git_cmd, cwd, stash_ref)
+    if error:
+        return set(), error
+    if not stash_entries:
+        return set(), None
+
+    current_untracked, error = _untracked_paths(git_cmd, cwd)
+    if error:
+        return set(), error
+
+    candidates = set(stash_entries) & current_untracked - preexisting_untracked
+    removable: set[str] = set()
+    ambiguous: list[str] = []
+    for path in sorted(candidates):
+        try:
+            hash_result = subprocess.run(
+                git_cmd + ["hash-object", f"--path={path}", "--", path],
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="surrogateescape",
+            )
+        except OSError:
+            ambiguous.append(path)
+            continue
+        if hash_result.returncode == 0 and hash_result.stdout.strip() == stash_entries[path]:
+            removable.add(path)
+        else:
+            ambiguous.append(path)
+
+    if ambiguous:
+        return removable, (
+            "could not prove ownership of concurrent untracked path(s): "
+            + ", ".join(ambiguous[:8])
+        )
+    return removable, None
+
+
 def _restored_python_paths(
     git_cmd: list[str], cwd: Path
 ) -> tuple[tuple[str, ...], str | None]:
@@ -2218,12 +2351,14 @@ def _reject_unsafe_stash_restore(
         for line in str(detail).splitlines()[:6]:
             print(f"    {line}")
 
-    current_untracked, inventory_error = _untracked_paths(git_cmd, cwd)
+    restored_untracked, inventory_error = _safe_restored_untracked_paths(
+        git_cmd,
+        cwd,
+        stash_ref,
+        preexisting_untracked,
+    )
     if inventory_error:
         print(f"  Cleanup inventory failed: {inventory_error}")
-        restored_untracked: set[str] = set()
-    else:
-        restored_untracked = current_untracked - preexisting_untracked
 
     try:
         reset = subprocess.run(
@@ -7668,7 +7803,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # Desktop rebuild failure must not be reported as "0" — the gateway's
         # /update watcher (gateway/run.py) polls this file.
         if gateway_mode:
-            _write_gateway_update_exit_code(desktop_build_ok)
+            _write_gateway_update_exit_code(
+                desktop_build_ok, pending_restart=True
+            )
 
         gateway_fleet_restart_incomplete = False
         # Snapshot of gateways running before we touch anything. Stays empty
@@ -8373,11 +8510,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             if failed_or_stale_units:
                 gateway_fleet_restart_incomplete = True
                 if gateway_mode:
-                    _exit_code_path = get_hermes_home() / ".update_exit_code"
-                    try:
-                        _exit_code_path.write_text("1", encoding="utf-8")
-                    except OSError:
-                        pass
+                    _write_gateway_update_exit_code(False)
             _warn_incomplete_gateway_fleet_restart(failed_or_stale_units)
 
             try:
@@ -8459,11 +8592,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 gateway_fleet_restart_incomplete = True
                 _warn_gateway_restart_phase_aborted(e, _surviving)
                 if gateway_mode:
-                    _exit_code_path = get_hermes_home() / ".update_exit_code"
-                    try:
-                        _exit_code_path.write_text("1", encoding="utf-8")
-                    except OSError:
-                        pass
+                    _write_gateway_update_exit_code(False)
             try:
                 from hermes_cli.update_receipt import record_gateway_restart
 
@@ -8624,6 +8753,15 @@ def _cmd_update_impl(args, gateway_mode: bool):
         except Exception as _receipt_exc:
             logger.debug("Update receipt finalize failed: %s", _receipt_exc)
 
+        if gateway_mode:
+            # The pending marker is consumed by the restarted gateway's
+            # post-start agent health probe. When no gateway was running, this
+            # process is the only verifier and can finalize the outcome here.
+            _write_gateway_update_exit_code(
+                not gateway_fleet_restart_incomplete,
+                only_if_pending=True,
+            )
+
         if gateway_fleet_restart_incomplete:
             # Code update itself succeeded, but at least one gateway still
             # runs pre-update modules — surface that as a failed update so
@@ -8667,6 +8805,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 finalize_update_receipt("failed")
             except Exception:
                 pass
+            if gateway_mode:
+                _write_gateway_update_exit_code(False)
             sys.exit(1)
 
 # --- Hoisted from the body of _cmd_update_impl (self-contained, no closure state) ---

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -369,6 +369,31 @@ def _editable_install_is_current(git_cmd, cwd, pre_pull_sha: str | None) -> bool
         return False
     return not result.stdout.strip()
 
+def _validate_python_files_syntax(
+    root, relpaths
+) -> tuple[bool, str | None, str | None]:
+    """Compile selected Python files without writing bytecode into the tree."""
+    import py_compile
+    import tempfile
+
+    root = Path(root)
+    with tempfile.TemporaryDirectory(prefix="hermes-syntax-check-") as tmpdir:
+        for index, relpath in enumerate(relpaths):
+            path = root / relpath
+            if not path.exists():
+                continue
+            cfile = Path(tmpdir) / (
+                f"{index}__{str(relpath).replace('/', '__')}c"
+            )
+            try:
+                py_compile.compile(str(path), cfile=str(cfile), doraise=True)
+            except py_compile.PyCompileError as exc:
+                return False, str(path), str(exc)
+            except OSError as exc:
+                return False, str(path), f"could not read: {exc}"
+    return True, None, None
+
+
 def _validate_critical_files_syntax(root) -> tuple[bool, str | None, str | None]:
     """Compile each file in ``_UPDATE_CRITICAL_FILES`` to catch SyntaxErrors.
 
@@ -388,27 +413,7 @@ def _validate_critical_files_syntax(root) -> tuple[bool, str | None, str | None]
     Returns ``(ok, failing_path, error_message)``. ``ok=True`` means every
     file parsed cleanly.
     """
-    import py_compile
-    import tempfile
-
-    root = Path(root)
-    with tempfile.TemporaryDirectory(prefix="hermes-syntax-check-") as tmpdir:
-        for relpath in _UPDATE_CRITICAL_FILES:
-            path = root / relpath
-            if not path.exists():
-                # Missing file is suspicious but not necessarily fatal — a future
-                # refactor may legitimately remove one of these. Skip and move on.
-                continue
-            # Mirror the relative path under the tmpdir so two different
-            # files with the same basename don't collide on the cfile name.
-            cfile = Path(tmpdir) / (relpath.replace("/", "__") + "c")
-            try:
-                py_compile.compile(str(path), cfile=str(cfile), doraise=True)
-            except py_compile.PyCompileError as exc:
-                return False, str(path), str(exc)
-            except OSError as exc:
-                return False, str(path), f"could not read: {exc}"
-    return True, None, None
+    return _validate_python_files_syntax(root, _UPDATE_CRITICAL_FILES)
 
 
 # Modules imported on every agent startup. Unlike _UPDATE_CRITICAL_FILES (which
@@ -423,7 +428,9 @@ _UPDATE_CRITICAL_MODULES = (
 )
 
 
-def _validate_critical_modules_import(root) -> tuple[bool, str | None, str | None]:
+def _validate_critical_modules_import(
+    root, *, strict: bool = False
+) -> tuple[bool, str | None, str | None]:
     """Import each module in ``_UPDATE_CRITICAL_MODULES`` in a subprocess.
 
     ``_validate_critical_files_syntax`` only *parses* files, so it cannot see
@@ -446,6 +453,13 @@ def _validate_critical_modules_import(root) -> tuple[bool, str | None, str | Non
     different Python than the install's own, and probing the wrong
     interpreter would test a tree the user never runs.
 
+    ``strict=True`` is used after applying user source changes. In that phase,
+    failing to execute the proof is itself unsafe: the updater must not drop
+    the recovery stash or proceed to a gateway restart without a verdict.
+    Existing post-install callers keep the historical best-effort behavior
+    with the default ``strict=False`` because they may run before dependency
+    installation.
+
     Returns ``(ok, failing_module, error_message)``.
     """
     from hermes_constants import FIRST_PARTY_MODULE_ROOTS
@@ -465,6 +479,9 @@ def _validate_critical_modules_import(root) -> tuple[bool, str | None, str | Non
         "            sys.stdout.write(name + '\\n' + str(exc))\n"
         "            raise SystemExit(3)\n"
         "    except ImportError as exc:\n"
+        "        sys.stdout.write(name + '\\n' + str(exc))\n"
+        "        raise SystemExit(3)\n"
+        "    except SyntaxError as exc:\n"
         "        sys.stdout.write(name + '\\n' + str(exc))\n"
         "        raise SystemExit(3)\n"
         "    except Exception:\n"
@@ -491,14 +508,25 @@ def _validate_critical_modules_import(root) -> tuple[bool, str | None, str | Non
             errors="replace",
             timeout=120,
         )
-    except (OSError, subprocess.SubprocessError):
-        # Can't run the probe — don't block the update on our own tooling.
+    except (OSError, subprocess.SubprocessError) as exc:
+        if strict:
+            return False, "critical-module-import-probe", f"could not run probe: {exc}"
+        # The pre-dependency-install callers cannot always execute the probe;
+        # preserve their existing best-effort behavior.
         return True, None, None
     if result.returncode == 3:
         parts = (result.stdout or "").split("\n", 1)
         module = parts[0].strip() or "unknown"
         detail = parts[1].strip() if len(parts) > 1 else ""
         return False, module, detail
+    if strict and result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        suffix = f": {detail[:400]}" if detail else ""
+        return (
+            False,
+            "critical-module-import-probe",
+            f"probe exited with status {result.returncode}{suffix}",
+        )
     return True, None, None
 
 def _gateway_prompt(prompt_text: str, default: str = "", timeout: float = 300.0) -> str:
@@ -2103,6 +2131,127 @@ def _park_stashed_changes(stash_ref: str) -> None:
     print(f"  Restore manually with: git stash apply {stash_ref}")
 
 
+def _git_nul_paths(
+    git_cmd: list[str], cwd: Path, args: list[str]
+) -> tuple[tuple[str, ...], str | None]:
+    """Run a Git path query without losing filenames containing whitespace.
+
+    A failed inventory is not equivalent to an empty inventory. The updater
+    uses this distinction as a safety boundary: it must never drop a stash
+    merely because a Git query failed to prove which files were restored.
+    """
+    command = git_cmd + args
+    rendered = " ".join(str(part) for part in command)
+    try:
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="surrogateescape",
+        )
+    except OSError as exc:
+        return (), f"{rendered} could not run: {exc}"
+    if result.returncode != 0:
+        detail = (result.stderr or "").strip()
+        suffix = f": {detail.splitlines()[0][:400]}" if detail else ""
+        return (), f"{rendered} exited with status {result.returncode}{suffix}"
+    return tuple(path for path in (result.stdout or "").split("\0") if path), None
+
+
+def _untracked_paths(
+    git_cmd: list[str], cwd: Path
+) -> tuple[set[str], str | None]:
+    paths, error = _git_nul_paths(
+        git_cmd,
+        cwd,
+        ["ls-files", "--others", "--exclude-standard", "-z"],
+    )
+    return set(paths), error
+
+
+def _restored_python_paths(
+    git_cmd: list[str], cwd: Path
+) -> tuple[tuple[str, ...], str | None]:
+    """Find every tracked or untracked Python file visible after restore.
+
+    ``git diff`` does not report untracked files, while the update stash is
+    created with ``--include-untracked``. Both inventories are therefore part
+    of the proof. If either query fails, returning an empty list would turn a
+    tool failure into a false health verdict, so the error is propagated.
+    """
+    changed, error = _git_nul_paths(
+        git_cmd,
+        cwd,
+        ["diff", "--name-only", "-z", "HEAD", "--", "*.py"],
+    )
+    if error:
+        return (), f"could not enumerate restored Python files: {error}"
+
+    untracked, error = _untracked_paths(git_cmd, cwd)
+    if error:
+        return (), f"could not enumerate restored untracked files: {error}"
+
+    paths = set(changed)
+    paths.update(path for path in untracked if path.endswith(".py"))
+    return tuple(sorted(paths)), None
+
+
+def _reject_unsafe_stash_restore(
+    git_cmd: list[str],
+    cwd: Path,
+    stash_ref: str,
+    preexisting_untracked: set[str],
+    failing_target: str,
+    detail: str | None,
+) -> None:
+    """Reset to the updated tree and abort without dropping the recovery stash."""
+    print()
+    print("✗ Restored local changes failed the Hermes agent health proof.")
+    print(f"  Health check failed: {failing_target}")
+    if detail:
+        for line in str(detail).splitlines()[:6]:
+            print(f"    {line}")
+
+    current_untracked, inventory_error = _untracked_paths(git_cmd, cwd)
+    if inventory_error:
+        print(f"  Cleanup inventory failed: {inventory_error}")
+        restored_untracked: set[str] = set()
+    else:
+        restored_untracked = current_untracked - preexisting_untracked
+
+    try:
+        reset = subprocess.run(
+            git_cmd + ["reset", "--hard", "HEAD"],
+            cwd=cwd,
+            capture_output=True,
+        )
+        if reset.returncode != 0:
+            print("  Could not reset the tracked files automatically.")
+    except OSError as exc:
+        print(f"  Could not reset the tracked files automatically: {exc}")
+
+    if restored_untracked:
+        try:
+            clean = subprocess.run(
+                git_cmd + ["clean", "-fd", "--", *sorted(restored_untracked)],
+                cwd=cwd,
+                capture_output=True,
+            )
+            if clean.returncode != 0:
+                print("  Some restored untracked files could not be removed.")
+        except OSError as exc:
+            print(f"  Some restored untracked files could not be removed: {exc}")
+
+    print("  The gateway was not allowed to restart on an unproven tree.")
+    print("  Platform connectivity alone does not prove agent-turn health.")
+    print(f"  Your local changes remain preserved in stash: {stash_ref}")
+    print(f"  Inspect them with: git stash show --stat {stash_ref}")
+    print(f"  Restore manually after fixing them: git stash apply {stash_ref}")
+    raise SystemExit(1)
+
+
 def _restore_stashed_changes(
     git_cmd: list[str],
     cwd: Path,
@@ -2111,15 +2260,19 @@ def _restore_stashed_changes(
     input_fn=None,
 ) -> bool:
     if prompt_user:
+        remote_prompt = input_fn is not None
+        prompt_suffix = "[y/N]" if remote_prompt else "[Y/n]"
         print()
         print("⚠ Local changes were stashed before updating.")
         print(
             "  Restoring them may reapply local customizations onto the updated codebase."
         )
         print("  Review the result afterward if Hermes behaves unexpectedly.")
-        print("Restore local changes now? [Y/n]")
+        print(f"Restore local changes now? {prompt_suffix}")
         if input_fn is not None:
-            response = input_fn("Restore local changes now? [Y/n]", "y")
+            response = str(
+                input_fn(f"Restore local changes now? {prompt_suffix}", "n") or ""
+            ).strip().lower()
         else:
             try:
                 response = input().strip().lower()
@@ -2130,11 +2283,20 @@ def _restore_stashed_changes(
                 # skip-restore path below, which already explains how to
                 # restore manually from git stash.
                 response = "n"
-        if response not in {"", "y", "yes"}:
+        accepted = response in {"y", "yes"} or (not remote_prompt and response == "")
+        if not accepted:
             print("Skipped restoring local changes.")
             print("Your changes are still preserved in git stash.")
             print(f"Restore manually with: git stash apply {stash_ref}")
             return False
+
+    preexisting_untracked, inventory_error = _untracked_paths(git_cmd, cwd)
+    if inventory_error:
+        print("✗ Cannot safely restore local changes because the file inventory failed.")
+        print(f"  {inventory_error}")
+        print(f"  Your changes remain preserved in stash: {stash_ref}")
+        print(f"  Restore manually after checking the checkout: git stash apply {stash_ref}")
+        raise SystemExit(1)
 
     print("→ Restoring local changes...")
     restore = subprocess.run(
@@ -2196,6 +2358,43 @@ def _restore_stashed_changes(
         # restore had conflicts.  Let cmd_update continue with pip install,
         # skill sync, and gateway restart.
         return False
+
+    restored_python, inventory_error = _restored_python_paths(git_cmd, cwd)
+    if inventory_error:
+        _reject_unsafe_stash_restore(
+            git_cmd,
+            cwd,
+            stash_ref,
+            preexisting_untracked,
+            "restored-file inventory",
+            inventory_error,
+        )
+
+    syntax_ok, failing_path, syntax_error = _validate_python_files_syntax(
+        cwd, restored_python
+    )
+    if not syntax_ok:
+        _reject_unsafe_stash_restore(
+            git_cmd,
+            cwd,
+            stash_ref,
+            preexisting_untracked,
+            failing_path or "restored Python source",
+            syntax_error,
+        )
+
+    import_ok, failing_module, import_error = _validate_critical_modules_import(
+        cwd, strict=True
+    )
+    if not import_ok:
+        _reject_unsafe_stash_restore(
+            git_cmd,
+            cwd,
+            stash_ref,
+            preexisting_untracked,
+            f"agent import {failing_module or 'unknown'}",
+            import_error,
+        )
 
     stash_selector = _resolve_stash_selector(git_cmd, cwd, stash_ref)
     if stash_selector is None:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -478,8 +478,13 @@ def _critical_module_import_failures(
                 interpreter = str(venv_python)
         except Exception:
             pass  # fall back to the running interpreter
-        probe_env = os.environ.copy()
-        probe_env["PYTHONDONTWRITEBYTECODE"] = "1"
+        from tools.environments.local import build_subprocess_env
+
+        probe_env = build_subprocess_env(
+            scrub_secrets=False,
+            inherit_profile_home=False,
+            extra={"PYTHONDONTWRITEBYTECODE": "1"},
+        )
         result = subprocess.run(
             [interpreter, "-c", probe],
             cwd=str(root),

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -172,6 +172,7 @@ class TestHandleUpdateCommand:
         assert call_args[0] == "bash"
         assert "nohup" not in call_args[2]
         assert ".update_exit_code" in call_args[2]
+        assert "marker_state" in call_args[2]
         # start_new_session=True should be in kwargs
         call_kwargs = mock_popen.call_args[1]
         assert call_kwargs.get("start_new_session") is True
@@ -288,6 +289,60 @@ class TestSendUpdateNotification:
         assert result is False
         mock_adapter.send.assert_not_called()
         assert pending_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_defers_notification_while_post_restart_health_is_pending(self, tmp_path):
+        """Code 2 is not a successful update outcome."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        pending_path = hermes_home / ".update_pending.json"
+        exit_code_path = hermes_home / ".update_exit_code"
+        pending_path.write_text(json.dumps({
+            "platform": "telegram", "chat_id": "67890", "user_id": "12345",
+        }))
+        exit_code_path.write_text("2")
+
+        mock_adapter = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: mock_adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            result = await runner._send_update_notification()
+
+        assert result is False
+        mock_adapter.send.assert_not_called()
+        assert pending_path.exists()
+        assert exit_code_path.read_text() == "2"
+
+    def test_post_restart_health_probe_finalizes_pending_success(self, tmp_path):
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        exit_code_path = hermes_home / ".update_exit_code"
+        exit_code_path.write_text("2")
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run._post_restart_agent_health_check", return_value=(True, None)):
+            runner._finalize_pending_update_health()
+
+        assert exit_code_path.read_text() == "0"
+
+    def test_post_restart_health_probe_failure_is_terminal(self, tmp_path):
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        exit_code_path = hermes_home / ".update_exit_code"
+        exit_code_path.write_text("2")
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch(
+                 "gateway.run._post_restart_agent_health_check",
+                 return_value=(False, "agent import probe exited with status 1"),
+             ):
+            runner._finalize_pending_update_health()
+
+        assert exit_code_path.read_text() == "1"
 
     @pytest.mark.asyncio
     async def test_recovers_from_claimed_pending_file(self, tmp_path):

--- a/tests/hermes_cli/test_update_restored_tree_proof.py
+++ b/tests/hermes_cli/test_update_restored_tree_proof.py
@@ -179,6 +179,89 @@ def test_invalid_untracked_python_is_part_of_the_restore_proof(
     assert _git(repo, "stash", "list").stdout.strip()
 
 
+def test_failed_restore_does_not_delete_concurrent_untracked_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo = _repo(tmp_path)
+    stash_ref, source = _stash_invalid_tracked_file(repo)
+    _stub_import_probe(monkeypatch)
+    real_run = update_cmd.subprocess.run
+    concurrent = repo / "created-during-restore.py"
+
+    def create_concurrent_file(cmd, *args, **kwargs):
+        result = real_run(cmd, *args, **kwargs)
+        if cmd[:3] == ["git", "stash", "apply"]:
+            concurrent.write_text("user-owned = True\n", encoding="utf-8")
+        return result
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", create_concurrent_file)
+
+    with pytest.raises(SystemExit) as exc_info:
+        update_cmd._restore_stashed_changes(["git"], repo, stash_ref)
+
+    assert exc_info.value.code == 1
+    assert source.read_text(encoding="utf-8") == "VALUE = 1\n"
+    assert concurrent.read_text(encoding="utf-8") == "user-owned = True\n"
+    assert _git(repo, "stash", "list").stdout.strip()
+
+
+def test_invalid_untracked_python_path_with_spaces_is_removed_safely(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo = _repo(tmp_path)
+    source = repo / "directory with spaces" / "untracked feature.py"
+    source.parent.mkdir()
+    source.write_text("<<<<<<< Updated upstream\n", encoding="utf-8")
+    stash_ref = update_cmd._stash_local_changes_if_needed(["git"], repo)
+    assert stash_ref
+    _stub_import_probe(monkeypatch)
+
+    with pytest.raises(SystemExit):
+        update_cmd._restore_stashed_changes(["git"], repo, stash_ref)
+
+    assert not source.exists()
+    assert _git(repo, "status", "--porcelain").stdout == ""
+    assert _git(repo, "stash", "list").stdout.strip()
+
+
+def test_untracked_cleanup_probe_failure_preserves_ambiguous_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo = _repo(tmp_path)
+    source = repo / "restored.py"
+    source.write_text("<<<<<<< Updated upstream\n", encoding="utf-8")
+    stash_ref = update_cmd._stash_local_changes_if_needed(["git"], repo)
+    assert stash_ref
+    _stub_import_probe(monkeypatch)
+    real_run = update_cmd.subprocess.run
+
+    def fail_hash_object(cmd, *args, **kwargs):
+        if len(cmd) >= 2 and cmd[1] == "hash-object":
+            raise OSError("simulated hash-object launch failure")
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", fail_hash_object)
+
+    with pytest.raises(SystemExit) as exc_info:
+        update_cmd._restore_stashed_changes(["git"], repo, stash_ref)
+
+    assert exc_info.value.code == 1
+    assert source.exists()
+    assert _git(repo, "stash", "list").stdout.strip()
+
+
+def test_gateway_success_marker_does_not_overwrite_terminal_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    exit_code_path = tmp_path / ".update_exit_code"
+    exit_code_path.write_text("1", encoding="utf-8")
+    monkeypatch.setattr(update_cmd, "get_hermes_home", lambda: tmp_path)
+
+    update_cmd._write_gateway_update_exit_code(True, only_if_pending=True)
+
+    assert exit_code_path.read_text(encoding="utf-8") == "1"
+
+
 def test_invalid_python_path_with_spaces_is_compiled_from_nul_inventory(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/hermes_cli/test_update_restored_tree_proof.py
+++ b/tests/hermes_cli/test_update_restored_tree_proof.py
@@ -1,0 +1,213 @@
+"""Regression coverage for the post-restore agent health proof (#94264)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import update_cmd
+
+
+def _git(
+    repo: Path, *args: str, check: bool = True
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Hermes test")
+    source = repo / "agent_entry.py"
+    source.write_text("VALUE = 1\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "initial")
+    return repo
+
+
+def _stash_invalid_tracked_file(repo: Path) -> tuple[str, Path]:
+    source = repo / "agent_entry.py"
+    source.write_text("<<<<<<< Updated upstream\nVALUE = 2\n", encoding="utf-8")
+    stash_ref = update_cmd._stash_local_changes_if_needed(["git"], repo)
+    assert stash_ref
+    return stash_ref, source
+
+
+def _stub_import_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep these repository-state tests independent of optional dependencies."""
+    monkeypatch.setattr(update_cmd, "_UPDATE_CRITICAL_MODULES", ())
+
+
+def test_clean_stash_apply_with_invalid_python_is_rejected_and_parked(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repo = _repo(tmp_path)
+    stash_ref, source = _stash_invalid_tracked_file(repo)
+    _stub_import_probe(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc_info:
+        update_cmd._restore_stashed_changes(["git"], repo, stash_ref)
+
+    assert exc_info.value.code == 1
+    assert source.read_text(encoding="utf-8") == "VALUE = 1\n"
+    assert _git(repo, "status", "--porcelain").stdout == ""
+    assert _git(repo, "stash", "list").stdout.strip()
+    output = capsys.readouterr().out
+    assert "health proof" in output
+    assert "gateway was not allowed to restart" in output
+    assert f"git stash apply {stash_ref}" in output
+
+
+def test_valid_python_restore_still_drops_the_stash(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo = _repo(tmp_path)
+    source = repo / "agent_entry.py"
+    source.write_text("VALUE = 2  # local customization\n", encoding="utf-8")
+    stash_ref = update_cmd._stash_local_changes_if_needed(["git"], repo)
+    assert stash_ref
+    _stub_import_probe(monkeypatch)
+
+    assert update_cmd._restore_stashed_changes(["git"], repo, stash_ref) is True
+    assert source.read_text(encoding="utf-8") == "VALUE = 2  # local customization\n"
+    assert _git(repo, "stash", "list").stdout == ""
+
+
+def test_invalid_untracked_python_is_part_of_the_restore_proof(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo = _repo(tmp_path)
+    source = repo / "new_agent_feature.py"
+    source.write_text("<<<<<<< Updated upstream\n", encoding="utf-8")
+    stash_ref = update_cmd._stash_local_changes_if_needed(["git"], repo)
+    assert stash_ref
+    _stub_import_probe(monkeypatch)
+
+    with pytest.raises(SystemExit):
+        update_cmd._restore_stashed_changes(["git"], repo, stash_ref)
+
+    assert not source.exists()
+    assert _git(repo, "status", "--porcelain").stdout == ""
+    assert _git(repo, "stash", "list").stdout.strip()
+
+
+def test_invalid_python_path_with_spaces_is_compiled_from_nul_inventory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo = _repo(tmp_path)
+    source = repo / "directory with spaces" / "agent feature.py"
+    source.parent.mkdir()
+    source.write_text("VALUE = 1\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "add spaced source path")
+    source.write_text("<<<<<<< Updated upstream\n", encoding="utf-8")
+    stash_ref = update_cmd._stash_local_changes_if_needed(["git"], repo)
+    assert stash_ref
+    _stub_import_probe(monkeypatch)
+
+    with pytest.raises(SystemExit):
+        update_cmd._restore_stashed_changes(["git"], repo, stash_ref)
+
+    assert source.read_text(encoding="utf-8") == "VALUE = 1\n"
+    assert _git(repo, "status", "--porcelain").stdout == ""
+    assert _git(repo, "stash", "list").stdout.strip()
+
+
+def test_failed_git_path_inventory_cannot_become_a_success(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo = _repo(tmp_path)
+    stash_ref, source = _stash_invalid_tracked_file(repo)
+    _stub_import_probe(monkeypatch)
+    real_run = update_cmd.subprocess.run
+
+    def fail_python_inventory(cmd, *args, **kwargs):
+        if (
+            cmd[:2] == ["git", "diff"]
+            and "--name-only" in cmd
+            and "-z" in cmd
+            and "HEAD" in cmd
+        ):
+            return subprocess.CompletedProcess(
+                cmd, 1, stdout="", stderr="fatal: simulated inventory failure"
+            )
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", fail_python_inventory)
+
+    with pytest.raises(SystemExit) as exc_info:
+        update_cmd._restore_stashed_changes(["git"], repo, stash_ref)
+
+    assert exc_info.value.code == 1
+    assert source.read_text(encoding="utf-8") == "VALUE = 1\n"
+    assert _git(repo, "stash", "list").stdout.strip()
+
+
+def test_unavailable_import_probe_cannot_drop_the_stash(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo = _repo(tmp_path)
+    stash_ref, source = _stash_invalid_tracked_file(repo)
+    _stub_import_probe(monkeypatch)
+    real_run = update_cmd.subprocess.run
+
+    def fail_import_probe(cmd, *args, **kwargs):
+        if cmd and cmd[0] != "git" and len(cmd) >= 2 and cmd[1] == "-c":
+            raise OSError("simulated interpreter launch failure")
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", fail_import_probe)
+
+    with pytest.raises(SystemExit) as exc_info:
+        update_cmd._restore_stashed_changes(["git"], repo, stash_ref)
+
+    assert exc_info.value.code == 1
+    assert source.read_text(encoding="utf-8") == "VALUE = 1\n"
+    assert _git(repo, "stash", "list").stdout.strip()
+
+
+def test_strict_import_probe_reports_syntax_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    broken = tmp_path / "broken.py"
+    broken.write_text("def broken(:\n    pass\n", encoding="utf-8")
+    monkeypatch.setattr(update_cmd, "_UPDATE_CRITICAL_MODULES", ("broken",))
+
+    ok, module, detail = update_cmd._validate_critical_modules_import(
+        tmp_path, strict=True
+    )
+
+    assert ok is False
+    assert module == "broken"
+    assert detail and ("SyntaxError" in detail or "invalid syntax" in detail)
+
+
+def test_gateway_restore_prompt_defaults_to_parking(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    prompts: list[tuple[str, str]] = []
+
+    def gateway_input(prompt: str, default: str = "") -> str:
+        prompts.append((prompt, default))
+        return ""
+
+    def unexpected_git(*_args, **_kwargs):
+        raise AssertionError("declining the prompt must not apply the stash")
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", unexpected_git)
+    result = update_cmd._restore_stashed_changes(
+        ["git"], tmp_path, "stash@{0}", prompt_user=True, input_fn=gateway_input
+    )
+
+    assert result is False
+    assert prompts == [("Restore local changes now? [y/N]", "n")]

--- a/tests/hermes_cli/test_update_restored_tree_proof.py
+++ b/tests/hermes_cli/test_update_restored_tree_proof.py
@@ -83,6 +83,84 @@ def test_valid_python_restore_still_drops_the_stash(
     assert _git(repo, "stash", "list").stdout == ""
 
 
+def test_new_import_time_failure_is_rejected_and_parked(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo = _repo(tmp_path)
+    source = repo / "consumer.py"
+    source.write_text("VALUE = 1\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "add import probe module")
+    source.write_text(
+        "raise RuntimeError('restored local failure')\n", encoding="utf-8"
+    )
+    stash_ref = update_cmd._stash_local_changes_if_needed(["git"], repo)
+    assert stash_ref
+    monkeypatch.setattr(update_cmd, "_UPDATE_CRITICAL_MODULES", ("consumer",))
+
+    with pytest.raises(SystemExit) as exc_info:
+        update_cmd._restore_stashed_changes(["git"], repo, stash_ref)
+
+    assert exc_info.value.code == 1
+    assert source.read_text(encoding="utf-8") == "VALUE = 1\n"
+    assert _git(repo, "status", "--porcelain").stdout == ""
+    assert _git(repo, "stash", "list").stdout.strip()
+
+
+def test_unavailable_import_probe_cannot_drop_new_runtime_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo = _repo(tmp_path)
+    source = repo / "consumer.py"
+    source.write_text("VALUE = 1\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "add import probe module")
+    source.write_text(
+        "raise RuntimeError('restored local failure')\n", encoding="utf-8"
+    )
+    stash_ref = update_cmd._stash_local_changes_if_needed(["git"], repo)
+    assert stash_ref
+    monkeypatch.setattr(update_cmd, "_UPDATE_CRITICAL_MODULES", ("consumer",))
+    real_run = update_cmd.subprocess.run
+
+    def fail_import_probe(cmd, *args, **kwargs):
+        if cmd and cmd[0] != "git" and len(cmd) >= 2 and cmd[1] == "-c":
+            raise OSError("simulated interpreter launch failure")
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", fail_import_probe)
+
+    with pytest.raises(SystemExit) as exc_info:
+        update_cmd._restore_stashed_changes(["git"], repo, stash_ref)
+
+    assert exc_info.value.code == 1
+    assert source.read_text(encoding="utf-8") == "VALUE = 1\n"
+    assert _git(repo, "status", "--porcelain").stdout == ""
+    assert _git(repo, "stash", "list").stdout.strip()
+
+
+def test_preexisting_import_time_failure_does_not_block_valid_restore(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo = _repo(tmp_path)
+    consumer = repo / "consumer.py"
+    consumer.write_text(
+        "raise RuntimeError('missing local config')\n", encoding="utf-8"
+    )
+    local_file = repo / "local.txt"
+    local_file.write_text("original\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "add preexisting import failure")
+    local_file.write_text("restored\n", encoding="utf-8")
+    stash_ref = update_cmd._stash_local_changes_if_needed(["git"], repo)
+    assert stash_ref
+    monkeypatch.setattr(update_cmd, "_UPDATE_CRITICAL_MODULES", ("consumer",))
+
+    assert update_cmd._restore_stashed_changes(["git"], repo, stash_ref) is True
+    assert local_file.read_text(encoding="utf-8") == "restored\n"
+    assert _git(repo, "stash", "list").stdout == ""
+
+
 def test_invalid_untracked_python_is_part_of_the_restore_proof(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -67,7 +67,7 @@ updates:
   # non_interactive_local_changes: discard  # throw local source edits away
 ```
 
-- `stash` (default) — auto-stash, pull, then ask through the gateway before restoring. The remote default is to keep the stash parked (`[y/N]`), so a timeout cannot silently re-apply a risky local edit. If an explicit restore hits conflicts or fails the restored-source health proof, Hermes keeps the stash and resets to the clean updated tree; an unproven tree is not restarted.
+- `stash` (default) — auto-stash, pull, then ask through the gateway before restoring. The remote default is to keep the stash parked (`[y/N]`), so a timeout cannot silently re-apply a risky local edit. If an explicit restore hits conflicts or fails the restored-source health proof, Hermes keeps the stash and resets to the clean updated tree; an unproven tree is not restarted. After a restart, the new gateway runs an isolated `run_agent` import probe before the success notification is allowed.
 - `discard` — auto-stash and drop the stash after the pull, so the update always lands on a clean tree. Use this only on machines where you never intend to keep local edits to the Hermes source. It stash-drops (not `git reset --hard` + `git clean -fd`), so ignored paths like `node_modules`, `venv`, and build outputs are never touched.
 
 In the desktop app this is **Settings → Advanced → In-App Update Local Changes**.

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -27,9 +27,10 @@ When you run `hermes update`, the following steps occur:
 1. **Pre-update snapshot** — a lightweight state snapshot is saved by default (covers pairing data, cron jobs, `config.yaml`, `.env`, `auth.json`, and other state files that get modified at runtime; individual files over 1 GiB are skipped so a large sessions DB never slows the update down). Because the code swap and gateway restarts touch every profile, the same snapshot is taken for **every profile** on the install — each into its own `state-snapshots/` directory — and the post-update cron-jobs safety net checks each profile against its own snapshot. Controlled by `updates.pre_update_backup` (`quick` by default, `full` for a zip of all of `HERMES_HOME`, `off` to disable). Recoverable via the snapshot restore flow described under [Snapshots and rollback](../user-guide/checkpoints-and-rollback.md). Quick snapshots are file-loss recovery, not code-rollback insurance — for a coherent point-in-time rollback use `--backup` (full mode).
 2. **Git pull** — pulls the latest code from the `main` branch and updates submodules
 3. **Post-pull syntax validation + auto-rollback** — after the pull, Hermes compiles the nine critical files every `hermes` invocation imports at startup. If any fails to parse (e.g. an orphan merge-conflict marker, an accidentally truncated file), Hermes runs `git reset --hard <pre-pull-sha>` to roll the install back so your shell stays bootable. Re-run `hermes update` once the upstream fix lands.
-4. **Dependency install** — runs `uv pip install -e ".[all]"` to pick up new or changed dependencies
-5. **Config migration** — detects new config options added since your version and prompts you to set them
-6. **Gateway auto-restart** — running gateways are refreshed after the update completes so the new code takes effect immediately. Service-managed gateways (systemd on Linux, launchd on macOS) are restarted through the service manager. Manual gateways are relaunched automatically when Hermes can map the running PID back to a profile.
+4. **Restored-source health proof** — when local changes are restored, Hermes compiles every restored Python file, checks the critical agent imports in the install's own interpreter, and only then drops the recovery stash. A clean Git apply is not proof that Python is valid. If Git cannot provide a complete file inventory or the proof cannot run, Hermes resets the tracked tree to the clean updated revision, keeps the stash, exits unsuccessfully, and does not restart a gateway on an unproven tree.
+5. **Dependency install** — runs `uv pip install -e ".[all]"` to pick up new or changed dependencies
+6. **Config migration** — detects new config options added since your version and prompts you to set them
+7. **Gateway auto-restart** — running gateways are refreshed after the update completes so the new code takes effect immediately. Service-managed gateways (systemd on Linux, launchd on macOS) are restarted through the service manager. Manual gateways are relaunched automatically when Hermes can map the running PID back to a profile.
 
 ### Updating against a non-default branch: `--branch`
 
@@ -66,7 +67,7 @@ updates:
   # non_interactive_local_changes: discard  # throw local source edits away
 ```
 
-- `stash` (default) — auto-stash, pull, then auto-restore your changes on top of the updated code. Nothing is lost; if a restore hits conflicts they're preserved in a git stash for manual recovery.
+- `stash` (default) — auto-stash, pull, then ask through the gateway before restoring. The remote default is to keep the stash parked (`[y/N]`), so a timeout cannot silently re-apply a risky local edit. If an explicit restore hits conflicts or fails the restored-source health proof, Hermes keeps the stash and resets to the clean updated tree; an unproven tree is not restarted.
 - `discard` — auto-stash and drop the stash after the pull, so the update always lands on a clean tree. Use this only on machines where you never intend to keep local edits to the Hermes source. It stash-drops (not `git reset --hard` + `git clean -fd`), so ignored paths like `node_modules`, `venv`, and build outputs are never touched.
 
 In the desktop app this is **Settings → Advanced → In-App Update Local Changes**.


### PR DESCRIPTION
Fixes #94264

## Summary

`git stash apply` can succeed even when it re-applies syntactically invalid local Python. The updater must prove that the restored tree is runnable before dropping the recovery stash or allowing a gateway restart to continue.

This PR now closes both false-success boundaries:

- the restored local tree is proven before the stash can be dropped;
- the restarted gateway must prove that `run_agent` imports before the remote update is reported as successful.

## Root cause

The reported failure is real and reproducible:

1. A local Python file containing an orphan conflict marker is stashed.
2. The update lands on a clean checkout.
3. Git reapplies the file without creating a new merge conflict.
4. The previous restore path treated a successful `stash apply` as sufficient, dropped the stash, and continued toward gateway restart.
5. Platform adapters could reconnect while the agent entrypoint remained unimportable, so every agent turn failed even though Telegram/Discord connectivity looked healthy.

The earlier post-pull syntax guard ran before stash restoration. The previous import probe also treated probe-launch failures and incomplete health evidence as success.

## Canonical implementation

### Restored-tree proof

- Compiles every tracked Python file changed by the restore.
- Compiles every restored non-ignored untracked Python file.
- Uses NUL-delimited Git inventories so whitespace and unusual filenames are preserved.
- Treats Git inventory failure, interpreter-launch failure, non-zero probe exit, malformed probe output, `SyntaxError`, and incomplete health evidence as failure.
- Compares critical-module import failures before and after restore so an environmental failure that already existed does not block a valid restore, while a new failure introduced by the stash is rejected.
- Runs the import probe with the install interpreter and uses the canonical `build_subprocess_env()` factory with `PYTHONDONTWRITEBYTECODE=1`, avoiding both secret-env drift and probe-created `__pycache__` files.

### Fail-closed recovery

When proof fails:

- the recovery stash is retained;
- tracked files are reset to the clean updated `HEAD`;
- only untracked files whose ownership is proven from the stash's third parent and matching blob hash are removed;
- concurrent or modified same-name files remain untouched;
- the updater exits non-zero and prints explicit recovery commands;
- gateway restart is not allowed to continue on an unproven restored tree.

A valid restore still restores local edits and drops only the matching stash entry. Gateway/remote restore prompts use `[y/N]`, while interactive terminal Enter-as-yes behavior remains `[Y/n]`.

### Post-restart agent health and durable outcome

The gateway update marker now has a monotonic state transition:

- `2` = restart pending; no success notification is allowed;
- `0` = final success after agent health proof;
- `1` = terminal failure.

The new gateway consumes the pending marker and runs an isolated `import run_agent` probe before finalizing `0`. The watcher defers while the marker is `2`. A terminal failure cannot later be overwritten by a success result, and detached POSIX/Windows wrappers preserve existing terminal markers instead of blindly replacing them.

This closes the distinction between “messenger gateway connected” and “agent executable is healthy.”

## Why this is not a duplicate

I inspected the live issue and competing PRs #94287 and #94303, including their current diffs, tests, labels, and checks.

- #94287 covers the main post-restore syntax/import boundary but still treated an unavailable import probe as empty evidence in the adversarial launch-failure case.
- #94303 remains marked duplicate.
- This PR owns the stricter proof contract, stash-owned cleanup, concurrent-file protection, and durable post-restart agent-health outcome without copying either implementation.

## Regression coverage

The regression suite covers:

- clean stash apply of invalid tracked Python;
- invalid restored untracked Python;
- untracked paths containing spaces;
- a concurrent untracked file that must not be deleted;
- ambiguous cleanup when `hash-object` cannot run;
- valid Python restore and stash drop;
- new import-time failure versus pre-existing import-time failure;
- unavailable import probe and unavailable Git inventory;
- gateway park-default prompt behavior;
- pending post-restart marker deferral;
- successful and failed post-restart agent health finalization;
- monotonic protection against overwriting terminal failure;
- canonical subprocess-environment guard coverage.

## Validation

### Local

Using the repository's canonical wrapper with `HERMES_PYTHON=C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe`:

- Focused updater suite: **5 files, 50 tests passed, 0 failed, 1 skipped**.
- Restored-tree proof: **15 tests passed**.
- Gateway update command applicable tests on the Windows host: **17 tests passed**; the excluded `fallback_when_no_setsid` case assumes a POSIX `bash` argv layout.
- Gateway streaming applicable tests on the Windows host: **7 tests passed**; the excluded spawn-shape case assumes POSIX command layout.
- Subprocess environment guard: **2 tests passed**.
- Ruff: passed.
- `py_compile`: passed.
- `git diff --check`: passed.

The isolated worktree did not contain a local virtualenv with pytest; the canonical wrapper was run with the existing Hermes development interpreter through `HERMES_PYTHON`. A direct standalone probe invocation was blocked by the local Windows execution guard and produced no result; no success is inferred from that attempt. The probe path is covered by deterministic tests and the remote CI suite.

### Remote CI

Head verified on the live PR: `ca12cbd68d8b85fc1f51c4a5db2dcb64e75604d1`.

`All required checks pass` is green, including:

- Python tests;
- Python E2E;
- Python lint, Ruff, and type diff;
- Windows-only and macOS-only tests;
- Docs Site checks;
- Docker amd64 and arm64 builds;
- Nix flake check;
- supply-chain checks;
- attribution and common-ancestor checks;
- no committed infographic check.

JavaScript, Desktop E2E, Installer, Rust, lockfile, and other unrelated surfaces were correctly skipped by the affected-area classifier.

## GPT-5.6 Luna hardening record

- GitHub priority: issue #94264 is `P1`; PR #94344 is labeled `P2`. Because this change crosses persistence, subprocesses, external Git I/O, gateway restart, and security-sensitive failure handling, it was treated at difficult intensity with three hardening passes.
- Pass 1 — premise/root cause: reproduced clean stash re-application of invalid Python, traced restore → validation → stash drop → restart, and compared competing PRs.
- Pass 2 — failure modes: covered unavailable probes/inventories, tracked and untracked Python, whitespace paths, concurrent file creation/modification, cleanup ownership, wrapper timeouts, marker races, terminal failure overwrite, and gateway restart health.
- Pass 3 — simplification/regression: reused existing updater and gateway choke points, adopted the repository subprocess-env factory, prevented probe bytecode churn, added behavioral regressions, and re-ran the focused suites after the CI failure was corrected.

## Infographic: 
<img width="1672" height="941" alt="pr-94344-infographic" src="https://github.com/user-attachments/assets/e7326e2d-8863-448b-a005-a8ac634e4865" />




 
