### PR TITLE
fix(cron): make a recurring job stuck in state=error recoverable again

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -640,6 +640,37 @@ def is_terminal_job(job: Dict[str, Any]) -> bool:
     return job.get("state") in {"completed", "error"}
 
 
+def _is_recoverable_error_job(job: Dict[str, Any]) -> bool:
+    """True for a recurring job stuck in ``state=error``.
+
+    ``state=error`` is set ONLY on a cron/interval job when
+    ``compute_next_run()`` fails to produce a next occurrence (e.g. the
+    ``croniter`` package is missing, or a malformed schedule) — see
+    ``_mark_job_run_locked``'s issue #16265 comment: recurring jobs must
+    NEVER be silently disabled. Unlike ``state=completed`` (a one-shot
+    that genuinely has no more occurrences, ever), an error-state
+    recurring job still has a schedule with future occurrences once the
+    underlying issue resolves — it is stuck pending a ``next_run_at``
+    recompute, not truly done.
+
+    ``is_terminal_job()`` treats both states identically, which is correct
+    for blocking bare reactivation through ``update_job`` on a genuinely
+    completed job, but wrong here: it also blocks the due-scan's own
+    ``next_run_at`` self-heal (``_get_due_jobs_locked`` already recomputes
+    it for ``cron``/``interval`` jobs, but never reaches that code), the
+    at-most-once pre-advance (``advance_next_runs``), the dispatch claim
+    (``_claim_job_for_fire_locked``), and manual recovery (``resume_job``)
+    — wedging the job forever with no exit except deleting and recreating
+    it. Callers that need "is this job truly done" should keep using
+    ``is_terminal_job()`` alone; callers that need "can this job still
+    reach a future occurrence" should exclude this case.
+    """
+    return (
+        job.get("state") == "error"
+        and job.get("schedule", {}).get("kind") in {"cron", "interval"}
+    )
+
+
 def _secure_dir(path: Path):
     """Set directory to owner-only access (0700). No-op on Windows."""
     try:
@@ -2267,10 +2298,14 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})
 
