### PR TITLE
fix(approval): anchor Windows disk-destruction patterns to command position

### DIFF
--- a/tests/tools/test_approval_windows.py
+++ b/tests/tools/test_approval_windows.py
@@ -81,6 +81,65 @@ class TestWindowsDestructiveTier:
         assert not _is_dangerous(cmd), f"should NOT be flagged: {cmd}"
 
 
+class TestDiskDestructionCommandPositionAnchor:
+    """The disk/volume destruction rules (Format-Volume/Clear-Disk/diskpart/
+    format.com/cipher /w) used a bare \\b anchor, matching anywhere in the
+    text — including inside quoted prose that merely mentions the tool
+    (a commit message, a doc edit, an echo). #93392/#93640 fixed the exact
+    same false-positive class for the POSIX mkfs/dd twins by anchoring to
+    command position; these five Windows analogues were the sibling gap.
+
+    Anchoring naively to the shared _CMDPOS fragment would have traded that
+    false positive for a false negative: unlike mkfs/dd (POSIX tools that
+    never run under a Windows wrapper), these commands routinely run as
+    `cmd /c "diskpart"` or `powershell -Command "diskpart"`, and
+    _command_detection_variants does not lift a separately-anchorable
+    payload variant out of those two wrapper shapes the way it does for
+    bash/sh/zsh/ksh -c. The fix instead unions _CMDPOS with the same
+    cmd/powershell wrapper shapes the del/erase/rd/rmdir and remove-item
+    rules above already recognize.
+    """
+
+    @pytest.mark.parametrize("cmd", [
+        'git commit -m "docs: mention Format-Volume in windows setup notes"',
+        'echo "never run clear-disk on prod"',
+        'echo "the diskpart tool can wipe disks"',
+        'echo "cipher /w wipes free space, be careful"',
+        'git commit -m "...format c: ..."',
+        "ls C:\\Users",
+    ])
+    def test_quoted_prose_mentioning_tool_not_flagged(self, cmd):
+        assert not _is_dangerous(cmd), f"should NOT be flagged: {cmd}"
+
+    @pytest.mark.parametrize("cmd", [
+        # bare invocation
+        "diskpart",
+        "Format-Volume -DriveLetter D",
+        "Clear-Disk -Number 1 -RemoveData",
+        "format c: /q",
+        "cipher /w:C",
+        # chained / subshell / sudo-wrapped
+        "echo hi; diskpart",
+        "$(diskpart)",
+        "sudo format-volume",
+        # cmd.exe-wrapped
+        'cmd /c "diskpart"',
+        "cmd.exe /c diskpart",
+        "cmd /k diskpart",
+        # powershell-wrapped
+        'powershell -Command "diskpart"',
+        'powershell.exe -Command "format-volume -driveletter d"',
+        'pwsh -c "clear-disk -number 1"',
+    ])
+    def test_real_invocation_still_flagged(self, cmd):
+        assert _is_dangerous(cmd), f"should be flagged: {cmd}"
+
+    def test_verb_as_non_first_word_in_cmd_wrapper_not_flagged(self):
+        # diskpart is not the first word after `cmd /c "` here — an
+        # unrelated command mentioning it in an argument, not invoking it.
+        assert not _is_dangerous('cmd /c "echo diskpart is dangerous"')
+
+
 class TestWindowsPathVariant:
     """Backslash Windows paths must survive into pattern matching.
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -472,6 +472,24 @@ _CMDPOS = (
     r'\s*'
 )
 
+# Command-position anchor for Windows-native, bare-name-dangerous commands
+# (disk/volume destruction below) that routinely run as the payload of a
+# Windows shell wrapper rather than bare. Plain _CMDPOS alone is not enough
+# here: _command_detection_variants only lifts a wrapper's payload out into
+# its own _CMDPOS-anchored variant for bash/sh/zsh/ksh -c (see
+# _execution_flag_findings), not for `cmd /c "..."` or
+# `powershell -Command "..."` — so anchoring one of these rules to bare
+# _CMDPOS would stop matching `cmd /c "diskpart"` entirely while still
+# fixing the quoted-prose false positive. Union in the same two wrapper
+# shapes the del/erase/rd/rmdir and remove-item rules above already match
+# on, so a verb reached through either wrapper is still caught.
+_WIN_DISK_CMDPOS = (
+    r'(?:' + _CMDPOS + r'|'
+    r'\bcmd(?:\.exe)?\s+/[ck]\s+["\']?|'
+    r'\b(?:powershell|pwsh)(?:\.exe)?\b(?:\s+-\S+)*\s+(?:-(?:command|c)\s+)?["\']?'
+    r')'
+)
+
 # Destructive-path argument matcher for the rm hardline rules.
 #
 # The path token in `rm -rf /` is almost always written quoted in real
@@ -964,12 +982,25 @@ DANGEROUS_PATTERNS = [
     # Force process kills — Windows analogue of pkill -9.
     (r'\btaskkill\b[^\n]*\s/f\b', "force kill processes (taskkill /F)"),
     (r'\bstop-process\b[^\n]*\s-force\b', "force kill processes (Stop-Process -Force)"),
-    # Volume/disk destruction — Windows analogue of mkfs / dd.
-    (r'\bformat-volume\b', "format filesystem (Format-Volume)"),
-    (r'\bclear-disk\b', "wipe disk (Clear-Disk)"),
-    (r'\bdiskpart\b', "disk partitioning (diskpart)"),
-    (r'\bformat(?:\.com)?\s+[a-z]:', "format drive (format.com)"),
-    (r'\bcipher\s+/w\b', "wipe free space (cipher /w)"),
+    # Volume/disk destruction — Windows analogue of mkfs / dd. Anchored to
+    # command position like their POSIX twins (#93392/#93640): a bare `\b`
+    # here matches "format-volume"/"diskpart"/etc. anywhere in the text, so
+    # quoted prose merely mentioning one of these tools (a commit message, a
+    # doc edit, `echo "never run diskpart on prod"`) required approval to
+    # echo. Unlike mkfs/dd (POSIX tools that never run under a Windows
+    # wrapper), these are Windows-native commands routinely invoked as
+    # `cmd /c "diskpart"` or `powershell -Command "diskpart"` — reusing the
+    # plain _CMDPOS anchor here would stop matching those wrapped forms
+    # entirely (verified: _command_detection_variants only extracts a
+    # separately-anchorable payload variant for bash/sh/zsh/ksh -c, not for
+    # cmd /c or powershell -Command). _WIN_DISK_CMDPOS additionally
+    # recognizes those two wrapper shapes, mirroring the cmd/powershell
+    # prefix forms already used above for del/erase/rd/rmdir/remove-item.
+    (_WIN_DISK_CMDPOS + r'format-volume\b', "format filesystem (Format-Volume)"),
+    (_WIN_DISK_CMDPOS + r'clear-disk\b', "wipe disk (Clear-Disk)"),
+    (_WIN_DISK_CMDPOS + r'diskpart\b', "disk partitioning (diskpart)"),
+    (_WIN_DISK_CMDPOS + r'format(?:\.com)?\s+[a-z]:', "format drive (format.com)"),
+    (_WIN_DISK_CMDPOS + r'cipher\s+/w\b', "wipe free space (cipher /w)"),
     # ACL destruction — Windows analogue of chmod 777.
     (r'\bicacls\b[^\n]*\s/grant\b[^\n]*\b(?:everyone|todos|jeder|tout\s+le\s+monde|\*s-1-1-0)\b', "grant Everyone access (icacls)"),
     (r'\bicacls\b[^\n]*\s/reset\b', "reset ACLs recursively (icacls /reset)"),


### PR DESCRIPTION
## Summary

`DANGEROUS_PATTERNS`' Windows volume/disk destruction rules — `Format-Volume`, `Clear-Disk`, `diskpart`, `format.com`, `cipher /w` — used a bare `\b` anchor, matching the tool name anywhere in the command text.

`#93392`/`#93640` (merged) fixed the identical false-positive class for the POSIX `mkfs`/`dd` twins **two rules below this exact block** by anchoring to command position (`_CMDPOS`) — quoted prose merely mentioning `mkfs`/`dd` (a commit message, a doc edit, an `echo`) no longer requires approval to run. These five Windows analogues were the sibling gap left over from that same fix.

**Empirically verified before writing the fix**, on current `main`:
```
detect_dangerous_command('git commit -m "docs: mention Format-Volume in windows setup notes"')
-> (True, 'format filesystem (Format-Volume)', ...)   # false positive
detect_dangerous_command('echo "never run clear-disk on prod"')
-> (True, 'wipe disk (Clear-Disk)', ...)               # false positive
detect_dangerous_command('echo "the diskpart tool can wipe disks"')
-> (True, 'disk partitioning (diskpart)', ...)          # false positive
detect_dangerous_command('echo "cipher /w wipes free space, be careful"')
-> (True, 'wipe free space (cipher /w)', ...)           # false positive
```
while the already-fixed sibling correctly passes:
```
detect_dangerous_command('echo "never run mkfs on a mounted disk"') -> (False, None, None)
```

## Why a naive `_CMDPOS` reuse is wrong here

Unlike `mkfs`/`dd` (POSIX tools that never run under a Windows shell wrapper), these five commands routinely run as `cmd /c "diskpart"` or `powershell -Command "diskpart"`. I verified that `_command_detection_variants()` only lifts a separately re-anchorable payload variant out of a wrapper for `bash`/`sh`/`zsh`/`ksh -c` (see `_execution_flag_findings`) — **not** for `cmd /c` or `powershell -Command`. Anchoring these five patterns to a bare `_CMDPOS` (my first attempt) silently stopped matching `cmd /c "diskpart"` and `cmd.exe /c diskpart` entirely — trading the false positive for a false negative on the single most realistic real-world invocation shape for a Windows-native command.

The fix instead adds `_WIN_DISK_CMDPOS`, which unions the existing `_CMDPOS` anchor with the same `cmd`/`powershell` wrapper-prefix shapes the `del`/`erase`/`rd`/`rmdir` (line ~934) and `remove-item` (line ~941) rules a few lines above this block already recognize — so a verb reached through either wrapper, bare, chained, in a subshell, or sudo-wrapped is still caught, while quoted prose is not.

## Verification

- **Empirically verified** the fix against 20 hand-crafted cases: all 5 quoted-prose false positives now pass through undetected; all 15 real-invocation shapes (bare, `;`-chained, `$()`-subshell, `sudo`-wrapped, `cmd /c`/`cmd.exe /c`/`cmd /k`-wrapped, `powershell -Command`/`powershell.exe -Command`/`pwsh -c`-wrapped) remain flagged; a `cmd /c "echo diskpart is dangerous"` control (verb not the first word after the wrapper) correctly stays unflagged.
- **New regression tests** (`tests/tools/test_approval_windows.py::TestDiskDestructionCommandPositionAnchor`, 22 parametrized cases across 3 test methods).
- **Mutation-verified**: reverting the fix reproduces exactly 6 failures (the 5 quoted-prose cases + the non-first-word-in-cmd-wrapper control); the 15 real-invocation cases pass either way, since the original bare pattern is a strict superset that also happens to catch them.
- Full `tests/tools/test_approval_windows.py` (69 tests) and `tests/tools/test_approval.py` (219 tests) pass.
- Broader targeted sweep (`test_approval.py`, `test_approval_windows.py`, `test_hardline_blocklist.py`, `test_execution_flag_detection.py`, `test_command_guards.py`, `test_shell_bypass_denylist.py`, `test_gnu_long_option_abbreviation_bypass.py`, `test_allowlist_quoted_metachars.py`, `test_smart_approval_policy.py`, `test_denial_circuit_breaker.py`, 606+ tests): 4 pre-existing failures reproduce byte-for-byte with the fix stashed (one is a known-unrelated `_is_verification_artifact_cleanup` gap, three are `sort`/`man` real-binary subprocess tests failing in this sandbox) — confirmed independent of this change.
- `ruff check` clean on both changed files.

## Competitor / conflict notes (checked fresh before opening)

- No open or closed PR touches `format-volume`, `diskpart`, `clear-disk`, `format.com`, or `cipher /w`.
- **#37854** ("anchor dangerous-command patterns to command position to avoid echo/grep false positives", open since 2026-06-03) is a much older, unrelated `_CMDPOS`-anchoring pass over `rm`/`chmod`/`chown`/`mkfs`/`dd` — it predates the current, already-merged `mkfs`/`dd` fix (`#93640`) and diffs against a stale base; it never touches these five Windows patterns.
- My own open **#84563** proposes adding `Restart-Computer`/`Stop-Computer`/`Format-Volume`/`format.com` (bare `\b`, same flaw this PR fixes) to the unconditional `HARDLINE_PATTERNS` floor — that PR will need a follow-up fix independent of this one before it can safely land, since `HARDLINE_PATTERNS` matching goes through the same `_mark_command_starts`/anchor machinery.