### PR TITLE
feat(sessions): add verified local cold archive

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -20,6 +20,8 @@ from datetime import datetime, timedelta
 from dataclasses import dataclass, field, replace
 from typing import Dict, List, Optional, Any
 
+from hermes_cold_archive_errors import is_cold_archive_tombstone_rejection
+
 logger = logging.getLogger(__name__)
 
 
@@ -1736,6 +1738,8 @@ class SessionStore:
                         )
                         db_saved = True
                     except Exception as exc:
+                        if is_cold_archive_tombstone_rejection(exc):
+                            raise
                         logger.warning(
                             "gateway.session: state.db routing save failed: %s", exc
                         )
@@ -1905,6 +1909,8 @@ class SessionStore:
                     fast_persisted[session_key] = (revision, entry_json)
                 return
             except Exception as exc:
+                if is_cold_archive_tombstone_rejection(exc):
+                    raise
                 logger.warning(
                     "gateway.session: single-entry routing save failed for %r "
                     "(%s); falling back to full index rewrite",

--- a/hermes_accounting_locks.py
+++ b/hermes_accounting_locks.py
@@ -1,0 +1,105 @@
+"""Cross-process advisory locks for pending session accounting."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from hashlib import sha256
+import os
+from pathlib import Path
+import stat
+from typing import Iterator
+
+
+class PendingSessionAccountingError(RuntimeError):
+    """Raised when cold archive and pending accounting overlap."""
+
+
+def _lock_directory(db_path: Path) -> Path:
+    db_path = Path(os.path.abspath(os.fspath(db_path)))
+    return db_path.parent / f".{db_path.name}.accounting-locks"
+
+
+def _open_lock_file(db_path: Path, session_id: str) -> int:
+    lock_dir = _lock_directory(db_path)
+    lock_dir.mkdir(mode=0o700, parents=False, exist_ok=True)
+    directory_stat = lock_dir.lstat()
+    if (
+        not stat.S_ISDIR(directory_stat.st_mode)
+        or directory_stat.st_uid != os.geteuid()
+        or stat.S_IMODE(directory_stat.st_mode) & 0o077
+    ):
+        raise PendingSessionAccountingError(
+            f"unsafe pending-accounting lock directory: {lock_dir}"
+        )
+    name = sha256(session_id.encode("utf-8")).hexdigest() + ".lock"
+    flags = os.O_RDWR | os.O_CREAT | os.O_CLOEXEC | os.O_NOFOLLOW
+    directory_fd = os.open(
+        lock_dir,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW,
+    )
+    try:
+        descriptor = os.open(name, flags, 0o600, dir_fd=directory_fd)
+    except OSError as exc:
+        raise PendingSessionAccountingError(
+            f"could not open pending-accounting lock for session {session_id}"
+        ) from exc
+    finally:
+        os.close(directory_fd)
+    opened = os.fstat(descriptor)
+    if (
+        not stat.S_ISREG(opened.st_mode)
+        or opened.st_uid != os.geteuid()
+        or stat.S_IMODE(opened.st_mode) & 0o077
+    ):
+        os.close(descriptor)
+        raise PendingSessionAccountingError(
+            f"unsafe pending-accounting lock for session {session_id}"
+        )
+    return descriptor
+
+
+def acquire_pending_accounting_lock(db_path: Path, session_id: str) -> int | None:
+    """Acquire a shared lock held while one owner has queued/in-flight deltas."""
+    if os.name != "posix":
+        return None
+    import fcntl
+
+    descriptor = _open_lock_file(db_path, session_id)
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_SH | fcntl.LOCK_NB)
+    except BlockingIOError as exc:
+        os.close(descriptor)
+        raise PendingSessionAccountingError(
+            f"session {session_id} is locked for cold archive"
+        ) from exc
+    return descriptor
+
+
+@contextmanager
+def exclusive_lineage_accounting_locks(
+    db_path: Path,
+    session_ids: tuple[str, ...],
+) -> Iterator[None]:
+    """Exclude queued/in-flight accounting for every physical lineage ID."""
+    if os.name != "posix":
+        raise PendingSessionAccountingError(
+            "pending-accounting locks require a POSIX runtime"
+        )
+    import fcntl
+
+    descriptors: list[int] = []
+    try:
+        for session_id in sorted(set(session_ids)):
+            descriptor = _open_lock_file(db_path, session_id)
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError as exc:
+                os.close(descriptor)
+                raise PendingSessionAccountingError(
+                    f"pending token accounting exists for session {session_id}"
+                ) from exc
+            descriptors.append(descriptor)
+        yield
+    finally:
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13787,6 +13787,30 @@ def main():
         "bare number of days, or ISO timestamp)",
     )
 
+    sessions_cold_store = sessions_subparsers.add_parser(
+        "cold-store",
+        help="Store one archived terminal session lineage under a local root",
+    )
+    sessions_cold_store.add_argument(
+        "root",
+        type=Path,
+        metavar="ROOT",
+        help="Local archive root for sensitive raw transcript output",
+    )
+    sessions_cold_store.add_argument(
+        "--session-id",
+        required=True,
+        help="Exact session ID or unique prefix to store",
+    )
+    sessions_cold_store.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Resolve and report the requested store without writing anything",
+    )
+    sessions_cold_store.add_argument(
+        "--yes", "-y", action="store_true", help="Skip confirmation"
+    )
+
     sessions_subparsers.add_parser(
         "optimize",
         help="Reclaim disk space: merge FTS5 segments + VACUUM (no data change)",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13827,6 +13827,30 @@ def main():
         help="Exact session ID or unique prefix to verify",
     )
 
+    sessions_cold_purge = sessions_subparsers.add_parser(
+        "cold-purge",
+        help="Delete one verified archived terminal lineage from SQLite",
+    )
+    sessions_cold_purge.add_argument(
+        "root",
+        type=Path,
+        metavar="ROOT",
+        help="Existing local archive root containing the current snapshot",
+    )
+    sessions_cold_purge.add_argument(
+        "--session-id",
+        required=True,
+        help="Exact session ID or unique prefix to purge",
+    )
+    sessions_cold_purge.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Verify and report exact IDs without deleting anything",
+    )
+    sessions_cold_purge.add_argument(
+        "--yes", "-y", action="store_true", help="Confirm permanent SQLite deletion"
+    )
+
     sessions_subparsers.add_parser(
         "optimize",
         help="Reclaim disk space: merge FTS5 segments + VACUUM (no data change)",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13787,68 +13787,32 @@ def main():
         "bare number of days, or ISO timestamp)",
     )
 
-    sessions_cold_store = sessions_subparsers.add_parser(
-        "cold-store",
-        help="Store one archived terminal session lineage under a local root",
+    sessions_cold_archive = sessions_subparsers.add_parser(
+        "cold-archive",
+        help="Store, verify, and purge one archived terminal session lineage",
     )
-    sessions_cold_store.add_argument(
+    sessions_cold_archive.add_argument(
         "root",
         type=Path,
         metavar="ROOT",
         help="Local archive root for sensitive raw transcript output",
     )
-    sessions_cold_store.add_argument(
+    sessions_cold_archive.add_argument(
         "--session-id",
         required=True,
-        help="Exact session ID or unique prefix to store",
+        help="Exact session ID or unique prefix to cold-archive",
     )
-    sessions_cold_store.add_argument(
+    cold_archive_mode = sessions_cold_archive.add_mutually_exclusive_group()
+    cold_archive_mode.add_argument(
         "--dry-run",
         action="store_true",
-        help="Resolve and report the requested store without writing anything",
+        help="Resolve and report Store → Verify → Purge without changing anything",
     )
-    sessions_cold_store.add_argument(
-        "--yes", "-y", action="store_true", help="Skip confirmation"
-    )
-
-    sessions_cold_verify = sessions_subparsers.add_parser(
-        "cold-verify",
-        help="Verify one archived terminal session lineage snapshot",
-    )
-    sessions_cold_verify.add_argument(
-        "root",
-        type=Path,
-        metavar="ROOT",
-        help="Existing local archive root containing the current snapshot",
-    )
-    sessions_cold_verify.add_argument(
-        "--session-id",
-        required=True,
-        help="Exact session ID or unique prefix to verify",
-    )
-
-    sessions_cold_purge = sessions_subparsers.add_parser(
-        "cold-purge",
-        help="Delete one verified archived terminal lineage from SQLite",
-    )
-    sessions_cold_purge.add_argument(
-        "root",
-        type=Path,
-        metavar="ROOT",
-        help="Existing local archive root containing the current snapshot",
-    )
-    sessions_cold_purge.add_argument(
-        "--session-id",
-        required=True,
-        help="Exact session ID or unique prefix to purge",
-    )
-    sessions_cold_purge.add_argument(
-        "--dry-run",
+    cold_archive_mode.add_argument(
+        "--yes",
+        "-y",
         action="store_true",
-        help="Verify and report exact IDs without deleting anything",
-    )
-    sessions_cold_purge.add_argument(
-        "--yes", "-y", action="store_true", help="Confirm permanent SQLite deletion"
+        help="Run Store → Verify → Purge and retain the local snapshot",
     )
 
     sessions_subparsers.add_parser(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13811,6 +13811,22 @@ def main():
         "--yes", "-y", action="store_true", help="Skip confirmation"
     )
 
+    sessions_cold_verify = sessions_subparsers.add_parser(
+        "cold-verify",
+        help="Verify one archived terminal session lineage snapshot",
+    )
+    sessions_cold_verify.add_argument(
+        "root",
+        type=Path,
+        metavar="ROOT",
+        help="Existing local archive root containing the current snapshot",
+    )
+    sessions_cold_verify.add_argument(
+        "--session-id",
+        required=True,
+        help="Exact session ID or unique prefix to verify",
+    )
+
     sessions_subparsers.add_parser(
         "optimize",
         help="Reclaim disk space: merge FTS5 segments + VACUUM (no data change)",

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -1,9 +1,4 @@
-"""Store-only local cold archive primitives.
-
-This first slice deliberately has no CLI registration and never deletes database
-rows. It validates the basic Mark → Store handoff against a caller-supplied
-``SessionDB`` and local archive root.
-"""
+"""Local cold archive Store and read-only Verify primitives."""
 
 from __future__ import annotations
 
@@ -32,6 +27,16 @@ _MAX_SQLITE_IN_PARAMS = 500
 @dataclass(frozen=True)
 class StoredLineage:
     """Identity and current local snapshot emitted by :func:`store_archived_lineage`."""
+
+    terminal_id: str
+    physical_ids: tuple[str, ...]
+    source_fingerprint: str
+    snapshot_dir: Path
+
+
+@dataclass(frozen=True)
+class VerifiedLineage:
+    """Identity of a current snapshot verified against its live Store plan."""
 
     terminal_id: str
     physical_ids: tuple[str, ...]
@@ -340,6 +345,7 @@ def _valid_existing_snapshot_at(
     terminal_id: str,
     lineage: tuple[str, ...],
     fingerprint: str,
+    record_count: int,
 ) -> bool | None:
     try:
         snapshot_fd = os.open(
@@ -370,7 +376,8 @@ def _valid_existing_snapshot_at(
             and metadata.get("terminal_id") == terminal_id
             and metadata.get("physical_ids") == list(lineage)
             and metadata.get("source_fingerprint") == fingerprint
-            and metadata.get("record_count") == len(records)
+            and type(metadata.get("record_count")) is int
+            and metadata.get("record_count") == record_count == len(records)
             and _fingerprint(records) == fingerprint
             and _directory_entry_matches(snapshot_parent_fd, snapshot_name, snapshot_fd)
         )
@@ -487,12 +494,119 @@ def _build_store_plan(conn: sqlite3.Connection, terminal_id: str) -> _StorePlan:
     )
 
 
+def _read_store_plan(db: SessionDB, terminal_id: str) -> _StorePlan:
+    """Build one transactionally consistent Store plan using SELECTs only."""
+    conn = _connection(db)
+    with db._lock:
+        conn.execute("SAVEPOINT cold_store_snapshot")
+        try:
+            return _build_store_plan(conn, terminal_id)
+        finally:
+            conn.execute("RELEASE SAVEPOINT cold_store_snapshot")
+
+
 def plan_archived_lineage(db: SessionDB, terminal_id: str) -> None:
     """Run Store eligibility and source planning without writing any state."""
     _require_supported_platform()
-    conn = _connection(db)
-    with db._lock:
-        _build_store_plan(conn, terminal_id)
+    _read_store_plan(db, terminal_id)
+
+
+def _snapshot_location(
+    archive_root: Path, plan: _StorePlan
+) -> tuple[Path, str, tuple[str, ...]]:
+    terminal_date = datetime.fromtimestamp(plan.started_at, UTC)
+    snapshot_name = _safe_component(plan.terminal_id)
+    parent_parts = (
+        "sessions",
+        "started",
+        f"{terminal_date:%Y}",
+        f"{terminal_date:%m}",
+        f"{terminal_date:%d}",
+    )
+    return (
+        archive_root.joinpath(*parent_parts, snapshot_name),
+        snapshot_name,
+        parent_parts,
+    )
+
+
+def _open_existing_snapshot_parent(
+    archive_root: Path,
+    relative_parts: tuple[str, ...],
+    snapshot_dir: Path,
+) -> tuple[list[int], list[tuple[int, str, int, Path]]]:
+    """Open a no-follow parent chain without creating any filesystem entry."""
+    names = (*archive_root.parts[1:], *relative_parts)
+    descriptors = [os.open(os.sep, _directory_open_flags())]
+    edges: list[tuple[int, str, int, Path]] = []
+    current_path = Path(os.sep)
+    try:
+        for name in names:
+            current_path /= name
+            try:
+                descriptor = os.open(
+                    name, _directory_open_flags(), dir_fd=descriptors[-1]
+                )
+            except FileNotFoundError as exc:
+                raise ValueError(
+                    f"cold-store snapshot not found: {snapshot_dir}"
+                ) from exc
+            except OSError as exc:
+                raise _unsafe_archive_parent(current_path, exc)
+            edges.append((descriptors[-1], name, descriptor, current_path))
+            descriptors.append(descriptor)
+    except BaseException:
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
+        raise
+    return descriptors, edges
+
+
+def verify_archived_lineage(
+    db: SessionDB, terminal_id: str, archive_root: Path
+) -> VerifiedLineage:
+    """Verify one existing current snapshot against the live Store plan.
+
+    This primitive is strictly read-only: it performs no database writes and
+    opens only existing archive directories and payloads with no-follow flags.
+    """
+    _require_supported_platform()
+    archive_root = Path(os.path.abspath(os.fspath(archive_root)))
+    plan = _read_store_plan(db, terminal_id)
+    snapshot_dir, snapshot_name, parent_parts = _snapshot_location(
+        archive_root, plan
+    )
+    descriptors, edges = _open_existing_snapshot_parent(
+        archive_root, parent_parts, snapshot_dir
+    )
+    try:
+        _validate_directory_chain(edges)
+        valid = _valid_existing_snapshot_at(
+            descriptors[-1],
+            snapshot_name,
+            plan.terminal_id,
+            plan.physical_ids,
+            plan.source_fingerprint,
+            len(plan.records),
+        )
+        if valid is None:
+            raise ValueError(f"cold-store snapshot not found: {snapshot_dir}")
+        if not valid:
+            raise ValueError(
+                "cold-store snapshot is corrupt or does not match the current "
+                "Store plan (metadata/JSONL/record count/fingerprint/physical IDs): "
+                f"{snapshot_dir}"
+            )
+        _validate_directory_chain(edges)
+    finally:
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
+    return VerifiedLineage(
+        plan.terminal_id,
+        plan.physical_ids,
+        plan.source_fingerprint,
+        snapshot_dir,
+    )
 
 
 def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) -> StoredLineage:
@@ -505,34 +619,13 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
     _require_supported_platform()
 
     archive_root = Path(os.path.abspath(os.fspath(archive_root)))
-    conn = _connection(db)
-    with db._lock:
-        conn.execute("SAVEPOINT cold_store_snapshot")
-        try:
-            plan = _build_store_plan(conn, terminal_id)
-        finally:
-            conn.execute("RELEASE SAVEPOINT cold_store_snapshot")
+    plan = _read_store_plan(db, terminal_id)
 
     lineage = plan.physical_ids
     records = plan.records
     fingerprint = plan.source_fingerprint
-    terminal_date = datetime.fromtimestamp(plan.started_at, UTC)
-    snapshot_name = _safe_component(terminal_id)
-    snapshot_dir = (
-        archive_root
-        / "sessions"
-        / "started"
-        / f"{terminal_date:%Y}"
-        / f"{terminal_date:%m}"
-        / f"{terminal_date:%d}"
-        / snapshot_name
-    )
-    snapshot_parent_parts = (
-        "sessions",
-        "started",
-        f"{terminal_date:%Y}",
-        f"{terminal_date:%m}",
-        f"{terminal_date:%d}",
+    snapshot_dir, snapshot_name, snapshot_parent_parts = _snapshot_location(
+        archive_root, plan
     )
     descriptors, edges = _open_snapshot_parent(archive_root, snapshot_parent_parts)
     snapshot_parent_fd = descriptors[-1]
@@ -547,6 +640,7 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
             terminal_id,
             lineage,
             fingerprint,
+            len(records),
         )
         if existing is True:
             return StoredLineage(terminal_id, lineage, fingerprint, snapshot_dir)
@@ -581,6 +675,7 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
             terminal_id,
             lineage,
             fingerprint,
+            len(records),
         ):
             raise ValueError("staged cold-store snapshot failed verification")
         _validate_directory_chain(edges)

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -281,15 +281,18 @@ def _read_regular_text_at(directory_fd: int, name: str) -> str | None:
     try:
         descriptor = os.open(
             name,
-            os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            os.O_RDONLY | os.O_NONBLOCK | os.O_NOFOLLOW | os.O_CLOEXEC,
             dir_fd=directory_fd,
         )
     except OSError:
         return None
-    with os.fdopen(descriptor, "r", encoding="utf-8") as source:
-        if not stat.S_ISREG(os.fstat(source.fileno()).st_mode):
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
             return None
-        return source.read()
+        with os.fdopen(descriptor, "r", encoding="utf-8", closefd=False) as source:
+            return source.read()
+    finally:
+        os.close(descriptor)
 
 
 def _valid_existing_snapshot_at(
@@ -399,9 +402,12 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
                 raise ValueError("all compression lineage rows must be marked archived")
             if any(row.get("pinned") for row in rows):
                 raise ValueError("pinned sessions are not cold-store candidates")
+            started_at = rows[-1].get("started_at")
             ended_at = rows[-1].get("ended_at")
             if ended_at is None or rows[-1].get("end_reason") == "compression":
                 raise ValueError("terminal session must be ended and non-compression before cold storage")
+            if started_at is None:
+                raise ValueError("terminal session must have a start time before cold storage")
 
             _enforce_message_limit(conn, lineage)
             records = _records(conn, lineage)
@@ -409,12 +415,12 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
         finally:
             conn.execute("RELEASE SAVEPOINT cold_store_snapshot")
 
-    terminal_date = datetime.fromtimestamp(float(ended_at), UTC)
+    terminal_date = datetime.fromtimestamp(float(started_at), UTC)
     snapshot_name = _safe_component(terminal_id)
     snapshot_dir = (
         archive_root
         / "sessions"
-        / "ended"
+        / "started"
         / f"{terminal_date:%Y}"
         / f"{terminal_date:%m}"
         / f"{terminal_date:%d}"
@@ -422,7 +428,7 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
     )
     snapshot_parent_parts = (
         "sessions",
-        "ended",
+        "started",
         f"{terminal_date:%Y}",
         f"{terminal_date:%m}",
         f"{terminal_date:%d}",

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -19,16 +19,15 @@ import stat
 from typing import Any, Iterator
 
 from hermes_state import SessionDB, resolved_max_export_messages
+from hermes_accounting_locks import exclusive_lineage_accounting_locks
+from hermes_cli.session_reference_contract import (
+    ASYNC_DELEGATION_SESSION_COLUMNS,
+    STATE_META_SESSION_NAMESPACES,
+)
 
 
 _ARCHIVE_FORMAT = "hermes-cold-archive-store-spike/v1"
 _MAX_SQLITE_IN_PARAMS = 500
-_STATE_META_SESSION_NAMESPACES = ("goal", "loop", "heartbeat")
-_ASYNC_DELEGATION_SESSION_COLUMNS = (
-    "origin_session",
-    "parent_session_id",
-    "origin_session_id",
-)
 _COORDINATION_SESSION_REFERENCES = (
     ("compression_locks", "session_id"),
     ("session_turn_leases", "conversation_id"),
@@ -423,6 +422,17 @@ def _exclusive_cold_archive_root_lock(archive_root: Path) -> Iterator[None]:
             os.close(lock_fd)
         for descriptor in reversed(descriptors):
             os.close(descriptor)
+
+
+@contextmanager
+def _exclusive_lineage_accounting_locks(
+    db: SessionDB,
+    terminal_id: str,
+) -> Iterator[None]:
+    """Exclude cross-process queued accounting across Store→Verify→Purge."""
+    plan = _read_store_plan(db, terminal_id)
+    with exclusive_lineage_accounting_locks(db.db_path, plan.physical_ids):
+        yield
 
 
 def _write_text_fsync_at(directory_fd: int, name: str, text: str) -> None:
@@ -885,7 +895,7 @@ def _reject_state_meta_references(
 ) -> None:
     """Reject goal/loop/heartbeat keys owned by any covered session."""
     _required_table_columns(conn, "state_meta", ("key",))
-    for namespace in _STATE_META_SESSION_NAMESPACES:
+    for namespace in STATE_META_SESSION_NAMESPACES:
         for ids in _id_chunks(physical_ids):
             keys = tuple(f"{namespace}:{session_id}" for session_id in ids)
             placeholders = ",".join("?" for _ in keys)
@@ -907,9 +917,9 @@ def _reject_async_delegation_references(
     conn: sqlite3.Connection, physical_ids: tuple[str, ...]
 ) -> None:
     """Reject durable delegation rows naming any covered session."""
-    required_columns = ("delegation_id", *_ASYNC_DELEGATION_SESSION_COLUMNS)
+    required_columns = ("delegation_id", *ASYNC_DELEGATION_SESSION_COLUMNS)
     _required_table_columns(conn, "async_delegations", required_columns)
-    for column in _ASYNC_DELEGATION_SESSION_COLUMNS:
+    for column in ASYNC_DELEGATION_SESSION_COLUMNS:
         quoted_column = _quoted_identifier(column)
         for ids in _id_chunks(physical_ids):
             placeholders = ",".join("?" for _ in ids)

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -396,7 +396,7 @@ def _exclusive_cold_archive_root_lock(archive_root: Path) -> Iterator[None]:
             raise ValueError(f"unsafe cold archive lock sidecar: {lock_path}") from exc
 
         opened = os.fstat(lock_fd)
-        if not stat.S_ISREG(opened.st_mode):
+        if not _is_private_owned_entry(opened, directory=False):
             raise ValueError(f"unsafe cold archive lock sidecar: {lock_path}")
         try:
             fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -59,15 +59,23 @@ def _session(conn: sqlite3.Connection, session_id: str) -> dict[str, Any] | None
 
 
 def _is_explicit_fork(row: dict[str, Any]) -> bool:
+    if row.get("source") == "tool":
+        return True
     raw_config = row.get("model_config")
+    if not raw_config:
+        return False
     try:
-        config = json.loads(raw_config) if isinstance(raw_config, str) else raw_config or {}
-    except json.JSONDecodeError:
-        return True
+        config = json.loads(raw_config) if isinstance(raw_config, str) else raw_config
+    except (TypeError, json.JSONDecodeError):
+        return False
     if not isinstance(config, dict):
-        return True
+        return False
     parent_id = row.get("parent_session_id")
-    return bool(config.get("_branched_from") or config.get("_delegate_from")) and bool(parent_id)
+    branched = config.get("_branched_from")
+    delegated = config.get("_delegate_from")
+    if parent_id:
+        return branched == parent_id or delegated == parent_id
+    return branched is not None or delegated is not None
 
 
 def _raw_compression_lineage(conn: sqlite3.Connection, terminal_id: str) -> tuple[str, ...]:
@@ -195,15 +203,17 @@ def _valid_existing_revision(revision_dir: Path, terminal_id: str, lineage: tupl
     )
 
 
-def _fsync_created_parents(archive_root: Path, revision_parent: Path) -> None:
-    """Fsync each directory created between archive root and the revision parent."""
-    current = revision_parent
-    parents: list[Path] = []
-    while current != archive_root:
-        parents.append(current)
+def _ensure_dir_tree_fsynced(path: Path) -> None:
+    """Create a directory chain and fsync every new entry plus its parent."""
+    missing: list[Path] = []
+    current = path
+    while not current.exists():
+        missing.append(current)
         current = current.parent
-    for directory in reversed(parents):
+    for directory in reversed(missing):
+        directory.mkdir()
         _fsync_dir(directory)
+        _fsync_dir(directory.parent)
 
 
 def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) -> StoredLineage:
@@ -258,9 +268,7 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
             return StoredLineage(terminal_id, lineage, fingerprint, revision_dir)
         raise ValueError("existing cold-store revision is invalid or mismatched")
 
-    archive_root.mkdir(parents=True, exist_ok=True)
-    revision_dir.parent.mkdir(parents=True, exist_ok=True)
-    _fsync_created_parents(archive_root, revision_dir.parent)
+    _ensure_dir_tree_fsynced(revision_dir.parent)
     staging = Path(tempfile.mkdtemp(prefix=".staging-", dir=revision_dir.parent))
     try:
         metadata = {

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -738,7 +738,13 @@ def _reject_gateway_routing_references(
                 f"scope={scope!r}, session_key={session_key!r}"
             )
         session_id = entry.get("session_id")
-        if isinstance(session_id, str) and session_id in covered:
+        if not isinstance(session_id, str):
+            raise ValueError(
+                "cold purge refuses gateway_routing row whose session reference "
+                "cannot be verified: "
+                f"scope={scope!r}, session_key={session_key!r}"
+            )
+        if session_id in covered:
             raise ValueError(
                 "cold purge refuses gateway_routing soft reference to lineage "
                 f"session {session_id}: scope={scope!r}, "

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -1224,12 +1224,30 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
         if not _directory_entry_matches(snapshot_parent_fd, staging_name, staging_fd):
             raise ValueError("unsafe cold-store staging directory")
         stale_name = _move_current_snapshot_aside(snapshot_parent_fd, snapshot_name)
-        os.rename(
-            staging_name,
-            snapshot_name,
-            src_dir_fd=snapshot_parent_fd,
-            dst_dir_fd=snapshot_parent_fd,
-        )
+        try:
+            os.rename(
+                staging_name,
+                snapshot_name,
+                src_dir_fd=snapshot_parent_fd,
+                dst_dir_fd=snapshot_parent_fd,
+            )
+        except BaseException:
+            if stale_name is not None:
+                try:
+                    os.rename(
+                        stale_name,
+                        snapshot_name,
+                        src_dir_fd=snapshot_parent_fd,
+                        dst_dir_fd=snapshot_parent_fd,
+                    )
+                    os.fsync(snapshot_parent_fd)
+                    stale_name = None
+                except BaseException as restore_exc:
+                    raise RuntimeError(
+                        "cold-store snapshot publication failed and the previous "
+                        f"snapshot remains displaced as {stale_name}"
+                    ) from restore_exc
+            raise
         published = True
         os.fsync(snapshot_parent_fd)
         if stale_name is not None:

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -300,6 +300,19 @@ def _unsafe_archive_parent(path: Path, exc: OSError | None = None) -> ValueError
     return error
 
 
+def _validate_directory_authority(descriptor: int, path: Path) -> None:
+    opened = os.fstat(descriptor)
+    owner_is_trusted = opened.st_uid in {0, os.geteuid()}
+    writable_by_others = stat.S_IMODE(opened.st_mode) & 0o022
+    sticky = opened.st_mode & stat.S_ISVTX
+    if (
+        not stat.S_ISDIR(opened.st_mode)
+        or not owner_is_trusted
+        or (writable_by_others and not sticky)
+    ):
+        raise _unsafe_archive_parent(path)
+
+
 def _open_or_create_directory(parent_fd: int, name: str, path: Path) -> int:
     flags = _directory_open_flags()
     try:
@@ -337,6 +350,7 @@ def _open_snapshot_parent(
             descriptor = _open_or_create_directory(descriptors[-1], name, current_path)
             edges.append((descriptors[-1], name, descriptor, current_path))
             descriptors.append(descriptor)
+            _validate_directory_authority(descriptor, current_path)
     except BaseException:
         for descriptor in reversed(descriptors):
             os.close(descriptor)
@@ -359,6 +373,7 @@ def _directory_entry_matches(parent_fd: int, name: str, descriptor: int) -> bool
 
 def _validate_directory_chain(edges: list[tuple[int, str, int, Path]]) -> None:
     for parent_fd, name, descriptor, path in edges:
+        _validate_directory_authority(descriptor, path)
         if not _directory_entry_matches(parent_fd, name, descriptor):
             raise _unsafe_archive_parent(path)
 
@@ -683,6 +698,7 @@ def _open_existing_snapshot_parent(
                 raise _unsafe_archive_parent(current_path, exc)
             edges.append((descriptors[-1], name, descriptor, current_path))
             descriptors.append(descriptor)
+            _validate_directory_authority(descriptor, current_path)
     except BaseException:
         for descriptor in reversed(descriptors):
             os.close(descriptor)

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -16,6 +16,7 @@ import os
 from pathlib import Path
 import re
 import secrets
+import shutil
 import sqlite3
 import stat
 from typing import Any
@@ -29,12 +30,12 @@ _MAX_SQLITE_IN_PARAMS = 500
 
 @dataclass(frozen=True)
 class StoredLineage:
-    """Identity and immutable local snapshot emitted by :func:`store_archived_lineage`."""
+    """Identity and current local snapshot emitted by :func:`store_archived_lineage`."""
 
     terminal_id: str
     physical_ids: tuple[str, ...]
     source_fingerprint: str
-    revision_dir: Path
+    snapshot_dir: Path
 
 
 def _connection(db: SessionDB) -> sqlite3.Connection:
@@ -378,16 +379,48 @@ def _remove_staging_at(snapshot_parent_fd: int, name: str, staging_fd: int) -> N
             pass
 
 
+def _remove_stale_snapshot_at(snapshot_parent_fd: int, name: str) -> None:
+    """Best-effort cleanup for a displaced snapshot; it is never archive history."""
+    try:
+        shutil.rmtree(name, dir_fd=snapshot_parent_fd)
+    except OSError:
+        try:
+            os.unlink(name, dir_fd=snapshot_parent_fd)
+        except OSError:
+            pass
+
+
+def _move_current_snapshot_aside(snapshot_parent_fd: int, snapshot_name: str) -> str | None:
+    for _ in range(100):
+        stale_name = f".stale-{secrets.token_hex(8)}"
+        try:
+            os.rename(
+                snapshot_name,
+                stale_name,
+                src_dir_fd=snapshot_parent_fd,
+                dst_dir_fd=snapshot_parent_fd,
+            )
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            if exc.errno in (errno.EEXIST, errno.ENOTEMPTY):
+                continue
+            raise
+        return stale_name
+    raise FileExistsError("could not allocate displaced cold-store snapshot name")
+
+
 def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) -> StoredLineage:
     """Store one marked completed compression lineage without deleting DB rows.
 
-    The safe terminal ID names a single immutable snapshot. Repeated stores of
-    the exact source are idempotent; a changed source fails at the archival
-    boundary instead of creating a revision or overwriting the snapshot.
+    The safe terminal ID names one current snapshot. Repeated stores of the exact
+    source are idempotent; a changed or damaged snapshot is staged, verified, and
+    replaced. The source database is never modified by this operation.
     """
     if os.name == "nt":
         raise OSError("cold store is not yet supported on Windows")
 
+    archive_root = Path(os.path.abspath(os.fspath(archive_root)))
     conn = _connection(db)
     with db._lock:
         conn.execute("SAVEPOINT cold_store_snapshot")
@@ -440,6 +473,7 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
     staging_name: str | None = None
     staging_fd = -1
     published = False
+    stale_name: str | None = None
     try:
         existing = _valid_existing_snapshot_at(
             snapshot_parent_fd,
@@ -450,11 +484,6 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
         )
         if existing is True:
             return StoredLineage(terminal_id, lineage, fingerprint, snapshot_dir)
-        if existing is False:
-            raise ValueError(
-                "cold-store archival boundary violation: existing snapshot is invalid "
-                "or the marked source changed after Store"
-            )
 
         staging_name, staging_fd = _create_staging_directory(snapshot_parent_fd)
         _validate_directory_chain(edges)
@@ -480,33 +509,32 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
         )
         os.mkdir("artifacts", dir_fd=staging_fd)
         os.fsync(staging_fd)
+        if not _valid_existing_snapshot_at(
+            snapshot_parent_fd,
+            staging_name,
+            terminal_id,
+            lineage,
+            fingerprint,
+        ):
+            raise ValueError("staged cold-store snapshot failed verification")
         _validate_directory_chain(edges)
         if not _directory_entry_matches(snapshot_parent_fd, staging_name, staging_fd):
             raise ValueError("unsafe cold-store staging directory")
-        try:
-            os.rename(
-                staging_name,
-                snapshot_name,
-                src_dir_fd=snapshot_parent_fd,
-                dst_dir_fd=snapshot_parent_fd,
-            )
-        except OSError as exc:
-            if exc.errno not in (errno.EEXIST, errno.ENOTEMPTY):
-                raise
-            if _valid_existing_snapshot_at(
-                snapshot_parent_fd,
-                snapshot_name,
-                terminal_id,
-                lineage,
-                fingerprint,
-            ):
-                return StoredLineage(terminal_id, lineage, fingerprint, snapshot_dir)
-            raise ValueError(
-                "cold-store archival boundary violation: existing snapshot is invalid "
-                "or the marked source changed after Store"
-            ) from exc
+        stale_name = _move_current_snapshot_aside(snapshot_parent_fd, snapshot_name)
+        os.rename(
+            staging_name,
+            snapshot_name,
+            src_dir_fd=snapshot_parent_fd,
+            dst_dir_fd=snapshot_parent_fd,
+        )
         published = True
         os.fsync(snapshot_parent_fd)
+        if stale_name is not None:
+            _remove_stale_snapshot_at(snapshot_parent_fd, stale_name)
+            try:
+                os.fsync(snapshot_parent_fd)
+            except OSError:
+                pass
     finally:
         if staging_fd >= 0:
             if not published and staging_name is not None:

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -1057,6 +1057,17 @@ def purge_archived_lineage(
             conn, terminal_id, archive_root
         )
 
+        deleted_at = datetime.now(UTC).timestamp()
+        conn.executemany(
+            "INSERT INTO cold_archive_tombstones "
+            "(session_id, terminal_id, source_fingerprint, deleted_at) "
+            "VALUES (?, ?, ?, ?)",
+            (
+                (physical_id, plan.terminal_id, plan.source_fingerprint, deleted_at)
+                for physical_id in plan.physical_ids
+            ),
+        )
+
         prompt_hashes = tuple(
             sorted(
                 {

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime
 import errno
 from hashlib import sha256
 import json
+from math import isfinite
 import os
 from pathlib import Path
 import re
@@ -198,6 +199,32 @@ def _fingerprint(records: list[dict[str, Any]]) -> str:
         for record in records
     )
     return sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _validate_sqlite_values(records: list[dict[str, Any]]) -> None:
+    """Reject SQLite values that archive format v1 cannot represent."""
+    for record in records:
+        kind = str(record["kind"])
+        for column, value in record["row"].items():
+            location = f"{kind}.{column}"
+            if isinstance(value, bytes):
+                raise ValueError(
+                    "cold store v1 does not support SQLite BLOB/bytes values "
+                    f"at {location}"
+                )
+            if value is None or isinstance(value, (str, int)):
+                continue
+            if isinstance(value, float):
+                if isfinite(value):
+                    continue
+                raise ValueError(
+                    "cold store v1 requires finite SQLite numeric values "
+                    f"at {location}"
+                )
+            raise ValueError(
+                f"cold store v1 does not support SQLite value type "
+                f"{type(value).__name__} at {location}"
+            )
 
 
 def _directory_open_flags() -> int:
@@ -450,6 +477,7 @@ def _build_store_plan(conn: sqlite3.Connection, terminal_id: str) -> _StorePlan:
 
     _enforce_message_limit(conn, lineage)
     records = _records(conn, lineage)
+    _validate_sqlite_values(records)
     return _StorePlan(
         terminal_id=terminal_id,
         physical_ids=lineage,

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -167,8 +167,9 @@ def _is_explicit_fork(row: dict[str, Any]) -> bool:
     parent_id = row.get("parent_session_id")
     branched = config.get("_branched_from")
     delegated = config.get("_delegate_from")
+    reset = config.get("_reset_from")
     if parent_id:
-        return branched == parent_id or delegated == parent_id
+        return branched == parent_id or delegated == parent_id or reset == parent_id
     return branched is not None or delegated is not None
 
 
@@ -305,7 +306,7 @@ def _open_or_create_directory(parent_fd: int, name: str, path: Path) -> int:
         return os.open(name, flags, dir_fd=parent_fd)
     except FileNotFoundError:
         try:
-            os.mkdir(name, dir_fd=parent_fd)
+            os.mkdir(name, 0o700, dir_fd=parent_fd)
         except FileExistsError:
             pass
         except OSError as exc:
@@ -929,6 +930,20 @@ def _reject_uncovered_session_references(
     chunks = _id_chunks(physical_ids)
     for ids in chunks:
         placeholders = ",".join("?" for _ in ids)
+        delegates = conn.execute(
+            "SELECT id FROM sessions "
+            "WHERE json_extract(COALESCE(model_config, '{}'), '$._delegate_from') "
+            f"IN ({placeholders})",
+            ids,
+        ).fetchall()
+        uncovered_delegates = [
+            str(row[0]) for row in delegates if str(row[0]) not in covered
+        ]
+        if uncovered_delegates:
+            raise ValueError(
+                "cold purge refuses an uncovered child session referencing the "
+                f"lineage: {uncovered_delegates[0]}"
+            )
         children = conn.execute(
             f"SELECT id FROM sessions WHERE parent_session_id IN ({placeholders})",
             ids,

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -38,6 +38,15 @@ class StoredLineage:
     snapshot_dir: Path
 
 
+@dataclass(frozen=True)
+class _StorePlan:
+    terminal_id: str
+    physical_ids: tuple[str, ...]
+    started_at: float
+    records: list[dict[str, Any]]
+    source_fingerprint: str
+
+
 def _connection(db: SessionDB) -> sqlite3.Connection:
     if db._conn is None:
         raise RuntimeError("SessionDB connection is closed")
@@ -291,7 +300,10 @@ def _read_regular_text_at(directory_fd: int, name: str) -> str | None:
         if not stat.S_ISREG(os.fstat(descriptor).st_mode):
             return None
         with os.fdopen(descriptor, "r", encoding="utf-8", closefd=False) as source:
-            return source.read()
+            try:
+                return source.read()
+            except UnicodeDecodeError:
+                return None
     finally:
         os.close(descriptor)
 
@@ -410,6 +422,52 @@ def _move_current_snapshot_aside(snapshot_parent_fd: int, snapshot_name: str) ->
     raise FileExistsError("could not allocate displaced cold-store snapshot name")
 
 
+def _require_supported_platform() -> None:
+    if os.name == "nt":
+        raise OSError("cold store is not yet supported on Windows")
+
+
+def _build_store_plan(conn: sqlite3.Connection, terminal_id: str) -> _StorePlan:
+    lineage = _raw_compression_lineage(conn, terminal_id)
+    if lineage[-1] != terminal_id:
+        raise ValueError("store requires the terminal compression session ID")
+
+    rows = [_session(conn, session_id) for session_id in lineage]
+    if any(session is None for session in rows):
+        raise ValueError("compression lineage changed while resolving store candidate")
+    rows = [session for session in rows if session is not None]
+    if any(not row.get("archived") for row in rows):
+        raise ValueError("all compression lineage rows must be marked archived")
+    if any(row.get("pinned") for row in rows):
+        raise ValueError("pinned sessions are not cold-store candidates")
+    started_at = rows[-1].get("started_at")
+    ended_at = rows[-1].get("ended_at")
+    if ended_at is None or rows[-1].get("end_reason") == "compression":
+        raise ValueError(
+            "terminal session must be ended and non-compression before cold storage"
+        )
+    if started_at is None:
+        raise ValueError("terminal session must have a start time before cold storage")
+
+    _enforce_message_limit(conn, lineage)
+    records = _records(conn, lineage)
+    return _StorePlan(
+        terminal_id=terminal_id,
+        physical_ids=lineage,
+        started_at=float(started_at),
+        records=records,
+        source_fingerprint=_fingerprint(records),
+    )
+
+
+def plan_archived_lineage(db: SessionDB, terminal_id: str) -> None:
+    """Run Store eligibility and source planning without writing any state."""
+    _require_supported_platform()
+    conn = _connection(db)
+    with db._lock:
+        _build_store_plan(conn, terminal_id)
+
+
 def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) -> StoredLineage:
     """Store one marked completed compression lineage without deleting DB rows.
 
@@ -417,40 +475,21 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
     source are idempotent; a changed or damaged snapshot is staged, verified, and
     replaced. The source database is never modified by this operation.
     """
-    if os.name == "nt":
-        raise OSError("cold store is not yet supported on Windows")
+    _require_supported_platform()
 
     archive_root = Path(os.path.abspath(os.fspath(archive_root)))
     conn = _connection(db)
     with db._lock:
         conn.execute("SAVEPOINT cold_store_snapshot")
         try:
-            lineage = _raw_compression_lineage(conn, terminal_id)
-            if lineage[-1] != terminal_id:
-                raise ValueError("store requires the terminal compression session ID")
-
-            rows = [_session(conn, session_id) for session_id in lineage]
-            if any(session is None for session in rows):
-                raise ValueError("compression lineage changed while resolving store candidate")
-            rows = [session for session in rows if session is not None]
-            if any(not row.get("archived") for row in rows):
-                raise ValueError("all compression lineage rows must be marked archived")
-            if any(row.get("pinned") for row in rows):
-                raise ValueError("pinned sessions are not cold-store candidates")
-            started_at = rows[-1].get("started_at")
-            ended_at = rows[-1].get("ended_at")
-            if ended_at is None or rows[-1].get("end_reason") == "compression":
-                raise ValueError("terminal session must be ended and non-compression before cold storage")
-            if started_at is None:
-                raise ValueError("terminal session must have a start time before cold storage")
-
-            _enforce_message_limit(conn, lineage)
-            records = _records(conn, lineage)
-            fingerprint = _fingerprint(records)
+            plan = _build_store_plan(conn, terminal_id)
         finally:
             conn.execute("RELEASE SAVEPOINT cold_store_snapshot")
 
-    terminal_date = datetime.fromtimestamp(float(started_at), UTC)
+    lineage = plan.physical_ids
+    records = plan.records
+    fingerprint = plan.source_fingerprint
+    terminal_date = datetime.fromtimestamp(plan.started_at, UTC)
     snapshot_name = _safe_component(terminal_id)
     snapshot_dir = (
         archive_root

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -81,8 +81,21 @@ class _StorePlan:
     terminal_id: str
     physical_ids: tuple[str, ...]
     started_at: float
+    source_store_key: str
     records: list[dict[str, Any]]
     source_fingerprint: str
+
+
+def _source_store_key(conn: sqlite3.Connection) -> str:
+    """Return a non-secret stable namespace for this file-backed SQLite store."""
+    for row in conn.execute("PRAGMA database_list").fetchall():
+        if str(row[1]) != "main":
+            continue
+        database_path = row[2]
+        if not isinstance(database_path, str) or not database_path:
+            break
+        return sha256(os.fsencode(os.path.abspath(database_path))).hexdigest()[:16]
+    raise ValueError("cold store requires a file-backed SQLite source store")
 
 
 def _connection(db: SessionDB) -> sqlite3.Connection:
@@ -575,6 +588,7 @@ def _build_store_plan(conn: sqlite3.Connection, terminal_id: str) -> _StorePlan:
         terminal_id=terminal_id,
         physical_ids=lineage,
         started_at=validated_started_at,
+        source_store_key=_source_store_key(conn),
         records=records,
         source_fingerprint=_fingerprint(records),
     )
@@ -601,7 +615,9 @@ def _snapshot_location(
     archive_root: Path, plan: _StorePlan
 ) -> tuple[Path, str, tuple[str, ...]]:
     terminal_date = datetime.fromtimestamp(plan.started_at, UTC)
-    snapshot_name = _safe_component(plan.terminal_id)
+    snapshot_name = _safe_component(
+        f"{plan.source_store_key}:{plan.terminal_id}:{float(plan.started_at).hex()}"
+    )
     parent_parts = (
         "sessions",
         "started",

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -747,10 +747,15 @@ def _reject_gateway_routing_references(
 
 
 def _reject_legacy_routing_references(physical_ids: tuple[str, ...]) -> None:
-    """Fail closed when the legacy sessions.json routes to this lineage."""
-    from hermes_constants import get_hermes_home
+    """Fail closed when the configured legacy sessions.json routes to this lineage."""
+    from gateway.config import load_gateway_config
 
-    sessions_file = get_hermes_home() / "sessions" / "sessions.json"
+    try:
+        sessions_file = Path(load_gateway_config().sessions_dir) / "sessions.json"
+    except Exception as exc:
+        raise ValueError(
+            "cold purge cannot resolve the configured gateway sessions directory"
+        ) from exc
     flags = os.O_RDONLY | os.O_NONBLOCK | os.O_NOFOLLOW | os.O_CLOEXEC
     try:
         descriptor = os.open(sessions_file, flags)

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -29,7 +29,7 @@ _MAX_SQLITE_IN_PARAMS = 500
 
 @dataclass(frozen=True)
 class StoredLineage:
-    """Identity and exact local revision emitted by :func:`store_archived_lineage`."""
+    """Identity and immutable local snapshot emitted by :func:`store_archived_lineage`."""
 
     terminal_id: str
     physical_ids: tuple[str, ...]
@@ -227,10 +227,10 @@ def _open_or_create_directory(parent_fd: int, name: str, path: Path) -> int:
         raise _unsafe_archive_parent(path, exc)
 
 
-def _open_revision_parent(
+def _open_snapshot_parent(
     archive_root: Path, relative_parts: tuple[str, ...]
 ) -> tuple[list[int], list[tuple[int, str, int, Path]]]:
-    """Open/create a no-follow chain from ``/`` through the revision parent."""
+    """Open/create a no-follow chain from ``/`` through the snapshot parent."""
     absolute_root = Path(os.path.abspath(os.fspath(archive_root)))
     names = (*absolute_root.parts[1:], *relative_parts)
     descriptors = [os.open(os.sep, _directory_open_flags())]
@@ -292,28 +292,32 @@ def _read_regular_text_at(directory_fd: int, name: str) -> str | None:
         return source.read()
 
 
-def _valid_existing_revision_at(
-    revisions_fd: int,
-    revision_name: str,
+def _valid_existing_snapshot_at(
+    snapshot_parent_fd: int,
+    snapshot_name: str,
     terminal_id: str,
     lineage: tuple[str, ...],
     fingerprint: str,
 ) -> bool | None:
     try:
-        revision_fd = os.open(revision_name, _directory_open_flags(), dir_fd=revisions_fd)
+        snapshot_fd = os.open(
+            snapshot_name,
+            _directory_open_flags(),
+            dir_fd=snapshot_parent_fd,
+        )
     except FileNotFoundError:
         return None
     except OSError:
         return False
     try:
         try:
-            metadata_text = _read_regular_text_at(revision_fd, "metadata.json")
-            payload_text = _read_regular_text_at(revision_fd, "session.jsonl")
+            metadata_text = _read_regular_text_at(snapshot_fd, "metadata.json")
+            payload_text = _read_regular_text_at(snapshot_fd, "session.jsonl")
             if metadata_text is None or payload_text is None:
                 return False
             metadata = json.loads(metadata_text)
             records = [json.loads(line) for line in payload_text.splitlines()]
-            artifacts_fd = os.open("artifacts", _directory_open_flags(), dir_fd=revision_fd)
+            artifacts_fd = os.open("artifacts", _directory_open_flags(), dir_fd=snapshot_fd)
             os.close(artifacts_fd)
         except (OSError, json.JSONDecodeError):
             return False
@@ -324,35 +328,35 @@ def _valid_existing_revision_at(
             and metadata.get("source_fingerprint") == fingerprint
             and metadata.get("record_count") == len(records)
             and _fingerprint(records) == fingerprint
-            and _directory_entry_matches(revisions_fd, revision_name, revision_fd)
+            and _directory_entry_matches(snapshot_parent_fd, snapshot_name, snapshot_fd)
         )
     finally:
-        os.close(revision_fd)
+        os.close(snapshot_fd)
 
 
-def _create_staging_directory(revisions_fd: int) -> tuple[str, int]:
+def _create_staging_directory(snapshot_parent_fd: int) -> tuple[str, int]:
     for _ in range(100):
         name = f".staging-{secrets.token_hex(8)}"
         try:
-            os.mkdir(name, 0o700, dir_fd=revisions_fd)
+            os.mkdir(name, 0o700, dir_fd=snapshot_parent_fd)
         except FileExistsError:
             continue
         try:
-            descriptor = os.open(name, _directory_open_flags(), dir_fd=revisions_fd)
+            descriptor = os.open(name, _directory_open_flags(), dir_fd=snapshot_parent_fd)
         except BaseException:
             try:
-                os.rmdir(name, dir_fd=revisions_fd)
+                os.rmdir(name, dir_fd=snapshot_parent_fd)
             except OSError:
                 pass
             raise
-        if not _directory_entry_matches(revisions_fd, name, descriptor):
+        if not _directory_entry_matches(snapshot_parent_fd, name, descriptor):
             os.close(descriptor)
             raise ValueError("unsafe cold-store staging directory")
         return name, descriptor
     raise FileExistsError("could not allocate cold-store staging directory")
 
 
-def _remove_staging_at(revisions_fd: int, name: str, staging_fd: int) -> None:
+def _remove_staging_at(snapshot_parent_fd: int, name: str, staging_fd: int) -> None:
     for member in ("metadata.json", "session.jsonl"):
         try:
             os.unlink(member, dir_fd=staging_fd)
@@ -362,9 +366,9 @@ def _remove_staging_at(revisions_fd: int, name: str, staging_fd: int) -> None:
         os.rmdir("artifacts", dir_fd=staging_fd)
     except OSError:
         pass
-    if _directory_entry_matches(revisions_fd, name, staging_fd):
+    if _directory_entry_matches(snapshot_parent_fd, name, staging_fd):
         try:
-            os.rmdir(name, dir_fd=revisions_fd)
+            os.rmdir(name, dir_fd=snapshot_parent_fd)
         except OSError:
             pass
 
@@ -372,9 +376,9 @@ def _remove_staging_at(revisions_fd: int, name: str, staging_fd: int) -> None:
 def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) -> StoredLineage:
     """Store one marked completed compression lineage without deleting DB rows.
 
-    The terminal ID determines the logical session directory. A content-addressed
-    fingerprint directory makes repeated stores idempotent and lets a later
-    changed source produce a separate local revision.
+    The safe terminal ID names a single immutable snapshot. Repeated stores of
+    the exact source are idempotent; a changed source fails at the archival
+    boundary instead of creating a revision or overwriting the snapshot.
     """
     if os.name == "nt":
         raise OSError("cold store is not yet supported on Windows")
@@ -406,45 +410,45 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
             conn.execute("RELEASE SAVEPOINT cold_store_snapshot")
 
     terminal_date = datetime.fromtimestamp(float(ended_at), UTC)
-    revision_dir = (
+    snapshot_name = _safe_component(terminal_id)
+    snapshot_dir = (
         archive_root
         / "sessions"
         / "ended"
         / f"{terminal_date:%Y}"
         / f"{terminal_date:%m}"
         / f"{terminal_date:%d}"
-        / _safe_component(terminal_id)
-        / "revisions"
-        / fingerprint
+        / snapshot_name
     )
-    revision_parent_parts = (
+    snapshot_parent_parts = (
         "sessions",
         "ended",
         f"{terminal_date:%Y}",
         f"{terminal_date:%m}",
         f"{terminal_date:%d}",
-        _safe_component(terminal_id),
-        "revisions",
     )
-    descriptors, edges = _open_revision_parent(archive_root, revision_parent_parts)
-    revisions_fd = descriptors[-1]
+    descriptors, edges = _open_snapshot_parent(archive_root, snapshot_parent_parts)
+    snapshot_parent_fd = descriptors[-1]
     staging_name: str | None = None
     staging_fd = -1
     published = False
     try:
-        existing = _valid_existing_revision_at(
-            revisions_fd,
-            fingerprint,
+        existing = _valid_existing_snapshot_at(
+            snapshot_parent_fd,
+            snapshot_name,
             terminal_id,
             lineage,
             fingerprint,
         )
         if existing is True:
-            return StoredLineage(terminal_id, lineage, fingerprint, revision_dir)
+            return StoredLineage(terminal_id, lineage, fingerprint, snapshot_dir)
         if existing is False:
-            raise ValueError("existing cold-store revision is invalid or mismatched")
+            raise ValueError(
+                "cold-store archival boundary violation: existing snapshot is invalid "
+                "or the marked source changed after Store"
+            )
 
-        staging_name, staging_fd = _create_staging_directory(revisions_fd)
+        staging_name, staging_fd = _create_staging_directory(snapshot_parent_fd)
         _validate_directory_chain(edges)
         metadata = {
             "format": _ARCHIVE_FORMAT,
@@ -469,34 +473,37 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
         os.mkdir("artifacts", dir_fd=staging_fd)
         os.fsync(staging_fd)
         _validate_directory_chain(edges)
-        if not _directory_entry_matches(revisions_fd, staging_name, staging_fd):
+        if not _directory_entry_matches(snapshot_parent_fd, staging_name, staging_fd):
             raise ValueError("unsafe cold-store staging directory")
         try:
             os.rename(
                 staging_name,
-                fingerprint,
-                src_dir_fd=revisions_fd,
-                dst_dir_fd=revisions_fd,
+                snapshot_name,
+                src_dir_fd=snapshot_parent_fd,
+                dst_dir_fd=snapshot_parent_fd,
             )
         except OSError as exc:
             if exc.errno not in (errno.EEXIST, errno.ENOTEMPTY):
                 raise
-            if _valid_existing_revision_at(
-                revisions_fd,
-                fingerprint,
+            if _valid_existing_snapshot_at(
+                snapshot_parent_fd,
+                snapshot_name,
                 terminal_id,
                 lineage,
                 fingerprint,
             ):
-                return StoredLineage(terminal_id, lineage, fingerprint, revision_dir)
-            raise
+                return StoredLineage(terminal_id, lineage, fingerprint, snapshot_dir)
+            raise ValueError(
+                "cold-store archival boundary violation: existing snapshot is invalid "
+                "or the marked source changed after Store"
+            ) from exc
         published = True
-        os.fsync(revisions_fd)
+        os.fsync(snapshot_parent_fd)
     finally:
         if staging_fd >= 0:
             if not published and staging_name is not None:
-                _remove_staging_at(revisions_fd, staging_name, staging_fd)
+                _remove_staging_at(snapshot_parent_fd, staging_name, staging_fd)
             os.close(staging_fd)
         for descriptor in reversed(descriptors):
             os.close(descriptor)
-    return StoredLineage(terminal_id, lineage, fingerprint, revision_dir)
+    return StoredLineage(terminal_id, lineage, fingerprint, snapshot_dir)

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -15,9 +15,9 @@ import json
 import os
 from pathlib import Path
 import re
-import shutil
+import secrets
 import sqlite3
-import tempfile
+import stat
 from typing import Any
 
 from hermes_state import SessionDB, resolved_max_export_messages
@@ -191,72 +191,182 @@ def _fingerprint(records: list[dict[str, Any]]) -> str:
     return sha256(canonical.encode("utf-8")).hexdigest()
 
 
-def _write_text_fsync(path: Path, text: str) -> None:
-    with path.open("w", encoding="utf-8") as output:
+def _directory_open_flags() -> int:
+    try:
+        return os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+    except AttributeError as exc:
+        raise OSError(errno.ENOTSUP, "cold store requires no-follow directory descriptors") from exc
+
+
+def _unsafe_archive_parent(path: Path, exc: OSError | None = None) -> ValueError:
+    error = ValueError(f"unsafe archive parent path: {path}")
+    if exc is not None:
+        error.__cause__ = exc
+    return error
+
+
+def _open_or_create_directory(parent_fd: int, name: str, path: Path) -> int:
+    flags = _directory_open_flags()
+    try:
+        return os.open(name, flags, dir_fd=parent_fd)
+    except FileNotFoundError:
+        try:
+            os.mkdir(name, dir_fd=parent_fd)
+        except FileExistsError:
+            pass
+        except OSError as exc:
+            raise _unsafe_archive_parent(path, exc)
+        try:
+            descriptor = os.open(name, flags, dir_fd=parent_fd)
+        except OSError as exc:
+            raise _unsafe_archive_parent(path, exc)
+        os.fsync(descriptor)
+        os.fsync(parent_fd)
+        return descriptor
+    except OSError as exc:
+        raise _unsafe_archive_parent(path, exc)
+
+
+def _open_revision_parent(
+    archive_root: Path, relative_parts: tuple[str, ...]
+) -> tuple[list[int], list[tuple[int, str, int, Path]]]:
+    """Open/create a no-follow chain from ``/`` through the revision parent."""
+    absolute_root = Path(os.path.abspath(os.fspath(archive_root)))
+    names = (*absolute_root.parts[1:], *relative_parts)
+    descriptors = [os.open(os.sep, _directory_open_flags())]
+    edges: list[tuple[int, str, int, Path]] = []
+    current_path = Path(os.sep)
+    try:
+        for name in names:
+            current_path /= name
+            descriptor = _open_or_create_directory(descriptors[-1], name, current_path)
+            edges.append((descriptors[-1], name, descriptor, current_path))
+            descriptors.append(descriptor)
+    except BaseException:
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
+        raise
+    return descriptors, edges
+
+
+def _directory_entry_matches(parent_fd: int, name: str, descriptor: int) -> bool:
+    try:
+        entry = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except OSError:
+        return False
+    opened = os.fstat(descriptor)
+    return (
+        stat.S_ISDIR(entry.st_mode)
+        and entry.st_dev == opened.st_dev
+        and entry.st_ino == opened.st_ino
+    )
+
+
+def _validate_directory_chain(edges: list[tuple[int, str, int, Path]]) -> None:
+    for parent_fd, name, descriptor, path in edges:
+        if not _directory_entry_matches(parent_fd, name, descriptor):
+            raise _unsafe_archive_parent(path)
+
+
+def _write_text_fsync_at(directory_fd: int, name: str, text: str) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC
+    descriptor = os.open(name, flags, 0o600, dir_fd=directory_fd)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as output:
         output.write(text)
         output.flush()
         os.fsync(output.fileno())
 
 
-def _fsync_dir(path: Path) -> None:
-    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+def _read_regular_text_at(directory_fd: int, name: str) -> str | None:
     try:
-        os.fsync(descriptor)
+        descriptor = os.open(
+            name,
+            os.O_RDONLY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            dir_fd=directory_fd,
+        )
+    except OSError:
+        return None
+    with os.fdopen(descriptor, "r", encoding="utf-8") as source:
+        if not stat.S_ISREG(os.fstat(source.fileno()).st_mode):
+            return None
+        return source.read()
+
+
+def _valid_existing_revision_at(
+    revisions_fd: int,
+    revision_name: str,
+    terminal_id: str,
+    lineage: tuple[str, ...],
+    fingerprint: str,
+) -> bool | None:
+    try:
+        revision_fd = os.open(revision_name, _directory_open_flags(), dir_fd=revisions_fd)
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return False
+    try:
+        try:
+            metadata_text = _read_regular_text_at(revision_fd, "metadata.json")
+            payload_text = _read_regular_text_at(revision_fd, "session.jsonl")
+            if metadata_text is None or payload_text is None:
+                return False
+            metadata = json.loads(metadata_text)
+            records = [json.loads(line) for line in payload_text.splitlines()]
+            artifacts_fd = os.open("artifacts", _directory_open_flags(), dir_fd=revision_fd)
+            os.close(artifacts_fd)
+        except (OSError, json.JSONDecodeError):
+            return False
+        return (
+            metadata.get("format") == _ARCHIVE_FORMAT
+            and metadata.get("terminal_id") == terminal_id
+            and metadata.get("physical_ids") == list(lineage)
+            and metadata.get("source_fingerprint") == fingerprint
+            and metadata.get("record_count") == len(records)
+            and _fingerprint(records) == fingerprint
+            and _directory_entry_matches(revisions_fd, revision_name, revision_fd)
+        )
     finally:
-        os.close(descriptor)
+        os.close(revision_fd)
 
 
-def _valid_existing_revision(revision_dir: Path, terminal_id: str, lineage: tuple[str, ...], fingerprint: str) -> bool:
-    if not revision_dir.is_dir() or revision_dir.is_symlink():
-        return False
-    metadata_path = revision_dir / "metadata.json"
-    payload_path = revision_dir / "session.jsonl"
-    if any(not path.is_file() or path.is_symlink() for path in (metadata_path, payload_path)):
-        return False
-    try:
-        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
-        records = [json.loads(line) for line in payload_path.read_text(encoding="utf-8").splitlines()]
-    except (OSError, json.JSONDecodeError):
-        return False
-    return (
-        metadata.get("format") == _ARCHIVE_FORMAT
-        and metadata.get("terminal_id") == terminal_id
-        and metadata.get("physical_ids") == list(lineage)
-        and metadata.get("source_fingerprint") == fingerprint
-        and metadata.get("record_count") == len(records)
-        and _fingerprint(records) == fingerprint
-        and (revision_dir / "artifacts").is_dir()
-        and not (revision_dir / "artifacts").is_symlink()
-    )
-
-
-def _ensure_dir_tree_fsynced(path: Path) -> None:
-    """Create and validate every path component through the revision parent."""
-    chain: list[Path] = []
-    current = path
-    while True:
-        chain.append(current)
-        if current.parent == current:
-            break
-        current = current.parent
-    for directory in reversed(chain):
-        if directory.exists():
-            if not directory.is_dir() or directory.is_symlink():
-                raise ValueError(f"unsafe archive parent path: {directory}")
+def _create_staging_directory(revisions_fd: int) -> tuple[str, int]:
+    for _ in range(100):
+        name = f".staging-{secrets.token_hex(8)}"
+        try:
+            os.mkdir(name, 0o700, dir_fd=revisions_fd)
+        except FileExistsError:
             continue
         try:
-            directory.mkdir()
-        except FileExistsError:
+            descriptor = os.open(name, _directory_open_flags(), dir_fd=revisions_fd)
+        except BaseException:
+            try:
+                os.rmdir(name, dir_fd=revisions_fd)
+            except OSError:
+                pass
+            raise
+        if not _directory_entry_matches(revisions_fd, name, descriptor):
+            os.close(descriptor)
+            raise ValueError("unsafe cold-store staging directory")
+        return name, descriptor
+    raise FileExistsError("could not allocate cold-store staging directory")
+
+
+def _remove_staging_at(revisions_fd: int, name: str, staging_fd: int) -> None:
+    for member in ("metadata.json", "session.jsonl"):
+        try:
+            os.unlink(member, dir_fd=staging_fd)
+        except OSError:
             pass
-        if not directory.is_dir() or directory.is_symlink():
-            raise ValueError(f"unsafe archive parent path: {directory}")
-        _fsync_dir(directory)
-        _fsync_dir(directory.parent)
-
-
-def _remove_staging(path: Path) -> None:
-    if path.exists():
-        shutil.rmtree(path)
+    try:
+        os.rmdir("artifacts", dir_fd=staging_fd)
+    except OSError:
+        pass
+    if _directory_entry_matches(revisions_fd, name, staging_fd):
+        try:
+            os.rmdir(name, dir_fd=revisions_fd)
+        except OSError:
+            pass
 
 
 def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) -> StoredLineage:
@@ -307,14 +417,35 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
         / "revisions"
         / fingerprint
     )
-    if revision_dir.exists():
-        if _valid_existing_revision(revision_dir, terminal_id, lineage, fingerprint):
-            return StoredLineage(terminal_id, lineage, fingerprint, revision_dir)
-        raise ValueError("existing cold-store revision is invalid or mismatched")
-
-    _ensure_dir_tree_fsynced(revision_dir.parent)
-    staging = Path(tempfile.mkdtemp(prefix=".staging-", dir=revision_dir.parent))
+    revision_parent_parts = (
+        "sessions",
+        "ended",
+        f"{terminal_date:%Y}",
+        f"{terminal_date:%m}",
+        f"{terminal_date:%d}",
+        _safe_component(terminal_id),
+        "revisions",
+    )
+    descriptors, edges = _open_revision_parent(archive_root, revision_parent_parts)
+    revisions_fd = descriptors[-1]
+    staging_name: str | None = None
+    staging_fd = -1
+    published = False
     try:
+        existing = _valid_existing_revision_at(
+            revisions_fd,
+            fingerprint,
+            terminal_id,
+            lineage,
+            fingerprint,
+        )
+        if existing is True:
+            return StoredLineage(terminal_id, lineage, fingerprint, revision_dir)
+        if existing is False:
+            raise ValueError("existing cold-store revision is invalid or mismatched")
+
+        staging_name, staging_fd = _create_staging_directory(revisions_fd)
+        _validate_directory_chain(edges)
         metadata = {
             "format": _ARCHIVE_FORMAT,
             "terminal_id": terminal_id,
@@ -322,24 +453,50 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
             "source_fingerprint": fingerprint,
             "record_count": len(records),
         }
-        _write_text_fsync(staging / "metadata.json", json.dumps(metadata, sort_keys=True, indent=2) + "\n")
-        _write_text_fsync(
-            staging / "session.jsonl",
-            "".join(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n" for record in records),
+        _write_text_fsync_at(
+            staging_fd,
+            "metadata.json",
+            json.dumps(metadata, sort_keys=True, indent=2) + "\n",
         )
-        (staging / "artifacts").mkdir()
-        _fsync_dir(staging)
+        _write_text_fsync_at(
+            staging_fd,
+            "session.jsonl",
+            "".join(
+                json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n"
+                for record in records
+            ),
+        )
+        os.mkdir("artifacts", dir_fd=staging_fd)
+        os.fsync(staging_fd)
+        _validate_directory_chain(edges)
+        if not _directory_entry_matches(revisions_fd, staging_name, staging_fd):
+            raise ValueError("unsafe cold-store staging directory")
         try:
-            os.replace(staging, revision_dir)
+            os.rename(
+                staging_name,
+                fingerprint,
+                src_dir_fd=revisions_fd,
+                dst_dir_fd=revisions_fd,
+            )
         except OSError as exc:
             if exc.errno not in (errno.EEXIST, errno.ENOTEMPTY):
                 raise
-            if _valid_existing_revision(revision_dir, terminal_id, lineage, fingerprint):
-                _remove_staging(staging)
+            if _valid_existing_revision_at(
+                revisions_fd,
+                fingerprint,
+                terminal_id,
+                lineage,
+                fingerprint,
+            ):
                 return StoredLineage(terminal_id, lineage, fingerprint, revision_dir)
             raise
-        _fsync_dir(revision_dir.parent)
-    except BaseException:
-        _remove_staging(staging)
-        raise
+        published = True
+        os.fsync(revisions_fd)
+    finally:
+        if staging_fd >= 0:
+            if not published and staging_name is not None:
+                _remove_staging_at(revisions_fd, staging_name, staging_fd)
+            os.close(staging_fd)
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
     return StoredLineage(terminal_id, lineage, fingerprint, revision_dir)

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -76,8 +76,8 @@ def _raw_compression_lineage(conn: sqlite3.Connection, terminal_id: str) -> tupl
         raise ValueError(f"session not found: {terminal_id}")
     if _is_explicit_fork(current):
         return (terminal_id,)
-    lineage = [str(current["id"])]
-    seen = set(lineage)
+    ancestors = [str(current["id"])]
+    seen = set(ancestors)
     while current.get("parent_session_id"):
         parent = _session(conn, str(current["parent_session_id"]))
         if parent is None or parent.get("end_reason") != "compression" or _is_explicit_fork(current):
@@ -85,10 +85,31 @@ def _raw_compression_lineage(conn: sqlite3.Connection, terminal_id: str) -> tupl
         parent_id = str(parent["id"])
         if parent_id in seen:
             raise ValueError("cyclic compression lineage")
-        lineage.append(parent_id)
+        ancestors.append(parent_id)
         seen.add(parent_id)
         current = parent
-    return tuple(reversed(lineage))
+
+    lineage = list(reversed(ancestors))
+    current = _session(conn, lineage[-1])
+    assert current is not None
+    while current.get("end_reason") == "compression":
+        children = _rows(
+            conn,
+            "SELECT * FROM sessions WHERE parent_session_id = ? ORDER BY started_at ASC",
+            (str(current["id"]),),
+        )
+        candidates = [child for child in children if not _is_explicit_fork(child)]
+        if not candidates:
+            break
+        if len(candidates) > 1:
+            raise ValueError("ambiguous compression continuation")
+        current = candidates[0]
+        current_id = str(current["id"])
+        if current_id in seen:
+            raise ValueError("cyclic compression lineage")
+        lineage.append(current_id)
+        seen.add(current_id)
+    return tuple(lineage)
 
 
 def _records(conn: sqlite3.Connection, physical_ids: tuple[str, ...]) -> list[dict[str, Any]]:
@@ -120,7 +141,8 @@ def _records(conn: sqlite3.Connection, physical_ids: tuple[str, ...]) -> list[di
             {"v": 1, "kind": "model-usage", "row": row}
             for row in _rows(
                 conn,
-                "SELECT * FROM session_model_usage WHERE session_id = ? ORDER BY model, task",
+                "SELECT * FROM session_model_usage WHERE session_id = ? "
+                "ORDER BY model, billing_provider, billing_base_url, billing_mode, task",
                 (session_id,),
             )
         )
@@ -150,6 +172,40 @@ def _fsync_dir(path: Path) -> None:
         os.close(descriptor)
 
 
+def _valid_existing_revision(revision_dir: Path, terminal_id: str, lineage: tuple[str, ...], fingerprint: str) -> bool:
+    if not revision_dir.is_dir() or revision_dir.is_symlink():
+        return False
+    metadata_path = revision_dir / "metadata.json"
+    payload_path = revision_dir / "session.jsonl"
+    if any(not path.is_file() or path.is_symlink() for path in (metadata_path, payload_path)):
+        return False
+    try:
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        records = [json.loads(line) for line in payload_path.read_text(encoding="utf-8").splitlines()]
+    except (OSError, json.JSONDecodeError):
+        return False
+    return (
+        metadata.get("terminal_id") == terminal_id
+        and metadata.get("physical_ids") == list(lineage)
+        and metadata.get("source_fingerprint") == fingerprint
+        and metadata.get("record_count") == len(records)
+        and _fingerprint(records) == fingerprint
+        and (revision_dir / "artifacts").is_dir()
+        and not (revision_dir / "artifacts").is_symlink()
+    )
+
+
+def _fsync_created_parents(archive_root: Path, revision_parent: Path) -> None:
+    """Fsync each directory created between archive root and the revision parent."""
+    current = revision_parent
+    parents: list[Path] = []
+    while current != archive_root:
+        parents.append(current)
+        current = current.parent
+    for directory in reversed(parents):
+        _fsync_dir(directory)
+
+
 def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) -> StoredLineage:
     """Store one marked completed compression lineage without deleting DB rows.
 
@@ -157,25 +213,34 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
     fingerprint directory makes repeated stores idempotent and lets a later
     changed source produce a separate local revision.
     """
+    if os.name == "nt":
+        raise OSError("cold store is not yet supported on Windows")
+
     conn = _connection(db)
-    lineage = _raw_compression_lineage(conn, terminal_id)
-    if lineage[-1] != terminal_id:
-        raise ValueError("store requires the terminal compression session ID")
+    with db._lock:
+        conn.execute("SAVEPOINT cold_store_snapshot")
+        try:
+            lineage = _raw_compression_lineage(conn, terminal_id)
+            if lineage[-1] != terminal_id:
+                raise ValueError("store requires the terminal compression session ID")
 
-    rows = [_session(conn, session_id) for session_id in lineage]
-    if any(session is None for session in rows):
-        raise ValueError("compression lineage changed while resolving store candidate")
-    rows = [session for session in rows if session is not None]
-    if any(not row.get("archived") for row in rows):
-        raise ValueError("all compression lineage rows must be marked archived")
-    if any(row.get("pinned") for row in rows):
-        raise ValueError("pinned sessions are not cold-store candidates")
-    ended_at = rows[-1].get("ended_at")
-    if ended_at is None:
-        raise ValueError("terminal session must be ended before cold storage")
+            rows = [_session(conn, session_id) for session_id in lineage]
+            if any(session is None for session in rows):
+                raise ValueError("compression lineage changed while resolving store candidate")
+            rows = [session for session in rows if session is not None]
+            if any(not row.get("archived") for row in rows):
+                raise ValueError("all compression lineage rows must be marked archived")
+            if any(row.get("pinned") for row in rows):
+                raise ValueError("pinned sessions are not cold-store candidates")
+            ended_at = rows[-1].get("ended_at")
+            if ended_at is None or rows[-1].get("end_reason") == "compression":
+                raise ValueError("terminal session must be ended and non-compression before cold storage")
 
-    records = _records(conn, lineage)
-    fingerprint = _fingerprint(records)
+            records = _records(conn, lineage)
+            fingerprint = _fingerprint(records)
+        finally:
+            conn.execute("RELEASE SAVEPOINT cold_store_snapshot")
+
     terminal_date = datetime.fromtimestamp(float(ended_at), UTC)
     revision_dir = (
         archive_root
@@ -189,12 +254,13 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
         / fingerprint
     )
     if revision_dir.exists():
-        return StoredLineage(terminal_id, lineage, fingerprint, revision_dir)
+        if _valid_existing_revision(revision_dir, terminal_id, lineage, fingerprint):
+            return StoredLineage(terminal_id, lineage, fingerprint, revision_dir)
+        raise ValueError("existing cold-store revision is invalid or mismatched")
 
-    if os.name == "nt":
-        raise OSError("cold store is not yet supported on Windows")
-
+    archive_root.mkdir(parents=True, exist_ok=True)
     revision_dir.parent.mkdir(parents=True, exist_ok=True)
+    _fsync_created_parents(archive_root, revision_dir.parent)
     staging = Path(tempfile.mkdtemp(prefix=".staging-", dir=revision_dir.parent))
     try:
         metadata = {

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -485,10 +485,17 @@ def _build_store_plan(conn: sqlite3.Connection, terminal_id: str) -> _StorePlan:
     _enforce_message_limit(conn, lineage)
     records = _records(conn, lineage)
     _validate_sqlite_values(records)
+    try:
+        validated_started_at = float(started_at)
+        datetime.fromtimestamp(validated_started_at, UTC)
+    except (OSError, OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(
+            "terminal session start time is outside the supported range"
+        ) from exc
     return _StorePlan(
         terminal_id=terminal_id,
         physical_ids=lineage,
-        started_at=float(started_at),
+        started_at=validated_started_at,
         records=records,
         source_fingerprint=_fingerprint(records),
     )
@@ -643,6 +650,7 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
             len(records),
         )
         if existing is True:
+            _validate_directory_chain(edges)
             return StoredLineage(terminal_id, lineage, fingerprint, snapshot_dir)
 
         staging_name, staging_fd = _create_staging_directory(snapshot_parent_fd)

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -54,8 +54,8 @@ def _connection(db: SessionDB) -> sqlite3.Connection:
 
 
 def _safe_component(value: str) -> str:
-    raw = str(value or "").strip()
-    safe = re.sub(r"[^A-Za-z0-9_-]", "_", raw).strip("._")[:96] or "session"
+    raw = str(value or "")
+    safe = re.sub(r"[^A-Za-z0-9_-]", "_", raw.strip()).strip("._")[:96] or "session"
     if raw == safe:
         return safe
     return f"{safe}_{sha256(raw.encode('utf-8', 'surrogatepass')).hexdigest()[:12]}"

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -1,0 +1,176 @@
+"""Store-only local cold archive primitives.
+
+This first slice deliberately has no CLI registration and never deletes database
+rows. It validates the basic Mark → Store handoff against a caller-supplied
+``SessionDB`` and local archive root.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from hashlib import sha256
+import json
+import os
+from pathlib import Path
+import re
+import sqlite3
+import tempfile
+from typing import Any
+
+from hermes_state import SessionDB
+
+
+@dataclass(frozen=True)
+class StoredLineage:
+    """Identity and exact local revision emitted by :func:`store_archived_lineage`."""
+
+    terminal_id: str
+    physical_ids: tuple[str, ...]
+    source_fingerprint: str
+    revision_dir: Path
+
+
+def _connection(db: SessionDB) -> sqlite3.Connection:
+    if db._conn is None:
+        raise RuntimeError("SessionDB connection is closed")
+    return db._conn
+
+
+def _safe_component(value: str) -> str:
+    raw = str(value or "").strip()
+    safe = re.sub(r"[^A-Za-z0-9_-]", "_", raw).strip("._")[:96] or "session"
+    if raw == safe:
+        return safe
+    return f"{safe}_{sha256(raw.encode('utf-8', 'surrogatepass')).hexdigest()[:12]}"
+
+
+def _rows(conn: sqlite3.Connection, query: str, params: tuple[Any, ...]) -> list[dict[str, Any]]:
+    cursor = conn.execute(query, params)
+    return [
+        {column[0]: value for column, value in zip(cursor.description, row, strict=True)}
+        for row in cursor.fetchall()
+    ]
+
+
+def _records(conn: sqlite3.Connection, physical_ids: tuple[str, ...]) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for session_id in physical_ids:
+        sessions = _rows(conn, "SELECT * FROM sessions WHERE id = ?", (session_id,))
+        if len(sessions) != 1:
+            raise ValueError(f"session disappeared while storing: {session_id}")
+        records.append({"v": 1, "kind": "session-segment", "row": sessions[0]})
+        records.extend(
+            {"v": 1, "kind": "message", "row": row}
+            for row in _rows(
+                conn,
+                "SELECT * FROM messages WHERE session_id = ? ORDER BY id",
+                (session_id,),
+            )
+        )
+        records.extend(
+            {"v": 1, "kind": "model-usage", "row": row}
+            for row in _rows(
+                conn,
+                "SELECT * FROM session_model_usage WHERE session_id = ? ORDER BY model, task",
+                (session_id,),
+            )
+        )
+    return records
+
+
+def _fingerprint(records: list[dict[str, Any]]) -> str:
+    canonical = "\n".join(
+        json.dumps(record, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        for record in records
+    )
+    return sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _write_text_fsync(path: Path, text: str) -> None:
+    with path.open("w", encoding="utf-8") as output:
+        output.write(text)
+        output.flush()
+        os.fsync(output.fileno())
+
+
+def _fsync_dir(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) -> StoredLineage:
+    """Store one marked completed compression lineage without deleting DB rows.
+
+    The terminal ID determines the logical session directory. A content-addressed
+    fingerprint directory makes repeated stores idempotent and lets a later
+    changed source produce a separate local revision.
+    """
+    lineage = tuple(db.get_compression_lineage(terminal_id))
+    if not lineage:
+        raise ValueError(f"session not found: {terminal_id}")
+    if lineage[-1] != terminal_id:
+        raise ValueError("store requires the terminal compression session ID")
+
+    sessions = [db.get_session(session_id) for session_id in lineage]
+    if any(session is None for session in sessions):
+        raise ValueError("compression lineage changed while resolving store candidate")
+    rows = [session for session in sessions if session is not None]
+    if any(not row.get("archived") for row in rows):
+        raise ValueError("all compression lineage rows must be marked archived")
+    if any(row.get("pinned") for row in rows):
+        raise ValueError("pinned sessions are not cold-store candidates")
+    ended_at = rows[-1].get("ended_at")
+    if ended_at is None:
+        raise ValueError("terminal session must be ended before cold storage")
+
+    conn = _connection(db)
+    records = _records(conn, lineage)
+    fingerprint = _fingerprint(records)
+    terminal_date = datetime.fromtimestamp(float(ended_at), UTC)
+    revision_dir = (
+        archive_root
+        / "sessions"
+        / "ended"
+        / f"{terminal_date:%Y}"
+        / f"{terminal_date:%m}"
+        / f"{terminal_date:%d}"
+        / _safe_component(terminal_id)
+        / "revisions"
+        / fingerprint
+    )
+    if revision_dir.exists():
+        return StoredLineage(terminal_id, lineage, fingerprint, revision_dir)
+
+    revision_dir.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=".staging-", dir=revision_dir.parent))
+    try:
+        metadata = {
+            "format": "hermes-cold-archive-store-spike/v1",
+            "terminal_id": terminal_id,
+            "physical_ids": list(lineage),
+            "source_fingerprint": fingerprint,
+            "record_count": len(records),
+        }
+        _write_text_fsync(staging / "metadata.json", json.dumps(metadata, sort_keys=True, indent=2) + "\n")
+        _write_text_fsync(
+            staging / "session.jsonl",
+            "".join(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n" for record in records),
+        )
+        (staging / "artifacts").mkdir()
+        _fsync_dir(staging)
+        os.replace(staging, revision_dir)
+        _fsync_dir(revision_dir.parent)
+    except BaseException:
+        if staging.exists():
+            for item in staging.iterdir():
+                if item.is_file():
+                    item.unlink()
+                elif item.is_dir():
+                    item.rmdir()
+            staging.rmdir()
+        raise
+    return StoredLineage(terminal_id, lineage, fingerprint, revision_dir)

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -22,6 +22,10 @@ from typing import Any
 from hermes_state import SessionDB, resolved_max_export_messages
 
 
+_ARCHIVE_FORMAT = "hermes-cold-archive-store-spike/v1"
+_MAX_SQLITE_IN_PARAMS = 500
+
+
 @dataclass(frozen=True)
 class StoredLineage:
     """Identity and exact local revision emitted by :func:`store_archived_lineage`."""
@@ -58,15 +62,20 @@ def _enforce_message_limit(conn: sqlite3.Connection, physical_ids: tuple[str, ..
     limit = resolved_max_export_messages()
     if limit <= 0:
         return
-    placeholders = ",".join("?" for _ in physical_ids)
-    count = conn.execute(
-        f"SELECT COUNT(*) FROM messages WHERE session_id IN ({placeholders})",
-        physical_ids,
-    ).fetchone()[0]
-    if count > limit:
-        raise ValueError(
-            f"cold store lineage has {count} messages, exceeding the configured export limit {limit}"
-        )
+    seen = 0
+    for start in range(0, len(physical_ids), _MAX_SQLITE_IN_PARAMS):
+        ids = physical_ids[start : start + _MAX_SQLITE_IN_PARAMS]
+        placeholders = ",".join("?" for _ in ids)
+        remaining = limit + 1 - seen
+        rows = conn.execute(
+            f"SELECT 1 FROM messages WHERE session_id IN ({placeholders}) LIMIT ?",
+            (*ids, remaining),
+        ).fetchall()
+        seen += len(rows)
+        if seen > limit:
+            raise ValueError(
+                f"cold store lineage has more than the configured export limit {limit} messages"
+            )
 
 
 def _session(conn: sqlite3.Connection, session_id: str) -> dict[str, Any] | None:
@@ -209,7 +218,8 @@ def _valid_existing_revision(revision_dir: Path, terminal_id: str, lineage: tupl
     except (OSError, json.JSONDecodeError):
         return False
     return (
-        metadata.get("terminal_id") == terminal_id
+        metadata.get("format") == _ARCHIVE_FORMAT
+        and metadata.get("terminal_id") == terminal_id
         and metadata.get("physical_ids") == list(lineage)
         and metadata.get("source_fingerprint") == fingerprint
         and metadata.get("record_count") == len(records)
@@ -299,7 +309,7 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
     staging = Path(tempfile.mkdtemp(prefix=".staging-", dir=revision_dir.parent))
     try:
         metadata = {
-            "format": "hermes-cold-archive-store-spike/v1",
+            "format": _ARCHIVE_FORMAT,
             "terminal_id": terminal_id,
             "physical_ids": list(lineage),
             "source_fingerprint": fingerprint,

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 import errno
@@ -15,7 +16,7 @@ import secrets
 import shutil
 import sqlite3
 import stat
-from typing import Any
+from typing import Any, Iterator
 
 from hermes_state import SessionDB, resolved_max_export_messages
 
@@ -32,6 +33,17 @@ _COORDINATION_SESSION_REFERENCES = (
     ("compression_locks", "session_id"),
     ("session_turn_leases", "conversation_id"),
 )
+
+
+def _canonical_archive_root(archive_root: Path) -> Path:
+    return Path(os.path.abspath(os.fspath(archive_root)))
+
+
+def _cold_archive_lock_path(archive_root: Path) -> Path:
+    """Return the stable sidecar path for one lexical archive root."""
+    canonical_root = _canonical_archive_root(archive_root)
+    digest = sha256(os.fsencode(canonical_root)).hexdigest()
+    return canonical_root.parent / f".hermes-cold-archive-{digest}.lock"
 
 
 @dataclass(frozen=True)
@@ -327,6 +339,53 @@ def _validate_directory_chain(edges: list[tuple[int, str, int, Path]]) -> None:
     for parent_fd, name, descriptor, path in edges:
         if not _directory_entry_matches(parent_fd, name, descriptor):
             raise _unsafe_archive_parent(path)
+
+
+@contextmanager
+def _exclusive_cold_archive_root_lock(archive_root: Path) -> Iterator[None]:
+    """Hold one non-blocking process lock beside an archive root."""
+    _require_supported_platform()
+    import fcntl
+
+    canonical_root = _canonical_archive_root(archive_root)
+    lock_path = _cold_archive_lock_path(canonical_root)
+    descriptors, edges = _open_snapshot_parent(canonical_root.parent, ())
+    parent_fd = descriptors[-1]
+    lock_fd = -1
+    try:
+        flags = os.O_RDWR | os.O_CREAT | os.O_NONBLOCK | os.O_NOFOLLOW | os.O_CLOEXEC
+        try:
+            lock_fd = os.open(lock_path.name, flags, 0o600, dir_fd=parent_fd)
+        except OSError as exc:
+            raise ValueError(f"unsafe cold archive lock sidecar: {lock_path}") from exc
+
+        opened = os.fstat(lock_fd)
+        if not stat.S_ISREG(opened.st_mode):
+            raise ValueError(f"unsafe cold archive lock sidecar: {lock_path}")
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise RuntimeError(
+                f"another cold-archive is already active for archive root {canonical_root}"
+            ) from exc
+
+        _validate_directory_chain(edges)
+        try:
+            entry = os.stat(lock_path.name, dir_fd=parent_fd, follow_symlinks=False)
+        except OSError as exc:
+            raise ValueError(f"unsafe cold archive lock sidecar: {lock_path}") from exc
+        if (
+            not stat.S_ISREG(entry.st_mode)
+            or entry.st_dev != opened.st_dev
+            or entry.st_ino != opened.st_ino
+        ):
+            raise ValueError(f"unsafe cold archive lock sidecar: {lock_path}")
+        yield
+    finally:
+        if lock_fd >= 0:
+            os.close(lock_fd)
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
 
 
 def _write_text_fsync_at(directory_fd: int, name: str, text: str) -> None:
@@ -687,6 +746,55 @@ def _reject_gateway_routing_references(
             )
 
 
+def _reject_legacy_routing_references(physical_ids: tuple[str, ...]) -> None:
+    """Fail closed when the legacy sessions.json routes to this lineage."""
+    from hermes_constants import get_hermes_home
+
+    sessions_file = get_hermes_home() / "sessions" / "sessions.json"
+    flags = os.O_RDONLY | os.O_NONBLOCK | os.O_NOFOLLOW | os.O_CLOEXEC
+    try:
+        descriptor = os.open(sessions_file, flags)
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise ValueError(
+            "cold purge cannot verify sessions.json legacy routes"
+        ) from exc
+
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise ValueError("cold purge cannot verify sessions.json legacy routes")
+        try:
+            with os.fdopen(
+                descriptor, "r", encoding="utf-8", closefd=False
+            ) as source:
+                routes = json.load(source)
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ValueError(
+                "cold purge cannot verify sessions.json legacy routes"
+            ) from exc
+    finally:
+        os.close(descriptor)
+
+    if not isinstance(routes, dict):
+        raise ValueError("cold purge cannot verify sessions.json legacy routes")
+    covered = set(physical_ids)
+    for session_key, entry in routes.items():
+        if str(session_key).startswith("_"):
+            continue
+        if not isinstance(entry, dict) or not isinstance(entry.get("session_id"), str):
+            raise ValueError(
+                "cold purge cannot verify sessions.json legacy routes: "
+                f"session_key={str(session_key)!r}"
+            )
+        session_id = entry["session_id"]
+        if session_id in covered:
+            raise ValueError(
+                "cold purge refuses sessions.json legacy route to lineage "
+                f"session {session_id}: session_key={str(session_key)!r}"
+            )
+
+
 def _required_table_columns(
     conn: sqlite3.Connection, table: str, required: tuple[str, ...]
 ) -> None:
@@ -835,6 +943,7 @@ def _build_purge_reference_plan(
     """Build the archived source plan and reject every deletion reference."""
     plan = _build_store_plan(conn, terminal_id)
     _reject_uncovered_session_references(conn, plan.physical_ids)
+    _reject_legacy_routing_references(plan.physical_ids)
     return plan
 
 

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -22,6 +22,12 @@ from hermes_state import SessionDB, resolved_max_export_messages
 
 _ARCHIVE_FORMAT = "hermes-cold-archive-store-spike/v1"
 _MAX_SQLITE_IN_PARAMS = 500
+_STATE_META_SESSION_NAMESPACES = ("goal", "loop", "heartbeat")
+_ASYNC_DELEGATION_SESSION_COLUMNS = (
+    "origin_session",
+    "parent_session_id",
+    "origin_session_id",
+)
 
 
 @dataclass(frozen=True)
@@ -677,11 +683,77 @@ def _reject_gateway_routing_references(
             )
 
 
+def _required_table_columns(
+    conn: sqlite3.Connection, table: str, required: tuple[str, ...]
+) -> None:
+    """Reject stale or damaged soft-reference schemas before purge."""
+    quoted_table = _quoted_identifier(table)
+    rows = conn.execute(f"PRAGMA table_info({quoted_table})").fetchall()
+    columns = {str(row[1]) for row in rows}
+    missing = [column for column in required if column not in columns]
+    if missing:
+        missing_names = ", ".join(f"{table}.{column}" for column in missing)
+        raise ValueError(
+            "cold purge cannot verify soft references because the session "
+            f"database schema is missing {missing_names}"
+        )
+
+
+def _reject_state_meta_references(
+    conn: sqlite3.Connection, physical_ids: tuple[str, ...]
+) -> None:
+    """Reject goal/loop/heartbeat keys owned by any covered session."""
+    _required_table_columns(conn, "state_meta", ("key",))
+    for namespace in _STATE_META_SESSION_NAMESPACES:
+        for ids in _id_chunks(physical_ids):
+            keys = tuple(f"{namespace}:{session_id}" for session_id in ids)
+            placeholders = ",".join("?" for _ in keys)
+            row = conn.execute(
+                f"SELECT key FROM state_meta WHERE key IN ({placeholders}) LIMIT 1",
+                keys,
+            ).fetchone()
+            if row is None:
+                continue
+            key = str(row[0])
+            session_id = key.split(":", 1)[1]
+            raise ValueError(
+                "cold purge refuses state_meta soft reference to lineage "
+                f"session {session_id}: namespace={namespace!r}, key={key!r}"
+            )
+
+
+def _reject_async_delegation_references(
+    conn: sqlite3.Connection, physical_ids: tuple[str, ...]
+) -> None:
+    """Reject durable delegation rows naming any covered session."""
+    required_columns = ("delegation_id", *_ASYNC_DELEGATION_SESSION_COLUMNS)
+    _required_table_columns(conn, "async_delegations", required_columns)
+    for column in _ASYNC_DELEGATION_SESSION_COLUMNS:
+        quoted_column = _quoted_identifier(column)
+        for ids in _id_chunks(physical_ids):
+            placeholders = ",".join("?" for _ in ids)
+            row = conn.execute(
+                "SELECT delegation_id, "
+                f"{quoted_column} FROM async_delegations "
+                f"WHERE {quoted_column} IN ({placeholders}) LIMIT 1",
+                ids,
+            ).fetchone()
+            if row is None:
+                continue
+            raise ValueError(
+                "cold purge refuses async_delegations soft reference to "
+                f"lineage session {row[1]}: column={column!r}, "
+                f"delegation_id={str(row[0])!r}"
+            )
+
+
 def _reject_uncovered_session_references(
     conn: sqlite3.Connection, physical_ids: tuple[str, ...]
 ) -> None:
     """Fail if deleting the covered rows would mutate any unsnapshotted row."""
     _reject_gateway_routing_references(conn, physical_ids)
+    _reject_state_meta_references(conn, physical_ids)
+    _reject_async_delegation_references(conn, physical_ids)
     covered = set(physical_ids)
     chunks = _id_chunks(physical_ids)
     for ids in chunks:

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -14,11 +14,12 @@ import json
 import os
 from pathlib import Path
 import re
+import shutil
 import sqlite3
 import tempfile
 from typing import Any
 
-from hermes_state import SessionDB
+from hermes_state import SessionDB, resolved_max_export_messages
 
 
 @dataclass(frozen=True)
@@ -51,6 +52,21 @@ def _rows(conn: sqlite3.Connection, query: str, params: tuple[Any, ...]) -> list
         {column[0]: value for column, value in zip(cursor.description, row, strict=True)}
         for row in cursor.fetchall()
     ]
+
+
+def _enforce_message_limit(conn: sqlite3.Connection, physical_ids: tuple[str, ...]) -> None:
+    limit = resolved_max_export_messages()
+    if limit <= 0:
+        return
+    placeholders = ",".join("?" for _ in physical_ids)
+    count = conn.execute(
+        f"SELECT COUNT(*) FROM messages WHERE session_id IN ({placeholders})",
+        physical_ids,
+    ).fetchone()[0]
+    if count > limit:
+        raise ValueError(
+            f"cold store lineage has {count} messages, exceeding the configured export limit {limit}"
+        )
 
 
 def _session(conn: sqlite3.Connection, session_id: str) -> dict[str, Any] | None:
@@ -211,9 +227,19 @@ def _ensure_dir_tree_fsynced(path: Path) -> None:
         missing.append(current)
         current = current.parent
     for directory in reversed(missing):
-        directory.mkdir()
+        try:
+            directory.mkdir()
+        except FileExistsError:
+            pass
+        if not directory.is_dir() or directory.is_symlink():
+            raise ValueError(f"unsafe archive parent path: {directory}")
         _fsync_dir(directory)
         _fsync_dir(directory.parent)
+
+
+def _remove_staging(path: Path) -> None:
+    if path.exists():
+        shutil.rmtree(path)
 
 
 def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) -> StoredLineage:
@@ -246,6 +272,7 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
             if ended_at is None or rows[-1].get("end_reason") == "compression":
                 raise ValueError("terminal session must be ended and non-compression before cold storage")
 
+            _enforce_message_limit(conn, lineage)
             records = _records(conn, lineage)
             fingerprint = _fingerprint(records)
         finally:
@@ -285,15 +312,15 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
         )
         (staging / "artifacts").mkdir()
         _fsync_dir(staging)
-        os.replace(staging, revision_dir)
+        try:
+            os.replace(staging, revision_dir)
+        except FileExistsError:
+            if _valid_existing_revision(revision_dir, terminal_id, lineage, fingerprint):
+                _remove_staging(staging)
+                return StoredLineage(terminal_id, lineage, fingerprint, revision_dir)
+            raise
         _fsync_dir(revision_dir.parent)
     except BaseException:
-        if staging.exists():
-            for item in staging.iterdir():
-                if item.is_file():
-                    item.unlink()
-                elif item.is_dir():
-                    item.rmdir()
-            staging.rmdir()
+        _remove_staging(staging)
         raise
     return StoredLineage(terminal_id, lineage, fingerprint, revision_dir)

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -419,6 +419,15 @@ def _write_text_fsync_at(directory_fd: int, name: str, text: str) -> None:
         os.fsync(output.fileno())
 
 
+def _is_private_owned_entry(metadata: os.stat_result, *, directory: bool) -> bool:
+    expected_type = stat.S_ISDIR if directory else stat.S_ISREG
+    return (
+        expected_type(metadata.st_mode)
+        and metadata.st_uid == os.geteuid()
+        and stat.S_IMODE(metadata.st_mode) & 0o077 == 0
+    )
+
+
 def _read_regular_text_at(directory_fd: int, name: str) -> str | None:
     try:
         descriptor = os.open(
@@ -429,7 +438,7 @@ def _read_regular_text_at(directory_fd: int, name: str) -> str | None:
     except OSError:
         return None
     try:
-        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+        if not _is_private_owned_entry(os.fstat(descriptor), directory=False):
             return None
         with os.fdopen(descriptor, "r", encoding="utf-8", closefd=False) as source:
             try:
@@ -460,6 +469,8 @@ def _valid_existing_snapshot_at(
         return False
     try:
         try:
+            if not _is_private_owned_entry(os.fstat(snapshot_fd), directory=True):
+                return False
             metadata_text = _read_regular_text_at(snapshot_fd, "metadata.json")
             payload_text = _read_regular_text_at(snapshot_fd, "session.jsonl")
             if metadata_text is None or payload_text is None:
@@ -469,7 +480,13 @@ def _valid_existing_snapshot_at(
                 return False
             records = [json.loads(line) for line in payload_text.splitlines()]
             artifacts_fd = os.open("artifacts", _directory_open_flags(), dir_fd=snapshot_fd)
-            os.close(artifacts_fd)
+            try:
+                if not _is_private_owned_entry(
+                    os.fstat(artifacts_fd), directory=True
+                ):
+                    return False
+            finally:
+                os.close(artifacts_fd)
         except (OSError, json.JSONDecodeError):
             return False
         return (
@@ -1176,7 +1193,7 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
                 for record in records
             ),
         )
-        os.mkdir("artifacts", dir_fd=staging_fd)
+        os.mkdir("artifacts", 0o700, dir_fd=staging_fd)
         os.fsync(staging_fd)
         if not _valid_existing_snapshot_at(
             snapshot_parent_fd,

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -94,7 +94,15 @@ def _source_store_key(conn: sqlite3.Connection) -> str:
         database_path = row[2]
         if not isinstance(database_path, str) or not database_path:
             break
-        return sha256(os.fsencode(os.path.abspath(database_path))).hexdigest()[:16]
+        canonical_path = os.path.abspath(database_path)
+        try:
+            file_identity = os.stat(canonical_path)
+        except OSError as exc:
+            raise ValueError("cold store cannot identify the SQLite source store") from exc
+        namespace = (
+            f"{canonical_path}\x00{file_identity.st_dev}:{file_identity.st_ino}"
+        )
+        return sha256(os.fsencode(namespace)).hexdigest()[:16]
     raise ValueError("cold store requires a file-backed SQLite source store")
 
 

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -53,6 +53,44 @@ def _rows(conn: sqlite3.Connection, query: str, params: tuple[Any, ...]) -> list
     ]
 
 
+def _session(conn: sqlite3.Connection, session_id: str) -> dict[str, Any] | None:
+    rows = _rows(conn, "SELECT * FROM sessions WHERE id = ?", (session_id,))
+    return rows[0] if rows else None
+
+
+def _is_explicit_fork(row: dict[str, Any]) -> bool:
+    raw_config = row.get("model_config")
+    try:
+        config = json.loads(raw_config) if isinstance(raw_config, str) else raw_config or {}
+    except json.JSONDecodeError:
+        return True
+    if not isinstance(config, dict):
+        return True
+    parent_id = row.get("parent_session_id")
+    return bool(config.get("_branched_from") or config.get("_delegate_from")) and bool(parent_id)
+
+
+def _raw_compression_lineage(conn: sqlite3.Connection, terminal_id: str) -> tuple[str, ...]:
+    current = _session(conn, terminal_id)
+    if current is None:
+        raise ValueError(f"session not found: {terminal_id}")
+    if _is_explicit_fork(current):
+        return (terminal_id,)
+    lineage = [str(current["id"])]
+    seen = set(lineage)
+    while current.get("parent_session_id"):
+        parent = _session(conn, str(current["parent_session_id"]))
+        if parent is None or parent.get("end_reason") != "compression" or _is_explicit_fork(current):
+            break
+        parent_id = str(parent["id"])
+        if parent_id in seen:
+            raise ValueError("cyclic compression lineage")
+        lineage.append(parent_id)
+        seen.add(parent_id)
+        current = parent
+    return tuple(reversed(lineage))
+
+
 def _records(conn: sqlite3.Connection, physical_ids: tuple[str, ...]) -> list[dict[str, Any]]:
     records: list[dict[str, Any]] = []
     for session_id in physical_ids:
@@ -60,6 +98,16 @@ def _records(conn: sqlite3.Connection, physical_ids: tuple[str, ...]) -> list[di
         if len(sessions) != 1:
             raise ValueError(f"session disappeared while storing: {session_id}")
         records.append({"v": 1, "kind": "session-segment", "row": sessions[0]})
+        system_prompt_hash = sessions[0].get("system_prompt_hash")
+        if system_prompt_hash:
+            prompts = _rows(
+                conn,
+                "SELECT hash, prompt FROM system_prompts WHERE hash = ?",
+                (str(system_prompt_hash),),
+            )
+            if len(prompts) != 1:
+                raise ValueError(f"missing normalized system prompt: {system_prompt_hash}")
+            records.append({"v": 1, "kind": "system-prompt", "row": prompts[0]})
         records.extend(
             {"v": 1, "kind": "message", "row": row}
             for row in _rows(
@@ -109,16 +157,15 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
     fingerprint directory makes repeated stores idempotent and lets a later
     changed source produce a separate local revision.
     """
-    lineage = tuple(db.get_compression_lineage(terminal_id))
-    if not lineage:
-        raise ValueError(f"session not found: {terminal_id}")
+    conn = _connection(db)
+    lineage = _raw_compression_lineage(conn, terminal_id)
     if lineage[-1] != terminal_id:
         raise ValueError("store requires the terminal compression session ID")
 
-    sessions = [db.get_session(session_id) for session_id in lineage]
-    if any(session is None for session in sessions):
+    rows = [_session(conn, session_id) for session_id in lineage]
+    if any(session is None for session in rows):
         raise ValueError("compression lineage changed while resolving store candidate")
-    rows = [session for session in sessions if session is not None]
+    rows = [session for session in rows if session is not None]
     if any(not row.get("archived") for row in rows):
         raise ValueError("all compression lineage rows must be marked archived")
     if any(row.get("pinned") for row in rows):
@@ -127,7 +174,6 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
     if ended_at is None:
         raise ValueError("terminal session must be ended before cold storage")
 
-    conn = _connection(db)
     records = _records(conn, lineage)
     fingerprint = _fingerprint(records)
     terminal_date = datetime.fromtimestamp(float(ended_at), UTC)
@@ -144,6 +190,9 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
     )
     if revision_dir.exists():
         return StoredLineage(terminal_id, lineage, fingerprint, revision_dir)
+
+    if os.name == "nt":
+        raise OSError("cold store is not yet supported on Windows")
 
     revision_dir.parent.mkdir(parents=True, exist_ok=True)
     staging = Path(tempfile.mkdtemp(prefix=".staging-", dir=revision_dir.parent))

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -32,6 +32,7 @@ _COORDINATION_SESSION_REFERENCES = (
     ("compression_locks", "session_id"),
     ("session_turn_leases", "conversation_id"),
 )
+_PRE_UPGRADE_OPTIONAL_ASYNC_DELEGATION_COLUMNS = frozenset({"origin_session_id"})
 
 
 def _canonical_archive_root(archive_root: Path) -> Path:
@@ -876,7 +877,7 @@ def _reject_legacy_routing_references(physical_ids: tuple[str, ...]) -> None:
 
 def _required_table_columns(
     conn: sqlite3.Connection, table: str, required: tuple[str, ...]
-) -> None:
+) -> set[str]:
     """Reject stale or damaged soft-reference schemas before purge."""
     quoted_table = _quoted_identifier(table)
     rows = conn.execute(f"PRAGMA table_info({quoted_table})").fetchall()
@@ -888,6 +889,7 @@ def _required_table_columns(
             "cold purge cannot verify soft references because the session "
             f"database schema is missing {missing_names}"
         )
+    return columns
 
 
 def _reject_state_meta_references(
@@ -917,9 +919,26 @@ def _reject_async_delegation_references(
     conn: sqlite3.Connection, physical_ids: tuple[str, ...]
 ) -> None:
     """Reject durable delegation rows naming any covered session."""
-    required_columns = ("delegation_id", *ASYNC_DELEGATION_SESSION_COLUMNS)
-    _required_table_columns(conn, "async_delegations", required_columns)
+    required_columns = (
+        "delegation_id",
+        *(
+            column
+            for column in ASYNC_DELEGATION_SESSION_COLUMNS
+            if column not in _PRE_UPGRADE_OPTIONAL_ASYNC_DELEGATION_COLUMNS
+        ),
+    )
+    available_columns = _required_table_columns(
+        conn, "async_delegations", required_columns
+    )
     for column in ASYNC_DELEGATION_SESSION_COLUMNS:
+        if column not in available_columns:
+            # ``origin_session_id`` was added with an empty default. A read-only
+            # first post-upgrade dry-run cannot reconcile the schema, and an
+            # absent column cannot contain a reference. Older reference columns
+            # remain mandatory above so unknown schema damage still fails closed.
+            if column not in _PRE_UPGRADE_OPTIONAL_ASYNC_DELEGATION_COLUMNS:
+                raise AssertionError(f"required async delegation column missing: {column}")
+            continue
         quoted_column = _quoted_identifier(column)
         for ids in _id_chunks(physical_ids):
             placeholders = ",".join("?" for _ in ids)
@@ -1030,12 +1049,20 @@ def _reject_uncovered_session_references(
                     )
 
 
+def _build_sqlite_purge_reference_plan(
+    conn: sqlite3.Connection, terminal_id: str
+) -> _StorePlan:
+    """Build the source plan and reject references stored in SQLite."""
+    plan = _build_store_plan(conn, terminal_id)
+    _reject_uncovered_session_references(conn, plan.physical_ids)
+    return plan
+
+
 def _build_purge_reference_plan(
     conn: sqlite3.Connection, terminal_id: str
 ) -> _StorePlan:
-    """Build the archived source plan and reject every deletion reference."""
-    plan = _build_store_plan(conn, terminal_id)
-    _reject_uncovered_session_references(conn, plan.physical_ids)
+    """Build the source plan and reject SQLite plus legacy-file references."""
+    plan = _build_sqlite_purge_reference_plan(conn, terminal_id)
     _reject_legacy_routing_references(plan.physical_ids)
     return plan
 
@@ -1088,17 +1115,34 @@ def purge_archived_lineage(
 ) -> PurgedLineage:
     """Delete exactly one verified archived compression lineage from SQLite.
 
-    Store eligibility, source records, and the existing snapshot fingerprint
-    are re-read under the final ``BEGIN IMMEDIATE`` transaction. Archive files
-    are read for verification only and are never removed by this operation.
+    Archive and legacy-route files are verified before the final write
+    transaction. Store eligibility, source records, and SQLite references are
+    then re-read under ``BEGIN IMMEDIATE`` and compared with that evidence.
+    Archive files are never removed by this operation.
     """
     _require_supported_platform()
     archive_root = Path(os.path.abspath(os.fspath(archive_root)))
 
+    if not db.flush_token_counts():
+        raise RuntimeError("cold purge could not flush pending token accounting")
+
+    verified = validate_purge_archived_lineage(db, terminal_id, archive_root)
+
     def _purge(conn: sqlite3.Connection) -> PurgedLineage:
-        plan, snapshot_dir = _validated_purge_plan(
-            conn, terminal_id, archive_root
-        )
+        # Keep this final transaction SQLite-only and short. Supported gateway
+        # route persistence writes SQLite before its legacy mirror: a write that
+        # committed before BEGIN is visible here, while one that starts later is
+        # blocked and then rejected by the tombstone trigger after commit.
+        plan = _build_sqlite_purge_reference_plan(conn, terminal_id)
+        if (
+            plan.terminal_id != verified.terminal_id
+            or plan.physical_ids != verified.physical_ids
+            or plan.source_fingerprint != verified.source_fingerprint
+        ):
+            raise ValueError(
+                "cold purge source lineage changed after snapshot verification"
+            )
+        snapshot_dir = verified.snapshot_dir
 
         deleted_at = datetime.now(UTC).timestamp()
         conn.executemany(
@@ -1155,8 +1199,6 @@ def purge_archived_lineage(
             snapshot_dir,
         )
 
-    if not db.flush_token_counts():
-        raise RuntimeError("cold purge could not flush pending token accounting")
     return db._execute_write(_purge)
 
 

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -231,13 +231,19 @@ def _valid_existing_revision(revision_dir: Path, terminal_id: str, lineage: tupl
 
 
 def _ensure_dir_tree_fsynced(path: Path) -> None:
-    """Create a directory chain and fsync every new entry plus its parent."""
-    missing: list[Path] = []
+    """Create and validate every path component through the revision parent."""
+    chain: list[Path] = []
     current = path
-    while not current.exists():
-        missing.append(current)
+    while True:
+        chain.append(current)
+        if current.parent == current:
+            break
         current = current.parent
-    for directory in reversed(missing):
+    for directory in reversed(chain):
+        if directory.exists():
+            if not directory.is_dir() or directory.is_symlink():
+                raise ValueError(f"unsafe archive parent path: {directory}")
+            continue
         try:
             directory.mkdir()
         except FileExistsError:

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -309,7 +309,7 @@ def _unsafe_archive_parent(path: Path, exc: OSError | None = None) -> ValueError
 
 def _validate_directory_authority(descriptor: int, path: Path) -> None:
     opened = os.fstat(descriptor)
-    owner_is_trusted = opened.st_uid in {0, os.geteuid()}
+    owner_is_trusted = opened.st_uid in {0, os.geteuid()}  # windows-footgun: ok — cold store is POSIX-only and public entry points reject Windows
     writable_by_others = stat.S_IMODE(opened.st_mode) & 0o022
     sticky = opened.st_mode & stat.S_ISVTX
     if (
@@ -456,7 +456,7 @@ def _is_private_owned_entry(metadata: os.stat_result, *, directory: bool) -> boo
     expected_type = stat.S_ISDIR if directory else stat.S_ISREG
     return (
         expected_type(metadata.st_mode)
-        and metadata.st_uid == os.geteuid()
+        and metadata.st_uid == os.geteuid()  # windows-footgun: ok — cold store is POSIX-only and public entry points reject Windows
         and stat.S_IMODE(metadata.st_mode) & 0o077 == 0
     )
 

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -86,6 +86,12 @@ class _StorePlan:
     source_fingerprint: str
 
 
+@dataclass(frozen=True)
+class _StorePlanInputs:
+    message_limit: int
+    source_store_key: str
+
+
 def _source_store_key(conn: sqlite3.Connection) -> str:
     """Return a non-secret stable namespace for this file-backed SQLite store."""
     for row in conn.execute("PRAGMA database_list").fetchall():
@@ -127,8 +133,9 @@ def _rows(conn: sqlite3.Connection, query: str, params: tuple[Any, ...]) -> list
     ]
 
 
-def _enforce_message_limit(conn: sqlite3.Connection, physical_ids: tuple[str, ...]) -> None:
-    limit = resolved_max_export_messages()
+def _enforce_message_limit(
+    conn: sqlite3.Connection, physical_ids: tuple[str, ...], limit: int
+) -> None:
     if limit <= 0:
         return
     seen = 0
@@ -604,7 +611,11 @@ def _require_supported_platform() -> None:
         raise OSError("cold store is not yet supported on Windows")
 
 
-def _build_store_plan(conn: sqlite3.Connection, terminal_id: str) -> _StorePlan:
+def _build_store_plan(
+    conn: sqlite3.Connection,
+    terminal_id: str,
+    inputs: _StorePlanInputs,
+) -> _StorePlan:
     lineage = _raw_compression_lineage(conn, terminal_id)
     if lineage[-1] != terminal_id:
         raise ValueError("store requires the terminal compression session ID")
@@ -626,7 +637,7 @@ def _build_store_plan(conn: sqlite3.Connection, terminal_id: str) -> _StorePlan:
     if started_at is None:
         raise ValueError("terminal session must have a start time before cold storage")
 
-    _enforce_message_limit(conn, lineage)
+    _enforce_message_limit(conn, lineage, inputs.message_limit)
     records = _records(conn, lineage)
     _validate_sqlite_values(records)
     try:
@@ -640,9 +651,17 @@ def _build_store_plan(conn: sqlite3.Connection, terminal_id: str) -> _StorePlan:
         terminal_id=terminal_id,
         physical_ids=lineage,
         started_at=validated_started_at,
-        source_store_key=_source_store_key(conn),
+        source_store_key=inputs.source_store_key,
         records=records,
         source_fingerprint=_fingerprint(records),
+    )
+
+
+def _store_plan_inputs(conn: sqlite3.Connection) -> _StorePlanInputs:
+    """Resolve config and file identity before any SQLite transaction."""
+    return _StorePlanInputs(
+        message_limit=resolved_max_export_messages(),
+        source_store_key=_source_store_key(conn),
     )
 
 
@@ -650,9 +669,10 @@ def _read_store_plan(db: SessionDB, terminal_id: str) -> _StorePlan:
     """Build one transactionally consistent Store plan using SELECTs only."""
     conn = _connection(db)
     with db._lock:
+        inputs = _store_plan_inputs(conn)
         conn.execute("SAVEPOINT cold_store_snapshot")
         try:
-            return _build_store_plan(conn, terminal_id)
+            return _build_store_plan(conn, terminal_id, inputs)
         finally:
             conn.execute("RELEASE SAVEPOINT cold_store_snapshot")
 
@@ -1050,19 +1070,23 @@ def _reject_uncovered_session_references(
 
 
 def _build_sqlite_purge_reference_plan(
-    conn: sqlite3.Connection, terminal_id: str
+    conn: sqlite3.Connection,
+    terminal_id: str,
+    inputs: _StorePlanInputs,
 ) -> _StorePlan:
     """Build the source plan and reject references stored in SQLite."""
-    plan = _build_store_plan(conn, terminal_id)
+    plan = _build_store_plan(conn, terminal_id, inputs)
     _reject_uncovered_session_references(conn, plan.physical_ids)
     return plan
 
 
 def _build_purge_reference_plan(
-    conn: sqlite3.Connection, terminal_id: str
+    conn: sqlite3.Connection,
+    terminal_id: str,
+    inputs: _StorePlanInputs,
 ) -> _StorePlan:
     """Build the source plan and reject SQLite plus legacy-file references."""
-    plan = _build_sqlite_purge_reference_plan(conn, terminal_id)
+    plan = _build_sqlite_purge_reference_plan(conn, terminal_id, inputs)
     _reject_legacy_routing_references(plan.physical_ids)
     return plan
 
@@ -1072,42 +1096,57 @@ def preflight_purge_archived_lineage(db: SessionDB, terminal_id: str) -> None:
     _require_supported_platform()
     conn = _connection(db)
     with db._lock:
+        inputs = _store_plan_inputs(conn)
         conn.execute("SAVEPOINT cold_purge_reference_preflight")
         try:
-            _build_purge_reference_plan(conn, terminal_id)
+            _build_purge_reference_plan(conn, terminal_id, inputs)
         finally:
             conn.execute("RELEASE SAVEPOINT cold_purge_reference_preflight")
 
 
 def _validated_purge_plan(
-    conn: sqlite3.Connection, terminal_id: str, archive_root: Path
+    conn: sqlite3.Connection,
+    terminal_id: str,
+    archive_root: Path,
+    inputs: _StorePlanInputs,
 ) -> tuple[_StorePlan, Path]:
-    plan = _build_purge_reference_plan(conn, terminal_id)
+    plan = _build_purge_reference_plan(conn, terminal_id, inputs)
     snapshot_dir = _verify_plan_snapshot(archive_root, plan)
     return plan, snapshot_dir
+
+
+def _validate_purge_with_inputs(
+    db: SessionDB, terminal_id: str, archive_root: Path
+) -> tuple[VerifiedLineage, _StorePlanInputs]:
+    _require_supported_platform()
+    archive_root = Path(os.path.abspath(os.fspath(archive_root)))
+    conn = _connection(db)
+    with db._lock:
+        inputs = _store_plan_inputs(conn)
+        conn.execute("SAVEPOINT cold_purge_snapshot")
+        try:
+            plan, snapshot_dir = _validated_purge_plan(
+                conn, terminal_id, archive_root, inputs
+            )
+        finally:
+            conn.execute("RELEASE SAVEPOINT cold_purge_snapshot")
+    return (
+        VerifiedLineage(
+            plan.terminal_id,
+            plan.physical_ids,
+            plan.source_fingerprint,
+            snapshot_dir,
+        ),
+        inputs,
+    )
 
 
 def validate_purge_archived_lineage(
     db: SessionDB, terminal_id: str, archive_root: Path
 ) -> VerifiedLineage:
     """Run the final Purge eligibility gate without deleting any rows."""
-    _require_supported_platform()
-    archive_root = Path(os.path.abspath(os.fspath(archive_root)))
-    conn = _connection(db)
-    with db._lock:
-        conn.execute("SAVEPOINT cold_purge_snapshot")
-        try:
-            plan, snapshot_dir = _validated_purge_plan(
-                conn, terminal_id, archive_root
-            )
-        finally:
-            conn.execute("RELEASE SAVEPOINT cold_purge_snapshot")
-    return VerifiedLineage(
-        plan.terminal_id,
-        plan.physical_ids,
-        plan.source_fingerprint,
-        snapshot_dir,
-    )
+    verified, _inputs = _validate_purge_with_inputs(db, terminal_id, archive_root)
+    return verified
 
 
 def purge_archived_lineage(
@@ -1126,14 +1165,14 @@ def purge_archived_lineage(
     if not db.flush_token_counts():
         raise RuntimeError("cold purge could not flush pending token accounting")
 
-    verified = validate_purge_archived_lineage(db, terminal_id, archive_root)
+    verified, inputs = _validate_purge_with_inputs(db, terminal_id, archive_root)
 
     def _purge(conn: sqlite3.Connection) -> PurgedLineage:
         # Keep this final transaction SQLite-only and short. Supported gateway
         # route persistence writes SQLite before its legacy mirror: a write that
         # committed before BEGIN is visible here, while one that starts later is
         # blocked and then rejected by the tombstone trigger after commit.
-        plan = _build_sqlite_purge_reference_plan(conn, terminal_id)
+        plan = _build_sqlite_purge_reference_plan(conn, terminal_id, inputs)
         if (
             plan.terminal_id != verified.terminal_id
             or plan.physical_ids != verified.physical_ids
@@ -1237,6 +1276,11 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
         )
         if existing is True:
             _validate_directory_chain(edges)
+            # A prior publication may have made this exact snapshot visible
+            # before its parent-directory fsync failed. Idempotent success must
+            # establish the missing rename durability barrier, not merely trust
+            # the visible directory entry.
+            os.fsync(snapshot_parent_fd)
             return StoredLineage(terminal_id, lineage, fingerprint, snapshot_dir)
 
         staging_name, staging_fd = _create_staging_directory(snapshot_parent_fd)

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -55,10 +55,9 @@ def _connection(db: SessionDB) -> sqlite3.Connection:
 
 def _safe_component(value: str) -> str:
     raw = str(value or "")
-    safe = re.sub(r"[^A-Za-z0-9_-]", "_", raw.strip()).strip("._")[:96] or "session"
-    if raw == safe:
-        return safe
-    return f"{safe}_{sha256(raw.encode('utf-8', 'surrogatepass')).hexdigest()[:12]}"
+    safe = re.sub(r"[^A-Za-z0-9_-]", "_", raw).strip("._")[:96] or "session"
+    digest = sha256(raw.encode("utf-8", "surrogatepass")).hexdigest()[:12]
+    return f"{safe}_{digest}"
 
 
 def _rows(conn: sqlite3.Connection, query: str, params: tuple[Any, ...]) -> list[dict[str, Any]]:

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
+import errno
 from hashlib import sha256
 import json
 import os
@@ -324,7 +325,9 @@ def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) 
         _fsync_dir(staging)
         try:
             os.replace(staging, revision_dir)
-        except FileExistsError:
+        except OSError as exc:
+            if exc.errno not in (errno.EEXIST, errno.ENOTEMPTY):
+                raise
             if _valid_existing_revision(revision_dir, terminal_id, lineage, fingerprint):
                 _remove_staging(staging)
                 return StoredLineage(terminal_id, lineage, fingerprint, revision_dir)

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -643,10 +643,45 @@ def _id_chunks(ids: tuple[str, ...]) -> list[tuple[str, ...]]:
     ]
 
 
+def _reject_gateway_routing_references(
+    conn: sqlite3.Connection, physical_ids: tuple[str, ...]
+) -> None:
+    """Fail closed on gateway routes that may name a covered session."""
+    covered = set(physical_ids)
+    rows = conn.execute(
+        "SELECT scope, session_key, entry_json FROM gateway_routing"
+    ).fetchall()
+    for row in rows:
+        scope = str(row[0])
+        session_key = str(row[1])
+        try:
+            entry = json.loads(row[2])
+        except Exception as exc:
+            raise ValueError(
+                "cold purge refuses gateway_routing row whose session reference "
+                "cannot be verified: "
+                f"scope={scope!r}, session_key={session_key!r}"
+            ) from exc
+        if not isinstance(entry, dict):
+            raise ValueError(
+                "cold purge refuses gateway_routing row whose session reference "
+                "cannot be verified: "
+                f"scope={scope!r}, session_key={session_key!r}"
+            )
+        session_id = entry.get("session_id")
+        if isinstance(session_id, str) and session_id in covered:
+            raise ValueError(
+                "cold purge refuses gateway_routing soft reference to lineage "
+                f"session {session_id}: scope={scope!r}, "
+                f"session_key={session_key!r}"
+            )
+
+
 def _reject_uncovered_session_references(
     conn: sqlite3.Connection, physical_ids: tuple[str, ...]
 ) -> None:
     """Fail if deleting the covered rows would mutate any unsnapshotted row."""
+    _reject_gateway_routing_references(conn, physical_ids)
     covered = set(physical_ids)
     chunks = _id_chunks(physical_ids)
     for ids in chunks:
@@ -694,6 +729,38 @@ def _reject_uncovered_session_references(
                     )
 
 
+def _validated_purge_plan(
+    conn: sqlite3.Connection, terminal_id: str, archive_root: Path
+) -> tuple[_StorePlan, Path]:
+    plan = _build_store_plan(conn, terminal_id)
+    snapshot_dir = _verify_plan_snapshot(archive_root, plan)
+    _reject_uncovered_session_references(conn, plan.physical_ids)
+    return plan, snapshot_dir
+
+
+def validate_purge_archived_lineage(
+    db: SessionDB, terminal_id: str, archive_root: Path
+) -> VerifiedLineage:
+    """Run the final Purge eligibility gate without deleting any rows."""
+    _require_supported_platform()
+    archive_root = Path(os.path.abspath(os.fspath(archive_root)))
+    conn = _connection(db)
+    with db._lock:
+        conn.execute("SAVEPOINT cold_purge_snapshot")
+        try:
+            plan, snapshot_dir = _validated_purge_plan(
+                conn, terminal_id, archive_root
+            )
+        finally:
+            conn.execute("RELEASE SAVEPOINT cold_purge_snapshot")
+    return VerifiedLineage(
+        plan.terminal_id,
+        plan.physical_ids,
+        plan.source_fingerprint,
+        snapshot_dir,
+    )
+
+
 def purge_archived_lineage(
     db: SessionDB, terminal_id: str, archive_root: Path
 ) -> PurgedLineage:
@@ -707,9 +774,9 @@ def purge_archived_lineage(
     archive_root = Path(os.path.abspath(os.fspath(archive_root)))
 
     def _purge(conn: sqlite3.Connection) -> PurgedLineage:
-        plan = _build_store_plan(conn, terminal_id)
-        snapshot_dir = _verify_plan_snapshot(archive_root, plan)
-        _reject_uncovered_session_references(conn, plan.physical_ids)
+        plan, snapshot_dir = _validated_purge_plan(
+            conn, terminal_id, archive_root
+        )
 
         prompt_hashes = tuple(
             sorted(

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -829,12 +829,32 @@ def _reject_uncovered_session_references(
                     )
 
 
+def _build_purge_reference_plan(
+    conn: sqlite3.Connection, terminal_id: str
+) -> _StorePlan:
+    """Build the archived source plan and reject every deletion reference."""
+    plan = _build_store_plan(conn, terminal_id)
+    _reject_uncovered_session_references(conn, plan.physical_ids)
+    return plan
+
+
+def preflight_purge_archived_lineage(db: SessionDB, terminal_id: str) -> None:
+    """Check Store planning and Purge references without a snapshot or writes."""
+    _require_supported_platform()
+    conn = _connection(db)
+    with db._lock:
+        conn.execute("SAVEPOINT cold_purge_reference_preflight")
+        try:
+            _build_purge_reference_plan(conn, terminal_id)
+        finally:
+            conn.execute("RELEASE SAVEPOINT cold_purge_reference_preflight")
+
+
 def _validated_purge_plan(
     conn: sqlite3.Connection, terminal_id: str, archive_root: Path
 ) -> tuple[_StorePlan, Path]:
-    plan = _build_store_plan(conn, terminal_id)
+    plan = _build_purge_reference_plan(conn, terminal_id)
     snapshot_dir = _verify_plan_snapshot(archive_root, plan)
-    _reject_uncovered_session_references(conn, plan.physical_ids)
     return plan, snapshot_dir
 
 

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -1,4 +1,4 @@
-"""Local cold archive Store and read-only Verify primitives."""
+"""Local cold archive Store, read-only Verify, and explicit Purge primitives."""
 
 from __future__ import annotations
 
@@ -37,6 +37,16 @@ class StoredLineage:
 @dataclass(frozen=True)
 class VerifiedLineage:
     """Identity of a current snapshot verified against its live Store plan."""
+
+    terminal_id: str
+    physical_ids: tuple[str, ...]
+    source_fingerprint: str
+    snapshot_dir: Path
+
+
+@dataclass(frozen=True)
+class PurgedLineage:
+    """Identity deleted from SQLite while its verified snapshot remains local."""
 
     terminal_id: str
     physical_ids: tuple[str, ...]
@@ -569,17 +579,8 @@ def _open_existing_snapshot_parent(
     return descriptors, edges
 
 
-def verify_archived_lineage(
-    db: SessionDB, terminal_id: str, archive_root: Path
-) -> VerifiedLineage:
-    """Verify one existing current snapshot against the live Store plan.
-
-    This primitive is strictly read-only: it performs no database writes and
-    opens only existing archive directories and payloads with no-follow flags.
-    """
-    _require_supported_platform()
-    archive_root = Path(os.path.abspath(os.fspath(archive_root)))
-    plan = _read_store_plan(db, terminal_id)
+def _verify_plan_snapshot(archive_root: Path, plan: _StorePlan) -> Path:
+    """Verify the existing snapshot for an already-consistent Store plan."""
     snapshot_dir, snapshot_name, parent_parts = _snapshot_location(
         archive_root, plan
     )
@@ -608,12 +609,153 @@ def verify_archived_lineage(
     finally:
         for descriptor in reversed(descriptors):
             os.close(descriptor)
+    return snapshot_dir
+
+
+def verify_archived_lineage(
+    db: SessionDB, terminal_id: str, archive_root: Path
+) -> VerifiedLineage:
+    """Verify one existing current snapshot against the live Store plan.
+
+    This primitive is strictly read-only: it performs no database writes and
+    opens only existing archive directories and payloads with no-follow flags.
+    """
+    _require_supported_platform()
+    archive_root = Path(os.path.abspath(os.fspath(archive_root)))
+    plan = _read_store_plan(db, terminal_id)
+    snapshot_dir = _verify_plan_snapshot(archive_root, plan)
     return VerifiedLineage(
         plan.terminal_id,
         plan.physical_ids,
         plan.source_fingerprint,
         snapshot_dir,
     )
+
+
+def _quoted_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def _id_chunks(ids: tuple[str, ...]) -> list[tuple[str, ...]]:
+    return [
+        ids[start : start + _MAX_SQLITE_IN_PARAMS]
+        for start in range(0, len(ids), _MAX_SQLITE_IN_PARAMS)
+    ]
+
+
+def _reject_uncovered_session_references(
+    conn: sqlite3.Connection, physical_ids: tuple[str, ...]
+) -> None:
+    """Fail if deleting the covered rows would mutate any unsnapshotted row."""
+    covered = set(physical_ids)
+    chunks = _id_chunks(physical_ids)
+    for ids in chunks:
+        placeholders = ",".join("?" for _ in ids)
+        children = conn.execute(
+            f"SELECT id FROM sessions WHERE parent_session_id IN ({placeholders})",
+            ids,
+        ).fetchall()
+        uncovered = [str(row[0]) for row in children if str(row[0]) not in covered]
+        if uncovered:
+            raise ValueError(
+                "cold purge refuses an uncovered child session referencing the "
+                f"lineage: {uncovered[0]}"
+            )
+
+    tables = conn.execute(
+        "SELECT name FROM sqlite_schema "
+        "WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+    ).fetchall()
+    covered_fk_tables = {"messages", "session_model_usage", "sessions"}
+    for table_row in tables:
+        table = str(table_row[0])
+        if table in covered_fk_tables:
+            continue
+        quoted_table = _quoted_identifier(table)
+        foreign_keys = conn.execute(
+            f"PRAGMA foreign_key_list({quoted_table})"
+        ).fetchall()
+        for foreign_key in foreign_keys:
+            if str(foreign_key[2]) != "sessions":
+                continue
+            source_column = str(foreign_key[3])
+            quoted_column = _quoted_identifier(source_column)
+            for ids in chunks:
+                placeholders = ",".join("?" for _ in ids)
+                referenced = conn.execute(
+                    f"SELECT 1 FROM {quoted_table} "
+                    f"WHERE {quoted_column} IN ({placeholders}) LIMIT 1",
+                    ids,
+                ).fetchone()
+                if referenced is not None:
+                    raise ValueError(
+                        "cold purge refuses an uncovered foreign-key row in "
+                        f"{table}.{source_column}"
+                    )
+
+
+def purge_archived_lineage(
+    db: SessionDB, terminal_id: str, archive_root: Path
+) -> PurgedLineage:
+    """Delete exactly one verified archived compression lineage from SQLite.
+
+    Store eligibility, source records, and the existing snapshot fingerprint
+    are re-read under the final ``BEGIN IMMEDIATE`` transaction. Archive files
+    are read for verification only and are never removed by this operation.
+    """
+    _require_supported_platform()
+    archive_root = Path(os.path.abspath(os.fspath(archive_root)))
+
+    def _purge(conn: sqlite3.Connection) -> PurgedLineage:
+        plan = _build_store_plan(conn, terminal_id)
+        snapshot_dir = _verify_plan_snapshot(archive_root, plan)
+        _reject_uncovered_session_references(conn, plan.physical_ids)
+
+        prompt_hashes = tuple(
+            sorted(
+                {
+                    str(record["row"]["hash"])
+                    for record in plan.records
+                    if record["kind"] == "system-prompt"
+                }
+            )
+        )
+        for ids in _id_chunks(plan.physical_ids):
+            placeholders = ",".join("?" for _ in ids)
+            conn.execute(
+                f"DELETE FROM messages WHERE session_id IN ({placeholders})", ids
+            )
+            conn.execute(
+                "DELETE FROM session_model_usage "
+                f"WHERE session_id IN ({placeholders})",
+                ids,
+            )
+        deleted_rows = 0
+        for ids in _id_chunks(tuple(reversed(plan.physical_ids))):
+            placeholders = ",".join("?" for _ in ids)
+            cursor = conn.execute(
+                f"DELETE FROM sessions WHERE id IN ({placeholders})", ids
+            )
+            deleted_rows += cursor.rowcount
+        if deleted_rows != len(plan.physical_ids):
+            raise RuntimeError("cold purge source lineage changed during deletion")
+        for hashes in _id_chunks(prompt_hashes):
+            placeholders = ",".join("?" for _ in hashes)
+            conn.execute(
+                f"DELETE FROM system_prompts WHERE hash IN ({placeholders}) "
+                "AND NOT EXISTS ("
+                "SELECT 1 FROM sessions "
+                "WHERE sessions.system_prompt_hash = system_prompts.hash)",
+                hashes,
+            )
+        return PurgedLineage(
+            plan.terminal_id,
+            plan.physical_ids,
+            plan.source_fingerprint,
+            snapshot_dir,
+        )
+
+    return db._execute_write(_purge)
 
 
 def store_archived_lineage(db: SessionDB, terminal_id: str, archive_root: Path) -> StoredLineage:

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -319,6 +319,8 @@ def _valid_existing_snapshot_at(
             if metadata_text is None or payload_text is None:
                 return False
             metadata = json.loads(metadata_text)
+            if not isinstance(metadata, dict):
+                return False
             records = [json.loads(line) for line in payload_text.splitlines()]
             artifacts_fd = os.open("artifacts", _directory_open_flags(), dir_fd=snapshot_fd)
             os.close(artifacts_fd)

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -28,6 +28,10 @@ _ASYNC_DELEGATION_SESSION_COLUMNS = (
     "parent_session_id",
     "origin_session_id",
 )
+_COORDINATION_SESSION_REFERENCES = (
+    ("compression_locks", "session_id"),
+    ("session_turn_leases", "conversation_id"),
+)
 
 
 @dataclass(frozen=True)
@@ -747,6 +751,29 @@ def _reject_async_delegation_references(
             )
 
 
+def _reject_coordination_references(
+    conn: sqlite3.Connection, physical_ids: tuple[str, ...]
+) -> None:
+    """Reject locks or turn leases naming any covered session."""
+    for table, column in _COORDINATION_SESSION_REFERENCES:
+        _required_table_columns(conn, table, (column,))
+        quoted_table = _quoted_identifier(table)
+        quoted_column = _quoted_identifier(column)
+        for ids in _id_chunks(physical_ids):
+            placeholders = ",".join("?" for _ in ids)
+            row = conn.execute(
+                f"SELECT {quoted_column} FROM {quoted_table} "
+                f"WHERE {quoted_column} IN ({placeholders}) LIMIT 1",
+                ids,
+            ).fetchone()
+            if row is None:
+                continue
+            raise ValueError(
+                f"cold purge refuses {table}.{column} soft reference to "
+                f"lineage session {row[0]}"
+            )
+
+
 def _reject_uncovered_session_references(
     conn: sqlite3.Connection, physical_ids: tuple[str, ...]
 ) -> None:
@@ -754,6 +781,7 @@ def _reject_uncovered_session_references(
     _reject_gateway_routing_references(conn, physical_ids)
     _reject_state_meta_references(conn, physical_ids)
     _reject_async_delegation_references(conn, physical_ids)
+    _reject_coordination_references(conn, physical_ids)
     covered = set(physical_ids)
     chunks = _id_chunks(physical_ids)
     for ids in chunks:

--- a/hermes_cli/session_cold_store.py
+++ b/hermes_cli/session_cold_store.py
@@ -1101,6 +1101,8 @@ def purge_archived_lineage(
             snapshot_dir,
         )
 
+    if not db.flush_token_counts():
+        raise RuntimeError("cold purge could not flush pending token accounting")
     return db._execute_write(_purge)
 
 

--- a/hermes_cli/session_lost_and_found.py
+++ b/hermes_cli/session_lost_and_found.py
@@ -28,6 +28,7 @@ import shutil
 import sqlite3
 import subprocess
 import tempfile
+from math import isfinite
 from pathlib import Path
 from typing import Any, Optional
 
@@ -251,8 +252,22 @@ def classify_lost_and_found_row(
 ) -> Optional[str]:
     """Classify one lost_and_found record by field count + sentinel values.
 
-    Returns 'sessions', 'messages', 'session_model_usage', or None.
+    Returns a recognized canonical table name or None.
     """
+
+    if (
+        nfield == 4
+        and len(cells) == 4
+        and isinstance(cells[0], str)
+        and bool(cells[0])
+        and isinstance(cells[1], str)
+        and bool(cells[1])
+        and isinstance(cells[2], str)
+        and re.fullmatch(r"[0-9a-f]{64}", cells[2]) is not None
+        and type(cells[3]) in {int, float}
+        and isfinite(float(cells[3]))
+    ):
+        return "cold_archive_tombstones"
 
     if len(cells) >= 3 and cells[0] is None:
         # Rowid-alias tables store their INTEGER PRIMARY KEY as NULL in the
@@ -331,6 +346,7 @@ def _copy_direct_tables(
         "sessions",
         "messages",
         "session_model_usage",
+        "cold_archive_tombstones",
         "compression_locks",
         "gateway_routing",
         "async_delegations",
@@ -370,7 +386,12 @@ def map_lost_and_found_rows(
 
     report: dict[str, Any] = {
         "direct_table_rows": {},
-        "mapped": {"sessions": 0, "messages": 0, "session_model_usage": 0},
+        "mapped": {
+            "sessions": 0,
+            "messages": 0,
+            "session_model_usage": 0,
+            "cold_archive_tombstones": 0,
+        },
         "legacy_minimal_sessions": 0,
         "unmapped_rows": 0,
         "insert_conflicts": 0,
@@ -384,6 +405,7 @@ def map_lost_and_found_rows(
         sessions_columns = _table_columns(dest, "sessions")
         messages_columns = _table_columns(dest, "messages")
         usage_columns = _table_columns(dest, "session_model_usage")
+        tombstone_columns = _table_columns(dest, "cold_archive_tombstones")
         sessions_defaults = _notnull_defaults(dest, "sessions")
         messages_defaults = _notnull_defaults(dest, "messages")
         usage_defaults = _notnull_defaults(dest, "session_model_usage")
@@ -425,7 +447,14 @@ def map_lost_and_found_rows(
                     report["unmapped_rows"] += 1
                     continue
                 try:
-                    if kind == "messages":
+                    if kind == "cold_archive_tombstones":
+                        inserted = _insert_prefix_row(
+                            dest,
+                            "cold_archive_tombstones",
+                            tombstone_columns,
+                            list(cells),
+                        )
+                    elif kind == "messages":
                         values = [lf_rowid, *cells[1 : min(nfield, len(messages_columns))]]
                         inserted = _insert_prefix_row(
                             dest, "messages", messages_columns, values,

--- a/hermes_cli/session_lost_and_found.py
+++ b/hermes_cli/session_lost_and_found.py
@@ -33,6 +33,11 @@ from math import isfinite
 from pathlib import Path
 from typing import Any, Optional
 
+from hermes_cli.session_reference_contract import (
+    ASYNC_DELEGATION_SESSION_COLUMNS,
+    STATE_META_SESSION_NAMESPACES,
+)
+
 # Hermes session ids are timestamps: 20260812_135332_ab12cd. This is the
 # strongest sentinel available for classifying schema-less rows.
 SESSION_ID_PATTERN = re.compile(r"^\d{8}_\d{6}_")
@@ -347,9 +352,10 @@ def _copy_direct_tables(
         "sessions",
         "messages",
         "session_model_usage",
+        "state_meta",
+        "gateway_routing",
         "cold_archive_tombstones",
         "compression_locks",
-        "gateway_routing",
         "async_delegations",
     ):
         source_columns = _table_columns(lf_conn, table)
@@ -377,6 +383,8 @@ def _copy_direct_tables(
 
 def reconcile_cold_archive_tombstones(
     destination: sqlite3.Connection,
+    *,
+    rejected_prompt_hashes: set[str] | None = None,
 ) -> dict[str, int]:
     """Remove recovered hot rows whose IDs carry cold-archive authority."""
 
@@ -386,6 +394,8 @@ def reconcile_cold_archive_tombstones(
         "system_prompts_removed": 0,
         "gateway_routes_removed": 0,
         "gateway_routes_unverifiable": 0,
+        "state_meta_removed": 0,
+        "async_delegations_removed": 0,
         "messages_removed": 0,
         "session_model_usage_removed": 0,
         "compression_locks_removed": 0,
@@ -410,12 +420,34 @@ def reconcile_cold_archive_tombstones(
                 "AND system_prompt_hash IS NOT NULL"
             ).fetchall()
         }
+        prompt_hashes.update(rejected_prompt_hashes or ())
         parent_cursor = destination.execute(
             "UPDATE sessions SET parent_session_id = NULL "
             "WHERE parent_session_id IN ("
             "SELECT session_id FROM cold_archive_tombstones)"
         )
         result["sessions_parent_cleared"] = parent_cursor.rowcount
+
+        if _table_columns(destination, "state_meta"):
+            for namespace in STATE_META_SESSION_NAMESPACES:
+                cursor = destination.execute(
+                    "DELETE FROM state_meta WHERE key IN ("
+                    "SELECT ? || ':' || session_id "
+                    "FROM cold_archive_tombstones)",
+                    (namespace,),
+                )
+                result["state_meta_removed"] += cursor.rowcount
+
+        if _table_columns(destination, "async_delegations"):
+            predicates = " OR ".join(
+                f'"{column}" IN (SELECT session_id '
+                "FROM cold_archive_tombstones)"
+                for column in ASYNC_DELEGATION_SESSION_COLUMNS
+            )
+            cursor = destination.execute(
+                f"DELETE FROM async_delegations WHERE {predicates}"
+            )
+            result["async_delegations_removed"] = cursor.rowcount
 
         if _table_columns(destination, "gateway_routing"):
             route_rows = destination.execute(
@@ -499,6 +531,7 @@ def map_lost_and_found_rows(
         "insert_conflicts": 0,
         "lost_and_found_tables": [],
     }
+    rejected_session_prompts: set[tuple[str, str]] = set()
 
     dest.execute("BEGIN IMMEDIATE")
     try:
@@ -508,6 +541,10 @@ def map_lost_and_found_rows(
         messages_columns = _table_columns(dest, "messages")
         usage_columns = _table_columns(dest, "session_model_usage")
         tombstone_columns = _table_columns(dest, "cold_archive_tombstones")
+        try:
+            system_prompt_hash_index = sessions_columns.index("system_prompt_hash")
+        except ValueError:
+            system_prompt_hash_index = -1
         sessions_defaults = _notnull_defaults(dest, "sessions")
         messages_defaults = _notnull_defaults(dest, "messages")
         usage_defaults = _notnull_defaults(dest, "session_model_usage")
@@ -548,6 +585,18 @@ def map_lost_and_found_rows(
                 if kind is None:
                     report["unmapped_rows"] += 1
                     continue
+                rejected_prompt_candidate: tuple[str, str] | None = None
+                if (
+                    kind == "sessions"
+                    and system_prompt_hash_index >= 0
+                    and len(cells) > system_prompt_hash_index
+                    and isinstance(cells[0], str)
+                    and isinstance(cells[system_prompt_hash_index], str)
+                ):
+                    rejected_prompt_candidate = (
+                        cells[0],
+                        cells[system_prompt_hash_index],
+                    )
                 try:
                     if kind == "cold_archive_tombstones":
                         inserted = _insert_prefix_row(
@@ -597,6 +646,8 @@ def map_lost_and_found_rows(
                             sessions_defaults,
                         )
                 except sqlite3.DatabaseError:
+                    if rejected_prompt_candidate is not None:
+                        rejected_session_prompts.add(rejected_prompt_candidate)
                     report["unmapped_rows"] += 1
                     continue
                 if inserted:
@@ -604,8 +655,24 @@ def map_lost_and_found_rows(
                         "sessions" if kind == "sessions" else kind
                     ] += 1
                 else:
+                    if rejected_prompt_candidate is not None:
+                        rejected_session_prompts.add(rejected_prompt_candidate)
                     report["insert_conflicts"] += 1
-        report["tombstone_reconciliation"] = reconcile_cold_archive_tombstones(dest)
+        tombstoned_ids = {
+            str(row[0])
+            for row in dest.execute(
+                "SELECT session_id FROM cold_archive_tombstones"
+            ).fetchall()
+        }
+        rejected_prompt_hashes = {
+            prompt_hash
+            for session_id, prompt_hash in rejected_session_prompts
+            if session_id in tombstoned_ids
+        }
+        report["tombstone_reconciliation"] = reconcile_cold_archive_tombstones(
+            dest,
+            rejected_prompt_hashes=rejected_prompt_hashes,
+        )
         dest.execute("COMMIT")
     except BaseException:
         dest.execute("ROLLBACK")

--- a/hermes_cli/session_lost_and_found.py
+++ b/hermes_cli/session_lost_and_found.py
@@ -374,6 +374,61 @@ def _copy_direct_tables(
     return copied
 
 
+def reconcile_cold_archive_tombstones(
+    destination: sqlite3.Connection,
+) -> dict[str, int]:
+    """Remove recovered hot rows whose IDs carry cold-archive authority."""
+
+    result = {
+        "sessions_removed": 0,
+        "sessions_parent_cleared": 0,
+        "messages_removed": 0,
+        "session_model_usage_removed": 0,
+        "compression_locks_removed": 0,
+        "telegram_dm_topic_bindings_removed": 0,
+    }
+    if not _table_columns(destination, "cold_archive_tombstones"):
+        return result
+
+    destination.execute("SAVEPOINT reconcile_cold_archive_tombstones")
+    try:
+        parent_cursor = destination.execute(
+            "UPDATE sessions SET parent_session_id = NULL "
+            "WHERE parent_session_id IN ("
+            "SELECT session_id FROM cold_archive_tombstones)"
+        )
+        result["sessions_parent_cleared"] = parent_cursor.rowcount
+
+        for table, report_key in (
+            ("messages", "messages_removed"),
+            ("session_model_usage", "session_model_usage_removed"),
+            ("compression_locks", "compression_locks_removed"),
+            (
+                "telegram_dm_topic_bindings",
+                "telegram_dm_topic_bindings_removed",
+            ),
+        ):
+            if not _table_columns(destination, table):
+                continue
+            cursor = destination.execute(
+                f'DELETE FROM "{table}" WHERE session_id IN ('
+                "SELECT session_id FROM cold_archive_tombstones)"
+            )
+            result[report_key] = cursor.rowcount
+
+        sessions_cursor = destination.execute(
+            "DELETE FROM sessions WHERE id IN ("
+            "SELECT session_id FROM cold_archive_tombstones)"
+        )
+        result["sessions_removed"] = sessions_cursor.rowcount
+        destination.execute("RELEASE SAVEPOINT reconcile_cold_archive_tombstones")
+    except BaseException:
+        destination.execute("ROLLBACK TO SAVEPOINT reconcile_cold_archive_tombstones")
+        destination.execute("RELEASE SAVEPOINT reconcile_cold_archive_tombstones")
+        raise
+    return result
+
+
 def map_lost_and_found_rows(
     lf_conn: sqlite3.Connection,
     dest: sqlite3.Connection,
@@ -503,6 +558,7 @@ def map_lost_and_found_rows(
                     ] += 1
                 else:
                     report["insert_conflicts"] += 1
+        report["tombstone_reconciliation"] = reconcile_cold_archive_tombstones(dest)
         dest.execute("COMMIT")
     except BaseException:
         dest.execute("ROLLBACK")

--- a/hermes_cli/session_lost_and_found.py
+++ b/hermes_cli/session_lost_and_found.py
@@ -23,6 +23,7 @@ data, and derived FTS indexes are rebuilt from scratch.
 
 from __future__ import annotations
 
+import json
 import re
 import shutil
 import sqlite3
@@ -382,6 +383,9 @@ def reconcile_cold_archive_tombstones(
     result = {
         "sessions_removed": 0,
         "sessions_parent_cleared": 0,
+        "system_prompts_removed": 0,
+        "gateway_routes_removed": 0,
+        "gateway_routes_unverifiable": 0,
         "messages_removed": 0,
         "session_model_usage_removed": 0,
         "compression_locks_removed": 0,
@@ -392,12 +396,48 @@ def reconcile_cold_archive_tombstones(
 
     destination.execute("SAVEPOINT reconcile_cold_archive_tombstones")
     try:
+        tombstoned_ids = {
+            str(row[0])
+            for row in destination.execute(
+                "SELECT session_id FROM cold_archive_tombstones"
+            ).fetchall()
+        }
+        prompt_hashes = {
+            str(row[0])
+            for row in destination.execute(
+                "SELECT DISTINCT system_prompt_hash FROM sessions "
+                "WHERE id IN (SELECT session_id FROM cold_archive_tombstones) "
+                "AND system_prompt_hash IS NOT NULL"
+            ).fetchall()
+        }
         parent_cursor = destination.execute(
             "UPDATE sessions SET parent_session_id = NULL "
             "WHERE parent_session_id IN ("
             "SELECT session_id FROM cold_archive_tombstones)"
         )
         result["sessions_parent_cleared"] = parent_cursor.rowcount
+
+        if _table_columns(destination, "gateway_routing"):
+            route_rows = destination.execute(
+                "SELECT scope, session_key, entry_json FROM gateway_routing"
+            ).fetchall()
+            for scope, session_key, entry_json in route_rows:
+                try:
+                    entry = json.loads(entry_json)
+                except (TypeError, json.JSONDecodeError):
+                    result["gateway_routes_unverifiable"] += 1
+                    continue
+                session_id = entry.get("session_id") if isinstance(entry, dict) else None
+                if not isinstance(session_id, str):
+                    result["gateway_routes_unverifiable"] += 1
+                    continue
+                if session_id not in tombstoned_ids:
+                    continue
+                cursor = destination.execute(
+                    "DELETE FROM gateway_routing WHERE scope = ? AND session_key = ?",
+                    (scope, session_key),
+                )
+                result["gateway_routes_removed"] += cursor.rowcount
 
         for table, report_key in (
             ("messages", "messages_removed"),
@@ -421,6 +461,13 @@ def reconcile_cold_archive_tombstones(
             "SELECT session_id FROM cold_archive_tombstones)"
         )
         result["sessions_removed"] = sessions_cursor.rowcount
+        for prompt_hash in prompt_hashes:
+            prompt_cursor = destination.execute(
+                "DELETE FROM system_prompts WHERE hash = ? AND NOT EXISTS ("
+                "SELECT 1 FROM sessions WHERE system_prompt_hash = ?)",
+                (prompt_hash, prompt_hash),
+            )
+            result["system_prompts_removed"] += prompt_cursor.rowcount
         destination.execute("RELEASE SAVEPOINT reconcile_cold_archive_tombstones")
     except BaseException:
         destination.execute("ROLLBACK TO SAVEPOINT reconcile_cold_archive_tombstones")

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -35,9 +35,9 @@ _CANONICAL_TABLES = (
     "sessions",
     "messages",
     "session_model_usage",
+    "gateway_routing",
     "cold_archive_tombstones",
     "compression_locks",
-    "gateway_routing",
     "async_delegations",
 )
 

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -1443,6 +1443,7 @@ def _recover_via_lost_and_found(
     try:
         destination_conn.execute("PRAGMA foreign_keys=OFF")
         mapping = map_lost_and_found_rows(lf_conn, destination_conn)
+        tombstone_reconciliation = mapping["tombstone_reconciliation"]
         stubbing = stub_missing_parent_sessions(destination_conn)
         fts = rebuild_fts_indexes(destination_conn)
         derived_metadata = _finalize_derived_metadata(destination_conn)
@@ -1513,6 +1514,7 @@ def _recover_via_lost_and_found(
         "unreadable_schemas": missing_required,
         "sqlite3_cli": cli_report,
         "lost_and_found": mapping,
+        "tombstone_reconciliation": tombstone_reconciliation,
         "session_stubs": stubbing,
         "fts_rebuild": fts,
         "copy": copy_report,
@@ -1663,6 +1665,13 @@ def recover_session_database(
                     progress_cb=progress_cb,
                     source_rows=table_inspection.get("rows"),
                 )
+            from hermes_cli.session_lost_and_found import (
+                reconcile_cold_archive_tombstones,
+            )
+
+            tombstone_reconciliation = reconcile_cold_archive_tombstones(
+                destination_conn
+            )
             orphan_cleanup = (
                 _cleanup_partial_orphans(destination_conn)
                 if allow_partial
@@ -1676,12 +1685,23 @@ def recover_session_database(
             if destination_db is not None:
                 destination_db.close()
 
+        expected_counts = {
+            table: inspection["tables"][table].get("rows")
+            for table in _CANONICAL_TABLES
+        }
+        for table, removed_key in (
+            ("sessions", "sessions_removed"),
+            ("messages", "messages_removed"),
+        ):
+            expected = expected_counts.get(table)
+            if expected is not None:
+                expected_counts[table] = max(
+                    0, int(expected) - tombstone_reconciliation[removed_key]
+                )
+
         verification = _verify_recovered_database(
             output,
-            expected_counts={
-                table: inspection["tables"][table].get("rows")
-                for table in _CANONICAL_TABLES
-            },
+            expected_counts=expected_counts,
             copy_report=copy_report,
             allow_partial=allow_partial,
             orphan_cleanup=orphan_cleanup,
@@ -1711,6 +1731,7 @@ def recover_session_database(
                 "warnings": inspection["warnings"],
             },
             "copy": copy_report,
+            "tombstone_reconciliation": tombstone_reconciliation,
             "orphan_cleanup": orphan_cleanup,
             "derived_metadata": derived_metadata,
             "verification": verification,

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -35,6 +35,7 @@ _CANONICAL_TABLES = (
     "sessions",
     "messages",
     "session_model_usage",
+    "cold_archive_tombstones",
     "compression_locks",
     "gateway_routing",
     "async_delegations",

--- a/hermes_cli/session_reference_contract.py
+++ b/hermes_cli/session_reference_contract.py
@@ -1,0 +1,11 @@
+"""Shared durable session-reference contract for cold Purge and recovery."""
+
+from __future__ import annotations
+
+STATE_META_SESSION_NAMESPACES = ("goal", "loop", "heartbeat")
+
+ASYNC_DELEGATION_SESSION_COLUMNS = (
+    "origin_session",
+    "parent_session_id",
+    "origin_session_id",
+)

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -318,7 +318,8 @@ def cmd_sessions(args, sessions_parser=None):
         from hermes_state import SessionDB
 
         read_only = action == "cold-verify" or (
-            action == "cold-purge" and bool(getattr(args, "dry_run", False))
+            action in {"cold-store", "cold-purge"}
+            and bool(getattr(args, "dry_run", False))
         )
         db = SessionDB(read_only=read_only)
     except Exception as e:

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -905,6 +905,14 @@ def cmd_sessions(args, sessions_parser=None):
 
         archive_root = args.root.expanduser()
         if args.dry_run:
+            from hermes_cli.session_cold_store import plan_archived_lineage
+
+            try:
+                plan_archived_lineage(db, resolved_session_id)
+            except (OSError, ValueError) as exc:
+                print(f"Error: could not cold-store session lineage: {exc}")
+                db.close()
+                return 1
             print(
                 f"Would store archived session lineage '{resolved_session_id}' "
                 f"under {archive_root}; nothing was written."

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -331,7 +331,7 @@ def cmd_sessions(args, sessions_parser=None):
         read_only = action == "cold-archive" and bool(
             getattr(args, "dry_run", False)
         )
-        db = SessionDB(read_only=read_only)
+        db = SessionDB(read_only=True) if read_only else SessionDB()
     except Exception as e:
         print(f"Error: Could not open session database: {e}")
         return 1

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -981,10 +981,12 @@ def cmd_sessions(args, sessions_parser=None):
 
         archive_root = args.root.expanduser()
         if args.dry_run:
-            from hermes_cli.session_cold_store import verify_archived_lineage
+            from hermes_cli.session_cold_store import (
+                validate_purge_archived_lineage,
+            )
 
             try:
-                verified = verify_archived_lineage(
+                verified = validate_purge_archived_lineage(
                     db, resolved_session_id, archive_root
                 )
             except (OSError, ValueError) as exc:

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -957,8 +957,7 @@ def cmd_sessions(args, sessions_parser=None):
                     print(f"Error: cold archive Store failed: {exc}")
                     print(
                         "The source rows were retained; no verified local snapshot was "
-                        "produced by this run, and any pre-existing snapshot was left "
-                        "unchanged."
+                        "produced by this run, and no Purge was attempted."
                     )
                     db.close()
                     return 1

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -317,7 +317,7 @@ def cmd_sessions(args, sessions_parser=None):
     try:
         from hermes_state import SessionDB
 
-        db = SessionDB()
+        db = SessionDB(read_only=action == "cold-verify")
     except Exception as e:
         print(f"Error: Could not open session database: {e}")
         return 1
@@ -893,6 +893,30 @@ def cmd_sessions(args, sessions_parser=None):
         else:
             print(f"Session '{args.session_id}' not found.")
             return 1
+
+    elif action == "cold-verify":
+        resolved_session_id = db.resolve_session_id(args.session_id)
+        if not resolved_session_id:
+            print(f"Session '{args.session_id}' was not found or is ambiguous.")
+            db.close()
+            return 1
+
+        from hermes_cli.session_cold_store import verify_archived_lineage
+
+        try:
+            verified = verify_archived_lineage(
+                db, resolved_session_id, args.root.expanduser()
+            )
+        except (OSError, ValueError) as exc:
+            print(f"Error: could not cold-verify session lineage: {exc}")
+            db.close()
+            return 1
+
+        print("Verified archived session lineage:")
+        print(f"  terminal ID: {verified.terminal_id}")
+        print(f"  physical IDs: {', '.join(verified.physical_ids)}")
+        print(f"  fingerprint: {verified.source_fingerprint}")
+        print(f"  verified snapshot: {verified.snapshot_dir}")
 
     elif action == "cold-store":
         resolved_session_id = db.resolve_session_id(args.session_id)

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -935,7 +935,7 @@ def cmd_sessions(args, sessions_parser=None):
         print(f"  terminal ID: {stored.terminal_id}")
         print(f"  physical IDs: {', '.join(stored.physical_ids)}")
         print(f"  fingerprint: {stored.source_fingerprint}")
-        print(f"  local snapshot: {stored.revision_dir}")
+        print(f"  local snapshot: {stored.snapshot_dir}")
 
     elif action == "prune" and getattr(args, "never_active", False):
         # Separate branch on purpose: the shared prune/archive selector is

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -1013,7 +1013,7 @@ def cmd_sessions(args, sessions_parser=None):
                 print(f"  local snapshot retained: {purged.snapshot_dir}")
                 db.close()
                 return 0
-        except (OSError, RuntimeError, ValueError) as exc:
+        except (OSError, RuntimeError, sqlite3.DatabaseError, ValueError) as exc:
             print(f"Error: cold archive lock failed: {exc}")
             print("The source rows and local archive were left unchanged.")
             db.close()

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -909,7 +909,12 @@ def cmd_sessions(args, sessions_parser=None):
             return 1
 
     elif action == "cold-archive":
-        resolved_session_id = db.resolve_session_id(args.session_id)
+        try:
+            resolved_session_id = db.resolve_session_id(args.session_id)
+        except sqlite3.DatabaseError as exc:
+            print(f"Error: could not resolve cold-archive session: {exc}")
+            db.close()
+            return 1
         if not resolved_session_id:
             print(
                 f"Session '{args.session_id}' was not found or is ambiguous."

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -936,48 +936,81 @@ def cmd_sessions(args, sessions_parser=None):
             return 0
 
         from hermes_cli.session_cold_store import (
+            _exclusive_cold_archive_root_lock,
             purge_archived_lineage,
             store_archived_lineage,
             verify_archived_lineage,
         )
 
         try:
-            stored = store_archived_lineage(db, resolved_session_id, archive_root)
-        except (OSError, RuntimeError, sqlite3.DatabaseError, ValueError) as exc:
-            print(f"Error: cold archive Store failed: {exc}")
-            print(
-                "The source rows were retained; no verified local snapshot was "
-                "produced by this run, and any pre-existing snapshot was left "
-                "unchanged."
-            )
+            with _exclusive_cold_archive_root_lock(archive_root):
+                try:
+                    stored = store_archived_lineage(
+                        db, resolved_session_id, archive_root
+                    )
+                except (
+                    OSError,
+                    RuntimeError,
+                    sqlite3.DatabaseError,
+                    ValueError,
+                ) as exc:
+                    print(f"Error: cold archive Store failed: {exc}")
+                    print(
+                        "The source rows were retained; no verified local snapshot was "
+                        "produced by this run, and any pre-existing snapshot was left "
+                        "unchanged."
+                    )
+                    db.close()
+                    return 1
+
+                try:
+                    verified = verify_archived_lineage(
+                        db, resolved_session_id, archive_root
+                    )
+                except (
+                    OSError,
+                    RuntimeError,
+                    sqlite3.DatabaseError,
+                    ValueError,
+                ) as exc:
+                    print(f"Error: cold archive Verify failed: {exc}")
+                    print(
+                        "The source rows were retained and the local snapshot was retained:"
+                    )
+                    print(f"  {stored.snapshot_dir}")
+                    db.close()
+                    return 1
+
+                try:
+                    purged = purge_archived_lineage(
+                        db, resolved_session_id, archive_root
+                    )
+                except (
+                    OSError,
+                    RuntimeError,
+                    sqlite3.DatabaseError,
+                    ValueError,
+                ) as exc:
+                    print(f"Error: cold archive Purge failed: {exc}")
+                    print(
+                        "The source rows were retained and the local snapshot was retained:"
+                    )
+                    print(f"  {verified.snapshot_dir}")
+                    db.close()
+                    return 1
+
+                print("Cold-archived session lineage:")
+                print(f"  terminal ID: {purged.terminal_id}")
+                print(f"  physical IDs: {', '.join(purged.physical_ids)}")
+                print(f"  fingerprint: {purged.source_fingerprint}")
+                print(f"  local snapshot retained: {purged.snapshot_dir}")
+                db.close()
+                return 0
+        except (OSError, RuntimeError, ValueError) as exc:
+            print(f"Error: cold archive lock failed: {exc}")
+            print("The source rows and local archive were left unchanged.")
             db.close()
             return 1
-
-        try:
-            verified = verify_archived_lineage(db, resolved_session_id, archive_root)
-        except (OSError, RuntimeError, sqlite3.DatabaseError, ValueError) as exc:
-            print(f"Error: cold archive Verify failed: {exc}")
-            print("The source rows were retained and the local snapshot was retained:")
-            print(f"  {stored.snapshot_dir}")
-            db.close()
-            return 1
-
-        try:
-            purged = purge_archived_lineage(db, resolved_session_id, archive_root)
-        except (OSError, RuntimeError, sqlite3.DatabaseError, ValueError) as exc:
-            print(f"Error: cold archive Purge failed: {exc}")
-            print("The source rows were retained and the local snapshot was retained:")
-            print(f"  {verified.snapshot_dir}")
-            db.close()
-            return 1
-
-        print("Cold-archived session lineage:")
-        print(f"  terminal ID: {purged.terminal_id}")
-        print(f"  physical IDs: {', '.join(purged.physical_ids)}")
-        print(f"  fingerprint: {purged.source_fingerprint}")
-        print(f"  local snapshot retained: {purged.snapshot_dir}")
-        db.close()
-        return 0
 
     elif action == "prune" and getattr(args, "never_active", False):
         # Separate branch on purpose: the shared prune/archive selector is

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -317,7 +317,10 @@ def cmd_sessions(args, sessions_parser=None):
     try:
         from hermes_state import SessionDB
 
-        db = SessionDB(read_only=action == "cold-verify")
+        read_only = action == "cold-verify" or (
+            action == "cold-purge" and bool(getattr(args, "dry_run", False))
+        )
+        db = SessionDB(read_only=read_only)
     except Exception as e:
         print(f"Error: Could not open session database: {e}")
         return 1
@@ -968,6 +971,56 @@ def cmd_sessions(args, sessions_parser=None):
         print(f"  physical IDs: {', '.join(stored.physical_ids)}")
         print(f"  fingerprint: {stored.source_fingerprint}")
         print(f"  local snapshot: {stored.snapshot_dir}")
+
+    elif action == "cold-purge":
+        resolved_session_id = db.resolve_session_id(args.session_id)
+        if not resolved_session_id:
+            print(f"Session '{args.session_id}' was not found or is ambiguous.")
+            db.close()
+            return 1
+
+        archive_root = args.root.expanduser()
+        if args.dry_run:
+            from hermes_cli.session_cold_store import verify_archived_lineage
+
+            try:
+                verified = verify_archived_lineage(
+                    db, resolved_session_id, archive_root
+                )
+            except (OSError, ValueError) as exc:
+                print(f"Error: could not cold-purge session lineage: {exc}")
+                db.close()
+                return 1
+            print("Would purge archived session lineage:")
+            print(f"  terminal ID: {verified.terminal_id}")
+            print(f"  physical IDs: {', '.join(verified.physical_ids)}")
+            print("Dry run: nothing was deleted; the cold snapshot remains local.")
+            db.close()
+            return 0
+
+        if not args.yes:
+            print("Error: actual cold purge requires --yes; nothing was deleted.")
+            db.close()
+            return 1
+
+        from hermes_cli.session_cold_store import purge_archived_lineage
+
+        try:
+            purged = purge_archived_lineage(
+                db, resolved_session_id, archive_root
+            )
+        except (OSError, RuntimeError, ValueError) as exc:
+            print(f"Error: could not cold-purge session lineage: {exc}")
+            db.close()
+            return 1
+
+        print("Purged archived session lineage from SQLite:")
+        print(f"  terminal ID: {purged.terminal_id}")
+        print(f"  physical IDs: {', '.join(purged.physical_ids)}")
+        print(f"  fingerprint: {purged.source_fingerprint}")
+        print(f"  cold snapshot remains local: {purged.snapshot_dir}")
+        db.close()
+        return 0
 
     elif action == "prune" and getattr(args, "never_active", False):
         # Separate branch on purpose: the shared prune/archive selector is

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -919,10 +919,10 @@ def cmd_sessions(args, sessions_parser=None):
 
         archive_root = args.root.expanduser()
         if args.dry_run:
-            from hermes_cli.session_cold_store import plan_archived_lineage
+            from hermes_cli.session_cold_store import preflight_purge_archived_lineage
 
             try:
-                plan_archived_lineage(db, resolved_session_id)
+                preflight_purge_archived_lineage(db, resolved_session_id)
             except (OSError, sqlite3.DatabaseError, ValueError) as exc:
                 print(f"Error: could not plan cold archive: {exc}")
                 db.close()

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -315,12 +315,21 @@ def cmd_sessions(args, sessions_parser=None):
             return 1
         return
 
+    if action == "cold-archive" and not (
+        bool(getattr(args, "dry_run", False))
+        or bool(getattr(args, "yes", False))
+    ):
+        print(
+            "Error: cold-archive requires either --dry-run or --yes; "
+            "nothing was written or deleted."
+        )
+        return 1
+
     try:
         from hermes_state import SessionDB
 
-        read_only = action == "cold-verify" or (
-            action in {"cold-store", "cold-purge"}
-            and bool(getattr(args, "dry_run", False))
+        read_only = action == "cold-archive" and bool(
+            getattr(args, "dry_run", False)
         )
         db = SessionDB(read_only=read_only)
     except Exception as e:
@@ -899,31 +908,7 @@ def cmd_sessions(args, sessions_parser=None):
             print(f"Session '{args.session_id}' not found.")
             return 1
 
-    elif action == "cold-verify":
-        resolved_session_id = db.resolve_session_id(args.session_id)
-        if not resolved_session_id:
-            print(f"Session '{args.session_id}' was not found or is ambiguous.")
-            db.close()
-            return 1
-
-        from hermes_cli.session_cold_store import verify_archived_lineage
-
-        try:
-            verified = verify_archived_lineage(
-                db, resolved_session_id, args.root.expanduser()
-            )
-        except (OSError, sqlite3.DatabaseError, ValueError) as exc:
-            print(f"Error: could not cold-verify session lineage: {exc}")
-            db.close()
-            return 1
-
-        print("Verified archived session lineage:")
-        print(f"  terminal ID: {verified.terminal_id}")
-        print(f"  physical IDs: {', '.join(verified.physical_ids)}")
-        print(f"  fingerprint: {verified.source_fingerprint}")
-        print(f"  verified snapshot: {verified.snapshot_dir}")
-
-    elif action == "cold-store":
+    elif action == "cold-archive":
         resolved_session_id = db.resolve_session_id(args.session_id)
         if not resolved_session_id:
             print(
@@ -939,90 +924,58 @@ def cmd_sessions(args, sessions_parser=None):
             try:
                 plan_archived_lineage(db, resolved_session_id)
             except (OSError, sqlite3.DatabaseError, ValueError) as exc:
-                print(f"Error: could not cold-store session lineage: {exc}")
+                print(f"Error: could not plan cold archive: {exc}")
                 db.close()
                 return 1
-            print(
-                f"Would store archived session lineage '{resolved_session_id}' "
-                f"under {archive_root}; nothing was written."
-            )
-            db.close()
-            return
-
-        if not args.yes and not _confirm_prompt(
-            f"Store session lineage '{resolved_session_id}' as sensitive raw "
-            f"transcript output under {archive_root}? [y/N] "
-        ):
-            print("Cancelled.")
-            db.close()
-            return
-
-        from hermes_cli.session_cold_store import store_archived_lineage
-
-        try:
-            stored = store_archived_lineage(
-                db, resolved_session_id, archive_root
-            )
-        except (OSError, sqlite3.DatabaseError, ValueError) as exc:
-            print(f"Error: could not cold-store session lineage: {exc}")
-            db.close()
-            return 1
-
-        print("Stored archived session lineage:")
-        print(f"  terminal ID: {stored.terminal_id}")
-        print(f"  physical IDs: {', '.join(stored.physical_ids)}")
-        print(f"  fingerprint: {stored.source_fingerprint}")
-        print(f"  local snapshot: {stored.snapshot_dir}")
-
-    elif action == "cold-purge":
-        resolved_session_id = db.resolve_session_id(args.session_id)
-        if not resolved_session_id:
-            print(f"Session '{args.session_id}' was not found or is ambiguous.")
-            db.close()
-            return 1
-
-        archive_root = args.root.expanduser()
-        if args.dry_run:
-            from hermes_cli.session_cold_store import (
-                validate_purge_archived_lineage,
-            )
-
-            try:
-                verified = validate_purge_archived_lineage(
-                    db, resolved_session_id, archive_root
-                )
-            except (OSError, sqlite3.DatabaseError, ValueError) as exc:
-                print(f"Error: could not cold-purge session lineage: {exc}")
-                db.close()
-                return 1
-            print("Would purge archived session lineage:")
-            print(f"  terminal ID: {verified.terminal_id}")
-            print(f"  physical IDs: {', '.join(verified.physical_ids)}")
-            print("Dry run: nothing was deleted; the cold snapshot remains local.")
+            print("Resolved archived session lineage:")
+            print(f"  resolved terminal ID: {resolved_session_id}")
+            print(f"  local archive root: {archive_root}")
+            print("Would run: Store → Verify → Purge")
+            print("Dry run: nothing was written or deleted.")
             db.close()
             return 0
 
-        if not args.yes:
-            print("Error: actual cold purge requires --yes; nothing was deleted.")
-            db.close()
-            return 1
-
-        from hermes_cli.session_cold_store import purge_archived_lineage
+        from hermes_cli.session_cold_store import (
+            purge_archived_lineage,
+            store_archived_lineage,
+            verify_archived_lineage,
+        )
 
         try:
-            purged = purge_archived_lineage(
-                db, resolved_session_id, archive_root
-            )
+            stored = store_archived_lineage(db, resolved_session_id, archive_root)
         except (OSError, RuntimeError, sqlite3.DatabaseError, ValueError) as exc:
-            print(f"Error: could not cold-purge session lineage: {exc}")
+            print(f"Error: cold archive Store failed: {exc}")
+            print(
+                "The source rows were retained; no verified local snapshot was "
+                "produced by this run, and any pre-existing snapshot was left "
+                "unchanged."
+            )
             db.close()
             return 1
 
-        print("Purged archived session lineage from SQLite:")
+        try:
+            verified = verify_archived_lineage(db, resolved_session_id, archive_root)
+        except (OSError, RuntimeError, sqlite3.DatabaseError, ValueError) as exc:
+            print(f"Error: cold archive Verify failed: {exc}")
+            print("The source rows were retained and the local snapshot was retained:")
+            print(f"  {stored.snapshot_dir}")
+            db.close()
+            return 1
+
+        try:
+            purged = purge_archived_lineage(db, resolved_session_id, archive_root)
+        except (OSError, RuntimeError, sqlite3.DatabaseError, ValueError) as exc:
+            print(f"Error: cold archive Purge failed: {exc}")
+            print("The source rows were retained and the local snapshot was retained:")
+            print(f"  {verified.snapshot_dir}")
+            db.close()
+            return 1
+
+        print("Cold-archived session lineage:")
         print(f"  terminal ID: {purged.terminal_id}")
         print(f"  physical IDs: {', '.join(purged.physical_ids)}")
         print(f"  fingerprint: {purged.source_fingerprint}")
-        print(f"  cold snapshot remains local: {purged.snapshot_dir}")
+        print(f"  local snapshot retained: {purged.snapshot_dir}")
         db.close()
         return 0
 

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -942,13 +942,16 @@ def cmd_sessions(args, sessions_parser=None):
 
         from hermes_cli.session_cold_store import (
             _exclusive_cold_archive_root_lock,
+            _exclusive_lineage_accounting_locks,
             purge_archived_lineage,
             store_archived_lineage,
             verify_archived_lineage,
         )
 
         try:
-            with _exclusive_cold_archive_root_lock(archive_root):
+            with _exclusive_cold_archive_root_lock(
+                archive_root
+            ), _exclusive_lineage_accounting_locks(db, resolved_session_id):
                 try:
                     stored = store_archived_lineage(
                         db, resolved_session_id, archive_root

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -894,6 +894,49 @@ def cmd_sessions(args, sessions_parser=None):
             print(f"Session '{args.session_id}' not found.")
             return 1
 
+    elif action == "cold-store":
+        resolved_session_id = db.resolve_session_id(args.session_id)
+        if not resolved_session_id:
+            print(
+                f"Session '{args.session_id}' was not found or is ambiguous."
+            )
+            db.close()
+            return 1
+
+        archive_root = args.root.expanduser()
+        if args.dry_run:
+            print(
+                f"Would store archived session lineage '{resolved_session_id}' "
+                f"under {archive_root}; nothing was written."
+            )
+            db.close()
+            return
+
+        if not args.yes and not _confirm_prompt(
+            f"Store session lineage '{resolved_session_id}' as sensitive raw "
+            f"transcript output under {archive_root}? [y/N] "
+        ):
+            print("Cancelled.")
+            db.close()
+            return
+
+        from hermes_cli.session_cold_store import store_archived_lineage
+
+        try:
+            stored = store_archived_lineage(
+                db, resolved_session_id, archive_root
+            )
+        except (OSError, ValueError) as exc:
+            print(f"Error: could not cold-store session lineage: {exc}")
+            db.close()
+            return 1
+
+        print("Stored archived session lineage:")
+        print(f"  terminal ID: {stored.terminal_id}")
+        print(f"  physical IDs: {', '.join(stored.physical_ids)}")
+        print(f"  fingerprint: {stored.source_fingerprint}")
+        print(f"  local snapshot: {stored.revision_dir}")
+
     elif action == "prune" and getattr(args, "never_active", False):
         # Separate branch on purpose: the shared prune/archive selector is
         # pinned to `ended_at IS NOT NULL`, so never-closed rows sit outside

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -20,6 +20,7 @@ time — no import cycle).
 """
 
 import os
+import sqlite3
 import sys
 from pathlib import Path
 
@@ -911,7 +912,7 @@ def cmd_sessions(args, sessions_parser=None):
             verified = verify_archived_lineage(
                 db, resolved_session_id, args.root.expanduser()
             )
-        except (OSError, ValueError) as exc:
+        except (OSError, sqlite3.DatabaseError, ValueError) as exc:
             print(f"Error: could not cold-verify session lineage: {exc}")
             db.close()
             return 1
@@ -937,7 +938,7 @@ def cmd_sessions(args, sessions_parser=None):
 
             try:
                 plan_archived_lineage(db, resolved_session_id)
-            except (OSError, ValueError) as exc:
+            except (OSError, sqlite3.DatabaseError, ValueError) as exc:
                 print(f"Error: could not cold-store session lineage: {exc}")
                 db.close()
                 return 1
@@ -962,7 +963,7 @@ def cmd_sessions(args, sessions_parser=None):
             stored = store_archived_lineage(
                 db, resolved_session_id, archive_root
             )
-        except (OSError, ValueError) as exc:
+        except (OSError, sqlite3.DatabaseError, ValueError) as exc:
             print(f"Error: could not cold-store session lineage: {exc}")
             db.close()
             return 1
@@ -990,7 +991,7 @@ def cmd_sessions(args, sessions_parser=None):
                 verified = validate_purge_archived_lineage(
                     db, resolved_session_id, archive_root
                 )
-            except (OSError, ValueError) as exc:
+            except (OSError, sqlite3.DatabaseError, ValueError) as exc:
                 print(f"Error: could not cold-purge session lineage: {exc}")
                 db.close()
                 return 1
@@ -1012,7 +1013,7 @@ def cmd_sessions(args, sessions_parser=None):
             purged = purge_archived_lineage(
                 db, resolved_session_id, archive_root
             )
-        except (OSError, RuntimeError, ValueError) as exc:
+        except (OSError, RuntimeError, sqlite3.DatabaseError, ValueError) as exc:
             print(f"Error: could not cold-purge session lineage: {exc}")
             db.close()
             return 1

--- a/hermes_cold_archive_errors.py
+++ b/hermes_cold_archive_errors.py
@@ -1,0 +1,10 @@
+"""Shared classification for durable cold-archive tombstone rejections."""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def is_cold_archive_tombstone_rejection(exc: BaseException) -> bool:
+    """Return whether SQLite rejected a write to a permanently fenced ID."""
+    return isinstance(exc, sqlite3.IntegrityError) and "cold-archived" in str(exc)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -52,6 +52,7 @@ from agent.skill_commands import (
     describe_skill_invocation,
 )
 from hermes_constants import get_hermes_home
+from hermes_accounting_locks import acquire_pending_accounting_lock
 from hermes_cli.sqlite_runtime import (
     is_sqlite_wal_reset_vulnerable as _is_sqlite_wal_reset_vulnerable,
 )
@@ -4261,6 +4262,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self._token_writer_thread: Optional[threading.Thread] = None
         self._token_writer_stop = False
         self._token_writer_busy = False
+        self._token_accounting_lock_fds: Dict[str, Optional[int]] = {}
+        self._token_writer_failed_sessions: Set[str] = set()
         self._token_atexit_hook: Optional[Callable[[], None]] = None
         initialization_complete = False
         try:
@@ -5451,6 +5454,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         #45383). Read-only connections never request a checkpoint.
         """
         self._stop_token_writer()
+        self._release_token_accounting_locks_if_idle()
         hook, self._token_atexit_hook = self._token_atexit_hook, None
         if hook is not None:
             atexit.unregister(hook)
@@ -8293,6 +8297,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 thread is None or not thread.is_alive()
             )
             if not writer_stopped:
+                if session_id not in self._token_accounting_lock_fds:
+                    self._token_accounting_lock_fds[session_id] = (
+                        acquire_pending_accounting_lock(self.db_path, session_id)
+                    )
                 self._token_queue.append((session_id, kwargs))
                 if thread is None or not thread.is_alive():
                     # Daemon so process exit never hangs on accounting; the
@@ -8331,6 +8339,41 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # update_token_counts path these call sites still guard for.
             self.update_token_counts(session_id, **kwargs)
 
+    def _finish_token_accounting_batch_locked(
+        self,
+        batch: List[Tuple[str, Dict[str, Any]]],
+        failed_sessions: Set[str],
+    ) -> None:
+        """Release shared locks only for successfully drained session queues."""
+        self._token_writer_failed_sessions.update(failed_sessions)
+        still_queued = {session_id for session_id, _kwargs in self._token_queue}
+        completed = {
+            session_id for session_id, _kwargs in batch
+        } - still_queued - failed_sessions
+        for session_id in completed:
+            descriptor = self._token_accounting_lock_fds.pop(session_id, None)
+            if descriptor is not None:
+                os.close(descriptor)
+
+    def _release_token_accounting_locks_if_idle(self) -> None:
+        """Release retained failure locks only after this owner is fully stopped."""
+        with self._token_queue_cond:
+            thread = self._token_writer_thread
+            if (
+                self._token_queue
+                or self._token_writer_busy
+                or (thread is not None and thread.is_alive())
+            ):
+                return
+            descriptors = [
+                descriptor
+                for descriptor in self._token_accounting_lock_fds.values()
+                if descriptor is not None
+            ]
+            self._token_accounting_lock_fds.clear()
+        for descriptor in descriptors:
+            os.close(descriptor)
+
     def flush_token_counts(self, timeout: float = 5.0) -> bool:
         """Block until every queued token delta has been applied.
 
@@ -8341,7 +8384,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         # Fast path — nothing queued, nothing in flight.
         if not self._token_queue and not self._token_writer_busy:
-            return True
+            return not self._token_writer_failed_sessions
         batch = None
         with self._token_queue_cond:
             deadline = time.monotonic() + timeout
@@ -8374,13 +8417,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     return False
                 self._token_queue_cond.wait(remaining)
         if batch:
+            failed_sessions: Set[str] = set()
             try:
-                self._apply_token_batch(batch)
+                failed_sessions = self._apply_token_batch(batch) or set()
             finally:
                 with self._token_queue_cond:
+                    self._finish_token_accounting_batch_locked(
+                        batch, failed_sessions
+                    )
                     self._token_writer_busy = False
                     self._token_queue_cond.notify_all()
-        return True
+        return not self._token_writer_failed_sessions
 
     def _token_writer_loop(self) -> None:
         while True:
@@ -8405,15 +8452,22 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 self._token_writer_busy = True
                 batch = list(self._token_queue)
                 self._token_queue.clear()
+            failed_sessions: Set[str] = set()
             try:
-                self._apply_token_batch(batch)
+                failed_sessions = self._apply_token_batch(batch) or set()
             finally:
                 with self._token_queue_cond:
+                    self._finish_token_accounting_batch_locked(
+                        batch, failed_sessions
+                    )
                     self._token_writer_busy = False
                     self._token_queue_cond.notify_all()
 
-    def _apply_token_batch(self, batch: List[Tuple[str, Dict[str, Any]]]) -> None:
-        """Apply queued deltas in order, coalescing where safe. Never raises."""
+    def _apply_token_batch(
+        self, batch: List[Tuple[str, Dict[str, Any]]]
+    ) -> Set[str]:
+        """Apply queued deltas and return session IDs whose accounting failed."""
+        failed_sessions: Set[str] = set()
         try:
             coalesced = self._coalesce_token_deltas(batch)
         except Exception as exc:
@@ -8429,12 +8483,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             try:
                 self.update_token_counts(session_id, **kwargs)
             except Exception as exc:
+                failed_sessions.add(session_id)
                 # Same contract as the old inline call sites: accounting
                 # loss is logged, never raised into a turn.
                 logger.warning(
                     "async token accounting: apply failed (session=%s): %s",
                     session_id, exc,
                 )
+        return failed_sessions
 
     def _coalesce_token_deltas(
         self, batch: List[Tuple[str, Dict[str, Any]]]
@@ -8513,10 +8569,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 self._token_writer_busy = True
                 self._token_queue.clear()
         if batch:
+            failed_sessions: Set[str] = set()
             try:
-                self._apply_token_batch(batch)
+                failed_sessions = self._apply_token_batch(batch) or set()
             finally:
                 with self._token_queue_cond:
+                    self._finish_token_accounting_batch_locked(
+                        batch, failed_sessions
+                    )
                     self._token_writer_busy = False
                     self._token_queue_cond.notify_all()
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8349,7 +8349,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         still_queued = {session_id for session_id, _kwargs in self._token_queue}
         completed = {
             session_id for session_id, _kwargs in batch
-        } - still_queued - failed_sessions
+        } - still_queued - self._token_writer_failed_sessions
         for session_id in completed:
             descriptor = self._token_accounting_lock_fds.pop(session_id, None)
             if descriptor is not None:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8444,6 +8444,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     self._token_queue_cond.wait(remaining)
                 if not self._token_queue:
                     self._token_writer_thread = None
+                    descriptors = [
+                        descriptor
+                        for descriptor in self._token_accounting_lock_fds.values()
+                        if descriptor is not None
+                    ]
+                    self._token_accounting_lock_fds.clear()
+                    for descriptor in descriptors:
+                        os.close(descriptor)
                     return  # stop requested and fully drained
                 # busy is set BEFORE the queue is cleared: the lock-free
                 # fast path in flush_token_counts() reads queue-then-busy,

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -505,6 +505,32 @@ CREATE TABLE IF NOT EXISTS gateway_routing (
     PRIMARY KEY (scope, session_key)
 );
 
+CREATE TRIGGER IF NOT EXISTS gateway_routing_reject_cold_archive_tombstone_insert
+BEFORE INSERT ON gateway_routing
+WHEN CASE
+    WHEN json_valid(NEW.entry_json) THEN EXISTS (
+        SELECT 1 FROM cold_archive_tombstones
+        WHERE session_id = json_extract(NEW.entry_json, '$.session_id')
+    )
+    ELSE 0
+END
+BEGIN
+    SELECT RAISE(ABORT, 'gateway route targets a cold-archived session ID');
+END;
+
+CREATE TRIGGER IF NOT EXISTS gateway_routing_reject_cold_archive_tombstone_update
+BEFORE UPDATE OF entry_json ON gateway_routing
+WHEN CASE
+    WHEN json_valid(NEW.entry_json) THEN EXISTS (
+        SELECT 1 FROM cold_archive_tombstones
+        WHERE session_id = json_extract(NEW.entry_json, '$.session_id')
+    )
+    ELSE 0
+END
+BEGIN
+    SELECT RAISE(ABORT, 'gateway route targets a cold-archived session ID');
+END;
+
 CREATE TABLE IF NOT EXISTS gateway_hygiene_state (
     session_key TEXT PRIMARY KEY,
     failure_streak INTEGER NOT NULL DEFAULT 0

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -525,7 +525,8 @@ CREATE TABLE IF NOT EXISTS async_delegations (
     owner_started_at INTEGER,
     task_json TEXT,
     delivery_claim TEXT,
-    delivery_claimed_at REAL
+    delivery_claimed_at REAL,
+    origin_session_id TEXT NOT NULL DEFAULT ''
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -427,6 +427,23 @@ CREATE TABLE IF NOT EXISTS sessions (
     FOREIGN KEY (system_prompt_hash) REFERENCES system_prompts(hash)
 );
 
+CREATE TABLE IF NOT EXISTS cold_archive_tombstones (
+    session_id TEXT PRIMARY KEY,
+    terminal_id TEXT NOT NULL,
+    source_fingerprint TEXT NOT NULL,
+    deleted_at REAL NOT NULL
+);
+
+CREATE TRIGGER IF NOT EXISTS sessions_reject_cold_archive_tombstone
+BEFORE INSERT ON sessions
+WHEN EXISTS (
+    SELECT 1 FROM cold_archive_tombstones
+    WHERE session_id = NEW.id
+)
+BEGIN
+    SELECT RAISE(ABORT, 'session ID is cold-archived and cannot be recreated');
+END;
+
 CREATE TABLE IF NOT EXISTS messages (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     session_id TEXT NOT NULL REFERENCES sessions(id),

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -814,6 +814,11 @@ class SessionSchemaMixin:
             "FROM gateway_routing_legacy_pk ORDER BY updated_at ASC"
         )
         cursor.execute("DROP TABLE gateway_routing_legacy_pk")
+        # Renaming the legacy table retargets its triggers to the temporary
+        # name, and dropping that table drops those triggers. Reapply the
+        # idempotent schema DDL now so the replacement table is fenced before
+        # this first post-upgrade connection can be used.
+        cursor.executescript(SCHEMA_SQL)
 
     def _heal_session_model_usage_pk(self, cursor: sqlite3.Cursor) -> None:
         """Rebuild ``session_model_usage`` when its PRIMARY KEY lacks ``task``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -430,6 +430,8 @@ py-modules = [
   "cli",
   "hermes_bootstrap",
   "hermes_constants",
+  "hermes_accounting_locks",
+  "hermes_cold_archive_errors",
   "hermes_state",
   "hermes_state_common",
   "hermes_state_portability",

--- a/tests/gateway/test_routing_save_fast_path.py
+++ b/tests/gateway/test_routing_save_fast_path.py
@@ -10,9 +10,11 @@ sessions.json mirror lagged behind (or never existed).
 from __future__ import annotations
 
 import json
+import sqlite3
 import threading
 
 import hermes_state
+import pytest
 from gateway.config import GatewayConfig, Platform
 from gateway.session import SessionSource, SessionStore
 
@@ -180,6 +182,51 @@ class TestFallbacks:
         data = json.loads(sessions_json.read_text(encoding="utf-8"))
         assert data[entry.session_key]["last_prompt_tokens"] == 1234
         assert _routing_row(store, entry.session_key)["last_prompt_tokens"] == 1234
+        store._db.close()
+
+    def test_tombstone_rejected_upsert_does_not_fall_back_to_legacy_mirror(
+        self, tmp_path, monkeypatch
+    ):
+        store = _make_store(tmp_path, monkeypatch)
+        entry = store.get_or_create_session(_source())
+        sessions_json = tmp_path / "sessions" / "sessions.json"
+        before = sessions_json.read_bytes()
+
+        def reject(*args, **kwargs):
+            raise sqlite3.IntegrityError(
+                "gateway route targets a cold-archived session ID"
+            )
+
+        monkeypatch.setattr(store._db, "save_gateway_routing_entry", reject)
+        with pytest.raises(sqlite3.IntegrityError, match="cold-archived"):
+            store.update_session(entry.session_key, last_prompt_tokens=4321)
+
+        assert sessions_json.read_bytes() == before
+        store._db.close()
+
+    def test_tombstone_rejected_full_rewrite_does_not_write_legacy_mirror(
+        self, tmp_path, monkeypatch
+    ):
+        store = _make_store(tmp_path, monkeypatch)
+        store.get_or_create_session(_source())
+        with store._lock:
+            data, generation = store._snapshot_routing_locked()
+
+        def reject(*args, **kwargs):
+            raise sqlite3.IntegrityError(
+                "gateway route targets a cold-archived session ID"
+            )
+
+        monkeypatch.setattr(store._db, "replace_gateway_routing_entries", reject)
+        monkeypatch.setattr(
+            store,
+            "_save_sessions_json",
+            lambda _data: (_ for _ in ()).throw(
+                AssertionError("legacy mirror must not be written")
+            ),
+        )
+        with pytest.raises(sqlite3.IntegrityError, match="cold-archived"):
+            store._persist_routing_data(data, generation)
         store._db.close()
 
 

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+import hermes_cli.session_cold_store as cold_store
 from hermes_cli.session_cold_store import store_archived_lineage
 from hermes_state import SessionDB
 
@@ -31,6 +32,7 @@ def test_store_archived_compression_lineage_writes_terminal_id_revision(tmp_path
         assert result.revision_dir.parent.parent.name == "terminal"
         assert (result.revision_dir / "metadata.json").is_file()
         assert (result.revision_dir / "session.jsonl").is_file()
+        assert store_archived_lineage(db, "terminal", archive_root) == result
         assert db.get_session("root") is not None
         assert db.get_session("terminal") is not None
     finally:
@@ -97,5 +99,47 @@ def test_store_reads_raw_rows_without_flushing_and_preserves_system_prompt(
             for line in (result.revision_dir / "session.jsonl").read_text(encoding="utf-8").splitlines()
         ]
         assert any(record["kind"] == "system-prompt" for record in records)
+    finally:
+        db.close()
+
+
+def test_store_rejects_revisions_symlink_swap_before_staging(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A validated revision parent cannot be swapped to redirect transcript writes."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    try:
+        db.create_session("terminal", source="cli")
+        db.append_message("terminal", role="user", content="sensitive transcript")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+
+        real_mkdir = cold_store.os.mkdir
+        swapped = False
+
+        def racing_mkdir(
+            path: str | Path,
+            mode: int = 0o777,
+            *,
+            dir_fd: int | None = None,
+        ) -> None:
+            nonlocal swapped
+            if not swapped and Path(path).name.startswith(".staging-"):
+                revisions = next(archive_root.rglob("revisions"))
+                revisions.rename(revisions.with_name("revisions-displaced"))
+                revisions.symlink_to(outside, target_is_directory=True)
+                swapped = True
+            real_mkdir(path, mode, dir_fd=dir_fd)
+
+        monkeypatch.setattr(cold_store.os, "mkdir", racing_mkdir)
+
+        with pytest.raises(ValueError, match="unsafe archive parent path"):
+            store_archived_lineage(db, "terminal", archive_root)
+
+        assert swapped
+        assert not any(outside.iterdir())
     finally:
         db.close()

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -578,6 +578,53 @@ def test_store_reports_the_same_canonical_path_it_writes(tmp_path: Path) -> None
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are required")
+def test_store_rejects_rename_unsafe_archive_parent_before_creating_root(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    shared_parent = tmp_path / "shared"
+    archive_root = shared_parent / "archive"
+    shared_parent.mkdir(mode=0o770)
+    shared_parent.chmod(0o770)
+    try:
+        db.create_session("terminal", source="cli")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+
+        with pytest.raises(ValueError, match="unsafe archive parent path"):
+            store_archived_lineage(db, "terminal", archive_root)
+
+        assert not archive_root.exists()
+    finally:
+        db.close()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX ownership is required")
+def test_directory_authority_rejects_foreign_owned_component(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    directory = tmp_path / "foreign-owned"
+    directory.mkdir(mode=0o700)
+    descriptor = os.open(directory, cold_store._directory_open_flags())
+    real_fstat = os.fstat
+
+    def foreign_owner_fstat(fd: int) -> os.stat_result:
+        opened = real_fstat(fd)
+        if fd != descriptor:
+            return opened
+        values = list(opened)
+        values[4] = os.geteuid() + 1
+        return os.stat_result(values)
+
+    monkeypatch.setattr(os, "fstat", foreign_owner_fstat)
+    try:
+        with pytest.raises(ValueError, match="unsafe archive parent path"):
+            cold_store._validate_directory_authority(descriptor, directory)
+    finally:
+        os.close(descriptor)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are required")
 @pytest.mark.parametrize(
     ("member", "insecure_mode"),
     [

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -37,7 +37,23 @@ def test_store_archived_compression_lineage_writes_terminal_id_revision(tmp_path
         db.close()
 
 
-def test_store_reads_raw_rows_without_flushing_and_preserves_system_prompt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_store_rejects_a_compression_ancestor_when_a_tip_exists(tmp_path: Path) -> None:
+    """An archive revision must be keyed to the complete chain terminal, never a prefix."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("root", source="cli")
+        db.end_session("root", "compression")
+        db.create_session("terminal", source="cli", parent_session_id="root")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+
+        with pytest.raises(ValueError, match="terminal"):
+            store_archived_lineage(db, "root", tmp_path / "archive")
+    finally:
+        db.close()
+def test_store_reads_raw_rows_without_flushing_and_preserves_system_prompt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Store neither flushes pending accounting nor drops normalized prompt rows."""
     db = SessionDB(db_path=tmp_path / "state.db")
     try:

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -169,7 +169,10 @@ def test_purge_rejects_uncovered_child_and_preserves_foreign_key_rows(
         db.close()
 
 
-@pytest.mark.parametrize("entry_json", ["{malformed", "[]"])
+@pytest.mark.parametrize(
+    "entry_json",
+    ["{malformed", "[]", '{"session_id": 123}'],
+)
 def test_purge_rejects_unverifiable_routing_entries_and_retains_all_rows(
     tmp_path: Path,
     entry_json: str,

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -239,6 +239,22 @@ def test_store_rejects_fifo_payload_without_blocking(
         db.close()
 
 
+def test_store_rejects_non_object_snapshot_metadata(tmp_path: Path) -> None:
+    """Valid JSON scalars/lists are still invalid archive metadata envelopes."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("terminal", source="cli")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+        result = store_archived_lineage(db, "terminal", tmp_path / "archive")
+        (result.revision_dir / "metadata.json").write_text("[]\n", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="existing snapshot is invalid"):
+            store_archived_lineage(db, "terminal", tmp_path / "archive")
+    finally:
+        db.close()
+
+
 def test_store_rejects_snapshot_parent_symlink_swap_before_staging(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -745,6 +745,69 @@ def test_store_isolates_same_id_and_generation_from_distinct_source_stores(
         second_db.close()
 
 
+def test_store_keeps_purged_snapshot_when_source_db_is_replaced_at_same_path(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "state.db"
+    archive_root = tmp_path / "archive"
+    started_at = datetime(2026, 1, 2, 3, 4, tzinfo=UTC).timestamp()
+    first_db = SessionDB(db_path=db_path)
+    second_db: SessionDB | None = None
+    try:
+        first_db.create_session("same-id", source="cli")
+        first_db.append_message("same-id", role="user", content="first database")
+        first_db.end_session("same-id", "completed")
+        assert first_db.set_session_archived("same-id", True)
+        assert first_db._conn is not None
+        first_db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (started_at, "same-id"),
+        )
+        first_db._conn.commit()
+        first = store_archived_lineage(first_db, "same-id", archive_root)
+        purge_archived_lineage(first_db, "same-id", archive_root)
+        first_db.close()
+        first_file_identity = (os.stat(db_path).st_dev, os.stat(db_path).st_ino)
+
+        replacement_path = tmp_path / "replacement.db"
+        replacement_db = SessionDB(db_path=replacement_path)
+        try:
+            replacement_db.create_session("same-id", source="cli")
+            replacement_db.append_message(
+                "same-id", role="user", content="replacement database"
+            )
+            replacement_db.end_session("same-id", "completed")
+            assert replacement_db.set_session_archived("same-id", True)
+            assert replacement_db._conn is not None
+            replacement_db._conn.execute(
+                "UPDATE sessions SET started_at = ? WHERE id = ?",
+                (started_at, "same-id"),
+            )
+            replacement_db._conn.commit()
+        finally:
+            replacement_db.close()
+
+        for suffix in ("-wal", "-shm"):
+            (db_path.parent / f"{db_path.name}{suffix}").unlink(missing_ok=True)
+        os.replace(replacement_path, db_path)
+        assert (os.stat(db_path).st_dev, os.stat(db_path).st_ino) != first_file_identity
+
+        second_db = SessionDB(db_path=db_path)
+        second = store_archived_lineage(second_db, "same-id", archive_root)
+
+        assert first.snapshot_dir != second.snapshot_dir
+        assert "first database" in (first.snapshot_dir / "session.jsonl").read_text(
+            encoding="utf-8"
+        )
+        assert "replacement database" in (
+            second.snapshot_dir / "session.jsonl"
+        ).read_text(encoding="utf-8")
+    finally:
+        if second_db is not None:
+            second_db.close()
+        first_db.close()
+
+
 @pytest.mark.skipif(
     not hasattr(os, "mkfifo") or not hasattr(signal, "setitimer"),
     reason="requires POSIX FIFOs and interval timers",

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -164,7 +164,9 @@ def test_purge_rejects_uncovered_child_and_preserves_foreign_key_rows(
 
         assert db.get_session("root") is not None
         assert db.get_session("terminal") is not None
-        assert db.get_session("branch")["parent_session_id"] == "root"
+        branch = db.get_session("branch")
+        assert branch is not None
+        assert branch["parent_session_id"] == "root"
     finally:
         db.close()
 

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -79,6 +79,40 @@ def test_store_reports_the_same_canonical_path_it_writes(tmp_path: Path) -> None
         db.close()
 
 
+def test_store_keeps_distinct_ids_that_only_differ_by_trailing_space(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    started_at = datetime(2026, 1, 2, 3, 4, tzinfo=UTC).timestamp()
+    try:
+        for session_id, marker in (("foo", "plain"), ("foo ", "trailing-space")):
+            db.create_session(session_id, source="cli")
+            db.append_message(session_id, role="user", content=marker)
+            db.end_session(session_id, "completed")
+            assert db.set_session_archived(session_id, True)
+            assert db._conn is not None
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ? WHERE id = ?",
+                (started_at, session_id),
+            )
+
+        plain = store_archived_lineage(db, "foo", archive_root)
+        trailing_space = store_archived_lineage(db, "foo ", archive_root)
+
+        assert plain.snapshot_dir != trailing_space.snapshot_dir
+        assert plain.snapshot_dir.is_dir()
+        assert trailing_space.snapshot_dir.is_dir()
+        assert '"content":"plain"' in (
+            plain.snapshot_dir / "session.jsonl"
+        ).read_text(encoding="utf-8")
+        assert '"content":"trailing-space"' in (
+            trailing_space.snapshot_dir / "session.jsonl"
+        ).read_text(encoding="utf-8")
+    finally:
+        db.close()
+
+
 def test_store_rejects_a_compression_ancestor_when_a_tip_exists(tmp_path: Path) -> None:
     """An archive snapshot must be keyed to the complete chain terminal, never a prefix."""
     db = SessionDB(db_path=tmp_path / "state.db")

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -9,7 +9,11 @@ import signal
 import pytest
 
 import hermes_cli.session_cold_store as cold_store
-from hermes_cli.session_cold_store import plan_archived_lineage, store_archived_lineage
+from hermes_cli.session_cold_store import (
+    plan_archived_lineage,
+    purge_archived_lineage,
+    store_archived_lineage,
+)
 from hermes_state import SessionDB
 
 
@@ -56,6 +60,110 @@ def test_store_archived_compression_lineage_writes_one_terminal_id_snapshot(
         assert store_archived_lineage(db, "terminal", archive_root) == result
         assert db.get_session("root") is not None
         assert db.get_session("terminal") is not None
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize("snapshot_state", ["missing", "mismatched"])
+def test_purge_rejects_missing_or_mismatched_snapshot_and_retains_source_rows(
+    tmp_path: Path,
+    snapshot_state: str,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("terminal", source="cli")
+        db.append_message("terminal", role="user", content="keep me")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+        stored = store_archived_lineage(db, "terminal", archive_root)
+        if snapshot_state == "missing":
+            archive_root = tmp_path / "missing-archive"
+        else:
+            metadata_path = stored.snapshot_dir / "metadata.json"
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            metadata["source_fingerprint"] = "0" * 64
+            metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="snapshot"):
+            purge_archived_lineage(db, "terminal", archive_root)
+
+        assert db.get_session("terminal") is not None
+        assert db.get_messages("terminal")[0]["content"] == "keep me"
+    finally:
+        db.close()
+
+
+def test_purge_rejects_source_mutation_after_store_and_retains_source_rows(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("terminal", source="cli")
+        db.append_message("terminal", role="user", content="stored")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+        store_archived_lineage(db, "terminal", archive_root)
+        db.append_message("terminal", role="assistant", content="changed after Store")
+
+        with pytest.raises(ValueError, match="fingerprint"):
+            purge_archived_lineage(db, "terminal", archive_root)
+
+        assert db.get_session("terminal") is not None
+        assert [message["content"] for message in db.get_messages("terminal")] == [
+            "stored",
+            "changed after Store",
+        ]
+    finally:
+        db.close()
+
+
+def test_purge_rechecks_pin_inside_delete_transaction(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("terminal", source="cli")
+        db.append_message("terminal", role="user", content="stored")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+        store_archived_lineage(db, "terminal", archive_root)
+        assert db.set_session_pinned("terminal", True)
+
+        with pytest.raises(ValueError, match="pinned"):
+            purge_archived_lineage(db, "terminal", archive_root)
+
+        assert db.get_session("terminal") is not None
+        assert db.get_messages("terminal")[0]["content"] == "stored"
+    finally:
+        db.close()
+
+
+def test_purge_rejects_uncovered_child_and_preserves_foreign_key_rows(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("root", source="cli")
+        db.end_session("root", "compression")
+        db.create_session("terminal", source="cli", parent_session_id="root")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+        store_archived_lineage(db, "terminal", archive_root)
+        db.create_session(
+            "branch",
+            source="cli",
+            parent_session_id="root",
+            model_config={"_branched_from": "root"},
+        )
+
+        with pytest.raises(ValueError, match="uncovered child"):
+            purge_archived_lineage(db, "terminal", archive_root)
+
+        assert db.get_session("root") is not None
+        assert db.get_session("terminal") is not None
+        assert db.get_session("branch")["parent_session_id"] == "root"
     finally:
         db.close()
 

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 import os
 from pathlib import Path
 import signal
+import sqlite3
 
 import pytest
 
@@ -130,6 +131,98 @@ def test_purge_flushes_pending_token_accounting_before_final_recheck(
         assert row is not None
         assert row["source"] == "cli"
         assert row["input_tokens"] == 7
+    finally:
+        db.close()
+
+
+def test_purge_tombstone_blocks_cross_instance_session_resurrection(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "state.db"
+    archive_root = tmp_path / "archive"
+    purge_db = SessionDB(db_path)
+    late_writer = SessionDB(db_path)
+    try:
+        purge_db.create_session("root", source="cli")
+        purge_db.append_message("root", role="user", content="first")
+        purge_db.end_session("root", "compression")
+        purge_db.create_session(
+            "terminal", source="cli", parent_session_id="root"
+        )
+        purge_db.append_message("terminal", role="user", content="stored")
+        purge_db.end_session("terminal", "completed")
+        assert purge_db.set_session_archived("terminal", True)
+        store_archived_lineage(purge_db, "terminal", archive_root)
+
+        purged = purge_archived_lineage(purge_db, "terminal", archive_root)
+        assert purge_db.get_session("root") is None
+        assert purge_db.get_session("terminal") is None
+        assert late_writer._conn is not None
+        tombstones = late_writer._conn.execute(
+            "SELECT session_id, terminal_id, source_fingerprint "
+            "FROM cold_archive_tombstones ORDER BY session_id"
+        ).fetchall()
+        assert [tuple(row) for row in tombstones] == [
+            ("root", "terminal", purged.source_fingerprint),
+            ("terminal", "terminal", purged.source_fingerprint),
+        ]
+
+        with pytest.raises(sqlite3.IntegrityError, match="cold-archived"):
+            late_writer.update_token_counts(
+                "terminal",
+                input_tokens=7,
+                model="late-model",
+                billing_provider="late-provider",
+                api_call_count=1,
+            )
+        assert late_writer.get_session("terminal") is None
+
+        def _direct_insert(conn: sqlite3.Connection) -> None:
+            conn.execute(
+                "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+                ("root", "gateway", 1.0),
+            )
+
+        with pytest.raises(sqlite3.IntegrityError, match="cold-archived"):
+            late_writer._execute_write(_direct_insert)
+        assert late_writer.get_session("root") is None
+    finally:
+        late_writer.close()
+        purge_db.close()
+
+
+def test_purge_rolls_back_tombstone_when_source_delete_fails(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("terminal", source="cli")
+        db.append_message("terminal", role="user", content="stored")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+        store_archived_lineage(db, "terminal", archive_root)
+        assert db._conn is not None
+        db._conn.executescript(
+            """
+            CREATE TRIGGER force_cold_purge_delete_failure
+            BEFORE DELETE ON sessions
+            WHEN OLD.id = 'terminal'
+            BEGIN
+                SELECT RAISE(ABORT, 'forced cold purge delete failure');
+            END;
+            """
+        )
+
+        with pytest.raises(sqlite3.IntegrityError, match="forced cold purge"):
+            purge_archived_lineage(db, "terminal", archive_root)
+
+        assert db.get_session("terminal") is not None
+        assert db.get_messages("terminal")[0]["content"] == "stored"
+        assert db._conn.execute(
+            "SELECT 1 FROM cold_archive_tombstones WHERE session_id = ?",
+            ("terminal",),
+        ).fetchone() is None
     finally:
         db.close()
 
@@ -836,6 +929,16 @@ def test_store_keeps_purged_snapshot_when_same_id_is_reused_in_new_generation(
         db._conn.commit()
         first = store_archived_lineage(db, "reused", archive_root)
         purge_archived_lineage(db, "reused", archive_root)
+
+        # Cold Purge deliberately fences this ID from implicit resurrection.
+        # Simulate a future explicit restore/new-generation authorization; v1
+        # exposes no public untombstone operation.
+        untombstoned = db._conn.execute(
+            "DELETE FROM cold_archive_tombstones WHERE session_id = ?",
+            ("reused",),
+        )
+        assert untombstoned.rowcount == 1
+        db._conn.commit()
 
         db.create_session("reused", source="cli")
         db.append_message("reused", role="user", content="second generation")

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -1,6 +1,7 @@
 """Contract tests for the first Store-only cold archive slice."""
 
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -10,8 +11,10 @@ from hermes_cli.session_cold_store import store_archived_lineage
 from hermes_state import SessionDB
 
 
-def test_store_archived_compression_lineage_writes_terminal_id_revision(tmp_path: Path) -> None:
-    """Store writes a verified local revision without deleting temp-DB rows."""
+def test_store_archived_compression_lineage_writes_one_terminal_id_snapshot(
+    tmp_path: Path,
+) -> None:
+    """Store writes one immutable terminal-ID snapshot without deleting DB rows."""
     db = SessionDB(db_path=tmp_path / "state.db")
     archive_root = tmp_path / "archive"
     try:
@@ -27,11 +30,28 @@ def test_store_archived_compression_lineage_writes_terminal_id_revision(tmp_path
 
         assert result.terminal_id == "terminal"
         assert result.physical_ids == ("root", "terminal")
-        assert result.revision_dir.name == result.source_fingerprint
-        assert result.revision_dir.parent.name == "revisions"
-        assert result.revision_dir.parent.parent.name == "terminal"
+        terminal = db.get_session("terminal")
+        assert terminal is not None
+        ended = datetime.fromtimestamp(float(terminal["ended_at"]), UTC)
+        expected_snapshot = (
+            archive_root
+            / "sessions"
+            / "ended"
+            / f"{ended:%Y}"
+            / f"{ended:%m}"
+            / f"{ended:%d}"
+            / "terminal"
+        )
+        assert result.revision_dir == expected_snapshot
+        assert {path.name for path in result.revision_dir.iterdir()} == {
+            "artifacts",
+            "metadata.json",
+            "session.jsonl",
+        }
+        assert (result.revision_dir / "artifacts").is_dir()
         assert (result.revision_dir / "metadata.json").is_file()
         assert (result.revision_dir / "session.jsonl").is_file()
+        assert not list(archive_root.rglob("revisions"))
         assert store_archived_lineage(db, "terminal", archive_root) == result
         assert db.get_session("root") is not None
         assert db.get_session("terminal") is not None
@@ -40,7 +60,7 @@ def test_store_archived_compression_lineage_writes_terminal_id_revision(tmp_path
 
 
 def test_store_rejects_a_compression_ancestor_when_a_tip_exists(tmp_path: Path) -> None:
-    """An archive revision must be keyed to the complete chain terminal, never a prefix."""
+    """An archive snapshot must be keyed to the complete chain terminal, never a prefix."""
     db = SessionDB(db_path=tmp_path / "state.db")
     try:
         db.create_session("root", source="cli")
@@ -96,17 +116,57 @@ def test_store_reads_raw_rows_without_flushing_and_preserves_system_prompt(
 
         records = [
             json.loads(line)
-            for line in (result.revision_dir / "session.jsonl").read_text(encoding="utf-8").splitlines()
+            for line in (result.revision_dir / "session.jsonl").read_text(
+                encoding="utf-8"
+            ).splitlines()
         ]
         assert any(record["kind"] == "system-prompt" for record in records)
     finally:
         db.close()
 
 
-def test_store_rejects_revisions_symlink_swap_before_staging(
+def test_store_rejects_post_store_source_mutation_without_changing_db_or_snapshot(
+    tmp_path: Path,
+) -> None:
+    """A marked lineage is an archival boundary, not a source of new revisions."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("terminal", source="cli")
+        db.append_message("terminal", role="user", content="original")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+
+        result = store_archived_lineage(db, "terminal", archive_root)
+        metadata_before = (result.revision_dir / "metadata.json").read_bytes()
+        session_before = (result.revision_dir / "session.jsonl").read_bytes()
+
+        db.append_message("terminal", role="assistant", content="changed after Store")
+        changed_messages = db.get_messages("terminal")
+
+        with pytest.raises(
+            ValueError,
+            match=r"archival boundary.*source changed after Store",
+        ):
+            store_archived_lineage(db, "terminal", archive_root)
+
+        assert db.get_messages("terminal") == changed_messages
+        assert (result.revision_dir / "metadata.json").read_bytes() == metadata_before
+        assert (result.revision_dir / "session.jsonl").read_bytes() == session_before
+        assert {path.name for path in result.revision_dir.iterdir()} == {
+            "artifacts",
+            "metadata.json",
+            "session.jsonl",
+        }
+        assert not list(archive_root.rglob("revisions"))
+    finally:
+        db.close()
+
+
+def test_store_rejects_snapshot_parent_symlink_swap_before_staging(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A validated revision parent cannot be swapped to redirect transcript writes."""
+    """A validated snapshot parent cannot be swapped to redirect transcript writes."""
     db = SessionDB(db_path=tmp_path / "state.db")
     archive_root = tmp_path / "archive"
     outside = tmp_path / "outside"
@@ -128,9 +188,9 @@ def test_store_rejects_revisions_symlink_swap_before_staging(
         ) -> None:
             nonlocal swapped
             if not swapped and Path(path).name.startswith(".staging-"):
-                revisions = next(archive_root.rglob("revisions"))
-                revisions.rename(revisions.with_name("revisions-displaced"))
-                revisions.symlink_to(outside, target_is_directory=True)
+                snapshot_parent = next(archive_root.glob("sessions/ended/*/*/*"))
+                snapshot_parent.rename(snapshot_parent.with_name("day-displaced"))
+                snapshot_parent.symlink_to(outside, target_is_directory=True)
                 swapped = True
             real_mkdir(path, mode, dir_fd=dir_fd)
 

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -170,6 +170,42 @@ def test_purge_rejects_uncovered_child_and_preserves_foreign_key_rows(
         db.close()
 
 
+@pytest.mark.parametrize("delegate_parent_id", [None, "different-parent"])
+def test_purge_rejects_uncovered_delegate_marker_and_retains_source_rows(
+    tmp_path: Path,
+    delegate_parent_id: str | None,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("source", source="cli")
+        db.append_message("source", role="user", content="keep source")
+        db.end_session("source", "completed")
+        assert db.set_session_archived("source", True)
+        store_archived_lineage(db, "source", archive_root)
+        if delegate_parent_id is not None:
+            db.create_session(delegate_parent_id, source="cli")
+        db.create_session(
+            "delegate",
+            source="delegate",
+            parent_session_id=delegate_parent_id,
+            model_config={"_delegate_from": "source"},
+        )
+        db.append_message("delegate", role="assistant", content="keep delegate")
+
+        with pytest.raises(ValueError, match="uncovered child"):
+            purge_archived_lineage(db, "source", archive_root)
+
+        assert db.get_session("source") is not None
+        assert db.get_messages("source")[0]["content"] == "keep source"
+        delegate = db.get_session("delegate")
+        assert delegate is not None
+        assert delegate["parent_session_id"] == delegate_parent_id
+        assert db.get_messages("delegate")[0]["content"] == "keep delegate"
+    finally:
+        db.close()
+
+
 @pytest.mark.parametrize(
     "entry_json",
     ["{malformed", "[]", '{"session_id": 123}'],
@@ -407,6 +443,30 @@ def test_store_reports_the_same_canonical_path_it_writes(tmp_path: Path) -> None
         db.close()
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX directory modes are required")
+def test_store_creates_archive_hierarchy_directories_with_private_modes(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    original_umask = os.umask(0)
+    try:
+        db.create_session("terminal", source="cli")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+
+        result = store_archived_lineage(db, "terminal", archive_root)
+
+        hierarchy = [archive_root]
+        relative_parent = result.snapshot_dir.parent.relative_to(archive_root)
+        for part in relative_parent.parts:
+            hierarchy.append(hierarchy[-1] / part)
+        assert all(path.stat().st_mode & 0o777 == 0o700 for path in hierarchy)
+    finally:
+        os.umask(original_umask)
+        db.close()
+
+
 def test_store_keeps_distinct_ids_that_only_differ_by_trailing_space(
     tmp_path: Path,
 ) -> None:
@@ -482,6 +542,58 @@ def test_store_keeps_a_compression_child_with_an_inherited_old_delegate_marker(t
         result = store_archived_lineage(db, "terminal", tmp_path / "archive")
 
         assert result.physical_ids == ("root", "terminal")
+    finally:
+        db.close()
+
+
+def test_store_and_purge_isolate_a_direct_reset_from_its_compression_parent(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("compression-parent", source="cli")
+        db.end_session("compression-parent", "compression")
+        db.create_session(
+            "reset-child",
+            source="cli",
+            parent_session_id="compression-parent",
+            model_config={"_reset_from": "compression-parent"},
+        )
+        db.end_session("reset-child", "completed")
+        assert db.set_session_archived("reset-child", True)
+
+        stored = store_archived_lineage(db, "reset-child", archive_root)
+        purged = purge_archived_lineage(db, "reset-child", archive_root)
+
+        assert stored.physical_ids == ("reset-child",)
+        assert purged.physical_ids == ("reset-child",)
+        assert db.get_session("reset-child") is None
+        assert db.get_session("compression-parent") is not None
+    finally:
+        db.close()
+
+
+def test_store_keeps_a_compression_child_with_an_inherited_old_reset_marker(
+    tmp_path: Path,
+) -> None:
+    """An inherited reset marker names an older parent, not a new reset."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("reset-root", source="cli")
+        db.end_session("reset-root", "compression")
+        db.create_session(
+            "terminal",
+            source="cli",
+            parent_session_id="reset-root",
+            model_config={"_reset_from": "pre-reset-parent"},
+        )
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+
+        result = store_archived_lineage(db, "terminal", tmp_path / "archive")
+
+        assert result.physical_ids == ("reset-root", "terminal")
     finally:
         db.close()
 

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -1,5 +1,6 @@
 """Contract tests for the first Store-only cold archive slice."""
 
+import errno
 import json
 from datetime import UTC, datetime
 import os
@@ -879,6 +880,57 @@ def test_store_replaces_current_snapshot_when_archived_source_changes(
             "metadata.json",
             "session.jsonl",
         }
+    finally:
+        db.close()
+
+
+def test_store_restores_current_snapshot_when_replacement_publish_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("terminal", source="cli")
+        db.append_message("terminal", role="user", content="original")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+        first = store_archived_lineage(db, "terminal", archive_root)
+        original_payload = (first.snapshot_dir / "session.jsonl").read_bytes()
+
+        db.append_message("terminal", role="assistant", content="changed")
+        changed_messages = db.get_messages("terminal")
+        real_rename = os.rename
+
+        def fail_staging_publication(
+            src: str,
+            dst: str,
+            *,
+            src_dir_fd: int | None = None,
+            dst_dir_fd: int | None = None,
+        ) -> None:
+            if src.startswith(".staging-") and dst == first.snapshot_dir.name:
+                raise OSError(errno.EIO, "injected snapshot publication failure")
+            real_rename(
+                src,
+                dst,
+                src_dir_fd=src_dir_fd,
+                dst_dir_fd=dst_dir_fd,
+            )
+
+        monkeypatch.setattr(os, "rename", fail_staging_publication)
+
+        with pytest.raises(OSError, match="injected snapshot publication failure"):
+            store_archived_lineage(db, "terminal", archive_root)
+
+        assert first.snapshot_dir.is_dir()
+        assert (first.snapshot_dir / "session.jsonl").read_bytes() == original_payload
+        assert db.get_messages("terminal") == changed_messages
+        leftovers = {
+            path.name
+            for path in first.snapshot_dir.parent.iterdir()
+            if path.name.startswith((".stale-", ".staging-"))
+        }
+        assert leftovers == set()
     finally:
         db.close()
 

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -40,16 +40,15 @@ def test_store_archived_compression_lineage_writes_one_terminal_id_snapshot(
         terminal = db.get_session("terminal")
         assert terminal is not None
         started = datetime.fromtimestamp(float(terminal["started_at"]), UTC)
-        expected_snapshot = (
+        expected_snapshot_parent = (
             archive_root
             / "sessions"
             / "started"
             / f"{started:%Y}"
             / f"{started:%m}"
             / f"{started:%d}"
-            / cold_store._safe_component("terminal")
         )
-        assert result.snapshot_dir == expected_snapshot
+        assert result.snapshot_dir.parent == expected_snapshot_parent
         assert {path.name for path in result.snapshot_dir.iterdir()} == {
             "artifacts",
             "metadata.json",
@@ -649,28 +648,101 @@ def test_store_does_not_use_old_snapshot_after_replacement(tmp_path: Path) -> No
 
         replacement = store_archived_lineage(db, "terminal", archive_root)
 
-        assert replacement.snapshot_dir == first.snapshot_dir == (
-            archive_root
-            / "sessions"
-            / "started"
-            / "2026"
-            / "01"
-            / "02"
-            / cold_store._safe_component("terminal")
+        assert replacement.snapshot_dir == first.snapshot_dir
+        assert replacement.snapshot_dir.parent == (
+            archive_root / "sessions" / "started" / "2026" / "01" / "02"
         )
         current_metadata = json.loads(
             (replacement.snapshot_dir / "metadata.json").read_text(encoding="utf-8")
         )
         assert current_metadata["source_fingerprint"] == replacement.source_fingerprint
         assert current_metadata["source_fingerprint"] != first.source_fingerprint
-        assert list(archive_root.rglob(cold_store._safe_component("terminal"))) == [
-            replacement.snapshot_dir
-        ]
         payloads = list(archive_root.rglob("session.jsonl"))
         assert payloads == [replacement.snapshot_dir / "session.jsonl"]
         assert "new payload marker" in payloads[0].read_text(encoding="utf-8")
     finally:
         db.close()
+
+
+def test_store_keeps_purged_snapshot_when_same_id_is_reused_in_new_generation(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    first_started_at = datetime(2026, 1, 2, 3, 4, tzinfo=UTC).timestamp()
+    second_started_at = datetime(2026, 1, 2, 3, 5, tzinfo=UTC).timestamp()
+    try:
+        db.create_session("reused", source="cli")
+        db.append_message("reused", role="user", content="first generation")
+        db.end_session("reused", "completed")
+        assert db.set_session_archived("reused", True)
+        assert db._conn is not None
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (first_started_at, "reused"),
+        )
+        db._conn.commit()
+        first = store_archived_lineage(db, "reused", archive_root)
+        purge_archived_lineage(db, "reused", archive_root)
+
+        db.create_session("reused", source="cli")
+        db.append_message("reused", role="user", content="second generation")
+        db.end_session("reused", "completed")
+        assert db.set_session_archived("reused", True)
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (second_started_at, "reused"),
+        )
+        db._conn.commit()
+        second = store_archived_lineage(db, "reused", archive_root)
+
+        assert first.snapshot_dir != second.snapshot_dir
+        assert "first generation" in (first.snapshot_dir / "session.jsonl").read_text(
+            encoding="utf-8"
+        )
+        assert "second generation" in (second.snapshot_dir / "session.jsonl").read_text(
+            encoding="utf-8"
+        )
+    finally:
+        db.close()
+
+
+def test_store_isolates_same_id_and_generation_from_distinct_source_stores(
+    tmp_path: Path,
+) -> None:
+    first_db = SessionDB(db_path=tmp_path / "first" / "state.db")
+    second_db = SessionDB(db_path=tmp_path / "second" / "state.db")
+    archive_root = tmp_path / "archive"
+    started_at = datetime(2026, 1, 2, 3, 4, tzinfo=UTC).timestamp()
+    try:
+        for db, content in (
+            (first_db, "first source store"),
+            (second_db, "second source store"),
+        ):
+            db.create_session("same-id", source="cli")
+            db.append_message("same-id", role="user", content=content)
+            db.end_session("same-id", "completed")
+            assert db.set_session_archived("same-id", True)
+            assert db._conn is not None
+            db._conn.execute(
+                "UPDATE sessions SET started_at = ? WHERE id = ?",
+                (started_at, "same-id"),
+            )
+            db._conn.commit()
+
+        first = store_archived_lineage(first_db, "same-id", archive_root)
+        second = store_archived_lineage(second_db, "same-id", archive_root)
+
+        assert first.snapshot_dir != second.snapshot_dir
+        assert "first source store" in (first.snapshot_dir / "session.jsonl").read_text(
+            encoding="utf-8"
+        )
+        assert "second source store" in (second.snapshot_dir / "session.jsonl").read_text(
+            encoding="utf-8"
+        )
+    finally:
+        first_db.close()
+        second_db.close()
 
 
 @pytest.mark.skipif(

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -168,6 +168,35 @@ def test_purge_rejects_uncovered_child_and_preserves_foreign_key_rows(
         db.close()
 
 
+@pytest.mark.parametrize("entry_json", ["{malformed", "[]"])
+def test_purge_rejects_unverifiable_routing_entries_and_retains_all_rows(
+    tmp_path: Path,
+    entry_json: str,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("terminal", source="cli")
+        db.append_message("terminal", role="user", content="keep me")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+        store_archived_lineage(db, "terminal", archive_root)
+        db.save_gateway_routing_entry(
+            "route-key", entry_json, scope="test-routing-scope"
+        )
+
+        with pytest.raises(ValueError, match="gateway_routing.*cannot be verified"):
+            purge_archived_lineage(db, "terminal", archive_root)
+
+        assert db.get_session("terminal") is not None
+        assert db.get_messages("terminal")[0]["content"] == "keep me"
+        assert db.load_gateway_routing_entries(scope="test-routing-scope") == {
+            "route-key": entry_json
+        }
+    finally:
+        db.close()
+
+
 def test_verify_rejects_live_source_change_after_store(tmp_path: Path) -> None:
     """Verify compares the current read-only Store plan with the snapshot."""
     db = SessionDB(db_path=tmp_path / "state.db")

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -1,6 +1,9 @@
 """Contract tests for the first Store-only cold archive slice."""
 
+import json
 from pathlib import Path
+
+import pytest
 
 from hermes_cli.session_cold_store import store_archived_lineage
 from hermes_state import SessionDB
@@ -30,5 +33,29 @@ def test_store_archived_compression_lineage_writes_terminal_id_revision(tmp_path
         assert (result.revision_dir / "session.jsonl").is_file()
         assert db.get_session("root") is not None
         assert db.get_session("terminal") is not None
+    finally:
+        db.close()
+
+
+def test_store_reads_raw_rows_without_flushing_and_preserves_system_prompt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Store neither flushes pending accounting nor drops normalized prompt rows."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("terminal", source="cli", system_prompt="be helpful")
+        db.append_message("terminal", role="user", content="hello")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+
+        def unexpected_flush() -> None:
+            raise AssertionError("Store must not flush accounting")
+
+        monkeypatch.setattr(db, "flush_token_counts", unexpected_flush)
+        result = store_archived_lineage(db, "terminal", tmp_path / "archive")
+
+        records = [
+            json.loads(line)
+            for line in (result.revision_dir / "session.jsonl").read_text(encoding="utf-8").splitlines()
+        ]
+        assert any(record["kind"] == "system-prompt" for record in records)
     finally:
         db.close()

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -381,6 +381,53 @@ def test_store_same_fingerprint_is_idempotent_without_staging(
         db.close()
 
 
+@pytest.mark.parametrize("operation", ["store", "verify"])
+def test_existing_snapshot_rejects_replaced_open_parent_chain(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    """A valid snapshot is not accepted after its opened parent is displaced."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("terminal", source="cli")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+        stored = store_archived_lineage(db, "terminal", archive_root)
+        snapshot_parent = stored.snapshot_dir.parent
+        displaced_parent = snapshot_parent.with_name("day-displaced")
+        real_validate = cold_store._valid_existing_snapshot_at
+        swapped = False
+
+        def validate_then_replace_parent(*args, **kwargs):
+            nonlocal swapped
+            valid = real_validate(*args, **kwargs)
+            if valid is True and not swapped:
+                snapshot_parent.rename(displaced_parent)
+                snapshot_parent.mkdir()
+                swapped = True
+            return valid
+
+        monkeypatch.setattr(
+            cold_store,
+            "_valid_existing_snapshot_at",
+            validate_then_replace_parent,
+        )
+
+        with pytest.raises(ValueError, match="unsafe archive parent path"):
+            if operation == "store":
+                store_archived_lineage(db, "terminal", archive_root)
+            else:
+                cold_store.verify_archived_lineage(db, "terminal", archive_root)
+
+        assert swapped
+        assert not stored.snapshot_dir.exists()
+        assert (displaced_parent / stored.snapshot_dir.name).is_dir()
+    finally:
+        db.close()
+
+
 def test_store_does_not_use_old_snapshot_after_replacement(tmp_path: Path) -> None:
     """Only the replacement payload remains at the logical session's current path."""
     db = SessionDB(db_path=tmp_path / "state.db")

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import signal
 import sqlite3
 import stat
+import threading
 
 import pytest
 
@@ -316,6 +317,53 @@ def test_failed_accounting_lock_survives_later_success_until_owner_close(
     finally:
         if not accounting_closed:
             accounting_db.close()
+        archive_db.close()
+
+
+def test_timed_out_stopped_writer_releases_retained_accounting_lock_on_exit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "state.db"
+    archive_db = SessionDB(db_path)
+    accounting_db = SessionDB(db_path)
+    entered_apply = threading.Event()
+    release_apply = threading.Event()
+    try:
+        archive_db.create_session("terminal", source="cli")
+        archive_db.end_session("terminal", "completed")
+        assert archive_db.set_session_archived("terminal", True)
+
+        def blocked_failed_apply(_batch):
+            entered_apply.set()
+            if not release_apply.wait(10):
+                raise AssertionError("test did not release blocked writer")
+            return {"terminal"}
+
+        monkeypatch.setattr(accounting_db, "_apply_token_batch", blocked_failed_apply)
+        accounting_db.queue_token_counts(
+            "terminal", input_tokens=1, model="failed-model"
+        )
+        assert entered_apply.wait(5)
+        writer = accounting_db._token_writer_thread
+        assert writer is not None
+
+        accounting_db._stop_token_writer(join_timeout=0.01)
+        with pytest.raises(PendingSessionAccountingError, match="pending token"):
+            with cold_store._exclusive_lineage_accounting_locks(
+                archive_db, "terminal"
+            ):
+                pass
+
+        release_apply.set()
+        writer.join(timeout=10)
+        assert not writer.is_alive()
+        with cold_store._exclusive_lineage_accounting_locks(
+            archive_db, "terminal"
+        ):
+            pass
+    finally:
+        release_apply.set()
+        accounting_db.close()
         archive_db.close()
 
 
@@ -724,6 +772,30 @@ def test_store_rejects_rename_unsafe_archive_parent_before_creating_root(
         assert not archive_root.exists()
     finally:
         db.close()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX ownership is required")
+def test_root_lock_rejects_foreign_owned_sidecar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive_root = tmp_path / "archive"
+    lock_path = cold_store._cold_archive_lock_path(archive_root)
+    lock_path.write_text("", encoding="utf-8")
+    lock_path.chmod(0o600)
+    real_fstat = os.fstat
+
+    def foreign_regular_owner(fd: int) -> os.stat_result:
+        opened = real_fstat(fd)
+        if not stat.S_ISREG(opened.st_mode):
+            return opened
+        values = list(opened)
+        values[4] = os.geteuid() + 1
+        return os.stat_result(values)
+
+    monkeypatch.setattr(os, "fstat", foreign_regular_owner)
+    with pytest.raises(ValueError, match="unsafe cold archive lock sidecar"):
+        with cold_store._exclusive_cold_archive_root_lock(archive_root):
+            pass
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX ownership is required")

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -42,7 +42,7 @@ def test_store_archived_compression_lineage_writes_one_terminal_id_snapshot(
             / f"{started:%Y}"
             / f"{started:%m}"
             / f"{started:%d}"
-            / "terminal"
+            / cold_store._safe_component("terminal")
         )
         assert result.snapshot_dir == expected_snapshot
         assert {path.name for path in result.snapshot_dir.iterdir()} == {
@@ -111,6 +111,13 @@ def test_store_keeps_distinct_ids_that_only_differ_by_trailing_space(
         ).read_text(encoding="utf-8")
     finally:
         db.close()
+
+
+def test_safe_component_reserves_the_hash_suffix_namespace() -> None:
+    """A generated component cannot collide with an already-safe literal ID."""
+    generated = cold_store._safe_component("foo ")
+
+    assert cold_store._safe_component(generated) != generated
 
 
 def test_store_rejects_a_compression_ancestor_when_a_tip_exists(tmp_path: Path) -> None:
@@ -267,14 +274,22 @@ def test_store_does_not_use_old_snapshot_after_replacement(tmp_path: Path) -> No
         replacement = store_archived_lineage(db, "terminal", archive_root)
 
         assert replacement.snapshot_dir == first.snapshot_dir == (
-            archive_root / "sessions" / "started" / "2026" / "01" / "02" / "terminal"
+            archive_root
+            / "sessions"
+            / "started"
+            / "2026"
+            / "01"
+            / "02"
+            / cold_store._safe_component("terminal")
         )
         current_metadata = json.loads(
             (replacement.snapshot_dir / "metadata.json").read_text(encoding="utf-8")
         )
         assert current_metadata["source_fingerprint"] == replacement.source_fingerprint
         assert current_metadata["source_fingerprint"] != first.source_fingerprint
-        assert list(archive_root.rglob("terminal")) == [replacement.snapshot_dir]
+        assert list(archive_root.rglob(cold_store._safe_component("terminal"))) == [
+            replacement.snapshot_dir
+        ]
         payloads = list(archive_root.rglob("session.jsonl"))
         assert payloads == [replacement.snapshot_dir / "session.jsonl"]
         assert "new payload marker" in payloads[0].read_text(encoding="utf-8")

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -16,7 +16,7 @@ from hermes_state import SessionDB
 def test_store_archived_compression_lineage_writes_one_terminal_id_snapshot(
     tmp_path: Path,
 ) -> None:
-    """Store writes one immutable terminal-ID snapshot without deleting DB rows."""
+    """Store writes one current terminal-ID snapshot without deleting DB rows."""
     db = SessionDB(db_path=tmp_path / "state.db")
     archive_root = tmp_path / "archive"
     try:
@@ -44,19 +44,37 @@ def test_store_archived_compression_lineage_writes_one_terminal_id_snapshot(
             / f"{started:%d}"
             / "terminal"
         )
-        assert result.revision_dir == expected_snapshot
-        assert {path.name for path in result.revision_dir.iterdir()} == {
+        assert result.snapshot_dir == expected_snapshot
+        assert {path.name for path in result.snapshot_dir.iterdir()} == {
             "artifacts",
             "metadata.json",
             "session.jsonl",
         }
-        assert (result.revision_dir / "artifacts").is_dir()
-        assert (result.revision_dir / "metadata.json").is_file()
-        assert (result.revision_dir / "session.jsonl").is_file()
-        assert not list(archive_root.rglob("revisions"))
+        assert (result.snapshot_dir / "artifacts").is_dir()
+        assert (result.snapshot_dir / "metadata.json").is_file()
+        assert (result.snapshot_dir / "session.jsonl").is_file()
         assert store_archived_lineage(db, "terminal", archive_root) == result
         assert db.get_session("root") is not None
         assert db.get_session("terminal") is not None
+    finally:
+        db.close()
+
+
+def test_store_reports_the_same_canonical_path_it_writes(tmp_path: Path) -> None:
+    """A lexical ROOT alias cannot make the reported snapshot path misleading."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    canonical_root = tmp_path / "archive"
+    root_spelling = canonical_root / "not-created" / ".."
+    try:
+        db.create_session("terminal", source="cli")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+
+        result = store_archived_lineage(db, "terminal", root_spelling)
+
+        assert result.snapshot_dir.is_dir()
+        assert result.snapshot_dir.is_relative_to(canonical_root)
+        assert "not-created" not in result.snapshot_dir.parts
     finally:
         db.close()
 
@@ -118,7 +136,7 @@ def test_store_reads_raw_rows_without_flushing_and_preserves_system_prompt(
 
         records = [
             json.loads(line)
-            for line in (result.revision_dir / "session.jsonl").read_text(
+            for line in (result.snapshot_dir / "session.jsonl").read_text(
                 encoding="utf-8"
             ).splitlines()
         ]
@@ -127,10 +145,10 @@ def test_store_reads_raw_rows_without_flushing_and_preserves_system_prompt(
         db.close()
 
 
-def test_store_rejects_post_store_source_mutation_without_changing_db_or_snapshot(
+def test_store_replaces_current_snapshot_when_archived_source_changes(
     tmp_path: Path,
 ) -> None:
-    """A marked lineage is an archival boundary, not a source of new revisions."""
+    """A changed archived source replaces the snapshot and leaves source rows intact."""
     db = SessionDB(db_path=tmp_path / "state.db")
     archive_root = tmp_path / "archive"
     try:
@@ -139,34 +157,55 @@ def test_store_rejects_post_store_source_mutation_without_changing_db_or_snapsho
         db.end_session("terminal", "completed")
         assert db.set_session_archived("terminal", True)
 
-        result = store_archived_lineage(db, "terminal", archive_root)
-        metadata_before = (result.revision_dir / "metadata.json").read_bytes()
-        session_before = (result.revision_dir / "session.jsonl").read_bytes()
+        first = store_archived_lineage(db, "terminal", archive_root)
+        session_before = (first.snapshot_dir / "session.jsonl").read_bytes()
 
         db.append_message("terminal", role="assistant", content="changed after Store")
         changed_messages = db.get_messages("terminal")
 
-        with pytest.raises(
-            ValueError,
-            match=r"archival boundary.*source changed after Store",
-        ):
-            store_archived_lineage(db, "terminal", archive_root)
+        replacement = store_archived_lineage(db, "terminal", archive_root)
 
         assert db.get_messages("terminal") == changed_messages
-        assert (result.revision_dir / "metadata.json").read_bytes() == metadata_before
-        assert (result.revision_dir / "session.jsonl").read_bytes() == session_before
-        assert {path.name for path in result.revision_dir.iterdir()} == {
+        assert replacement.snapshot_dir == first.snapshot_dir
+        assert replacement.source_fingerprint != first.source_fingerprint
+        replacement_payload = (replacement.snapshot_dir / "session.jsonl").read_bytes()
+        assert replacement_payload != session_before
+        assert b"changed after Store" in replacement_payload
+        assert {path.name for path in replacement.snapshot_dir.iterdir()} == {
             "artifacts",
             "metadata.json",
             "session.jsonl",
         }
-        assert not list(archive_root.rglob("revisions"))
     finally:
         db.close()
 
 
-def test_store_uses_started_date_when_terminal_ended_at_changes(tmp_path: Path) -> None:
-    """A reopened terminal keeps one snapshot identity even if it ends again later."""
+def test_store_same_fingerprint_is_idempotent_without_staging(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("terminal", source="cli")
+        db.append_message("terminal", role="user", content="unchanged")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+
+        first = store_archived_lineage(db, "terminal", archive_root)
+
+        def unexpected_staging(_snapshot_parent_fd: int) -> tuple[str, int]:
+            raise AssertionError("same fingerprint must not create a staged replacement")
+
+        monkeypatch.setattr(cold_store, "_create_staging_directory", unexpected_staging)
+
+        assert store_archived_lineage(db, "terminal", archive_root) == first
+        assert first.snapshot_dir.is_dir()
+    finally:
+        db.close()
+
+
+def test_store_does_not_use_old_snapshot_after_replacement(tmp_path: Path) -> None:
+    """Only the replacement payload remains at the logical session's current path."""
     db = SessionDB(db_path=tmp_path / "state.db")
     archive_root = tmp_path / "archive"
     started_at = datetime(2026, 1, 2, 3, 4, tzinfo=UTC).timestamp()
@@ -174,7 +213,7 @@ def test_store_uses_started_date_when_terminal_ended_at_changes(tmp_path: Path) 
     second_ended_at = datetime(2026, 3, 4, 5, 6, tzinfo=UTC).timestamp()
     try:
         db.create_session("terminal", source="cli")
-        db.append_message("terminal", role="user", content="immutable")
+        db.append_message("terminal", role="user", content="old payload marker")
         db.end_session("terminal", "completed")
         assert db.set_session_archived("terminal", True)
         conn = db._conn
@@ -184,22 +223,27 @@ def test_store_uses_started_date_when_terminal_ended_at_changes(tmp_path: Path) 
             (started_at, first_ended_at, "terminal"),
         )
 
-        result = store_archived_lineage(db, "terminal", archive_root)
+        first = store_archived_lineage(db, "terminal", archive_root)
         conn.execute(
             "UPDATE sessions SET ended_at = ? WHERE id = ?",
             (second_ended_at, "terminal"),
         )
+        db.append_message("terminal", role="assistant", content="new payload marker")
 
-        with pytest.raises(
-            ValueError,
-            match=r"archival boundary.*source changed after Store",
-        ):
-            store_archived_lineage(db, "terminal", archive_root)
+        replacement = store_archived_lineage(db, "terminal", archive_root)
 
-        assert result.revision_dir == (
+        assert replacement.snapshot_dir == first.snapshot_dir == (
             archive_root / "sessions" / "started" / "2026" / "01" / "02" / "terminal"
         )
-        assert list(archive_root.rglob("terminal")) == [result.revision_dir]
+        current_metadata = json.loads(
+            (replacement.snapshot_dir / "metadata.json").read_text(encoding="utf-8")
+        )
+        assert current_metadata["source_fingerprint"] == replacement.source_fingerprint
+        assert current_metadata["source_fingerprint"] != first.source_fingerprint
+        assert list(archive_root.rglob("terminal")) == [replacement.snapshot_dir]
+        payloads = list(archive_root.rglob("session.jsonl"))
+        assert payloads == [replacement.snapshot_dir / "session.jsonl"]
+        assert "new payload marker" in payloads[0].read_text(encoding="utf-8")
     finally:
         db.close()
 
@@ -209,18 +253,18 @@ def test_store_uses_started_date_when_terminal_ended_at_changes(tmp_path: Path) 
     reason="requires POSIX FIFOs and interval timers",
 )
 @pytest.mark.parametrize("payload_name", ["metadata.json", "session.jsonl"])
-def test_store_rejects_fifo_payload_without_blocking(
+def test_store_replaces_fifo_payload_without_blocking(
     tmp_path: Path,
     payload_name: str,
 ) -> None:
-    """A damaged snapshot payload that is a FIFO is invalid, not a blocking read."""
+    """A damaged current payload is safely replaced without blocking on a FIFO."""
     db = SessionDB(db_path=tmp_path / "state.db")
     try:
         db.create_session("terminal", source="cli")
         db.end_session("terminal", "completed")
         assert db.set_session_archived("terminal", True)
         result = store_archived_lineage(db, "terminal", tmp_path / "archive")
-        payload = result.revision_dir / payload_name
+        payload = result.snapshot_dir / payload_name
         payload.unlink()
         os.mkfifo(payload)
 
@@ -230,27 +274,32 @@ def test_store_rejects_fifo_payload_without_blocking(
         previous_handler = signal.signal(signal.SIGALRM, fail_if_blocked)
         signal.setitimer(signal.ITIMER_REAL, 2.0)
         try:
-            with pytest.raises(ValueError, match="existing snapshot is invalid"):
-                store_archived_lineage(db, "terminal", tmp_path / "archive")
+            replacement = store_archived_lineage(db, "terminal", tmp_path / "archive")
         finally:
             signal.setitimer(signal.ITIMER_REAL, 0.0)
             signal.signal(signal.SIGALRM, previous_handler)
+
+        assert (replacement.snapshot_dir / payload_name).is_file()
     finally:
         db.close()
 
 
-def test_store_rejects_non_object_snapshot_metadata(tmp_path: Path) -> None:
-    """Valid JSON scalars/lists are still invalid archive metadata envelopes."""
+def test_store_replaces_non_object_snapshot_metadata(tmp_path: Path) -> None:
+    """A malformed current metadata envelope is replaced by a valid snapshot."""
     db = SessionDB(db_path=tmp_path / "state.db")
     try:
         db.create_session("terminal", source="cli")
         db.end_session("terminal", "completed")
         assert db.set_session_archived("terminal", True)
         result = store_archived_lineage(db, "terminal", tmp_path / "archive")
-        (result.revision_dir / "metadata.json").write_text("[]\n", encoding="utf-8")
+        (result.snapshot_dir / "metadata.json").write_text("[]\n", encoding="utf-8")
 
-        with pytest.raises(ValueError, match="existing snapshot is invalid"):
-            store_archived_lineage(db, "terminal", tmp_path / "archive")
+        replacement = store_archived_lineage(db, "terminal", tmp_path / "archive")
+
+        metadata = json.loads(
+            (replacement.snapshot_dir / "metadata.json").read_text(encoding="utf-8")
+        )
+        assert metadata["source_fingerprint"] == replacement.source_fingerprint
     finally:
         db.close()
 

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -60,6 +60,100 @@ def test_store_archived_compression_lineage_writes_one_terminal_id_snapshot(
         db.close()
 
 
+def test_verify_rejects_live_source_change_after_store(tmp_path: Path) -> None:
+    """Verify compares the current read-only Store plan with the snapshot."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("terminal", source="cli")
+        db.append_message("terminal", role="user", content="original")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+        stored = store_archived_lineage(db, "terminal", archive_root)
+        db.append_message("terminal", role="assistant", content="changed after Store")
+        before_changes = db._conn.total_changes if db._conn is not None else -1
+
+        with pytest.raises(ValueError, match="fingerprint"):
+            cold_store.verify_archived_lineage(db, "terminal", archive_root)
+
+        assert db._conn is not None
+        assert db._conn.total_changes == before_changes
+        assert stored.snapshot_dir.is_dir()
+        assert "changed after Store" not in (
+            stored.snapshot_dir / "session.jsonl"
+        ).read_text(encoding="utf-8")
+    finally:
+        db.close()
+
+
+def test_verify_missing_snapshot_does_not_create_archive_root(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "missing-archive"
+    try:
+        db.create_session("terminal", source="cli")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+        before_changes = db._conn.total_changes if db._conn is not None else -1
+
+        with pytest.raises(ValueError, match="snapshot not found"):
+            cold_store.verify_archived_lineage(db, "terminal", archive_root)
+
+        assert not archive_root.exists()
+        assert db._conn is not None
+        assert db._conn.total_changes == before_changes
+    finally:
+        db.close()
+
+
+def test_verify_rejects_corrupt_snapshot_without_replacing_it(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("terminal", source="cli")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+        stored = store_archived_lineage(db, "terminal", archive_root)
+        metadata = stored.snapshot_dir / "metadata.json"
+        metadata.write_text("{corrupt\n", encoding="utf-8")
+        before_files = sorted(
+            path.relative_to(archive_root) for path in archive_root.rglob("*")
+        )
+
+        with pytest.raises(ValueError, match="snapshot is corrupt"):
+            cold_store.verify_archived_lineage(db, "terminal", archive_root)
+
+        assert metadata.read_text(encoding="utf-8") == "{corrupt\n"
+        assert sorted(
+            path.relative_to(archive_root) for path in archive_root.rglob("*")
+        ) == before_files
+    finally:
+        db.close()
+
+
+def test_verify_rejects_symlinked_snapshot_payload(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    outside = tmp_path / "outside-metadata.json"
+    try:
+        db.create_session("terminal", source="cli")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+        stored = store_archived_lineage(db, "terminal", archive_root)
+        metadata = stored.snapshot_dir / "metadata.json"
+        original = metadata.read_text(encoding="utf-8")
+        outside.write_text(original, encoding="utf-8")
+        metadata.unlink()
+        metadata.symlink_to(outside)
+
+        with pytest.raises(ValueError, match="snapshot is corrupt"):
+            cold_store.verify_archived_lineage(db, "terminal", archive_root)
+
+        assert metadata.is_symlink()
+        assert outside.read_text(encoding="utf-8") == original
+    finally:
+        db.close()
+
+
 @pytest.mark.parametrize("operation", ["store", "preflight"])
 def test_store_rejects_blob_message_content_before_writing(
     tmp_path: Path,

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -51,6 +51,30 @@ def test_store_rejects_a_compression_ancestor_when_a_tip_exists(tmp_path: Path) 
             store_archived_lineage(db, "root", tmp_path / "archive")
     finally:
         db.close()
+
+
+def test_store_keeps_a_compression_child_with_an_inherited_old_delegate_marker(tmp_path: Path) -> None:
+    """Inherited markers are not forks unless they name the direct parent."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("root", source="cli")
+        db.end_session("root", "compression")
+        db.create_session(
+            "terminal",
+            source="cli",
+            parent_session_id="root",
+            model_config={"_delegate_from": "older-delegate-parent"},
+        )
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+
+        result = store_archived_lineage(db, "terminal", tmp_path / "archive")
+
+        assert result.physical_ids == ("root", "terminal")
+    finally:
+        db.close()
+
+
 def test_store_reads_raw_rows_without_flushing_and_preserves_system_prompt(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -13,6 +13,7 @@ from hermes_cli.session_cold_store import (
     plan_archived_lineage,
     purge_archived_lineage,
     store_archived_lineage,
+    validate_purge_archived_lineage,
 )
 from hermes_state import SessionDB
 
@@ -193,6 +194,56 @@ def test_purge_rejects_unverifiable_routing_entries_and_retains_all_rows(
         assert db.load_gateway_routing_entries(scope="test-routing-scope") == {
             "route-key": entry_json
         }
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize("operation", ["preflight", "purge"])
+def test_purge_fails_closed_when_optional_delegation_reference_column_is_absent(
+    tmp_path: Path,
+    operation: str,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("terminal", source="cli")
+        db.append_message("terminal", role="user", content="keep me")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+        store_archived_lineage(db, "terminal", archive_root)
+        assert db._conn is not None
+        db._conn.execute(
+            "ALTER TABLE async_delegations DROP COLUMN origin_session_id"
+        )
+        db._conn.commit()
+        before_meta = db._conn.execute(
+            "SELECT key, value FROM state_meta ORDER BY key"
+        ).fetchall()
+        before_delegations = db._conn.execute(
+            "SELECT * FROM async_delegations ORDER BY delegation_id"
+        ).fetchall()
+        assert (
+            db._conn.execute("SELECT COUNT(*) FROM gateway_routing").fetchone()[0]
+            == 0
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=r"schema is missing async_delegations\.origin_session_id",
+        ):
+            if operation == "preflight":
+                validate_purge_archived_lineage(db, "terminal", archive_root)
+            else:
+                purge_archived_lineage(db, "terminal", archive_root)
+
+        assert db.get_session("terminal") is not None
+        assert db.get_messages("terminal")[0]["content"] == "keep me"
+        assert db._conn.execute(
+            "SELECT key, value FROM state_meta ORDER BY key"
+        ).fetchall() == before_meta
+        assert db._conn.execute(
+            "SELECT * FROM async_delegations ORDER BY delegation_id"
+        ).fetchall() == before_delegations
     finally:
         db.close()
 

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -1,0 +1,34 @@
+"""Contract tests for the first Store-only cold archive slice."""
+
+from pathlib import Path
+
+from hermes_cli.session_cold_store import store_archived_lineage
+from hermes_state import SessionDB
+
+
+def test_store_archived_compression_lineage_writes_terminal_id_revision(tmp_path: Path) -> None:
+    """Store writes a verified local revision without deleting temp-DB rows."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("root", source="cli")
+        db.append_message("root", role="user", content="first")
+        db.end_session("root", "compression")
+        db.create_session("terminal", source="cli", parent_session_id="root")
+        db.append_message("terminal", role="assistant", content="second")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+
+        result = store_archived_lineage(db, "terminal", archive_root)
+
+        assert result.terminal_id == "terminal"
+        assert result.physical_ids == ("root", "terminal")
+        assert result.revision_dir.name == result.source_fingerprint
+        assert result.revision_dir.parent.name == "revisions"
+        assert result.revision_dir.parent.parent.name == "terminal"
+        assert (result.revision_dir / "metadata.json").is_file()
+        assert (result.revision_dir / "session.jsonl").is_file()
+        assert db.get_session("root") is not None
+        assert db.get_session("terminal") is not None
+    finally:
+        db.close()

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -270,6 +270,55 @@ def test_lineage_accounting_lock_rejects_late_queue_and_releases_after_flush(
         archive_db.close()
 
 
+def test_failed_accounting_lock_survives_later_success_until_owner_close(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "state.db"
+    archive_db = SessionDB(db_path)
+    accounting_db = SessionDB(db_path)
+    accounting_closed = False
+    try:
+        archive_db.create_session("terminal", source="cli")
+        archive_db.end_session("terminal", "completed")
+        assert archive_db.set_session_archived("terminal", True)
+        original_update = accounting_db.update_token_counts
+        attempts = 0
+
+        def fail_once(session_id: str, **kwargs) -> None:
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise sqlite3.OperationalError("forced accounting failure")
+            original_update(session_id, **kwargs)
+
+        accounting_db.update_token_counts = fail_once  # type: ignore[method-assign]
+        accounting_db.queue_token_counts(
+            "terminal", input_tokens=1, model="failed-model"
+        )
+        assert not accounting_db.flush_token_counts(timeout=10)
+        accounting_db.queue_token_counts(
+            "terminal", input_tokens=2, model="successful-model"
+        )
+        assert not accounting_db.flush_token_counts(timeout=10)
+
+        with pytest.raises(PendingSessionAccountingError, match="pending token"):
+            with cold_store._exclusive_lineage_accounting_locks(
+                archive_db, "terminal"
+            ):
+                pass
+
+        accounting_db.close()
+        accounting_closed = True
+        with cold_store._exclusive_lineage_accounting_locks(
+            archive_db, "terminal"
+        ):
+            pass
+    finally:
+        if not accounting_closed:
+            accounting_db.close()
+        archive_db.close()
+
+
 def test_purge_rolls_back_tombstone_when_source_delete_fails(
     tmp_path: Path,
 ) -> None:

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 import signal
 import sqlite3
+import stat
 
 import pytest
 
@@ -572,6 +573,47 @@ def test_store_reports_the_same_canonical_path_it_writes(tmp_path: Path) -> None
         assert result.snapshot_dir.is_dir()
         assert result.snapshot_dir.is_relative_to(canonical_root)
         assert "not-created" not in result.snapshot_dir.parts
+    finally:
+        db.close()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are required")
+@pytest.mark.parametrize(
+    ("member", "insecure_mode"),
+    [
+        pytest.param(".", 0o750, id="snapshot-directory"),
+        pytest.param("artifacts", 0o750, id="artifacts-directory"),
+        pytest.param("metadata.json", 0o640, id="metadata-file"),
+        pytest.param("session.jsonl", 0o640, id="payload-file"),
+    ],
+)
+def test_verify_rejects_insecure_snapshot_permissions_and_store_repairs_them(
+    tmp_path: Path,
+    member: str,
+    insecure_mode: int,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("terminal", source="cli")
+        db.append_message("terminal", role="user", content="private")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+        stored = store_archived_lineage(db, "terminal", archive_root)
+        target = stored.snapshot_dir if member == "." else stored.snapshot_dir / member
+        target.chmod(insecure_mode)
+
+        with pytest.raises(ValueError, match="snapshot"):
+            cold_store.verify_archived_lineage(db, "terminal", archive_root)
+        assert db.get_session("terminal") is not None
+
+        repaired = store_archived_lineage(db, "terminal", archive_root)
+        assert repaired.snapshot_dir == stored.snapshot_dir
+        repaired_target = (
+            repaired.snapshot_dir if member == "." else repaired.snapshot_dir / member
+        )
+        assert stat.S_IMODE(repaired_target.stat().st_mode) & 0o077 == 0
+        cold_store.verify_archived_lineage(db, "terminal", archive_root)
     finally:
         db.close()
 

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -12,6 +12,7 @@ import stat
 import pytest
 
 import hermes_cli.session_cold_store as cold_store
+from hermes_accounting_locks import PendingSessionAccountingError
 from hermes_cli.session_cold_store import (
     plan_archived_lineage,
     purge_archived_lineage,
@@ -191,6 +192,82 @@ def test_purge_tombstone_blocks_cross_instance_session_resurrection(
     finally:
         late_writer.close()
         purge_db.close()
+
+
+def test_purge_tombstone_blocks_cross_instance_gateway_routes(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "state.db"
+    archive_root = tmp_path / "archive"
+    purge_db = SessionDB(db_path)
+    late_writer = SessionDB(db_path)
+    survivor_entry = json.dumps({"session_id": "survivor"})
+    try:
+        purge_db.create_session("terminal", source="cli")
+        purge_db.append_message("terminal", role="user", content="stored")
+        purge_db.end_session("terminal", "completed")
+        assert purge_db.set_session_archived("terminal", True)
+        late_writer.save_gateway_routing_entry(
+            "existing-key", survivor_entry, scope="test"
+        )
+        store_archived_lineage(purge_db, "terminal", archive_root)
+        purge_archived_lineage(purge_db, "terminal", archive_root)
+
+        tombstoned_entry = json.dumps({"session_id": "terminal"})
+        with pytest.raises(sqlite3.IntegrityError, match="cold-archived"):
+            late_writer.save_gateway_routing_entry(
+                "new-key", tombstoned_entry, scope="test"
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="cold-archived"):
+            late_writer.save_gateway_routing_entry(
+                "existing-key", tombstoned_entry, scope="test"
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="cold-archived"):
+            late_writer.replace_gateway_routing_entries(
+                {"replacement-key": tombstoned_entry}, scope="test"
+            )
+
+        assert late_writer.load_gateway_routing_entries(scope="test") == {
+            "existing-key": survivor_entry
+        }
+    finally:
+        late_writer.close()
+        purge_db.close()
+
+
+def test_lineage_accounting_lock_rejects_late_queue_and_releases_after_flush(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "state.db"
+    archive_db = SessionDB(db_path)
+    accounting_db = SessionDB(db_path)
+    try:
+        archive_db.create_session("terminal", source="cli")
+        archive_db.end_session("terminal", "completed")
+        assert archive_db.set_session_archived("terminal", True)
+
+        with cold_store._exclusive_lineage_accounting_locks(
+            archive_db, "terminal"
+        ):
+            with pytest.raises(
+                PendingSessionAccountingError, match="locked for cold archive"
+            ):
+                accounting_db.queue_token_counts(
+                    "terminal", input_tokens=1, model="late-model"
+                )
+            assert not accounting_db._token_queue
+
+        accounting_db.queue_token_counts(
+            "terminal", input_tokens=2, model="settled-model"
+        )
+        assert accounting_db.flush_token_counts(timeout=10)
+        with cold_store._exclusive_lineage_accounting_locks(
+            archive_db, "terminal"
+        ):
+            pass
+    finally:
+        accounting_db.close()
+        archive_db.close()
 
 
 def test_purge_rolls_back_tombstone_when_source_delete_fails(

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -112,8 +112,10 @@ def test_purge_finishes_filesystem_reads_before_final_write_transaction(
         stored = store_archived_lineage(db, "terminal", archive_root)
 
         final_write_started = False
-        filesystem_reads: list[str] = []
+        external_reads: list[str] = []
         original_execute_write = db._execute_write
+        original_message_limit = cold_store.resolved_max_export_messages
+        original_source_store_key = cold_store._source_store_key
         original_verify_snapshot = cold_store._verify_plan_snapshot
         original_legacy_routes = cold_store._reject_legacy_routing_references
 
@@ -122,17 +124,31 @@ def test_purge_finishes_filesystem_reads_before_final_write_transaction(
             final_write_started = True
             return original_execute_write(callback)
 
+        def tracked_message_limit():
+            assert not final_write_started, "config read ran inside final write"
+            external_reads.append("config")
+            return original_message_limit()
+
+        def tracked_source_store_key(*args, **kwargs):
+            assert not final_write_started, "source-store stat ran inside final write"
+            external_reads.append("source-store")
+            return original_source_store_key(*args, **kwargs)
+
         def tracked_verify_snapshot(*args, **kwargs):
             assert not final_write_started, "snapshot verification ran inside final write"
-            filesystem_reads.append("snapshot")
+            external_reads.append("snapshot")
             return original_verify_snapshot(*args, **kwargs)
 
         def tracked_legacy_routes(*args, **kwargs):
             assert not final_write_started, "legacy-route read ran inside final write"
-            filesystem_reads.append("legacy-routes")
+            external_reads.append("legacy-routes")
             return original_legacy_routes(*args, **kwargs)
 
         monkeypatch.setattr(db, "_execute_write", tracked_execute_write)
+        monkeypatch.setattr(
+            cold_store, "resolved_max_export_messages", tracked_message_limit
+        )
+        monkeypatch.setattr(cold_store, "_source_store_key", tracked_source_store_key)
         monkeypatch.setattr(cold_store, "_verify_plan_snapshot", tracked_verify_snapshot)
         monkeypatch.setattr(
             cold_store, "_reject_legacy_routing_references", tracked_legacy_routes
@@ -140,7 +156,12 @@ def test_purge_finishes_filesystem_reads_before_final_write_transaction(
 
         result = purge_archived_lineage(db, "terminal", archive_root)
 
-        assert filesystem_reads == ["legacy-routes", "snapshot"]
+        assert external_reads == [
+            "config",
+            "source-store",
+            "legacy-routes",
+            "snapshot",
+        ]
         assert result.snapshot_dir == stored.snapshot_dir
         assert db.get_session("terminal") is None
     finally:
@@ -1263,6 +1284,69 @@ def test_store_restores_current_snapshot_when_replacement_publish_fails(
             if path.name.startswith((".stale-", ".staging-"))
         }
         assert leftovers == set()
+    finally:
+        db.close()
+
+
+def test_store_retry_requires_successful_parent_fsync_after_publication_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("terminal", source="cli")
+        db.append_message("terminal", role="user", content="durable payload")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+
+        real_rename = os.rename
+        real_fsync = os.fsync
+        published = False
+        fail_publication_fsync = True
+        retrying = False
+        retry_fsyncs = 0
+
+        def track_publication_rename(
+            src: str,
+            dst: str,
+            *,
+            src_dir_fd: int | None = None,
+            dst_dir_fd: int | None = None,
+        ) -> None:
+            nonlocal published
+            real_rename(
+                src,
+                dst,
+                src_dir_fd=src_dir_fd,
+                dst_dir_fd=dst_dir_fd,
+            )
+            if src.startswith(".staging-"):
+                published = True
+
+        def fail_once_after_publication(descriptor: int) -> None:
+            nonlocal fail_publication_fsync, retry_fsyncs
+            if published and fail_publication_fsync:
+                fail_publication_fsync = False
+                raise OSError(errno.EIO, "injected snapshot parent fsync failure")
+            if retrying:
+                retry_fsyncs += 1
+            real_fsync(descriptor)
+
+        monkeypatch.setattr(os, "rename", track_publication_rename)
+        monkeypatch.setattr(os, "fsync", fail_once_after_publication)
+
+        with pytest.raises(OSError, match="injected snapshot parent fsync failure"):
+            store_archived_lineage(db, "terminal", archive_root)
+
+        assert published
+        visible_snapshot = next(archive_root.rglob("metadata.json")).parent
+        assert visible_snapshot.is_dir()
+
+        retrying = True
+        result = store_archived_lineage(db, "terminal", archive_root)
+
+        assert result.snapshot_dir == visible_snapshot
+        assert retry_fsyncs == 1
     finally:
         db.close()
 

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -94,6 +94,46 @@ def test_purge_rejects_missing_or_mismatched_snapshot_and_retains_source_rows(
         db.close()
 
 
+def test_purge_flushes_pending_token_accounting_before_final_recheck(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("terminal", source="cli")
+        db.append_message("terminal", role="user", content="stored")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+        store_archived_lineage(db, "terminal", archive_root)
+
+        # Deterministically model a queued delta that the background writer has
+        # not started applying yet. A post-delete apply would recreate the row
+        # as source='unknown' and the snapshot would miss these counters.
+        with db._token_queue_cond:
+            assert db._token_writer_thread is None
+            db._token_queue.append(
+                (
+                    "terminal",
+                    {
+                        "input_tokens": 7,
+                        "model": "late-model",
+                        "billing_provider": "late-provider",
+                        "api_call_count": 1,
+                    },
+                )
+            )
+
+        with pytest.raises(ValueError, match="fingerprint"):
+            purge_archived_lineage(db, "terminal", archive_root)
+
+        row = db.get_session("terminal")
+        assert row is not None
+        assert row["source"] == "cli"
+        assert row["input_tokens"] == 7
+    finally:
+        db.close()
+
+
 def test_purge_rejects_source_mutation_after_store_and_retains_source_rows(
     tmp_path: Path,
 ) -> None:

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -809,7 +809,10 @@ def test_store_keeps_purged_snapshot_when_source_db_is_replaced_at_same_path(
 
 
 @pytest.mark.skipif(
-    not hasattr(os, "mkfifo") or not hasattr(signal, "setitimer"),
+    not all(
+        hasattr(module, name)
+        for module, name in ((os, "mkfifo"), (signal, "setitimer"), (signal, "SIGALRM"))
+    ),
     reason="requires POSIX FIFOs and interval timers",
 )
 @pytest.mark.parametrize("payload_name", ["metadata.json", "session.jsonl"])
@@ -831,13 +834,15 @@ def test_store_replaces_fifo_payload_without_blocking(
         def fail_if_blocked(*_args: object) -> None:
             raise AssertionError("cold-store validation blocked while opening a FIFO")
 
-        previous_handler = signal.signal(signal.SIGALRM, fail_if_blocked)
+        sigalrm = getattr(signal, "SIGALRM", None)
+        assert sigalrm is not None
+        previous_handler = signal.signal(sigalrm, fail_if_blocked)
         signal.setitimer(signal.ITIMER_REAL, 2.0)
         try:
             replacement = store_archived_lineage(db, "terminal", tmp_path / "archive")
         finally:
             signal.setitimer(signal.ITIMER_REAL, 0.0)
-            signal.signal(signal.SIGALRM, previous_handler)
+            signal.signal(sigalrm, previous_handler)
 
         assert (replacement.snapshot_dir / payload_name).is_file()
     finally:

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -99,6 +99,54 @@ def test_purge_rejects_missing_or_mismatched_snapshot_and_retains_source_rows(
         db.close()
 
 
+def test_purge_finishes_filesystem_reads_before_final_write_transaction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = SessionDB(tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("terminal", source="cli")
+        db.append_message("terminal", role="user", content="stored")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+        stored = store_archived_lineage(db, "terminal", archive_root)
+
+        final_write_started = False
+        filesystem_reads: list[str] = []
+        original_execute_write = db._execute_write
+        original_verify_snapshot = cold_store._verify_plan_snapshot
+        original_legacy_routes = cold_store._reject_legacy_routing_references
+
+        def tracked_execute_write(callback):
+            nonlocal final_write_started
+            final_write_started = True
+            return original_execute_write(callback)
+
+        def tracked_verify_snapshot(*args, **kwargs):
+            assert not final_write_started, "snapshot verification ran inside final write"
+            filesystem_reads.append("snapshot")
+            return original_verify_snapshot(*args, **kwargs)
+
+        def tracked_legacy_routes(*args, **kwargs):
+            assert not final_write_started, "legacy-route read ran inside final write"
+            filesystem_reads.append("legacy-routes")
+            return original_legacy_routes(*args, **kwargs)
+
+        monkeypatch.setattr(db, "_execute_write", tracked_execute_write)
+        monkeypatch.setattr(cold_store, "_verify_plan_snapshot", tracked_verify_snapshot)
+        monkeypatch.setattr(
+            cold_store, "_reject_legacy_routing_references", tracked_legacy_routes
+        )
+
+        result = purge_archived_lineage(db, "terminal", archive_root)
+
+        assert filesystem_reads == ["legacy-routes", "snapshot"]
+        assert result.snapshot_dir == stored.snapshot_dir
+        assert db.get_session("terminal") is None
+    finally:
+        db.close()
+
+
 def test_purge_flushes_pending_token_accounting_before_final_recheck(
     tmp_path: Path,
 ) -> None:
@@ -428,6 +476,51 @@ def test_purge_rejects_source_mutation_after_store_and_retains_source_rows(
         db.close()
 
 
+def test_purge_rechecks_source_after_pretransaction_snapshot_verification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("terminal", source="cli")
+        db.append_message("terminal", role="user", content="stored")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+        store_archived_lineage(db, "terminal", archive_root)
+        original_execute_write = db._execute_write
+
+        def mutate_before_final_transaction(callback):
+            with sqlite3.connect(db.db_path) as mutator:
+                mutator.execute(
+                    "INSERT INTO messages (session_id, role, content, timestamp) "
+                    "VALUES (?, ?, ?, ?)",
+                    ("terminal", "assistant", "late source change", 1.0),
+                )
+            return original_execute_write(callback)
+
+        monkeypatch.setattr(
+            db, "_execute_write", mutate_before_final_transaction
+        )
+
+        with pytest.raises(
+            ValueError, match="source lineage changed after snapshot verification"
+        ):
+            purge_archived_lineage(db, "terminal", archive_root)
+
+        assert db.get_session("terminal") is not None
+        assert [message["content"] for message in db.get_messages("terminal")] == [
+            "stored",
+            "late source change",
+        ]
+        assert db._conn is not None
+        assert db._conn.execute(
+            "SELECT 1 FROM cold_archive_tombstones WHERE session_id = ?",
+            ("terminal",),
+        ).fetchone() is None
+    finally:
+        db.close()
+
+
 def test_purge_rechecks_pin_inside_delete_transaction(tmp_path: Path) -> None:
     db = SessionDB(db_path=tmp_path / "state.db")
     archive_root = tmp_path / "archive"
@@ -548,7 +641,7 @@ def test_purge_rejects_unverifiable_routing_entries_and_retains_all_rows(
 
 
 @pytest.mark.parametrize("operation", ["preflight", "purge"])
-def test_purge_fails_closed_when_optional_delegation_reference_column_is_absent(
+def test_purge_accepts_absent_pre_upgrade_delegation_reference_column(
     tmp_path: Path,
     operation: str,
 ) -> None:
@@ -571,14 +664,55 @@ def test_purge_fails_closed_when_optional_delegation_reference_column_is_absent(
         before_delegations = db._conn.execute(
             "SELECT * FROM async_delegations ORDER BY delegation_id"
         ).fetchall()
-        assert (
-            db._conn.execute("SELECT COUNT(*) FROM gateway_routing").fetchone()[0]
-            == 0
+
+        if operation == "preflight":
+            result = validate_purge_archived_lineage(db, "terminal", archive_root)
+            assert db.get_session("terminal") is not None
+            assert db.get_messages("terminal")[0]["content"] == "keep me"
+        else:
+            result = purge_archived_lineage(db, "terminal", archive_root)
+            assert db.get_session("terminal") is None
+            assert db.get_messages("terminal") == []
+
+        assert result.terminal_id == "terminal"
+        assert db._conn.execute(
+            "SELECT key, value FROM state_meta ORDER BY key"
+        ).fetchall() == before_meta
+        assert db._conn.execute(
+            "SELECT * FROM async_delegations ORDER BY delegation_id"
+        ).fetchall() == before_delegations
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize("operation", ["preflight", "purge"])
+def test_purge_fails_closed_when_required_delegation_reference_column_is_absent(
+    tmp_path: Path,
+    operation: str,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("terminal", source="cli")
+        db.append_message("terminal", role="user", content="keep me")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+        store_archived_lineage(db, "terminal", archive_root)
+        assert db._conn is not None
+        db._conn.execute(
+            "ALTER TABLE async_delegations DROP COLUMN parent_session_id"
         )
+        db._conn.commit()
+        before_meta = db._conn.execute(
+            "SELECT key, value FROM state_meta ORDER BY key"
+        ).fetchall()
+        before_delegations = db._conn.execute(
+            "SELECT * FROM async_delegations ORDER BY delegation_id"
+        ).fetchall()
 
         with pytest.raises(
             ValueError,
-            match=r"schema is missing async_delegations\.origin_session_id",
+            match=r"schema is missing async_delegations\.parent_session_id",
         ):
             if operation == "preflight":
                 validate_purge_archived_lineage(db, "terminal", archive_root)

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -304,6 +304,28 @@ def test_store_replaces_non_object_snapshot_metadata(tmp_path: Path) -> None:
         db.close()
 
 
+@pytest.mark.parametrize("payload_name", ["metadata.json", "session.jsonl"])
+def test_store_replaces_snapshot_with_invalid_utf8(
+    tmp_path: Path,
+    payload_name: str,
+) -> None:
+    """Invalid UTF-8 is damaged snapshot state, just like malformed JSON."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("terminal", source="cli")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+        result = store_archived_lineage(db, "terminal", tmp_path / "archive")
+        (result.snapshot_dir / payload_name).write_bytes(b"\xff")
+
+        replacement = store_archived_lineage(db, "terminal", tmp_path / "archive")
+
+        assert replacement == result
+        (replacement.snapshot_dir / payload_name).read_text(encoding="utf-8")
+    finally:
+        db.close()
+
+
 def test_store_rejects_snapshot_parent_symlink_swap_before_staging(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -9,7 +9,7 @@ import signal
 import pytest
 
 import hermes_cli.session_cold_store as cold_store
-from hermes_cli.session_cold_store import store_archived_lineage
+from hermes_cli.session_cold_store import plan_archived_lineage, store_archived_lineage
 from hermes_state import SessionDB
 
 
@@ -56,6 +56,48 @@ def test_store_archived_compression_lineage_writes_one_terminal_id_snapshot(
         assert store_archived_lineage(db, "terminal", archive_root) == result
         assert db.get_session("root") is not None
         assert db.get_session("terminal") is not None
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize("operation", ["store", "preflight"])
+def test_store_rejects_blob_message_content_before_writing(
+    tmp_path: Path,
+    operation: str,
+) -> None:
+    """Archive v1 fails closed on SQLite BLOBs without changing its source."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    try:
+        db.create_session("terminal", source="cli")
+        message_id = db.append_message("terminal", role="user", content="placeholder")
+        assert db._conn is not None
+        db._conn.execute(
+            "UPDATE messages SET content = ? WHERE id = ?",
+            (b"future-blob", message_id),
+        )
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+
+        with pytest.raises(
+            ValueError,
+            match=r"cold store v1 does not support SQLite BLOB/bytes values.*message\.content",
+        ):
+            if operation == "store":
+                store_archived_lineage(db, "terminal", archive_root)
+            else:
+                plan_archived_lineage(db, "terminal")
+
+        assert not archive_root.exists()
+        assert db._conn is not None
+        session = db._conn.execute(
+            "SELECT archived FROM sessions WHERE id = ?", ("terminal",)
+        ).fetchone()
+        message = db._conn.execute(
+            "SELECT content FROM messages WHERE session_id = ?", ("terminal",)
+        ).fetchone()
+        assert session is not None and session["archived"] == 1
+        assert message is not None and message["content"] == b"future-blob"
     finally:
         db.close()
 

--- a/tests/hermes_cli/test_session_cold_store.py
+++ b/tests/hermes_cli/test_session_cold_store.py
@@ -2,7 +2,9 @@
 
 import json
 from datetime import UTC, datetime
+import os
 from pathlib import Path
+import signal
 
 import pytest
 
@@ -32,14 +34,14 @@ def test_store_archived_compression_lineage_writes_one_terminal_id_snapshot(
         assert result.physical_ids == ("root", "terminal")
         terminal = db.get_session("terminal")
         assert terminal is not None
-        ended = datetime.fromtimestamp(float(terminal["ended_at"]), UTC)
+        started = datetime.fromtimestamp(float(terminal["started_at"]), UTC)
         expected_snapshot = (
             archive_root
             / "sessions"
-            / "ended"
-            / f"{ended:%Y}"
-            / f"{ended:%m}"
-            / f"{ended:%d}"
+            / "started"
+            / f"{started:%Y}"
+            / f"{started:%m}"
+            / f"{started:%d}"
             / "terminal"
         )
         assert result.revision_dir == expected_snapshot
@@ -163,6 +165,80 @@ def test_store_rejects_post_store_source_mutation_without_changing_db_or_snapsho
         db.close()
 
 
+def test_store_uses_started_date_when_terminal_ended_at_changes(tmp_path: Path) -> None:
+    """A reopened terminal keeps one snapshot identity even if it ends again later."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    archive_root = tmp_path / "archive"
+    started_at = datetime(2026, 1, 2, 3, 4, tzinfo=UTC).timestamp()
+    first_ended_at = datetime(2026, 2, 3, 4, 5, tzinfo=UTC).timestamp()
+    second_ended_at = datetime(2026, 3, 4, 5, 6, tzinfo=UTC).timestamp()
+    try:
+        db.create_session("terminal", source="cli")
+        db.append_message("terminal", role="user", content="immutable")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+        conn = db._conn
+        assert conn is not None
+        conn.execute(
+            "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = ?",
+            (started_at, first_ended_at, "terminal"),
+        )
+
+        result = store_archived_lineage(db, "terminal", archive_root)
+        conn.execute(
+            "UPDATE sessions SET ended_at = ? WHERE id = ?",
+            (second_ended_at, "terminal"),
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=r"archival boundary.*source changed after Store",
+        ):
+            store_archived_lineage(db, "terminal", archive_root)
+
+        assert result.revision_dir == (
+            archive_root / "sessions" / "started" / "2026" / "01" / "02" / "terminal"
+        )
+        assert list(archive_root.rglob("terminal")) == [result.revision_dir]
+    finally:
+        db.close()
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "mkfifo") or not hasattr(signal, "setitimer"),
+    reason="requires POSIX FIFOs and interval timers",
+)
+@pytest.mark.parametrize("payload_name", ["metadata.json", "session.jsonl"])
+def test_store_rejects_fifo_payload_without_blocking(
+    tmp_path: Path,
+    payload_name: str,
+) -> None:
+    """A damaged snapshot payload that is a FIFO is invalid, not a blocking read."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("terminal", source="cli")
+        db.end_session("terminal", "completed")
+        assert db.set_session_archived("terminal", True)
+        result = store_archived_lineage(db, "terminal", tmp_path / "archive")
+        payload = result.revision_dir / payload_name
+        payload.unlink()
+        os.mkfifo(payload)
+
+        def fail_if_blocked(*_args: object) -> None:
+            raise AssertionError("cold-store validation blocked while opening a FIFO")
+
+        previous_handler = signal.signal(signal.SIGALRM, fail_if_blocked)
+        signal.setitimer(signal.ITIMER_REAL, 2.0)
+        try:
+            with pytest.raises(ValueError, match="existing snapshot is invalid"):
+                store_archived_lineage(db, "terminal", tmp_path / "archive")
+        finally:
+            signal.setitimer(signal.ITIMER_REAL, 0.0)
+            signal.signal(signal.SIGALRM, previous_handler)
+    finally:
+        db.close()
+
+
 def test_store_rejects_snapshot_parent_symlink_swap_before_staging(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -188,7 +264,7 @@ def test_store_rejects_snapshot_parent_symlink_swap_before_staging(
         ) -> None:
             nonlocal swapped
             if not swapped and Path(path).name.startswith(".staging-"):
-                snapshot_parent = next(archive_root.glob("sessions/ended/*/*/*"))
+                snapshot_parent = next(archive_root.glob("sessions/started/*/*/*"))
                 snapshot_parent.rename(snapshot_parent.with_name("day-displaced"))
                 snapshot_parent.symlink_to(outside, target_is_directory=True)
                 swapped = True

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -336,6 +336,48 @@ def test_recovery_preserves_cold_archive_tombstone_fence(tmp_path: Path) -> None
         recovered.close()
 
 
+def test_recovery_removes_rows_that_conflict_with_cold_archive_tombstones(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source-conflict.db"
+    output = tmp_path / "recovered-conflict.db"
+    db = SessionDB(db_path=source)
+    try:
+        db.create_session("cold-purged", source="cli")
+        db.append_message("cold-purged", role="user", content="stale hot row")
+        assert db._conn is not None
+        db._conn.execute(
+            "INSERT INTO cold_archive_tombstones "
+            "(session_id, terminal_id, source_fingerprint, deleted_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("cold-purged", "terminal", "e" * 64, 321.0),
+        )
+    finally:
+        db.close()
+
+    report = recover_session_database(source, output, work_dir=tmp_path)
+
+    assert report["tombstone_reconciliation"] == {
+        "sessions_removed": 1,
+        "sessions_parent_cleared": 0,
+        "messages_removed": 1,
+        "session_model_usage_removed": 0,
+        "compression_locks_removed": 0,
+        "telegram_dm_topic_bindings_removed": 0,
+    }
+    assert report["verification"]["healthy"] is True
+    assert report["verification"]["table_counts"]["sessions"] == 0
+    assert report["verification"]["table_counts"]["messages"] == 0
+    recovered = SessionDB(db_path=output)
+    try:
+        assert recovered.get_session("cold-purged") is None
+        assert recovered.get_messages("cold-purged") == []
+        with pytest.raises(sqlite3.IntegrityError, match="cold-archived"):
+            recovered.create_session("cold-purged", source="recovery-test")
+    finally:
+        recovered.close()
+
+
 def test_snapshot_blocks_connections_opened_during_the_copy(
     tmp_path: Path,
 ) -> None:

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -363,6 +363,8 @@ def test_recovery_removes_rows_that_conflict_with_cold_archive_tombstones(
         "system_prompts_removed": 0,
         "gateway_routes_removed": 0,
         "gateway_routes_unverifiable": 0,
+        "state_meta_removed": 0,
+        "async_delegations_removed": 0,
         "messages_removed": 1,
         "session_model_usage_removed": 0,
         "compression_locks_removed": 0,
@@ -479,6 +481,77 @@ def test_recovery_removes_only_routes_targeting_tombstoned_ids(
         }
         assert recovered.get_session("cold-purged") is None
         assert recovered.get_session("survivor") is not None
+    finally:
+        recovered.close()
+
+
+def test_recovery_removes_state_and_delegation_references_to_tombstones(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source-soft-references.db"
+    output = tmp_path / "recovered-soft-references.db"
+    db = SessionDB(db_path=source)
+    try:
+        db.create_session("cold-purged", source="cli")
+        db.create_session("survivor", source="cli")
+        assert db._conn is not None
+        db._conn.execute(
+            "INSERT INTO cold_archive_tombstones "
+            "(session_id, terminal_id, source_fingerprint, deleted_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("cold-purged", "cold-purged", "4" * 64, 103.0),
+        )
+        db._conn.executemany(
+            "INSERT INTO state_meta (key, value) VALUES (?, ?)",
+            [
+                ("goal:cold-purged", "stale"),
+                ("loop:cold-purged", "stale"),
+                ("heartbeat:cold-purged", "stale"),
+                ("goal:survivor", "keep"),
+                ("other:cold-purged", "keep"),
+            ],
+        )
+        db._conn.executemany(
+            "INSERT INTO async_delegations ("
+            "delegation_id, origin_session, parent_session_id, origin_session_id, "
+            "state, dispatched_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [
+                ("by-origin", "cold-purged", None, "", "completed", 1.0, 2.0),
+                ("by-parent", "survivor", "cold-purged", "", "completed", 1.0, 2.0),
+                ("by-origin-id", "survivor", None, "cold-purged", "completed", 1.0, 2.0),
+                ("keep", "survivor", None, "survivor", "completed", 1.0, 2.0),
+            ],
+        )
+    finally:
+        db.close()
+
+    report = recover_session_database(source, output, work_dir=tmp_path)
+
+    reconciliation = report["tombstone_reconciliation"]
+    assert reconciliation["state_meta_removed"] == 3
+    assert reconciliation["async_delegations_removed"] == 3
+    recovered = SessionDB(db_path=output)
+    try:
+        assert recovered._conn is not None
+        meta = recovered._conn.execute(
+            "SELECT key, value FROM state_meta WHERE key IN (?, ?, ?, ?, ?) "
+            "ORDER BY key",
+            (
+                "goal:cold-purged",
+                "loop:cold-purged",
+                "heartbeat:cold-purged",
+                "goal:survivor",
+                "other:cold-purged",
+            ),
+        ).fetchall()
+        assert [tuple(row) for row in meta] == [
+            ("goal:survivor", "keep"),
+            ("other:cold-purged", "keep"),
+        ]
+        delegations = recovered._conn.execute(
+            "SELECT delegation_id FROM async_delegations ORDER BY delegation_id"
+        ).fetchall()
+        assert [str(row[0]) for row in delegations] == ["keep"]
     finally:
         recovered.close()
 

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -300,6 +300,42 @@ def _corrupt_table_root(path: Path, root_page: int) -> None:
     path.write_bytes(data)
 
 
+def test_recovery_preserves_cold_archive_tombstone_fence(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    output = tmp_path / "recovered.db"
+    db = SessionDB(db_path=source)
+    try:
+        assert db._conn is not None
+        db._conn.execute(
+            "INSERT INTO cold_archive_tombstones "
+            "(session_id, terminal_id, source_fingerprint, deleted_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("cold-purged", "terminal", "f" * 64, 123.0),
+        )
+    finally:
+        db.close()
+
+    report = recover_session_database(source, output, work_dir=tmp_path)
+
+    assert report["copy"]["cold_archive_tombstones"]["status"] == "complete"
+    assert report["verification"]["table_counts"]["cold_archive_tombstones"] == 1
+    recovered = SessionDB(db_path=output)
+    try:
+        assert recovered._conn is not None
+        row = recovered._conn.execute(
+            "SELECT terminal_id, source_fingerprint, deleted_at "
+            "FROM cold_archive_tombstones WHERE session_id = ?",
+            ("cold-purged",),
+        ).fetchone()
+        assert row is not None
+        assert tuple(row) == ("terminal", "f" * 64, 123.0)
+        with pytest.raises(sqlite3.IntegrityError, match="cold-archived"):
+            recovered.create_session("cold-purged", source="recovery-test")
+        assert recovered.get_session("cold-purged") is None
+    finally:
+        recovered.close()
+
+
 def test_snapshot_blocks_connections_opened_during_the_copy(
     tmp_path: Path,
 ) -> None:

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -360,6 +360,9 @@ def test_recovery_removes_rows_that_conflict_with_cold_archive_tombstones(
     assert report["tombstone_reconciliation"] == {
         "sessions_removed": 1,
         "sessions_parent_cleared": 0,
+        "system_prompts_removed": 0,
+        "gateway_routes_removed": 0,
+        "gateway_routes_unverifiable": 0,
         "messages_removed": 1,
         "session_model_usage_removed": 0,
         "compression_locks_removed": 0,
@@ -374,6 +377,108 @@ def test_recovery_removes_rows_that_conflict_with_cold_archive_tombstones(
         assert recovered.get_messages("cold-purged") == []
         with pytest.raises(sqlite3.IntegrityError, match="cold-archived"):
             recovered.create_session("cold-purged", source="recovery-test")
+    finally:
+        recovered.close()
+
+
+def test_recovery_removes_only_prompts_orphaned_by_tombstone_authority(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source-prompts.db"
+    output = tmp_path / "recovered-prompts.db"
+    db = SessionDB(db_path=source)
+    try:
+        db.create_session("cold-unique", source="cli")
+        db.update_system_prompt("cold-unique", "orphaned secret prompt")
+        db.create_session("cold-shared", source="cli")
+        db.update_system_prompt("cold-shared", "shared surviving prompt")
+        db.create_session("survivor", source="cli")
+        db.update_system_prompt("survivor", "shared surviving prompt")
+        assert db._conn is not None
+        db._conn.executemany(
+            "INSERT INTO cold_archive_tombstones "
+            "(session_id, terminal_id, source_fingerprint, deleted_at) "
+            "VALUES (?, ?, ?, ?)",
+            [
+                ("cold-unique", "cold-unique", "1" * 64, 100.0),
+                ("cold-shared", "cold-shared", "2" * 64, 101.0),
+            ],
+        )
+    finally:
+        db.close()
+
+    report = recover_session_database(source, output, work_dir=tmp_path)
+
+    assert report["tombstone_reconciliation"]["system_prompts_removed"] == 1
+    recovered = SessionDB(db_path=output)
+    try:
+        assert recovered._conn is not None
+        prompts = [
+            str(row[0])
+            for row in recovered._conn.execute(
+                "SELECT prompt FROM system_prompts ORDER BY prompt"
+            ).fetchall()
+        ]
+        assert prompts == ["shared surviving prompt"]
+        assert recovered.get_session("cold-unique") is None
+        assert recovered.get_session("cold-shared") is None
+        assert recovered.get_session("survivor") is not None
+    finally:
+        recovered.close()
+
+
+def test_recovery_removes_only_routes_targeting_tombstoned_ids(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source-routes.db"
+    output = tmp_path / "recovered-routes.db"
+    db = SessionDB(db_path=source)
+    try:
+        db.create_session("cold-purged", source="cli")
+        db.create_session("survivor", source="cli")
+        db.save_gateway_routing_entry(
+            "cold-key",
+            json.dumps({"session_id": "cold-purged"}),
+            scope="test",
+        )
+        db.save_gateway_routing_entry(
+            "survivor-key",
+            json.dumps({"session_id": "survivor"}),
+            scope="test",
+        )
+        db.save_gateway_routing_entry("malformed-key", "{broken", scope="test")
+        assert db._conn is not None
+        db._conn.execute(
+            "INSERT INTO cold_archive_tombstones "
+            "(session_id, terminal_id, source_fingerprint, deleted_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("cold-purged", "cold-purged", "3" * 64, 102.0),
+        )
+    finally:
+        db.close()
+
+    report = recover_session_database(source, output, work_dir=tmp_path)
+
+    reconciliation = report["tombstone_reconciliation"]
+    assert reconciliation["gateway_routes_removed"] == 1
+    assert reconciliation["gateway_routes_unverifiable"] == 1
+    recovered = SessionDB(db_path=output)
+    try:
+        assert recovered._conn is not None
+        routes = {
+            str(row[0]): str(row[1])
+            for row in recovered._conn.execute(
+                "SELECT session_key, entry_json FROM gateway_routing "
+                "WHERE scope = ? ORDER BY session_key",
+                ("test",),
+            ).fetchall()
+        }
+        assert routes == {
+            "malformed-key": "{broken",
+            "survivor-key": json.dumps({"session_id": "survivor"}),
+        }
+        assert recovered.get_session("cold-purged") is None
+        assert recovered.get_session("survivor") is not None
     finally:
         recovered.close()
 

--- a/tests/hermes_cli/test_session_recovery_lost_and_found.py
+++ b/tests/hermes_cli/test_session_recovery_lost_and_found.py
@@ -472,10 +472,33 @@ def test_classify_lost_and_found_row_sentinels() -> None:
     assert classify_lost_and_found_row(0, ()) is None
 
 
+def _add_direct_session_conflicting_with_tombstone(
+    lf_conn: sqlite3.Connection,
+) -> None:
+    lf_conn.execute(
+        "CREATE TABLE sessions ("
+        "id TEXT PRIMARY KEY, source TEXT NOT NULL, started_at REAL NOT NULL)"
+    )
+    lf_conn.execute(
+        "INSERT INTO sessions VALUES (?, ?, ?)",
+        ("cold-purged", "cli", 123.0),
+    )
+    lf_conn.execute(
+        "CREATE TABLE messages ("
+        "id INTEGER PRIMARY KEY, session_id TEXT NOT NULL, role TEXT NOT NULL, "
+        "content TEXT, timestamp REAL NOT NULL)"
+    )
+    lf_conn.execute(
+        "INSERT INTO messages VALUES (?, ?, ?, ?, ?)",
+        (1, "cold-purged", "user", "stale hot row", 124.0),
+    )
+
+
 def test_mapper_preserves_unattributed_cold_archive_tombstones(
     tmp_path: Path,
 ) -> None:
     lf_conn = sqlite3.connect(":memory:", isolation_level=None)
+    _add_direct_session_conflicting_with_tombstone(lf_conn)
     lf_conn.execute(
         "CREATE TABLE lost_and_found ("
         "rootpgno INTEGER, pgno INTEGER, nfield INTEGER, id INTEGER, "
@@ -491,12 +514,16 @@ def test_mapper_preserves_unattributed_cold_archive_tombstones(
     try:
         mapping = map_lost_and_found_rows(lf_conn, dest)
         assert mapping["mapped"]["cold_archive_tombstones"] == 1
+        assert mapping["tombstone_reconciliation"]["sessions_removed"] == 1
+        assert mapping["tombstone_reconciliation"]["messages_removed"] == 1
+        assert stub_missing_parent_sessions(dest)["sessions_stubbed"] == 0
     finally:
         lf_conn.close()
         dest.close()
 
     recovered = SessionDB(db_path=output)
     try:
+        assert recovered.get_messages("cold-purged") == []
         with pytest.raises(sqlite3.IntegrityError, match="cold-archived"):
             recovered.create_session("cold-purged", source="recovery-test")
         assert recovered.get_session("cold-purged") is None
@@ -508,6 +535,7 @@ def test_mapper_preserves_attributed_cold_archive_tombstones(
     tmp_path: Path,
 ) -> None:
     lf_conn = sqlite3.connect(":memory:", isolation_level=None)
+    _add_direct_session_conflicting_with_tombstone(lf_conn)
     lf_conn.execute(
         "CREATE TABLE cold_archive_tombstones ("
         "session_id TEXT PRIMARY KEY, "
@@ -525,12 +553,16 @@ def test_mapper_preserves_attributed_cold_archive_tombstones(
     try:
         mapping = map_lost_and_found_rows(lf_conn, dest)
         assert mapping["direct_table_rows"]["cold_archive_tombstones"] == 1
+        assert mapping["tombstone_reconciliation"]["sessions_removed"] == 1
+        assert mapping["tombstone_reconciliation"]["messages_removed"] == 1
+        assert stub_missing_parent_sessions(dest)["sessions_stubbed"] == 0
     finally:
         lf_conn.close()
         dest.close()
 
     recovered = SessionDB(db_path=output)
     try:
+        assert recovered.get_messages("cold-purged") == []
         with pytest.raises(sqlite3.IntegrityError, match="cold-archived"):
             recovered.create_session("cold-purged", source="recovery-test")
         assert recovered.get_session("cold-purged") is None

--- a/tests/hermes_cli/test_session_recovery_lost_and_found.py
+++ b/tests/hermes_cli/test_session_recovery_lost_and_found.py
@@ -426,6 +426,12 @@ def _make_synthetic_lost_and_found(
 def test_classify_lost_and_found_row_sentinels() -> None:
     assert (
         classify_lost_and_found_row(
+            4, ("cold-purged", "terminal", "b" * 64, 123.0)
+        )
+        == "cold_archive_tombstones"
+    )
+    assert (
+        classify_lost_and_found_row(
             23, (None, "20260101_010101_aaa001", "user", "hi")
         )
         == "messages"
@@ -464,6 +470,72 @@ def test_classify_lost_and_found_row_sentinels() -> None:
         classify_lost_and_found_row(23, (None, "sess", "not-a-role", "x")) is None
     )
     assert classify_lost_and_found_row(0, ()) is None
+
+
+def test_mapper_preserves_unattributed_cold_archive_tombstones(
+    tmp_path: Path,
+) -> None:
+    lf_conn = sqlite3.connect(":memory:", isolation_level=None)
+    lf_conn.execute(
+        "CREATE TABLE lost_and_found ("
+        "rootpgno INTEGER, pgno INTEGER, nfield INTEGER, id INTEGER, "
+        "c0, c1, c2, c3)"
+    )
+    lf_conn.execute(
+        "INSERT INTO lost_and_found VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (1, 2, 4, 9, "cold-purged", "terminal", "c" * 64, 789.0),
+    )
+    output = tmp_path / "mapped-unattributed.db"
+    SessionDB(db_path=output).close()
+    dest = sqlite3.connect(str(output), isolation_level=None)
+    try:
+        mapping = map_lost_and_found_rows(lf_conn, dest)
+        assert mapping["mapped"]["cold_archive_tombstones"] == 1
+    finally:
+        lf_conn.close()
+        dest.close()
+
+    recovered = SessionDB(db_path=output)
+    try:
+        with pytest.raises(sqlite3.IntegrityError, match="cold-archived"):
+            recovered.create_session("cold-purged", source="recovery-test")
+        assert recovered.get_session("cold-purged") is None
+    finally:
+        recovered.close()
+
+
+def test_mapper_preserves_attributed_cold_archive_tombstones(
+    tmp_path: Path,
+) -> None:
+    lf_conn = sqlite3.connect(":memory:", isolation_level=None)
+    lf_conn.execute(
+        "CREATE TABLE cold_archive_tombstones ("
+        "session_id TEXT PRIMARY KEY, "
+        "terminal_id TEXT NOT NULL, "
+        "source_fingerprint TEXT NOT NULL, "
+        "deleted_at REAL NOT NULL)"
+    )
+    lf_conn.execute(
+        "INSERT INTO cold_archive_tombstones VALUES (?, ?, ?, ?)",
+        ("cold-purged", "terminal", "a" * 64, 456.0),
+    )
+    output = tmp_path / "mapped.db"
+    SessionDB(db_path=output).close()
+    dest = sqlite3.connect(str(output), isolation_level=None)
+    try:
+        mapping = map_lost_and_found_rows(lf_conn, dest)
+        assert mapping["direct_table_rows"]["cold_archive_tombstones"] == 1
+    finally:
+        lf_conn.close()
+        dest.close()
+
+    recovered = SessionDB(db_path=output)
+    try:
+        with pytest.raises(sqlite3.IntegrityError, match="cold-archived"):
+            recovered.create_session("cold-purged", source="recovery-test")
+        assert recovered.get_session("cold-purged") is None
+    finally:
+        recovered.close()
 
 
 def test_mapper_rebuilds_sessiondb_from_synthetic_lost_and_found(

--- a/tests/hermes_cli/test_session_recovery_lost_and_found.py
+++ b/tests/hermes_cli/test_session_recovery_lost_and_found.py
@@ -571,6 +571,66 @@ def test_mapper_preserves_attributed_cold_archive_tombstones(
         recovered.close()
 
 
+def test_mapper_removes_prompt_from_tombstone_rejected_session(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "mapped-rejected-prompt.db"
+    SessionDB(db_path=output).close()
+    dest = sqlite3.connect(str(output), isolation_level=None)
+    session_columns = [
+        str(row[1]) for row in dest.execute("PRAGMA table_info(sessions)").fetchall()
+    ]
+    prompt_index = session_columns.index("system_prompt_hash")
+    cells: list[object | None] = [None] * len(session_columns)
+    cells[0] = "20260824_120000_deadbe"
+    cells[1] = "cli"
+    cells[prompt_index] = "orphan-prompt-hash"
+
+    lf_conn = sqlite3.connect(":memory:", isolation_level=None)
+    lf_conn.execute(
+        "CREATE TABLE system_prompts (hash TEXT PRIMARY KEY, prompt TEXT NOT NULL)"
+    )
+    lf_conn.execute(
+        "INSERT INTO system_prompts VALUES (?, ?)",
+        ("orphan-prompt-hash", "recovered orphan prompt"),
+    )
+    lf_conn.execute(
+        "CREATE TABLE cold_archive_tombstones ("
+        "session_id TEXT PRIMARY KEY, terminal_id TEXT NOT NULL, "
+        "source_fingerprint TEXT NOT NULL, deleted_at REAL NOT NULL)"
+    )
+    lf_conn.execute(
+        "INSERT INTO cold_archive_tombstones VALUES (?, ?, ?, ?)",
+        (
+            "20260824_120000_deadbe",
+            "20260824_120000_deadbe",
+            "f" * 64,
+            900.0,
+        ),
+    )
+    cell_columns = ", ".join(f"c{index}" for index in range(len(cells)))
+    placeholders = ", ".join("?" for _ in range(4 + len(cells)))
+    lf_conn.execute(
+        "CREATE TABLE lost_and_found ("
+        "rootpgno INTEGER, pgno INTEGER, nfield INTEGER, id INTEGER, "
+        f"{cell_columns})"
+    )
+    lf_conn.execute(
+        f"INSERT INTO lost_and_found VALUES ({placeholders})",
+        (1, 2, len(cells), 99, *cells),
+    )
+
+    try:
+        mapping = map_lost_and_found_rows(lf_conn, dest)
+        assert mapping["unmapped_rows"] == 1
+        assert mapping["tombstone_reconciliation"]["system_prompts_removed"] == 1
+        assert dest.execute("SELECT COUNT(*) FROM system_prompts").fetchone()[0] == 0
+        assert dest.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 0
+    finally:
+        lf_conn.close()
+        dest.close()
+
+
 def test_mapper_reconciles_prompts_and_routes_for_tombstoned_ids(
     tmp_path: Path,
 ) -> None:
@@ -616,6 +676,24 @@ def test_mapper_reconciles_prompts_and_routes_for_tombstoned_ids(
             ("test", "survivor-key", json.dumps({"session_id": "survivor"}), 2.0),
         ],
     )
+    lf_conn.execute("CREATE TABLE state_meta (key TEXT PRIMARY KEY, value TEXT)")
+    lf_conn.executemany(
+        "INSERT INTO state_meta VALUES (?, ?)",
+        [("goal:cold-purged", "stale"), ("goal:survivor", "keep")],
+    )
+    lf_conn.execute(
+        "CREATE TABLE async_delegations ("
+        "delegation_id TEXT PRIMARY KEY, origin_session TEXT NOT NULL, "
+        "parent_session_id TEXT, origin_session_id TEXT NOT NULL DEFAULT '', "
+        "state TEXT NOT NULL, dispatched_at REAL NOT NULL, updated_at REAL NOT NULL)"
+    )
+    lf_conn.executemany(
+        "INSERT INTO async_delegations VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [
+            ("cold-delegation", "cold-purged", None, "", "completed", 1.0, 2.0),
+            ("keep-delegation", "survivor", None, "", "completed", 1.0, 2.0),
+        ],
+    )
 
     output = tmp_path / "mapped-prompt-route.db"
     SessionDB(db_path=output).close()
@@ -625,11 +703,19 @@ def test_mapper_reconciles_prompts_and_routes_for_tombstoned_ids(
         reconciliation = mapping["tombstone_reconciliation"]
         assert reconciliation["system_prompts_removed"] == 1
         assert reconciliation["gateway_routes_removed"] == 1
+        assert reconciliation["state_meta_removed"] == 1
+        assert reconciliation["async_delegations_removed"] == 1
         assert dest.execute("SELECT COUNT(*) FROM system_prompts").fetchone()[0] == 0
         routes = dest.execute(
             "SELECT session_key FROM gateway_routing ORDER BY session_key"
         ).fetchall()
         assert routes == [("survivor-key",)]
+        assert dest.execute(
+            "SELECT key FROM state_meta ORDER BY key"
+        ).fetchall() == [("goal:survivor",)]
+        assert dest.execute(
+            "SELECT delegation_id FROM async_delegations ORDER BY delegation_id"
+        ).fetchall() == [("keep-delegation",)]
         assert stub_missing_parent_sessions(dest)["sessions_stubbed"] == 0
     finally:
         lf_conn.close()

--- a/tests/hermes_cli/test_session_recovery_lost_and_found.py
+++ b/tests/hermes_cli/test_session_recovery_lost_and_found.py
@@ -8,6 +8,7 @@ b-tree/schema header bytes), not mocked cursor exceptions.
 
 from __future__ import annotations
 
+import json
 import shutil
 import sqlite3
 from pathlib import Path
@@ -568,6 +569,71 @@ def test_mapper_preserves_attributed_cold_archive_tombstones(
         assert recovered.get_session("cold-purged") is None
     finally:
         recovered.close()
+
+
+def test_mapper_reconciles_prompts_and_routes_for_tombstoned_ids(
+    tmp_path: Path,
+) -> None:
+    lf_conn = sqlite3.connect(":memory:", isolation_level=None)
+    lf_conn.execute(
+        "CREATE TABLE system_prompts (hash TEXT PRIMARY KEY, prompt TEXT NOT NULL)"
+    )
+    lf_conn.execute(
+        "INSERT INTO system_prompts VALUES (?, ?)",
+        ("prompt-hash", "recovered secret prompt"),
+    )
+    lf_conn.execute(
+        "CREATE TABLE sessions ("
+        "id TEXT PRIMARY KEY, source TEXT NOT NULL, started_at REAL NOT NULL, "
+        "system_prompt_hash TEXT)"
+    )
+    lf_conn.executemany(
+        "INSERT INTO sessions VALUES (?, ?, ?, ?)",
+        [
+            ("cold-purged", "cli", 123.0, "prompt-hash"),
+            ("survivor", "cli", 124.0, None),
+        ],
+    )
+    lf_conn.execute(
+        "CREATE TABLE cold_archive_tombstones ("
+        "session_id TEXT PRIMARY KEY, terminal_id TEXT NOT NULL, "
+        "source_fingerprint TEXT NOT NULL, deleted_at REAL NOT NULL)"
+    )
+    lf_conn.execute(
+        "INSERT INTO cold_archive_tombstones VALUES (?, ?, ?, ?)",
+        ("cold-purged", "cold-purged", "d" * 64, 789.0),
+    )
+    lf_conn.execute(
+        "CREATE TABLE gateway_routing ("
+        "scope TEXT NOT NULL, session_key TEXT NOT NULL, "
+        "entry_json TEXT NOT NULL, updated_at REAL NOT NULL, "
+        "PRIMARY KEY (scope, session_key))"
+    )
+    lf_conn.executemany(
+        "INSERT INTO gateway_routing VALUES (?, ?, ?, ?)",
+        [
+            ("test", "cold-key", json.dumps({"session_id": "cold-purged"}), 1.0),
+            ("test", "survivor-key", json.dumps({"session_id": "survivor"}), 2.0),
+        ],
+    )
+
+    output = tmp_path / "mapped-prompt-route.db"
+    SessionDB(db_path=output).close()
+    dest = sqlite3.connect(str(output), isolation_level=None)
+    try:
+        mapping = map_lost_and_found_rows(lf_conn, dest)
+        reconciliation = mapping["tombstone_reconciliation"]
+        assert reconciliation["system_prompts_removed"] == 1
+        assert reconciliation["gateway_routes_removed"] == 1
+        assert dest.execute("SELECT COUNT(*) FROM system_prompts").fetchone()[0] == 0
+        routes = dest.execute(
+            "SELECT session_key FROM gateway_routing ORDER BY session_key"
+        ).fetchall()
+        assert routes == [("survivor-key",)]
+        assert stub_missing_parent_sessions(dest)["sessions_stubbed"] == 0
+    finally:
+        lf_conn.close()
+        dest.close()
 
 
 def test_mapper_rebuilds_sessiondb_from_synthetic_lost_and_found(

--- a/tests/hermes_cli/test_sessions_cold_store_cli.py
+++ b/tests/hermes_cli/test_sessions_cold_store_cli.py
@@ -78,6 +78,35 @@ def _lineage_rows() -> list[tuple[str, int]]:
         db.close()
 
 
+def _purge_database_rows() -> tuple[list[tuple[object, ...]], ...]:
+    db = SessionDB()
+    try:
+        assert db._conn is not None
+        return (
+            [
+                tuple(row)
+                for row in db._conn.execute(
+                    "SELECT id, archived FROM sessions ORDER BY id"
+                ).fetchall()
+            ],
+            [
+                tuple(row)
+                for row in db._conn.execute(
+                    "SELECT session_id, role, content FROM messages ORDER BY id"
+                ).fetchall()
+            ],
+            [
+                tuple(row)
+                for row in db._conn.execute(
+                    "SELECT scope, session_key, entry_json "
+                    "FROM gateway_routing ORDER BY scope, session_key"
+                ).fetchall()
+            ],
+        )
+    finally:
+        db.close()
+
+
 @pytest.mark.parametrize(
     ("arguments", "required_argument"),
     [
@@ -285,6 +314,69 @@ def test_cold_purge_dry_run_is_read_only_and_prints_exact_ids(
         for path in archive_root.rglob("*")
         if path.is_file()
     } == before_files
+
+
+@pytest.mark.parametrize("purge_flag", ["--dry-run", "--yes"])
+def test_cold_purge_refuses_routed_verified_lineage_and_retains_database_rows(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    purge_flag: str,
+) -> None:
+    _seed_archived_lineage()
+    archive_root = session_home.parent / "cold-root"
+    store_code, _store_out, store_err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-store",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+        "--yes",
+    )
+    assert store_code == 0
+    assert store_err == ""
+
+    db = SessionDB()
+    try:
+        db.save_gateway_routing_entry(
+            "route-key",
+            '{"session_id":"lineage-root","platform":"test"}',
+            scope="test-routing-scope",
+        )
+    finally:
+        db.close()
+
+    verify_code, _verify_out, verify_err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-verify",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+    )
+    assert verify_code == 0
+    assert verify_err == ""
+    before_rows = _purge_database_rows()
+
+    code, out, err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-purge",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+        purge_flag,
+    )
+
+    assert code == 1
+    assert err == ""
+    assert "gateway_routing" in out
+    assert "lineage-root" in out
+    assert _purge_database_rows() == before_rows
 
 
 def test_cold_purge_without_yes_refuses_actual_deletion(

--- a/tests/hermes_cli/test_sessions_cold_store_cli.py
+++ b/tests/hermes_cli/test_sessions_cold_store_cli.py
@@ -26,13 +26,16 @@ def session_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 def _seed_archived_lineage() -> None:
     db = SessionDB()
     try:
-        db.create_session("lineage-root", source="cli")
+        db.create_session(
+            "lineage-root", source="cli", system_prompt="cold purge root prompt"
+        )
         db.append_message("lineage-root", role="user", content="sensitive first turn")
         db.end_session("lineage-root", "compression")
         db.create_session(
             "lineage-terminal",
             source="cli",
             parent_session_id="lineage-root",
+            system_prompt="cold purge shared prompt",
         )
         db.append_message(
             "lineage-terminal", role="assistant", content="sensitive final turn"
@@ -82,6 +85,8 @@ def _lineage_rows() -> list[tuple[str, int]]:
         (("sessions", "cold-store", "archive"), "--session-id"),
         (("sessions", "cold-verify"), "ROOT"),
         (("sessions", "cold-verify", "archive"), "--session-id"),
+        (("sessions", "cold-purge"), "ROOT"),
+        (("sessions", "cold-purge", "archive"), "--session-id"),
     ],
 )
 def test_cold_store_requires_root_and_named_session_id(
@@ -132,6 +137,191 @@ def test_cold_store_yes_stores_exactly_one_resolved_lineage_and_reports_identity
         "session.jsonl",
     }
     assert _lineage_rows() == before == [
+        ("lineage-root", 1),
+        ("lineage-terminal", 1),
+    ]
+
+
+def test_cold_store_verify_purge_deletes_only_snapshot_lineage_and_keeps_snapshot(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_archived_lineage()
+    archive_root = session_home.parent / "cold-root"
+    db = SessionDB()
+    try:
+        db.create_session(
+            "unrelated",
+            source="cli",
+            system_prompt="cold purge shared prompt",
+        )
+        assert db._conn is not None
+        db._conn.execute(
+            "INSERT INTO session_model_usage (session_id, model) VALUES (?, ?)",
+            ("lineage-terminal", "test-model"),
+        )
+    finally:
+        db.close()
+
+    store_code, store_out, store_err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-store",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+        "--yes",
+    )
+    assert store_code == 0
+    assert store_err == ""
+    snapshot_match = re.search(r"local snapshot: (.+)$", store_out, re.MULTILINE)
+    assert snapshot_match is not None
+    snapshot = Path(snapshot_match.group(1))
+    before_snapshot = {
+        path.relative_to(snapshot): path.read_bytes()
+        for path in snapshot.rglob("*")
+        if path.is_file()
+    }
+
+    verify_code, _verify_out, verify_err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-verify",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+    )
+    assert verify_code == 0
+    assert verify_err == ""
+
+    code, out, err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-purge",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+        "--yes",
+    )
+
+    assert code == 0
+    assert err == ""
+    assert "terminal ID: lineage-terminal" in out
+    assert "physical IDs: lineage-root, lineage-terminal" in out
+    assert "cold snapshot remains local" in out
+    assert _lineage_rows() == [("unrelated", 0)]
+    db = SessionDB()
+    try:
+        assert db._conn is not None
+        assert db._conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 0
+        assert (
+            db._conn.execute("SELECT COUNT(*) FROM session_model_usage").fetchone()[0]
+            == 0
+        )
+        prompts = db._conn.execute(
+            "SELECT prompt FROM system_prompts ORDER BY prompt"
+        ).fetchall()
+        assert [row[0] for row in prompts] == ["cold purge shared prompt"]
+    finally:
+        db.close()
+    assert snapshot.is_dir()
+    assert {
+        path.relative_to(snapshot): path.read_bytes()
+        for path in snapshot.rglob("*")
+        if path.is_file()
+    } == before_snapshot
+
+
+def test_cold_purge_dry_run_is_read_only_and_prints_exact_ids(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_archived_lineage()
+    archive_root = session_home.parent / "cold-root"
+    store_code, _store_out, store_err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-store",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+        "--yes",
+    )
+    assert store_code == 0
+    assert store_err == ""
+    before_rows = _lineage_rows()
+    before_files = {
+        path.relative_to(archive_root): path.read_bytes()
+        for path in archive_root.rglob("*")
+        if path.is_file()
+    }
+
+    code, out, err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-purge",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+        "--dry-run",
+    )
+
+    assert code == 0
+    assert err == ""
+    assert "Would purge archived session lineage:" in out
+    assert "terminal ID: lineage-terminal" in out
+    assert "physical IDs: lineage-root, lineage-terminal" in out
+    assert "nothing was deleted" in out
+    assert _lineage_rows() == before_rows
+    assert {
+        path.relative_to(archive_root): path.read_bytes()
+        for path in archive_root.rglob("*")
+        if path.is_file()
+    } == before_files
+
+
+def test_cold_purge_without_yes_refuses_actual_deletion(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_archived_lineage()
+    archive_root = session_home.parent / "cold-root"
+    store_code, _store_out, store_err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-store",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+        "--yes",
+    )
+    assert store_code == 0
+    assert store_err == ""
+
+    code, out, err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-purge",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+    )
+
+    assert code == 1
+    assert err == ""
+    assert "requires --yes" in out
+    assert "nothing was deleted" in out
+    assert _lineage_rows() == [
         ("lineage-root", 1),
         ("lineage-terminal", 1),
     ]

--- a/tests/hermes_cli/test_sessions_cold_store_cli.py
+++ b/tests/hermes_cli/test_sessions_cold_store_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import sqlite3
 import sys
 from pathlib import Path
 
@@ -208,6 +209,78 @@ def test_cold_verify_missing_snapshot_fails_without_creating_root(
     assert "Error: could not cold-verify session lineage" in out
     assert "snapshot not found" in out
     assert not archive_root.exists()
+
+
+def test_cold_verify_database_open_failure_exits_nonzero(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_archived_lineage()
+
+    def fail_read_only_open(*args, **kwargs):
+        assert kwargs.get("read_only") is True
+        raise sqlite3.OperationalError("read-only open failed")
+
+    monkeypatch.setattr("hermes_state.SessionDB", fail_read_only_open)
+
+    code, out, err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-verify",
+        str(session_home.parent / "cold-root"),
+        "--session-id",
+        "lineage-terminal",
+    )
+
+    assert code == 1
+    assert err == ""
+    assert "Error: Could not open session database: read-only open failed" in out
+
+
+@pytest.mark.parametrize(
+    ("action", "execution_flags"),
+    [
+        ("cold-store", ("--yes",)),
+        ("cold-verify", ()),
+    ],
+)
+def test_cold_commands_reject_finite_out_of_range_started_at_cleanly(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    action: str,
+    execution_flags: tuple[str, ...],
+) -> None:
+    db = SessionDB()
+    try:
+        db.create_session("bad-start-time", source="cli")
+        db.end_session("bad-start-time", "completed")
+        assert db.set_session_archived("bad-start-time", True)
+        assert db._conn is not None
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (1e300, "bad-start-time"),
+        )
+    finally:
+        db.close()
+
+    code, out, err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        action,
+        str(session_home.parent / "cold-root"),
+        "--session-id",
+        "bad-start-time",
+        *execution_flags,
+    )
+
+    assert code == 1
+    assert err == ""
+    assert "terminal session start time is outside the supported range" in out
+    assert "Traceback" not in out
 
 
 def test_cold_store_default_confirmation_warns_about_raw_transcript_and_cancels(

--- a/tests/hermes_cli/test_sessions_cold_store_cli.py
+++ b/tests/hermes_cli/test_sessions_cold_store_cli.py
@@ -114,6 +114,18 @@ def _purge_database_rows() -> tuple[list[tuple[object, ...]], ...]:
                     "SELECT * FROM async_delegations ORDER BY delegation_id"
                 ).fetchall()
             ],
+            [
+                tuple(row)
+                for row in db._conn.execute(
+                    "SELECT * FROM compression_locks ORDER BY session_id"
+                ).fetchall()
+            ],
+            [
+                tuple(row)
+                for row in db._conn.execute(
+                    "SELECT * FROM session_turn_leases ORDER BY conversation_id"
+                ).fetchall()
+            ],
         )
     finally:
         db.close()
@@ -409,6 +421,16 @@ def test_cold_purge_refuses_routed_verified_lineage_and_retains_database_rows(
             "origin_session_id",
             id="delegation-origin-session-id",
         ),
+        pytest.param(
+            "compression_locks",
+            "session_id",
+            id="compression-lock",
+        ),
+        pytest.param(
+            "session_turn_leases",
+            "conversation_id",
+            id="session-turn-lease",
+        ),
     ],
 )
 def test_cold_purge_refuses_unsnapshotted_soft_references_without_mutation(
@@ -449,7 +471,7 @@ def test_cold_purge_refuses_unsnapshotted_soft_references_without_mutation(
                 "INSERT INTO state_meta(key, value) VALUES (?, ?)",
                 (f"{reference_name}:lineage-root", '{"keep":"unchanged"}'),
             )
-        else:
+        elif reference_kind == "async_delegations":
             reference_values = {
                 "origin_session": "unrelated-origin",
                 "parent_session_id": None,
@@ -470,6 +492,13 @@ def test_cold_purge_refuses_unsnapshotted_soft_references_without_mutation(
                     1.0,
                     2.0,
                 ),
+            )
+        else:
+            db._conn.execute(
+                f"INSERT INTO {reference_kind} "
+                f"({reference_name}, holder, acquired_at, expires_at) "
+                "VALUES (?, ?, ?, ?)",
+                ("lineage-root", "keep-holder", 1.0, 2.0),
             )
         assert (
             db._conn.execute("SELECT COUNT(*) FROM gateway_routing").fetchone()[0]
@@ -641,6 +670,35 @@ def test_cold_verify_database_open_failure_exits_nonzero(
     assert "Error: Could not open session database: read-only open failed" in out
 
 
+def test_cold_store_database_open_failure_exits_nonzero(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_archived_lineage()
+
+    def fail_writable_open(*args, **kwargs):
+        assert kwargs.get("read_only") is False
+        raise sqlite3.OperationalError("writable open failed")
+
+    monkeypatch.setattr("hermes_state.SessionDB", fail_writable_open)
+
+    code, out, err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-store",
+        str(session_home.parent / "cold-root"),
+        "--session-id",
+        "lineage-terminal",
+        "--yes",
+    )
+
+    assert code == 1
+    assert err == ""
+    assert "Error: Could not open session database: writable open failed" in out
+
+
 @pytest.mark.parametrize(
     ("action", "execution_flags"),
     [
@@ -751,6 +809,56 @@ def test_cold_store_dry_run_creates_nothing_and_does_not_prompt(
     assert "nothing was written" in out
     assert not archive_root.exists()
     assert _lineage_rows() == before
+
+
+def test_cold_store_dry_run_opens_database_read_only_without_reconciliation(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_archived_lineage()
+    db_path = session_home / "state.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DROP INDEX idx_compression_locks_expires")
+        schema_version = int(conn.execute("PRAGMA schema_version").fetchone()[0])
+        before_rows = conn.execute(
+            "SELECT id, archived FROM sessions ORDER BY id"
+        ).fetchall()
+
+    opens: list[bool] = []
+
+    def tracked_open(*args, **kwargs):
+        opens.append(bool(kwargs.get("read_only")))
+        return SessionDB(*args, **kwargs)
+
+    monkeypatch.setattr("hermes_state.SessionDB", tracked_open)
+    archive_root = session_home.parent / "cold-root"
+
+    code, out, err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-store",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+        "--dry-run",
+    )
+
+    assert code == 0
+    assert err == ""
+    assert "nothing was written" in out
+    assert opens == [True]
+    assert not archive_root.exists()
+    with sqlite3.connect(db_path) as conn:
+        assert int(conn.execute("PRAGMA schema_version").fetchone()[0]) == schema_version
+        assert conn.execute(
+            "SELECT 1 FROM sqlite_schema "
+            "WHERE type = 'index' AND name = 'idx_compression_locks_expires'"
+        ).fetchone() is None
+        assert conn.execute(
+            "SELECT id, archived FROM sessions ORDER BY id"
+        ).fetchall() == before_rows
 
 
 @pytest.mark.parametrize("execution_flag", ["--yes", "--dry-run"])

--- a/tests/hermes_cli/test_sessions_cold_store_cli.py
+++ b/tests/hermes_cli/test_sessions_cold_store_cli.py
@@ -110,9 +110,11 @@ def _snapshot_files(archive_root: Path) -> dict[Path, bytes]:
     }
 
 
-def _write_legacy_route(session_home: Path, session_id: str) -> Path:
-    sessions_file = session_home / "sessions" / "sessions.json"
-    sessions_file.parent.mkdir(exist_ok=True)
+def _write_legacy_route(
+    session_home: Path, session_id: str, *, sessions_dir: Path | None = None
+) -> Path:
+    sessions_file = (sessions_dir or session_home / "sessions") / "sessions.json"
+    sessions_file.parent.mkdir(parents=True, exist_ok=True)
     sessions_file.write_text(
         json.dumps(
             {
@@ -282,6 +284,48 @@ def test_cold_archive_dry_run_rejects_legacy_route_without_mutation(
     _seed_archived_lineage(unrelated=True)
     archive_root = session_home.parent / "new-cold-root"
     sessions_file = _write_legacy_route(session_home, "lineage-root")
+    before_route = sessions_file.read_bytes()
+    before_sessions = _session_rows()
+    before_messages = _message_rows()
+
+    code, out, err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-archive",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+        "--dry-run",
+    )
+
+    assert code == 1
+    assert err == ""
+    assert "could not plan cold archive" in out
+    assert "sessions.json legacy route" in out
+    assert not archive_root.exists()
+    assert sessions_file.read_bytes() == before_route
+    assert _session_rows() == before_sessions
+    assert _message_rows() == before_messages
+
+
+def test_cold_archive_dry_run_rejects_legacy_route_in_configured_sessions_dir(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_archived_lineage(unrelated=True)
+    archive_root = session_home.parent / "new-cold-root"
+    configured_sessions_dir = session_home.parent / "gateway-sessions"
+    (session_home / "gateway.json").write_text(
+        json.dumps({"sessions_dir": str(configured_sessions_dir)}),
+        encoding="utf-8",
+    )
+    sessions_file = _write_legacy_route(
+        session_home,
+        "lineage-root",
+        sessions_dir=configured_sessions_dir,
+    )
     before_route = sessions_file.read_bytes()
     before_sessions = _session_rows()
     before_messages = _message_rows()

--- a/tests/hermes_cli/test_sessions_cold_store_cli.py
+++ b/tests/hermes_cli/test_sessions_cold_store_cli.py
@@ -6,6 +6,7 @@ import json
 import re
 import sqlite3
 import sys
+import threading
 from pathlib import Path
 from typing import Callable
 
@@ -494,6 +495,58 @@ def test_cold_archive_yes_runs_store_verify_purge_serially_and_keeps_snapshot(
     }
     assert _session_rows() == [("unrelated", 0)]
     assert _message_rows() == [("unrelated", "keep this row")]
+
+
+def test_cold_archive_refuses_cross_instance_pending_accounting(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_archived_lineage()
+    archive_root = session_home.parent / "cold-root"
+    before_sessions = _session_rows()
+    accounting_owner = SessionDB()
+    entered_apply = threading.Event()
+    release_apply = threading.Event()
+    original_apply = accounting_owner._apply_token_batch
+
+    def blocked_apply(batch):
+        entered_apply.set()
+        if not release_apply.wait(10):
+            raise AssertionError("test did not release blocked accounting")
+        return original_apply(batch)
+
+    monkeypatch.setattr(accounting_owner, "_apply_token_batch", blocked_apply)
+    try:
+        accounting_owner.queue_token_counts(
+            "lineage-terminal",
+            input_tokens=7,
+            model="pending-model",
+            billing_provider="pending-provider",
+            api_call_count=1,
+        )
+        assert entered_apply.wait(5)
+
+        code, out, err = _run_cli(
+            monkeypatch,
+            capsys,
+            "sessions",
+            "cold-archive",
+            str(archive_root),
+            "--session-id",
+            "lineage-terminal",
+            "--yes",
+        )
+
+        assert code == 1
+        assert err == ""
+        assert "pending token accounting" in out
+        assert not archive_root.exists()
+        assert _session_rows() == before_sessions
+    finally:
+        release_apply.set()
+        accounting_owner.flush_token_counts(timeout=10)
+        accounting_owner.close()
 
 
 def test_cold_archive_resolution_database_error_fails_closed(

--- a/tests/hermes_cli/test_sessions_cold_store_cli.py
+++ b/tests/hermes_cli/test_sessions_cold_store_cli.py
@@ -242,10 +242,12 @@ def test_cold_store_rejects_missing_or_ambiguous_ids_before_writing(
     assert not archive_root.exists()
 
 
+@pytest.mark.parametrize("execution_flag", ["--yes", "--dry-run"])
 def test_cold_store_surfaces_store_eligibility_rejection_without_db_changes(
     session_home: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    execution_flag: str,
 ) -> None:
     db = SessionDB()
     try:
@@ -264,7 +266,7 @@ def test_cold_store_surfaces_store_eligibility_rejection_without_db_changes(
         str(archive_root),
         "--session-id",
         "not-archived",
-        "--yes",
+        execution_flag,
     )
 
     assert code == 1
@@ -273,10 +275,12 @@ def test_cold_store_surfaces_store_eligibility_rejection_without_db_changes(
     assert _lineage_rows() == before == [("not-archived", 0)]
 
 
+@pytest.mark.parametrize("execution_flag", ["--yes", "--dry-run"])
 def test_cold_store_surfaces_non_terminal_rejection_without_db_changes(
     session_home: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    execution_flag: str,
 ) -> None:
     db = SessionDB()
     try:
@@ -295,7 +299,7 @@ def test_cold_store_surfaces_non_terminal_rejection_without_db_changes(
         str(archive_root),
         "--session-id",
         "still-open",
-        "--yes",
+        execution_flag,
     )
 
     assert code == 1

--- a/tests/hermes_cli/test_sessions_cold_store_cli.py
+++ b/tests/hermes_cli/test_sessions_cold_store_cli.py
@@ -79,6 +79,8 @@ def _lineage_rows() -> list[tuple[str, int]]:
     [
         (("sessions", "cold-store"), "ROOT"),
         (("sessions", "cold-store", "archive"), "--session-id"),
+        (("sessions", "cold-verify"), "ROOT"),
+        (("sessions", "cold-verify", "archive"), "--session-id"),
     ],
 )
 def test_cold_store_requires_root_and_named_session_id(
@@ -132,6 +134,80 @@ def test_cold_store_yes_stores_exactly_one_resolved_lineage_and_reports_identity
         ("lineage-root", 1),
         ("lineage-terminal", 1),
     ]
+
+
+def test_cold_verify_successfully_checks_one_stored_lineage_read_only(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_archived_lineage()
+    archive_root = session_home.parent / "cold-root"
+    store_code, _store_out, store_err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-store",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+        "--yes",
+    )
+    assert store_code == 0
+    assert store_err == ""
+    before_rows = _lineage_rows()
+    before_files = sorted(
+        path.relative_to(archive_root) for path in archive_root.rglob("*")
+    )
+
+    code, out, err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-verify",
+        str(archive_root),
+        "--session-id",
+        "lineage-term",
+    )
+
+    assert code == 0
+    assert err == ""
+    assert "Verified archived session lineage:" in out
+    assert "terminal ID: lineage-terminal" in out
+    assert "physical IDs: lineage-root, lineage-terminal" in out
+    assert re.search(r"fingerprint: [0-9a-f]{64}\b", out)
+    snapshot_match = re.search(r"verified snapshot: (.+)$", out, re.MULTILINE)
+    assert snapshot_match is not None
+    assert Path(snapshot_match.group(1)).is_relative_to(archive_root)
+    assert _lineage_rows() == before_rows
+    assert sorted(
+        path.relative_to(archive_root) for path in archive_root.rglob("*")
+    ) == before_files
+
+
+def test_cold_verify_missing_snapshot_fails_without_creating_root(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_archived_lineage()
+    archive_root = session_home.parent / "missing-cold-root"
+
+    code, out, err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-verify",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+    )
+
+    assert code == 1
+    assert err == ""
+    assert "Error: could not cold-verify session lineage" in out
+    assert "snapshot not found" in out
+    assert not archive_root.exists()
 
 
 def test_cold_store_default_confirmation_warns_about_raw_transcript_and_cancels(

--- a/tests/hermes_cli/test_sessions_cold_store_cli.py
+++ b/tests/hermes_cli/test_sessions_cold_store_cli.py
@@ -1,4 +1,4 @@
-"""CLI contract for storing one explicit archived session lineage locally."""
+"""Public CLI contract for cold-archiving one marked session lineage."""
 
 from __future__ import annotations
 
@@ -6,13 +6,15 @@ import re
 import sqlite3
 import sys
 from pathlib import Path
+from typing import Callable
 
 import pytest
 
+import hermes_cli.session_cold_store as cold_store
 from hermes_state import SessionDB
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def session_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     import hermes_state
 
@@ -23,11 +25,11 @@ def session_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return home
 
 
-def _seed_archived_lineage() -> None:
+def _seed_archived_lineage(*, unrelated: bool = False) -> None:
     db = SessionDB()
     try:
         db.create_session(
-            "lineage-root", source="cli", system_prompt="cold purge root prompt"
+            "lineage-root", source="cli", system_prompt="cold archive root prompt"
         )
         db.append_message("lineage-root", role="user", content="sensitive first turn")
         db.end_session("lineage-root", "compression")
@@ -35,13 +37,18 @@ def _seed_archived_lineage() -> None:
             "lineage-terminal",
             source="cli",
             parent_session_id="lineage-root",
-            system_prompt="cold purge shared prompt",
+            system_prompt="cold archive shared prompt",
         )
         db.append_message(
             "lineage-terminal", role="assistant", content="sensitive final turn"
         )
         db.end_session("lineage-terminal", "completed")
         assert db.set_session_archived("lineage-terminal", True)
+        if unrelated:
+            db.create_session(
+                "unrelated", source="cli", system_prompt="cold archive shared prompt"
+            )
+            db.append_message("unrelated", role="user", content="keep this row")
     finally:
         db.close()
 
@@ -64,7 +71,7 @@ def _run_cli(
     return code, captured.out, captured.err
 
 
-def _lineage_rows() -> list[tuple[str, int]]:
+def _session_rows() -> list[tuple[str, int]]:
     db = SessionDB()
     try:
         assert db._conn is not None
@@ -78,71 +85,66 @@ def _lineage_rows() -> list[tuple[str, int]]:
         db.close()
 
 
-def _purge_database_rows() -> tuple[list[tuple[object, ...]], ...]:
+def _message_rows() -> list[tuple[str, str]]:
     db = SessionDB()
     try:
         assert db._conn is not None
-        return (
-            [
-                tuple(row)
-                for row in db._conn.execute(
-                    "SELECT id, archived FROM sessions ORDER BY id"
-                ).fetchall()
-            ],
-            [
-                tuple(row)
-                for row in db._conn.execute(
-                    "SELECT session_id, role, content FROM messages ORDER BY id"
-                ).fetchall()
-            ],
-            [
-                tuple(row)
-                for row in db._conn.execute(
-                    "SELECT scope, session_key, entry_json "
-                    "FROM gateway_routing ORDER BY scope, session_key"
-                ).fetchall()
-            ],
-            [
-                tuple(row)
-                for row in db._conn.execute(
-                    "SELECT key, value FROM state_meta ORDER BY key"
-                ).fetchall()
-            ],
-            [
-                tuple(row)
-                for row in db._conn.execute(
-                    "SELECT * FROM async_delegations ORDER BY delegation_id"
-                ).fetchall()
-            ],
-            [
-                tuple(row)
-                for row in db._conn.execute(
-                    "SELECT * FROM compression_locks ORDER BY session_id"
-                ).fetchall()
-            ],
-            [
-                tuple(row)
-                for row in db._conn.execute(
-                    "SELECT * FROM session_turn_leases ORDER BY conversation_id"
-                ).fetchall()
-            ],
-        )
+        return [
+            (str(row["session_id"]), str(row["content"]))
+            for row in db._conn.execute(
+                "SELECT session_id, content FROM messages ORDER BY id"
+            ).fetchall()
+        ]
     finally:
         db.close()
+
+
+def _snapshot_files(archive_root: Path) -> dict[Path, bytes]:
+    if not archive_root.exists():
+        return {}
+    return {
+        path.relative_to(archive_root): path.read_bytes()
+        for path in archive_root.rglob("*")
+        if path.is_file()
+    }
+
+
+def test_sessions_help_exposes_only_converged_public_cold_archive_command(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    code, out, err = _run_cli(monkeypatch, capsys, "sessions", "--help")
+
+    assert code == 0
+    assert err == ""
+    assert re.search(r"\barchive\b", out)
+    assert re.search(r"\bcold-archive\b", out)
+    assert "cold-store" not in out
+    assert "cold-verify" not in out
+    assert "cold-purge" not in out
+
+
+@pytest.mark.parametrize("hidden_action", ["cold-store", "cold-verify", "cold-purge"])
+def test_hidden_stage_commands_are_rejected_by_argparse(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    hidden_action: str,
+) -> None:
+    code, _out, err = _run_cli(monkeypatch, capsys, "sessions", hidden_action)
+
+    assert code == 2
+    assert "invalid choice" in err
+    assert hidden_action in err
 
 
 @pytest.mark.parametrize(
     ("arguments", "required_argument"),
     [
-        (("sessions", "cold-store"), "ROOT"),
-        (("sessions", "cold-store", "archive"), "--session-id"),
-        (("sessions", "cold-verify"), "ROOT"),
-        (("sessions", "cold-verify", "archive"), "--session-id"),
-        (("sessions", "cold-purge"), "ROOT"),
-        (("sessions", "cold-purge", "archive"), "--session-id"),
+        (("sessions", "cold-archive"), "ROOT"),
+        (("sessions", "cold-archive", "archive-root"), "--session-id"),
     ],
 )
-def test_cold_store_requires_root_and_named_session_id(
+def test_cold_archive_requires_root_and_named_session_id(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
     arguments: tuple[str, ...],
@@ -155,699 +157,48 @@ def test_cold_store_requires_root_and_named_session_id(
     assert "required" in err
 
 
-def test_cold_store_yes_stores_exactly_one_resolved_lineage_and_reports_identity(
+def test_cold_archive_dry_run_is_read_only_and_does_not_require_snapshot(
     session_home: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     _seed_archived_lineage()
-    archive_root = session_home.parent / "cold-root"
-    before = _lineage_rows()
-
-    code, out, err = _run_cli(
-        monkeypatch,
-        capsys,
-        "sessions",
-        "cold-store",
-        str(archive_root),
-        "--session-id",
-        "lineage-term",
-        "--yes",
-    )
-
-    assert code == 0
-    assert err == ""
-    assert "terminal ID: lineage-terminal" in out
-    assert "physical IDs: lineage-root, lineage-terminal" in out
-    assert re.search(r"fingerprint: [0-9a-f]{64}\b", out)
-    snapshot_match = re.search(r"local snapshot: (.+)$", out, re.MULTILINE)
-    assert snapshot_match is not None
-    snapshot = Path(snapshot_match.group(1))
-    assert snapshot.is_relative_to(archive_root)
-    assert {path.name for path in snapshot.iterdir()} == {
-        "artifacts",
-        "metadata.json",
-        "session.jsonl",
-    }
-    assert _lineage_rows() == before == [
-        ("lineage-root", 1),
-        ("lineage-terminal", 1),
-    ]
-
-
-def test_cold_store_verify_purge_deletes_only_snapshot_lineage_and_keeps_snapshot(
-    session_home: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    _seed_archived_lineage()
-    archive_root = session_home.parent / "cold-root"
-    db = SessionDB()
-    try:
-        db.create_session(
-            "unrelated",
-            source="cli",
-            system_prompt="cold purge shared prompt",
-        )
-        assert db._conn is not None
-        db._conn.execute(
-            "INSERT INTO session_model_usage (session_id, model) VALUES (?, ?)",
-            ("lineage-terminal", "test-model"),
-        )
-    finally:
-        db.close()
-
-    store_code, store_out, store_err = _run_cli(
-        monkeypatch,
-        capsys,
-        "sessions",
-        "cold-store",
-        str(archive_root),
-        "--session-id",
-        "lineage-terminal",
-        "--yes",
-    )
-    assert store_code == 0
-    assert store_err == ""
-    snapshot_match = re.search(r"local snapshot: (.+)$", store_out, re.MULTILINE)
-    assert snapshot_match is not None
-    snapshot = Path(snapshot_match.group(1))
-    before_snapshot = {
-        path.relative_to(snapshot): path.read_bytes()
-        for path in snapshot.rglob("*")
-        if path.is_file()
-    }
-
-    verify_code, _verify_out, verify_err = _run_cli(
-        monkeypatch,
-        capsys,
-        "sessions",
-        "cold-verify",
-        str(archive_root),
-        "--session-id",
-        "lineage-terminal",
-    )
-    assert verify_code == 0
-    assert verify_err == ""
-
-    code, out, err = _run_cli(
-        monkeypatch,
-        capsys,
-        "sessions",
-        "cold-purge",
-        str(archive_root),
-        "--session-id",
-        "lineage-terminal",
-        "--yes",
-    )
-
-    assert code == 0
-    assert err == ""
-    assert "terminal ID: lineage-terminal" in out
-    assert "physical IDs: lineage-root, lineage-terminal" in out
-    assert "cold snapshot remains local" in out
-    assert _lineage_rows() == [("unrelated", 0)]
-    db = SessionDB()
-    try:
-        assert db._conn is not None
-        assert db._conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 0
-        assert (
-            db._conn.execute("SELECT COUNT(*) FROM session_model_usage").fetchone()[0]
-            == 0
-        )
-        prompts = db._conn.execute(
-            "SELECT prompt FROM system_prompts ORDER BY prompt"
-        ).fetchall()
-        assert [row[0] for row in prompts] == ["cold purge shared prompt"]
-    finally:
-        db.close()
-    assert snapshot.is_dir()
-    assert {
-        path.relative_to(snapshot): path.read_bytes()
-        for path in snapshot.rglob("*")
-        if path.is_file()
-    } == before_snapshot
-
-
-def test_cold_purge_dry_run_is_read_only_and_prints_exact_ids(
-    session_home: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    _seed_archived_lineage()
-    archive_root = session_home.parent / "cold-root"
-    store_code, _store_out, store_err = _run_cli(
-        monkeypatch,
-        capsys,
-        "sessions",
-        "cold-store",
-        str(archive_root),
-        "--session-id",
-        "lineage-terminal",
-        "--yes",
-    )
-    assert store_code == 0
-    assert store_err == ""
-    before_rows = _lineage_rows()
-    before_files = {
-        path.relative_to(archive_root): path.read_bytes()
-        for path in archive_root.rglob("*")
-        if path.is_file()
-    }
-
-    code, out, err = _run_cli(
-        monkeypatch,
-        capsys,
-        "sessions",
-        "cold-purge",
-        str(archive_root),
-        "--session-id",
-        "lineage-terminal",
-        "--dry-run",
-    )
-
-    assert code == 0
-    assert err == ""
-    assert "Would purge archived session lineage:" in out
-    assert "terminal ID: lineage-terminal" in out
-    assert "physical IDs: lineage-root, lineage-terminal" in out
-    assert "nothing was deleted" in out
-    assert _lineage_rows() == before_rows
-    assert {
-        path.relative_to(archive_root): path.read_bytes()
-        for path in archive_root.rglob("*")
-        if path.is_file()
-    } == before_files
-
-
-@pytest.mark.parametrize("purge_flag", ["--dry-run", "--yes"])
-def test_cold_purge_refuses_routed_verified_lineage_and_retains_database_rows(
-    session_home: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-    purge_flag: str,
-) -> None:
-    _seed_archived_lineage()
-    archive_root = session_home.parent / "cold-root"
-    store_code, _store_out, store_err = _run_cli(
-        monkeypatch,
-        capsys,
-        "sessions",
-        "cold-store",
-        str(archive_root),
-        "--session-id",
-        "lineage-terminal",
-        "--yes",
-    )
-    assert store_code == 0
-    assert store_err == ""
-
-    db = SessionDB()
-    try:
-        db.save_gateway_routing_entry(
-            "route-key",
-            '{"session_id":"lineage-root","platform":"test"}',
-            scope="test-routing-scope",
-        )
-    finally:
-        db.close()
-
-    verify_code, _verify_out, verify_err = _run_cli(
-        monkeypatch,
-        capsys,
-        "sessions",
-        "cold-verify",
-        str(archive_root),
-        "--session-id",
-        "lineage-terminal",
-    )
-    assert verify_code == 0
-    assert verify_err == ""
-    before_rows = _purge_database_rows()
-
-    code, out, err = _run_cli(
-        monkeypatch,
-        capsys,
-        "sessions",
-        "cold-purge",
-        str(archive_root),
-        "--session-id",
-        "lineage-terminal",
-        purge_flag,
-    )
-
-    assert code == 1
-    assert err == ""
-    assert "gateway_routing" in out
-    assert "lineage-root" in out
-    assert _purge_database_rows() == before_rows
-
-
-@pytest.mark.parametrize("purge_flag", ["--dry-run", "--yes"])
-@pytest.mark.parametrize(
-    ("reference_kind", "reference_name"),
-    [
-        pytest.param("state_meta", "goal", id="state-meta-goal"),
-        pytest.param("state_meta", "loop", id="state-meta-loop"),
-        pytest.param("state_meta", "heartbeat", id="state-meta-heartbeat"),
-        pytest.param("async_delegations", "origin_session", id="delegation-origin"),
-        pytest.param(
-            "async_delegations",
-            "parent_session_id",
-            id="delegation-parent",
-        ),
-        pytest.param(
-            "async_delegations",
-            "origin_session_id",
-            id="delegation-origin-session-id",
-        ),
-        pytest.param(
-            "compression_locks",
-            "session_id",
-            id="compression-lock",
-        ),
-        pytest.param(
-            "session_turn_leases",
-            "conversation_id",
-            id="session-turn-lease",
-        ),
-    ],
-)
-def test_cold_purge_refuses_unsnapshotted_soft_references_without_mutation(
-    session_home: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-    purge_flag: str,
-    reference_kind: str,
-    reference_name: str,
-) -> None:
-    _seed_archived_lineage()
-    archive_root = session_home.parent / "cold-root"
-    store_code, _store_out, store_err = _run_cli(
-        monkeypatch,
-        capsys,
-        "sessions",
-        "cold-store",
-        str(archive_root),
-        "--session-id",
-        "lineage-terminal",
-        "--yes",
-    )
-    assert store_code == 0
-    assert store_err == ""
-
-    db = SessionDB()
-    try:
-        assert db._conn is not None
-        columns = {
-            str(row[1])
-            for row in db._conn.execute(
-                "PRAGMA table_info(async_delegations)"
-            ).fetchall()
-        }
-        assert "origin_session_id" in columns
-        if reference_kind == "state_meta":
-            db._conn.execute(
-                "INSERT INTO state_meta(key, value) VALUES (?, ?)",
-                (f"{reference_name}:lineage-root", '{"keep":"unchanged"}'),
-            )
-        elif reference_kind == "async_delegations":
-            reference_values = {
-                "origin_session": "unrelated-origin",
-                "parent_session_id": None,
-                "origin_session_id": "unrelated-api-session",
-            }
-            reference_values[reference_name] = "lineage-root"
-            db._conn.execute(
-                "INSERT INTO async_delegations ("
-                "delegation_id, origin_session, parent_session_id, "
-                "origin_session_id, state, dispatched_at, updated_at"
-                ") VALUES (?, ?, ?, ?, ?, ?, ?)",
-                (
-                    f"delegation-{reference_name}",
-                    reference_values["origin_session"],
-                    reference_values["parent_session_id"],
-                    reference_values["origin_session_id"],
-                    "completed",
-                    1.0,
-                    2.0,
-                ),
-            )
-        else:
-            db._conn.execute(
-                f"INSERT INTO {reference_kind} "
-                f"({reference_name}, holder, acquired_at, expires_at) "
-                "VALUES (?, ?, ?, ?)",
-                ("lineage-root", "keep-holder", 1.0, 2.0),
-            )
-        assert (
-            db._conn.execute("SELECT COUNT(*) FROM gateway_routing").fetchone()[0]
-            == 0
-        )
-    finally:
-        db.close()
-
-    before_rows = _purge_database_rows()
-
-    code, out, err = _run_cli(
-        monkeypatch,
-        capsys,
-        "sessions",
-        "cold-purge",
-        str(archive_root),
-        "--session-id",
-        "lineage-terminal",
-        purge_flag,
-    )
-
-    assert code == 1
-    assert err == ""
-    assert reference_kind in out
-    assert reference_name in out
-    assert "lineage-root" in out
-    assert _purge_database_rows() == before_rows
-
-
-def test_cold_purge_without_yes_refuses_actual_deletion(
-    session_home: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    _seed_archived_lineage()
-    archive_root = session_home.parent / "cold-root"
-    store_code, _store_out, store_err = _run_cli(
-        monkeypatch,
-        capsys,
-        "sessions",
-        "cold-store",
-        str(archive_root),
-        "--session-id",
-        "lineage-terminal",
-        "--yes",
-    )
-    assert store_code == 0
-    assert store_err == ""
-
-    code, out, err = _run_cli(
-        monkeypatch,
-        capsys,
-        "sessions",
-        "cold-purge",
-        str(archive_root),
-        "--session-id",
-        "lineage-terminal",
-    )
-
-    assert code == 1
-    assert err == ""
-    assert "requires --yes" in out
-    assert "nothing was deleted" in out
-    assert _lineage_rows() == [
-        ("lineage-root", 1),
-        ("lineage-terminal", 1),
-    ]
-
-
-def test_cold_verify_successfully_checks_one_stored_lineage_read_only(
-    session_home: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    _seed_archived_lineage()
-    archive_root = session_home.parent / "cold-root"
-    store_code, _store_out, store_err = _run_cli(
-        monkeypatch,
-        capsys,
-        "sessions",
-        "cold-store",
-        str(archive_root),
-        "--session-id",
-        "lineage-terminal",
-        "--yes",
-    )
-    assert store_code == 0
-    assert store_err == ""
-    before_rows = _lineage_rows()
-    before_files = sorted(
-        path.relative_to(archive_root) for path in archive_root.rglob("*")
-    )
-
-    code, out, err = _run_cli(
-        monkeypatch,
-        capsys,
-        "sessions",
-        "cold-verify",
-        str(archive_root),
-        "--session-id",
-        "lineage-term",
-    )
-
-    assert code == 0
-    assert err == ""
-    assert "Verified archived session lineage:" in out
-    assert "terminal ID: lineage-terminal" in out
-    assert "physical IDs: lineage-root, lineage-terminal" in out
-    assert re.search(r"fingerprint: [0-9a-f]{64}\b", out)
-    snapshot_match = re.search(r"verified snapshot: (.+)$", out, re.MULTILINE)
-    assert snapshot_match is not None
-    assert Path(snapshot_match.group(1)).is_relative_to(archive_root)
-    assert _lineage_rows() == before_rows
-    assert sorted(
-        path.relative_to(archive_root) for path in archive_root.rglob("*")
-    ) == before_files
-
-
-def test_cold_verify_missing_snapshot_fails_without_creating_root(
-    session_home: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    _seed_archived_lineage()
-    archive_root = session_home.parent / "missing-cold-root"
-
-    code, out, err = _run_cli(
-        monkeypatch,
-        capsys,
-        "sessions",
-        "cold-verify",
-        str(archive_root),
-        "--session-id",
-        "lineage-terminal",
-    )
-
-    assert code == 1
-    assert err == ""
-    assert "Error: could not cold-verify session lineage" in out
-    assert "snapshot not found" in out
-    assert not archive_root.exists()
-
-
-def test_cold_verify_database_open_failure_exits_nonzero(
-    session_home: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    _seed_archived_lineage()
-
-    def fail_read_only_open(*args, **kwargs):
-        assert kwargs.get("read_only") is True
-        raise sqlite3.OperationalError("read-only open failed")
-
-    monkeypatch.setattr("hermes_state.SessionDB", fail_read_only_open)
-
-    code, out, err = _run_cli(
-        monkeypatch,
-        capsys,
-        "sessions",
-        "cold-verify",
-        str(session_home.parent / "cold-root"),
-        "--session-id",
-        "lineage-terminal",
-    )
-
-    assert code == 1
-    assert err == ""
-    assert "Error: Could not open session database: read-only open failed" in out
-
-
-def test_cold_store_database_open_failure_exits_nonzero(
-    session_home: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    _seed_archived_lineage()
-
-    def fail_writable_open(*args, **kwargs):
-        assert kwargs.get("read_only") is False
-        raise sqlite3.OperationalError("writable open failed")
-
-    monkeypatch.setattr("hermes_state.SessionDB", fail_writable_open)
-
-    code, out, err = _run_cli(
-        monkeypatch,
-        capsys,
-        "sessions",
-        "cold-store",
-        str(session_home.parent / "cold-root"),
-        "--session-id",
-        "lineage-terminal",
-        "--yes",
-    )
-
-    assert code == 1
-    assert err == ""
-    assert "Error: Could not open session database: writable open failed" in out
-
-
-@pytest.mark.parametrize(
-    ("action", "execution_flags"),
-    [
-        ("cold-store", ("--yes",)),
-        ("cold-verify", ()),
-    ],
-)
-def test_cold_commands_reject_finite_out_of_range_started_at_cleanly(
-    session_home: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-    action: str,
-    execution_flags: tuple[str, ...],
-) -> None:
-    db = SessionDB()
-    try:
-        db.create_session("bad-start-time", source="cli")
-        db.end_session("bad-start-time", "completed")
-        assert db.set_session_archived("bad-start-time", True)
-        assert db._conn is not None
-        db._conn.execute(
-            "UPDATE sessions SET started_at = ? WHERE id = ?",
-            (1e300, "bad-start-time"),
-        )
-    finally:
-        db.close()
-
-    code, out, err = _run_cli(
-        monkeypatch,
-        capsys,
-        "sessions",
-        action,
-        str(session_home.parent / "cold-root"),
-        "--session-id",
-        "bad-start-time",
-        *execution_flags,
-    )
-
-    assert code == 1
-    assert err == ""
-    assert "terminal session start time is outside the supported range" in out
-    assert "Traceback" not in out
-
-
-def test_cold_store_default_confirmation_warns_about_raw_transcript_and_cancels(
-    session_home: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    _seed_archived_lineage()
-    archive_root = session_home.parent / "cold-root"
-    prompts: list[str] = []
-
-    def decline(prompt: str) -> str:
-        prompts.append(prompt)
-        return ""
-
-    monkeypatch.setattr("builtins.input", decline)
-    before = _lineage_rows()
-
-    code, out, _err = _run_cli(
-        monkeypatch,
-        capsys,
-        "sessions",
-        "cold-store",
-        str(archive_root),
-        "--session-id",
-        "lineage-terminal",
-    )
-
-    assert code == 0
-    assert out.strip() == "Cancelled."
-    assert len(prompts) == 1
-    assert "sensitive raw transcript" in prompts[0]
-    assert str(archive_root) in prompts[0]
-    assert prompts[0].endswith("[y/N] ")
-    assert not archive_root.exists()
-    assert _lineage_rows() == before
-
-
-def test_cold_store_dry_run_creates_nothing_and_does_not_prompt(
-    session_home: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    _seed_archived_lineage()
-    archive_root = session_home.parent / "cold-root"
-    before = _lineage_rows()
-
-    def unexpected_prompt(_prompt: str) -> str:
-        raise AssertionError("dry-run must not prompt")
-
-    monkeypatch.setattr("builtins.input", unexpected_prompt)
-    code, out, _err = _run_cli(
-        monkeypatch,
-        capsys,
-        "sessions",
-        "cold-store",
-        str(archive_root),
-        "--session-id",
-        "lineage-term",
-        "--dry-run",
-    )
-
-    assert code == 0
-    assert "Would store archived session lineage 'lineage-terminal'" in out
-    assert str(archive_root) in out
-    assert "nothing was written" in out
-    assert not archive_root.exists()
-    assert _lineage_rows() == before
-
-
-def test_cold_store_dry_run_opens_database_read_only_without_reconciliation(
-    session_home: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    _seed_archived_lineage()
+    archive_root = session_home.parent / "new-cold-root"
+    before_sessions = _session_rows()
+    before_messages = _message_rows()
     db_path = session_home / "state.db"
     with sqlite3.connect(db_path) as conn:
         conn.execute("DROP INDEX idx_compression_locks_expires")
         schema_version = int(conn.execute("PRAGMA schema_version").fetchone()[0])
-        before_rows = conn.execute(
-            "SELECT id, archived FROM sessions ORDER BY id"
-        ).fetchall()
-
     opens: list[bool] = []
+    original_session_db = SessionDB
 
     def tracked_open(*args, **kwargs):
         opens.append(bool(kwargs.get("read_only")))
-        return SessionDB(*args, **kwargs)
+        return original_session_db(*args, **kwargs)
+
+    def unexpected_prompt(_prompt: str) -> str:
+        raise AssertionError("dry-run must not prompt")
 
     monkeypatch.setattr("hermes_state.SessionDB", tracked_open)
-    archive_root = session_home.parent / "cold-root"
+    monkeypatch.setattr("builtins.input", unexpected_prompt)
 
     code, out, err = _run_cli(
         monkeypatch,
         capsys,
         "sessions",
-        "cold-store",
+        "cold-archive",
         str(archive_root),
         "--session-id",
-        "lineage-terminal",
+        "lineage-term",
         "--dry-run",
     )
 
     assert code == 0
     assert err == ""
-    assert "nothing was written" in out
+    assert "resolved terminal ID: lineage-terminal" in out
+    assert "Store → Verify → Purge" in out
+    assert "nothing was written or deleted" in out
     assert opens == [True]
     assert not archive_root.exists()
     with sqlite3.connect(db_path) as conn:
@@ -856,168 +207,202 @@ def test_cold_store_dry_run_opens_database_read_only_without_reconciliation(
             "SELECT 1 FROM sqlite_schema "
             "WHERE type = 'index' AND name = 'idx_compression_locks_expires'"
         ).fetchone() is None
-        assert conn.execute(
-            "SELECT id, archived FROM sessions ORDER BY id"
-        ).fetchall() == before_rows
+    assert _session_rows() == before_sessions
+    assert _message_rows() == before_messages
 
 
-@pytest.mark.parametrize("execution_flag", ["--yes", "--dry-run"])
-def test_cold_store_cli_reports_unsupported_blob_without_writing(
+def test_cold_archive_yes_runs_store_verify_purge_serially_and_keeps_snapshot(
     session_home: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
-    execution_flag: str,
 ) -> None:
-    db = SessionDB()
-    try:
-        db.create_session("blob-session", source="cli")
-        message_id = db.append_message(
-            "blob-session", role="user", content="placeholder"
-        )
-        assert db._conn is not None
-        db._conn.execute(
-            "UPDATE messages SET content = ? WHERE id = ?",
-            (b"future-blob", message_id),
-        )
-        db.end_session("blob-session", "completed")
-        assert db.set_session_archived("blob-session", True)
-    finally:
-        db.close()
+    _seed_archived_lineage(unrelated=True)
     archive_root = session_home.parent / "cold-root"
-    before = _lineage_rows()
+    calls: list[str] = []
+    original_store = cold_store.store_archived_lineage
+    original_verify = cold_store.verify_archived_lineage
+    original_purge = cold_store.purge_archived_lineage
+
+    def record_store(*args, **kwargs):
+        calls.append("Store")
+        return original_store(*args, **kwargs)
+
+    def record_verify(*args, **kwargs):
+        calls.append("Verify")
+        return original_verify(*args, **kwargs)
+
+    def record_purge(*args, **kwargs):
+        calls.append("Purge")
+        return original_purge(*args, **kwargs)
+
+    def unexpected_prompt(_prompt: str) -> str:
+        raise AssertionError("--yes must not prompt")
+
+    monkeypatch.setattr(cold_store, "store_archived_lineage", record_store)
+    monkeypatch.setattr(cold_store, "verify_archived_lineage", record_verify)
+    monkeypatch.setattr(cold_store, "purge_archived_lineage", record_purge)
+    monkeypatch.setattr("builtins.input", unexpected_prompt)
 
     code, out, err = _run_cli(
         monkeypatch,
         capsys,
         "sessions",
-        "cold-store",
+        "cold-archive",
         str(archive_root),
         "--session-id",
-        "blob-session",
-        execution_flag,
+        "lineage-terminal",
+        "--yes",
     )
 
-    assert code == 1
+    assert code == 0
     assert err == ""
-    assert (
-        "cold store v1 does not support SQLite BLOB/bytes values at message.content"
-        in out
-    )
-    assert not archive_root.exists()
-    assert _lineage_rows() == before == [("blob-session", 1)]
-
-    db = SessionDB()
-    try:
-        assert db._conn is not None
-        row = db._conn.execute(
-            "SELECT content FROM messages WHERE session_id = ?", ("blob-session",)
-        ).fetchone()
-        assert row is not None and row["content"] == b"future-blob"
-    finally:
-        db.close()
+    assert calls == ["Store", "Verify", "Purge"]
+    assert "Cold-archived session lineage:" in out
+    assert "terminal ID: lineage-terminal" in out
+    assert "physical IDs: lineage-root, lineage-terminal" in out
+    assert re.search(r"fingerprint: [0-9a-f]{64}\b", out)
+    snapshot_match = re.search(r"local snapshot retained: (.+)$", out, re.MULTILINE)
+    assert snapshot_match is not None
+    snapshot = Path(snapshot_match.group(1))
+    assert snapshot.is_relative_to(archive_root)
+    assert snapshot.is_dir()
+    assert {path.name for path in snapshot.iterdir()} == {
+        "artifacts",
+        "metadata.json",
+        "session.jsonl",
+    }
+    assert _session_rows() == [("unrelated", 0)]
+    assert _message_rows() == [("unrelated", "keep this row")]
 
 
 @pytest.mark.parametrize(
-    ("session_id", "extra_session"),
+    ("failed_stage", "expected_calls", "snapshot_retained"),
     [
-        ("missing", None),
-        ("lineage-", "lineage-another"),
+        pytest.param("Store", ["Store"], False, id="store"),
+        pytest.param("Verify", ["Store", "Verify"], True, id="verify"),
+        pytest.param("Purge", ["Store", "Verify", "Purge"], True, id="purge"),
     ],
 )
-def test_cold_store_rejects_missing_or_ambiguous_ids_before_writing(
+def test_cold_archive_stage_failure_stops_and_retains_source_rows_and_snapshot(
     session_home: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
-    session_id: str,
-    extra_session: str | None,
+    failed_stage: str,
+    expected_calls: list[str],
+    snapshot_retained: bool,
 ) -> None:
     _seed_archived_lineage()
-    if extra_session is not None:
-        db = SessionDB()
-        try:
-            db.create_session(extra_session, source="cli")
-            db.end_session(extra_session, "completed")
-        finally:
-            db.close()
     archive_root = session_home.parent / "cold-root"
+    before_sessions = _session_rows()
+    before_messages = _message_rows()
+    calls: list[str] = []
+    original_store = cold_store.store_archived_lineage
+    original_verify = cold_store.verify_archived_lineage
 
-    code, out, _err = _run_cli(
+    def stage(
+        name: str, implementation: Callable[..., object] | None
+    ) -> Callable[..., object]:
+        def run(*args, **kwargs):
+            calls.append(name)
+            if name == failed_stage:
+                raise OSError(f"forced {name} failure")
+            assert implementation is not None
+            return implementation(*args, **kwargs)
+
+        return run
+
+    monkeypatch.setattr(
+        cold_store, "store_archived_lineage", stage("Store", original_store)
+    )
+    monkeypatch.setattr(
+        cold_store, "verify_archived_lineage", stage("Verify", original_verify)
+    )
+    monkeypatch.setattr(cold_store, "purge_archived_lineage", stage("Purge", None))
+
+    code, out, err = _run_cli(
         monkeypatch,
         capsys,
         "sessions",
-        "cold-store",
+        "cold-archive",
         str(archive_root),
         "--session-id",
-        session_id,
+        "lineage-terminal",
         "--yes",
     )
 
     assert code == 1
-    assert f"Session '{session_id}' was not found or is ambiguous." in out
-    assert not archive_root.exists()
+    assert err == ""
+    assert calls == expected_calls
+    assert f"Error: cold archive {failed_stage} failed: forced {failed_stage} failure" in out
+    assert "source rows were retained" in out.lower()
+    assert _session_rows() == before_sessions
+    assert _message_rows() == before_messages
+    files = _snapshot_files(archive_root)
+    assert bool(files) is snapshot_retained
+    if snapshot_retained:
+        assert any(path.name == "metadata.json" for path in files)
+        assert "local snapshot was retained" in out.lower()
+    else:
+        assert "no verified local snapshot was produced" in out.lower()
 
 
-@pytest.mark.parametrize("execution_flag", ["--yes", "--dry-run"])
-def test_cold_store_surfaces_store_eligibility_rejection_without_db_changes(
+def test_cold_archive_without_confirmation_refuses_without_prompt_or_mutation(
     session_home: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
-    execution_flag: str,
 ) -> None:
-    db = SessionDB()
-    try:
-        db.create_session("not-archived", source="cli")
-        db.end_session("not-archived", "completed")
-    finally:
-        db.close()
+    _seed_archived_lineage()
     archive_root = session_home.parent / "cold-root"
-    before = _lineage_rows()
+    before_sessions = _session_rows()
+    before_messages = _message_rows()
 
-    code, out, _err = _run_cli(
+    def unexpected_prompt(_prompt: str) -> str:
+        raise AssertionError("cold-archive confirmation is flag-based")
+
+    monkeypatch.setattr("builtins.input", unexpected_prompt)
+    code, out, err = _run_cli(
         monkeypatch,
         capsys,
         "sessions",
-        "cold-store",
+        "cold-archive",
         str(archive_root),
         "--session-id",
-        "not-archived",
-        execution_flag,
+        "lineage-terminal",
     )
 
     assert code == 1
-    assert "all compression lineage rows must be marked archived" in out
+    assert err == ""
+    assert "requires either --dry-run or --yes" in out
+    assert "nothing was written or deleted" in out
     assert not archive_root.exists()
-    assert _lineage_rows() == before == [("not-archived", 0)]
+    assert _session_rows() == before_sessions
+    assert _message_rows() == before_messages
 
 
-@pytest.mark.parametrize("execution_flag", ["--yes", "--dry-run"])
-def test_cold_store_surfaces_non_terminal_rejection_without_db_changes(
+def test_cold_archive_rejects_conflicting_confirmation_flags(
     session_home: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
-    execution_flag: str,
 ) -> None:
-    db = SessionDB()
-    try:
-        db.create_session("still-open", source="cli")
-        assert db.set_session_archived("still-open", True)
-    finally:
-        db.close()
+    _seed_archived_lineage()
     archive_root = session_home.parent / "cold-root"
-    before = _lineage_rows()
 
-    code, out, _err = _run_cli(
+    code, _out, err = _run_cli(
         monkeypatch,
         capsys,
         "sessions",
-        "cold-store",
+        "cold-archive",
         str(archive_root),
         "--session-id",
-        "still-open",
-        execution_flag,
+        "lineage-terminal",
+        "--dry-run",
+        "--yes",
     )
 
-    assert code == 1
-    assert "terminal session must be ended and non-compression" in out
+    assert code == 2
+    assert "not allowed with argument" in err
     assert not archive_root.exists()
-    assert _lineage_rows() == before == [("still-open", 1)]
+    assert _session_rows() == [
+        ("lineage-root", 1),
+        ("lineage-terminal", 1),
+    ]

--- a/tests/hermes_cli/test_sessions_cold_store_cli.py
+++ b/tests/hermes_cli/test_sessions_cold_store_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 import sqlite3
 import sys
@@ -109,6 +110,27 @@ def _snapshot_files(archive_root: Path) -> dict[Path, bytes]:
     }
 
 
+def _write_legacy_route(session_home: Path, session_id: str) -> Path:
+    sessions_file = session_home / "sessions" / "sessions.json"
+    sessions_file.parent.mkdir(exist_ok=True)
+    sessions_file.write_text(
+        json.dumps(
+            {
+                "_README": "legacy routing mirror",
+                "agent:main:telegram:dm:123": {
+                    "session_key": "agent:main:telegram:dm:123",
+                    "session_id": session_id,
+                    "created_at": "2026-08-18T00:00:00+00:00",
+                    "updated_at": "2026-08-18T00:00:00+00:00",
+                },
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return sessions_file
+
+
 def test_sessions_help_exposes_only_converged_public_cold_archive_command(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -164,6 +186,7 @@ def test_cold_archive_dry_run_is_read_only_and_does_not_require_snapshot(
 ) -> None:
     _seed_archived_lineage()
     archive_root = session_home.parent / "new-cold-root"
+    lock_path = cold_store._cold_archive_lock_path(archive_root)
     before_sessions = _session_rows()
     before_messages = _message_rows()
     db_path = session_home / "state.db"
@@ -201,12 +224,118 @@ def test_cold_archive_dry_run_is_read_only_and_does_not_require_snapshot(
     assert "nothing was written or deleted" in out
     assert opens == [True]
     assert not archive_root.exists()
+    assert not lock_path.exists()
     with sqlite3.connect(db_path) as conn:
         assert int(conn.execute("PRAGMA schema_version").fetchone()[0]) == schema_version
         assert conn.execute(
             "SELECT 1 FROM sqlite_schema "
             "WHERE type = 'index' AND name = 'idx_compression_locks_expires'"
         ).fetchone() is None
+    assert _session_rows() == before_sessions
+    assert _message_rows() == before_messages
+
+
+def test_cold_archive_lock_contention_fails_before_store_without_mutation(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_archived_lineage(unrelated=True)
+    archive_root = session_home.parent / "cold-root"
+    equivalent_root = archive_root.parent / "unused" / ".." / archive_root.name
+    before_sessions = _session_rows()
+    before_messages = _message_rows()
+    before_files = _snapshot_files(archive_root)
+
+    def unexpected_stage(*_args, **_kwargs):
+        raise AssertionError("lock contention must fail before Store/Verify/Purge")
+
+    monkeypatch.setattr(cold_store, "store_archived_lineage", unexpected_stage)
+    monkeypatch.setattr(cold_store, "verify_archived_lineage", unexpected_stage)
+    monkeypatch.setattr(cold_store, "purge_archived_lineage", unexpected_stage)
+
+    with cold_store._exclusive_cold_archive_root_lock(archive_root):
+        code, out, err = _run_cli(
+            monkeypatch,
+            capsys,
+            "sessions",
+            "cold-archive",
+            str(equivalent_root),
+            "--session-id",
+            "lineage-terminal",
+            "--yes",
+        )
+
+    assert code == 1
+    assert err == ""
+    assert "already active for archive root" in out
+    assert _snapshot_files(archive_root) == before_files
+    assert _session_rows() == before_sessions
+    assert _message_rows() == before_messages
+
+
+def test_cold_archive_dry_run_rejects_legacy_route_without_mutation(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_archived_lineage(unrelated=True)
+    archive_root = session_home.parent / "new-cold-root"
+    sessions_file = _write_legacy_route(session_home, "lineage-root")
+    before_route = sessions_file.read_bytes()
+    before_sessions = _session_rows()
+    before_messages = _message_rows()
+
+    code, out, err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-archive",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+        "--dry-run",
+    )
+
+    assert code == 1
+    assert err == ""
+    assert "could not plan cold archive" in out
+    assert "sessions.json legacy route" in out
+    assert not archive_root.exists()
+    assert sessions_file.read_bytes() == before_route
+    assert _session_rows() == before_sessions
+    assert _message_rows() == before_messages
+
+
+def test_cold_archive_yes_rejects_legacy_route_at_purge_and_retains_state(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_archived_lineage(unrelated=True)
+    archive_root = session_home.parent / "cold-root"
+    sessions_file = _write_legacy_route(session_home, "lineage-terminal")
+    before_route = sessions_file.read_bytes()
+    before_sessions = _session_rows()
+    before_messages = _message_rows()
+
+    code, out, err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-archive",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+        "--yes",
+    )
+
+    assert code == 1
+    assert err == ""
+    assert "cold archive Purge failed" in out
+    assert "sessions.json legacy route" in out
+    assert any(path.name == "metadata.json" for path in _snapshot_files(archive_root))
+    assert sessions_file.read_bytes() == before_route
     assert _session_rows() == before_sessions
     assert _message_rows() == before_messages
 

--- a/tests/hermes_cli/test_sessions_cold_store_cli.py
+++ b/tests/hermes_cli/test_sessions_cold_store_cli.py
@@ -496,6 +496,41 @@ def test_cold_archive_yes_runs_store_verify_purge_serially_and_keeps_snapshot(
     assert _message_rows() == [("unrelated", "keep this row")]
 
 
+def test_cold_archive_resolution_database_error_fails_closed(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_archived_lineage()
+    archive_root = session_home.parent / "cold-root"
+    before_sessions = _session_rows()
+    before_messages = _message_rows()
+
+    def fail_resolution(_db: SessionDB, _session_id: str) -> str:
+        raise sqlite3.DatabaseError("forced damaged-page lookup")
+
+    monkeypatch.setattr(SessionDB, "resolve_session_id", fail_resolution)
+
+    code, out, err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-archive",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+        "--dry-run",
+    )
+
+    assert code == 1
+    assert err == ""
+    assert "Error: could not resolve cold-archive session" in out
+    assert "forced damaged-page lookup" in out
+    assert not archive_root.exists()
+    assert _session_rows() == before_sessions
+    assert _message_rows() == before_messages
+
+
 @pytest.mark.parametrize(
     ("failed_stage", "expected_calls", "snapshot_retained"),
     [

--- a/tests/hermes_cli/test_sessions_cold_store_cli.py
+++ b/tests/hermes_cli/test_sessions_cold_store_cli.py
@@ -549,6 +549,49 @@ def test_cold_archive_refuses_cross_instance_pending_accounting(
         accounting_owner.close()
 
 
+def test_cold_archive_accounting_lock_database_error_fails_closed(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_archived_lineage()
+    archive_root = session_home.parent / "cold-root"
+    before_sessions = _session_rows()
+    before_messages = _message_rows()
+
+    class FailingAccountingLock:
+        def __enter__(self):
+            raise sqlite3.DatabaseError("forced accounting-lock plan failure")
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(
+        cold_store,
+        "_exclusive_lineage_accounting_locks",
+        lambda *_args, **_kwargs: FailingAccountingLock(),
+    )
+
+    code, out, err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-archive",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+        "--yes",
+    )
+
+    assert code == 1
+    assert err == ""
+    assert "Error: cold archive lock failed" in out
+    assert "forced accounting-lock plan failure" in out
+    assert not archive_root.exists()
+    assert _session_rows() == before_sessions
+    assert _message_rows() == before_messages
+
+
 def test_cold_archive_resolution_database_error_fails_closed(
     session_home: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/hermes_cli/test_sessions_cold_store_cli.py
+++ b/tests/hermes_cli/test_sessions_cold_store_cli.py
@@ -1,0 +1,304 @@
+"""CLI contract for storing one explicit archived session lineage locally."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def session_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    import hermes_state
+
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", home / "state.db")
+    return home
+
+
+def _seed_archived_lineage() -> None:
+    db = SessionDB()
+    try:
+        db.create_session("lineage-root", source="cli")
+        db.append_message("lineage-root", role="user", content="sensitive first turn")
+        db.end_session("lineage-root", "compression")
+        db.create_session(
+            "lineage-terminal",
+            source="cli",
+            parent_session_id="lineage-root",
+        )
+        db.append_message(
+            "lineage-terminal", role="assistant", content="sensitive final turn"
+        )
+        db.end_session("lineage-terminal", "completed")
+        assert db.set_session_archived("lineage-terminal", True)
+    finally:
+        db.close()
+
+
+def _run_cli(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    *argv: str,
+) -> tuple[int, str, str]:
+    import hermes_cli.main as main_mod
+
+    monkeypatch.setattr(sys, "argv", ["hermes", *argv])
+    try:
+        main_mod.main()
+    except SystemExit as exc:
+        code = int(exc.code or 0)
+    else:
+        code = 0
+    captured = capsys.readouterr()
+    return code, captured.out, captured.err
+
+
+def _lineage_rows() -> list[tuple[str, int]]:
+    db = SessionDB()
+    try:
+        assert db._conn is not None
+        return [
+            (str(row["id"]), int(row["archived"]))
+            for row in db._conn.execute(
+                "SELECT id, archived FROM sessions ORDER BY id"
+            ).fetchall()
+        ]
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize(
+    ("arguments", "required_argument"),
+    [
+        (("sessions", "cold-store"), "ROOT"),
+        (("sessions", "cold-store", "archive"), "--session-id"),
+    ],
+)
+def test_cold_store_requires_root_and_named_session_id(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    arguments: tuple[str, ...],
+    required_argument: str,
+) -> None:
+    code, _out, err = _run_cli(monkeypatch, capsys, *arguments)
+
+    assert code == 2
+    assert required_argument in err
+    assert "required" in err
+
+
+def test_cold_store_yes_stores_exactly_one_resolved_lineage_and_reports_identity(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_archived_lineage()
+    archive_root = session_home.parent / "cold-root"
+    before = _lineage_rows()
+
+    code, out, err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-store",
+        str(archive_root),
+        "--session-id",
+        "lineage-term",
+        "--yes",
+    )
+
+    assert code == 0
+    assert err == ""
+    assert "terminal ID: lineage-terminal" in out
+    assert "physical IDs: lineage-root, lineage-terminal" in out
+    assert re.search(r"fingerprint: [0-9a-f]{64}\b", out)
+    snapshot_match = re.search(r"local snapshot: (.+)$", out, re.MULTILINE)
+    assert snapshot_match is not None
+    snapshot = Path(snapshot_match.group(1))
+    assert snapshot.is_relative_to(archive_root)
+    assert {path.name for path in snapshot.iterdir()} == {
+        "artifacts",
+        "metadata.json",
+        "session.jsonl",
+    }
+    assert _lineage_rows() == before == [
+        ("lineage-root", 1),
+        ("lineage-terminal", 1),
+    ]
+
+
+def test_cold_store_default_confirmation_warns_about_raw_transcript_and_cancels(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_archived_lineage()
+    archive_root = session_home.parent / "cold-root"
+    prompts: list[str] = []
+
+    def decline(prompt: str) -> str:
+        prompts.append(prompt)
+        return ""
+
+    monkeypatch.setattr("builtins.input", decline)
+    before = _lineage_rows()
+
+    code, out, _err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-store",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+    )
+
+    assert code == 0
+    assert out.strip() == "Cancelled."
+    assert len(prompts) == 1
+    assert "sensitive raw transcript" in prompts[0]
+    assert str(archive_root) in prompts[0]
+    assert prompts[0].endswith("[y/N] ")
+    assert not archive_root.exists()
+    assert _lineage_rows() == before
+
+
+def test_cold_store_dry_run_creates_nothing_and_does_not_prompt(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_archived_lineage()
+    archive_root = session_home.parent / "cold-root"
+    before = _lineage_rows()
+
+    def unexpected_prompt(_prompt: str) -> str:
+        raise AssertionError("dry-run must not prompt")
+
+    monkeypatch.setattr("builtins.input", unexpected_prompt)
+    code, out, _err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-store",
+        str(archive_root),
+        "--session-id",
+        "lineage-term",
+        "--dry-run",
+    )
+
+    assert code == 0
+    assert "Would store archived session lineage 'lineage-terminal'" in out
+    assert str(archive_root) in out
+    assert "nothing was written" in out
+    assert not archive_root.exists()
+    assert _lineage_rows() == before
+
+
+@pytest.mark.parametrize(
+    ("session_id", "extra_session"),
+    [
+        ("missing", None),
+        ("lineage-", "lineage-another"),
+    ],
+)
+def test_cold_store_rejects_missing_or_ambiguous_ids_before_writing(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    session_id: str,
+    extra_session: str | None,
+) -> None:
+    _seed_archived_lineage()
+    if extra_session is not None:
+        db = SessionDB()
+        try:
+            db.create_session(extra_session, source="cli")
+            db.end_session(extra_session, "completed")
+        finally:
+            db.close()
+    archive_root = session_home.parent / "cold-root"
+
+    code, out, _err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-store",
+        str(archive_root),
+        "--session-id",
+        session_id,
+        "--yes",
+    )
+
+    assert code == 1
+    assert f"Session '{session_id}' was not found or is ambiguous." in out
+    assert not archive_root.exists()
+
+
+def test_cold_store_surfaces_store_eligibility_rejection_without_db_changes(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    db = SessionDB()
+    try:
+        db.create_session("not-archived", source="cli")
+        db.end_session("not-archived", "completed")
+    finally:
+        db.close()
+    archive_root = session_home.parent / "cold-root"
+    before = _lineage_rows()
+
+    code, out, _err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-store",
+        str(archive_root),
+        "--session-id",
+        "not-archived",
+        "--yes",
+    )
+
+    assert code == 1
+    assert "all compression lineage rows must be marked archived" in out
+    assert not archive_root.exists()
+    assert _lineage_rows() == before == [("not-archived", 0)]
+
+
+def test_cold_store_surfaces_non_terminal_rejection_without_db_changes(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    db = SessionDB()
+    try:
+        db.create_session("still-open", source="cli")
+        assert db.set_session_archived("still-open", True)
+    finally:
+        db.close()
+    archive_root = session_home.parent / "cold-root"
+    before = _lineage_rows()
+
+    code, out, _err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-store",
+        str(archive_root),
+        "--session-id",
+        "still-open",
+        "--yes",
+    )
+
+    assert code == 1
+    assert "terminal session must be ended and non-compression" in out
+    assert not archive_root.exists()
+    assert _lineage_rows() == before == [("still-open", 1)]

--- a/tests/hermes_cli/test_sessions_cold_store_cli.py
+++ b/tests/hermes_cli/test_sessions_cold_store_cli.py
@@ -211,6 +211,54 @@ def test_cold_archive_dry_run_is_read_only_and_does_not_require_snapshot(
     assert _message_rows() == before_messages
 
 
+def test_cold_archive_dry_run_rejects_state_meta_reference_without_mutation(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_archived_lineage()
+    archive_root = session_home.parent / "new-cold-root"
+    db = SessionDB()
+    try:
+        db.set_meta("goal:lineage-terminal", '{"status":"active"}')
+        assert db._conn is not None
+        before_meta = db._conn.execute(
+            "SELECT key, value FROM state_meta ORDER BY key"
+        ).fetchall()
+    finally:
+        db.close()
+    before_sessions = _session_rows()
+    before_messages = _message_rows()
+
+    code, out, err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-archive",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+        "--dry-run",
+    )
+
+    assert code == 1
+    assert err == ""
+    assert "could not plan cold archive" in out
+    assert "cold purge refuses state_meta soft reference" in out
+    assert "Would run: Store → Verify → Purge" not in out
+    assert not archive_root.exists()
+    assert _session_rows() == before_sessions
+    assert _message_rows() == before_messages
+    db = SessionDB()
+    try:
+        assert db._conn is not None
+        assert db._conn.execute(
+            "SELECT key, value FROM state_meta ORDER BY key"
+        ).fetchall() == before_meta
+    finally:
+        db.close()
+
+
 def test_cold_archive_yes_runs_store_verify_purge_serially_and_keeps_snapshot(
     session_home: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/hermes_cli/test_sessions_cold_store_cli.py
+++ b/tests/hermes_cli/test_sessions_cold_store_cli.py
@@ -102,6 +102,18 @@ def _purge_database_rows() -> tuple[list[tuple[object, ...]], ...]:
                     "FROM gateway_routing ORDER BY scope, session_key"
                 ).fetchall()
             ],
+            [
+                tuple(row)
+                for row in db._conn.execute(
+                    "SELECT key, value FROM state_meta ORDER BY key"
+                ).fetchall()
+            ],
+            [
+                tuple(row)
+                for row in db._conn.execute(
+                    "SELECT * FROM async_delegations ORDER BY delegation_id"
+                ).fetchall()
+            ],
         )
     finally:
         db.close()
@@ -375,6 +387,114 @@ def test_cold_purge_refuses_routed_verified_lineage_and_retains_database_rows(
     assert code == 1
     assert err == ""
     assert "gateway_routing" in out
+    assert "lineage-root" in out
+    assert _purge_database_rows() == before_rows
+
+
+@pytest.mark.parametrize("purge_flag", ["--dry-run", "--yes"])
+@pytest.mark.parametrize(
+    ("reference_kind", "reference_name"),
+    [
+        pytest.param("state_meta", "goal", id="state-meta-goal"),
+        pytest.param("state_meta", "loop", id="state-meta-loop"),
+        pytest.param("state_meta", "heartbeat", id="state-meta-heartbeat"),
+        pytest.param("async_delegations", "origin_session", id="delegation-origin"),
+        pytest.param(
+            "async_delegations",
+            "parent_session_id",
+            id="delegation-parent",
+        ),
+        pytest.param(
+            "async_delegations",
+            "origin_session_id",
+            id="delegation-origin-session-id",
+        ),
+    ],
+)
+def test_cold_purge_refuses_unsnapshotted_soft_references_without_mutation(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    purge_flag: str,
+    reference_kind: str,
+    reference_name: str,
+) -> None:
+    _seed_archived_lineage()
+    archive_root = session_home.parent / "cold-root"
+    store_code, _store_out, store_err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-store",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+        "--yes",
+    )
+    assert store_code == 0
+    assert store_err == ""
+
+    db = SessionDB()
+    try:
+        assert db._conn is not None
+        columns = {
+            str(row[1])
+            for row in db._conn.execute(
+                "PRAGMA table_info(async_delegations)"
+            ).fetchall()
+        }
+        assert "origin_session_id" in columns
+        if reference_kind == "state_meta":
+            db._conn.execute(
+                "INSERT INTO state_meta(key, value) VALUES (?, ?)",
+                (f"{reference_name}:lineage-root", '{"keep":"unchanged"}'),
+            )
+        else:
+            reference_values = {
+                "origin_session": "unrelated-origin",
+                "parent_session_id": None,
+                "origin_session_id": "unrelated-api-session",
+            }
+            reference_values[reference_name] = "lineage-root"
+            db._conn.execute(
+                "INSERT INTO async_delegations ("
+                "delegation_id, origin_session, parent_session_id, "
+                "origin_session_id, state, dispatched_at, updated_at"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    f"delegation-{reference_name}",
+                    reference_values["origin_session"],
+                    reference_values["parent_session_id"],
+                    reference_values["origin_session_id"],
+                    "completed",
+                    1.0,
+                    2.0,
+                ),
+            )
+        assert (
+            db._conn.execute("SELECT COUNT(*) FROM gateway_routing").fetchone()[0]
+            == 0
+        )
+    finally:
+        db.close()
+
+    before_rows = _purge_database_rows()
+
+    code, out, err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-purge",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+        purge_flag,
+    )
+
+    assert code == 1
+    assert err == ""
+    assert reference_kind in out
+    assert reference_name in out
     assert "lineage-root" in out
     assert _purge_database_rows() == before_rows
 

--- a/tests/hermes_cli/test_sessions_cold_store_cli.py
+++ b/tests/hermes_cli/test_sessions_cold_store_cli.py
@@ -202,6 +202,62 @@ def test_cold_store_dry_run_creates_nothing_and_does_not_prompt(
     assert _lineage_rows() == before
 
 
+@pytest.mark.parametrize("execution_flag", ["--yes", "--dry-run"])
+def test_cold_store_cli_reports_unsupported_blob_without_writing(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    execution_flag: str,
+) -> None:
+    db = SessionDB()
+    try:
+        db.create_session("blob-session", source="cli")
+        message_id = db.append_message(
+            "blob-session", role="user", content="placeholder"
+        )
+        assert db._conn is not None
+        db._conn.execute(
+            "UPDATE messages SET content = ? WHERE id = ?",
+            (b"future-blob", message_id),
+        )
+        db.end_session("blob-session", "completed")
+        assert db.set_session_archived("blob-session", True)
+    finally:
+        db.close()
+    archive_root = session_home.parent / "cold-root"
+    before = _lineage_rows()
+
+    code, out, err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-store",
+        str(archive_root),
+        "--session-id",
+        "blob-session",
+        execution_flag,
+    )
+
+    assert code == 1
+    assert err == ""
+    assert (
+        "cold store v1 does not support SQLite BLOB/bytes values at message.content"
+        in out
+    )
+    assert not archive_root.exists()
+    assert _lineage_rows() == before == [("blob-session", 1)]
+
+    db = SessionDB()
+    try:
+        assert db._conn is not None
+        row = db._conn.execute(
+            "SELECT content FROM messages WHERE session_id = ?", ("blob-session",)
+        ).fetchone()
+        assert row is not None and row["content"] == b"future-blob"
+    finally:
+        db.close()
+
+
 @pytest.mark.parametrize(
     ("session_id", "extra_session"),
     [

--- a/tests/hermes_cli/test_sessions_cold_store_cli.py
+++ b/tests/hermes_cli/test_sessions_cold_store_cli.py
@@ -238,6 +238,58 @@ def test_cold_archive_dry_run_is_read_only_and_does_not_require_snapshot(
     assert _message_rows() == before_messages
 
 
+def test_cold_archive_dry_run_accepts_pre_upgrade_delegation_schema(
+    session_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_archived_lineage()
+    archive_root = session_home.parent / "new-cold-root"
+    db_path = session_home / "state.db"
+    before_sessions = _session_rows()
+    before_messages = _message_rows()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "ALTER TABLE async_delegations DROP COLUMN origin_session_id"
+        )
+        columns_before = tuple(
+            str(row[1])
+            for row in conn.execute("PRAGMA table_info(async_delegations)")
+        )
+        schema_version = int(conn.execute("PRAGMA schema_version").fetchone()[0])
+    assert "origin_session_id" not in columns_before
+
+    code, out, err = _run_cli(
+        monkeypatch,
+        capsys,
+        "sessions",
+        "cold-archive",
+        str(archive_root),
+        "--session-id",
+        "lineage-terminal",
+        "--dry-run",
+    )
+
+    assert code == 0
+    assert err == ""
+    assert "resolved terminal ID: lineage-terminal" in out
+    assert "nothing was written or deleted" in out
+    assert not archive_root.exists()
+    with sqlite3.connect(db_path) as conn:
+        columns_after = tuple(
+            str(row[1])
+            for row in conn.execute("PRAGMA table_info(async_delegations)")
+        )
+        assert columns_after == columns_before
+        assert int(conn.execute("PRAGMA schema_version").fetchone()[0]) == schema_version
+        assert conn.execute(
+            "SELECT id, archived FROM sessions ORDER BY id"
+        ).fetchall() == before_sessions
+        assert conn.execute(
+            "SELECT session_id, content FROM messages ORDER BY id"
+        ).fetchall() == before_messages
+
+
 def test_cold_archive_lock_contention_fails_before_store_without_mutation(
     session_home: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/state/test_gateway_routing_pk_heal.py
+++ b/tests/state/test_gateway_routing_pk_heal.py
@@ -1,0 +1,82 @@
+"""Gateway-routing PK healing must preserve cold-archive fences."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from hermes_state import SessionDB
+from hermes_state_common import SCHEMA_VERSION
+
+
+_ROUTE_TOMBSTONE_TRIGGERS = {
+    "gateway_routing_reject_cold_archive_tombstone_insert",
+    "gateway_routing_reject_cold_archive_tombstone_update",
+}
+
+
+_LEGACY_GATEWAY_ROUTING_SQL = """
+CREATE TABLE gateway_routing (
+    session_key TEXT PRIMARY KEY,
+    entry_json TEXT NOT NULL,
+    updated_at REAL NOT NULL
+)
+"""
+
+
+def _make_legacy_gateway_routing_db(tmp_path):
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.close()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DROP TABLE gateway_routing")
+        conn.execute(_LEGACY_GATEWAY_ROUTING_SQL)
+        conn.execute("UPDATE schema_version SET version = ?", (SCHEMA_VERSION,))
+    return db_path
+
+
+def test_legacy_gateway_routing_pk_heal_reinstalls_tombstone_triggers(
+    tmp_path,
+) -> None:
+    db_path = _make_legacy_gateway_routing_db(tmp_path)
+    db = SessionDB(db_path=db_path)
+    try:
+        assert db._conn is not None
+        trigger_names = {
+            str(row[0])
+            for row in db._conn.execute(
+                "SELECT name FROM sqlite_schema "
+                "WHERE type = 'trigger' AND tbl_name = 'gateway_routing'"
+            ).fetchall()
+        }
+        assert _ROUTE_TOMBSTONE_TRIGGERS <= trigger_names
+
+        db._conn.execute(
+            "INSERT INTO cold_archive_tombstones "
+            "(session_id, terminal_id, source_fingerprint, deleted_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("purged-id", "purged-id", "f" * 64, 1.0),
+        )
+        db._conn.commit()
+
+        with sqlite3.connect(db_path) as concurrent:
+            with pytest.raises(
+                sqlite3.IntegrityError,
+                match="gateway route targets a cold-archived session ID",
+            ):
+                concurrent.execute(
+                    "INSERT INTO gateway_routing "
+                    "(scope, session_key, entry_json, updated_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    (
+                        "test-scope",
+                        "test-key",
+                        json.dumps({"session_id": "purged-id"}),
+                        2.0,
+                    ),
+                )
+    finally:
+        db.close()

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -46,6 +46,19 @@ def test_packaging_declared_as_core_dependency():
     )
 
 
+def test_cold_archive_top_level_modules_are_packaged() -> None:
+    """Container/installed launches must resolve cold-archive runtime imports.
+
+    Repository-root tests can import undeclared top-level modules through the
+    working directory, masking a missing ``tool.setuptools.py-modules`` entry.
+    Docker and sealed/editable installs start elsewhere and expose the defect.
+    """
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    packaged = set(data["tool"]["setuptools"]["py-modules"])
+
+    assert {"hermes_accounting_locks", "hermes_cold_archive_errors"} <= packaged
+
+
 def test_faster_whisper_is_not_a_base_dependency():
     data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     deps = data["project"]["dependencies"]


### PR DESCRIPTION
## What does this PR do?

Draft implementation for #91005.

Adds a bounded, local-only cold-archive lifecycle for one already-soft-archived logical session at a time:

```console
hermes sessions cold-archive ROOT --session-id ID --dry-run
hermes sessions cold-archive ROOT --session-id ID --yes
```

The public command composes:

```text
Store exact logical lineage
→ fsync and Verify the local snapshot
→ flush/fence pending accounting
→ exact source and reference recheck
→ atomically install durable tombstones and delete source rows
```

Filesystem Store/Verify work remains outside the SQLite write transaction. The final transaction is intentionally short: re-read the exact source plan, insert tombstones for every physical lineage ID, delete the covered rows, and commit. Any uncertainty retains the source rows.

This is intentionally a draft while maintainers decide the contribution surface in #91005.

## Related issue

Related to #91005. This draft does **not** close the design issue; scope feedback is requested before ready-for-review.

## Supported v1 boundary

- Hermes session transcripts and logical lineages are append-only.
- Cold storage retains one latest verified snapshot per logical session, not competing revision history. A later Store of the same logical session may replace its earlier current snapshot.
- Manual in-place replacement of `state.db` with a divergent database image while reusing the same path/inode, session ID, and `started_at` is unsupported database surgery/restore behavior. Restore/import/history-branch reconciliation is a separate lifecycle.
- Ordinary session delete/prune behavior is unchanged and does not create tombstones.
- Intentional reuse or restoration of a cold-purged ID requires a future explicit untombstone/restore contract.

## Retained and derived data

The v1 snapshot conservatively retains complete raw SQLite rows for:

- every physical session segment and its lifecycle/lineage metadata;
- ordered messages;
- normalized system prompts;
- aggregate session usage/cost fields; and
- per-model/provider `session_model_usage` rows.

Raw JSON-looking text columns are preserved without parsing and reserialization. This retained payload is archive authority.

Search indexes, previews, counts, summaries, vector indexes, and similar reproducible projections are derived data. They are not archive authority and can be regenerated from `session.jsonl`. Format minimization is deliberately deferred; v1 keeps complete source rows for lossless fidelity.

## Changes made

- `hermes_cli/session_cold_store.py`
  - resolves a complete linear compression lineage;
  - writes typed, private JSONL snapshots with source fingerprints;
  - uses private no-follow staging, verification, fsync, and atomic publication;
  - verifies trusted root ownership/modes and stable directory identity;
  - rejects unsupported values, malformed snapshots, active leases/locks, routing, metadata/delegation references, and uncovered reset/branch/delegate children;
  - coordinates pending/in-flight/failed accounting across processes;
  - atomically tombstones and deletes only the verified unchanged physical ID set.
- `hermes_state_common.py`
  - adds durable `cold_archive_tombstones`;
  - adds database-level session and gateway-route resurrection fences;
  - leaves ordinary delete/prune semantics unchanged.
- `gateway/session.py`
  - treats tombstone-trigger rejection as terminal authority rather than falling back to legacy `sessions.json` persistence.
- `hermes_cli/session_recovery.py` and `hermes_cli/session_lost_and_found.py`
  - preserve tombstones through normal and page-level recovery;
  - reconcile conflicting sessions, messages, usage, prompts, routing, metadata, delegation references, locks, and parent links.
- `hermes_cli/main.py` and `hermes_cli/sessions_cmd.py`
  - expose one explicit public `cold-archive` command;
  - require `--dry-run` or `--yes`;
  - keep dry-run read-only;
  - return bounded nonzero errors and retain source rows on every phase failure.

## Verification

Exact current-upstream candidate:

```text
base: 64a6f42cb38def7ad6524bdfe640a16997c88760
head: b35ae79f8bd61b1e92c560fe7b72bcbf7e1326c6
```

The first 50 commits are commit-for-commit equivalent to the prior candidate (`git range-diff`: 50 equivalent, 0 changed). The 51st commit adds only the repository-required `windows-footgun: ok` annotations to two POSIX-only ownership checks. The 52nd declares the two new top-level runtime modules in `tool.setuptools.py-modules` and adds a packaging regression.

Affected and adjacent wrapper gate:

```bash
scripts/run_tests.sh -q \
  tests/gateway/test_routing_save_fast_path.py \
  tests/agent/test_async_token_accounting.py \
  tests/hermes_cli/test_session_cold_store.py \
  tests/hermes_cli/test_sessions_cold_store_cli.py \
  tests/hermes_cli/test_sessions_delete.py \
  tests/hermes_cli/test_sessions_error_exit_codes.py \
  tests/hermes_cli/test_sessions_export_md_cli.py \
  tests/hermes_cli/test_session_recovery.py \
  tests/hermes_cli/test_session_recovery_lost_and_found.py \
  tests/test_hermes_state.py \
  tests/state/test_gateway_routing_pk_heal.py \
  tests/state/test_session_model_usage_pk_heal.py
```

Observed at the stopping-review head `6b734bc580c1e8705950f5f0116602e2cb1dbbb6`:

```text
12 files: 395 passed, 1 failed
candidate-specific failures: 0
affected gateway/cold-archive/recovery/accounting/CLI tests: 151 passed, 0 failed
```

The one failure independently reproduces on exact base `64a6f42cb38def7ad6524bdfe640a16997c88760`:

```text
tests/test_hermes_state.py::TestFTS5Search::
test_search_projection_skips_context_enrichment_queries
```

Additional exact-tree checks:

```text
current-head full-repo Windows-footgun scan: 1,014 files, no findings
current-head Windows-footgun regression: 1 passed
current-head cold-store suite: 62 passed
current-head packaging metadata suite: 8 passed
current-head cold-store + gateway routing suites: 80 passed
editable install imports both new modules outside the repository root
uv lock --check: passed
Ruff (changed modules/tests): passed
Ty (changed modules): passed
git diff --check: passed
required co-author trailers: 52 / 52
```

Disposable `HERMES_HOME` public-command E2E:

```text
public command exit: 0
snapshot record count/fingerprint/private modes: verified
remaining source sessions/messages/model-usage rows: 0 / 0 / 0
tombstones: 2, both matching the archive fingerprint
SQLite integrity: ok
foreign-key violations: 0
late session recreation: rejected
late gateway-route recreation: rejected
synthetic home/archive: removed after verification
```

## Review disposition

Final stopping exact-SHA Codex CLI 0.149.1 / GPT-5.6-Sol review of `6b734bc580c1e8705950f5f0116602e2cb1dbbb6` returned `READY` with zero P0/P1/P2 findings. The current head adds two scanner-suppression comments and declares the already-reviewed cold-archive modules in the installed top-level module set; the latter addresses cross-architecture Docker startup failures caused by `ModuleNotFoundError`.

The reviewer confirmed the prior P1 closures:

- idempotent Store success now requires a successful snapshot-parent `fsync`;
- legacy `gateway_routing` primary-key healing reinstalls both tombstone route triggers before first use;
- non-SQL plan inputs are precomputed, leaving the final `BEGIN IMMEDIATE` callback SQLite-only and short.

The reviewer sandbox could not rerun pytest because it had no writable temporary directory; parent-side exact-head tests, static checks, base-failure reproduction, and disposable public-command E2E are reported above. The divergent in-place database restoration scenario remains outside the supported append-only v1 contract.

## Deferred scope

This PR does not implement:

- restore/import or untombstone UX;
- tar.zst packing or pack manifests;
- remote replication/mirroring;
- search/vector indexes or derived analytics products;
- retention scheduling or automated Purge policy;
- migration/retrofit of existing private snapshots; or
- VACUUM/physical SQLite page reclamation.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Checklist

- [x] Read the contributing guide
- [x] Conventional commit messages
- [x] Searched open/closed PRs for overlap
- [x] Focused and adjacent tests added and run
- [x] Tested through the real public command on disposable state
- [x] Tested on Raspberry Pi OS / Linux (aarch64)
- [ ] Repository-wide test suite run — not claimed; exact affected/adjacent evidence is reported above
- [ ] User-facing documentation — deferred pending #91005 scope feedback
