### PR TITLE
fix(desktop): drop dead pooled remote backends with a cadence-sized failure window

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -275,6 +275,7 @@ import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySet
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
 import * as remoteLifecycle from './remote-lifecycle'
 import {
+  REMOTE_POOLED_LIVENESS_FAILURE_WINDOW_MS,
   RemoteLivenessTracker,
   RemoteRevalidationCoordinator,
   revalidatePooledRemoteBackends,
@@ -1313,6 +1314,14 @@ function registerMediaProtocol() {
 let mainWindow = null
 const backendConnectionState = createBackendConnectionState<ReturnType<typeof spawn>, any>()
 const remoteLiveness = new RemoteLivenessTracker()
+// Pooled remotes are probed on the renderer reconnect cadence (minutes apart),
+// not the primary's sub-minute retry loop, so they need a failure window wider
+// than that cadence or a dead pooled descriptor's streak resets on every tick
+// and it is never dropped (#94381).
+const pooledRemoteLiveness = new RemoteLivenessTracker(
+  undefined,
+  REMOTE_POOLED_LIVENESS_FAILURE_WINDOW_MS
+)
 const remoteRevalidation = new RemoteRevalidationCoordinator()
 // True while connection-config:apply soft-rehomes the primary — suppresses the
 // backend-exit toast so an intentional kill doesn't look like a crash.
@@ -12608,7 +12617,7 @@ function revalidatePool() {
     log: rememberLog,
     probe: (connection, path, options) => fetchJsonForBackend(connection, path, options),
     stopBackend: stopPoolBackend,
-    tracker: remoteLiveness
+    tracker: pooledRemoteLiveness
   })
 }
 

