### PR TITLE
fix(desktop): Windows right-click Paste no longer grayed out with text on the clipboard (#91553, salvage #91576)

### DIFF
--- a/apps/desktop/src/app/context-menu/app-context-menu.test.tsx
+++ b/apps/desktop/src/app/context-menu/app-context-menu.test.tsx
@@ -335,22 +335,12 @@ describe('AppContextMenu', () => {
     expect(item('Select all').getAttribute('data-disabled')).not.toBeNull()
   })
 
-  it('grays out paste until the clipboard reports text', async () => {
-    const readClipboard = vi.fn().mockResolvedValue('clip content')
-
-    installBridge({ readClipboard: readClipboard as unknown as Window['hermesDesktop']['readClipboard'] })
-    mountMenu()
-    const host = attach('<textarea>text</textarea>')
-
-    fireEvent.contextMenu(host.querySelector('textarea')!)
-
-    // The clipboard read is async — the item enables when it lands.
-    const pasteItem = (await screen.findByText('Paste')).closest('[data-slot="dropdown-menu-item"]')!
-
-    await waitFor(() => expect(pasteItem.getAttribute('data-disabled')).toBeNull())
-  })
-
-  it('keeps paste grayed out on an empty clipboard', async () => {
+  it('keeps paste clickable even when the clipboard probe reports empty', async () => {
+    // #91553: the dom paste action runs webContents.paste() in main — the
+    // same path Ctrl+V takes, which resolves the system clipboard itself.
+    // A renderer-side probe that comes back empty (as the Win32
+    // clipboard.readText() bridge can while that path succeeds) must not
+    // gray the item out; pasting on a truly empty clipboard is a no-op.
     const readClipboard = vi.fn().mockResolvedValue('')
 
     installBridge({ readClipboard: readClipboard as unknown as Window['hermesDesktop']['readClipboard'] })
@@ -361,8 +351,19 @@ describe('AppContextMenu', () => {
 
     const pasteItem = (await screen.findByText('Paste')).closest('[data-slot="dropdown-menu-item"]')!
 
-    await waitFor(() => expect(readClipboard).toHaveBeenCalled())
-    expect(pasteItem.getAttribute('data-disabled')).not.toBeNull()
+    expect(pasteItem.getAttribute('data-disabled')).toBeNull()
+  })
+
+  it('keeps paste clickable when the bridge has no clipboard read at all', async () => {
+    installBridge()
+    mountMenu()
+    const host = attach('<textarea>text</textarea>')
+
+    fireEvent.contextMenu(host.querySelector('textarea')!)
+
+    const pasteItem = (await screen.findByText('Paste')).closest('[data-slot="dropdown-menu-item"]')!
+
+    expect(pasteItem.getAttribute('data-disabled')).toBeNull()
   })
 
   it('offers the window verbs on bare chrome', async () => {

--- a/apps/desktop/src/app/context-menu/app-context-menu.tsx
+++ b/apps/desktop/src/app/context-menu/app-context-menu.tsx
@@ -307,8 +307,13 @@ function domSections(open: Extract<OpenContextMenu, { kind: 'dom' }>, t: Transla
     // SELECTION, so they need selected text — not just field content.
     // Inputs and textareas carry their selection on the element (Chrome
     // never reflects it into window.getSelection()); contenteditable uses
-    // the document selection the resolver captured. Paste needs a
-    // non-empty clipboard, select all needs the field to hold anything.
+    // the document selection the resolver captured. Select all needs the
+    // field to hold anything. Paste is intentionally NOT gated on a
+    // clipboard probe: its action is webContents.paste() in main — the
+    // same path Ctrl+V takes — which resolves the system clipboard itself,
+    // while the renderer-side readClipboard probe can report empty on
+    // Windows even when that path succeeds (#91553). Pasting with an
+    // empty clipboard is a harmless no-op, so the item fails open.
     const formField =
       target.editable instanceof HTMLInputElement || target.editable instanceof HTMLTextAreaElement
         ? target.editable
@@ -338,7 +343,6 @@ function domSections(open: Extract<OpenContextMenu, { kind: 'dom' }>, t: Transla
         shortcut={EDIT_SHORTCUTS.copy}
       />,
       <Item
-        disabled={!open.clipboardHasText}
         key="edit-paste"
         label={copy.edit.paste}
         onSelect={() => editableCommand('paste')}

--- a/apps/desktop/src/app/context-menu/store.ts
+++ b/apps/desktop/src/app/context-menu/store.ts
@@ -51,9 +51,6 @@ export type OpenContextMenu =
       y: number
       target: ContextMenuDomTarget
       spellcheck: SpellcheckContext | null
-      /** Whether the clipboard held text when the menu opened (grays out
-       *  Paste). Arrives async right after open; false until then. */
-      clipboardHasText: boolean
     }
   | {
       kind: 'guest'
@@ -67,7 +64,12 @@ export type OpenContextMenu =
       x: number
       y: number
       terminal: TerminalMenuHandle
-      /** Same async clipboard fact as the dom shape, for the paste item. */
+      /** Whether the clipboard held text when the menu opened (grays out
+       *  Paste). Arrives async right after open; false until then. Unlike
+       *  the dom menu — whose paste runs webContents.paste() in main and
+       *  must NOT depend on this probe (#91553) — the terminal paste item
+       *  inserts the readClipboard() text itself, so its gate and its
+       *  action share one mechanism. */
       clipboardHasText: boolean
     }
 
@@ -75,17 +77,18 @@ export type OpenContextMenu =
  *  menus can never be open at once. */
 export const $contextMenu = atom<null | OpenContextMenu>(null)
 
-/** Read the clipboard and flag the OPEN menu when text is available. The
- *  read is an IPC round-trip, so the menu opens first (empty-clipboard
- *  verdict) and the flag lands a tick later — same late-fact pattern as
- *  spellcheck. Guarded by identity: a stale read never flags a newer menu. */
-function probeClipboard(opened: OpenContextMenu): void {
+/** Read the clipboard and flag the OPEN terminal menu when text is
+ *  available. The read is an IPC round-trip, so the menu opens first
+ *  (empty-clipboard verdict) and the flag lands a tick later — same
+ *  late-fact pattern as spellcheck. Guarded by identity: a stale read
+ *  never flags a newer menu. */
+function probeClipboard(opened: Extract<OpenContextMenu, { kind: 'terminal' }>): void {
   void window.hermesDesktop
     ?.readClipboard?.()
     .then((text: string) => {
       const current = $contextMenu.get()
 
-      if (current === opened && (current.kind === 'dom' || current.kind === 'terminal') && text) {
+      if (current === opened && current.kind === 'terminal' && text) {
         $contextMenu.set({ ...current, clipboardHasText: true })
       }
     })
@@ -93,13 +96,7 @@ function probeClipboard(opened: OpenContextMenu): void {
 }
 
 export function openDomContextMenu(x: number, y: number, target: ContextMenuDomTarget): void {
-  const opened: OpenContextMenu = { kind: 'dom', x, y, target, spellcheck: null, clipboardHasText: false }
-
-  $contextMenu.set(opened)
-
-  if (target.editable) {
-    probeClipboard(opened)
-  }
+  $contextMenu.set({ kind: 'dom', x, y, target, spellcheck: null })
 }
 
 export function openGuestContextMenu(x: number, y: number, params: GuestMenuParams, guest: GuestMenuHandle): void {


### PR DESCRIPTION
## Summary

The Desktop right-click menu's Paste item no longer stays grayed out on Windows when the clipboard actually has text (#91553, salvage of #91576 by @Enough1122).

Root cause: the dom edit menu gated Paste on a renderer-side probe (`readClipboard()` → main-process `clipboard.readText()`, the Win32 bridge), but the Paste action itself dispatches `webContents.paste()` — the same Chromium path Ctrl+V takes, which resolves the system clipboard on its own. On Windows the Win32 probe can report empty while that path succeeds, so the item was disabled even though pasting worked. Gate tested one mechanism; action used another.

## Changes

- `app-context-menu.tsx`: dom-menu Paste item no longer `disabled` by the clipboard probe — pasting an empty clipboard is a harmless no-op, so it fails open
- `store.ts`: `clipboardHasText` removed from the dom menu shape; the probe is kept for the terminal menu only, whose paste item inserts the `readClipboard()` text itself (gate and action share one mechanism there)
- `app-context-menu.test.tsx`: the two probe-gating tests flipped to pin the new contract (paste clickable on empty probe / missing bridge)

## Validation

| | Before | After |
|---|---|---|
| Windows, clipboard has text, probe returns empty | Paste grayed out | Paste clickable, `webContents.paste()` works |
| Terminal menu paste gating | probe-gated | unchanged (probe-gated, correct) |
| `app-context-menu.test.tsx` | — | 36/36 pass |

Cherry-picked from #91576 with @Enough1122's authorship preserved (author closed the original during a self-triage sweep; fix is correct and current).

## Infographic

![PASTE FAILS OPEN — desktop context menu clipboard probe fix](https://v3b.fal.media/files/b/0aa7b39b/ZNBIjdXhQhefV62beDIDw_Lm2FG7OS.png)
