### PR TITLE
fix(gateway): translate Docker media paths on Windows

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -431,7 +431,7 @@ def is_host_excluded_by_no_proxy(hostname: str, no_proxy_value: str | None = Non
 
 import dataclasses
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Dict, List, Optional, Any, Callable, Awaitable, Tuple, Union
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
@@ -940,7 +940,7 @@ def _tenv(name: str, default: str = "") -> str:
     return terminal_env(name, default)
 
 
-def _parse_docker_volume_mounts() -> List[Tuple[Path, Path]]:
+def _parse_docker_volume_mounts() -> List[Tuple[Path, PurePosixPath]]:
     """Parse ``TERMINAL_DOCKER_VOLUMES`` (JSON list of ``host:container[:mode]``) into
     ``(host_path, container_path)``; named volumes / non-absolute hosts can't resolve here."""
     raw = _tenv("TERMINAL_DOCKER_VOLUMES", "").strip()
@@ -952,8 +952,11 @@ def _parse_docker_volume_mounts() -> List[Tuple[Path, Path]]:
     mounts: List[Tuple[Path, Path]] = []
     for entry in parsed if isinstance(parsed, list) else ():
         spec = entry.strip() if isinstance(entry, str) else ""
-        # Prefer the first ':/' so absolute container paths are unambiguous.
-        sep = spec.find(":/")
+        # Find the host/container delimiter, skipping a Windows drive prefix
+        # ("C:/host:/workspace") whose drive colon would otherwise be taken
+        # as the separator and silently drop a valid mount.
+        start = 2 if len(spec) > 2 and spec[1] == ":" and spec[2] in "\\/" else 0
+        sep = spec.find(":/", start)
         if sep <= 0:
             continue
         container_raw = spec[sep + 1:].split(":", 1)[0]  # starts with /
@@ -961,7 +964,7 @@ def _parse_docker_volume_mounts() -> List[Tuple[Path, Path]]:
         host_expanded = os.path.expanduser(spec[:sep])
         if not (host_expanded.startswith("/") or (len(host_expanded) > 1 and host_expanded[1] == ":")):
             continue
-        host_path, container_path = _resolve_path(Path(host_expanded)), Path(container_raw)
+        host_path, container_path = _resolve_path(Path(host_expanded)), PurePosixPath(container_raw)
         if host_path is not None and container_path.is_absolute():
             mounts.append((host_path, container_path))
     return mounts
@@ -1046,7 +1049,7 @@ def _cache_dir_container_mounts() -> List[Tuple[Path, Path]]:
         return []
     try:
         from tools.credential_files import get_cache_directory_mounts
-        return [(Path(m["host_path"]), Path(m["container_path"])) for m in get_cache_directory_mounts()]
+        return [(Path(m["host_path"]), PurePosixPath(m["container_path"])) for m in get_cache_directory_mounts()]
     except Exception:
         return []
 
@@ -1068,6 +1071,19 @@ def _warn_unresolved_docker_media(candidate: Path, session_key: str, reason: str
 def _translate_docker_container_media_path(candidate: Path, session_key: str = "") -> Optional[Path]:
     """Container-absolute path -> host path via longest-prefix match over ``docker_volumes``, the
     auto-mounted cache dirs (``/root/.hermes/...``), persistent ``/workspace`` and ``/root``."""
+    # A container path is always POSIX. On a native-Windows gateway
+    # ``Path("/workspace")`` is drive-relative and NOT absolute, so this
+    # function used to reject every container path before translation ran.
+    # Re-type as PurePosixPath so container semantics stay independent of the
+    # host path flavour.
+    # ``as_posix()`` first: str(WindowsPath('/workspace/x')) uses backslashes,
+    # which PurePosixPath would treat as one non-absolute component. Callers pass
+    # either a Path (upstream) or a str (this PR's original form).
+    try:
+        candidate = PurePosixPath(
+            candidate.as_posix() if hasattr(candidate, "as_posix") else str(candidate))
+    except (TypeError, ValueError):
+        return None
     if not candidate.is_absolute():
         return None
     # In-process gateways (Desktop, `hermes serve`) may not have bridged terminal.* config into
@@ -1079,13 +1095,13 @@ def _translate_docker_container_media_path(candidate: Path, session_key: str = "
     mounted = {c.as_posix() for _, c in mounts}
     # Synthetic /workspace mounts: profile-scoped layout first, then legacy per-session.
     if "/workspace" not in mounted:
-        mounts.extend((root, Path("/workspace")) for root in _default_docker_workspace_host_roots(session_key))
+        mounts.extend((root, PurePosixPath("/workspace")) for root in _default_docker_workspace_host_roots(session_key))
     # Synthetic /root mounts catch stray home writes (/root/out.png; cache mounts are longer
     # prefixes). /root/.hermes/* that missed a cache mount is the container's credential surface —
     # translating it via the home mount would dodge the host denylist.
     if "/root" not in mounted and not candidate.as_posix().startswith("/root/.hermes"):
         mounts.extend(
-            (root, Path("/root")) for root in _docker_persistent_sandbox_roots(session_key, "home"))
+            (root, PurePosixPath("/root")) for root in _docker_persistent_sandbox_roots(session_key, "home"))
     if not mounts:
         _warn_unresolved_docker_media(candidate, session_key, "no sandbox mounts resolved")
         return None

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -23,6 +23,13 @@ from gateway.platforms.base import (
 from gateway.platforms.event import MessageEvent
 
 
+def _set_test_home(monkeypatch, home):
+    """Set the home variables used by native POSIX and Windows path lookup."""
+    monkeypatch.setenv("HOME", str(home))
+    if os.name == "nt":
+        monkeypatch.setenv("USERPROFILE", str(home))
+
+
 def test_media_delivery_denies_encrypted_bitwarden_cache(tmp_path, monkeypatch):
     """Encrypted Bitwarden cache is covered by the media credential guard."""
     import gateway.platforms.base as base
@@ -560,7 +567,7 @@ class TestMediaDeliveryPathValidation:
         ssh_dir.mkdir(parents=True)
         secret = ssh_dir / "id_rsa.txt"
         secret.write_bytes(b"-----BEGIN ...")  # mtime = now
-        monkeypatch.setenv("HOME", str(fake_home))
+        _set_test_home(monkeypatch, fake_home)
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(secret)) is None
 
@@ -623,7 +630,7 @@ class TestMediaDeliveryDefaultMode:
         (hermes_dir / "mcp-tokens").mkdir(parents=True)
         secret = hermes_dir / rel
         secret.write_text('{"access_token": "live-bearer-abc123"}')
-        monkeypatch.setenv("HOME", str(fake_home))
+        _set_test_home(monkeypatch, fake_home)
         monkeypatch.setattr(
             "gateway.platforms.base._HERMES_HOME",
             hermes_dir,
@@ -650,7 +657,7 @@ class TestMediaDeliveryDefaultMode:
         hermes_dir.mkdir(parents=True)
         token = hermes_dir / "google_token.json"
         token.write_text('{"access_token": "***", "refresh_token": "***"}')
-        monkeypatch.setenv("HOME", str(fake_home))
+        _set_test_home(monkeypatch, fake_home)
         monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_dir)
         monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_dir)
 
@@ -672,7 +679,7 @@ class TestMediaDeliveryDefaultMode:
         hermes_dir.mkdir(parents=True)
         artifact = hermes_dir / "adhoc_report.pdf"
         artifact.write_bytes(b"%PDF-1.4")  # fresh mtime
-        monkeypatch.setenv("HOME", str(fake_home))
+        _set_test_home(monkeypatch, fake_home)
         monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_dir)
         monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_dir)
 
