### PR TITLE
feat(cli): independent hybrid agent network (NAI-68)

### DIFF
--- a/contributors/emails/jose@naicipa.com
+++ b/contributors/emails/jose@naicipa.com
@@ -1,0 +1,2 @@
+josenaicipa
+# NAI-68 independent hybrid agent network

--- a/hermes_cli/independent_network/__init__.py
+++ b/hermes_cli/independent_network/__init__.py
@@ -1,0 +1,61 @@
+"""Independent hybrid agent network (NAI-68).
+
+Canonical roster, isolated profiles, deterministic alias routing, an
+asynchronous dispatch broker, mandatory Linear issue linking, and
+brokered 1Password credential access that never puts secret values in
+prompts, memory, receipts, or audit logs.
+"""
+
+from hermes_cli.independent_network.broker import (
+    DispatchBroker,
+    DispatchError,
+    Job,
+)
+from hermes_cli.independent_network.credentials import (
+    CredentialBroker,
+    CredentialReceipt,
+    SecretRevealedError,
+)
+from hermes_cli.independent_network.linear import (
+    LinearLink,
+    LinearLinkError,
+    parse_linear_issue,
+    require_linear_issue,
+)
+from hermes_cli.independent_network.provision import (
+    ProvisionResult,
+    provision_roster,
+)
+from hermes_cli.independent_network.roster import (
+    AgentSpec,
+    CANONICAL_ROSTER,
+    get_agent,
+    list_roster,
+    provider_for_model,
+)
+from hermes_cli.independent_network.routing import (
+    UnknownAgentError,
+    resolve_agent,
+)
+
+__all__ = [
+    "AgentSpec",
+    "CANONICAL_ROSTER",
+    "CredentialBroker",
+    "CredentialReceipt",
+    "DispatchBroker",
+    "DispatchError",
+    "Job",
+    "LinearLink",
+    "LinearLinkError",
+    "ProvisionResult",
+    "SecretRevealedError",
+    "UnknownAgentError",
+    "get_agent",
+    "list_roster",
+    "parse_linear_issue",
+    "provider_for_model",
+    "provision_roster",
+    "require_linear_issue",
+    "resolve_agent",
+]

