### PR TITLE
Follow-ups to #93757: boundary test, skip warning, doc sync for secure_parent_dir install-tree exclusion

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1424,7 +1424,8 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
     auth_file.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir to 0o700 so siblings can't traverse to creds.
     # No-op on Windows (POSIX mode bits not enforced); ignore failures.
-    # secure_parent_dir refuses to chmod / or top-level dirs (#25821).
+    # secure_parent_dir refuses to chmod /, top-level dirs, or the
+    # hermes-agent install tree (#25821, #93050).
     secure_parent_dir(auth_file)
     auth_store["version"] = AUTH_STORE_VERSION
     auth_store["updated_at"] = datetime.now(timezone.utc).isoformat()
@@ -2812,7 +2813,8 @@ def _read_qwen_cli_tokens() -> Dict[str, Any]:
 def _save_qwen_cli_tokens(tokens: Dict[str, Any]) -> Path:
     auth_path = _qwen_cli_auth_path()
     auth_path.parent.mkdir(parents=True, exist_ok=True)
-    # secure_parent_dir refuses to chmod / or top-level dirs (#25821).
+    # secure_parent_dir refuses to chmod /, top-level dirs, or the
+    # hermes-agent install tree (#25821, #93050).
     secure_parent_dir(auth_path)
     # Per-process random temp suffix avoids collisions between concurrent
     # writers and stale leftovers from a crashed prior write.
@@ -5628,7 +5630,8 @@ def _write_shared_nous_state(state: Dict[str, Any]) -> None:
         with _nous_shared_store_lock():
             path = _nous_shared_store_path()
             path.parent.mkdir(parents=True, exist_ok=True)
-            # secure_parent_dir refuses to chmod / or top-level dirs (#25821).
+            # secure_parent_dir refuses to chmod /, top-level dirs, or the
+            # hermes-agent install tree (#25821, #93050).
             secure_parent_dir(path)
             tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
             # Create with 0o600 atomically via os.open(O_EXCL) — closes the TOCTOU

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1022,7 +1022,13 @@ def secure_parent_dir(path: Path) -> None:
     prevent catastrophic host bricking when ``HERMES_HOME`` or other path
     env vars resolve to an unexpected location.
 
