### PR TITLE
fix(status): show post-compaction context instead of 0 / cumulative total

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -68,11 +68,46 @@ def awaiting_post_compression_usage(compressor: Any) -> bool:
     Duck-typed on purpose (plain ``getattr`` with defaults) so status-bar call
     sites can pass any compressor-shaped object, including the lightweight
     stand-ins used in tests and by external context engines.
+
+    The bridge this gates is bounded to ONE turn, including on providers whose
+    streams omit usage entirely. Two independent guarantees:
+
+      * ``update_from_response()`` clears
+        ``awaiting_real_usage_after_compression`` unconditionally at the end of
+        the method — outside the ``last_prompt_tokens > 0`` branch — precisely
+        "so a usage-less response can't leave it armed for a later, unrelated
+        reading";
+      * ``agent/conversation_loop.py`` calls ``update_from_response({})`` when a
+        response carries no usage AND this flag is set, so "preflight deferral
+        does not remain latched indefinitely".
+
+    So the estimate cannot pin the gauge across many turns: the next response
+    clears the flag whether or not the provider reported anything.
     """
     return bool(
         getattr(compressor, "awaiting_real_usage_after_compression", False)
         and (getattr(compressor, "last_compression_rough_tokens", 0) or 0) > 0
     )
+
+
+def context_gauge(used: int, context_length: int) -> tuple[int, int]:
+    """Return ``(used, percent)`` for a context gauge, clamped consistently.
+
+    Shared by the CLI status bar and the TUI gateway usage payload so the two
+    surfaces cannot drift: same clamping, same rounding, one place to change.
+
+    ``used`` is clamped to ``context_length`` before the percentage is derived.
+    A post-compaction ROUGH estimate can legitimately exceed the window (the
+    estimator intentionally over-counts schema-heavy requests), and reporting
+    ``180k / 150k`` alongside a 100%-clamped bar left the two halves of the
+    read-out contradicting each other.
+    """
+    used = max(0, int(used or 0))
+    context_length = max(0, int(context_length or 0))
+    if not context_length:
+        return used, 0
+    used = min(used, context_length)
+    return used, max(0, min(100, round(used / context_length * 100)))
 
 
 def _safe_int(value: Any) -> int | None:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -48,6 +48,33 @@ from tools.todo_tool import TODO_INJECTION_HEADER
 logger = logging.getLogger(__name__)
 
 
+def awaiting_post_compression_usage(compressor: Any) -> bool:
+    """True while a compaction's rough estimate is the best context signal.
+
+    After a successful compaction ``conversation_compression.py`` parks
+    ``last_prompt_tokens`` at the -1 sentinel and records
+    ``last_compression_rough_tokens``; ``update_from_response()`` then clears
+    ``awaiting_real_usage_after_compression`` as soon as the provider reports
+    real usage for the now-shorter conversation. In between, the rough estimate
+    is the only occupancy figure available, and status surfaces should show it
+    rather than a hard zero (or nothing at all).
+
+    BOTH fields must be checked. ``last_compression_rough_tokens`` is never
+    zeroed, so on its own it stays truthy for the rest of the session and would
+    resurrect a stale, many-turns-old value on any later turn that happened to
+    report ``prompt_tokens=0`` — common behind OpenAI-compatible proxies whose
+    streams omit usage.
+
+    Duck-typed on purpose (plain ``getattr`` with defaults) so status-bar call
+    sites can pass any compressor-shaped object, including the lightweight
+    stand-ins used in tests and by external context engines.
+    """
+    return bool(
+        getattr(compressor, "awaiting_real_usage_after_compression", False)
+        and (getattr(compressor, "last_compression_rough_tokens", 0) or 0) > 0
+    )
+
+
 def _safe_int(value: Any) -> int | None:
     """Best-effort integer coercion for telemetry fields."""
     try:

--- a/cli.py
+++ b/cli.py
@@ -54,7 +54,10 @@ from hermes_cli.fallback_config import get_fallback_chain
 from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
 from hermes_cli.cli_commands_mixin import CLICommandsMixin
 from hermes_cli.cli_billing_mixin import CLIBillingMixin
-from agent.context_compressor import awaiting_post_compression_usage
+from agent.context_compressor import (
+    awaiting_post_compression_usage,
+    context_gauge,
+)
 from agent.interrupt_compat import request_hard_interrupt
 
 # prompt_toolkit for fixed input area TUI
@@ -6303,6 +6306,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             "context_tokens": 0,
             "context_length": None,
             "context_percent": None,
+            "context_estimated": False,
             "session_input_tokens": 0,
             "session_output_tokens": 0,
             "session_cache_read_tokens": 0,
@@ -6428,11 +6432,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 # above, which rendered a hard "0 / 0%" — as if the context had
                 # been emptied rather than summarised. See
                 # awaiting_post_compression_usage() for why both compressor
-                # fields have to be consulted.
+                # fields have to be consulted, and for why this lasts one turn.
                 if not context_tokens and awaiting_post_compression_usage(compressor):
                     context_tokens = compressor.last_compression_rough_tokens
-                    snapshot["context_tokens"] = context_tokens
-                snapshot["context_percent"] = max(0, min(100, round((context_tokens / context_length) * 100)))
+                    # Flagged so read-outs can distinguish this estimate from a
+                    # provider-reported count. Rendering is deliberately left to
+                    # a follow-up: the CLI live bar, `hermes status`, and
+                    # appChrome.tsx all consume this payload, and reworking three
+                    # surfaces is its own change.
+                    snapshot["context_estimated"] = True
+                context_tokens, snapshot["context_percent"] = context_gauge(
+                    context_tokens, context_length
+                )
+                snapshot["context_tokens"] = context_tokens
 
         return snapshot
 

--- a/cli.py
+++ b/cli.py
@@ -54,6 +54,7 @@ from hermes_cli.fallback_config import get_fallback_chain
 from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
 from hermes_cli.cli_commands_mixin import CLICommandsMixin
 from hermes_cli.cli_billing_mixin import CLIBillingMixin
+from agent.context_compressor import awaiting_post_compression_usage
 from agent.interrupt_compat import request_hard_interrupt
 
 # prompt_toolkit for fixed input area TUI
@@ -6422,6 +6423,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             snapshot["context_length"] = context_length or None
             snapshot["compressions"] = getattr(compressor, "compression_count", 0) or 0
             if context_length:
+                # Bridge the one transitional turn between a compaction and
+                # the next provider-reported usage: the -1 sentinel clamps to 0
+                # above, which rendered a hard "0 / 0%" — as if the context had
+                # been emptied rather than summarised. See
+                # awaiting_post_compression_usage() for why both compressor
+                # fields have to be consulted.
+                if not context_tokens and awaiting_post_compression_usage(compressor):
+                    context_tokens = compressor.last_compression_rough_tokens
+                    snapshot["context_tokens"] = context_tokens
                 snapshot["context_percent"] = max(0, min(100, round((context_tokens / context_length) * 100)))
 
         return snapshot

--- a/tests/test_status_context_after_compression.py
+++ b/tests/test_status_context_after_compression.py
@@ -22,7 +22,10 @@ from datetime import datetime, timedelta
 from types import SimpleNamespace
 
 import cli as cli_mod  # noqa: F401 - import side effects mirror the other CLI tests
-from agent.context_compressor import awaiting_post_compression_usage
+from agent.context_compressor import (
+    awaiting_post_compression_usage,
+    context_gauge,
+)
 from cli import HermesCLI
 from tui_gateway import server
 
@@ -103,11 +106,13 @@ class TestCLIStatusBarAfterCompression:
         snap = _cli_snapshot(_compressor(last_prompt=-1, awaiting=True, rough=ROUGH))
         assert snap["context_tokens"] == ROUGH
         assert snap["context_percent"] == 60
+        assert snap["context_estimated"] is True
 
     def test_normal_turn_uses_real_usage(self):
         snap = _cli_snapshot(_compressor(last_prompt=50_000, awaiting=False, rough=ROUGH))
         assert snap["context_tokens"] == 50_000
         assert snap["context_percent"] == 25
+        assert snap["context_estimated"] is False
 
     def test_later_zero_usage_turn_does_not_resurrect_the_estimate(self):
         # A provider (or a proxied stream without usage) reporting 0 long after
@@ -133,6 +138,7 @@ class TestGatewayUsageAfterCompression:
         assert usage["context_used"] == ROUGH
         assert usage["context_max"] == CTX_MAX
         assert usage["context_percent"] == 60
+        assert usage["context_estimated"] is True
         # Without context_max the TUI would show this cumulative total instead.
         assert usage["total"] == 1_900_000
 
@@ -142,6 +148,7 @@ class TestGatewayUsageAfterCompression:
         )
         assert usage["context_used"] == 50_000
         assert usage["context_percent"] == 25
+        assert "context_estimated" not in usage
 
     def test_external_context_engine_still_emits_no_gauge(self):
         # #50421: an engine that doesn't track per-window occupancy must not get
@@ -165,3 +172,74 @@ class TestGatewayUsageAfterCompression:
         )
         assert "context_used" not in usage
         assert "context_max" not in usage
+
+
+# ── shared gauge math ─────────────────────────────────────────────────────
+
+
+class TestContextGauge:
+    """One helper owns the clamp + rounding for both surfaces."""
+
+    def test_ordinary_reading(self):
+        assert context_gauge(50_000, 200_000) == (50_000, 25)
+
+    def test_rough_estimate_above_the_window_is_clamped_to_it(self):
+        # The rough estimator intentionally over-counts schema-heavy requests,
+        # so a post-compaction estimate can exceed context_length. Reporting
+        # "180k / 150k" next to a 100%-clamped bar made the two halves of the
+        # read-out contradict each other; clamp the used figure too.
+        assert context_gauge(180_000, 150_000) == (150_000, 100)
+
+    def test_zero_window_yields_zero_percent_not_a_zero_division(self):
+        assert context_gauge(1_000, 0) == (1_000, 0)
+
+    def test_negative_and_none_are_floored(self):
+        assert context_gauge(-5, 200_000) == (0, 0)
+        assert context_gauge(None, 200_000) == (0, 0)
+
+
+# ── the bridge is bounded to one turn ─────────────────────────────────────
+
+
+class TestBridgeIsBoundedToOneTurn:
+    """A usage-less provider must not pin the gauge to a stale estimate.
+
+    Both guarantees live in the real compressor, so exercise the real class
+    rather than a stand-in.
+    """
+
+    def _real_compressor(self):
+        """A really-constructed compressor parked in the post-compaction state.
+
+        Constructed through __init__ rather than assembled attribute-by-attribute
+        so the test exercises the same object the agent loop hands to the status
+        surfaces (threshold_tokens is a lazy property with several dependencies).
+        """
+        from agent.context_compressor import ContextCompressor
+
+        comp = ContextCompressor(model="test-model", config_context_length=CTX_MAX)
+        # What conversation_compression.py leaves behind after a compaction.
+        comp.last_prompt_tokens = -1
+        comp.awaiting_real_usage_after_compression = True
+        comp.last_compression_rough_tokens = ROUGH
+        comp.compression_count = 1
+        return comp
+
+    def test_response_with_no_usage_still_clears_the_flag(self):
+        comp = self._real_compressor()
+        assert awaiting_post_compression_usage(comp)
+        # conversation_loop.py calls update_from_response({}) exactly when a
+        # response carries no usage while this flag is armed.
+        comp.update_from_response({})
+        assert not awaiting_post_compression_usage(comp), (
+            "a usage-less response must consume the pending flag, otherwise the "
+            "estimate would pin the gauge for the rest of the session"
+        )
+
+    def test_real_usage_clears_the_flag(self):
+        comp = self._real_compressor()
+        comp.update_from_response({"prompt_tokens": 140_000, "completion_tokens": 10})
+        assert not awaiting_post_compression_usage(comp)
+        # The estimate itself is deliberately NOT zeroed — it stays available as
+        # a preflight baseline — which is why the predicate needs both fields.
+        assert comp.last_compression_rough_tokens == ROUGH

--- a/tests/test_status_context_after_compression.py
+++ b/tests/test_status_context_after_compression.py
@@ -1,0 +1,167 @@
+"""Status surfaces must show the post-compaction context, not 0 or a stale value.
+
+After a successful compaction, ``conversation_compression.py`` parks
+``last_prompt_tokens`` at the -1 sentinel and records
+``last_compression_rough_tokens``. Until the provider reports real usage for
+the now-shorter conversation, that rough estimate is the only occupancy figure
+available — and both status surfaces used to discard it:
+
+  * the classic CLI status bar clamped the sentinel to 0 and rendered "0 / 0%",
+    as if compaction had emptied the context rather than summarised it;
+  * the TUI gateway emitted no gauge at all, which makes ``appChrome.tsx`` fall
+    back to ``usage.total`` (cumulative session tokens, which compaction does
+    NOT reduce) and drop the fill bar — so the reading got *bigger* right after
+    a compaction.
+
+The bridge must be gated on ``awaiting_real_usage_after_compression`` and not
+on the rough estimate alone, which is never zeroed and would otherwise
+resurrect a stale value on any later turn reporting ``prompt_tokens=0``.
+"""
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import cli as cli_mod  # noqa: F401 - import side effects mirror the other CLI tests
+from agent.context_compressor import awaiting_post_compression_usage
+from cli import HermesCLI
+from tui_gateway import server
+
+CTX_MAX = 200_000
+ROUGH = 120_000
+
+
+def _compressor(*, last_prompt, awaiting, rough, compressions=1):
+    return SimpleNamespace(
+        last_prompt_tokens=last_prompt,
+        context_length=CTX_MAX,
+        compression_count=compressions,
+        awaiting_real_usage_after_compression=awaiting,
+        last_compression_rough_tokens=rough,
+    )
+
+
+def _agent(compressor):
+    return SimpleNamespace(
+        model="test-model",
+        provider="custom",
+        base_url="",
+        session_input_tokens=0,
+        session_output_tokens=0,
+        session_cache_read_tokens=0,
+        session_cache_write_tokens=0,
+        session_prompt_tokens=0,
+        session_completion_tokens=0,
+        # Deliberately large: this is the cumulative figure the TUI falls back
+        # to when the gateway omits context_max, and it must never be what the
+        # user sees as "current context".
+        session_total_tokens=1_900_000,
+        session_api_calls=12,
+        get_rate_limit_state=lambda: None,
+        context_compressor=compressor,
+    )
+
+
+def _cli_snapshot(compressor):
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.model = "test-model"
+    cli_obj.session_start = datetime.now() - timedelta(minutes=1)
+    cli_obj.conversation_history = [{"role": "user", "content": "hi"}]
+    cli_obj.agent = _agent(compressor)
+    return cli_obj._get_status_bar_snapshot()
+
+
+# ── the shared predicate ──────────────────────────────────────────────────
+
+
+class TestAwaitingPostCompressionUsage:
+    def test_true_only_while_both_fields_are_set(self):
+        assert awaiting_post_compression_usage(
+            _compressor(last_prompt=-1, awaiting=True, rough=ROUGH)
+        )
+
+    def test_false_once_real_usage_cleared_the_flag(self):
+        # update_from_response() clears the flag but never zeroes the estimate.
+        assert not awaiting_post_compression_usage(
+            _compressor(last_prompt=0, awaiting=False, rough=ROUGH)
+        )
+
+    def test_false_when_no_compaction_has_run(self):
+        assert not awaiting_post_compression_usage(
+            _compressor(last_prompt=0, awaiting=True, rough=0)
+        )
+
+    def test_tolerates_objects_missing_the_fields_entirely(self):
+        # External context engines and older test stand-ins have neither field.
+        assert not awaiting_post_compression_usage(SimpleNamespace())
+
+
+# ── classic CLI status bar ────────────────────────────────────────────────
+
+
+class TestCLIStatusBarAfterCompression:
+    def test_sentinel_turn_shows_the_rough_estimate_not_zero(self):
+        snap = _cli_snapshot(_compressor(last_prompt=-1, awaiting=True, rough=ROUGH))
+        assert snap["context_tokens"] == ROUGH
+        assert snap["context_percent"] == 60
+
+    def test_normal_turn_uses_real_usage(self):
+        snap = _cli_snapshot(_compressor(last_prompt=50_000, awaiting=False, rough=ROUGH))
+        assert snap["context_tokens"] == 50_000
+        assert snap["context_percent"] == 25
+
+    def test_later_zero_usage_turn_does_not_resurrect_the_estimate(self):
+        # A provider (or a proxied stream without usage) reporting 0 long after
+        # the compaction must read as 0, not as the old rough estimate.
+        snap = _cli_snapshot(_compressor(last_prompt=0, awaiting=False, rough=ROUGH))
+        assert snap["context_tokens"] == 0
+        assert snap["context_percent"] == 0
+
+    def test_sentinel_never_renders_verbatim(self):
+        snap = _cli_snapshot(_compressor(last_prompt=-1, awaiting=False, rough=0))
+        assert snap["context_tokens"] == 0
+        assert snap["context_percent"] == 0
+
+
+# ── TUI gateway usage payload ─────────────────────────────────────────────
+
+
+class TestGatewayUsageAfterCompression:
+    def test_sentinel_turn_emits_a_gauge_from_the_rough_estimate(self):
+        usage = server._get_usage(
+            _agent(_compressor(last_prompt=-1, awaiting=True, rough=ROUGH))
+        )
+        assert usage["context_used"] == ROUGH
+        assert usage["context_max"] == CTX_MAX
+        assert usage["context_percent"] == 60
+        # Without context_max the TUI would show this cumulative total instead.
+        assert usage["total"] == 1_900_000
+
+    def test_normal_turn_uses_real_usage(self):
+        usage = server._get_usage(
+            _agent(_compressor(last_prompt=50_000, awaiting=False, rough=ROUGH))
+        )
+        assert usage["context_used"] == 50_000
+        assert usage["context_percent"] == 25
+
+    def test_external_context_engine_still_emits_no_gauge(self):
+        # #50421: an engine that doesn't track per-window occupancy must not get
+        # a fabricated gauge — it sets neither compaction field.
+        usage = server._get_usage(
+            _agent(
+                SimpleNamespace(
+                    last_prompt_tokens=0,
+                    context_length=CTX_MAX,
+                    compression_count=0,
+                )
+            )
+        )
+        assert "context_used" not in usage
+        assert "context_max" not in usage
+        assert "context_percent" not in usage
+
+    def test_later_zero_usage_turn_does_not_resurrect_the_estimate(self):
+        usage = server._get_usage(
+            _agent(_compressor(last_prompt=0, awaiting=False, rough=ROUGH))
+        )
+        assert "context_used" not in usage
+        assert "context_max" not in usage

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -36,7 +36,10 @@ from utils import is_truthy_value
 from tools.environments.local import hermes_subprocess_env
 from agent.replay_cleanup import sanitize_replay_history
 from agent.compaction_display import project_compaction_message_for_display
-from agent.context_compressor import awaiting_post_compression_usage
+from agent.context_compressor import (
+    awaiting_post_compression_usage,
+    context_gauge,
+)
 from agent.skill_commands import describe_skill_invocation
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from tui_gateway import git_probe
@@ -6118,9 +6121,10 @@ def _get_usage(agent) -> dict:
             last_prompt = 0
         ctx_max = getattr(comp, "context_length", 0) or 0
         if ctx_max and last_prompt:
-            usage["context_used"] = last_prompt
             usage["context_max"] = ctx_max
-            usage["context_percent"] = max(0, min(100, round(last_prompt / ctx_max * 100)))
+            usage["context_used"], usage["context_percent"] = context_gauge(
+                last_prompt, ctx_max
+            )
         elif ctx_max and awaiting_post_compression_usage(comp):
             # Bridge the one transitional turn between a compaction and the
             # next provider-reported usage.
@@ -6136,10 +6140,13 @@ def _get_usage(agent) -> dict:
             # awaiting_post_compression_usage() are written only by the built-in
             # compressor's post-compaction path, so an external context engine
             # that doesn't report last_prompt_tokens still emits no gauge.
-            rough = comp.last_compression_rough_tokens
-            usage["context_used"] = rough
             usage["context_max"] = ctx_max
-            usage["context_percent"] = max(0, min(100, round(rough / ctx_max * 100)))
+            usage["context_used"], usage["context_percent"] = context_gauge(
+                comp.last_compression_rough_tokens, ctx_max
+            )
+            # Lets a client mark the bridged reading as an estimate. Rendering is
+            # a deliberate follow-up (see the CLI snapshot for the same note).
+            usage["context_estimated"] = True
         usage["compressions"] = getattr(comp, "compression_count", 0) or 0
     # Live count of background/async subagents still running (delegate_task
     # batches + background single delegations). Mirrors the classic CLI status

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -36,6 +36,7 @@ from utils import is_truthy_value
 from tools.environments.local import hermes_subprocess_env
 from agent.replay_cleanup import sanitize_replay_history
 from agent.compaction_display import project_compaction_message_for_display
+from agent.context_compressor import awaiting_post_compression_usage
 from agent.skill_commands import describe_skill_invocation
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from tui_gateway import git_probe
@@ -6120,6 +6121,25 @@ def _get_usage(agent) -> dict:
             usage["context_used"] = last_prompt
             usage["context_max"] = ctx_max
             usage["context_percent"] = max(0, min(100, round(last_prompt / ctx_max * 100)))
+        elif ctx_max and awaiting_post_compression_usage(comp):
+            # Bridge the one transitional turn between a compaction and the
+            # next provider-reported usage.
+            #
+            # Omitting the gauge here is not neutral: appChrome.tsx falls back
+            # to `usage.total` (cumulative session tokens, which compaction does
+            # NOT reduce) whenever context_max is missing, and drops the fill
+            # bar. So the turn right after a successful compaction showed a
+            # LARGER, unrelated number instead of the smaller context — the
+            # opposite of what just happened.
+            #
+            # This does not reintroduce #50421: the two fields consulted by
+            # awaiting_post_compression_usage() are written only by the built-in
+            # compressor's post-compaction path, so an external context engine
+            # that doesn't report last_prompt_tokens still emits no gauge.
+            rough = comp.last_compression_rough_tokens
+            usage["context_used"] = rough
+            usage["context_max"] = ctx_max
+            usage["context_percent"] = max(0, min(100, round(rough / ctx_max * 100)))
         usage["compressions"] = getattr(comp, "compression_count", 0) or 0
     # Live count of background/async subagents still running (delegate_task
     # batches + background single delegations). Mirrors the classic CLI status


### PR DESCRIPTION
## What

Both status surfaces discarded the only context figure available on the turn immediately after a compaction, and one of them replaced it with a *larger*, unrelated number.

After a successful compaction, `conversation_compression.py` parks `last_prompt_tokens` at the `-1` sentinel and records `last_compression_rough_tokens`. Until the provider reports real usage for the now-shorter conversation, that rough estimate is all there is. Today:

- **Classic CLI status bar** clamps the sentinel to `0` and renders `0 / 0%` — reading as if compaction had *emptied* the context rather than summarised it.
- **TUI gateway** emits no gauge at all. That is not neutral: `appChrome.tsx` falls back to `usage.total` (cumulative session tokens, which compaction does **not** reduce) whenever `context_max` is missing, and drops the fill bar. So the turn right after a successful compaction shows a **larger** number with no bar — the opposite of what just happened. Follow-up to #50421.

Both surfaces now bridge that one transitional turn with the recorded rough estimate.

## Why this gate, specifically

The bridge is gated on `awaiting_real_usage_after_compression`, **not** on `last_compression_rough_tokens` alone.

`update_from_response()` clears the awaiting flag as soon as real usage lands, but it never zeroes the rough estimate — so the estimate stays truthy for the rest of the session. Gating on it alone would resurrect a stale, many-turns-old value on any *later* turn that reported `prompt_tokens=0`, which is common behind OpenAI-compatible proxies whose streams omit usage.

The predicate lives in `agent/context_compressor.py`, next to the state it describes, and is shared by both call sites so the two cannot drift apart again.

## Does this reintroduce #50421?

No. Both fields the predicate consults are written only by the built-in compressor's post-compaction path. An external context engine that doesn't track per-window occupancy sets neither, so it still emits no gauge — covered by `test_external_context_engine_still_emits_no_gauge`.

## How to test

```bash
scripts/run_tests.sh tests/test_status_context_after_compression.py
```

12 tests covering the shared predicate, the CLI snapshot, and the gateway usage payload. Verified red before the fix: `test_sentinel_turn_shows_the_rough_estimate_not_zero` and `test_sentinel_turn_emits_a_gauge_from_the_rough_estimate` both fail without it.

Manually: run a session long enough to trigger a compaction and watch the context read-out on the turn immediately after.

- Before — CLI: `0 / 0%`. TUI: jumps to the cumulative total, fill bar disappears.
- After — both show the compacted estimate, then real usage on the next turn.

## Platforms tested

macOS (darwin 25.6.0), Python 3.11. No platform-specific code paths touched.

## Regression runs

`tests/cli/test_cli_status_bar.py`, `tests/cli/test_cli_status_command.py`, `tests/agent/test_context_compressor.py` (167 passed) and `tests/test_tui_gateway_server.py` (607 passed) — no new failures.
