### PR TITLE
fix(mcp): stdio liveness returned dead for every healthy child

### DIFF
--- a/tests/tools/test_mcp_stdio_children_liveness.py
+++ b/tests/tools/test_mcp_stdio_children_liveness.py
@@ -1,0 +1,90 @@
+"""`_stdio_children_dead()` must only be True when every child has exited.
+
+The fast-fail gate at the `call_tool` site (#81995) turns a True here into an
+immediate ``TimeoutError`` for the whole call, so an inverted answer does not
+degrade gracefully — it takes out every tool call on a perfectly healthy stdio
+MCP server before the RPC is even issued.
+
+The liveness probe was rewritten to ``psutil.pid_exists`` (#85125 CI) because
+``os.kill(pid, 0)`` cannot answer the question on Windows: an exited-but-
+unreaped child raises nothing, and a vanished PID raises ``OSError`` WinError 87
+rather than ``ProcessLookupError``. The rewrite kept the "dead" branch but
+returned True from the "alive" branch, stranding the correct ``return False``
+below it as unreachable code — so the helper answered True unconditionally.
+Nothing covered it. These tests do.
+"""
+
+import subprocess
+import sys
+import time
+
+import psutil
+import pytest
+
+from tools.mcp_tool import MCPServerTask
+
+
+def _stdio_task(pids, config=None):
+    """A bare MCPServerTask carrying just what the liveness probe reads."""
+    task = object.__new__(MCPServerTask)
+    # `_is_http()` is `"url" in self._config`; no url == stdio transport.
+    task._config = {} if config is None else config
+    task._stdio_child_pids = set(pids)
+    return task
+
+
+class TestStdioChildrenDead:
+    def test_live_child_is_not_reported_dead(self, monkeypatch):
+        monkeypatch.setattr(psutil, "pid_exists", lambda pid: True)
+
+        assert _stdio_task([4242])._stdio_children_dead() is False
+
+    def test_exited_child_is_reported_dead(self, monkeypatch):
+        monkeypatch.setattr(psutil, "pid_exists", lambda pid: False)
+
+        assert _stdio_task([4242])._stdio_children_dead() is True
+
+    def test_one_live_child_among_dead_ones_keeps_the_transport_alive(self, monkeypatch):
+        # "every child has exited" — a single survivor means the answer is False.
+        monkeypatch.setattr(psutil, "pid_exists", lambda pid: pid == 43)
+
+        assert _stdio_task([41, 42, 43])._stdio_children_dead() is False
+
+    def test_all_children_exited_is_dead(self, monkeypatch):
+        monkeypatch.setattr(psutil, "pid_exists", lambda pid: False)
+
+        assert _stdio_task([41, 42, 43])._stdio_children_dead() is True
+
+    @pytest.mark.parametrize("pids", [set(), None])
+    def test_unknown_without_captured_pids(self, pids):
+        # Unknown must not fail fast.
+        assert _stdio_task(pids or [])._stdio_children_dead() is False
+
+    def test_http_transport_never_fails_fast(self, monkeypatch):
+        monkeypatch.setattr(psutil, "pid_exists", lambda pid: False)
+        task = _stdio_task([4242], config={"url": "https://example.invalid/mcp"})
+
+        assert task._stdio_children_dead() is False
+
+
+class TestStdioChildrenDeadAgainstRealProcesses:
+    """The same contract against a real OS process, no monkeypatching."""
+
+    def test_real_child_flips_from_alive_to_dead_when_killed(self):
+        child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+        try:
+            deadline = time.monotonic() + 5
+            while not psutil.pid_exists(child.pid) and time.monotonic() < deadline:
+                time.sleep(0.05)
+
+            assert _stdio_task([child.pid])._stdio_children_dead() is False
+        finally:
+            child.kill()
+            child.wait()
+
+        # psutil reports a reaped PID as gone; give the OS a moment on slower CI.
+        deadline = time.monotonic() + 5
+        while psutil.pid_exists(child.pid) and time.monotonic() < deadline:
+            time.sleep(0.05)
+
+        assert _stdio_task([child.pid])._stdio_children_dead() is True

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2988,13 +2988,15 @@ class MCPServerTask:
         if not pids or self._is_http():
             return False
         for pid in pids:
-            # windows-footgun: ok — psutil.pid_exists handles Windows; the
-            # os.kill probe below only runs when psutil is unavailable.
+            # windows-footgun: ok — psutil.pid_exists is the cross-platform
+            # liveness probe. os.kill(pid, 0) cannot answer this on Windows:
+            # an exited-but-unreaped child raises nothing (the parent still
+            # holds the handle) and a vanished PID raises OSError WinError 87,
+            # not ProcessLookupError.
             import psutil
 
             if not psutil.pid_exists(pid):
                 continue  # this one is dead
-            return True  # alive (signal permission irrelevant for liveness)
             return False  # at least one child alive
         return True
 


### PR DESCRIPTION
## The bug

`_stdio_children_dead()` (`tools/mcp_tool.py`) answers **True unconditionally**. The fast-fail gate in front of `call_tool` (#81995) turns that into an immediate failure for **every tool call on a healthy stdio MCP server**, before the RPC is issued:

```
MCP stdio subprocess for '<server>' has exited; failing the call fast instead of waiting 300s
```

`_watch_stdio_children()` resolves instantly for the same reason and cancels any in-flight call.

**This is not platform-specific** — it breaks stdio MCP on Linux and macOS identically.

## Cause

`786f37071a` correctly rewrote the probe to `psutil.pid_exists` (#85125 CI). `os.kill(pid, 0)` genuinely cannot answer this on Windows: an exited-but-unreaped child raises nothing (the parent still holds the handle), and a vanished PID raises `OSError` WinError 87, not `ProcessLookupError`. That part is right.

Only the return value went the wrong way — the "dead" branch was kept, but the "alive" branch returns `True`, stranding the correctly-commented `return False` below it as unreachable code:

```python
for pid in pids:
    if not psutil.pid_exists(pid):
        continue          # this one is dead
    return True           # <- reports "all dead" when one is ALIVE
    return False          # <- unreachable
return True
```

The fix deletes the stray `return True`. It also corrects the comment above the probe, which still describes an `os.kill` fallback "below" that the same rewrite removed.

## Reproduction

Against a real OS process, using the unmodified function:

```
live child pid=48968: _stdio_children_dead() = True     (expected False)
dead child pid=48968: _stdio_children_dead() = True     (expected True)
```

After the fix:

```
live child pid=48968: _stdio_children_dead() = False    (expected False)
dead child pid=48968: _stdio_children_dead() = True     (expected True)
```

## Testing

Nothing covered this helper — `git grep` finds no reference to `_stdio_children_dead` or `_watch_stdio_children` outside `tools/mcp_tool.py`. That is how an inverted one-liner shipped.

Adds `tests/tools/test_mcp_stdio_children_liveness.py` (8 cases): alive, exited, one-survivor-among-dead, all-dead, no-captured-pids and HTTP-transport under a stubbed `pid_exists`, plus one end-to-end case against a real process transitioning from alive to killed.

```
tests/tools/test_mcp_stdio_children_liveness.py    8 passed
without the fix                                    3 failed, 5 passed
```

Regression sweep over the MCP suite (`pytest tests/tools/ -k mcp`), comparing the **set** of failing ids rather than counts:

| | failing ids | passed |
|---|---|---|
| `upstream/main` | 8 pre-existing | 630 |
| this branch | 8 pre-existing | 632 |

No new failures. One cross-process discovery test (`test_two_processes_each_complete_local_mcp_discovery`) flaked once under full-suite load and passes 3/3 in isolation; it does not exercise this code path.

## Note for whoever picks this up

`pytest tests/tools/` currently **cannot be collected on Windows at all** — `tests/tools/test_bot_turn_lock.py:12` imports `fcntl` unconditionally, which aborts the entire run. I had to `--ignore` that file to run the sweep above. That is a separate one-line fix and I'm happy to send it separately if useful.

## Platforms

Verified on Windows 11 / CPython 3.11. The defect and the fix are platform-independent.