-    See https://github.com/NousResearch/hermes-agent/issues/25821.
+    Also refuses to chmod the hermes-agent install tree (the directory this
+    module lives in, and anything below it): restricting the install dir to
+    0700 locks the runtime user out of traversing it when it does not own
+    the dir, as in the Docker image. A warning is logged when this happens.
+
+    See https://github.com/NousResearch/hermes-agent/issues/25821 and
+    https://github.com/NousResearch/hermes-agent/pull/93050.
     """
     parent = path.parent.resolve()
     # Refuse root and its direct children (/usr, /home, /var, /tmp, …).

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1032,6 +1032,19 @@ def secure_parent_dir(path: Path) -> None:
     # traversal in Docker (UID 10000) and any other install where the
     # runtime user doesn't own the install dir. See #25821, #93050.
     if parent == _INSTALL_ROOT or _INSTALL_ROOT in parent.parents:
+        # A credential file inside the install tree usually means HERMES_HOME
+        # resolved somewhere unexpected — surface it instead of skipping
+        # silently, since this same misconfiguration previously caused
+        # production lockouts.
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "Not restricting permissions on %s: it is inside the "
+            "hermes-agent install directory (%s). Credential files are "
+            "normally stored under the hermes home directory instead.",
+            parent,
+            _INSTALL_ROOT,
+        )
         return
     try:
         os.chmod(parent, 0o700)

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -584,6 +584,38 @@ class TestSecureParentDir:
         secure_parent_dir(target2)
         assert called_with2 == [], "must not chmod dirs inside the install tree"
 
+    def test_install_tree_siblings_still_hardened(self, monkeypatch):
+        """Paths OUTSIDE the install tree must still be chmod'd.
+
+        Negative boundary for the install-tree exclusion (#93050): the guard
+        compares path components, so a sibling directory whose name merely
+        starts with the install root's name (``<install_root>-data``) must
+        still receive parent-dir hardening. Pins that the exclusion cannot
+        silently widen into a string-prefix match.
+        """
+        install_root = Path(hermes_constants.__file__).resolve().parent
+
+        # Prefix-named sibling of the install root (/opt/hermes-data/...).
+        prefix_sibling = Path(str(install_root) + "-data")
+        called_with = []
+        monkeypatch.setattr(os, "chmod", lambda p, m: called_with.append((str(p), m)))
+        secure_parent_dir(prefix_sibling / "auth.json")
+        assert called_with == [(str(prefix_sibling), 0o700)], (
+            "prefix-named siblings of the install root must still be hardened"
+        )
+
+        # Ordinary sibling next to the install root (same parent dir).
+        sibling = install_root.parent / "unrelated-dir"
+        if len(sibling.parts) >= 3 and install_root not in sibling.parents:
+            called_with2 = []
+            monkeypatch.setattr(
+                os, "chmod", lambda p, m: called_with2.append((str(p), m))
+            )
+            secure_parent_dir(sibling / "auth.json")
+            assert called_with2 == [(str(sibling), 0o700)], (
+                "siblings of the install root must still be hardened"
+            )
+
     @pytest.mark.require_symlinks
     def test_symlink_resolved(self, tmp_path, monkeypatch):
         """Symlinks should be resolved before checking depth."""

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -424,7 +424,8 @@ def _write_json(path: Path, data: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir to 0o700 so siblings can't traverse to the creds.
     # No-op on Windows (POSIX mode bits aren't enforced); ignore failures.
-    # secure_parent_dir refuses to chmod / or top-level dirs (#25821).
+    # secure_parent_dir refuses to chmod /, top-level dirs, or the
+    # hermes-agent install tree (#25821, #93050).
     secure_parent_dir(path)
     # Per-process random suffix avoids collisions between concurrent
     # writers and stale leftovers from a prior crashed write.

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -802,6 +802,16 @@ docker run -d \
 
 `docker exec hermes <cmd>` automatically drops to UID 10000 too — see [`docker exec` automatically drops to the `hermes` user](#docker-exec-automatically-drops-to-the-hermes-user) for details and the per-invocation opt-out.
 
+### "Permission denied" on every `docker exec` (install dir locked to 0700)
+
+Images built before late August 2026 had a bug where writing a credential file directly under `/opt/hermes` restricted that directory to `0700`, locking the `hermes` user (UID 10000) out of the install tree. Every new `docker exec` then fails with `Permission denied`.
+
+Pulling a newer image and recreating the container fixes it permanently (the install dir ships as `0755` and current releases no longer restrict it). If you need to recover a running container in place without recreating it:
+
+```sh
+docker exec -u root hermes chmod 0755 /opt/hermes
+```
+
 ### Browser tools not working
 
 Playwright needs shared memory. Add `--shm-size=1g` to your Docker run command:


### PR DESCRIPTION
## Summary

Follow-ups from the post-merge dual review (sol-reviewer + fable-reviewer) of #93757, which added the install-tree exclusion to `secure_parent_dir()`. Both reviews verdicted approve-with-nits; these commits close the verified findings. One commit per finding.

## Changes

1. **test: pin that install-root siblings still get parent-dir hardening** — #93757 added a positive test (inside the tree → skipped) but no negative boundary. A future rewrite of the guard to a string-prefix match (`startswith`) would silently strip 0700 hardening from prefix-named siblings like `/opt/hermes-data` with the suite staying green. New test covers a prefix-named sibling and an ordinary sibling. **Mutation-verified**: replacing the guard with `str(parent).startswith(str(_INSTALL_ROOT))` turns the new test red.

2. **fix: log a warning when parent-dir hardening is skipped for the install tree** — the exclusion returned silently. A credential file landing in the install tree is exactly the misconfiguration that caused the 2026-07-06 / 2026-08-22 production lockouts, and a hermes home nested inside a git clone silently loses previously-working hardening. One `logger.warning` naming the skipped dir and install root.

3. **docs: update `secure_parent_dir` docstring and caller comments** — the docstring and all four credential-write call sites (`hermes_cli/auth.py` ×3, `tools/mcp_oauth.py` ×1) still said the helper refuses only `/` and top-level dirs.

4. **docs: operator remediation for already-locked containers** — the Dockerfile fix helps new builds only; image upgrades self-heal (install dir is image-layer FS), but an old image whose container was stop/start-ed after lockout stays at 0700 and no shipped code can reach it. Added the in-place recovery (`docker exec -u root hermes chmod 0755 /opt/hermes`) to the Docker troubleshooting docs.

## Validation

| Check | Result |
|---|---|
| `tests/test_hermes_constants.py` | 63 passed, 5 skipped |
| Mutation check on new test | red under `startswith` rewrite, green on real guard |
| Live probe of warning | fires on install-tree path; absent (and chmod still applied) on sibling path |
| ruff on touched files | clean |
| Full suite vs baseline | identical failure sets on this branch and bare `41447a6d70` (local env gaps: missing `acp` module etc.) — zero new failures |

Refs #93757, #93050, #25821.