@@ -767,7 +774,7 @@ class TestMediaDeliveryDefaultMode:
         workdir.mkdir(parents=True)
         doc = workdir / "proposal.docx"
         doc.write_bytes(b"PK\x03\x04")
-        monkeypatch.setenv("HOME", str(fake_home))
+        _set_test_home(monkeypatch, fake_home)
         # $HOME is itself on the denied-prefix list, mirroring /root.
         monkeypatch.setattr(
             "gateway.platforms.base._MEDIA_DELIVERY_DENIED_PREFIXES",
@@ -802,7 +809,7 @@ class TestMediaDeliveryDefaultMode:
         # $HOME is NOT the denied prefix (mirrors HOME=/opt/data/home).
         fake_home = tmp_path / "opt" / "data" / "home"
         fake_home.mkdir(parents=True)
-        monkeypatch.setenv("HOME", str(fake_home))
+        _set_test_home(monkeypatch, fake_home)
         monkeypatch.setattr(
             "gateway.platforms.base._MEDIA_DELIVERY_DENIED_PREFIXES",
             (str(denied_root),),
@@ -832,7 +839,7 @@ class TestMediaDeliveryDefaultMode:
         workdir.mkdir()
         link = workdir / "innocent.pdf"
         link.symlink_to(key)
-        monkeypatch.setenv("HOME", str(fake_home))
+        _set_test_home(monkeypatch, fake_home)
         monkeypatch.setattr(
             "gateway.platforms.base._MEDIA_DELIVERY_DENIED_PREFIXES",
             (str(fake_home),),
@@ -844,16 +851,20 @@ class TestMediaDeliveryDefaultMode:
 class TestDockerContainerMediaPathTranslation:
     """MEDIA:/workspace (and configured mounts) must resolve to host paths."""
 
-    def test_configured_workspace_mount_translates(self, tmp_path, monkeypatch):
+    @pytest.mark.parametrize("forward_slash_host", [False, True])
+    def test_configured_workspace_mount_translates(
+        self, tmp_path, monkeypatch, forward_slash_host
+    ):
         import json
 
         host_ws = tmp_path / "host-ws"
         host_ws.mkdir()
         media = host_ws / "shot.png"
         media.write_bytes(b"\x89PNG\r\n\x1a\n")
+        host_spec = host_ws.as_posix() if forward_slash_host else str(host_ws)
         monkeypatch.setenv(
             "TERMINAL_DOCKER_VOLUMES",
-            json.dumps([f"{host_ws}:/workspace"]),
+            json.dumps([f"{host_spec}:/workspace"]),
         )
         monkeypatch.delenv("TERMINAL_ENV", raising=False)
 
@@ -953,11 +964,22 @@ class TestDockerContainerMediaPathTranslation:
             "/root/.hermes/cache/images/generated.png"
         ) == str(media.resolve())
 
-    def test_container_credential_path_never_translates_through_home(self, tmp_path, monkeypatch):
+    @pytest.mark.parametrize(
+        "container_path",
+        [
+            "/root/.hermes/auth.json",
+            "/root/x/../.hermes/auth.json",
+        ],
+    )
+    @pytest.mark.parametrize("strict_mode", [False, True])
+    def test_container_credential_path_never_translates_through_home(
+        self, tmp_path, monkeypatch, container_path, strict_mode
+    ):
         """/root/.hermes/* outside a cache mount (the sandbox's credential
         surface: .env, auth.json) must NOT resolve through the persistent
-        home mount — those host-side copies sit outside the credential
-        denylist prefixes and would otherwise deliver."""
+        home mount — including lexical dot-segment spellings. Those host-side
+        copies sit outside the credential denylist prefixes and would
+        otherwise deliver, even under strict-mode recency fallback."""
         sandbox = tmp_path / "sandboxes"
         home = sandbox / "docker" / "default" / "home"
         secret = home / ".hermes"
@@ -970,10 +992,13 @@ class TestDockerContainerMediaPathTranslation:
         monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "true")
         monkeypatch.setenv("TERMINAL_SANDBOX_DIR", str(sandbox))
         monkeypatch.delenv("TERMINAL_DOCKER_VOLUMES", raising=False)
+        if strict_mode:
+            monkeypatch.setenv("HERMES_MEDIA_DELIVERY_STRICT", "1")
+            monkeypatch.setenv("HERMES_MEDIA_TRUST_RECENT_FILES", "1")
+        else:
+            monkeypatch.delenv("HERMES_MEDIA_DELIVERY_STRICT", raising=False)
 
-        assert BasePlatformAdapter.validate_media_delivery_path(
-            "/root/.hermes/auth.json"
-        ) is None
+        assert BasePlatformAdapter.validate_media_delivery_path(container_path) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- translate Docker container media paths with POSIX semantics on native Windows
- preserve both `C:\\...` and `C:/...` drive-letter host-volume forms
- normalize container dot segments before persistent-home credential-boundary matching
- retain fail-closed behavior for UNC host-volume specifications

## Validation
- `C:\\Program Files\\Git\\bin\\bash.exe -lc './scripts/run_tests.sh tests/gateway/test_platform_base.py'` — 89 passed, 0 failed, 1 valid host skip
- `uv run ruff check gateway/platforms/base.py tests/gateway/test_platform_base.py`
- `git diff --check`