### PR TITLE
fix(singularity): sanitize sandbox launch env for apptainer spawns

### DIFF
--- a/tests/tools/test_singularity_launch_env.py
+++ b/tests/tools/test_singularity_launch_env.py
@@ -1,0 +1,60 @@
+"""Tests for the apptainer sandbox launch-env sanitization.
+
+The backend process env can carry host-only values — ``SSL_CERT_FILE``
+pointing at the venv's certifi bundle, a launch cwd like
+``/usr/local/lib/hermes-agent`` — that do not exist inside the sandbox.
+That kills HTTPS (curl error 77) and makes every ``cd`` fail. These helpers
+rewrite the launch env to a container-visible CA bundle and launch from a
+container-valid cwd, mirroring the Docker backend's CA rewrite.
+"""
+
+import os
+from unittest.mock import patch
+
+from tools.environments.singularity import (
+    _SANDBOX_LAUNCH_CWD,
+    _container_ca_bundle,
+    _sandbox_launch_env,
+)
+
+
+class TestContainerCaBundle:
+    def test_prefers_system_bundle(self):
+        with patch("os.path.exists", return_value=True):
+            assert _container_ca_bundle() == "/etc/ssl/certs/ca-certificates.crt"
+
+    def test_falls_back_to_inherited_cert_when_system_missing(self):
+        def exists(path):
+            return path == "/custom/ca.pem"
+
+        with patch.dict(os.environ, {"SSL_CERT_FILE": "/custom/ca.pem"}, clear=False), \
+             patch("os.path.exists", side_effect=exists):
+            assert _container_ca_bundle() == "/custom/ca.pem"
+
+    def test_ignores_stale_inherited_cert(self):
+        with patch.dict(os.environ, {"SSL_CERT_FILE": "/host-only/venv/cacert.pem"}, clear=False), \
+             patch("os.path.exists", return_value=False):
+            # Nothing exists on the host: must still return a non-empty
+            # fallback (certifi / canonical path), never the dead path.
+            result = _container_ca_bundle()
+            assert result
+            assert result != "/host-only/venv/cacert.pem"
+
+
+class TestSandboxLaunchEnv:
+    def test_rewrites_ca_env_vars_to_container_visible_path(self):
+        with patch("os.path.exists", return_value=True):
+            env = _sandbox_launch_env()
+        ca = "/etc/ssl/certs/ca-certificates.crt"
+        assert env["SSL_CERT_FILE"] == ca
+        assert env["CURL_CA_BUNDLE"] == ca
+        assert env["REQUESTS_CA_BUNDLE"] == ca
+
+    def test_preserves_other_env(self):
+        with patch.dict(os.environ, {"SOME_VAR": "value"}, clear=False), \
+             patch("os.path.exists", return_value=True):
+            env = _sandbox_launch_env()
+        assert env["SOME_VAR"] == "value"
+
+    def test_launch_cwd_is_container_visible_root(self):
+        assert _SANDBOX_LAUNCH_CWD == "/root"

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -27,6 +27,14 @@ logger = logging.getLogger(__name__)
 
 _SNAPSHOT_STORE = get_hermes_home() / "singularity_snapshots.json"
 
+# Container-visible launch cwd. The backend process can be started from a
+# host-only path (e.g. /usr/local/lib/hermes-agent) that does not exist
+# inside the sandbox; apptainer then warns "Error changing the container
+# working directory" on every exec and the terminal wrapper's `cd` fails
+# with exit 126. Launching from /root — the container home, and the same
+# default_cwd terminal_tool uses for container backends — avoids that.
+_SANDBOX_LAUNCH_CWD = "/root"
+
 
 def _find_singularity_executable() -> str:
     """Locate the apptainer or singularity CLI binary."""
@@ -159,6 +167,52 @@ def _get_or_build_sif(image: str, executable: str = "apptainer") -> str:
             return image
 
 
