### PR TITLE
fix(weixin): make rate-limited sends observable and recoverable (#94146)

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -65,6 +65,7 @@ from gateway.platforms.base import (
     cache_audio_from_bytes,
     cache_document_from_bytes,
     cache_image_from_bytes,
+    classify_send_error,
 )
 from hermes_constants import get_hermes_home
 from utils import atomic_json_write
@@ -124,6 +125,65 @@ def _is_stale_session_ret(
     if ret != RATE_LIMIT_ERRCODE and errcode != RATE_LIMIT_ERRCODE:
         return False
     return (errmsg or "").lower() == "unknown error"
+
+
+def _sendmessage_response_error(resp: Dict[str, Any]) -> Optional[RuntimeError]:
+    """Return a RuntimeError when an iLink sendmessage response is non-zero.
+
+    iLink marks success with ``ret=0``/``errcode=0`` (or by omitting both).
+    Any non-zero value means the server refused the message — a response
+    that is never inspected is exactly the false-success state of #94146,
+    where Hermes reported the send as accepted while nothing was delivered.
+    """
+    ret = resp.get("ret")
+    errcode = resp.get("errcode")
+    if (ret is not None and ret not in {0,}) or (errcode is not None and errcode not in {0,}):
+        errmsg = str(resp.get("errmsg") or resp.get("msg") or "unknown error")[:200]
+        if ret == RATE_LIMIT_ERRCODE or errcode == RATE_LIMIT_ERRCODE:
+            # Wording matches the existing rate-limit text so
+            # classify_send_error() maps it to ``rate_limited`` and the retry
+            # layer honors cooldown semantics instead of the plain-text
+            # formatting fallback.
+            return RuntimeError(
+                f"iLink sendmessage rate limited: ret={ret} errcode={errcode} errmsg={errmsg}"
+            )
+        return RuntimeError(
+            f"iLink sendmessage error: ret={ret} errcode={errcode} errmsg={errmsg}"
+        )
+    return None
+
+
+def _log_send_response(
+    name: str,
+    endpoint: str,
+    chat_id: str,
+    client_id: str,
+    resp: Dict[str, Any],
+    *,
+    context_token: bool,
+) -> None:
+    """Log one sanitized line per sendmessage response (#94146 observability).
+
+    Success responses previously logged nothing, so a server-side
+    accepted-but-dropped send was indistinguishable from a healthy one.
+    Fields: endpoint ``ret`` ``errcode`` ``errmsg`` (truncated), client-id
+    prefix, whether a context token was attached.
+    """
+    ret = resp.get("ret")
+    errcode = resp.get("errcode")
+    errmsg = str(resp.get("errmsg") or resp.get("msg") or "")[:200] or "-"
+    ok = _sendmessage_response_error(resp) is None
+    (logger.info if ok else logger.warning)(
+        "[%s] %s to=%s client_id=%s ret=%s errcode=%s errmsg=%s context_token=%s",
+        name,
+        endpoint,
+        _safe_id(chat_id),
+        str(client_id)[:12],
+        ret,
+        errcode,
+        errmsg,
+        "yes" if context_token else "no",
+    )
 
 
 MEDIA_IMAGE = 1
@@ -511,7 +571,7 @@ async def _send_typing(
     typing_ticket: str,
     status: int,
 ) -> None:
-    await _api_post(
+    resp = await _api_post(
         session,
         base_url=base_url,
         endpoint=EP_SEND_TYPING,
@@ -523,6 +583,13 @@ async def _send_typing(
         token=token,
         timeout_ms=CONFIG_TIMEOUT_MS,
     )
+    # #94146: typing bursts hit the same server-side rate limit as text
+    # sends, but the response was never inspected — a throttled typing
+    # signal was 100% invisible. Surface it so the suppression trigger is
+    # observable instead of silent.
+    error = _sendmessage_response_error(resp)
+    if error is not None:
+        raise error
 
 
 async def _get_config(
@@ -1789,6 +1856,50 @@ class WeixinAdapter(BasePlatformAdapter):
         self._rate_limit_events.clear()
         self._rate_limit_circuit_until = 0.0
 
+    def _invalidate_context_token(self, chat_id: str, reason: str) -> None:
+        """Drop the cached ``context_token`` for a peer and persist removal.
+
+        #94146: a stale/poisoned context token is a plausible server-side
+        suppression trigger. Once the rate-limit circuit opens we stop
+        reusing it, so the next send after the cooldown falls back to the
+        tokenless degraded path iLink accepts. Mirrors the session-expired
+        recovery in ``_send_text_chunk_locked``.
+        """
+        key = self._token_store._key(self._account_id, chat_id)
+        if self._token_store._cache.pop(key, None) is None:
+            return
+        try:
+            self._token_store._persist(self._account_id)
+        except Exception:
+            pass
+        logger.warning(
+            "[%s] invalidated cached context_token for %s (%s); next send will retry tokenless",
+            self.name, _safe_id(chat_id), reason,
+        )
+
+    def _send_result_from_exception(self, chat_id: str, exc: Exception) -> SendResult:
+        """Build a classified ``SendResult`` from a send exception.
+
+        #94146: rate-limited failures previously surfaced as bare
+        ``SendResult(success=False, error=...)`` without ``retryable``/
+        ``retry_after``/``error_kind``, so the gateway's retry layer treated
+        them as non-network failures and mangled the reply through the
+        "plain-text fallback" instead of retrying after the cooldown.
+        """
+        error_str = str(exc)
+        kind = classify_send_error(exc, error_str)
+        retry_after: Optional[float] = None
+        if kind == "rate_limited":
+            remaining = self._rate_limit_cooldown_remaining()
+            retry_after = remaining if remaining > 0 else 5.0
+        return SendResult(
+            success=False,
+            error=error_str,
+            error_kind=kind,
+            retryable=kind in {"rate_limited", "transient"},
+            retry_after=retry_after,
+        )
+
     async def _send_text_chunk(
         self,
         *,
@@ -1836,6 +1947,29 @@ class WeixinAdapter(BasePlatformAdapter):
                     context_token=context_token,
                     client_id=client_id,
                 )
+                # #94146: every sendmessage response is logged sanitized so an
+                # accepted-but-dropped send is distinguishable in logs, and
+                # non-dict responses can no longer fall through as success.
+                if resp is None:
+                    logger.warning(
+                        "[%s] sendmessage returned EMPTY response to=%s client_id=%s; "
+                        "treating as accepted (no server acknowledgement received)",
+                        self.name, _safe_id(chat_id), str(client_id)[:12],
+                    )
+                elif not isinstance(resp, dict):
+                    raise RuntimeError(
+                        "iLink sendmessage returned unexpected response type: "
+                        f"{type(resp).__name__}"
+                    )
+                else:
+                    _log_send_response(
+                        self.name,
+                        "sendmessage",
+                        chat_id,
+                        client_id,
+                        resp,
+                        context_token=bool(context_token),
+                    )
                 # Check iLink response for session-expired error
                 if resp and isinstance(resp, dict):
                     ret = resp.get("ret")
@@ -1872,6 +2006,14 @@ class WeixinAdapter(BasePlatformAdapter):
                                 f"iLink sendmessage rate limited: ret={ret} errcode={errcode} errmsg={errmsg}"
                             )
                             if self._record_rate_limit_event():
+                                # #94146 recovery: a poisoned/stale context
+                                # token may keep the server-side session
+                                # suppressed. Stop reusing it; the retry after
+                                # the cooldown falls back to the tokenless
+                                # degraded path.
+                                self._invalidate_context_token(
+                                    chat_id, "rate-limit circuit opened"
+                                )
                                 last_error = self._rate_limit_error()
                                 break
                             if attempt >= self._send_chunk_retries:
@@ -1959,6 +2101,17 @@ class WeixinAdapter(BasePlatformAdapter):
 
             # Deliver text content.
             chunks = [c for c in self._split_text(self.format_message(final_content)) if c and c.strip()]
+            if not chunks:
+                # #94146: an empty chunk list previously returned
+                # SendResult(success=True, message_id=None) — a false success
+                # with nothing sent. Make it a visible failure instead.
+                return SendResult(
+                    success=False,
+                    error=(
+                        "Weixin: no deliverable content in reply "
+                        "(empty after formatting/splitting)"
+                    ),
+                )
             for idx, chunk in enumerate(chunks):
                 client_id = f"hermes-weixin-{uuid.uuid4().hex}"
                 await self._send_text_chunk(
@@ -1973,7 +2126,7 @@ class WeixinAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=last_message_id)
         except Exception as exc:
             logger.error("[%s] send failed to=%s: %s", self.name, _safe_id(chat_id), exc)
-            return SendResult(success=False, error=str(exc))
+            return self._send_result_from_exception(chat_id, exc)
 
     async def _ensure_typing_ticket(self, chat_id: str) -> Optional[str]:
         """Return a valid typing ticket, refreshing from getConfig if expired.
@@ -2012,6 +2165,24 @@ class WeixinAdapter(BasePlatformAdapter):
             )
         return None
 
+    def _log_typing_failure(self, action: str, chat_id: str, exc: Exception) -> None:
+        """Log a typing failure, at WARNING when it is a rate limit.
+
+        #94146: typing/interim bursts are a suspected trigger for server-side
+        suppression, but throttled typing signals were previously swallowed
+        at debug level — invisible in production logs.
+        """
+        if classify_send_error(exc, str(exc)) == "rate_limited":
+            logger.warning(
+                "[%s] %s rate limited for %s: %s",
+                self.name, action, _safe_id(chat_id), exc,
+            )
+        else:
+            logger.debug(
+                "[%s] %s failed for %s: %s",
+                self.name, action, _safe_id(chat_id), exc,
+            )
+
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         if not self._send_session or not self._token:
             return
@@ -2028,7 +2199,7 @@ class WeixinAdapter(BasePlatformAdapter):
                 status=TYPING_START,
             )
         except Exception as exc:
-            logger.debug("[%s] typing start failed for %s: %s", self.name, _safe_id(chat_id), exc)
+            self._log_typing_failure("typing start", chat_id, exc)
 
     async def stop_typing(self, chat_id: str) -> None:
         if not self._send_session or not self._token:
@@ -2046,7 +2217,7 @@ class WeixinAdapter(BasePlatformAdapter):
                 status=TYPING_STOP,
             )
         except Exception as exc:
-            logger.debug("[%s] typing stop failed for %s: %s", self.name, _safe_id(chat_id), exc)
+            self._log_typing_failure("typing stop", chat_id, exc)
 
     async def send_image(
         self,
@@ -2108,7 +2279,7 @@ class WeixinAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=message_id)
         except Exception as exc:
             logger.error("[%s] send_document failed to=%s: %s", self.name, _safe_id(chat_id), exc)
-            return SendResult(success=False, error=str(exc))
+            return self._send_result_from_exception(chat_id, exc)
 
     async def send_video(
         self,
@@ -2125,7 +2296,7 @@ class WeixinAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=message_id)
         except Exception as exc:
             logger.error("[%s] send_video failed to=%s: %s", self.name, _safe_id(chat_id), exc)
-            return SendResult(success=False, error=str(exc))
+            return self._send_result_from_exception(chat_id, exc)
 
     async def send_voice(
         self,
@@ -2152,7 +2323,7 @@ class WeixinAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=message_id)
         except Exception as exc:
             logger.error("[%s] send_voice failed to=%s: %s", self.name, _safe_id(chat_id), exc)
-            return SendResult(success=False, error=str(exc))
+            return self._send_result_from_exception(chat_id, exc)
 
     async def _download_remote_media(self, url: str) -> str:
         from tools.url_safety import is_safe_url
@@ -2240,7 +2411,7 @@ class WeixinAdapter(BasePlatformAdapter):
         last_message_id = None
         if caption:
             last_message_id = f"hermes-weixin-{uuid.uuid4().hex}"
-            await _send_message(
+            caption_resp = await _send_message(
                 self._send_session,
                 base_url=self._base_url,
                 token=self._token,
@@ -2249,9 +2420,19 @@ class WeixinAdapter(BasePlatformAdapter):
                 context_token=context_token,
                 client_id=last_message_id,
             )
+            _log_send_response(
+                self.name, "sendmessage", chat_id, last_message_id, caption_resp,
+                context_token=bool(context_token),
+            )
+            caption_err = _sendmessage_response_error(caption_resp)
+            if caption_err is not None:
+                # #94146: media sends previously ignored iLink error
+                # responses entirely — a throttled caption/media send was
+                # reported to the user as success while nothing arrived.
+                raise caption_err
 
         last_message_id = f"hermes-weixin-{uuid.uuid4().hex}"
-        await _api_post(
+        media_resp = await _api_post(
             self._send_session,
             base_url=self._base_url,
             endpoint=EP_SEND_MESSAGE,
@@ -2263,12 +2444,19 @@ class WeixinAdapter(BasePlatformAdapter):
                     "message_type": MSG_TYPE_BOT,
                     "message_state": MSG_STATE_FINISH,
                     "item_list": [media_item],
-                    **({"context_token": context_token} if context_token else {}),
+                    **( {"context_token": context_token} if context_token else {}),
                 }
             },
             token=self._token,
             timeout_ms=API_TIMEOUT_MS,
         )
+        _log_send_response(
+            self.name, "sendmessage", chat_id, last_message_id, media_resp,
+            context_token=bool(context_token),
+        )
+        media_err = _sendmessage_response_error(media_resp)
+        if media_err is not None:
+            raise media_err
         return last_message_id
 
     def _outbound_media_builder(self, path: str, force_file_attachment: bool = False):
@@ -2383,10 +2571,13 @@ async def send_weixin_direct(
             and send_session._loop is asyncio.get_running_loop()):
         last_result: Optional[SendResult] = None
         cleaned = live_adapter.format_message(message)
-        if cleaned:
-            last_result = await live_adapter.send(chat_id, cleaned)
-            if not last_result.success:
-                return {"error": f"Weixin send failed: {last_result.error}"}
+        if not cleaned:
+            # #94146: an empty message previously skipped the send and still
+            # returned success=True with message_id=None — a false success.
+            return {"error": "Weixin send failed: no deliverable content in message"}
+        last_result = await live_adapter.send(chat_id, cleaned)
+        if not last_result.success:
+            return {"error": f"Weixin send failed: {last_result.error}"}
 
         for media_path, _is_voice in media_files or []:
             ext = Path(media_path).suffix.lower()
@@ -2428,10 +2619,13 @@ async def send_weixin_direct(
 
         last_result: Optional[SendResult] = None
         cleaned = adapter.format_message(message)
-        if cleaned:
-            last_result = await adapter.send(chat_id, cleaned)
-            if not last_result.success:
-                return {"error": f"Weixin send failed: {last_result.error}"}
+        if not cleaned:
+            # #94146: an empty message previously skipped the send and still
+            # returned success=True with message_id=None — a false success.
+            return {"error": "Weixin send failed: no deliverable content in message"}
+        last_result = await adapter.send(chat_id, cleaned)
+        if not last_result.success:
+            return {"error": f"Weixin send failed: {last_result.error}"}
 
         for media_path, _is_voice in media_files or []:
             ext = Path(media_path).suffix.lower()

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -3,6 +3,7 @@
 import asyncio
 import base64
 import json
+import logging
 import os
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -271,6 +272,206 @@ class TestWeixinChunkDelivery:
         assert sleep_mock.await_count == 1
 
 
+class TestWeixinRateLimitRecovery:
+    """Regression tests for #94146.
+
+    After a rate-limit episode, Weixin live replies were silently lost: once
+    the rate-limit circuit opened, ``send()`` reported a plain failure that
+    the gateway's retry layer misclassified as a *formatting* failure
+    (mangling the reply into a duplicate "plain text" send), and iLink
+    responses were treated as accepted even when they carried error codes.
+    These tests pin the observable/recoverable contract:
+
+    - rate-limited sends carry ``rate_limited`` kind + ``retryable`` +
+      ``retry_after`` so the gateway retries after the cooldown instead of
+      mangling the message;
+    - a stale cached context token is invalidated when the circuit opens;
+    - every sendmessage response is logged (sanitized) so an accepted-but-
+      dropped send is distinguishable in logs;
+    - media/typing paths surface iLink error responses instead of reporting
+      success and logging nothing;
+    - blank replies are a visible failure, not a false success.
+    """
+
+    def _connected_adapter(self) -> WeixinAdapter:
+        adapter = _make_adapter()
+        adapter._session = object()
+        adapter._send_session = adapter._session
+        adapter._token = "test-token"
+        adapter._base_url = "https://weixin.example.com"
+        adapter._token_store.get = lambda account_id, chat_id: "ctx-token"
+        return adapter
+
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_circuit_open_send_is_rate_limited_retryable(self, send_message_mock, sleep_mock):
+        adapter = self._connected_adapter()
+        adapter._send_chunk_retries = 3
+        adapter._send_chunk_retry_delay_seconds = 0
+        adapter._rate_limit_circuit_threshold = 2
+        adapter._rate_limit_circuit_window_seconds = 60
+        adapter._rate_limit_circuit_open_seconds = 60
+
+        send_message_mock.return_value = {
+            "ret": weixin.RATE_LIMIT_ERRCODE,
+            "errcode": weixin.RATE_LIMIT_ERRCODE,
+            "errmsg": "frequency limit",
+        }
+
+        asyncio.run(adapter.send("wxid_test123", "first"))
+        result = asyncio.run(adapter.send("wxid_test123", "second"))
+
+        assert result.success is False
+        assert "cooldown" in (result.error or "")
+        # The gateway retry layer must treat this as a throttle, not a
+        # formatting failure, and honor the cooldown before retrying.
+        assert result.error_kind == "rate_limited"
+        assert result.retryable is True
+        assert result.retry_after is not None and result.retry_after > 0
+
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_rate_limit_loop_exhaustion_keeps_retryable_semantics(
+        self, send_message_mock, sleep_mock,
+    ):
+        # -2 responses below the circuit threshold exhaust the per-chunk
+        # retry loop without opening the circuit; the result must still
+        # advertise rate_limited semantics so the outer retry layer waits.
+        adapter = self._connected_adapter()
+        adapter._send_chunk_retries = 0
+        adapter._send_chunk_retry_delay_seconds = 0
+        adapter._rate_limit_circuit_threshold = 10
+
+        send_message_mock.return_value = {
+            "ret": weixin.RATE_LIMIT_ERRCODE,
+            "errcode": weixin.RATE_LIMIT_ERRCODE,
+            "errmsg": "frequency limit",
+        }
+
+        result = asyncio.run(adapter.send("wxid_test123", "hello"))
+
+        assert result.success is False
+        assert result.error_kind == "rate_limited"
+        assert result.retryable is True
+
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_circuit_open_invalidates_cached_context_token(
+        self, send_message_mock, sleep_mock, tmp_path, caplog,
+    ):
+        adapter = self._connected_adapter()
+        adapter._token_store = ContextTokenStore(str(tmp_path))
+        adapter._token_store.set(adapter._account_id, "wxid_test123", "ctx-token")
+        adapter._send_chunk_retries = 3
+        adapter._send_chunk_retry_delay_seconds = 0
+        adapter._rate_limit_circuit_threshold = 2
+        adapter._rate_limit_circuit_window_seconds = 60
+        adapter._rate_limit_circuit_open_seconds = 60
+
+        send_message_mock.return_value = {
+            "ret": weixin.RATE_LIMIT_ERRCODE,
+            "errcode": weixin.RATE_LIMIT_ERRCODE,
+            "errmsg": "frequency limit",
+        }
+
+        with caplog.at_level(logging.INFO, logger="gateway.platforms.weixin"):
+            asyncio.run(adapter.send("wxid_test123", "first"))
+
+        # A stale/poisoned context token can keep the server-side session
+        # suppressed; opening the circuit must stop reusing it so the next
+        # send falls back to the tokenless degraded path.
+        assert adapter._token_store.get(adapter._account_id, "wxid_test123") is None
+        assert any("invalidated" in r.message for r in caplog.records)
+
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_successful_send_logs_sanitized_response(self, send_message_mock, sleep_mock, caplog):
+        adapter = self._connected_adapter()
+        send_message_mock.return_value = {"ret": 0, "errcode": 0, "errmsg": ""}
+
+        with caplog.at_level(logging.INFO, logger="gateway.platforms.weixin"):
+            result = asyncio.run(adapter.send("wxid_test123", "hello"))
+
+        assert result.success is True
+        assert any(
+            r.message.startswith("[Weixin]")
+            and "sendmessage" in r.message
+            and "ret=0" in r.message
+            and "client_id=" in r.message
+            for r in caplog.records
+        )
+
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_unexpected_response_is_not_silent_success(self, send_message_mock, sleep_mock):
+        # A non-dict response previously fell through every error check and
+        # was reported as delivered — the silent-drop false-success state.
+        adapter = self._connected_adapter()
+        send_message_mock.return_value = ["not", "a", "dict"]
+
+        result = asyncio.run(adapter.send("wxid_test123", "hello"))
+
+        assert result.success is False
+        assert "unexpected" in (result.error or "").lower()
+
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_blank_reply_returns_visible_failure(self, send_message_mock, sleep_mock):
+        adapter = self._connected_adapter()
+
+        result = asyncio.run(adapter.send("wxid_test123", "   "))
+
+        assert result.success is False
+        assert "no deliverable" in (result.error or "")
+        send_message_mock.assert_not_called()
+
+    def test_send_document_surfaces_link_error_response(self, tmp_path):
+        adapter = _make_adapter()
+        adapter._session = object()
+        adapter._send_session = adapter._session
+        adapter._token = "test-token"
+        adapter._base_url = "https://weixin.example.com"
+        adapter._token_store.get = lambda account_id, chat_id: None
+
+        image_path = tmp_path / "demo.png"
+        image_path.write_bytes(b"fake-png-bytes")
+
+        with (
+            patch("gateway.platforms.weixin._get_upload_url", new_callable=AsyncMock) as upload_mock,
+            patch("gateway.platforms.weixin._upload_ciphertext", new_callable=AsyncMock) as cipher_mock,
+            patch("gateway.platforms.weixin._api_post", new_callable=AsyncMock) as api_post_mock,
+        ):
+            upload_mock.return_value = {"ret": 0, "upload_full_url": "https://cdn.example.com/up"}
+            cipher_mock.return_value = "enc-param"
+            api_post_mock.return_value = {
+                "ret": weixin.RATE_LIMIT_ERRCODE,
+                "errcode": weixin.RATE_LIMIT_ERRCODE,
+                "errmsg": "frequency limit",
+            }
+            result = asyncio.run(adapter.send_document("wxid_test123", str(image_path)))
+
+        # Previously the media sendmessage response was never inspected:
+        # iLink's -2 was silently ignored and success=True returned.
+        assert result.success is False
+        assert "rate limit" in (result.error or "").lower()
+        assert result.error_kind == "rate_limited"
+
+    def test_typing_rate_limit_is_logged_at_warning(self, caplog):
+        adapter = self._connected_adapter()
+        adapter._typing_cache.set("wxid_test123", "ticket-1")
+
+        with patch("gateway.platforms.weixin._api_post", new_callable=AsyncMock) as api_post_mock:
+            api_post_mock.return_value = {
+                "ret": weixin.RATE_LIMIT_ERRCODE,
+                "errcode": weixin.RATE_LIMIT_ERRCODE,
+                "errmsg": "frequency limit",
+            }
+            with caplog.at_level(logging.WARNING, logger="gateway.platforms.weixin"):
+                asyncio.run(adapter.send_typing("wxid_test123"))
+
+        assert any("limit" in r.message.lower() for r in caplog.records)
+
+
 class TestWeixinOutboundMedia:
 
 
@@ -322,6 +523,9 @@ class TestWeixinOutboundMedia:
              patch("gateway.platforms.weixin._api_post", new_callable=AsyncMock) as api_post_mock, \
              patch("gateway.platforms.weixin.secrets.token_hex", return_value="filekey-123"), \
              patch("gateway.platforms.weixin.secrets.token_bytes", return_value=aes_key):
+            # The media sendmessage response is inspected since #94146;
+            # an accepted response keeps the send flowing.
+            api_post_mock.return_value = {"ret": 0, "errcode": 0}
             message_id = asyncio.run(adapter._send_file("wxid_test123", str(image_path), ""))
 
         assert message_id.startswith("hermes-weixin-")


### PR DESCRIPTION
## Summary

This PR hardens the Weixin adapter's outbound path against **client-side false success**: five defects in `gateway/platforms/weixin.py` that let refused, throttled, or empty sends be reported as delivered (or swallowed silently) are fixed and covered by regression tests.

It does **not** claim to fix the reported outage itself. The #94146 report describes replies that were dropped **server-side with no error code at all** (no `send failed`, `rate limited`, `session expired`, `-14`, or `-2` log lines). That suppression is **not reproduced or root-caused here** — see "What this PR does not fix".

## What this PR fixes (client-side defects, all confirmed by code inspection; red→green tests)

1. **Media sends ignored iLink responses.** `send_document` / `send_video` / `send_voice` (and the caption send) returned `SendResult(success=True, ...)` even for `ret=-2` / `-14` responses — a literal false success with no log line (the issue's "no `-14` or `-2` log").
2. **Typing signals were throttled invisibly.** `_send_typing()` never inspected its response, and throttled typing bursts (a suspected suppression trigger in #94146) left no trace — now they surface at WARNING instead of a debug-level swallow.
3. **Empty replies reported success.** A reply that formatted/split to nothing returned `SendResult(success=True, message_id=None)`; `send_weixin_direct` skipped the send and still returned success.
4. **Non-dict / absent responses fell through as success.** Any non-dict `sendmessage` response was treated as delivered; now an empty response is a WARNING + classified failure and non-dict responses raise.
5. **Rate-limited results were not classified.** `send()` returned `SendResult(success=False, error=...)` with no `retryable` / `retry_after` / `error_kind`, so `BasePlatformAdapter._send_with_retry()` matched it against connection-error patterns, treated a throttle as a formatting failure, and re-sent a mangled `"(Response formatting failed, plain text:)... "` duplicate instead of honoring the cooldown. Now `classify_send_error()` marks `rate_limited` with `retryable=True` + `retry_after` (remaining cooldown, 5 s fallback).

Plus: every `sendmessage` response (text, caption, media) is now logged sanitized at INFO/WARNING (`ret`, `errcode`, `errmsg` truncated, `client_id` prefix, `context_token` used), so an accepted-but-dropped send is at least distinguishable in production logs.

## What this PR does not fix (the reported case)

The #94146 repro shows a reply that produced **no refusal code at all**: the gateway logged the send as completed and no `-2` / `-14` / rate-limit / session-expired line appeared, while the message never arrived. The client-side defects above do not cover that: a `ret=0`/`errcode=0` (or absent) response is still treated as *accepted* and the send still reports success. If iLink suppresses delivery without an error code, this PR cannot detect it. **The server-side suppression is not reproduced (needs-repro)** — the new per-send log lines are the instrumentation to capture it, and an evidence request has been left on #94146. The protocol-level gaps from #24989 also remain open.

## Hypothesized recovery — **unverified**, not a fix

The circuit-open path in this PR (invalidate the peer's cached `context_token` so the post-cooldown retry starts from a tokenless send) is a **hypothesis** that a stale/poisoned context token suppresses server-side delivery. The report directly weakens it: the reporter states that **a fresh QR login that produced a new bot account/token did not recover outbound delivery** (#94146). A fresh login cannot carry a stale cached token, so a token-invalidation recovery cannot explain that case. This path is therefore labeled **unverified**: it may mitigate future incidents where a genuinely stale token matters, but it is not claimed to fix #94146.

## Rate-limit retry: double-send uncertainty

`ret=-2` semantics are ambiguous. In-repo, `RATE_LIMIT_ERRCODE` is documented as "iLink frequency limit — backoff and retry", while `_is_stale_session_ret()` treats `ret=-2` with `errmsg == "unknown error"` as a **stale-session** signal (same as `-14`). If `-2` instead means "message accepted but delivery throttled", a post-cooldown retry **double-sends**. The handling here is conservative but cannot rule that out:

- the in-flight chunk loop retries at most `WEIXIN_SEND_CHUNK_RETRIES` (default 4) times with 3x backoff, then stops;
- the rate-limit circuit breaker (`_record_rate_limit_event()`) aborts the in-flight send and surfaces a classified failure instead of hammering the endpoint;
- `_send_with_retry()` re-invokes the whole send at most 2 further times, honoring `retry_after` when present.

The double-send possibility is documented rather than asserted away; distinguishing "refused-and-retryable" from "accepted-but-throttled" needs a wire-level answer from iLink (see the evidence request on #94146).

## Tests

8 new regression tests in `tests/gateway/test_weixin.py` (`TestWeixinRateLimitRecovery`) using the fake-transport/stub-session pattern: circuit-open send returns `rate_limited` kind + `retryable` + `retry_after`; per-chunk loop exhaustion keeps rate_limited semantics; circuit open invalidates the cached context token; successful send logs a sanitized response line (accepted-but-dropped distinguishable); non-dict response is not a silent success; blank reply is a visible failure with no `_send_message` call; `send_document` surfaces a `-2` media response (was `success=True`); typing rate limit logs at WARNING. All 8 were **red** pre-fix and **green** post-fix.

## Test results

- `tests/gateway/test_weixin.py` + `test_weixin_secret_scope.py` + `test_weixin_typing.py` + `test_poller_fd_lifecycle.py`: 57 passed; 2 failures are pre-existing on `main` in this environment (`test_qr_login_timeout_uses_monotonic_clock`, `test_recycle_closes_old_and_installs_fresh_session` — both fail identically with `weixin.aiohttp` unpatched/None in the test process, unrelated to this change).
- `test_send_error_classification.py`, `test_send_retry.py`, `test_retry_response.py`, `test_completion_delivery.py`: pass.
- `tests/tools/test_send_message_tool.py`: same result as `main` in this environment (12 pre-existing Discord-forum failures, 94 passed).

## Status

- Client-side false-success defects: **fixed** (this PR).
- Server-side suppression of the reported case (#94146): **not reproduced — needs-repro**; evidence request left on the issue.

Related: #94146 (stays open pending the evidence; the server-side root cause is not resolved by this PR).

