### PR TITLE
fix(gateway-windows): write .vbs launchers as utf-16 with BOM

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -575,7 +575,12 @@ def _write_task_script() -> Path:
     # into string literals (HERMES_HOME with é/ü/CJK usernames), so the
     # launcher's own FileExists guard silently quits at every logon. Same
     # reasoning as the utf-16 task XML below.
-    vbs_tmp.write_text(vbs_content, encoding="utf-16", newline="")
+    #
+    # utf-16-LE + an explicit BOM rather than bare "utf-16": the latter follows
+    # the WRITING platform's native byte order, so the \xff\xfe guarantee would
+    # depend on the host that generated the file. Every Windows target is
+    # little-endian, so pin it (#94391 review).
+    vbs_tmp.write_text("\ufeff" + vbs_content, encoding="utf-16-le", newline="")
     vbs_tmp.replace(vbs_path)
     return script_path
 
@@ -712,9 +717,14 @@ def _install_startup_entry(script_path: Path) -> Path:
     entry = get_startup_entry_path()
     entry.parent.mkdir(parents=True, exist_ok=True)
     tmp = entry.with_suffix(".tmp")
-    # utf-16 with BOM so wscript decodes non-ASCII path literals correctly
-    # (see the comment in _write_task_script).
-    tmp.write_text(_build_startup_launcher(script_path), encoding="utf-16", newline="")
+    # utf-16-LE + explicit BOM so wscript decodes non-ASCII path literals
+    # correctly regardless of the writing platform's byte order (see the
+    # comment in _write_task_script).
+    tmp.write_text(
+        "\ufeff" + _build_startup_launcher(script_path),
+        encoding="utf-16-le",
+        newline="",
+    )
     tmp.replace(entry)
     legacy_entry = _legacy_startup_entry_path()
     try:

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -570,7 +570,12 @@ def _write_task_script() -> Path:
     vbs_content = _build_gateway_vbs_script(python_path, working_dir, hermes_home, profile_arg)
     vbs_path = script_path.with_suffix(".vbs")
     vbs_tmp = vbs_path.with_name(vbs_path.name + ".tmp")
-    vbs_tmp.write_text(vbs_content, encoding="utf-8", newline="")
+    # wscript/cscript decode .vbs as ANSI (cp1252 on Western locales) unless the
+    # file carries a UTF-16 BOM. UTF-8-no-BOM mangles any non-ASCII path baked
+    # into string literals (HERMES_HOME with é/ü/CJK usernames), so the
+    # launcher's own FileExists guard silently quits at every logon. Same
+    # reasoning as the utf-16 task XML below.
+    vbs_tmp.write_text(vbs_content, encoding="utf-16", newline="")
     vbs_tmp.replace(vbs_path)
     return script_path
 
@@ -707,7 +712,9 @@ def _install_startup_entry(script_path: Path) -> Path:
     entry = get_startup_entry_path()
     entry.parent.mkdir(parents=True, exist_ok=True)
     tmp = entry.with_suffix(".tmp")
-    tmp.write_text(_build_startup_launcher(script_path), encoding="utf-8", newline="")
+    # utf-16 with BOM so wscript decodes non-ASCII path literals correctly
+    # (see the comment in _write_task_script).
+    tmp.write_text(_build_startup_launcher(script_path), encoding="utf-16", newline="")
     tmp.replace(entry)
     legacy_entry = _legacy_startup_entry_path()
     try:

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -344,17 +344,30 @@ def test_generated_vbs_launchers_carry_utf16_bom(monkeypatch, tmp_path):
 
     script = gateway_windows._write_task_script()
     task_raw = script.with_suffix(".vbs").read_bytes()
-    assert task_raw.startswith(b"\xff\xfe"), "task .vbs must carry a UTF-16 BOM"
+    # Little-endian BOM specifically: the writer pins utf-16-LE so the byte
+    # order does not depend on the platform that generated the file.
+    assert task_raw.startswith(b"\xff\xfe"), "task .vbs must carry a UTF-16LE BOM"
     task_text = task_raw.decode("utf-16")
+    # THE regression assertion: the non-ASCII HERMES_HOME segment must survive
+    # inside the embedded string literal. The script path alone sits under an
+    # all-ASCII tmp_path, so asserting on it would pass even with a BOM-less
+    # writer mangling the home path (#94391 review nit 1).
+    assert "hömè-höme" in task_text, (
+        "non-ASCII HERMES_HOME must survive in the task launcher's literals"
+    )
     assert str(script.with_suffix(".vbs")) in gateway_windows._build_startup_launcher(script)
 
     entry = gateway_windows._install_startup_entry(script)
     entry_raw = entry.read_bytes()
-    assert entry_raw.startswith(b"\xff\xfe"), "startup .vbs must carry a UTF-16 BOM"
+    assert entry_raw.startswith(b"\xff\xfe"), "startup .vbs must carry a UTF-16LE BOM"
     entry_text = entry_raw.decode("utf-16")
     assert 'target = "' in entry_text
     assert str(script.with_suffix(".vbs")) in entry_text
