### PR TITLE
fix(desktop/bots): keep a substantive group reply after a synthetic (pass)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -6377,7 +6377,9 @@ function isGroupPassText(text) {
  *  substantive (non-pass) assistant answer over a trailing pass — a Codex
  *  intent-ack continuation nudge can land a complete answer and then get a
  *  synthetic "(pass)" to the nudge itself, which must not hide the answer.
- *  Returns null only when no assistant message appears in that range. */
+ *  When only pass text exists in range, returns the newest (last
+ *  chronological) one rather than the oldest. Returns null only when no
+ *  assistant message appears in that range. */
 function pickGroupTurnReply(messages, before) {
   let passText = null
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -6372,6 +6372,42 @@ function isGroupPassText(text) {
   return /^\(?\s*pass\s*\)?\.?$/i.test(trimmed)
 }
 
+/** #94376: pick the reply a finished turn should surface among the messages
+ *  appended since `before`. Scans newest-first and prefers the last
+ *  substantive (non-pass) assistant answer over a trailing pass — a Codex
+ *  intent-ack continuation nudge can land a complete answer and then get a
+ *  synthetic "(pass)" to the nudge itself, which must not hide the answer.
+ *  Returns null only when no assistant message appears in that range. */
+function pickGroupTurnReply(messages, before) {
+  let passText = null
+
+  for (let i = messages.length - 1; i >= before; i--) {
+    const msg = messages[i]
+
+    if (msg?.role !== 'assistant') {
+      continue
+    }
+
+    const text = typeof msg.content === 'string'
+      ? msg.content
+      : Array.isArray(msg.content)
+        ? msg.content.map(p => (typeof p === 'string' ? p : p?.text || '')).join('')
+        : msg?.text || ''
+    const replyText = String(text).trim()
+
+    if (isGroupPassText(replyText)) {
+      if (passText === null) {
+        passText = replyText
+      }
+      continue
+    }
+
+    return replyText
+  }
+
+  return passText
+}
+
 /** Deterministic @mention parse. Handles @name, @"two words" via display
  *  titles, and @everyone/@all. Names match case-insensitively against member
  *  profile names, display titles, and collapsed no-space forms. */
@@ -7377,25 +7413,16 @@ async function runGroupChatMemberTurnLeased(group, member, prompt, thread, image
     const done = !busy && !awaitingUser
 
     if (messages.length > before && done) {
-      for (let i = messages.length - 1; i >= 0; i--) {
-        const msg = messages[i]
+      const replyText = pickGroupTurnReply(messages, before)
 
-        if (msg?.role === 'assistant') {
-          const text = typeof msg.content === 'string'
-            ? msg.content
-            : Array.isArray(msg.content)
-              ? msg.content.map(p => (typeof p === 'string' ? p : p?.text || '')).join('')
-              : msg?.text || ''
-          const replyText = String(text).trim()
+      if (replyText !== null) {
+        recordGroupActivity(group, {
+          kind: isGroupPassText(replyText) ? 'passed' : 'replied',
+          member: member.name,
+          thread
+        })
 
-          recordGroupActivity(group, {
-            kind: isGroupPassText(replyText) ? 'passed' : 'replied',
-            member: member.name,
-            thread
-          })
-
-          return replyText
-        }
+        return replyText
       }
 
       recordGroupActivity(group, { kind: 'passed', member: member.name, thread })
@@ -7476,33 +7503,20 @@ async function harvestStrandedGroupReply(group, member) {
     return
   }
 
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i]
+  const reply = pickGroupTurnReply(messages, strandedBefore)
 
-    if (msg?.role === 'assistant') {
-      const text = typeof msg.content === 'string'
-        ? msg.content
-        : Array.isArray(msg.content)
-          ? msg.content.map(p => (typeof p === 'string' ? p : p?.text || '')).join('')
-          : msg?.text || ''
-      const reply = String(text).trim()
-
-      if (reply && !isGroupPassText(reply)) {
-        recordGroupActivity(group, { kind: 'delivered', member: member.name, thread: strandedThread })
-        appendGroupChatEntry(
-          group,
-          { kind: 'member', name: member.name, ...(member.remoteSource ? { source: member.connectionLabel || member.connectionId } : {}) },
-          reply,
-          strandedThread
-        )
-        updateGroupChat(group, r => {
-          r.watermarks[`${strandedThread}::${memberKey}`] = r.log.length
-          return r
-        })
-      }
-
-      return
-    }
+  if (reply && !isGroupPassText(reply)) {
+    recordGroupActivity(group, { kind: 'delivered', member: member.name, thread: strandedThread })
+    appendGroupChatEntry(
+      group,
+      { kind: 'member', name: member.name, ...(member.remoteSource ? { source: member.connectionLabel || member.connectionId } : {}) },
+      reply,
+      strandedThread
+    )
+    updateGroupChat(group, r => {
+      r.watermarks[`${strandedThread}::${memberKey}`] = r.log.length
+      return r
+    })
   }
 }
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -1527,6 +1527,40 @@ test('stranded harvest: a timed-out turn whose reply landed late posts into the 
   assert.equal(gc.$groupChats.get().Late.stranded.research, undefined, 'marker consumed')
 })
 
+test('stranded harvest: a rescued reply prefers the substantive answer over a trailing synthetic (pass)', async () => {
+  const gc = load(() => '(pass)')
+
+  // #94376 class bug at the second call site: the late-landing turn ends
+  // with a Codex intent-ack continuation nudge that gets a synthetic
+  // "(pass)" — the harvest must still surface the substantive answer that
+  // preceded it, not the trailing pass.
+  gc.updateGroupChat('Rescue', r => {
+    r.stranded = { research: 0 }
+    r.sessions = { research: 'sid-research' }
+    return r
+  })
+  gc.sessions.set('sid-research', {
+    stored: 'sid-research',
+    runtime: 'rt-research',
+    profile: 'research',
+    title: 'Group: Rescue',
+    messages: [
+      { role: 'user', content: 'the turn prompt' },
+      { role: 'assistant', content: 'Here is the full research result, delivered late.' },
+      { role: 'user', content: '[System: Continue now. Execute the required tool calls and only send your final answer after completing the task.]' },
+      { role: 'assistant', content: '(pass)' }
+    ]
+  })
+
+  await gc.harvestStrandedGroupReply('Rescue', { name: 'research', title: '' })
+
+  const log = roomLog(gc, 'Rescue')
+  assert.equal(log.length, 1)
+  assert.equal(log[0].from.name, 'research')
+  assert.match(log[0].text, /delivered late/)
+  assert.equal(gc.$groupChats.get().Rescue.stranded.research, undefined, 'marker consumed')
+})
+
 test('stranded + still busy: the round loop never re-submits into a member whose harvest just confirmed they are still running', async () => {
   // research is confirmed busy on exactly its first two session.resume
   // calls — the number of harvest-only touches the FIXED code makes across

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-turn-lease.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-turn-lease.test.mjs
@@ -18,7 +18,7 @@ const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf
 /** Harness mirroring group-chat-attachments.test.mjs, extended with a
  *  refcounted host.requestProfile/host.retainProfile pair so socket lease
  *  lifetimes are assertable. */
-function load({ failFirstSubmitWith = null, failEverySubmitWith = null, reply = 'hello from turn' } = {}) {
+function load({ failFirstSubmitWith = null, failEverySubmitWith = null, reply = 'hello from turn', replyMessages = null } = {}) {
   const values = new Map()
   const atom = initial => {
     const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
@@ -114,7 +114,13 @@ function load({ failFirstSubmitWith = null, failEverySubmitWith = null, reply = 
         throw err
       }
       session.messages.push({ role: 'user', content: params.text })
-      session.messages.push({ role: 'assistant', content: reply })
+      if (replyMessages) {
+        for (const msg of replyMessages) {
+          session.messages.push(msg)
+        }
+      } else {
+        session.messages.push({ role: 'assistant', content: reply })
+      }
       return {}
     }
     return {}
@@ -269,4 +275,29 @@ test('hosts without retainProfile still run the turn (feature detection)', async
   const reply = await gc.runGroupChatMemberTurn('Room', ROUTED_MEMBER, 'hi', 't1', [])
 
   assert.equal(reply, 'legacy ok')
+})
+
+// #94376: a Codex intent-ack continuation nudge can land a substantive
+// answer, then get a synthetic "(pass)" reply to the nudge itself. The
+// substantive answer must still surface, not the trailing pass.
+test('a substantive answer followed by a synthetic continuation (pass) still surfaces the answer', async () => {
+  const gc = load({
+    replyMessages: [
+      { role: 'assistant', content: "Yes. I welcomed them, and I'll review their first assignments with them." },
+      { role: 'user', content: '[System: Continue now. Execute the required tool calls and only send your final answer after completing the task.]' },
+      { role: 'assistant', content: '(pass)' }
+    ]
+  })
+
+  const reply = await gc.runGroupChatMemberTurn('Room', LOCAL_MEMBER, 'Did you welcome the new teammate?', 't1', [])
+
+  assert.equal(reply, "Yes. I welcomed them, and I'll review their first assignments with them.")
+})
+
+test('a genuine pass-only turn (no prior substantive answer) still reads as silent', async () => {
+  const gc = load({ reply: '(pass)' })
+
+  const reply = await gc.runGroupChatMemberTurn('Room', LOCAL_MEMBER, 'anything new?', 't1', [])
+
+  assert.equal(reply, '(pass)')
 })


### PR DESCRIPTION
## What does this PR do?

Fixes a Bot Mode group chat bug: a completed, substantive member reply can be silently discarded when the Codex intent-ack continuation guard fires on it.

Sequence that triggers the bug:

1. A member gives a complete, short group answer that happens to contain a future-tense ack phrase ("I'll ...") plus an action word ("review"), and the generated group-turn prompt contains workspace/project vocabulary.
2. `agent/conversation_loop.py` treats that as an unfinished Codex intermediate ack and appends `_CODEX_ACK_CONTINUATION_NUDGE` as a synthetic follow-up user message.
3. The member has nothing left to add and returns `(pass)` to the nudge.
4. `runGroupChatMemberTurn` (and the analogous stranded-turn path, `harvestStrandedGroupReply`) in `apps/desktop/src/plugins/hermes-bots/plugin.js` scanned backward for the *last* assistant message and returned it as-is — which is the synthetic `(pass)`, not the real answer. The room shows the member working, then passing, with the actual answer never appearing.

Both functions now scan the messages appended during the current turn for the last **substantive** (non-pass) assistant reply, and only fall back to a pass when no substantive reply exists in that window. A genuine pass-only turn (no prior substantive answer) is unaffected and still reads as silent.

This is the Bot Mode-side fix option from the two proposed in the issue — it's self-contained to the plugin and doesn't touch the agent-core intent-ack heuristic, which still needs to keep firing for genuinely unfinished action announcements in ordinary task sessions.

## Related Issue

Fixes #94376

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js`
  - New helper `pickGroupTurnReply(messages, before)`: scans messages appended since the turn's baseline newest-first, preferring the last substantive (non-pass) assistant reply over a trailing pass.
  - `runGroupChatMemberTurnLeased`'s finished-turn branch now uses this helper instead of returning the first (i.e. last-chronological) assistant message it finds.
  - `harvestStrandedGroupReply`'s late-reply scan uses the same helper, fixing the identical bug for replies that land after the turn timed out.
- `apps/desktop/src/plugins/hermes-bots/tests/group-turn-lease.test.mjs`
  - Extended the test harness with a `replyMessages` option to stage a multi-message turn (substantive answer → synthetic continuation → pass).
  - Added: a substantive answer followed by a synthetic continuation `(pass)` still surfaces the answer.
  - Added: a genuine pass-only turn still reads as silent (no regression).

## How to Test

1. `node --test apps/desktop/src/plugins/hermes-bots/tests/group-turn-lease.test.mjs`
2. `node --test apps/desktop/src/plugins/hermes-bots/tests/*.test.mjs` (full plugin suite)

### Proof the new test fails without the fix

Reverted `plugin.js` to `HEAD~0` (pre-fix) while keeping the new test, then ran the targeted test file:

```
not ok 8 - a substantive answer followed by a synthetic continuation (pass) still surfaces the answer
  error: |-
    Expected values to be strictly equal:
    + actual - expected

    + '(pass)'
    - "Yes. I welcomed them, and I'll review their first assignments with them."
```

The genuine-pass regression test (`a genuine pass-only turn (no prior substantive answer) still reads as silent`) still passed in that same run, confirming the assertion actually depends on the fix rather than being a tautology.

### Full suite with the fix applied

```
$ node --test apps/desktop/src/plugins/hermes-bots/tests/*.test.mjs
...
1..558
# tests 558
# pass 558
# fail 0
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, this is a desktop-plugin-only (JS) change; see the `node --test` output above instead
- [x] I've added tests for my changes
- [ ] I've tested on my platform — not run in an Electron shell in this sandbox; verified via the plugin's `node --test` harness only

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, behavior-only fix, no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — pure renderer/plugin JS, platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## AI assistance disclosure

This fix was authored by an AI coding agent (Claude) operating autonomously against the public issue, with the diff and test results verified before pushing.