--- a/hermes_cli/independent_network/broker.py
+++ b/hermes_cli/independent_network/broker.py
@@ -1,0 +1,229 @@
+"""Asynchronous dispatch broker for the independent agent network.
+
+Dispatch resolves an alias, requires a Linear issue, requests brokered
+credentials, records a job, and starts the child without waiting. Job
+files and receipts never contain secret values.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping, Optional
+
+from hermes_cli.independent_network.credentials import (
+    CredentialBroker,
+    CredentialReceipt,
+    assert_no_secret_values,
+)
+from hermes_cli.independent_network.linear import require_linear_issue
+from hermes_cli.independent_network.routing import resolve_agent
+from hermes_cli.independent_network.store import jobs_dir, read_json, write_json
+
+
+Runner = Callable[["Job", Dict[str, str]], Optional[int]]
+
+
+class DispatchError(ValueError):
+    """Raised when a job cannot be accepted."""
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _job_id() -> str:
+    return uuid.uuid4().hex[:12]
+
+
+@dataclass
+class Job:
+    """Durable record of an asynchronous network dispatch."""
+
+    id: str
+    target: str
+    profile: str
+    lane: str
+    alias: str
+    model: str
+    provider: str
+    linear: Dict[str, str]
+    goal: str
+    status: str
+    created_at: str
+    pid: Optional[int] = None
+    credential_names: List[str] = field(default_factory=list)
+    credential_receipts: List[Dict[str, Any]] = field(default_factory=list)
+    error: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "target": self.target,
+            "profile": self.profile,
+            "lane": self.lane,
+            "alias": self.alias,
+            "model": self.model,
+            "provider": self.provider,
+            "linear": dict(self.linear),
+            "goal": self.goal,
+            "status": self.status,
+            "created_at": self.created_at,
+            "pid": self.pid,
+            "credential_names": list(self.credential_names),
+            "credential_receipts": list(self.credential_receipts),
+            "error": self.error,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Job":
+        return cls(
+            id=str(data["id"]),
+            target=str(data.get("target") or ""),
+            profile=str(data.get("profile") or ""),
+            lane=str(data.get("lane") or ""),
+            alias=str(data.get("alias") or ""),
+            model=str(data.get("model") or ""),
+            provider=str(data.get("provider") or ""),
+            linear=dict(data.get("linear") or {}),
+            goal=str(data.get("goal") or ""),
+            status=str(data.get("status") or "queued"),
+            created_at=str(data.get("created_at") or ""),
+            pid=data.get("pid"),
+            credential_names=list(data.get("credential_names") or []),
+            credential_receipts=list(data.get("credential_receipts") or []),
+            error=data.get("error"),
+        )
+
+    def prompt(self) -> str:
+        """User-message payload for the child agent. Contains no secrets."""
+        identifier = self.linear.get("identifier", "")
+        url = self.linear.get("url", "")
+        return (
+            f"Independent-agent dispatch for {self.alias} ({self.lane}).\n"
+            f"Linear: {identifier} {url}\n"
+            f"Pinned model: {self.model}\n\n"
+            f"{self.goal.strip()}\n"
+        )
+
+
+class DispatchBroker:
+    """Queue + spawn broker. ``dispatch()`` returns without waiting."""
+
+    def __init__(
+        self,
+        *,
+        home: Optional[Path] = None,
+        credentials: Optional[CredentialBroker] = None,
+        runner: Optional[Runner] = None,
+    ) -> None:
+        self.home = home
+        self.credentials = credentials or CredentialBroker(home=home)
+        self.runner = runner
+
+    def dispatch(
+        self,
+        target: str,
+        goal: str,
+        linear: str,
+        *,
+        inject_credentials: bool = True,
+    ) -> Job:
+        """Accept a job, persist it, and start the child asynchronously."""
+        if not (goal or "").strip():
+            raise DispatchError("goal is required")
+        agent = resolve_agent(target)
+        link = require_linear_issue(linear)
+        job = Job(
+            id=_job_id(),
+            target=target.strip(),
+            profile=agent.profile,
+            lane=agent.lane,
+            alias=agent.alias,
+            model=agent.model,
+            provider=agent.provider,
+            linear=link.to_dict(),
+            goal=goal.strip(),
+            status="queued",
+            created_at=_utcnow(),
+        )
+
+        child_env: Dict[str, str] = {}
+        receipts: List[CredentialReceipt] = []
+        secret_values: List[str] = []
+        if inject_credentials:
+            child_env, receipts = self.credentials.collect_for_profile(agent.profile)
+            secret_values = [v for v in child_env.values() if v]
+            job.credential_names = sorted(child_env)
+            job.credential_receipts = [r.to_dict() for r in receipts]
+
+        payload = job.to_dict()
+        assert_no_secret_values(payload, secret_values)
+        assert_no_secret_values(job.prompt(), secret_values)
+        self._save(job)
+
+        try:
+            pid = self._start(job, child_env)
+        except Exception as exc:
+            job.status = "failed"
+            job.error = type(exc).__name__
+            self._save(job)
+            raise DispatchError(f"failed to start job {job.id}") from exc
+
+        job.pid = pid
+        job.status = "running" if pid else "queued"
+        self._save(job)
+        return job
+
+    def get(self, job_id: str) -> Job:
+        path = jobs_dir(self.home) / f"{job_id}.json"
+        if not path.exists():
+            raise DispatchError(f"unknown job {job_id}")
+        return Job.from_dict(read_json(path))
+
+    def list_jobs(self) -> List[Job]:
+        jobs = []
+        for path in sorted(jobs_dir(self.home).glob("*.json")):
+            try:
+                jobs.append(Job.from_dict(read_json(path)))
+            except (OSError, ValueError, KeyError, TypeError):
+                continue
+        jobs.sort(key=lambda job: job.created_at, reverse=True)
+        return jobs
+
+    def _save(self, job: Job) -> None:
+        write_json(jobs_dir(self.home) / f"{job.id}.json", job.to_dict())
+
+    def _start(self, job: Job, child_env: Dict[str, str]) -> Optional[int]:
+        runner = self.runner if self.runner is not None else default_runner
+        return runner(job, child_env)
+
+
+def default_runner(job: Job, child_env: Mapping[str, str]) -> Optional[int]:
+    """Spawn ``hermes -p <profile> --oneshot`` detached. Does not wait."""
+    env = os.environ.copy()
+    env.update(child_env)
+    prompt = job.prompt()
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "-p",
+            job.profile,
+            "--oneshot",
+            prompt,
+        ],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+        close_fds=True,
+    )
+    return proc.pid

--- a/hermes_cli/independent_network/cli.py
+++ b/hermes_cli/independent_network/cli.py
@@ -1,0 +1,274 @@
+"""``hermes network`` operator CLI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+from hermes_cli.independent_network.broker import DispatchBroker, DispatchError
+from hermes_cli.independent_network.credentials import CredentialBroker
+from hermes_cli.independent_network.linear import LinearLinkError
+from hermes_cli.independent_network.provision import provision_roster, read_pinned_model
+from hermes_cli.independent_network.roster import list_roster
+from hermes_cli.independent_network.routing import UnknownAgentError, resolve_agent
+
+
+def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
+    """Attach the ``network`` subcommand tree."""
+    parser = parent_subparsers.add_parser(
+        "network",
+        help="Independent hybrid agent network (roster, dispatch, credentials)",
+        description=(
+            "Canonical roster of isolated agent profiles, deterministic "
+            "alias routing, asynchronous dispatch bound to a Linear issue, "
+            "and brokered 1Password credential access."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Machine-readable JSON on stdout",
+    )
+    subs = parser.add_subparsers(dest="network_command")
+
+    subs.add_parser("roster", help="List the canonical agent roster")
+
+    provision = subs.add_parser(
+        "provision",
+        help="Create isolated profiles with pinned models",
+    )
+    provision.add_argument(
+        "--core",
+        action="store_true",
+        help="Provision only the six core specialists",
+    )
+    provision.add_argument(
+        "--seed-skills",
+        action="store_true",
+        help="Copy bundled skills into each new profile (slow)",
+    )
+    provision.add_argument(
+        "names",
+        nargs="*",
+        help="Optional alias/lane subset (default: full canonical roster)",
+    )
+
+    route = subs.add_parser(
+        "route",
+        help="Resolve an alias, lane, or handle to a roster agent",
+    )
+    route.add_argument("name", help="Alias, lane, profile, or lane/Alias")
+
+    dispatch = subs.add_parser(
+        "dispatch",
+        help="Queue an asynchronous job (Linear issue required)",
+    )
+    dispatch.add_argument("target", help="Alias, lane, profile, or lane/Alias")
+    dispatch.add_argument("--linear", required=True, help="Linear issue id or URL")
+    dispatch.add_argument("--goal", required=True, help="Task for the target agent")
+    dispatch.add_argument(
+        "--no-credentials",
+        action="store_true",
+        help="Skip 1Password grant injection (job still records the request surface)",
+    )
+
+    jobs = subs.add_parser("jobs", help="List dispatched jobs")
+    jobs.add_argument("--id", dest="job_id", help="Show a single job")
+
+    creds = subs.add_parser(
+        "credentials",
+        help="Brokered 1Password credential requests (values never printed)",
+    )
+    cred_subs = creds.add_subparsers(dest="credentials_command")
+    cred_subs.add_parser("catalog", help="Show env-name → op:// reference catalog")
+    request = cred_subs.add_parser(
+        "request",
+        help="Request a named secret for a profile (receipt only, no value)",
+    )
+    request.add_argument("--profile", required=True, help="Roster profile or alias")
+    request.add_argument("--name", required=True, help="Env var name, e.g. OPENAI_API_KEY")
+
+    subs.add_parser("status", help="Roster + recent jobs summary")
+    return parser
+
+
+def network_command(args: argparse.Namespace) -> int:
+    action = getattr(args, "network_command", None)
+    as_json = bool(getattr(args, "json", False))
+    try:
+        if action == "roster":
+            return _cmd_roster(as_json)
+        if action == "provision":
+            return _cmd_provision(args, as_json)
+        if action == "route":
+            return _cmd_route(args.name, as_json)
+        if action == "dispatch":
+            return _cmd_dispatch(args, as_json)
+        if action == "jobs":
+            return _cmd_jobs(args, as_json)
+        if action == "credentials":
+            return _cmd_credentials(args, as_json)
+        if action == "status":
+            return _cmd_status(as_json)
+        print(
+            "Usage: hermes network {roster|provision|route|dispatch|jobs|credentials|status}",
+            file=sys.stderr,
+        )
+        return 2
+    except (UnknownAgentError, LinearLinkError, DispatchError) as exc:
+        _emit({"error": str(exc)}, as_json, error=True)
+        return 1
+
+
+def _emit(payload: Any, as_json: bool, *, error: bool = False) -> None:
+    stream = sys.stderr if error else sys.stdout
+    if as_json:
+        json.dump(payload, stream, indent=2, sort_keys=True)
+        stream.write("\n")
+        return
+    if isinstance(payload, dict) and "error" in payload and len(payload) == 1:
+        print(f"error: {payload['error']}", file=stream)
+        return
+    if isinstance(payload, list):
+        for item in payload:
+            print(_fmt_line(item))
+        return
+    print(_fmt_line(payload))
+
+
+def _fmt_line(item: Any) -> str:
+    if not isinstance(item, dict):
+        return str(item)
+    if "handle" in item and "model" in item:
+        core = " core" if item.get("core") else ""
+        created = ""
+        if "created" in item:
+            created = " created" if item["created"] else " exists"
+        return (
+            f"{item['handle']:22s}  {item.get('profile', ''):12s}  "
+            f"{item['model']:18s}{core}{created}"
+        )
+    if "identifier" in item and "goal" in item:
+        return (
+            f"{item.get('id', '')}  {item.get('status', ''):8s}  "
+            f"{item.get('alias', '')}  {item.get('linear', {}).get('identifier', '')}"
+        )
+    if item.get("granted") is not None and "secret_name" in item:
+        state = "granted" if item["granted"] else "denied"
+        err = f" ({item['error']})" if item.get("error") else ""
+        return f"{item['profile']} {item['secret_name']} {state}{err}"
+    if "error" in item:
+        return f"error: {item['error']}"
+    return json.dumps(item, sort_keys=True)
+
+
+def _cmd_roster(as_json: bool) -> int:
+    rows = [
+        {
+            "lane": agent.lane,
+            "alias": agent.alias,
+            "profile": agent.profile,
+            "handle": agent.handle,
+            "model": agent.model,
+            "provider": agent.provider,
+            "role": agent.role,
+            "core": agent.core,
+        }
+        for agent in list_roster()
+    ]
+    _emit(rows, as_json)
+    return 0
+
+
+def _cmd_provision(args: argparse.Namespace, as_json: bool) -> int:
+    results = provision_roster(
+        core_only=bool(args.core),
+        names=list(args.names) or None,
+        no_skills=not bool(args.seed_skills),
+    )
+    _emit([row.to_dict() for row in results], as_json)
+    return 0
+
+
+def _cmd_route(name: str, as_json: bool) -> int:
+    agent = resolve_agent(name)
+    _emit(
+        {
+            "query": name,
+            "lane": agent.lane,
+            "alias": agent.alias,
+            "profile": agent.profile,
+            "handle": agent.handle,
+            "model": agent.model,
+            "provider": agent.provider,
+            "core": agent.core,
+        },
+        as_json,
+    )
+    return 0
+
+
+def _cmd_dispatch(args: argparse.Namespace, as_json: bool) -> int:
+    broker = DispatchBroker()
+    job = broker.dispatch(
+        args.target,
+        args.goal,
+        args.linear,
+        inject_credentials=not bool(args.no_credentials),
+    )
+    _emit(job.to_dict(), as_json)
+    return 0
+
+
+def _cmd_jobs(args: argparse.Namespace, as_json: bool) -> int:
+    broker = DispatchBroker()
+    if args.job_id:
+        _emit(broker.get(args.job_id).to_dict(), as_json)
+        return 0
+    _emit([job.to_dict() for job in broker.list_jobs()], as_json)
+    return 0
+
+
+def _cmd_credentials(args: argparse.Namespace, as_json: bool) -> int:
+    action = getattr(args, "credentials_command", None)
+    broker = CredentialBroker()
+    if action == "catalog":
+        catalog = [
+            {"name": name, "reference": ref}
+            for name, ref in broker.catalog().items()
+        ]
+        _emit(catalog, as_json)
+        return 0
+    if action == "request":
+        agent = resolve_agent(args.profile)
+        receipt = broker.request(agent.profile, args.name)
+        _emit(receipt.to_dict(), as_json)
+        return 0 if receipt.granted else 1
+    print("Usage: hermes network credentials {catalog|request}", file=sys.stderr)
+    return 2
+
+
+def _cmd_status(as_json: bool) -> int:
+    from hermes_cli.profiles import get_profile_dir
+
+    roster_rows = []
+    for agent in list_roster():
+        profile_dir = get_profile_dir(agent.profile)
+        provider, model = read_pinned_model(profile_dir) if profile_dir.exists() else ("", "")
+        roster_rows.append(
+            {
+                "handle": agent.handle,
+                "profile": agent.profile,
+                "expected_model": agent.model,
+                "pinned_model": model,
+                "pinned_provider": provider,
+                "provisioned": profile_dir.exists(),
+                "core": agent.core,
+            }
+        )
+    jobs = [job.to_dict() for job in DispatchBroker().list_jobs()[:10]]
+    payload = {"roster": roster_rows, "recent_jobs": jobs}
+    _emit(payload, as_json)
+    return 0

--- a/hermes_cli/independent_network/credentials.py
+++ b/hermes_cli/independent_network/credentials.py
@@ -1,0 +1,288 @@
+"""Brokered 1Password credential access for isolated profiles.
+
+Profiles request named secrets through this broker. The broker fetches via
+the existing 1Password secret source, records an audit row, and returns a
+receipt that never contains secret values. Granted values stay in a
+process-local map used only to populate a child process environment —
+they are never written to prompts, memory, job files, or receipts.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Dict, Mapping, Optional, Sequence
+
+from hermes_cli.independent_network.store import append_jsonl, audit_dir, network_root, write_json
+
+
+Fetcher = Callable[[str, str], str]
+# (op_reference, env_name) -> secret value
+
+
+class SecretRevealedError(RuntimeError):
+    """Raised when a receipt, audit row, or job payload would contain a secret."""
+
+
+_OP_REF_RE = re.compile(r"^op://[A-Za-z0-9._-]+/.+$")
+_ENV_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+
+# Catalog of named secrets the fleet may request. Values are 1Password
+# *references*, never the credentials themselves.
+DEFAULT_REFERENCES: Dict[str, str] = {
+    "LINEAR_API_KEY": "op://Naicipa/Linear/credential",
+    "OPENAI_API_KEY": "op://Naicipa/OpenAI/credential",
+    "ANTHROPIC_API_KEY": "op://Naicipa/Anthropic/credential",
+    "XAI_API_KEY": "op://Naicipa/xAI/credential",
+}
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _request_id() -> str:
+    return uuid.uuid4().hex
+
+
+def is_op_reference(value: str) -> bool:
+    return bool(_OP_REF_RE.match((value or "").strip()))
+
+
+def assert_no_secret_values(payload: object, secrets: Sequence[str]) -> None:
+    """Raise if any granted secret value appears in a serializable payload."""
+    if not secrets:
+        return
+    blob = json.dumps(payload, default=str)
+    for secret in secrets:
+        if secret and secret in blob:
+            raise SecretRevealedError("secret value leaked into broker payload")
+
+
+@dataclass(frozen=True)
+class CredentialReceipt:
+    """Public record of a credential request. Contains no secret values."""
+
+    request_id: str
+    profile: str
+    secret_name: str
+    granted: bool
+    source: str
+    reference: str
+    timestamp: str
+    error: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "request_id": self.request_id,
+            "profile": self.profile,
+            "secret_name": self.secret_name,
+            "granted": self.granted,
+            "source": self.source,
+            "reference": self.reference,
+            "timestamp": self.timestamp,
+            "error": self.error,
+        }
+
+
+@dataclass
+class CredentialBroker:
+    """On-demand 1Password broker with scope + audit and no value leakage."""
+
+    home: Optional[Path] = None
+    references: Mapping[str, str] = field(default_factory=lambda: dict(DEFAULT_REFERENCES))
+    allowlist: Optional[Mapping[str, Sequence[str]]] = None
+    fetcher: Optional[Fetcher] = None
+    source: str = "onepassword"
+    _grants: Dict[str, str] = field(default_factory=dict, init=False, repr=False)
+
+    def catalog(self) -> Dict[str, str]:
+        """Return env-name → op:// reference mappings (no secret values)."""
+        return {name: ref for name, ref in self.references.items() if is_op_reference(ref)}
+
+    def allowed_names(self, profile: str) -> frozenset[str]:
+        catalog = set(self.catalog())
+        if self.allowlist is None:
+            return frozenset(catalog)
+        scoped = self.allowlist.get(profile) or self.allowlist.get(profile.lower())
+        if scoped is None:
+            return frozenset(catalog)
+        return frozenset(n for n in scoped if n in catalog)
+
+    def request(self, profile: str, secret_name: str) -> CredentialReceipt:
+        """Request a named secret for ``profile``.
+
+        On success the value is stored only in the process-local grant map
+        under ``request_id``. The returned receipt never includes it.
+        """
+        name = (secret_name or "").strip()
+        profile_id = (profile or "").strip().lower()
+        request_id = _request_id()
+        timestamp = _utcnow()
+
+        if not profile_id:
+            return self._finish(
+                CredentialReceipt(
+                    request_id=request_id,
+                    profile=profile_id,
+                    secret_name=name,
+                    granted=False,
+                    source=self.source,
+                    reference="",
+                    timestamp=timestamp,
+                    error="profile is required",
+                )
+            )
+        if not _ENV_NAME_RE.match(name):
+            return self._finish(
+                CredentialReceipt(
+                    request_id=request_id,
+                    profile=profile_id,
+                    secret_name=name,
+                    granted=False,
+                    source=self.source,
+                    reference="",
+                    timestamp=timestamp,
+                    error="invalid secret name",
+                )
+            )
+        if name not in self.allowed_names(profile_id):
+            return self._finish(
+                CredentialReceipt(
+                    request_id=request_id,
+                    profile=profile_id,
+                    secret_name=name,
+                    granted=False,
+                    source=self.source,
+                    reference=self.catalog().get(name, ""),
+                    timestamp=timestamp,
+                    error="secret not in profile scope",
+                )
+            )
+
+        reference = self.catalog()[name]
+        try:
+            value = self._fetch(reference, name)
+        except Exception as exc:
+            return self._finish(
+                CredentialReceipt(
+                    request_id=request_id,
+                    profile=profile_id,
+                    secret_name=name,
+                    granted=False,
+                    source=self.source,
+                    reference=reference,
+                    timestamp=timestamp,
+                    error=_safe_error(exc),
+                )
+            )
+
+        if not isinstance(value, str) or not value:
+            return self._finish(
+                CredentialReceipt(
+                    request_id=request_id,
+                    profile=profile_id,
+                    secret_name=name,
+                    granted=False,
+                    source=self.source,
+                    reference=reference,
+                    timestamp=timestamp,
+                    error="empty credential",
+                )
+            )
+
+        self._grants[request_id] = value
+        receipt = CredentialReceipt(
+            request_id=request_id,
+            profile=profile_id,
+            secret_name=name,
+            granted=True,
+            source=self.source,
+            reference=reference,
+            timestamp=timestamp,
+        )
+        self._finish(receipt, secrets=(value,))
+        return receipt
+
+    def take_grant(self, request_id: str) -> Optional[str]:
+        """Pop a granted value out of process memory. Not for serialization."""
+        return self._grants.pop(request_id, None)
+
+    def peek_grant(self, request_id: str) -> Optional[str]:
+        """Read a granted value without removing it. Not for serialization."""
+        return self._grants.get(request_id)
+
+    def collect_for_profile(self, profile: str) -> tuple[Dict[str, str], list[CredentialReceipt]]:
+        """Request every in-scope secret and return env overlay + receipts.
+
+        The env overlay is for the child process only. Receipts stay
+        value-free. Failed requests are audited and omitted from the overlay.
+        """
+        env: Dict[str, str] = {}
+        receipts: list[CredentialReceipt] = []
+        for name in sorted(self.allowed_names(profile)):
+            receipt = self.request(profile, name)
+            receipts.append(receipt)
+            if receipt.granted:
+                value = self.peek_grant(receipt.request_id)
+                if value:
+                    env[name] = value
+        return env, receipts
+
+    def _fetch(self, reference: str, secret_name: str) -> str:
+        if self.fetcher is not None:
+            return self.fetcher(reference, secret_name)
+        return _default_onepassword_fetch(reference, secret_name, home=self.home)
+
+    def _finish(
+        self,
+        receipt: CredentialReceipt,
+        *,
+        secrets: Sequence[str] = (),
+    ) -> CredentialReceipt:
+        payload = receipt.to_dict()
+        assert_no_secret_values(payload, secrets)
+        path = audit_dir(self.home) / "credentials.jsonl"
+        append_jsonl(path, payload)
+        return receipt
+
+
+def _safe_error(exc: BaseException) -> str:
+    """Surface a coarse error kind without echoing possible secret material."""
+    name = type(exc).__name__
+    return f"{name}: unavailable"
+
+
+def _default_onepassword_fetch(
+    reference: str,
+    secret_name: str,
+    *,
+    home: Optional[Path],
+) -> str:
+    """Resolve one ``op://`` reference through the existing 1Password source."""
+    from agent.secret_sources.onepassword import fetch_onepassword_secrets
+
+    secrets, warnings = fetch_onepassword_secrets(
+        references={secret_name: reference},
+        use_cache=False,
+        home_path=home,
+    )
+    value = secrets.get(secret_name)
+    if not value:
+        detail = "; ".join(warnings) if warnings else "not granted"
+        raise RuntimeError(detail)
+    return value
+
+
+def write_default_catalog(home: Optional[Path] = None) -> Path:
+    """Persist the reference catalog (references only) next to the job store."""
+    path = network_root(home) / "credentials.yaml"
+    payload = {
+        "source": "onepassword",
+        "references": dict(DEFAULT_REFERENCES),
+    }
+    write_json(path.with_suffix(".json"), payload)
+    return path.with_suffix(".json")

--- a/hermes_cli/independent_network/linear.py
+++ b/hermes_cli/independent_network/linear.py
@@ -1,0 +1,93 @@
+"""Mandatory Linear issue linking for network dispatch.
+
+A job is not dispatchable without a Linear identifier. This module parses
+and normalizes issue ids; it does not put API tokens into prompts.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import urlparse
+
+
+_ISSUE_RE = re.compile(r"^[A-Z][A-Z0-9]{0,10}-\d+$")
+_ISSUE_IN_TEXT_RE = re.compile(r"\b([A-Za-z][A-Za-z0-9]{0,10}-\d+)\b")
+_LINEAR_HOSTS = frozenset({"linear.app", "www.linear.app"})
+
+
+class LinearLinkError(ValueError):
+    """Raised when a Linear issue id is missing or malformed."""
+
+
+@dataclass(frozen=True)
+class LinearLink:
+    """A required Linear issue binding for a dispatched job."""
+
+    identifier: str
+    url: str
+    team_key: str = "NAI"
+
+    def to_dict(self) -> dict:
+        return {
+            "identifier": self.identifier,
+            "url": self.url,
+            "team_key": self.team_key,
+        }
+
+
+def parse_linear_issue(raw: str, *, default_team: str = "NAI") -> str:
+    """Return a normalized Linear identifier (e.g. ``NAI-68``).
+
+    Accepts a bare id, a Linear URL, or text containing exactly one id.
+    """
+    text = (raw or "").strip()
+    if not text:
+        raise LinearLinkError("Linear issue is required")
+
+    parsed = urlparse(text)
+    if parsed.scheme in {"http", "https"}:
+        host = parsed.netloc.lower()
+        if host not in _LINEAR_HOSTS:
+            raise LinearLinkError(f"invalid Linear issue {raw!r}")
+        parts = [p for p in parsed.path.split("/") if p]
+        # /<workspace>/issue/<ID>/optional-slug
+        if "issue" in parts:
+            idx = parts.index("issue")
+            if idx + 1 < len(parts):
+                text = parts[idx + 1]
+        else:
+            raise LinearLinkError(f"invalid Linear issue {raw!r}")
+
+    candidate = text.strip().upper()
+    if _ISSUE_RE.match(candidate):
+        return candidate
+
+    matches = _ISSUE_IN_TEXT_RE.findall(text)
+    unique = {m.upper() for m in matches if _ISSUE_RE.match(m.upper())}
+    if len(unique) == 1:
+        return next(iter(unique))
+
+    raise LinearLinkError(f"invalid Linear issue {raw!r}")
+
+
+def linear_url(identifier: str, *, workspace: str = "naicipa") -> str:
+    """Return the canonical Linear issue URL for ``identifier``."""
+    return f"https://linear.app/{workspace}/issue/{identifier}"
+
+
+def require_linear_issue(
+    raw: Optional[str],
+    *,
+    workspace: str = "naicipa",
+    default_team: str = "NAI",
+) -> LinearLink:
+    """Parse ``raw`` or raise :class:`LinearLinkError`."""
+    identifier = parse_linear_issue(raw or "", default_team=default_team)
+    team_key = identifier.split("-", 1)[0]
+    return LinearLink(
+        identifier=identifier,
+        url=linear_url(identifier, workspace=workspace),
+        team_key=team_key,
+    )

--- a/hermes_cli/independent_network/provision.py
+++ b/hermes_cli/independent_network/provision.py
@@ -1,0 +1,184 @@
+"""Provision isolated Hermes profiles for the canonical roster.
+
+Each agent gets its own profile directory (config, .env, memory, sessions)
+with a pinned model. Profiles are created through the existing
+``create_profile`` path so isolation, HOME anchoring, and empty .env
+seeding stay intact. Secrets are never copied between profiles.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence
+
+from hermes_cli.independent_network.credentials import write_default_catalog
+from hermes_cli.independent_network.roster import AgentSpec, list_roster
+
+
+@dataclass(frozen=True)
+class ProvisionResult:
+    """Outcome of provisioning one roster agent."""
+
+    agent: AgentSpec
+    profile_dir: Path
+    created: bool
+    model: str
+    provider: str
+
+    def to_dict(self) -> dict:
+        return {
+            "lane": self.agent.lane,
+            "alias": self.agent.alias,
+            "profile": self.agent.profile,
+            "handle": self.agent.handle,
+            "core": self.agent.core,
+            "profile_dir": str(self.profile_dir),
+            "created": self.created,
+            "model": self.model,
+            "provider": self.provider,
+        }
+
+
+def pin_profile_model(profile_dir: Path, provider: str, model: str) -> None:
+    """Write the pinned model into the profile's config.yaml."""
+    import yaml
+
+    config_path = profile_dir / "config.yaml"
+    cfg = {}
+    if config_path.exists():
+        loaded = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        if isinstance(loaded, dict):
+            cfg = loaded
+    model_cfg = cfg.get("model")
+    if not isinstance(model_cfg, dict):
+        model_cfg = {}
+    model_cfg["provider"] = provider
+    model_cfg["default"] = model
+    cfg["model"] = model_cfg
+    config_path.write_text(
+        yaml.safe_dump(cfg, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
+def write_agent_soul(profile_dir: Path, agent: AgentSpec) -> None:
+    """Write a stable, role-specific SOUL.md (byte-stable for prompt cache)."""
+    soul = (
+        f"# {agent.alias}\n\n"
+        f"You are {agent.alias}, the {agent.role} agent in the Naicipa "
+        f"independent-agent network.\n\n"
+        f"- Lane: `{agent.lane}`\n"
+        f"- Profile: `{agent.profile}`\n"
+        f"- Model: `{agent.model}` (pinned; do not switch)\n"
+        f"- Linear: every task you accept must already be linked to a Linear issue.\n"
+        f"- Secrets: request credentials through `hermes network credentials`; "
+        f"never print, paste, or remember secret values.\n"
+    )
+    (profile_dir / "SOUL.md").write_text(soul, encoding="utf-8")
+
+
+def _ensure_empty_env(profile_dir: Path) -> None:
+    """Keep .env present and free of copied fleet secrets."""
+    env_path = profile_dir / ".env"
+    if env_path.exists():
+        return
+    env_path.write_text(
+        "# Per-profile secrets for this independent agent.\n"
+        "# Do not paste shared fleet credentials here. Request them through\n"
+        "# `hermes network credentials` (1Password broker).\n",
+        encoding="utf-8",
+    )
+    try:
+        env_path.chmod(0o600)
+    except OSError:
+        pass
+
+
+def provision_agent(
+    agent: AgentSpec,
+    *,
+    no_skills: bool = True,
+    exist_ok: bool = True,
+) -> ProvisionResult:
+    """Create or update one isolated profile for ``agent``."""
+    from hermes_cli.profiles import (
+        create_profile,
+        get_profile_dir,
+        write_profile_meta,
+    )
+
+    profile_dir = get_profile_dir(agent.profile)
+    created = False
+    if not profile_dir.exists():
+        create_profile(
+            agent.profile,
+            no_alias=True,
+            no_skills=no_skills,
+            description=f"{agent.handle} — {agent.role} (model {agent.model})",
+        )
+        created = True
+    elif not exist_ok:
+        raise FileExistsError(f"profile {agent.profile!r} already exists at {profile_dir}")
+
+    pin_profile_model(profile_dir, agent.provider, agent.model)
+    write_agent_soul(profile_dir, agent)
+    _ensure_empty_env(profile_dir)
+    try:
+        write_profile_meta(
+            profile_dir,
+            description=f"{agent.handle} — {agent.role} (model {agent.model})",
+            display_name=agent.alias,
+            description_auto=False,
+        )
+    except Exception:
+        pass
+    return ProvisionResult(
+        agent=agent,
+        profile_dir=profile_dir,
+        created=created,
+        model=agent.model,
+        provider=agent.provider,
+    )
+
+
+def provision_roster(
+    *,
+    core_only: bool = False,
+    names: Optional[Sequence[str]] = None,
+    no_skills: bool = True,
+    exist_ok: bool = True,
+    home: Optional[Path] = None,
+) -> List[ProvisionResult]:
+    """Provision isolated profiles for the canonical (or requested) roster."""
+    from hermes_cli.independent_network.routing import resolve_agent
+
+    if names:
+        agents: Iterable[AgentSpec] = [resolve_agent(name) for name in names]
+    else:
+        agents = list_roster(core_only=core_only)
+
+    results = [
+        provision_agent(agent, no_skills=no_skills, exist_ok=exist_ok)
+        for agent in agents
+    ]
+    write_default_catalog(home)
+    return results
+
+
+def read_pinned_model(profile_dir: Path) -> tuple[str, str]:
+    """Return ``(provider, model)`` from a profile config.yaml."""
+    import yaml
+
+    config_path = profile_dir / "config.yaml"
+    if not config_path.exists():
+        return "", ""
+    cfg = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(cfg, dict):
+        return "", ""
+    model_cfg = cfg.get("model")
+    if isinstance(model_cfg, dict):
+        return str(model_cfg.get("provider") or ""), str(model_cfg.get("default") or "")
+    if isinstance(model_cfg, str):
+        return "", model_cfg
+    return "", ""

--- a/hermes_cli/independent_network/roster.py
+++ b/hermes_cli/independent_network/roster.py
@@ -1,0 +1,101 @@
+"""Canonical NAI-68 independent-agent roster.
+
+The roster is the source of truth for lane, alias, isolated profile name,
+and pinned model. Routing, provision, and dispatch all read from here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class AgentSpec:
+    """One independent agent in the hybrid network."""
+
+    lane: str
+    alias: str
+    profile: str
+    model: str
+    provider: str
+    role: str
+    core: bool = False
+
+    @property
+    def handle(self) -> str:
+        return f"{self.lane}/{self.alias}"
+
+
+def provider_for_model(model: str) -> str:
+    """Return the native Hermes provider key for a pinned roster model."""
+    name = (model or "").strip().lower()
+    if name.startswith("grok"):
+        return "xai"
+    if name.startswith("claude"):
+        return "anthropic"
+    if name.startswith("gpt") or name.startswith("o1") or name.startswith("o3"):
+        return "openai"
+    raise ValueError(f"unsupported roster model: {model!r}")
+
+
+def _spec(
+    lane: str,
+    alias: str,
+    model: str,
+    role: str,
+    *,
+    core: bool,
+    profile: Optional[str] = None,
+) -> AgentSpec:
+    profile_name = (profile or alias).strip().lower()
+    return AgentSpec(
+        lane=lane,
+        alias=alias,
+        profile=profile_name,
+        model=model,
+        provider=provider_for_model(model),
+        role=role,
+        core=core,
+    )
+
+
+# Exact NAI-68 roster. Core six are the named specialists in the pilot.
+CANONICAL_ROSTER: Tuple[AgentSpec, ...] = (
+    _spec("producto", "Oscar", "grok-4.6", "Product", core=True),
+    _spec("critico", "Ada", "claude-opus-5", "Critic", core=True),
+    _spec("visual", "Sebastian", "claude-sonnet-5", "Visual", core=True),
+    _spec("growth", "Juan", "grok-4.6", "Growth", core=True),
+    _spec("crm", "CRM", "grok-4.6", "CRM", core=False),
+    _spec("revenue", "Revenue", "gpt-5.6-terra", "Revenue", core=False),
+    _spec("commerce", "Commerce", "grok-4.6", "Commerce", core=False),
+    _spec("educacion", "Edu", "grok-4.6", "Education", core=False),
+    _spec("contenido", "Content", "claude-sonnet-5", "Content", core=False),
+    _spec("infra", "Frank", "grok-4.6", "Infrastructure", core=True),
+    _spec("research", "Nerd", "gpt-5.6-terra", "Research", core=True),
+    _spec("finanzas", "Mat", "gpt-5.6-terra", "Finance", core=False),
+)
+
+
+def list_roster(*, core_only: bool = False) -> Tuple[AgentSpec, ...]:
+    """Return the canonical roster, optionally restricted to core agents."""
+    if not core_only:
+        return CANONICAL_ROSTER
+    return tuple(agent for agent in CANONICAL_ROSTER if agent.core)
+
+
+def get_agent(profile: str) -> Optional[AgentSpec]:
+    """Return the spec for an exact profile name, or None."""
+    key = (profile or "").strip().lower()
+    for agent in CANONICAL_ROSTER:
+        if agent.profile == key:
+            return agent
+    return None
+
+
+def iter_routing_keys(agent: AgentSpec) -> Iterable[str]:
+    """Yield every deterministic routing key for ``agent`` (already casefolded)."""
+    yield agent.profile.casefold()
+    yield agent.alias.casefold()
+    yield agent.lane.casefold()
+    yield agent.handle.casefold()

--- a/hermes_cli/independent_network/routing.py
+++ b/hermes_cli/independent_network/routing.py
@@ -1,0 +1,82 @@
+"""Deterministic alias/name routing onto the canonical roster.
+
+Matching is exact after casefold. Unknown names fail closed — they never
+fall through to a default profile. Duplicate keys in the roster are a
+load-time error so routing cannot become ambiguous later.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Mapping, Optional
+
+from hermes_cli.independent_network.roster import (
+    AgentSpec,
+    CANONICAL_ROSTER,
+    iter_routing_keys,
+    list_roster,
+)
+
+
+class UnknownAgentError(KeyError):
+    """Raised when no roster agent matches the supplied alias or name."""
+
+
+class AmbiguousRosterError(RuntimeError):
+    """Raised when two roster entries claim the same routing key."""
+
+
+def build_routing_index(
+    roster: Optional[Iterable[AgentSpec]] = None,
+) -> Dict[str, AgentSpec]:
+    """Build the casefolded alias/name index.
+
+    Duplicate keys that point at *different* agents are rejected. Keys that
+    collapse onto the same agent (profile == alias.casefold(), etc.) are
+    expected and kept.
+    """
+    index: Dict[str, AgentSpec] = {}
+    for agent in roster if roster is not None else CANONICAL_ROSTER:
+        for key in iter_routing_keys(agent):
+            existing = index.get(key)
+            if existing is not None and existing.profile != agent.profile:
+                raise AmbiguousRosterError(
+                    f"routing key {key!r} maps to both {existing.handle} and {agent.handle}"
+                )
+            index[key] = agent
+    return index
+
+
+_INDEX: Optional[Dict[str, AgentSpec]] = None
+
+
+def routing_index() -> Mapping[str, AgentSpec]:
+    """Return the process-wide canonical index, building it once."""
+    global _INDEX
+    if _INDEX is None:
+        _INDEX = build_routing_index()
+    return _INDEX
+
+
+def resolve_agent(
+    name: str,
+    *,
+    roster: Optional[Iterable[AgentSpec]] = None,
+) -> AgentSpec:
+    """Resolve an alias, lane, profile, or ``lane/Alias`` handle.
+
+    Resolution is deterministic: one name, one agent. Unknown names raise
+    :class:`UnknownAgentError` instead of falling back.
+    """
+    query = (name or "").strip()
+    if not query:
+        raise UnknownAgentError("agent name is required")
+    index = build_routing_index(roster) if roster is not None else routing_index()
+    agent = index.get(query.casefold())
+    if agent is None:
+        raise UnknownAgentError(f"unknown agent {name!r}")
+    return agent
+
+
+def assert_roster_unambiguous(roster: Optional[Iterable[AgentSpec]] = None) -> None:
+    """Fail if the roster would produce ambiguous routing."""
+    build_routing_index(roster if roster is not None else list_roster())

--- a/hermes_cli/independent_network/store.py
+++ b/hermes_cli/independent_network/store.py
@@ -1,0 +1,69 @@
+"""On-disk state for the independent agent network.
+
+Lives under the default Hermes root so every isolated profile shares the
+same broker store. Secret *values* are never written here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+
+NETWORK_DIRNAME = "independent-agent-network"
+
+
+def network_root(home: Optional[Path] = None) -> Path:
+    """Return the network state directory, creating it if needed."""
+    if home is None:
+        from hermes_constants import get_default_hermes_root
+
+        home = get_default_hermes_root()
+    root = Path(home) / NETWORK_DIRNAME
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def jobs_dir(home: Optional[Path] = None) -> Path:
+    path = network_root(home) / "jobs"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def audit_dir(home: Optional[Path] = None) -> Path:
+    path = network_root(home) / "audit"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def atomic_write(path: Path, text: str, *, mode: int = 0o600) -> None:
+    """Write ``text`` via a temp file, then chmod owner-only."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
+    try:
+        os.chmod(path, mode)
+    except OSError:
+        pass
+
+
+def write_json(path: Path, payload: Any, *, mode: int = 0o600) -> None:
+    atomic_write(path, json.dumps(payload, indent=2, sort_keys=True) + "\n", mode=mode)
+
+
+def read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def append_jsonl(path: Path, payload: Any, *, mode: int = 0o600) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(payload, sort_keys=True) + "\n"
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(line)
+    try:
+        os.chmod(path, mode)
+    except OSError:
+        pass

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5631,6 +5631,13 @@ def cmd_kanban(args):
     return kanban_command(args)
 
 
+def cmd_network(args):
+    """Independent hybrid agent network (roster, dispatch, credentials)."""
+    from hermes_cli.independent_network.cli import network_command
+
+    return network_command(args)
+
+
 def cmd_project(args):
     """Manage projects (named, multi-folder workspaces)."""
     from hermes_cli.projects_cmd import projects_command
@@ -13058,6 +13065,14 @@ def main():
 
     kanban_parser = _build_kanban_parser(subparsers)
     kanban_parser.set_defaults(func=cmd_kanban)
+
+    # =========================================================================
+    # network command — independent hybrid agent fleet (NAI-68)
+    # =========================================================================
+    from hermes_cli.independent_network.cli import build_parser as _build_network_parser
+
+    network_parser = _build_network_parser(subparsers)
+    network_parser.set_defaults(func=cmd_network)
 
     # =========================================================================
     # project command — named, multi-folder workspaces

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -260,7 +260,7 @@ _HERMES_SUBCOMMANDS = frozenset({
     "chat", "model", "gateway", "setup", "whatsapp", "login", "logout",
     "status", "cron", "doctor", "dump", "config", "pairing", "skills", "tools",
     "mcp", "sessions", "insights", "version", "update", "uninstall",
-    "profile", "plugins", "honcho", "acp",
+    "profile", "plugins", "honcho", "acp", "network",
 })
 
 

--- a/skills/autonomous-ai-agents/independent-agent-network/SKILL.md
+++ b/skills/autonomous-ai-agents/independent-agent-network/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: independent-agent-network
+description: Route work to isolated agents via the network broker.
+version: 1.0.0
+author: Jose Naicipa (@josenaicipa)
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Multi-Agent, Profiles, Linear, 1Password, Dispatch]
+    category: autonomous-ai-agents
+    related_skills: [hermes-agent]
+---
+
+# Independent Agent Network Skill
+
+Dispatch work to the canonical Naicipa fleet. Each agent is an isolated
+Hermes profile with a pinned model. Routing is by alias or lane name.
+Every job must cite a Linear issue. Credentials come from the 1Password
+broker — never from prompts, memory, or receipts.
+
+This skill does not spawn Discord bots or create extra platform tokens.
+
+## When to Use
+
+- Provision or inspect the canonical roster.
+- Send a task to Oscar, Ada, or any other named agent.
+- Request a credential for a profile without printing the value.
+
+## Prerequisites
+
+- Hermes CLI on PATH (`hermes network --help`).
+- Isolated profiles created with `hermes network provision`.
+- A Linear issue id such as `NAI-68` for every dispatch.
+- 1Password CLI (`op`) authenticated in the **broker** process, not in
+  the agent prompt.
+
+## How to Run
+
+Use `` `terminal` ``. Do not add a core tool.
+
+```
+hermes network roster --json
+hermes network provision --core
+hermes network route Oscar
+hermes network dispatch Ada --linear NAI-68 --goal "Review the landing copy"
+hermes network credentials request --profile oscar --name OPENAI_API_KEY
+```
+
+## Quick Reference
+
+| Agent | Lane | Model |
+|---|---|---|
+| Oscar | producto | grok-4.6 |
+| Ada | critico | claude-opus-5 |
+| Sebastian | visual | claude-sonnet-5 |
+| Juan | growth | grok-4.6 |
+| Frank | infra | grok-4.6 |
+| Nerd | research | gpt-5.6-terra |
+
+Department agents: CRM, Revenue, Commerce, Edu, Content, Mat. Full
+roster: `hermes network roster`.
+
+## Procedure
+
+1. Resolve the target with `hermes network route <alias>`.
+2. Confirm a Linear issue exists. Dispatch without `--linear` is refused.
+3. Dispatch asynchronously. The command returns a job id and exits.
+4. If the child needs a provider key, request it through
+   `hermes network credentials`. The receipt has `granted` and
+   `reference` only — never the secret.
+5. Do not copy `.env` files between profiles.
+
+## Pitfalls
+
+- Unknown aliases fail closed. There is no default-profile fallback.
+- Do not paste `op://` resolved values, tokens, or `.env` contents into
+  chat, memory, or the job goal.
+- Do not run `systemctl` against `hermes-gateway-*` or
+  `memory-fabric.service`.
+- Do not create Discord bots or extra platform tokens from this skill.
+
+## Verification
+
+```
+hermes network status --json
+hermes network jobs --json
+```
+
+A provisioned core agent has `provisioned: true` and `pinned_model`
+equal to the roster model. A credentials receipt must omit any secret
+value.

--- a/tests/hermes_cli/test_independent_agent_network_e2e.py
+++ b/tests/hermes_cli/test_independent_agent_network_e2e.py
@@ -1,0 +1,124 @@
+"""E2E for the independent agent network against a temp HERMES_HOME.
+
+Exercises real ``create_profile`` imports (not mocks): roster routing,
+pinned models, profile isolation, async dispatch with mandatory Linear,
+and brokered credentials that never persist secret values.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.independent_network.broker import DispatchBroker
+from hermes_cli.independent_network.credentials import CredentialBroker
+from hermes_cli.independent_network.provision import provision_roster, read_pinned_model
+from hermes_cli.independent_network.roster import list_roster
+from hermes_cli.independent_network.routing import resolve_agent
+from hermes_cli.profiles import get_profile_dir, list_profiles
+
+
+SECRET = "e2e-secret-must-not-leak"
+
+
+@pytest.fixture()
+def profile_env(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir(exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    import hermes_constants as hc
+
+    hc._default_hermes_root_memo = None
+    return default_home
+
+
+def test_e2e_core_fleet_isolation_dispatch_and_credentials(profile_env):
+    started = []
+
+    def runner(job, child_env):
+        started.append({"id": job.id, "keys": sorted(child_env), "env": dict(child_env)})
+        return 99
+
+    results = provision_roster(core_only=True, no_skills=True, home=profile_env)
+    assert len(results) == 6
+    assert {row.agent.alias for row in results} == {
+        "Oscar",
+        "Ada",
+        "Sebastian",
+        "Juan",
+        "Frank",
+        "Nerd",
+    }
+
+    names = {p.name for p in list_profiles() if not p.is_default}
+    for agent in list_roster(core_only=True):
+        assert agent.profile in names
+        profile_dir = get_profile_dir(agent.profile)
+        provider, model = read_pinned_model(profile_dir)
+        assert provider == agent.provider
+        assert model == agent.model
+        assert (profile_dir / ".env").is_file()
+        assert SECRET not in (profile_dir / ".env").read_text(encoding="utf-8")
+        assert (profile_dir / "SOUL.md").read_text(encoding="utf-8").startswith(f"# {agent.alias}")
+
+    oscar_dir = get_profile_dir("oscar")
+    ada_dir = get_profile_dir("ada")
+    (oscar_dir / "workspace" / "note.txt").parent.mkdir(parents=True, exist_ok=True)
+    (oscar_dir / "workspace" / "note.txt").write_text("oscar-workspace", encoding="utf-8")
+    assert not (ada_dir / "workspace" / "note.txt").exists()
+    assert oscar_dir.resolve() != ada_dir.resolve()
+
+    creds = CredentialBroker(
+        home=profile_env,
+        fetcher=lambda _ref, _name: SECRET,
+        allowlist={"ada": ["ANTHROPIC_API_KEY", "LINEAR_API_KEY"]},
+    )
+    broker = DispatchBroker(home=profile_env, credentials=creds, runner=runner)
+    job = broker.dispatch(
+        "critico/Ada",
+        "Review the landing page against NAI-68 acceptance.",
+        "https://linear.app/naicipa/issue/NAI-68/piloto-desplegar-seis-agentes-nucleo",
+    )
+
+    assert job.status == "running"
+    assert job.pid == 99
+    assert job.linear["identifier"] == "NAI-68"
+    assert resolve_agent(job.target).profile == "ada"
+    assert job.model == "claude-opus-5"
+    assert set(job.credential_names) <= {"ANTHROPIC_API_KEY", "LINEAR_API_KEY"}
+    assert started and started[0]["id"] == job.id
+    assert "ANTHROPIC_API_KEY" in started[0]["keys"]
+    assert started[0]["env"]["ANTHROPIC_API_KEY"] == SECRET
+
+    job_path = profile_env / "independent-agent-network" / "jobs" / f"{job.id}.json"
+    blob = job_path.read_text(encoding="utf-8")
+    assert SECRET not in blob
+    stored = json.loads(blob)
+    assert stored["linear"]["identifier"] == "NAI-68"
+    assert "value" not in json.dumps(stored["credential_receipts"])
+    for receipt in stored["credential_receipts"]:
+        assert "granted" in receipt
+        assert SECRET not in json.dumps(receipt)
+
+    audit = (profile_env / "independent-agent-network" / "audit" / "credentials.jsonl").read_text()
+    assert SECRET not in audit
+    assert "ANTHROPIC_API_KEY" in audit
+
+    listed = broker.list_jobs()
+    assert listed[0].id == job.id
+    assert listed[0].status == "running"
+
+
+def test_e2e_full_roster_models_stay_pinned(profile_env):
+    results = provision_roster(no_skills=True, home=profile_env)
+    assert len(results) == 12
+    for row in results:
+        provider, model = read_pinned_model(row.profile_dir)
+        assert (provider, model) == (row.provider, row.model)
+        # Re-provision is idempotent and does not clone secrets.
+        again = provision_roster(names=[row.agent.alias], no_skills=True, home=profile_env)
+        assert again[0].created is False
+        assert read_pinned_model(again[0].profile_dir) == (row.provider, row.model)

--- a/tests/plugins/test_independent_agent_network.py
+++ b/tests/plugins/test_independent_agent_network.py
@@ -1,0 +1,265 @@
+"""Focal tests for the independent hybrid agent network (NAI-68)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.independent_network.broker import DispatchBroker
+from hermes_cli.independent_network.cli import network_command
+from hermes_cli.independent_network.credentials import (
+    DEFAULT_REFERENCES,
+    CredentialBroker,
+    SecretRevealedError,
+    assert_no_secret_values,
+)
+from hermes_cli.independent_network.linear import LinearLinkError, require_linear_issue
+from hermes_cli.independent_network.provision import (
+    provision_roster,
+    read_pinned_model,
+)
+from hermes_cli.independent_network.roster import (
+    CANONICAL_ROSTER,
+    list_roster,
+    provider_for_model,
+)
+from hermes_cli.independent_network.routing import (
+    AmbiguousRosterError,
+    UnknownAgentError,
+    assert_roster_unambiguous,
+    build_routing_index,
+    resolve_agent,
+)
+from hermes_cli.independent_network.roster import AgentSpec
+
+
+SECRET_VALUE = "s3cret-value-that-must-never-leak"
+
+
+@pytest.fixture()
+def profile_env(tmp_path, monkeypatch):
+    """Isolate HERMES_HOME and Path.home() like tests/hermes_cli/test_profiles.py."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir(exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    import hermes_constants as hc
+
+    hc._default_hermes_root_memo = None
+    return default_home
+
+
+def _fake_fetcher(_reference: str, _name: str) -> str:
+    return SECRET_VALUE
+
+
+def _quiet_runner(started):
+    def _run(job, child_env):
+        started.append({"job": job, "env": dict(child_env)})
+        return 4242
+
+    return _run
+
+
+class TestRosterAndRouting:
+    def test_canonical_roster_has_twelve_agents_and_six_core(self):
+        roster = list_roster()
+        assert len(roster) == 12
+        assert len(list_roster(core_only=True)) == 6
+        by_handle = {agent.handle: agent for agent in roster}
+        assert by_handle["producto/Oscar"].model == "grok-4.6"
+        assert by_handle["critico/Ada"].model == "claude-opus-5"
+        assert by_handle["visual/Sebastian"].model == "claude-sonnet-5"
+        assert by_handle["growth/Juan"].model == "grok-4.6"
+        assert by_handle["crm/CRM"].model == "grok-4.6"
+        assert by_handle["revenue/Revenue"].model == "gpt-5.6-terra"
+        assert by_handle["commerce/Commerce"].model == "grok-4.6"
+        assert by_handle["educacion/Edu"].model == "grok-4.6"
+        assert by_handle["contenido/Content"].model == "claude-sonnet-5"
+        assert by_handle["infra/Frank"].model == "grok-4.6"
+        assert by_handle["research/Nerd"].model == "gpt-5.6-terra"
+        assert by_handle["finanzas/Mat"].model == "gpt-5.6-terra"
+
+    def test_each_roster_model_has_a_provider(self):
+        for agent in CANONICAL_ROSTER:
+            assert agent.provider == provider_for_model(agent.model)
+            assert agent.provider in {"xai", "anthropic", "openai"}
+
+    def test_routing_is_deterministic_for_alias_lane_profile_and_handle(self):
+        oscar = resolve_agent("Oscar")
+        assert oscar is resolve_agent("producto")
+        assert oscar is resolve_agent("oscar")
+        assert oscar is resolve_agent("producto/Oscar")
+        assert oscar.profile == "oscar"
+        ada = resolve_agent("ADA")
+        assert ada.alias == "Ada"
+        assert ada.model == "claude-opus-5"
+
+    def test_unknown_alias_fails_closed(self):
+        with pytest.raises(UnknownAgentError):
+            resolve_agent("nobody")
+        with pytest.raises(UnknownAgentError):
+            resolve_agent("")
+
+    def test_roster_index_rejects_colliding_agents(self):
+        dup = (
+            AgentSpec("lane-a", "Alpha", "alpha", "grok-4.6", "xai", "A", True),
+            AgentSpec("lane-b", "Alpha", "beta", "grok-4.6", "xai", "B", True),
+        )
+        with pytest.raises(AmbiguousRosterError):
+            build_routing_index(dup)
+
+    def test_canonical_roster_is_unambiguous(self):
+        assert_roster_unambiguous()
+
+
+class TestLinearLink:
+    def test_parses_id_and_url(self):
+        link = require_linear_issue("NAI-68")
+        assert link.identifier == "NAI-68"
+        assert link.url.endswith("/NAI-68")
+        from_url = require_linear_issue(
+            "https://linear.app/naicipa/issue/NAI-68/piloto-desplegar-seis-agentes-nucleo"
+        )
+        assert from_url.identifier == "NAI-68"
+
+    def test_missing_or_garbage_is_rejected(self):
+        with pytest.raises(LinearLinkError):
+            require_linear_issue(None)
+        with pytest.raises(LinearLinkError):
+            require_linear_issue("not-an-issue")
+        with pytest.raises(LinearLinkError):
+            require_linear_issue("https://example.com/NAI-68")
+
+
+class TestProvisionIsolation:
+    def test_provision_pins_models_and_isolates_profiles(self, profile_env):
+        results = provision_roster(names=["Oscar", "Ada"], no_skills=True)
+        assert len(results) == 2
+        oscar = next(row for row in results if row.agent.profile == "oscar")
+        ada = next(row for row in results if row.agent.profile == "ada")
+        assert oscar.profile_dir != ada.profile_dir
+        assert oscar.profile_dir.is_dir()
+        assert ada.profile_dir.is_dir()
+        assert read_pinned_model(oscar.profile_dir) == ("xai", "grok-4.6")
+        assert read_pinned_model(ada.profile_dir) == ("anthropic", "claude-opus-5")
+
+        marker = oscar.profile_dir / "memories" / "PRIVATE.md"
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("oscar-only", encoding="utf-8")
+        assert not (ada.profile_dir / "memories" / "PRIVATE.md").exists()
+
+        oscar_env = (oscar.profile_dir / ".env").read_text(encoding="utf-8")
+        ada_env = (ada.profile_dir / ".env").read_text(encoding="utf-8")
+        assert SECRET_VALUE not in oscar_env
+        assert SECRET_VALUE not in ada_env
+        for ref in DEFAULT_REFERENCES.values():
+            assert ref.startswith("op://")
+
+        soul = (oscar.profile_dir / "SOUL.md").read_text(encoding="utf-8")
+        assert "Oscar" in soul
+        assert "grok-4.6" in soul
+
+
+class TestAsyncDispatch:
+    def test_dispatch_requires_linear_and_starts_without_waiting(self, profile_env):
+        provision_roster(names=["Ada"], no_skills=True)
+        started = []
+        broker = DispatchBroker(
+            home=profile_env,
+            credentials=CredentialBroker(home=profile_env, fetcher=_fake_fetcher),
+            runner=_quiet_runner(started),
+        )
+        with pytest.raises(LinearLinkError):
+            broker.dispatch("Ada", "review copy", "")
+        with pytest.raises(LinearLinkError):
+            broker.dispatch("Ada", "review copy", "nope")
+
+        job = broker.dispatch("Ada", "review copy", "NAI-68")
+        assert job.status == "running"
+        assert job.pid == 4242
+        assert job.linear["identifier"] == "NAI-68"
+        assert job.profile == "ada"
+        assert len(started) == 1
+        assert started[0]["job"].id == job.id
+
+        stored = json.loads((profile_env / "independent-agent-network" / "jobs" / f"{job.id}.json").read_text())
+        assert stored["status"] == "running"
+        assert SECRET_VALUE not in json.dumps(stored)
+        assert SECRET_VALUE not in job.prompt()
+
+    def test_unknown_target_does_not_create_a_job(self, profile_env):
+        broker = DispatchBroker(
+            home=profile_env,
+            credentials=CredentialBroker(home=profile_env, fetcher=_fake_fetcher),
+            runner=_quiet_runner([]),
+        )
+        with pytest.raises(UnknownAgentError):
+            broker.dispatch("ghost", "do a thing", "NAI-68")
+        jobs_path = profile_env / "independent-agent-network" / "jobs"
+        if jobs_path.exists():
+            assert list(jobs_path.glob("*.json")) == []
+
+
+class TestBrokeredCredentials:
+    def test_receipt_and_audit_omit_secret_values(self, profile_env):
+        broker = CredentialBroker(home=profile_env, fetcher=_fake_fetcher)
+        receipt = broker.request("oscar", "OPENAI_API_KEY")
+        assert receipt.granted is True
+        payload = receipt.to_dict()
+        assert SECRET_VALUE not in json.dumps(payload)
+        assert "OPENAI_API_KEY" in payload["secret_name"]
+        assert payload["reference"].startswith("op://")
+        assert broker.peek_grant(receipt.request_id) == SECRET_VALUE
+
+        audit = (profile_env / "independent-agent-network" / "audit" / "credentials.jsonl").read_text()
+        assert SECRET_VALUE not in audit
+        row = json.loads(audit.strip().splitlines()[-1])
+        assert row["granted"] is True
+        assert "value" not in row
+        assert row["request_id"] == receipt.request_id
+
+    def test_out_of_scope_name_is_denied(self, profile_env):
+        broker = CredentialBroker(
+            home=profile_env,
+            fetcher=_fake_fetcher,
+            allowlist={"oscar": ["OPENAI_API_KEY"]},
+        )
+        denied = broker.request("oscar", "ANTHROPIC_API_KEY")
+        assert denied.granted is False
+        assert denied.error == "secret not in profile scope"
+        assert broker.peek_grant(denied.request_id) is None
+
+    def test_assert_no_secret_values_catches_leaks(self):
+        with pytest.raises(SecretRevealedError):
+            assert_no_secret_values({"note": SECRET_VALUE}, [SECRET_VALUE])
+        assert_no_secret_values({"reference": "op://Naicipa/OpenAI/credential"}, [SECRET_VALUE])
+
+    def test_fetch_failure_is_audited_without_values(self, profile_env):
+        def _boom(_ref, _name):
+            raise RuntimeError(f"op failed with {SECRET_VALUE}")
+
+        broker = CredentialBroker(home=profile_env, fetcher=_boom)
+        receipt = broker.request("ada", "ANTHROPIC_API_KEY")
+        assert receipt.granted is False
+        assert SECRET_VALUE not in (receipt.error or "")
+        assert SECRET_VALUE not in json.dumps(receipt.to_dict())
+
+
+class TestCliSurface:
+    def test_roster_json(self, capsys):
+        rc = network_command(SimpleNamespace(network_command="roster", json=True))
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert {row["alias"] for row in payload} >= {"Oscar", "Ada", "Frank", "Nerd"}
+
+    def test_route_and_unknown(self, capsys):
+        rc = network_command(SimpleNamespace(network_command="route", name="Juan", json=True))
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["profile"] == "juan"
+        rc = network_command(SimpleNamespace(network_command="route", name="nope", json=True))
+        assert rc == 1

--- a/tests/skills/test_independent_agent_network_skill.py
+++ b/tests/skills/test_independent_agent_network_skill.py
@@ -1,0 +1,37 @@
+"""Invariants for the independent-agent-network skill."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+SKILL_MD = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "autonomous-ai-agents"
+    / "independent-agent-network"
+    / "SKILL.md"
+)
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+def test_description_is_one_short_sentence(skill_text):
+    match = re.search(r"^description:\s+(.*)$", skill_text, re.MULTILINE)
+    assert match, "missing description frontmatter"
+    description = match.group(1).strip().strip('"').strip("'")
+    assert description.endswith(".")
+    assert len(description) <= 60
+    assert " " in description
+
+
+def test_skill_points_at_native_surfaces(skill_text):
+    assert "`terminal`" in skill_text
+    assert "hermes network" in skill_text
+    assert "--linear" in skill_text
+    assert "never the secret" in skill_text


### PR DESCRIPTION
## Summary
- add canonical 12-agent roster with six core profiles
- add isolated profile provisioning and deterministic alias/name routing
- add asynchronous Linear-bound dispatch broker
- add scoped, audited 1Password credential requests without persisting secret values
- add focused unit, E2E, and skill contract tests

Linear: NAI-68

## Verification
- 21 focused tests passed locally
- CI is required before merge