### PR TITLE
fix(cron): enforce profile-scoped scheduler ownership

### DIFF
--- a/agent/monitoring/cron_health.py
+++ b/agent/monitoring/cron_health.py
@@ -18,7 +18,7 @@ from cron.jobs import (
     get_ticker_success_age,
     load_jobs,
 )
-from cron.scheduler import get_running_job_ids
+from cron.scheduler import get_running_cron_runs
 from hermes_time import now as _hermes_now
 
 logger = logging.getLogger(__name__)
@@ -185,7 +185,7 @@ def build_cron_health_snapshot() -> CronHealthSnapshot:
 
     try:
         metrics.append(
-            GatewayMetric("hermes.cron.jobs.running", len(get_running_job_ids()), {})
+            GatewayMetric("hermes.cron.jobs.running", len(get_running_cron_runs()), {})
         )
     except Exception:
         logger.debug("cron running-job metric unavailable", exc_info=True)

--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -56,6 +56,9 @@ def is_multiplex_active() -> bool:
 _SECRET_SCOPE: ContextVar[Optional[Mapping[str, str]]] = ContextVar(
     "_SECRET_SCOPE", default=None
 )
+_SECRET_SCOPE_AUTHORITATIVE: ContextVar[bool] = ContextVar(
+    "_SECRET_SCOPE_AUTHORITATIVE", default=False
+)
 
 
 class UnscopedSecretError(RuntimeError):
@@ -82,9 +85,36 @@ def reset_secret_scope(token: Token) -> None:
     _SECRET_SCOPE.reset(token)
 
 
+def set_authoritative_secret_scope(
+    secrets: Optional[Mapping[str, str]],
+) -> tuple[Token, Token]:
+    """Install a scope whose misses never fall through to process credentials.
+
+    Desktop cron can arbitrate several profiles without enabling the gateway's
+    process-global multiplex mode. This context-local flag gives those cron
+    workers the same fail-closed credential boundary without changing unrelated
+    Desktop turns.
+    """
+    scope_token = _SECRET_SCOPE.set(secrets)
+    authoritative_token = _SECRET_SCOPE_AUTHORITATIVE.set(True)
+    return scope_token, authoritative_token
+
+
+def reset_authoritative_secret_scope(tokens: tuple[Token, Token]) -> None:
+    """Restore a scope installed by :func:`set_authoritative_secret_scope`."""
+    scope_token, authoritative_token = tokens
+    _SECRET_SCOPE_AUTHORITATIVE.reset(authoritative_token)
+    _SECRET_SCOPE.reset(scope_token)
+
+
 def current_secret_scope() -> Optional[Mapping[str, str]]:
     """Return the active secret mapping, or None when no scope is installed."""
     return _SECRET_SCOPE.get()
+
+
+def is_secret_scope_authoritative() -> bool:
+    """Whether scope misses must not read or mutate process-global secrets."""
+    return _SECRET_SCOPE_AUTHORITATIVE.get()
 
 
 # ── genuinely-global env vars (NOT per-profile secrets) ──────────────────
@@ -178,7 +208,7 @@ def get_secret(name: str, default: Optional[str] = None) -> Optional[str]:
         val = scope.get(name)
         if val is not None:
             return val
-        if _MULTIPLEX_ACTIVE:
+        if _MULTIPLEX_ACTIVE or _SECRET_SCOPE_AUTHORITATIVE.get():
             return default
         # Multiplex off: the scope is an overlay over the process environment,
         # not an isolation boundary — there is no other profile to leak from.

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -252,8 +252,8 @@ def _job_running_in_this_process(job_id: str) -> bool:
     module-level import here would be circular.
     """
     try:
-        from cron.scheduler import get_running_job_ids
-        return job_id in get_running_job_ids()
+        from cron.scheduler import is_cron_job_running
+        return is_cron_job_running(job_id)
     except Exception:
         logger.warning(
             "Cron running-set liveness check failed for job %r; keeping the "

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -37,7 +37,7 @@ except ImportError:
     except ImportError:
         msvcrt = None
 from pathlib import Path
-from typing import Any, List, Optional, Protocol
+from typing import Any, List, NamedTuple, Optional, Protocol
 
 # Add parent directory to path for imports BEFORE repo-level imports.
 # Without this, standalone invocations (e.g. after `hermes update` reloads
@@ -588,8 +588,10 @@ def _is_cron_silence_response(text: str) -> bool:
 # ---------------------------------------------------------------------------
 _parallel_pool: Optional[concurrent.futures.ThreadPoolExecutor] = None
 _parallel_pool_max_workers: Optional[int] = None
+# Correctness keys are (canonical profile home, job id). A bare job ID is not
+# globally unique because cloned/copied profiles may carry the same record ID.
 _running_job_ids: set = set()
-_running_fire_owners: dict[str, dict[object, tuple[Optional[str], Path]]] = {}
+_running_fire_owners: dict[object, dict[object, tuple[Optional[str], Path]]] = {}
 _running_lock = threading.Lock()
 
 # Wall-clock (time.time()) instant each in-flight job id was claimed by
@@ -668,58 +670,74 @@ class _CombinedCancelEvent:
             event.set()
 
 
+class RunningCronRun(NamedTuple):
+    profile_home: Path
+    job_id: str
+
+
+def _cron_run_key(job_id: str, profile_home: Path | str | None = None) -> tuple[str, str]:
+    home = Path(profile_home) if profile_home is not None else _get_hermes_home()
+    return str(home.expanduser().resolve(strict=False)), str(job_id)
+
+
+def _cron_run_parts(key: object) -> RunningCronRun:
+    if isinstance(key, tuple) and len(key) == 2:
+        return RunningCronRun(Path(str(key[0])), str(key[1]))
+    # Compatibility for legacy tests/plugins that inserted a bare id directly.
+    return RunningCronRun(_get_hermes_home().resolve(strict=False), str(key))
+
+
+def get_running_cron_runs() -> tuple[RunningCronRun, ...]:
+    """Thread-safe profile-qualified snapshot of in-flight cron runs."""
+    with _running_lock:
+        runs = {_cron_run_parts(key) for key in _running_job_ids}
+        for key, executions in _running_fire_owners.items():
+            if isinstance(key, tuple) and len(key) == 2:
+                runs.add(_cron_run_parts(key))
+                continue
+            for _token, (_owner, profile_home) in executions.items():
+                runs.add(RunningCronRun(profile_home.resolve(strict=False), str(key)))
+        return tuple(sorted(runs, key=lambda run: (str(run.profile_home), run.job_id)))
+
+
 def get_running_job_ids() -> "frozenset[str]":
-    """Thread-safe snapshot of cron job IDs currently executing.
+    """Compatibility display snapshot of cron job IDs currently executing."""
+    return frozenset(run.job_id for run in get_running_cron_runs())
 
-    A job ID is a member from the moment ``_submit_with_guard`` dispatches
-    it onto the parallel/sequential pool until ``_process_job`` returns —
-    i.e. for the job's *entire* run, tool calls included, not just the
-    ticker's dispatch instant.
 
