### PR TITLE
fix(desktop): drop persisted tiles of deleted bots so they cannot resurrect

### DIFF
--- a/apps/desktop/src/app/profiles/delete-profile-dialog.tsx
+++ b/apps/desktop/src/app/profiles/delete-profile-dialog.tsx
@@ -4,6 +4,7 @@ import { deleteProfile } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { retireLocalProfileGateways } from '@/store/gateway'
 import { $activeGatewayProfile, normalizeProfileKey, selectProfile, setActiveProfile } from '@/store/profile'
+import { dropTilesForProfile } from '@/store/session-states'
 
 // Thin wrapper over ConfirmDialog: owns the deleteProfile call, inherits
 // Enter-to-confirm + busy/done/error from the shared dialog. The single choke
@@ -69,6 +70,11 @@ export function DeleteProfileDialog({
 
         // Legacy arity when unscoped: callers and tests pin the one-arg call.
         await (remote ? deleteProfile(profile.name, scope) : deleteProfile(profile.name))
+        // The profile is gone. Drop its persisted tiles now — a leftover
+        // session/Bot tile restores on relaunch and dials the deleted
+        // profile's backend, whose ensure_hermes_home() re-creates the
+        // directory the delete just removed (hermes-agent#94235).
+        dropTilesForProfile(profile.name)
         await onDeleted?.()
 
         if (wasActive) {

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -90,7 +90,8 @@ import {
   $focusedSessionState,
   $focusedStoredSessionId,
   $sessionStates,
-  $sessionTiles
+  $sessionTiles,
+  dropTilesForProfile
 } from '@/store/session-states'
 import { runGatewayRestart } from '@/store/system-actions'
 import type { PaginatedSessions, UsageStats } from '@/types/hermes'
@@ -711,6 +712,17 @@ export const host = {
         : ambientRemoteConnectionId
           ? { connectionId: ambientRemoteConnectionId, profile: name }
           : undefined
+    )
+
+    // The profile is gone. Drop its persisted tiles NOW: a leftover Bot Mode
+    // tile restores on relaunch and dials the deleted profile's backend, whose
+    // ensure_hermes_home() re-creates the profile directory the delete just
+    // removed (hermes-agent#94235).
+    dropTilesForProfile(
+      route ? route.profile : name,
+      route
+        ? { connectionId: route.connectionId, profile: route.profile, targetProfile: route.targetProfile }
+        : undefined
     )
 
     // The profile rail paints from the shared $profiles cache; without a

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -714,10 +714,8 @@ export const host = {
           : undefined
     )
 
-    // The profile is gone. Drop its persisted tiles NOW: a leftover Bot Mode
-    // tile restores on relaunch and dials the deleted profile's backend, whose
-    // ensure_hermes_home() re-creates the profile directory the delete just
-    // removed (hermes-agent#94235).
+    // The profile is gone. Drop its persisted tiles now — a leftover tile
+    // restores on relaunch and re-creates the deleted profile (hermes-agent#94235).
     dropTilesForProfile(
       route ? route.profile : name,
       route

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -44,7 +44,8 @@ vi.mock('@/store/session-states', async () => {
     $focusedSessionState: atom(null),
     $focusedStoredSessionId: atom(null),
     $sessionTiles: atom([]),
-    $sessionStates: atom({})
+    $sessionStates: atom({}),
+    dropTilesForProfile: vi.fn()
   }
 })
 vi.mock('@/store/profile', async () => {
@@ -129,6 +130,7 @@ const {
 
 const { $focusedRuntimeId, $focusedSessionState, $focusedStoredSessionId, $sessionStates, $sessionTiles } =
   await import('@/store/session-states')
+const { dropTilesForProfile } = await import('@/store/session-states')
 
 const { setWorkspaceScope } = await import('@/components/pane-shell/workspace-scope')
 
@@ -192,6 +194,9 @@ describe('connection-aware plugin host APIs', () => {
     // The rail paints from $profiles; skipping the refresh leaves a stale
     // badge whose click hot-loops against the deletion guard (#88769).
     expect(refreshProfiles).toHaveBeenCalled()
+    // A leftover Bot Mode tile would restore on relaunch and dial the deleted
+    // profile's backend, re-creating its HERMES_HOME (#94235).
+    expect(dropTilesForProfile).toHaveBeenCalledWith('worker', undefined)
   })
 
   it('pins an ambient SSH profile delete to the active connection and target profile', async () => {
@@ -346,6 +351,11 @@ describe('connection-aware plugin host APIs', () => {
       profile: 'worker'
     })
     expect(retireLocalProfileGateways).not.toHaveBeenCalled()
+    expect(dropTilesForProfile).toHaveBeenCalledWith('worker', {
+      connectionId: 'source-a',
+      profile: 'worker',
+      targetProfile: 'backend-worker'
+    })
   })
 
   it('rejects a remote deletion route without a connection id', async () => {
@@ -391,6 +401,11 @@ describe('connection-aware plugin host APIs', () => {
     expect(deleteProfile).toHaveBeenCalledWith('backend-worker', {
       connectionId: 'source-local',
       profile: 'worker'
+    })
+    expect(dropTilesForProfile).toHaveBeenCalledWith('worker', {
+      connectionId: 'source-local',
+      profile: 'worker',
+      targetProfile: 'backend-worker'
     })
   })
 

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -6,13 +6,13 @@ import { $layoutTree } from '@/components/pane-shell/tree/store'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $activeSessionId, $connection, $selectedStoredSessionId, setSessions } from '@/store/session'
 import type { SessionTile } from '@/store/session-states'
+import type * as SessionStatesModule from '@/store/session-states'
 import {
   $sessionStates,
   $sessionTiles,
   blankDraftTile,
   clearAllSessionStates,
   closeAllOpenSessionTiles,
-  dropTilesForProfile,
   focusedSessionNeedsRoute,
   focusOpenSession,
   foregroundSessionScopes,
@@ -370,15 +370,17 @@ describe('closeAllOpenSessionTiles persists Bot Mode Close All (#94137)', () => 
 describe('dropTilesForProfile', () => {
   const TILES_KEY = 'hermes.desktop.sessionTiles.v2'
   const BOTS_BUCKET = '__bots_workspace__'
+
   const storedTiles = (): Record<string, unknown> => {
     const raw = window.localStorage.getItem(TILES_KEY)
+
     return raw ? (JSON.parse(raw) as Record<string, unknown>) : {}
   }
   // The tile buckets are module-private and other suites leave persisted
   // entries behind, so each test re-imports a FRESH session-states module
   // (empty tilesByProfile + empty storage) instead of fighting the residue —
   // the same isolation the browser gets between app launches.
-  type SessionStates = typeof import('@/store/session-states')
+  type SessionStates = typeof SessionStatesModule
   let mod: SessionStates
   let activeGatewayProfile: { set: (name: string) => void }
   beforeEach(async () => {
@@ -438,6 +440,7 @@ describe('dropTilesForProfile', () => {
       profile: 'worker',
       targetProfile: 'backend-worker'
     }
+
     mod.openSessionTile('bot-a', 'right', undefined, undefined, {
       ownerRoute: route,
       workspaceMode: 'bots' as const,
@@ -463,6 +466,92 @@ describe('dropTilesForProfile', () => {
     expect(
       (storedTiles()[BOTS_BUCKET] as Array<{ storedSessionId: string }>).map(tile => tile.storedSessionId)
     ).toEqual(['bot-b', 'bot-local'])
+  })
+
+  it('keeps a same-named bot tile owned by another connection when a local profile is deleted', () => {
+    mod.openSessionTile('bot-local', 'right', undefined, undefined, {
+      ownerRoute: { connectionId: 'local', mode: 'local' as const, profile: 'copilot' },
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'copilot'
+    })
+    mod.openSessionTile('bot-remote', 'right', undefined, undefined, {
+      ownerRoute: {
+        connectionId: 'work-vps',
+        mode: 'remote' as const,
+        profile: 'copilot',
+        targetProfile: 'copilot'
+      },
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'work-vps::copilot'
+    })
+
+    mod.dropTilesForProfile('copilot')
+
+    // Only the LOCAL connection's tile points at the deleted local profile; the
+    // same-named agent on another connection keeps its tile and conversation.
+    expect(mod.$sessionTiles.get().map(tile => tile.storedSessionId)).toEqual(['bot-remote'])
+    expect(
+      (storedTiles()[BOTS_BUCKET] as Array<{ storedSessionId: string }>).map(tile => tile.storedSessionId)
+    ).toEqual(['bot-remote'])
+  })
+
+  it('normalizes whitespace in the deleted identity on both delete paths', () => {
+    mod.openSessionTile('bot-local', 'right', undefined, undefined, {
+      ownerRoute: { connectionId: 'local', mode: 'local' as const, profile: 'press-bot' },
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'press-bot'
+    })
+    mod.openSessionTile('bot-routed', 'right', undefined, undefined, {
+      ownerRoute: {
+        connectionId: 'source-a',
+        mode: 'remote' as const,
+        profile: 'worker',
+        targetProfile: 'backend-worker'
+      },
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'source-a::worker'
+    })
+
+    // Non-route delete with a whitespace-padded name matches the trimmed tile.
+    mod.dropTilesForProfile('   press-bot   ')
+    expect(mod.$sessionTiles.get().map(tile => tile.storedSessionId)).toEqual(['bot-routed'])
+
+    // Route delete with padded route fields matches the exact route's tile.
+    mod.dropTilesForProfile('worker', {
+      connectionId: ' source-a ',
+      profile: '  worker  ',
+      targetProfile: '  backend-worker  '
+    })
+    expect(mod.$sessionTiles.get()).toEqual([])
+  })
+
+  it('keeps profile identity case-exact on both delete paths', () => {
+    mod.openSessionTile('bot-local', 'right', undefined, undefined, {
+      ownerRoute: { connectionId: 'local', mode: 'local' as const, profile: 'press-bot' },
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'press-bot'
+    })
+    mod.openSessionTile('bot-routed', 'right', undefined, undefined, {
+      ownerRoute: {
+        connectionId: 'source-a',
+        mode: 'remote' as const,
+        profile: 'worker',
+        targetProfile: 'backend-worker'
+      },
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'source-a::worker'
+    })
+
+    // normalizeProfileKey trims but never lowercases: a differing case is a
+    // different profile identity, consistently in the local and route branches.
+    mod.dropTilesForProfile('PRESS-BOT')
+    mod.dropTilesForProfile('worker', {
+      connectionId: 'source-a',
+      profile: 'WORKER',
+      targetProfile: 'backend-worker'
+    })
+
+    expect(mod.$sessionTiles.get().map(tile => tile.storedSessionId)).toEqual(['bot-local', 'bot-routed'])
   })
 })
 

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -12,6 +12,7 @@ import {
   blankDraftTile,
   clearAllSessionStates,
   closeAllOpenSessionTiles,
+  dropTilesForProfile,
   focusedSessionNeedsRoute,
   focusOpenSession,
   foregroundSessionScopes,
@@ -335,7 +336,6 @@ describe('closeAllOpenSessionTiles persists Bot Mode Close All (#94137)', () => 
     $layoutTree.set(null)
     $sessionTiles.set([])
   })
-
   it('drops persisted bot tiles so a roster/profile rehydrate cannot restore them', () => {
     openSessionTile('chat-a', 'center', 'workspace', undefined, {
       workspaceMode: 'bots',
@@ -346,11 +346,8 @@ describe('closeAllOpenSessionTiles persists Bot Mode Close All (#94137)', () => 
       workspaceOwnerKey: 'bot:b'
     })
     $layoutTree.set(group(['workspace', tilePane('chat-a'), tilePane('chat-b')], { active: 'workspace', id: 'main' }))
-
     closeAllOpenSessionTiles('workspace')
-
     expect($sessionTiles.get()).toEqual([])
-
     // Profile swap re-reads the shared Bot bucket. Close All must have
     // emptied it, not only dismissed the tree panes.
     $activeGatewayProfile.set('other-profile')
@@ -358,7 +355,6 @@ describe('closeAllOpenSessionTiles persists Bot Mode Close All (#94137)', () => 
     $activeGatewayProfile.set('default')
     expect($sessionTiles.get()).toEqual([])
   })
-
   it('leaves session tiles stacked in a different zone open', () => {
     openSessionTile('keep', 'right', 'workspace')
     openSessionTile('close-me', 'center', 'workspace')
@@ -368,10 +364,105 @@ describe('closeAllOpenSessionTiles persists Bot Mode Close All (#94137)', () => 
         group([tilePane('keep')], { active: tilePane('keep'), id: 'right' })
       ])
     )
-
     closeAllOpenSessionTiles('workspace')
-
     expect($sessionTiles.get().map(tile => tile.storedSessionId)).toEqual(['keep'])
+
+describe('dropTilesForProfile', () => {
+  const TILES_KEY = 'hermes.desktop.sessionTiles.v2'
+  const BOTS_BUCKET = '__bots_workspace__'
+  const storedTiles = (): Record<string, unknown> => {
+    const raw = window.localStorage.getItem(TILES_KEY)
+    return raw ? (JSON.parse(raw) as Record<string, unknown>) : {}
+  }
+  // The tile buckets are module-private and other suites leave persisted
+  // entries behind, so each test re-imports a FRESH session-states module
+  // (empty tilesByProfile + empty storage) instead of fighting the residue —
+  // the same isolation the browser gets between app launches.
+  type SessionStates = typeof import('@/store/session-states')
+  let mod: SessionStates
+  let activeGatewayProfile: { set: (name: string) => void }
+  beforeEach(async () => {
+    window.localStorage.clear()
+    vi.resetModules()
+    // Re-import the module graph so the private tile buckets start empty; the
+    // profile atom session-states subscribes to is the freshly loaded one too.
+    mod = await import('@/store/session-states')
+    const profile = await import('@/store/profile')
+    activeGatewayProfile = profile.$activeGatewayProfile
+    activeGatewayProfile.set('default')
+    mod.$sessionTiles.set([])
+  })
+  afterEach(() => {
+    window.localStorage.clear()
+    $activeGatewayProfile.set('default')
+    $layoutTree.set(null)
+    $selectedStoredSessionId.set(null)
+    $sessionTiles.set([])
+  })
+  it("drops the deleted profile's persisted session tiles from memory and storage", () => {
+    activeGatewayProfile.set('worker')
+    mod.openSessionTile('worker-session-1')
+    mod.openSessionTile('worker-session-2', 'left')
+    expect(mod.$sessionTiles.get().map(tile => tile.storedSessionId)).toEqual(['worker-session-1', 'worker-session-2'])
+    expect(storedTiles()).toHaveProperty('worker')
+    mod.dropTilesForProfile('worker')
+    expect(mod.$sessionTiles.get()).toEqual([])
+    expect(storedTiles()).not.toHaveProperty('worker')
+    // Session tiles of another profile survive the drop.
+    activeGatewayProfile.set('writer')
+    mod.openSessionTile('writer-session-1')
+    expect(mod.$sessionTiles.get().map(tile => tile.storedSessionId)).toEqual(['writer-session-1'])
+    expect(storedTiles()).toHaveProperty('writer')
+  })
+  it("drops Bot Mode tiles owned by a locally-deleted profile and keeps the other bots' tiles", () => {
+    mod.openSessionTile('bot-chat-1', 'right', undefined, undefined, {
+      ownerRoute: { connectionId: 'local', mode: 'local' as const, profile: 'researcher-1' },
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'researcher-1'
+    })
+    mod.openSessionTile('bot-chat-2', 'right', undefined, undefined, {
+      ownerRoute: { connectionId: 'local', mode: 'local' as const, profile: 'writer-1' },
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'writer-1'
+    })
+    mod.dropTilesForProfile('researcher-1')
+    expect(mod.$sessionTiles.get().map(tile => tile.storedSessionId)).toEqual(['bot-chat-2'])
+    expect(
+      (storedTiles()[BOTS_BUCKET] as Array<{ storedSessionId: string }>).map(tile => tile.storedSessionId)
+    ).toEqual(['bot-chat-2'])
+  })
+  it('drops a source-scoped bot tile only for the exact route and keeps same-name agents elsewhere', () => {
+    const route = {
+      connectionId: 'source-a',
+      mode: 'remote' as const,
+      profile: 'worker',
+      targetProfile: 'backend-worker'
+    }
+    mod.openSessionTile('bot-a', 'right', undefined, undefined, {
+      ownerRoute: route,
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'source-a::worker'
+    })
+    mod.openSessionTile('bot-b', 'right', undefined, undefined, {
+      ownerRoute: {
+        connectionId: 'source-b',
+        mode: 'remote' as const,
+        profile: 'worker',
+        targetProfile: 'backend-worker'
+      },
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'source-b::worker'
+    })
+    mod.openSessionTile('bot-local', 'right', undefined, undefined, {
+      ownerRoute: { connectionId: 'local', mode: 'local' as const, profile: 'worker' },
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'local::worker'
+    })
+    mod.dropTilesForProfile('worker', route)
+    expect(mod.$sessionTiles.get().map(tile => tile.storedSessionId)).toEqual(['bot-b', 'bot-local'])
+    expect(
+      (storedTiles()[BOTS_BUCKET] as Array<{ storedSessionId: string }>).map(tile => tile.storedSessionId)
+    ).toEqual(['bot-b', 'bot-local'])
   })
 })
 

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -5,6 +5,7 @@ import { findGroupOfPane, group, split } from '@/components/pane-shell/tree/mode
 import { $layoutTree } from '@/components/pane-shell/tree/store'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $activeSessionId, $connection, $selectedStoredSessionId, setSessions } from '@/store/session'
+import type { SessionProfileRoute } from '@/store/session-request-router'
 import type { SessionTile } from '@/store/session-states'
 import type * as SessionStatesModule from '@/store/session-states'
 import {
@@ -366,6 +367,8 @@ describe('closeAllOpenSessionTiles persists Bot Mode Close All (#94137)', () => 
     )
     closeAllOpenSessionTiles('workspace')
     expect($sessionTiles.get().map(tile => tile.storedSessionId)).toEqual(['keep'])
+  })
+})
 
 describe('dropTilesForProfile', () => {
   const TILES_KEY = 'hermes.desktop.sessionTiles.v2'
@@ -552,6 +555,77 @@ describe('dropTilesForProfile', () => {
     })
 
     expect(mod.$sessionTiles.get().map(tile => tile.storedSessionId)).toEqual(['bot-local', 'bot-routed'])
+  })
+
+  it('drops a legacy Bot tile whose ownerRoute predates the connectionId field', () => {
+    // Tiles persisted before ownerRoute.connectionId existed (pre-#94235) carry
+    // no connection id at all. `String(undefined ?? '').trim()` yields '', so a
+    // local-delete branch comparing against `=== 'local'` never matches and the
+    // tile survives every delete, resurrecting the deleted profile on relaunch
+    // (hermes-agent#94235). The branch must treat a missing id as local.
+    mod.openSessionTile('bot-legacy', 'right', undefined, undefined, {
+      ownerRoute: { mode: 'local' as const, profile: 'press-bot' } as unknown as SessionProfileRoute,
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'press-bot'
+    })
+
+    mod.dropTilesForProfile('press-bot')
+
+    expect(mod.$sessionTiles.get().map(tile => tile.storedSessionId)).toEqual([])
+    expect(storedTiles()).not.toHaveProperty(BOTS_BUCKET)
+  })
+
+  it("treats a missing connectionId as the canonical 'local' spelling", () => {
+    // The local-delete branch compares ownerConnection to 'local', and
+    // local-mode owner routes record that same spelling. No renderer-importable
+    // constant exists (LOCAL_CONNECTION_ID lives in the electron main process),
+    // so this pins the two spellings together: legacy (no id), canonical
+    // ('local'), and divergent ('Local') tiles differ only in this field, and
+    // only the first two may be dropped by a local delete. Renaming either side
+    // fails the suite before it can silently orphan local Bot tiles
+    // (Enough1122 review of #94426).
+    mod.openSessionTile('bot-legacy', 'right', undefined, undefined, {
+      ownerRoute: { mode: 'local' as const, profile: 'press-bot' } as unknown as SessionProfileRoute,
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'press-bot'
+    })
+    mod.openSessionTile('bot-canonical', 'right', undefined, undefined, {
+      ownerRoute: { connectionId: 'local', mode: 'local' as const, profile: 'press-bot' },
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'press-bot'
+    })
+    mod.openSessionTile('bot-divergent', 'right', undefined, undefined, {
+      ownerRoute: { connectionId: 'Local', mode: 'local' as const, profile: 'press-bot' },
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'press-bot'
+    })
+
+    mod.dropTilesForProfile('press-bot')
+
+    expect(mod.$sessionTiles.get().map(tile => tile.storedSessionId)).toEqual(['bot-divergent'])
+  })
+
+  it('throws on a route without profile instead of silently falling into the local-delete branch', () => {
+    // A caller passing a route with only connectionId/targetProfile would
+    // silently take the local branch and start requiring
+    // `ownerConnection === 'local'` — dropping nothing remotely owned while
+    // appearing to succeed. Both current call sites always populate profile, so
+    // refuse the malformed shape loudly (Enough1122 review of #94426).
+    mod.openSessionTile('bot-remote', 'right', undefined, undefined, {
+      ownerRoute: {
+        connectionId: 'work-vps',
+        mode: 'remote' as const,
+        profile: 'copilot',
+        targetProfile: 'copilot'
+      },
+      workspaceMode: 'bots' as const,
+      workspaceOwnerKey: 'work-vps::copilot'
+    })
+
+    expect(() => mod.dropTilesForProfile('copilot', { connectionId: 'work-vps', targetProfile: 'copilot' })).toThrow(
+      /route without profile/
+    )
+    expect(mod.$sessionTiles.get().map(tile => tile.storedSessionId)).toEqual(['bot-remote'])
   })
 })
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1551,6 +1551,84 @@ export function discardSessionTile(storedSessionId: string) {
   saveTiles($sessionTiles.get().filter(t => t.storedSessionId !== storedSessionId))
 }
 
+/**
+ * Drop every persisted tile owned by a profile that is being deleted — the
+ * profile's own session-tile bucket and any Bot Mode tile whose ownerRoute
+ * points at it (matched by desktop profile name, or by exact connection /
+ * backend target profile when a source-scoped route is given).
+ *
+ * A leftover tile RESURRECTS the deleted profile on the next launch: Bot tab
+ * restore re-dials the profile's backend, whose ensure_hermes_home() re-creates
+ * the profile directory the delete just removed (hermes-agent#94235). Same
+ * discard (no ⌘⇧T) semantics as discardSessionTile — undoing the delete of the
+ * owning profile would resolve to a 404 again.
+ */
+export function dropTilesForProfile(
+  profile: string,
+  route?: { connectionId?: string; profile?: string; targetProfile?: string }
+): void {
+  const name = normalizeProfileKey(profile)
+  const routeProfile = String(route?.profile ?? '').trim()
+  const routeTarget = String(route?.targetProfile ?? '').trim()
+  const routeConnection = String(route?.connectionId ?? '').trim()
+
+  const ownerMatches = (owner: SessionProfileRoute | undefined): boolean => {
+    if (!owner) {
+      return false
+    }
+
+    const ownerProfile = String(owner.profile ?? '').trim()
+    const ownerTarget = String(owner.targetProfile ?? '').trim()
+    const ownerConnection = String(owner.connectionId ?? '').trim()
+
+    if (routeProfile) {
+      // Source-scoped delete: the route's desktop profile name, backend target,
+      // and connection must all agree with the tile's owner route.
+      if (ownerProfile !== routeProfile) {
+        return false
+      }
+
+      if (routeTarget && ownerTarget !== routeTarget) {
+        return false
+      }
+
+      return !routeConnection || ownerConnection === routeConnection
+    }
+
+    return ownerProfile === name || ownerTarget === name
+  }
+
+  // The profile's own sessions bucket (Bot tiles live in the shared bucket
+  // and are keyed by ownerRoute, not by bucket).
+  delete tilesByProfile[name]
+
+  const botTiles = tilesByProfile[BOTS_TILE_BUCKET]
+
+  if (botTiles) {
+    const remaining = botTiles.filter(tile => !ownerMatches(tile.ownerRoute))
+
+    if (remaining.length > 0) {
+      tilesByProfile[BOTS_TILE_BUCKET] = remaining
+    } else {
+      delete tilesByProfile[BOTS_TILE_BUCKET]
+    }
+  }
+
+  // Live atom: drop the deleted profile's Bot tiles, and — when the deleted
+  // profile IS the live gateway's profile — the session tiles in view (they
+  // belong to that bucket; the caller re-homes afterwards).
+  const live = $sessionTiles.get()
+  const next = live.filter(tile =>
+    tile.workspaceMode === 'bots' ? !ownerMatches(tile.ownerRoute) : profileKey() !== name
+  )
+
+  if (next.length !== live.length) {
+    $sessionTiles.set(next)
+  }
+
+  persistTiles()
+}
+
 /** ⌘⇧T — reopen the most recently closed tab where it was, then focus it.
  *  Adoption alone is silent (won't steal the active tab), so restore has to
  *  front the pane explicitly. Skips ids that are live again (reopened / now

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1568,8 +1568,11 @@ export function dropTilesForProfile(
   route?: { connectionId?: string; profile?: string; targetProfile?: string }
 ): void {
   const name = normalizeProfileKey(profile)
-  const routeProfile = String(route?.profile ?? '').trim()
-  const routeTarget = String(route?.targetProfile ?? '').trim()
+  // Route fields go through the SAME canonicalization as `name` below — a
+  // source-scoped delete must not be defeated by stray whitespace around a
+  // profile name that a non-route delete trims away.
+  const routeProfile = route?.profile ? normalizeProfileKey(route.profile) : ''
+  const routeTarget = route?.targetProfile ? normalizeProfileKey(route.targetProfile) : ''
   const routeConnection = String(route?.connectionId ?? '').trim()
 
   const ownerMatches = (owner: SessionProfileRoute | undefined): boolean => {
@@ -1577,8 +1580,8 @@ export function dropTilesForProfile(
       return false
     }
 
-    const ownerProfile = String(owner.profile ?? '').trim()
-    const ownerTarget = String(owner.targetProfile ?? '').trim()
+    const ownerProfile = normalizeProfileKey(owner.profile)
+    const ownerTarget = normalizeProfileKey(owner.targetProfile)
     const ownerConnection = String(owner.connectionId ?? '').trim()
 
     if (routeProfile) {
@@ -1595,7 +1598,11 @@ export function dropTilesForProfile(
       return !routeConnection || ownerConnection === routeConnection
     }
 
-    return ownerProfile === name || ownerTarget === name
+    // Desktop-local delete: also require the tile's owner connection to be the
+    // LOCAL connection. A same-named bot on another connection is a different
+    // agent — the deleted local profile never owned it, and dropping its tile
+    // would orphan a live conversation (hermes-agent#94235).
+    return (ownerProfile === name || ownerTarget === name) && ownerConnection === 'local'
   }
 
   // The profile's own sessions bucket (Bot tiles live in the shared bucket
@@ -1618,6 +1625,7 @@ export function dropTilesForProfile(
   // profile IS the live gateway's profile — the session tiles in view (they
   // belong to that bucket; the caller re-homes afterwards).
   const live = $sessionTiles.get()
+
   const next = live.filter(tile =>
     tile.workspaceMode === 'bots' ? !ownerMatches(tile.ownerRoute) : profileKey() !== name
   )

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -55,7 +55,7 @@ import {
   setSessions
 } from './session'
 import { assertSessionOwnerResolved } from './session-owner-resolution'
-import { requestForSessionProfile, type SessionOwnerRoute, type SessionOwnerScope } from './session-request-router'
+import { requestForSessionProfile, type SessionOwnerRoute, type SessionOwnerScope, type SessionProfileRoute } from './session-request-router'
 import { ackStoredSessionId, markSessionUnreadFinished } from './session-unread'
 import { isBrowserWindow, isSecondaryWindow } from './windows'
 
@@ -1567,6 +1567,16 @@ export function dropTilesForProfile(
   profile: string,
   route?: { connectionId?: string; profile?: string; targetProfile?: string }
 ): void {
+  // A route without profile has no owner side to match: it would silently fall
+  // into the local-delete branch below and require `ownerConnection === 'local'`,
+  // dropping nothing remotely owned while appearing to succeed. Both current
+  // call sites always populate profile, so refuse the malformed shape loudly
+  // instead of letting a future caller misuse the optional route (Enough1122
+  // review of #94426).
+  if (route && !route.profile?.trim()) {
+    throw new Error('dropTilesForProfile: route without profile cannot be scoped')
+  }
+
   const name = normalizeProfileKey(profile)
   // Route fields go through the SAME canonicalization as `name` below — a
   // source-scoped delete must not be defeated by stray whitespace around a
@@ -1601,8 +1611,12 @@ export function dropTilesForProfile(
     // Desktop-local delete: also require the tile's owner connection to be the
     // LOCAL connection. A same-named bot on another connection is a different
     // agent — the deleted local profile never owned it, and dropping its tile
-    // would orphan a live conversation (hermes-agent#94235).
-    return (ownerProfile === name || ownerTarget === name) && ownerConnection === 'local'
+    // would orphan a live conversation (hermes-agent#94235). Tiles persisted
+    // before ownerRoute.connectionId existed carry no id; that empty string IS
+    // the local connection (the only source a pre-connectionId tile could have
+    // been opened on), so treat it as 'local' — otherwise those legacy tiles
+    // survive every local delete and resurrect the profile on relaunch.
+    return (ownerProfile === name || ownerTarget === name) && (ownerConnection || 'local') === 'local'
   }
 
   // The profile's own sessions bucket (Bot tiles live in the shared bucket
@@ -1627,7 +1641,13 @@ export function dropTilesForProfile(
   const live = $sessionTiles.get()
 
   const next = live.filter(tile =>
-    tile.workspaceMode === 'bots' ? !ownerMatches(tile.ownerRoute) : profileKey() !== name
+    // Bot tiles map to the shared Bot bucket (keyed by ownerRoute here): drop
+    // the deleted profile's bots, matched by owner.
+    tile.workspaceMode === 'bots'
+      ? !ownerMatches(tile.ownerRoute)
+      : // Session tiles map to the owning profile's own bucket: drop only when
+        // the deleted profile IS the live gateway's profile.
+        profileKey() !== name
   )
 
   if (next.length !== live.length) {


### PR DESCRIPTION
## Problem

Partially addresses #94235 — a bot created via **"Clone from profile"** in Hermes Desktop (Windows) resurrects after deletion:

1. Delete the bot (panel right-click → Delete, and/or server-side `DELETE /api/profiles/<name>` returning `{"ok": true}`).
2. Within ~1–2 minutes the bot reappears in the panel and the server-side profile directory is recreated as an **empty skeleton** (`state.db` with 0 sessions, empty `cron/`, a bare `profile.yaml` with `ui_meta.hermes-bots`, no `config.yaml`).

`deleteBot()` already removes the bot's `bot-meta`/`bot-meta-v2` roster entry, but **the bot's persisted Bot Mode chat tile survives** in the desktop's local storage (`localStorage` → Electron `Local Storage/leveldb`, the `hermes.desktop.sessionTiles.v2` key — the "local bot list" in the report). On the next launch the tile restores, the Bot tab re-dials the deleted profile's backend, and `ensure_hermes_home()` re-creates the profile directory the delete just removed.

## Root cause

The desktop keeps a **per-profile tile registry** (`__bots_workspace__` bucket for Bot Mode tiles, one bucket per profile for session tabs), persisted in local storage. Tile entries carry a credential-free `ownerRoute` (`connectionId` / `profile` / `targetProfile`) that restore re-dials. Neither delete door cleaned this registry up:

- `DeleteProfileDialog` (profiles rail/view) — deletes the profile, never touches persisted tiles.
- `host.deleteProfile` (the SDK door the Bots plugin's `deleteBot()` uses) — same.

A leftover tile is a live pointer back to the deleted profile: `session.resume` / `openGatewayForProfile` re-spawns its backend, whose `ensure_hermes_home()` materializes an empty skeleton profile — both the "bot reappears in the panel" and the "profile directory re-created" halves of the report. The server-side read paths are already 404-safe (`_resolve_profile_dir` → `profile_exists`); the resurrection goes through backend spawn, driven by the desktop's leftover tile.

## Fix

New `dropTilesForProfile(profile, route?)` in `store/session-states.ts`:

- deletes the deleted profile's session-tile bucket,
- drops every Bot Mode tile whose `ownerRoute` points at it (matched by desktop profile name, or by exact `connectionId` + `targetProfile` for source-scoped deletes — same-name agents on other connections stay),
- updates the live atom and the persisted local-storage copy,
- uses **discard** semantics (no ⌘⇧T undo — reopening the tile would 404 anyway).

Wired into both delete doors: `DeleteProfileDialog` and `host.deleteProfile` (which `hermes-bots`' `deleteBot()` calls on modern desktop builds, covering the report's exact flow).

**Relationship to #90141:** the resurrection is a two-link chain. (1) The desktop-side leftover tile pointer is the half fixed here; (2) the respawned backend lazily materializing a skeleton home for a deleted profile is the server-side half, owned by #90141 (deletion tombstones, still open). This PR removes link (1), so the desktop no longer re-dials a deleted profile and link (2) is unreachable from the desktop today; #94235 is therefore only partially addressed by this PR and will fully close when #90141 lands (it covers server-side spawns that bypass the desktop tile path).

## Tests

- `store/session-states.test.ts` — 3 regression tests: local profile delete (memory + local storage), local Bot tile delete (other bots' tiles kept), source-scoped route delete (same-name agents on other connections kept). Each re-imports a fresh module so the private tile buckets start clean.
- `sdk/profile-routing.test.ts` — extended the 3 existing `host.deleteProfile` tests to assert `dropTilesForProfile` is called with the exact profile/route identity.
- **Sabotage run**: with the cleanup disabled the 3 new tests fail (tiles survive the delete); with the fix they pass.

Run:

```
npx vitest run src/store/session-states.test.ts src/sdk/profile-routing.test.ts src/sdk/index.test.ts src/hermes.test.ts src/app/profiles/index.test.tsx   # 131 passed
node --test src/plugins/hermes-bots/tests/bot-delete.test.mjs   # 9 passed
npm run typecheck   # clean (ui + electron + e2e projects)
```

## Risk

Low: only profile deletion paths change; single-profile users never trigger a bucket drop. Tiles of other profiles/agents are untouched (covered by tests).

