### PR TITLE
fix(security): gateway lifecycle guard recognises Windows command spellings

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -71,7 +71,14 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     # matching via the `/hermes` tail, while every real command position
     # (start of text, whitespace, `;`/`&`/`|`, `$(`, backtick, even a
     # U+FFFD from binary-content decoding) still matches.
-    r"(?:(?<![/\w.\-])hermes\s+gateway\s+(?:restart|stop|uninstall)\b)"
+    # The optional suffix is what the CLI is actually spelled as on Windows:
+    # `hermes.exe gateway restart` is the same command as `hermes gateway
+    # restart`, and npm-style shims install `hermes.cmd` / `hermes.ps1`
+    # alongside it. Anchoring on the bare name let every one of those spellings
+    # walk past a guard that stops the unsuffixed form, and the guard is gated
+    # on PID-file ownership rather than platform, so the bypass is live wherever
+    # a supervised gateway runs on Windows.
+    r"(?:(?<![/\w.\-])hermes(?:\.(?:exe|cmd|bat|com|ps1))?\s+gateway\s+(?:restart|stop|uninstall)\b)"
     # Branch B: launchctl ops on a hermes-gateway label. macOS launchd
     # labels look like `ai.hermes.gateway` / `hermes-gateway`. Requiring the
     # gateway identifier prevents blocking unrelated hermes services (e.g.
@@ -98,8 +105,15 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     # token orders because real reproductions show both.
     # Leading \b ensures we match "pkill" or "kill" as whole words, not as
     # suffixes of other words (e.g. "skill" -> "kill").
