### PR TITLE
fix(desktop): retire dead pooled remote backend descriptors (#94381)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12605,13 +12605,16 @@ ipcMain.handle('hermes:connection:revalidate', async () => {
 // Pooled remote descriptors get the same treatment as the primary: they have no
 // child process to signal their host's death, and the renderer's keepalive touch
 // spares them from the idle reaper, so nothing else can retire a dead one.
+// The pooled path owns its own failure policy (#94381): revalidation probes
+// are tick-spaced (multi-minute), far outside the primary connection's 60s
+// failure window, so sharing `remoteLiveness` would reset the streak on every
+// probe and never drop the stale descriptor.
 function revalidatePool() {
   return revalidatePooledRemoteBackends({
     entries: backendPool.entries(),
     log: rememberLog,
     probe: (connection, path, options) => fetchJsonForBackend(connection, path, options),
-    stopBackend: stopPoolBackend,
-    tracker: remoteLiveness
+    stopBackend: stopPoolBackend
   })
 }
 

--- a/apps/desktop/electron/remote-liveness.test.ts
+++ b/apps/desktop/electron/remote-liveness.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   REMOTE_LIVENESS_FAILURE_LIMIT,
   REMOTE_LIVENESS_FAILURE_WINDOW_MS,
+  REMOTE_LIVENESS_POOLED_FAILURE_WINDOW_MS,
   REMOTE_LIVENESS_TIMEOUT_MS,
   RemoteLivenessTracker,
   RemoteRevalidationCoordinator,
@@ -61,6 +62,42 @@ describe('RemoteLivenessTracker', () => {
     expect(tracker.recordFailure('https://gateway.example.com')).toEqual({ failures: 1, shouldReset: false })
     now += REMOTE_LIVENESS_FAILURE_WINDOW_MS + 1
     expect(tracker.recordFailure('https://gateway.example.com')).toEqual({ failures: 1, shouldReset: false })
+  })
+
+  it('reproduces the #94381 leak: tick-spaced failures reset a 60s-window streak forever', () => {
+    let now = 0
+    const tracker = new RemoteLivenessTracker(3, REMOTE_LIVENESS_FAILURE_WINDOW_MS, () => now)
+
+    // #94381: pooled revalidation probes arrive on a multi-minute tick
+    // (observed ~4 min apart in the issue's desktop.log), so every observation
+    // falls outside the primary connection's 60s failure window and the streak
+    // resets to 1 on each tick — the indefinite "(1/3); keeping descriptor for
+    // retry." line. The dead descriptor is never dropped.
+    for (let tick = 1; tick <= 12; tick += 1) {
+      now += 4 * 60_000
+
+      expect(tracker.recordFailure('https://gateway.example.com')).toEqual({ failures: 1, shouldReset: false })
+    }
+  })
+
+  it('accumulates tick-spaced failures under the pooled failure window (#94381)', () => {
+    let now = 0
+    const tracker = new RemoteLivenessTracker(3, REMOTE_LIVENESS_POOLED_FAILURE_WINDOW_MS, () => now)
+
+    now += 4 * 60_000
+    expect(tracker.recordFailure('https://gateway.example.com')).toEqual({ failures: 1, shouldReset: false })
+    now += 4 * 60_000
+    expect(tracker.recordFailure('https://gateway.example.com')).toEqual({ failures: 2, shouldReset: false })
+    now += 4 * 60_000
+    expect(tracker.recordFailure('https://gateway.example.com')).toEqual({ failures: 3, shouldReset: true })
+  })
+
+  it('calibrates the pooled failure window to the revalidation tick (#94381)', () => {
+    // Suggested fix for #94381: the pooled tracker needs a window ≥ 2× the
+    // multi-minute revalidation tick so three consecutive tick failures
+    // accumulate; ~4 min was the observed probe cadence in the issue report.
+    expect(REMOTE_LIVENESS_POOLED_FAILURE_WINDOW_MS).toBeGreaterThanOrEqual(2 * 4 * 60_000)
+    expect(REMOTE_LIVENESS_POOLED_FAILURE_WINDOW_MS).toBeGreaterThan(REMOTE_LIVENESS_FAILURE_WINDOW_MS)
   })
 
   it('clears all failure streaks when the connection state resets', () => {
@@ -292,8 +329,8 @@ describe('revalidatePooledRemoteBackends', () => {
       probe,
       stopBackend,
       unreachable,
-      run: (tracker: RemoteLivenessTracker) =>
-        revalidatePooledRemoteBackends({ entries, log, probe, stopBackend, tracker })
+      run: (tracker?: RemoteLivenessTracker) =>
+        revalidatePooledRemoteBackends({ entries, log, probe, stopBackend, ...(tracker ? { tracker } : {}) })
     }
   }
 
@@ -387,6 +424,22 @@ describe('revalidatePooledRemoteBackends', () => {
 
     await expect(pool.run(tracker)).resolves.toEqual({ dropped: ['coder'] })
     expect(pool.stopBackend).toHaveBeenCalledTimes(1)
+    expect(pool.stopBackend).toHaveBeenCalledWith('coder')
+  })
+
+  it('drops a stale pooled descriptor under the default pooled policy (#94381)', async () => {
+    // No explicit tracker: the pooled path must own a tick-tolerant policy
+    // instead of reusing the primary connection's 60s-window tracker, which
+    // never accumulates a streak of tick-spaced failures (#94381).
+    const pool = harness([['coder', { process: null, remoteBaseUrl: 'https://remote.example.com' }]])
+    pool.unreachable.add('https://remote.example.com')
+
+    for (let attempt = 1; attempt < REMOTE_LIVENESS_FAILURE_LIMIT; attempt += 1) {
+      await expect(pool.run()).resolves.toEqual({ dropped: [] })
+      expect(pool.stopBackend).not.toHaveBeenCalled()
+    }
+
+    await expect(pool.run()).resolves.toEqual({ dropped: ['coder'] })
     expect(pool.stopBackend).toHaveBeenCalledWith('coder')
   })
 })

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -4,6 +4,14 @@ export const REMOTE_LIVENESS_FAILURE_LIMIT = 3
 // about 48s apart (ticket mint + socket open + backoff + the next status probe).
 // One minute keeps a continuous outage together without carrying old failures.
 export const REMOTE_LIVENESS_FAILURE_WINDOW_MS = 60_000
+// Pooled remote descriptors are probed only by the revalidation tick, which
+// runs on a multi-minute cadence (observed ~4 min apart in #94381). The
+// primary's 60s window above is shorter than that tick, so sharing it resets
+// the failure streak on every probe and a dead pooled descriptor is never
+// retired (#94381). Ten minutes is ~2.5× the observed tick: three consecutive
+// tick failures accumulate, while a probe-free gap (e.g. app sleep) still
+// decays a stale streak exactly as the primary policy does.
+export const REMOTE_LIVENESS_POOLED_FAILURE_WINDOW_MS = 10 * 60_000
 
 export interface RemoteLivenessFailure {
   failures: number
@@ -117,6 +125,15 @@ export class RemoteLivenessTracker {
   }
 }
 
+// Default policy for pooled remote descriptors: the tick-tolerant window above,
+// keyed per base URL and independent of the primary connection's 60s-window
+// tracker. Passing the primary tracker here would reset the streak on every
+// tick-spaced probe and permanently keep a dead descriptor pooled (#94381).
+const pooledRemoteLiveness = new RemoteLivenessTracker(
+  REMOTE_LIVENESS_FAILURE_LIMIT,
+  REMOTE_LIVENESS_POOLED_FAILURE_WINDOW_MS
+)
+
 export interface PooledRemoteEntry<TConnection extends RemoteConnectionDescriptor = RemoteConnectionDescriptor> {
   connectionPromise?: null | Promise<TConnection>
   process?: unknown
@@ -128,7 +145,14 @@ export interface RevalidatePooledRemoteBackendsOptions<TConnection extends Remot
   log: (message: string) => void
   probe: (connection: TConnection, path: string, options: { timeoutMs: number }) => Promise<unknown>
   stopBackend: (profile: string) => void
-  tracker: RemoteLivenessTracker
+  /**
+   * Failure policy for the pooled entries. Defaults to a tick-tolerant tracker
+   * (REMOTE_LIVENESS_POOLED_FAILURE_WINDOW_MS): pooled probes arrive on a
+   * multi-minute revalidation tick, so the primary connection's 60s window
+   * would reset the streak on every probe and never retire a dead descriptor
+   * (#94381). Pass on only to share an explicit policy.
+   */
+  tracker?: RemoteLivenessTracker
 }
 
 /**
@@ -139,15 +163,19 @@ export interface RevalidatePooledRemoteBackendsOptions<TConnection extends Remot
  * keepalive touch keeps the idle reaper off it. Without this the pool serves a
  * descriptor for an unreachable host indefinitely.
  *
- * Entries share the primary's failure policy, keyed per base URL, so a profile
- * pointing at the same host as another does not burn the streak twice as fast.
+ * Failure streaks are keyed per base URL, so profiles pointing at the same host
+ * share one budget instead of burning the pool three times as fast. The
+ * default policy uses the pooled failure window (see above): the window is
+ * sized to the revalidation tick, not the primary connection's 60s window,
+ * because tick-spaced probes must accumulate into a streak for #72835's
+ * retirement path to ever fire.
  */
 export async function revalidatePooledRemoteBackends<TConnection extends RemoteConnectionDescriptor>({
   entries,
   log,
   probe,
   stopBackend,
-  tracker
+  tracker = pooledRemoteLiveness
 }: RevalidatePooledRemoteBackendsOptions<TConnection>): Promise<{ dropped: string[] }> {
   const remotes = [...entries].filter(([, entry]) => !entry.process && entry.remoteBaseUrl)
   const dropped: string[] = []


### PR DESCRIPTION
## Root cause

`revalidatePool()` in `apps/desktop/electron/main.ts` passed the **primary connection's** liveness tracker into `revalidatePooledRemoteBackends()`. That tracker is built with `REMOTE_LIVENESS_FAILURE_WINDOW_MS = 60_000` (#68250), calibrated for the primary path where consecutive observations are at most ~48 s apart. Its streak decays whenever two observations are more than 60 s apart, so it resets to 1 before any probe can reach the 3-failure limit.

But pooled remote descriptors are probed only by the revalidation tick introduced in #72835, which runs on a **multi-minute cadence** — the issue's `desktop.log` shows probes at `00:51:24` → `00:55:25` → `00:59:24` (~4 min apart). Every probe lands outside the 60 s window, `recordFailure` returns `{ failures: 1, shouldReset: false }` forever, `stopBackend(profile)` is never called, and the dead pooled descriptor is served until app restart:

```
Pooled remote backend for profile "conn:hermes-ubuntu::default" failed liveness probe (1/3); keeping descriptor for retry.
... (identical lines every ~4 min, indefinitely; renderer calls fail with read ECONNRESET)
```

Net effect: the #72835 retirement path ("drops a descriptor only after the shared failure limit") is unreachable in production timing for pooled remotes — exactly the failure mode #72835 set out to fix.

## Fix (issue's suggested option 1 — smallest change)

- New `REMOTE_LIVENESS_POOLED_FAILURE_WINDOW_MS = 10 * 60_000` (10 min ≈ 2.5× the observed ~4 min tick): three consecutive tick failures now accumulate into a streak, while a probe-free gap (e.g. app sleep) still decays a stale streak exactly as the primary policy does.
- `revalidatePooledRemoteBackends` now owns a module-level pooled tracker built with that window and uses it by default; the `tracker` option remains as an explicit override. Streaks stay keyed per base URL, so profiles pointing at the same host still share one failure budget.
- `main.ts` no longer wires the primary 60 s-window tracker into the pooled path. The primary `revalidateRemoteConnection` path keeps its original policy unchanged.

## Tests (red → green)

- `reproduces the #94381 leak: tick-spaced failures reset a 60s-window streak forever` — pins the exact failure mode (12 probes at 4 min spacing, every one a fresh 1/3).
- `accumulates tick-spaced failures under the pooled failure window (#94381)` — fake clock: 1/3 → 2/3 → 3/3 + reset at 4 min spacing.
- `calibrates the pooled failure window to the revalidation tick (#94381)` — locks the new constant to ≥ 2× the observed revalidation tick.
- `drops a stale pooled descriptor under the default pooled policy (#94381)` — full pooled revalidation with no explicit tracker, which is the production call shape.

Pre-fix: the three new tests failed (missing `REMOTE_LIVENESS_POOLED_FAILURE_WINDOW_MS` export ×2; default-policy test threw `TypeError: Cannot read properties of undefined (reading 'recordFailure')`). Post-fix: `remote-liveness.test.ts` 25/25 pass; the full `--project electron` suite shows only the 9 pre-existing environment-specific failures (chmod/SSH/fs tests on this Windows box) that also fail on clean `main`; `tsc` typecheck clean for all three desktop projects (`tsconfig.json`, `tsconfig.electron.json`, `tsconfig.e2e.json`); eslint and prettier clean.

Closes #94381
