### PR TITLE
feat(plugins): index hermes-a2a-peers in community seed

### DIFF
--- a/plugin-catalog/hermes-a2a-peers.yaml
+++ b/plugin-catalog/hermes-a2a-peers.yaml
@@ -1,0 +1,13 @@
+name: hermes-a2a-peers
+repo: https://github.com/kadiratesdev/hermes-a2a-peers
+sha: 1044970c70656df0b3e2957ff71bb6cb969663df
+description: Dashboard tab and /node slash command for configured a2a_agents via server-side dispatch.
+maintainer: kadiratesdev
+tier: community
+docs_url: https://github.com/kadiratesdev/hermes-a2a-peers
+platforms: []
+capabilities:
+  provides_tools: []
+  provides_hooks: []
+  provides_middleware: []
+  requires_env: []


### PR DESCRIPTION
## Summary
Adds one entry to the community plugin catalog: `plugin-catalog/hermes-a2a-peers.yaml`.

- **name:** `hermes-a2a-peers`
- **repo:** `kadiratesdev/hermes-a2a-peers`
- **What it does:** Dashboard tab for direct A2A chat with configured `a2a_agents` via server-side dispatch, plus `/node` slash command. Probe and multi-conversation per node live in the plugin; this PR only lists it.
- **pin:** tag `v0.1.0` → commit `1044970c70656df0b3e2957ff71bb6cb969663df`
- **release:** https://github.com/kadiratesdev/hermes-a2a-peers/releases/tag/v0.1.0
- Standalone MIT plugin, no core Hermes files.

## Test Plan
- [x] `python scripts/validate_plugin_catalog.py plugin-catalog/hermes-a2a-peers.yaml` → OK: 1 file(s) valid
- [x] Plugin suite at pinned tag: 75 passed (`pytest tests/ -q`, network-blocked harness)
- [ ] Plugin Catalog CI on this PR
- [ ] `hermes plugins install hermes-a2a-peers` resolves the pinned SHA