### PR TITLE
fix(terminal): fail closed on ambiguous exit semantics

### DIFF
--- a/tests/tools/test_terminal_exit_semantics.py
+++ b/tests/tools/test_terminal_exit_semantics.py
@@ -63,6 +63,44 @@ class TestInterpretExitCode:
 
     # ---- pipeline / chain handling ----
 
+    @pytest.mark.parametrize("cmd", [
+        "crontab -l | grep -c parlami-queue-health.py",
+        "false | grep needle",
+        "false || grep needle",
+        "false && grep needle",
+        "false & grep needle",
+        "false; grep needle",
+        'grep "$(printf needle | cat)" file.txt',
+        "grep `printf needle` file.txt",
+        "grep needle <(printf needle)",
+        r"grep 'a\' file.txt | grep needle",
+        r"grep $'a\'b' file.txt | grep needle",
+        "grep missing file.txt 2>&1",
+        "grep missing file.txt &>/tmp/grep.out",
+        "grep missing file.txt 3</dev/null 0<&3",
+        "grep missing file.txt >| /tmp/grep.out",
+        "grep needle /dev/null > /missing-dir/out",
+    ])
+    def test_masking_compound_commands_do_not_get_benign_grep_meaning(self, cmd):
+        """A final grep status cannot prove earlier segments succeeded."""
+        assert _interpret_exit_code(cmd, 1) is None
+
+
+    @pytest.mark.parametrize("cmd", [
+        "grep 'a|b' file.txt",
+        'grep "a;b" file.txt',
+        "grep 'a&&b' file.txt",
+        r"grep a\|b file.txt",
+        r"grep a\;b file.txt",
+        "grep $'a|b' file.txt",
+        "grep missing file.txt # | ignored",
+        "grep missing \\\nfile.txt",
+    ])
+    def test_inert_operators_and_redirections_keep_simple_grep_semantics(self, cmd):
+        result = _interpret_exit_code(cmd, 1)
+        assert result is not None
+        assert "no matches" in result.lower()
+
 
     # ---- full paths ----
 

--- a/tests/tools/test_terminal_hints.py
+++ b/tests/tools/test_terminal_hints.py
@@ -114,12 +114,92 @@ class TestTerminalIntegration:
         hint = annotate_failure("python x.py", 127, "bash: python: command not found")
         assert hint and "python3" in hint
 
-    def test_exit_note_suppresses_pattern_hint(self):
-        # grep exit 1 is informational; annotate_failure must not be reached
-        # for it in the wiring (exit_note wins). Just verify the semantics
-        # table still covers it.
+    def test_simple_grep_exit_note_suppresses_pattern_hint(self):
+        # A single grep with exit 1 is informational; the semantics table
+        # still owns that unambiguous case.
         from tools import terminal_tool
         assert terminal_tool._interpret_exit_code("grep foo bar.txt", 1) is not None
