### PR TITLE
fix(state): platform-aware default path for fts5_cjk extension

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3470,11 +3470,19 @@ END;
 """
 
 def fts5_cjk_so_path() -> Path:
-    """Location of the cjk_unicode61 loadable extension."""
+    """Location of the cjk_unicode61 loadable extension.
+
+    Platform-aware default name: Windows builds produce a .dll (LoadLibrary
+    has no fixed extension convention, but a POSIX-named ".so" file would
+    never match what a Windows builder produces), POSIX builds keep the
+    libfts5_cjk.so name from native/fts5_cjk/build.sh. The
+    HERMES_FTS5_CJK_SO env override wins over either default.
+    """
     env = os.getenv("HERMES_FTS5_CJK_SO")
     if env:
         return Path(env).expanduser()
-    return get_hermes_home() / "lib" / "libfts5_cjk.so"
+    name = "libfts5_cjk.dll" if sys.platform == "win32" else "libfts5_cjk.so"
+    return get_hermes_home() / "lib" / name
 
 
 def _cjk_fts_config_enabled() -> bool:

--- a/native/fts5_cjk/README.md
+++ b/native/fts5_cjk/README.md
@@ -19,6 +19,11 @@ storage discipline as the other indexes). On a populated database, run
 
 to backfill it; new messages are indexed live either way. Set
 `sessions.cjk_fts: false` in `~/.hermes/config.yaml` to disable. Override
-the .so location with `HERMES_FTS5_CJK_SO`.
+the extension location with `HERMES_FTS5_CJK_SO`.
+
+Windows: there is no build script for this platform yet. If you compile
+`fts5_cjk.c` yourself (MSVC or MinGW), install the result as
+`~/.hermes/lib/libfts5_cjk.dll` — that is the name the default lookup
+expects on win32 — or point `HERMES_FTS5_CJK_SO` at it directly.
 
 Contributed by Soju06 (PR #65544).

--- a/tests/test_fts_cjk_bigram.py
+++ b/tests/test_fts_cjk_bigram.py
@@ -7,15 +7,40 @@ skips when no C toolchain / extension loading is available.
 import shutil
 import sqlite3
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
-from hermes_state import FTS_CJK_STALE_KEY, SessionDB
+from hermes_state import FTS_CJK_STALE_KEY, SessionDB, fts5_cjk_so_path
 
 REPO = Path(__file__).resolve().parent.parent
 SRC = REPO / "native" / "fts5_cjk" / "fts5_cjk.c"
 VENDOR = REPO / "native" / "fts5_cjk" / "vendor"
+
+
+@pytest.mark.parametrize("platform,expected_name", [
+    ("win32", "libfts5_cjk.dll"),
+    ("linux", "libfts5_cjk.so"),
+    ("darwin", "libfts5_cjk.so"),
+])
+def test_default_so_path_matches_platform(platform, expected_name, monkeypatch, tmp_path):
+    """The default extension filename must match what a builder on that
+    platform produces. The old hardcoded libfts5_cjk.so meant a Windows
+    build installed as ~/.hermes/lib/ was never found without the env
+    override."""
+    fake_home = tmp_path / "hermes-home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(fake_home))
+    monkeypatch.delenv("HERMES_FTS5_CJK_SO", raising=False)
+    monkeypatch.setattr(sys, "platform", platform)
+    assert fts5_cjk_so_path() == fake_home / "lib" / expected_name
+
+
+def test_env_override_wins_over_platform_default(monkeypatch, tmp_path):
+    override = tmp_path / "custom" / "tokenizer.dll"
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(override))
+    assert fts5_cjk_so_path() == override
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Problem

`fts5_cjk_so_path()` hardcoded the POSIX filename `libfts5_cjk.so` on every platform. On Windows, a compiled SQLite loadable extension is a `.dll` — so a user who built `native/fts5_cjk/fts5_cjk.c` (MSVC/MinGW) and installed it under `%USERPROFILE%\.hermes\lib\` was **never found by the default lookup**. The CJK bigram index silently stayed off unless they discovered the undocumented-in-practice escape hatch `HERMES_FTS5_CJK_SO`. This compounds the existing platform gap: `build.sh` is POSIX-only, so Windows was effectively excluded end-to-end.

No runtime behavior changes for POSIX: same name, same directory, env override still wins.

## Fix

- Default filename follows `sys.platform`: `libfts5_cjk.dll` on win32, `libfts5_cjk.so` elsewhere. `HERMES_FTS5_CJK_SO` override unchanged and still takes precedence.
- `native/fts5_cjk/README.md` documents the Windows story: no official build script yet, install as `~/.hermes/lib/libfts5_cjk.dll` or point the env var at the artifact.

## Verification

New tests in `tests/test_fts_cjk_bigram.py`:
- parametrized platform→filename mapping (`win32`→`.dll`, `linux`/`darwin`→`.so`) against a patched `HERMES_HOME`, env cleared
- env-override precedence preserved

4 passed; the 9 toolchain-dependent tests skip cleanly as designed.