### PR TITLE
fix(title): fall back to reasoning_content when content is empty

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -411,7 +411,22 @@ def generate_title(
             main_runtime=main_runtime,
             extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
         )
-        content = response.choices[0].message.content or ""
+        _message = response.choices[0].message
+        content = getattr(_message, "content", None) or ""
+        if not content.strip():
+            # Reasoning models (R1-style APIs, OpenRouter :thinking variants)
+            # sometimes leave ``content`` empty and put everything — including
+            # the requested title JSON — in ``reasoning_content``. Without this
+            # fallback every auto-title attempt on such a backend silently
+            # fails and the session stays untitled.
+            reasoning_text = getattr(_message, "reasoning_content", None) or ""
+            if isinstance(_message, dict):
+                content = _message.get("content") or ""
+                if not content.strip():
+                    reasoning_text = _message.get("reasoning_content") or ""
+            if reasoning_text.strip():
+                logger.debug("title: content empty; falling back to reasoning_content")
+                content = reasoning_text
         title = _clean_title(_extract_title_text(content))
         # Answer-shaped output guard: titling is a 3-7 word task, so a title
         # with many words is a model that ignored the task and answered

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -107,6 +107,32 @@ class TestGenerateTitle:
         with patch("agent.title_generator.call_llm", return_value=mock_response):
             assert generate_title("how does the registration system work?", "...") is None
 
+    def test_falls_back_to_reasoning_content_when_content_empty(self):
+        """Reasoning models (R1-style APIs) can return empty ``content`` with
+        everything in ``reasoning_content``. Without the fallback every
+        auto-title attempt failed and sessions stayed untitled."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = ""
+        mock_response.choices[0].message.reasoning_content = (
+            'Let me think... the user asks about X. Output: {"title": "Debug the reasoning fallback"}'
+        )
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("question", "answer") == "Debug the reasoning fallback"
+
+    def test_falls_back_to_reasoning_content_dict_message(self):
+        """Dict-shaped messages (non-object clients) get the same fallback."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message = {
+            "content": None,
+            "reasoning_content": '{"title": "Dict message title"}',
+        }
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("question", "answer") == "Dict message title"
+
     def test_rejects_many_short_words(self):
         """13 short words stays under the 80-char cap but is not a title."""
         mock_response = MagicMock()


### PR DESCRIPTION
## Problem

`generate_title()` read only `response.choices[0].message.content`. Reasoning models served through R1-style APIs and OpenRouter `:thinking` variants frequently return an **empty `content`** with the entire answer — including the requested `{"title": ...}` JSON — in **`message.reasoning_content`**. On such backends every auto-title attempt silently produced no title, so sessions stayed untitled despite the first-two-exchanges retry in `maybe_auto_title`.

The module already anticipated reasoning-model quirks elsewhere (`_extract_title_text` scrubs `<think>` blocks from `content`) — the empty-content case was the gap.

## Fix

When `content` is blank, fall back to `reasoning_content` (attribute access, plus dict-shaped messages via `.get`). The existing JSON extraction, prose fallback, length cap, and answer-shape guard apply unchanged to the fallback text. Debug log records when the fallback engages.

## Verification

Two new tests in `tests/agent/test_title_generator.py`:
- empty `content` + title JSON inside `reasoning_content` → title extracted
- dict-shaped message (`content: None`, `reasoning_content` set) → same fallback

Suite: 38/38 pass.