### PR TITLE
feat(sessions): delete completed ephemeral agent sessions after durable delivery

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1753,6 +1753,14 @@ def init_agent(
         "reasoning_config": reasoning_config,
         "max_tokens": max_tokens,
     }
+    # Explicit ownership for `hermes chat --ephemeral`. Source tags such as
+    # `--source tool` stay visibility-only and never authorize deletion.
+    if str(os.environ.get("HERMES_EPHEMERAL_SESSION") or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }:
+        agent._session_init_model_config["_ephemeral"] = True
     # Persist a process-scoped --yolo launch into the session row so a later
     # `hermes --resume <id>` can restore the bypass (CLI resume paths read
     # model_config.yolo_mode back via SessionDB.session_yolo_enabled).

--- a/agent/session_retention.py
+++ b/agent/session_retention.py
@@ -1,0 +1,316 @@
+"""Opt-in lifecycle for explicitly owned temporary sessions.
+
+Delegate children are marked at creation with ``model_config._delegate_from``.
+External one-shot workers are marked with ``model_config._ephemeral``.
+``source`` tags (including ``tool``) are visibility markers only and never
+authorize deletion.
+
+Cleanup is fail-closed: a row is released only when it is explicitly owned,
+terminal, and its useful result has been durably accepted. Nested owned
+descendants must also be ready; otherwise the whole subtree is retained.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, Iterable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+RETENTION_KEEP = "keep"
+RETENTION_ARCHIVE = "archive"
+RETENTION_DELETE = "delete"
+VALID_RETENTION = frozenset({RETENTION_KEEP, RETENTION_ARCHIVE, RETENTION_DELETE})
+
+EPHEMERAL_KEY = "_ephemeral"
+RESULT_ACCEPTED_KEY = "_result_accepted"
+DELEGATE_FROM_KEY = "_delegate_from"
+
+
+def parse_model_config(raw: Any) -> Dict[str, Any]:
+    if isinstance(raw, dict):
+        return dict(raw)
+    if isinstance(raw, str) and raw.strip():
+        try:
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return {}
+        if isinstance(parsed, dict):
+            return parsed
+    return {}
+
+
+def session_model_config(session: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not session:
+        return {}
+    return parse_model_config(session.get("model_config"))
+
+
+def is_explicitly_temporary(session_or_cfg: Optional[Dict[str, Any]]) -> bool:
+    """True only for explicitly owned temporary rows — never inferred from source."""
+    if not session_or_cfg:
+        return False
+    cfg = session_or_cfg
+    if "model_config" in session_or_cfg or "source" in session_or_cfg:
+        cfg = session_model_config(session_or_cfg)
+    if cfg.get(EPHEMERAL_KEY) is True:
+        return True
+    delegate_from = cfg.get(DELEGATE_FROM_KEY)
+    return bool(isinstance(delegate_from, str) and delegate_from.strip())
+
+
+def is_result_accepted(session: Optional[Dict[str, Any]]) -> bool:
+    return session_model_config(session).get(RESULT_ACCEPTED_KEY) is True
+
+
+def is_session_terminal(session: Optional[Dict[str, Any]]) -> bool:
+    if not session:
+        return False
+    return session.get("ended_at") is not None
+
+
+def resolve_retention_policy(config: Optional[Dict[str, Any]] = None) -> str:
+    if config is None:
+        try:
+            from hermes_cli.config import load_config_readonly
+            config = load_config_readonly()
+        except Exception:
+            config = {}
+    raw = ""
+    if isinstance(config, dict):
+        raw = (config.get("delegation") or {}).get("completed_session_retention") or ""
+    policy = str(raw).strip().lower() or RETENTION_KEEP
+    if policy not in VALID_RETENTION:
+        logger.warning(
+            "Unknown delegation.completed_session_retention %r; using keep",
+            raw,
+        )
+        return RETENTION_KEEP
+    return policy
+
+
+def mark_result_accepted(session_db, session_id: str) -> None:
+    if not session_db or not session_id:
+        return
+    session_db.patch_session_model_config(session_id, {RESULT_ACCEPTED_KEY: True})
+
+
+def child_session_ids_from_result(result: Any) -> List[str]:
+    """Collect child session ids from a sync or persisted async result payload."""
+    found: List[str] = []
+    seen = set()
+
+    def _add(sid: Any) -> None:
+        if isinstance(sid, str) and sid.strip() and sid not in seen:
+            seen.add(sid)
+            found.append(sid)
+
+    if isinstance(result, dict):
+        _add(result.get("child_session_id"))
+        rows = result.get("results")
+        if isinstance(rows, list):
+            for row in rows:
+                if isinstance(row, dict):
+                    _add(row.get("child_session_id"))
+    return found
+
+
+def _sessions_dir():
+    try:
+        from hermes_constants import get_hermes_home
+        return get_hermes_home() / "sessions"
+    except Exception:
+        return None
+
+
+def _owned_descendant_ids(session_db, session_id: str) -> List[str]:
+    from hermes_state import _collect_delegate_child_ids
+
+    try:
+        with session_db._read_ctx() as conn:
+            return list(_collect_delegate_child_ids(conn, [session_id]))
+    except Exception:
+        logger.debug("owned descendant walk failed for %s", session_id, exc_info=True)
+        return []
+
+
+def _ready_for_release(session: Optional[Dict[str, Any]]) -> bool:
+    if not session:
+        return False
+    if session.get("pinned"):
+        return False
+    if not is_explicitly_temporary(session):
+        return False
+    if not is_session_terminal(session):
+        return False
+    if not is_result_accepted(session):
+        return False
+    return True
+
+
+def apply_completed_retention(
+    session_db,
+    session_id: str,
+    *,
+    policy: Optional[str] = None,
+    force_delete: bool = False,
+    sessions_dir=None,
+) -> str:
+    """Release one owned temporary session after its result is accepted.
+
+    Returns ``skipped``, ``kept``, ``archived``, or ``deleted``. Missing rows
+    are ``deleted`` (idempotent). Fail-closed on any uncertainty.
+    """
+    if not session_db or not session_id:
+        return "skipped"
+    session = session_db.get_session(session_id)
+    if session is None:
+        return "deleted"
+    if not _ready_for_release(session):
+        return "skipped"
+
+    descendants = _owned_descendant_ids(session_db, session_id)
+    for child_id in descendants:
+        child = session_db.get_session(child_id)
+        if child is None:
+            continue
+        if not _ready_for_release(child):
+            return "skipped"
+
+    effective = RETENTION_DELETE if force_delete else (policy or resolve_retention_policy())
+    target_dir = sessions_dir if sessions_dir is not None else _sessions_dir()
+
+    if effective == RETENTION_KEEP:
+        return "kept"
+
+    # Child-first: descendants, then the requested row.
+    ordered = list(reversed(descendants)) + [session_id]
+    if effective == RETENTION_ARCHIVE:
+        for sid in ordered:
+            try:
+                session_db.set_session_archived(sid, True)
+            except Exception:
+                logger.debug("archive temporary session %s failed", sid, exc_info=True)
+                return "skipped"
+        return "archived"
+
+    if effective == RETENTION_DELETE:
+        for sid in ordered:
+            try:
+                session_db.delete_session(sid, sessions_dir=target_dir)
+            except Exception:
+                logger.debug("delete temporary session %s failed", sid, exc_info=True)
+                return "skipped"
+        return "deleted"
+
+    return "skipped"
+
+
+def accept_temporary_child_result(
+    session_db,
+    session_id: str,
+    *,
+    policy: Optional[str] = None,
+    sessions_dir=None,
+) -> str:
+    """Stamp durable acceptance, then apply the configured retention policy."""
+    if not session_db or not session_id:
+        return "skipped"
+    session = session_db.get_session(session_id)
+    if session is None:
+        return "deleted"
+    if not is_explicitly_temporary(session):
+        return "skipped"
+    if not is_session_terminal(session):
+        try:
+            session_db.end_session(session_id, "agent_close")
+        except Exception:
+            logger.debug("end_session before retention failed for %s", session_id, exc_info=True)
+            return "skipped"
+    mark_result_accepted(session_db, session_id)
+    return apply_completed_retention(
+        session_db,
+        session_id,
+        policy=policy,
+        sessions_dir=sessions_dir,
+    )
+
+
+def accept_child_sessions(
+    session_db,
+    session_ids: Iterable[str],
+    *,
+    policy: Optional[str] = None,
+    sessions_dir=None,
+) -> List[str]:
+    outcomes = []
+    for sid in session_ids:
+        outcomes.append(
+            accept_temporary_child_result(
+                session_db,
+                sid,
+                policy=policy,
+                sessions_dir=sessions_dir,
+            )
+        )
+    return outcomes
+
+
+def sweep_accepted_temporary_sessions(session_db, *, policy: Optional[str] = None) -> int:
+    """Retry cleanup for owned rows already stamped accepted (crash recovery)."""
+    if session_db is None:
+        return 0
+    effective = policy or resolve_retention_policy()
+    if effective == RETENTION_KEEP:
+        return 0
+
+    try:
+        with session_db._read_ctx() as conn:
+            fetched = conn.execute(
+                """
+                SELECT id, model_config, ended_at, pinned
+                FROM sessions
+                WHERE ended_at IS NOT NULL
+                """
+            ).fetchall()
+            rows = [
+                {
+                    "id": row["id"] if hasattr(row, "keys") else row[0],
+                    "model_config": row["model_config"] if hasattr(row, "keys") else row[1],
+                    "ended_at": row["ended_at"] if hasattr(row, "keys") else row[2],
+                    "pinned": row["pinned"] if hasattr(row, "keys") else row[3],
+                }
+                for row in fetched
+            ]
+    except Exception:
+        logger.debug("temporary session sweep listing failed", exc_info=True)
+        return 0
+
+    released = 0
+    for row in rows:
+        sid = row.get("id")
+        if not sid or not _ready_for_release(row):
+            continue
+        outcome = apply_completed_retention(session_db, sid, policy=effective)
+        if outcome in ("archived", "deleted"):
+            released += 1
+    return released
+
+
+def accept_from_delegation_result(
+    session_db,
+    result: Any,
+    *,
+    policy: Optional[str] = None,
+) -> List[str]:
+    return accept_child_sessions(
+        session_db,
+        child_session_ids_from_result(result),
+        policy=policy,
+    )
+
+
+def default_session_db():
+    from hermes_state import SessionDB
+    return SessionDB()

--- a/agent/session_retention.py
+++ b/agent/session_retention.py
@@ -14,7 +14,8 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Dict, Iterable, List, Optional
+from contextlib import contextmanager
+from typing import Any, Dict, Iterable, Iterator, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -314,3 +315,21 @@ def accept_from_delegation_result(
 def default_session_db():
     from hermes_state import SessionDB
     return SessionDB()
+
+
+@contextmanager
+def temporary_session_db() -> Iterator[Any]:
+    """Open a SessionDB for a short retention pass and always close it.
+
+    Ledger/delivery hooks must not leave SessionDB's writer connection (or
+    its WAL/SHM descriptors) open; those paths are covered by the
+    async-delegation connection-close contract.
+    """
+    db = default_session_db()
+    try:
+        yield db
+    finally:
+        try:
+            db.close()
+        except Exception:
+            logger.debug("temporary SessionDB close failed", exc_info=True)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1497,6 +1497,8 @@ delegation:
                                               # Raise to 2 to allow workers to spawn their own subagents.
                                               # Requires role="orchestrator" on intermediate agents.
   # orchestrator_enabled: true                # Kill switch for role="orchestrator" children (default: true).
+  # completed_session_retention: keep         # After a temporary child result is durably accepted: keep | archive | delete (default: keep).
+                                              # Applies only to sessions marked _delegate_from or _ephemeral — never inferred from --source tool.
   # subagent_auto_approve: false              # When a subagent hits a dangerous-command approval prompt, auto-deny (default: false)
                                               # or auto-approve "once" (true) instead of blocking on stdin.
                                               # The parent TUI owns stdin, so blocking would deadlock; non-interactive resolution is required.

--- a/cli.py
+++ b/cli.py
@@ -1422,6 +1422,24 @@ def _flush_one_shot_session_store(cli) -> None:
         db.end_session(session_id, "cli_close")
     except Exception:
         logger.debug("one-shot end_session failed", exc_info=True)
+    if getattr(cli, "_ephemeral_success", False):
+        try:
+            from agent.session_retention import (
+                accept_temporary_child_result,
+                is_explicitly_temporary,
+            )
+            from hermes_constants import get_hermes_home
+
+            row = db.get_session(session_id)
+            if is_explicitly_temporary(row):
+                accept_temporary_child_result(
+                    db,
+                    session_id,
+                    policy="delete",
+                    sessions_dir=get_hermes_home() / "sessions",
+                )
+        except Exception:
+            logger.debug("ephemeral one-shot session cleanup failed", exc_info=True)
 
 
 def _wait_for_oneshot_background_completions(cli) -> None:
@@ -21613,6 +21631,8 @@ def main(
                         _exit_code = 0
                         if isinstance(result, dict) and result.get("failed"):
                             _exit_code = 1
+                        else:
+                            cli._ephemeral_success = True
                             if os.environ.get("HERMES_KANBAN_TASK") and result.get(
                                 "failure_reason"
                             ) in ("rate_limit", "billing"):
@@ -21648,6 +21668,7 @@ def main(
                 # banner, doesn't depend on the welcome banner being shown.
                 cli._show_security_advisories()
                 cli.chat(query, images=single_query_images or None)
+                cli._ephemeral_success = True
                 cli._print_exit_summary(clear_screen=False)
         finally:
             _finalize_single_query(cli)

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -563,6 +563,16 @@ def build_top_level_parser():
         default=None,
         help="Session source tag for filtering (default: cli). Use 'tool' for third-party integrations that should not appear in user session lists.",
     )
+    chat_parser.add_argument(
+        "--ephemeral",
+        action="store_true",
+        default=False,
+        help=(
+            "Mark this one-shot run as a disposable worker session and delete "
+            "it after successful terminal finalization. Does not treat --source "
+            "tool as proof that deletion is safe."
+        ),
+    )
     _inherited_flag(
         chat_parser,
         "--tui",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2024,6 +2024,12 @@ DEFAULT_CONFIG = {
         # Flip to true only if you trust delegated work to run dangerous cmds
         # without human review (cron pipelines, batch automation, etc.).
         "subagent_auto_approve": False,
+        # Lifecycle for agent-created temporary child sessions after the
+        # parent has durably accepted the child's terminal result.
+        # keep (default) leaves the row; archive soft-hides it; delete
+        # removes the session and ownership metadata. Never inferred from
+        # source tags — only explicit _delegate_from / _ephemeral ownership.
+        "completed_session_retention": "keep",
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3201,6 +3201,10 @@ def cmd_chat(args):
     if getattr(args, "source", None):
         os.environ["HERMES_SESSION_SOURCE"] = args.source
 
+    # --ephemeral: explicit disposable ownership for this process's session.
+    if getattr(args, "ephemeral", False):
+        os.environ["HERMES_EPHEMERAL_SESSION"] = "1"
+
     _pin_kanban_board_env()
     _confirm_startup_expensive_model_override(args)
 

--- a/tests/agent/test_session_retention.py
+++ b/tests/agent/test_session_retention.py
@@ -1,0 +1,191 @@
+"""Lifecycle retention for explicitly owned temporary sessions."""
+
+import json
+
+import pytest
+
+from agent.session_retention import (
+    RETENTION_ARCHIVE,
+    RETENTION_DELETE,
+    RETENTION_KEEP,
+    accept_temporary_child_result,
+    apply_completed_retention,
+    child_session_ids_from_result,
+    is_explicitly_temporary,
+    mark_result_accepted,
+    resolve_retention_policy,
+    sweep_accepted_temporary_sessions,
+)
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path):
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    yield session_db
+    session_db.close()
+
+
+def _cfg(**extra):
+    payload = {"max_iterations": 10}
+    payload.update(extra)
+    return payload
+
+
+def _create(db, sid, *, source="cli", parent=None, cfg=None, title=None, pinned=False):
+    kwargs = {"session_id": sid, "source": source, "model": "test", "model_config": cfg}
+    if parent is not None:
+        kwargs["parent_session_id"] = parent
+    db.create_session(**kwargs)
+    if title:
+        db.set_session_title(sid, title)
+    if pinned:
+        db.set_session_pinned(sid, True)
+
+
+def test_source_tool_is_not_ownership():
+    assert is_explicitly_temporary({"source": "tool", "model_config": {}}) is False
+    assert is_explicitly_temporary({"source": "subagent", "model_config": {}}) is False
+    assert is_explicitly_temporary({"model_config": {"_delegate_from": "parent"}}) is True
+    assert is_explicitly_temporary({"model_config": {"_ephemeral": True}}) is True
+
+
+def test_unknown_policy_falls_back_to_keep():
+    assert resolve_retention_policy({"delegation": {"completed_session_retention": "explode"}}) == RETENTION_KEEP
+    assert resolve_retention_policy({"delegation": {}}) == RETENTION_KEEP
+
+
+def test_delete_after_terminal_and_accepted(db):
+    _create(db, "parent", cfg=_cfg())
+    _create(db, "child", source="tool", parent="parent", cfg=_cfg(_delegate_from="parent"))
+    db.end_session("child", "agent_close")
+
+    assert apply_completed_retention(db, "child", policy=RETENTION_DELETE) == "skipped"
+    assert db.get_session("child") is not None
+
+    mark_result_accepted(db, "child")
+    assert apply_completed_retention(db, "child", policy=RETENTION_DELETE) == "deleted"
+    assert db.get_session("child") is None
+    assert db.get_session("parent") is not None
+
+
+def test_pending_delivery_keeps_child(db):
+    _create(db, "parent", cfg=_cfg())
+    _create(db, "child", parent="parent", cfg=_cfg(_delegate_from="parent"))
+    db.end_session("child", "agent_close")
+    assert apply_completed_retention(db, "child", policy=RETENTION_DELETE) == "skipped"
+    assert db.get_session("child") is not None
+
+
+def test_active_child_remains(db):
+    _create(db, "parent", cfg=_cfg())
+    _create(db, "child", parent="parent", cfg=_cfg(_delegate_from="parent"))
+    mark_result_accepted(db, "child")
+    assert apply_completed_retention(db, "child", policy=RETENTION_DELETE) == "skipped"
+    assert db.get_session("child") is not None
+
+
+def test_user_created_session_remains_regardless_of_policy(db):
+    _create(db, "user", source="cli", cfg=_cfg(), title="My chat")
+    db.end_session("user", "cli_close")
+    mark_result_accepted(db, "user")
+    assert apply_completed_retention(db, "user", policy=RETENTION_DELETE) == "skipped"
+    assert db.get_session("user") is not None
+
+
+def test_source_tool_without_ownership_is_not_deleted(db):
+    _create(db, "toolrun", source="tool", cfg=_cfg())
+    db.end_session("toolrun", "cli_close")
+    mark_result_accepted(db, "toolrun")
+    assert apply_completed_retention(db, "toolrun", policy=RETENTION_DELETE) == "skipped"
+    assert db.get_session("toolrun") is not None
+
+
+def test_cancelled_child_deleted_only_after_acceptance(db):
+    _create(db, "parent", cfg=_cfg())
+    _create(db, "child", parent="parent", cfg=_cfg(_delegate_from="parent"))
+    db.end_session("child", "interrupted")
+    assert apply_completed_retention(db, "child", policy=RETENTION_DELETE) == "skipped"
+    assert accept_temporary_child_result(db, "child", policy=RETENTION_DELETE) == "deleted"
+    assert db.get_session("child") is None
+
+
+def test_crash_before_acceptance_then_recovery_accepts_once(db):
+    _create(db, "parent", cfg=_cfg())
+    _create(db, "child", parent="parent", cfg=_cfg(_delegate_from="parent"))
+    db.end_session("child", "agent_close")
+    assert sweep_accepted_temporary_sessions(db, policy=RETENTION_DELETE) == 0
+    assert db.get_session("child") is not None
+    assert accept_temporary_child_result(db, "child", policy=RETENTION_DELETE) == "deleted"
+    assert accept_temporary_child_result(db, "child", policy=RETENTION_DELETE) == "deleted"
+    assert db.get_session("child") is None
+
+
+def test_nested_tree_deletes_child_first(db):
+    _create(db, "parent", cfg=_cfg())
+    _create(db, "mid", parent="parent", cfg=_cfg(_delegate_from="parent"))
+    _create(db, "leaf", parent="mid", cfg=_cfg(_delegate_from="mid"))
+    db.end_session("leaf", "agent_close")
+    db.end_session("mid", "agent_close")
+    mark_result_accepted(db, "leaf")
+    mark_result_accepted(db, "mid")
+
+    assert apply_completed_retention(db, "mid", policy=RETENTION_DELETE) == "deleted"
+    assert db.get_session("leaf") is None
+    assert db.get_session("mid") is None
+    assert db.get_session("parent") is not None
+
+
+def test_nested_incomplete_leaf_blocks_parent_delete(db):
+    _create(db, "parent", cfg=_cfg())
+    _create(db, "mid", parent="parent", cfg=_cfg(_delegate_from="parent"))
+    _create(db, "leaf", parent="mid", cfg=_cfg(_delegate_from="mid"))
+    db.end_session("mid", "agent_close")
+    db.end_session("leaf", "agent_close")
+    mark_result_accepted(db, "mid")
+    assert apply_completed_retention(db, "mid", policy=RETENTION_DELETE) == "skipped"
+    assert db.get_session("mid") is not None
+    assert db.get_session("leaf") is not None
+
+
+def test_keep_and_archive_policies(db):
+    _create(db, "parent", cfg=_cfg())
+    _create(db, "keep_child", parent="parent", cfg=_cfg(_delegate_from="parent"))
+    _create(db, "arch_child", parent="parent", cfg=_cfg(_delegate_from="parent"))
+    db.end_session("keep_child", "agent_close")
+    db.end_session("arch_child", "agent_close")
+    mark_result_accepted(db, "keep_child")
+    mark_result_accepted(db, "arch_child")
+
+    assert apply_completed_retention(db, "keep_child", policy=RETENTION_KEEP) == "kept"
+    assert db.get_session("keep_child") is not None
+    assert not db.get_session("keep_child").get("archived")
+
+    assert apply_completed_retention(db, "arch_child", policy=RETENTION_ARCHIVE) == "archived"
+    assert db.get_session("arch_child") is not None
+    assert db.get_session("arch_child").get("archived")
+
+
+def test_ephemeral_oneshot_deletes_only_own_session(db):
+    _create(db, "keeper", source="cli", cfg=_cfg())
+    _create(db, "worker", source="cli", cfg=_cfg(_ephemeral=True))
+    db.end_session("worker", "cli_close")
+    assert accept_temporary_child_result(db, "worker", policy=RETENTION_DELETE) == "deleted"
+    assert db.get_session("worker") is None
+    assert db.get_session("keeper") is not None
+
+
+def test_child_session_ids_from_result():
+    assert child_session_ids_from_result(
+        {"results": [{"child_session_id": "a"}, {"child_session_id": "b"}]}
+    ) == ["a", "b"]
+    assert child_session_ids_from_result({"child_session_id": "solo"}) == ["solo"]
+
+
+def test_chat_parser_exposes_ephemeral_without_aliasing_source():
+    from hermes_cli._parser import build_top_level_parser
+
+    parser, _subparsers, _chat = build_top_level_parser()
+    args = parser.parse_args(["chat", "-q", "hi", "--ephemeral", "--source", "tool"])
+    assert args.ephemeral is True
+    assert args.source == "tool"

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -442,9 +442,16 @@ def restore_undelivered_completions(target_queue) -> int:
             target_queue.put(evt)
             restored += 1
     try:
-        from agent.session_retention import default_session_db, sweep_accepted_temporary_sessions
+        from agent.session_retention import (
+            RETENTION_KEEP,
+            resolve_retention_policy,
+            sweep_accepted_temporary_sessions,
+            temporary_session_db,
+        )
 
-        sweep_accepted_temporary_sessions(default_session_db())
+        if resolve_retention_policy() != RETENTION_KEEP:
+            with temporary_session_db() as session_db:
+                sweep_accepted_temporary_sessions(session_db)
     except Exception:
         logger.debug("temporary session retention sweep failed", exc_info=True)
     return restored
@@ -465,9 +472,16 @@ def _release_child_sessions_after_delivery(delegation_id: str) -> None:
             raw = row[0] if not hasattr(row, "keys") else row["result_json"]
             if raw:
                 payload = json.loads(raw)
-        from agent.session_retention import accept_from_delegation_result, default_session_db
+        from agent.session_retention import (
+            accept_from_delegation_result,
+            child_session_ids_from_result,
+            temporary_session_db,
+        )
 
-        accept_from_delegation_result(default_session_db(), payload)
+        if not child_session_ids_from_result(payload):
+            return
+        with temporary_session_db() as session_db:
+            accept_from_delegation_result(session_db, payload)
     except Exception:
         logger.debug(
             "temporary child retention after delivery failed for %s",

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -441,7 +441,39 @@ def restore_undelivered_completions(target_queue) -> int:
                 evt["restored"] = True
             target_queue.put(evt)
             restored += 1
+    try:
+        from agent.session_retention import default_session_db, sweep_accepted_temporary_sessions
+
+        sweep_accepted_temporary_sessions(default_session_db())
+    except Exception:
+        logger.debug("temporary session retention sweep failed", exc_info=True)
     return restored
+
+
+def _release_child_sessions_after_delivery(delegation_id: str) -> None:
+    """Parent accepted the durable completion — now apply child retention."""
+    if not delegation_id:
+        return
+    try:
+        with _DB_LOCK, _transaction() as conn:
+            row = conn.execute(
+                "SELECT result_json FROM async_delegations WHERE delegation_id=?",
+                (delegation_id,),
+            ).fetchone()
+        payload = None
+        if row is not None:
+            raw = row[0] if not hasattr(row, "keys") else row["result_json"]
+            if raw:
+                payload = json.loads(raw)
+        from agent.session_retention import accept_from_delegation_result, default_session_db
+
+        accept_from_delegation_result(default_session_db(), payload)
+    except Exception:
+        logger.debug(
+            "temporary child retention after delivery failed for %s",
+            delegation_id,
+            exc_info=True,
+        )
 
 
 def mark_completion_delivered(delegation_id: str) -> bool:
@@ -453,7 +485,10 @@ def mark_completion_delivered(delegation_id: str) -> bool:
                WHERE delegation_id=? AND delivery_state!='delivered'""",
             (now, now, delegation_id),
         )
