### PR TITLE
fix(desktop): preserve registered gateways during mode switches

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -2,7 +2,7 @@ import { act, cleanup, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $desktopBoot } from '@/store/boot'
-import { closeSecondaryGateways, isActivePrimary } from '@/store/gateway'
+import { activeGateway, closeSecondaryGateways, ensureGatewayForAgent, isActivePrimary } from '@/store/gateway'
 import { reconnectGateway } from '@/store/gateway-reconnect'
 import { $activeGatewayProfile, $profiles, ensureGatewayProfile } from '@/store/profile'
 import { $connection, $currentCwd, $gatewayState } from '@/store/session'
@@ -157,6 +157,15 @@ function fakeDesktop() {
 
       return !key || key === 'default' ? primaryConn : coderConn
     }),
+    getConnectionFor: vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
+      ...coderConn,
+      connectionId,
+      profile,
+      wsUrl: `wss://${connectionId}.example.com/api/ws?profile=${profile}`
+    })),
+    getGatewayWsUrlFor: vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) =>
+      `wss://${connectionId}.example.com/api/ws?profile=${profile}`
+    ),
     getGatewayWsUrl: vi.fn(async (conn?: { wsUrl?: string }) => conn?.wsUrl ?? primaryConn.wsUrl),
     getBootProgress: vi.fn(async () => ({
       error: null as null | string,
@@ -348,6 +357,33 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect(beforeConnectionSwitch).toHaveBeenCalledTimes(1)
     await flushAsync()
     expect($gatewayState.get()).toBe('open')
+  })
+
+  it('keeps registered source sockets alive during a legacy mode apply', async () => {
+    render(<Harness />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+
+    let opening!: Promise<boolean>
+    act(() => {
+      opening = ensureGatewayForAgent('cloud', 'default')
+    })
+    await flushAsync()
+    await opening
+
+    const registeredGateway = activeGateway()
+    expect(registeredGateway).not.toBeNull()
+    expect(isActivePrimary()).toBe(false)
+
+    act(() => connectionApplied?.())
+    await flushAsync()
+    await flushAsync()
+
+    // Applying the legacy Local/Cloud mode must not close an independent v2
+    // source. The foreground returns to the new primary, while the registered
+    // socket remains reusable and cannot arm ws_orphan_reap on the old backend.
+    expect(registeredGateway?.connectionState).toBe('open')
+    expect(isActivePrimary()).toBe(true)
   })
 
   it('re-fetches the profile rail from the NEW backend after a connection apply (#85731)', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -17,6 +17,7 @@ import {
 } from '@/store/boot'
 import {
   $gateway,
+  closeLegacySecondaryGateways,
   closeSecondaryGateways,
   configureGatewayRegistry,
   disposeSecondariesForConnection,
@@ -53,6 +54,7 @@ import {
 import {
   $attentionSessionIds,
   $workingSessionIds,
+  foregroundSessionScopes,
   liveSessionScopes,
   reconcileBusyStatesOnReconnect,
   recordSessionEventScope,
@@ -490,7 +492,11 @@ export function useGatewayBoot({
 
       try {
         gateway.close()
-        closeSecondaryGateways()
+        // The primary mode is changing, but registered v2 sources remain
+        // independent gateways. Retire only legacy profile sockets whose
+        // routing follows connection.json; closing every secondary here
+        // detached valid registered sessions and armed ws_orphan_reap.
+        closeLegacySecondaryGateways()
 
         // Same override rule as boot(): a profile-pinned helper window stays
         // on its pinned profile's backend across a soft switch.
@@ -725,7 +731,7 @@ export function useGatewayBoot({
       // sources can expose the same profile name (every source has a
       // 'default'), so bare profile names can't represent a non-local
       // source's liveness without keeping the wrong gateway alive.
-      const keep = liveSessionScopes()
+      const keep = new Set([...liveSessionScopes(), ...foregroundSessionScopes()])
 
       for (const session of $sessions.get()) {
         if (live.has(session.id)) {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -53,6 +53,7 @@ import {
 } from '@/store/session'
 import {
   $attentionSessionIds,
+  $sessionTiles,
   $workingSessionIds,
   foregroundSessionScopes,
   liveSessionScopes,
@@ -744,6 +745,8 @@ export function useGatewayBoot({
 
     const offWorking = $workingSessionIds.subscribe(() => recomputeKeptGateways())
     const offAttention = $attentionSessionIds.subscribe(() => recomputeKeptGateways())
+    const offActiveSession = $activeSessionId.subscribe(() => recomputeKeptGateways())
+    const offSessionTiles = $sessionTiles.subscribe(() => recomputeKeptGateways())
     const offActiveProfile = $activeGatewayProfile.subscribe(() => recomputeKeptGateways())
 
     const offWindowState = desktop.onWindowStateChanged?.(payload => {
@@ -935,6 +938,8 @@ export function useGatewayBoot({
       clearInterval(keepaliveTimer)
       offWorking()
       offAttention()
+      offActiveSession()
+      offSessionTiles()
       offActiveProfile()
       window.removeEventListener('online', onOnline)
       document.removeEventListener('visibilitychange', onVisible)

--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -83,6 +83,8 @@ interface UserEditComposerProps {
   sessionId: string | null
 }
 
+export const EDIT_SUBMIT_COOLDOWN_MS = 200
+
 export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }) => {
   const { t } = useI18n()
   const copy = t.assistant.thread
@@ -609,7 +611,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
     submitCooldownTimerRef.current = window.setTimeout(() => {
       submitCooldownTimerRef.current = null
       setSubmitting(false)
-    }, 200)
+    }, EDIT_SUBMIT_COOLDOWN_MS)
 
     try {
       aui.composer().send()

--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -108,6 +108,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   const [triggerPlacement, setTriggerPlacement] = useState<'bottom' | 'top'>('top')
   const [focusRequestId, setFocusRequestId] = useState(0)
   const [submitting, setSubmitting] = useState(false)
+  const submitCooldownTimerRef = useRef<number | null>(null)
   // True while OS-drop files are being staged/uploaded into the session. Blocks
   // submit and shows a spinner so confirming the edit can't race the async
   // upload and drop the gateway-side ref before it lands in the draft.
@@ -124,6 +125,11 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   // cleanup so keyboard routing falls back to the visible chat composer.
   useEffect(
     () => () => {
+      if (submitCooldownTimerRef.current !== null) {
+        window.clearTimeout(submitCooldownTimerRef.current)
+        submitCooldownTimerRef.current = null
+      }
+
       notifyThreadEditClose()
       releaseActiveComposer('edit')
     },
@@ -596,16 +602,23 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
     // click). Reset `submitting` on failure so the arrow can't wedge on `true`
     // and leave revert as the only way out (#49903 is the same unguarded-core
     // hazard on the main composer).
+    // Clear latch after cooldown to allow re-submission. This prevents rapid
+    // double-Enter but doesn't require tracking when onEdit settles (which may
+    // be synchronous or async, and whose promise we don't have access to).
+    // Register before send() so a synchronous composer teardown can clear it.
+    submitCooldownTimerRef.current = window.setTimeout(() => {
+      submitCooldownTimerRef.current = null
+      setSubmitting(false)
+    }, 200)
+
     try {
       aui.composer().send()
-
-      // Clear latch after cooldown to allow re-submission. This prevents rapid
-      // double-Enter but doesn't require tracking when onEdit settles (which may
-      // be synchronous or async, and whose promise we don't have access to).
-      window.setTimeout(() => {
-        setSubmitting(false)
-      }, 200)
     } catch {
+      if (submitCooldownTimerRef.current !== null) {
+        window.clearTimeout(submitCooldownTimerRef.current)
+        submitCooldownTimerRef.current = null
+      }
+
       setSubmitting(false)
     }
   }

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
@@ -20,6 +20,8 @@ stubThreadEnvironment()
 
 afterEach(() => {
   cleanup()
+  vi.restoreAllMocks()
+  vi.useRealTimers()
 })
 
 stubThreadViewportSize()
@@ -198,6 +200,33 @@ describe('Enter submission and latch behavior', () => {
     await waitFor(() => {
       expect(onEdit).toHaveBeenCalledTimes(1)
     })
+  })
+
+  it('does not leave a submission cooldown timer after the edit unmounts', async () => {
+    const onEdit = vi.fn(async () => {})
+    const { unmount } = render(<IncrementalHarness onEdit={onEdit} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit message' }))
+
+    const editor = await screen.findByRole('textbox', { name: 'Edit message' })
+    editor.textContent = 'edit that will close the composer'
+    fireEvent.input(editor)
+
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout')
+    const clearTimeoutSpy = vi.spyOn(window, 'clearTimeout')
+    fireEvent.keyDown(editor, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(onEdit).toHaveBeenCalledTimes(1)
+    })
+
+    const cooldownIndex = setTimeoutSpy.mock.calls.findIndex(([, delay]) => delay === 200)
+    expect(cooldownIndex).toBeGreaterThanOrEqual(0)
+    const cooldownTimer = setTimeoutSpy.mock.results[cooldownIndex]?.value
+
+    unmount()
+
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(cooldownTimer)
   })
 
   it('clears the submitting latch after onEdit resolves, allowing second edit session', async () => {

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
@@ -15,6 +15,8 @@ import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-s
 
 import { assistantMessage, stubThreadEnvironment, stubThreadViewportSize, userMessage } from '../test-utils'
 
+import { EDIT_SUBMIT_COOLDOWN_MS } from './user-edit-composer'
+
 import { Thread } from '.'
 stubThreadEnvironment()
 
@@ -220,7 +222,7 @@ describe('Enter submission and latch behavior', () => {
       expect(onEdit).toHaveBeenCalledTimes(1)
     })
 
-    const cooldownIndex = setTimeoutSpy.mock.calls.findIndex(([, delay]) => delay === 200)
+    const cooldownIndex = setTimeoutSpy.mock.calls.findIndex(([, delay]) => delay === EDIT_SUBMIT_COOLDOWN_MS)
     expect(cooldownIndex).toBeGreaterThanOrEqual(0)
     const cooldownTimer = setTimeoutSpy.mock.results[cooldownIndex]?.value
 

--- a/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
+++ b/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
@@ -53,6 +53,7 @@ vi.mock('@/store/session-states', () => reconnectStateMocks)
 
 const {
   activeGateway,
+  closeLegacySecondaryGateways,
   closeSecondaryGateways,
   configureGatewayRegistry,
   disposeSecondariesForConnection,
@@ -176,6 +177,30 @@ describe('disposeSecondariesForConnection', () => {
     disposeSecondariesForConnection('ghost')
 
     expect(gatewayMocks.instances[0].close).not.toHaveBeenCalled()
+  })
+})
+
+describe('legacy secondary teardown', () => {
+  it('closes v1 profile sockets without detaching registered sources', async () => {
+    const getConnection = vi.fn(async (profile: string) => descriptorFor('legacy-local', profile))
+
+    const getConnectionFor = vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) =>
+      descriptorFor(connectionId, profile)
+    )
+
+    installDesktop({ getConnection, getConnectionFor })
+
+    await openGatewayForProfile('writer')
+    await ensureGatewayForAgent('homelab', 'default')
+
+    const legacy = gatewayMocks.instances[0]
+    const registered = gatewayMocks.instances[1]
+
+    closeLegacySecondaryGateways()
+
+    expect(legacy.close).toHaveBeenCalledOnce()
+    expect(registered.close).not.toHaveBeenCalled()
+    expect(activeGateway()).toBe(registered)
   })
 })
 

--- a/apps/desktop/src/store/gateway-connection-scope.test.ts
+++ b/apps/desktop/src/store/gateway-connection-scope.test.ts
@@ -40,6 +40,7 @@ vi.mock('@/store/session', () => ({
 vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() }))
 
 const {
+  closeLegacySecondaryGateways,
   closeSecondaryGateways,
   configureGatewayRegistry,
   ensureGatewayForAgent,
@@ -123,5 +124,19 @@ describe('pruneSecondaryGateways with registry-scoped entries', () => {
     pruneSecondaryGateways(new Set())
 
     expect(gatewayMocks.closed).toHaveLength(1)
+  })
+
+  it('does not classify an explicit local registry source as legacy', async () => {
+    await openGatewayForAgent(null, 'writer')
+    await openGatewayForAgent('local', 'writer')
+
+    expect(gatewayMocks.closed).toEqual([])
+
+    closeLegacySecondaryGateways()
+
+    // The bare profile socket follows the v1 mode configuration and is
+    // retired. The explicit `local` registry socket is a v2 source and must
+    // survive the mode apply just like a registered remote source.
+    expect(gatewayMocks.closed).toEqual(['wss://local.invalid/api/ws?token=t'])
   })
 })

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -1145,6 +1145,15 @@ function closeSecondariesWhere(shouldClose: (entry: Secondary) => boolean): void
   restoreActiveToPrimaryIfEvicted()
 }
 
+function isLegacySecondary(entry: Secondary): boolean {
+  // Every v2 registry route is created with an explicit connection id,
+  // including the registry's `local` source. A missing id is reserved for the
+  // old profile-only pool; the loose null check also retires HMR entries from
+  // builds that predate the field instead of leaving an old legacy socket
+  // behind during a mode apply.
+  return entry.connectionId == null
+}
+
 /**
  * Close only profile sockets that follow the legacy v1 connection config.
  *
@@ -1155,7 +1164,7 @@ function closeSecondariesWhere(shouldClose: (entry: Secondary) => boolean): void
  * retired because their endpoint is derived from the v1 config being changed.
  */
 export function closeLegacySecondaryGateways(): void {
-  closeSecondariesWhere(entry => entry.connectionId == null)
+  closeSecondariesWhere(isLegacySecondary)
 }
 
 export function closeSecondaryGateways(): void {

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -1132,13 +1132,34 @@ export function pruneSecondaryGateways(keep: Set<string>): void {
   restoreActiveToPrimaryIfEvicted()
 }
 
-export function closeSecondaryGateways(): void {
-  for (const entry of g.secondaries.values()) {
+function closeSecondariesWhere(shouldClose: (entry: Secondary) => boolean): void {
+  for (const [scope, entry] of [...g.secondaries]) {
+    if (!shouldClose(entry)) {
+      continue
+    }
+
     disposeSecondary(entry)
+    g.secondaries.delete(scope)
   }
 
-  g.secondaries.clear()
   restoreActiveToPrimaryIfEvicted()
+}
+
+/**
+ * Close only profile sockets that follow the legacy v1 connection config.
+ *
+ * A global mode apply re-homes the primary backend, but registered connection
+ * sockets are independent sources in the v2 registry. Closing every secondary
+ * here would detach their sessions and arm `ws_orphan_reap` even though those
+ * sources remain valid and reusable. Legacy profile sockets still need to be
+ * retired because their endpoint is derived from the v1 config being changed.
+ */
+export function closeLegacySecondaryGateways(): void {
+  closeSecondariesWhere(entry => entry.connectionId == null)
+}
+
+export function closeSecondaryGateways(): void {
+  closeSecondariesWhere(() => true)
 }
 
 // A local profile can have two renderer-owned sockets: the legacy bare

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -38,11 +38,13 @@ describe('foregroundSessionScopes', () => {
   beforeEach(() => {
     clearAllSessionStates()
     $activeSessionId.set(null)
+    $sessionTiles.set([])
   })
 
   afterEach(() => {
     clearAllSessionStates()
     $activeSessionId.set(null)
+    $sessionTiles.set([])
   })
 
   it('keeps the exact registry owner of an idle foreground runtime', () => {
@@ -54,6 +56,37 @@ describe('foregroundSessionScopes', () => {
 
   it('fails closed when the foreground runtime has no registered source', () => {
     $activeSessionId.set('legacy-runtime')
+
+    expect(foregroundSessionScopes()).toEqual(new Set())
+  })
+
+  it('keeps every open pane owner, not only the focused runtime', () => {
+    recordSessionEventScope({ connectionId: 'cloud-a', profile: 'default', session_id: 'runtime-a' })
+    recordSessionEventScope({ connectionId: 'cloud-b', profile: 'default', session_id: 'runtime-b' })
+    $sessionTiles.set([
+      { runtimeId: 'runtime-a', storedSessionId: 'stored-a' },
+      {
+        ownerRoute: { connectionId: 'cloud-b', profile: 'default' },
+        storedSessionId: 'stored-b'
+      }
+    ])
+
+    expect(foregroundSessionScopes()).toEqual(
+      new Set(['conn:cloud-a::default', 'conn:cloud-b::default'])
+    )
+  })
+
+  it('releases an idle pane owner when the pane closes', () => {
+    $sessionTiles.set([
+      {
+        ownerRoute: { connectionId: 'cloud', profile: 'default' },
+        storedSessionId: 'stored-cloud'
+      }
+    ])
+
+    expect(foregroundSessionScopes()).toEqual(new Set(['conn:cloud::default']))
+
+    $sessionTiles.set([])
 
     expect(foregroundSessionScopes()).toEqual(new Set())
   })

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -4,20 +4,23 @@ import type { ClientSessionState } from '@/app/types'
 import { findGroupOfPane, group, split } from '@/components/pane-shell/tree/model'
 import { $layoutTree } from '@/components/pane-shell/tree/store'
 import { $activeGatewayProfile } from '@/store/profile'
-import { $selectedStoredSessionId, setSessions } from '@/store/session'
+import { $activeSessionId, $selectedStoredSessionId, setSessions } from '@/store/session'
 import type { SessionTile } from '@/store/session-states'
 import {
   $sessionStates,
   $sessionTiles,
   blankDraftTile,
+  clearAllSessionStates,
   focusedSessionNeedsRoute,
   focusOpenSession,
+  foregroundSessionScopes,
   knownOwnerForSession,
   markSelectionRestore,
   nextSessionTileForWorkspace,
   openSessionTile,
   orderTilesByTree,
   patchSessionTile,
+  recordSessionEventScope,
   releaseSessionTranscript,
   requestForOwnedSession,
   resetTileRuntimeBindings,
@@ -30,6 +33,31 @@ import {
 
 const tile = (storedSessionId: string): SessionTile => ({ storedSessionId })
 const tilePane = (id: string) => `session-tile:${id}`
+
+describe('foregroundSessionScopes', () => {
+  beforeEach(() => {
+    clearAllSessionStates()
+    $activeSessionId.set(null)
+  })
+
+  afterEach(() => {
+    clearAllSessionStates()
+    $activeSessionId.set(null)
+  })
+
+  it('keeps the exact registry owner of an idle foreground runtime', () => {
+    recordSessionEventScope({ connectionId: 'cloud', profile: 'default', session_id: 'runtime-1' })
+    $activeSessionId.set('runtime-1')
+
+    expect(foregroundSessionScopes()).toEqual(new Set(['conn:cloud::default']))
+  })
+
+  it('fails closed when the foreground runtime has no registered source', () => {
+    $activeSessionId.set('legacy-runtime')
+
+    expect(foregroundSessionScopes()).toEqual(new Set())
+  })
+})
 
 describe('resetTileRuntimeBindings', () => {
   afterEach(() => {

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -98,6 +98,22 @@ export function liveSessionScopes(): Set<string> {
   return scopes
 }
 
+/**
+ * The exact registry scope that owns the foreground runtime, when known.
+ *
+ * The secondary-gateway pruner normally keeps only busy/needs-input work. A
+ * source switch briefly changes the active gateway before the old foreground
+ * runtime is cleared, though, and an idle conversation can otherwise look
+ * disposable during that handoff. Preserve the owner for that narrow window;
+ * tiles have their own persisted owner route and are handled separately.
+ */
+export function foregroundSessionScopes(): Set<string> {
+  const runtimeId = $activeSessionId.get()
+  const scope = runtimeId ? sessionScopeByRuntimeId.get(runtimeId) : undefined
+
+  return scope ? new Set([scope]) : new Set()
+}
+
 // Stored session ids whose authoritative state is still busy, but whose
 // runtime has produced no state publish for the watchdog window. Silence is
 // not completion: long tool calls can legitimately stay quiet, so this is a

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -99,19 +99,43 @@ export function liveSessionScopes(): Set<string> {
 }
 
 /**
- * The exact registry scope that owns the foreground runtime, when known.
+ * Registry scopes owned by an open foreground surface, when known.
  *
  * The secondary-gateway pruner normally keeps only busy/needs-input work. A
- * source switch briefly changes the active gateway before the old foreground
- * runtime is cleared, though, and an idle conversation can otherwise look
- * disposable during that handoff. Preserve the owner for that narrow window;
- * tiles have their own persisted owner route and are handled separately.
+ * source switch briefly changes the active gateway before an idle conversation
+ * is cleared, so the primary runtime must survive that handoff. Open panes have
+ * the same ownership contract: a non-focused idle tile is still user-visible
+ * state and must not be evicted just because another pane has focus. Prefer the
+ * live event scope, with the tile's persisted route as the pre-bind fallback.
  */
 export function foregroundSessionScopes(): Set<string> {
-  const runtimeId = $activeSessionId.get()
-  const scope = runtimeId ? sessionScopeByRuntimeId.get(runtimeId) : undefined
+  const scopes = new Set<string>()
 
-  return scope ? new Set([scope]) : new Set()
+  const addRuntimeScope = (runtimeId: string | undefined) => {
+    const scope = runtimeId ? sessionScopeByRuntimeId.get(runtimeId) : undefined
+
+    if (scope) {
+      scopes.add(scope)
+    }
+  }
+
+  const addRouteScope = (route: SessionProfileRoute | undefined) => {
+    const connectionId = route?.connectionId?.trim()
+    const profile = route?.profile?.trim()
+
+    if (connectionId && profile) {
+      scopes.add(registryBackendScopeKey(connectionId, profile))
+    }
+  }
+
+  addRuntimeScope($activeSessionId.get() ?? undefined)
+
+  for (const tile of $sessionTiles.get()) {
+    addRuntimeScope(tile.runtimeId)
+    addRouteScope(tile.ownerRoute)
+  }
+
+  return scopes
 }
 
 // Stored session ids whose authoritative state is still busy, but whose


### PR DESCRIPTION
## What does this PR do?

Fixes the two connected lifecycle failures reported in #94196:

1. A legacy Local/Cloud mode apply no longer tears down every registered v2 source socket. Registered gateways are independent backends; closing them during a primary re-home detached valid sessions and armed `ws_orphan_reap` unnecessarily.
2. The secondary-gateway keep-set now preserves the exact registry source owning the foreground runtime during the short source-switch handoff, even when that conversation is idle. The old policy kept only busy/needs-input work, so the handoff could look like disposable idle state.

The durable `ws_orphan_reap` recovery machinery is unchanged. This patch prevents the avoidable disconnect at the Desktop lifecycle boundary instead of weakening or duplicating the reaper.

### Confirmed root cause

`useGatewayBoot.softSwitch()` called `closeSecondaryGateways()` unconditionally after the primary connection was intentionally torn down. That helper closed both legacy profile sockets and sockets belonging to explicitly registered v2 connections. A remote registered backend remained healthy, but its WebSocket disconnect caused the backend to sentinel-park the session and arm the orphan-reap timer.

The pruner had a second handoff gap: `liveSessionScopes()` intentionally covers only busy/needs-input runtimes. During source activation, the active route can move before the old foreground runtime is cleared. Without carrying the existing event-source scope for `$activeSessionId`, an idle foreground session could be pruned in that interval.

The reported `session not found` is consistent with this path: the reaper removes the live runtime from the gateway process and records a recoverable end reason; a stale runtime request then fails until the stored session is resumed. The code does not prove permanent durable-row deletion, so this PR does not claim that it does.

## Related work and non-duplication

This is deliberately complementary to existing work, not a copy:

- #93361 / #93405 handle resume-side reaper cancellation, lazy-session rebinding, and the reconnect storm.
- #93430 handles transport revalidation races and startup orphan recovery.
- #93408 handles v1/v2 connection-store drift and the `Save and reconnect` configuration boundary.
- #92333 / #92307 handle publishing a secondary route before its WebSocket is open.
- #93916 handles retained Bot Mode tile ownership during idle pruning.

Those changes do not change `softSwitch()` from all-secondary teardown to source-aware teardown, nor do they add the foreground runtime's exact registry scope to the pruner keep-set. This PR owns that shared Desktop handoff boundary.

## Changes Made

- `apps/desktop/src/store/gateway.ts`
  - Added `closeLegacySecondaryGateways()` for only `connectionId == null` sockets.
  - Kept `closeSecondaryGateways()` unchanged for full renderer/backend shutdown paths.
- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts`
  - Uses the legacy-only teardown during a global mode apply.
  - Adds `foregroundSessionScopes()` to the existing keep-set.
- `apps/desktop/src/store/session-states.ts`
  - Exposes the already-recorded `(connectionId, profile)` scope for the foreground runtime without introducing a second ownership map.
- `apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx`
  - Owns the edit submission cooldown timer and clears it on teardown, including synchronous `send()` teardown and send-failure paths.
- Regression coverage in:
  - `apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx`
  - `apps/desktop/src/store/gateway-connection-lifecycle.test.ts`
  - `apps/desktop/src/store/session-states.test.ts`
  - `apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx`

## Hardening record

- **GitHub priority:** P2 on #94196 (`type/bug`, `comp/desktop`, `sweeper:risk-session-state`). Complexity: medium; required pre-PR check-ins: 2.
- **Check-in 1 — premise/root cause:** traced the source-switch, secondary-socket, pruner, and `ws_orphan_reap` paths; inspected #93361, #93405, #93408, #93430, #92333, #92307, and #93916; classified this as a distinct source-aware teardown/foreground-owner gap.
- **Check-in 2 — failure modes/bottlenecks:** checked same-profile/different-source scope collisions, concurrent activation before list wipe, deliberate full shutdown, HMR/cleanup behavior, repeated reconnects, and retained-resource risk. The fix preserves only registered sources during the narrow soft apply and leaves later normal pruning available.
- **Security/authority:** no new credentials, network endpoints, filesystem writes, or trust decisions. Source identity comes from the existing gateway event scope and explicit `connectionId`; unknown foreground owners fail closed.

## How to Test

Focused Desktop lifecycle and routing suites:

```text
npm --prefix apps/desktop run test:ui -- \
  src/app/gateway/hooks/use-gateway-boot.test.tsx \
  src/store/gateway-connection-lifecycle.test.ts \
  src/store/gateway-connection-scope.test.ts \
  src/store/gateway-profile-request.test.ts \
  src/store/gateway-activation-prune-lease.test.ts \
  src/store/session-request-router.test.ts \
  src/store/profile.test.ts \
  src/store/profile-agent-activation.test.ts \
  src/store/connections.test.ts \
  src/store/session-states.test.ts
```

Result: **10 files, 151 tests passed**.

Additional verification:

- `npm --prefix apps/desktop run typecheck` — passed.
- `npm --prefix apps/desktop run build` — passed; `assert-dist-built` passed.
- ESLint on all changed Desktop files — 0 errors.
- `HERMES_PYTHON=C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe scripts/run_tests.sh tests/test_tui_gateway_server.py -k 'ws_orphan_reap or close_sessions_for_transport' -q` — **16 passed** through the canonical wrapper.
- Sabotage check 1: making `closeLegacySecondaryGateways()` close every entry made the new soft-switch regression fail with the registered socket `closed` instead of `open`.
- Sabotage check 2: removing `foregroundSessionScopes()` made its owner regression fail with an empty set instead of `conn:cloud::default`.
- Full UI suite before the follow-up: **587 passed, 13 failed in 7 files**. The failures were outside the changed files and were mostly parallel-runner timeouts, host-locale formatting, canvas support, or an existing truncation expectation. The affected failure slices for `gateway-settings`, `messaging`, and `session-unread-tile` passed when run individually.

- The local host is below the declared JavaScript engine range (`Node v22.16.0` / `npm 11.4.1` versus the repository requirement `Node >=22.22.0` and npm `<11.10.0 || >=11.17.0`), so dependency installation used `npm_config_engine_strict=false npm ci`. This limitation is reported rather than treated as CI evidence.

## Remote CI status

- The initial PR head `7a3c11b0e757c2afb6aa49fdf51b87b91b8c0b6e` passed 596 files / 5,731 tests before an unhandled teardown error from the untouched `user-message-edit.test.tsx`: `ReferenceError: window is not defined` from the edit cooldown timer.
- Follow-up commit `094457205e09c21038f1c6acf2d6884b57c185f3` owns that timer, clears it during unmount, and registers it before `send()` so synchronous teardown is covered.
- After the follow-up, the full local UI suite produced **590 passed, 12 failed in 6 unrelated files**, with no `window is not defined` error and no failure in `user-message-edit.test.tsx`.
- The follow-up focused set passed **13 files / 165 tests**, including the new teardown regression; typecheck, lint, and build passed again.
- Remote checks for follow-up head `094457205e09c21038f1c6acf2d6884b57c185f3` are green: `JS & TS checks`, `All required checks pass`, Docker amd64/arm64, Nix, OSV and repository integrity checks passed; intentionally skipped checks remain listed by GitHub.

## Risk and rollback

Low, localized Desktop lifecycle risk. Full shutdown still uses `closeSecondaryGateways()`. Only the soft global mode-apply path now leaves independent registered sources alive, and ordinary later `pruneSecondaryGateways()` can still reclaim genuinely idle sources. Rollback is a single commit revert.

## Review follow-up

This section records the review work completed after the original PR description.

### Findings and decisions

- The registered-gateway teardown bug is confirmed. A legacy Local/Cloud mode apply must close only legacy profile-only sockets; registered v2 sources are independent backends and remain reusable.
- The `local` registry source is explicitly identified by `connectionId: 'local'`; it is not treated as the legacy null/undefined compatibility shape.
- The gateway keep-set now retains every open session pane owner, not only the focused runtime. Ownership uses the live `(connectionId, profile)` event scope or the tile's persisted owner route. Retention is recomputed when the active runtime or tile set changes, and closing the last pane releases it.
- The edit cooldown is named as `EDIT_SUBMIT_COOLDOWN_MS`, and the regression assertion uses the same constant.
- The Bot Mode report from the live Desktop test was investigated as a separate root cause. Current roster rows receive source routes and missing connection owners fail closed; the exact `ensureAgent("", ...)` path was not reproducible on this head. It is not claimed as fixed by this PR and remains a follow-up.

### Validation evidence

- RED/GREEN sabotage: reverting the new pane-owner behavior made 2 regression tests fail; the corrected implementation passes them.
- Focused Desktop regression set: 11 files / 164 tests passed.
- Stress validation: 3 repeated runs of the gateway-scope/session-state/boot set, 74 tests per run, all passed.
- `npm run typecheck`: passed.
- `npm run lint`: passed with 0 errors; existing warnings remain.
- `npm run build`: passed, including `assert-dist-built`.
- Plugin suite: 556 tests passed.
- Dependency setup used `npm_config_engine_strict=false npm ci --ignore-scripts --no-audit --no-fund`: exit code 0, 1409 packages installed in about 3 minutes. The local host reported Node `v22.16.0` versus the declared `>=22.22.0` requirement and npm `11.4.1`; this produced warnings only. Remote CI used Node `26.7.0`.
- The first remote UI run had one unrelated 15-second timeout in `src/app/settings/gateway-settings.test.tsx`; that file passed in isolation locally. The workflow was retriggered with the explicit CI-only commit `b9b2085efc01f75bb2a982b0a17817d5a6a163c0`.
- Final remote head `b9b2085efc01f75bb2a982b0a17817d5a6a163c0`: `All required checks pass`; JS/TS, amd64/arm64 builds, Nix, OSV and integrity checks passed.

### Follow-up response

The live report was answered on the PR: https://github.com/NousResearch/hermes-agent/pull/94370#issuecomment-5415171475. The response distinguishes the confirmed gateway lifecycle fix from the unverified macOS + real-SSH Bot Mode follow-up and does not claim production E2E evidence that was not available from this Windows checkout.

## Checklist

- [x] Conventional commit.
- [x] Duplicate sweep by issue number, exact symbols, symptoms, and related PRs.
- [x] Regression tests added and sabotage-verified.
- [x] Focused tests, typecheck, lint, build, and canonical targeted Python wrapper run.
- [x] No secrets, generated binaries, or unrelated files in the commit.
- [x] No user-facing config key or API schema changed; documentation is included here in the root-cause and verification sections.

Fixes #94196
