### PR TITLE
fix(desktop): re-bind open pane to rebuilt runtime after model switch

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
@@ -4,12 +4,14 @@ import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { requestDesktopOnboardingForCredentialWarning } from '@/store/onboarding'
 import { followActiveSessionCwd } from '@/store/projects'
 import {
+  $activeSessionId,
   $currentCwd,
   $currentModel,
   $currentProvider,
   $selectedStoredSessionId,
   $sessions,
   sessionMatchesStoredId,
+  setActiveSessionId,
   setCurrentBranch,
   setCurrentCwdTransient,
   setCurrentFastMode,
@@ -65,6 +67,48 @@ function sessionInfoDescribesSelectedSession(storedSessionId: string | undefined
     .some(session => sessionMatchesStoredId(session, infoStoredSessionId) && sessionMatchesStoredId(session, selected))
 }
 
+/**
+ * Adopt a rebuilt runtime back into the open pane (#93942 scenario B).
+ *
+ * A mid-conversation model/provider switch rebuilds the agent runtime: the
+ * new runtime emits `session.info` (and every later event) under a NEW
+ * explicit session_id while the pane still holds the dead one as its active
+ * id — so `isActiveEvent` is false for the same conversation and the view
+ * stops receiving live updates until a full resume. When an incoming
+ * `session.info` lineage-matches the selected conversation but carries a
+ * different runtime id, and the OLD runtime shows no live turn (not busy,
+ * not streaming), re-bind: adopt the new id as the active session id,
+ * keeping the durable selection untouched. A live turn on the old runtime
+ * (overlap window during a manual switch) refuses the adoption.
+ */
+function maybeRebindPaneToRebuiltRuntime(ctx: GatewayEventContext): boolean {
+  const { deps, explicitSid, isActiveEvent, payload } = ctx
+
+  if (!explicitSid || isActiveEvent || typeof payload?.stored_session_id !== 'string') {
+    return false
+  }
+
+  const selected = $selectedStoredSessionId.get()
+
+  if (!selected || !sessionInfoDescribesSelectedSession(payload.stored_session_id)) {
+    return false
+  }
+
+  const activeId = $activeSessionId.get()
+  const oldState = activeId ? deps.sessionStateByRuntimeIdRef.current.get(activeId) : undefined
+
+  // Only a dead old runtime may be adopted over: hijacking a streaming turn
+  // would split one conversation's events across two panes.
+  if (oldState?.busy || oldState?.awaitingResponse || oldState?.streamId) {
+    return false
+  }
+
+  setActiveSessionId(explicitSid)
+  ctx.deps.activeSessionIdRef.current = explicitSid
+
+  return true
+}
+
 /** session.info / session.usage / session.title. */
 export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
   const { deps, event, payload, sessionId, explicitSid, isActiveEvent, occurredAt, fromActiveSource } = ctx
@@ -81,9 +125,16 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
   } = deps
 
   if (event.type === 'session.info') {
+    // A rebuilt runtime (mid-conversation model/provider switch) speaks under
+    // a NEW session_id. Before scoping anything by isActiveEvent, check
+    // whether this event is the rebuilt runtime announcing itself for the
+    // conversation already on screen — if so, re-bind the pane so every
+    // subsequent isActiveEvent gate keeps matching (#93942 scenario B).
+    const rebound = maybeRebindPaneToRebuiltRuntime(ctx)
+
     // Apply session-scoped fields when the event targets the active
     // session, OR when it's a global broadcast and we have no session.
-    const apply = explicitSid ? isActiveEvent : !activeSessionIdRef.current
+    const apply = (explicitSid ? isActiveEvent : !activeSessionIdRef.current) || rebound
     const statePatch = sessionInfoStatePatch(payload)
     const hasStatePatch = hasSessionInfoStatePatch(statePatch)
     const modelChanged = typeof payload?.model === 'string'

--- a/tests/desktop/test_bots_chat_stream_rekey.py
+++ b/tests/desktop/test_bots_chat_stream_rekey.py
@@ -64,10 +64,54 @@ def test_rebind_is_guarded_against_live_turns():
     still streaming/busy — only a dead runtime may be adopted over."""
     src = _session_info_source()
 
-    # The guard reads the previous runtime's cached state before adopting.
-    m = re.search(r"rebind[A-Za-z]*|adoptRebuiltRuntime|sessionStateByRuntimeIdRef", src)
-
-    assert m and "busy" in src[m.start() : m.start() + 2000] or "state?.busy" in src, (
-        "pre-fix state: no guarded adoption path exists; the re-bind must check "
-        "the outgoing runtime's busy/streaming state before switching"
+    # Locate the rebind helper's body precisely, then assert its guard inside.
+    fn = re.search(
+        r"function maybeRebindPaneToRebuiltRuntime\([^)]*\): boolean \{", src
     )
+    assert fn, (
+        "pre-fix state: no maybeRebindPaneToRebuiltRuntime adoption path "
+        "exists; the rebuilt runtime is never adopted into the open pane"
+    )
+
+    body_start = fn.end()
+    next_fn = min(
+        (i for i in (src.find("\nfunction ", body_start), src.find("\nexport function ", body_start)) if i != -1),
+        default=-1,
+    )
+    assert next_fn != -1, "re-anchor needed: rebind helper is no longer followed by another function"
+
+    body = src[body_start:next_fn]
+
+    # The busy/awaiting/streaming guard must appear INSIDE the helper body —
+    # not merely somewhere in the file (fixes the precedence hazard the
+    # #94417 review flagged in the original draft of this assertion).
+    guard = re.search(r"oldState\?\.(busy|awaitingResponse|streamId)", body)
+
+    assert guard, (
+        "the re-bind helper must check the outgoing runtime's busy/streaming "
+        "state before switching; adopting over a live turn would split one "
+        "conversation across two panes"
+    )
+
+
+def test_rebind_requires_stored_session_id_lineage():
+    """The gateway always stamps stored_session_id on session.info (server.py:
+    'stored_session_id': session_key or ''), but an empty string must NOT be
+    adopted as lineage proof — only a real stored id may trigger the re-bind."""
+    src = _session_info_source()
+
+    fn = re.search(r"function maybeRebindPaneToRebuiltRuntime\([^)]*\): boolean \{", src)
+    assert fn, "rebind helper missing"
+    body_start = fn.end()
+    body = src[body_start : min(
+        (i for i in (src.find("\nfunction ", body_start), src.find("\nexport function ", body_start)) if i != -1),
+        default=-1,
+    )]
+
+    # The early return guards on the field being a non-empty usable string via
+    # the typeof check + downstream sessionInfoDescribesSelectedSession('' →
+    # null → wildcard refusal).
+    assert 'typeof payload?.stored_session_id !== "string"' in body or (
+        "typeof payload?.stored_session_id !== 'string'" in body
+    ), "rebind must refuse events without a string stored_session_id"
+

--- a/tests/desktop/test_bots_chat_stream_rekey.py
+++ b/tests/desktop/test_bots_chat_stream_rekey.py
@@ -1,0 +1,73 @@
+"""Regression tests for #93942 slice 2 — open chat pane never follows a runtime
+rebuild after a mid-conversation model switch.
+
+Mechanism (traced on 41447a6d70):
+
+* A mid-conversation model/provider switch rebuilds the agent runtime. The
+  rebuilt runtime emits its ``session.info`` (and all later stream events)
+  under a NEW explicit ``session_id``; the old id is dead.
+* The pane's identity is the pair ``(activeSessionIdRef, selectedStoredSessionIdRef)``.
+  After the rebuild, incoming events carry an explicit sid that no longer
+  equals ``activeSessionIdRef.current``, so ``isActiveEvent`` is False for every
+  subsequent event of the SAME conversation — view-scoped side effects stop,
+  and the pane keeps listening on a dead runtime until a full resume.
+* Existing machinery covers compression rotation only:
+  ``ensureSessionState`` fires the stored-id rotation signal when the SAME
+  runtime's stored id rotates — but a model-switch rebuild produces a NEW
+  runtime with a NEW stored id, which is invisible to that path.
+
+Fix contract: when a ``session.info`` event's lineage
+(``sessionMatchesStoredId`` on ``stored_session_id``) matches the currently
+selected conversation but its runtime id differs from the active one, re-bind
+the pane: adopt the new runtime id as the active session id (keeping the same
+durable selection), so live events keep flowing to the view without a resume.
+Guarded to only fire when the old runtime is dead (no busy/streaming state) so
+an overlapping turn is never hijacked mid-flight.
+
+Together with #94255 (slice 1), this closes #93942.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2] / "apps" / "desktop" / "src"
+
+
+def _session_info_source() -> str:
+    return (
+        ROOT / "app" / "session" / "hooks" / "use-message-stream" / "gateway-event" / "session-info.ts"
+    ).read_text(encoding="utf-8")
+
+
+def test_session_info_rebinds_pane_to_rebuilt_runtime():
+    """A session.info whose lineage matches the selected conversation but whose
+    runtime id differs from the active one must trigger the re-bind path."""
+    src = _session_info_source()
+
+    # The fix adds a lineage-checked re-bind call in handleSessionInfoEvent,
+    # distinct from the cwd-claim helper (#71254). Pre-fix there is exactly one
+    # sessionInfoDescribesSelectedSession use site (cwd claim); post-fix a
+    # second consumer exists for the re-bind.
+    uses = len(re.findall(r"sessionInfoDescribesSelectedSession\(", src))
+
+    assert uses >= 3, (
+        "pre-fix state: session.info lineage matching is used only for the cwd "
+        "claim; a rebuilt runtime (model switch) under a new session_id is "
+        "never adopted back into the open pane (#93942 scenario B)"
+    )
+
+
+def test_rebind_is_guarded_against_live_turns():
+    """The re-bind must not hijack a conversation while its OLD runtime is
+    still streaming/busy — only a dead runtime may be adopted over."""
+    src = _session_info_source()
+
+    # The guard reads the previous runtime's cached state before adopting.
+    m = re.search(r"rebind[A-Za-z]*|adoptRebuiltRuntime|sessionStateByRuntimeIdRef", src)
+
+    assert m and "busy" in src[m.start() : m.start() + 2000] or "state?.busy" in src, (
+        "pre-fix state: no guarded adoption path exists; the re-bind must check "
+        "the outgoing runtime's busy/streaming state before switching"
+    )


### PR DESCRIPTION
Fixes part of #93942

## Summary

A mid-conversation model/provider switch rebuilds the agent runtime. The rebuilt runtime emits `session.info` and all later events under a NEW explicit `session_id` while the pane still holds the dead id as its active session — `isActiveEvent` goes false for the same conversation, so the open chat freezes until a full resume (scenario B of #93942; the backend even logs "client should resume the stored session," but the client never does).

## Mechanism

Event routing pins explicit-sid events correctly (`gateway-events.ts:resolveGatewayEventSessionId`), but identity matching is `(newId === activeSessionIdRef.current)` at `index.ts:196` — a rebuilt runtime's new id never matches. The existing compression-rotation path doesn't cover this: it fires when the *same* runtime's stored id rotates; a rebuild produces a *new* runtime with a *new* stored id.

## This PR

When a `session.info` lineage-matches the selected conversation (`sessionMatchesStoredId` over `stored_session_id`) but carries a different runtime id, adopt the new runtime id as the active session id — durable selection untouched — so every downstream `isActiveEvent` gate keeps matching without a resume. Guarded: adoption refused while the old runtime shows any live turn (busy/awaiting/streaming), so an overlapping manual switch can never split a conversation across panes.

## Non-goals

- No changes to tile reconcile (#94255 covers that), event routing rules, or backend retry behavior.
- No auto-resume: if the guard refuses adoption (live turn overlap), behavior stays as today until the turn settles.

## Test plan

Two regression tests verified failing pre-fix on `41447a6d70`; adjacent gateway-event suites 130/130; typecheck clean ×3 projects; eslint clean on touched file.

Together with #94255, closes #93942.

Platforms: Electron desktop, platform-independent logic; tested on Linux (Pop!_OS 24.04).
