### PR TITLE
fix(model-switch): expand provider aliases in excluded_providers filters

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2404,6 +2404,31 @@ def _prefetch_provider_models_parallel(provider_slugs: list[str]) -> None:
         list(executor.map(_fetch_one, stale_slugs))
 
 
+def _expanded_excluded_provider_set(entries) -> set:
+    """Lowercase an excluded-providers list and expand provider aliases.
+
+    ``model_catalog.excluded_providers`` accepts alias spellings ("grok",
+    "zhipu"). The CLI picker (``hermes_cli.main``) hides a canonical row when
+    its slug OR any alias mapping to it is listed; these shared filters are
+    what the gateway/TUI pickers call, so they must apply the same expansion
+    or an aliased exclusion works in the CLI but not on those surfaces.
+    """
+    try:
+        from hermes_cli.providers import ALIASES as _alias_table
+    except Exception:
+        _alias_table = {}
+    out: set = set()
+    for p in entries or ():
+        s = str(p).strip().lower()
+        if not s:
+            continue
+        out.add(s)
+        canon = _alias_table.get(s)
+        if canon:
+            out.add(str(canon).strip().lower())
+    return out
+
+
 def _collect_authed_provider_slugs(
     models_dev_data: dict,
     curated: dict[str, list[str]],
@@ -2428,7 +2453,7 @@ def _collect_authed_provider_slugs(
     from hermes_cli.providers import HERMES_OVERLAYS, ALIASES as _PROVIDER_ALIAS_TABLE
     from hermes_cli.models import _AGGREGATOR_PROVIDERS as _AGG_PROVIDERS, CANONICAL_PROVIDERS
 
-    _excluded_set = {str(p).strip().lower() for p in excluded if p}
+    _excluded_set = _expanded_excluded_provider_set(excluded)
     slugs: list[str] = []
     seen: set[str] = set()
 
@@ -2655,7 +2680,9 @@ def list_authenticated_providers(
     # Compared against hermes_id / mdev_id (section 1), pid / hermes_slug
     # (section 2) and canonical slug (section 2b) so a single entry like
     # ``copilot`` hides the provider regardless of which key it surfaces under.
-    _excluded: set = {str(p).strip().lower() for p in (excluded_providers or []) if p}
+    # Aliases are expanded so ``grok`` also hides the xai row — same rule the
+    # CLI picker applies (parity; see _expanded_excluded_provider_set).
+    _excluded: set = _expanded_excluded_provider_set(excluded_providers)
     # Effective base URLs of every built-in row we emit (normalized lower+rstrip).
     # Section 4 uses this to hide ``custom_providers`` entries that point at the
     # same endpoint as a built-in (e.g. a user-defined "my-dashscope" on

--- a/tests/hermes_cli/test_model_picker_excluded_providers.py
+++ b/tests/hermes_cli/test_model_picker_excluded_providers.py
@@ -117,3 +117,42 @@ def test_cli_picker_hides_excluded_provider_by_alias(config_home):
     )
 
 
+def test_shared_filter_expands_aliases_for_gateway_parity(monkeypatch):
+    """list_authenticated_providers / the picker-data builder must expand
+    provider aliases in ``excluded_providers`` exactly like the CLI picker,
+    else an aliased exclusion (e.g. ``grok`` for xai) hides the row on one
+    surface but not the other."""
+    from hermes_cli import model_switch
+
+    monkeypatch.setattr(
+        "hermes_cli.providers.ALIASES",
+        {"grok": "xai", "zhipu": "zai"},
+    )
+
+    expanded = model_switch._expanded_excluded_provider_set(
+        [" Grok ", "", "zhipu", "openrouter"]
+    )
+    assert expanded == {"grok", "xai", "zhipu", "zai", "openrouter"}
+
+    # Section-1 style check: an entry whose canonical slug is excluded is
+    # filtered even when the raw id differs from the configured alias.
+    fake_models_dev = {
+        "xai": {"env": ["XAI_API_KEY"]},
+        "zai": {"env": ["ZAI_API_KEY"]},
+        "openrouter": {"env": ["OPENROUTER_API_KEY"]},
+    }
+    monkeypatch.setattr("hermes_cli.auth.is_runtime_provider_routable", lambda _p: True)
+    monkeypatch.setattr("hermes_cli.auth._load_auth_store", lambda: {})
+    monkeypatch.setenv("XAI_API_KEY", "k")
+    monkeypatch.setenv("ZAI_API_KEY", "k")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "k")
+
+    slugs = model_switch._collect_authed_provider_slugs(
+        models_dev_data=fake_models_dev,
+        curated={},
+        excluded=["grok"],
+    )
+    assert "xai" not in slugs, f"alias 'grok' should hide xai; got {slugs}"
+    assert "zai" in slugs, "unrelated providers must survive"
+
+


### PR DESCRIPTION
## Problem

`model_catalog.excluded_providers` accepts alias spellings (`"grok"`, `"zhipu"`, … — `hermes_cli.providers.ALIASES` has 80 non-trivial aliases). The two surfaces disagree on what those mean:

- **CLI picker** (`hermes_cli/main.py:3863-3868`): expands `_PROVIDER_ALIASES`, so excluding an alias hides the canonical row. Its comment explicitly claims parity: *"hides the same providers the gateway/TUI pickers do"*.
- **Gateway/TUI pickers** (shared `_collect_authed_provider_slugs` and the `list_authenticated_providers` picker-data builder, both in `hermes_cli/model_switch.py`): compared only raw `hermes_id` / `mdev_id` / slug strings against a lowercase set — no alias expansion.

So `excluded_providers: ["grok"]` hid xAI from `hermes model` but left it visible in the gateway `/model` picker.

## Fix

New `_expanded_excluded_provider_set()` in `model_switch.py`: lowercases entries and maps aliases to their canonical slugs via `hermes_cli.providers.ALIASES`. Wired into both filter sites; membership checks unchanged, canonical entries behave exactly as before.

## Verification

- New test drives `_collect_authed_provider_slugs` with a patched alias table and faked credentials: excluded `["grok"]` removes the `xai` row while unrelated providers survive; helper expansion handles case/whitespace/empty entries.
- Pre-existing exclusion tests still pass (`test_model_picker_excluded_providers.py` 3/3, `test_excluded_providers_hides_builtin_row`, `test_aux_picker_inventory.py`).