### PR TITLE
fix(cli): stop telling users to run `doctor --fix` for npm vulnerabilities it can't fix

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2446,7 +2446,12 @@ def run_doctor(args):
                             "errors with an arborist crash it's a known npm bug — clears "
                             "via a lockfile bump"
                         )
-                    issues.append(
+                    # `--fix` never runs npm here (workspace-scoped `npm audit
+                    # fix` crashes with a known arborist bug, see above; the
+                    # root-scoped fix_cmd is only ever printed, not executed),
+                    # so this can't land in `issues` — that list drives the
+                    # "run hermes doctor --fix" tip, which would be false.
+                    manual_issues.append(
                         f"{label} has {total} npm "
                         f"{'vulnerability' if total == 1 else 'vulnerabilities'}"
                     )
@@ -3154,7 +3159,7 @@ def run_doctor(args):
         for i, issue in enumerate(remaining_issues, 1):
             print(f"  {i}. {issue}")
         print()
-        if not should_fix:
+        if not should_fix and issues:
             print(color("  Tip: run 'hermes doctor --fix' to auto-fix what's possible.", Colors.DIM))
     else:
         print(color("─" * 60, Colors.GREEN))

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -371,6 +371,51 @@ def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkey
     assert "docker not found (optional)" not in out
 
 
+def test_run_doctor_omits_fix_tip_when_only_npm_vulnerabilities_remain(monkeypatch, tmp_path):
+    """#94375: `npm audit fix --workspace <name>` crashes with a known
+    arborist bug (see doctor.py's own `fix_cmd = None` comment for
+    --workspace-scoped audits), and `hermes doctor --fix` never actually
+    invokes npm here regardless of scope. Reporting only such vulnerabilities
+    and still printing "run 'hermes doctor --fix'" tells the user a flag will
+    fix something it provably cannot."""
+    import json as _json
+    from types import SimpleNamespace as _SimpleNamespace
+
+    helper = TestDoctorMemoryProviderSection()
+    project = tmp_path / "project"
+    (project / "node_modules").mkdir(parents=True, exist_ok=True)
+    # Keep unrelated checks quiet so the only remaining issue is the npm one:
+    # a configured .env avoids the real "Run 'hermes setup'" issue.
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".env").write_text("OPENAI_API_KEY=sk-test\n", encoding="utf-8")
+
+    real_which = doctor_mod.shutil.which
+
+    def fake_which(cmd):
+        if cmd in {"node", "npm"}:
+            return f"/usr/bin/{cmd}"
+        return real_which(cmd)
+
+    monkeypatch.setattr(doctor_mod.shutil, "which", fake_which)
+
+    real_run = doctor_mod.subprocess.run
+
+    def fake_run(cmd, **kwargs):
+        if "audit" in cmd:
+            high = 4 if "web" in cmd else 0
+            payload = {"metadata": {"vulnerabilities": {"critical": 0, "high": high, "moderate": 0}}}
+            return _SimpleNamespace(stdout=_json.dumps(payload), stderr="", returncode=0)
+        return real_run(cmd, **kwargs)
+
+    monkeypatch.setattr(doctor_mod.subprocess, "run", fake_run)
+
+    out = helper._run_doctor_and_capture(monkeypatch, tmp_path, provider="")
+
+    assert "web workspace has 4 npm vulnerabilities" in out
+    assert "Tip: run 'hermes doctor --fix'" not in out
+
+
 def test_run_doctor_accepts_named_provider_from_providers_section(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## What does this PR do?

`hermes doctor` reports npm vulnerabilities in the `web` and `ui-tui`
workspaces, and its footer says "Tip: run 'hermes doctor --fix' to auto-fix
what's possible." Running `hermes doctor --fix` does nothing for these
vulnerabilities: `npm audit fix --workspace <name>` crashes with a known
arborist bug (`hermes_cli/doctor.py` already documents this — it sets
`fix_cmd = None` for workspace-scoped audits precisely because there's no
safe automatic fix), and more fundamentally the entire npm-audit block never
checks `should_fix` at all, so `--fix` never invokes any npm command
regardless of scope. The reporter (#94375) followed the tip, got nothing,
then tried the suggested manual commands and hit an unrelated `ERESOLVE`
peer-dependency error trying to fully resolve the monorepo's dependency tree.

The npm-audit findings were being appended to the generic `issues` list,
which drives that footer tip unconditionally whenever anything remains. The
codebase already has a `manual_issues` list for exactly this situation —
findings `--fix` cannot resolve (see the security-advisory and MCP-security
checks earlier in the same function) — but the npm-audit block wasn't using
it, so the tip fired even when literally every remaining item was one of
these un-autofixable npm entries.

## Related Issue

Fixes #94375

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/doctor.py`: route npm-audit vulnerability findings into
  `manual_issues` instead of `issues` (consistent with how the file already
  treats other not-auto-fixable findings), and only print the "run
  `hermes doctor --fix`" tip when the auto-fixable `issues` list is
  non-empty.
- `tests/hermes_cli/test_doctor.py`: added
  `test_run_doctor_omits_fix_tip_when_only_npm_vulnerabilities_remain`,
  which mocks `npm audit --json` to report vulnerabilities only in the `web`
  workspace and asserts the finding is reported but the misleading `--fix`
  tip is not.

## How to Test

1. Reproduce: mock `npm`/`node` as present and `npm audit --json` to report
   4 high-severity vulnerabilities for the `web` workspace only (all other
   audit targets clean), then run `hermes_cli.doctor.run_doctor(Namespace(fix=False))`.
2. Before this fix, the summary still printed "Tip: run 'hermes doctor
   --fix' to auto-fix what's possible" even though nothing about npm
   vulnerabilities is ever touched by `--fix`. Confirmed by reverting
   `hermes_cli/doctor.py` to the prior commit (`git checkout HEAD~1 --
   hermes_cli/doctor.py`) and re-running the new test — it fails:
   ```
   FAILED tests/hermes_cli/test_doctor.py::test_run_doctor_omits_fix_tip_when_only_npm_vulnerabilities_remain
   - assert "Tip: run 'h...octor --fix'" not in '...'
     "Tip: run 'hermes doctor --fix'" is contained here:
       [all]'
       Tip: run 'hermes doctor --fix' to auto-fix what's possible.
   ```
3. After this fix (`git checkout HEAD -- hermes_cli/doctor.py`), the same
   test passes: the npm vulnerability is still reported, but the tip is
   gone since it's the only remaining issue and it's not auto-fixable.

Actual output:

```
$ source venv/bin/activate && python -m pytest tests/hermes_cli/test_doctor.py -q
57 passed in 15.88s

$ python -m pytest tests/hermes_cli/test_doctor.py -k npm_vulnerabilities_remain -v
tests/hermes_cli/test_doctor.py::test_run_doctor_omits_fix_tip_when_only_npm_vulnerabilities_remain PASSED

$ python -m pytest tests/hermes_cli/test_doctor_journal_modes.py tests/hermes_cli/test_doctor_command_install.py tests/hermes_cli/test_doctor_dedicated_provider_skip.py tests/hermes_cli/test_doctor_live.py -q
66 passed in 3.39s

$ ruff check hermes_cli/doctor.py tests/hermes_cli/test_doctor.py
All checks passed!
```

Note: I did not attempt to make workspace-scoped `npm audit fix` actually
succeed (e.g. by forcing `--legacy-peer-deps` or bumping the lockfile) —
that's the maintainers' call on the dependency tree, and per this repo's own
guidance that's out of scope for an external contribution. This PR only
makes the tool stop claiming it can do something it demonstrably can't.

*Disclosure: this PR was prepared with AI assistance (Claude).*