-    r"|(?:\bp?kill\b[^\n]*\bhermes\b[^\n]*\bgateway)"
-    r"|(?:\bp?kill\b[^\n]*\bgateway\b[^\n]*\bhermes)"
+    # `taskkill` and `Stop-Process` are the Windows spellings of the same
+    # operation — the same reasoning that put `bootout` next to `unload`
+    # (#80260). `\bp?kill\b` cannot reach inside `taskkill` (no word boundary
+    # between the two `k`s), so they need naming outright. Service-control
+    # forms (`net stop`, `sc stop`, `Stop-Service`) are deliberately not
+    # covered here: they presuppose a service install this guard has no
+    # evidence of, and guessing at one risks blocking unrelated services.
+    r"|(?:\b(?:p?kill|taskkill|stop-process)\b[^\n]*\bhermes\b[^\n]*\bgateway)"
+    r"|(?:\b(?:p?kill|taskkill|stop-process)\b[^\n]*\bgateway\b[^\n]*\bhermes)"
 )
 
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -37,6 +37,54 @@ class TestGatewayLifecyclePattern:
         assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
 
     @pytest.mark.parametrize("text", [
+        # Windows spells the CLI with an executable suffix, and npm-style
+        # shims install `hermes.cmd` / `hermes.ps1` beside the `.exe`.
+        # Anchoring Branch A on the bare name let every one of these walk past
+        # a guard that stops `hermes gateway restart`. The guard is gated on
+        # PID-file ownership, not on platform, so the bypass was live for any
+        # supervised gateway running on Windows.
+        "hermes.exe gateway restart",
+        "hermes.cmd gateway stop",
+        "hermes.bat gateway restart",
+        "hermes.ps1 gateway uninstall",
+        "HERMES.EXE gateway restart",
+        r"C:\tools\hermes.exe gateway stop",
+        r".\hermes.exe gateway restart",
+        # Quoted and wrapped spellings reach the same place via the
+        # tokenizing rescan; pin them so the suffix survives that path too.
+        r'"C:\Program Files\hermes.exe" gateway restart',
+        "cmd /c hermes.exe gateway restart",
+        'powershell -Command "hermes.exe gateway restart"',
+    ])
+    def test_windows_executable_suffix_is_caught(self, text):
+        assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
+
+    @pytest.mark.parametrize("text", [
+        # `taskkill` / `Stop-Process` are the Windows spellings of pkill.
+        # `\bp?kill\b` cannot reach inside `taskkill` — there is no word
+        # boundary between the two `k`s — so they need naming outright.
+        "taskkill /F /IM hermes-gateway.exe",
+        "Stop-Process -Name hermes-gateway -Force",
+        "stop-process -name hermes-gateway",
+    ])
+    def test_windows_process_kill_forms_are_caught(self, text):
+        assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
+
+    @pytest.mark.parametrize("text", [
+        # The suffix must not widen the match. `start` stays deliberately
+        # benign, an unrelated process is not the gateway, and the word-tail
+        # exclusion still holds once a suffix is attached.
+        "hermes.exe gateway start",
+        "hermes.exe chat",
+        "taskkill /F /IM notepad.exe",
+        "Stop-Process -Name chrome",
+        "my-hermes.exe gateway restart",
+        "hermesexe gateway restart",
+    ])
+    def test_windows_forms_do_not_overmatch(self, text):
+        assert not _contains_gateway_lifecycle_command(text), f"Should NOT match: {text!r}"
+
+    @pytest.mark.parametrize("text", [
         # #62891: a blocked direct restart/kill laundered through a NEW
         # launchd keepalive job wrapping a helper script, instead of a
         # direct kickstart/unload/stop/restart on the existing service.


### PR DESCRIPTION
## The gap

The guard that stops a supervised gateway from restarting, stopping or uninstalling **itself** only knows POSIX spellings. The Windows spelling of the very same operation walks straight past it.

Branch A anchors on the bare CLI name. On Windows the CLI is spelled with an executable suffix, and npm-style shims install `hermes.cmd` / `hermes.ps1` beside the `.exe`. Measured against the guard on `upstream/main`:

| command | before | after |
|---|---|---|
| `hermes gateway restart` | BLOCKED | BLOCKED |
| `hermes.exe gateway restart` | **ALLOWED** | BLOCKED |
| `hermes.cmd gateway stop` | **ALLOWED** | BLOCKED |
| `hermes.bat gateway restart` | **ALLOWED** | BLOCKED |
| `hermes.ps1 gateway uninstall` | **ALLOWED** | BLOCKED |
| `C:\tools\hermes.exe gateway stop` | **ALLOWED** | BLOCKED |
| `taskkill /F /IM hermes-gateway.exe` | **ALLOWED** | BLOCKED |
| `Stop-Process -Name hermes-gateway` | **ALLOWED** | BLOCKED |

Branch D has the same gap for process termination: `\bp?kill\b` cannot reach inside `taskkill` — there is no word boundary between the two `k`s — so the Windows spelling was never considered, while `pkill -f hermes gateway` was blocked.

## Why it is reachable

The guard is gated on `_is_supervised_gateway_process()` — PID-file ownership — **not on platform**. Its callers (`tools/terminal_tool.py`, `tools/code_execution_tool.py`, `tools/approval.py`, `hermes_cli/cron.py`) all run on Windows; two of them already branch on `platform.system() == "Windows"` elsewhere. So on Windows the agent could restart or uninstall the gateway it is running inside, which is exactly the foot-gun this guard exists to prevent.

## Scope — deliberately narrow

Two things are **not** changed, on purpose:

- **Service-control spellings** (`net stop`, `sc stop`, `Stop-Service`) presuppose a Windows service install this guard has no evidence of; guessing at one risks blocking unrelated services.
- **`C:/tools/hermes.exe`** (forward slashes, which Windows accepts) stays allowed. The `/` in the Branch A lookbehind is the deliberate #77173 path false-positive fix, and narrowing it is a separate decision for whoever owns that trade-off — the same lookbehind is why `/usr/bin/hermes gateway restart` is allowed today.

## Testing

19 new cases in `tests/hermes_cli/test_gateway_restart_loop.py`, matching the existing `TestGatewayLifecyclePattern` style — the caught spellings, the quoted/wrapped forms that reach the same place through the tokenizing rescan (`"C:\Program Files\hermes.exe" gateway restart`, `cmd /c …`, `powershell -Command "…"`), and that the suffix does **not** widen the match:

- `hermes.exe gateway start` stays benign (`start` is deliberately excluded)
- `my-hermes.exe gateway restart` is still a different binary
- `taskkill /F /IM notepad.exe` is not the gateway

**13 of the 19 fail without this change.**

Full-file sweep, comparing the **set** of failing ids rather than counts:

| | failing ids | passed |
|---|---|---|
| `upstream/main` | 61 pre-existing | 236 |
| this branch | 61 (identical set) | 255 |

Zero new failures; the +19 passes are exactly the new cases. The 61 pre-existing failures are unrelated Windows environment issues in that file. `tests/tools/test_approval.py` (the other consumer of this guard) also shows no new failures.

## Platforms

Verified on Windows 11 / CPython 3.11.
