### PR TITLE
fix(agent): preserve profile in session_search dispatch

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3276,6 +3276,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                     window=next_args.get("window", 5),
                     sort=next_args.get("sort"),
                     detail=next_args.get("detail", "adaptive"),
+                    profile=next_args.get("profile"),
                     db=session_db,
                     current_session_id=agent.session_id,
                 ),

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -2137,6 +2137,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     window=next_args.get("window", 5),
                     sort=next_args.get("sort"),
                     detail=next_args.get("detail", "adaptive"),
+                    profile=next_args.get("profile"),
                     db=session_db,
                     current_session_id=agent.session_id,
                 )

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2115,6 +2115,50 @@ class TestConcurrentToolExecution:
             )
             assert result == "result"
 
+    def test_concurrent_session_search_forwards_profile(self, agent):
+        """Cross-profile recall must reach the profile-aware search implementation."""
+        session_db = object()
+        agent._get_session_db_for_recall = lambda: session_db
+
+        with patch(
+            "tools.session_search_tool.session_search",
+            return_value='{"success": true}',
+        ) as mock_search:
+            result = agent._invoke_tool(
+                "session_search",
+                {"query": "continuity", "profile": "cso_montecristo"},
+                "task-1",
+                pre_tool_block_checked=True,
+                skip_tool_request_middleware=True,
+                skip_tool_execution_middleware=True,
+            )
+
+        assert json.loads(result)["success"] is True
+        assert mock_search.call_args.kwargs["db"] is session_db
+        assert mock_search.call_args.kwargs["profile"] == "cso_montecristo"
+
+    def test_sequential_session_search_forwards_profile(self, agent):
+        """The single-tool executor must preserve the same profile selector."""
+        session_db = object()
+        agent._get_session_db_for_recall = lambda: session_db
+        tool_call = _mock_tool_call(
+            name="session_search",
+            arguments='{"query":"continuity","profile":"default"}',
+            call_id="c-profile",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
+        messages = []
+
+        with patch(
+            "tools.session_search_tool.session_search",
+            return_value='{"success": true}',
+        ) as mock_search:
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        assert json.loads(messages[0]["content"])["success"] is True
+        assert mock_search.call_args.kwargs["db"] is session_db
+        assert mock_search.call_args.kwargs["profile"] == "default"
+
     def test_sequential_tool_callbacks_fire_in_order(self, agent):
         tool_call = _mock_tool_call(name="web_search", arguments='{"query":"hello"}', call_id="c1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])


### PR DESCRIPTION
## Summary

- forward the existing `profile` argument through both agent-level `session_search` dispatch paths
- add focused regressions for the concurrent and sequential executors
- preserve the original fix commit and authorship from @t-lights' stale #60792 branch

Closes #60789.
Supersedes the profile-dispatch portion of #60792 on current `main`; the read-only FTS prerequisite from that PR is already implemented on `main`.

## Root cause

`tools.session_search_tool.session_search()` already resolves an explicitly named profile to that profile's read-only session database. However, the agent runtime intercepted `session_search` and reconstructed its argument list without `profile` in two places:

- `agent/agent_runtime_helpers.py` (concurrent/direct invocation)
- `agent/tool_executor.py` (sequential execution)

As a result, `session_search(profile="other", ...)` silently searched the caller's current profile database.

## Fix

Pass `next_args.get("profile")` to `_session_search()` in both dispatch paths. No schema, database, session-content, or profile-resolution behavior changes.

## Verification

```text
scripts/run_tests.sh tests/run_agent/test_run_agent.py
282 passed

scripts/run_tests.sh tests/tools/test_session_search.py
53 passed

git diff --check origin/main...HEAD
python -m py_compile agent/agent_runtime_helpers.py agent/tool_executor.py tests/run_agent/test_run_agent.py
```

Live acceptance was also performed on an 11-profile gateway: the same discovery query produced distinct results and correctly scoped links for `profile="default"` (`@session:default/...`) and `profile="cso_montecristo"` (`@session:cso_montecristo/...`). No session data was modified during that check.

## Provenance

The first commit is a current-`main` salvage of @t-lights' original fix commit `5330f5748d9e5b954986ab6b16af0764d595b335` from #60792, retaining its author metadata. The second commit adds current-main regression coverage derived from the reproduced production failure.