### PR TITLE
fix(gateway-windows): keep configured HERMES_HOME spelling on junction installs

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -874,7 +874,13 @@ def windowless_gateway_restart_spec(
     working_dir = _stable_gateway_working_dir(PROJECT_ROOT)
     project_root = str(PROJECT_ROOT)
     try:
-        hermes_home = str(Path(get_hermes_home()).resolve())
+        # Preserve the configured HERMES_HOME spelling on junction/symlink
+        # installs (same invariant as _preserve_hermes_home_path). Resolving
+        # here made detached spawns identify their home by the junction
+        # target while the Scheduled Task / Startup .vbs launchers set the
+        # configured AppData path — runtime state identity then depended on
+        # which launch route started the gateway.
+        hermes_home = _preserve_hermes_home_path(Path(get_hermes_home()))
     except Exception:
         hermes_home = ""
 

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -80,6 +80,47 @@ def test_build_gateway_argv_keeps_venv_console_python_for_uv_venv(monkeypatch, t
 
 
 @pytest.mark.windows_only
+def test_build_gateway_argv_preserves_junction_hermes_home_spelling(monkeypatch, tmp_path):
+    """Detached spawns must carry the CONFIGURED HERMES_HOME spelling.
+
+    %LOCALAPPDATA%\\hermes is sometimes a junction to another drive.
+    _build_gateway_argv() used Path(...).resolve(), so gateways started via
+    _spawn_detached() (install immediate-start, Startup fallback, restarts)
+    identified their home by the junction target while the Scheduled Task /
+    Startup .vbs launchers set the configured AppData spelling — runtime
+    state identity depended on which launch route started the gateway.
+    """
+    import _winapi
+
+    real_home = tmp_path / "real-home"
+    link_home = tmp_path / "link-home"
+    real_home.mkdir()
+    _winapi.CreateJunction(str(real_home), str(link_home))
+
+    project = tmp_path / "project"
+    scripts = project / "venv" / "Scripts"
+    base = tmp_path / "uv" / "python" / "cpython-3.11-windows-x86_64-none"
+    scripts.mkdir(parents=True)
+    base.mkdir(parents=True)
+
+    venv_python = scripts / "python.exe"
+    venv_python.write_text("", encoding="utf-8")
+    (project / "venv" / "pyvenv.cfg").write_text(
+        f"home = {base}\nimplementation = CPython\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(gateway, "PROJECT_ROOT", project)
+    monkeypatch.setattr(gateway, "get_python_path", lambda: str(venv_python))
+    monkeypatch.setattr(gateway, "_profile_arg", lambda hermes_home: "")
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: str(link_home))
+
+    argv, cwd, env_overlay = gateway_windows._build_gateway_argv()
+
+    assert env_overlay["HERMES_HOME"] == str(link_home)
+
+
+@pytest.mark.windows_only
 def test_spawn_detached_marks_primary_breakaway_success(monkeypatch, tmp_path, caplog):
     """A successful breakaway spawn reports true without a warning."""
     argv = ["python.exe", "-m", "hermes_cli.main", "gateway", "run"]


### PR DESCRIPTION
## Problem

On Windows installs where `%LOCALAPPDATA%\hermes` is a junction/symlink to another drive, `hermes_cli/gateway_windows.py` produced **two different home identities depending on launch route**:

- Scheduled Task XML and the Startup-folder `.vbs` launcher set `HERMES_HOME` from the non-resolved, configured spelling (`_write_task_script` → `_build_gateway_vbs_script`, and `_preserve_hermes_home_path` exists precisely to enforce this — its docstring: "Runtime state should still identify itself by the configured AppData path").
- But `_build_gateway_argv()` (used by every `_spawn_detached()` start: install immediate-start, Startup fallback, manual/restart spawns) set `HERMES_HOME` to `Path(get_hermes_home()).resolve()` — baking in the junction **target**.

Runtime state keyed on `HERMES_HOME` identity (locks, registries, ledgers, status checks) could then split by which route started the gateway.

## Fix

Route the value through the module's own `_preserve_hermes_home_path()` instead of `.resolve()`. No behavior change for plain installs (the two spellings are identical); junction installs now get one consistent home identity across detached spawns, Task XML, and Startup launcher.

## Verification

New Windows-only test `test_build_gateway_argv_preserves_junction_hermes_home_spelling`: creates a real junction with `_winapi.CreateJunction`, points `get_hermes_home` at the link spelling, asserts `env_overlay["HERMES_HOME"]` keeps the configured spelling rather than the resolved target.

Suite: 10/10 pass in `tests/hermes_cli/test_gateway_windows.py`.