### PR TITLE
fix(tui): stop Windows pid probe from killing the host

### DIFF
--- a/tests/tui_gateway/test_host_supervisor_pid_alive.py
+++ b/tests/tui_gateway/test_host_supervisor_pid_alive.py
@@ -1,0 +1,43 @@
+"""_pid_alive must never kill the process it probes.
+
+``os.kill(pid, 0)`` is a POSIX liveness probe, but on Windows sig=0 is
+not a no-op (bpo-14484): it terminates the target / Ctrl+C's its console
+group. tui_gateway/host_supervisor.py used the bare POSIX form, so on a
+Windows host every registry staleness check terminated a healthy TUI
+host. These tests pin the contract: probing a live PID must succeed
+without ever reaching ``os.kill``.
+"""
+
+import os
+import subprocess
+import sys
+
+from tui_gateway import host_supervisor
+
+
+def test_pid_alive_never_calls_os_kill(monkeypatch):
+    def _boom(*_a, **_kw):  # noqa: ANN002, ANN003
+        raise AssertionError("os.kill reached — Windows would kill the probe target")
+
+    monkeypatch.setattr(os, "kill", _boom)
+    assert host_supervisor._pid_alive(os.getpid()) is True
+
+
+def test_pid_alive_rejects_nonpositive_pids(monkeypatch):
+    def _boom(*_a, **_kw):  # noqa: ANN002, ANN003
+        raise AssertionError("os.kill reached for non-positive pid")
+
+    monkeypatch.setattr(os, "kill", _boom)
+    assert host_supervisor._pid_alive(0) is False
+    assert host_supervisor._pid_alive(-1) is False
+
+
+def test_pid_alive_reports_dead_pid_false():
+    # A fully reaped child PID must not be reported alive.
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "pass"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    proc.wait()  # reaped -> definitely dead
+    assert host_supervisor._pid_alive(proc.pid) is False

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -88,15 +88,14 @@ def _default_registry_path() -> Path:
 def _pid_alive(pid: int) -> bool:
     if pid <= 0:
         return False
-    try:
-        os.kill(pid, 0)
-        return True
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    except Exception:
-        return False
+    # Delegate to the canonical cross-platform probe (psutil, with a
+    # Win32 OpenProcess fallback). Do NOT probe with os.kill(pid, 0):
+    # on Windows that is not a no-op — sig=0 maps to TerminateProcess /
+    # console-group Ctrl+C, so the "probe" kills the host it is
+    # checking (bpo-14484).
+    from gateway.status import _pid_exists
+
+    return bool(_pid_exists(int(pid)))
 
 
 def _pid_command(pid: int) -> str:


### PR DESCRIPTION
## Problem

`_pid_alive()` in `tui_gateway/host_supervisor.py:88` probed liveness with bare `os.kill(pid, 0)` — the POSIX idiom. On Windows, sig=0 is **not** a no-op (bpo-14484): CPython maps it through `GenerateConsoleCtrlEvent`/`TerminateProcess`, so every "is this host still alive?" check **terminated the healthy TUI host process it was probing**, often along with siblings in the same console group.

Callers affected: registry staleness checks (`:226`) and the shutdown path (`:543`). This was the last runtime-reachable unguarded `os.kill(pid, 0)` in the repo — all others are annotated `windows-footgun: ok` with explicit win32 guards, and `scripts/check-windows-footguns.py` exists specifically to police this pattern.

## Fix

Delegate to the canonical cross-platform probe `gateway.status._pid_exists` (psutil-first with zombie handling, Win32 `OpenProcess`/`WaitForSingleObject` fallback, POSIX-only `os.kill` branch) — the same helper the gateway uses for exactly this reason. Function-level import keeps tui_gateway startup light; no import cycle (other `tui_gateway` modules already import from `gateway.*`, and `gateway.status` imports only stdlib + `hermes_constants` + `utils`).

The `pid <= 0` early return is preserved (POSIX `os.kill(0, 0)` would signal the whole process group).

## Verification

New `tests/tui_gateway/test_host_supervisor_pid_alive.py` (3 tests):
- live PID (`os.getpid()`) probes `True` with `os.kill` monkeypatched to raise — proves no signal path on any platform
- non-positive PIDs return `False` without touching signals
- a fully reaped child PID reports dead

3/3 pass; `scripts/check-windows-footguns.py --all` clean (1010 files).