### PR TITLE
fix(skills): let human approval satisfy an ask verdict instead of deadlocking

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -537,9 +537,31 @@ class TestSecurityScanGate:
 
         with patch("tools.skill_manager_tool._guard_agent_created_enabled", return_value=True), \
              patch("tools.skill_manager_tool.scan_skill", return_value=self._ask_result()), \
-             patch("tools.skill_manager_tool._skill_gate_bypass") as bypass:
+             patch("tools.skill_manager_tool._skill_approval_bypass") as bypass:
             bypass.get.return_value = False
             result = _security_scan_skill(tmp_path)
+
+        assert result is not None
+        assert "Security scan blocked" in result
+
+    def test_ask_verdict_blocks_when_only_staging_bypass_set(self, tmp_path):
+        """Regression (#94358 review): the operations[] batch executor
+        (#97295) sets _skill_gate_bypass — "skip the staging gate" loop
+        prevention, no human involved. The ask-override must key off
+        _skill_approval_bypass ("a human approved this exact write") instead,
+        so an agent-driven batch can never satisfy an "ask" verdict."""
+        from tools.skill_manager_tool import (
+            _security_scan_skill,
+            _skill_gate_bypass,
+        )
+
+        with patch("tools.skill_manager_tool._guard_agent_created_enabled", return_value=True), \
+             patch("tools.skill_manager_tool.scan_skill", return_value=self._ask_result()):
+            token = _skill_gate_bypass.set(True)
+            try:
+                result = _security_scan_skill(tmp_path)
+            finally:
+                _skill_gate_bypass.reset(token)
 
         assert result is not None
         assert "Security scan blocked" in result
