### PR TITLE
fix(cli): fail cleanly when interactive chat has no TTY

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -28,6 +28,7 @@ import copy
 import os
 import shutil
 import sys
+import typing
 import json
 import re
 import concurrent.futures
@@ -21052,6 +21053,17 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
     )
 
 
+def _exit_needs_tty() -> "typing.NoReturn":
+    """Report the missing TTY and exit 1."""
+    print(
+        "Error: interactive chat requires a terminal (stdin is not a TTY).\n"
+        "Run 'hermes chat' directly in a terminal, or pass a one-shot query:\n"
+        '  hermes chat -q "your prompt"',
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
 def will_enter_interactive_repl(
     *,
     query: str | None = None,
@@ -21179,14 +21191,7 @@ def main(
         list_tools=list_tools,
         list_toolsets=list_toolsets,
     ) and not sys.stdin.isatty():
-        print(
-            "Error: interactive chat requires a terminal (stdin is not a TTY).\n"
-            "Run 'hermes chat' directly in a terminal, or pass a one-shot "
-            "query:\n"
-            '  hermes chat -q "your prompt"',
-            file=sys.stderr,
-        )
-        sys.exit(1)
+        _exit_needs_tty()
 
     # Skip worktree for list commands (they exit immediately)
     if not list_tools and not list_toolsets:
@@ -21717,6 +21722,21 @@ def main(
             _finalize_single_query(cli)
         return
     
+    # Backstop: the early guard above is the one that fires in practice (it
+    # runs before worktree setup and agent init, so the user does not pay for
+    # either), but it necessarily predicts which branch main() will take. This
+    # check sits on the actual REPL entry, where no prediction is involved, so a
+    # future flag that carves out a new non-interactive path — or reorders the
+    # dispatch below — cannot silently bypass the TTY requirement and reintroduce
+    # the raw `OSError: [Errno 22]` from prompt_toolkit.
+    #
+    # Only stdin is checked, deliberately. prompt_toolkit tolerates a non-TTY
+    # stdout: with a pty stdin and a piped stdout, Application.run() completes
+    # normally (verified against the vendored prompt_toolkit), so gating on
+    # stdout too would break `hermes chat | tee session.log`, which works today.
+    if not sys.stdin.isatty():
+        _exit_needs_tty()
+
     # Run interactive mode
     cli.run()
 

--- a/cli.py
+++ b/cli.py
@@ -21052,6 +21052,28 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
     )
 
 
+def will_enter_interactive_repl(
+    *,
+    query: str | None = None,
+    q: str | None = None,
+    image: str | None = None,
+    list_tools: bool = False,
+    list_toolsets: bool = False,
+    gateway: bool = False,
+) -> bool:
+    """True when this invocation will end up in the interactive REPL.
+
+    Every other entry point produces its output and returns before
+    ``cli.run()``: ``--gateway`` starts the messaging gateway, ``--list-tools``
+    / ``--list-toolsets`` print and exit, and ``--query``/``-q``/``--image``
+    take the one-shot path. Only a bare invocation reaches prompt_toolkit,
+    which is the one case that needs a real terminal.
+    """
+    if gateway or list_tools or list_toolsets:
+        return False
+    return not (query or q or image)
+
+
 def main(
     query: str = None,
     q: str = None,
@@ -21135,6 +21157,36 @@ def main(
         print("Starting Hermes Gateway (messaging platforms)...")
         asyncio.run(start_gateway())
         return
+
+    # ── Interactive mode requires a real TTY ──────────────────────────────
+    # prompt_toolkit's vt100 input registers stdin's fd with the asyncio
+    # selector (Application.run -> _attached_input -> loop.add_reader), which a
+    # redirected stdin cannot satisfy. `nohup hermes chat`, a pipe, or any
+    # non-interactive subprocess therefore died with a bare
+    #
+    #     OSError: [Errno 22] Invalid argument
+    #       ... selectors.py in register -> self._selector.control([kev], 0, 0)
+    #
+    # raised out of prompt_toolkit — after paying for git worktree setup, full
+    # agent init, and the entire welcome banner. Check before any of that and
+    # exit with an actionable message instead. Mirrors the _require_tty() guard
+    # hermes_cli/main.py already applies to its other interactive commands
+    # (model, tools, whatsapp).
+    if will_enter_interactive_repl(
+        query=query,
+        q=q,
+        image=image,
+        list_tools=list_tools,
+        list_toolsets=list_toolsets,
+    ) and not sys.stdin.isatty():
+        print(
+            "Error: interactive chat requires a terminal (stdin is not a TTY).\n"
+            "Run 'hermes chat' directly in a terminal, or pass a one-shot "
+            "query:\n"
+            '  hermes chat -q "your prompt"',
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     # Skip worktree for list commands (they exit immediately)
     if not list_tools and not list_toolsets:

--- a/tests/cli/test_cli_requires_tty.py
+++ b/tests/cli/test_cli_requires_tty.py
@@ -77,3 +77,30 @@ class TestInteractiveTTYGuard:
         with pytest.raises(SystemExit) as exc:
             cli_mod.main()
         assert exc.value.code == 1
+
+
+class TestBackstopGuard:
+    """The REPL entry itself is guarded, not only the predicted branch.
+
+    The early guard predicts which branch main() will take; this one sits on the
+    actual REPL entry. A future flag that carves out a new non-interactive path,
+    or a reordering of main()'s dispatch, must not be able to reach
+    prompt_toolkit with a non-TTY stdin.
+    """
+
+    def test_repl_entry_is_guarded_even_if_the_early_check_is_bypassed(
+        self, monkeypatch, capsys
+    ):
+        # Simulate exactly that regression: force the predicate to claim this
+        # invocation is non-interactive, so the early guard does not fire.
+        monkeypatch.setattr(cli_mod, "will_enter_interactive_repl", lambda **_kw: False)
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False, raising=False)
+
+        def _boom(*_a, **_k):
+            raise AssertionError("reached cli.run() with a non-TTY stdin")
+
+        monkeypatch.setattr(cli_mod.HermesCLI, "run", _boom, raising=False)
+        with pytest.raises(SystemExit) as exc:
+            cli_mod.main()
+        assert exc.value.code == 1
+        assert "requires a terminal" in capsys.readouterr().err

--- a/tests/cli/test_cli_requires_tty.py
+++ b/tests/cli/test_cli_requires_tty.py
@@ -1,0 +1,79 @@
+"""Interactive chat must refuse a non-TTY stdin instead of crashing.
+
+prompt_toolkit's vt100 input registers stdin's fd with the asyncio selector
+(``Application.run`` -> ``_attached_input`` -> ``loop.add_reader``), which a
+redirected stdin cannot satisfy. Before the guard, ``nohup hermes chat`` / a
+pipe / any non-interactive subprocess died with a bare
+
+    OSError: [Errno 22] Invalid argument
+
+out of ``selectors.control()`` -- after git worktree setup, full agent init and
+the whole welcome banner had already run.
+"""
+
+import sys
+
+import pytest
+
+import cli as cli_mod
+from cli import will_enter_interactive_repl
+
+
+class TestWillEnterInteractiveRepl:
+    """Only a bare invocation reaches prompt_toolkit."""
+
+    def test_bare_invocation_is_interactive(self):
+        assert will_enter_interactive_repl() is True
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            pytest.param({"query": "hello"}, id="--query"),
+            pytest.param({"q": "hello"}, id="-q-shorthand"),
+            pytest.param({"image": "/tmp/cat.png"}, id="--image"),
+            pytest.param({"list_tools": True}, id="--list-tools"),
+            pytest.param({"list_toolsets": True}, id="--list-toolsets"),
+            pytest.param({"gateway": True}, id="--gateway"),
+        ],
+    )
+    def test_non_interactive_entry_points(self, kwargs):
+        # Each of these returns before cli.run(), so a redirected stdin is
+        # legitimate -- driving `hermes chat -q "..."` from a script, a cron
+        # job or a CI step must keep working.
+        assert will_enter_interactive_repl(**kwargs) is False
+
+    def test_empty_string_query_is_not_a_one_shot(self):
+        # Fire passes "" for an omitted value in some shells; an empty query is
+        # not a query, so this stays interactive (and therefore still gated).
+        assert will_enter_interactive_repl(query="") is True
+
+
+class TestInteractiveTTYGuard:
+    @pytest.fixture
+    def non_tty_stdin(self, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False, raising=False)
+
+    def test_exits_with_code_1(self, non_tty_stdin):
+        with pytest.raises(SystemExit) as exc:
+            cli_mod.main()
+        assert exc.value.code == 1
+
+    def test_message_is_actionable_and_on_stderr(self, non_tty_stdin, capsys):
+        with pytest.raises(SystemExit):
+            cli_mod.main()
+        captured = capsys.readouterr()
+        assert "requires a terminal" in captured.err
+        # Point the user at the supported non-interactive form.
+        assert '-q "your prompt"' in captured.err
+        assert "requires a terminal" not in captured.out
+
+    def test_fires_before_any_worktree_or_agent_setup(self, non_tty_stdin, monkeypatch):
+        # The whole point is to fail fast: nothing expensive or side-effecting
+        # may run first. HermesCLI construction stands in for "agent init".
+        def _fail(*_args, **_kwargs):
+            raise AssertionError("guard ran too late — setup already started")
+
+        monkeypatch.setattr(cli_mod, "HermesCLI", _fail)
+        with pytest.raises(SystemExit) as exc:
+            cli_mod.main()
+        assert exc.value.code == 1


### PR DESCRIPTION
## What

`nohup hermes chat`, a piped stdin, or any non-interactive subprocess dies with a bare traceback:

```
Warning: Input is not a terminal (fd=0).
...
  File ".../prompt_toolkit/input/vt100.py", line 165, in _attached_input
    loop.add_reader(fd, callback_wrapper)
  File ".../asyncio/selector_events.py", line 344, in add_reader
    self._add_reader(fd, callback, *args)
  File ".../selectors.py", line 523, in register
    self._selector.control([kev], 0, 0)
OSError: [Errno 22] Invalid argument
```

prompt_toolkit's vt100 input registers stdin's fd with the asyncio selector, which a redirected stdin cannot satisfy.

Worse, this surfaced only at `cli.run()` — **after** git worktree setup, full agent init, and the entire welcome banner had already printed. The user paid several seconds and a screenful of output to receive an `Errno 22` with no indication of what went wrong or what to do.

This checks for a TTY up front and exits `1` with an actionable message instead.

## Why here

`hermes_cli/main.py` already has a `_require_tty()` guard, applied to `model`, `tools`, `whatsapp`, `whatsapp-cloud`, `skills config`, and `uninstall`. `chat` was the one interactive entry point without it — and the only one that reaches prompt_toolkit, which fails harder than the `input()`-based commands the existing guard protects.

The guard is placed immediately after the `--gateway` early return, before the worktree block, so nothing expensive or side-effecting runs first. `test_fires_before_any_worktree_or_agent_setup` pins that ordering.

## Non-interactive entry points are unaffected

The interactive/non-interactive distinction is extracted into `will_enter_interactive_repl()` so it is explicit and directly testable rather than implied by control flow:

| Invocation | Reaches `cli.run()`? | Gated? |
|---|---|---|
| `hermes chat` | yes | ✅ requires TTY |
| `hermes chat -q "..."` / `--query` / `--image` | no — one-shot path | not gated |
| `hermes chat --list-tools` / `--list-toolsets` | no — prints and exits | not gated |
| `hermes chat --gateway` | no — returns earlier | not gated |

Driving `hermes chat -q "..."` from a script, a cron job, or a CI step keeps working.

## How to test

```bash
scripts/run_tests.sh tests/cli/test_cli_requires_tty.py
```

11 tests: the predicate across every entry point, plus exit code, stream, message content, and the fail-fast ordering.

Manually:

```bash
hermes chat < /dev/null                  # before: traceback; after: clean error, exit 1
hermes chat -q "hi" < /dev/null          # unaffected
hermes chat --list-toolsets < /dev/null  # unaffected
```

## Platforms tested

macOS (darwin 25.6.0), Python 3.11. `sys.stdin.isatty()` is portable; no platform-specific behaviour.

## Regression runs

`tests/cli/` — 1321 passed, no new failures.