-            if is_terminal_job(job) and (
-                updated.get("state") not in {"completed", "error"}
-                or updated.get("enabled") is True
-                or updated.get("next_run_at") is not None
+            if (
+                is_terminal_job(job)
+                and not _is_recoverable_error_job(job)
+                and (
+                    updated.get("state") not in {"completed", "error"}
+                    or updated.get("enabled") is True
+                    or updated.get("next_run_at") is not None
+                )
             ):
                 raise ValueError(
                     f"Cannot activate terminal cron job '{job.get('name', job_id)}' "
@@ -2364,10 +2399,14 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     )
                 updated["next_run_at"] = next_run
 
-            if is_terminal_job(job) and (
-                updated.get("state") not in {"completed", "error"}
-                or updated.get("enabled") is True
-                or updated.get("next_run_at") is not None
+            if (
+                is_terminal_job(job)
+                and not _is_recoverable_error_job(job)
+                and (
+                    updated.get("state") not in {"completed", "error"}
+                    or updated.get("enabled") is True
+                    or updated.get("next_run_at") is not None
+                )
             ):
                 raise ValueError(
                     f"Cannot activate terminal cron job '{job.get('name', job_id)}' "
@@ -3047,7 +3086,7 @@ def advance_next_runs(job_ids) -> int:
         for job in jobs:
             if job["id"] not in ids:
                 continue
-            if is_terminal_job(job):
+            if is_terminal_job(job) and not _is_recoverable_error_job(job):
                 continue
             kind = job.get("schedule", {}).get("kind")
             if kind not in {"cron", "interval"}:
@@ -3148,7 +3187,7 @@ def _claim_job_for_fire_locked(
         for job in jobs:
             if job["id"] != job_id:
                 continue
-            if is_terminal_job(job):
+            if is_terminal_job(job) and not _is_recoverable_error_job(job):
                 return False
             # enabled + pause markers must both clear — a half-paused record
             # (enabled=true, state=paused/paused_at set) must not claim. An
@@ -3448,7 +3487,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
         # job this tick" so healthy siblings still run and their recovered
         # state still reaches save_jobs() below.
         try:
-            if is_terminal_job(job):
+            if is_terminal_job(job) and not _is_recoverable_error_job(job):
                 continue
             if not job.get("enabled", True):
                 continue

--- a/tests/cron/test_terminal_job_rearm.py
+++ b/tests/cron/test_terminal_job_rearm.py
@@ -2,16 +2,21 @@
 
 from datetime import datetime, timedelta, timezone
 import copy
+from unittest import mock
 
 import pytest
 
 from cron.jobs import (
     advance_next_run,
+    advance_next_runs,
+    claim_job_for_fire,
     create_job,
     get_due_jobs,
     get_job,
     load_jobs,
     mark_job_run,
+    rearm_oneshot,
+    resume_job,
     save_jobs,
     trigger_job,
     update_job,
@@ -136,3 +141,105 @@ def test_rearm_refuses_recurring_and_live_claim(tmp_cron_dir):
     save_jobs([record])
     with pytest.raises(ValueError, match="claim"):
         rearm_oneshot(oneshot["id"], future)
+
+
+class TestRecurringJobStuckInErrorStateIsRecoverable:
+    """A recurring (cron/interval) job that could not compute its next
+    occurrence is marked ``state=error`` but left ``enabled=True`` — issue
+    #16265's invariant that recurring jobs must never be silently disabled.
+
+    ``is_terminal_job()`` previously treated ``state=error`` identically to
+    ``state=completed`` at every call site, which blocked BOTH the due-scan's
+    own ``next_run_at`` self-heal AND every manual recovery path
+    (``resume_job``, ``claim_job_for_fire``, ``advance_next_runs``) — wedging
+    the job forever with no exit except deleting and recreating it. These
+    tests pin the fix: an error-state recurring job stays recoverable through
+    every one of those paths, while a genuinely terminal ``state=completed``
+    job (covered by the tests above) remains blocked through all of them.
+    """
+
+    @staticmethod
+    def _force_error_state(job_id):
+        """Reproduce the exact state _mark_job_run_locked produces when
+        compute_next_run() fails for a recurring job (e.g. croniter
+        missing): state=error, enabled stays True, next_run_at=None."""
+        with mock.patch("cron.jobs.compute_next_run", return_value=None):
+            mark_job_run(job_id, success=True)
+
+    def test_due_scan_self_heals_next_run_at(self, tmp_cron_dir):
+        job = create_job("recurring", "every 5m")
+        self._force_error_state(job["id"])
+        stuck = get_job(job["id"])
+        assert stuck["state"] == "error"
+        assert stuck["enabled"] is True
+        assert stuck["next_run_at"] is None
+
+        # compute_next_run works again on the next tick (the transient
+        # issue resolved) — the due-scan must recompute next_run_at even
+        # though the persisted record is still state=error.
+        get_due_jobs()
+
+        healed = get_job(job["id"])
+        assert healed["next_run_at"] is not None, (
+            "due-scan self-heal never reached an error-state recurring job"
+        )
+
+    def test_resume_job_recovers_error_state(self, tmp_cron_dir):
+        job = create_job("recurring", "every 5m")
+        self._force_error_state(job["id"])
+
+        resumed = resume_job(job["id"])
+
+        assert resumed is not None, "resume_job must not raise on state=error"
+        assert resumed["state"] == "scheduled"
+        assert resumed["enabled"] is True
+        assert resumed["next_run_at"] is not None
+
+    def test_claim_job_for_fire_recovers_error_state(self, tmp_cron_dir):
+        job = create_job("recurring", "every 5m")
+        self._force_error_state(job["id"])
+
+        claimed = claim_job_for_fire(job["id"], return_job=True)
+
+        assert isinstance(claimed, dict), (
+            "claim_job_for_fire must not refuse an error-state recurring "
+            "job — it still has future occurrences"
+        )
+        assert claimed["fire_claim"] is not None
+
+    def test_advance_next_runs_recovers_error_state(self, tmp_cron_dir):
+        job = create_job("recurring", "every 5m")
+        self._force_error_state(job["id"])
+
+        advanced = advance_next_runs([job["id"]])
+
+        assert advanced == 1, (
+            "advance_next_runs must still pre-advance an error-state "
+            "recurring job's next_run_at before it fires (crash-safety)"
+        )
+
+    def test_pause_job_now_works_on_error_state(self, tmp_cron_dir):
+        from cron.jobs import pause_job
+
+        job = create_job("recurring", "every 5m")
+        self._force_error_state(job["id"])
+
+        paused = pause_job(job["id"])
+
+        assert paused is not None, "pause_job must not raise on state=error"
+        assert paused["state"] == "paused"
+        assert paused["enabled"] is False
+
+    def test_completed_oneshot_still_blocked_on_every_path(self, tmp_cron_dir):
+        """Control: the fix must not weaken protection for a genuinely
+        terminal state=completed job — only state=error recurring jobs are
+        exempted."""
+        job = create_job("done", "30m", repeat=1)
+        mark_job_run(job["id"], success=True)
+        assert get_job(job["id"])["state"] == "completed"
+
+        with pytest.raises(ValueError, match="terminal"):
+            resume_job(job["id"])
+        assert claim_job_for_fire(job["id"], return_job=True) is False
+        assert advance_next_runs([job["id"]]) == 0
+        assert get_due_jobs() == []


### PR DESCRIPTION
## Summary

`is_terminal_job()` treats `state=error` identically to `state=completed` at every one of its 6 call sites (all added together in `c3a63a16f1`, "refuse to run terminal jobs"). That conflates two very different situations:

- **`state=completed`**: a one-shot that genuinely has no more occurrences, ever. Correctly terminal.
- **`state=error`**: set ONLY on a `cron`/`interval` job when `compute_next_run()` fails to produce a next occurrence (e.g. the `croniter` package is missing at runtime). `_mark_job_run_locked`'s own comment is explicit: *"Recurring jobs must NEVER be silently disabled"* (issue #16265) — the job is left `enabled=True` specifically so it stays a live, recoverable job once the underlying issue resolves.

Because `is_terminal_job()` lumps both together, a recurring job that ever reaches `state=error` is wedged **forever**, with every recovery path refusing it:

- `_get_due_jobs_locked()`'s own `next_run_at` self-heal (a few lines below its own `is_terminal_job()` check) never runs, because the check itself skips the job first.
- `resume_job()` → `update_job()` raises `"Cannot activate terminal cron job ... use cron resume --run-now or --at."`
- `rearm_oneshot()` — the alternative suggested in that exact error message — itself raises `"Cannot re-arm recurring jobs: re-arm is one-shot-only."`
- `advance_next_runs()` and `_claim_job_for_fire_locked()` — the pre-advance and claim steps the scheduler's own dispatch loop calls immediately after `get_due_jobs()` for anything that DOES make it into the due list — both also refuse the job, so even a manually-recovered `next_run_at` would fail to actually fire.
- `pause_job()` (itself just an `update_job()` call) can't even pause a broken recurring job through the normal path.

The only way out was deleting the job and recreating it.

## Fix

`_is_recoverable_error_job()` identifies this specific case (`state == "error"` and schedule `kind` in `{"cron", "interval"}` — the only shape `state=error` ever takes) and is excluded from the `is_terminal_job()` gate at `update_job()` (both checks), `advance_next_runs()`, `_claim_job_for_fire_locked()`, and `_get_due_jobs_locked()`.

`trigger_job()` is left untouched: its own error message already points users at `cron resume`, which this fix makes work correctly.

## Verification

**Empirically verified end-to-end** against the real module before writing the fix: create a recurring job, force `state=error` via `_mark_job_run_locked()` with `compute_next_run()` mocked to return `None` (the exact croniter-missing scenario), then confirm `resume_job()` raises `ValueError`, `rearm_oneshot()` raises `ValueError`, and `get_due_jobs()` never recovers `next_run_at`. Verified after the fix: `resume_job()`/`rearm_oneshot()`'s replacement path succeed, `get_due_jobs()` recovers `next_run_at`, and `claim_job_for_fire()`/`advance_next_runs()` correctly stop refusing the job — while still correctly refusing a genuinely `state=completed` one-shot through every one of those same paths.

**New regression tests** (`tests/cron/test_terminal_job_rearm.py::TestRecurringJobStuckInErrorStateIsRecoverable`, 6 tests): due-scan self-heal, `resume_job`, `claim_job_for_fire`, `advance_next_runs`, `pause_job` recovery, plus a control confirming a genuinely completed one-shot stays blocked on every one of the same paths.

**Mutation-verified**: reverting the fix reproduces exactly 5 failures (all but the completed-oneshot control, which was never broken).

**Test sweep**: full `tests/cron/` (952 tests, 1 pre-existing skip) + `tests/hermes_cli/test_cron.py` + `tests/tools/test_cronjob_tools.py`/`test_cronjob_run_background.py`/`test_cronjob_run_immediate.py`/`test_cron_approval_mode.py` (138 tests) all pass. `ruff check` clean on both changed files.

## Competitor / related-PR notes (checked fresh before opening)

- No open or closed PR touches `is_terminal_job()` or `_is_recoverable_error_job`-shaped logic for this specific recovery gap.
- **#16428** (open since 2026-04-27, `resume_job() sets state=error when compute_next_run() returns None`) is a related but **complementary, opposite-direction** fix: it makes `resume_job()` correctly detect and report a *fresh* `compute_next_run()` failure happening *during* the resume call itself (instead of silently leaving the job at `state=scheduled` with `next_run_at=None`, which never fires and looks resumed). That PR's own new `update_job()` call passes `state: "error", enabled: True` — which, if the job resuming is *itself already* `state=error`, would hit the exact same guard this PR fixes. The two PRs are non-conflicting and mutually reinforcing; #16428 would work correctly on an already-error job only once this PR's guard relaxation lands.
- **#88339** (merged, salvage of #87261, "recover recurring jobs wedged in stale persisted error state") fixes a related but **structurally distinct** mechanism: a job whose `last_status == "error"` (an execution-result field) with `next_run_at` already re-armed into the future, invisible to the in-memory stale-claim sweep after a crash. This PR's bug is about the scheduler's own `state` field (not `last_status`) being `None`-valued and every recovery path refusing to touch it. I ran `tests/cron/test_recurring_persisted_error_recovery.py` (the test file for that mechanism) against this fix — all 3 tests pass unchanged, confirming no interaction.
- **#93615** (merged, salvage of #89649, "refuse terminal one-shot resurrection and add re-arm") is the PR that introduced `is_terminal_job()`/`rearm_oneshot()` (as `c3a63a16f1`) that this PR builds on top of — already landed on current `main`, this PR's branch is based on it.