@@ -548,14 +570,16 @@ class TestSecurityScanGate:
         """The reported deadlock (#94353): /skills approve replays the exact
         write a human just reviewed. An "ask" verdict means "needs a human
         decision" — the approval IS that decision, so the replay proceeds
-        with the findings logged for the audit trail."""
+        with the findings logged for the audit trail. The override keys off
+        _skill_approval_bypass, the human-decision var, not the staging-gate
+        _skill_gate_bypass."""
         import logging
 
         from tools.skill_manager_tool import _security_scan_skill
 
         with patch("tools.skill_manager_tool._guard_agent_created_enabled", return_value=True), \
              patch("tools.skill_manager_tool.scan_skill", return_value=self._ask_result()), \
-             patch("tools.skill_manager_tool._skill_gate_bypass") as bypass, \
+             patch("tools.skill_manager_tool._skill_approval_bypass") as bypass, \
              caplog.at_level(logging.WARNING, logger="tools.skill_manager_tool"):
             bypass.get.return_value = True
             result = _security_scan_skill(tmp_path)
@@ -576,7 +600,7 @@ class TestSecurityScanGate:
                  "tools.skill_manager_tool.should_allow_install",
                  return_value=(False, "hard denial (blocklist)"),
              ), \
-             patch("tools.skill_manager_tool._skill_gate_bypass") as bypass:
+             patch("tools.skill_manager_tool._skill_approval_bypass") as bypass:
             bypass.get.return_value = True
             result = _security_scan_skill(tmp_path)
 

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -511,6 +511,10 @@ class TestSecurityScanGate:
 
     @staticmethod
     def _ask_result():
+        # Coupled to INSTALL_POLICY on purpose: the agent-created row routes
+        # a "dangerous" verdict to "ask" → should_allow_install returns None
+        # (allowed is None), which is the branch these tests exercise. If the
+        # matrix is ever reordered, this fixture silently changes meaning.
         from tools.skills_guard import ScanResult, Finding
 
         finding = Finding(

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -509,6 +509,76 @@ class TestSecurityScanGate:
         with patch("hermes_cli.config.load_config", side_effect=RuntimeError("boom")):
             assert _guard_agent_created_enabled() is False
 
+    @staticmethod
+    def _ask_result():
+        from tools.skills_guard import ScanResult, Finding
+
+        finding = Finding(
+            pattern_id="test", severity="critical", category="exfiltration",
+            file="SKILL.md", line=1, match="curl $TOKEN", description="test",
+        )
+        return ScanResult(
+            skill_name="test",
+            source="agent-created",
+            trust_level="agent-created",
+            verdict="dangerous",
+            findings=[finding],
+            summary="dangerous",
+        )
+
+    def test_ask_verdict_blocks_normal_write(self, tmp_path):
+        """Outside the approval replay an "ask" verdict still blocks the
+        agent's own write (fail-closed for the unattended path)."""
+        from tools.skill_manager_tool import _security_scan_skill
+
+        with patch("tools.skill_manager_tool._guard_agent_created_enabled", return_value=True), \
+             patch("tools.skill_manager_tool.scan_skill", return_value=self._ask_result()), \
+             patch("tools.skill_manager_tool._skill_gate_bypass") as bypass:
+            bypass.get.return_value = False
+            result = _security_scan_skill(tmp_path)
+
+        assert result is not None
+        assert "Security scan blocked" in result
+
+    def test_ask_verdict_yields_to_human_approval_replay(self, tmp_path, caplog):
+        """The reported deadlock (#94353): /skills approve replays the exact
+        write a human just reviewed. An "ask" verdict means "needs a human
+        decision" — the approval IS that decision, so the replay proceeds
+        with the findings logged for the audit trail."""
+        import logging
+
+        from tools.skill_manager_tool import _security_scan_skill
+
+        with patch("tools.skill_manager_tool._guard_agent_created_enabled", return_value=True), \
+             patch("tools.skill_manager_tool.scan_skill", return_value=self._ask_result()), \
+             patch("tools.skill_manager_tool._skill_gate_bypass") as bypass, \
+             caplog.at_level(logging.WARNING, logger="tools.skill_manager_tool"):
+            bypass.get.return_value = True
+            result = _security_scan_skill(tmp_path)
+
+        assert result is None
+        assert any(
+            "approved despite scan findings" in r.message for r in caplog.records
+        )
+
+    def test_hard_denial_blocks_even_during_approval_replay(self, tmp_path):
+        """Fail-closed pin: a hard denial is policy, not judgment — the
+        human approval replay must NOT override it."""
+        from tools.skill_manager_tool import _security_scan_skill
+
+        with patch("tools.skill_manager_tool._guard_agent_created_enabled", return_value=True), \
+             patch("tools.skill_manager_tool.scan_skill", return_value=self._ask_result()), \
+             patch(
+                 "tools.skill_manager_tool.should_allow_install",
+                 return_value=(False, "hard denial (blocklist)"),
+             ), \
+             patch("tools.skill_manager_tool._skill_gate_bypass") as bypass:
+            bypass.get.return_value = True
+            result = _security_scan_skill(tmp_path)
+
+        assert result is not None
+        assert "Security scan blocked" in result
+
     def test_guard_flag_quoted_false_stays_disabled(self):
         """Quoted 'false' from YAML edits must not enable the guard."""
         from tools.skill_manager_tool import _guard_agent_created_enabled

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -149,7 +149,7 @@ def _security_scan_skill(skill_dir: Path) -> Optional[str]:
             return f"Security scan blocked this skill ({reason}):\n{report}"
         if allowed is None:
             report = format_scan_report(result)
-            if _skill_gate_bypass.get():
+            if _skill_approval_bypass.get():
                 # Human-approval replay: the operator just reviewed and
                 # approved this exact write. The "ask" decision has been
                 # made; record what was overridden for the audit trail.
@@ -1437,11 +1437,24 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
 # Main entry point
 # =============================================================================
 