--- a/apps/desktop/electron/remote-liveness.test.ts
+++ b/apps/desktop/electron/remote-liveness.test.ts
@@ -4,6 +4,7 @@ import {
   REMOTE_LIVENESS_FAILURE_LIMIT,
   REMOTE_LIVENESS_FAILURE_WINDOW_MS,
   REMOTE_LIVENESS_TIMEOUT_MS,
+  REMOTE_POOLED_LIVENESS_FAILURE_WINDOW_MS,
   RemoteLivenessTracker,
   RemoteRevalidationCoordinator,
   revalidatePooledRemoteBackends,
@@ -349,6 +350,56 @@ describe('revalidatePooledRemoteBackends', () => {
 
     await expect(pool.run(tracker)).resolves.toEqual({ dropped: ['coder'] })
     expect(pool.stopBackend).toHaveBeenCalledWith('coder')
+  })
+
+  it('accumulates failures across probes minutes apart under the pooled failure window', async () => {
+    // Regression test for #94381: the pool revalidation tick is driven by the
+    // renderer's reconnect IPC, which fires minutes apart once the primary
+    // connection is healthy — far beyond the primary's 60s failure window.
+    // With that window a dead pooled descriptor's streak reset on every tick
+    // and the drop path was never reached; the pool served ECONNRESETs until
+    // app restart.
+    const pool = harness([['coder', { process: null, remoteBaseUrl: 'https://remote.example.com' }]])
+    pool.unreachable.add('https://remote.example.com')
+
+    let now = 1_000_000
+
+    const tracker = new RemoteLivenessTracker(
+      REMOTE_LIVENESS_FAILURE_LIMIT,
+      REMOTE_POOLED_LIVENESS_FAILURE_WINDOW_MS,
+      () => now
+    )
+
+    for (let attempt = 1; attempt < REMOTE_LIVENESS_FAILURE_LIMIT; attempt += 1) {
+      await expect(pool.run(tracker)).resolves.toEqual({ dropped: [] })
+      expect(pool.stopBackend).not.toHaveBeenCalled()
+      now += 4 * 60_000 // observed production cadence: ~4 minutes between probes
+    }
+
+    await expect(pool.run(tracker)).resolves.toEqual({ dropped: ['coder'] })
+    expect(pool.stopBackend).toHaveBeenCalledWith('coder')
+  })
+
+  it('still resets a genuinely stale streak past the pooled window', async () => {
+    const pool = harness([['coder', { process: null, remoteBaseUrl: 'https://remote.example.com' }]])
+    pool.unreachable.add('https://remote.example.com')
+
+    let now = 1_000_000
+
+    const tracker = new RemoteLivenessTracker(
+      REMOTE_LIVENESS_FAILURE_LIMIT,
+      REMOTE_POOLED_LIVENESS_FAILURE_WINDOW_MS,
+      () => now
+    )
+
+    // Two failures 20 minutes apart (beyond the pooled window): each must
+    // count as a fresh streak of 1, not silently accumulate across outages.
+    await expect(pool.run(tracker)).resolves.toEqual({ dropped: [] })
+    now += 20 * 60_000
+    await expect(pool.run(tracker)).resolves.toEqual({ dropped: [] })
+    now += 4 * 60_000
+    await expect(pool.run(tracker)).resolves.toEqual({ dropped: [] })
+    expect(pool.stopBackend).not.toHaveBeenCalled()
   })
 
   it('clears the streak when the host answers again', async () => {

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -4,6 +4,14 @@ export const REMOTE_LIVENESS_FAILURE_LIMIT = 3
 // about 48s apart (ticket mint + socket open + backoff + the next status probe).
 // One minute keeps a continuous outage together without carrying old failures.
 export const REMOTE_LIVENESS_FAILURE_WINDOW_MS = 60_000
+// Pooled remote backends are probed from the renderer's reconnect IPC, which
+// fires on a minutes-long cadence once the primary connection is healthy — far
+// beyond REMOTE_LIVENESS_FAILURE_WINDOW_MS. With the primary's 60s window a
+// dead pooled descriptor's failure streak resets on every tick, the drop path
+// is never reached, and the pool serves the dead descriptor until app restart
+// (every call fails with ECONNRESET). A successful probe still clears the
+// streak via recordSuccess(), so a wide window cannot produce false drops.
+export const REMOTE_POOLED_LIVENESS_FAILURE_WINDOW_MS = 15 * 60_000
 
 export interface RemoteLivenessFailure {
   failures: number


### PR DESCRIPTION
## What does this PR do?

Fixes dead pooled remote backends never being evicted from Desktop's backend pool. Pooled remote descriptors are probed via `revalidatePooledRemoteBackends()` on the renderer reconnect IPC, which fires on a **minutes-long cadence** once the primary connection is healthy (observed in production logs: ~4 minutes between probes). The shared `RemoteLivenessTracker` uses `REMOTE_LIVENESS_FAILURE_WINDOW_MS = 60s` — calibrated for the primary connection's sub-minute retry loop. Between pooled probes the window expires, so the failure streak resets on every tick, the log repeats `failed liveness probe (1/3)` forever, `stopBackend()` is never called, and every renderer call routed to the dead descriptor fails with `read ECONNRESET` until the app is restarted.

The fix gives pooled revalidation its own tracker with a 15-minute failure window: wide enough for the observed cadence to accumulate the 3-failure drop streak, narrow enough that genuinely stale failures still reset. `recordSuccess()` still clears the streak on any successful probe, so the wider window cannot produce false drops. The primary connection's policy is untouched.

## Related Issue

Fixes #94381

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/remote-liveness.ts` — new `REMOTE_POOLED_LIVENESS_FAILURE_WINDOW_MS` (15 min) with a comment explaining why the primary's 60s window cannot work for pooled probes
- `apps/desktop/electron/main.ts` — dedicated `pooledRemoteLiveness` tracker instance wired into `revalidatePool()`; the primary path keeps the existing tracker and window
- `apps/desktop/electron/remote-liveness.test.ts` — two new tests (see below)

## How to Test

1. `cd apps/desktop && npx vitest run electron/remote-liveness.test.ts` — 23/23 pass, including the new regression test `accumulates failures across probes minutes apart under the pooled failure window`, which reproduces #94381's production timing (probes 4 minutes apart) and fails against the old shared-window wiring
2. `npx tsc -p tsconfig.electron.json --noEmit` — clean
3. `npx eslint electron/remote-liveness.ts electron/remote-liveness.test.ts` — clean
4. Manual repro from the issue: pool a remote SSH profile backend, let it be idle-reaped (`Reaping idle profile backend "conn:<host>::<profile>" (idle > 600s)`), keep Desktop running — before: `failed liveness probe (1/3)` repeats forever and calls ECONNRESET; after: descriptor is dropped after 3 probes and the next use spawns a fresh backend

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (closest: #72835 introduced pooled revalidation; #68250 introduced the liveness window — neither covers the cadence mismatch)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected test suite (`npx vitest run electron/remote-liveness.test.ts`) and all tests pass — N/A for `pytest tests/ -q` (no Python changes)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Desktop) → Ubuntu 26.04 (SSH remote)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — change is platform-agnostic (timing constants only)