+def _container_ca_bundle() -> str:
+    """Return a CA bundle path that exists INSIDE the sandbox.
+
+    The host process env can carry a host-only CA path (``SSL_CERT_FILE``
+    pointing at the venv's certifi bundle) that is not mounted into the
+    container, which kills HTTPS for curl/Python inside. Python
+    (``SSL_CERT_FILE``/``REQUESTS_CA_BUNDLE``) and curl (``CURL_CA_BUNDLE``)
+    REPLACE the CA store rather than adding to it, so the sandbox launch env
+    must point at a bundle the container can actually read. Debian-based
+    images ship the system bundle at the canonical path — prefer it, then
+    fall back to the inherited value (best effort).
+    """
+    for candidate in (
+        "/etc/ssl/certs/ca-certificates.crt",    # Debian/Ubuntu
+        "/etc/pki/tls/certs/ca-bundle.crt",      # RHEL/CentOS
+        "/etc/ssl/cert.pem",                     # Alpine/macOS
+    ):
+        if os.path.exists(candidate):
+            return candidate
+    inherited = os.environ.get("SSL_CERT_FILE") or os.environ.get("CURL_CA_BUNDLE")
+    if inherited and os.path.exists(inherited):
+        return inherited
+    try:
+        import certifi
+        return certifi.where()
+    except ImportError:
+        return "/etc/ssl/certs/ca-certificates.crt"
+
+
+def _sandbox_launch_env() -> dict:
+    """Env for apptainer spawns: container-visible CA paths.
+
+    Mirrors the Docker backend's egress CA rewrite
+    (``tools/environments/docker.py``): the sandbox inherits the backend
+    process env, which may reference host-only paths. Rewriting the CA vars
+    here is what makes HTTPS work inside the container regardless of how the
+    host process was launched.
+    """
+    env = os.environ.copy()
+    ca = _container_ca_bundle()
+    env["SSL_CERT_FILE"] = ca
+    env["REQUESTS_CA_BUNDLE"] = ca
+    env["CURL_CA_BUNDLE"] = ca
+    return env
+
+
 class SingularityEnvironment(BaseEnvironment):
     """Hardened Singularity/Apptainer container with resource limits and persistence.
 
@@ -228,7 +282,11 @@ class SingularityEnvironment(BaseEnvironment):
         cmd.extend([str(self.image), self.instance_id])
 
         try:
-            result = subprocess.run(cmd, capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=120, stdin=subprocess.DEVNULL)
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, encoding='utf-8', errors='replace',
+                timeout=120, stdin=subprocess.DEVNULL,
+                env=_sandbox_launch_env(), cwd=_SANDBOX_LAUNCH_CWD,
+            )
             if result.returncode != 0:
                 raise RuntimeError(f"Failed to start instance: {result.stderr}")
             self._instance_started = True
@@ -245,13 +303,17 @@ class SingularityEnvironment(BaseEnvironment):
             raise RuntimeError("Singularity instance not started")
 
         cmd = [self.executable, "exec",
+               "--pwd", _SANDBOX_LAUNCH_CWD,
                f"instance://{self.instance_id}"]
         if login:
             cmd.extend(["bash", "-l", "-c", cmd_string])
         else:
             cmd.extend(["bash", "-c", cmd_string])
 
-        return _popen_bash(cmd, stdin_data)
+        return _popen_bash(
+            cmd, stdin_data,
+            env=_sandbox_launch_env(), cwd=_SANDBOX_LAUNCH_CWD,
+        )
 
     def cleanup(self):
         """Stop the instance. If persistent, the overlay dir survives."""


### PR DESCRIPTION
## Problem

The apptainer sandbox inherits the backend process env, which can carry host-only values that don't exist inside the container:

- `SSL_CERT_FILE` / `CURL_CA_BUNDLE` pointing at the venv's certifi bundle (not mounted in the container) → HTTPS dead: `curl: (77) error setting certificate file`
- Launch cwd like `/usr/local/lib/hermes-agent` (not present in the sandbox) → every exec warns `chdir: no such file or directory` and the terminal wrapper's `cd` fails with exit 126

Reproduction (apptainer 1.5.3, Debian-based image):

```
$ apptainer exec instance://test bash -c 'curl -sS -o /dev/null -w "%{http_code}" https://pypi.org/simple/'
WARNING: Error changing the container working directory. Using '/root' instead: chdir /usr/local/lib/hermes-agent: no such file or directory
curl: (77) error setting certificate file: /usr/local/lib/hermes-agent/venv/.../certifi/cacert.pem
```

## Fix

In `tools/environments/singularity.py`, sanitize the launch env for every apptainer spawn (instance start + exec):

- `_sandbox_launch_env()` rewrites `SSL_CERT_FILE` / `CURL_CA_BUNDLE` / `REQUESTS_CA_BUNDLE` to a container-visible CA bundle (system CA path when present, with fallbacks), mirroring the Docker backend's existing egress CA rewrite in `tools/environments/docker.py`
- Launch cwd pinned to a container-valid path (`--pwd /root` + subprocess cwd), matching `terminal_tool`'s `default_cwd` for container backends

## Verification

- New unit tests: `tests/tools/test_singularity_launch_env.py` (6 tests)
- End-to-end: poisoned env in → `pwd` = `/root`, `SSL_CERT_FILE` rewritten to the system bundle, curl + Python https both HTTP 200
