### PR TITLE
fix(desktop): make approval alerts unmistakable

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -105,7 +105,6 @@ vi.mock('@/store/session-states', async importOriginal => {
 
   return {
     ...actual,
-    $attentionSessionIds: atom<string[]>([]),
     $stalledSessionIds: atom<string[]>([]),
     openSessionTile: vi.fn()
   }
@@ -178,7 +177,7 @@ const renderRow = (session: SessionInfo, extra?: { card?: boolean }) =>
 // the wiring rather than the predicate — the arc has gone missing before.
 describe('SidebarSessionRow running arc', () => {
   afterEach(() => {
-    clearAllSessionStates()
+    act(() => clearAllSessionStates())
   })
 
   const arc = (container: HTMLElement) => container.querySelector('.arc-row')
@@ -195,6 +194,17 @@ describe('SidebarSessionRow running arc', () => {
     const { container } = renderRow(makeSession({ title: 'Running' }))
 
     expect(arc(container)).toBeTruthy()
+  })
+
+  it('persistently highlights and labels the session that needs input', () => {
+    act(() => {
+      publishSessionState('rt1', { ...createClientSessionState('s1'), busy: true, needsInput: true })
+    })
+
+    const { container } = renderRow(makeSession({ title: 'Blocked deployment' }))
+
+    expect(container.querySelector('[data-needs-input="true"]')).toBeTruthy()
+    expect(screen.getByText('Needs input')).toBeTruthy()
   })
 
   // The row owns its status subscription so a turn starting repaints that row

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -257,6 +257,13 @@ function SidebarSessionRowImpl({
   // whenever any session's status changes, but a row only repaints on its own.
   const dotState = useStoreSelector($sessionDotStateById, states => states[session.id] ?? 'idle')
   const liveTurn = hasLiveTurn(dotState)
+  const needsInput = dotState === 'needs-input'
+
+  const needsInputBadge = needsInput ? (
+    <span className="shrink-0 rounded-[3px] bg-amber-500/18 px-1.5 py-0.5 text-[0.625rem] font-semibold leading-none text-amber-700 dark:text-amber-300">
+      {r.needsInput}
+    </span>
+  ) : null
 
   // Card header line: the workspace this belongs to — the project when it
   // resolves (same function the session color reads, so name and tint agree;
@@ -362,6 +369,7 @@ function SidebarSessionRowImpl({
           // token rather than row opacity — dimming the whole row would take
           // the title and the status dot down with it.
           openUnfocused && 'bg-(--ui-row-open-background)',
+          needsInput && 'bg-amber-500/10 ring-1 ring-inset ring-amber-500/45',
           liveTurn && 'text-foreground',
           // Opaque surface while lifted so the dragged row erases what's under
           // it (translucency let the rows below bleed through). data-glass-opaque
@@ -370,6 +378,7 @@ function SidebarSessionRowImpl({
           className
         )}
         data-glass-opaque={dragging ? '' : undefined}
+        data-needs-input={needsInput ? 'true' : undefined}
         data-working={liveTurn ? 'true' : undefined}
         // The row runs BOTH drags off one press, and each declines outside its
         // own region — so no timing/arbitration rule is needed and neither can
@@ -492,6 +501,7 @@ function SidebarSessionRowImpl({
                 <>
                   {leadNode}
                   {handoffBadge}
+                  {needsInputBadge}
                   <span className="min-w-0 flex-1 self-center">
                     <OverflowTip label={title}>
                       <SidebarRowLabel
@@ -539,6 +549,7 @@ function SidebarSessionRowImpl({
                     entire width — nothing truncates against the kebab. */}
                 <div className="flex min-w-0 items-center gap-1.5">
                   {leadNode}
+                  {needsInputBadge}
                   <span
                     className={cn(
                       'min-w-0 flex-1 truncate text-[0.6875rem] text-(--ui-text-tertiary)',

--- a/apps/desktop/src/app/session/hooks/use-message-stream/approval-attention.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/approval-attention.test.tsx
@@ -1,0 +1,116 @@
+import { act, cleanup } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createClientSessionState } from '@/lib/chat-runtime'
+import type * as NativeNotificationsStore from '@/store/native-notifications'
+import { clearAllPrompts } from '@/store/prompts'
+import { setSessions } from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
+
+import { type MessageStreamHarness, renderMessageStream } from './test-harness'
+
+const { dispatchNativeNotification, playApprovalSound } = vi.hoisted(() => ({
+  dispatchNativeNotification: vi.fn(() => true),
+  playApprovalSound: vi.fn(async () => undefined)
+}))
+
+vi.mock('@/lib/approval-sound', () => ({ playApprovalSound }))
+vi.mock('@/store/native-notifications', async importOriginal => {
+  const actual = await importOriginal<typeof NativeNotificationsStore>()
+
+  return { ...actual, dispatchNativeNotification }
+})
+
+const RUNTIME_SID = 'runtime-approval'
+const STORED_SID = 'stored-approval'
+
+let stream: MessageStreamHarness
+
+const session = {
+  id: STORED_SID,
+  profile: 'regular',
+  title: 'Deploy notification fix'
+} as unknown as SessionInfo
+
+describe('approval attention event', () => {
+  beforeEach(() => {
+    dispatchNativeNotification.mockReset()
+    dispatchNativeNotification.mockReturnValue(true)
+    playApprovalSound.mockClear()
+    clearAllPrompts()
+    setSessions([session])
+    stream = renderMessageStream(RUNTIME_SID, {
+      states: new Map([[RUNTIME_SID, createClientSessionState(STORED_SID)]])
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    clearAllPrompts()
+    setSessions([])
+    vi.restoreAllMocks()
+  })
+
+  it('sounds the alarm and names the blocked session in the native notification', () => {
+    act(() =>
+      stream.handleEvent({
+        payload: {
+          command: 'safe approval probe',
+          description: 'approval probe',
+          request_id: 'req-approval'
+        },
+        profile: 'regular',
+        session_id: RUNTIME_SID,
+        type: 'approval.request'
+      })
+    )
+
+    expect(playApprovalSound).toHaveBeenCalledWith(`${RUNTIME_SID}:req-approval`)
+    expect(dispatchNativeNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: 'safe approval probe',
+        kind: 'approval',
+        sessionId: RUNTIME_SID,
+        title: 'Approval needed · Deploy notification fix'
+      })
+    )
+    expect(stream.state().needsInput).toBe(true)
+  })
+
+  it('uses the session title from the exact connection and profile source', () => {
+    setSessions([
+      { ...session, connection_id: 'source-a', title: 'Wrong source title' },
+      { ...session, connection_id: 'source-b', title: 'Correct source title' }
+    ])
+
+    act(() =>
+      stream.handleEvent({
+        connectionId: 'source-b',
+        payload: { command: 'safe approval probe', request_id: 'req-scoped' },
+        profile: 'regular',
+        session_id: RUNTIME_SID,
+        type: 'approval.request'
+      })
+    )
+
+    expect(dispatchNativeNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Approval needed · Correct source title' })
+    )
+  })
+
+  it('does not sound when notification preferences or replay guards suppress the alert', () => {
+    dispatchNativeNotification.mockReturnValue(false)
+
+    act(() =>
+      stream.handleEvent({
+        payload: { command: 'safe approval probe', request_id: 'req-suppressed' },
+        profile: 'regular',
+        session_id: RUNTIME_SID,
+        type: 'approval.request'
+      })
+    )
+
+    expect(playApprovalSound).not.toHaveBeenCalled()
+    expect(stream.state().needsInput).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
@@ -1,6 +1,10 @@
+import { registryBackendScopeKey } from '@hermes/shared'
+
 import { pendingClarifyToolPayload } from '@/app/session/hooks/use-session-actions/restore-pending-clarify'
 import { translateNow } from '@/i18n'
+import { playApprovalSound } from '@/lib/approval-sound'
 import { restorePendingClarifyToolCall, settlePendingClarifyToolCall } from '@/lib/chat-messages'
+import { sessionTitle } from '@/lib/chat-runtime'
 import {
   $clarifyRequests,
   clearClarifyRequest,
@@ -13,6 +17,7 @@ import { $gateway } from '@/store/gateway'
 import { setMcpSetupRequest } from '@/store/mcp-setup'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { receiveApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
+import { $sessions, sessionMatchesStoredId } from '@/store/session'
 import { requestScrollToBottom } from '@/store/thread-scroll'
 
 import type { GatewayEventContext } from './types'
@@ -22,7 +27,7 @@ import type { GatewayEventContext } from './types'
  *  each of these must be parked per-session and surfaced. */
 export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
   const { deps, event, payload, sessionId, occurredAt } = ctx
-  const { activeSessionIdRef, sessionInterrupted, updateSessionState, upsertToolCall } = deps
+  const { activeSessionIdRef, sessionInterrupted, sessionStateByRuntimeIdRef, updateSessionState, upsertToolCall } = deps
 
   if (event.type === 'clarify.request') {
     // Surface the clarify tool's overlay. The Python side is blocked on
@@ -235,6 +240,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
     // surfaces once the user focuses that chat.
     const command = typeof payload?.command === 'string' ? payload.command : ''
     const description = typeof payload?.description === 'string' ? payload.description : 'dangerous command'
+    const requestId = typeof payload?.request_id === 'string' ? payload.request_id : undefined
 
     void receiveApprovalRequest($gateway.get(), {
       // false only when a tirith warning forbids it; backend omits the field otherwise.
@@ -244,7 +250,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         : undefined,
       command,
       description,
-      requestId: typeof payload?.request_id === 'string' ? payload.request_id : undefined,
+      requestId,
       sessionId: sessionId ?? null,
       smartDenied: payload?.smart_denied === true
     }).catch(() => undefined)
@@ -253,7 +259,26 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
       updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
     }
 
-    dispatchNativeNotification({
+    const storedSessionId = sessionId
+      ? (sessionStateByRuntimeIdRef.current.get(sessionId)?.storedSessionId ?? sessionId)
+      : null
+
+    const eventScope = registryBackendScopeKey(event.connectionId ?? null, event.profile ?? null)
+
+    const blockedSession = storedSessionId
+      ? $sessions
+          .get()
+          .find(
+            session =>
+              sessionMatchesStoredId(session, storedSessionId) &&
+              registryBackendScopeKey(session.connection_id ?? null, session.profile ?? null) === eventScope
+          )
+      : undefined
+
+    const approvalTitle = translateNow('notifications.native.approvalTitle')
+    const cueKey = [sessionId, requestId].filter(Boolean).join(':')
+
+    const notified = dispatchNativeNotification({
       actions: [
         { id: 'approve', text: translateNow('notifications.native.approveAction') },
         { id: 'reject', text: translateNow('notifications.native.rejectAction') }
@@ -261,8 +286,12 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
       body: command || description,
       kind: 'approval',
       sessionId,
-      title: translateNow('notifications.native.approvalTitle')
+      title: blockedSession ? `${approvalTitle} · ${sessionTitle(blockedSession)}` : approvalTitle
     })
+
+    if (notified) {
+      void playApprovalSound(cueKey || undefined)
+    }
 
     return true
   }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/message-stream.ts
@@ -331,7 +331,7 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
     flushQueuedDeltas(sessionId)
 
     // Keyed by session so only one window beeps when several are open.
-    playCompletionSound(sessionId)
+    void playCompletionSound(sessionId)
 
     const finalText = coerceGatewayText(payload?.text) || coerceGatewayText(payload?.rendered)
 

--- a/apps/desktop/src/lib/approval-sound.test.ts
+++ b/apps/desktop/src/lib/approval-sound.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $hapticsMuted } from '@/store/haptics'
+
+import { playApprovalSound } from './approval-sound'
+
+const { getRunningAudioContext, ownsAmbientCue } = vi.hoisted(() => ({
+  getRunningAudioContext: vi.fn(),
+  ownsAmbientCue: vi.fn()
+}))
+
+vi.mock('@/lib/audio-context', () => ({ getRunningAudioContext }))
+vi.mock('@/store/ambient', () => ({ ownsAmbientCue }))
+
+class FakeParam {
+  setValueAtTime = vi.fn()
+  exponentialRampToValueAtTime = vi.fn()
+}
+
+class FakeOscillator {
+  type = 'sine'
+  frequency = new FakeParam()
+  connect = vi.fn()
+  start = vi.fn()
+  stop = vi.fn()
+}
+
+class FakeGain {
+  gain = new FakeParam()
+  connect = vi.fn()
+}
+
+let gains: FakeGain[]
+let oscillators: FakeOscillator[]
+let releaseContext: ((context: AudioContext | null) => void) | null
+let releaseOwnership: ((owned: boolean) => void) | null
+
+const context = {
+  currentTime: 0,
+  destination: {},
+  createGain: () => {
+    const gain = new FakeGain()
+    gains.push(gain)
+
+    return gain
+  },
+  createOscillator: () => {
+    const oscillator = new FakeOscillator()
+    oscillators.push(oscillator)
+
+    return oscillator
+  }
+} as unknown as AudioContext
+
+describe('playApprovalSound', () => {
+  beforeEach(() => {
+    gains = []
+    oscillators = []
+    releaseContext = null
+    releaseOwnership = null
+    getRunningAudioContext.mockReset()
+    getRunningAudioContext.mockResolvedValue(context)
+    ownsAmbientCue.mockReset()
+    ownsAmbientCue.mockResolvedValue(true)
+    $hapticsMuted.set(false)
+  })
+
+  afterEach(() => {
+    $hapticsMuted.set(false)
+  })
+
+  it('plays a repeated two-tone approval alarm in one window', async () => {
+    await playApprovalSound('session-1:req-1')
+
+    expect(ownsAmbientCue).toHaveBeenCalledWith('approval-sound:session-1:req-1')
+    expect(oscillators).toHaveLength(4)
+    expect(oscillators.map(oscillator => oscillator.frequency.setValueAtTime.mock.calls[0][0])).toEqual([
+      659.25,
+      987.77,
+      659.25,
+      987.77
+    ])
+    expect(gains[0].gain.setValueAtTime).toHaveBeenCalledWith(0.9, expect.any(Number))
+  })
+
+  it('stays silent when another window owns the cue', async () => {
+    ownsAmbientCue.mockResolvedValue(false)
+
+    await playApprovalSound('session-1:req-1')
+
+    expect(getRunningAudioContext).toHaveBeenCalledOnce()
+    expect(oscillators).toHaveLength(0)
+  })
+
+  it('stays silent when shared sounds are muted', async () => {
+    $hapticsMuted.set(true)
+
+    await playApprovalSound('session-1:req-1')
+
+    expect(ownsAmbientCue).not.toHaveBeenCalled()
+    expect(getRunningAudioContext).not.toHaveBeenCalled()
+  })
+
+  it('stays silent when muted while the audio context is resuming', async () => {
+    getRunningAudioContext.mockReturnValue(
+      new Promise<AudioContext | null>(resolve => {
+        releaseContext = resolve
+      })
+    )
+
+    const playing = playApprovalSound('session-1:req-resume')
+    $hapticsMuted.set(true)
+    releaseContext?.(context)
+    await playing
+
+    expect(ownsAmbientCue).not.toHaveBeenCalled()
+    expect(oscillators).toHaveLength(0)
+  })
+
+  it('stays silent when muted while cross-window ownership is pending', async () => {
+    ownsAmbientCue.mockReturnValue(
+      new Promise<boolean>(resolve => {
+        releaseOwnership = resolve
+      })
+    )
+
+    const playing = playApprovalSound('session-1:req-owner')
+    await vi.waitFor(() => expect(ownsAmbientCue).toHaveBeenCalledOnce())
+    $hapticsMuted.set(true)
+    releaseOwnership?.(true)
+    await playing
+
+    expect(oscillators).toHaveLength(0)
+  })
+
+  it('does not throw when no running audio context is available', async () => {
+    getRunningAudioContext.mockResolvedValue(null)
+
+    await expect(playApprovalSound()).resolves.toBeUndefined()
+    expect(ownsAmbientCue).not.toHaveBeenCalled()
+    expect(oscillators).toHaveLength(0)
+  })
+})

--- a/apps/desktop/src/lib/approval-sound.ts
+++ b/apps/desktop/src/lib/approval-sound.ts
@@ -1,0 +1,66 @@
+// Dedicated approval alarm: two identical rising pulses, separated enough to
+// read as "attention required" rather than as a turn-completion chime. Synthesized
+// with WebAudio so there is no asset to ship. One window owns each cue.
+
+import { getRunningAudioContext } from '@/lib/audio-context'
+import { ownsAmbientCue } from '@/store/ambient'
+import { $hapticsMuted } from '@/store/haptics'
+
+function tone(ac: AudioContext, master: GainNode, start: number, frequency: number, type: OscillatorType) {
+  const oscillator = ac.createOscillator()
+  const envelope = ac.createGain()
+  const end = start + 0.2
+
+  oscillator.type = type
+  oscillator.frequency.setValueAtTime(frequency, start)
+
+  envelope.gain.setValueAtTime(0.0001, start)
+  envelope.gain.exponentialRampToValueAtTime(0.16, start + 0.008)
+  envelope.gain.exponentialRampToValueAtTime(0.0001, end)
+
+  oscillator.connect(envelope)
+  envelope.connect(master)
+  oscillator.start(start)
+  oscillator.stop(end + 0.02)
+}
+
+function playAlarm(ac: AudioContext): void {
+  try {
+    const master = ac.createGain()
+    master.gain.setValueAtTime(0.9, ac.currentTime)
+    master.connect(ac.destination)
+
+    const t0 = ac.currentTime + 0.01
+
+    // E5→B5, pause, E5→B5. The repeated cadence is deliberately unlike every
+    // completion preset: this asks for action rather than announcing "done".
+    tone(ac, master, t0, 659.25, 'triangle')
+    tone(ac, master, t0 + 0.12, 987.77, 'square')
+    tone(ac, master, t0 + 0.48, 659.25, 'triangle')
+    tone(ac, master, t0 + 0.6, 987.77, 'square')
+  } catch {
+    // A dead audio context must never disrupt approval rendering.
+  }
+}
+
+export async function playApprovalSound(dedupeKey?: string): Promise<void> {
+  if ($hapticsMuted.get()) {
+    return
+  }
+
+  const ac = await getRunningAudioContext()
+
+  if (!ac || $hapticsMuted.get()) {
+    return
+  }
+
+  if (dedupeKey && !(await ownsAmbientCue(`approval-sound:${dedupeKey}`))) {
+    return
+  }
+
+  if ($hapticsMuted.get()) {
+    return
+  }
+
+  playAlarm(ac)
+}

--- a/apps/desktop/src/lib/audio-context.test.ts
+++ b/apps/desktop/src/lib/audio-context.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getRunningAudioContext } from './audio-context'
+
+let context: SuspendedAudioContext | null
+let releaseResume: (() => void) | null
+
+class SuspendedAudioContext {
+  state = 'suspended'
+  private readonly resumePromise: Promise<void>
+
+  constructor() {
+    context = this
+    this.resumePromise = new Promise<void>(resolve => {
+      releaseResume = () => {
+        this.state = 'running'
+        resolve()
+      }
+    })
+  }
+
+  resume = vi.fn(() => this.resumePromise)
+}
+
+function finishResume() {
+  const release = releaseResume
+
+  if (!release) {
+    throw new Error('Expected a pending AudioContext resume')
+  }
+
+  release()
+}
+
+describe('getRunningAudioContext', () => {
+  beforeEach(() => {
+    context = null
+    releaseResume = null
+    vi.stubGlobal('AudioContext', SuspendedAudioContext)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('does not resolve until a suspended shared context has resumed', async () => {
+    const running = getRunningAudioContext()
+
+    await vi.waitFor(() => expect(context).not.toBeNull())
+    expect(context?.resume).toHaveBeenCalled()
+
+    let resolved = false
+    void running.then(() => {
+      resolved = true
+    })
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+
+    finishResume()
+
+    await expect(running).resolves.toBe(context)
+
+    const first = context
+    first!.state = 'closed'
+    releaseResume = null
+
+    const replacement = getRunningAudioContext()
+
+    await vi.waitFor(() => expect(context).not.toBe(first))
+    finishResume()
+
+    await expect(replacement).resolves.toBe(context)
+  })
+})

--- a/apps/desktop/src/lib/audio-context.ts
+++ b/apps/desktop/src/lib/audio-context.ts
@@ -13,14 +13,14 @@ export function getAudioContext(): AudioContext | null {
   }
 
   try {
-    if (!ctx) {
-      const Ctor =
-        window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+    const Ctor =
+      window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
 
-      if (!Ctor) {
-        return null
-      }
+    if (!Ctor) {
+      return null
+    }
 
+    if (!ctx || ctx.state === 'closed' || !(ctx instanceof Ctor)) {
       ctx = new Ctor()
     }
 
@@ -34,4 +34,26 @@ export function getAudioContext(): AudioContext | null {
   } catch {
     return null
   }
+}
+
+/** Wait until the shared context can actually schedule audible work. The
+ * synchronous getter initiates resume for legacy callers; attention/completion
+ * cues await the same transition so tones are not scheduled into a context
+ * that never left `suspended`. */
+export async function getRunningAudioContext(): Promise<AudioContext | null> {
+  const ac = getAudioContext()
+
+  if (!ac) {
+    return null
+  }
+
+  if (ac.state === 'suspended') {
+    try {
+      await ac.resume()
+    } catch {
+      return null
+    }
+  }
+
+  return ac.state === 'running' ? ac : null
 }

--- a/apps/desktop/src/lib/completion-sound.test.ts
+++ b/apps/desktop/src/lib/completion-sound.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $hapticsMuted } from '@/store/haptics'
+
+import { playCompletionSound, previewCompletionSound } from './completion-sound'
+
+const { getRunningAudioContext, ownsAmbientCue } = vi.hoisted(() => ({
+  getRunningAudioContext: vi.fn(),
+  ownsAmbientCue: vi.fn()
+}))
+
+vi.mock('@/lib/audio-context', () => ({ getRunningAudioContext }))
+vi.mock('@/store/ambient', () => ({ ownsAmbientCue }))
+
+class FakeParam {
+  setValueAtTime = vi.fn()
+  exponentialRampToValueAtTime = vi.fn()
+}
+
+class FakeGain {
+  gain = new FakeParam()
+  connect = vi.fn()
+}
+
+class FakeFilter {
+  type = 'lowpass'
+  frequency = new FakeParam()
+  Q = new FakeParam()
+  connect = vi.fn()
+}
+
+class FakeConvolver {
+  buffer: AudioBuffer | null = null
+  connect = vi.fn()
+}
+
+class FakeOscillator {
+  type = 'sine'
+  frequency = new FakeParam()
+  connect = vi.fn()
+  start = vi.fn()
+  stop = vi.fn()
+}
+
+let gains: FakeGain[]
+let oscillators: FakeOscillator[]
+let releaseContext: (() => void) | null
+let releaseOwnership: ((owned: boolean) => void) | null
+
+const context = {
+  currentTime: 0,
+  destination: {},
+  sampleRate: 100,
+  createGain: () => {
+    const gain = new FakeGain()
+    gains.push(gain)
+
+    return gain
+  },
+  createBiquadFilter: () => new FakeFilter(),
+  createConvolver: () => new FakeConvolver(),
+  createBuffer: (channels: number, length: number) => {
+    const data = Array.from({ length: channels }, () => new Float32Array(length))
+
+    return { getChannelData: (channel: number) => data[channel] }
+  },
+  createOscillator: () => {
+    const oscillator = new FakeOscillator()
+    oscillators.push(oscillator)
+
+    return oscillator
+  }
+} as unknown as AudioContext
+
+describe('previewCompletionSound', () => {
+  beforeEach(() => {
+    gains = []
+    oscillators = []
+    releaseContext = null
+    releaseOwnership = null
+    getRunningAudioContext.mockReset()
+    getRunningAudioContext.mockResolvedValue(context)
+    ownsAmbientCue.mockReset()
+    ownsAmbientCue.mockResolvedValue(true)
+    $hapticsMuted.set(false)
+  })
+
+  afterEach(() => {
+    $hapticsMuted.set(false)
+  })
+
+  it('waits for a runnable audio context before scheduling an audible preview', async () => {
+    getRunningAudioContext.mockReturnValue(
+      new Promise<AudioContext | null>(resolve => {
+        releaseContext = () => resolve(context)
+      })
+    )
+
+    const playing = previewCompletionSound(8)
+
+    expect(playing).toBeInstanceOf(Promise)
+    expect(oscillators).toHaveLength(0)
+
+    releaseContext?.()
+    await playing
+
+    expect(oscillators).toHaveLength(2)
+    expect(gains[0].gain.setValueAtTime).toHaveBeenCalledWith(1.15, expect.any(Number))
+  })
+
+  it('stays silent when muted while the audio context is resuming', async () => {
+    getRunningAudioContext.mockReturnValue(
+      new Promise<AudioContext | null>(resolve => {
+        releaseContext = () => resolve(context)
+      })
+    )
+
+    const playing = playCompletionSound('session-1')
+    $hapticsMuted.set(true)
+    releaseContext?.()
+    await playing
+
+    expect(ownsAmbientCue).not.toHaveBeenCalled()
+    expect(oscillators).toHaveLength(0)
+  })
+
+  it('stays silent when muted while cross-window ownership is pending', async () => {
+    ownsAmbientCue.mockReturnValue(
+      new Promise<boolean>(resolve => {
+        releaseOwnership = resolve
+      })
+    )
+
+    const playing = playCompletionSound('session-1')
+    await vi.waitFor(() => expect(ownsAmbientCue).toHaveBeenCalledOnce())
+    $hapticsMuted.set(true)
+    releaseOwnership?.(true)
+    await playing
+
+    expect(oscillators).toHaveLength(0)
+  })
+})

--- a/apps/desktop/src/lib/completion-sound.ts
+++ b/apps/desktop/src/lib/completion-sound.ts
@@ -1,7 +1,7 @@
 // Completion sound bank for agent turn-end cues.
 // Fourteen curated presets for A/B in Settings → Appearance. Default is variant 1.
 
-import { getAudioContext } from '@/lib/audio-context'
+import { getRunningAudioContext } from '@/lib/audio-context'
 import { ownsAmbientCue } from '@/store/ambient'
 import { $completionSoundVariantId, resolveCompletionSoundVariantId } from '@/store/completion-sound'
 import { $hapticsMuted } from '@/store/haptics'
@@ -380,65 +380,79 @@ export const COMPLETION_SOUND_VARIANTS: readonly CompletionSoundVariant[] = [
   }
 ] as const
 
-function playVariant(variantId: number) {
+function renderVariant(ac: AudioContext, variantId: number): void {
   const variant = COMPLETION_SOUND_VARIANTS.find(v => v.id === variantId)
 
   if (!variant) {
     return
   }
 
-  const ac = getAudioContext()
+  try {
+    // Signal path: voices → master → low-pass → (dry + reverb send) → out.
+    const master = ac.createGain()
+    const tone = ac.createBiquadFilter()
+    tone.type = 'lowpass'
+    tone.frequency.setValueAtTime(3800, ac.currentTime)
+    tone.Q.setValueAtTime(0.32, ac.currentTime)
+    master.gain.setValueAtTime(1.15, ac.currentTime)
+    master.connect(tone)
 
-  if (!ac) {
-    return
+    const dry = ac.createGain()
+    dry.gain.setValueAtTime(0.88, ac.currentTime)
+    tone.connect(dry)
+    dry.connect(ac.destination)
+
+    const reverb = makeReverb(ac)
+    const wet = ac.createGain()
+    wet.gain.setValueAtTime(0.34, ac.currentTime)
+    tone.connect(reverb)
+    reverb.connect(wet)
+    wet.connect(ac.destination)
+
+    variant.play(ac, master, ac.currentTime + 0.01)
+  } catch {
+    // The context can close between the awaited resume and node creation.
   }
+}
 
-  // Signal path: voices → master → low-pass → (dry + reverb send) → out.
-  const master = ac.createGain()
-  const tone = ac.createBiquadFilter()
-  tone.type = 'lowpass'
-  tone.frequency.setValueAtTime(3800, ac.currentTime)
-  tone.Q.setValueAtTime(0.32, ac.currentTime)
-  master.gain.setValueAtTime(0.48, ac.currentTime)
-  master.connect(tone)
+async function playVariant(variantId: number): Promise<void> {
+  const ac = await getRunningAudioContext()
 
-  const dry = ac.createGain()
-  dry.gain.setValueAtTime(0.88, ac.currentTime)
-  tone.connect(dry)
-  dry.connect(ac.destination)
-
-  const reverb = makeReverb(ac)
-  const wet = ac.createGain()
-  wet.gain.setValueAtTime(0.34, ac.currentTime)
-  tone.connect(reverb)
-  reverb.connect(wet)
-  wet.connect(ac.destination)
-
-  variant.play(ac, master, ac.currentTime + 0.01)
+  if (ac) {
+    renderVariant(ac, variantId)
+  }
 }
 
 // Audition the selected variant from settings. Bypasses the haptics mute toggle so
 // sound design can be compared even when turn-end cues are silenced.
 export function previewCompletionSound(variantId?: number) {
-  playVariant(resolveCompletionSoundVariantId(variantId ?? $completionSoundVariantId.get()))
+  return playVariant(resolveCompletionSoundVariantId(variantId ?? $completionSoundVariantId.get()))
 }
 
 // Plays the selected completion cue on any `message.complete`. Pass a dedupeKey
 // (the session id) so only one window beeps when several are open — the mute
 // check runs first, so a muted window never claims the cue out from under an
 // audible peer.
-export function playCompletionSound(dedupeKey?: string) {
+export async function playCompletionSound(dedupeKey?: string): Promise<void> {
   if ($hapticsMuted.get()) {
     return
   }
 
-  const play = () => playVariant($completionSoundVariantId.get())
+  const ac = await getRunningAudioContext()
 
-  if (!dedupeKey) {
-    return play()
+  if (!ac || $hapticsMuted.get()) {
+    return
   }
 
-  void ownsAmbientCue(`sound:${dedupeKey}`).then(owns => owns && play())
+  if (dedupeKey && !(await ownsAmbientCue(`sound:${dedupeKey}`))) {
+    return
+  }
+
+  if ($hapticsMuted.get()) {
+    return
+  }
+
+  renderVariant(ac, $completionSoundVariantId.get())
 }
 
 interface AirPuffSpec {

--- a/apps/desktop/src/store/native-notifications.test.ts
+++ b/apps/desktop/src/store/native-notifications.test.ts
@@ -98,11 +98,18 @@ describe('dispatchNativeNotification focus gating', () => {
     expect(notify).toHaveBeenCalledTimes(1)
   })
 
-  it('suppresses an attention notification for the active session when focused', () => {
+  it('fires an approval notification for the active session when focused', () => {
     setWindowState({ focused: true, hidden: false })
     setActiveSessionId('on-screen')
     dispatchNativeNotification({ kind: 'approval', sessionId: 'on-screen', title: 'approve' })
-    expect(notify).not.toHaveBeenCalled()
+    expect(notify).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires an input notification for the active session when focused', () => {
+    setWindowState({ focused: true, hidden: false })
+    setActiveSessionId('on-screen')
+    dispatchNativeNotification({ kind: 'input', sessionId: 'on-screen', title: 'answer' })
+    expect(notify).toHaveBeenCalledTimes(1)
   })
 
   it('fires a global completion notification while away with no active session (pet gen)', () => {

--- a/apps/desktop/src/store/native-notifications.ts
+++ b/apps/desktop/src/store/native-notifications.ts
@@ -26,7 +26,8 @@ export const NATIVE_NOTIFICATION_KINDS: readonly NativeNotificationKind[] = [
   'plugin'
 ]
 
-// Blocking prompts — surface even while focused if they're for another session.
+// Blocking prompts always surface: a focused window can stay focused while the
+// user is physically away, so focus is not proof that the prompt was seen.
 const ATTENTION_KINDS = new Set<NativeNotificationKind>(['approval', 'input'])
 
 export interface NativeNotificationPrefs {
@@ -138,9 +139,9 @@ function shouldFire(kind: NativeNotificationKind, sessionId?: null | string, glo
     return isBackgrounded()
   }
 
-  // Attention kinds break through for an off-screen session even while focused.
+  // A blocking prompt must not confuse window focus with human presence.
   if (ATTENTION_KINDS.has(kind)) {
-    return isBackgrounded() || (Boolean(sessionId) && sessionId !== $activeSessionId.get())
+    return true
   }
 
   // Completion kinds: only the active session, only while away — so a busy


### PR DESCRIPTION
## Summary

- always surface blocking approval/input notifications, even when the Hermes window remains focused
- add a distinctive, cross-window-deduplicated approval alarm and name the owning session in the Windows toast
- persist an amber `Needs input` badge/highlight on the blocked session row
- harden synthesized sound playback around suspended/closed AudioContexts, async mute changes, and cross-window ownership
- raise completion-cue gain from an effectively inaudible level while retaining the existing mute and preference gates

## Root cause

Desktop used `document.hasFocus()` as a proxy for human presence. If someone walked away while Hermes remained focused, an approval for the active chat was deliberately suppressed. The only persistent sidebar cue was a 6px amber dot. Synthesized sounds also scheduled tones before an async AudioContext resume completed, and cross-window ownership could be claimed before a window proved it could play audio.

## Verification

- `55/55` focused UI tests pass
- `npm run typecheck` passes for renderer, Electron, and E2E projects
- ESLint passes on every changed file
- `npm run build` succeeds on Windows
- final independent diff-only review found no security concerns or blocking logic errors
- manual Windows verification confirmed the approval alarm, session-named toast, amber row highlight/badge, and persistent approval controls together

## Baseline note

`npm run check` reaches `5,734` passing UI tests and fails two billing currency-format assertions on this Windows locale. With this entire change stashed, `src/app/settings/billing/index.test.tsx` fails the same two assertions (`USD 10`/`USD 25` expected while the locale renders `$10`/`$25`), confirming they are pre-existing baseline failures.