-    assert task_text  # decoded cleanly
+    # Exactly one BOM, not a doubled one — the writer prepends U+FEFF and
+    # encodes with utf-16-LE (which adds none), so a future switch back to
+    # bare "utf-16" would show up here as b"\xff\xfe\xff\xfe".
+    assert not task_raw.startswith(b"\xff\xfe\xff\xfe")
+    assert not entry_raw.startswith(b"\xff\xfe\xff\xfe")
 
 
 def test_gateway_vbs_script_is_console_less(monkeypatch):

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -314,6 +314,49 @@ def test_install_scheduled_task_recreates_instead_of_change(monkeypatch, tmp_pat
     assert "cmd.exe" not in xml_seen["text"]
 
 
+@pytest.mark.windows_only
+def test_generated_vbs_launchers_carry_utf16_bom(monkeypatch, tmp_path):
+    """Generated .vbs launchers must be utf-16 with BOM, not UTF-8.
+
+    wscript/cscript decode .vbs as ANSI (cp1252 on Western locales) unless a
+    UTF-16 BOM is present. With a non-ASCII HERMES_HOME the embedded path
+    literal mojibakes under the old utf-8-no-BOM writer, so the startup
+    launcher's own FileExists guard quits silently at every logon. Verified
+    with a live cscript probe: utf-8-noBOM -> QUIT-MISS, utf-16 -> FOUND.
+    """
+    project = tmp_path / "project"
+    scripts = project / "venv" / "Scripts"
+    base = tmp_path / "uv" / "py"
+    scripts.mkdir(parents=True)
+    base.mkdir(parents=True)
+    venv_python = scripts / "python.exe"
+    venv_python.write_text("", encoding="utf-8")
+    (project / "venv" / "pyvenv.cfg").write_text(f"home = {base}\n", encoding="utf-8")
+
+    home = tmp_path / "hömè-höme"
+    home.mkdir()
+    monkeypatch.setattr(gateway, "PROJECT_ROOT", project)
+    monkeypatch.setattr(gateway, "get_python_path", lambda: str(venv_python))
+    monkeypatch.setattr(gateway, "_profile_arg", lambda hermes_home: "")
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: str(home))
+    monkeypatch.setattr(gateway_windows, "get_task_name", lambda: "Hermes_Gateway_alice")
+    monkeypatch.setenv("APPDATA", str(tmp_path / "appdata"))
+
+    script = gateway_windows._write_task_script()
+    task_raw = script.with_suffix(".vbs").read_bytes()
+    assert task_raw.startswith(b"\xff\xfe"), "task .vbs must carry a UTF-16 BOM"
+    task_text = task_raw.decode("utf-16")
+    assert str(script.with_suffix(".vbs")) in gateway_windows._build_startup_launcher(script)
+
+    entry = gateway_windows._install_startup_entry(script)
+    entry_raw = entry.read_bytes()
+    assert entry_raw.startswith(b"\xff\xfe"), "startup .vbs must carry a UTF-16 BOM"
+    entry_text = entry_raw.decode("utf-16")
+    assert 'target = "' in entry_text
+    assert str(script.with_suffix(".vbs")) in entry_text
+    assert task_text  # decoded cleanly
+
+
 def test_gateway_vbs_script_is_console_less(monkeypatch):
     """The .vbs launcher must avoid cmd.exe entirely and Run pythonw hidden
     (issue #45599 fix A: no console -> no logon CTRL_CLOSE_EVENT / 0xC000013A)."""


### PR DESCRIPTION
## Problem

`wscript.exe`/`cscript.exe` decode `.vbs` files as **ANSI (cp1252 on Western locales) unless the file carries a UTF-16 BOM**. The generated `gateway.vbs` (Scheduled Task launcher, issue #45599 fix A) and the Startup-folder fallback launcher were written `encoding="utf-8"` without BOM.

Consequence for any install whose paths contain non-ASCII characters — `C:\Users\José`, umlauts, CJK usernames are common on Windows: the non-ASCII path baked into the launcher's string literals (`target = "..."`, `sh.Run "..."`) mojibakes at parse time, and the startup launcher's own existence guard (`If Not fso.FileExists(target) Then WScript.Quit 0`) then **silently quits at every logon** — the gateway never starts, with zero diagnostics.

## Live repro (cscript probe, identical launcher targeting a non-ASCII dir)

| Written as | Result |
|---|---|
| utf-8 no BOM (current code) | `QUIT-MISS` — guard kills the launcher |
| utf-16 with BOM (this PR) | `FOUND` — target resolves |

## Fix

Both `.vbs` writers (`_write_task_script`, `_install_startup_entry`) switch to `encoding="utf-16"` — the same choice this module already makes for the schtasks task XML. The `.cmd` wrapper is unchanged: cmd.exe's batch parser has its own codepage behavior and the file is documented as a manual-run compatibility artifact only; service persistence routes through the `.vbs`.

## Verification

New Windows-only regression test asserts both generated launchers start with the `FF FE` BOM and decode cleanly to the expected content. `tests/hermes_cli/test_gateway_windows.py`: 10/10 pass. The 3 failures in `test_service_manager.py` are pre-existing on clean `main` on this host (POSIX s6 tests) — reproduced with the change stashed.