+
+    def test_pipeline_does_not_suppress_upstream_permission_hint(self):
+        # In a pipeline the final grep status says nothing about an upstream
+        # failure. Do not stamp the whole result "not an error"; this lets the
+        # output-pattern tier surface the real failure text.
+        from tools import terminal_tool
+
+        command = "crontab -l | grep -c parlami-queue-health.py"
+        output = "crontabs/cryptonovado/: fopen: Permission denied\n0"
+        assert terminal_tool._interpret_exit_code(command, 1) is None
+        hint = annotate_failure(command, 1, output)
+        assert hint and "Permission denied" in hint
+
+    def test_real_pipeline_surfaces_upstream_permission_denied(self, tmp_path, monkeypatch):
+        """Exercise the terminal result assembly, not only the pure helpers."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        from tools.terminal_tool import terminal_tool
+
+        command = (
+            "sh -c 'printf \"crontabs/user/: fopen: Permission denied\\n\" >&2; exit 1' "
+            "| grep -c needle"
+        )
+        result = json.loads(terminal_tool(command, task_id="pipeline-permission-denied"))
+
+        assert result["exit_code"] == 1
+        assert "Permission denied" in result["output"]
+        assert "exit_code_meaning" not in result
+        assert "Permission denied" in result["hint"]
+
+    def test_short_circuited_and_chain_surfaces_upstream_permission_denied(
+        self, tmp_path, monkeypatch
+    ):
+        """The final grep never runs when an earlier && segment fails."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        from tools.terminal_tool import terminal_tool
+
+        command = (
+            "sh -c 'printf \"crontabs/user/: fopen: Permission denied\\n\" >&2; exit 1' "
+            "&& grep -c needle /dev/null"
+        )
+        result = json.loads(terminal_tool(command, task_id="and-permission-denied"))
+
+        assert result["exit_code"] == 1
+        assert "Permission denied" in result["output"]
+        assert "exit_code_meaning" not in result
+        assert "Permission denied" in result["hint"]
+
+    def test_quoted_command_substitution_surfaces_permission_denied(
+        self, tmp_path, monkeypatch
+    ):
+        """Double quotes do not make an embedded command substitution inert."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        from tools.terminal_tool import terminal_tool
+
+        command = (
+            'grep "$(sh -c \'printf "source: Permission denied\\n" >&2; exit 1\')" '
+            "/dev/null"
+        )
+        result = json.loads(
+            terminal_tool(command, task_id="substitution-permission-denied")
+        )
+
+        assert result["exit_code"] == 1
+        assert "Permission denied" in result["output"]
+        assert "exit_code_meaning" not in result
+        assert "Permission denied" in result["hint"]
+
+    def test_redirection_failure_is_not_relabelled_as_benign(
+        self, tmp_path, monkeypatch
+    ):
+        """A redirect can fail before grep runs, while still exiting with 1."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        from tools.terminal_tool import terminal_tool
+
+        missing_parent = tmp_path / "missing" / "out.txt"
+        command = f"grep needle /dev/null > {missing_parent}"
+        result = json.loads(terminal_tool(command, task_id="redirect-failure"))
+
+        assert result["exit_code"] == 1
+        assert "No such file or directory" in result["output"]
+        assert "exit_code_meaning" not in result
 
 
 class TestMaskedSuccess:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2406,6 +2406,97 @@ def _interpret_signal_exit(exit_code: int) -> str | None:
     return None
 
 