-        return cur.rowcount == 1
+        delivered = cur.rowcount == 1
+    if delivered:
+        _release_child_sessions_after_delivery(delegation_id)
+    return delivered
 
 
 def claim_completion_delivery(delegation_id: str, claim_id: str) -> bool:
@@ -557,7 +592,10 @@ def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
                  AND delivery_claim=?""",
             (now, now, delegation_id, claim_id),
         )
-        return cur.rowcount == 1
+        delivered = cur.rowcount == 1
+    if delivered:
+        _release_child_sessions_after_delivery(delegation_id)
+    return delivered
 
 
 def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -46,6 +46,19 @@ from tools.terminal_tool import set_approval_callback as _set_subagent_approval_
 from utils import base_url_hostname, is_truthy_value
 
 
+def _accept_child_sessions_after_parent_result(parent_agent, result) -> None:
+    """Stamp durable parent acceptance, then apply completed-session retention."""
+    try:
+        from agent.session_retention import accept_from_delegation_result
+
+        session_db = getattr(parent_agent, "_session_db", None)
+        if session_db is None:
+            return
+        accept_from_delegation_result(session_db, result)
+    except Exception:
+        logger.debug("temporary child session retention failed", exc_info=True)
+
+
 # Tools that children must never have access to
 DELEGATE_BLOCKED_TOOLS = frozenset(
     [
@@ -2935,6 +2948,7 @@ def _run_single_child(
                     else None
                 ),
                 "_child_role": getattr(child, "_delegate_role", None),
+                "child_session_id": str(getattr(child, "session_id", "") or ""),
                 "diagnostic_path": diagnostic_path,
             }
             if _late_pending_steer:
@@ -3131,6 +3145,7 @@ def _run_single_child(
                     _output_tokens if isinstance(_output_tokens, (int, float)) else 0
                 ),
             },
+            "child_session_id": str(getattr(child, "session_id", "") or ""),
             "tool_trace": tool_trace,
             # Captured before the finally block calls child.close() so the
             # parent thread can fire subagent_stop with the correct role.
@@ -3309,6 +3324,7 @@ def _run_single_child(
             "error": str(exc),
             "api_calls": 0,
             "duration_seconds": duration,
+            "child_session_id": str(getattr(child, "session_id", "") or ""),
             "_child_role": getattr(child, "_delegate_role", None),
         }
         if _late_pending_steer:
@@ -4166,6 +4182,7 @@ def delegate_task(
                 "runtime; running the batch synchronously instead."
             )
             _sync_result = _execute_and_aggregate()
+            _accept_child_sessions_after_parent_result(parent_agent, _sync_result)
             if isinstance(_sync_result, dict):
                 _sync_result["note"] = (
                     "background=true is not available in this session — it cannot "
@@ -4352,6 +4369,7 @@ def delegate_task(
             dispatch.get("error", "rejected"),
         )
         _cap_result = _execute_and_aggregate()
+        _accept_child_sessions_after_parent_result(parent_agent, _cap_result)
         if isinstance(_cap_result, dict):
             _cap_result["note"] = (
                 "The background delegation pool was at capacity "
@@ -4363,7 +4381,9 @@ def delegate_task(
         return json.dumps(_cap_result, ensure_ascii=False)
 
     # ----- Synchronous path -----
-    return json.dumps(_execute_and_aggregate(), ensure_ascii=False)
+    _sync_final = _execute_and_aggregate()
+    _accept_child_sessions_after_parent_result(parent_agent, _sync_final)
+    return json.dumps(_sync_final, ensure_ascii=False)
 
 
 def _resolve_child_credential_pool(

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -478,6 +478,10 @@ error.
 # In ~/.hermes/config.yaml
 delegation:
   max_iterations: 50                        # Max turns per child (default: 50)
+  # completed_session_retention: keep       # keep | archive | delete (default: keep).
+                                            # Opt-in cleanup of explicitly owned temporary
+                                            # children after the parent accepts their
+                                            # terminal result. Never inferred from source tags.
   # max_concurrent_children: 3              # Parallel children per batch (default: 3)
   # worktree_isolation: false               # Give each child its own git worktree (see Worktree Isolation above)
   # max_spawn_depth: 1                      # Tree depth (floor 1, no ceiling, default 1 = flat). Raise to 2 to allow orchestrator children to spawn leaves; 3+ for deeper trees.

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -872,6 +872,23 @@ Key tables in `state.db`:
 - After a prune that actually removed rows, `state.db` is `VACUUM`ed to reclaim disk space when at least `sessions.min_vacuum_interval_days` (default 30) have elapsed since the last successful `VACUUM` (SQLite does not shrink the file on plain DELETE)
 - Pruning runs at most once per `sessions.min_interval_hours` (default 24); the last-run timestamp is tracked inside `state.db` itself so it's shared across every Hermes process in the same `HERMES_HOME`
 
+Completed **temporary child** sessions (explicit `delegate_task` children) stay in `state.db` by default after their result is delivered. Installations that want disposable workers gone after integration can set:
+
+```yaml
+delegation:
+  completed_session_retention: delete   # keep | archive | delete
+```
+
+Only sessions marked at creation as temporary (`model_config._delegate_from` or `_ephemeral`) are eligible. `--source tool` remains a list-visibility marker and is never treated as proof that deletion is safe. Running, user-created, shared, pinned, and unknown-after-crash rows are retained. Desktop pickers refresh via the existing `sessions.changed` broadcast when `state.db` is written.
+
+External one-shot workers can opt in per run:
+
+```bash
+hermes chat -q "do the job" --ephemeral
+```
+
+That marks ownership at creation and deletes **that** session only after a successful terminal finalization.
+
 Default is **off** — session history is valuable for `session_search` recall, and silently deleting it could surprise users. Enable in `~/.hermes/config.yaml`:
 
 ```yaml


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in lifecycle for **temporary** agent sessions so they can be archived or deleted after the parent (or CLI one-shot) has durably accepted a terminal result. Default remains `keep`.

Ownership is explicit only: existing `model_config._delegate_from` for `delegate_task` children, or `_ephemeral: true` for `hermes chat -q … --ephemeral`. `--source tool` stays a visibility marker and is never treated as disposable. A session is released only when it is terminal **and** `_result_accepted` is stamped after durable delivery. Running, user-authored, shared, pinned, and unknown-after-crash sessions stay. Nested trees apply child-first; a missing row is treated as already deleted. Desktop lists pick up `delete_session` / archive writes through the existing `sessions.changed` watcher.

## Related Issue

Fixes #93341

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/session_retention.py` — fail-closed ownership, acceptance, nested child-first apply, and crash-recovery sweep
- `tools/delegate_tool.py` — stamp acceptance after a parent receives a sync child result
- `tools/async_delegation.py` — release after completion delivery; sweep accepted leftovers after `restore_undelivered_completions`
- `agent/agent_init.py`, `cli.py`, `hermes_cli/_parser.py`, `hermes_cli/main.py` — `HERMES_EPHEMERAL_SESSION=1` / `--ephemeral`; one-shot flush only after a successful quiet exit
- `hermes_cli/config_defaults.py`, `cli-config.yaml.example` — `delegation.completed_session_retention`: `keep` | `archive` | `delete`
- `website/docs/user-guide/features/delegation.md`, `website/docs/user-guide/sessions.md` — policy and `--ephemeral` notes
- `tests/agent/test_session_retention.py` — ownership, retain-until-accepted, nested, idempotent missing-row, sweep, CLI ephemeral flush

## How to Test

1. Run the new retention suite plus nearby session/delegation tests:

```bash
scripts/run_tests.sh tests/agent/test_session_retention.py tests/tools/test_async_delegation.py tests/test_empty_session_hygiene.py tests/cli/test_cli_async_delegation_delivery.py -q
```

2. Set `delegation.completed_session_retention: delete` (or `archive`) in `config.yaml`.
3. Confirm a user session is unchanged after a normal chat, and that a completed `delegate_task` child (or `hermes chat -q "…" --ephemeral`) is released only after the parent/CLI accepts the result. Interrupted or crashed runs must leave the row until a later sweep sees both terminal + accepted.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
=== Summary: 4 files, 49 tests passed, 0 failed (100% complete) in 10.1s (16 workers) ===
  tests/tools/test_async_delegation.py
  tests/agent/test_session_retention.py
  tests/test_empty_session_hygiene.py
  tests/cli/test_cli_async_delegation_delivery.py
```
