### PR TITLE
fix(streaming): abort live stream on mid-stream repetition degeneration (#94224)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -43,6 +43,13 @@ from agent.message_sanitization import (
     _sanitize_surrogates,
     _repair_tool_call_arguments,
 )
+# Mid-stream repetition-degeneration guard (#94224): reuses the #86581
+# post-truncation heuristic so there is exactly one repetition detector.
+from agent.repetition_guard import (
+    MIN_FRAGMENT_LENGTH as _REPETITION_GUARD_MIN_FRAGMENT,
+    StreamDegenerationError,
+    is_repetition_dominated,
+)
 from agent.reasoning_summaries import separate_glued_reasoning_blocks
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
 from tools.terminal_tool import is_persistent_env
@@ -53,6 +60,13 @@ _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
 _PROVIDER_STREAM_ERROR_FINISH_REASONS = {"error", "error_finish"}
 _PROVIDER_STREAM_SSE_FIELDS = {"event", "data", "id", "retry"}
 _PROVIDER_STREAM_ERROR_TEXT_LIMIT = 4096
+
+# Mid-stream repetition-degeneration guard (#94224).  The accumulated
+# visible stream text is re-checked only after it has grown by this many
+# characters since the previous check — ``is_repetition_dominated`` scans
+# the whole accumulated fragment, so running it on every delta would make
+# the hottest loop in the agent quadratic.
+_REPETITION_GUARD_CHECK_INTERVAL = max(_REPETITION_GUARD_MIN_FRAGMENT // 2, 1)
 
 # When the fallback chain is fully exhausted on a non-rate-limit failure
 # (e.g. every provider returns a non-retryable client error like HTTP 400),
@@ -3900,6 +3914,56 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         content_parts: list = []
         tool_calls_acc: dict = {}
         tool_gen_notified: set = set()
+        # ── Mid-stream repetition-degeneration guard state (#94224) ──
+        # ``content_parts`` is the authoritative accumulated visible text;
+        # these track when the guard last ran so the (whole-fragment)
+        # heuristic only executes every _REPETITION_GUARD_CHECK_INTERVAL
+        # characters of growth instead of on every delta.
+        repetition_guard_checked_at = 0
+
+        def _repetition_guard_check() -> None:
+            """Abort a stream whose visible text turned repetition-dominated.
+
+            Runs :func:`is_repetition_dominated` over the accumulated
+            visible text — the same conservative heuristic the
+            post-truncation guard applies to ``finish_reason=length``
+            responses (#86581), just earlier: while deltas are still
+            arriving, so the model cannot spend minutes of wall-clock and
+            its entire output budget echoing one fragment (#94224).
+
+            Fail-open by design: below MIN_FRAGMENT_LENGTH chars there is
+            nothing to judge, and any heuristic error is swallowed — an
+            evaluation bug must never abort a healthy stream.
+            """
+            nonlocal repetition_guard_checked_at
+            visible_len = sum(len(part) for part in content_parts)
+            if visible_len - repetition_guard_checked_at < _REPETITION_GUARD_CHECK_INTERVAL:
+                return
+            repetition_guard_checked_at = visible_len
+            try:
+                degenerate = is_repetition_dominated("".join(content_parts))
+            except Exception:
+                logger.warning(
+                    "Repetition guard evaluation failed; continuing stream.",
+                    exc_info=True,
+                )
+                return
+            if not degenerate:
+                return
+            logger.warning(
+                "Mid-stream repetition detected after ~%s visible chars "
+                "(model=%s) — aborting stream before the loop floods the "
+                "response.",
+                visible_len,
+                api_kwargs.get("model", "unknown"),
+            )
+            # Raising unwinds the chunk-consumption loop; Relay's managed
+            # stream scope is closed by the worker's cleanup paths.
+            raise StreamDegenerationError(
+                "Model output entered a repetition loop mid-stream; "
+                "stream aborted."
+            )
+
         # Ollama-compatible endpoints reuse index 0 for every tool call
         # in a parallel batch, distinguishing them only by id.  Track
         # the last seen id per raw index so we can detect a new tool
@@ -4160,6 +4224,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             delta_content = getattr(delta, "content", None)
             if delta_content:
                 content_parts.append(delta_content)
+                # Mid-stream repetition-degeneration guard (#94224). Only
+                # visible response text is judged — reasoning blocks are
+                # separate scratchpad output, and once real tool calls
+                # exist this stream is an action turn whose suppressed
+                # narration is not the final answer.
+                if not tool_calls_acc:
+                    _repetition_guard_check()
                 if not tool_calls_acc:
                     if pending_text_parts or _provider_stream_text_may_be_sse(delta.content):
                         pending_text_parts.append(delta.content)
@@ -4741,6 +4812,18 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 except Exception as e:
                     _emit_stream_end(final_text="", finished=False, error=str(e))
                     _close_managed_stream()
+                    # ── Mid-stream repetition-degeneration abort (#94224) ──
+                    # The guard tripped while deltas were still arriving:
+                    # the same provider/model would re-enter the identical
+                    # loop on a retry or fallback, and the partial text must
+                    # NOT be rescued into a finish_reason=length stub (the
+                    # continuation machinery would stitch the degenerate
+                    # draft back into the response). Fail fast so the
+                    # conversation loop can discard the draft and surface
+                    # the user-facing repetition notice.
+                    if isinstance(e, StreamDegenerationError):
+                        result["error"] = e
+                        return
                     # If the main poll loop force-closed this request because
                     # of an interrupt, the resulting transport error is the
                     # expected consequence of our own close — NOT a transient
@@ -5244,6 +5327,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     if agent._interrupt_requested:
         raise InterruptedError("Agent interrupted during streaming API call (post-worker)")
     if result["error"] is not None:
+        # ── Mid-stream repetition-degeneration abort (#94224) ──
+        # Must precede the partial-delivery stub below: the degenerate
+        # draft is exactly what that length-stub would preserve and feed
+        # to the continuation machinery. Re-raise so the conversation loop
+        # sees StreamDegenerationError and discards the aborted draft.
+        if isinstance(result["error"], StreamDegenerationError):
+            raise result["error"]
         if deltas_were_sent["yes"]:
             # Streaming failed AFTER some tokens were already delivered to
             # the platform.  Re-raising would let the outer retry loop make

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -90,7 +90,7 @@ from agent.retry_utils import (
     jittered_backoff,
     zai_coding_overload_retry_ceiling,
 )
-from agent.repetition_guard import is_repetition_dominated
+from agent.repetition_guard import is_repetition_dominated, StreamDegenerationError
 from agent.trajectory import has_incomplete_scratchpad
 # Bind before the turn starts so a source-tree swap cannot load a skewed
 # finalizer at turn end.
@@ -4409,6 +4409,71 @@ def run_conversation(
                 )
                 agent._touch_activity(f"API call #{api_call_count} completed")
                 break  # Success, exit retry loop
+
+            except StreamDegenerationError:
+                # ── Mid-stream repetition-degeneration abort (#94224) ──
+                # The streaming layer detected the response turning
+                # repetition-dominated (same heuristic as the #86581
+                # post-truncation guard) and killed the live stream. The
+                # degenerate draft must NOT reach history: it was never a
+                # real answer, and appending it would break role alternation
+                # on the next turn. Discard it, clear the streamed-text
+                # tracking so the poisoned deltas can't leak into the
+                # interim-visible-text comparison, settle the Relay logical
+                # call as cancelled, and exit with the same user-facing
+                # notice shape as the post-truncation repetition guard.
+                if thinking_spinner:
+                    thinking_spinner.stop("")
+                    thinking_spinner = None
+                if agent.thinking_callback:
+                    agent.thinking_callback("")
+                try:
+                    agent._reset_stream_delivery_tracking()
+                except Exception:
+                    logger.debug(
+                        "stream delivery tracking reset failed after "
+                        "degeneration abort",
+                        exc_info=True,
+                    )
+                try:
+                    relay_llm.complete_logical_call(
+                        api_request_id,
+                        outcome="cancelled",
+                    )
+                except Exception:
+                    logger.debug(
+                        "relay logical-call completion failed after "
+                        "degeneration abort",
+                        exc_info=True,
+                    )
+                agent._vprint(
+                    f"{agent.log_prefix}🔁 Response dominated by repeated "
+                    f"text — stream stopped before the repetition loop "
+                    f"flooded the response.",
+                    force=True,
+                )
+                _deg_response = (
+                    "⚠️ **Response Stopped — Repetition Detected**\n\n"
+                    "The model fell into a repetition loop while writing "
+                    "this response, so the partial response was discarded "
+                    "before it could flood the conversation.\n\n"
+                    "→ Switch to a different model with `/model`\n"
+                    "→ Or resend your message (your conversation history "
+                    "is preserved)"
+                )
+                agent._cleanup_task_resources(effective_task_id)
+                agent._persist_session(messages, conversation_history)
+                return {
+                    "final_response": _deg_response,
+                    "messages": messages,
+                    "api_calls": api_call_count,
+                    "completed": False,
+                    "partial": True,
+                    "error": (
+                        "Model output entered a repetition loop mid-stream; "
+                        "the live stream was aborted."
+                    ),
+                }
 
             except InterruptedError:
                 if thinking_spinner:

--- a/agent/repetition_guard.py
+++ b/agent/repetition_guard.py
@@ -93,3 +93,22 @@ def _line_repetition_dominated(text: str, n: int) -> bool:
         if c >= _MIN_REPEAT_COUNT and c * len(line) >= n * _DOMINANCE_RATIO:
             return True
     return False
+
+
+class StreamDegenerationError(Exception):
+    """A live stream turned repetition-dominated and was aborted (#94224).
+
+    Raised by the streaming paths in ``chat_completion_helpers.py`` while
+    deltas are still arriving, when the accumulated visible text trips
+    :func:`is_repetition_dominated` — the same heuristic the post-truncation
+    guard applies after ``finish_reason=length`` (#86581), but moved upstream
+    so the abort happens while the loop is still running instead of after the
+    model burned its entire output budget.
+
+    Consumers must treat this as terminal-for-the-request, never transient:
+    retrying or falling back would ask the same degenerating model to try
+    again and re-enter the same loop. The caller that can actually honour
+    that contract is the conversation loop, which discards the aborted draft,
+    keeps it out of history, and shows a user-facing explanation — mirroring
+    the post-truncation repetition guard there.
+    """

--- a/tests/agent/test_stream_degeneration_guard_94224.py
+++ b/tests/agent/test_stream_degeneration_guard_94224.py
@@ -1,0 +1,399 @@
+"""Mid-stream repetition-degeneration guard (#94224).
+
+Issue: on very large contexts a model can enter a degenerate repetition
+loop (e.g. echoing ``！！！`` forever). Before this fix nothing watched the
+LIVE stream — the loop ran for minutes, flooded the consumer with deltas,
+and the poisoned draft was stitched into the conversation as if it were a
+real answer. The #86581 guard only ran AFTER a ``finish_reason=length``
+truncation, so a loop that never hits the cap was invisible to it.
+
+The fix reuses :func:`agent.repetition_guard.is_repetition_dominated`
+(ONE detector, two call sites) on the accumulated visible stream text,
+cheaply: only every ``_REPETITION_GUARD_CHECK_INTERVAL`` chars of growth.
+On trip, the live stream attempt is cancelled and ``StreamDegenerationError``
+propagates to the conversation loop, which discards the aborted draft
+(keeping strict role alternation intact) and shows the same user-facing
+notice shape as the post-truncation repetition guard.
+
+Behavior contracts pinned here:
+1. A degenerate stream is aborted BEFORE the provider iterator is drained.
+2. The conversation history never receives the aborted draft.
+3. Healthy long streams never trip the guard.
+4. Tool-call streams never trip the guard (action turns are exempt).
+5. A raising heuristic fails open — the stream completes untouched.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ── Chunk factories (mirror tests/run_agent/test_streaming.py) ──────────
+
+
+def _make_stream_chunk(
+    content=None, tool_calls=None, finish_reason=None,
+    model=None, reasoning_content=None, usage=None,
+):
+    delta = SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls,
+        reasoning_content=reasoning_content,
+        reasoning=None,
+    )
+    choice = SimpleNamespace(index=0, delta=delta, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model=model, usage=usage)
+
+
+def _make_tool_call_delta(index=0, tc_id=None, name=None, arguments=None):
+    return SimpleNamespace(
+        index=index,
+        id=tc_id,
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _degenerate_text(chars=1600):
+    """The #94224 incident shape: one short fragment echoed far past the
+    heuristic's MIN_FRAGMENT_LENGTH (400) with 60+-char windows repeated
+    5+ times covering half the fragment."""
+    return "！！！" * (chars // 3 + 1)
+
+
+def _healthy_prose(target_chars=2200):
+    """Varied sentences — no 60-char window repeats anywhere near the
+    dominance ratio."""
+    sentences = [
+        "The parser walks the token stream left to right.",
+        "Each node carries a span back to its source range.",
+        "Recovery happens at statement boundaries only.",
+        "Diagnostics are deduplicated before rendering.",
+        "The whole pass stays allocation-light in the hot path.",
+    ]
+    out = []
+    total = 0
+    i = 0
+    while total < target_chars:
+        s = f"{i}. {sentences[i % len(sentences)]}\n"
+        out.append(s)
+        total += len(s)
+        i += 1
+    return "".join(out)
+
+
+def _tracking_stream(chunks):
+    """Iterator wrapper recording delivery order so tests can assert the
+    stream was aborted BEFORE being fully drained."""
+    consumed = []
+
+    def _gen():
+        for c in chunks:
+            consumed.append(c)
+            yield c
+
+    return _gen(), consumed
+
+
+def _make_stream_agent():
+    """AIAgent wired for the chat_completions streaming path with a mocked
+    provider client (mirrors tests/run_agent/test_streaming.py)."""
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    return agent
+
+
+@contextmanager
+def _staged_stream_client(gen):
+    """Stage a mocked provider client returning ``gen`` as the stream."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = gen
+    with (
+        patch(
+            "run_agent.AIAgent._create_request_openai_client",
+            return_value=mock_client,
+        ),
+        patch("run_agent.AIAgent._close_request_openai_client"),
+    ):
+        yield mock_client
+
+
+# ── 1. Mid-stream abort on the streaming helper ──────────────────────────
+
+
+class TestMidStreamAbort:
+    def test_degenerate_stream_aborts_before_iterator_ends(self):
+        """A '！！！' echo loop must raise StreamDegenerationError while the
+        provider iterator still has unread chunks left."""
+        from agent.repetition_guard import StreamDegenerationError
+
+        echo = "！！！" * 12  # 36 chars/chunk → trips within ~14 chunks
+        filler = "Intro paragraph explaining the answer.\n\n"
+        chunks = [_make_stream_chunk(content=filler)]
+        chunks += [_make_stream_chunk(content=echo) for _ in range(80)]
+        chunks.append(_make_stream_chunk(finish_reason="stop", model="m"))
+        gen, consumed = _tracking_stream(chunks)
+
+        agent = _make_stream_agent()
+        with _staged_stream_client(gen):
+            with pytest.raises(StreamDegenerationError):
+                agent._interruptible_streaming_api_call({})
+
+        assert len(consumed) < len(chunks), (
+            "The guard must abort the LIVE stream — chunks after the "
+            "detection point were still consumed, meaning the iterator "
+            "was drained to completion."
+        )
+
+    def test_abort_happens_mid_stream_not_after_final_chunk(self):
+        """Detection point must precede the finish_reason chunk."""
+        from agent.repetition_guard import StreamDegenerationError
+
+        echo = "！！！" * 12
+        chunks = [_make_stream_chunk(content=echo) for _ in range(80)]
+        final = _make_stream_chunk(finish_reason="stop", model="m")
+        chunks.append(final)
+        gen, consumed = _tracking_stream(chunks)
+
+        agent = _make_stream_agent()
+        with _staged_stream_client(gen):
+            with pytest.raises(StreamDegenerationError):
+                agent._interruptible_streaming_api_call({})
+
+        assert final not in consumed
+
+    def test_short_repeated_text_is_fail_open(self):
+        """Below MIN_FRAGMENT_LENGTH chars the guard must never fire — a
+        short stuttering reply is not evidence of degeneration."""
+        chunks = [
+            _make_stream_chunk(content="！！！" * 20),  # 60 chars < 400
+            _make_stream_chunk(content="Done.", finish_reason="stop", model="m"),
+        ]
+        agent = _make_stream_agent()
+        with _staged_stream_client(iter(chunks)):
+            response = agent._interruptible_streaming_api_call({})
+        assert response.choices[0].finish_reason == "stop"
+        assert "Done." in response.choices[0].message.content
+
+
+# ── 2. Exemptions: healthy streams and tool-call streams ────────────────
+
+
+class TestGuardExemptions:
+    def test_long_healthy_stream_never_trips(self):
+        """Varied prose well past the check interval completes normally."""
+        chunks = [
+            _make_stream_chunk(content=_healthy_prose()),
+            _make_stream_chunk(content=" All done.", finish_reason="stop", model="m"),
+        ]
+        agent = _make_stream_agent()
+        with _staged_stream_client(iter(chunks)):
+            response = agent._interruptible_streaming_api_call({})
+        assert response.choices[0].finish_reason == "stop"
+        assert "All done." in response.choices[0].message.content
+
+    def test_tool_call_stream_with_looking_narration_never_trips(self):
+        """Once a tool call is in flight the stream is an action turn: even
+        repetitive-looking suppressed narration must not abort it."""
+        echo = _degenerate_text()
+        chunks = [
+            _make_stream_chunk(content="Reading the file now."),
+            _make_stream_chunk(
+                tool_calls=[
+                    _make_tool_call_delta(
+                        index=0, tc_id="call_1",
+                        name="terminal", arguments='{"command": "ls"}',
+                    )
+                ]
+            ),
+        ]
+        chunks += [_make_stream_chunk(content=echo) for _ in range(40)]
+        chunks.append(_make_stream_chunk(finish_reason="tool_calls", model="m"))
+        agent = _make_stream_agent()
+        with _staged_stream_client(iter(chunks)):
+            response = agent._interruptible_streaming_api_call({})
+        assert response.choices[0].finish_reason == "tool_calls"
+        assert response.choices[0].message.tool_calls[0].function.name == "terminal"
+
+    def test_short_preamble_then_tool_call_never_trips(self):
+        """Ordinary chatty preambles are far below the fragment floor."""
+        chunks = [
+            _make_stream_chunk(content=f"Step {i}: checking. " * 4)
+            for i in range(8)
+        ]
+        chunks += [
+            _make_stream_chunk(
+                tool_calls=[
+                    _make_tool_call_delta(
+                        index=0, tc_id="call_1", name="files",
+                        arguments='{"action": "list"}',
+                    )
+                ]
+            ),
+            _make_stream_chunk(finish_reason="tool_calls", model="m"),
+        ]
+        agent = _make_stream_agent()
+        with _staged_stream_client(iter(chunks)):
+            response = agent._interruptible_streaming_api_call({})
+        assert response.choices[0].finish_reason == "tool_calls"
+
+
+# ── 3. Fail-open on heuristic errors ────────────────────────────────────
+
+
+class TestHeuristicFailOpen:
+    def test_raising_heuristic_never_aborts_the_stream(self):
+        """A bug inside is_repetition_dominated must degrade to 'keep the
+        stream', never kill a possibly-healthy response."""
+        chunks = [
+            _make_stream_chunk(content=_degenerate_text()),
+            _make_stream_chunk(content="tail", finish_reason="stop", model="m"),
+        ]
+        agent = _make_stream_agent()
+        with (
+            _staged_stream_client(iter(chunks)),
+            patch(
+                "agent.chat_completion_helpers.is_repetition_dominated",
+                side_effect=RuntimeError("heuristic bug"),
+            ),
+        ):
+            response = agent._interruptible_streaming_api_call({})
+        assert response.choices[0].finish_reason == "stop"
+        assert response.choices[0].message.content.endswith("tail")
+
+    def test_non_string_accumulation_cannot_raise(self):
+        """Non-str deltas are filtered by the heuristic's own guard; the
+        stream completes."""
+        weird = SimpleNamespace(content=None, tool_calls=None,
+                                reasoning_content=None, reasoning=None)
+        chunks = [
+            SimpleNamespace(
+                choices=[SimpleNamespace(index=0, delta=weird,
+                                         finish_reason=None)],
+                model="m", usage=None,
+            ),
+            _make_stream_chunk(content="ok", finish_reason="stop", model="m"),
+        ]
+        agent = _make_stream_agent()
+        with _staged_stream_client(iter(chunks)):
+            response = agent._interruptible_streaming_api_call({})
+        assert response.choices[0].message.content == "ok"
+
+
+# ── 4. Conversation-loop integration: draft kept out of history ─────────
+
+
+@pytest.fixture()
+def loop_agent():
+    """AIAgent for run_conversation with a mocked provider client staged on
+    .chat.completions.create (mirrors test_dropped_tool_call_recovery).
+    agent.client must NOT be a Mock instance, otherwise the loop disables
+    streaming and the mid-stream guard never engages."""
+    from run_agent import AIAgent
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = SimpleNamespace()  # not a Mock → streaming allowed
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        return agent
+
+
+class TestConversationLoopDiscardsDraft:
+    def test_degenerate_turn_aborts_and_keeps_draft_out_of_history(
+        self, loop_agent
+    ):
+        """End to end: the poisoned draft must never become an assistant
+        message; the user-facing notice explains the abort; role
+        alternation is preserved (history still ends on the user message);
+        no continuation retry burns budget."""
+        echo = "！！！" * 12
+        chunks = [_make_stream_chunk(content="Sure, here is the answer.\n\n")]
+        chunks += [_make_stream_chunk(content=echo) for _ in range(80)]
+        chunks.append(_make_stream_chunk(finish_reason="stop", model="m"))
+        gen, consumed = _tracking_stream(chunks)
+
+        seen_deltas = []
+        loop_agent.stream_delta_callback = seen_deltas.append
+
+        with (
+            _staged_stream_client(gen) as mock_client,
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("write me a haiku")
+
+        # Deltas really streamed before the abort (this was a LIVE stream).
+        assert any(echo.strip() in d for d in seen_deltas)
+
+        # Abort surfaced as StreamDegenerationError, not a stub/retry.
+        assert len(consumed) < len(chunks)
+        assert mock_client.chat.completions.create.call_count == 1, (
+            "No continuation/retry may follow a degeneration abort."
+        )
+
+        # User-facing notice mirrors the #86581 post-truncation guard tone.
+        assert "Repetition Detected" in result["final_response"]
+        assert result["completed"] is False
+        assert result.get("partial") is True
+
+        # THE core contract: the aborted draft is nowhere in history and
+        # strict role alternation holds (turn still ends on the user msg).
+        messages = result["messages"]
+        for m in messages:
+            if m.get("role") == "assistant":
+                assert "！！！" not in (m.get("content") or ""), (
+                    "The degenerate draft leaked into the conversation "
+                    "history — it must be discarded entirely."
+                )
+        assert messages[-1]["role"] == "user"
+
+    def test_healthy_streamed_turn_still_completes_normally(self, loop_agent):
+        """Control: a healthy streamed turn is untouched by the guard."""
+        chunks = [
+            _make_stream_chunk(content=_healthy_prose()),
+            _make_stream_chunk(
+                content=" Hope that helps!", finish_reason="stop", model="m"
+            ),
+        ]
+        with (
+            _staged_stream_client(iter(chunks)),
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert "Hope that helps!" in result["final_response"]
+
+        assistant = [
+            m for m in result["messages"] if m.get("role") == "assistant"
+        ]
+        assert assistant, "Healthy response must land in history"


### PR DESCRIPTION
Fixes #94224 — mid-stream repetition-degeneration detection that auto-aborts the live stream and keeps the aborted draft out of the context.

## Summary

On very large contexts a model can collapse into a degenerate repetition loop while streaming (the issue incident: `"！！！"` echoed for 4+ minutes with the Stop button unresponsive). Nothing watched the **live** stream: the existing repetition guard from #86581 only runs *after* a `finish_reason=length` truncation, so a loop that never hits the output cap flooded the consumer for minutes, and its poisoned draft was stitched into the conversation as if it were a real answer.

This PR reuses `agent/repetition_guard.is_repetition_dominated()` — the same conservative heuristic, one detector, two call sites — as a **live guard** inside the streaming path:

- **Cheap by construction.** The accumulated visible text is re-checked only every `_REPETITION_GUARD_CHECK_INTERVAL` (= 200) chars of growth since the last check; running the whole-fragment scan per delta would make the hottest loop in the agent quadratic. Reasoning deltas are exempt (separate scratchpad output), and once real tool calls exist the stream is an action turn whose suppressed narration is not judged.
- **Clean abort.** On trip, the worker raises the new `StreamDegenerationError`, which fails fast past the retry/fallback machinery in `_call()` and past the partial-delivery stub in `interruptible_streaming_api_call` — that length-stub would otherwise feed the degenerate draft straight back into the continuation machinery.
- **Poison stays out of context.** `conversation_loop.run_conversation` catches the error, discards the aborted draft entirely (strict role alternation preserved — history still ends on the user message), clears streamed-text delivery tracking so the poisoned deltas cannot leak into the interim-visible-text comparison, settles the Relay logical call as `cancelled`, and exits with the same user-facing notice shape as the #86581 post-truncation guard ("⚠️ Response Stopped — Repetition Detected").

Fail-open everywhere: short streams never reach the check interval, tool-call turns are exempt, and if the heuristic itself raises, the guard logs and keeps streaming instead of aborting a possibly-healthy response.

Scope note: this covers the OpenAI-compatible `chat_completions` streaming path, which is where the incident's provider class streams. The `bedrock_converse` path has its own callback pipeline and was deliberately left untouched to keep this a minimal one-fix PR.

Related: #86581 (post-truncation repetition guard this builds on).

## Design notes

- No new env var / config flag / model-tool surface: the guard inherits its thresholds from the existing #86581 heuristic constants (`MIN_FRAGMENT_LENGTH=400`, 60-char windows, ≥5 repeats, dominance ≥0.5), which are deliberately tuned to only trip on long verbatim echo loops.
- Prompt caching and byte-stable system prompt untouched: nothing mutates past context; the degenerate turn contributes no messages at all.
- The abort rides the existing per-attempt stream lifecycle (`_emit_stream_end(error=...)`, managed-stream close, request-client cleanup in the worker `finally`); no new cancellation channel was added.

## Test Plan

New behavior-contract suite `tests/agent/test_stream_degeneration_guard_94224.py` (10 tests):

- a mocked `"！！！"×N` stream raises `StreamDegenerationError` **before** the provider iterator is drained (asserted on chunk delivery order), including before the `finish_reason` chunk
- end-to-end through `run_conversation`: deltas really streamed first, exactly one API call (no continuation retry), the notice lands in `final_response`, and **no assistant message containing the draft exists in history** with role alternation preserved
- long healthy prose streams complete normally
- tool-call streams with repetitive-looking narration complete normally
- below `MIN_FRAGMENT_LENGTH` chars the guard never fires
- a raising heuristic fails open (stream completes)
- healthy streamed turns still land their full response in history

Regression suites green: `tests/run_agent/test_run_agent.py` (280 passed), targeted neighbors for the truncation/continuation/streaming machinery (`tests/agent/test_repetition_guard.py`, `test_continuation_repetition_guard.py`, `test_anthropic_truncation_continuation.py`, `test_partial_stream_finish_reason.py`, `tests/run_agent/test_streaming.py`, interrupt/stale-stream suites — all passing), plus the full `tests/agent/` directory.

---

Credits: Bruno Bza (@BrunoBza)