+def _has_masking_shell_control(command: str) -> bool:
+    """Return True when shell structure can hide which command produced the status.
+
+    Single-quoted text and escaped characters are inert. Double-quoted text is
+    inert except for command substitutions, and backticks/process substitutions
+    are executable even when the surrounding command looks simple.
+    """
+    quote: str | None = None
+    i = 0
+    n = len(command)
+
+    while i < n:
+        ch = command[i]
+
+        # Backslashes are literal inside single quotes; only the closing quote
+        # changes parser state.
+        if quote == "single":
+            if ch == "'":
+                quote = None
+            i += 1
+            continue
+
+        # ANSI-C $'...' quotes interpret backslash escapes, including an
+        # escaped quote, but shell operators inside remain inert.
+        if quote == "ansi_single":
+            if ch == "\\":
+                i += 2 if i + 1 < n else 1
+                continue
+            if ch == "'":
+                quote = None
+            i += 1
+            continue
+
+        if ch == "\\":
+            i += 2 if i + 1 < n else 1
+            continue
+
+        if quote == "double":
+            if ch == '"':
+                quote = None
+                i += 1
+                continue
+            if ch == "`" or command.startswith("$(", i):
+                return True
+            i += 1
+            continue
+
+        if command.startswith("$'", i):
+            quote = "ansi_single"
+            i += 2
+            continue
+        if ch == "'":
+            quote = "single"
+            i += 1
+            continue
+        if ch == '"':
+            quote = "double"
+            i += 1
+            continue
+
+        # Command, process, and legacy backtick substitutions can fail without
+        # determining the outer command's final exit status.
+        if ch == "`" or command.startswith(("$(", "<(", ">("), i):
+            return True
+
+        # Ignore a shell comment. A newline followed by another statement is
+        # still a masking sequence; a trailing comment is inert.
+        if ch == "#" and (
+            i == 0 or command[i - 1].isspace() or command[i - 1] in ";|&()"
+        ):
+            newline = command.find("\n", i)
+            if newline == -1:
+                return False
+            return bool(command[newline + 1 :].strip())
+
+        if ch == "\n" or ch == ";":
+            return True
+        if command.startswith("&&", i) or command.startswith("||", i):
+            return True
+        # Redirection setup can fail before the apparent command runs (for
+        # example, an unwritable output path), while returning the same code
+        # that the command uses for a benign result. Treat all unquoted shell
+        # redirections as ambiguous rather than guessing which layer failed.
+        if ch in "<>|&":
+            return True
+
+        i += 1
+
+    return False
+
+
 def _interpret_exit_code(command: str, exit_code: int) -> str | None:
     """Return a human-readable note when a non-zero exit code is non-erroneous.
 
@@ -2431,11 +2522,19 @@ def _interpret_exit_code(command: str, exit_code: int) -> str | None:
     if signal_note is not None:
         return signal_note
 
-    # Extract the last command in a pipeline/chain — that determines the
-    # exit code.  Handles  `cmd1 && cmd2`, `cmd1 | cmd2`, `cmd1; cmd2`.
-    # Deliberately simple: split on shell operators and take the last piece.
-    segments = re.split(r'\s*(?:\|\||&&|[|;])\s*', command)
-    last_segment = (segments[-1] if segments else command).strip()
+    # A pipeline, compound sequence, or executable substitution does not prove
+    # that the apparent final segment produced the observed status: pipelines
+    # expose only the last process, `&&` may short-circuit before that segment
+    # runs, and substitutions can fail without setting the outer command's
+    # status. Applying the apparent final segment's benign semantics to the
+    # whole command can turn an upstream "Permission denied" into a reassuring
+    # "No matches found (not an error)". Fail closed so the output-pattern hint
+    # tier can surface the real failure text.
+    if _has_masking_shell_control(command):
+        return None
+
+    unquoted_command = _strip_quotes(command)
+    last_segment = unquoted_command.strip()
 
     # Get base command name (first word), stripping env var assignments
     # like  VAR=val cmd ...


### PR DESCRIPTION
## What does this PR do?

Prevents terminal results from labeling a compound command as benign based only on its apparent final segment.

Today, a command such as:

```sh
crontab -l | grep -c parlami-queue-health.py
```

can produce `Permission denied` upstream, exit with grep's status `1`, and still receive:

```json
{"exit_code_meaning":"No matches found (not an error)"}
```

That annotation can turn an unreadable source into a false zero/all-clear. The fix keeps command-specific benign meanings for unambiguous single commands, but fails closed for pipelines and compound sequences so existing output-pattern hints can surface the real error.

This is intentionally conservative: any unquoted shell redirection also suppresses the benign annotation because redirection setup can fail before the apparent command executes. For example, `grep ... > /missing-dir/out` exits `1` without running grep. The usability cost is fewer explanatory annotations on redirected commands; the safety benefit is avoiding a false all-clear when the shell itself failed.

## Related Issue

No existing issue found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/terminal_tool.py`
  - suppress benign final-command meanings for pipelines, chains, executable substitutions, backgrounding, and shell redirections
  - preserve simple-command semantics while distinguishing inert quotes, escapes, comments, and line continuations
- `tests/tools/test_terminal_exit_semantics.py`
  - cover masking compound/substitution/redirection shapes plus inert quote, escape, comment, and continuation forms
- `tests/tools/test_terminal_hints.py`
  - add real terminal-tool regressions for pipeline, short-circuited `&&`, and quoted command-substitution permission failures

## How to Test

1. Run:
   ```sh
   uv run --extra dev pytest tests/tools/test_terminal*.py -q -o 'addopts='
   ```
2. Confirm all terminal owning-suite tests pass.
3. Run:
   ```sh
   uv run --extra dev ruff check tools/terminal_tool.py tests/tools/test_terminal_exit_semantics.py tests/tools/test_terminal_hints.py
   git diff --check
   ```

Observed locally on Linux ARM64: `266 passed`; Ruff and diff checks passed.

## Checklist

### Code

- [x] I've read the Contributing Guide / repo `AGENTS.md`
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (full repository suite not run; the terminal owning suite passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux ARM64

### Documentation & Housekeeping

- [x] Documentation update — N/A; behavior is covered in code comments and tests
- [x] `cli-config.yaml.example` update — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture change
- [x] Cross-platform impact considered: the change is pure command-string interpretation; no platform-specific APIs
- [x] Tool description/schema update — N/A; no schema or user-facing invocation contract changed

## Screenshots / Logs

Before:

```text
crontabs/user/: fopen: Permission denied
0
exit_code=1
exit_code_meaning="No matches found (not an error)"
```

After:

```text
crontabs/user/: fopen: Permission denied
0
exit_code=1
hint="Permission denied. Check ownership/mode ..."
# no exit_code_meaning field
```
