### PR TITLE
test(bot-mode): skip the turn-lock module on Windows instead of aborting collection

### DIFF
--- a/tests/tools/test_bot_turn_lock.py
+++ b/tests/tools/test_bot_turn_lock.py
@@ -9,14 +9,25 @@ process, so threads exercise the true kernel-lock semantics.
 
 from __future__ import annotations
 
-import fcntl
 import json
 import os
 import re
+import sys
 import threading
 import time
 
 import pytest
+
+# `fcntl` does not exist on Windows, and an unguarded module-level import here
+# aborts collection for the whole `tests/tools/` directory rather than skipping
+# this one file. Skip before importing it, matching
+# `tests/cli/test_termios_drift_heal.py`. There is nothing to run here anyway:
+# `acquire_turn_lock()` degrades to a no-op contextmanager on Windows (no
+# `fcntl`), so the contention this module asserts on cannot occur.
+if sys.platform == "win32":  # pragma: no cover
+    pytest.skip("bot turn lock contention is POSIX flock-only", allow_module_level=True)
+
+import fcntl
 
 from tools import bot_mode_dm, bot_relay
 from tools.bot_relay import TurnBusyError, acquire_turn_lock, turn_lock_path


### PR DESCRIPTION
## The problem

`tests/tools/test_bot_turn_lock.py` (added by `ac3f9a2dc4`, #93091) imports `fcntl` unconditionally at module level. `fcntl` does not exist on Windows, so the import raises during collection — and an uncaught collection error is not "skip this file", it **aborts the entire run**:

```
ERROR collecting tests/tools/test_bot_turn_lock.py
tests\tools\test_bot_turn_lock.py:12: in <module>
    import fcntl
E   ModuleNotFoundError: No module named 'fcntl'
!!!!!!! Interrupted: 1 error during collection !!!!!!!
no tests collected, 1 error in 0.74s
```

That takes out **all of `tests/tools/`** on Windows — 7732 collectable tests — not just this one module. A Windows contributor cannot run the tools suite at all without `--ignore`ing this file by hand.

## The fix

Skip before the import, matching `tests/cli/test_termios_drift_heal.py`:

```python
if sys.platform == "win32":  # pragma: no cover
    pytest.skip("bot turn lock contention is POSIX flock-only", allow_module_level=True)

import fcntl
```

The tree's other convention — `pytestmark = pytest.mark.skipif(...)`, used by `tests/state/test_fts_rebuild_admission.py` — **cannot** work here: `pytestmark` is evaluated after the module body has already been imported, so the `fcntl` import would still raise first. That module gets away with it because it never imports `fcntl` itself; it spawns subprocesses instead.

## No coverage is lost

`acquire_turn_lock()` in `tools/bot_relay.py` already degrades to a no-op contextmanager on Windows (`try: import fcntl / except ImportError: yield`), precisely because `fcntl` is unavailable. The cross-process flock contention this module asserts on cannot occur there, so these tests could never have passed on Windows — they could only ever abort the run.

## Before / after

```
before:  no tests collected, 1 error
after:   7732/7739 tests collected (7 deselected); this module reports 1 skipped
```

POSIX behaviour is unchanged — the guard only fires on `win32`, and `import fcntl` still happens exactly as before everywhere else.

## Platforms

Verified on Windows 11 / CPython 3.11.
