### PR TITLE
fix(tests): e2e group-restart test no longer flakes on cold SessionDB init (#92130)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -347,6 +347,10 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     # (user shell, earlier leaky test, CI env), they change gateway auth
     # behavior and flake button-authorization tests.
     "TELEGRAM_ALLOWED_USERS",
+    "TELEGRAM_GROUP_ALLOWED_USERS",
+    "TELEGRAM_GROUP_ALLOWED_CHATS",
+    "QQ_ALLOWED_USERS",
+    "QQ_GROUP_ALLOWED_USERS",
     "DISCORD_ALLOWED_USERS",
     "WHATSAPP_ALLOWED_USERS",
     "SLACK_ALLOWED_USERS",

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -235,6 +235,17 @@ def make_runner(platform: Platform, session_entry: SessionEntry = None) -> "Gate
     # telegram param only — first parametrization pays the cold-resolution cost).
     runner._reset_notice_session_info = lambda source: ""
 
+    # Keep the agent-turn path hermetic: _run_post_turn_hooks runs the /goal
+    # continuation, whose SessionDB warm-up constructs a REAL SessionDB on an
+    # executor thread at the turn boundary. On a cold/loaded CI runner that
+    # state.db init can exceed send_and_capture's 2s poll window, so the send
+    # lands after the assertion — the "Expected 'mock' to have been called
+    # once. Called 0 times." flake on
+    # test_plaintext_restart_gateway_in_group_stays_plain_text[telegram]
+    # (issue #92130; e.g. runs 32802504263 / 32799192528 / 32796821900).
+    # e2e tests exercise gateway command dispatch, not post-turn goal hooks.
+    runner._run_post_turn_hooks = AsyncMock()
+
     runner.pairing_store = MagicMock()
     runner.pairing_store._is_rate_limited = MagicMock(return_value=False)
     runner.pairing_store.generate_code = MagicMock(return_value="ABC123")


### PR DESCRIPTION
## Summary

The e2e group-restart test no longer fails CI with the bare "Expected 'mock' to have been called once. Called 0 times." — the flake tracked in #92130 that hit unrelated PRs (#89118, #92058, #94388) and two main runs tonight.

Root cause: the e2e runner fixture left `GatewayRunner._run_post_turn_hooks` real. That path runs the /goal continuation, whose SessionDB warm-up constructs a REAL `SessionDB` on an executor thread at the turn boundary. On a cold or loaded CI runner that state.db init exceeds `send_and_capture`'s 2s poll window, so the send lands after the assertion. Proven by sabotage A/B: injecting a 3s `SessionDB.__init__` delay reproduces the exact CI failure deterministically on current main, and passes with this fix.

## Changes

- `tests/e2e/conftest.py`: mock `_run_post_turn_hooks` in the e2e runner — these tests exercise gateway command dispatch, not post-turn goal hooks
- `tests/conftest.py`: scrub `TELEGRAM_GROUP_ALLOWED_USERS` / `TELEGRAM_GROUP_ALLOWED_CHATS` / `QQ_ALLOWED_USERS` / `QQ_GROUP_ALLOWED_USERS` in the hermetic env — a developer shell with a group allowlist set flips `_get_unauthorized_dm_behavior` to "ignore" and deterministically fails the pairing e2e test locally (the per-user vars were already scrubbed; the group vars checked by `authz_mixin.py` were not)

## Validation

| | Before | After |
|---|---|---|
| 3s slow-SessionDB sabotage, group-restart test | FAILED (identical to CI runs 32802504263 / 32799192528 / 32796821900) | 1 passed in 0.36s |
| `tests/e2e/` full directory ×3 (shell has `TELEGRAM_GROUP_ALLOWED_CHATS` set) | pairing test failed deterministically | 61 passed, 7 skipped ×3 |

Related: #92130 (diagnostics-only PR by @mehmetkr-31 — complementary, this PR fixes the flake itself).

## Infographic

![Flake Slayer](https://v3b.fal.media/files/b/0aa7b3f1/p8lSFZG_dEQNOdY9qgGuP_cWC9UY0H.png)
