### PR TITLE
fix(desktop): keep UI scale across in-page route navigation

### DIFF
--- a/apps/desktop/e2e/zoom-preservation.spec.ts
+++ b/apps/desktop/e2e/zoom-preservation.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * E2E regression: in-page route navigation must preserve the chosen UI scale.
+ *
+ * Desktop is a HashRouter over one file:// document, so every route is a
+ * distinct URL to Chromium's per-URL zoom store, and a route with no record of
+ * its own resolves to the host default (100%). In-page navigation fires no load
+ * or window event, so nothing re-asserted the persisted level: switching
+ * sessions dropped the window to 100% while Appearance kept reading the chosen
+ * scale (#48658, #38854, #79863).
+ *
+ * Prerequisite: `npm run build` must have been run so dist/ exists.
+ */
+
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+import { expect, test } from './test'
+
+const SCALE = 110
+
+let fixture: MockBackendFixture | null = null
+
+async function readZoomPercent(): Promise<number> {
+  return fixture!.page.evaluate(async () => {
+    const desktop = window as unknown as {
+      hermesDesktop: { zoom: { get: () => Promise<{ percent: number }> } }
+    }
+
+    return (await desktop.hermesDesktop.zoom.get()).percent
+  })
+}
+
+async function setZoomPercent(percent: number): Promise<void> {
+  await fixture!.page.evaluate(target => {
+    const desktop = window as unknown as {
+      hermesDesktop: { zoom: { setPercent: (percent: number) => void } }
+    }
+
+    desktop.hermesDesktop.zoom.setPercent(target)
+  }, percent)
+  await expect.poll(readZoomPercent).toBe(percent)
+}
+
+async function gotoRoute(route: string): Promise<void> {
+  const page = fixture!.page
+
+  await page.evaluate(target => {
+    window.location.hash = target
+  }, route)
+  await page.waitForFunction(target => window.location.hash === `#${target}`, route)
+}
+
+test.beforeAll(async () => {
+  fixture = await setupMockBackend()
+  await waitForAppReady(fixture, 120_000)
+})
+
+test.afterAll(async () => {
+  await fixture?.cleanup()
+  fixture = null
+})
+
+test('a non-default UI scale survives navigation to never-zoomed routes', async () => {
+  await setZoomPercent(SCALE)
+
+  // Routes Chromium has no zoom record for — what opening a new session looks
+  // like to the per-URL store. Pre-fix, the first hop reports 100%.
+  const fresh = `/e2e-zoom-${Date.now()}`
+
+  for (const route of [`${fresh}-one`, `${fresh}-two`, '/settings?tab=config%3Aappearance']) {
+    await gotoRoute(route)
+    await expect.poll(readZoomPercent, { message: `UI scale after navigating to ${route}` }).toBe(SCALE)
+  }
+})
+
+test('Cmd/Ctrl+N preserves a non-default UI scale', async () => {
+  const page = fixture!.page
+
+  await gotoRoute('/settings')
+  await setZoomPercent(SCALE)
+
+  await page.evaluate(() => {
+    ;(document.activeElement as HTMLElement | null)?.blur()
+  })
+  await page.keyboard.press(process.platform === 'darwin' ? 'Meta+N' : 'Control+N')
+  await page.waitForFunction(() => window.location.hash === '#/')
+
+  await expect.poll(readZoomPercent).toBe(SCALE)
+})

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6557,6 +6557,7 @@ function installPreviewShortcut(window) {
 import {
   applyZoomLevel,
   DEFAULT_ZOOM_LEVEL,
+  installZoomReassertOnNavigation,
   installZoomReassertOnWindowEvents,
   percentToZoomLevel,
   ZOOM_STEP,
@@ -11202,13 +11203,15 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
   if (zoom) {
     installZoomShortcuts(win)
     // Re-apply persisted zoom on show/restore/resize/cross-display move
-    // (Chromium can drop webContents zoom after these window transitions) and
-    // on EVERY full load — not once. The crash-recovery path calls
-    // webContents.reload(), which fires did-finish-load again after a `once`
-    // listener is spent, so zoom was silently lost on renderer crash
-    // recovery and any in-place reload/navigation (#46429).
-    installZoomReassertOnWindowEvents(win, () => restorePersistedZoomLevel(win))
-    win.webContents.on('did-finish-load', () => restorePersistedZoomLevel(win))
+    // (Chromium can drop webContents zoom after these window transitions), on
+    // EVERY full load — not once, since crash recovery reloads and would
+    // outlive a spent `once` listener (#46429) — and after in-page navigation,
+    // where Chromium applies the target hash route's own per-URL zoom record
+    // (see installZoomReassertOnNavigation; #48658, #38854, #79863).
+    const reassertZoom = () => restorePersistedZoomLevel(win)
+
+    installZoomReassertOnWindowEvents(win, reassertZoom)
+    installZoomReassertOnNavigation(win.webContents, reassertZoom)
   }
 
   installContextMenuBridge(win)

--- a/apps/desktop/electron/zoom.test.ts
+++ b/apps/desktop/electron/zoom.test.ts
@@ -12,6 +12,7 @@ import {
   applyZoomLevel,
   clampZoomLevel,
   DEFAULT_ZOOM_LEVEL,
+  installZoomReassertOnNavigation,
   installZoomReassertOnWindowEvents,
   isDebouncedReassertEvent,
   percentToZoomLevel,
@@ -290,6 +291,34 @@ test('installZoomReassertOnWindowEvents skips destroyed windows', () => {
   destroyed = true
   handlers.get('show')()
   assert.equal(calls, 0)
+})
+
+test('installZoomReassertOnNavigation covers full loads and main-frame in-page routes', () => {
+  const handlers = new Map()
+  let destroyed = false
+  let calls = 0
+
+  const webContents = {
+    isDestroyed: () => destroyed,
+    on(event, listener) {
+      handlers.set(event, listener)
+    }
+  }
+
+  installZoomReassertOnNavigation(webContents, () => {
+    calls += 1
+  })
+
+  assert.deepEqual([...handlers.keys()], ['did-finish-load', 'did-navigate-in-page'])
+
+  handlers.get('did-finish-load')()
+  handlers.get('did-navigate-in-page')({}, 'file:///app/index.html#/new', true)
+  handlers.get('did-navigate-in-page')({}, 'file:///app/frame.html#anchor', false)
+  assert.equal(calls, 2)
+
+  destroyed = true
+  handlers.get('did-navigate-in-page')({}, 'file:///app/index.html#/session/next', true)
+  assert.equal(calls, 2)
 })
 
 // Zoom-wiring contract: chat windows keep global UI zoom while fixed-size

--- a/apps/desktop/electron/zoom.ts
+++ b/apps/desktop/electron/zoom.ts
@@ -155,6 +155,45 @@ export function installZoomReassertOnWindowEvents(win, reassert, platform = proc
 }
 
 /**
+ * Chromium persists zoom PER URL, and a hash route is a distinct URL. Desktop
+ * is a HashRouter over one `file://index.html`, so every session/settings route
+ * carries its own `partition.per_host_zoom_levels` record, and an in-page
+ * navigation applies the target route's record over whatever the window is
+ * showing. A route the user never zoomed on has no record at all, so it
+ * resolves to the host default — level 0, i.e. 100%.
+ *
+ * In-page navigation fires neither `did-finish-load` nor any window event, so
+ * nothing re-asserted the persisted level: opening a fresh session dropped the
+ * window to 100% while the Appearance control kept reading the chosen scale (it
+ * only learns of changes through `hermes:zoom:changed`, which never fired —
+ * which is why touching the setting appeared to fix it). #48658, #38854, #79863.
+ *
+ * Verified on real Electron 40.10.2 / Chromium 144 (win32): at
+ * `did-navigate-in-page` the frame already reports the target route's level, so
+ * restorePersistedZoomLevel's drift-guard sees the drop and re-applies — and
+ * still no-ops when the route's record already matches. Subframe hash changes
+ * must not touch the chat window's UI scale.
+ */
+export function installZoomReassertOnNavigation(webContents, reassert) {
+  if (!webContents?.on) {
+    return
+  }
+
+  const reassertIfAlive = () => {
+    if (!webContents.isDestroyed?.()) {
+      reassert()
+    }
+  }
+
+  webContents.on('did-finish-load', reassertIfAlive)
+  webContents.on('did-navigate-in-page', (_event, _url, isMainFrame) => {
+    if (isMainFrame) {
+      reassertIfAlive()
+    }
+  })
+}
+
+/**
  * Zoom-wiring decision per window kind. Chat windows (main + session + the HUD)
  * keep global UI zoom; the pet overlay and the Quick Entry composer opt out
  * because they size their own OS window and inheriting zoom would crop or


### PR DESCRIPTION
## Summary

Switching sessions could drop the desktop window back to 100% while Appearance still showed the chosen UI Scale. Touching the setting "fixed" it.

Desktop is a HashRouter over one `file://` document, so **every route is a distinct URL to Chromium's per-URL zoom store**. A route the user never zoomed on has no record and resolves to the host default — level 0, i.e. 100%. That is every fresh session and every never-visited settings tab. In-page navigation fires neither `did-finish-load` nor any window event, so nothing re-asserted the persisted level, and the renderer kept displaying the old value because it only learns of zoom changes through `hermes:zoom:changed`, which never fired.

This is why the symptom looked random rather than constant: it only bites on routes with no zoom record yet, and once a route has one it behaves.

Fix: re-assert the persisted level on main-frame `did-navigate-in-page`, alongside the existing full-load and window-event paths. Subframe hash changes are ignored.

Reporter's own `Preferences` showed the mechanism directly — one record per route, including a session stranded at its own stale scale:

```
90%  .../dist/index.html#/20260819_115618_322fc0
90%  .../dist/index.html#/settings?tab=config%3Aappearance
85%  .../dist/index.html#/20260730_073915_865057   <- stale record, its own scale forever
```

## Verification

Reproduced and fix-verified against **real Electron 40.10.2 / Chromium 144 on win32**, driving actual `BrowserWindow` navigation rather than mocks.

Bug, on a route with no zoom record:

```
event did-navigate-in-page mainFrame=true zoomAtEvent=100%
+50ms=100%   +650ms=100%
VERDICT reset-on-recordless-route: YES (bug reproduces)
```

The `restorePersistedZoomLevel` drift-guard (skip when the level already matches) was the risk here — a re-assert that fires while the frame still reads the *old* value would be skipped and the fix would silently do nothing. Probing the real guard logic across five route hops shows it sees the drop:

```
[sess1..sess3, settings, revisit]  all 110%
applies=5 guardSkips=1
VERDICT every-route-holds-110: YES (fix works)
```

The single `guardSkip` is the revisit whose record already matched — correct no-op, no notification churn.

## Test plan

- [x] `npx vitest run --project electron electron/zoom.test.ts` — 22 passed
- [x] `npm run test:desktop:platforms` — 1735 passed, 3 skipped, 0 failed
- [x] `npx tsc -p tsconfig.electron.json --noEmit` — clean
- [x] `npx tsc -p tsconfig.e2e.json --noEmit` — clean
- [x] `npx eslint electron/zoom.ts electron/zoom.test.ts e2e/zoom-preservation.spec.ts electron/main.ts` — clean
- [x] Live win32 Electron probe: bug reproduces pre-fix, all five route hops hold 110% post-fix
- [ ] `npm run test:e2e` — **not run**, and it will not run in CI either: the `Desktop E2E` job is hard-disabled repo-wide (`if: ${{ false && … }}` in `ci.yaml`, since Aug 2, tracking #76627). The spec is written against the current fixtures but is unexecuted; the win32 probe above is what actually backs the fix. Same limitation applied to #75015's spec.

## Notes

Salvaged from @clarkvines' #75015, cherry-picked to keep authorship. That PR found the same mechanism; two things are corrected here:

- **Not macOS-specific.** The original diagnosed it as "Chromium resets file:// zoom to level 0 on hash navigation on macOS." It's the per-URL zoom store, reproduced above on Windows. Platform-scoped comments would have sent the next reader looking in the wrong place.
- **E2E covers the reported path.** The original only exercised Cmd+N; this drives navigation to recordless session routes, which is what users actually hit. The Cmd+N case is kept.

Supersedes #75015.

Fixes #48658
Fixes #38854
Fixes #79863