-    The gateway shutdown path (``gateway/run.py::GatewayRunner.
-    _drain_active_agents``) reads this to treat in-flight cron work as
-    active the same way it already treats in-flight chat sessions via
-    ``_running_agents`` — cron jobs run through their own thread pool here,
-    entirely outside that dict, so without this the drain is structurally
-    blind to them (#60432).
-    """
+def is_cron_job_running(
+    job_id: str, *, profile_home: Path | str | None = None
+) -> bool:
+    """Return whether this exact profile+job pair is in flight."""
+    key = _cron_run_key(job_id, profile_home)
     with _running_lock:
-        return frozenset(_running_job_ids | _running_fire_owners.keys())
+        return key in _running_job_ids or key in _running_fire_owners
 
 
-def try_register_running_job(job_id: str) -> bool:
-    """Atomically add ``job_id`` to the in-flight running set.
-
-    Returns False (without registering) when the job is already mid-run —
-    the caller must skip the fire. This is the single dedupe owner shared by
-    the ticker's ``_submit_with_guard`` and manual runs
-    (``tools/cronjob_tools``): the fire claim alone cannot prevent a
-    double-fire because its TTL (300s) is routinely outlived by real jobs,
-    after which a manual ``cronjob(action='run')`` would claim successfully
-    and run the same job concurrently (idea from #53395 by @izumi0uu).
-
-    Registration also makes the run visible to ``get_running_job_ids`` (the
-    gateway shutdown drain, #60432) and ``mark_running_jobs_interrupted``.
-    Callers MUST pair a successful registration with
-    ``release_running_job`` in a ``finally`` block.
-    """
+def try_register_running_job(
+    job_id: str, *, profile_home: Path | str | None = None
+) -> bool:
+    """Atomically register one profile-qualified job execution."""
+    key = _cron_run_key(job_id, profile_home)
     with _running_lock:
-        if job_id in _running_job_ids:
+        if key in _running_job_ids or job_id in _running_job_ids:
             return False
-        _running_job_ids.add(job_id)
-        # Claim timestamp + pending-future sentinel are recorded in the SAME
-        # critical section as the add, so there is never a window where an
-        # id is in-flight without an age the stale sweep can bound it by
-        # (t_3778a491).  The sentinel is replaced by the real owning future
-        # once ``pool.submit`` returns.
-        _running_since[job_id] = time.time()
-        _running_futures[job_id] = _FUTURE_PENDING
+        _running_job_ids.add(key)
+        _running_since[key] = time.time()
+        _running_futures[key] = _FUTURE_PENDING
         return True
 
 
-def release_running_job(job_id: str) -> None:
-    """Remove ``job_id`` from the in-flight running set (idempotent)."""
+def release_running_job(
+    job_id: str, *, profile_home: Path | str | None = None
+) -> None:
+    """Remove one profile-qualified running claim (idempotent)."""
+    key = _cron_run_key(job_id, profile_home)
     with _running_lock:
+        _running_job_ids.discard(key)
+        _running_since.pop(key, None)
+        _running_futures.pop(key, None)
+        # Compatibility cleanup for legacy direct set injection.
         _running_job_ids.discard(job_id)
         _running_since.pop(job_id, None)
         _running_futures.pop(job_id, None)
@@ -840,12 +858,23 @@ def get_inflight_guard_stats() -> dict:
     """
     now = time.time()
     with _running_lock:
+        run_parts = [_cron_run_parts(key) for key in _running_job_ids]
+        id_counts = {
+            run.job_id: sum(1 for item in run_parts if item.job_id == run.job_id)
+            for run in run_parts
+        }
+        age_rows = {}
+        for key, started in _running_since.items():
+            run = _cron_run_parts(key)
+            label = (
+                run.job_id
+                if id_counts.get(run.job_id, 0) <= 1
+                else f"{run.profile_home}::{run.job_id}"
+            )
+            age_rows[label] = round(now - started, 1)
         return {
-            "running": sorted(_running_job_ids),
-            "running_ages_seconds": {
-                jid: round(now - started, 1)
-                for jid, started in _running_since.items()
-            },
+            "running": sorted({run.job_id for run in run_parts}),
+            "running_ages_seconds": age_rows,
             "forced_releases": _forced_release_count,
             "recent_forced_releases": list(_forced_releases),
         }
@@ -912,13 +941,19 @@ def sweep_stale_inflight(due_jobs: Optional[list] = None) -> list:
     # for the next tick's query.
     from cron.executions import _TERMINAL_STATES as _terminal_states
 
+    current_home = _get_hermes_home().resolve(strict=False)
     with _running_lock:
+        current_run_keys = [
+            key
+            for key in _running_job_ids
+            if _cron_run_parts(key).profile_home.resolve(strict=False) == current_home
+        ]
         _claim_futures = {
-            job_id: _running_futures.get(job_id) for job_id in _running_job_ids
+            key: _running_futures.get(key) for key in current_run_keys
         }
     _ledger_candidates = [
-        job_id
-        for job_id, fut in _claim_futures.items()
+        _cron_run_parts(key).job_id
+        for key, fut in _claim_futures.items()
         if fut is None or fut is _FUTURE_PENDING or fut.done()
     ]
     _latest: dict = {}
@@ -956,19 +991,20 @@ def sweep_stale_inflight(due_jobs: Optional[list] = None) -> list:
     _intervals = {jid: _job_interval_minutes(j) for jid, j in by_id.items()}
 
     with _running_lock:
-        for job_id in list(_running_job_ids):
-            started = _running_since.get(job_id)
+        for run_key in list(current_run_keys):
+            job_id = _cron_run_parts(run_key).job_id
+            started = _running_since.get(run_key)
             if started is None:
                 # Claim predates this guard (or was injected directly) — adopt
                 # it now so it becomes sweepable one allowance from here.
-                _running_since[job_id] = now
+                _running_since[run_key] = now
                 continue
             age = now - started
             interval_minutes = _intervals.get(job_id)
             allowance = floor_seconds
             if interval_minutes:
                 allowance = max(allowance, 2.0 * interval_minutes * 60.0)
-            fut = _running_futures.get(job_id)
+            fut = _running_futures.get(run_key)
             if fut is _FUTURE_PENDING:
                 # The claim is past its allowance and the owning future still
                 # has not been installed — the submit path itself (SessionDB
@@ -1004,9 +1040,9 @@ def sweep_stale_inflight(due_jobs: Optional[list] = None) -> list:
                 reason = "age"
             else:
                 continue
-            _running_job_ids.discard(job_id)
-            _running_since.pop(job_id, None)
-            _running_futures.pop(job_id, None)
+            _running_job_ids.discard(run_key)
+            _running_since.pop(run_key, None)
+            _running_futures.pop(run_key, None)
             _forced_release_count += 1
             stale.append((job_id, age, allowance, fut, reason))
 
@@ -1109,8 +1145,8 @@ def mark_running_jobs_interrupted(
     """
     with _running_lock:
         active_fires = [
-            (token, job_id, owner, profile_home)
-            for job_id, executions in _running_fire_owners.items()
+            (token, _cron_run_parts(run_key).job_id, owner, profile_home)
+            for run_key, executions in _running_fire_owners.items()
             for token, (owner, profile_home) in executions.items()
         ]
         if only_owners is not None:
@@ -1118,15 +1154,29 @@ def mark_running_jobs_interrupted(
                 fire for fire in active_fires
                 if (fire[1], fire[2]) in only_owners
             ]
-        registered_ids = {job_id for _t, job_id, _o, _p in active_fires}
+        registered_keys = {
+            _cron_run_key(job_id, profile_home)
+            for _t, job_id, _o, profile_home in active_fires
+        }
         if only_owners is None:
             active_fires.extend(
-                (None, job_id, None, _get_hermes_home())
-                for job_id in _running_job_ids - registered_ids
+                (
+                    None,
+                    _cron_run_parts(run_key).job_id,
+                    None,
+                    _cron_run_parts(run_key).profile_home,
+                )
+                for run_key in _running_job_ids
+                if _cron_run_key(
+                    _cron_run_parts(run_key).job_id,
+                    _cron_run_parts(run_key).profile_home,
+                ) not in registered_keys
             )
         _interrupted_job_ids.update(
-            token if token is not None else job_id
-            for token, job_id, _owner, _profile_home in active_fires
+            token
+            if token is not None
+            else _cron_run_key(job_id, profile_home)
+            for token, job_id, _owner, profile_home in active_fires
         )
     marked = []
     for _token, job_id, fire_owner, profile_home in active_fires:
@@ -1173,10 +1223,11 @@ def _is_interrupted(job_id: str, token: Optional[object] = None) -> bool:
     targeted its dead predecessor. The bare job ID is only ever stored
     for legacy dispatch paths with no registered fire owner.
     """
+    run_key = _cron_run_key(job_id)
     with _running_lock:
         if token is not None and token in _interrupted_job_ids:
             return True
-        return job_id in _interrupted_job_ids
+        return run_key in _interrupted_job_ids or job_id in _interrupted_job_ids
 
 
 def _consume_interrupted_flag(job_id: str, token: Optional[object] = None) -> bool:
@@ -1187,10 +1238,14 @@ def _consume_interrupted_flag(job_id: str, token: Optional[object] = None) -> bo
     ``last_status``. Consuming (discarding) rather than just checking keeps
     the flag from leaking across a later, unrelated run of the same job ID
     (recurring jobs reuse their ID every fire)."""
+    run_key = _cron_run_key(job_id)
     with _running_lock:
         hit = False
         if token is not None and token in _interrupted_job_ids:
             _interrupted_job_ids.discard(token)
+            hit = True
+        if run_key in _interrupted_job_ids:
+            _interrupted_job_ids.discard(run_key)
             hit = True
         if job_id in _interrupted_job_ids:
             _interrupted_job_ids.discard(job_id)
@@ -1457,6 +1512,20 @@ def _get_hermes_home() -> Path:
     anchor it at the shared default root — either re-breaks profile isolation.
     """
     return _hermes_home or get_hermes_home()
+
+
+def _reload_cron_dotenv_if_safe(*, reset_external_cache: bool = False) -> bool:
+    """Reload this profile's dotenv only when process-global mutation is safe."""
+    from agent.secret_scope import is_secret_scope_authoritative
+
+    if is_secret_scope_authoritative():
+        return False
+    from hermes_cli.env_loader import load_hermes_dotenv, reset_secret_source_cache
+
+    if reset_external_cache:
+        reset_secret_source_cache()
+    load_hermes_dotenv(hermes_home=_get_hermes_home())
+    return True
 
 
 def _get_lock_paths() -> tuple[Path, Path]:
@@ -5109,17 +5178,13 @@ def run_job(
     #                               the whole point of no_agent is that there
     #                               is no agent to wake
     if job.get("no_agent"):
-        # Load .env before the script runs so auto-delivery can resolve home
-        # channels. A standalone cron tick process typically starts WITHOUT
-        # TELEGRAM_HOME_CHANNEL/DISCORD_HOME_CHANNEL in its environment, and
-        # the agent path's per-run dotenv reload below never executes for
-        # no_agent jobs — every deliver=telegram/all script job failed with
-        # "no delivery target resolved". load_hermes_dotenv does not override
-        # already-set vars, so the gateway's in-process tick is unaffected.
+        # Standalone and dedicated single-profile runtimes reload .env so home
+        # delivery targets and refreshed credentials take effect. Multiplex and
+        # Desktop workers already carry an authoritative, profile-local secret
+        # snapshot. Reloading there would copy one profile's values into the
+        # process-global environment shared by sibling jobs.
         try:
-            from hermes_cli.env_loader import load_hermes_dotenv
-
-            load_hermes_dotenv(hermes_home=_get_hermes_home())
+            _reload_cron_dotenv_if_safe()
         except Exception:
             logger.debug(
                 "Job '%s': no_agent .env reload failed", job_id, exc_info=True
@@ -5601,12 +5666,7 @@ def run_job(
         # is set (mirrors startup), and the Bitwarden value-cache keeps the
         # forced re-pull off the network. load_hermes_dotenv also handles the
         # utf-8/latin-1 encoding fallback internally.
-        from hermes_cli.env_loader import (
-            load_hermes_dotenv,
-            reset_secret_source_cache,
-        )
-        reset_secret_source_cache()
-        load_hermes_dotenv(hermes_home=_get_hermes_home())
+        _reload_cron_dotenv_if_safe(reset_external_cache=True)
 
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:
@@ -6679,8 +6739,9 @@ def run_one_job(
     fire_owner = str(claim.get("by") or "") if isinstance(claim, dict) else ""
     execution_token = object()
     profile_home = _get_hermes_home().resolve()
+    run_key = _cron_run_key(job["id"], profile_home)
     with _running_lock:
-        _running_fire_owners.setdefault(job["id"], {})[execution_token] = (
+        _running_fire_owners.setdefault(run_key, {})[execution_token] = (
             fire_owner or None,
             profile_home,
         )
@@ -6703,11 +6764,11 @@ def run_one_job(
         )
     finally:
         with _running_lock:
-            executions = _running_fire_owners.get(job["id"])
+            executions = _running_fire_owners.get(run_key)
             if executions is not None:
                 executions.pop(execution_token, None)
                 if not executions:
-                    _running_fire_owners.pop(job["id"], None)
+                    _running_fire_owners.pop(run_key, None)
 
 
 def _run_one_job_body(
@@ -7373,10 +7434,19 @@ def tick(
         # tick) and reuses due_jobs when they already cover the in-flight set
         # (get_due_jobs calls load_jobs internally, so this avoids a redundant
         # second file read on every active tick).
-        if _running_job_ids:
+        current_home = _get_hermes_home().resolve(strict=False)
+        with _running_lock:
+            current_run_keys = [
+                key
+                for key in _running_job_ids
+                if _cron_run_parts(key).profile_home.resolve(strict=False) == current_home
+            ]
+        if current_run_keys:
             _sweep_jobs = due_jobs
             try:
-                _inflight_ids = set(_running_job_ids)
+                _inflight_ids = {
+                    _cron_run_parts(key).job_id for key in current_run_keys
+                }
                 _due_ids = {j.get("id") for j in due_jobs if isinstance(j, dict)}
                 if not _inflight_ids <= _due_ids:
                     from cron.jobs import load_jobs as _load_all_jobs
@@ -7536,7 +7606,9 @@ def tick(
                 )
                 _clear_run_claim_best_effort()
                 return None
-            if not try_register_running_job(job_id):
+            run_home = _get_hermes_home().resolve(strict=False)
+            run_key = _cron_run_key(job_id, run_home)
+            if not try_register_running_job(job_id, profile_home=run_home):
                 logger.info("Job '%s' already running — skipping", job.get("name", job_id))
                 return None
             # Record the attempt before executor dispatch. Recovery classifies
@@ -7551,7 +7623,7 @@ def tick(
                 # retry instead of wedging on 'already running' forever (the
                 # audit requirement: every add is paired with guaranteed
                 # cleanup).
-                release_running_job(job_id)
+                release_running_job(job_id, profile_home=run_home)
                 _clear_run_claim_best_effort()
                 logger.exception(
                     "Job '%s' not dispatched: execution creation failed: %s",
@@ -7560,16 +7632,16 @@ def tick(
                 )
                 return None
 
-            def _run_and_release(j=dispatched_job, ctx=_ctx):
+            def _run_and_release(j=dispatched_job, ctx=_ctx, home=run_home):
                 try:
                     return ctx.run(_process_job, j)
                 finally:
-                    release_running_job(j["id"])
+                    release_running_job(j["id"], profile_home=home)
 
             try:
                 fut = pool.submit(_run_and_release)
             except Exception as submit_err:
-                release_running_job(job_id)
+                release_running_job(job_id, profile_home=run_home)
                 _clear_run_claim_best_effort()
                 finish_execution(
                     execution["id"],
@@ -7594,8 +7666,8 @@ def tick(
             # Record the owning future so the stale sweep can distinguish
             # "still executing" from "claim leaked before/after the future".
             with _running_lock:
-                if job_id in _running_job_ids:
-                    _running_futures[job_id] = fut
+                if run_key in _running_job_ids:
+                    _running_futures[run_key] = fut
             return fut
 
         # Sequential pass for env-mutating (workdir) jobs.

--- a/cron/scheduler_ownership.py
+++ b/cron/scheduler_ownership.py
@@ -1,0 +1,301 @@
+"""Atomic, profile-scoped ownership for in-process cron schedulers.
+
+A scheduler ownership lease decides which runtime may inspect and dispatch one
+profile's cron store. It is separate from the per-tick lock and per-job fire
+claims. The ownership mutex is held from the final token check through dispatch
+submission, closing the check-then-execute race between competing runtimes.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import errno
+import json
+import logging
+import os
+from pathlib import Path
+import sys
+import time
+from typing import Callable, Iterator, Optional
+import uuid
+
+from utils import atomic_json_write
+
+if sys.platform == "win32":
+    import msvcrt
+else:
+    import fcntl
+
+logger = logging.getLogger(__name__)
+
+_OWNERSHIP_VERSION = 1
+_DEFAULT_LEASE_SECONDS = 180.0
+_LOCK_TIMEOUT_SECONDS = 1.0
+_OWNER_PRIORITIES = {
+    "desktop-fallback": 10,
+    "gateway-dedicated": 100,
+    "gateway-multiplex": 100,
+}
+
+
+class SchedulerOwnershipLease:
+    """Renewable ownership token for one profile's cron scheduler."""
+
+    def __init__(
+        self,
+        *,
+        profile_home: Path | str,
+        profile: str,
+        runtime_id: str,
+        owner_kind: str,
+        lease_seconds: float = _DEFAULT_LEASE_SECONDS,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        if owner_kind not in _OWNER_PRIORITIES:
+            raise ValueError(f"Unsupported cron scheduler owner kind: {owner_kind}")
+        if not profile or not runtime_id:
+            raise ValueError("profile and runtime_id are required")
+        if lease_seconds <= 0:
+            raise ValueError("lease_seconds must be positive")
+
+        self.profile_home = Path(profile_home).expanduser().resolve(strict=False)
+        self.profile = profile
+        self.runtime_id = runtime_id
+        self.owner_kind = owner_kind
+        self.lease_seconds = float(lease_seconds)
+        self._clock = clock
+        self.token = uuid.uuid4().hex
+        self._cron_dir = self.profile_home / "cron"
+        self._record_path = self._cron_dir / "scheduler_ownership.json"
+        self._lock_path = self._cron_dir / ".scheduler_ownership.lock"
+
+    @property
+    def priority(self) -> int:
+        return _OWNER_PRIORITIES[self.owner_kind]
+
+    def _record(self, *, now: float, acquired_at: Optional[float] = None) -> dict:
+        return {
+            "version": _OWNERSHIP_VERSION,
+            "profile": self.profile,
+            "profile_home": str(self.profile_home),
+            "runtime_id": self.runtime_id,
+            "owner_kind": self.owner_kind,
+            "priority": self.priority,
+            "pid": os.getpid(),
+            "token": self.token,
+            "acquired_at": now if acquired_at is None else acquired_at,
+            "renewed_at": now,
+            "expires_at": now + self.lease_seconds,
+        }
+
+    def _read_record_locked(self) -> Optional[dict]:
+        if not self._record_path.exists():
+            return None
+        raw = json.loads(self._record_path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            raise ValueError("cron scheduler ownership record is not an object")
+        required = {
+            "version",
+            "profile",
+            "profile_home",
+            "runtime_id",
+            "owner_kind",
+            "priority",
+            "token",
+            "expires_at",
+        }
+        if not required <= raw.keys():
+            raise ValueError("cron scheduler ownership record is incomplete")
+        if raw.get("version") != _OWNERSHIP_VERSION:
+            raise ValueError("unsupported cron scheduler ownership record version")
+        if raw.get("profile") != self.profile:
+            raise ValueError("cron scheduler ownership profile mismatch")
+        persisted_home = Path(str(raw.get("profile_home"))).expanduser().resolve(strict=False)
+        if persisted_home != self.profile_home:
+            raise ValueError("cron scheduler ownership home mismatch")
+        if raw.get("owner_kind") not in _OWNER_PRIORITIES:
+            raise ValueError("cron scheduler ownership kind is invalid")
+        float(raw["expires_at"])
+        int(raw["priority"])
+        return raw
+
+    def _write_record_locked(self, record: dict) -> None:
+        atomic_json_write(self._record_path, record, mode=0o600, sort_keys=True)
+
+    @contextmanager
+    def _ownership_lock(self) -> Iterator[None]:
+        self._cron_dir.mkdir(parents=True, exist_ok=True)
+        handle = self._lock_path.open("a+b")
+        acquired = False
+        deadline = time.monotonic() + _LOCK_TIMEOUT_SECONDS
+        try:
+            if sys.platform == "win32":
+                handle.seek(0, os.SEEK_END)
+                if handle.tell() == 0:
+                    handle.write(b"\0")
+                    handle.flush()
+                while True:
+                    try:
+                        handle.seek(0)
+                        msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                        acquired = True
+                        break
+                    except OSError as exc:
+                        if exc.errno not in (errno.EACCES, errno.EDEADLK):
+                            raise
+                        if time.monotonic() >= deadline:
+                            raise TimeoutError("cron scheduler ownership lock is busy") from exc
+                        time.sleep(0.01)
+            else:
+                while True:
+                    try:
+                        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                        acquired = True
+                        break
+                    except OSError as exc:
+                        if exc.errno not in (errno.EACCES, errno.EAGAIN, errno.EWOULDBLOCK):
+                            raise
+                        if time.monotonic() >= deadline:
+                            raise TimeoutError("cron scheduler ownership lock is busy") from exc
+                        time.sleep(0.01)
+            yield
+        finally:
+            if acquired:
+                try:
+                    if sys.platform == "win32":
+                        handle.seek(0)
+                        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                    else:
+                        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                except OSError:
+                    pass
+            handle.close()
+
+    def _owned_record(self, record: Optional[dict], now: float) -> bool:
+        if not record:
+            return False
+        return record.get("token") == self.token and float(record["expires_at"]) > now
+
+    def claim(self) -> bool:
+        """Atomically claim, renew, or preempt a lower-priority owner."""
+        try:
+            with self._ownership_lock():
+                now = self._clock()
+                current = self._read_record_locked()
+                if self._owned_record(current, now):
+                    assert current is not None
+                    self._write_record_locked(
+                        self._record(now=now, acquired_at=float(current["acquired_at"]))
+                    )
+                    return True
+                expired = current is None or float(current["expires_at"]) <= now
+                lower_priority = current is not None and int(current["priority"]) < self.priority
+                if not expired and not lower_priority:
+                    return False
+                self._write_record_locked(self._record(now=now))
+                return True
+        except Exception as exc:
+            logger.warning(
+                "Cron scheduler ownership claim failed closed for profile %s: %s",
+                self.profile,
+                type(exc).__name__,
+            )
+            return False
+
+    def renew(self) -> bool:
+        """Renew only if this exact token still owns the profile."""
+        try:
+            with self._ownership_lock():
+                now = self._clock()
+                current = self._read_record_locked()
+                if not self._owned_record(current, now):
+                    return False
+                assert current is not None
+                self._write_record_locked(
+                    self._record(now=now, acquired_at=float(current["acquired_at"]))
+                )
+                return True
+        except Exception as exc:
+            logger.warning(
+                "Cron scheduler ownership renewal failed closed for profile %s: %s",
+                self.profile,
+                type(exc).__name__,
+            )
+            return False
+
+    def is_owner(self) -> bool:
+        """Return whether this exact, unexpired token owns the profile."""
+        try:
+            with self._ownership_lock():
+                return self._owned_record(self._read_record_locked(), self._clock())
+        except Exception:
+            return False
+
+    @contextmanager
+    def dispatch_guard(self) -> Iterator[bool]:
+        """Hold the ownership mutex across the final check and dispatch submit."""
+        lock_context = self._ownership_lock()
+        try:
+            lock_context.__enter__()
+        except Exception as exc:
+            logger.warning(
+                "Cron scheduler dispatch ownership check failed closed for profile %s: %s",
+                self.profile,
+                type(exc).__name__,
+            )
+            yield False
+            return
+
+        try:
+            now = self._clock()
+            current = self._read_record_locked()
+            allowed = self._owned_record(current, now)
+            if allowed:
+                assert current is not None
+                self._write_record_locked(
+                    self._record(now=now, acquired_at=float(current["acquired_at"]))
+                )
+        except Exception as exc:
+            lock_context.__exit__(None, None, None)
+            logger.warning(
+                "Cron scheduler dispatch ownership check failed closed for profile %s: %s",
+                self.profile,
+                type(exc).__name__,
+            )
+            yield False
+            return
+
+        try:
+            yield allowed
+        finally:
+            lock_context.__exit__(None, None, None)
+
+    def release(self) -> bool:
+        """Release only if this exact token still owns the persisted lease."""
+        try:
+            with self._ownership_lock():
+                current = self._read_record_locked()
+                if not current or current.get("token") != self.token:
+                    return False
+                try:
+                    self._record_path.unlink()
+                except FileNotFoundError:
+                    return False
+                return True
+        except Exception as exc:
+            logger.warning(
+                "Cron scheduler ownership release failed for profile %s: %s",
+                self.profile,
+                type(exc).__name__,
+            )
+            return False
+
+
+def read_scheduler_ownership(profile_home: Path | str) -> Optional[dict]:
+    """Return the persisted owner record for diagnostics, without prompts/jobs."""
+    path = Path(profile_home).expanduser().resolve(strict=False) / "cron" / "scheduler_ownership.json"
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return None
+    return value if isinstance(value, dict) else None

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -21,7 +21,9 @@ from __future__ import annotations
 
 import inspect
 import threading
+import time
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any
 
 # Cap for the exponential tick backoff applied while consecutive ticks fail
@@ -237,6 +239,267 @@ class CronScheduler(ABC):
         return None
 
 
+_OWNED_EXTERNAL_PROVIDERS: dict[str, "OwnedExternalCronScheduler"] = {}
+_OWNED_EXTERNAL_PROVIDERS_LOCK = threading.Lock()
+
+
+def _owned_provider_key(profile_home: Path | str) -> str:
+    return str(Path(profile_home).expanduser().resolve(strict=False))
+
+
+class OwnedExternalCronScheduler(CronScheduler):
+    """Ownership-fenced proxy for a single-profile external provider.
+
+    External providers may return from ``start`` after one reconciliation. The
+    proxy keeps their scheduler thread alive to renew the profile lease and
+    fences every later registry/fire hook through the same token.
+    """
+
+    def __init__(
+        self,
+        provider: CronScheduler,
+        *,
+        profile_home: Path | str,
+        profile: str,
+        runtime_id: str,
+        owner_kind: str,
+        poll_interval: float = 30.0,
+    ) -> None:
+        from cron.scheduler_ownership import SchedulerOwnershipLease
+
+        self._provider = provider
+        self._profile_home = Path(profile_home).expanduser().resolve(strict=False)
+        self._profile = profile
+        self._poll_interval = max(0.01, float(poll_interval))
+        self._lease = SchedulerOwnershipLease(
+            profile_home=self._profile_home,
+            profile=profile,
+            runtime_id=runtime_id,
+            owner_kind=owner_kind,
+        )
+        self._eager_stop = threading.Event()
+        self._state_lock = threading.Lock()
+        self._provider_started = False
+        self._provider_thread: threading.Thread | None = None
+        self._provider_stop_event: threading.Event | None = None
+
+    @property
+    def name(self) -> str:
+        return self._provider.name
+
+    def is_available(self) -> bool:
+        return self._provider.is_available()
+
+    @property
+    def supports_force_fire(self) -> bool:
+        return self._provider.supports_force_fire
+
+    def _start_provider_if_needed(
+        self,
+        *,
+        adapters: Any,
+        loop: Any,
+        interval: int,
+        kwargs: dict[str, Any],
+    ) -> None:
+        with self._state_lock:
+            if self._provider_started:
+                return
+            provider_stop = threading.Event()
+
+            def _run_provider() -> None:
+                try:
+                    self._provider.start(
+                        provider_stop,
+                        adapters=adapters,
+                        loop=loop,
+                        interval=interval,
+                        **kwargs,
+                    )
+                except BaseException as exc:
+                    import logging
+
+                    logging.getLogger("cron.scheduler_provider").error(
+                        "External cron provider '%s' start failed: %s",
+                        self.name,
+                        exc,
+                        exc_info=True,
+                    )
+
+            provider_thread = threading.Thread(
+                target=_run_provider,
+                daemon=True,
+                name=f"cron-provider-{self.name}",
+            )
+            self._provider_started = True
+            self._provider_stop_event = provider_stop
+            self._provider_thread = provider_thread
+            provider_thread.start()
+
+    def _stop_provider_if_started(self) -> None:
+        with self._state_lock:
+            if not self._provider_started:
+                return
+            self._provider_started = False
+            provider_stop = self._provider_stop_event
+            provider_thread = self._provider_thread
+            self._provider_stop_event = None
+            self._provider_thread = None
+        if provider_stop is not None:
+            provider_stop.set()
+        try:
+            self._provider.stop()
+        except Exception:
+            import logging
+
+            logging.getLogger("cron.scheduler_provider").debug(
+                "External cron provider stop failed", exc_info=True
+            )
+        if provider_thread is not None and provider_thread is not threading.current_thread():
+            provider_thread.join(timeout=2.0)
+
+    def start(
+        self,
+        stop_event: threading.Event,
+        *,
+        adapters: Any = None,
+        loop: Any = None,
+        interval: int = 60,
+        **kwargs: Any,
+    ) -> None:
+        try:
+            while not stop_event.is_set() and not self._eager_stop.is_set():
+                if not self._lease.claim():
+                    self._stop_provider_if_started()
+                    stop_event.wait(self._poll_interval)
+                    continue
+                with self._lease.dispatch_guard() as allowed:
+                    if allowed:
+                        # Submit provider activation while ownership is fenced,
+                        # but never hold the mutex for the provider's lifetime.
+                        self._start_provider_if_needed(
+                            adapters=adapters,
+                            loop=loop,
+                            interval=interval,
+                            kwargs=kwargs,
+                        )
+                stop_event.wait(self._poll_interval)
+        finally:
+            self._stop_provider_if_started()
+            self._lease.release()
+            key = _owned_provider_key(self._profile_home)
+            with _OWNED_EXTERNAL_PROVIDERS_LOCK:
+                if _OWNED_EXTERNAL_PROVIDERS.get(key) is self:
+                    _OWNED_EXTERNAL_PROVIDERS.pop(key, None)
+
+    def stop(self) -> None:
+        self._eager_stop.set()
+        self._stop_provider_if_started()
+
+    def on_jobs_changed(self) -> None:
+        with self._lease.dispatch_guard() as allowed:
+            if allowed:
+                self._provider.on_jobs_changed()
+
+    def register_job(self, job: dict[str, Any]) -> None:
+        with self._lease.dispatch_guard() as allowed:
+            if not allowed:
+                raise RuntimeError(
+                    f"Cron scheduler registration refused: profile {self._profile} "
+                    "is owned by another runtime"
+                )
+            self._provider.register_job(job)
+
+    def recover_interrupted(self) -> int:
+        with self._lease.dispatch_guard() as allowed:
+            return self._provider.recover_interrupted() if allowed else 0
+
+    def reconcile(self) -> None:
+        with self._lease.dispatch_guard() as allowed:
+            if allowed:
+                self._provider.reconcile()
+
+    def claim_fire(self, job_id: str, *, force: bool = False) -> dict | None:
+        with self._lease.dispatch_guard() as allowed:
+            if not allowed:
+                return None
+            return self._provider.claim_fire(job_id, force=force)
+
+    def fire_claimed(
+        self,
+        claimed_job: dict,
+        *,
+        adapters: Any = None,
+        loop: Any = None,
+        cancel_event: Any = None,
+    ) -> bool:
+        # A durable claim already belongs to this process. Finish it even if a
+        # takeover occurs between admission and worker execution.
+        kwargs = {"adapters": adapters, "loop": loop}
+        if provider_supports_fire_cancel(self._provider):
+            kwargs["cancel_event"] = cancel_event
+        return self._provider.fire_claimed(claimed_job, **kwargs)
+
+    def fire_due(
+        self,
+        job_id: str,
+        *,
+        adapters: Any = None,
+        loop: Any = None,
+        force: bool = False,
+    ) -> bool:
+        with self._lease.dispatch_guard() as allowed:
+            if not allowed:
+                return False
+            if self._provider.supports_force_fire:
+                return self._provider.fire_due(
+                    job_id,
+                    adapters=adapters,
+                    loop=loop,
+                    force=force,
+                )
+            return self._provider.fire_due(job_id, adapters=adapters, loop=loop)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._provider, name)
+
+
+def bind_external_scheduler_ownership(
+    provider: CronScheduler,
+    *,
+    profile_home: Path | str,
+    profile: str,
+    runtime_id: str,
+    owner_kind: str,
+    poll_interval: float = 30.0,
+) -> CronScheduler:
+    """Bind one external provider lifecycle to a profile ownership lease."""
+    if isinstance(provider, (InProcessCronScheduler, OwnedExternalCronScheduler)):
+        return provider
+    owned = OwnedExternalCronScheduler(
+        provider,
+        profile_home=profile_home,
+        profile=profile,
+        runtime_id=runtime_id,
+        owner_kind=owner_kind,
+        poll_interval=poll_interval,
+    )
+    with _OWNED_EXTERNAL_PROVIDERS_LOCK:
+        _OWNED_EXTERNAL_PROVIDERS[_owned_provider_key(profile_home)] = owned
+    return owned
+
+
+def _active_owned_external_provider() -> CronScheduler | None:
+    try:
+        from hermes_constants import get_hermes_home
+
+        key = _owned_provider_key(get_hermes_home())
+    except Exception:
+        return None
+    with _OWNED_EXTERNAL_PROVIDERS_LOCK:
+        return _OWNED_EXTERNAL_PROVIDERS.get(key)
+
+
 def provider_supports_force_fire(provider: Any) -> bool:
     """Return whether a provider can safely receive ``fire_due(force=...)``."""
     try:
@@ -257,6 +520,9 @@ def provider_supports_force_fire(provider: Any) -> bool:
 def provider_supports_split_fire(provider: Any) -> bool:
     """Return whether a provider implements the two-phase fire contract.
 
+    Ownership wrappers preserve the underlying provider's fire contract. A
+    legacy custom ``fire_due`` must stay on its single-phase path.
+
     The webhook admission path uses ``claim_fire`` + ``fire_claimed`` so the
     202 response is backed by a durable, owner-fenced claim. A legacy
     third-party provider that overrides the documented single-phase
@@ -266,6 +532,8 @@ def provider_supports_split_fire(provider: Any) -> bool:
     behavior. Providers that customize ``claim_fire`` itself are already
     split-aware and keep the two-phase path.
     """
+    if isinstance(provider, OwnedExternalCronScheduler):
+        return provider_supports_split_fire(provider._provider)
     cls = type(provider)
     fire_due_impl = getattr(cls, "fire_due", None)
     claim_fire_impl = getattr(cls, "claim_fire", None)
@@ -459,6 +727,10 @@ def resolve_cron_scheduler() -> "CronScheduler":
 
     logger = logging.getLogger("cron.scheduler_provider")
 
+    active_owned = _active_owned_external_provider()
+    if active_owned is not None:
+        return active_owned
+
     name = ""
     try:
         from hermes_cli.config import cfg_get, load_config
@@ -532,6 +804,9 @@ class InProcessCronScheduler(CronScheduler):
         interval=60,
         can_dispatch=None,
         profile_homes=None,
+        profile_adapters=None,
+        owner_kind=None,
+        runtime_id=None,
     ):
         import logging
         from cron.scheduler import tick as cron_tick
@@ -556,9 +831,12 @@ class InProcessCronScheduler(CronScheduler):
                 stop_event,
                 profile_homes=profile_homes,
                 adapters=adapters,
+                profile_adapters=profile_adapters,
                 loop=loop,
                 interval=interval,
                 can_dispatch=can_dispatch,
+                owner_kind=owner_kind,
+                runtime_id=runtime_id,
             )
             return
 
@@ -627,19 +905,31 @@ class InProcessCronScheduler(CronScheduler):
         *,
         profile_homes,
         adapters=None,
+        profile_adapters=None,
         loop=None,
         interval=60,
         can_dispatch=None,
+        owner_kind=None,
+        runtime_id=None,
     ):
-        """Tick every served profile's cron store when multiplex_profiles is on.
+        """Tick each profile only while this runtime owns its scheduler lease.
 
-        Each profile uses ``set_hermes_home_override()`` + ``use_cron_store()``
-        to scope its tick, heartbeat, recovery, lock file, config/.env, and
-        agent execution to that profile's home — mirroring how
-        ``_profile_runtime_scope`` scopes the multiplexed inbound path and
-        ``web_server.py`` scopes per-profile cron API calls.
+        The profile's home, cron store, secret scope, and adapter map are bound
+        together before recovery, heartbeat, and dispatch. Ownership is checked
+        atomically under the lease mutex through ``cron_tick`` submission, so a
+        higher-priority dedicated gateway can take over from Desktop without a
+        check-then-dispatch race.
         """
+        import contextlib
         import logging
+
+        from agent.secret_scope import (
+            build_profile_secret_scope,
+            reset_authoritative_secret_scope,
+            reset_secret_scope,
+            set_authoritative_secret_scope,
+            set_secret_scope,
+        )
         from cron.scheduler import tick as cron_tick
         from cron.jobs import (
             clear_ticker_error,
@@ -647,78 +937,173 @@ class InProcessCronScheduler(CronScheduler):
             record_ticker_heartbeat,
             use_cron_store,
         )
+        from cron.scheduler_ownership import SchedulerOwnershipLease
+        from hermes_cli.env_loader import hydrate_profile_secret_sources
         from hermes_constants import set_hermes_home_override, reset_hermes_home_override
 
         logger = logging.getLogger("cron.scheduler_provider")
+        entries = [
+            (entry[0], entry[1]) if isinstance(entry, tuple) else (entry.name, entry)
+            for entry in profile_homes
+        ]
         logger.info(
-            "Multiplex cron scheduler started for %d profile(s): %s",
-            len(profile_homes),
-            [p[0] if isinstance(p, tuple) else p for p in profile_homes],
+            "Profile-aware cron scheduler started for %d candidate profile(s): %s",
+            len(entries),
+            [name for name, _home in entries],
         )
 
-        # Recovery + initial heartbeat for every profile.
-        for entry in profile_homes:
-            home = entry[1] if isinstance(entry, tuple) else entry
+        leases = {}
+        ownership_identity_requested = bool(owner_kind or runtime_id)
+        ownership_identity_valid = not ownership_identity_requested
+        if ownership_identity_requested:
+            if not owner_kind or not runtime_id:
+                logger.error(
+                    "Cron scheduler ownership identity is incomplete; refusing all profile dispatch"
+                )
+            else:
+                ownership_identity_valid = True
+                leases = {
+                    name: SchedulerOwnershipLease(
+                        profile_home=home,
+                        profile=name,
+                        runtime_id=runtime_id,
+                        owner_kind=owner_kind,
+                    )
+                    for name, home in entries
+                }
+
+        authoritative_secret_scope = not (
+            owner_kind == "gateway-dedicated" and len(entries) == 1
+        )
+
+        @contextlib.contextmanager
+        def _runtime_scope(home):
             home_token = set_hermes_home_override(str(home))
+            hydrate_profile_secret_sources(home)
+            secrets = build_profile_secret_scope(home)
+            if authoritative_secret_scope:
+                secret_tokens = set_authoritative_secret_scope(secrets)
+            else:
+                secret_token = set_secret_scope(secrets)
             try:
                 with use_cron_store(home):
+                    yield
+            finally:
+                if authoritative_secret_scope:
+                    reset_authoritative_secret_scope(secret_tokens)
+                else:
+                    reset_secret_scope(secret_token)
+                reset_hermes_home_override(home_token)
+
+        def _profile_adapters(name):
+            if profile_adapters is not None:
+                return profile_adapters.get(name)
+            if len(entries) == 1:
+                return adapters
+            # A shared adapter map in a multi-profile process can carry another
+            # profile's delivery identity. Fail closed unless the caller supplies
+            # an explicit per-profile map.
+            return None
+
+        def _claim(name):
+            if not ownership_identity_valid:
+                return False
+            lease = leases.get(name)
+            if lease is None:
+                # Compatibility for direct/test callers that do not yet pass an
+                # ownership identity. Production Desktop/gateway entry points do.
+                return True
+            return lease.claim()
+
+        # Recovery + initial heartbeat only for profiles this runtime owns.
+        active = []
+        for name, home in entries:
+            if not _claim(name):
+                continue
+            lease = leases.get(name)
+            guard = lease.dispatch_guard() if lease is not None else contextlib.nullcontext(True)
+            with guard as allowed:
+                if not allowed:
+                    continue
+                with _runtime_scope(home):
                     recovered = self.recover_interrupted()
                     if recovered:
                         logger.warning(
-                            "Marked %d interrupted cron execution(s) for profile at %s",
+                            "Marked %d interrupted cron execution(s) for profile %s unknown",
                             recovered,
-                            home,
+                            name,
                         )
                     record_ticker_heartbeat()
-            finally:
-                reset_hermes_home_override(home_token)
+                active.append(name)
+        logger.info("Cron scheduler currently owns %d profile(s): %s", len(active), active)
 
         consecutive_failures = 0
-        while not stop_event.is_set():
-            ok = False
-            _tick_error = None
-            try:
-                if can_dispatch is not None and not can_dispatch():
-                    logger.debug("Cron dispatch paused while gateway drains existing work")
-                else:
-                    for entry in profile_homes:
-                        home = entry[1] if isinstance(entry, tuple) else entry
-                        home_token = set_hermes_home_override(str(home))
-                        try:
-                            with use_cron_store(home):
+        try:
+            while not stop_event.is_set():
+                cycle_failed = False
+                owned_in_cycle = False
+                for name, home in entries:
+                    if stop_event.is_set():
+                        break
+                    if can_dispatch is not None and not can_dispatch():
+                        logger.debug("Cron dispatch paused while gateway drains existing work")
+                        break
+                    if not _claim(name):
+                        continue
+                    # The ownership claim can wait behind another runtime's
+                    # dispatch guard. Re-check shutdown after that wait so a
+                    # stopped successor cannot dispatch one late fire after the
+                    # prior owner releases during restart.
+                    if stop_event.is_set():
+                        break
+                    lease = leases.get(name)
+                    guard = (
+                        lease.dispatch_guard()
+                        if lease is not None
+                        else contextlib.nullcontext(True)
+                    )
+                    with guard as allowed:
+                        if not allowed:
+                            continue
+                        owned_in_cycle = True
+                        ok = False
+                        tick_error = None
+                        with _runtime_scope(home):
+                            try:
                                 cron_tick(
                                     verbose=False,
-                                    adapters=adapters,
+                                    adapters=_profile_adapters(name),
                                     loop=loop,
                                     sync=False,
                                     can_dispatch=can_dispatch,
                                 )
-                        finally:
-                            reset_hermes_home_override(home_token)
-                ok = True
-            except BaseException as e:
-                logger.error("Cron tick error: %s", e, exc_info=True)
-                _tick_error = f"{type(e).__name__}: {e}"
-                # EMFILE: reclaim fds + exponential backoff (#87644).
-                consecutive_failures = _note_tick_failure(e, consecutive_failures)
-            else:
-                _tick_error = None
-            # Record per-profile heartbeat after each tick cycle.
-            for entry in profile_homes:
-                home = entry[1] if isinstance(entry, tuple) else entry
-                home_token = set_hermes_home_override(str(home))
-                try:
-                    with use_cron_store(home):
-                        record_ticker_heartbeat(success=ok)
-                        # Surface the failure reason (or clear it) per profile
-                        # so `hermes cron status` can show WHY ticks fail
-                        # (#68483).
-                        if ok:
-                            clear_ticker_error()
-                        elif _tick_error:
-                            record_ticker_error(_tick_error)
-                finally:
-                    reset_hermes_home_override(home_token)
-            if ok:
-                consecutive_failures = 0
-            stop_event.wait(_backoff_wait_seconds(interval, consecutive_failures))
+                                ok = True
+                            except BaseException as exc:
+                                cycle_failed = True
+                                tick_error = f"{type(exc).__name__}: {exc}"
+                                logger.error(
+                                    "Cron tick error for profile %s: %s",
+                                    name,
+                                    exc,
+                                    exc_info=True,
+                                )
+                                consecutive_failures = _note_tick_failure(
+                                    exc, consecutive_failures
+                                )
+                            record_ticker_heartbeat(success=ok)
+                            if ok:
+                                clear_ticker_error()
+                            elif tick_error:
+                                record_ticker_error(tick_error)
+                if not cycle_failed:
+                    consecutive_failures = 0
+                wait_seconds = _backoff_wait_seconds(interval, consecutive_failures)
+                if leases and not owned_in_cycle:
+                    # A dedicated gateway may be waiting behind Desktop's short
+                    # dispatch guard. Retry standby ownership promptly instead
+                    # of sleeping a full scheduler interval after lock timeout.
+                    wait_seconds = min(wait_seconds, 1.0)
+                stop_event.wait(wait_seconds)
+        finally:
+            for lease in leases.values():
+                lease.release()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2214,6 +2214,41 @@ def _multiplex_profile_homes(config: object) -> list[tuple[str, "Path"]]:
     )
 
 
+def _cron_scheduler_start_kwargs(runner, cron_provider, *, loop) -> Dict[str, Any]:
+    """Build an explicit profile/runtime identity for gateway cron ownership."""
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    kwargs: Dict[str, Any] = {"adapters": runner.adapters, "loop": loop}
+    if not isinstance(cron_provider, InProcessCronScheduler):
+        return kwargs
+
+    active_profile = runner._active_profile_name()
+    multiplex = bool(getattr(runner.config, "multiplex_profiles", False))
+    if multiplex:
+        profile_homes = _multiplex_profile_homes(runner.config)
+        owner_kind = "gateway-multiplex"
+    else:
+        profile_homes = [(active_profile, get_hermes_home())]
+        owner_kind = "gateway-dedicated"
+
+    served_names = {name for name, _home in profile_homes}
+    per_profile_adapters = {active_profile: runner.adapters}
+    for name, adapter_map in getattr(runner, "_profile_adapters", {}).items():
+        if name in served_names:
+            per_profile_adapters[name] = adapter_map
+
+    kwargs.update(
+        profile_homes=profile_homes,
+        profile_adapters=per_profile_adapters,
+        owner_kind=owner_kind,
+        runtime_id=f"gateway:{active_profile}:{os.getpid()}",
+        can_dispatch=lambda: not (
+            runner._draining or runner._external_drain_active
+        ),
+    )
+    return kwargs
+
+
 @_contextmanager
 def _profile_runtime_scope(profile_home: "Path"):
     """Scope config/skills/memory AND credentials to a profile for one turn.
@@ -8609,8 +8644,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         can't be imported (e.g. a minimal test double for this class).
         """
         try:
-            from cron.scheduler import get_running_job_ids
-            return len(get_running_job_ids())
+            from cron.scheduler import get_running_cron_runs
+            return len(get_running_cron_runs())
         except Exception:
             return 0
 
@@ -8839,9 +8874,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # mid-job freeze. Here an unreadable source counts as work (sentinel 1)
         # so the machine stays awake until the source is readable again.
         try:
-            from cron.scheduler import get_running_job_ids
+            from cron.scheduler import get_running_cron_runs
 
-            cron_count = len(get_running_job_ids())
+            cron_count = len(get_running_cron_runs())
         except Exception:  # noqa: BLE001 - unreadable source => assume busy
             logger.debug("scale-to-zero: cron work count unreadable — staying awake", exc_info=True)
             cron_count = 1
@@ -31218,6 +31253,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # use live adapters (E2EE support).
     from cron.scheduler_provider import (
         InProcessCronScheduler,
+        bind_external_scheduler_ownership,
         resolve_cron_scheduler,
         scheduler_for_profile_mode,
     )
@@ -31227,39 +31263,27 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         resolve_cron_scheduler(),
         multiplex_profiles=multiplex_cron,
     )
-    cron_start_kwargs: Dict[str, Any] = {"adapters": runner.adapters, "loop": asyncio.get_running_loop()}
-
-    # Multiplex profiles: tell the built-in ticker which profile homes to
-    # tick so secondary-profile cron jobs actually fire (#69377).
-    # Without this, only the process-global HERMES_HOME (default profile)
-    # is iterated and every secondary profile's cron store is silently
-    # ignored — jobs show as "scheduled" with a valid next_run_at but
-    # never execute because no ticker owns that store.
-    if (
-        isinstance(cron_provider, InProcessCronScheduler)
-        and multiplex_cron
-    ):
-        try:
-            profile_homes = _multiplex_profile_homes(runner.config)
-            if profile_homes:
-                cron_start_kwargs["profile_homes"] = profile_homes
-                logger.info(
-                    "Cron scheduler will tick %d profile(s) under multiplex: %s",
-                    len(profile_homes),
-                    [p[0] if isinstance(p, tuple) else p for p in profile_homes],
-                )
-        except Exception as exc:
-            logger.warning(
-                "Could not resolve profile homes for multiplex cron: %s",
-                exc,
-            )
-
-    # External cron providers own their remote scheduling contract. Only the
-    # in-process ticker polls local due jobs, so only it receives the local
-    # external-drain dispatch gate.
+    if not isinstance(cron_provider, InProcessCronScheduler):
+        _cron_profile = runner._active_profile_name()
+        cron_provider = bind_external_scheduler_ownership(
+            cron_provider,
+            profile_home=get_hermes_home(),
+            profile=_cron_profile,
+            runtime_id=f"gateway:{_cron_profile}:{os.getpid()}",
+            owner_kind="gateway-dedicated",
+        )
+    cron_start_kwargs = _cron_scheduler_start_kwargs(
+        runner,
+        cron_provider,
+        loop=asyncio.get_running_loop(),
+    )
     if isinstance(cron_provider, InProcessCronScheduler):
-        cron_start_kwargs["can_dispatch"] = lambda: not (
-            runner._draining or runner._external_drain_active
+        _owned_candidates = cron_start_kwargs.get("profile_homes", [])
+        logger.info(
+            "Cron scheduler will arbitrate %d profile candidate(s) as %s: %s",
+            len(_owned_candidates),
+            cron_start_kwargs.get("owner_kind"),
+            [p[0] if isinstance(p, tuple) else p for p in _owned_candidates],
         )
     cron_thread = threading.Thread(
         target=cron_provider.start,

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -484,6 +484,17 @@ def load_hermes_dotenv(
       ``load_external_secrets=False`` to avoid loading optional secret-manager
       dependencies into the process that replaces that same environment.
     """
+    # An authoritative profile scope already contains the complete credential
+    # snapshot for this cron/turn. Mutating os.environ here would leak that
+    # profile into concurrent sibling-profile work in the same process.
+    try:
+        from agent.secret_scope import is_secret_scope_authoritative
+
+        if is_secret_scope_authoritative():
+            return []
+    except ImportError:
+        pass
+
     loaded: list[Path] = []
 
     home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -271,22 +271,22 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
     scheduler provider here (no live adapters; delivery falls back to the
     per-platform send path).
 
-    Every local profile's store is ticked, not just this backend's own
-    (#69377's desktop sibling): the desktop pools per-profile backends and
-    reaps them after ~10 idle minutes, so a secondary profile's ticker dies
-    with its backend and that profile's jobs silently stop firing until the
-    user next opens it ("tasks on the sleeping profile could be idle" —
-    community report, Aug 2026). The primary backend outlives the pool, so it
-    owns every profile's tick, exactly like a multiplex gateway. External
-    providers keep the single-store behavior — their registries are not
-    profile-scoped (see _notify_cron_provider_for_profile).
+    Every local profile is a candidate, not an implicit Desktop-owned store.
+    The built-in provider takes a profile-local scheduler ownership lease before
+    recovery, heartbeat, or dispatch. A dedicated or intentional multiplex
+    gateway has higher priority and atomically preempts Desktop fallback. Desktop
+    keeps retrying unowned candidates so it can take over after a lease expires.
 
-    Cross-process safe: the built-in provider's ``cron.scheduler.tick`` takes
-    the per-store ``cron/.tick.lock`` file lock, so this never double-fires
-    alongside a real gateway or a live pool backend on the same profile home —
-    whichever process grabs the lock first wins the tick.
+    The per-store ``cron/.tick.lock`` remains the short critical section for one
+    tick. It is not scheduler ownership. The ownership mutex is held through the
+    final token check and tick submission, which closes the process-discovery
+    and check-then-execute races.
     """
-    from cron.scheduler_provider import InProcessCronScheduler, resolve_cron_scheduler
+    from cron.scheduler_provider import (
+        InProcessCronScheduler,
+        bind_external_scheduler_ownership,
+        resolve_cron_scheduler,
+    )
 
     provider = resolve_cron_scheduler()
 
@@ -296,17 +296,37 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
             from hermes_cli.profiles import profiles_to_serve
 
             profile_homes = list(profiles_to_serve(multiplex=True))
-            if len(profile_homes) > 1:
-                start_kwargs["profile_homes"] = profile_homes
-                _log.info(
-                    "Desktop cron scheduler will tick %d profile(s): %s",
-                    len(profile_homes),
-                    [name for name, _home in profile_homes],
-                )
         except Exception:
-            # Fail open to the single-store ticker — the active profile's
-            # jobs must keep firing even if profile enumeration breaks.
-            _log.exception("Desktop cron: profile enumeration failed; ticking active profile only")
+            # Ownership is profile-scoped. If the complete candidate set cannot
+            # be resolved, do not silently tick the active profile under a
+            # possibly wrong Desktop runtime.
+            _log.exception("Desktop cron: profile enumeration failed; scheduler not started")
+            return
+        if not profile_homes:
+            _log.error("Desktop cron: no profile homes resolved; scheduler not started")
+            return
+        start_kwargs.update(
+            profile_homes=profile_homes,
+            owner_kind="desktop-fallback",
+            runtime_id=f"desktop:{os.getpid()}",
+        )
+        _log.info(
+            "Desktop cron scheduler will arbitrate %d profile candidate(s): %s",
+            len(profile_homes),
+            [name for name, _home in profile_homes],
+        )
+    else:
+        from hermes_cli.profiles import get_active_profile_name
+        from hermes_constants import get_hermes_home
+
+        _cron_profile = get_active_profile_name() or "default"
+        provider = bind_external_scheduler_ownership(
+            provider,
+            profile_home=get_hermes_home(),
+            profile=_cron_profile,
+            runtime_id=f"desktop:{os.getpid()}",
+            owner_kind="desktop-fallback",
+        )
 
     _log.info("Desktop cron scheduler started (provider=%s, interval=%ds)", provider.name, interval)
     provider.start(stop_event, **start_kwargs)

--- a/tests/agent/test_secret_scope.py
+++ b/tests/agent/test_secret_scope.py
@@ -92,6 +92,29 @@ class TestScopedSingleProfile:
             ss.reset_secret_scope(token)
 
 
+class TestAuthoritativeScopeProcessMutation:
+    def test_load_hermes_dotenv_is_inert(self, tmp_path, monkeypatch):
+        from hermes_cli.env_loader import load_hermes_dotenv
+
+        home = tmp_path / ".hermes" / "profiles" / "brand"
+        home.mkdir(parents=True)
+        (home / ".env").write_text(
+            "CROSS_PROFILE_SENTINEL=brand\n", encoding="utf-8"
+        )
+        monkeypatch.delenv("CROSS_PROFILE_SENTINEL", raising=False)
+
+        tokens = ss.set_authoritative_secret_scope(
+            {"CROSS_PROFILE_SENTINEL": "brand"}
+        )
+        try:
+            loaded = load_hermes_dotenv(hermes_home=home)
+        finally:
+            ss.reset_authoritative_secret_scope(tokens)
+
+        assert loaded == []
+        assert "CROSS_PROFILE_SENTINEL" not in __import__("os").environ
+
+
 class TestScopeIsolation:
     """Two scopes never see each other's secrets."""
 

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -107,6 +107,43 @@ def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
     assert "RAM 92% on host" in doc
 
 
+def test_run_job_no_agent_authoritative_scope_skips_process_dotenv_reload(
+    hermes_env,
+):
+    """Multiplex/Desktop workers must not copy one profile's .env into the
+    process-global environment shared by other profile jobs."""
+    from agent.secret_scope import (
+        reset_authoritative_secret_scope,
+        set_authoritative_secret_scope,
+    )
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    script_path = hermes_env / "scripts" / "probe.sh"
+    script_path.write_text("#!/bin/bash\necho ok\n")
+    job = create_job(
+        prompt=None,
+        schedule="every 5m",
+        script="probe.sh",
+        no_agent=True,
+        deliver="local",
+    )
+    tokens = set_authoritative_secret_scope({"PROFILE_ONLY": "brand"})
+    try:
+        with patch("hermes_cli.env_loader.load_hermes_dotenv") as reload_env, patch(
+            "cron.scheduler._run_job_script_with_claim_heartbeat",
+            return_value=(True, "ok"),
+        ):
+            success, _doc, final, error = run_job(job)
+    finally:
+        reset_authoritative_secret_scope(tokens)
+
+    assert success is True
+    assert final == "ok"
+    assert error is None
+    reload_env.assert_not_called()
+
+
 def test_run_job_no_agent_reloads_dotenv_before_script(hermes_env, monkeypatch):
     """Regression: a standalone cron tick process starts without home-channel
     vars in its environment, and the agent path's per-run dotenv reload never

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -941,6 +941,26 @@ class TestRunJobSessionPersistence:
         # reset MUST precede the reload, else _APPLIED_HOMES no-ops the re-pull.
         assert call_order[:2] == ["reset", "load"], call_order
 
+    def test_authoritative_scope_skips_profile_dotenv_helper(self, tmp_path):
+        from agent.secret_scope import (
+            reset_authoritative_secret_scope,
+            set_authoritative_secret_scope,
+        )
+        from cron.scheduler import _reload_cron_dotenv_if_safe
+
+        tokens = set_authoritative_secret_scope({"PROFILE_ONLY": "brand"})
+        try:
+            with patch("cron.scheduler._hermes_home", tmp_path), \
+                 patch("hermes_cli.env_loader.reset_secret_source_cache") as reset_cache, \
+                 patch("hermes_cli.env_loader.load_hermes_dotenv") as reload_env:
+                reloaded = _reload_cron_dotenv_if_safe(reset_external_cache=True)
+        finally:
+            reset_authoritative_secret_scope(tokens)
+
+        assert reloaded is False
+        reset_cache.assert_not_called()
+        reload_env.assert_not_called()
+
     def test_run_job_clears_stale_auto_delivery_thread_id_between_jobs(self, tmp_path, monkeypatch):
         jobs = [
             {

--- a/tests/cron/test_scheduler_ownership.py
+++ b/tests/cron/test_scheduler_ownership.py
@@ -1,0 +1,643 @@
+"""Profile-scoped cron scheduler ownership lease regressions.
+
+The scheduler owner is distinct from a job fire claim. It decides which runtime
+may inspect and dispatch one profile's cron store. Job claims still provide the
+per-fire at-most-once backstop.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+import threading
+import time
+
+import pytest
+
+
+def test_two_gateway_schedulers_racing_for_one_profile_have_one_owner(tmp_path):
+    from cron.scheduler_ownership import SchedulerOwnershipLease
+
+    profile_home = tmp_path / "profiles" / "brand"
+    barrier = threading.Barrier(2)
+
+    def claim(runtime_id: str):
+        lease = SchedulerOwnershipLease(
+            profile_home=profile_home,
+            profile="brand",
+            runtime_id=runtime_id,
+            owner_kind="gateway-dedicated",
+            lease_seconds=30,
+        )
+        barrier.wait(timeout=5)
+        return lease, lease.claim()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(claim, ("brand-gateway-a", "brand-gateway-b")))
+
+    assert sum(int(claimed) for _lease, claimed in results) == 1
+    winner = next(lease for lease, claimed in results if claimed)
+    loser = next(lease for lease, claimed in results if not claimed)
+    assert winner.is_owner() is True
+    assert loser.is_owner() is False
+
+
+def test_dedicated_gateway_atomically_preempts_desktop_fallback(tmp_path):
+    from cron.scheduler_ownership import SchedulerOwnershipLease
+
+    profile_home = tmp_path / "profiles" / "brand"
+    desktop = SchedulerOwnershipLease(
+        profile_home=profile_home,
+        profile="brand",
+        runtime_id="aya-desktop",
+        owner_kind="desktop-fallback",
+        lease_seconds=30,
+    )
+    dedicated = SchedulerOwnershipLease(
+        profile_home=profile_home,
+        profile="brand",
+        runtime_id="brand-gateway",
+        owner_kind="gateway-dedicated",
+        lease_seconds=30,
+    )
+
+    assert desktop.claim() is True
+    assert dedicated.claim() is True
+    assert dedicated.is_owner() is True
+    assert desktop.is_owner() is False
+
+    with desktop.dispatch_guard() as allowed:
+        assert allowed is False
+    with dedicated.dispatch_guard() as allowed:
+        assert allowed is True
+
+
+def test_equal_priority_takeover_waits_for_expiry(tmp_path):
+    from cron.scheduler_ownership import SchedulerOwnershipLease
+
+    profile_home = tmp_path / "profiles" / "brand"
+    now = [1000.0]
+    first = SchedulerOwnershipLease(
+        profile_home=profile_home,
+        profile="brand",
+        runtime_id="brand-gateway-old",
+        owner_kind="gateway-dedicated",
+        lease_seconds=10,
+        clock=lambda: now[0],
+    )
+    successor = SchedulerOwnershipLease(
+        profile_home=profile_home,
+        profile="brand",
+        runtime_id="brand-gateway-new",
+        owner_kind="gateway-dedicated",
+        lease_seconds=10,
+        clock=lambda: now[0],
+    )
+
+    assert first.claim() is True
+    now[0] = 1009.9
+    assert successor.claim() is False
+    now[0] = 1010.1
+    assert successor.claim() is True
+    assert successor.is_owner() is True
+    assert first.renew() is False
+
+
+def test_release_is_token_guarded_and_allows_controlled_takeover(tmp_path):
+    from cron.scheduler_ownership import SchedulerOwnershipLease
+
+    profile_home = tmp_path / "profiles" / "brand"
+    owner = SchedulerOwnershipLease(
+        profile_home=profile_home,
+        profile="brand",
+        runtime_id="brand-gateway-old",
+        owner_kind="gateway-dedicated",
+    )
+    contender = SchedulerOwnershipLease(
+        profile_home=profile_home,
+        profile="brand",
+        runtime_id="brand-gateway-new",
+        owner_kind="gateway-dedicated",
+    )
+
+    assert owner.claim() is True
+    assert contender.release() is False
+    assert contender.claim() is False
+    assert owner.release() is True
+    assert contender.claim() is True
+
+
+def test_dispatch_guard_preserves_exception_from_guarded_body(tmp_path):
+    from cron.scheduler_ownership import SchedulerOwnershipLease
+
+    lease = SchedulerOwnershipLease(
+        profile_home=tmp_path,
+        profile="brand",
+        runtime_id="brand-gateway",
+        owner_kind="gateway-dedicated",
+    )
+    assert lease.claim() is True
+
+    with pytest.raises(ValueError, match="body failed"):
+        with lease.dispatch_guard() as allowed:
+            assert allowed is True
+            raise ValueError("body failed")
+
+
+def test_dedicated_preemption_retries_promptly_after_busy_guard(tmp_path, monkeypatch):
+    from cron.scheduler_ownership import SchedulerOwnershipLease
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    home = tmp_path / ".hermes" / "profiles" / "brand"
+    (home / "cron").mkdir(parents=True)
+    desktop = SchedulerOwnershipLease(
+        profile_home=home,
+        profile="brand",
+        runtime_id="desktop",
+        owner_kind="desktop-fallback",
+    )
+    assert desktop.claim() is True
+
+    guard_entered = threading.Event()
+    release_guard = threading.Event()
+
+    def hold_desktop_guard():
+        with desktop.dispatch_guard() as allowed:
+            assert allowed is True
+            guard_entered.set()
+            release_guard.wait(timeout=10)
+
+    holder = threading.Thread(target=hold_desktop_guard)
+    holder.start()
+    assert guard_entered.wait(timeout=5)
+
+    dispatched = threading.Event()
+    stop = threading.Event()
+
+    def tracking_tick(*_args, **_kwargs):
+        dispatched.set()
+        stop.set()
+        return 0
+
+    monkeypatch.setattr("cron.scheduler.tick", tracking_tick)
+    monkeypatch.setattr("cron.jobs.record_ticker_heartbeat", lambda **_kwargs: None)
+    scheduler_thread = threading.Thread(
+        target=InProcessCronScheduler().start,
+        args=(stop,),
+        kwargs={
+            "interval": 60,
+            "profile_homes": [("brand", home)],
+            "owner_kind": "gateway-dedicated",
+            "runtime_id": "brand-gateway",
+        },
+    )
+    scheduler_thread.start()
+    # Force both the initial claim and first loop claim past the one-second
+    # lock timeout, then make ownership available.
+    time.sleep(2.3)
+    release_guard.set()
+
+    try:
+        assert dispatched.wait(timeout=3), (
+            "dedicated gateway did not retry ownership promptly after Desktop released"
+        )
+    finally:
+        stop.set()
+        release_guard.set()
+        holder.join(timeout=5)
+        scheduler_thread.join(timeout=5)
+    assert not holder.is_alive()
+    assert not scheduler_thread.is_alive()
+
+
+def test_identical_job_ids_in_two_profiles_track_independently(tmp_path):
+    from cron.scheduler import (
+        get_running_cron_runs,
+        is_cron_job_running,
+        release_running_job,
+        try_register_running_job,
+    )
+
+    brand = tmp_path / "profiles" / "brand"
+    scout = tmp_path / "profiles" / "scout"
+    assert try_register_running_job("same-id", profile_home=brand) is True
+    assert try_register_running_job("same-id", profile_home=scout) is True
+    try:
+        assert is_cron_job_running("same-id", profile_home=brand) is True
+        assert is_cron_job_running("same-id", profile_home=scout) is True
+        assert len(get_running_cron_runs()) == 2
+        release_running_job("same-id", profile_home=brand)
+        assert is_cron_job_running("same-id", profile_home=brand) is False
+        assert is_cron_job_running("same-id", profile_home=scout) is True
+    finally:
+        release_running_job("same-id", profile_home=brand)
+        release_running_job("same-id", profile_home=scout)
+
+
+def test_two_scheduler_instances_racing_dispatch_once_then_transfer(
+    tmp_path,
+    monkeypatch,
+):
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    profile_home = tmp_path / ".hermes" / "profiles" / "brand"
+    (profile_home / "cron").mkdir(parents=True)
+    starts = threading.Barrier(2)
+    stops = [threading.Event(), threading.Event()]
+    dispatched = []
+
+    def tracking_tick(*_args, **_kwargs):
+        dispatched.append(threading.current_thread().name)
+        for event in stops:
+            event.set()
+        return 0
+
+    def run(index: int):
+        starts.wait(timeout=5)
+        InProcessCronScheduler().start(
+            stops[index],
+            interval=0,
+            profile_homes=[("brand", profile_home)],
+            owner_kind="gateway-dedicated",
+            runtime_id=f"brand-gateway-{index}",
+        )
+
+    monkeypatch.setattr("cron.scheduler.tick", tracking_tick)
+    monkeypatch.setattr("cron.jobs.record_ticker_heartbeat", lambda **_kwargs: None)
+
+    threads = [
+        threading.Thread(target=run, args=(index,), name=f"scheduler-{index}")
+        for index in range(2)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+        assert not thread.is_alive()
+
+    assert len(dispatched) == 1
+
+    successor_stop = threading.Event()
+
+    def successor_tick(*_args, **_kwargs):
+        dispatched.append("successor")
+        successor_stop.set()
+        return 0
+
+    monkeypatch.setattr("cron.scheduler.tick", successor_tick)
+    InProcessCronScheduler().start(
+        successor_stop,
+        interval=0,
+        profile_homes=[("brand", profile_home)],
+        owner_kind="gateway-dedicated",
+        runtime_id="brand-gateway-successor",
+    )
+
+    assert dispatched == [dispatched[0], "successor"]
+
+
+def test_external_provider_equal_priority_race_starts_one_owner(tmp_path):
+    from cron.scheduler_provider import CronScheduler, bind_external_scheduler_ownership
+
+    starts = []
+
+    class External(CronScheduler):
+        def __init__(self, label):
+            self.label = label
+
+        @property
+        def name(self):
+            return "external-test"
+
+        def start(self, stop_event, **_kwargs):
+            starts.append(self.label)
+
+    stop_a = threading.Event()
+    stop_b = threading.Event()
+    owner_a = bind_external_scheduler_ownership(
+        External("a"),
+        profile_home=tmp_path,
+        profile="brand",
+        runtime_id="gateway-a",
+        owner_kind="gateway-dedicated",
+        poll_interval=0.02,
+    )
+    owner_b = bind_external_scheduler_ownership(
+        External("b"),
+        profile_home=tmp_path,
+        profile="brand",
+        runtime_id="gateway-b",
+        owner_kind="gateway-dedicated",
+        poll_interval=0.02,
+    )
+    threads = [
+        threading.Thread(target=owner_a.start, args=(stop_a,)),
+        threading.Thread(target=owner_b.start, args=(stop_b,)),
+    ]
+    for thread in threads:
+        thread.start()
+    deadline = time.monotonic() + 2
+    while not starts and time.monotonic() < deadline:
+        time.sleep(0.01)
+    time.sleep(0.1)
+
+    assert len(starts) == 1
+
+    stop_a.set()
+    stop_b.set()
+    for thread in threads:
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+
+
+def test_external_dedicated_gateway_preempts_desktop_and_guards_hooks(tmp_path):
+    from cron.scheduler_provider import CronScheduler, bind_external_scheduler_ownership
+
+    events = []
+
+    class External(CronScheduler):
+        def __init__(self, label):
+            self.label = label
+
+        @property
+        def name(self):
+            return "external-test"
+
+        def start(self, stop_event, **_kwargs):
+            events.append((self.label, "start"))
+
+        def on_jobs_changed(self):
+            events.append((self.label, "changed"))
+
+    desktop_stop = threading.Event()
+    gateway_stop = threading.Event()
+    desktop = bind_external_scheduler_ownership(
+        External("desktop"),
+        profile_home=tmp_path,
+        profile="brand",
+        runtime_id="desktop",
+        owner_kind="desktop-fallback",
+        poll_interval=0.02,
+    )
+    gateway = bind_external_scheduler_ownership(
+        External("gateway"),
+        profile_home=tmp_path,
+        profile="brand",
+        runtime_id="gateway",
+        owner_kind="gateway-dedicated",
+        poll_interval=0.02,
+    )
+    desktop_thread = threading.Thread(target=desktop.start, args=(desktop_stop,))
+    gateway_thread = threading.Thread(target=gateway.start, args=(gateway_stop,))
+    desktop_thread.start()
+    deadline = time.monotonic() + 2
+    while ("desktop", "start") not in events and time.monotonic() < deadline:
+        time.sleep(0.01)
+    gateway_thread.start()
+    deadline = time.monotonic() + 2
+    while ("gateway", "start") not in events and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    desktop.on_jobs_changed()
+    gateway.on_jobs_changed()
+
+    assert ("gateway", "start") in events
+    assert ("desktop", "changed") not in events
+    assert ("gateway", "changed") in events
+
+    desktop_stop.set()
+    gateway_stop.set()
+    desktop_thread.join(timeout=5)
+    gateway_thread.join(timeout=5)
+    assert not desktop_thread.is_alive()
+    assert not gateway_thread.is_alive()
+
+
+def test_external_wrapper_preserves_legacy_single_phase_fire(tmp_path):
+    from cron.scheduler_provider import (
+        CronScheduler,
+        bind_external_scheduler_ownership,
+        provider_supports_split_fire,
+    )
+
+    calls = []
+
+    class LegacyExternal(CronScheduler):
+        @property
+        def name(self):
+            return "legacy"
+
+        def start(self, stop_event, **_kwargs):
+            return None
+
+        def fire_due(self, job_id, *, adapters=None, loop=None):
+            calls.append(job_id)
+            return True
+
+    raw = LegacyExternal()
+    wrapped = bind_external_scheduler_ownership(
+        raw,
+        profile_home=tmp_path,
+        profile="brand",
+        runtime_id="gateway",
+        owner_kind="gateway-dedicated",
+        poll_interval=0.02,
+    )
+    assert provider_supports_split_fire(raw) is False
+    assert provider_supports_split_fire(wrapped) is False
+
+    stop = threading.Event()
+    thread = threading.Thread(target=wrapped.start, args=(stop,))
+    thread.start()
+    deadline = time.monotonic() + 2
+    while not wrapped._lease.is_owner() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    try:
+        assert wrapped.fire_due("job-1") is True
+        assert calls == ["job-1"]
+    finally:
+        stop.set()
+        thread.join(timeout=5)
+    assert not thread.is_alive()
+
+
+def test_blocking_external_start_does_not_block_dedicated_preemption(tmp_path):
+    from cron.scheduler_provider import CronScheduler, bind_external_scheduler_ownership
+
+    desktop_started = threading.Event()
+    gateway_started = threading.Event()
+
+    class BlockingExternal(CronScheduler):
+        def __init__(self, started):
+            self.started = started
+
+        @property
+        def name(self):
+            return "blocking"
+
+        def start(self, stop_event, **_kwargs):
+            self.started.set()
+            stop_event.wait(timeout=10)
+
+    desktop = bind_external_scheduler_ownership(
+        BlockingExternal(desktop_started),
+        profile_home=tmp_path,
+        profile="brand",
+        runtime_id="desktop",
+        owner_kind="desktop-fallback",
+        poll_interval=0.02,
+    )
+    gateway = bind_external_scheduler_ownership(
+        BlockingExternal(gateway_started),
+        profile_home=tmp_path,
+        profile="brand",
+        runtime_id="gateway",
+        owner_kind="gateway-dedicated",
+        poll_interval=0.02,
+    )
+    desktop_stop = threading.Event()
+    gateway_stop = threading.Event()
+    desktop_thread = threading.Thread(target=desktop.start, args=(desktop_stop,))
+    gateway_thread = threading.Thread(target=gateway.start, args=(gateway_stop,))
+    desktop_thread.start()
+    assert desktop_started.wait(timeout=2)
+    gateway_thread.start()
+    try:
+        assert gateway_started.wait(timeout=3), (
+            "blocking Desktop provider prevented dedicated gateway preemption"
+        )
+    finally:
+        desktop_stop.set()
+        gateway_stop.set()
+        desktop.stop()
+        gateway.stop()
+        desktop_thread.join(timeout=5)
+        gateway_thread.join(timeout=5)
+    assert not desktop_thread.is_alive()
+    assert not gateway_thread.is_alive()
+
+
+def test_desktop_fallback_skips_profile_owned_by_live_dedicated_gateway(
+    tmp_path,
+    monkeypatch,
+):
+    from cron.scheduler_ownership import SchedulerOwnershipLease
+    from cron.scheduler_provider import InProcessCronScheduler
+    from hermes_constants import get_hermes_home
+
+    default_home = tmp_path / ".hermes"
+    brand_home = default_home / "profiles" / "brand"
+    monkeypatch.setenv("AYA_ONLY_SECRET", "must-not-reach-brand")
+    for home, marker in ((default_home, "aya"), (brand_home, "brand")):
+        (home / "cron").mkdir(parents=True)
+        (home / ".env").write_text(f"PROFILE_MARKER={marker}\n", encoding="utf-8")
+
+    dedicated = SchedulerOwnershipLease(
+        profile_home=brand_home,
+        profile="brand",
+        runtime_id="brand-gateway",
+        owner_kind="gateway-dedicated",
+    )
+    assert dedicated.claim() is True
+
+    seen = []
+    stop = threading.Event()
+
+    def tracking_tick(*_args, **kwargs):
+        from agent.secret_scope import current_secret_scope, get_secret
+        from cron.jobs import _current_cron_store
+
+        scope = current_secret_scope() or {}
+        seen.append(
+            {
+                "home": get_hermes_home(),
+                "store": _current_cron_store().jobs_file,
+                "secret": scope.get("PROFILE_MARKER"),
+                "foreign_secret": get_secret("AYA_ONLY_SECRET"),
+                "adapters": kwargs.get("adapters"),
+            }
+        )
+        stop.set()
+        return 0
+
+    monkeypatch.setattr("cron.scheduler.tick", tracking_tick)
+    monkeypatch.setattr("cron.jobs.record_ticker_heartbeat", lambda **_kwargs: None)
+
+    provider = InProcessCronScheduler()
+    provider.start(
+        stop,
+        interval=0,
+        profile_homes=[("default", default_home), ("brand", brand_home)],
+        profile_adapters={
+            "default": {"identity": "aya"},
+            "brand": {"identity": "brand"},
+        },
+        owner_kind="desktop-fallback",
+        runtime_id="aya-desktop",
+    )
+
+    assert seen == [
+        {
+            "home": default_home,
+            "store": default_home / "cron" / "jobs.json",
+            "secret": "aya",
+            "foreign_secret": None,
+            "adapters": {"identity": "aya"},
+        }
+    ]
+
+
+def test_dedicated_profile_dispatch_uses_its_complete_runtime_scope(tmp_path, monkeypatch):
+    from cron.scheduler_provider import InProcessCronScheduler
+    from hermes_constants import get_hermes_home
+
+    brand_home = tmp_path / ".hermes" / "profiles" / "brand"
+    (brand_home / "cron").mkdir(parents=True)
+    (brand_home / ".env").write_text("PROFILE_MARKER=brand\n", encoding="utf-8")
+    (brand_home / "config.yaml").write_text("profile_marker: brand\n", encoding="utf-8")
+    monkeypatch.setenv("BRAND_PROCESS_ONLY_SECRET", "brand-process-secret")
+
+    seen = []
+    stop = threading.Event()
+
+    def tracking_tick(*_args, **kwargs):
+        from agent.secret_scope import get_secret
+        from cron.jobs import _current_cron_store
+        from hermes_cli.config import read_user_config_raw
+
+        seen.append(
+            {
+                "home": get_hermes_home(),
+                "store": _current_cron_store().jobs_file,
+                "config": read_user_config_raw(get_hermes_home() / "config.yaml")[
+                    "profile_marker"
+                ],
+                "secret": get_secret("PROFILE_MARKER"),
+                "process_secret": get_secret("BRAND_PROCESS_ONLY_SECRET"),
+                "adapters": kwargs.get("adapters"),
+            }
+        )
+        stop.set()
+        return 0
+
+    monkeypatch.setattr("cron.scheduler.tick", tracking_tick)
+    monkeypatch.setattr("cron.jobs.record_ticker_heartbeat", lambda **_kwargs: None)
+
+    InProcessCronScheduler().start(
+        stop,
+        interval=0,
+        profile_homes=[("brand", brand_home)],
+        profile_adapters={"brand": {"delivery_identity": "brand"}},
+        owner_kind="gateway-dedicated",
+        runtime_id="brand-gateway",
+    )
+
+    assert seen == [
+        {
+            "home": brand_home,
+            "store": brand_home / "cron" / "jobs.json",
+            "config": "brand",
+            "secret": "brand",
+            "process_secret": "brand-process-secret",
+            "adapters": {"delivery_identity": "brand"},
+        }
+    ]

--- a/tests/cron/test_shutdown_interrupt.py
+++ b/tests/cron/test_shutdown_interrupt.py
@@ -99,12 +99,13 @@ class TestMarkRunningJobsInterrupted:
     def test_sets_interrupted_flag_for_consumption_by_run_one_job(self):
         import cron.scheduler as sched
 
-        sched._running_job_ids.add("job-1")
+        run_key = sched._cron_run_key("job-1")
+        sched._running_job_ids.add(run_key)
 
         with patch("cron.scheduler.mark_job_run"):
             sched.mark_running_jobs_interrupted("shutdown")
 
-        assert "job-1" in sched._interrupted_job_ids
+        assert run_key in sched._interrupted_job_ids
 
     def test_one_job_marking_failure_does_not_block_the_others(self):
         """mark_job_run raising for one job (e.g. a jobs.json write race)
@@ -150,8 +151,9 @@ class TestMarkRunningJobsInterrupted:
             replacement = {**claimed, "fire_claim": replacement_claim}
             jobs.save_jobs([replacement])
 
-            sched._running_job_ids.add(created["id"])
-            sched._running_fire_owners[created["id"]] = {
+            run_key = sched._cron_run_key(created["id"], profile_home)
+            sched._running_job_ids.add(run_key)
+            sched._running_fire_owners[run_key] = {
                 object(): (stale_owner, profile_home)
             }
             marked = sched.mark_running_jobs_interrupted("shutdown")
@@ -173,7 +175,8 @@ class TestRunningFireOwnerRegistry:
         }
 
         def _observe_registry(current_job, run):
-            assert list(sched._running_fire_owners[current_job["id"]].values()) == [
+            run_key = sched._cron_run_key(current_job["id"])
+            assert list(sched._running_fire_owners[run_key].values()) == [
                 ("owner-1", sched._get_hermes_home().resolve())
             ]
             return True

--- a/tests/gateway/test_multiplex_lifecycle.py
+++ b/tests/gateway/test_multiplex_lifecycle.py
@@ -41,6 +41,77 @@ def test_cron_profile_homes_follow_allowlist(tmp_path, monkeypatch):
     assert [name for name, _home in homes] == ["default", "worker"]
 
 
+def test_dedicated_gateway_cron_start_kwargs_bind_one_profile(tmp_path, monkeypatch):
+    import gateway.run as gateway_run
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    brand_home = tmp_path / ".hermes" / "profiles" / "brand"
+    runner = type(
+        "Runner",
+        (),
+        {
+            "config": GatewayConfig(multiplex_profiles=False),
+            "adapters": {"slack": "brand-adapter"},
+            "_profile_adapters": {},
+            "_draining": False,
+            "_external_drain_active": False,
+            "_active_profile_name": lambda self: "brand",
+        },
+    )()
+    monkeypatch.setattr(gateway_run, "get_hermes_home", lambda: brand_home)
+
+    kwargs = gateway_run._cron_scheduler_start_kwargs(
+        runner,
+        InProcessCronScheduler(),
+        loop="loop",
+    )
+
+    assert kwargs["profile_homes"] == [("brand", brand_home)]
+    assert kwargs["profile_adapters"] == {"brand": {"slack": "brand-adapter"}}
+    assert kwargs["owner_kind"] == "gateway-dedicated"
+    assert kwargs["runtime_id"].startswith("gateway:brand:")
+    assert kwargs["loop"] == "loop"
+
+
+def test_intentional_multiplex_gateway_keeps_configured_profile_ownership(
+    tmp_path,
+    monkeypatch,
+):
+    import gateway.run as gateway_run
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    default_home = tmp_path / ".hermes"
+    brand_home = default_home / "profiles" / "brand"
+    homes = [("default", default_home), ("brand", brand_home)]
+    runner = type(
+        "Runner",
+        (),
+        {
+            "config": GatewayConfig(multiplex_profiles=True),
+            "adapters": {"slack": "aya-adapter"},
+            "_profile_adapters": {"brand": {"slack": "brand-adapter"}},
+            "_draining": False,
+            "_external_drain_active": False,
+            "_active_profile_name": lambda self: "default",
+        },
+    )()
+    monkeypatch.setattr(gateway_run, "_multiplex_profile_homes", lambda _cfg: homes)
+
+    kwargs = gateway_run._cron_scheduler_start_kwargs(
+        runner,
+        InProcessCronScheduler(),
+        loop="loop",
+    )
+
+    assert kwargs["profile_homes"] == homes
+    assert kwargs["profile_adapters"] == {
+        "default": {"slack": "aya-adapter"},
+        "brand": {"slack": "brand-adapter"},
+    }
+    assert kwargs["owner_kind"] == "gateway-multiplex"
+    assert kwargs["runtime_id"].startswith("gateway:default:")
+
+
 class TestNamedProfileMultiplexerGuard:
     """_guard_named_profile_under_multiplexer is inert unless all conditions hold."""
 

--- a/tests/gateway/test_scale_to_zero_watcher.py
+++ b/tests/gateway/test_scale_to_zero_watcher.py
@@ -438,7 +438,7 @@ def _work_count_runner(monkeypatch, *, agents=0, cron_ids=(), api_runs=0):
         r, "_scale_to_zero_idle_timeout_seconds", lambda: 300.0, raising=False
     )
     monkeypatch.setattr(
-        "cron.scheduler.get_running_job_ids", lambda: set(cron_ids)
+        "cron.scheduler.get_running_cron_runs", lambda: tuple(cron_ids)
     )
     api_adapter = SimpleNamespace(active_agent_work_count=lambda: api_runs)
     from gateway.platforms.base import Platform
@@ -471,7 +471,7 @@ def test_unreadable_cron_source_fails_awake(monkeypatch):
     def _boom():
         raise RuntimeError("registry unavailable")
 
-    monkeypatch.setattr("cron.scheduler.get_running_job_ids", _boom)
+    monkeypatch.setattr("cron.scheduler.get_running_cron_runs", _boom)
     assert r._scale_to_zero_is_idle() is False
 
 

--- a/tests/hermes_cli/test_desktop_cron_ticker_profiles.py
+++ b/tests/hermes_cli/test_desktop_cron_ticker_profiles.py
@@ -10,6 +10,7 @@ every profile's store — the desktop sibling of the multiplex-gateway fix for
 
 from pathlib import Path
 import threading
+import time
 
 import pytest
 
@@ -38,6 +39,9 @@ class _RecordingExternal:
 
     def start(self, stop_event, **kwargs):
         self.start_kwargs = kwargs
+
+    def stop(self):
+        return None
 
 
 @pytest.fixture()
@@ -70,23 +74,23 @@ def test_multi_profile_homes_passed_to_builtin(monkeypatch, _providers, tmp_path
     assert builtin.start_kwargs["profile_homes"] == homes
 
 
-def test_single_profile_keeps_legacy_path(monkeypatch, _providers, tmp_path):
+def test_single_profile_still_uses_explicit_ownership(monkeypatch, _providers, tmp_path):
     _sp, builtin = _providers
     import hermes_cli.profiles as profiles_mod
 
-    monkeypatch.setattr(
-        profiles_mod,
-        "profiles_to_serve",
-        lambda **_kw: [("default", tmp_path / "root")],
-    )
+    homes = [("default", tmp_path / "root")]
+    monkeypatch.setattr(profiles_mod, "profiles_to_serve", lambda **_kw: homes)
 
     ws._start_desktop_cron_ticker(threading.Event(), interval=9)
 
-    assert builtin.start_kwargs == {"interval": 9}
+    assert builtin.start_kwargs["interval"] == 9
+    assert builtin.start_kwargs["profile_homes"] == homes
+    assert builtin.start_kwargs["owner_kind"] == "desktop-fallback"
+    assert builtin.start_kwargs["runtime_id"].startswith("desktop:")
 
 
-def test_enumeration_failure_fails_open(monkeypatch, _providers):
-    """The active profile's jobs keep firing even if profile listing breaks."""
+def test_enumeration_failure_fails_closed(monkeypatch, _providers):
+    """Unknown profile scope must not fall back to an unowned active store."""
     _sp, builtin = _providers
     import hermes_cli.profiles as profiles_mod
 
@@ -97,7 +101,36 @@ def test_enumeration_failure_fails_open(monkeypatch, _providers):
 
     ws._start_desktop_cron_ticker(threading.Event(), interval=11)
 
-    assert builtin.start_kwargs == {"interval": 11}
+    assert builtin.start_kwargs is None
+
+
+def test_desktop_passes_explicit_fallback_owner_identity(monkeypatch, _providers, tmp_path):
+    _sp, builtin = _providers
+    import hermes_cli.profiles as profiles_mod
+
+    homes = [("default", tmp_path / "root"), ("brand", tmp_path / "brand")]
+    monkeypatch.setattr(profiles_mod, "profiles_to_serve", lambda **_kw: homes)
+
+    ws._start_desktop_cron_ticker(threading.Event(), interval=17)
+
+    assert builtin.start_kwargs["owner_kind"] == "desktop-fallback"
+    assert builtin.start_kwargs["runtime_id"].startswith("desktop:")
+    assert builtin.start_kwargs["profile_homes"] == homes
+
+
+def test_desktop_profile_enumeration_failure_fails_closed(monkeypatch, _providers):
+    _sp, builtin = _providers
+    import hermes_cli.profiles as profiles_mod
+
+    monkeypatch.setattr(
+        profiles_mod,
+        "profiles_to_serve",
+        lambda **_kw: (_ for _ in ()).throw(RuntimeError("profiles unreadable")),
+    )
+
+    ws._start_desktop_cron_ticker(threading.Event(), interval=19)
+
+    assert builtin.start_kwargs is None
 
 
 def test_external_provider_never_gets_profile_homes(monkeypatch, tmp_path):
@@ -115,6 +148,19 @@ def test_external_provider_never_gets_profile_homes(monkeypatch, tmp_path):
         lambda **_kw: [("default", tmp_path / "a"), ("b", tmp_path / "b")],
     )
 
-    ws._start_desktop_cron_ticker(threading.Event(), interval=13)
+    stop = threading.Event()
+    thread = threading.Thread(
+        target=ws._start_desktop_cron_ticker,
+        args=(stop,),
+        kwargs={"interval": 13},
+    )
+    thread.start()
+    deadline = time.monotonic() + 2
+    while external.start_kwargs is None and time.monotonic() < deadline:
+        time.sleep(0.01)
+    stop.set()
+    thread.join(timeout=5)
 
-    assert external.start_kwargs == {"interval": 13}
+    assert not thread.is_alive()
+    assert external.start_kwargs == {"adapters": None, "loop": None, "interval": 13}
+    assert "profile_homes" not in external.start_kwargs

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1067,9 +1067,9 @@ def _try_dispatch_background_run(
         # authoritative (atomic) check is try_register_running_job inside
         # _run_claimed_job on the worker.
         try:
-            from cron.scheduler import get_running_job_ids
+            from cron.scheduler import is_cron_job_running
 
-            if job_id in get_running_job_ids():
+            if is_cron_job_running(job_id):
                 return {
                     "claimed": False,
                     "success": False,


### PR DESCRIPTION
## Summary

- add an atomic, profile-local scheduler ownership lease for built-in and external cron providers
- make dedicated and intentional multiplex gateways authoritative over Desktop fallback schedulers
- bind each dispatched profile to its own home, cron store, config, secret scope, adapter map, delivery identity, and in-flight bookkeeping
- preserve controlled failover, existing job-level fire claims, and intentional `gateway.multiplex_profiles` deployments

## Related open work

This is a current-main, single-commit consolidation of the scheduler-ownership bug class covered in part by:

- #72179, single scheduler owner per home
- #91795, multiplex delivery identity and per-profile adapters
- #92526, secret scope retained through delivery
- #91399, live-gateway handoff for continuable jobs

Those PRs were reviewed as inputs. This PR packages the complete profile ownership, runtime isolation, external-provider fencing, failover, and duplicate-prevention contract in one current implementation. It does not depend on merging those branches in sequence.

## Problem

Cron stores are profile-local, but scheduler ownership was not.

Hermes Desktop could enumerate and tick every profile while dedicated profile gateways also ticked their own stores. The existing `.tick.lock` serialized individual ticks but did not elect one scheduler for the profile. This allowed different processes to alternate ownership across ticker windows and could execute a profile job with another runtime's adapters, process environment, delivery identity, or process-global workdir lock.

The same class of ambiguity affected external scheduler startup/reconciliation and process-local in-flight tracking for copied profiles with identical job IDs.

## Solution

### Profile scheduler ownership

Each profile now has a lease record and a separate ownership mutex under its own cron directory. The lease records the profile, canonical home, owner kind, runtime ID, PID, token, and expiry.

- dedicated and intentional multiplex gateways outrank Desktop fallback
- equal-priority owners cannot replace an unexpired lease
- ownership is renewed while healthy and released on clean shutdown
- takeover occurs after release, expiry, or higher-priority preemption
- the ownership mutex stays held through the final token check and dispatch submission, closing the check-then-execute race
- lock, record, and identity errors fail closed

### Runtime isolation

Profile-aware scheduling now binds:

- `HERMES_HOME`
- the profile-local cron store
- profile config and output/session paths
- an authoritative profile secret scope for Desktop and multiplex workers
- the exact per-profile adapter map
- profile-qualified in-flight state keyed by canonical home plus job ID

Authoritative scopes prevent dotenv reloads from mutating the process-global environment. Dedicated single-profile gateways still retain legitimate process-injected credentials.

### External providers

External provider lifecycle and fire admission are wrapped by the same ownership contract. The wrapper:

- preserves legacy single-phase `fire_due` behavior
- preserves split-fire and cancellation capability detection
- runs potentially blocking provider startup outside the ownership mutex
- stops a lower-priority provider after ownership loss
- allows already-durably-claimed work to finish without duplicate admission

## Tests

- focused cron/Desktop/gateway/profile/secret suites: 355 passed
- broader affected cron and gateway-cron suites: 1,123 passed, 1 Windows-only skip
- full gateway suite on Linux: 6,203 passed, 3 failed, 38 skipped
  - two WeCom XML failures reproduce unchanged on `origin/main`
  - one load-only turn-lease timeout passes in isolation on both this branch and `origin/main`
- Ruff, Python compilation, and `git diff --check` pass
- isolated five-profile runtime canary:
  - default owned by Desktop fallback
  - four named profiles owned by their dedicated gateways
  - exactly one local-only execution per profile
  - correct profile home, secrets, adapters, and delivery identity
  - a long workdir job in one runtime did not block another profile

## Compatibility and safety

- cron stores remain profile-local
- no job migration, database migration, permission change, or credential change
- manual fire and durable per-job claim behavior remain intact
- intentional gateway multiplexing remains supported
- external providers under unsupported multiplex mode retain the existing built-in fallback
- no credential values or cron prompt contents are logged by the ownership paths