-# ContextVar bypass: set while replaying an already-approved staged skill write
-# so skill_manage() does not re-gate (and re-stage) it.
+# ContextVar bypass: "skip the write gate" — set while replaying an
+# already-approved staged skill write so skill_manage() does not re-gate
+# (and re-stage) it. The batch executor added by #97295 sets the same var
+# around its per-op loop, for loop prevention — no human involved.
 import contextvars as _ctxvars
 _skill_gate_bypass: "_ctxvars.ContextVar[bool]" = _ctxvars.ContextVar(
     "skill_gate_bypass", default=False
+)
+# Distinct meaning from _skill_gate_bypass: that var means "skip the
+# staging/anti-reentry gate" (set by BOTH apply_skill_pending and the
+# operations[] batch executor, for different reasons). This var means
+# "a HUMAN approved this exact write" — set only inside apply_skill_pending,
+# the /skills approve replay. _security_scan_skill's ask-verdict override
+# keys off THIS var, so an agent-driven operations[] batch (gate bypass set
+# by the batch executor, no human anywhere) can never satisfy an "ask"
+# verdict or mint a human-approval audit line. #94353
+_skill_approval_bypass: "_ctxvars.ContextVar[bool]" = _ctxvars.ContextVar(
+    "skill_approval_bypass", default=False
 )
 
 
@@ -1489,6 +1502,7 @@ def apply_skill_pending(payload: Dict[str, Any]) -> str:
     JSON string. Called by the /skills approve handler.
     """
     token = _skill_gate_bypass.set(True)
+    approval_token = _skill_approval_bypass.set(True)
     try:
         return skill_manage(
             action=payload.get("action", ""),
@@ -1503,6 +1517,7 @@ def apply_skill_pending(payload: Dict[str, Any]) -> str:
             absorbed_into=payload.get("absorbed_into"),
         )
     finally:
+        _skill_approval_bypass.reset(approval_token)
         _skill_gate_bypass.reset(token)
 
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -126,6 +126,16 @@ def _security_scan_skill(skill_dir: Path) -> Optional[str]:
     """Scan a skill directory after write. Returns error string if blocked, else None.
 
     No-op when skills.guard_agent_created is disabled (the default).
