### PR TITLE
fix(cli): preserve top-level help line breaks

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -13,6 +13,24 @@ because its dispatch is tightly coupled to module-level ``cmd_*`` functions.
 import argparse
 
 
+class _NoWrapHelpFormatter(argparse.RawDescriptionHelpFormatter):
+    """Keep top-level CLI help on the lines authored by the parser."""
+
+    def __init__(self, prog, indent_increment=2, max_help_position=24):
+        # Help is also consumed by terminal tools and pagers. A large formatter
+        # width prevents argparse from inserting terminal-width line breaks;
+        # explicit newlines in descriptions and epilogues remain intact.
+        super().__init__(
+            prog,
+            indent_increment=indent_increment,
+            max_help_position=max_help_position,
+            width=10_000,
+        )
+
+    def _split_lines(self, text, width):
+        return text.splitlines() or [""]
+
+
 # `--profile` / `-p` is consumed by ``main._apply_profile_override`` before
 # argparse runs (it sets ``HERMES_HOME`` and strips itself from ``sys.argv``),
 # so it isn't on the parser. Listed here so all "carry over on relaunch"
@@ -92,7 +110,7 @@ def build_top_level_parser():
     parser = argparse.ArgumentParser(
         prog="hermes",
         description="Hermes Agent - AI assistant with tool-calling capabilities",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=_NoWrapHelpFormatter,
         epilog=_EPILOGUE,
     )
 
@@ -302,12 +320,14 @@ def build_top_level_parser():
     # test_argparse_flag_propagation.py).
     _inherited_flag(
         chat_parser,
-        "-m", "--model",
+        "-m",
+        "--model",
         default=argparse.SUPPRESS,
         help="Model to use (e.g., anthropic/claude-sonnet-4)",
     )
     chat_parser.add_argument(
-        "-t", "--toolsets",
+        "-t",
+        "--toolsets",
         default=argparse.SUPPRESS,
         help="Comma-separated toolsets to enable",
     )

--- a/tests/cli/test_cli_help_formatting.py
+++ b/tests/cli/test_cli_help_formatting.py
@@ -1,0 +1,12 @@
+"""Tests for stable, non-wrapped top-level CLI help output."""
+
+from hermes_cli._parser import build_top_level_parser
+
+
+def test_top_level_help_does_not_insert_terminal_width_wraps():
+    parser, _, _ = build_top_level_parser()
+
+    help_text = parser.format_help()
+
+    assert "No banner, no spinner, no tool previews" in help_text
+    assert "No banner, no spinner,\n" not in help_text


### PR DESCRIPTION
## What does this PR do?

Fixes the top-level `hermes help`/`hermes --help` output so argparse does not insert terminal-width hard wraps into option descriptions. Explicit newlines in the authored epilogue remain unchanged.

## Problem

The parser used `RawDescriptionHelpFormatter`, which preserves the epilogue but still wraps option help text at the detected terminal width. This makes help output harder to read in pagers and harder to parse as stable text.

## Root Cause

Argparse's default `_split_lines` and formatter width remained active for option descriptions.

## Solution

Use a dedicated top-level formatter with a large width and line-preserving `_split_lines`, plus a focused test that protects the no-wrap contract.

## Related Issue

Fixes #94345

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- Add `_NoWrapHelpFormatter` in `hermes_cli/_parser.py`.
- Use it for the top-level parser.
- Add `tests/cli/test_cli_help_formatting.py`.

## Reviewer Test Plan

### How to verify

1. Run `py -m hermes_cli.main --help` and inspect the option descriptions.
2. Confirm the one-shot help text remains on one authored line instead of splitting after `No banner, no spinner,`.
3. Run the focused pytest test to verify the parser contract.

### Evidence (Before & After)

Before: the baseline parser contained `No banner, no spinner,\n` and wrapped option help at the terminal width.

After: the focused test passes, and the CLI help keeps that description on one line while retaining explicit epilogue newlines.

### Tested on

| OS | Status |
|---|---|
| Windows 11 | ✅ |

## Testing

- Baseline direct parser probe reproduced the unwanted wrap.
- `py -m pytest tests/cli/test_cli_help_formatting.py -q`: 1 passed.
- `py -m ruff check hermes_cli/_parser.py tests/cli/test_cli_help_formatting.py`: passed.
- `py -m ruff format --check hermes_cli/_parser.py tests/cli/test_cli_help_formatting.py`: passed after formatting the touched parser file; the baseline parser was already not clean under the installed Ruff version.
- `py -m compileall -q hermes_cli/_parser.py tests/cli/test_cli_help_formatting.py`: passed.
- `git diff --check`: passed.
- Full `pytest tests/ -q`: not run; the change is isolated to top-level argparse formatting and the focused parser test covers it.

## Compatibility/Risk

Non-breaking CLI presentation change. Command parsing and option semantics are unchanged; only inserted terminal-width wrapping is removed from top-level help output. Explicit line breaks remain supported.

## Notes for Reviewer

This contribution was AI-assisted. The diff is limited to the parser formatter and its regression test. No comments, claims, assignments, review replies, reruns, or merges were made.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing PRs for duplicates
- [x] The PR contains only changes related to this fix
- [x] I've run the focused test and lint/format gates
- [x] I've added a regression test
- [x] Tested on Windows 11

### Documentation & Housekeeping

- [x] No documentation update is needed; this changes help formatting only.
- [x] No config or architecture change is included.
- [x] Cross-platform impact is limited to stdlib argparse formatting.

## Screenshots / Logs

No screenshot is needed for this text-output formatting fix; the baseline and final CLI probes are described above.