+
+    Verdict routing: a hard denial (``allowed is False``) always blocks,
+    including the approval replay — those findings are policy, not judgment.
+    An "ask" verdict (``allowed is None``, dangerous findings detected)
+    blocks the agent's own write so it can retry with the flagged content
+    removed, but during a human-approval replay (``/skills approve`` →
+    ``apply_skill_pending``) it degrades to a logged warning: "ask" means
+    "needs a human decision", and the operator's approval IS that decision.
+    Blocking it anyway deadlocked every flagged write — false positives
+    included — with no confirmation surface at all (#94353).
     """
     if not _GUARD_AVAILABLE:
         return None
@@ -138,10 +148,16 @@ def _security_scan_skill(skill_dir: Path) -> Optional[str]:
             report = format_scan_report(result)
             return f"Security scan blocked this skill ({reason}):\n{report}"
         if allowed is None:
-            # "ask" verdict — for agent-created skills this means dangerous
-            # findings were detected.  Surface as an error so the agent can
-            # retry with the flagged content removed.
             report = format_scan_report(result)
+            if _skill_gate_bypass.get():
+                # Human-approval replay: the operator just reviewed and
+                # approved this exact write. The "ask" decision has been
+                # made; record what was overridden for the audit trail.
+                logger.warning(
+                    "Agent-created skill approved despite scan findings "
+                    "(human approval replay): %s\n%s", reason, report,
+                )
+                return None
             logger.warning("Agent-created skill blocked (dangerous findings): %s", reason)
             return f"Security scan blocked this skill ({reason}):\n{report}"
     except Exception as e:

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -60,8 +60,10 @@ INSTALL_POLICY = {
     # Agent-created: "ask" on dangerous surfaces as an error to the agent,
     # which can retry without the flagged content. Exception: during an
     # operator's replayed ``/skills approve`` write (``apply_skill_pending``
-    # with the approval-gate bypass set) the "ask" verdict is satisfied by
-    # the human approval instead of deadlocking the write — see
+    # with ``_skill_approval_bypass`` set — the "a human approved this exact
+    # write" var, distinct from the staging-gate ``_skill_gate_bypass`` also
+    # set by the operations[] batch executor) the "ask" verdict is satisfied
+    # by the human approval instead of deadlocking the write — see
     # ``skill_manager_tool.py::apply_skill_pending`` (#94353); outside that
     # replay the error-and-retry behavior is unchanged. This gate only runs
     # when skills.guard_agent_created is enabled (off by default) — see

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -58,8 +58,13 @@ INSTALL_POLICY = {
     "trusted":       ("allow",  "allow",   "block"),
     "community":     ("allow",  "block",   "block"),
     # Agent-created: "ask" on dangerous surfaces as an error to the agent,
-    # which can retry without the flagged content. This gate only runs when
-    # skills.guard_agent_created is enabled (off by default) — see
+    # which can retry without the flagged content. Exception: during an
+    # operator's replayed ``/skills approve`` write (``apply_skill_pending``
+    # with the approval-gate bypass set) the "ask" verdict is satisfied by
+    # the human approval instead of deadlocking the write — see
+    # ``skill_manager_tool.py::apply_skill_pending`` (#94353); outside that
+    # replay the error-and-retry behavior is unchanged. This gate only runs
+    # when skills.guard_agent_created is enabled (off by default) — see
     # tools/skill_manager_tool.py::_guard_agent_created_enabled.
     "agent-created": ("allow",  "allow",   "ask"),
 }


### PR DESCRIPTION
## What does this PR do?

`_security_scan_skill()` converted the Skills Guard scanner's "ask" verdict into a hard error string unconditionally — including on the `/skills approve` replay path. The approval handler received the refusal from `apply_skill_pending` and rolled the write back, so with `skills.write_approval: true` + `skills.guard_agent_created: true` every agent-created skill that tripped a static heuristic could **never** be approved: no confirmation surface existed anywhere in the flow, and the only way out was writing the identical bytes with generic file tools — bypassing both the scan and the approval gate, a strictly worse security posture than a reviewable override. False positives (the reporter's case: legitimate SKILL.md prose quoting an injection phrase) were unapprovable by construction.

Verdicts now route by meaning: a **hard denial** (`allowed is False`) is policy, not judgment — it still blocks, including during the replay. An **"ask" verdict** (`allowed is None`) means "needs a human decision": on the unattended write path it still blocks fail-closed (the agent can retry with the flagged content removed), but during a human-approval replay (`_skill_gate_bypass` active, i.e. the operator just reviewed and approved this exact staged write) the write proceeds with the full findings report logged at WARNING for the audit trail. The operator's approval **is** the confirmation "ask" was asking for.

## Related Issue

Fixes #94353

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/skill_manager_tool.py` (`_security_scan_skill`) — the "ask" branch checks `_skill_gate_bypass`: during an approval replay it logs `"Agent-created skill approved despite scan findings (human approval replay)"` with the reason and full scan report, then returns `None` (write proceeds); otherwise the existing fail-closed block is unchanged. Hard denials are untouched. Docstring documents the routing rule.
- `tests/tools/test_skill_manager_tool.py` — three new tests in `TestSecurityScanGate`:
  - `test_ask_verdict_blocks_normal_write` — unattended path stays fail-closed;
  - `test_ask_verdict_yields_to_human_approval_replay` — the reporter's deadlock: replay proceeds and the override is logged;
  - `test_hard_denial_blocks_even_during_approval_replay` — fail-closed pin: hard denial is NOT overridable by human approval.

## How to Test

- Run: `.venv/bin/python -m pytest tests/tools/test_skill_manager_tool.py tests/tools/test_skills_guard.py -q`
- Observed result: `81 passed`. Fail-on-main check (source checked out at the parent commit): the approval-replay test fails with the reported refusal string; the unattended-block and hard-denial pins pass both ways.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of the completed code performed
- [x] New and existing unit tests pass locally
- [x] Changes are backward-compatible (unattended behavior and hard denials unchanged; only the human-approval replay gains the override, with an audit log)
